### PR TITLE
fix: use target-aware AWS instance defaults

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -172,6 +172,7 @@ Brokered AWS credentials live as Worker secrets:
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN optional
+CRABBOX_AWS_MAC_HOST_ID required for brokered target=macos
 ```
 
 Direct fallback env is whatever the AWS SDK can resolve, such as:
@@ -296,6 +297,7 @@ HETZNER_TOKEN
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_SESSION_TOKEN optional
+CRABBOX_AWS_MAC_HOST_ID required for brokered target=macos
 CRABBOX_SHARED_TOKEN
 CRABBOX_GITHUB_CLIENT_ID
 CRABBOX_GITHUB_CLIENT_SECRET

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -95,6 +95,7 @@ CRABBOX_SHARED_TOKEN
 HETZNER_TOKEN
 AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
+CRABBOX_AWS_MAC_HOST_ID required for brokered target=macos
 ```
 
 Cost-control secrets and settings:

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,7 +59,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stdout, "ok      remote  %s\n%s\n", *id, out)
 	}
 	if os.Getenv("CRABBOX_SERVER_TYPE") == "" {
-		cfg.ServerType = serverTypeForProviderClass(cfg.Provider, cfg.Class)
+		applyServerTypeFlagOverrides(&cfg, fs, "")
 	}
 	useCoordinator := false
 	if coord, coordinatorConfigured, err := newTargetCoordinatorClient(cfg); err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,6 +23,20 @@ func applyCapacityMarketFlag(cfg *Config, fs *flag.FlagSet, market string) error
 	}
 }
 
