### PR TITLE
fix: surface Azure in portal filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `provider: azure` for managed Azure Linux and native Windows SSH leases, including direct and brokered provisioning, shared Azure networking, SKU fallback, Azure docs, and cleanup support. Thanks @jwmoss.
 
+### Fixed
+
+- Fixed the portal provider filters so Azure leases show their own filter badge and provider icon. Thanks @stainlu.
+
 ## 0.7.0 - 2026-05-07
 
 ### Added

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -58,6 +58,7 @@ export function portalHome(
     "stuck:stuck",
     ...(admin ? ["mine:mine", "system:system"] : []),
     "aws:aws",
+    "azure:azure",
     "hetzner:hetzner",
     "blacksmith-testbox:blacksmith",
     "linux:linux",
@@ -1628,6 +1629,9 @@ function providerIcon(provider: string): string {
   if (provider === "aws") {
     return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 15.5c3.8 2.2 9.1 2.5 14.8.9"/><path d="M17.5 13.2 20 16l-3.7.7"/><path d="M7 8.5h10l1.8 4H5.2z"/></svg>`;
   }
+  if (provider === "azure") {
+    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 17.5h9.2a4 4 0 0 0 .5-8 5.5 5.5 0 0 0-10.5-1.6A4.8 4.8 0 0 0 7.5 17.5Z"/><path d="M9 13h6"/></svg>`;
+  }
   if (provider === "hetzner") {
     return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 20 7.5v9L12 21l-8-4.5v-9z"/><path d="M8 8v8M16 8v8M8 12h8"/></svg>`;
   }
@@ -1828,6 +1832,7 @@ function html(
     .icon-label svg { width:14px; height:14px; flex:0 0 14px; fill:none; stroke:currentColor; stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; color:#cbd5e1; }
     .icon-label span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
     .icon-label[data-provider="aws"] svg { color:#fbbf24; }
+    .icon-label[data-provider="azure"] svg { color:#60a5fa; }
     .icon-label[data-provider="hetzner"] svg { color:#ef4444; }
     .icon-label[data-provider="blacksmith-testbox"] svg { color:#a78bfa; }
     .icon-label[data-target="linux"] svg { color:#34d399; }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -772,6 +772,17 @@ describe("fleet lease identity and idle", () => {
         windowsMode: "wsl2",
       }),
     );
+    storage.seed(
+      "lease:cbx_000000000006",
+      testLease({
+        id: "cbx_000000000006",
+        slug: "azure-box",
+        owner: "peter@example.com",
+        org: "openclaw",
+        provider: "azure",
+        target: "linux",
+      }),
+    );
     await fleet.fetch(
       request("POST", "/v1/runners/sync", {
         headers: {
@@ -839,7 +850,7 @@ describe("fleet lease identity and idle", () => {
     expect(body).toContain("table-scroll");
     expect(body).toContain(".lease-table th:nth-child(1)");
     expect(body).toContain(
-      'data-filter-buttons="active:active,ended:ended,external:external,stale:stale,stuck:stuck,aws:aws,hetzner:hetzner,blacksmith-testbox:blacksmith,linux:linux,macos:macos,windows:windows,all:all"',
+      'data-filter-buttons="active:active,ended:ended,external:external,stale:stale,stuck:stuck,aws:aws,azure:azure,hetzner:hetzner,blacksmith-testbox:blacksmith,linux:linux,macos:macos,windows:windows,all:all"',
     );
     expect(body).toContain('data-filter-default="active"');
     expect(body).not.toContain("external runners");
@@ -863,12 +874,14 @@ describe("fleet lease identity and idle", () => {
       'data-copy-value="crabbox stop --provider blacksmith-testbox tbx_01testbox"',
     );
     expect(body).not.toContain("tbx_friendbox");
+    expect(body).toContain('data-provider="azure"');
     expect(body).toContain('data-provider="hetzner"');
     expect(body).toContain('data-target="linux"');
     expect(body).toContain('data-target="windows"');
     expect(body).toContain("<span>win</span>");
     expect(body).toContain("<span>win (wsl2)</span>");
     expect(body).toContain('data-filter-tags="active mine hetzner linux"');
+    expect(body).toContain('data-filter-tags="active mine azure linux"');
     expect(body).toContain('class="access-cell"');
     expect(body).toContain('title="server"');
     expect(body).toContain('data-access="vscode"');


### PR DESCRIPTION
## Summary
- add Azure to the portal lease filter buttons
- render Azure leases with a distinct provider icon/color
- cover Azure provider filter tags in the portal rendering test

## Verification
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npx --yes node@24 ./node_modules/vitest/vitest.mjs run fleet.test.ts`
- `npx --yes node@24 ./node_modules/vitest/vitest.mjs run`

Note: local default Node lacks global WebSocket, so `npm test --prefix worker -- fleet.test.ts` fails in this checkout for the known Node runtime reason addressed by https://github.com/openclaw/crabbox/pull/44.