### PR TITLE
Add E2B provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `provider: azure` for managed Azure Linux and native Windows SSH leases, including direct and brokered provisioning, shared Azure networking, SKU fallback, Azure docs, and cleanup support. Thanks @jwmoss.
+- Added `provider: e2b` for delegated E2B sandbox runs using E2B sandbox REST/envd APIs. Thanks @zozo123.
 - Added an authenticated coordinator control WebSocket for low-latency run attach streams and lease heartbeats, with HTTP polling/heartbeat fallback for older brokers. Thanks @vincentkoc.
 - Added rescue-first desktop/WebVNC failure output that names the failing layer and prints exact `rescue:` or native VNC fallback commands when bridges, viewers, browser launches, VNC targets, or input stacks hang.
 - Added collaborative WebVNC observer mode, with one active controller, read-only observers, and a portal takeover button that shows who is controlling the session.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crabbox is an open-source remote testbox runner for maintainers and AI agents. L
 crabbox run -- pnpm test
 ```
 
-Behind that single command: a Go CLI on your laptop, a Cloudflare Worker broker that owns provider credentials and lease state, and a managed runner on Hetzner Cloud, AWS EC2, or Azure. Azure supports managed Linux and native Windows VMs. Crabbox can also wrap Blacksmith Testboxes when you choose `provider: blacksmith-testbox`, use Daytona or Islo sandboxes for direct-provider workflows, or use `provider: ssh` for existing macOS and Windows targets.
+Behind that single command: a Go CLI on your laptop, a Cloudflare Worker broker that owns provider credentials and lease state, and a managed runner on Hetzner Cloud, AWS EC2, or Azure. Azure supports managed Linux and native Windows VMs. Crabbox can also wrap Blacksmith Testboxes when you choose `provider: blacksmith-testbox`, use Daytona, Islo, or E2B sandboxes for direct-provider workflows, or use `provider: ssh` for existing macOS and Windows targets.
 
 ---
 
@@ -77,7 +77,7 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Azure Linux and native Windows.** `provider: azure` provisions Linux and native Windows VMs in a configurable Azure subscription using `DefaultAzureCredential` in direct mode or service-principal secrets in the broker. Crabbox creates a shared resource group, vnet, subnet, and NSG on first use, then per-lease public IPs, NICs, and VMs. Linux uses cloud-init; Windows uses VM Agent Custom Script Extension to install OpenSSH/Git and configure the Crabbox user.
 - **macOS and Windows static hosts.** `provider: ssh` reuses existing machines; it does not create macOS or Windows Crabbox boxes. macOS and Windows WSL2 use the POSIX rsync path; native Windows uses PowerShell plus tar archive sync.
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, config conventions, and portal visibility for active external runners.
-- **Daytona and Islo sandboxes.** Set `provider: daytona` for Daytona SDK/toolbox execution from a snapshot with explicit SSH access when needed, or `provider: islo` for delegated Islo sandbox execution through the Islo Go SDK.
+- **Daytona, Islo, and E2B sandboxes.** Set `provider: daytona` for Daytona SDK/toolbox execution from a snapshot with explicit SSH access when needed, `provider: islo` for delegated Islo sandbox execution through the Islo Go SDK, or `provider: e2b` for delegated E2B sandbox execution through E2B sandbox APIs.
 - **Trusted AWS images.** Operators can create AMIs from active brokered AWS leases and promote a known-good image as the coordinator default.
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type.
 - **GitHub Actions hydration.** `crabbox actions hydrate` registers a leased box as an ephemeral Actions runner, so the repo's own workflow installs runtimes, services, and secrets. Crabbox does not parse Actions YAML.
@@ -195,6 +195,15 @@ Optional Islo sandbox:
 provider: islo
 islo:
   image: docker.io/library/ubuntu:24.04
+  workdir: crabbox
+```
+
+Optional E2B sandbox:
+
+```yaml
+provider: e2b
+e2b:
+  template: base
   workdir: crabbox
 ```
 

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -9,6 +9,7 @@ crabbox list --provider ssh --target macos --static-host mac-studio.local
 crabbox list --provider blacksmith-testbox
 crabbox list --provider daytona
 crabbox list --provider islo
+crabbox list --provider e2b
 crabbox list --json
 ```
 
@@ -29,13 +30,13 @@ owners as `stuck`, exposes a copyable local stop command, and links each row to
 a visibility-only runner detail page. Missing runners from later syncs are
 marked stale rather than treated as Crabbox leases.
 
-In `daytona` and `islo` modes, rendering is core-owned: human output and `--json`
-use the normalized Crabbox lease view.
+In `daytona`, `islo`, and `e2b` modes, rendering is core-owned: human output
+and `--json` use the normalized Crabbox lease view.
 
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo
+--provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -43,4 +44,6 @@ Flags:
 --static-port <port>
 --static-work-root <path>
 --json
+--e2b-api-url <url>
+--e2b-domain <domain>
 ```

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -15,6 +15,7 @@ crabbox run --id cbx_abcdef123456 --junit junit.xml -- go test ./...
 crabbox run --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job test -- pnpm test
 crabbox run --provider daytona --daytona-snapshot crabbox-ready -- pnpm test
 crabbox run --provider islo --islo-image docker.io/library/ubuntu:24.04 -- pnpm test
+crabbox run --provider e2b --e2b-template base -- pnpm test
 crabbox run --provider ssh --target macos --static-host mac-studio.local -- xcodebuild test
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local -- dotnet test
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local --shell 'Write-Output ("BROWSER=" + $env:BROWSER)'
@@ -34,6 +35,12 @@ With `--provider islo`, `--id` accepts an `isb_<crabbox-sandbox-name>` lease ID,
 a Crabbox-created sandbox name, or a local Crabbox slug. Islo owns sandbox
 workspace setup and command execution, so sync is delegated and the final timing
 summary reports `sync=delegated`.
+
+With `--provider e2b`, `--id` accepts a Crabbox `cbx_...` lease ID, local slug,
+or Crabbox-owned E2B sandbox ID in raw or `e2b_<sandboxID>` form. Crabbox uploads
+the sync archive through E2B file APIs, extracts it in the sandbox, and runs the
+command through E2B process APIs. The final timing summary reports
+`sync=delegated`.
 
 When the lease has been hydrated by `crabbox actions hydrate`, `run` reads the remote marker under `$HOME/.crabbox/actions`, syncs into the workflow's `$GITHUB_WORKSPACE`, and sources the non-secret env file written by the workflow. That preserves the setup the workflow performed: checkout path, installed dependencies, service containers, caches, runner temp/toolcache paths, and any project-specific preparation. GitHub secrets and OIDC request tokens remain workflow-step scoped unless the project explicitly persists its own short-lived credentials.
 
@@ -89,7 +96,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo
+--provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -126,6 +133,11 @@ Flags:
 --blacksmith-workflow <file|name|id>
 --blacksmith-job <job>
 --blacksmith-ref <ref>
+--e2b-api-url <url>
+--e2b-domain <domain>
+--e2b-template <template-id>
+--e2b-workdir <path>
+--e2b-user <user>
 ```
 
 `--idle-timeout` controls inactivity expiry, default `30m`. `--ttl` remains the maximum wall-clock lifetime, default `90m`.

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -9,6 +9,7 @@ crabbox status --id blue-lobster --wait --wait-timeout 10m
 crabbox status --id blue-lobster --json
 crabbox status --provider daytona --id blue-lobster
 crabbox status --provider islo --id blue-lobster
+crabbox status --provider e2b --id blue-lobster
 crabbox status --provider ssh --target macos --static-host mac-studio.local
 ```
 
@@ -17,7 +18,10 @@ crabbox status --provider ssh --target macos --static-host mac-studio.local
 normalized Crabbox status view from `blacksmith testbox list --all`. In
 `daytona` mode it resolves Crabbox labels and sandbox state through Daytona
 APIs. In `islo` mode it accepts an `isb_...` ID, Crabbox-created sandbox name,
-or local slug and renders SDK status through the core status view. In
+or local slug and renders SDK status through the core status view. In `e2b`
+mode it accepts a Crabbox lease ID, local slug, or Crabbox-owned E2B sandbox ID
+in raw or `e2b_<sandboxID>` form and renders E2B sandbox state through the core
+status view. In
 `provider=ssh` mode `--id` is optional and resolves the configured static target
 or local claim. Plain status is read-only; `--wait` touches the lease while
 waiting for Crabbox brokered leases.
@@ -26,7 +30,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo
+--provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -37,6 +41,8 @@ Flags:
 --wait
 --wait-timeout <duration>
 --json
+--e2b-api-url <url>
+--e2b-domain <domain>
 ```
 
 Human and JSON output include the selected network. With Tailscale metadata,

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -6,20 +6,23 @@
 crabbox stop blue-lobster
 crabbox stop --provider daytona blue-lobster
 crabbox stop --provider islo blue-lobster
+crabbox stop --provider e2b blue-lobster
 crabbox stop --provider ssh --static-host mac-studio.local mac-studio.local
 ```
 
 `crabbox release` remains as a compatibility alias.
-The argument accepts the stable `cbx_...` ID or an active friendly slug. In `blacksmith-testbox` mode it accepts a `tbx_...` ID or local slug and forwards to `blacksmith testbox stop`. In `daytona` mode it deletes the Daytona sandbox. In `islo` mode it accepts an `isb_...` ID, Crabbox-created sandbox name, or local slug and deletes the Islo sandbox. In `provider=ssh` mode it removes the local claim for the configured static target; it never deletes the host.
+The argument accepts the stable `cbx_...` ID or an active friendly slug. In `blacksmith-testbox` mode it accepts a `tbx_...` ID or local slug and forwards to `blacksmith testbox stop`. In `daytona` mode it deletes the Daytona sandbox. In `islo` mode it accepts an `isb_...` ID, Crabbox-created sandbox name, or local slug and deletes the Islo sandbox. In `e2b` mode it accepts a Crabbox lease ID, local slug, or Crabbox-owned E2B sandbox ID in raw or `e2b_<sandboxID>` form and deletes the E2B sandbox. In `provider=ssh` mode it removes the local claim for the configured static target; it never deletes the host.
 
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo
+--provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
 --static-user <user>
 --static-port <port>
 --static-work-root <path>
+--e2b-api-url <url>
+--e2b-domain <domain>
 ```

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -15,6 +15,7 @@ crabbox warmup --actions-runner
 crabbox warmup --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job test
 crabbox warmup --provider daytona --daytona-snapshot crabbox-ready
 crabbox warmup --provider islo --islo-image docker.io/library/ubuntu:24.04
+crabbox warmup --provider e2b --e2b-template base
 crabbox warmup --provider ssh --target macos --static-host mac-studio.local
 crabbox warmup --provider ssh --target windows --windows-mode normal --static-host win-dev.local --static-work-root 'C:\crabbox' --browser
 ```