+func applyServerTypeFlagOverrides(cfg *Config, fs *flag.FlagSet, serverType string) {
+	if flagWasSet(fs, "type") {
+		cfg.ServerType = serverType
+		cfg.ServerTypeExplicit = true
+		return
+	}
+	if cfg.ServerTypeExplicit {
+		return
+	}
+	if cfg.ServerType == "" || flagWasSet(fs, "provider") || flagWasSet(fs, "class") || flagWasSet(fs, "target") {
+		cfg.ServerType = serverTypeForConfig(*cfg)
+	}
+}
+
 func (a App) warmup(ctx context.Context, args []string) error {
 	started := time.Now()
 	defaults := defaultConfig()
@@ -56,16 +70,10 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
-	if flagWasSet(fs, "type") {
-		cfg.ServerType = *serverType
-		cfg.ServerTypeExplicit = true
-	}
 	if err := applyCapacityMarketFlag(&cfg, fs, *market); err != nil {
 		return err
 	}
-	if cfg.ServerType == "" || ((flagWasSet(fs, "provider") || flagWasSet(fs, "class")) && !flagWasSet(fs, "type")) {
-		cfg.ServerType = serverTypeForProviderClass(cfg.Provider, *class)
-	}
+	applyServerTypeFlagOverrides(&cfg, fs, *serverType)
 	if flagWasSet(fs, "ttl") {
 		cfg.TTL = *ttl
 	}
@@ -190,16 +198,10 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
-	if flagWasSet(fs, "type") {
-		cfg.ServerType = *serverType
-		cfg.ServerTypeExplicit = true
-	}
 	if err := applyCapacityMarketFlag(&cfg, fs, *market); err != nil {
 		return err
 	}
-	if cfg.ServerType == "" || ((flagWasSet(fs, "provider") || flagWasSet(fs, "class")) && !flagWasSet(fs, "type")) {
-		cfg.ServerType = serverTypeForProviderClass(cfg.Provider, *class)
-	}
+	applyServerTypeFlagOverrides(&cfg, fs, *serverType)
 	if flagWasSet(fs, "ttl") {
 		cfg.TTL = *ttl
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -133,6 +133,86 @@ func TestApplyCapacityMarketFlag(t *testing.T) {
 	}
 }
 
+func TestApplyServerTypeFlagOverridesUsesTargetAwareAWSDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "macos",
+			args: []string{"--provider", "aws", "--target", "macos", "--class", "standard"},
+			want: "mac2.metal",
+		},
+		{
+			name: "windows",
+			args: []string{"--provider", "aws", "--target", "windows", "--class", "standard"},
+			want: "m7i.large",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Provider:    "aws",
+				TargetOS:    targetLinux,
+				WindowsMode: windowsModeNormal,
+				Class:       "beast",
+				ServerType:  "c7a.48xlarge",
+			}
+			fs := newFlagSet("test", io.Discard)
+			provider := fs.String("provider", cfg.Provider, "")
+			class := fs.String("class", cfg.Class, "")
+			serverType := fs.String("type", "", "")
+			targetFlags := registerTargetFlags(fs, cfg)
+			if err := parseFlags(fs, tt.args); err != nil {
+				t.Fatal(err)
+			}
+			cfg.Provider = *provider
+			cfg.Class = *class
+			if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
+				t.Fatal(err)
+			}
+			applyServerTypeFlagOverrides(&cfg, fs, *serverType)
+			if cfg.ServerType != tt.want {
+				t.Fatalf("serverType=%q want %q", cfg.ServerType, tt.want)
+			}
+			if cfg.ServerTypeExplicit {
+				t.Fatal("ServerTypeExplicit=true, want false")
+			}
+		})
+	}
+}
+
+func TestApplyServerTypeFlagOverridesPreservesExplicitType(t *testing.T) {
+	cfg := Config{
+		Provider:    "aws",
+		TargetOS:    targetLinux,
+		WindowsMode: windowsModeNormal,
+		Class:       "beast",
+		ServerType:  "c7a.48xlarge",
+	}
+	fs := newFlagSet("test", io.Discard)
+	provider := fs.String("provider", cfg.Provider, "")
+	class := fs.String("class", cfg.Class, "")
+	serverType := fs.String("type", "", "")
+	targetFlags := registerTargetFlags(fs, cfg)
+	if err := parseFlags(fs, []string{"--provider", "aws", "--target", "macos", "--class", "standard", "--type", "mac1.metal"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Provider = *provider
+	cfg.Class = *class
+	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
+		t.Fatal(err)
+	}
+	applyServerTypeFlagOverrides(&cfg, fs, *serverType)
+	if cfg.ServerType != "mac1.metal" {
+		t.Fatalf("serverType=%q want mac1.metal", cfg.ServerType)
+	}
+	if !cfg.ServerTypeExplicit {
+		t.Fatal("ServerTypeExplicit=false, want true")
+	}
+}
+
 func TestCommandNeedsHydrationHint(t *testing.T) {
 	if !commandNeedsHydrationHint([]string{"env NODE_OPTIONS=--max-old-space-size=4096 pnpm test"}, true) {
 		t.Fatal("expected shell pnpm command to need hydration hint")


### PR DESCRIPTION
## Summary
- recalculate default provider instance type after `--target`, `--provider`, or `--class` flag overrides
- fixes `--provider aws --target macos --class standard` preferring Linux `c7a.8xlarge` instead of `mac2.metal`
- keeps explicit `--type` / `CRABBOX_SERVER_TYPE` behavior unchanged
- documents `CRABBOX_AWS_MAC_HOST_ID` as required broker config for `target=macos`

## Root Cause
`loadConfig()` resolves `serverType` before command flags are applied. `run` and `warmup` recalculated the type after `--provider` or `--class`, but used `serverTypeForProviderClass`, which ignores target OS. That made macOS and Windows requests inherit Linux AWS defaults when flags changed class/provider/target.

## AWS Mac Proof
Before this PR, the merged local binary sent the wrong preferred type:

```text
coordinator lease class=standard preferred_type=c7a.8xlarge ...
coordinator POST /v1/leases: http 500: {"error":"c7a.8xlarge: aws target=macos requires CRABBOX_AWS_MAC_HOST_ID"}
```

With this branch binary, the CLI sends the correct Mac type:

```text
recording run run_0abf1aef651e
coordinator lease class=standard preferred_type=mac2.metal keep=false slug=brisk-crab idle_timeout=15m0s ttl=45m0s
coordinator POST /v1/leases: http 500: {"error":"mac2.metal: aws target=macos requires CRABBOX_AWS_MAC_HOST_ID"}
```

That means the CLI selection bug is fixed. Full AWS Mac leasing is still blocked on infra: the Cloudflare Worker needs `CRABBOX_AWS_MAC_HOST_ID` set to an allocated EC2 Mac Dedicated Host. I could not verify or set it locally because Wrangler has no `CLOUDFLARE_API_TOKEN` in this shell, and local AWS credentials return `InvalidClientTokenId`.

## Validation
- `go test ./internal/cli -run 'TestApplyServerTypeFlagOverrides|TestApplyCapacityMarketFlag|TestValidateProviderTarget|TestVersion'`
- `go test ./internal/cli -run TestAWSServerTypeForClass`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
