### PR TITLE
feat: add islo provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crabbox is an open-source remote testbox runner for maintainers and AI agents. L
 crabbox run -- pnpm test
 ```
 
-Behind that single command: a Go CLI on your laptop, a Cloudflare Worker broker that owns provider credentials and lease state, and a vanilla Ubuntu runner on Hetzner Cloud or AWS EC2 Spot. Crabbox can also wrap Blacksmith Testboxes when you choose `provider: blacksmith-testbox`, or use `provider: ssh` for existing macOS and Windows targets.
+Behind that single command: a Go CLI on your laptop, a Cloudflare Worker broker that owns provider credentials and lease state, and a vanilla Ubuntu runner on Hetzner Cloud or AWS EC2 Spot. Crabbox can also wrap Blacksmith Testboxes when you choose `provider: blacksmith-testbox`, wrap [islo.dev](https://islo.dev) sandboxes when you choose `provider: islo`, or use `provider: ssh` for existing macOS and Windows targets.
 
 ---
 
@@ -78,6 +78,7 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Brokered cloud.** Maintainers and agents share infra without sharing provider tokens. Hetzner and AWS EC2 Spot are first-class; both fall back across instance families when capacity or quota rejects a request.
 - **macOS and Windows static hosts.** `provider: ssh` reuses existing machines; it does not create macOS or Windows Crabbox boxes. macOS and Windows WSL2 use the POSIX rsync path; native Windows uses PowerShell plus tar archive sync.
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, and config conventions.
+- **islo sandbox wrapper.** Set `provider: islo` to delegate warmup/run/list/status/stop to the [islo.dev](https://islo.dev) CLI; auth and sandbox networking stay with islo while Crabbox keeps local slugs, repo claims, and timing summaries. See [docs/features/islo.md](docs/features/islo.md).
 - **Trusted AWS images.** Operators can create AMIs from active brokered AWS leases and promote a known-good image as the coordinator default.
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type.
 - **GitHub Actions hydration.** `crabbox actions hydrate` registers a leased box as an ephemeral Actions runner, so the repo's own workflow installs runtimes, services, and secrets. Crabbox does not parse Actions YAML.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -11,6 +11,7 @@ crabbox run --desktop --browser --shell 'echo "$DISPLAY"; "$BROWSER" --version'
 crabbox run --id blue-lobster --shell 'pnpm install --frozen-lockfile && pnpm test'
 crabbox run --id cbx_abcdef123456 --junit junit.xml -- go test ./...
 crabbox run --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job test -- pnpm test
+crabbox run --provider islo --islo-image docker.io/library/ubuntu:24.04 -- pnpm test
 crabbox run --provider ssh --target macos --static-host mac-studio.local -- xcodebuild test
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local -- dotnet test
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local --shell 'Write-Output ("BROWSER=" + $env:BROWSER)'
@@ -20,6 +21,8 @@ crabbox run --provider ssh --target windows --windows-mode wsl2 --static-host wi
 If `--id` is omitted, Crabbox creates a fresh non-kept lease and releases it when the command exits. `--id` accepts the stable `cbx_...` ID or the active friendly slug.
 
 With `--provider blacksmith-testbox`, `--id` accepts a Blacksmith `tbx_...` ID or a local Crabbox slug. Crabbox forwards the command to `blacksmith testbox run`, delegates sync to Blacksmith, and prints `sync=delegated` in the final timing summary.
+
+With `--provider islo`, `--id` accepts an islo sandbox name, an `isb_<name>` Crabbox lease id, or a local Crabbox slug. Crabbox forwards the command to `islo use <name> -- <command>`, delegates sync to islo, and prints `sync=delegated` in the final timing summary. See [islo](../features/islo.md).
 
 When the lease has been hydrated by `crabbox actions hydrate`, `run` reads the remote marker under `$HOME/.crabbox/actions`, syncs into the workflow's `$GITHUB_WORKSPACE`, and sources the non-secret env file written by the workflow. That preserves the setup the workflow performed: checkout path, installed dependencies, service containers, caches, runner temp/toolcache paths, and any project-specific preparation. GitHub secrets and OIDC request tokens remain workflow-step scoped unless the project explicitly persists its own short-lived credentials.
 
@@ -51,7 +54,7 @@ Before rsync starts, Crabbox prints the candidate file count and byte estimate. 
 
 At the end of every command, `run` prints a one-line summary with sync duration, command duration, total duration, whether sync was skipped by fingerprint, and the remote exit code.
 
-Use `--timing-json` to emit a final JSON timing record with provider, lease ID, sync phases, command duration, total duration, exit code, and Actions run URL when available. In `blacksmith-testbox` mode, sync is reported as delegated in the same schema.
+Use `--timing-json` to emit a final JSON timing record with provider, lease ID, sync phases, command duration, total duration, exit code, and Actions run URL when available. In `blacksmith-testbox` and `islo` modes, sync is reported as delegated in the same schema.
 
 Before the first rsync into a Git checkout, Crabbox tries to seed the remote worktree from the local `origin` remote so the first sync is a dirty-tree overlay instead of a full source upload. Project-specific excludes, env forwarding, and base ref belong in `crabbox.yaml` or `.crabbox.yaml`.
 
@@ -67,7 +70,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|ssh|blacksmith-testbox
+--provider hetzner|aws|ssh|blacksmith-testbox|islo
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -96,6 +99,12 @@ Flags:
 --blacksmith-workflow <file|name|id>
 --blacksmith-job <job>
 --blacksmith-ref <ref>
+--islo-image <image>
+--islo-source <repo>
+--islo-workdir <dir>
+--islo-gateway-profile <profile>
+--islo-session <session>
+--islo-org <org>
 ```
 
 `--idle-timeout` controls inactivity expiry, default `30m`. `--ttl` remains the maximum wall-clock lifetime, default `90m`.
@@ -106,3 +115,5 @@ Explicit `--type` keeps exact-type semantics; Crabbox reports why that type
 failed rather than falling back to a different size.
 
 Blacksmith Testbox mode does not support `--sync-only`; Blacksmith owns its own sync behavior.
+
+islo mode does not support `--sync-only`, `--checksum`, or `--force-sync-large`; islo owns sandbox sync via `--islo-source` cloning.

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -11,6 +11,7 @@ crabbox warmup --provider aws --target windows --desktop --market on-demand
 crabbox warmup --provider aws --target macos --desktop --market on-demand --type mac2.metal
 crabbox warmup --actions-runner
 crabbox warmup --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job test
+crabbox warmup --provider islo --islo-image docker.io/library/ubuntu:24.04
 crabbox warmup --provider ssh --target macos --static-host mac-studio.local
 crabbox warmup --provider ssh --target windows --windows-mode normal --static-host win-dev.local --static-work-root 'C:\crabbox' --browser
 ```
@@ -18,6 +19,8 @@ crabbox warmup --provider ssh --target windows --windows-mode normal --static-ho
 The command returns a stable `cbx_...` lease ID and a friendly slug. Reuse either for subsequent `run`, `status`, `ssh`, `inspect`, and `stop` commands; scripts should keep using the canonical ID.
 
 With `--provider blacksmith-testbox`, the canonical ID is the Blacksmith `tbx_...` ID returned by `blacksmith testbox warmup`; Crabbox still assigns and stores a local slug for reuse.
+
+With `--provider islo`, the canonical ID is `isb_<sandbox-name>` where `<sandbox-name>` is the islo sandbox name (auto-generated as `crabbox-<hex>` when not specified). Crabbox still assigns and stores a local slug for reuse. See [islo](../features/islo.md).
 
 With `--provider ssh`, warmup claims an existing static SSH host instead of
 creating cloud capacity. Use `--target macos`, `--target windows
@@ -44,7 +47,7 @@ On success, `warmup` prints a concise total duration line. Add `--timing-json` t
 Flags:
 
 ```text
---provider hetzner|aws|ssh|blacksmith-testbox
+--provider hetzner|aws|ssh|blacksmith-testbox|islo
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -67,6 +70,12 @@ Flags:
 --blacksmith-workflow <file|name|id>
 --blacksmith-job <job>
 --blacksmith-ref <ref>
+--islo-image <image>
+--islo-source <repo>
+--islo-workdir <dir>
+--islo-gateway-profile <profile>
+--islo-session <session>
+--islo-org <org>
 ```
 
 `--idle-timeout` releases the lease after no touch for that duration, default `30m`. `--ttl` remains the maximum wall-clock lifetime, default `90m`.
@@ -89,7 +98,7 @@ changing capacity.
 
 `--actions-runner` immediately registers the warm box as an ephemeral self-hosted GitHub Actions runner for the current repository. Most projects should prefer `crabbox actions hydrate --id <lease-id-or-slug>` after warmup because it also dispatches the workflow and waits for the ready marker.
 
