### PR TITLE
Add Cloudflare Access service-token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added GitHub org membership enforcement before minting browser-login tokens.
 - Added the canonical coordinator endpoint configured for OAuth callback generation.
 - Added Blacksmith Testbox workflow flags for `crabbox warmup` and `crabbox run`, enabling one-command Testbox runs without repo YAML or environment variables.
+- Added Cloudflare Access service-token headers for coordinator CLI requests. Thanks @stainlu.
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -249,6 +249,9 @@ broker:
   url: https://crabbox.openclaw.ai
   provider: aws
   token: ...
+  access:
+    clientId: ...
+    clientSecret: ...
 profile: project-check
 class: beast
 lease:
@@ -345,6 +348,9 @@ blacksmith:
 ```text
 CRABBOX_COORDINATOR
 CRABBOX_COORDINATOR_TOKEN
+CRABBOX_ACCESS_CLIENT_ID
+CRABBOX_ACCESS_CLIENT_SECRET
+CRABBOX_ACCESS_TOKEN
 CRABBOX_PROVIDER
 CRABBOX_PROFILE
 CRABBOX_CONFIG

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -17,6 +17,8 @@ show [--json]
 set-broker --url <url> --token-stdin [--provider hetzner|aws]
 ```
 
+`config show` reports `access_auth` as `missing`, `service-token`, `token`, `service-token+token`, or `incomplete` so operators can confirm whether Cloudflare Access credentials are configured without printing secret values. Store Access secrets only in user config or environment variables, not repo-local config.
+
 User config lives under the OS user config directory. Repo-local `crabbox.yaml` or `.crabbox.yaml` can override user defaults for a checkout. Keep project-specific sync, env, capacity, and Actions policy in repo config, not in the Crabbox binary:
 
 ```yaml

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -43,6 +43,8 @@ X-Crabbox-Owner: <email>
 X-Crabbox-Org: <org>
 ```
 
+If the coordinator route is also protected by Cloudflare Access, the CLI can send Access credentials before the Worker receives the request. Configure `CRABBOX_ACCESS_CLIENT_ID` and `CRABBOX_ACCESS_CLIENT_SECRET` for a Cloudflare Access service token, or `CRABBOX_ACCESS_TOKEN` to forward an already minted Access JWT as `cf-access-token`. These Access credentials only satisfy Cloudflare Access; the Worker still requires the Crabbox bearer token or a signed Crabbox user token.
+
 Owner selection for bearer-token requests:
 
 ```text

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -87,6 +87,7 @@ Current local status:
 - Core Cloudflare, Hetzner, and GitHub tokens are present in local `~/.profile`.
 - The Crabbox Cloudflare token is mirrored to MacBook Pro `~/.profile`.
 - `CRABBOX_COORDINATOR` and `CRABBOX_COORDINATOR_TOKEN` are present in local and MacBook Pro `~/.profile`.
+- Cloudflare Access service-token CLI credentials can be stored locally as `CRABBOX_ACCESS_CLIENT_ID` and `CRABBOX_ACCESS_CLIENT_SECRET`; `CRABBOX_ACCESS_TOKEN` can carry an already minted Access JWT for protected fallback routes.
 - Cloudflare Access GitHub OAuth client ID and secret may be stored locally as `CRABBOX_GITHUB_OAUTH_*`.
 - Crabbox browser-login OAuth secrets are deployed as Worker secrets `CRABBOX_GITHUB_CLIENT_ID`, `CRABBOX_GITHUB_CLIENT_SECRET`, and `CRABBOX_SESSION_SECRET`.
 - Cloudflare Access GitHub IdP is created.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,7 +78,7 @@ The canonical Worker URL is:
 https://crabbox.openclaw.ai
 ```
 
-The `crabbox.openclaw.ai/*` route is attached to the coordinator Worker. Bearer-token CLI automation talks to the Worker with `CRABBOX_SHARED_TOKEN`/`CRABBOX_COORDINATOR_TOKEN`; GitHub browser login stores a user-scoped signed token.
+The `crabbox.openclaw.ai/*` route is attached to the coordinator Worker. Bearer-token CLI automation talks to the Worker with `CRABBOX_SHARED_TOKEN`/`CRABBOX_COORDINATOR_TOKEN`; GitHub browser login stores a user-scoped signed token. Access-protected fallback routes can also use `CRABBOX_ACCESS_CLIENT_ID` plus `CRABBOX_ACCESS_CLIENT_SECRET`, or `CRABBOX_ACCESS_TOKEN` for an already minted Access JWT.
 
 Use `crabbox config show` to confirm which URL and provider the CLI will use:
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -168,6 +168,9 @@ Config:
 Environment:
   CRABBOX_COORDINATOR          Broker URL
   CRABBOX_COORDINATOR_TOKEN    Broker bearer token
