### PR TITLE
feat: add durable run events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, and config conventions.
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type.
 - **GitHub Actions hydration.** `crabbox actions hydrate` registers a leased box as an ephemeral Actions runner, so the repo's own workflow installs runtimes, services, and secrets. Crabbox does not parse Actions YAML.
-- **OpenClaw plugin.** The repo root is a native OpenClaw plugin. Agents drive Crabbox through `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, and `crabbox_stop` instead of shelling out.
+- **OpenClaw plugin.** The repo root is a native OpenClaw plugin. Agents drive Crabbox through `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, `crabbox_events`, and `crabbox_stop` instead of shelling out.
 - **Operator surface.** `doctor`, `init`, `status`, `inspect`, `list`, `usage`, `history`, `logs`, `results`, `cache`, `admin`, `cleanup`, plus `--json` output where it matters.
 
 ## Machine classes
@@ -139,7 +139,7 @@ Forwarded environment is intentionally narrow: `NODE_OPTIONS` and `CI`. Do not p
 
 The repo root is a native OpenClaw plugin package. Once installed, it exposes Crabbox as agent tools:
 
-- `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, `crabbox_stop`
+- `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, `crabbox_events`, `crabbox_stop`
 
 The plugin shells out to the configured `crabbox` binary, so local config, broker login, repo claims, and sync behavior stay owned by the CLI. Set `plugins.entries.crabbox.config.binary` if `crabbox` is not on `PATH`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ The repository root is also a native OpenClaw plugin package. Once installed in 
 - `crabbox_warmup`
 - `crabbox_status`
 - `crabbox_list`
