### PR TITLE
fix: reject unsafe E2B users

### DIFF
--- a/docs/features/e2b.md
+++ b/docs/features/e2b.md
@@ -38,6 +38,8 @@ e2b:
 Relative `e2b.workdir` values resolve inside the selected E2B user's home. The
 default user home is `/home/user`, `user: ubuntu` resolves under `/home/ubuntu`,
 and `user: root` resolves under `/root`. Absolute workdirs are used as-is.
+`e2b.user` must be a login name, not a path; values such as `../tmp` or
+`team/dev` are rejected before sandbox or process calls.
 
 Equivalent one-off flags:
 

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -84,6 +84,8 @@ e2b:
 Relative `e2b.workdir` values resolve inside the selected E2B user's home. The
 default user home is `/home/user`, `user: ubuntu` resolves under `/home/ubuntu`,
 and `user: root` resolves under `/root`. Absolute workdirs are used as-is.
+`e2b.user` must be a login name, not a path; values such as `../tmp` or
+`team/dev` are rejected before sandbox or process calls.
 
 Provider flags:
 

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -73,6 +73,9 @@ type e2bBackend struct {
 func (b *e2bBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if err := validateE2BUser(b.cfg.E2B.User); err != nil {
+		return err
+	}
 	started := b.now()
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
@@ -102,6 +105,10 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 
 func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err := rejectE2BSyncOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	processUser, err := e2bProcessUser(b.cfg.E2B.User)
+	if err != nil {
 		return RunResult{}, err
 	}
 	started := b.now()
@@ -181,7 +188,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 		Command: command,
 		CWD:     workspace,
 		Env:     allowedEnv(req.Options.EnvAllow),
-		User:    b.cfg.E2B.User,
+		User:    processUser,
 		Timeout: b.cfg.TTL,
 		Stdout:  b.rt.Stdout,
 		Stderr:  b.rt.Stderr,
@@ -475,7 +482,7 @@ func e2bWorkspacePath(cfg Config) string {
 }
 
 func e2bUserHome(user string) string {
-	user = strings.TrimSpace(user)
+	user = e2bWorkspaceUser(user)
 	if user == "" {
 		user = "user"
 	}
@@ -483,6 +490,30 @@ func e2bUserHome(user string) string {
 		return "/root"
 	}
 	return path.Join("/home", user)
+}
+
+func e2bWorkspaceUser(user string) string {
+	clean, err := e2bProcessUser(user)
+	if err != nil || clean == "" {
+		return "user"
+	}
+	return clean
+}
+
+func validateE2BUser(user string) error {
+	_, err := e2bProcessUser(user)
+	return err
+}
+
+func e2bProcessUser(user string) (string, error) {
+	clean := strings.TrimSpace(user)
+	if clean == "" {
+		return "", nil
+	}
+	if clean == "." || clean == ".." || strings.ContainsAny(clean, `/\`) || strings.ContainsRune(clean, 0) {
+		return "", exit(2, "invalid e2b.user %q: use a login name, not a path", user)
+	}
+	return clean, nil
 }
 
 func e2bCommandString(command []string, shellMode bool) string {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -79,6 +79,53 @@ func TestE2BWorkspacePath(t *testing.T) {
 	}
 }
 
+func TestE2BProcessUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		user    string
+		want    string
+		wantErr string
+	}{
+		{name: "empty keeps default process user", user: "", want: ""},
+		{name: "trims user", user: " ubuntu ", want: "ubuntu"},
+		{name: "root allowed", user: "root", want: "root"},
+		{name: "rejects slash", user: "../tmp", wantErr: "not a path"},
+		{name: "rejects backslash", user: `team\dev`, wantErr: "not a path"},
+		{name: "rejects dot", user: ".", wantErr: "not a path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := e2bProcessUser(tt.user)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("user=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestE2BWarmupRejectsUnsafeUserBeforeClient(t *testing.T) {
+	backend := &e2bBackend{
+		cfg: Config{E2B: E2BConfig{User: "../tmp"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	err := backend.Warmup(context.Background(), WarmupRequest{})
+	if err == nil || !strings.Contains(err.Error(), "invalid e2b.user") {
+		t.Fatalf("err=%v, want invalid e2b.user", err)
+	}
+	if strings.Contains(err.Error(), "E2B_API_KEY") {
+		t.Fatalf("validated user after client setup: %v", err)
+	}
+}
+
 func TestCleanE2BWorkspacePath(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -102,9 +102,13 @@ func cleanE2BWorkspacePath(workspace string) (string, error) {
 }
 
 func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSession, command string, stdout io.Writer) error {
+	user, err := e2bProcessUser(b.cfg.E2B.User)
+	if err != nil {
+		return err
+	}
 	code, err := client.StartProcess(ctx, session, e2bProcessRequest{
 		Command: command,
-		User:    b.cfg.E2B.User,
+		User:    user,
 		Timeout: b.cfg.TTL,
 		Stdout:  stdout,
 		Stderr:  b.rt.Stderr,


### PR DESCRIPTION
## Summary
- reject path-like e2b.user values before E2B client or process calls
- trim valid E2B users before envd process requests
- document the E2B user login-name constraint

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/e2b ./internal/cli
- node scripts/build-docs-site.mjs