### PR TITLE
fix: show Semaphore lease slugs in lists

### DIFF
--- a/internal/providers/semaphore/backend.go
+++ b/internal/providers/semaphore/backend.go
@@ -162,11 +162,7 @@ func (b *semaphoreBackend) resolveByJobID(ctx context.Context, jobID string) (co
 		return core.LeaseTarget{}, fmt.Errorf("store SSH key: %w", err)
 	}
 
-	// Read slug from claim if available
-	slug := ""
-	if claim, err := core.ReadLeaseClaim(leaseID); err == nil && claim.Slug != "" {
-		slug = claim.Slug
-	}
+	slug := semaphoreClaimSlug(leaseID)
 
 	target := core.SSHTarget{
 		User:       "semaphore",
@@ -179,7 +175,7 @@ func (b *semaphoreBackend) resolveByJobID(ctx context.Context, jobID string) (co
 	server := core.Server{
 		CloudID:  jobID,
 		Provider: providerName,
-		Name:     "sem-testbox",
+		Name:     semaphoreListName("sem-testbox", slug),
 		Status:   "running",
 		Labels: map[string]string{
 			"lease":    leaseID,
@@ -205,15 +201,20 @@ func (b *semaphoreBackend) List(ctx context.Context, req core.ListRequest) ([]co
 		if !isCrabboxJobName(j.Name) {
 			continue
 		}
+		leaseID := "sem_" + j.ID
+		slug := semaphoreClaimSlug(leaseID)
 		s := core.Server{
 			CloudID:  j.ID,
 			Provider: providerName,
-			Name:     j.Name,
+			Name:     semaphoreListName(j.Name, slug),
 			Status:   j.State,
 			Labels: map[string]string{
-				"lease":    "sem_" + j.ID,
+				"lease":    leaseID,
 				"provider": providerName,
 			},
+		}
+		if slug != "" {
+			s.Labels["slug"] = slug
 		}
 		servers = append(servers, s)
 	}
@@ -255,4 +256,19 @@ func stripLeasePrefix(leaseID string) string {
 		return leaseID[4:]
 	}
 	return leaseID
+}
+
+func semaphoreClaimSlug(leaseID string) string {
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || claim.Provider != providerName {
+		return ""
+	}
+	return claim.Slug
+}
+
+func semaphoreListName(jobName, slug string) string {
+	if slug == "" {
+		return jobName
+	}
+	return "sem-testbox-" + slug
 }

--- a/internal/providers/semaphore/backend_test.go
+++ b/internal/providers/semaphore/backend_test.go
@@ -438,6 +438,14 @@ func TestResolveIgnoresOtherProviderClaims(t *testing.T) {
 }
 
 func TestListFiltersNonCrabboxJobs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	if err := core.ClaimLeaseForRepoProvider("sem_job-crabbox", "blue-lobster", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" && r.URL.Path == "/api/v1alpha/jobs" && r.URL.Query().Get("states") == "RUNNING" {
 			json.NewEncoder(w).Encode(map[string]any{
@@ -475,6 +483,12 @@ func TestListFiltersNonCrabboxJobs(t *testing.T) {
 	}
 	if servers[0].CloudID != "job-crabbox" {
 		t.Errorf("cloud id = %q, want job-crabbox", servers[0].CloudID)
+	}
+	if servers[0].Name != "sem-testbox-blue-lobster" {
+		t.Errorf("name = %q, want sem-testbox-blue-lobster", servers[0].Name)
+	}
+	if servers[0].Labels["slug"] != "blue-lobster" {
+		t.Errorf("slug = %q, want blue-lobster", servers[0].Labels["slug"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- reuse local Semaphore lease claims to attach slugs to running job list results
- show claimed Semaphore jobs with sem-testbox-<slug> display names
- share claim slug lookup between resolve and list paths

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/semaphore ./internal/cli