### PR TITLE
fix: harden Semaphore provider guardrails

### DIFF
--- a/docs/providers/semaphore.md
+++ b/docs/providers/semaphore.md
@@ -39,15 +39,17 @@ the debug SSH key API, returns a standard `LeaseTarget`.
 provider: semaphore
 semaphore:
   host: myorg.semaphoreci.com     # required
-  token: ...                       # required
+  # Prefer CRABBOX_SEMAPHORE_TOKEN or SEMAPHORE_API_TOKEN.
+  # Use user config only; do not commit tokens in repo config.
+  token: ...                       # required unless provided by env
   project: my-app                  # required
   machine: f1-standard-2           # optional, default: f1-standard-2
   osImage: ubuntu2204              # optional, default: ubuntu2204
   idleTimeout: 30m                 # optional, default: 30m
 ```
 
-Flags: `--semaphore-host`, `--semaphore-token`, `--semaphore-project`,
-`--semaphore-machine`, `--semaphore-os-image`, `--semaphore-idle-timeout`.
+Flags: `--semaphore-host`, `--semaphore-project`, `--semaphore-machine`,
+`--semaphore-os-image`, `--semaphore-idle-timeout`.
 
 Environment variables:
 

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -27,6 +27,13 @@ type jobInfo struct {
 	State string
 }
 
+type jobStatus struct {
+	Name    string
+	State   string
+	IP      string
+	SSHPort int
+}
+
 const userAgent = "SemaphoreCI v2.0 Client"
 
 func newAPIClient(host, token string, rt core.Runtime) *apiClient {
@@ -91,23 +98,26 @@ func (c *apiClient) WaitForRunning(ctx context.Context, jobID string, tick func(
 		}
 		tick()
 
-		state, ip, port, err := c.GetJobStatus(ctx, jobID)
+		status, err := c.GetJobStatus(ctx, jobID)
 		if err != nil {
 			continue
 		}
-		if state == "FINISHED" {
+		if status.State == "FINISHED" {
 			return "", 0, core.Exit(5, "job %s finished before reaching RUNNING state", jobID)
 		}
-		if state == "RUNNING" {
-			return ip, port, nil
+		if status.State == "RUNNING" {
+			return status.IP, status.SSHPort, nil
 		}
 	}
 	return "", 0, core.Exit(5, "job %s did not reach RUNNING state within timeout", jobID)
 }
 
-// GetJobStatus returns the job state, IP, and SSH port.
-func (c *apiClient) GetJobStatus(ctx context.Context, jobID string) (state, ip string, sshPort int, err error) {
+// GetJobStatus returns the job metadata, state, IP, and SSH port.
+func (c *apiClient) GetJobStatus(ctx context.Context, jobID string) (jobStatus, error) {
 	var result struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
 		Status struct {
 			State string `json:"state"`
 			Agent struct {
@@ -120,7 +130,7 @@ func (c *apiClient) GetJobStatus(ctx context.Context, jobID string) (state, ip s
 		} `json:"status"`
 	}
 	if err := c.get(ctx, "/api/v1alpha/jobs/"+jobID, &result); err != nil {
-		return "", "", 0, err
+		return jobStatus{}, err
 	}
 	port := 0
 	for _, p := range result.Status.Agent.Ports {
@@ -128,7 +138,12 @@ func (c *apiClient) GetJobStatus(ctx context.Context, jobID string) (state, ip s
 			port = p.Number
 		}
 	}
-	return result.Status.State, result.Status.Agent.IP, port, nil
+	return jobStatus{
+		Name:    result.Metadata.Name,
+		State:   result.Status.State,
+		IP:      result.Status.Agent.IP,
+		SSHPort: port,
+	}, nil
 }
 
 // GetSSHKey returns the SSH private key for a job.

--- a/internal/providers/semaphore/backend.go
+++ b/internal/providers/semaphore/backend.go
@@ -18,7 +18,7 @@ type semaphoreBackend struct {
 
 func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.Semaphore.Host == "" || cfg.Semaphore.Token == "" {
-		return nil, core.Exit(2, "semaphore provider requires semaphore.host and semaphore.token in config or --semaphore-host/--semaphore-token flags")
+		return nil, core.Exit(2, "semaphore provider requires semaphore.host in config, environment, or --semaphore-host and semaphore.token in config or environment")
 	}
 	cfg.Provider = providerName
 	client := newAPIClient(cfg.Semaphore.Host, cfg.Semaphore.Token, rt)
@@ -137,12 +137,15 @@ func isLeaseID(id string) bool {
 }
 
 func (b *semaphoreBackend) resolveByJobID(ctx context.Context, jobID string) (core.LeaseTarget, error) {
-	state, ip, sshPort, err := b.client.GetJobStatus(ctx, jobID)
+	status, err := b.client.GetJobStatus(ctx, jobID)
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if state != "RUNNING" {
-		return core.LeaseTarget{}, core.Exit(4, "semaphore job %s is not running (state: %s)", jobID, state)
+	if !isCrabboxJobName(status.Name) {
+		return core.LeaseTarget{}, core.Exit(4, "semaphore job %s is not Crabbox-managed", jobID)
+	}
+	if status.State != "RUNNING" {
+		return core.LeaseTarget{}, core.Exit(4, "semaphore job %s is not running (state: %s)", jobID, status.State)
 	}
 
 	sshKey, err := b.client.GetSSHKey(ctx, jobID)
@@ -164,9 +167,9 @@ func (b *semaphoreBackend) resolveByJobID(ctx context.Context, jobID string) (co
 
 	target := core.SSHTarget{
 		User:       "semaphore",
-		Host:       ip,
+		Host:       status.IP,
 		Key:        keyPath,
-		Port:       fmt.Sprintf("%d", sshPort),
+		Port:       fmt.Sprintf("%d", status.SSHPort),
 		TargetOS:   core.TargetLinux,
 		ReadyCheck: "true",
 	}
@@ -181,7 +184,7 @@ func (b *semaphoreBackend) resolveByJobID(ctx context.Context, jobID string) (co
 			"provider": providerName,
 		},
 	}
-	server.PublicNet.IPv4.IP = ip
+	server.PublicNet.IPv4.IP = status.IP
 	server.ServerType.Name = withDefault(b.cfg.Semaphore.Machine, "f1-standard-2")
 
 	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -196,6 +199,9 @@ func (b *semaphoreBackend) List(ctx context.Context, req core.ListRequest) ([]co
 
 	var servers []core.Server
 	for _, j := range jobs {
+		if !isCrabboxJobName(j.Name) {
+			continue
+		}
 		s := core.Server{
 			CloudID:  j.ID,
 			Provider: providerName,
@@ -214,7 +220,12 @@ func (b *semaphoreBackend) List(ctx context.Context, req core.ListRequest) ([]co
 // ReleaseLease stops the Semaphore job.
 func (b *semaphoreBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	jobID := stripLeasePrefix(req.Lease.LeaseID)
-	return b.client.StopJob(ctx, jobID)
+	if err := b.client.StopJob(ctx, jobID); err != nil {
+		return err
+	}
+	core.RemoveLeaseClaim(req.Lease.LeaseID)
+	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
+	return nil
 }
 
 // Touch is a no-op for Semaphore — the keepalive script handles idle timeout.
@@ -223,8 +234,13 @@ func (b *semaphoreBackend) Touch(ctx context.Context, req core.TouchRequest) (co
 }
 
 func storeSSHKey(leaseID, keyContent string) (string, error) {
-	dir := os.TempDir()
-	path := filepath.Join(dir, ".crabbox-sem-"+leaseID+".key")
+	path, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", err
+	}
 	if err := os.WriteFile(path, []byte(keyContent), 0600); err != nil {
 		return "", err
 	}

--- a/internal/providers/semaphore/backend_test.go
+++ b/internal/providers/semaphore/backend_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -77,7 +79,6 @@ func TestRegisterAndApplyFlags(t *testing.T) {
 	values := registerFlags(fs, cfg)
 	err := fs.Parse([]string{
 		"--semaphore-host", "myorg.semaphoreci.com",
-		"--semaphore-token", "my-token",
 		"--semaphore-project", "my-app",
 		"--semaphore-machine", "f1-standard-4",
 		"--semaphore-os-image", "ubuntu2404",
@@ -91,9 +92,6 @@ func TestRegisterAndApplyFlags(t *testing.T) {
 
 	if cfg.Semaphore.Host != "myorg.semaphoreci.com" {
 		t.Errorf("host = %q", cfg.Semaphore.Host)
-	}
-	if cfg.Semaphore.Token != "my-token" {
-		t.Errorf("token = %q", cfg.Semaphore.Token)
 	}
 	if cfg.Semaphore.Project != "my-app" {
 		t.Errorf("project = %q", cfg.Semaphore.Project)
@@ -215,6 +213,9 @@ func TestCreateJob(t *testing.T) {
 func TestGetJobStatus(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]string{
+				"name": "crabbox testbox",
+			},
 			"status": map[string]any{
 				"state": "RUNNING",
 				"agent": map[string]any{
@@ -231,18 +232,21 @@ func TestGetJobStatus(t *testing.T) {
 	host := strings.TrimPrefix(server.URL, "https://")
 	client := &apiClient{host: host, token: "tok", http: server.Client()}
 
-	state, ip, port, err := client.GetJobStatus(context.Background(), "job-123")
+	status, err := client.GetJobStatus(context.Background(), "job-123")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state != "RUNNING" {
-		t.Errorf("state = %q", state)
+	if status.Name != "crabbox testbox" {
+		t.Errorf("name = %q", status.Name)
 	}
-	if ip != "1.2.3.4" {
-		t.Errorf("ip = %q", ip)
+	if status.State != "RUNNING" {
+		t.Errorf("state = %q", status.State)
 	}
-	if port != 40010 {
-		t.Errorf("port = %d", port)
+	if status.IP != "1.2.3.4" {
+		t.Errorf("ip = %q", status.IP)
+	}
+	if status.SSHPort != 40010 {
+		t.Errorf("port = %d", status.SSHPort)
 	}
 }
 
@@ -352,5 +356,143 @@ func TestStopJob(t *testing.T) {
 	}
 	if !stopped {
 		t.Error("stop endpoint was not called")
+	}
+}
+
+func TestResolveByJobIDRejectsNonCrabboxJob(t *testing.T) {
+	debugKeyHit := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/api/v1alpha/jobs/job-123" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]string{
+					"name": "deploy",
+				},
+				"status": map[string]any{
+					"state": "RUNNING",
+					"agent": map[string]any{
+						"ip": "1.2.3.4",
+						"ports": []map[string]any{
+							{"name": "ssh", "number": 40010},
+						},
+					},
+				},
+			})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/debug_ssh_key") {
+			debugKeyHit = true
+		}
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	backend := &semaphoreBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    testConfig(host),
+		rt:     testRuntime(server.Client()),
+		client: &apiClient{host: host, token: "tok", http: server.Client()},
+	}
+
+	_, err := backend.resolveByJobID(context.Background(), "job-123")
+	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
+		t.Fatalf("resolve error = %v, want Crabbox-managed rejection", err)
+	}
+	if debugKeyHit {
+		t.Fatal("debug SSH key endpoint should not be called for non-Crabbox jobs")
+	}
+}
+
+func TestListFiltersNonCrabboxJobs(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/api/v1alpha/jobs" && r.URL.Query().Get("states") == "RUNNING" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"jobs": []map[string]any{
+					{
+						"metadata": map[string]string{"id": "job-crabbox", "name": "crabbox testbox"},
+						"status":   map[string]string{"state": "RUNNING"},
+					},
+					{
+						"metadata": map[string]string{"id": "job-deploy", "name": "deploy"},
+						"status":   map[string]string{"state": "RUNNING"},
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	backend := &semaphoreBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    testConfig(host),
+		rt:     testRuntime(server.Client()),
+		client: &apiClient{host: host, token: "tok", http: server.Client()},
+	}
+
+	servers, err := backend.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("servers = %v, want exactly one Crabbox job", servers)
+	}
+	if servers[0].CloudID != "job-crabbox" {
+		t.Errorf("cloud id = %q, want job-crabbox", servers[0].CloudID)
+	}
+}
+
+func TestReleaseRemovesClaimAndStoredKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+
+	leaseID := "sem_job-release"
+	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue-lobster", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := storeSSHKey(leaseID, "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopped := false
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/api/v1alpha/jobs/job-release/stop" {
+			stopped = true
+			w.Write([]byte("{}"))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	backend := &semaphoreBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    testConfig(host),
+		rt:     testRuntime(server.Client()),
+		client: &apiClient{host: host, token: "tok", http: server.Client()},
+	}
+
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{LeaseID: leaseID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stopped {
+		t.Fatal("stop endpoint was not called")
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stored key still exists or stat failed with unexpected error: %v", err)
+	}
+	if _, found, err := core.ResolveLeaseClaim("blue-lobster"); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("lease claim still resolves after release")
 	}
 }

--- a/internal/providers/semaphore/helpers.go
+++ b/internal/providers/semaphore/helpers.go
@@ -2,6 +2,7 @@ package semaphore
 
 import (
 	"flag"
+	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -11,7 +12,6 @@ const providerName = "semaphore"
 
 type flagValues struct {
 	Host        *string
-	Token       *string
 	Project     *string
 	Machine     *string
 	OSImage     *string
@@ -22,7 +22,6 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) flagValues {
 	sem := defaults.Semaphore
 	return flagValues{
 		Host:        fs.String("semaphore-host", sem.Host, "Semaphore host (e.g. myorg.semaphoreci.com)"),
-		Token:       fs.String("semaphore-token", sem.Token, "Semaphore API token"),
 		Project:     fs.String("semaphore-project", sem.Project, "Semaphore project name"),
 		Machine:     fs.String("semaphore-machine", withDefault(sem.Machine, "f1-standard-2"), "Machine type"),
 		OSImage:     fs.String("semaphore-os-image", withDefault(sem.OSImage, "ubuntu2204"), "OS image"),
@@ -33,9 +32,6 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) flagValues {
 func applyFlagOverrides(cfg *core.Config, fs *flag.FlagSet, v flagValues) {
 	if wasSet(fs, "semaphore-host") {
 		cfg.Semaphore.Host = *v.Host
-	}
-	if wasSet(fs, "semaphore-token") {
-		cfg.Semaphore.Token = *v.Token
 	}
 	if wasSet(fs, "semaphore-project") {
 		cfg.Semaphore.Project = *v.Project
@@ -75,4 +71,8 @@ func idleTimeout(cfg core.Config) time.Duration {
 		}
 	}
 	return 30 * time.Minute
+}
+
+func isCrabboxJobName(name string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(name)), "crabbox testbox")
 }


### PR DESCRIPTION
## Summary
- reject raw Semaphore job IDs unless the job metadata identifies a Crabbox testbox
- hide unrelated Semaphore jobs from `crabbox list`
- store Semaphore debug SSH keys in Crabbox testbox key storage and remove claims/keys on release
- remove the token CLI flag from Semaphore docs/flags so tokens stay in config or env

Builds on https://github.com/openclaw/crabbox/pull/43.

## Verification
- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/semaphore ./internal/cli`
- `env GOCACHE=/private/tmp/crabbox-gocache go test ./...`
- `npm run docs:check`