### PR TITLE
fix: reject unsafe E2B workspaces

### DIFF
--- a/docs/features/e2b.md
+++ b/docs/features/e2b.md
@@ -52,6 +52,9 @@ crabbox stop --provider e2b <slug>
   `/home/user/<e2b.workdir>` unless the workdir is absolute, streams
   stdout/stderr, and returns the remote exit code.
 - `--sync-only` performs only the archive upload and extraction.
+- Workdirs must resolve to dedicated absolute directories. Broad roots such as
+  `/`, `/home`, and `/tmp` are rejected before sync touches the sandbox
+  filesystem.
 - `--checksum` is rejected because E2B does not expose a Crabbox SSH target.
 - `list`, `status`, and `stop` operate only on Crabbox-owned E2B sandboxes.
 

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -86,6 +86,9 @@ Provider flags:
   marks it as Crabbox-owned.
 - `--class` and `--type` are rejected because E2B template contents own sandbox
   resources.
+- E2B workdirs must resolve to dedicated absolute directories. Broad roots such
+  as `/`, `/home`, and `/tmp` are rejected before sync creates, deletes, or
+  extracts files.
 - `--checksum` is rejected because E2B does not expose a Crabbox SSH/rsync
   target. Large-sync guardrails still apply, and `--force-sync-large` is
   honored for intentional large archive syncs.

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -73,6 +73,39 @@ func TestE2BWorkspacePath(t *testing.T) {
 	}
 }
 
+func TestCleanE2BWorkspacePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		workspace string
+		want      string
+		wantErr   string
+	}{
+		{name: "cleans absolute path", workspace: " /home/user/repo/ ", want: "/home/user/repo"},
+		{name: "rejects empty path", workspace: " ", wantErr: "empty"},
+		{name: "rejects relative path", workspace: "repo", wantErr: "absolute"},
+		{name: "rejects root", workspace: "/", wantErr: "too broad"},
+		{name: "rejects home root", workspace: "/home", wantErr: "too broad"},
+		{name: "rejects tmp root", workspace: "/tmp", wantErr: "too broad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cleanE2BWorkspacePath(tt.workspace)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("workspace=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape(t *testing.T) {
 	var createBody map[string]any
 	listHits := 0
@@ -212,6 +245,23 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	}
 	if !client.commandContains("mkdir -p '/home/user/repo'") || !client.commandContains("tar -xzf") {
 		t.Fatalf("commands=%#v", client.commands)
+	}
+}
+
+func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
+	client := &fakeE2BSyncClient{}
+	cfg := Config{}
+	cfg.Sync.Delete = true
+	backend := &e2bBackend{
+		cfg: cfg,
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	err := backend.prepareWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, "/")
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("err=%v, want unsafe workspace error", err)
+	}
+	if len(client.commands) != 0 {
+		t.Fatalf("commands=%#v, want none", client.commands)
 	}
 }
 

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
+	workspace, err := cleanE2BWorkspacePath(workspace)
+	if err != nil {
+		return nil, 0, err
+	}
 	start := b.now()
 	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
 	if err != nil {
@@ -70,11 +74,31 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 }
 
 func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, session e2bSession, workspace string) error {
+	workspace, err := cleanE2BWorkspacePath(workspace)
+	if err != nil {
+		return err
+	}
 	command := "mkdir -p " + shellQuote(workspace)
 	if b.cfg.Sync.Delete {
 		command = "rm -rf " + shellQuote(workspace) + " && " + command
 	}
 	return b.execShell(ctx, client, session, command, io.Discard)
+}
+
+func cleanE2BWorkspacePath(workspace string) (string, error) {
+	trimmed := strings.TrimSpace(workspace)
+	if trimmed == "" {
+		return "", exit(2, "e2b workspace path is empty")
+	}
+	clean := path.Clean(trimmed)
+	if !strings.HasPrefix(clean, "/") {
+		return "", exit(2, "e2b workspace path %q must resolve to an absolute path", workspace)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
+		return "", exit(2, "e2b workspace path %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
 }
 
 func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSession, command string, stdout io.Writer) error {


### PR DESCRIPTION
## Summary
- reject empty, relative, and broad root E2B workspace paths before sync shell commands are built
- normalize safe E2B workspaces before mkdir, delete, and archive extraction
- document the dedicated-workdir guardrail

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/e2b ./internal/cli