+  CRABBOX_ACCESS_CLIENT_ID     Cloudflare Access service token client ID
+  CRABBOX_ACCESS_CLIENT_SECRET Cloudflare Access service token client secret
+  CRABBOX_ACCESS_TOKEN         Cloudflare Access JWT for protected routes
   CRABBOX_PROVIDER             hetzner or aws
   CRABBOX_OWNER                Usage owner override
   CRABBOX_ORG                  Usage org override

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	ServerType  string
 	Coordinator string
 	CoordToken  string
+	Access      AccessConfig
 	Location    string
 	Image       string
 	AWSRegion   string
@@ -96,6 +97,12 @@ type CacheConfig struct {
 	Git            bool
 	MaxGB          int
 	PurgeOnRelease bool
+}
+
+type AccessConfig struct {
+	ClientID     string
+	ClientSecret string
+	Token        string
 }
 
 func defaultConfig() Config {
@@ -201,9 +208,16 @@ type fileConfig struct {
 }
 
 type fileBrokerConfig struct {
-	URL      string `yaml:"url,omitempty"`
-	Token    string `yaml:"token,omitempty"`
-	Provider string `yaml:"provider,omitempty"`
+	URL      string            `yaml:"url,omitempty"`
+	Token    string            `yaml:"token,omitempty"`
+	Provider string            `yaml:"provider,omitempty"`
+	Access   *fileAccessConfig `yaml:"access,omitempty"`
+}
+
+type fileAccessConfig struct {
+	ClientID     string `yaml:"clientId,omitempty"`
+	ClientSecret string `yaml:"clientSecret,omitempty"`
+	Token        string `yaml:"token,omitempty"`
 }
 
 type fileHetznerConfig struct {
@@ -397,6 +411,17 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 		}
 		if file.Broker.Provider != "" {
 			cfg.Provider = file.Broker.Provider
+		}
+		if file.Broker.Access != nil {
+			if file.Broker.Access.ClientID != "" {
+				cfg.Access.ClientID = file.Broker.Access.ClientID
+			}
+			if file.Broker.Access.ClientSecret != "" {
+				cfg.Access.ClientSecret = file.Broker.Access.ClientSecret
+			}
+			if file.Broker.Access.Token != "" {
+				cfg.Access.Token = file.Broker.Access.Token
+			}
 		}
 	}
 	if file.Hetzner != nil {
@@ -594,6 +619,9 @@ func applyEnv(cfg *Config) {
 	cfg.ServerType = getenv("CRABBOX_SERVER_TYPE", cfg.ServerType)
 	cfg.Coordinator = getenv("CRABBOX_COORDINATOR", cfg.Coordinator)
 	cfg.CoordToken = getenv("CRABBOX_COORDINATOR_TOKEN", cfg.CoordToken)
+	cfg.Access.ClientID = getenv("CRABBOX_ACCESS_CLIENT_ID", getenv("CF_ACCESS_CLIENT_ID", cfg.Access.ClientID))
+	cfg.Access.ClientSecret = getenv("CRABBOX_ACCESS_CLIENT_SECRET", getenv("CF_ACCESS_CLIENT_SECRET", cfg.Access.ClientSecret))
+	cfg.Access.Token = getenv("CRABBOX_ACCESS_TOKEN", getenv("CF_ACCESS_TOKEN", cfg.Access.Token))
 	cfg.Location = getenv("CRABBOX_HETZNER_LOCATION", cfg.Location)
 	cfg.Image = getenv("CRABBOX_HETZNER_IMAGE", cfg.Image)
 	cfg.AWSRegion = getenv("CRABBOX_AWS_REGION", getenv("AWS_REGION", cfg.AWSRegion))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -47,6 +47,7 @@ func (a App) configShow(args []string) error {
 		"serverType":  cfg.ServerType,
 		"coordinator": cfg.Coordinator,
 		"brokerAuth":  tokenState(cfg.CoordToken),
+		"accessAuth":  accessAuthState(cfg.Access),
 		"sshKey":      cfg.SSHKey,
 		"sshUser":     cfg.SSHUser,
 		"sshPort":     cfg.SSHPort,
@@ -124,6 +125,7 @@ func (a App) configShow(args []string) error {
 	fmt.Fprintf(a.Stdout, "config=%s\n", userConfigPath())
 	fmt.Fprintf(a.Stdout, "provider=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.Class, cfg.ServerType, cfg.Profile)
 	fmt.Fprintf(a.Stdout, "broker=%s auth=%s\n", blank(cfg.Coordinator, "-"), tokenState(cfg.CoordToken))
+	fmt.Fprintf(a.Stdout, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(a.Stdout, "ssh=%s@<host>:%s key=%s\n", cfg.SSHUser, cfg.SSHPort, cfg.SSHKey)
 	fmt.Fprintf(a.Stdout, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), cfg.Sync.Timeout)
 	fmt.Fprintf(a.Stdout, "env allow=%s\n", strings.Join(cfg.EnvAllow, ","))
@@ -190,6 +192,24 @@ func tokenState(token string) string {
 		return "missing"
 	}
 	return "configured"
+}
+
+func accessAuthState(access AccessConfig) string {
+	hasServiceToken := access.ClientID != "" && access.ClientSecret != ""
+	hasToken := access.Token != ""
+	if hasServiceToken && hasToken {
+		return "service-token+token"
+	}
+	if hasServiceToken {
+		return "service-token"
+	}
+	if hasToken {
+		return "token"
+	}
+	if access.ClientID != "" || access.ClientSecret != "" {
+		return "incomplete"
+	}
+	return "missing"
 }
 
 func blank(value, fallback string) string {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -22,6 +22,10 @@ func TestLoadConfigFromUserFile(t *testing.T) {
   url: https://crabbox.example.test
   token: secret
   provider: aws
+  access:
+    clientId: access-client
+    clientSecret: access-secret
+    token: access-jwt
 class: standard
 lease:
   ttl: 2h
@@ -101,6 +105,9 @@ ssh:
 	if cfg.Coordinator != "https://crabbox.example.test" || cfg.CoordToken != "secret" {
 		t.Fatalf("broker config not loaded: %#v", cfg)
 	}
+	if cfg.Access.ClientID != "access-client" || cfg.Access.ClientSecret != "access-secret" || cfg.Access.Token != "access-jwt" {
+		t.Fatalf("access config not loaded: %#v", cfg.Access)
+	}
 	if cfg.TTL.String() != "2h0m0s" || cfg.IdleTimeout.String() != "45m0s" {
 		t.Fatalf("lease config not loaded: ttl=%s idle=%s", cfg.TTL, cfg.IdleTimeout)
 	}
@@ -155,6 +162,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_TTL", "3h")
 	t.Setenv("CRABBOX_IDLE_TIMEOUT", "20m")
 	t.Setenv("CRABBOX_AWS_SSH_CIDRS", "198.51.100.7/32,203.0.113.8/32")
+	t.Setenv("CRABBOX_ACCESS_CLIENT_ID", "env-access-client")
+	t.Setenv("CRABBOX_ACCESS_CLIENT_SECRET", "env-access-secret")
+	t.Setenv("CRABBOX_ACCESS_TOKEN", "env-access-jwt")
 	path := userConfigPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
@@ -172,6 +182,42 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if len(cfg.AWSSSHCIDRs) != 2 || cfg.AWSSSHCIDRs[0] != "198.51.100.7/32" || cfg.AWSSSHCIDRs[1] != "203.0.113.8/32" {
 		t.Fatalf("AWSSSHCIDRs=%v", cfg.AWSSSHCIDRs)
+	}
+	if cfg.Access.ClientID != "env-access-client" || cfg.Access.ClientSecret != "env-access-secret" || cfg.Access.Token != "env-access-jwt" {
+		t.Fatalf("unexpected access config: %#v", cfg.Access)
+	}
+}
+
+func TestAccessAuthState(t *testing.T) {
+	for name, tc := range map[string]struct {
+		access AccessConfig
+		want   string
+	}{
+		"missing": {
+			want: "missing",
+		},
+		"incomplete": {
+			access: AccessConfig{ClientID: "client"},
+			want:   "incomplete",
+		},
+		"service token": {
+			access: AccessConfig{ClientID: "client", ClientSecret: "secret"},
+			want:   "service-token",
+		},
+		"token": {
+			access: AccessConfig{Token: "jwt"},
+			want:   "token",
+		},
+		"service token plus token": {
+			access: AccessConfig{ClientID: "client", ClientSecret: "secret", Token: "jwt"},
+			want:   "service-token+token",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := accessAuthState(tc.access); got != tc.want {
+				t.Fatalf("accessAuthState()=%q want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -20,6 +20,7 @@ import (
 type CoordinatorClient struct {
 	BaseURL string
 	Token   string
+	Access  AccessConfig
 	Client  *http.Client
 }
 
@@ -204,6 +205,7 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 	return &CoordinatorClient{
 		BaseURL: strings.TrimRight(base.String(), "/"),
 		Token:   cfg.CoordToken,
+		Access:  cfg.Access,
 		Client: &http.Client{
 			Timeout: 5 * time.Minute,
 			Transport: &http.Transport{
@@ -502,6 +504,7 @@ func (c *CoordinatorClient) doHTTP(ctx context.Context, method, path string, dat
 	if c.Token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
+	c.addAccessHeaders(req.Header)
 	if owner := localCoordinatorOwner(); owner != "" {
 		req.Header.Set("X-Crabbox-Owner", owner)
 	}
@@ -580,6 +583,7 @@ func (c *CoordinatorClient) curlConfig(method, path string, data []byte, hasBody
 	if c.Token != "" {
 		curlConfigValue(&cfg, "header", "Authorization: Bearer "+c.Token)
 	}
+	c.addCurlAccessHeaders(&cfg)
 	if owner := localCoordinatorOwner(); owner != "" {
 		curlConfigValue(&cfg, "header", "X-Crabbox-Owner: "+owner)
 	}
@@ -587,6 +591,26 @@ func (c *CoordinatorClient) curlConfig(method, path string, data []byte, hasBody
 		curlConfigValue(&cfg, "header", "X-Crabbox-Org: "+org)
 	}
 	return cfg.String(), cleanup, nil
+}
+
+func (c *CoordinatorClient) addAccessHeaders(header http.Header) {
+	if c.Access.ClientID != "" && c.Access.ClientSecret != "" {
+		header.Set("CF-Access-Client-Id", c.Access.ClientID)
+		header.Set("CF-Access-Client-Secret", c.Access.ClientSecret)
+	}
+	if c.Access.Token != "" {
+		header.Set("cf-access-token", c.Access.Token)
+	}
+}
+
+func (c *CoordinatorClient) addCurlAccessHeaders(cfg *strings.Builder) {
+	if c.Access.ClientID != "" && c.Access.ClientSecret != "" {
+		curlConfigValue(cfg, "header", "CF-Access-Client-Id: "+c.Access.ClientID)
+		curlConfigValue(cfg, "header", "CF-Access-Client-Secret: "+c.Access.ClientSecret)
+	}
+	if c.Access.Token != "" {
+		curlConfigValue(cfg, "header", "cf-access-token: "+c.Access.Token)
+	}
 }
 
 func curlConfigValue(out *strings.Builder, key, value string) {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -55,7 +55,15 @@ func TestDecodeCoordinatorResponseCanReadTextBody(t *testing.T) {
 }
 
 func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
-	client := CoordinatorClient{BaseURL: "https://example.test", Token: "secret-token"}
+	client := CoordinatorClient{
+		BaseURL: "https://example.test",
+		Token:   "secret-token",
+		Access: AccessConfig{
+			ClientID:     "access-client",
+			ClientSecret: "access-secret",
+			Token:        "access-jwt",
+		},
+	}
 	config, cleanup, err := client.curlConfig("POST", "/v1/leases", []byte(`{"leaseID":"cbx"}`), true)
 	if err != nil {
 		t.Fatal(err)
@@ -66,6 +74,9 @@ func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
 		`url = "https://example.test/v1/leases"`,
 		`request = "POST"`,
 		`header = "Authorization: Bearer secret-token"`,
+		`header = "CF-Access-Client-Id: access-client"`,
+		`header = "CF-Access-Client-Secret: access-secret"`,
+		`header = "cf-access-token: access-jwt"`,
 		`header = "Content-Type: application/json"`,
 		`data-binary = "@`,
 	} {
@@ -77,6 +88,39 @@ func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
 	bodyPath = strings.TrimPrefix(bodyPath, "@")
 	if _, err := os.Stat(bodyPath); err != nil {
 		t.Fatalf("body file missing: %v", err)
+	}
+}
+
+func TestCoordinatorHTTPAddsAccessHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer broker-token" {
+			t.Fatalf("Authorization=%q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Id"); got != "access-client" {
+			t.Fatalf("CF-Access-Client-Id=%q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Secret"); got != "access-secret" {
+			t.Fatalf("CF-Access-Client-Secret=%q", got)
+		}
+		if got := r.Header.Get("cf-access-token"); got != "access-jwt" {
+			t.Fatalf("cf-access-token=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+	client := CoordinatorClient{
+		BaseURL: server.URL,
+		Token:   "broker-token",
+		Access: AccessConfig{
+			ClientID:     "access-client",
+			ClientSecret: "access-secret",
+			Token:        "access-jwt",
+		},
+		Client: server.Client(),
+	}
+	if err := client.Health(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -55,7 +55,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 			fmt.Fprintf(a.Stdout, "failed  coord    %v\n", err)
 			ok = false
 		} else {
-			fmt.Fprintf(a.Stdout, "ok      coord    %s\n", cfg.Coordinator)
+			fmt.Fprintf(a.Stdout, "ok      coord    %s access=%s\n", cfg.Coordinator, accessAuthState(cfg.Access))
 			if machines, err := coord.Pool(ctx, cfg); err != nil {
 				fmt.Fprintf(a.Stdout, "failed  broker   %v\n", err)
 				ok = false


### PR DESCRIPTION
## Summary

- add CLI config/env support for Cloudflare Access service-token credentials
- send `CF-Access-Client-Id`, `CF-Access-Client-Secret`, and optional `cf-access-token` on coordinator requests, including curl fallback
- surface redacted Access auth state in `config show` and `doctor`
- document operator setup and keep Access secrets in user config/env, not repo config

Upstream contract checked against Cloudflare Access service-token docs: https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/

## Verification

- `env PATH=/private/tmp/crabbox-go-1.26.2/bin:/usr/bin:/bin:/usr/sbin:/sbin GOMODCACHE=/private/tmp/crabbox-gomodcache GOCACHE=/private/tmp/crabbox-gocache go test ./internal/cli`
- `env PATH=/private/tmp/crabbox-go-1.26.2/bin:/usr/bin:/bin:/usr/sbin:/sbin GOMODCACHE=/private/tmp/crabbox-gomodcache GOCACHE=/private/tmp/crabbox-gocache go vet ./...`
- `env PATH=/private/tmp/crabbox-go-1.26.2/bin:/usr/bin:/bin:/usr/sbin:/sbin GOMODCACHE=/private/tmp/crabbox-gomodcache GOCACHE=/private/tmp/crabbox-gocache go test -race ./...`
- `env PATH=/private/tmp/crabbox-go-1.26.2/bin:/usr/bin:/bin:/usr/sbin:/sbin GOMODCACHE=/private/tmp/crabbox-gomodcache GOCACHE=/private/tmp/crabbox-gocache scripts/check-go-coverage.sh 85.0`
- `env PATH=/private/tmp/crabbox-go-1.26.2/bin:/usr/bin:/bin:/usr/sbin:/sbin GOMODCACHE=/private/tmp/crabbox-gomodcache GOCACHE=/private/tmp/crabbox-gocache go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run check`
- `node scripts/build-docs-site.mjs`
- `git diff --check`

## Config and Secret Implications

New optional CLI inputs:

- `CRABBOX_ACCESS_CLIENT_ID`
- `CRABBOX_ACCESS_CLIENT_SECRET`
- `CRABBOX_ACCESS_TOKEN`
- `broker.access.clientId`, `broker.access.clientSecret`, and `broker.access.token` in user config

These values are only used to pass Cloudflare Access before the request reaches the Worker. Crabbox Worker auth remains separate through the existing bearer token or signed user token.
