### PR TITLE
docs: fill Azure capability matrix

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -174,6 +174,9 @@ Managed provider targets are intentionally narrow:
 - AWS supports Linux, native Windows (`--target windows --windows-mode normal`),
   Windows WSL2 (`--target windows --windows-mode wsl2`), and EC2 Mac
   (`--target macos`) when the Mac Dedicated Host is provided.
+- Azure supports Linux and native Windows (`--target windows --windows-mode
+  normal`). Azure Windows does not provide managed desktop, browser, WSL2, or
+  macOS targets.
 - Existing macOS and Windows machines belong on `provider=ssh`.
 
 Use Tailscale as an optional network plane:

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -148,6 +148,7 @@ host's VNC or Screen Sharing prompt.
 | --- | --- | --- |
 | Hetzner Linux | Yes | Requires `--desktop`; installs slim XFCE, Xvfb, x11vnc, and capture tools. |
 | AWS Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
+| Azure Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
 | AWS Windows | Yes | Requires `--target windows --desktop`; installs Git for Windows and TightVNC after EC2Launch enables OpenSSH. Spot or On-Demand follows the AWS capacity config. |
 | AWS macOS | Yes | Requires `--target macos --desktop --market on-demand` plus `CRABBOX_AWS_MAC_HOST_ID` or `aws.macHostId`. |
 | Static Linux | Host-managed | Requires an existing loopback VNC service on the host. |

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -236,7 +236,7 @@ often machine- and user-encrypted.
 
 ## Where To Go Next
 
-- [Linux VNC](vnc-linux.md): Hetzner/AWS Linux desktop services and static Linux.
+- [Linux VNC](vnc-linux.md): Hetzner/AWS/Azure Linux desktop services and static Linux.
 - [Windows VNC](vnc-windows.md): AWS Windows, native Windows static hosts, and WSL2 boundaries.
 - [macOS VNC](vnc-macos.md): AWS EC2 Mac and static Mac Screen Sharing.
 - [AWS](aws.md): AWS target matrix, capacity, AMIs, and EC2 Mac host requirements.

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -58,16 +58,17 @@ the address is already on the tailnet.
 
 ## Public Reachability
 
-Brokered AWS Linux, AWS Windows, AWS Mac, Hetzner Linux, Daytona, and Islo
-leases all expose at least one public address. Crabbox stores the public
-address on the server record and uses it whenever the network mode resolves
-to `public`.
+Brokered AWS Linux, AWS Windows, AWS Mac, Azure Linux, Azure native Windows,
+Hetzner Linux, Daytona, and Islo leases all expose at least one public address.
+Crabbox stores the public address on the server record and uses it whenever
+the network mode resolves to `public`.
 
 Public addresses are gated by the provider's security group / firewall. AWS
 managed leases use the `crabbox-runners` security group with SSH ingress
 limited to the configured CIDRs or the request source IP. Hetzner managed
 leases use the cloud firewall attached to the project; the broker keeps it
-limited to the operator's IPs.
+limited to the operator's IPs. Azure managed leases use the configured network
+security group and `azure.sshCIDRs`.
 
 If your client IP changes during a long warmup, the existing security group
 rule may not include the new IP. Re-running `crabbox status` adds the

--- a/docs/features/vnc-linux.md
+++ b/docs/features/vnc-linux.md
@@ -2,13 +2,13 @@
 
 Read when:
 
-- using `--desktop` on Hetzner or AWS Linux;
+- using `--desktop` on Hetzner, AWS, or Azure Linux;
 - debugging Xvfb, XFCE/Openbox, x11vnc, or screenshots on a Linux lease;
 - preparing a static Linux host for Crabbox VNC.
 
-Linux is the simplest managed desktop path. Hetzner and AWS Linux leases use
-the same bootstrap shape: install a lightweight desktop, run it on `DISPLAY=:99`,
-bind x11vnc to loopback, and let the CLI create an SSH tunnel.
+Linux is the simplest managed desktop path. Hetzner, AWS, and Azure Linux
+leases use the same bootstrap shape: install a lightweight desktop, run it on
+`DISPLAY=:99`, bind x11vnc to loopback, and let the CLI create an SSH tunnel.
 
 ## Managed Linux
 
@@ -105,6 +105,7 @@ Related docs:
 - [Interactive desktop and VNC](interactive-desktop-vnc.md)
 - [Hetzner](hetzner.md)
 - [AWS](aws.md)
+- [Azure](azure.md)
 - [vnc command](../commands/vnc.md)
 - [webvnc command](../commands/webvnc.md)
 - [desktop command](../commands/desktop.md)


### PR DESCRIPTION
## Summary
- add Azure Linux to VNC/Linux desktop support docs
- add Azure native Windows to managed target and public reachability matrices
- link Azure from Linux VNC docs

## Verification
- `npm run docs:check`