+- `crabbox_events`
 - `crabbox_stop`
 
 The plugin shells out to the configured `crabbox` binary with argv arrays, so local Crabbox config, broker login, repo claims, and sync behavior stay owned by the CLI. Configure `plugins.entries.crabbox.config.binary` if the binary is not on `PATH`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,8 @@ crabbox warmup [--provider hetzner|aws|blacksmith-testbox] [--profile <name>] [-
 crabbox run [--id <lease-id-or-slug>] [--shell] [--checksum] [--debug] [--force-sync-large] [--blacksmith-workflow <workflow>] -- <command...>
 crabbox sync-plan [--limit <n>]
 crabbox history [--lease <lease-id>] [--owner <email>] [--org <name>] [--limit <n>] [--json]
+crabbox events <run-id> [--after <seq>] [--limit <n>] [--json]
+crabbox attach <run-id> [--after <seq>]
 crabbox logs <run-id> [--json]
 crabbox results <run-id> [--json]
 crabbox cache stats --id <lease-id-or-slug> [--json]
@@ -144,6 +146,8 @@ Inspect recorded runs:
 ```sh
 crabbox run --id blue-lobster --junit junit.xml -- go test ./...
 crabbox history --lease cbx_abcdef123456
+crabbox events run_123
+crabbox attach run_123
 crabbox logs run_123
 crabbox results run_123
 ```
@@ -184,7 +188,7 @@ Behavior:
 5. Sync current repo, unless a matching sync fingerprint lets Crabbox skip rsync.
 6. Seed remote Git from the configured origin/base ref before first sync when possible.
 7. Run command over SSH.
-8. Stream remote output and retain the latest log tail in coordinator history.
+8. Stream remote output, append run events, and retain the latest log tail in coordinator history.
 9. Heartbeat coordinator leases in the background.
 10. Release lease unless `--keep` is set.
 11. Exit with the remote command exit code.

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -12,6 +12,8 @@ Command docs live here, one file per top-level command. Keep `docs/cli.md` as th
 - [run](run.md)
 - [sync-plan](sync-plan.md)
 - [history](history.md)
+- [events](events.md)
+- [attach](attach.md)
 - [logs](logs.md)
 - [results](results.md)
 - [cache](cache.md)

--- a/docs/commands/attach.md
+++ b/docs/commands/attach.md
@@ -1,0 +1,21 @@
+# attach
+
+`crabbox attach` follows structured events for an active recorded run.
+
+```sh
+crabbox attach run_...
+crabbox attach --id run_... --after 42
+```
+
+Stdout and stderr events are written back to stdout and stderr. Lifecycle events are printed to stderr with their sequence number, timestamp, and event type. When the run has already finished, `attach` prints any remaining events and exits.
+
+Flags:
+
+```text
+--id <run-id>       run id
+--after <seq>       resume after this event sequence
+--poll <duration>   polling interval, default 1s
+```
+
+`attach` follows broker events emitted by the original CLI. It is not detached command execution; if the original CLI process dies, the last recorded phase remains inspectable through [history](history.md) and [events](events.md).
+

--- a/docs/commands/events.md
+++ b/docs/commands/events.md
@@ -1,0 +1,23 @@
+# events
+
+`crabbox events` lists structured lifecycle and output events for a recorded run.
+
+```sh
+crabbox events run_...
+crabbox events --id run_... --after 42
+crabbox events run_... --json
+```
+
+Events are recorded by the coordinator while the CLI is alive. They include run creation, lease use, sync and hydration phases, command start/finish, stdout/stderr chunks, and release attempts.
+
+Flags:
+
+```text
+--id <run-id>       run id
+--after <seq>       only show events after this sequence
+--limit <n>         default 500, maximum 500
+--json              print JSON
+```
+
+Use [attach](attach.md) to follow a still-running run. Use [logs](logs.md) for the retained output tail.
+

--- a/docs/commands/history.md
+++ b/docs/commands/history.md
@@ -21,8 +21,11 @@ Flags:
 ```
 
 Human output includes run ID, lease ID, state, exit code, duration, start time, and command. Use the run ID with [logs](logs.md).
+When event recording is available, human output also includes the last known phase, such as `sync`, `hydrate`, `command`, or `release`.
 
 Related docs:
 
+- [events](events.md)
+- [attach](attach.md)
 - [logs](logs.md)
 - [History and logs](../features/history-logs.md)

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -26,7 +26,7 @@ Before the first rsync into a Git checkout, Crabbox tries to seed the remote wor
 
 After sync, Crabbox runs a remote sanity check. If the remote checkout reports at least 200 tracked deletions, Crabbox fails before running tests unless local `CRABBOX_ALLOW_MASS_DELETIONS=1` is set.
 
-When a coordinator is configured, Crabbox records each remote command as a run history item. `crabbox history` lists those records and `crabbox logs <run-id>` prints the retained remote output tail. Log retention is intentionally bounded so a noisy command cannot fill Durable Object storage.
+When a coordinator is configured, Crabbox records each remote command as a run history item before sync starts. `crabbox history` lists those records, `crabbox events <run-id>` shows structured lifecycle/output events, `crabbox attach <run-id>` follows a still-active run, and `crabbox logs <run-id>` prints the retained remote output tail. Log and event retention are intentionally bounded so a noisy command cannot fill Durable Object storage.
 
 Add `--junit <path>` or configure `results.junit` to attach JUnit XML summaries to the run record. `crabbox results <run-id>` then prints failed tests without reading the raw log tail.
 

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -6,7 +6,7 @@ Read when:
 - debugging failed remote commands;
 - deciding what belongs in coordinator history.
 
-Coordinator-backed `crabbox run` records a run before the remote command starts. When the command exits, the CLI finishes that run with:
+Coordinator-backed `crabbox run` records a run before sync starts and appends lifecycle events as the CLI progresses. When the command exits, the CLI finishes that run with:
 
 - exit code;
 - sync duration;
@@ -16,20 +16,33 @@ Coordinator-backed `crabbox run` records a run before the remote command starts.
 - provider, class, and server type;
 - retained remote output tail.
 
+The append-only event stream records:
+
+- `run.created`
+- `lease.created` or `lease.reused`
+- `sync.started` and `sync.finished`
+- `hydrate.started` and `hydrate.finished`
+- `command.started`, `stdout`, `stderr`, and `command.finished`
+- `lease.released`
+
 Use:
 
 ```sh
 crabbox history
 crabbox history --lease cbx_...
+crabbox events run_...
+crabbox attach run_...
 crabbox logs run_...
 ```
 
-History records live in the Fleet Durable Object. Log text is stored separately from run metadata and intentionally capped to the latest tail so noisy commands cannot exhaust storage.
+History and events live in the Fleet Durable Object. Log text is stored separately from run metadata and intentionally capped to the latest tail so noisy commands cannot exhaust storage.
 
 Direct-provider mode does not have central history. Use shell output or local terminal logs there.
 
 Related docs:
 
 - [history command](../commands/history.md)
+- [events command](../commands/events.md)
+- [attach command](../commands/attach.md)
 - [logs command](../commands/logs.md)
 - [Observability](../observability.md)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,7 +47,7 @@ Reports include lease count, active lease count, elapsed runtime, estimated elap
 
 ## Run History And Logs
 
-Coordinator-backed `crabbox run` creates a run record before the remote command starts and finishes it with exit code, timing, and the latest retained output tail.
+Coordinator-backed `crabbox run` creates a run record before sync starts, appends lifecycle/output events while the CLI is alive, and finishes it with exit code, timing, and the latest retained output tail.
 
 Use:
 
@@ -55,11 +55,13 @@ Use:
 bin/crabbox history
 bin/crabbox history --lease cbx_...
 bin/crabbox history --owner steipete@gmail.com --json
+bin/crabbox events run_...
+bin/crabbox attach run_...
 bin/crabbox logs run_...
 bin/crabbox results run_...
 ```
 
-History is for command debugging, not unlimited log archival. Logs are bounded tails of remote stdout/stderr. Test results are stored as structured summaries when `--junit` or `results.junit` is configured.
+History is for command debugging, not unlimited log archival. Events are structured phase/output records with sequence numbers; logs are bounded tails of remote stdout/stderr. Test results are stored as structured summaries when `--junit` or `results.junit` is configured.
 
 ## Remote Debugging
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -150,7 +150,7 @@ Do not store:
 - file contents;
 - SSH keys.
 
-Coordinator run records keep bounded stdout/stderr tails and optional structured JUnit summaries for debugging.
+Coordinator run records keep bounded stdout/stderr tails, bounded run-event chunks, and optional structured JUnit summaries for debugging.
 
 ## Future Audit Trail
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -24,7 +24,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Friendly slug generation, normalization, provider names, and direct collision handling: `internal/cli/slug.go`
 - Repo claim files and reclaim checks: `internal/cli/claim.go`
 - Direct-provider labels, safe label encoding, idle touch labels, TTL cap math: `internal/cli/provider_labels.go`
-- Coordinator client request/response structs, slug lookup, heartbeats, usage, run history: `internal/cli/coordinator.go`
+- Coordinator client request/response structs, slug lookup, heartbeats, usage, run history, run events: `internal/cli/coordinator.go`
 - Worker lease records, public routes, slug allocation, heartbeat expiry math, alarms: `worker/src/fleet.ts`, `worker/src/types.ts`
 - Worker slug generation and provider labels: `worker/src/slug.ts`, `worker/src/provider-labels.ts`
 
@@ -50,7 +50,7 @@ Bootstrap is intentionally tiny: OpenSSH, CA certificates, curl, Git, rsync, jq,
 - Per-lease SSH known_hosts and ControlMaster config: `internal/cli/ssh.go`
 - GitHub Actions hydrate/register/dispatch bridge: `internal/cli/actions.go`
 - Cache stats/purge/warm commands: `internal/cli/cache.go`
-- Run history/log commands and retained run logs: `internal/cli/history.go`, `internal/cli/runlog.go`
+- Run history/log/event commands and retained run logs: `internal/cli/history.go`, `internal/cli/run_events.go`, `internal/cli/runlog.go`
 - JUnit result parsing and remote markers: `internal/cli/results.go`, `internal/cli/results_parse.go`, `internal/cli/results_remote.go`
 
 ## Worker API, Cost, And Operations

--- a/index.js
+++ b/index.js
@@ -378,6 +378,50 @@ function registerList(api, config) {
   });
 }
 
