### PR TITLE
fix(portal): polish run detail layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fixed portal Windows target badges to show compact `win` and `win (wsl2)` labels instead of `windows / normal`.
 - Fixed portal access and time columns to use compact capability icons, relative time labels, and sortable time metadata instead of wide action buttons and Zulu timestamps.
 - Fixed lease detail layout so local commands live inside the access panel instead of forcing a separate full-width commands section above recent runs.
+- Fixed portal run detail layout density, responsive action alignment, and run telemetry readability so long-lived run pages fit operator viewports cleanly.
 - Fixed Windows WebVNC credential handling so generated portal links preserve special characters and managed TightVNC sessions copy service passwords into the logged-in user's registry profile.
 - Fixed managed Linux browser setup so Chrome/Chromium launches skip first-run and default-browser prompts.
 - Fixed managed Linux browser cloud-init setup so Chrome/Chromium policy and wrapper generation cannot break YAML parsing.

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -214,7 +214,7 @@ export function portalRunDetail(
         `,
       })}
       <section class="detail-grid">
-        <div class="panel detail-card">
+        <div class="panel detail-card run-summary-card">
           <div class="section-head">
             <h2>run</h2>
             <span class="pill" data-tone="${stateTone}">${escapeHTML(run.state)}</span>
@@ -233,7 +233,7 @@ export function portalRunDetail(
             ${runTelemetryRows(run.telemetry)}
           </dl>
         </div>
-        <div class="panel detail-card">
+        <div class="panel detail-card run-artifact-card">
           <div class="section-head">
             <h2>artifacts</h2>
             <span>${run.results ? "junit" : "logs"}</span>
@@ -1100,6 +1100,12 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .bridge-row small { display:block; color:var(--muted); margin-top:2px; }
     .access-commands { display:grid; gap:8px; padding:10px; border-top:1px solid var(--line-soft); }
     .run-artifacts { display:grid; gap:8px; padding:10px; }
+    .run-shell .detail-grid { grid-template-columns:minmax(0,1fr) minmax(260px,0.42fr); }
+    .run-shell .meta-grid { grid-template-columns:repeat(3,minmax(0,1fr)); }
+    .run-shell .meta-grid div { padding:6px 10px; }
+    .run-shell .meta-grid dt { margin-bottom:2px; font-size:10px; }
+    .run-shell .meta-grid dd { font-size:13px; }
+    .run-artifact-card .run-artifacts { gap:6px; padding:8px; }
     .result-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:0; margin:4px -14px -14px; border-top:1px solid var(--line-soft); }
     .result-grid div { padding:8px 10px; border-bottom:1px solid var(--line-soft); }
     .result-grid dt { color:var(--muted); font-size:11px; text-transform:uppercase; margin-bottom:3px; }

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -230,8 +230,8 @@ export function portalRunDetail(
             ${metaRow("started", shortTime(run.startedAt))}
             ${metaRow("duration", formatDuration(run.durationMs))}
             ${metaRow("log", run.logBytes > 0 ? formatBytes(run.logBytes) : "empty")}
-            ${runTelemetryRows(run.telemetry)}
           </dl>
+          ${runTelemetryPanel(run.telemetry)}
         </div>
         <div class="panel detail-card run-artifact-card">
           <div class="section-head">
@@ -882,34 +882,43 @@ function formatTelemetryValue(value: number, unit: string): string {
   return value.toFixed(2);
 }
 
-function runTelemetryRows(telemetry: RunRecord["telemetry"]): string {
+function runTelemetryPanel(telemetry: RunRecord["telemetry"]): string {
   if (!telemetry) {
-    return "";
+    return `<div class="run-telemetry-grid"><div class="run-metric" data-muted="true"><span>telemetry</span><strong>not sampled</strong><small>no box metrics</small></div></div>`;
   }
   const current = telemetry.end || telemetry.start;
   if (!current) {
-    return "";
+    return `<div class="run-telemetry-grid"><div class="run-metric" data-muted="true"><span>telemetry</span><strong>not sampled</strong><small>no box metrics</small></div></div>`;
   }
-  return [
-    metaRow("box load", telemetryLoad(current)),
-    metaRow(
-      "box memory",
-      telemetryStorage(current.memoryUsedBytes, current.memoryTotalBytes, current.memoryPercent),
-    ),
-    metaRow(
-      "box disk",
-      telemetryStorage(current.diskUsedBytes, current.diskTotalBytes, current.diskPercent),
-    ),
-    metaRow(
-      "memory delta",
-      telemetryDelta(telemetry.start?.memoryUsedBytes, telemetry.end?.memoryUsedBytes),
-    ),
-    metaRow(
-      "disk delta",
-      telemetryDelta(telemetry.start?.diskUsedBytes, telemetry.end?.diskUsedBytes),
-    ),
-    metaRow("sampled", current.capturedAt ? relativeTime(current.capturedAt) : undefined),
-  ].join("");
+  const memory = telemetryStorage(
+    current.memoryUsedBytes,
+    current.memoryTotalBytes,
+    current.memoryPercent,
+  );
+  const disk = telemetryStorage(current.diskUsedBytes, current.diskTotalBytes, current.diskPercent);
+  return `<div class="run-telemetry-grid">
+    ${runMetric("load", telemetryLoad(current), "1 / 5 / 15")}
+    ${runMetric("memory", memory, telemetryDeltaLabel("delta", telemetry.start?.memoryUsedBytes, telemetry.end?.memoryUsedBytes))}
+    ${runMetric("disk", disk, telemetryDeltaLabel("delta", telemetry.start?.diskUsedBytes, telemetry.end?.diskUsedBytes))}
+    ${runMetric("sampled", current.capturedAt ? relativeTime(current.capturedAt) : undefined, current.capturedAt || "no timestamp")}
+  </div>`;
+}
+
+function runMetric(label: string, value: string | undefined, detail: string | undefined): string {
+  return `<div class="run-metric">
+    <span>${escapeHTML(label)}</span>
+    <strong>${escapeHTML(value || "-")}</strong>
+    <small>${escapeHTML(detail || "")}</small>
+  </div>`;
+}
+
+function telemetryDeltaLabel(
+  label: string,
+  start: number | undefined,
+  end: number | undefined,
+): string | undefined {
+  const delta = telemetryDelta(start, end);
+  return delta ? `${label} ${delta}` : undefined;
 }
 
 function runTelemetryCell(telemetry: RunRecord["telemetry"]): string {
@@ -1106,6 +1115,13 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .run-shell .meta-grid dt { margin-bottom:2px; font-size:10px; }
     .run-shell .meta-grid dd { font-size:13px; }
     .run-artifact-card .run-artifacts { gap:6px; padding:8px; }
+    .run-telemetry-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); border-top:1px solid var(--line-soft); background:var(--panel-2); }
+    .run-metric { min-width:0; padding:7px 10px; border-right:1px solid var(--line-soft); }
+    .run-metric:last-child { border-right:0; }
+    .run-metric span { display:block; color:var(--muted); font-size:10px; font-weight:700; letter-spacing:0.04em; text-transform:uppercase; }
+    .run-metric strong { display:block; margin-top:2px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:13px; }
+    .run-metric small { display:block; margin-top:1px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); font-size:11px; }
+    .run-metric[data-muted="true"] { grid-column:1 / -1; }
     .result-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:0; margin:4px -14px -14px; border-top:1px solid var(--line-soft); }
     .result-grid div { padding:8px 10px; border-bottom:1px solid var(--line-soft); }
     .result-grid dt { color:var(--muted); font-size:11px; text-transform:uppercase; margin-bottom:3px; }

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1080,7 +1080,8 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .top p,.muted,.empty { color:var(--muted); }
     .panel { min-width:0; border:1px solid var(--line); border-radius:8px; background:var(--panel); overflow:hidden; }
     .section-head { display:flex; justify-content:space-between; align-items:center; min-height:34px; padding:7px 10px; border-bottom:1px solid var(--line); }
-    .section-actions { display:flex; align-items:center; justify-content:flex-end; gap:8px; color:var(--muted); }
+    .section-actions { display:flex; align-items:center; justify-content:flex-end; gap:8px; min-width:0; color:var(--muted); }
+    .section-actions span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
     .button { display:inline-flex; align-items:center; justify-content:center; min-height:28px; padding:0 10px; border-radius:7px; background:var(--accent); color:#001018; text-decoration:none; font-size:12px; font-weight:700; white-space:nowrap; }
     .button.secondary { background:transparent; color:var(--fg); border:1px solid var(--line); font-weight:500; }
     .button.secondary:hover { background:#1b1f24; border-color:#3a4046; }
@@ -1108,13 +1109,15 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .bridge-row { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:8px; align-items:center; padding:9px 10px; border-bottom:1px solid var(--line-soft); }
     .bridge-row small { display:block; color:var(--muted); margin-top:2px; }
     .access-commands { display:grid; gap:8px; padding:10px; border-top:1px solid var(--line-soft); }
-    .run-artifacts { display:grid; gap:8px; padding:10px; }
+    .run-artifacts { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; padding:10px; }
     .run-shell .detail-grid { grid-template-columns:minmax(0,1fr) minmax(260px,0.42fr); }
     .run-shell .meta-grid { grid-template-columns:repeat(3,minmax(0,1fr)); }
     .run-shell .meta-grid div { padding:6px 10px; }
     .run-shell .meta-grid dt { margin-bottom:2px; font-size:10px; }
     .run-shell .meta-grid dd { font-size:13px; }
     .run-artifact-card .run-artifacts { gap:6px; padding:8px; }
+    .run-artifact-card .button { width:100%; }
+    .run-artifact-card .result-grid { grid-column:1 / -1; }
     .run-telemetry-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); border-top:1px solid var(--line-soft); background:var(--panel-2); }
     .run-metric { min-width:0; padding:7px 10px; border-right:1px solid var(--line-soft); }
     .run-metric:last-child { border-right:0; }
@@ -1190,7 +1193,7 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .vnc-meta p { display:inline-flex; align-items:center; gap:8px; color:var(--muted); font-size:12px; min-width:0; overflow:hidden; }
     .vnc-meta .vnc-id { font-family:var(--mono); font-size:11px; opacity:0.85; }
     .vnc-meta .vnc-dot { width:3px; height:3px; border-radius:50%; background:#3a4046; flex-shrink:0; }
-    .portal-actions { display:flex; align-items:center; gap:6px; flex-shrink:0; }
+    .portal-actions { display:flex; align-items:center; justify-content:flex-end; gap:6px; flex-shrink:0; flex-wrap:wrap; }
     .status-pill { display:inline-flex; align-items:center; gap:8px; height:32px; padding:0 12px 0 11px; border-radius:8px; background:var(--panel-2); border:1px solid var(--line); font-size:12px; color:var(--muted); white-space:nowrap; transition:color 0.2s, border-color 0.2s; }
     .status-pill::before { content:""; width:8px; height:8px; border-radius:50%; background:currentColor; box-shadow:0 0 0 3px color-mix(in srgb, currentColor 18%, transparent); flex-shrink:0; }
     .status-pill[data-tone="ok"] { color:var(--ok); border-color:color-mix(in srgb, var(--ok) 35%, var(--line)); }
@@ -1216,6 +1219,11 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
     .command-row small { display:block; color:var(--muted); margin-bottom:4px; text-transform:uppercase; font-size:11px; }
     .command-row code { min-width:0; white-space:pre; }
     .error { margin-top:20vh; padding:24px; display:grid; gap:12px; }
+    @media (max-width: 980px) {
+      .run-shell .detail-grid { grid-template-columns:1fr; }
+      .run-shell .meta-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+      .run-telemetry-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+    }
     @media (max-width: 760px) {
       main { width:min(100vw - 20px, 1180px); padding:10px 0; }
       .portal-shell { width:min(100vw - 12px, 1180px); height:auto; min-height:100dvh; overflow:visible; }
@@ -1223,6 +1231,9 @@ function html(title: string, body: string, status = 200, nonce = ""): Response {
       th:nth-child(4),td:nth-child(4),th:nth-child(6),td:nth-child(6){ display:none; }
       .detail-grid { grid-template-columns:1fr; }
       .meta-grid { grid-template-columns:1fr; }
+      .run-shell .meta-grid { grid-template-columns:1fr; }
+      .run-telemetry-grid { grid-template-columns:1fr; }
+      .run-artifacts { grid-template-columns:1fr; }
       .result-grid { grid-template-columns:1fr; }
       .bridge-row { grid-template-columns:1fr; align-items:start; }
       .table-panel { max-height:none; }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -964,6 +964,10 @@ describe("fleet lease identity and idle", () => {
     expect(runPage.headers.get("content-type")).toBe("text/html; charset=utf-8");
     const runBody = await runPage.text();
     expect(runBody).toContain('class="portal-shell run-shell"');
+    expect(runBody).toContain('class="panel detail-card run-summary-card"');
+    expect(runBody).toContain(
+      ".run-shell .meta-grid { grid-template-columns:repeat(3,minmax(0,1fr)); }",
+    );
     expect(runBody).toContain("<h1>🦀 crabbox</h1>");
     expect(runBody).toContain(
       ".portal-header-meta { flex:1 1 auto; min-width:0; overflow:hidden; }",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -986,6 +986,11 @@ describe("fleet lease identity and idle", () => {
     );
     expect(runBody).toContain('data-filter-tags="command failed"');
     expect(runBody).toContain('class="run-telemetry-grid"');
+    expect(runBody).toContain(".run-artifact-card .button { width:100%; }");
+    expect(runBody).toContain("@media (max-width: 980px)");
+    expect(runBody).toContain(
+      ".run-telemetry-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }",
+    );
     expect(runBody).toContain("<span>load</span>");
     expect(runBody).toContain("<strong>0.42 / 0.24 / 0.12</strong>");
     expect(runBody).toContain("<strong>1.5 KiB / 2.0 KiB (75%)</strong>");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -985,9 +985,11 @@ describe("fleet lease identity and idle", () => {
       'data-filter-buttons="run:run,command:command,sync:sync,stdout:stdout,stderr:stderr,all:all"',
     );
     expect(runBody).toContain('data-filter-tags="command failed"');
-    expect(runBody).toContain("<dt>box load</dt><dd>0.42 / 0.24 / 0.12</dd>");
-    expect(runBody).toContain("<dt>box memory</dt><dd>1.5 KiB / 2.0 KiB (75%)</dd>");
-    expect(runBody).toContain("<dt>memory delta</dt><dd>+512 B</dd>");
+    expect(runBody).toContain('class="run-telemetry-grid"');
+    expect(runBody).toContain("<span>load</span>");
+    expect(runBody).toContain("<strong>0.42 / 0.24 / 0.12</strong>");
+    expect(runBody).toContain("<strong>1.5 KiB / 2.0 KiB (75%)</strong>");
+    expect(runBody).toContain("<small>delta +512 B</small>");
     expect(runBody).toContain("table-search");
     expect(runBody).toContain("renders detail");
     expect(runBody).toContain("/portal/leases/cbx_000000000001");


### PR DESCRIPTION
## Summary
- tighten the run detail summary grid and artifact panel
- move run box telemetry into compact metric strips
- improve run detail actions and responsive collapse behavior

## Verification
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm test --prefix worker -- fleet.test.ts
- npm run build --prefix worker