### PR TITLE
docs: add E2B live smoke checklist

### DIFF
--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -28,6 +28,34 @@ crabbox status --provider e2b --id blue-lobster
 crabbox stop --provider e2b blue-lobster
 ```
 
+## Live Smoke
+
+Use a live smoke when changing E2B lifecycle, sync, status, or process-stream
+code. Keep the API key in `E2B_API_KEY`; do not pass it as a command-line
+argument.
+
+```sh
+export E2B_API_KEY=e2b_...
+go build -trimpath -o bin/crabbox ./cmd/crabbox
+
+bin/crabbox warmup --provider e2b --e2b-template base --timing-json
+lease=<slug-or-cbx_id-from-warmup-output>
+
+bin/crabbox status --provider e2b --id "$lease" --wait
+bin/crabbox run --provider e2b --id "$lease" --no-sync -- echo crabbox-e2b-ok
+bin/crabbox run --provider e2b --id "$lease" --sync-only
+bin/crabbox stop --provider e2b "$lease"
+```
+
+Expected results:
+
+- `warmup` prints `provider=e2b`, the Crabbox lease ID, slug, and E2B sandbox
+  ID.
+- `status --wait` reports the sandbox as ready.
+- The no-sync run prints `crabbox-e2b-ok`.
+- `--sync-only` prints the remote workdir it synced.
+- `stop` deletes the sandbox and removes the local lease claim.
+
 ## Auth
 
 ```sh


### PR DESCRIPTION
## Summary
- add an E2B live smoke checklist to the provider docs
- document expected warmup, status, no-sync run, sync-only, and stop results
- keep credential guidance on E2B_API_KEY instead of command-line secrets

## Verification
- node scripts/build-docs-site.mjs