+function registerEvents(api, config) {
+  api.registerTool({
+    name: "crabbox_events",
+    description: "List structured lifecycle and output events for a recorded Crabbox run.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Crabbox run ID.",
+        },
+        after: {
+          type: "number",
+          description: "Only return events after this sequence.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum events to return.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      const args = ["events", "--id", readString(params, "id")];
+      const after = readPositiveInteger(params, "after", undefined);
+      const limit = readPositiveInteger(params, "limit", undefined);
+      if (after !== undefined) {
+        args.push("--after", String(after));
+      }
+      if (limit !== undefined) {
+        args.push("--limit", String(limit));
+      }
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
 function registerStop(api, config) {
   api.registerTool({
     name: "crabbox_stop",
@@ -417,6 +461,7 @@ export default {
     registerWarmup(api, config);
     registerStatus(api, config);
     registerList(api, config);
+    registerEvents(api, config);
     registerStop(api, config);
     api.logger?.info?.("Crabbox plugin registered");
   },

--- a/index.test.js
+++ b/index.test.js
@@ -43,7 +43,14 @@ test("registers the Crabbox tool surface", () => {
   const tools = registerWithConfig({});
   assert.deepEqual(
     tools.map((tool) => tool.name).sort(),
-    ["crabbox_list", "crabbox_run", "crabbox_status", "crabbox_stop", "crabbox_warmup"],
+    [
+      "crabbox_events",
+      "crabbox_list",
+      "crabbox_run",
+      "crabbox_status",
+      "crabbox_stop",
+      "crabbox_warmup",
+    ],
   );
 });
 
@@ -84,6 +91,27 @@ test("crabbox_status includes optional flags", async () => {
     "--wait",
     "--wait-timeout",
     "10m",
+    "--json",
+  ]);
+});
+
+test("crabbox_events includes optional flags", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_events").execute("call-1", {
+    id: "run_123",
+    after: 4,
+    limit: 25,
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "events",
+    "--id",
+    "run_123",
+    "--after",
+    "4",
+    "--limit",
+    "25",
     "--json",
   ]);
 });

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -52,6 +52,10 @@ func (a App) Run(ctx context.Context, args []string) error {
 		return a.admin(ctx, args[1:])
 	case "history":
 		return a.history(ctx, args[1:])
+	case "events":
+		return a.events(ctx, args[1:])
+	case "attach":
+		return a.attach(ctx, args[1:])
 	case "logs":
 		return a.logs(ctx, args[1:])
 	case "results":
@@ -124,6 +128,8 @@ Commands:
   run         Sync the repo, run a remote command, stream output
   sync-plan   Show local sync manifest size hotspots
   history     List recorded remote runs
+  events      List structured events for a recorded run
+  attach      Follow structured output for an active recorded run
   logs        Print recorded run logs
   results     Show recorded test result summaries
   cache       Inspect, purge, or warm remote caches
@@ -147,6 +153,8 @@ Common Flows:
   crabbox ssh --id blue-lobster
   crabbox inspect --id blue-lobster --json
   crabbox history --lease cbx_abcdef123456
+  crabbox events run_123
+  crabbox attach run_123
   crabbox logs run_123
   crabbox results run_123
   crabbox cache stats --id blue-lobster

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -116,15 +116,37 @@ type CoordinatorRun struct {
 	ServerType   string             `json:"serverType"`
 	Command      []string           `json:"command"`
 	State        string             `json:"state"`
+	Phase        string             `json:"phase,omitempty"`
 	ExitCode     *int               `json:"exitCode,omitempty"`
 	SyncMs       int64              `json:"syncMs,omitempty"`
 	CommandMs    int64              `json:"commandMs,omitempty"`
 	DurationMs   int64              `json:"durationMs,omitempty"`
+	EventSeq     int64              `json:"eventSeq,omitempty"`
+	LastEventAt  string             `json:"lastEventAt,omitempty"`
 	LogBytes     int64              `json:"logBytes"`
 	LogTruncated bool               `json:"logTruncated"`
 	Results      *TestResultSummary `json:"results,omitempty"`
 	StartedAt    string             `json:"startedAt"`
 	EndedAt      string             `json:"endedAt,omitempty"`
+}
+
+type CoordinatorRunEventsResponse struct {
+	Events []CoordinatorRunEvent `json:"events"`
+}
+
+type CoordinatorRunEventResponse struct {
+	Event CoordinatorRunEvent `json:"event"`
+}
+
+type CoordinatorRunEvent struct {
+	ID        string         `json:"id"`
+	RunID     string         `json:"runID"`
+	Seq       int64          `json:"seq"`
+	Type      string         `json:"type"`
+	Stream    string         `json:"stream,omitempty"`
+	Message   string         `json:"message,omitempty"`
+	Data      map[string]any `json:"data,omitempty"`
+	CreatedAt string         `json:"createdAt"`
 }
 
 type TestResultSummary struct {
@@ -504,6 +526,41 @@ func (c *CoordinatorClient) RunLogs(ctx context.Context, runID string) (string, 
 	var buf bytes.Buffer
 	err := c.do(ctx, http.MethodGet, "/v1/runs/"+url.PathEscape(runID)+"/logs", nil, &buf)
 	return buf.String(), err
+}
+
+func (c *CoordinatorClient) AppendRunEvent(ctx context.Context, runID, eventType string, stream string, message string, data map[string]any) (CoordinatorRunEvent, error) {
+	var res CoordinatorRunEventResponse
+	body := map[string]any{
+		"type": eventType,
+	}
+	if stream != "" {
+		body["stream"] = stream
+	}
+	if message != "" {
+		body["message"] = message
+	}
+	if data != nil {
+		body["data"] = data
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/runs/"+url.PathEscape(runID)+"/events", body, &res)
+	return res.Event, err
+}
+
+func (c *CoordinatorClient) RunEvents(ctx context.Context, runID string, after int64, limit int) ([]CoordinatorRunEvent, error) {
+	var res CoordinatorRunEventsResponse
+	values := url.Values{}
+	if after > 0 {
+		values.Set("after", strconv.FormatInt(after, 10))
+	}
+	if limit > 0 {
+		values.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/v1/runs/" + url.PathEscape(runID) + "/events"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	err := c.do(ctx, http.MethodGet, path, nil, &res)
+	return res.Events, err
 }
 
 func (c *CoordinatorClient) Health(ctx context.Context) error {

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -31,8 +31,8 @@ func (a App) history(ctx context.Context, args []string) error {
 		return json.NewEncoder(a.Stdout).Encode(runs)
 	}
 	for _, run := range runs {
-		fmt.Fprintf(a.Stdout, "%-16s %-16s %-16s %-9s exit=%s duration=%s started=%s command=%s\n",
-			run.ID, run.LeaseID, blank(run.Slug, "-"), run.State, formatRunExit(run.ExitCode), formatMs(run.DurationMs), run.StartedAt, strings.Join(run.Command, " "))
+		fmt.Fprintf(a.Stdout, "%-16s %-16s %-16s %-9s phase=%-8s exit=%s duration=%s started=%s command=%s\n",
+			run.ID, run.LeaseID, blank(run.Slug, "-"), run.State, blank(run.Phase, "-"), formatRunExit(run.ExitCode), formatMs(run.DurationMs), run.StartedAt, strings.Join(run.Command, " "))
 	}
 	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -181,6 +181,8 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 	var server Server
 	var target SSHTarget
 	var leaseID string
+	var runID string
+	var runRecorder *runEventRecorder
 	acquired := false
 	coord, useCoordinator, err := newCoordinatorClient(cfg)
 	if err != nil {
@@ -230,6 +232,9 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 		defer func() {
 			if !*keep {
 				a.releaseAcquiredLeaseBestEffort(context.Background(), cfg, coord, useCoordinator, server, target, leaseID)
+				if runRecorder != nil {
+					runRecorder.appendBestEffort("lease.released", "", "", map[string]any{"leaseID": leaseID, "slug": serverSlug(server)})
+				}
 			}
 		}()
 	}
@@ -246,6 +251,29 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 		stopHeartbeat := startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.IdleTimeout, heartbeatIdleTimeout, a.Stderr)
 		defer stopHeartbeat()
 	}
+	if useCoordinator && leaseID != "" && coord != nil {
+		run, err := coord.CreateRun(ctx, leaseID, cfg, command)
+		if err != nil {
+			fmt.Fprintf(a.Stderr, "warning: run history create failed: %v\n", err)
+		} else {
+			runID = run.ID
+			runRecorder = newRunEventRecorder(coord, runID, a.Stderr)
+			base := strings.TrimRight(coord.BaseURL, "/")
+			fmt.Fprintf(a.Stderr, "recording run %s events=%s/v1/runs/%s/events logs=%s/v1/runs/%s/logs\n", runID, base, runID, base, runID)
+			leaseEvent := "lease.created"
+			if !acquired {
+				leaseEvent = "lease.reused"
+			}
+			runRecorder.append(ctx, leaseEvent, "", "", map[string]any{
+				"leaseID":  leaseID,
+				"slug":     serverSlug(server),
+				"provider": cfg.Provider,
+				"class":    cfg.Class,
+				"type":     cfg.ServerType,
+				"acquired": acquired,
+			})
+		}
+	}
 
 	if cfg.Sync.BaseRef == "" {
 		cfg.Sync.BaseRef = repo.BaseRef
@@ -258,8 +286,14 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 		actionsEnvFile = state.EnvFile
 		fmt.Fprintf(a.Stderr, "using GitHub Actions workspace %s\n", workdir)
 	}
+	if *noSync && runRecorder != nil {
+		runRecorder.append(ctx, "sync.finished", "", "", map[string]any{"skipped": true, "reason": "no-sync", "workdir": workdir})
+	}
 	if !*noSync {
 		syncStart := time.Now()
+		if runRecorder != nil {
+			runRecorder.append(ctx, "sync.started", "", "", map[string]any{"workdir": workdir})
+		}
 		fmt.Fprintf(a.Stderr, "syncing %s -> %s:%s\n", repo.Root, target.Host, workdir)
 		stepStart := time.Now()
 		if err := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute); err != nil {
@@ -296,6 +330,9 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 				if err == nil && remoteFingerprint == fingerprint {
 					timings.sync = time.Since(syncStart)
 					timings.syncSkipped = true
+					if runRecorder != nil {
+						runRecorder.append(ctx, "sync.finished", "", "", map[string]any{"durationMs": timings.sync.Milliseconds(), "skipped": true, "workdir": workdir})
+					}
 					fmt.Fprintf(a.Stderr, "No changes detected, skipping sync (%s)\n", timings.sync.Round(time.Millisecond))
 					goto afterSync
 				}
@@ -343,8 +380,16 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 		}
 		timings.syncSteps.sanity = time.Since(stepStart)
 		stepStart = time.Now()
+		if runRecorder != nil {
+			runRecorder.append(ctx, "hydrate.started", "", "", map[string]any{"baseRef": cfg.Sync.BaseRef, "workdir": workdir})
+		}
 		if err := runSSHQuiet(ctx, target, remoteGitHydrate(workdir, cfg.Sync.BaseRef)); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git hydrate failed: %v\n", err)
+			if runRecorder != nil {
+				runRecorder.append(ctx, "hydrate.finished", "", "", map[string]any{"ok": false, "error": err.Error(), "workdir": workdir})
+			}
+		} else if runRecorder != nil {
+			runRecorder.append(ctx, "hydrate.finished", "", "", map[string]any{"ok": true, "workdir": workdir})
 		}
 		timings.syncSteps.gitHydrate = time.Since(stepStart)
 		if fingerprint != "" {
@@ -355,12 +400,20 @@ func (a App) runCommand(ctx context.Context, args []string) error {
 			timings.syncSteps.fingerprintWrite = time.Since(stepStart)
 		}
 		timings.sync = time.Since(syncStart)
+		if runRecorder != nil {
+			runRecorder.append(ctx, "sync.finished", "", "", map[string]any{"durationMs": timings.sync.Milliseconds(), "skipped": false, "workdir": workdir})
+		}
 		fmt.Fprintf(a.Stderr, "sync complete in %s\n", timings.sync.Round(time.Millisecond))
 	}
 afterSync:
 	if *syncOnly {
 		fmt.Fprintf(a.Stdout, "synced %s\n", workdir)
 		fmt.Fprintln(a.Stderr, formatRunSummary(timings, time.Since(timings.started), 0))
+		if runID != "" {
+			if _, err := coord.FinishRun(context.Background(), runID, 0, timings.sync, 0, "", false, nil); err != nil {
+				fmt.Fprintf(a.Stderr, "warning: run history finish failed for %s: %v\n", runID, err)
+			}
+		}
 		return nil
 	}
 
@@ -380,25 +433,25 @@ afterSync:
 		}()
 	}
 	fmt.Fprintf(a.Stderr, "running on %s %s\n", target.Host, strings.Join(command, " "))
-	var runID string
-	if useCoordinator && leaseID != "" && coord != nil {
-		run, err := coord.CreateRun(ctx, leaseID, cfg, command)
-		if err != nil {
-			fmt.Fprintf(a.Stderr, "warning: run history create failed: %v\n", err)
-		} else {
-			runID = run.ID
-			fmt.Fprintf(a.Stderr, "recording run %s\n", runID)
-		}
-	}
 	remote := remoteCommandWithEnvFile(workdir, allowedEnv(cfg.EnvAllow), actionsEnvFile, command)
 	if *shellMode || shouldUseShell(command) {
 		remote = remoteShellCommandWithEnvFile(workdir, allowedEnv(cfg.EnvAllow), actionsEnvFile, strings.Join(command, " "))
 	}
+	if runRecorder != nil {
+		runRecorder.append(ctx, "command.started", "", "", map[string]any{"command": command, "workdir": workdir})
+	}
 	var logBuffer runLogBuffer
-	stdout := io.MultiWriter(a.Stdout, &logBuffer)
-	stderr := io.MultiWriter(a.Stderr, &logBuffer)
+	stdoutStreamer := newRunEventStreamer(runRecorder, "stdout")
+	stderrStreamer := newRunEventStreamer(runRecorder, "stderr")
+	stdout := runEventOutputWriter{local: a.Stdout, log: &logBuffer, streamer: stdoutStreamer}
+	stderr := runEventOutputWriter{local: a.Stderr, log: &logBuffer, streamer: stderrStreamer}
 	code := runSSHStream(ctx, target, remote, stdout, stderr)
+	stdoutStreamer.Close()
+	stderrStreamer.Close()
 	timings.command = time.Since(commandStart)
+	if runRecorder != nil {
+		runRecorder.appendBestEffort("command.finished", "", "", map[string]any{"exitCode": code, "durationMs": timings.command.Milliseconds()})
+	}
 	var results *TestResultSummary
 	if len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results.JUnit)

