### PR TITLE
fix: respect E2B user workdirs

### DIFF
--- a/docs/features/e2b.md
+++ b/docs/features/e2b.md
@@ -35,6 +35,10 @@ e2b:
   user: ""
 ```
 
+Relative `e2b.workdir` values resolve inside the selected E2B user's home. The
+default user home is `/home/user`, `user: ubuntu` resolves under `/home/ubuntu`,
+and `user: root` resolves under `/root`. Absolute workdirs are used as-is.
+
 Equivalent one-off flags:
 
 ```sh
@@ -49,7 +53,7 @@ crabbox stop --provider e2b <slug>
 - `warmup` creates an E2B sandbox from `e2b.template`, stores Crabbox metadata,
   and records a local `cbx_...` lease claim.
 - `run` creates or reuses a sandbox, syncs the manifest into
-  `/home/user/<e2b.workdir>` unless the workdir is absolute, streams
+  `<e2b user home>/<e2b.workdir>` unless the workdir is absolute, streams
   stdout/stderr, and returns the remote exit code.
 - `--sync-only` performs only the archive upload and extraction.
 - `--checksum` is rejected because E2B does not expose a Crabbox SSH target.

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -51,6 +51,10 @@ e2b:
   user: ""
 ```
 
+Relative `e2b.workdir` values resolve inside the selected E2B user's home. The
+default user home is `/home/user`, `user: ubuntu` resolves under `/home/ubuntu`,
+and `user: root` resolves under `/root`. Absolute workdirs are used as-is.
+
 Provider flags:
 
 ```text
@@ -66,7 +70,8 @@ Provider flags:
 1. Create or resolve a Crabbox-owned E2B sandbox from `e2b.template`.
 2. Store Crabbox metadata and a local repo claim.
 3. Build the Crabbox sync manifest, upload a gzipped archive into `/tmp`, and
-   extract it into `/home/user/<e2b.workdir>` or an absolute configured workdir.
+   extract it into `<e2b user home>/<e2b.workdir>` or an absolute configured
+   workdir.
 4. Execute commands through E2B's process stream in that workdir.
 5. Delete the sandbox on release unless the lease is kept.
 

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -471,7 +471,18 @@ func e2bWorkspacePath(cfg Config) string {
 	if strings.HasPrefix(workdir, "/") {
 		return path.Clean(workdir)
 	}
-	return path.Join("/home/user", workdir)
+	return path.Join(e2bUserHome(cfg.E2B.User), workdir)
+}
+
+func e2bUserHome(user string) string {
+	user = strings.TrimSpace(user)
+	if user == "" {
+		user = "user"
+	}
+	if user == "root" {
+		return "/root"
+	}
+	return path.Join("/home", user)
 }
 
 func e2bCommandString(command []string, shellMode bool) string {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -68,6 +68,12 @@ func TestE2BWorkspacePath(t *testing.T) {
 	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "repo"}}); got != "/home/user/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
+	if got := e2bWorkspacePath(Config{E2B: E2BConfig{User: "ubuntu", Workdir: "repo"}}); got != "/home/ubuntu/repo" {
+		t.Fatalf("workspace=%q", got)
+	}
+	if got := e2bWorkspacePath(Config{E2B: E2BConfig{User: "root", Workdir: "repo"}}); got != "/root/repo" {
+		t.Fatalf("workspace=%q", got)
+	}
 	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
@@ -195,12 +201,13 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	}
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{Workdir: "repo"}},
+		cfg: Config{E2B: E2BConfig{User: "ubuntu", Workdir: "repo"}},
 		rt:  Runtime{Stderr: io.Discard},
 	}
+	workspace := e2bWorkspacePath(backend.cfg)
 	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
 		Repo: Repo{Root: root, Name: "repo"},
-	}, "/home/user/repo")
+	}, workspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,8 +217,11 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if !tarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
 		t.Fatal("uploaded archive missing go.mod")
 	}
-	if !client.commandContains("mkdir -p '/home/user/repo'") || !client.commandContains("tar -xzf") {
+	if !client.commandContains("mkdir -p '/home/ubuntu/repo'") || !client.commandContains("tar -xzf") {
 		t.Fatalf("commands=%#v", client.commands)
+	}
+	if !client.userContains("ubuntu") {
+		t.Fatalf("users=%#v", client.users)
 	}
 }
 
@@ -276,6 +286,7 @@ func TestE2BResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
 
 type fakeE2BSyncClient struct {
 	commands   []string
+	users      []string
 	sandbox    e2bSandbox
 	getErr     error
 	uploadPath string
@@ -313,12 +324,22 @@ func (f *fakeE2BSyncClient) UploadFile(_ context.Context, _ e2bSession, targetPa
 
 func (f *fakeE2BSyncClient) StartProcess(_ context.Context, _ e2bSession, req e2bProcessRequest) (int, error) {
 	f.commands = append(f.commands, req.Command)
+	f.users = append(f.users, req.User)
 	return 0, nil
 }
 
 func (f *fakeE2BSyncClient) commandContains(value string) bool {
 	for _, command := range f.commands {
 		if strings.Contains(command, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeE2BSyncClient) userContains(value string) bool {
+	for _, user := range f.users {
+		if user == value {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- resolve relative E2B workdirs under the selected E2B user's home instead of always /home/user
- keep absolute E2B workdirs unchanged
- update E2B provider docs and regression tests

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/e2b ./internal/cli