### PR TITLE
feat: expose crabbox inspection plugin tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added OpenClaw plugin tools for run history, run events, retained logs, test results, and usage inspection. Thanks @stainlu.
+
 ## 0.3.0 - 2026-05-02
 
 Crabbox 0.3.0 makes brokered runs much easier to observe and debug, adds

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, and config conventions.
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type.
 - **GitHub Actions hydration.** `crabbox actions hydrate` registers a leased box as an ephemeral Actions runner, so the repo's own workflow installs runtimes, services, and secrets. Crabbox does not parse Actions YAML.
-- **OpenClaw plugin.** The repo root is a native OpenClaw plugin. Agents drive Crabbox through `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, and `crabbox_stop` instead of shelling out.
+- **OpenClaw plugin.** The repo root is a native OpenClaw plugin. Agents drive Crabbox through run, warmup, status, list, stop, history, events, logs, results, and usage tools instead of shelling out.
 - **Operator surface.** `doctor`, `init`, `status`, `inspect`, `list`, `usage`, `history`, `logs`, `results`, `cache`, `admin`, `cleanup`, plus `--json` output where it matters.
 
 ## Machine classes
@@ -140,8 +140,9 @@ Forwarded environment is intentionally narrow: `NODE_OPTIONS` and `CI`. Do not p
 The repo root is a native OpenClaw plugin package. Once installed, it exposes Crabbox as agent tools:
 
 - `crabbox_run`, `crabbox_warmup`, `crabbox_status`, `crabbox_list`, `crabbox_stop`
+- `crabbox_history`, `crabbox_events`, `crabbox_logs`, `crabbox_results`, `crabbox_usage`
 
-The plugin shells out to the configured `crabbox` binary, so local config, broker login, repo claims, and sync behavior stay owned by the CLI. Set `plugins.entries.crabbox.config.binary` if `crabbox` is not on `PATH`.
+The plugin shells out to the configured `crabbox` binary, so local config, broker login, repo claims, and sync behavior stay owned by the CLI. Set `plugins.entries.crabbox.config.binary` if `crabbox` is not on `PATH`. Set `plugins.entries.crabbox.config.allowInspection: false` to disable run history, event, log, result, and usage inspection tools.
 
 ## Development
 
@@ -184,7 +185,7 @@ open dist/docs-site/index.html
 
 ## Status
 
-Crabbox 0.1.0 (2026-05-01) is the first public release. Working today: brokered Hetzner + AWS Spot provisioning, warm-box reuse, GitHub Actions hydration, cost guardrails, run history, JUnit summaries, OpenClaw plugin, and the full CLI surface listed above. **Not yet:** untrusted multi-tenant isolation — Crabbox today assumes shared trust between operators of a single broker.
+Crabbox 0.3.0 (2026-05-02) is the current public release. Working today: brokered Hetzner + AWS Spot provisioning, warm-box reuse, GitHub Actions hydration, cost guardrails, durable run history and events, JUnit summaries, AWS image lifecycle commands, OpenClaw plugin tools, and the full CLI surface listed above. **Not yet:** untrusted multi-tenant isolation — Crabbox today assumes shared trust between operators of a single broker.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,8 +67,13 @@ The repository root is also a native OpenClaw plugin package. Once installed in 
 - `crabbox_status`
 - `crabbox_list`
 - `crabbox_stop`
+- `crabbox_history`
+- `crabbox_events`
+- `crabbox_logs`
+- `crabbox_results`
+- `crabbox_usage`
 
-The plugin shells out to the configured `crabbox` binary with argv arrays, so local Crabbox config, broker login, repo claims, and sync behavior stay owned by the CLI. Configure `plugins.entries.crabbox.config.binary` if the binary is not on `PATH`.
+The plugin shells out to the configured `crabbox` binary with argv arrays, so local Crabbox config, broker login, repo claims, and sync behavior stay owned by the CLI. Configure `plugins.entries.crabbox.config.binary` if the binary is not on `PATH`. Set `plugins.entries.crabbox.config.allowInspection: false` to disable run history, event, log, result, and usage inspection tools.
 
 ## Where to read next
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,16 @@ const providerSchema = {
   enum: ["aws", "hetzner"],
 };
 
+const runStateSchema = {
+  type: "string",
+  enum: ["running", "succeeded", "failed"],
+};
+
+const usageScopeSchema = {
+  type: "string",
+  enum: ["user", "org", "all"],
+};
+
 function readConfig(api) {
   const raw = api?.pluginConfig && typeof api.pluginConfig === "object" ? api.pluginConfig : {};
   return {
@@ -35,6 +45,7 @@ function readConfig(api) {
     allowRun: readBoolean(raw, "allowRun", true),
     allowWarmup: readBoolean(raw, "allowWarmup", true),
     allowStop: readBoolean(raw, "allowStop", true),
+    allowInspection: readBoolean(raw, "allowInspection", true),
   };
 }
 
@@ -53,6 +64,28 @@ function readPositiveInteger(source, key, fallback) {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : fallback;
+}
+
+function readOptionalPositiveInteger(source, key) {
+  const value = source?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  throw new Error(`${key} must be a positive number`);
+}
+
+function readOptionalNonNegativeInteger(source, key) {
+  const value = source?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  throw new Error(`${key} must be a non-negative number`);
 }
 
 function readStringArray(source, key) {
@@ -95,6 +128,12 @@ function maybePush(args, flag, value) {
 function maybePushBool(args, flag, value) {
   if (value === true) {
     args.push(flag);
+  }
+}
+
+function maybePushInteger(args, flag, value) {
+  if (value !== undefined) {
+    args.push(flag, String(value));
   }
 }
 
@@ -407,6 +446,200 @@ function registerStop(api, config) {
   });
 }
 
+function registerHistory(api, config) {
+  api.registerTool({
+    name: "crabbox_history",
+    description: "List coordinator-recorded Crabbox runs.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        lease: {
+          type: "string",
+          description: "Filter by Crabbox lease ID.",
+        },
+        owner: {
+          type: "string",
+          description: "Filter by owner email.",
+        },
+        org: {
+          type: "string",
+          description: "Filter by organization.",
+        },
+        state: runStateSchema,
+        limit: {
+          type: "number",
+          description: "Maximum runs to return.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowInspection) {
+        throw new Error("crabbox_history is disabled by plugin config");
+      }
+      const args = ["history"];
+      maybePush(args, "--lease", readString(params, "lease"));
+      maybePush(args, "--owner", readString(params, "owner"));
+      maybePush(args, "--org", readString(params, "org"));
+      maybePush(args, "--state", readString(params, "state"));
+      maybePushInteger(args, "--limit", readOptionalPositiveInteger(params, "limit"));
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerEvents(api, config) {
+  api.registerTool({
+    name: "crabbox_events",
+    description: "Read durable event records for a coordinator-backed Crabbox run.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Crabbox run ID.",
+        },
+        after: {
+          type: "number",
+          description: "Only return events after this sequence number.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum events to return.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowInspection) {
+        throw new Error("crabbox_events is disabled by plugin config");
+      }
+      const args = ["events", "--id", readString(params, "id")];
+      maybePushInteger(args, "--after", readOptionalNonNegativeInteger(params, "after"));
+      maybePushInteger(args, "--limit", readOptionalPositiveInteger(params, "limit"));
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerLogs(api, config) {
+  api.registerTool({
+    name: "crabbox_logs",
+    description: "Read the retained output tail for a coordinator-recorded Crabbox run.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Crabbox run ID.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowInspection) {
+        throw new Error("crabbox_logs is disabled by plugin config");
+      }
+      const args = ["logs", "--id", readString(params, "id")];
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerResults(api, config) {
+  api.registerTool({
+    name: "crabbox_results",
+    description: "Read structured test results recorded for a Crabbox run.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Crabbox run ID.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowInspection) {
+        throw new Error("crabbox_results is disabled by plugin config");
+      }
+      const args = ["results", "--id", readString(params, "id")];
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
+function registerUsage(api, config) {
+  api.registerTool({
+    name: "crabbox_usage",
+    description: "Read coordinator usage and cost estimates.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        scope: usageScopeSchema,
+        user: {
+          type: "string",
+          description: "Owner email for user-scoped usage.",
+        },
+        org: {
+          type: "string",
+          description: "Organization for org-scoped usage.",
+        },
+        month: {
+          type: "string",
+          description: "Usage month in YYYY-MM format.",
+        },
+        json: { type: "boolean" },
+        timeoutSeconds: {
+          type: "number",
+          description: "Local wrapper timeout for this Crabbox CLI invocation.",
+        },
+      },
+    },
+    async execute(_toolCallId, params, signal) {
+      if (!config.allowInspection) {
+        throw new Error("crabbox_usage is disabled by plugin config");
+      }
+      const args = ["usage"];
+      maybePush(args, "--scope", readString(params, "scope"));
+      maybePush(args, "--user", readString(params, "user"));
+      maybePush(args, "--org", readString(params, "org"));
+      maybePush(args, "--month", readString(params, "month"));
+      maybePushBool(args, "--json", params?.json);
+      return execute(config, args, params, signal);
+    },
+  });
+}
+
 export default {
   id: PLUGIN_ID,
   name: "Crabbox",
@@ -418,6 +651,11 @@ export default {
     registerStatus(api, config);
     registerList(api, config);
     registerStop(api, config);
+    registerHistory(api, config);
+    registerEvents(api, config);
+    registerLogs(api, config);
+    registerResults(api, config);
+    registerUsage(api, config);
     api.logger?.info?.("Crabbox plugin registered");
   },
 };

--- a/index.test.js
+++ b/index.test.js
@@ -43,7 +43,18 @@ test("registers the Crabbox tool surface", () => {
   const tools = registerWithConfig({});
   assert.deepEqual(
     tools.map((tool) => tool.name).sort(),
-    ["crabbox_list", "crabbox_run", "crabbox_status", "crabbox_stop", "crabbox_warmup"],
+    [
+      "crabbox_events",
+      "crabbox_history",
+      "crabbox_list",
+      "crabbox_logs",
+      "crabbox_results",
+      "crabbox_run",
+      "crabbox_status",
+      "crabbox_stop",
+      "crabbox_usage",
+      "crabbox_warmup",
+    ],
   );
 });
 
@@ -88,6 +99,101 @@ test("crabbox_status includes optional flags", async () => {
   ]);
 });
 
+test("crabbox_history includes run filters", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_history").execute("call-1", {
+    lease: "cbx_abcdef123456",
+    owner: "peter@example.com",
+    org: "openclaw",
+    state: "failed",
+    limit: 25,
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "history",
+    "--lease",
+    "cbx_abcdef123456",
+    "--owner",
+    "peter@example.com",
+    "--org",
+    "openclaw",
+    "--state",
+    "failed",
+    "--limit",
+    "25",
+    "--json",
+  ]);
+});
+
+test("crabbox_events includes pagination flags", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_events").execute("call-1", {
+    id: "run_abcdef123456",
+    after: 42,
+    limit: 100,
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "events",
+    "--id",
+    "run_abcdef123456",
+    "--after",
+    "42",
+    "--limit",
+    "100",
+    "--json",
+  ]);
+});
+
+test("crabbox_logs and results pass run IDs", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const logs = await getTool(tools, "crabbox_logs").execute("call-1", {
+    id: "run_abcdef123456",
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(logs.details.stdout).argv, [
+    "logs",
+    "--id",
+    "run_abcdef123456",
+    "--json",
+  ]);
+
+  const results = await getTool(tools, "crabbox_results").execute("call-2", {
+    id: "run_abcdef123456",
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(results.details.stdout).argv, [
+    "results",
+    "--id",
+    "run_abcdef123456",
+    "--json",
+  ]);
+});
+
+test("crabbox_usage includes scope filters", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file });
+  const result = await getTool(tools, "crabbox_usage").execute("call-1", {
+    scope: "org",
+    org: "openclaw",
+    month: "2026-05",
+    json: true,
+  });
+  assert.deepEqual(JSON.parse(result.details.stdout).argv, [
+    "usage",
+    "--scope",
+    "org",
+    "--org",
+    "openclaw",
+    "--month",
+    "2026-05",
+    "--json",
+  ]);
+});
+
 test("disabled run tool fails before invoking crabbox", async () => {
   const fake = createFakeCrabbox();
   const tools = registerWithConfig({ binary: fake.file, allowRun: false });
@@ -95,6 +201,17 @@ test("disabled run tool fails before invoking crabbox", async () => {
     getTool(tools, "crabbox_run").execute("call-1", {
       id: "blue-lobster",
       command: ["go", "test", "./..."],
+    }),
+    /disabled/,
+  );
+});
+
+test("disabled inspection tool fails before invoking crabbox", async () => {
+  const fake = createFakeCrabbox();
+  const tools = registerWithConfig({ binary: fake.file, allowInspection: false });
+  await assert.rejects(
+    getTool(tools, "crabbox_logs").execute("call-1", {
+      id: "run_abcdef123456",
     }),
     /disabled/,
   );

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -6,7 +6,18 @@
     "onStartup": true
   },
   "contracts": {
-    "tools": ["crabbox_run", "crabbox_warmup", "crabbox_status", "crabbox_list", "crabbox_stop"]
+    "tools": [
+      "crabbox_run",
+      "crabbox_warmup",
+      "crabbox_status",
+      "crabbox_list",
+      "crabbox_stop",
+      "crabbox_history",
+      "crabbox_events",
+      "crabbox_logs",
+      "crabbox_results",
+      "crabbox_usage"
+    ]
   },
   "configSchema": {
     "type": "object",
@@ -40,6 +51,11 @@
       "allowStop": {
         "type": "boolean",
         "description": "Allow the crabbox_stop tool.",
+        "default": true
+      },
+      "allowInspection": {
+        "type": "boolean",
+        "description": "Allow run history, events, logs, results, and usage inspection tools.",
         "default": true
       }
     }


### PR DESCRIPTION
## Summary
- add OpenClaw plugin tools for Crabbox run history, events, retained logs, test results, and usage inspection
- add `allowInspection` plugin config so operators can disable the new read-only inspection tools
- update plugin docs, manifest contract, README status, and changelog

## Safety / config
- no coordinator, provider, admin, deploy, or image behavior changes
- no new secrets or credential handling
- tools shell out to the existing `crabbox` CLI, so coordinator auth and owner/org scoping remain enforced by the CLI and Worker
- inspection tools can be disabled with `plugins.entries.crabbox.config.allowInspection: false`

## Verification
- `npm run check`
- `npm run docs:check`
- `npm pack --dry-run --json`
- `git diff --check`