-`--actions-runner` is not supported with `blacksmith-testbox` because Blacksmith owns Testbox workflow hydration.
+`--actions-runner` is not supported with `blacksmith-testbox` because Blacksmith owns Testbox workflow hydration. It is also not supported with `islo` because islo owns sandbox setup.
 
 New leases use per-lease SSH keys under the user config directory:
 

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -1,0 +1,115 @@
+# islo
+
+Read when:
+
+- choosing `provider: islo`;
+- changing islo CLI forwarding;
+- deciding what Crabbox owns versus islo owns.
+
+Crabbox can use [islo.dev](https://islo.dev) sandboxes as the machine backend without using the Crabbox broker. Select it with `--provider islo` for one command, or put `provider: islo` in config when a repo or machine should use it by default.
+
+## One-Liners
+
+If you already have an islo sandbox, no Crabbox YAML is required:
+
+```sh
+crabbox run --provider islo --id my-sandbox -- pnpm test
+```
+
+If Crabbox has already claimed a friendly slug for that sandbox, the slug works too:
+
+```sh
+crabbox run --provider islo --id blue-lobster -- pnpm test:changed
+crabbox status --provider islo --id blue-lobster
+crabbox stop --provider islo blue-lobster
+```
+
+That path only needs islo auth and a reachable sandbox. Crabbox resolves the name or slug, preserves the local repo claim, forwards the command to `islo use`, and prints `sync=delegated` in the final summary.
+
+To create a fresh sandbox without YAML, provide the image and source as flags:
+
+```sh
+crabbox warmup \
+  --provider islo \
+  --islo-image docker.io/library/ubuntu:24.04 \
+  --islo-source github://openclaw/crabbox:main \
+  --idle-timeout 90m
+```
+
+The same flags work for one-shot `run` when no `--id` is supplied:
+
+```sh
+crabbox run \
+  --provider islo \
+  --islo-image docker.io/library/ubuntu:24.04 \
+  -- pnpm test
+```
+
+YAML is a convenience, not a requirement, when the command line already tells Crabbox which backend and image to use. Environment variables such as `CRABBOX_ISLO_IMAGE`, `CRABBOX_ISLO_SOURCE`, `CRABBOX_ISLO_WORKDIR`, `CRABBOX_ISLO_GATEWAY_PROFILE`, `CRABBOX_ISLO_SESSION`, and `CRABBOX_ISLO_ORG` are also supported for shell defaults or scripts.
+
+## Repo Config
+
+Use repo config when every agent or maintainer should get the same islo defaults without repeating flags:
+
+```yaml
+provider: islo
+islo:
+  image: docker.io/library/ubuntu:24.04
+  source: github://openclaw/crabbox
+  workdir: /workspace/crabbox
+  gatewayProfile: default
+  session: main
+  idleTimeout: 90m
+```
+
+`islo-sandbox` is accepted as a long-form provider alias, but docs and scripts should prefer `islo`.
+
+## Forwarded Commands
+
+Crabbox forwards machine operations to the islo CLI:
+
+```sh
+islo use <name> [--image <image>] [--source <repo>] [--workdir <dir>] [--gateway-profile <profile>] [--session <session>] -- true
+islo use <name> [--image <image>] ... -- <command>
+islo status <name> [-o json]
+islo ls [-o json]
+islo rm <name> --force
+```
+
+The wrapper is deliberately thin. If islo adds behavior to those commands, Crabbox should prefer forwarding rather than reimplementing it.
+
+`crabbox list --provider islo --json` consumes islo's native `--output json` rather than parsing tables. If islo's JSON shape changes, the parser in `internal/cli/islo.go:parseIsloListJSON` is the single update site.
+
+## Auth
+
+Auth stays with islo. Run `islo login` before using this provider. Crabbox does not call the Crabbox login broker, does not send work to the Cloudflare coordinator, and does not hold islo credentials.
+
+## Ownership Boundary
+
+- islo owns provisioning, sandbox image setup, repo cloning via `--source`, command transport, logs emitted by its CLI, gateway/network policy, SSH cert provisioning, and idle expiry.
+- Crabbox owns local YAML/env config, friendly slugs, repo claims, provider selection, command quoting, and final timing summaries.
+
+Because islo owns sync in this mode, Crabbox sync flags such as `--sync-only`, `--checksum`, `--force-sync-large`, and sync guardrails do not apply. `crabbox run` prints `sync=delegated` in the final summary.
+
+`islo.image` is required only when Crabbox needs to warm or acquire a sandbox. Reusing an existing sandbox name or slug does not need image config.
+
+## Choosing The Path
+
+Use the one-liner when:
+
+- you already have a sandbox name;
+- you are trying islo on one command;
+- an agent can pass provider and image directly as flags.
+
+Use repo YAML when:
+
+- the repo should default to islo;
+- multiple agents should share the same image/source/session;
+- you want `crabbox warmup` to work without extra env.
+
+Related docs:
+
+- [Providers](providers.md)
+- [run command](../commands/run.md)
+- [warmup command](../commands/warmup.md)
+- [Source map](../source-map.md)

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -93,6 +93,12 @@ Because islo owns sync in this mode, Crabbox sync flags such as `--sync-only`, `
 
 `islo.image` is required only when Crabbox needs to warm or acquire a sandbox. Reusing an existing sandbox name or slug does not need image config.
 
+`crabbox status --provider islo --json` is not supported in v1: islo's native `--output json` returns a sandbox shape (`SandboxResponse`) that does not match Crabbox's uniform `statusView`. Run `islo status <name> -o json` directly when scripting against the islo schema. The human form (`crabbox status --provider islo --id <name>`) streams islo's CLI output verbatim.
+
+`islo.idleTimeout` is a Crabbox-local accounting value: it is recorded in the local repo claim so `crabbox list` and `crabbox status` can show idle expectations, but it is **not** forwarded to islo (`islo use` has no `--idle-timeout` flag). Configure idle/sandbox lifetime in islo itself when you need server-side enforcement.
+
+Reusing an existing sandbox: `crabbox run --provider islo --id <name> -- <cmd>` resumes a paused sandbox automatically (islo's `use` semantics). Creation flags such as `--islo-image` or `--islo-source` are silently ignored by islo when the sandbox already exists, so they're safe to leave in repo YAML for the warmup case.
+
 ## Choosing The Path
 
 Use the one-liner when:

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -2,7 +2,7 @@
 
 Read when:
 
-- changing Hetzner, AWS, or Blacksmith Testbox provisioning;
+- changing Hetzner, AWS, Blacksmith Testbox, or islo provisioning;
 - adding a backend;
 - adjusting machine classes, fallback order, regions, or images.
 
@@ -101,6 +101,8 @@ brokered Worker path.
 
 Crabbox can also wrap Blacksmith Testboxes with `provider: blacksmith-testbox`. That backend does not use the Crabbox broker or direct cloud credentials. It shells out to the authenticated Blacksmith CLI for `testbox warmup`, `run`, `status`, `list`, and `stop`, while Crabbox keeps local slugs, repo claims, config, and timing summaries. See [Blacksmith Testbox](blacksmith-testbox.md).
 
+Crabbox can also wrap [islo.dev](https://islo.dev) sandboxes with `provider: islo`. Like the Blacksmith path it bypasses the broker; it shells out to the authenticated islo CLI for `use`, `status`, `ls`, and `rm`, while Crabbox keeps local slugs, repo claims, config, and timing summaries. See [islo](islo.md).
+
 Static SSH targets:
 
 ```yaml
@@ -136,5 +138,6 @@ Related docs:
 
 - [Infrastructure](../infrastructure.md)
 - [Blacksmith Testbox](blacksmith-testbox.md)
+- [islo](islo.md)
 - [Runner bootstrap](runner-bootstrap.md)
 - [Cost and usage](cost-usage.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -34,6 +34,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Direct AWS provider: `internal/cli/aws.go`
 - Static SSH macOS/Windows provider: `internal/cli/static.go`
 - Blacksmith Testbox CLI wrapper: `internal/cli/blacksmith.go`
+- islo CLI wrapper: `internal/cli/islo.go`
 - Worker Hetzner provider: `worker/src/hetzner.ts`
 - Worker AWS EC2 Spot provider: `worker/src/aws.ts`
 - Worker AWS AMI create/read/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`

--- a/internal/cli/capabilities.go
+++ b/internal/cli/capabilities.go
@@ -36,6 +36,12 @@ func validateRequestedCapabilities(cfg Config) error {
 	if cfg.Browser && isBlacksmithProvider(cfg.Provider) {
 		return exit(2, "browser provisioning is not supported for provider=%s; use Blacksmith workflow setup for headless browser automation", cfg.Provider)
 	}
+	if cfg.Desktop && isIsloProvider(cfg.Provider) {
+		return exit(2, "desktop/VNC is not supported for provider=%s; islo owns sandbox connectivity", cfg.Provider)
+	}
+	if cfg.Browser && isIsloProvider(cfg.Provider) {
+		return exit(2, "browser provisioning is not supported for provider=%s; install browser tooling via the islo image or session", cfg.Provider)
+	}
 	return nil
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Capacity           CapacityConfig
 	Actions            ActionsConfig
 	Blacksmith         BlacksmithConfig
+	Islo               IsloConfig
 	Static             StaticConfig
 	Results            ResultsConfig
 	Cache              CacheConfig
@@ -95,6 +96,17 @@ type BlacksmithConfig struct {
 	Ref         string
 	IdleTimeout time.Duration
 	Debug       bool
+}
+
+type IsloConfig struct {
+	Org            string
+	Image          string
+	Source         string
+	Workdir        string
+	GatewayProfile string
+	Session        string
+	IdleTimeout    time.Duration
+	Debug          bool
 }
 
 type StaticConfig struct {
@@ -231,6 +243,7 @@ type fileConfig struct {
 	Capacity         *fileCapacityConfig   `yaml:"capacity,omitempty"`
 	Actions          *fileActionsConfig    `yaml:"actions,omitempty"`
 	Blacksmith       *fileBlacksmithConfig `yaml:"blacksmith,omitempty"`
+	Islo             *fileIsloConfig       `yaml:"islo,omitempty"`
 	Static           *fileStaticConfig     `yaml:"static,omitempty"`
 	Results          *fileResultsConfig    `yaml:"results,omitempty"`
 	Cache            *fileCacheConfig      `yaml:"cache,omitempty"`
@@ -328,6 +341,17 @@ type fileBlacksmithConfig struct {
 	Ref         string `yaml:"ref,omitempty"`
 	IdleTimeout string `yaml:"idleTimeout,omitempty"`
 	Debug       *bool  `yaml:"debug,omitempty"`
+}
+
+type fileIsloConfig struct {
+	Org            string `yaml:"org,omitempty"`
+	Image          string `yaml:"image,omitempty"`
+	Source         string `yaml:"source,omitempty"`
+	Workdir        string `yaml:"workdir,omitempty"`
+	GatewayProfile string `yaml:"gatewayProfile,omitempty"`
+	Session        string `yaml:"session,omitempty"`
+	IdleTimeout    string `yaml:"idleTimeout,omitempty"`
+	Debug          *bool  `yaml:"debug,omitempty"`
 }
 
 type fileStaticConfig struct {
@@ -675,6 +699,30 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.Blacksmith.Debug = *file.Blacksmith.Debug
 		}
 	}
+	if file.Islo != nil {
+		if file.Islo.Org != "" {
+			cfg.Islo.Org = file.Islo.Org
+		}
+		if file.Islo.Image != "" {
+			cfg.Islo.Image = file.Islo.Image
+		}
+		if file.Islo.Source != "" {
+			cfg.Islo.Source = file.Islo.Source
+		}
+		if file.Islo.Workdir != "" {
+			cfg.Islo.Workdir = file.Islo.Workdir
+		}
+		if file.Islo.GatewayProfile != "" {
+			cfg.Islo.GatewayProfile = file.Islo.GatewayProfile
+		}
+		if file.Islo.Session != "" {
+			cfg.Islo.Session = file.Islo.Session
+		}
+		applyLeaseDuration(&cfg.Islo.IdleTimeout, file.Islo.IdleTimeout)
+		if file.Islo.Debug != nil {
+			cfg.Islo.Debug = *file.Islo.Debug
+		}
+	}
 	if file.Static != nil {
 		if file.Static.ID != "" {
 			cfg.Static.ID = file.Static.ID
@@ -801,6 +849,18 @@ func applyEnv(cfg *Config) {
 	if value, ok := getenvBool("CRABBOX_BLACKSMITH_DEBUG"); ok {
 		cfg.Blacksmith.Debug = value
 	}
+	cfg.Islo.Org = getenv("CRABBOX_ISLO_ORG", cfg.Islo.Org)
+	cfg.Islo.Image = getenv("CRABBOX_ISLO_IMAGE", cfg.Islo.Image)
+	cfg.Islo.Source = getenv("CRABBOX_ISLO_SOURCE", cfg.Islo.Source)
+	cfg.Islo.Workdir = getenv("CRABBOX_ISLO_WORKDIR", cfg.Islo.Workdir)
+	cfg.Islo.GatewayProfile = getenv("CRABBOX_ISLO_GATEWAY_PROFILE", cfg.Islo.GatewayProfile)
+	cfg.Islo.Session = getenv("CRABBOX_ISLO_SESSION", cfg.Islo.Session)
+	if idleTimeout := os.Getenv("CRABBOX_ISLO_IDLE_TIMEOUT"); idleTimeout != "" {
+		applyLeaseDuration(&cfg.Islo.IdleTimeout, idleTimeout)
+	}
+	if value, ok := getenvBool("CRABBOX_ISLO_DEBUG"); ok {
+		cfg.Islo.Debug = value
+	}
 	if labels := os.Getenv("CRABBOX_ACTIONS_RUNNER_LABELS"); labels != "" {
 		cfg.Actions.RunnerLabels = splitCommaList(labels)
 	}
@@ -883,7 +943,7 @@ func serverTypeForClass(class string) string {
 }
 
 func serverTypeForConfig(cfg Config) string {
-	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
+	if isBlacksmithProvider(cfg.Provider) || isIsloProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
 		return ""
 	}
 	if cfg.Provider == "aws" {
@@ -893,7 +953,7 @@ func serverTypeForConfig(cfg Config) string {
 }
 
 func serverTypeForProviderClass(provider, class string) string {
-	if isBlacksmithProvider(provider) || isStaticProvider(provider) {
+	if isBlacksmithProvider(provider) || isIsloProvider(provider) || isStaticProvider(provider) {
 		return ""
 	}
 	if provider == "aws" {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -102,6 +102,15 @@ blacksmith:
   ref: main
   idleTimeout: 90m
   debug: true
+islo:
+  org: openclaw
+  image: docker.io/library/ubuntu:24.04
+  source: github://openclaw/crabbox
+  workdir: /workspace/crabbox
+  gatewayProfile: default
+  session: main
+  idleTimeout: 75m
+  debug: true
 static:
   id: win-dev
   name: windows-dev
@@ -189,6 +198,9 @@ ssh:
 	if cfg.Blacksmith.Org != "openclaw" || cfg.Blacksmith.Workflow != ".github/workflows/blacksmith-testbox.yml" || cfg.Blacksmith.Job != "hydrate" || cfg.Blacksmith.Ref != "main" || cfg.Blacksmith.IdleTimeout != 90*time.Minute || !cfg.Blacksmith.Debug {
 		t.Fatalf("blacksmith config not loaded: %#v", cfg.Blacksmith)
 	}
+	if cfg.Islo.Org != "openclaw" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Source != "github://openclaw/crabbox" || cfg.Islo.Workdir != "/workspace/crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.Session != "main" || cfg.Islo.IdleTimeout != 75*time.Minute || !cfg.Islo.Debug {
+		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
+	}
 	if cfg.Static.Host != "win-dev.local" || cfg.Static.User != "peter" || cfg.Static.Port != "22" || cfg.WorkRoot != "/home/peter/crabbox" {
 		t.Fatalf("static config not loaded: static=%#v workRoot=%s", cfg.Static, cfg.WorkRoot)
 	}
@@ -218,6 +230,14 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "env-admin-secret")
 	t.Setenv("CRABBOX_TARGET", "macos")
 	t.Setenv("CRABBOX_STATIC_HOST", "mac.local")
+	t.Setenv("CRABBOX_ISLO_ORG", "openclaw")
+	t.Setenv("CRABBOX_ISLO_IMAGE", "docker.io/library/ubuntu:24.04")
+	t.Setenv("CRABBOX_ISLO_SOURCE", "github://openclaw/crabbox")
+	t.Setenv("CRABBOX_ISLO_WORKDIR", "/workspace/crabbox")
+	t.Setenv("CRABBOX_ISLO_GATEWAY_PROFILE", "default")
+	t.Setenv("CRABBOX_ISLO_SESSION", "main")
+	t.Setenv("CRABBOX_ISLO_IDLE_TIMEOUT", "75m")
+	t.Setenv("CRABBOX_ISLO_DEBUG", "true")
 	path := userConfigPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
@@ -247,6 +267,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.TargetOS != targetMacOS || cfg.Static.Host != "mac.local" {
 		t.Fatalf("unexpected target env: target=%s static=%#v", cfg.TargetOS, cfg.Static)
+	}
+	if cfg.Islo.Org != "openclaw" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Source != "github://openclaw/crabbox" || cfg.Islo.Workdir != "/workspace/crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.Session != "main" || cfg.Islo.IdleTimeout != 75*time.Minute || !cfg.Islo.Debug {
+		t.Fatalf("islo env not loaded: %#v", cfg.Islo)
 	}
 }
 

--- a/internal/cli/islo.go
+++ b/internal/cli/islo.go
@@ -1,0 +1,433 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	isloProvider     = "islo"
+	isloSandboxAlias = "islo-sandbox"
+	isloIDPrefix     = "isb_"
+	isloNamePrefix   = "crabbox-"
+)
+
+var (
+	isloCommandContext = exec.CommandContext
+	isloIDPattern      = regexp.MustCompile(`\bisb_[A-Za-z0-9_-]+\b`)
+)
+
+type isloRunOptions struct {
+	ID          string
+	Keep        bool
+	Reclaim     bool
+	SyncOnly    bool
+	Debug       bool
+	ShellMode   bool
+	Command     []string
+	IdleTimeout time.Duration
+	TimingJSON  bool
+}
+
+type isloFlagValues struct {
+	Org            *string
+	Image          *string
+	Source         *string
+	Workdir        *string
+	GatewayProfile *string
+	Session        *string
+}
+
+type isloListItem struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Image     string `json:"image,omitempty"`
+	CreatedBy string `json:"createdBy,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	DeletedAt string `json:"deletedAt,omitempty"`
+}
+
+func isIsloProvider(provider string) bool {
+	return provider == isloProvider || provider == isloSandboxAlias
+}
+
+func registerIsloFlags(fs *flag.FlagSet, defaults Config) isloFlagValues {
+	return isloFlagValues{
+		Org:            fs.String("islo-org", defaults.Islo.Org, "islo organization"),
+		Image:          fs.String("islo-image", defaults.Islo.Image, "islo container image"),
+		Source:         fs.String("islo-source", defaults.Islo.Source, "islo repo source (github://owner/repo[:branch] or https://...)"),
+		Workdir:        fs.String("islo-workdir", defaults.Islo.Workdir, "islo working directory"),
+		GatewayProfile: fs.String("islo-gateway-profile", defaults.Islo.GatewayProfile, "islo gateway profile"),
+		Session:        fs.String("islo-session", defaults.Islo.Session, "islo session name (default: main)"),
+	}
+}
+
+func applyIsloFlagOverrides(cfg *Config, fs *flag.FlagSet, values isloFlagValues) {
+	if flagWasSet(fs, "islo-org") {
+		cfg.Islo.Org = *values.Org
+	}
+	if flagWasSet(fs, "islo-image") {
+		cfg.Islo.Image = *values.Image
+	}
+	if flagWasSet(fs, "islo-source") {
+		cfg.Islo.Source = *values.Source
+	}
+	if flagWasSet(fs, "islo-workdir") {
+		cfg.Islo.Workdir = *values.Workdir
+	}
+	if flagWasSet(fs, "islo-gateway-profile") {
+		cfg.Islo.GatewayProfile = *values.GatewayProfile
+	}
+	if flagWasSet(fs, "islo-session") {
+		cfg.Islo.Session = *values.Session
+	}
+}
+
+func (a App) isloWarmup(ctx context.Context, cfg Config, repo Repo, keep, reclaim, timingJSON bool) error {
+	started := time.Now()
+	sandboxName, leaseID, slug, err := a.isloWarmupLease(ctx, cfg, repo, "", reclaim)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(a.Stdout, "leased %s sandbox=%s slug=%s provider=%s idle_timeout=%s\n", leaseID, sandboxName, slug, isloProvider, isloIdleTimeout(cfg))
+	if !keep {
+		fmt.Fprintf(a.Stderr, "warning: islo warmup keeps the sandbox until idle timeout or explicit stop\n")
+	}
+	fmt.Fprintf(a.Stdout, "warmup complete total=%s\n", time.Since(started).Round(time.Millisecond))
+	if timingJSON {
+		total := time.Since(started)
+		if err := writeTimingJSON(a.Stderr, timingReport{
+			Provider: isloProvider,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a App) isloRun(ctx context.Context, cfg Config, repo Repo, opts isloRunOptions) error {
+	if opts.SyncOnly {
+		return exit(2, "islo delegates sync to the sandbox; --sync-only is not supported")
+	}
+	started := time.Now()
+	identifier := opts.ID
+	var sandboxName, leaseID, slug string
+	var err error
+	acquired := false
+	if identifier == "" {
+		sandboxName, leaseID, slug, err = a.isloWarmupLease(ctx, cfg, repo, "", opts.Reclaim)
+		if err != nil {
+			return err
+		}
+		acquired = true
+	} else {
+		sandboxName, leaseID, err = resolveIsloLeaseID(identifier, repo.Root, opts.Reclaim)
+		if err != nil {
+			return err
+		}
+		slug, err = isloClaimSlug(identifier, leaseID)
+		if err != nil {
+			return err
+		}
+		if err := claimLeaseForRepoProvider(leaseID, slug, isloProvider, repo.Root, opts.IdleTimeout, opts.Reclaim); err != nil {
+			return err
+		}
+	}
+	if acquired && !opts.Keep {
+		defer func() {
+			if err := a.isloRemoveSandbox(context.Background(), cfg, sandboxName); err != nil {
+				fmt.Fprintf(a.Stderr, "warning: islo rm failed for %s: %v\n", sandboxName, err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+	fmt.Fprintf(a.Stderr, "provider=islo id=%s sandbox=%s sync=delegated auth=islo\n", leaseID, sandboxName)
+	commandStart := time.Now()
+	code := a.runIsloUse(ctx, cfg, sandboxName, opts.Command, opts.Debug || cfg.Islo.Debug, opts.ShellMode)
+	commandDuration := time.Since(commandStart)
+	total := time.Since(started)
+	fmt.Fprintf(a.Stderr, "islo run summary sync=delegated command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code)
+	if opts.TimingJSON {
+		if err := writeTimingJSON(a.Stderr, timingReport{
+			Provider:      isloProvider,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncPhases:    []timingPhase{{Name: "delegated", Skipped: true, Reason: "islo owns sync"}},
+			SyncDelegated: true,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       total.Milliseconds(),
+			ExitCode:      code,
+		}); err != nil {
+			return err
+		}
+	}
+	if code != 0 {
+		return ExitError{Code: code, Message: fmt.Sprintf("islo run exited %d", code)}
+	}
+	return nil
+}
+
+func (a App) isloList(ctx context.Context, cfg Config, jsonOut bool) error {
+	args := isloListArgs(cfg, jsonOut)
+	if !jsonOut {
+		return a.streamIslo(ctx, args)
+	}
+	cmd := isloCommandContext(ctx, "islo", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		return ExitError{Code: exitCode(err), Message: fmt.Sprintf("islo failed: %v: %s", err, stderr)}
+	}
+	items := parseIsloListJSON(out)
+	return json.NewEncoder(a.Stdout).Encode(items)
+}
+
+func (a App) isloStatus(ctx context.Context, cfg Config, id string, wait bool, waitTimeout time.Duration, jsonOut bool) error {
+	sandboxName, _, err := resolveIsloLeaseID(id, "", false)
+	if err != nil {
+		return err
+	}
+	if !wait {
+		return a.streamIslo(ctx, isloStatusArgs(cfg, sandboxName, jsonOut))
+	}
+	deadline := time.Now().Add(waitTimeout)
+	for {
+		cmd := isloCommandContext(ctx, "islo", isloStatusArgs(cfg, sandboxName, true)...)
+		out, runErr := cmd.Output()
+		if runErr == nil {
+			var view struct {
+				Status string `json:"status"`
+			}
+			if jsonErr := json.Unmarshal(out, &view); jsonErr == nil && view.Status == "running" {
+				if jsonOut {
+					_, _ = a.Stdout.Write(out)
+					return nil
+				}
+				return a.streamIslo(ctx, isloStatusArgs(cfg, sandboxName, false))
+			}
+		}
+		if time.Now().After(deadline) {
+			return exit(5, "timed out waiting for %s to become ready", sandboxName)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (a App) isloStop(ctx context.Context, cfg Config, id string) error {
+	sandboxName, leaseID, err := resolveIsloLeaseID(id, "", false)
+	if err != nil {
+		return err
+	}
+	if err := a.isloRemoveSandbox(ctx, cfg, sandboxName); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	return nil
+}
+
+func (a App) isloWarmupLease(ctx context.Context, cfg Config, repo Repo, requestedName string, reclaim bool) (string, string, string, error) {
+	sandboxName := requestedName
+	if sandboxName == "" {
+		sandboxName = newIsloSandboxName()
+	}
+	args := isloWarmupArgs(cfg, sandboxName)
+	var stderr bytes.Buffer
+	cmd := isloCommandContext(ctx, "islo", args...)
+	cmd.Stdout = a.Stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", "", "", exit(exitCode(err), "islo use failed: %v: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	leaseID := isloIDPrefix + sandboxName
+	slug := newLeaseSlug(leaseID)
+	if err := claimLeaseForRepoProvider(leaseID, slug, isloProvider, repo.Root, isloIdleTimeout(cfg), reclaim); err != nil {
+		_ = a.isloRemoveSandbox(ctx, cfg, sandboxName)
+		return "", "", "", err
+	}
+	return sandboxName, leaseID, slug, nil
+}
+
+func (a App) runIsloUse(ctx context.Context, cfg Config, sandboxName string, command []string, debug, shellMode bool) int {
+	args := isloRunArgs(cfg, sandboxName, command, shellMode)
+	if debug {
+		fmt.Fprintf(a.Stderr, "islo %s\n", strings.Join(args, " "))
+	}
+	cmd := isloCommandContext(ctx, "islo", args...)
+	cmd.Stdout = a.Stdout
+	cmd.Stderr = a.Stderr
+	if err := cmd.Run(); err != nil {
+		return exitCode(err)
+	}
+	return 0
+}
+
+func (a App) isloRemoveSandbox(ctx context.Context, cfg Config, sandboxName string) error {
+	return a.streamIslo(ctx, isloStopArgs(cfg, sandboxName))
+}
+
+func (a App) streamIslo(ctx context.Context, args []string) error {
+	cmd := isloCommandContext(ctx, "islo", args...)
+	cmd.Stdout = a.Stdout
+	cmd.Stderr = a.Stderr
+	if err := cmd.Run(); err != nil {
+		return ExitError{Code: exitCode(err), Message: fmt.Sprintf("islo failed: %v", err)}
+	}
+	return nil
+}
+
+func isloWarmupArgs(cfg Config, sandboxName string) []string {
+	args := isloBaseArgs(cfg)
+	args = append(args, "use", sandboxName)
+	args = append(args, isloUseFlags(cfg)...)
+	args = append(args, "--", "true")
+	return args
+}
+
+func isloRunArgs(cfg Config, sandboxName string, command []string, shellMode bool) []string {
+	args := isloBaseArgs(cfg)
+	args = append(args, "use", sandboxName)
+	args = append(args, isloUseFlags(cfg)...)
+	if len(command) == 0 {
+		return args
+	}
+	if shellMode || shouldUseShell(command) {
+		return append(args, "--", "bash", "-lc", strings.Join(command, " "))
+	}
+	args = append(args, "--")
+	return append(args, command...)
+}
+
+func isloStatusArgs(cfg Config, sandboxName string, jsonOut bool) []string {
+	args := isloBaseArgs(cfg)
+	if jsonOut {
+		args = append(args, "-o", "json")
+	}
+	return append(args, "status", sandboxName)
+}
+
+func isloStopArgs(cfg Config, sandboxName string) []string {
+	args := isloBaseArgs(cfg)
+	return append(args, "rm", sandboxName, "--force")
+}
+
+func isloListArgs(cfg Config, jsonOut bool) []string {
+	args := isloBaseArgs(cfg)
+	if jsonOut {
+		args = append(args, "-o", "json")
+	}
+	return append(args, "ls")
+}
+
+func isloBaseArgs(cfg Config) []string {
+	return []string{}
+}
+
+func isloUseFlags(cfg Config) []string {
+	args := []string{}
+	if cfg.Islo.Image != "" {
+		args = append(args, "--image", cfg.Islo.Image)
+	}
+	if cfg.Islo.Source != "" {
+		args = append(args, "--source", cfg.Islo.Source)
+	}
+	if cfg.Islo.Workdir != "" {
+		args = append(args, "--workdir", cfg.Islo.Workdir)
+	}
+	if cfg.Islo.GatewayProfile != "" {
+		args = append(args, "--gateway-profile", cfg.Islo.GatewayProfile)
+	}
+	if cfg.Islo.Session != "" {
+		args = append(args, "--session", cfg.Islo.Session)
+	}
+	return args
+}
+
+func parseIsloListJSON(data []byte) []isloListItem {
+	items := []isloListItem{}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return items
+	}
+	if err := json.Unmarshal(trimmed, &items); err == nil {
+		return items
+	}
+	var wrapped struct {
+		Sandboxes []isloListItem `json:"sandboxes"`
+	}
+	if err := json.Unmarshal(trimmed, &wrapped); err == nil && wrapped.Sandboxes != nil {
+		return wrapped.Sandboxes
+	}
+	return items
+}
+
+func isloIdleTimeout(cfg Config) time.Duration {
+	if cfg.Islo.IdleTimeout > 0 {
+		return cfg.Islo.IdleTimeout
+	}
+	return cfg.IdleTimeout
+}
+
+func newIsloSandboxName() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return isloNamePrefix + strings.ReplaceAll(time.Now().UTC().Format("150405.000"), ".", "")
+	}
+	return isloNamePrefix + hex.EncodeToString(b[:])
+}
+
+func resolveIsloLeaseID(identifier, repoRoot string, reclaim bool) (string, string, error) {
+	if identifier == "" {
+		return "", "", exit(2, "islo requires --id <sandbox-name-or-slug>")
+	}
+	if isloIDPattern.MatchString(identifier) {
+		match := isloIDPattern.FindString(identifier)
+		if match == identifier {
+			return strings.TrimPrefix(match, isloIDPrefix), match, nil
+		}
+	}
+	claim, ok, err := resolveLeaseClaim(identifier)
+	if err != nil {
+		return "", "", err
+	}
+	if !ok {
+		return identifier, isloIDPrefix + identifier, nil
+	}
+	if claim.Provider != "" && claim.Provider != isloProvider {
+		return "", "", exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
+	}
+	if repoRoot != "" && claim.RepoRoot != "" && claim.RepoRoot != repoRoot && !reclaim {
+		return "", "", exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, repoRoot)
+	}
+	return strings.TrimPrefix(claim.LeaseID, isloIDPrefix), claim.LeaseID, nil
+}
+
+func isloClaimSlug(identifier, leaseID string) (string, error) {
+	for _, candidate := range []string{identifier, leaseID} {
+		claim, ok, err := resolveLeaseClaim(candidate)
+		if err != nil {
+			return "", err
+		}
+		if ok && claim.LeaseID == leaseID {
+			return claim.Slug, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/cli/islo.go
+++ b/internal/cli/islo.go
@@ -201,12 +201,15 @@ func (a App) isloList(ctx context.Context, cfg Config, jsonOut bool) error {
 }
 
 func (a App) isloStatus(ctx context.Context, cfg Config, id string, wait bool, waitTimeout time.Duration, jsonOut bool) error {
+	if jsonOut {
+		return exit(2, "islo status does not support --json; run 'islo status <name> -o json' for the islo-native shape")
+	}
 	sandboxName, _, err := resolveIsloLeaseID(id, "", false)
 	if err != nil {
 		return err
 	}
 	if !wait {
-		return a.streamIslo(ctx, isloStatusArgs(cfg, sandboxName, jsonOut))
+		return a.streamIslo(ctx, isloStatusArgs(cfg, sandboxName, false))
 	}
 	deadline := time.Now().Add(waitTimeout)
 	for {
@@ -217,10 +220,6 @@ func (a App) isloStatus(ctx context.Context, cfg Config, id string, wait bool, w
 				Status string `json:"status"`
 			}
 			if jsonErr := json.Unmarshal(out, &view); jsonErr == nil && view.Status == "running" {
-				if jsonOut {
-					_, _ = a.Stdout.Write(out)
-					return nil
-				}
 				return a.streamIslo(ctx, isloStatusArgs(cfg, sandboxName, false))
 			}
 		}
@@ -311,8 +310,39 @@ func isloRunArgs(cfg Config, sandboxName string, command []string, shellMode boo
 	if shellMode || shouldUseShell(command) {
 		return append(args, "--", "bash", "-lc", strings.Join(command, " "))
 	}
+	if hasLeadingEnvAssignment(command) {
+		return append(args, "--", "bash", "-lc", isloCommandString(command))
+	}
 	args = append(args, "--")
 	return append(args, command...)
+}
+
+func isloCommandString(command []string) string {
+	if len(command) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(command))
+	seenCommand := false
+	for _, word := range command {
+		if !seenCommand && isShellEnvAssignment(word) {
+			key, value, _ := strings.Cut(word, "=")
+			parts = append(parts, key+"="+shellQuote(value))
+			continue
+		}
+		seenCommand = true
+		parts = append(parts, shellQuote(word))
+	}
+	return strings.Join(parts, " ")
+}
+
+func hasLeadingEnvAssignment(command []string) bool {
+	for _, word := range command {
+		if isShellEnvAssignment(word) {
+			return true
+		}
+		return false
+	}
+	return false
 }
 
 func isloStatusArgs(cfg Config, sandboxName string, jsonOut bool) []string {
@@ -386,7 +416,7 @@ func isloIdleTimeout(cfg Config) time.Duration {
 }
 
 func newIsloSandboxName() string {
-	var b [4]byte
+	var b [6]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		return isloNamePrefix + strings.ReplaceAll(time.Now().UTC().Format("150405.000"), ".", "")
 	}

--- a/internal/cli/islo.go
+++ b/internal/cli/islo.go
@@ -52,9 +52,9 @@ type isloListItem struct {
 	Name      string `json:"name"`
 	Status    string `json:"status"`
 	Image     string `json:"image,omitempty"`
-	CreatedBy string `json:"createdBy,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	DeletedAt string `json:"deletedAt,omitempty"`
+	CreatedBy string `json:"created_by,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	DeletedAt string `json:"deleted_at,omitempty"`
 }
 
 func isIsloProvider(provider string) bool {

--- a/internal/cli/islo_test.go
+++ b/internal/cli/islo_test.go
@@ -135,13 +135,13 @@ func TestApplyIsloFlagOverrides(t *testing.T) {
 
 func TestParseIsloListJSONArray(t *testing.T) {
 	got := parseIsloListJSON([]byte(`[
-    {"id":"sbx_01","name":"crabbox-blue","status":"running","image":"ubuntu","createdBy":"me","createdAt":"2026-05-01T00:00:00Z"},
+    {"id":"019deeda-e2f2-70c7-b884-5dbe218b8e07","name":"crabbox-blue","status":"running","image":"ubuntu","created_by":"me@example.test","created_at":"2026-05-01T00:00:00Z","deleted_at":null},
     {"id":"sbx_02","name":"alpha","status":"stopped"}
   ]`))
 	if len(got) != 2 {
 		t.Fatalf("items=%d want 2", len(got))
 	}
-	if got[0].ID != "sbx_01" || got[0].Name != "crabbox-blue" || got[0].Status != "running" {
+	if got[0].ID != "019deeda-e2f2-70c7-b884-5dbe218b8e07" || got[0].Name != "crabbox-blue" || got[0].Status != "running" || got[0].CreatedBy != "me@example.test" {
 		t.Fatalf("unexpected item 0: %#v", got[0])
 	}
 	if got[1].Status != "stopped" {

--- a/internal/cli/islo_test.go
+++ b/internal/cli/islo_test.go
@@ -34,17 +34,68 @@ func TestIsloWarmupArgs(t *testing.T) {
 	}
 }
 
-func TestIsloRunArgsArgvQuoting(t *testing.T) {
+func TestIsloRunArgsLeadingEnvUsesShell(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Islo.Image = "docker.io/library/ubuntu:24.04"
 	got := isloRunArgs(cfg, "crabbox-abc", []string{"OPENCLAW_TESTBOX=1", "pnpm", "check:changed"}, false)
 	want := []string{
 		"use", "crabbox-abc",
 		"--image", "docker.io/library/ubuntu:24.04",
-		"--", "OPENCLAW_TESTBOX=1", "pnpm", "check:changed",
+		"--", "bash", "-lc", "OPENCLAW_TESTBOX='1' 'pnpm' 'check:changed'",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloRunArgsArgvWithoutEnv(t *testing.T) {
+	cfg := baseConfig()
+	got := isloRunArgs(cfg, "sb", []string{"go", "test", "./..."}, false)
+	want := []string{"use", "sb", "--", "go", "test", "./..."}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloCommandStringQuoting(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		want    string
+	}{
+		{name: "argv", command: []string{"pnpm", "test", "has space"}, want: "'pnpm' 'test' 'has space'"},
+		{name: "env assignment", command: []string{"FOO=1", "BAR=value with spaces", "pnpm", "check"}, want: "FOO='1' BAR='value with spaces' 'pnpm' 'check'"},
+		{name: "env after command stays argv", command: []string{"echo", "FOO=1"}, want: "'echo' 'FOO=1'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isloCommandString(tt.command); got != tt.want {
+				t.Fatalf("got=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasLeadingEnvAssignment(t *testing.T) {
+	if !hasLeadingEnvAssignment([]string{"FOO=1", "cmd"}) {
+		t.Error("FOO=1 cmd should be detected")
+	}
+	if hasLeadingEnvAssignment([]string{"cmd", "FOO=1"}) {
+		t.Error("cmd FOO=1 should NOT be detected (env after cmd)")
+	}
+	if hasLeadingEnvAssignment([]string{}) {
+		t.Error("empty command should NOT be detected")
+	}
+	if hasLeadingEnvAssignment([]string{"go", "test"}) {
+		t.Error("plain argv should NOT be detected")
+	}
+}
+
+func TestIsloStatusRejectsJSON(t *testing.T) {
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.isloStatus(context.Background(), baseConfig(), "sb", false, 0, true)
+	if err == nil || !strings.Contains(err.Error(), "does not support --json") {
+		t.Fatalf("expected --json rejection, got %v", err)
 	}
 }
 

--- a/internal/cli/islo_test.go
+++ b/internal/cli/islo_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsloWarmupArgs(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Islo = IsloConfig{
+		Image:          "docker.io/library/ubuntu:24.04",
+		Source:         "github://openclaw/crabbox:main",
+		Workdir:        "/workspace/crabbox",
+		GatewayProfile: "default",
+		Session:        "main",
+	}
+	got := isloWarmupArgs(cfg, "crabbox-deadbeef")
+	want := []string{
+		"use", "crabbox-deadbeef",
+		"--image", "docker.io/library/ubuntu:24.04",
+		"--source", "github://openclaw/crabbox:main",
+		"--workdir", "/workspace/crabbox",
+		"--gateway-profile", "default",
+		"--session", "main",
+		"--", "true",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloRunArgsArgvQuoting(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Islo.Image = "docker.io/library/ubuntu:24.04"
+	got := isloRunArgs(cfg, "crabbox-abc", []string{"OPENCLAW_TESTBOX=1", "pnpm", "check:changed"}, false)
+	want := []string{
+		"use", "crabbox-abc",
+		"--image", "docker.io/library/ubuntu:24.04",
+		"--", "OPENCLAW_TESTBOX=1", "pnpm", "check:changed",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloRunArgsShellMode(t *testing.T) {
+	cfg := baseConfig()
+	got := isloRunArgs(cfg, "sb", []string{"pnpm", "install", "&&", "pnpm", "test"}, false)
+	want := []string{
+		"use", "sb",
+		"--", "bash", "-lc", "pnpm install && pnpm test",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloRunArgsExplicitShellMode(t *testing.T) {
+	cfg := baseConfig()
+	got := isloRunArgs(cfg, "sb", []string{"echo", "hello"}, true)
+	want := []string{
+		"use", "sb",
+		"--", "bash", "-lc", "echo hello",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloListArgsJSON(t *testing.T) {
+	cfg := baseConfig()
+	got := isloListArgs(cfg, true)
+	want := []string{"-o", "json", "ls"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloStopArgs(t *testing.T) {
+	cfg := baseConfig()
+	got := isloStopArgs(cfg, "my-sandbox")
+	want := []string{"rm", "my-sandbox", "--force"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args=%#v want %#v", got, want)
+	}
+}
+
+func TestIsloStatusArgs(t *testing.T) {
+	cfg := baseConfig()
+	if got := isloStatusArgs(cfg, "sb", false); !reflect.DeepEqual(got, []string{"status", "sb"}) {
+		t.Fatalf("plain args=%#v", got)
+	}
+	if got := isloStatusArgs(cfg, "sb", true); !reflect.DeepEqual(got, []string{"-o", "json", "status", "sb"}) {
+		t.Fatalf("json args=%#v", got)
+	}
+}
+
+func TestApplyIsloFlagOverrides(t *testing.T) {
+	defaults := baseConfig()
+	defaults.Islo = IsloConfig{
+		Org:   "default-org",
+		Image: "default-image",
+	}
+	cfg := Config{}
+	fs := newFlagSet("test", io.Discard)
+	values := registerIsloFlags(fs, defaults)
+	if err := parseFlags(fs, []string{
+		"--islo-org", "openclaw",
+		"--islo-image", "docker.io/library/ubuntu:24.04",
+		"--islo-source", "github://openclaw/crabbox",
+		"--islo-workdir", "/workspace",
+		"--islo-gateway-profile", "default",
+		"--islo-session", "main",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	applyIsloFlagOverrides(&cfg, fs, values)
+	want := IsloConfig{
+		Org:            "openclaw",
+		Image:          "docker.io/library/ubuntu:24.04",
+		Source:         "github://openclaw/crabbox",
+		Workdir:        "/workspace",
+		GatewayProfile: "default",
+		Session:        "main",
+	}
+	if !reflect.DeepEqual(cfg.Islo, want) {
+		t.Fatalf("islo flags not applied: got=%#v want=%#v", cfg.Islo, want)
+	}
+}
+
+func TestParseIsloListJSONArray(t *testing.T) {
+	got := parseIsloListJSON([]byte(`[
+    {"id":"sbx_01","name":"crabbox-blue","status":"running","image":"ubuntu","createdBy":"me","createdAt":"2026-05-01T00:00:00Z"},
+    {"id":"sbx_02","name":"alpha","status":"stopped"}
+  ]`))
+	if len(got) != 2 {
+		t.Fatalf("items=%d want 2", len(got))
+	}
+	if got[0].ID != "sbx_01" || got[0].Name != "crabbox-blue" || got[0].Status != "running" {
+		t.Fatalf("unexpected item 0: %#v", got[0])
+	}
+	if got[1].Status != "stopped" {
+		t.Fatalf("unexpected item 1: %#v", got[1])
+	}
+}
+
+func TestParseIsloListJSONEmpty(t *testing.T) {
+	if got := parseIsloListJSON([]byte("")); len(got) != 0 {
+		t.Fatalf("items=%d want 0", len(got))
+	}
+	if got := parseIsloListJSON([]byte("   \n")); len(got) != 0 {
+		t.Fatalf("items=%d want 0", len(got))
+	}
+	if got := parseIsloListJSON([]byte("[]")); len(got) != 0 {
+		t.Fatalf("items=%d want 0", len(got))
+	}
+	if got := parseIsloListJSON([]byte("not-json")); got == nil {
+		t.Fatal("items=nil want empty slice for JSON []")
+	}
+}
+
+func TestParseIsloListJSONWrapped(t *testing.T) {
+	got := parseIsloListJSON([]byte(`{"sandboxes":[{"id":"a","name":"x","status":"running"}]}`))
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("unexpected: %#v", got)
+	}
+}
+
+func TestIsIsloProvider(t *testing.T) {
+	if !isIsloProvider("islo") {
+		t.Error("islo not recognized")
+	}
+	if !isIsloProvider("islo-sandbox") {
+		t.Error("islo-sandbox alias not recognized")
+	}
+	if isIsloProvider("hetzner") {
+		t.Error("hetzner falsely matched")
+	}
+	if isIsloProvider("blacksmith-testbox") {
+		t.Error("blacksmith falsely matched")
+	}
+}
+
+func TestResolveIsloLeaseID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if name, lease, err := resolveIsloLeaseID("isb_my-sandbox", "/repo", false); err != nil || name != "my-sandbox" || lease != "isb_my-sandbox" {
+		t.Fatalf("prefixed id name=%q lease=%q err=%v", name, lease, err)
+	}
+	if name, lease, err := resolveIsloLeaseID("plain-name", "/repo", false); err != nil || name != "plain-name" || lease != "isb_plain-name" {
+		t.Fatalf("plain name fallback name=%q lease=%q err=%v", name, lease, err)
+	}
+	if err := claimLeaseForRepoProvider("isb_crabbox-abc", "Blue Lobster", isloProvider, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	name, lease, err := resolveIsloLeaseID("blue-lobster", "/repo", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease != "isb_crabbox-abc" || name != "crabbox-abc" {
+		t.Fatalf("slug resolution: name=%q lease=%q", name, lease)
+	}
+	if _, _, err := resolveIsloLeaseID("blue-lobster", "/other", false); err == nil || !strings.Contains(err.Error(), "use --reclaim") {
+		t.Fatalf("expected repo claim error, got %v", err)
+	}
+	if name, lease, err := resolveIsloLeaseID("blue-lobster", "/other", true); err != nil || name != "crabbox-abc" || lease != "isb_crabbox-abc" {
+		t.Fatalf("reclaim path name=%q lease=%q err=%v", name, lease, err)
+	}
+}
+
+func TestIsloRejectsSyncOnly(t *testing.T) {
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err := app.isloRun(context.Background(), baseConfig(), Repo{Root: "/repo"}, isloRunOptions{SyncOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "--sync-only is not supported") {
+		t.Fatalf("expected sync-only rejection, got %v", err)
+	}
+}
+
+func TestIsloOneShotRunRemovesClaimAfterStop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+	t.Setenv("XDG_STATE_HOME", home+"/.local/state")
+
+	original := isloCommandContext
+	calls := 0
+	var stopArgs []string
+	isloCommandContext = func(_ context.Context, _ string, args ...string) *exec.Cmd {
+		calls++
+		if len(args) >= 1 && args[0] == "rm" {
+			stopArgs = append([]string{}, args...)
+			return exec.Command("sh", "-c", "exit 0")
+		}
+		return exec.Command("sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() { isloCommandContext = original })
+
+	cfg := baseConfig()
+	cfg.Islo.Image = "docker.io/library/ubuntu:24.04"
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+
+	if err := app.isloRun(context.Background(), cfg, Repo{Root: "/repo"}, isloRunOptions{Command: []string{"true"}}); err != nil {
+		t.Fatal(err)
+	}
+	if calls < 3 {
+		t.Fatalf("islo calls=%d, want at least warmup/run/stop", calls)
+	}
+	if len(stopArgs) == 0 || stopArgs[0] != "rm" || stopArgs[len(stopArgs)-1] != "--force" {
+		t.Fatalf("expected rm --force in stop args, got %v", stopArgs)
+	}
+}

--- a/internal/cli/pool.go
+++ b/internal/cli/pool.go
@@ -17,7 +17,7 @@ func (a App) pool(ctx context.Context, args []string) error {
 
 func (a App) list(ctx context.Context, args []string) error {
 	fs := newFlagSet("list", a.Stderr)
-	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, or blacksmith-testbox")
+	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, blacksmith-testbox, or islo")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	targetFlags := registerTargetFlags(fs, defaultConfig())
 	if err := parseFlags(fs, args); err != nil {
@@ -33,6 +33,9 @@ func (a App) list(ctx context.Context, args []string) error {
 	}
 	if isBlacksmithProvider(cfg.Provider) {
 		return a.blacksmithList(ctx, cfg, *jsonOut)
+	}
+	if isIsloProvider(cfg.Provider) {
+		return a.isloList(ctx, cfg, *jsonOut)
 	}
 	if isStaticProvider(cfg.Provider) {
 		server, _, _, err := staticLease(cfg)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -27,7 +27,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	started := time.Now()
 	defaults := defaultConfig()
 	fs := newFlagSet("warmup", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, ssh, or blacksmith-testbox")
+	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, ssh, blacksmith-testbox, or islo")
 	profile := fs.String("profile", defaults.Profile, "profile")
 	class := fs.String("class", defaults.Class, "machine class")
 	serverType := fs.String("type", getenv("CRABBOX_SERVER_TYPE", ""), "provider server/instance type")
@@ -41,6 +41,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	timingJSON := fs.Bool("timing-json", false, "print final timing as JSON")
 	blacksmithFlags := registerBlacksmithFlags(fs, defaults)
+	isloFlags := registerIsloFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -73,6 +74,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 		cfg.IdleTimeout = *idleTimeout
 	}
 	applyBlacksmithFlagOverrides(&cfg, fs, blacksmithFlags)
+	applyIsloFlagOverrides(&cfg, fs, isloFlags)
 	if err := validateProviderTarget(cfg); err != nil {
 		return err
 	}
@@ -94,6 +96,12 @@ func (a App) warmup(ctx context.Context, args []string) error {
 			return exit(2, "--actions-runner is not supported for provider=%s; Blacksmith owns runner hydration", cfg.Provider)
 		}
 		return a.blacksmithWarmup(ctx, cfg, repo, *keep, *reclaim, *timingJSON)
+	}
+	if isIsloProvider(cfg.Provider) {
+		if *actionsRunner {
+			return exit(2, "--actions-runner is not supported for provider=%s; islo owns sandbox setup", cfg.Provider)
+		}
+		return a.isloWarmup(ctx, cfg, repo, *keep, *reclaim, *timingJSON)
 	}
 
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
@@ -146,7 +154,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	defaults := defaultConfig()
 	fs := newFlagSet("run", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, ssh, or blacksmith-testbox")
+	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, ssh, blacksmith-testbox, or islo")
 	profile := fs.String("profile", defaults.Profile, "profile")
 	class := fs.String("class", defaults.Class, "machine class")
 	serverType := fs.String("type", getenv("CRABBOX_SERVER_TYPE", ""), "provider server/instance type")
@@ -167,6 +175,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	timingJSON := fs.Bool("timing-json", false, "print final timing as JSON")
 	blacksmithFlags := registerBlacksmithFlags(fs, defaults)
+	isloFlags := registerIsloFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -213,6 +222,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		cfg.Results.JUnit = splitCommaList(*junitResults)
 	}
 	applyBlacksmithFlagOverrides(&cfg, fs, blacksmithFlags)
+	applyIsloFlagOverrides(&cfg, fs, isloFlags)
 	if err := validateProviderTarget(cfg); err != nil {
 		return err
 	}
@@ -231,6 +241,19 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	}
 	if isBlacksmithProvider(cfg.Provider) {
 		return a.blacksmithRun(ctx, cfg, repo, blacksmithRunOptions{
+			ID:          *leaseIDFlag,
+			Keep:        *keep,
+			Reclaim:     *reclaim,
+			SyncOnly:    *syncOnly,
+			Debug:       *debugSync,
+			ShellMode:   *shellMode,
+			Command:     command,
+			IdleTimeout: cfg.IdleTimeout,
+			TimingJSON:  *timingJSON,
+		})
+	}
+	if isIsloProvider(cfg.Provider) {
+		return a.isloRun(ctx, cfg, repo, isloRunOptions{
 			ID:          *leaseIDFlag,
 			Keep:        *keep,
 			Reclaim:     *reclaim,
@@ -1274,7 +1297,7 @@ func findServerByAlias(servers []Server, id string) (Server, string, error) {
 
 func (a App) stop(ctx context.Context, args []string) error {
 	fs := newFlagSet("stop", a.Stderr)
-	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, or blacksmith-testbox")
+	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, blacksmith-testbox, or islo")
 	targetFlags := registerTargetFlags(fs, defaultConfig())
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -1292,6 +1315,9 @@ func (a App) stop(ctx context.Context, args []string) error {
 	}
 	if isBlacksmithProvider(cfg.Provider) {
 		return a.blacksmithStop(ctx, cfg, fs.Arg(0))
+	}
+	if isIsloProvider(cfg.Provider) {
+		return a.isloStop(ctx, cfg, fs.Arg(0))
 	}
 	if coord, ok, err := newTargetCoordinatorClient(cfg); err != nil {
 		return err

--- a/internal/cli/screenshot.go
+++ b/internal/cli/screenshot.go
@@ -37,6 +37,9 @@ func (a App) screenshot(ctx context.Context, args []string) error {
 	if isBlacksmithProvider(cfg.Provider) {
 		return exit(2, "desktop screenshots are not supported for provider=%s; Blacksmith owns machine connectivity", cfg.Provider)
 	}
+	if isIsloProvider(cfg.Provider) {
+		return exit(2, "desktop screenshots are not supported for provider=%s; islo owns sandbox connectivity", cfg.Provider)
+	}
 	if *id == "" && !isStaticProvider(cfg.Provider) {
 		return exit(2, "usage: crabbox screenshot --id <lease-id-or-slug> [--output <path>]")
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -9,7 +9,7 @@ import (
 
 func (a App) status(ctx context.Context, args []string) error {
 	fs := newFlagSet("status", a.Stderr)
-	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, or blacksmith-testbox")
+	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, ssh, blacksmith-testbox, or islo")
 	id := fs.String("id", "", "lease id or slug")
 	wait := fs.Bool("wait", false, "wait until ready")
 	waitTimeout := fs.Duration("wait-timeout", 5*time.Minute, "maximum wait duration")
@@ -34,6 +34,9 @@ func (a App) status(ctx context.Context, args []string) error {
 	}
 	if isBlacksmithProvider(cfg.Provider) {
 		return a.blacksmithStatus(ctx, cfg, *id, *wait, *waitTimeout, *jsonOut)
+	}
+	if isIsloProvider(cfg.Provider) {
+		return a.isloStatus(ctx, cfg, *id, *wait, *waitTimeout, *jsonOut)
 	}
 	deadline := time.Now().Add(*waitTimeout)
 	for {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -82,7 +82,7 @@ func validateTargetConfig(cfg Config) error {
 }
 
 func validateProviderTarget(cfg Config) error {
-	if isStaticProvider(cfg.Provider) || isBlacksmithProvider(cfg.Provider) {
+	if isStaticProvider(cfg.Provider) || isBlacksmithProvider(cfg.Provider) || isIsloProvider(cfg.Provider) {
 		return nil
 	}
 	if cfg.Provider == "aws" && cfg.TargetOS == targetWindows && cfg.WindowsMode == windowsModeNormal {
@@ -104,7 +104,7 @@ func validateProviderTarget(cfg Config) error {
 }
 
 func newTargetCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
-	if isStaticProvider(cfg.Provider) {
+	if isStaticProvider(cfg.Provider) || isIsloProvider(cfg.Provider) {
 		return nil, false, nil
 	}
 	return newCoordinatorClient(cfg)

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -37,6 +37,9 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	if isBlacksmithProvider(cfg.Provider) {
 		return exit(2, "desktop/VNC is not supported for provider=%s; Blacksmith owns machine connectivity", cfg.Provider)
 	}
+	if isIsloProvider(cfg.Provider) {
+		return exit(2, "desktop/VNC is not supported for provider=%s; islo owns sandbox connectivity", cfg.Provider)
+	}
 	if *id == "" && !isStaticProvider(cfg.Provider) {
 		return exit(2, "usage: crabbox vnc --id <lease-id-or-slug>")
 	}


### PR DESCRIPTION
## Summary

Adds `provider: islo` (alias `islo-sandbox`) as a thin pass-through to the local [`islo`](https://islo.dev) CLI, modeled after the existing Blacksmith Testbox integration in `internal/cli/blacksmith.go`. Lets maintainers and AI agents target islo sandboxes the same way they target Blacksmith Testboxes today:

```sh
crabbox run --provider islo --id my-sandbox -- pnpm test
```

## Motivation

Crabbox already supports an "external CLI passthrough" backend (Blacksmith Testbox) that bypasses the broker and keeps auth/sync with the upstream tool. islo.dev fits the same shape: it owns auth, sandbox networking, repo cloning, and idle expiry, while Crabbox owns local YAML/env config, friendly slugs, repo claims, command quoting, and timing summaries. Mirroring the Blacksmith pattern gives users a consistent on-ramp without a worker integration.

## What changed

| crabbox op | islo invocation |
|---|---|
| `warmup` | `islo use <name> -- true` |
| `run` | `islo use <name> -- <cmd...>` (or `bash -lc '...'` when shell metas present) |
| `status` | `islo status <name> [-o json]` |
| `list` | `islo ls -o json` |
| `stop` | `islo rm <name> --force` |

- New `internal/cli/islo.go` with `isIsloProvider`, flag/config wiring, and the warmup/run/list/status/stop methods.
- `IsloConfig` struct + `islo:` YAML block + `CRABBOX_ISLO_*` env overrides in `internal/cli/config.go`.
- Provider dispatch added to `run.go`, `pool.go`, `status.go`, `capabilities.go`, `target.go`, `screenshot.go`, `vnc.go` next to the existing `isBlacksmithProvider` checks.
- Lease IDs use a synthetic `isb_<sandbox-name>` prefix in the claim store to disambiguate from `cbx_` and `tbx_`; the raw sandbox name is what flows to the islo CLI.
- Tests in `internal/cli/islo_test.go` and `internal/cli/config_test.go` mirror the Blacksmith table-driven style.
- Docs: new `docs/features/islo.md`, plus updates to `README.md`, `docs/features/providers.md`, `docs/source-map.md`, `docs/commands/run.md`, `docs/commands/warmup.md`.

## What is intentionally not changed

- **Cloudflare Worker is untouched.** Like Blacksmith, islo bypasses the broker. A worker-side provider would need a public islo API.
- **Auth stays with islo (`islo login`).** Crabbox does not hold or forward islo credentials.
- **`--sync-only`, `--checksum`, `--force-sync-large` are rejected** for `provider: islo` (mirrors blacksmith); islo owns sync via `--islo-source`.
- **`--actions-runner` is rejected** for `provider: islo` (mirrors blacksmith); islo owns sandbox setup.
- **`--desktop` and `--browser` are rejected** for `provider: islo` (mirrors blacksmith).
- **`openclaw.plugin.json` is unchanged.** The existing `crabbox_*` tools work uniformly across providers.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...` (all green; new `TestIslo*` cases plus extended `TestLoadConfigFromUserFile` and `TestEnvOverridesConfig` pass)
- [x] `gofmt -l $(git ls-files '*.go')` returns clean
- [x] `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- [x] `node scripts/check-docs-links.mjs` and `node scripts/check-command-docs.mjs` pass
- [x] Core coverage gate: 86.1% on the listed core files (above the 85% threshold)
- [ ] End-to-end smoke against a real `islo` install with `islo login` previously run:
  ```sh
  crabbox run --provider islo --islo-image docker.io/library/ubuntu:24.04 -- echo hello
  crabbox warmup --provider islo --islo-image docker.io/library/ubuntu:24.04
  crabbox list --provider islo --json
  crabbox stop --provider islo <name>
  ```

## Example config

```yaml
provider: islo
islo:
  image: docker.io/library/ubuntu:24.04
  source: github://openclaw/crabbox
  workdir: /workspace/crabbox
  gatewayProfile: default
  session: main
  idleTimeout: 90m
```

## Related

- `provider: blacksmith-testbox` precedent: https://github.com/openclaw/crabbox/blob/main/internal/cli/blacksmith.go
- Blacksmith feature doc: https://github.com/openclaw/crabbox/blob/main/docs/features/blacksmith-testbox.md
- islo.dev: https://islo.dev