--- a/internal/cli/run_events.go
+++ b/internal/cli/run_events.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const maxRunEventChunkBytes = 8 * 1024
+
+type runEventRecorder struct {
+	coord    *CoordinatorClient
+	runID    string
+	stderr   io.Writer
+	disabled atomic.Bool
+	warnOnce sync.Once
+}
+
+func newRunEventRecorder(coord *CoordinatorClient, runID string, stderr io.Writer) *runEventRecorder {
+	if coord == nil || runID == "" {
+		return nil
+	}
+	return &runEventRecorder{coord: coord, runID: runID, stderr: stderr}
+}
+
+func (r *runEventRecorder) append(ctx context.Context, eventType, stream, message string, data map[string]any) {
+	if r == nil || r.disabled.Load() {
+		return
+	}
+	if _, err := r.coord.AppendRunEvent(ctx, r.runID, eventType, stream, message, data); err != nil {
+		r.disabled.Store(true)
+		r.warn(err)
+	}
+}
+
+func (r *runEventRecorder) appendBestEffort(eventType, stream, message string, data map[string]any) {
+	if r == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	r.append(ctx, eventType, stream, message, data)
+}
+
+func (r *runEventRecorder) warn(err error) {
+	r.warnOnce.Do(func() {
+		fmt.Fprintf(r.stderr, "warning: run event append failed for %s: %v\n", r.runID, err)
+	})
+}
+
+type runEventStreamer struct {
+	recorder *runEventRecorder
+	stream   string
+	ch       chan string
+	wg       sync.WaitGroup
+}
+
+func newRunEventStreamer(recorder *runEventRecorder, stream string) *runEventStreamer {
+	if recorder == nil {
+		return nil
+	}
+	s := &runEventStreamer{
+		recorder: recorder,
+		stream:   stream,
+		ch:       make(chan string, 128),
+	}
+	s.wg.Add(1)
+	go s.run()
+	return s
+}
+
+func (s *runEventStreamer) Write(p []byte) (int, error) {
+	written := len(p)
+	if s == nil || len(p) == 0 {
+		return written, nil
+	}
+	for len(p) > 0 {
+		n := len(p)
+		if n > maxRunEventChunkBytes {
+			n = maxRunEventChunkBytes
+		}
+		chunk := string(append([]byte(nil), p[:n]...))
+		s.ch <- chunk
+		p = p[n:]
+	}
+	return written, nil
+}
+
+func (s *runEventStreamer) Close() {
+	if s == nil {
+		return
+	}
+	close(s.ch)
+	s.wg.Wait()
+}
+
+func (s *runEventStreamer) run() {
+	defer s.wg.Done()
+	for chunk := range s.ch {
+		s.recorder.appendBestEffort(s.stream, s.stream, chunk, nil)
+	}
+}
+
+type runEventOutputWriter struct {
+	local    io.Writer
+	log      *runLogBuffer
+	streamer *runEventStreamer
+}
+
+func (w runEventOutputWriter) Write(p []byte) (int, error) {
+	if w.local != nil {
+		if _, err := w.local.Write(p); err != nil {
+			return 0, err
+		}
+	}
+	if w.log != nil {
+		_, _ = w.log.Write(p)
+	}
+	if w.streamer != nil {
+		_, _ = w.streamer.Write(p)
+	}
+	return len(p), nil
+}
+
+func (a App) events(ctx context.Context, args []string) error {
+	args, jsonAnywhere := extractBoolFlag(args, "json")
+	fs := newFlagSet("events", a.Stderr)
+	runID := fs.String("id", "", "run id")
+	after := fs.Int64("after", 0, "only show events after this sequence")
+	limit := fs.Int("limit", 500, "maximum events")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if *runID == "" && fs.NArg() > 0 {
+		*runID = fs.Arg(0)
+	}
+	if *runID == "" {
+		return exit(2, "usage: crabbox events <run-id>")
+	}
+	if jsonAnywhere {
+		*jsonOut = true
+	}
+	coord, err := configuredCoordinator()
+	if err != nil {
+		return err
+	}
+	events, err := coord.RunEvents(ctx, *runID, *after, *limit)
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(events)
+	}
+	for _, event := range events {
+		printRunEvent(a.Stdout, event)
+	}
+	return nil
+}
+
+func (a App) attach(ctx context.Context, args []string) error {
+	fs := newFlagSet("attach", a.Stderr)
+	runID := fs.String("id", "", "run id")
+	after := fs.Int64("after", 0, "resume after this event sequence")
+	poll := fs.Duration("poll", time.Second, "poll interval")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if *runID == "" && fs.NArg() > 0 {
+		*runID = fs.Arg(0)
+	}
+	if *runID == "" {
+		return exit(2, "usage: crabbox attach <run-id>")
+	}
+	coord, err := configuredCoordinator()
+	if err != nil {
+		return err
+	}
+	nextAfter := *after
+	for {
+		events, err := coord.RunEvents(ctx, *runID, nextAfter, 100)
+		if err != nil {
+			return err
+		}
+		for _, event := range events {
+			if event.Seq > nextAfter {
+				nextAfter = event.Seq
+			}
+			printAttachEvent(a.Stdout, a.Stderr, event)
+		}
+		if len(events) == 0 {
+			run, err := coord.Run(ctx, *runID)
+			if err != nil {
+				return err
+			}
+			if run.State != "running" {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(*poll):
+		}
+	}
+}
+
+func printRunEvent(out io.Writer, event CoordinatorRunEvent) {
+	stream := event.Stream
+	if stream == "" && (event.Type == "stdout" || event.Type == "stderr") {
+		stream = event.Type
+	}
+	message := strings.TrimSpace(event.Message)
+	if message != "" {
+		message = " " + firstLine(message)
+	}
+	if stream != "" {
+		stream = " stream=" + stream
+	}
+	fmt.Fprintf(out, "%-6d %-24s %-18s%s%s\n", event.Seq, event.CreatedAt, event.Type, stream, message)
+}
+
+func printAttachEvent(stdout, stderr io.Writer, event CoordinatorRunEvent) {
+	stream := event.Stream
+	if stream == "" && (event.Type == "stdout" || event.Type == "stderr") {
+		stream = event.Type
+	}
+	switch stream {
+	case "stdout":
+		fmt.Fprint(stdout, event.Message)
+	case "stderr":
+		fmt.Fprint(stderr, event.Message)
+	default:
+		printRunEvent(stderr, event)
+	}
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -6,7 +6,14 @@
     "onStartup": true
   },
   "contracts": {
-    "tools": ["crabbox_run", "crabbox_warmup", "crabbox_status", "crabbox_list", "crabbox_stop"]
+    "tools": [
+      "crabbox_run",
+      "crabbox_warmup",
+      "crabbox_status",
+      "crabbox_list",
+      "crabbox_events",
+      "crabbox_stop"
+    ]
   },
   "configSchema": {
     "type": "object",

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14,6 +14,8 @@ import type {
   ProviderMachine,
   PromotedImageRecord,
   RunCreateRequest,
+  RunEvent,
+  RunEventAppendRequest,
   RunFinishRequest,
   RunRecord,
   TestFailure,
@@ -366,6 +368,9 @@ export class FleetDurableObject implements DurableObject {
       serverType: input.serverType ?? lease?.serverType ?? "",
       command: Array.isArray(input.command) ? input.command.map(String) : [],
       state: "running",
+      phase: "created",
+      eventSeq: 1,
+      lastEventAt: now,
       logBytes: 0,
       logTruncated: false,
       startedAt: now,
@@ -373,6 +378,20 @@ export class FleetDurableObject implements DurableObject {
     if (lease?.slug) {
       run.slug = lease.slug;
     }
+    await this.putRunEvent({
+      id: runEventID(run.id, 1),
+      runID: run.id,
+      seq: 1,
+      type: "run.created",
+      data: {
+        leaseID: run.leaseID,
+        provider: run.provider,
+        class: run.class,
+        serverType: run.serverType,
+        command: run.command,
+      },
+      createdAt: now,
+    });
     await this.putRun(run);
     return json({ run }, { status: 201 });
   }
@@ -393,10 +412,64 @@ export class FleetDurableObject implements DurableObject {
         headers: { "content-type": "text/plain; charset=utf-8" },
       });
     }
+    if (method === "GET" && action === "events") {
+      const run = await this.getRun(runID);
+      if (!run || !this.runVisibleToRequest(run, request)) {
+        return notFound();
+      }
+      const url = new URL(request.url);
+      if (url.searchParams.get("stream") === "true") {
+        return this.streamRunEvents(request, run);
+      }
+      return json({ events: await this.listRunEvents(request, runID) });
+    }
+    if (method === "POST" && action === "events") {
+      return this.appendRunEvent(request, runID);
+    }
     if (method === "POST" && action === "finish") {
       return this.finishRun(request, runID);
     }
     return json({ error: "not_found" }, { status: 404 });
+  }
+
+  private async appendRunEvent(request: Request, runID: string): Promise<Response> {
+    const run = await this.getRun(runID);
+    if (!run || !this.runVisibleToRequest(run, request)) {
+      return notFound();
+    }
+    const input = await readJson<RunEventAppendRequest>(request);
+    if (!validRunEventType(input.type)) {
+      return json({ error: "invalid_event_type" }, { status: 400 });
+    }
+    const stream =
+      input.stream === "stdout" || input.stream === "stderr" ? input.stream : undefined;
+    const now = new Date().toISOString();
+    const seq = Math.max(run.eventSeq ?? 0, await this.latestRunEventSeq(runID)) + 1;
+    const event: RunEvent = {
+      id: runEventID(runID, seq),
+      runID,
+      seq,
+      type: input.type,
+      createdAt: now,
+    };
+    if (stream) {
+      event.stream = stream;
+    }
+    if (typeof input.message === "string" && input.message.length > 0) {
+      event.message = truncateString(input.message, MAX_RUN_EVENT_MESSAGE_BYTES);
+    }
+    if (isRecord(input.data)) {
+      event.data = boundedEventData(input.data);
+    }
+    run.eventSeq = seq;
+    run.lastEventAt = now;
+    const phase = runPhaseForEvent(input.type, run.phase);
+    if (phase !== undefined) {
+      run.phase = phase;
+    }
+    await this.putRunEvent(event);
+    await this.putRun(run);
+    return json({ event }, { status: 201 });
   }
 
   private async finishRun(request: Request, runID: string): Promise<Response> {
@@ -420,7 +493,9 @@ export class FleetDurableObject implements DurableObject {
       run.durationMs = now.getTime() - started;
     }
     run.state = run.exitCode === 0 ? "succeeded" : "failed";
+    run.phase = run.state === "succeeded" ? "finished" : "failed";
     run.endedAt = now.toISOString();
+    run.lastEventAt = run.endedAt;
     const log = input.log ?? "";
     run.logBytes = new TextEncoder().encode(log).byteLength;
     run.logTruncated = Boolean(input.logTruncated);
@@ -451,6 +526,62 @@ export class FleetDurableObject implements DurableObject {
         .filter((run) => !state || run.state === state)
         .toSorted((a, b) => b.startedAt.localeCompare(a.startedAt))
         .slice(0, limit),
+    });
+  }
+
+  private async listRunEvents(request: Request, runID: string): Promise<RunEvent[]> {
+    const url = new URL(request.url);
+    const after = finiteQueryNumber(url.searchParams.get("after")) ?? 0;
+    const limit = clampLimit(url.searchParams.get("limit"), 500);
+    const events = await this.runEventRecords(runID);
+    return events.filter((event) => event.seq > after).slice(0, limit);
+  }
+
+  private streamRunEvents(request: Request, run: RunRecord): Response {
+    const url = new URL(request.url);
+    let after = finiteQueryNumber(url.searchParams.get("after")) ?? 0;
+    const encoder = new TextEncoder();
+    const self = this;
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        let closed = false;
+        const close = () => {
+          closed = true;
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
+        };
+        request.signal.addEventListener("abort", close, { once: true });
+        try {
+          while (!closed) {
+            const events = (await self.runEventRecords(run.id))
+              .filter((event) => event.seq > after)
+              .slice(0, 100);
+            for (const event of events) {
+              after = event.seq;
+              controller.enqueue(encoder.encode(formatRunEventSSE(event)));
+            }
+            const current = await self.getRun(run.id);
+            if (events.length === 0 && current?.state !== "running") {
+              close();
+              return;
+            }
+            await sleep(1000);
+          }
+        } catch (error) {
+          controller.error(error);
+        } finally {
+          request.signal.removeEventListener("abort", close);
+        }
+      },
+    });
+    return new Response(stream, {
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache",
+      },
     });
   }
 