@@ -31,6 +32,10 @@ them from output.
 With `--provider islo`, the canonical ID is
 `isb_<crabbox-sandbox-name>`. Crabbox stores a local slug, but Islo owns sandbox
 setup and command execution.
+
+With `--provider e2b`, the canonical ID is a Crabbox `cbx_...` lease backed by
+an E2B sandbox created from `e2b.template`. Crabbox stores a local slug and uses
+E2B file/process APIs for later `run` calls.
 
 With `--provider ssh`, warmup claims an existing static SSH host instead of
 creating cloud capacity. Use `--target macos`, `--target windows
@@ -77,7 +82,7 @@ On success, `warmup` prints a concise total duration line. Add `--timing-json` t
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo
+--provider hetzner|aws|azure|ssh|blacksmith-testbox|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>
@@ -108,6 +113,11 @@ Flags:
 --blacksmith-workflow <file|name|id>
 --blacksmith-job <job>
 --blacksmith-ref <ref>
+--e2b-api-url <url>
+--e2b-domain <domain>
+--e2b-template <template-id>
+--e2b-workdir <path>
+--e2b-user <user>
 ```
 
 `--idle-timeout` releases the lease after no touch for that duration, default `30m`. `--ttl` remains the maximum wall-clock lifetime, default `90m`.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -40,6 +40,7 @@ Read when:
 - [Blacksmith Testbox](blacksmith-testbox.md): delegated Testbox backend behavior.
 - [Daytona](daytona.md): Daytona SDK/toolbox sandbox leases with optional short-lived SSH access.
 - [Islo](islo.md): delegated Islo sandbox runs using the Islo Go SDK.
+- [E2B](e2b.md): delegated E2B sandbox runs using E2B sandbox APIs.
 
 ## Runners and reachability
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -153,6 +153,17 @@ daytona:
   apiKey: <daytona-api-key>      # prefer DAYTONA_API_KEY env
 ```
 
+### E2B
+
+```yaml
+provider: e2b
+e2b:
+  template: base
+  workdir: crabbox
+  apiUrl: https://api.e2b.app
+  domain: e2b.app
+```
+
 ### Sync
 
 ```yaml

--- a/docs/features/e2b.md
+++ b/docs/features/e2b.md
@@ -1,0 +1,60 @@
+# E2B
+
+Read when:
+
+- choosing `provider: e2b`;
+- reviewing delegated sandbox execution behavior;
+- changing E2B provider sync, status, or command streaming.
+
+`provider: e2b` delegates Linux sandbox lifecycle and command execution to E2B.
+Crabbox creates E2B sandboxes with Crabbox metadata, syncs the local
+Git-managed working set as a gzipped archive, and streams remote command output
+through E2B's process API.
+
+## Auth
+
+```sh
+export E2B_API_KEY=e2b_...
+```
+
+Optional overrides:
+
+```sh
+export E2B_API_URL=https://api.e2b.app
+export E2B_DOMAIN=e2b.app
+```
+
+## Config
+
+```yaml
+provider: e2b
+target: linux
+e2b:
+  template: base
+  workdir: crabbox
+  user: ""
+```
+
+Equivalent one-off flags:
+
+```sh
+crabbox warmup --provider e2b --e2b-template base
+crabbox run --provider e2b --e2b-workdir repo -- pnpm test
+crabbox status --provider e2b --id <slug>
+crabbox stop --provider e2b <slug>
+```
+
+## Behavior
+
+- `warmup` creates an E2B sandbox from `e2b.template`, stores Crabbox metadata,
+  and records a local `cbx_...` lease claim.
+- `run` creates or reuses a sandbox, syncs the manifest into
+  `/home/user/<e2b.workdir>` unless the workdir is absolute, streams
+  stdout/stderr, and returns the remote exit code.
+- `--sync-only` performs only the archive upload and extraction.
+- `--checksum` is rejected because E2B does not expose a Crabbox SSH target.
+- `list`, `status`, and `stop` operate only on Crabbox-owned E2B sandboxes.
+
+E2B is not an SSH lease backend today. Commands that require a Crabbox SSH
+target, such as `ssh`, `vnc`, `code`, and Actions runner hydration, should use
+Hetzner, AWS, static SSH, or Daytona instead.

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -28,6 +28,7 @@ Direct provider backends can also run without the Crabbox coordinator:
 ```text
 daytona    Daytona sandboxes with SDK/toolbox run and short-lived SSH access
 islo       Islo sandboxes with delegated command execution
+e2b        E2B sandboxes with delegated command execution
 ```
 
 ## Provider Pages
@@ -40,6 +41,7 @@ islo       Islo sandboxes with delegated command execution
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Testbox backend behavior.
 - [Daytona](../providers/daytona.md): Daytona SDK/toolbox sandbox leases.
 - [Islo](../providers/islo.md): delegated Islo sandbox execution.
+- [E2B](../providers/e2b.md): delegated E2B sandbox execution.
 - [Provider backends](../provider-backends.md): implementation guide for adding a new provider/backend/plugin.
 
 ## Hetzner Summary
@@ -141,6 +143,11 @@ Crabbox can use Islo sandboxes with `provider: islo`. Islo is a delegated run
 backend: the Islo Go SDK owns sandbox lifecycle and Crabbox streams command
 output from Islo's exec SSE endpoint. See [Islo](islo.md).
 
