### PR TITLE
fix: stop stale bridge polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@
 - Fixed coordinator-backed `crabbox list` so a stale admin token no longer blocks normal logged-in users; the CLI now falls back to active user-visible leases instead of failing with `401 unauthorized`.
 - Fixed desktop, screenshot, VNC, and WebVNC SSH helpers so they retry live fallback ports when a coordinator lease advertises an SSH port that is not ready yet.
 
+### Fixed
+
+- Fixed stale Code, WebVNC, and egress bridge clients so expired or missing leases stop polling/restarting after terminal coordinator responses. Thanks @vincentkoc.
+
 ## 0.7.0 - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed E2B workspace guardrails so broad roots such as `/`, `/home`, and `/tmp` are rejected before sync creates, deletes, or extracts files.
 - Fixed E2B sandbox creation so unsafe workdirs are rejected before the API call. Thanks @stainlu.
 - Fixed E2B user validation so path-like users are rejected before sandbox or process calls. Thanks @stainlu.
+- Fixed stale Code, WebVNC, and egress bridge clients so expired or missing leases stop polling/restarting after terminal coordinator responses. Thanks @vincentkoc.
 - Fixed `crabbox desktop paste` for terminal windows so symbol-heavy text falls back to direct typing instead of sending a literal `Ctrl+V` into xterm-like sessions.
 - Removed the vulnerable transitive `fast-xml-builder` Worker dependency by updating fast-xml-parser.
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -24,6 +24,20 @@ type CoordinatorClient struct {
 	Client  *http.Client
 }
 