@@ -608,6 +739,16 @@ export class FleetDurableObject implements DurableObject {
     return [...runs.values()];
   }
 
+  private async runEventRecords(runID: string): Promise<RunEvent[]> {
+    const events = await this.state.storage.list<RunEvent>({ prefix: runEventPrefix(runID) });
+    return [...events.values()].toSorted((a, b) => a.seq - b.seq);
+  }
+
+  private async latestRunEventSeq(runID: string): Promise<number> {
+    const events = await this.runEventRecords(runID);
+    return events.at(-1)?.seq ?? 0;
+  }
+
   private filterLeasesForRequest(leases: LeaseRecord[], request: Request): LeaseRecord[] {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
@@ -644,6 +785,10 @@ export class FleetDurableObject implements DurableObject {
 
   private async putRun(run: RunRecord): Promise<void> {
     await this.state.storage.put(runKey(run.id), run);
+  }
+
+  private async putRunEvent(event: RunEvent): Promise<void> {
+    await this.state.storage.put(runEventKey(event.runID, event.seq), event);
   }
 
   private provider(provider: Provider, region = "eu-west-1"): CloudProvider {
@@ -684,6 +829,18 @@ function runLogKey(runID: string): string {
   return `runlog:${runID}`;
 }
 
+function runEventPrefix(runID: string): string {
+  return `runevent:${runID}:`;
+}
+
+function runEventKey(runID: string, seq: number): string {
+  return `${runEventPrefix(runID)}${String(seq).padStart(12, "0")}`;
+}
+
+function runEventID(runID: string, seq: number): string {
+  return `${runID}:${seq}`;
+}
+
 function promotedAWSImageKey(): string {
   return "image:aws:promoted";
 }
@@ -716,6 +873,15 @@ function validCrabboxProviderKey(value: string | undefined): value is string {
   return typeof value === "string" && /^crabbox-cbx-[a-f0-9]{12}$/.test(value);
 }
 
+function validRunEventType(value: string | undefined): value is string {
+  return (
+    typeof value === "string" &&
+    (value === "stdout" ||
+      value === "stderr" ||
+      /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/.test(value))
+  );
+}
+
 function clampLimit(value: string | null, fallback: number): number {
   const parsed = Number(value ?? "");
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -741,9 +907,97 @@ function finiteNumber(value: number | undefined): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
+function finiteQueryNumber(value: string | null): number | undefined {
+  const parsed = Number(value ?? "");
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function runPhaseForEvent(type: string, fallback: RunRecord["phase"]): RunRecord["phase"] {
+  if (type === "run.failed") {
+    return "failed";
+  }
+  if (type === "run.created") {
+    return "created";
+  }
+  if (type === "lease.released") {
+    return "release";
+  }
+  if (type.startsWith("lease.")) {
+    return "lease";
+  }
+  if (type.startsWith("sync.")) {
+    return "sync";
+  }
+  if (type.startsWith("hydrate.")) {
+    return "hydrate";
+  }
+  if (type.startsWith("command.")) {
+    return type === "command.finished" ? "finished" : "command";
+  }
+  return fallback;
+}
+
+function formatRunEventSSE(event: RunEvent): string {
+  return `id: ${event.seq}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 const MAX_RESULT_FILES = 50;
 const MAX_RESULT_FAILURES = 100;
 const MAX_RESULT_STRING_BYTES = 4096;
+const MAX_RUN_EVENT_MESSAGE_BYTES = 16 * 1024;
+const MAX_RUN_EVENT_DATA_KEYS = 50;
+const MAX_RUN_EVENT_DATA_DEPTH = 4;
+const MAX_RUN_EVENT_ARRAY_ITEMS = 50;
+const MAX_RUN_EVENT_STRING_BYTES = 4096;
+
+function boundedEventData(
+  data: Record<string, unknown>,
+  depth = MAX_RUN_EVENT_DATA_DEPTH,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data)
+      .slice(0, MAX_RUN_EVENT_DATA_KEYS)
+      .map(([key, value]) => [
+        truncateString(key, MAX_RUN_EVENT_STRING_BYTES),
+        boundedEventValue(value, depth),
+      ]),
+  );
+}
+
+function boundedEventValue(value: unknown, depth: number): unknown {
+  if (value === null || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
+  }
+  if (typeof value === "string") {
+    return truncateString(value, MAX_RUN_EVENT_STRING_BYTES);
+  }
+  if (Array.isArray(value)) {
+    if (depth <= 0) {
+      return "[array]";
+    }
+    return value
+      .slice(0, MAX_RUN_EVENT_ARRAY_ITEMS)
+      .map((entry) => boundedEventValue(entry, depth - 1));
+  }
+  if (isRecord(value)) {
+    if (depth <= 0) {
+      return "[object]";
+    }
+    return boundedEventData(value, depth - 1);
+  }
+  return String(value);
+}
 
 function boundedTestResults(results: TestResultSummary): TestResultSummary {
   return {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -126,15 +126,39 @@ export interface RunRecord {
   serverType: string;
   command: string[];
   state: "running" | "succeeded" | "failed";
+  phase?: RunPhase;
   exitCode?: number;
   syncMs?: number;
   commandMs?: number;
   durationMs?: number;
+  eventSeq?: number;
+  lastEventAt?: string;
   logBytes: number;
   logTruncated: boolean;
   results?: TestResultSummary;
   startedAt: string;
   endedAt?: string;
+}
+
+export type RunPhase =
+  | "created"
+  | "lease"
+  | "sync"
+  | "hydrate"
+  | "command"
+  | "release"
+  | "finished"
+  | "failed";
+
+export interface RunEvent {
+  id: string;
+  runID: string;
+  seq: number;
+  type: string;
+  stream?: "stdout" | "stderr";
+  message?: string;
+  data?: Record<string, unknown>;
+  createdAt: string;
 }
 
 export interface RunCreateRequest {
@@ -152,6 +176,13 @@ export interface RunFinishRequest {
   log?: string;
   logTruncated?: boolean;
   results?: TestResultSummary;
+}
+
+export interface RunEventAppendRequest {
+  type: string;
+  stream?: "stdout" | "stderr";
+  message?: string;
+  data?: Record<string, unknown>;
 }
 
 export interface TestResultSummary {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { FleetDurableObject } from "../src/fleet";
-import type { Env, LeaseRecord, RunRecord } from "../src/types";
+import type { Env, LeaseRecord, RunEvent, RunRecord } from "../src/types";
 
 class MemoryStorage {
   private readonly values = new Map<string, unknown>();
@@ -406,6 +406,66 @@ describe("fleet run history", () => {
     expect(await logs.text()).toBe("ok\n");
   });
 
+  it("records append-only run events with phases", async () => {
+    const fleet = testFleet();
+    const ownerHeaders = {
+      "x-crabbox-owner": "peter@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: ownerHeaders,
+        body: {
+          leaseID: "cbx_000000000001",
+          provider: "aws",
+          class: "beast",
+          serverType: "c7a.48xlarge",
+          command: ["go", "test", "./..."],
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const { run } = (await create.json()) as { run: RunRecord };
+    expect(run.phase).toBe("created");
+    expect(run.eventSeq).toBe(1);
+
+    const append = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: ownerHeaders,
+        body: {
+          type: "sync.started",
+          data: { workdir: "/work/crabbox/cbx_000000000001/repo" },
+        },
+      }),
+    );
+    expect(append.status).toBe(201);
+    const appended = (await append.json()) as { event: RunEvent };
+    expect(appended.event.seq).toBe(2);
+    expect(appended.event.type).toBe("sync.started");
+
+    await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: ownerHeaders,
+        body: { type: "stdout", stream: "stdout", message: "ok\n" },
+      }),
+    );
+
+    const events = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/events?after=1`, { headers: ownerHeaders }),
+    );
+    expect(events.status).toBe(200);
+    const body = (await events.json()) as { events: RunEvent[] };
+    expect(body.events.map((event) => [event.seq, event.type, event.message])).toEqual([
+      [2, "sync.started", undefined],
+      [3, "stdout", "ok\n"],
+    ]);
+
+    const read = await fleet.fetch(request("GET", `/v1/runs/${run.id}`, { headers: ownerHeaders }));
+    const current = (await read.json()) as { run: RunRecord };
+    expect(current.run.phase).toBe("sync");
+    expect(current.run.eventSeq).toBe(3);
+  });
+
   it("hides run records and logs from other non-admin users", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -446,6 +506,19 @@ describe("fleet run history", () => {
       request("GET", "/v1/runs/run_000000000001/logs", { headers: friendHeaders }),
     );
     expect(logs.status).toBe(404);
+
+    const events = await fleet.fetch(
+      request("GET", "/v1/runs/run_000000000001/events", { headers: friendHeaders }),
+    );
+    expect(events.status).toBe(404);
+
+    const append = await fleet.fetch(
+      request("POST", "/v1/runs/run_000000000001/events", {
+        headers: friendHeaders,
+        body: { type: "sync.started" },
+      }),
+    );
+    expect(append.status).toBe(404);
 
     const finish = await fleet.fetch(
       request("POST", "/v1/runs/run_000000000001/finish", {


### PR DESCRIPTION
## Summary

- create coordinator run records before sync starts
- add append-only run events for lease, sync, hydrate, command, stdout/stderr, and release phases
- expose run events through CLI commands and the OpenClaw plugin
- document events/attach alongside history/logs

Addresses #7.

## Validation

- go test ./internal/cli ./cmd/crabbox
- npm run format:check --prefix worker
- npm run check --prefix worker
- npm test --prefix worker -- --run --configLoader runner test/fleet.test.ts test/http.test.ts
- node --check index.js && node --test index.test.js
- node scripts/check-docs-links.mjs && node scripts/build-docs-site.mjs
- git diff --check