### PR TITLE
feat: add OpenClaw plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Native OpenClaw plugin package exposing Crabbox run, warmup, status, list, and stop tools.
+
 ## 0.1.0 - 2026-05-01
 
 Initial Crabbox release.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ crabbox usage --scope all --json
 
 `crabbox usage` reads coordinator history, so it requires a configured broker. Cost is an estimate for compute leases, not a provider invoice: the coordinator prefers explicit `CRABBOX_COST_RATES_JSON` overrides, then provider pricing from AWS Spot history or Hetzner server-type prices, then built-in fallback rates. Full reference: [docs/commands/usage.md](docs/commands/usage.md).
 
+Use the OpenClaw plugin when an agent should drive Crabbox through OpenClaw tools instead of shelling out manually. The repository root is also a native OpenClaw plugin package; install it from this repo or from a packaged release, then use the `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, and `crabbox_stop` tools.
+
 Stop a kept server:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,18 @@ crabbox stop blue-lobster
 
 `crabbox doctor` validates local config, network reachability, and SSH key availability before you commit to a long workflow. `crabbox usage` summarizes recent spend by user, org, provider, and server type.
 
+## OpenClaw plugin
+
+The repository root is also a native OpenClaw plugin package. Once installed in OpenClaw, it exposes Crabbox operations as agent tools:
+
+- `crabbox_run`
+- `crabbox_warmup`
+- `crabbox_status`
+- `crabbox_list`
+- `crabbox_stop`
+
+The plugin shells out to the configured `crabbox` binary with argv arrays, so local Crabbox config, broker login, repo claims, and sync behavior stay owned by the CLI. Configure `plugins.entries.crabbox.config.binary` if the binary is not on `PATH`.
+
 ## Where to read next
 
 Pick whichever matches your intent:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,423 @@
+import { spawn } from "node:child_process";
+
+const PLUGIN_ID = "crabbox";
+const DEFAULT_BINARY = "crabbox";
+const DEFAULT_MAX_OUTPUT_BYTES = 60_000;
+const DEFAULT_TIMEOUT_SECONDS = 30 * 60;
+
+const commandArraySchema = {
+  type: "array",
+  minItems: 1,
+  items: {
+    type: "string",
+    minLength: 1,
+  },
+};
+
+const envSchema = {
+  type: "object",
+  additionalProperties: {
+    type: "string",
+  },
+};
+
+const providerSchema = {
+  type: "string",
+  enum: ["aws", "hetzner"],
+};
+
+function readConfig(api) {
+  const raw = api?.pluginConfig && typeof api.pluginConfig === "object" ? api.pluginConfig : {};
+  return {
+    binary: readString(raw, "binary") ?? DEFAULT_BINARY,
+    maxOutputBytes: readPositiveInteger(raw, "maxOutputBytes", DEFAULT_MAX_OUTPUT_BYTES),
+    timeoutSeconds: readPositiveInteger(raw, "timeoutSeconds", DEFAULT_TIMEOUT_SECONDS),
+    allowRun: readBoolean(raw, "allowRun", true),
+    allowWarmup: readBoolean(raw, "allowWarmup", true),
+    allowStop: readBoolean(raw, "allowStop", true),
+  };
+}
+
+function readString(source, key) {
+  const value = source?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readBoolean(source, key, fallback) {
+  const value = source?.[key];
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readPositiveInteger(source, key, fallback) {
+  const value = source?.[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function readStringArray(source, key) {
+  const value = source?.[key];
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${key} must be a non-empty string array`);
+  }
+  const next = value.map((item) => {
+    if (typeof item !== "string" || !item.trim()) {
+      throw new Error(`${key} must contain only non-empty strings`);
+    }
+    return item;
+  });
+  return next;
+}
+
+function readEnv(source) {
+  const value = source?.env;
+  if (value === undefined) {
+    return {};
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("env must be an object of string values");
+  }
+  const entries = Object.entries(value).map(([key, entry]) => {
+    if (typeof entry !== "string") {
+      throw new Error(`env.${key} must be a string`);
+    }
+    return [key, entry];
+  });
+  return Object.fromEntries(entries);
+}
+
+function maybePush(args, flag, value) {
+  if (value !== undefined) {
+    args.push(flag, value);
+  }
+}
+
+function maybePushBool(args, flag, value) {
+  if (value === true) {
+    args.push(flag);
+  }
+}
+
+function toolResult(text, details) {
+  return {
+    content: [{ type: "text", text }],
+    details,
+  };
+}
+
+function commandLine(binary, args) {
+  return [binary, ...args].map((part) => (/\s/.test(part) ? JSON.stringify(part) : part)).join(" ");
+}
+
+function appendChunk(current, chunk, maxBytes) {
+  if (!chunk) {
+    return current;
+  }
+  const next = current + chunk;
+  if (Buffer.byteLength(next, "utf8") <= maxBytes) {
+    return next;
+  }
+  return next.slice(0, maxBytes) + "\n[truncated]\n";
+}
+
+function runCrabbox(config, args, options = {}) {
+  const timeoutSeconds = options.timeoutSeconds ?? config.timeoutSeconds;
+  const maxOutputBytes = config.maxOutputBytes;
+  return new Promise((resolve, reject) => {
+    const child = spawn(config.binary, args, {
+      env: { ...process.env, ...options.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let didTimeout = false;
+    const timer = setTimeout(() => {
+      didTimeout = true;
+      child.kill("SIGTERM");
+    }, timeoutSeconds * 1000);
+    const abort = () => child.kill("SIGTERM");
+    options.signal?.addEventListener("abort", abort, { once: true });
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout = appendChunk(stdout, chunk, maxOutputBytes);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr = appendChunk(stderr, chunk, maxOutputBytes);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abort);
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abort);
+      const result = {
+        ok: code === 0 && !didTimeout,
+        code,
+        signal,
+        timedOut: didTimeout,
+        stdout,
+        stderr,
+        command: commandLine(config.binary, args),
+      };
+      resolve(result);
+    });
+  });
+}
+
+function formatResult(result) {
+  const parts = [`$ ${result.command}`, `exit=${result.code ?? "signal"}${result.signal ? ` signal=${result.signal}` : ""}`];
+  if (result.timedOut) {
+    parts.push("timed out");
+  }
+  if (result.stdout.trim()) {
+    parts.push(`stdout:\n${result.stdout.trimEnd()}`);
+  }
+  if (result.stderr.trim()) {
+    parts.push(`stderr:\n${result.stderr.trimEnd()}`);
+  }
+  return parts.join("\n\n");
+}
+
+async function execute(config, args, params, signal) {
+  const timeoutSeconds = readPositiveInteger(params, "timeoutSeconds", config.timeoutSeconds);
+  const result = await runCrabbox(config, args, {
+    env: readEnv(params),
+    signal,
+    timeoutSeconds,
+  });
+  return toolResult(formatResult(result), result);
+}
+
+function registerRun(api, config) {
+  api.registerTool({
+    name: "crabbox_run",
+    description: "Run a command on an existing Crabbox lease after syncing the current repository.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "command"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Crabbox lease ID or friendly slug.",
+        },
+        command: commandArraySchema,
+        env: envSchema,
+        noSync: {
+          type: "boolean",
+          description: "Pass --no-sync.",
+        },
+        syncOnly: {
+          type: "boolean",
+          description: "Pass --sync-only.",
+        },
+        forceSyncLarge: {
+          type: "boolean",
+          description: "Pass --force-sync-large.",
+        },
+        checksum: {
+          type: "boolean",
+          description: "Pass --checksum.",
+        },
+        debug: {
+          type: "boolean",
+          description: "Pass --debug.",
+        },
+        reclaim: {
+          type: "boolean",
+          description: "Pass --reclaim.",
+        },
+        junit: {
+          type: "string",
+          description: "Comma-separated remote JUnit XML paths.",
+        },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowRun) {
+        throw new Error("crabbox_run is disabled by plugin config");
+      }
+      const args = ["run", "--id", readString(params, "id")];
+      maybePushBool(args, "--no-sync", params?.noSync);
+      maybePushBool(args, "--sync-only", params?.syncOnly);
+      maybePushBool(args, "--force-sync-large", params?.forceSyncLarge);
+      maybePushBool(args, "--checksum", params?.checksum);
+      maybePushBool(args, "--debug", params?.debug);
+      maybePushBool(args, "--reclaim", params?.reclaim);
+      maybePush(args, "--junit", readString(params, "junit"));
+      args.push("--", ...readStringArray(params, "command"));
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerWarmup(api, config) {
+  api.registerTool({
+    name: "crabbox_warmup",
+    description: "Provision or reuse a Crabbox lease and wait until it is ready.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        provider: providerSchema,
+        profile: { type: "string" },
+        class: { type: "string" },
+        type: {
+          type: "string",
+          description: "Provider server or instance type.",
+        },
+        ttl: {
+          type: "string",
+          description: "Maximum lease lifetime, for example 90m.",
+        },
+        idleTimeout: {
+          type: "string",
+          description: "Idle timeout, for example 30m.",
+        },
+        keep: {
+          type: "boolean",
+          description: "Pass --keep.",
+        },
+        actionsRunner: {
+          type: "boolean",
+          description: "Pass --actions-runner.",
+        },
+        reclaim: {
+          type: "boolean",
+          description: "Pass --reclaim.",
+        },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowWarmup) {
+        throw new Error("crabbox_warmup is disabled by plugin config");
+      }
+      const args = ["warmup"];
+      maybePush(args, "--provider", readString(params, "provider"));
+      maybePush(args, "--profile", readString(params, "profile"));
+      maybePush(args, "--class", readString(params, "class"));
+      maybePush(args, "--type", readString(params, "type"));
+      maybePush(args, "--ttl", readString(params, "ttl"));
+      maybePush(args, "--idle-timeout", readString(params, "idleTimeout"));
+      maybePushBool(args, "--keep", params?.keep);
+      maybePushBool(args, "--actions-runner", params?.actionsRunner);
+      maybePushBool(args, "--reclaim", params?.reclaim);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerStatus(api, config) {
+  api.registerTool({
+    name: "crabbox_status",
+    description: "Read the current state for a Crabbox lease.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: { type: "string" },
+        provider: providerSchema,
+        wait: { type: "boolean" },
+        waitTimeout: {
+          type: "string",
+          description: "Maximum wait duration, for example 10m.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      const args = ["status", "--id", readString(params, "id")];
+      maybePush(args, "--provider", readString(params, "provider"));
+      maybePushBool(args, "--wait", params?.wait);
+      maybePush(args, "--wait-timeout", readString(params, "waitTimeout"));
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerList(api, config) {
+  api.registerTool({
+    name: "crabbox_list",
+    description: "List current Crabbox machines.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        provider: providerSchema,
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      const args = ["list"];
+      maybePush(args, "--provider", readString(params, "provider"));
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerStop(api, config) {
+  api.registerTool({
+    name: "crabbox_stop",
+    description: "Stop a kept Crabbox lease by ID or friendly slug.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: { type: "string" },
+        provider: providerSchema,
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowStop) {
+        throw new Error("crabbox_stop is disabled by plugin config");
+      }
+      const args = ["stop"];
+      maybePush(args, "--provider", readString(params, "provider"));
+      args.push(readString(params, "id"));
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+export default {
+  id: PLUGIN_ID,
+  name: "Crabbox",
+  description: "Run Crabbox remote testbox checks from OpenClaw.",
+  register(api) {
+    const config = readConfig(api);
+    registerRun(api, config);
+    registerWarmup(api, config);
+    registerStatus(api, config);
+    registerList(api, config);
+    registerStop(api, config);
+    api.logger?.info?.("Crabbox plugin registered");
+  },
+};

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import plugin from "./index.js";
+
+function createFakeCrabbox() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-plugin-"));
+  const file = path.join(dir, "crabbox-fake.js");
+  fs.writeFileSync(
+    file,
+    `#!/usr/bin/env node
+const payload = { argv: process.argv.slice(2), env: { CRABBOX_TEST_VALUE: process.env.CRABBOX_TEST_VALUE } };
+process.stdout.write(JSON.stringify(payload));
+if (process.env.CRABBOX_FAKE_EXIT) process.exit(Number(process.env.CRABBOX_FAKE_EXIT));
+`,
+    "utf8",
+  );
+  fs.chmodSync(file, 0o755);
+  return { dir, file };
+}
+
+function registerWithConfig(pluginConfig) {
+  const tools = [];
+  plugin.register({
+    pluginConfig,
+    registerTool(tool) {
+      tools.push(tool);
+    },
+    logger: { info() {} },
+  });
+  return tools;
+}
+
+function getTool(tools, name) {
+  const tool = tools.find((entry) => entry.name === name);
+  assert.ok(tool, `expected ${name} to be registered`);
+  return tool;
+}
+
+test("registers the Crabbox tool surface", () => {
+  const tools = registerWithConfig({});
+  assert.deepEqual(
+    tools.map((tool) => tool.name).sort(),
+    ["crabbox_list", "crabbox_run", "crabbox_status", "crabbox_stop", "crabbox_warmup"],
+  );
+});
+
+test("crabbox_run executes the CLI without shell wrapping", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_run").execute("call-1", {
+    id: "blue-lobster",
+    command: ["go", "test", "./..."],
+    env: { CRABBOX_TEST_VALUE: "present" },
+  });
+  assert.equal(result.details.code, 0);
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "run",
+    "--id",
+    "blue-lobster",
+    "--",
+    "go",
+    "test",
+    "./...",
+  ]);
+  assert.equal(JSON.parse(result.details.stdout).env.CRABBOX_TEST_VALUE, "present");
+});
+
+test("crabbox_status includes optional flags", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_status").execute("call-1", {
+    id: "cbx_123",
+    wait: true,
+    waitTimeout: "10m",
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "status",
+    "--id",
+    "cbx_123",
+    "--wait",
+    "--wait-timeout",
+    "10m",
+    "--json",
+  ]);
+});
+
+test("disabled run tool fails before invoking crabbox", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file, allowRun: false });
+  await assert.rejects(
+    getTool(tools, "crabbox_run").execute("call-1", {
+      id: "blue-lobster",
+      command: ["go", "test", "./..."],
+    }),
+    /disabled/,
+  );
+});

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,47 @@
+{
+  "id": "crabbox",
+  "name": "Crabbox",
+  "description": "Run Crabbox remote testbox checks from OpenClaw.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["crabbox_run", "crabbox_warmup", "crabbox_status", "crabbox_list", "crabbox_stop"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "binary": {
+        "type": "string",
+        "description": "Crabbox executable path.",
+        "default": "crabbox"
+      },
+      "maxOutputBytes": {
+        "type": "number",
+        "description": "Maximum captured stdout/stderr bytes returned to the model.",
+        "default": 60000
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "description": "Default local wrapper timeout for Crabbox CLI invocations.",
+        "default": 1800
+      },
+      "allowRun": {
+        "type": "boolean",
+        "description": "Allow the crabbox_run tool.",
+        "default": true
+      },
+      "allowWarmup": {
+        "type": "boolean",
+        "description": "Allow the crabbox_warmup tool.",
+        "default": true
+      },
+      "allowStop": {
+        "type": "boolean",
+        "description": "Allow the crabbox_stop tool.",
+        "default": true
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openclaw/crabbox-plugin",
+  "version": "0.1.0",
+  "description": "OpenClaw plugin for running Crabbox remote testbox workflows",
+  "license": "MIT",
+  "type": "module",
+  "main": "index.js",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.25"
+    }
+  },
+  "scripts": {
+    "check": "node --check index.js && node --test index.test.js",
+    "test": "node --test index.test.js"
+  },
+  "files": [
+    "index.js",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a native OpenClaw plugin package at the Crabbox repo root
- expose Crabbox operations as `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, and `crabbox_stop` tools
- document the plugin surface in the README/docs and add an Unreleased changelog entry

## Verification
- `npm run check`
- `go test ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- `npm pack --dry-run --json`