+type CoordinatorHTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Message    string
+}
+
+func (e CoordinatorHTTPError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("coordinator %s %s: http %d: %s", e.Method, e.Path, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("coordinator %s %s: http %d", e.Method, e.Path, e.StatusCode)
+}
+
 type CoordinatorLease struct {
 	ID                   string                `json:"id"`
 	Slug                 string                `json:"slug,omitempty"`
@@ -1081,10 +1095,12 @@ func decodeCoordinatorResponse(method, path string, statusCode int, body io.Read
 	if statusCode < 200 || statusCode >= 300 {
 		data, _ := io.ReadAll(io.LimitReader(body, 600))
 		msg := strings.TrimSpace(string(data))
-		if msg != "" {
-			return fmt.Errorf("coordinator %s %s: http %d: %s", method, path, statusCode, msg)
+		return CoordinatorHTTPError{
+			Method:     method,
+			Path:       path,
+			StatusCode: statusCode,
+			Message:    msg,
 		}
-		return fmt.Errorf("coordinator %s %s: http %d", method, path, statusCode)
 	}
 	if out != nil {
 		if buf, ok := out.(*bytes.Buffer); ok {

--- a/internal/cli/daemon_unix_test.go
+++ b/internal/cli/daemon_unix_test.go
@@ -45,17 +45,23 @@ func TestStopDaemonProcessKillsProcessGroup(t *testing.T) {
 func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
 	for {
 		data, err := os.ReadFile(path)
 		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-			if parseErr != nil {
-				t.Fatal(parseErr)
+			value := strings.TrimSpace(string(data))
+			if value != "" {
+				pid, parseErr := strconv.Atoi(value)
+				if parseErr == nil {
+					return pid
+				}
+				lastErr = parseErr
 			}
-			return pid
+		} else {
+			lastErr = err
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for pid file %s: %v", path, err)
+			t.Fatalf("timed out waiting for pid file %s: %v", path, lastErr)
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -34,6 +34,7 @@ const (
 	egressDialTimeout       = 15 * time.Second
 	egressRemoteReadyWait   = 5 * time.Second
 	egressDaemonRestartWait = 1 * time.Second
+	egressDaemonFatalCode   = 4
 )
 
 type egressProxyMessage struct {
@@ -114,6 +115,9 @@ func (a App) egressHost(ctx context.Context, args []string) error {
 	}
 	bridge, err := connectEgressBridge(ctx, coord, leaseID, "host", *ticket, *sessionID, *profile, allow)
 	if err != nil {
+		if fatalEgressBridgeSetupError(err) {
+			return exit(egressDaemonFatalCode, "egress lease unavailable: %v", err)
+		}
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "egress host: connected lease=%s session=%s profile=%s allow=%s\n", leaseID, bridge.sessionID, blank(*profile, "-"), strings.Join(allow, ","))
@@ -145,6 +149,9 @@ func (a App) egressClient(ctx context.Context, args []string) error {
 	}
 	bridge, err := connectEgressBridge(ctx, coord, leaseID, "client", *ticket, *sessionID, "", nil)
 	if err != nil {
+		if fatalEgressBridgeSetupError(err) {
+			return exit(egressDaemonFatalCode, "egress lease unavailable: %v", err)
+		}
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "egress client: connected lease=%s session=%s listen=%s\n", leaseID, bridge.sessionID, *listen)
@@ -366,6 +373,19 @@ func connectEgressBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 		conns:     map[string]net.Conn{},
 		pending:   map[string]chan egressOpenResult{},
 	}, nil
+}
+
+func fatalEgressBridgeSetupError(err error) bool {
+	var httpErr CoordinatorHTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	switch httpErr.StatusCode {
+	case http.StatusForbidden, http.StatusNotFound, http.StatusGone, http.StatusConflict:
+		return true
+	default:
+		return false
+	}
 }
 
 func reusableEgressSessionID(ctx context.Context, coord *CoordinatorClient, leaseID, sessionID string) (string, error) {
@@ -954,6 +974,10 @@ func egressDaemonSupervisorScript(exe string, args []string) string {
 		"while :; do\n" +
 		"  " + strings.Join(argv, " ") + "\n" +
 		"  code=$?\n" +
+		"  if [ \"$code\" = " + strconv.Itoa(egressDaemonFatalCode) + " ]; then\n" +
+		"    echo \"egress daemon supervisor: child exited fatal code=$code; stopping\"\n" +
+		"    exit \"$code\"\n" +
+		"  fi\n" +
 		"  echo \"egress daemon supervisor: child exited code=$code; restarting in 1s\"\n" +
 		"  sleep " + strconv.Itoa(int(egressDaemonRestartWait/time.Second)) + "\n" +
 		"done\n"

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -135,6 +135,32 @@ func TestManualEgressTicketCreationReusesActiveSession(t *testing.T) {
 	}
 }
 
+func TestFatalEgressBridgeSetupError(t *testing.T) {
+	fatalStatuses := []int{http.StatusForbidden, http.StatusNotFound, http.StatusGone, http.StatusConflict}
+	for _, status := range fatalStatuses {
+		err := CoordinatorHTTPError{StatusCode: status}
+		if !fatalEgressBridgeSetupError(err) {
+			t.Fatalf("status %d should stop stale egress bridge retries", status)
+		}
+	}
+	if fatalEgressBridgeSetupError(CoordinatorHTTPError{StatusCode: http.StatusTooManyRequests}) {
+		t.Fatal("transient coordinator errors should stay retryable")
+	}
+}
+
+func TestEgressDaemonSupervisorStopsOnFatalExit(t *testing.T) {
+	script := egressDaemonSupervisorScript("crabbox", []string{"egress", "host"})
+	for _, want := range []string{
+		`if [ "$code" = 4 ]; then`,
+		`egress daemon supervisor: child exited fatal code=$code; stopping`,
+		`exit "$code"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("supervisor script missing %q:\n%s", want, script)
+		}
+	}
+}
+
 func TestEgressRequestHostPort(t *testing.T) {
 	connect := &http.Request{Method: http.MethodConnect, Host: "discord.com:443"}
 	host, port, err := egressRequestHostPort(connect)

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -597,8 +597,17 @@ export function portalVNC(lease: LeaseRecord): Response {
       let statusTimer;
       let controllerLabel = "";
       let isController = false;
+      const terminalStatusCodes = new Set([403, 404, 409, 410]);
       function retryDelay() {
         return Math.min(5000, 500 * 2 ** retryAttempt);
+      }
+      async function responseMessage(response, fallback) {
+        try {
+          const body = await response.json();
+          return body.message || body.error || fallback;
+        } catch (_) {
+          return fallback;
+        }
       }
       function fallbackCopyText(text) {
         const ta = document.createElement("textarea");
@@ -626,9 +635,16 @@ export function portalVNC(lease: LeaseRecord): Response {
       async function bridgeState() {
         try {
           const response = await fetch(statusURL, { cache: "no-store" });
-          return response.ok ? await response.json() : undefined;
-        } catch {
-          return undefined;
+          if (response.ok) {
+            return await response.json();
+          }
+          const message = await responseMessage(response, "WebVNC bridge unavailable");
+          if (terminalStatusCodes.has(response.status)) {
+            return { terminal: true, message };
+          }
+          return { transient: true, message };
+        } catch (error) {
+          return { transient: true, message: error instanceof Error ? error.message : String(error) };
         }
       }
       function applyCollaborationState(state) {
@@ -663,6 +679,15 @@ export function portalVNC(lease: LeaseRecord): Response {
         applyCollaborationState(state);
         return state;
       }
+      function stopPolling(label) {
+        stopped = true;
+        connected = false;
+        window.clearTimeout(retryTimer);
+        window.clearInterval(statusTimer);
+        try { rfb?.disconnect(); } catch (_) {}
+        screen.replaceChildren();
+        setStatus(label, "bad");
+      }
       function scheduleRetry(label) {
         if (stopped) return;
         const delay = retryDelay();
@@ -677,6 +702,14 @@ export function portalVNC(lease: LeaseRecord): Response {
         screen.replaceChildren();
         try {
           const state = await bridgeState();
+          if (state?.terminal) {
+            stopPolling(state.message || "WebVNC bridge unavailable");
+            return;
+          }
+          if (state?.transient) {
+            scheduleRetry(state.message || "WebVNC status unavailable");
+            return;
+          }
           if (state && !state.bridgeConnected) {
             scheduleRetry(state.message || "WebVNC daemon not running; run the bridge command below");
             return;
@@ -926,15 +959,39 @@ export function portalCode(lease: LeaseRecord): Response {
         const hint = document.getElementById("code-hint");
         const statusURL = new URL(${JSON.stringify(statusPath)}, window.location.href);
         let pollTimer;
+        let stopped = false;
+        const terminalStatusCodes = new Set([403, 404, 409, 410]);
         function setStatus(value, tone = "") {
           status.textContent = value;
           status.dataset.tone = tone;
         }
+        async function responseMessage(response, fallback) {
+          try {
+            const body = await response.json();
+            return body.message || body.error || fallback;
+          } catch (_) {
+            return fallback;
+          }
+        }
+        function stopPolling(message) {
+          stopped = true;
+          window.clearTimeout(pollTimer);
+          setStatus("bridge unavailable", "bad");
+          hint.textContent = message || "This lease is no longer available. Open a current lease from the portal.";
+        }
         async function pollBridge() {
+          if (stopped) return;
           window.clearTimeout(pollTimer);
           try {
             const response = await fetch(statusURL, { cache: "no-store" });
-            if (!response.ok) throw new Error("status " + response.status);
+            if (!response.ok) {
+              const message = await responseMessage(response, "Code bridge status unavailable");
+              if (terminalStatusCodes.has(response.status)) {
+                stopPolling(message);
+                return;
+              }
+              throw new Error(message);
+            }
             const state = await response.json();
             if (state?.code?.agentConnected) {
               setStatus("bridge connected; opening", "ok");
@@ -948,7 +1005,9 @@ export function portalCode(lease: LeaseRecord): Response {
             setStatus("status unavailable", "bad");
             hint.textContent = "Could not read bridge status. Reload or use the command below.";
           }
-          pollTimer = window.setTimeout(pollBridge, 2000);
+          if (!stopped) {
+            pollTimer = window.setTimeout(pollBridge, 2000);
+          }
         }
         document.getElementById("code-reload")?.addEventListener("click", () => {
           window.location.reload();

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1437,6 +1437,8 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain('id="code-copy"');
     expect(pageBody).toContain("/portal/leases/cbx_000000000001/code/health");
     expect(pageBody).toContain("window.location.reload()");
+    expect(pageBody).toContain("terminalStatusCodes");
+    expect(pageBody).toContain("stopPolling(message)");
 
     const health = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/code/health", { headers }),
@@ -1748,6 +1750,11 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).not.toContain("vnc-role");
     expect(pageBody).not.toContain("status-pill vnc-role");
     expect(pageBody).toContain("rfb.viewOnly = !controlling");
+    expect(pageBody).toContain(
+      "WebVNC viewer already active; close stale WebVNC tabs or run reset",
+    );
+    expect(pageBody).toContain("state?.terminal");
+    expect(pageBody).toContain("stopPolling(state.message");
     expect(pageBody).toContain('fragment.get("username")');
     expect(pageBody).toContain('types.includes("username")');
     expect(pageBody).not.toContain("cdn.jsdelivr.net");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1750,9 +1750,6 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).not.toContain("vnc-role");
     expect(pageBody).not.toContain("status-pill vnc-role");
     expect(pageBody).toContain("rfb.viewOnly = !controlling");
-    expect(pageBody).toContain(
-      "WebVNC viewer already active; close stale WebVNC tabs or run reset",
-    );
     expect(pageBody).toContain("state?.terminal");
     expect(pageBody).toContain("stopPolling(state.message");
     expect(pageBody).toContain('fragment.get("username")');

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1,3 +1,5 @@
+import { Script, createContext } from "node:vm";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -11,6 +13,7 @@ import {
   shouldActivateEgressSession,
   type WebVNCBuffer,
 } from "../src/fleet";
+import { portalCode } from "../src/portal";
 import type {
   Env,
   ExternalRunnerRecord,
@@ -1475,6 +1478,29 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(missingTicket.status).toBe(401);
+  });
+
+  it("stops code bridge polling after terminal status responses", async () => {
+    const page = await portalCode(
+      testLease({
+        id: "cbx_000000000001",
+        slug: "blue-lobster",
+        code: true,
+      }),
+    ).text();
+    const runtime = await runCodePortalScript(page, {
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "code_unavailable", message: "lease is not active" }),
+    });
+
+    expect(runtime.fetches).toEqual([
+      "https://example.test/portal/leases/cbx_000000000001/code/health",
+    ]);
+    expect(runtime.elements["code-status"]?.textContent).toBe("bridge unavailable");
+    expect(runtime.elements["code-status"]?.dataset.tone).toBe("bad");
+    expect(runtime.elements["code-hint"]?.textContent).toBe("lease is not active");
+    expect(runtime.timers).toEqual([]);
   });
 
   it("accepts bridge tickets in authorization before falling back to query strings", () => {
@@ -3126,6 +3152,83 @@ function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {
     expiresAt: "2026-05-01T01:30:00.000Z",
     ...overrides,
   };
+}
+
+type CodePortalRuntime = {
+  elements: Record<string, DOMElementStub>;
+  fetches: string[];
+  timers: Array<{ delay: number }>;
+};
+
+type DOMElementStub = {
+  dataset: Record<string, string>;
+  textContent: string;
+  disabled: boolean;
+  addEventListener: ReturnType<typeof vi.fn>;
+};
+
+function elementStub(textContent = ""): DOMElementStub {
+  return {
+    dataset: {},
+    textContent,
+    disabled: false,
+    addEventListener: vi.fn<() => void>(),
+  };
+}
+
+async function runCodePortalScript(
+  page: string,
+  response: { ok: boolean; status: number; json: () => Promise<unknown> },
+): Promise<CodePortalRuntime> {
+  const script = inlineScript(page, 'const status = document.getElementById("code-status")');
+  const elements: Record<string, DOMElementStub> = {
+    "code-status": elementStub("checking bridge"),
+    "code-hint": elementStub("Run the command below."),
+    "code-reload": elementStub(),
+    "code-copy": elementStub(),
+    "code-bridge-cmd": elementStub("crabbox code --id blue-lobster --open"),
+  };
+  const fetches: string[] = [];
+  const timers: Array<{ delay: number }> = [];
+  const context = createContext({
+    URL,
+    document: {
+      getElementById: (id: string) => elements[id] ?? null,
+      createRange: () => ({ selectNodeContents: vi.fn<(element: unknown) => void>() }),
+    },
+    fetch: vi.fn<(url: URL) => Promise<typeof response>>(async (url) => {
+      fetches.push(url.toString());
+      return response;
+    }),
+    navigator: { clipboard: { writeText: vi.fn<(text: string) => Promise<void>>() } },
+    window: {
+      location: { href: "https://example.test/portal/leases/blue-lobster/code/" },
+      clearTimeout: vi.fn<(timer?: unknown) => void>(),
+      setTimeout: (_callback: () => void, delay: number) => {
+        timers.push({ delay });
+        return timers.length;
+      },
+      addEventListener: vi.fn<() => void>(),
+      getSelection: () => ({
+        removeAllRanges: vi.fn<() => void>(),
+        addRange: vi.fn<(range: unknown) => void>(),
+      }),
+    },
+  });
+
+  new Script(script).runInContext(context);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+  return { elements, fetches, timers };
+}
+
+function inlineScript(page: string, marker: string): string {
+  const scripts = [...page.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g)];
+  const match = scripts.find((script) => script[1]?.includes(marker));
+  if (!match?.[1]) {
+    throw new Error(`script marker not found: ${marker}`);
+  }
+  return match[1];
 }
 
 function testRun(overrides: Partial<RunRecord>): RunRecord {


### PR DESCRIPTION
## Summary
- stop Code/WebVNC portal polling when coordinator returns terminal stale-lease statuses
- stop egress daemon supervisor restarts for expired or missing coordinator leases
- preserve typed coordinator HTTP status errors for retry decisions
- update changelog for the stale bridge cleanup

## Verification
- npm run format:check --prefix worker
- npm test --prefix worker -- fleet.test.ts
- npm run check --prefix worker
- go test ./internal/cli -run 'Test(FatalEgressBridgeSetupError|EgressDaemonSupervisorStopsOnFatalExit|ManualEgressTicketCreationReusesActiveSession)'\n- git diff --check