### PR TITLE
fix: normalize Semaphore host config

### DIFF
--- a/internal/providers/semaphore/backend.go
+++ b/internal/providers/semaphore/backend.go
@@ -17,6 +17,11 @@ type semaphoreBackend struct {
 }
 
 func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	host, err := normalizeSemaphoreHost(cfg.Semaphore.Host)
+	if err != nil {
+		return nil, core.Exit(2, "%v", err)
+	}
+	cfg.Semaphore.Host = host
 	if cfg.Semaphore.Host == "" || cfg.Semaphore.Token == "" {
 		return nil, core.Exit(2, "semaphore provider requires semaphore.host in config, environment, or --semaphore-host and semaphore.token in config or environment")
 	}

--- a/internal/providers/semaphore/backend_test.go
+++ b/internal/providers/semaphore/backend_test.go
@@ -165,6 +165,41 @@ func TestWithDefault(t *testing.T) {
 	}
 }
 
+func TestNormalizeSemaphoreHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{name: "bare host", input: "myorg.semaphoreci.com", want: "myorg.semaphoreci.com"},
+		{name: "trims whitespace", input: "  myorg.semaphoreci.com  ", want: "myorg.semaphoreci.com"},
+		{name: "strips trailing slash", input: "myorg.semaphoreci.com/", want: "myorg.semaphoreci.com"},
+		{name: "https url", input: "https://myorg.semaphoreci.com/", want: "myorg.semaphoreci.com"},
+		{name: "host with port", input: "https://myorg.semaphoreci.com:443", want: "myorg.semaphoreci.com:443"},
+		{name: "rejects api path", input: "https://myorg.semaphoreci.com/api/v1alpha", wantErr: "not an API URL"},
+		{name: "rejects query", input: "https://myorg.semaphoreci.com?token=secret", wantErr: "not an API URL"},
+		{name: "rejects path without scheme", input: "myorg.semaphoreci.com/api/v1alpha", wantErr: "not an API URL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeSemaphoreHost(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("host=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStripLeasePrefix(t *testing.T) {
 	if stripLeasePrefix("sem_abc123") != "abc123" {
 		t.Errorf("got %q", stripLeasePrefix("sem_abc123"))
@@ -349,6 +384,18 @@ func TestConfigureRequiresHostAndToken(t *testing.T) {
 	_, err := newBackend(Provider{}.Spec(), cfg, testRuntime(nil))
 	if err == nil {
 		t.Error("expected error when host/token missing")
+	}
+}
+
+func TestConfigureNormalizesSemaphoreHost(t *testing.T) {
+	cfg := testConfig("https://semaphore.example.test/")
+	backend, err := newBackend(Provider{}.Spec(), cfg, testRuntime(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := backend.(*semaphoreBackend).client.host
+	if got != "semaphore.example.test" {
+		t.Fatalf("host=%q, want semaphore.example.test", got)
 	}
 }
 

--- a/internal/providers/semaphore/helpers.go
+++ b/internal/providers/semaphore/helpers.go
@@ -3,6 +3,7 @@ package semaphore
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -63,6 +64,28 @@ func withDefault(value, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func normalizeSemaphoreHost(value string) (string, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return "", nil
+	}
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil || u.Host == "" {
+			return "", fmt.Errorf("invalid semaphore host %q", value)
+		}
+		if u.User != nil || strings.Trim(u.Path, "/") != "" || u.RawQuery != "" || u.Fragment != "" {
+			return "", fmt.Errorf("semaphore host %q must be a host name, not an API URL", value)
+		}
+		raw = u.Host
+	}
+	host := strings.TrimRight(raw, "/")
+	if strings.ContainsAny(host, "/?#") {
+		return "", fmt.Errorf("semaphore host %q must be a host name, not an API URL", value)
+	}
+	return host, nil
 }
 
 func idleTimeout(cfg core.Config) (time.Duration, error) {


### PR DESCRIPTION
## Summary
- normalize Semaphore hosts before constructing API URLs
- accept bare hosts and pasted https://host/ values
- reject host values that include API paths, query strings, fragments, or userinfo

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/semaphore ./internal/cli