+Crabbox can use E2B sandboxes with `provider: e2b`. E2B is a delegated run
+backend: Crabbox creates E2B sandboxes, syncs a gzipped archive through the
+sandbox file API, and streams command output from E2B's process API. See
+[E2B](e2b.md).
+
 Static SSH targets:
 
 ```yaml
@@ -184,5 +191,6 @@ Related docs:
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md)
 - [Daytona](../providers/daytona.md)
 - [Islo](../providers/islo.md)
+- [E2B](../providers/e2b.md)
 - [Runner bootstrap](runner-bootstrap.md)
 - [Cost and usage](cost-usage.md)

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -18,6 +18,7 @@ static SSH provider for existing machines.
 | [Blacksmith Testbox](blacksmith-testbox.md) | delegated run | Linux | existing Blacksmith Testbox workflows |
 | [Daytona](daytona.md) | hybrid delegated run + SSH | Linux | Daytona snapshot sandboxes |
 | [Islo](islo.md) | delegated run | Linux | Islo-owned sandbox execution |
+| [E2B](e2b.md) | delegated run | Linux | E2B-owned sandbox execution |
 
 ## Shared Rules
 
@@ -52,6 +53,7 @@ Delegated providers do not use the Crabbox coordinator:
 - Blacksmith uses the authenticated Blacksmith CLI.
 - Daytona uses Daytona API and SDK/toolbox APIs.
 - Islo uses the Islo API and SDK auth.
+- E2B uses E2B's sandbox REST and envd APIs.
 
 ## Feature Matrix
 
@@ -64,6 +66,7 @@ Delegated providers do not use the Crabbox coordinator:
 | Blacksmith Testbox | yes | yes | no | no | no | yes |
 | Daytona | yes | yes | yes | no | archive via Daytona toolbox | no |
 | Islo | yes | yes | no | no | no | yes |
+| E2B | yes | yes | no | no | archive via E2B envd | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
 Use AWS, Hetzner, or Static SSH for that path.

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -1,0 +1,96 @@
+# E2B Provider
+
+Read when:
+
+- choosing `provider: e2b`;
+- configuring E2B templates or sandbox workdirs;
+- changing `internal/providers/e2b`.
+
+E2B is a delegated run provider. Crabbox uses E2B's public sandbox REST API for
+sandbox lifecycle and the sandbox envd APIs for file upload and command
+execution. E2B owns sandbox state and process transport; Crabbox owns local
+config, repo claims, sync manifests and guardrails, slugs, timing summaries, and
+normalized list/status rendering.
+
+## When To Use
+
+Use E2B when the remote Linux sandbox should be owned by E2B and commands can
+run through the E2B sandbox APIs. Use AWS, Hetzner, Static SSH, or Daytona when
+you need Crabbox SSH access.
+
+## Commands
+
+```sh
+crabbox warmup --provider e2b --e2b-template base
+crabbox run --provider e2b -- pnpm test
+crabbox run --provider e2b --id blue-lobster --shell 'pnpm install && pnpm test'
+crabbox status --provider e2b --id blue-lobster
+crabbox stop --provider e2b blue-lobster
+```
+
+## Auth
+
+```sh
+export E2B_API_KEY=e2b_...
+```
+
+`E2B_API_URL` or `e2b.apiUrl` can override the default
+`https://api.e2b.app`. `E2B_DOMAIN` or `e2b.domain` can override the default
+sandbox domain `e2b.app`.
+
+## Config
+
+```yaml
+provider: e2b
+target: linux
+e2b:
+  apiUrl: https://api.e2b.app
+  domain: e2b.app
+  template: base
+  workdir: crabbox
+  user: ""
+```
+
+Provider flags:
+
+```text
+--e2b-api-url
+--e2b-domain
+--e2b-template
+--e2b-workdir
+--e2b-user
+```
+
+## Lifecycle
+
+1. Create or resolve a Crabbox-owned E2B sandbox from `e2b.template`.
+2. Store Crabbox metadata and a local repo claim.
+3. Build the Crabbox sync manifest, upload a gzipped archive into `/tmp`, and
+   extract it into `/home/user/<e2b.workdir>` or an absolute configured workdir.
+4. Execute commands through E2B's process stream in that workdir.
+5. Delete the sandbox on release unless the lease is kept.
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: yes, archive sync through E2B file and command APIs.
+- Desktop/browser/code: no Crabbox VNC/code surface.
+- Actions hydration: no.
+- Coordinator: no.
+
+## Gotchas
+
+- IDs can be Crabbox slugs, `cbx_...` lease IDs, or E2B sandbox IDs in raw or
+  `e2b_<sandboxID>` form.
+- Raw and synthetic E2B sandbox IDs are accepted only when the sandbox metadata
+  marks it as Crabbox-owned.
+- `--class` and `--type` are rejected because E2B template contents own sandbox
+  resources.
+- `--checksum` is rejected because E2B does not expose a Crabbox SSH/rsync
+  target. Large-sync guardrails still apply, and `--force-sync-large` is
+  honored for intentional large archive syncs.
+
+Related docs:
+
+- [Feature: E2B](../features/e2b.md)
+- [Provider backends](../provider-backends.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -40,6 +40,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Blacksmith Testbox backend and argument/parsing helpers: `internal/providers/blacksmith`
 - Daytona provider backend and SDK/toolbox wrapper: `internal/providers/daytona`
 - Islo delegated backend and SDK wrapper: `internal/providers/islo`
+- E2B delegated backend and REST/envd wrapper: `internal/providers/e2b`
 - Provider backend interfaces, registry, and request/result types:
   `internal/cli/provider_backend.go`
 - Built-in provider registration packages:
@@ -47,18 +48,20 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
   `internal/providers/azure`,
   `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/daytona`, `internal/providers/islo`,
+  `internal/providers/e2b`,
   `internal/providers/all`
 - Built-in provider backend implementations:
   `internal/providers/aws`, `internal/providers/azure`,
   `internal/providers/hetzner`,
   `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/daytona`, `internal/providers/islo`,
+  `internal/providers/e2b`,
   plus shared helpers in `internal/providers/shared`
 - Worker Hetzner provider: `worker/src/hetzner.ts`
 - Worker AWS EC2 provider: `worker/src/aws.ts`
 - Worker AWS AMI create/read/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`
-- Provider feature docs: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/daytona.md`, `docs/features/islo.md`
-- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/hetzner.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`
+- Provider feature docs: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
+- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/hetzner.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/e2b.md`
 - Provider/backend authoring guide: `docs/provider-backends.md`
 - CLI cloud-init bootstrap: `internal/cli/bootstrap.go`
 - Worker cloud-init bootstrap: `worker/src/bootstrap.ts`

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const envSchema = {
 
 const providerSchema = {
   type: "string",
-  enum: ["aws", "hetzner", "ssh", "blacksmith-testbox", "blacksmith", "daytona", "islo"],
+  enum: ["aws", "hetzner", "ssh", "blacksmith-testbox", "blacksmith", "daytona", "islo", "e2b"],
 };
 
 function readConfig(api) {

--- a/index.test.js
+++ b/index.test.js
@@ -73,7 +73,7 @@ test("crabbox_run passes selected provider", async () => {
   const tools = registerWithConfig({ binary: fake.file });
   const result = await getTool(tools, "crabbox_run").execute("call-1", {
     id: "blue-lobster",
-    provider: "islo",
+    provider: "e2b",
     command: ["go", "test", "./..."],
   });
   assert.equal(result.details.code, 0);
@@ -82,7 +82,7 @@ test("crabbox_run passes selected provider", async () => {
     "--id",
     "blue-lobster",
     "--provider",
-    "islo",
+    "e2b",
     "--",
     "go",
     "test",

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	Actions            ActionsConfig
 	Blacksmith         BlacksmithConfig
 	Daytona            DaytonaConfig
+	E2B                E2BConfig
 	Islo               IsloConfig
 	Tailscale          TailscaleConfig
 	Static             StaticConfig
@@ -124,6 +125,15 @@ type DaytonaConfig struct {
 	WorkRoot         string
 	SSHGatewayHost   string
 	SSHAccessMinutes int
+}
+
+type E2BConfig struct {
+	APIKey   string
+	APIURL   string
+	Domain   string
+	Template string
+	Workdir  string
+	User     string
 }
 
 type IsloConfig struct {
@@ -259,6 +269,12 @@ func baseConfig() Config {
 			SSHGatewayHost:   "ssh.app.daytona.io",
 			SSHAccessMinutes: 30,
 		},
+		E2B: E2BConfig{
+			APIURL:   "https://api.e2b.app",
+			Domain:   "e2b.app",
+			Template: "base",
+			Workdir:  "crabbox",
+		},
 		Islo: IsloConfig{
 			BaseURL:  "https://api.islo.dev",
 			Image:    "docker.io/library/ubuntu:24.04",
@@ -307,6 +323,7 @@ type fileConfig struct {
 	Actions          *fileActionsConfig    `yaml:"actions,omitempty"`
 	Blacksmith       *fileBlacksmithConfig `yaml:"blacksmith,omitempty"`
 	Daytona          *fileDaytonaConfig    `yaml:"daytona,omitempty"`
+	E2B              *fileE2BConfig        `yaml:"e2b,omitempty"`
 	Islo             *fileIsloConfig       `yaml:"islo,omitempty"`
 	Tailscale        *fileTailscaleConfig  `yaml:"tailscale,omitempty"`
 	Static           *fileStaticConfig     `yaml:"static,omitempty"`
@@ -430,6 +447,14 @@ type fileDaytonaConfig struct {
 	WorkRoot         string `yaml:"workRoot,omitempty"`
 	SSHGatewayHost   string `yaml:"sshGatewayHost,omitempty"`
 	SSHAccessMinutes int    `yaml:"sshAccessMinutes,omitempty"`
+}
+
+type fileE2BConfig struct {
+	APIURL   string `yaml:"apiUrl,omitempty"`
+	Domain   string `yaml:"domain,omitempty"`
+	Template string `yaml:"template,omitempty"`
+	Workdir  string `yaml:"workdir,omitempty"`
+	User     string `yaml:"user,omitempty"`
 }
 
 type fileIsloConfig struct {
@@ -862,6 +887,23 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.Daytona.SSHAccessMinutes = file.Daytona.SSHAccessMinutes
 		}
 	}
+	if file.E2B != nil {
+		if file.E2B.APIURL != "" {
+			cfg.E2B.APIURL = file.E2B.APIURL
+		}
+		if file.E2B.Domain != "" {
+			cfg.E2B.Domain = file.E2B.Domain
+		}
+		if file.E2B.Template != "" {
+			cfg.E2B.Template = file.E2B.Template
+		}
+		if file.E2B.Workdir != "" {
+			cfg.E2B.Workdir = file.E2B.Workdir
+		}
+		if file.E2B.User != "" {
+			cfg.E2B.User = file.E2B.User
+		}
+	}
 	if file.Islo != nil {
 		if file.Islo.BaseURL != "" {
 			cfg.Islo.BaseURL = file.Islo.BaseURL
@@ -1056,6 +1098,12 @@ func applyEnv(cfg *Config) {
 	cfg.Daytona.WorkRoot = getenv("CRABBOX_DAYTONA_WORK_ROOT", cfg.Daytona.WorkRoot)
 	cfg.Daytona.SSHGatewayHost = getenv("CRABBOX_DAYTONA_SSH_GATEWAY_HOST", cfg.Daytona.SSHGatewayHost)
 	cfg.Daytona.SSHAccessMinutes = getenvInt("CRABBOX_DAYTONA_SSH_ACCESS_MINUTES", cfg.Daytona.SSHAccessMinutes)
+	cfg.E2B.APIKey = getenv("CRABBOX_E2B_API_KEY", getenv("E2B_API_KEY", cfg.E2B.APIKey))
+	cfg.E2B.APIURL = getenv("CRABBOX_E2B_API_URL", getenv("E2B_API_URL", cfg.E2B.APIURL))
+	cfg.E2B.Domain = getenv("CRABBOX_E2B_DOMAIN", getenv("E2B_DOMAIN", cfg.E2B.Domain))
+	cfg.E2B.Template = getenv("CRABBOX_E2B_TEMPLATE", cfg.E2B.Template)
+	cfg.E2B.Workdir = getenv("CRABBOX_E2B_WORKDIR", cfg.E2B.Workdir)
+	cfg.E2B.User = getenv("CRABBOX_E2B_USER", cfg.E2B.User)
 	cfg.Islo.APIKey = getenv("CRABBOX_ISLO_API_KEY", getenv("ISLO_API_KEY", cfg.Islo.APIKey))
 	cfg.Islo.BaseURL = getenv("CRABBOX_ISLO_BASE_URL", getenv("ISLO_BASE_URL", cfg.Islo.BaseURL))
 	cfg.Islo.Image = getenv("CRABBOX_ISLO_IMAGE", cfg.Islo.Image)
@@ -1177,6 +1225,9 @@ func serverTypeForConfig(cfg Config) string {
 	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) || cfg.Provider == "islo" {
 		return ""
 	}
+	if cfg.Provider == "e2b" {
+		return blank(cfg.E2B.Template, "base")
+	}
 	if cfg.Provider == "daytona" {
 		return "snapshot"
 	}
@@ -1192,6 +1243,9 @@ func serverTypeForConfig(cfg Config) string {
 func serverTypeForProviderClass(provider, class string) string {
 	if isBlacksmithProvider(provider) || isStaticProvider(provider) || provider == "islo" {
 		return ""
+	}
+	if provider == "e2b" {
+		return "base"
 	}
 	if provider == "daytona" {
 		return "snapshot"

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -77,6 +77,13 @@ func (a App) configShow(args []string) error {
 			"idleTimeout": cfg.Blacksmith.IdleTimeout.String(),
 			"debug":       cfg.Blacksmith.Debug,
 		},
+		"e2b": map[string]any{
+			"apiUrl":   cfg.E2B.APIURL,
+			"domain":   cfg.E2B.Domain,
+			"template": cfg.E2B.Template,
+			"workdir":  cfg.E2B.Workdir,
+			"user":     cfg.E2B.User,
+		},
 		"static": map[string]any{
 			"id":       cfg.Static.ID,
 			"name":     cfg.Static.Name,
@@ -124,6 +131,7 @@ func (a App) configShow(args []string) error {
 	fmt.Fprintf(a.Stdout, "capacity market=%s strategy=%s fallback=%s regions=%s hints=%t\n", cfg.Capacity.Market, cfg.Capacity.Strategy, cfg.Capacity.Fallback, blank(strings.Join(cfg.Capacity.Regions, ","), "-"), cfg.Capacity.Hints)
 	fmt.Fprintf(a.Stdout, "actions repo=%s workflow=%s job=%s ref=%s runner_version=%s ephemeral=%t labels=%s\n", blank(cfg.Actions.Repo, "-"), blank(cfg.Actions.Workflow, "-"), blank(cfg.Actions.Job, "-"), blank(cfg.Actions.Ref, "-"), cfg.Actions.RunnerVersion, cfg.Actions.Ephemeral, blank(strings.Join(cfg.Actions.RunnerLabels, ","), "-"))
 	fmt.Fprintf(a.Stdout, "blacksmith org=%s workflow=%s job=%s ref=%s idle_timeout=%s debug=%t\n", blank(cfg.Blacksmith.Org, "-"), blank(cfg.Blacksmith.Workflow, "-"), blank(cfg.Blacksmith.Job, "-"), blank(cfg.Blacksmith.Ref, "-"), cfg.Blacksmith.IdleTimeout, cfg.Blacksmith.Debug)
+	fmt.Fprintf(a.Stdout, "e2b api_url=%s domain=%s template=%s workdir=%s user=%s\n", cfg.E2B.APIURL, cfg.E2B.Domain, cfg.E2B.Template, cfg.E2B.Workdir, blank(cfg.E2B.User, "-"))
 	fmt.Fprintf(a.Stdout, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(a.Stdout, "results junit=%s\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"))
 	fmt.Fprintf(a.Stdout, "cache pnpm=%t npm=%t docker=%t git=%t max_gb=%d purge_on_release=%t\n", cfg.Cache.Pnpm, cfg.Cache.Npm, cfg.Cache.Docker, cfg.Cache.Git, cfg.Cache.MaxGB, cfg.Cache.PurgeOnRelease)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -44,6 +44,15 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_DAYTONA_WORK_ROOT",
 		"CRABBOX_DAYTONA_SSH_GATEWAY_HOST",
 		"CRABBOX_DAYTONA_SSH_ACCESS_MINUTES",
+		"CRABBOX_E2B_API_KEY",
+		"E2B_API_KEY",
+		"CRABBOX_E2B_API_URL",
+		"E2B_API_URL",
+		"CRABBOX_E2B_DOMAIN",
+		"E2B_DOMAIN",
+		"CRABBOX_E2B_TEMPLATE",
+		"CRABBOX_E2B_WORKDIR",
+		"CRABBOX_E2B_USER",
 		"CRABBOX_ISLO_API_KEY",
 		"ISLO_API_KEY",
 		"CRABBOX_ISLO_BASE_URL",
@@ -146,6 +155,12 @@ daytona:
   workRoot: /home/daytona/crabbox
   sshGatewayHost: ssh.daytona.example.test
   sshAccessMinutes: 12
+e2b:
+  apiUrl: https://api.e2b.example.test
+  domain: e2b.example.test
+  template: crabbox-ready
+  workdir: work/repo
+  user: sandbox
 islo:
   baseUrl: https://islo.example.test
   image: docker.io/library/ubuntu:24.04
@@ -248,6 +263,9 @@ ssh:
 	if cfg.Daytona.APIURL != "https://daytona.example.test/api" || cfg.Daytona.Snapshot != "crabbox-ready" || cfg.Daytona.Target != "us" || cfg.Daytona.User != "daytona" || cfg.Daytona.WorkRoot != "/home/daytona/crabbox" || cfg.Daytona.SSHGatewayHost != "ssh.daytona.example.test" || cfg.Daytona.SSHAccessMinutes != 12 {
 		t.Fatalf("daytona config not loaded: %#v", cfg.Daytona)
 	}
+	if cfg.E2B.APIURL != "https://api.e2b.example.test" || cfg.E2B.Domain != "e2b.example.test" || cfg.E2B.Template != "crabbox-ready" || cfg.E2B.Workdir != "work/repo" || cfg.E2B.User != "sandbox" {
+		t.Fatalf("e2b config not loaded: %#v", cfg.E2B)
+	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
 		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
 	}
@@ -336,6 +354,15 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_DAYTONA_WORK_ROOT", "/home/daytona/env")
 	t.Setenv("CRABBOX_DAYTONA_SSH_GATEWAY_HOST", "ssh.env.example")
 	t.Setenv("CRABBOX_DAYTONA_SSH_ACCESS_MINUTES", "44")
+	t.Setenv("E2B_API_KEY", "e2b-api-file")
+	t.Setenv("CRABBOX_E2B_API_KEY", "e2b-api-env")
+	t.Setenv("E2B_API_URL", "https://api.e2b-file.example")
+	t.Setenv("CRABBOX_E2B_API_URL", "https://api.e2b-env.example")
+	t.Setenv("E2B_DOMAIN", "e2b-file.example")
+	t.Setenv("CRABBOX_E2B_DOMAIN", "e2b-env.example")
+	t.Setenv("CRABBOX_E2B_TEMPLATE", "template-env")
+	t.Setenv("CRABBOX_E2B_WORKDIR", "env-workdir")
+	t.Setenv("CRABBOX_E2B_USER", "sandbox-env")
 	t.Setenv("ISLO_API_KEY", "islo-api-file")
 	t.Setenv("CRABBOX_ISLO_API_KEY", "islo-api-env")
 	t.Setenv("ISLO_BASE_URL", "https://islo-file.example")
@@ -385,6 +412,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Daytona.APIKey != "daytona-api-env" || cfg.Daytona.APIURL != "https://daytona-env.example/api" || cfg.Daytona.Snapshot != "snapshot-env" || cfg.Daytona.Target != "target-env" || cfg.Daytona.User != "daytona-env-user" || cfg.Daytona.WorkRoot != "/home/daytona/env" || cfg.Daytona.SSHGatewayHost != "ssh.env.example" || cfg.Daytona.SSHAccessMinutes != 44 {
 		t.Fatalf("unexpected daytona env: %#v", cfg.Daytona)
+	}
+	if cfg.E2B.APIKey != "e2b-api-env" || cfg.E2B.APIURL != "https://api.e2b-env.example" || cfg.E2B.Domain != "e2b-env.example" || cfg.E2B.Template != "template-env" || cfg.E2B.Workdir != "env-workdir" || cfg.E2B.User != "sandbox-env" {
+		t.Fatalf("unexpected e2b env: %#v", cfg.E2B)
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {
 		t.Fatalf("unexpected islo env: %#v", cfg.Islo)

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -131,7 +131,7 @@ func TestAttachCommandStreamsOverControlWebSocket(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}
-	if err := app.attach(context.Background(), []string{"run_123", "--poll", "1ms"}); err != nil {
+	if err := app.attach(context.Background(), []string{"run_123", "--poll", "50ms"}); err != nil {
 		t.Fatal(err)
 	}
 	if stdout.String() != "hello ws\n" {
@@ -212,7 +212,7 @@ func TestAttachCommandDrainsControlWebSocketBacklogPages(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}
-	if err := app.attach(context.Background(), []string{"run_123", "--poll", "1ms"}); err != nil {
+	if err := app.attach(context.Background(), []string{"run_123", "--poll", "50ms"}); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("line 001\n")) || !bytes.Contains(stdout.Bytes(), []byte("line 101\n")) {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -311,7 +311,7 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: hetzner, aws, azure, ssh, blacksmith-testbox, daytona, or islo"
+	return "provider: hetzner, aws, azure, ssh, blacksmith-testbox, daytona, islo, or e2b"
 }
 
 func providerHelpSSH() string {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -22,7 +22,7 @@ func testRuntimeWithRunner(r CommandRunner) Runtime {
 }
 
 func TestProviderRegistryCanonicalAndAliases(t *testing.T) {
-	for _, name := range []string{"hetzner", "aws", "ssh", "static", "static-ssh", "blacksmith", "blacksmith-testbox", "daytona", "islo"} {
+	for _, name := range []string{"hetzner", "aws", "ssh", "static", "static-ssh", "blacksmith", "blacksmith-testbox", "daytona", "islo", "e2b"} {
 		if _, err := ProviderFor(name); err != nil {
 			t.Fatalf("ProviderFor(%q): %v", name, err)
 		}
@@ -61,6 +61,15 @@ func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 	if _, ok := backend.(DelegatedRunBackend); !ok {
 		t.Fatalf("backend=%T, want delegated run backend", backend)
 	}
+
+	cfg.Provider = "e2b"
+	backend, err = loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
+	if err != nil {
+		t.Fatalf("load e2b backend: %v", err)
+	}
+	if _, ok := backend.(DelegatedRunBackend); !ok {
+		t.Fatalf("backend=%T, want delegated run backend", backend)
+	}
 }
 
 func TestLeaseCreateFlagsApplySelectedProviderFlags(t *testing.T) {
@@ -85,7 +94,7 @@ func TestLeaseCreateFlagsApplySelectedProviderFlags(t *testing.T) {
 	}
 }
 
-func TestLeaseCreateFlagsRejectDaytonaResourceNoops(t *testing.T) {
+func TestLeaseCreateFlagsRejectSnapshotSandboxResourceNoops(t *testing.T) {
 	defaults := baseConfig()
 	for _, tc := range []struct {
 		name string
@@ -93,6 +102,8 @@ func TestLeaseCreateFlagsRejectDaytonaResourceNoops(t *testing.T) {
 	}{
 		{name: "class", args: []string{"--provider", "daytona", "--class", "standard"}},
 		{name: "type", args: []string{"--provider", "daytona", "--type", "large"}},
+		{name: "e2b class", args: []string{"--provider", "e2b", "--class", "standard"}},
+		{name: "e2b type", args: []string{"--provider", "e2b", "--type", "large"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := newFlagSet("test", io.Discard)
@@ -164,6 +175,25 @@ func TestProviderFlagsApplyDaytonaAndIsloWithoutCoreEdits(t *testing.T) {
 	}
 	if cfg.Islo.Image != "ubuntu:24.04" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 {
 		t.Fatalf("islo flags not applied: %#v", cfg.Islo)
+	}
+
+	fs = newFlagSet("test", io.Discard)
+	provider = fs.String("provider", defaults.Provider, "")
+	values = registerProviderFlags(fs, defaults)
+	if err := parseFlags(fs, []string{
+		"--provider", "e2b",
+		"--e2b-template", "crabbox-ready",
+		"--e2b-workdir", "work/repo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg = defaults
+	cfg.Provider = *provider
+	if err := applyProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.E2B.Template != "crabbox-ready" || cfg.E2B.Workdir != "work/repo" {
+		t.Fatalf("e2b flags not applied: %#v", cfg.E2B)
 	}
 }
 

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -13,6 +13,7 @@ func init() {
 	RegisterProvider(testBlacksmithProvider{})
 	RegisterProvider(testDaytonaProvider{})
 	RegisterProvider(testIsloProvider{})
+	RegisterProvider(testE2BProvider{})
 }
 
 type testAzureProvider struct{}
@@ -267,6 +268,56 @@ func (testIsloProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) er
 	return nil
 }
 func (p testIsloProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testDelegatedBackend{spec: p.Spec()}, nil
+}
+
+type testE2BProvider struct{}
+
+func (testE2BProvider) Name() string      { return "e2b" }
+func (testE2BProvider) Aliases() []string { return nil }
+func (testE2BProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "e2b",
+		Kind:        ProviderKindDelegatedRun,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    nil,
+		Coordinator: CoordinatorNever,
+	}
+}
+
+type testE2BFlagValues struct {
+	Template *string
+	Workdir  *string
+}
+
+func (testE2BProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return testE2BFlagValues{
+		Template: fs.String("e2b-template", defaults.E2B.Template, "E2B sandbox template ID"),
+		Workdir:  fs.String("e2b-workdir", defaults.E2B.Workdir, "E2B sandbox workdir"),
+	}
+}
+func (testE2BProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == "e2b" {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=e2b")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=e2b")
+		}
+	}
+	v, ok := values.(testE2BFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "e2b-template") {
+		cfg.E2B.Template = *v.Template
+	}
+	if flagWasSet(fs, "e2b-workdir") {
+		cfg.E2B.Workdir = *v.Workdir
+	}
+	return nil
+}
+func (p testE2BProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testDelegatedBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/azure"
 	_ "github.com/openclaw/crabbox/internal/providers/blacksmith"
 	_ "github.com/openclaw/crabbox/internal/providers/daytona"
+	_ "github.com/openclaw/crabbox/internal/providers/e2b"
 	_ "github.com/openclaw/crabbox/internal/providers/hetzner"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -1,0 +1,521 @@
+package e2b
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+)
+
+type e2bFlagValues struct {
+	APIURL   *string
+	Domain   *string
+	Template *string
+	Workdir  *string
+	User     *string
+}
+
+func RegisterE2BProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return e2bFlagValues{
+		APIURL:   fs.String("e2b-api-url", defaults.E2B.APIURL, "E2B API URL"),
+		Domain:   fs.String("e2b-domain", defaults.E2B.Domain, "E2B sandbox domain"),
+		Template: fs.String("e2b-template", defaults.E2B.Template, "E2B sandbox template ID"),
+		Workdir:  fs.String("e2b-workdir", defaults.E2B.Workdir, "E2B sandbox working directory"),
+		User:     fs.String("e2b-user", defaults.E2B.User, "E2B sandbox user for command and file ownership"),
+	}
+}
+
+func ApplyE2BProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == e2bProvider {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=e2b")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=e2b")
+		}
+	}
+	v, ok := values.(e2bFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "e2b-api-url") {
+		cfg.E2B.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "e2b-domain") {
+		cfg.E2B.Domain = *v.Domain
+	}
+	if flagWasSet(fs, "e2b-template") {
+		cfg.E2B.Template = *v.Template
+	}
+	if flagWasSet(fs, "e2b-workdir") {
+		cfg.E2B.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "e2b-user") {
+		cfg.E2B.User = *v.User
+	}
+	return nil
+}
+
+func NewE2BBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = e2bProvider
+	return &e2bBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type e2bBackend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func (b *e2bBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	started := b.now()
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, sandbox, slug, err := b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=e2b sandbox=%s\n", leaseID, slug, sandbox.SandboxID)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: e2b warmup keeps the sandbox until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: e2bProvider,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := rejectE2BSyncOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return RunResult{}, err
+	}
+	leaseID, sandboxID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		var sandbox e2bSandbox
+		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim)
+		if err != nil {
+			return RunResult{}, err
+		}
+		sandboxID = sandbox.SandboxID
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=e2b sandbox=%s\n", leaseID, slug, sandboxID)
+		acquired = true
+	} else {
+		leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	if acquired && !req.Keep {
+		defer func() {
+			if err := client.DeleteSandbox(context.Background(), sandboxID); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: e2b stop failed for %s: %v\n", sandboxID, err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+
+	session, err := client.ConnectSandbox(ctx, sandboxID, durationSecondsCeil(b.cfg.TTL))
+	if err != nil {
+		return RunResult{}, e2bError("connect sandbox", err)
+	}
+	workspace := e2bWorkspacePath(b.cfg)
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace)
+		if err != nil {
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, client, session, workspace); err != nil {
+		return RunResult{}, err
+	}
+	if req.SyncOnly {
+		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workspace)
+		if req.TimingJSON {
+			err := writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      e2bProvider,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+			})
+			return result, err
+		}
+		return result, nil
+	}
+	command := e2bCommandString(req.Command, req.ShellMode)
+	if command == "" {
+		return RunResult{}, exit(2, "missing command")
+	}
+	commandStarted := b.now()
+	fmt.Fprintf(b.rt.Stderr, "running on e2b %s\n", strings.Join(req.Command, " "))
+	exitCode, commandErr := client.StartProcess(ctx, session, e2bProcessRequest{
+		Command: command,
+		CWD:     workspace,
+		Env:     allowedEnv(req.Options.EnvAllow),
+		User:    b.cfg.E2B.User,
+		Timeout: b.cfg.TTL,
+		Stdout:  b.rt.Stdout,
+		Stderr:  b.rt.Stderr,
+	})
+	commandDuration := b.now().Sub(commandStarted)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "e2b run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "e2b run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      e2bProvider,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+		}); err != nil {
+			return result, err
+		}
+	}
+	if commandErr != nil {
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("e2b run failed: %v", commandErr)}
+	}
+	if result.ExitCode != 0 {
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("e2b run exited %d", result.ExitCode)}
+	}
+	return result, nil
+}
+
+func (b *e2bBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	sandboxes, err := client.ListSandboxes(ctx, map[string]string{"crabbox": "true", "provider": e2bProvider})
+	if err != nil {
+		return nil, e2bError("list sandboxes", err)
+	}
+	servers := make([]Server, 0, len(sandboxes))
+	for _, sandbox := range sandboxes {
+		servers = append(servers, e2bSandboxToServer(sandbox))
+	}
+	return servers, nil
+}
+
+func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return statusView{}, err
+	}
+	leaseID, sandboxID, _, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return statusView{}, err
+	}
+	deadline := b.now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = b.now().Add(5 * time.Minute)
+	}
+	for {
+		sandbox, err := client.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			return statusView{}, e2bError("get sandbox", err)
+		}
+		view := e2bStatusView(leaseID, sandbox)
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if b.now().After(deadline) {
+			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+		}
+		select {
+		case <-ctx.Done():
+			return statusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, sandboxID, _, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
+		return e2bError("delete sandbox", err)
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	return nil
+}
+
+func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo, keep, reclaim bool) (string, e2bSandbox, string, error) {
+	leaseID := newLeaseID()
+	slug := newLeaseSlug(leaseID)
+	cfg := b.cfg
+	cfg.Provider = e2bProvider
+	cfg.ServerType = blank(cfg.E2B.Template, "base")
+	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, b.now().UTC())
+	labels["state"] = "ready"
+	labels["workdir"] = e2bWorkspacePath(cfg)
+	labels["template"] = cfg.ServerType
+	if repo.Name != "" {
+		labels["repo"] = repo.Name
+	}
+	timeoutSeconds := durationSecondsCeil(cfg.TTL)
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 300
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=e2b lease=%s slug=%s template=%s timeout=%ds\n", leaseID, slug, cfg.ServerType, timeoutSeconds)
+	sandbox, err := client.CreateSandbox(ctx, e2bCreateSandboxRequest{
+		TemplateID:          cfg.ServerType,
+		TimeoutSeconds:      timeoutSeconds,
+		Metadata:            labels,
+		AllowInternetAccess: true,
+	})
+	if err != nil {
+		return "", e2bSandbox{}, "", e2bError("create sandbox", err)
+	}
+	if sandbox.SandboxID == "" {
+		return "", e2bSandbox{}, "", exit(5, "e2b create sandbox returned no sandbox id")
+	}
+	if err := claimLeaseForRepoProvider(leaseID, slug, e2bProvider, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+		_ = client.DeleteSandbox(context.Background(), sandbox.SandboxID)
+		return "", e2bSandbox{}, "", err
+	}
+	return leaseID, sandbox, slug, nil
+}
+
+func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
+	if id == "" {
+		return "", "", "", exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
+	}
+	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+		return "", "", "", err
+	} else if ok && claim.Provider == e2bProvider {
+		if repoRoot != "" {
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, e2bProvider, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+				return "", "", "", err
+			}
+		}
+		sandbox, err := resolveE2BSandboxByLease(ctx, client, claim.LeaseID)
+		if err != nil {
+			return "", "", "", err
+		}
+		return claim.LeaseID, sandbox.SandboxID, claim.Slug, nil
+	}
+	if isE2BSyntheticID(id) {
+		sandboxID := strings.TrimPrefix(id, "e2b_")
+		sandbox, err := client.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			return "", "", "", e2bError("get sandbox", err)
+		}
+		if !isCrabboxE2BSandbox(sandbox) {
+			return "", "", "", exit(4, "e2b sandbox %q is not claimed by Crabbox", id)
+		}
+		leaseID := e2bLeaseID(sandbox)
+		return leaseID, sandbox.SandboxID, e2bSlug(leaseID, sandbox), nil
+	}
+	if strings.HasPrefix(id, "cbx_") {
+		sandbox, err := resolveE2BSandboxByLease(ctx, client, id)
+		if err != nil {
+			return "", "", "", err
+		}
+		return id, sandbox.SandboxID, e2bSlug(id, sandbox), nil
+	}
+	sandbox, err := client.GetSandbox(ctx, id)
+	if err == nil && isCrabboxE2BSandbox(sandbox) {
+		leaseID := e2bLeaseID(sandbox)
+		return leaseID, sandbox.SandboxID, e2bSlug(leaseID, sandbox), nil
+	}
+	if err != nil && !isNotFoundError(err) {
+		return "", "", "", e2bError("get sandbox", err)
+	}
+	return "", "", "", exit(4, "e2b sandbox or claim %q was not found", id)
+}
+
+func resolveE2BSandboxByLease(ctx context.Context, client e2bAPI, leaseID string) (e2bSandbox, error) {
+	sandboxes, err := client.ListSandboxes(ctx, map[string]string{"lease": leaseID, "provider": e2bProvider})
+	if err != nil {
+		return e2bSandbox{}, e2bError("list sandboxes", err)
+	}
+	for _, sandbox := range sandboxes {
+		if isCrabboxE2BSandbox(sandbox) {
+			return sandbox, nil
+		}
+	}
+	return e2bSandbox{}, exit(4, "e2b lease %q was not found", leaseID)
+}
+
+func e2bSandboxToServer(sandbox e2bSandbox) Server {
+	labels := map[string]string{}
+	for k, v := range sandbox.Metadata {
+		labels[k] = v
+	}
+	labels["provider"] = e2bProvider
+	labels["lease"] = e2bLeaseID(sandbox)
+	if labels["slug"] == "" {
+		labels["slug"] = newLeaseSlug(labels["lease"])
+	}
+	labels["target"] = targetLinux
+	if labels["state"] == "" {
+		labels["state"] = sandbox.State
+	}
+	server := Server{
+		Provider: e2bProvider,
+		CloudID:  sandbox.SandboxID,
+		Name:     sandbox.SandboxID,
+		Status:   sandbox.State,
+		Labels:   labels,
+	}
+	server.ServerType.Name = blank(sandbox.TemplateID, sandbox.Alias)
+	if server.ServerType.Name == "" {
+		server.ServerType.Name = "base"
+	}
+	return server
+}
+
+func e2bStatusView(leaseID string, sandbox e2bSandbox) statusView {
+	server := e2bSandboxToServer(sandbox)
+	return statusView{
+		ID:         leaseID,
+		Slug:       e2bSlug(leaseID, sandbox),
+		Provider:   e2bProvider,
+		TargetOS:   targetLinux,
+		State:      sandbox.State,
+		ServerID:   sandbox.SandboxID,
+		ServerType: server.ServerType.Name,
+		Network:    NetworkPublic,
+		Ready:      e2bStatusReady(sandbox.State),
+		Labels:     server.Labels,
+	}
+}
+
+func e2bStatusReady(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "running":
+		return true
+	default:
+		return false
+	}
+}
+
+func e2bLeaseID(sandbox e2bSandbox) string {
+	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
+		return lease
+	}
+	return "e2b_" + sandbox.SandboxID
+}
+
+func e2bSlug(leaseID string, sandbox e2bSandbox) string {
+	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
+		return slug
+	}
+	return newLeaseSlug(leaseID)
+}
+
+func isE2BSyntheticID(id string) bool {
+	return strings.HasPrefix(id, "e2b_") && len(id) > len("e2b_")
+}
+
+func isCrabboxE2BSandbox(sandbox e2bSandbox) bool {
+	return sandbox.Metadata["provider"] == e2bProvider && sandbox.Metadata["crabbox"] == "true"
+}
+
+func e2bWorkspacePath(cfg Config) string {
+	workdir := strings.TrimSpace(cfg.E2B.Workdir)
+	if workdir == "" {
+		workdir = "crabbox"
+	}
+	if strings.HasPrefix(workdir, "/") {
+		return path.Clean(workdir)
+	}
+	return path.Join("/home/user", workdir)
+}
+
+func e2bCommandString(command []string, shellMode bool) string {
+	if len(command) == 0 {
+		return ""
+	}
+	if shellMode {
+		return strings.Join(command, " ")
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		return shellScriptFromArgv(command)
+	}
+	return strings.Join(shellWords(command), " ")
+}
+
+func rejectE2BSyncOptions(req RunRequest) error {
+	if req.ChecksumSync {
+		return exit(2, "%s uses E2B archive sync; --checksum is not supported", e2bProvider)
+	}
+	return nil
+}
+
+func durationSecondsCeil(duration time.Duration) int {
+	if duration <= 0 {
+		return 0
+	}
+	return int((duration + time.Second - 1) / time.Second)
+}
+
+func isNotFoundError(err error) bool {
+	var apiErr *e2bAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 404
+}
+
+func e2bError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("e2b %s: %w", action, err)
+}
+
+func (b *e2bBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -293,23 +293,23 @@ func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
 func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo, keep, reclaim bool) (string, e2bSandbox, string, error) {
 	leaseID := newLeaseID()
 	slug := newLeaseSlug(leaseID)
+	template := blank(b.cfg.E2B.Template, "base")
 	cfg := b.cfg
-	cfg.Provider = e2bProvider
-	cfg.ServerType = blank(cfg.E2B.Template, "base")
+	cfg.ServerType = template
 	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, b.now().UTC())
 	labels["state"] = "ready"
 	labels["workdir"] = e2bWorkspacePath(cfg)
-	labels["template"] = cfg.ServerType
+	labels["template"] = template
 	if repo.Name != "" {
 		labels["repo"] = repo.Name
 	}
-	timeoutSeconds := durationSecondsCeil(cfg.TTL)
+	timeoutSeconds := durationSecondsCeil(b.cfg.TTL)
 	if timeoutSeconds <= 0 {
 		timeoutSeconds = 300
 	}
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=e2b lease=%s slug=%s template=%s timeout=%ds\n", leaseID, slug, cfg.ServerType, timeoutSeconds)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=e2b lease=%s slug=%s template=%s timeout=%ds\n", leaseID, slug, template, timeoutSeconds)
 	sandbox, err := client.CreateSandbox(ctx, e2bCreateSandboxRequest{
-		TemplateID:          cfg.ServerType,
+		TemplateID:          template,
 		TimeoutSeconds:      timeoutSeconds,
 		Metadata:            labels,
 		AllowInternetAccess: true,
@@ -409,7 +409,7 @@ func e2bSandboxToServer(sandbox e2bSandbox) Server {
 		Status:   sandbox.State,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(sandbox.TemplateID, sandbox.Alias)
+	server.ServerType.Name = blank(sandbox.Alias, sandbox.TemplateID)
 	if server.ServerType.Name == "" {
 		server.ServerType.Name = "base"
 	}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -1,0 +1,360 @@
+package e2b
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestParseE2BProcessStream(t *testing.T) {
+	body := bytes.Join([][]byte{
+		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}),
+		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("hello"))}}}),
+		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": base64.StdEncoding.EncodeToString([]byte("warn"))}}}),
+		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 7, "exited": true}}}),
+		e2bTestEnvelope(2, map[string]any{}),
+	}, nil)
+	var stdout, stderr bytes.Buffer
+	code, err := parseE2BProcessStream(bytes.NewReader(body), &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 7 || stdout.String() != "hello" || stderr.String() != "warn" {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestParseE2BProcessStreamRequiresEndEvent(t *testing.T) {
+	body := bytes.Join([][]byte{
+		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("partial"))}}}),
+		e2bTestEnvelope(2, map[string]any{}),
+	}, nil)
+	var stdout bytes.Buffer
+	code, err := parseE2BProcessStream(bytes.NewReader(body), &stdout, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "without end event") {
+		t.Fatalf("code=%d err=%v, want missing end event error", code, err)
+	}
+	if stdout.String() != "partial" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestE2BCommandString(t *testing.T) {
+	if got := e2bCommandString([]string{"go", "test", "./..."}, false); got != "'go' 'test' './...'" {
+		t.Fatalf("plain command=%q", got)
+	}
+	if got := e2bCommandString([]string{"FOO=bar", "go", "test"}, false); !strings.Contains(got, "FOO=") || !strings.Contains(got, "'go'") {
+		t.Fatalf("env command=%q", got)
+	}
+	if got := e2bCommandString([]string{"pnpm install && pnpm test"}, true); got != "pnpm install && pnpm test" {
+		t.Fatalf("shell command=%q", got)
+	}
+}
+
+func TestE2BWorkspacePath(t *testing.T) {
+	if got := e2bWorkspacePath(Config{}); got != "/home/user/crabbox" {
+		t.Fatalf("workspace=%q", got)
+	}
+	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "repo"}}); got != "/home/user/repo" {
+		t.Fatalf("workspace=%q", got)
+	}
+	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
+		t.Fatalf("workspace=%q", got)
+	}
+}
+
+func TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape(t *testing.T) {
+	var createBody map[string]any
+	listHits := 0
+	deleteHit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-API-Key"); got != "e2b_test" {
+			t.Fatalf("X-API-Key=%q", got)
+		}
+		switch r.URL.Path {
+		case "/sandboxes":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method=%s", r.Method)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"templateID":      "base",
+				"sandboxID":       "sbx_1",
+				"envdVersion":     "0.5.7",
+				"envdAccessToken": "envd-token",
+			})
+		case "/sandboxes/sbx_1/connect":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["timeout"].(float64) != 120 {
+				t.Fatalf("connect body=%v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"templateID":      "base",
+				"sandboxID":       "sbx_1",
+				"envdVersion":     "0.5.7",
+				"envdAccessToken": "envd-token",
+			})
+		case "/v2/sandboxes":
+			listHits++
+			if got := r.URL.Query().Get("metadata"); !strings.Contains(got, "provider=e2b") || !strings.Contains(got, "crabbox=true") {
+				t.Fatalf("metadata query=%q", got)
+			}
+			if listHits == 1 {
+				w.Header().Set("x-next-token", "next")
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"templateID": "base", "sandboxID": "sbx_1", "state": "running", "metadata": map[string]string{"provider": "e2b", "crabbox": "true"}}})
+				return
+			}
+			if got := r.URL.Query().Get("nextToken"); got != "next" {
+				t.Fatalf("nextToken=%q", got)
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"templateID": "base", "sandboxID": "sbx_2", "state": "running", "metadata": map[string]string{"provider": "e2b", "crabbox": "true"}}})
+		case "/sandboxes/sbx_1":
+			if r.Method != http.MethodDelete {
+				t.Fatalf("method=%s", r.Method)
+			}
+			deleteHit = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandbox, err := api.CreateSandbox(t.Context(), e2bCreateSandboxRequest{
+		TemplateID:          "base",
+		TimeoutSeconds:      60,
+		AllowInternetAccess: true,
+		Metadata:            map[string]string{"provider": "e2b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sandbox.SandboxID != "sbx_1" {
+		t.Fatalf("sandbox=%#v", sandbox)
+	}
+	if createBody["templateID"] != "base" || createBody["timeout"].(float64) != 60 || createBody["secure"] != true || createBody["allow_internet_access"] != true {
+		t.Fatalf("create body=%v", createBody)
+	}
+	session, err := api.ConnectSandbox(t.Context(), "sbx_1", 120)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.SandboxID != "sbx_1" || session.EnvdAccessToken != "envd-token" {
+		t.Fatalf("session=%#v", session)
+	}
+	items, err := api.ListSandboxes(t.Context(), map[string]string{"provider": "e2b", "crabbox": "true"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 || listHits != 2 {
+		t.Fatalf("items=%d listHits=%d", len(items), listHits)
+	}
+	if err := api.DeleteSandbox(t.Context(), "sbx_1"); err != nil {
+		t.Fatal(err)
+	}
+	if !deleteHit {
+		t.Fatal("delete endpoint was not called")
+	}
+}
+
+func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(root+"/go.mod", []byte("module example.test/repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	client := &fakeE2BSyncClient{}
+	backend := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{Workdir: "repo"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
+		Repo: Repo{Root: root, Name: "repo"},
+	}, "/home/user/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.uploadPath == "" || !strings.HasPrefix(client.uploadPath, "/tmp/crabbox-") {
+		t.Fatalf("upload path=%q", client.uploadPath)
+	}
+	if !tarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
+		t.Fatal("uploaded archive missing go.mod")
+	}
+	if !client.commandContains("mkdir -p '/home/user/repo'") || !client.commandContains("tar -xzf") {
+		t.Fatalf("commands=%#v", client.commands)
+	}
+}
+
+func TestE2BStatusReady(t *testing.T) {
+	for _, status := range []string{"", "running"} {
+		if !e2bStatusReady(status) {
+			t.Fatalf("expected %q ready", status)
+		}
+	}
+	if e2bStatusReady("paused") {
+		t.Fatal("paused should not be ready")
+	}
+}
+
+func TestE2BSandboxToServerUsesMetadata(t *testing.T) {
+	server := e2bSandboxToServer(e2bSandbox{
+		SandboxID:  "sbx_1",
+		TemplateID: "base",
+		State:      "running",
+		Metadata: map[string]string{
+			"provider": "e2b",
+			"crabbox":  "true",
+			"lease":    "cbx_123",
+			"slug":     "blue-lobster",
+		},
+	})
+	if server.Provider != "e2b" || server.CloudID != "sbx_1" || server.Labels["lease"] != "cbx_123" || server.Labels["slug"] != "blue-lobster" {
+		t.Fatalf("server=%#v", server)
+	}
+	if server.ServerType.Name != "base" {
+		t.Fatalf("type=%q", server.ServerType.Name)
+	}
+}
+
+func TestE2BResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
+	backend := &e2bBackend{}
+	client := &fakeE2BSyncClient{
+		sandbox: e2bSandbox{
+			SandboxID: "sbx_1",
+			Metadata:  map[string]string{"provider": "other"},
+		},
+	}
+	_, _, _, err := backend.resolveSandboxID(context.Background(), client, "e2b_sbx_1", "", false)
+	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v, want ownership error", err)
+	}
+
+	client.sandbox.Metadata = map[string]string{
+		"provider": "e2b",
+		"crabbox":  "true",
+		"lease":    "cbx_123",
+		"slug":     "blue-lobster",
+	}
+	leaseID, sandboxID, slug, err := backend.resolveSandboxID(context.Background(), client, "e2b_sbx_1", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "cbx_123" || sandboxID != "sbx_1" || slug != "blue-lobster" {
+		t.Fatalf("lease=%q sandbox=%q slug=%q", leaseID, sandboxID, slug)
+	}
+}
+
+type fakeE2BSyncClient struct {
+	commands   []string
+	sandbox    e2bSandbox
+	getErr     error
+	uploadPath string
+	uploaded   bytes.Buffer
+}
+
+func (f *fakeE2BSyncClient) CreateSandbox(context.Context, e2bCreateSandboxRequest) (e2bSandbox, error) {
+	return e2bSandbox{}, nil
+}
+
+func (f *fakeE2BSyncClient) ConnectSandbox(context.Context, string, int) (e2bSession, error) {
+	return e2bSession{}, nil
+}
+
+func (f *fakeE2BSyncClient) GetSandbox(context.Context, string) (e2bSandbox, error) {
+	if f.getErr != nil {
+		return e2bSandbox{}, f.getErr
+	}
+	return f.sandbox, nil
+}
+
+func (f *fakeE2BSyncClient) ListSandboxes(context.Context, map[string]string) ([]e2bSandbox, error) {
+	return nil, nil
+}
+
+func (f *fakeE2BSyncClient) DeleteSandbox(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeE2BSyncClient) UploadFile(_ context.Context, _ e2bSession, targetPath string, r io.Reader) error {
+	f.uploadPath = targetPath
+	_, err := io.Copy(&f.uploaded, r)
+	return err
+}
+
+func (f *fakeE2BSyncClient) StartProcess(_ context.Context, _ e2bSession, req e2bProcessRequest) (int, error) {
+	f.commands = append(f.commands, req.Command)
+	return 0, nil
+}
+
+func (f *fakeE2BSyncClient) commandContains(value string) bool {
+	for _, command := range f.commands {
+		if strings.Contains(command, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func e2bTestEnvelope(flags byte, v any) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var out bytes.Buffer
+	out.WriteByte(flags)
+	out.Write([]byte{byte(len(data) >> 24), byte(len(data) >> 16), byte(len(data) >> 8), byte(len(data))})
+	out.Write(data)
+	return out.Bytes()
+}
+
+func tarGzipContains(t *testing.T, data []byte, name string) bool {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return false
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Name == name {
+			return true
+		}
+	}
+}

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -446,7 +446,7 @@ func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer) (int, error) {
 		if event.Event.End != nil {
 			exitCode = event.Event.End.ExitCode
 			seenEnd = true
-			if event.Event.End.Error != "" {
+			if !event.Event.End.Exited && event.Event.End.Error != "" {
 				fmt.Fprintln(stderr, event.Event.End.Error)
 			}
 		}

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -1,0 +1,477 @@
+package e2b
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type e2bAPI interface {
+	CreateSandbox(context.Context, e2bCreateSandboxRequest) (e2bSandbox, error)
+	ConnectSandbox(context.Context, string, int) (e2bSession, error)
+	GetSandbox(context.Context, string) (e2bSandbox, error)
+	ListSandboxes(context.Context, map[string]string) ([]e2bSandbox, error)
+	DeleteSandbox(context.Context, string) error
+	UploadFile(context.Context, e2bSession, string, io.Reader) error
+	StartProcess(context.Context, e2bSession, e2bProcessRequest) (int, error)
+}
+
+type e2bClient struct {
+	apiKey     string
+	apiURL     string
+	domain     string
+	user       string
+	httpClient *http.Client
+}
+
+type e2bCreateSandboxRequest struct {
+	TemplateID          string
+	TimeoutSeconds      int
+	Metadata            map[string]string
+	AllowInternetAccess bool
+}
+
+type e2bSandbox struct {
+	TemplateID      string            `json:"templateID"`
+	SandboxID       string            `json:"sandboxID"`
+	ClientID        string            `json:"clientID"`
+	StartedAt       string            `json:"startedAt"`
+	EndAt           string            `json:"endAt"`
+	EnvdVersion     string            `json:"envdVersion"`
+	EnvdAccessToken string            `json:"envdAccessToken"`
+	TrafficToken    string            `json:"trafficAccessToken"`
+	Alias           string            `json:"alias"`
+	Domain          string            `json:"domain"`
+	State           string            `json:"state"`
+	CPUCount        int               `json:"cpuCount"`
+	MemoryMB        int               `json:"memoryMB"`
+	DiskSizeMB      int               `json:"diskSizeMB"`
+	Metadata        map[string]string `json:"metadata"`
+}
+
+type e2bSession struct {
+	SandboxID       string
+	EnvdVersion     string
+	EnvdAccessToken string
+	Domain          string
+}
+
+type e2bProcessRequest struct {
+	Command string
+	CWD     string
+	Env     map[string]string
+	User    string
+	Timeout time.Duration
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+type e2bAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *e2bAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+func newE2BClient(cfg Config, rt Runtime) (e2bAPI, error) {
+	apiKey := strings.TrimSpace(cfg.E2B.APIKey)
+	if apiKey == "" {
+		return nil, exit(2, "provider=e2b requires E2B_API_KEY")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	apiURL := strings.TrimRight(blank(cfg.E2B.APIURL, "https://api.e2b.app"), "/")
+	domain := strings.TrimSpace(blank(cfg.E2B.Domain, "e2b.app"))
+	return &e2bClient{apiKey: apiKey, apiURL: apiURL, domain: domain, user: cfg.E2B.User, httpClient: httpClient}, nil
+}
+
+func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {
+	body := map[string]any{
+		"templateID":            req.TemplateID,
+		"timeout":               req.TimeoutSeconds,
+		"secure":                true,
+		"allow_internet_access": req.AllowInternetAccess,
+		"metadata":              req.Metadata,
+	}
+	var sandbox e2bSandbox
+	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes", nil, body, &sandbox); err != nil {
+		return e2bSandbox{}, err
+	}
+	if sandbox.Metadata == nil {
+		sandbox.Metadata = req.Metadata
+	}
+	if sandbox.State == "" {
+		sandbox.State = "running"
+	}
+	return sandbox, nil
+}
+
+func (c *e2bClient) ConnectSandbox(ctx context.Context, sandboxID string, timeoutSeconds int) (e2bSession, error) {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 300
+	}
+	body := map[string]any{"timeout": timeoutSeconds}
+	var sandbox e2bSandbox
+	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(sandboxID)+"/connect", nil, body, &sandbox); err != nil {
+		return e2bSession{}, err
+	}
+	return c.sessionFromSandbox(sandbox), nil
+}
+
+func (c *e2bClient) GetSandbox(ctx context.Context, sandboxID string) (e2bSandbox, error) {
+	var sandbox e2bSandbox
+	if err := c.doJSON(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, &sandbox); err != nil {
+		return e2bSandbox{}, err
+	}
+	if sandbox.Metadata == nil {
+		sandbox.Metadata = map[string]string{}
+	}
+	return sandbox, nil
+}
+
+func (c *e2bClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]e2bSandbox, error) {
+	var all []e2bSandbox
+	nextToken := ""
+	for {
+		query := url.Values{}
+		query.Set("limit", "100")
+		query.Set("state", "running,paused")
+		if nextToken != "" {
+			query.Set("nextToken", nextToken)
+		}
+		if len(metadata) > 0 {
+			values := url.Values{}
+			for key, value := range metadata {
+				values.Set(key, value)
+			}
+			query.Set("metadata", values.Encode())
+		}
+		var page []e2bSandbox
+		headers, err := c.doJSONWithHeaders(ctx, http.MethodGet, "/v2/sandboxes", query, nil, &page)
+		if err != nil {
+			return nil, err
+		}
+		for i := range page {
+			if page[i].Metadata == nil {
+				page[i].Metadata = map[string]string{}
+			}
+		}
+		all = append(all, page...)
+		nextToken = headers.Get("x-next-token")
+		if nextToken == "" {
+			return all, nil
+		}
+	}
+}
+
+func (c *e2bClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, nil)
+}
+
+func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPath string, r io.Reader) error {
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	go func() {
+		part, err := writer.CreateFormFile("file", targetPath)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, r); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := writer.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+	endpoint, err := url.Parse(c.envdURL(session, "/files"))
+	if err != nil {
+		return err
+	}
+	query := endpoint.Query()
+	query.Set("path", targetPath)
+	if strings.TrimSpace(c.user) != "" {
+		query.Set("username", c.user)
+	}
+	endpoint.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), pr)
+	if err != nil {
+		return err
+	}
+	c.setEnvdHeaders(req, session)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2bProcessRequest) (int, error) {
+	if req.Stdout == nil {
+		req.Stdout = io.Discard
+	}
+	if req.Stderr == nil {
+		req.Stderr = io.Discard
+	}
+	env := req.Env
+	if env == nil {
+		env = map[string]string{}
+	}
+	start := map[string]any{
+		"process": map[string]any{
+			"cmd":  "/bin/bash",
+			"args": []string{"-l", "-c", req.Command},
+			"envs": env,
+			"cwd":  req.CWD,
+		},
+		"stdin": false,
+	}
+	body, err := encodeConnectJSONEnvelope(start)
+	if err != nil {
+		return 1, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.envdURL(session, "/process.Process/Start"), bytes.NewReader(body))
+	if err != nil {
+		return 1, err
+	}
+	c.setEnvdHeaders(httpReq, session)
+	httpReq.Header.Set("Connect-Protocol-Version", "1")
+	httpReq.Header.Set("Connect-Content-Encoding", "identity")
+	httpReq.Header.Set("Content-Type", "application/connect+json")
+	httpReq.Header.Set("Keepalive-Ping-Interval", "50")
+	if req.User != "" {
+		httpReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(req.User+":")))
+	}
+	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
+		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
+	}
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return 1, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return 1, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+	}
+	return parseE2BProcessStream(resp.Body, req.Stdout, req.Stderr)
+}
+
+func (c *e2bClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
+	_, err := c.doJSONWithHeaders(ctx, method, path, query, body, out)
+	return err
+}
+
+func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, query url.Values, body any, out any) (http.Header, error) {
+	var r io.Reader
+	if body != nil {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return nil, err
+		}
+		r = &buf
+	}
+	endpoint := c.apiURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, r)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+	}
+	if out != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return nil, err
+		}
+	}
+	return resp.Header.Clone(), nil
+}
+
+func (c *e2bClient) sessionFromSandbox(sandbox e2bSandbox) e2bSession {
+	domain := strings.TrimSpace(sandbox.Domain)
+	if domain == "" {
+		domain = c.domain
+	}
+	return e2bSession{
+		SandboxID:       sandbox.SandboxID,
+		EnvdVersion:     sandbox.EnvdVersion,
+		EnvdAccessToken: sandbox.EnvdAccessToken,
+		Domain:          domain,
+	}
+}
+
+func (c *e2bClient) envdURL(session e2bSession, path string) string {
+	domain := strings.TrimSpace(session.Domain)
+	if domain == "" {
+		domain = c.domain
+	}
+	return "https://49983-" + session.SandboxID + "." + domain + path
+}
+
+func (c *e2bClient) setEnvdHeaders(req *http.Request, session e2bSession) {
+	req.Header.Set("X-Access-Token", session.EnvdAccessToken)
+	req.Header.Set("E2b-Sandbox-Id", session.SandboxID)
+	req.Header.Set("E2b-Sandbox-Port", "49983")
+}
+
+type e2bStartResponse struct {
+	Event struct {
+		Start *struct {
+			PID uint32 `json:"pid"`
+		} `json:"start,omitempty"`
+		Data *struct {
+			Stdout string `json:"stdout,omitempty"`
+			Stderr string `json:"stderr,omitempty"`
+			PTY    string `json:"pty,omitempty"`
+		} `json:"data,omitempty"`
+		End *struct {
+			ExitCode int    `json:"exitCode"`
+			Exited   bool   `json:"exited"`
+			Status   string `json:"status"`
+			Error    string `json:"error,omitempty"`
+		} `json:"end,omitempty"`
+		Keepalive map[string]any `json:"keepalive,omitempty"`
+	} `json:"event"`
+}
+
+type e2bEndStream struct {
+	Error *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func encodeConnectJSONEnvelope(v any) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	out.WriteByte(0)
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(data)))
+	out.Write(size[:])
+	out.Write(data)
+	return out.Bytes(), nil
+}
+
+func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer) (int, error) {
+	exitCode := 0
+	seenEnd := false
+	for {
+		var header [5]byte
+		if _, err := io.ReadFull(r, header[:]); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return 1, err
+		}
+		flags := header[0]
+		size := binary.BigEndian.Uint32(header[1:])
+		if flags&1 != 0 {
+			return 1, fmt.Errorf("compressed connect envelopes are not supported")
+		}
+		data := make([]byte, size)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return 1, err
+		}
+		if flags&2 != 0 {
+			var end e2bEndStream
+			if len(data) > 0 {
+				if err := json.Unmarshal(data, &end); err != nil {
+					return 1, err
+				}
+			}
+			if end.Error != nil {
+				return 1, fmt.Errorf("%s: %s", end.Error.Code, end.Error.Message)
+			}
+			break
+		}
+		var event e2bStartResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			return 1, err
+		}
+		if event.Event.Data != nil {
+			if err := writeBase64(event.Event.Data.Stdout, stdout); err != nil {
+				return 1, err
+			}
+			if err := writeBase64(event.Event.Data.Stderr, stderr); err != nil {
+				return 1, err
+			}
+		}
+		if event.Event.End != nil {
+			exitCode = event.Event.End.ExitCode
+			seenEnd = true
+			if event.Event.End.Error != "" {
+				fmt.Fprintln(stderr, event.Event.End.Error)
+			}
+		}
+	}
+	if !seenEnd {
+		return 1, fmt.Errorf("e2b process stream ended without end event")
+	}
+	return exitCode, nil
+}
+
+func writeBase64(value string, w io.Writer) error {
+	if value == "" {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func durationMillisCeil(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	return int64((duration + time.Millisecond - 1) / time.Millisecond)
+}

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -1,0 +1,122 @@
+package e2b
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type E2BConfig = core.E2BConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type SyncManifest = core.SyncManifest
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+
+const (
+	e2bProvider = "e2b"
+	targetLinux = core.TargetLinux
+
+	NetworkPublic = core.NetworkPublic
+)
+
+type statusView = core.StatusView
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellWords(words []string) []string {
+	return core.ShellWords(words)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
+}
+
+func allowedEnv(allow []string) map[string]string {
+	return core.AllowedEnv(allow)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes []string) (SyncManifest, error) {
+	return core.BuildSyncManifest(root, excludes)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func summarizeJSON(data []byte) string {
+	return core.SummarizeJSON(data)
+}

--- a/internal/providers/e2b/provider.go
+++ b/internal/providers/e2b/provider.go
@@ -1,0 +1,38 @@
+package e2b
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return e2bProvider }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        e2bProvider,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    nil,
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterE2BProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyE2BProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewE2BBackend(p.Spec(), cfg, rt), nil
+}

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -1,0 +1,126 @@
+package e2b
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+	manifestStarted := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStarted)
+	preflightStarted := b.now()
+	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStarted)
+	prepareStarted := b.now()
+	if err := b.prepareWorkspace(ctx, client, session, workspace); err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStarted)
+	archiveStarted := b.now()
+	archive, err := createE2BSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer os.Remove(archive.Name())
+	defer archive.Close()
+	archiveDuration := b.now().Sub(archiveStarted)
+	uploadStarted := b.now()
+	if _, err := archive.Seek(0, 0); err != nil {
+		return nil, 0, fmt.Errorf("e2b rewind archive: %w", err)
+	}
+	remoteArchive := path.Join("/tmp", "crabbox-"+e2bRandomSuffix()+".tgz")
+	if err := client.UploadFile(ctx, session, remoteArchive, archive); err != nil {
+		return nil, 0, e2bError("upload archive", err)
+	}
+	extract := strings.Join([]string{
+		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workspace),
+		"rm -f " + shellQuote(remoteArchive),
+	}, " && ")
+	if err := b.execShell(ctx, client, session, extract, io.Discard); err != nil {
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStarted)
+	total := b.now().Sub(start)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "e2b_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, session e2bSession, workspace string) error {
+	command := "mkdir -p " + shellQuote(workspace)
+	if b.cfg.Sync.Delete {
+		command = "rm -rf " + shellQuote(workspace) + " && " + command
+	}
+	return b.execShell(ctx, client, session, command, io.Discard)
+}
+
+func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSession, command string, stdout io.Writer) error {
+	code, err := client.StartProcess(ctx, session, e2bProcessRequest{
+		Command: command,
+		User:    b.cfg.E2B.User,
+		Timeout: b.cfg.TTL,
+		Stdout:  stdout,
+		Stderr:  b.rt.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("e2b exec %q: %w", command, err)
+	}
+	if code != 0 {
+		return exit(code, "e2b exec %q exited %d", command, code)
+	}
+	return nil
+}
+
+func createE2BSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
+	var input bytes.Buffer
+	input.Write(manifest.NUL())
+	archive, err := os.CreateTemp("", "crabbox-e2b-sync-*.tgz")
+	if err != nil {
+		return nil, fmt.Errorf("create sync archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
+	cmd.Stdin = &input
+	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
+	cmd.Stdout = archive
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	keep = true
+	return archive, nil
+}
+
+func e2bRandomSuffix() string {
+	return strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
+}


### PR DESCRIPTION
## Summary
- Add `provider: e2b` as a delegated-run backend using E2B sandbox REST APIs for lifecycle/list and the envd Connect-protocol stream for command execution and archive sync.
- Wire E2B config/env/flags into provider selection, CLI config output, built-in registration, and the OpenClaw plugin schema.
- Reject `--class` and `--type` for `provider=e2b` before any provisioning (E2B does not expose CPU/memory class knobs from the public REST API; exposing the surface as a no-op would be misleading).
- `--checksum` is rejected too — E2B uses a tar-archive upload-then-extract sync, not rsync.
- Document E2B commands, configuration, provider behavior, ownership checks, and source-map entries.

## Validation
Local gates:
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/providers/e2b ./internal/cli`
- `go build -trimpath ./cmd/crabbox`
- `npm run check`
- `npm run docs:check`
- `npm ci --prefix worker && npm test --prefix worker && npm run check --prefix worker`

Live E2B smoke against `api.e2b.app` / `*.e2b.app` envd, freshly provisioned key:

```
=== reject --class ===
--class is not supported for provider=e2b
exit=2

=== warmup ===
provisioning provider=e2b lease=cbx_b33d45bb636d slug=quick-shrimp template=base timeout=120s
leased cbx_b33d45bb636d slug=quick-shrimp provider=e2b sandbox=i0v482ipj3g8yez2c17qs
warmup complete total=472ms

=== list --json ===
server_type.name=\"base\"   (alias-preferred display)

=== status --id cbx_b33d45bb636d ===
state=running type=base ready=true

=== run --no-sync uname -a ===
Linux e2b.local 6.1.158 #2 SMP PREEMPT_DYNAMIC Fri Mar 13 10:12:54 UTC 2026 x86_64 GNU/Linux
exit=0  host_exit=0

=== run --no-sync bash -c 'exit 7' ===
e2b run summary sync_skipped=true command=205ms total=1.092s exit=7
e2b run exited 7        (no \"exit status 7\" stderr noise)
host_exit=7

=== status by synthetic e2b_<sandboxID> ===
resolves to lease cbx_b33d45bb636d via crabbox metadata ownership check

=== stop ===
released lease=cbx_b33d45bb636d sandbox=i0v482ipj3g8yez2c17qs

=== list after stop ===
[]

=== Raw GET /sandboxes ===
[]
```

No leaked sandboxes; all flows exit cleanly.

## Notes
- Defaults: API URL `https://api.e2b.app`, sandbox domain `e2b.app`, template `base`, workdir `crabbox` (resolved to `/home/user/crabbox`).
- Auth env: `E2B_API_KEY` (and `CRABBOX_E2B_API_KEY`); `newE2BClient` fails fast with exit=2 when unset.
- Ownership: list/status/stop reject sandboxes that are not tagged with `crabbox=true` and `provider=e2b`, mirroring the Daytona/Hetzner guardrails.