### PR TITLE
fix: validate E2B workdir before create

### DIFF
--- a/docs/features/e2b.md
+++ b/docs/features/e2b.md
@@ -57,8 +57,8 @@ crabbox stop --provider e2b <slug>
   stdout/stderr, and returns the remote exit code.
 - `--sync-only` performs only the archive upload and extraction.
 - Workdirs must resolve to dedicated absolute directories. Broad roots such as
-  `/`, `/home`, and `/tmp` are rejected before sync touches the sandbox
-  filesystem.
+  `/`, `/home`, and `/tmp` are rejected before sandbox creation or sync touches
+  the sandbox filesystem.
 - `--checksum` is rejected because E2B does not expose a Crabbox SSH target.
 - `list`, `status`, and `stop` operate only on Crabbox-owned E2B sandboxes.
 

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -122,8 +122,8 @@ Provider flags:
 - `--class` and `--type` are rejected because E2B template contents own sandbox
   resources.
 - E2B workdirs must resolve to dedicated absolute directories. Broad roots such
-  as `/`, `/home`, and `/tmp` are rejected before sync creates, deletes, or
-  extracts files.
+  as `/`, `/home`, and `/tmp` are rejected before sandbox creation or before
+  sync creates, deletes, or extracts files.
 - `--checksum` is rejected because E2B does not expose a Crabbox SSH/rsync
   target. Large-sync guardrails still apply, and `--force-sync-large` is
   honored for intentional large archive syncs.

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -295,10 +295,14 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 	slug := newLeaseSlug(leaseID)
 	template := blank(b.cfg.E2B.Template, "base")
 	cfg := b.cfg
+	workspace, err := cleanE2BWorkspacePath(e2bWorkspacePath(cfg))
+	if err != nil {
+		return "", e2bSandbox{}, "", err
+	}
 	cfg.ServerType = template
 	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, b.now().UTC())
 	labels["state"] = "ready"
-	labels["workdir"] = e2bWorkspacePath(cfg)
+	labels["workdir"] = workspace
 	labels["template"] = template
 	if repo.Name != "" {
 		labels["repo"] = repo.Name

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -275,6 +275,21 @@ func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 	}
 }
 
+func TestE2BCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
+	client := &fakeE2BSyncClient{}
+	backend := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{Workdir: "/"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{}, false, false)
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("err=%v, want unsafe workspace error", err)
+	}
+	if client.createCalls != 0 {
+		t.Fatalf("createCalls=%d, want 0", client.createCalls)
+	}
+}
+
 func TestE2BStatusReady(t *testing.T) {
 	for _, status := range []string{"", "running"} {
 		if !e2bStatusReady(status) {
@@ -335,15 +350,17 @@ func TestE2BResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
 }
 
 type fakeE2BSyncClient struct {
-	commands   []string
-	users      []string
-	sandbox    e2bSandbox
-	getErr     error
-	uploadPath string
-	uploaded   bytes.Buffer
+	commands    []string
+	users       []string
+	sandbox     e2bSandbox
+	createCalls int
+	getErr      error
+	uploadPath  string
+	uploaded    bytes.Buffer
 }
 
 func (f *fakeE2BSyncClient) CreateSandbox(context.Context, e2bCreateSandboxRequest) (e2bSandbox, error) {
+	f.createCalls++
 	return e2bSandbox{}, nil
 }
 


### PR DESCRIPTION
## Summary
- validate resolved E2B workspace paths before creating a new sandbox
- keep safe cleaned workdirs in sandbox metadata
- update E2B docs to make the pre-provision guardrail explicit

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/e2b ./internal/cli
- node scripts/build-docs-site.mjs