### PR TITLE
Harden signed user token identity forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Restricted Worker admin routes to shared-token admin auth so GitHub browser-login users cannot call admin endpoints.
 - Fixed `whoami` reporting for GitHub browser-login tokens.
 - Fixed exact `cbx_...` lookups bypassing owner-scoped slug authorization checks.
+- Prevented caller-supplied Access identity headers from overriding signed GitHub user token identity. Thanks @stainlu.
 - Added cleanup and a pending-login cap for unauthenticated GitHub OAuth login starts.
 
 ## 0.1.0 - 2026-05-01

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,6 +23,7 @@ MVP:
 - Workers.dev automation can still use a shared bearer token via `crabbox login --token-stdin`.
 - The CLI sends owner/org headers only for shared-token automation; GitHub login tokens carry owner/org inside the signed token.
 - GitHub browser-login tokens are user tokens, not admin tokens. They can only see and mutate leases, runs, logs, and usage for their own owner/org identity.
+- The Worker forwards signed GitHub token owner/org identity to the Fleet Durable Object and strips caller-supplied Access identity headers from that forwarded request.
 - Missing shared-token config fails closed for non-health coordinator routes.
 
 Target:

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -60,6 +60,7 @@ export async function authenticateRequest(
 
 export function requestWithAuthContext(request: Request, auth: AuthContext): Request {
   const headers = new Headers(request.headers);
+  headers.delete("cf-access-authenticated-user-email");
   headers.set("x-crabbox-auth", auth.auth);
   headers.set("x-crabbox-admin", auth.admin ? "true" : "false");
   headers.set("x-crabbox-owner", auth.owner);

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -27,8 +27,8 @@ export function bearerToken(request: Request): string {
 
 export function requestOwner(request: Request): string {
   return (
-    request.headers.get("cf-access-authenticated-user-email") ??
     request.headers.get("x-crabbox-owner") ??
+    request.headers.get("cf-access-authenticated-user-email") ??
     "unknown"
   );
 }

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { isAuthorized } from "../src";
-import { authenticateRequest, issueUserToken } from "../src/auth";
+import { authenticateRequest, issueUserToken, requestWithAuthContext } from "../src/auth";
+import { requestOwner } from "../src/http";
 
 describe("coordinator auth", () => {
   it("denies requests when no shared token is configured", async () => {
@@ -37,5 +38,25 @@ describe("coordinator auth", () => {
       org: "openclaw",
       login: "friend",
     });
+  });
+
+  it("does not let caller-supplied Access identity override signed user token identity", () => {
+    const request = new Request("https://example.test/v1/whoami", {
+      headers: {
+        "cf-access-authenticated-user-email": "spoof@example.com",
+        "x-crabbox-owner": "spoof@example.com",
+      },
+    });
+    const next = requestWithAuthContext(request, {
+      authorized: true,
+      admin: false,
+      auth: "github",
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+    });
+
+    expect(next.headers.get("cf-access-authenticated-user-email")).toBeNull();
+    expect(requestOwner(next)).toBe("friend@example.com");
   });
 });


### PR DESCRIPTION
## Summary

- Strip caller-supplied `cf-access-authenticated-user-email` before forwarding authenticated requests to the Fleet Durable Object.
- Prefer the authenticated `x-crabbox-owner` context when resolving request ownership, while keeping the Access email header as a fallback.
- Document the signed-token forwarding behavior and add a regression test for spoofed identity headers.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- `npm run check`
- `git diff --check`
