### PR TITLE
feat: add checkpoint ledger store

### DIFF
--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -119,11 +119,6 @@ func (s checkpointStore) Create(record CheckpointRecord) (CheckpointRecord, erro
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return CheckpointRecord{}, exit(2, "create checkpoint directory: %v", err)
 	}
-	if _, err := os.Stat(path); err == nil {
-		return CheckpointRecord{}, exit(2, "checkpoint %s already exists", record.ID)
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return CheckpointRecord{}, exit(2, "stat checkpoint %s: %v", path, err)
-	}
 	if err := writeCheckpointJSON(path, record); err != nil {
 		return CheckpointRecord{}, err
 	}
@@ -193,27 +188,27 @@ func writeCheckpointJSON(path string, record CheckpointRecord) error {
 		return err
 	}
 	data = append(data, '\n')
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".checkpoint-*.tmp")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		return exit(2, "create checkpoint temp file: %v", err)
+		if errors.Is(err, os.ErrExist) {
+			return exit(2, "checkpoint %s already exists", record.ID)
+		}
+		return exit(2, "create checkpoint %s: %v", path, err)
 	}
-	tmpPath := tmp.Name()
+	created := false
 	defer func() {
-		_ = os.Remove(tmpPath)
+		if !created {
+			_ = os.Remove(path)
+		}
 	}()
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
 		return exit(2, "write checkpoint %s: %v", path, err)
 	}
-	if err := tmp.Close(); err != nil {
+	if err := file.Close(); err != nil {
 		return exit(2, "close checkpoint %s: %v", path, err)
 	}
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		return exit(2, "chmod checkpoint %s: %v", path, err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return exit(2, "write checkpoint %s: %v", path, err)
-	}
+	created = true
 	return nil
 }
 

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const checkpointIDPrefix = "chk_"
+
+type CheckpointRecord struct {
+	ID               string                      `json:"id"`
+	ParentID         string                      `json:"parentId,omitempty"`
+	Name             string                      `json:"name,omitempty"`
+	Notes            string                      `json:"notes,omitempty"`
+	CreatedAt        string                      `json:"createdAt"`
+	CreatedBy        string                      `json:"createdBy,omitempty"`
+	Repo             CheckpointRepo              `json:"repo"`
+	Lease            CheckpointLease             `json:"lease,omitempty"`
+	Run              CheckpointRun               `json:"run,omitempty"`
+	Workspace        CheckpointWorkspace         `json:"workspace,omitempty"`
+	Artifacts        []CheckpointArtifact        `json:"artifacts,omitempty"`
+	ProviderSnapshot *CheckpointProviderSnapshot `json:"providerSnapshot,omitempty"`
+}
+
+type CheckpointRepo struct {
+	Root      string `json:"root,omitempty"`
+	Name      string `json:"name,omitempty"`
+	RemoteURL string `json:"remoteUrl,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	Head      string `json:"head,omitempty"`
+	BaseRef   string `json:"baseRef,omitempty"`
+}
+
+type CheckpointLease struct {
+	ID          string `json:"id,omitempty"`
+	Slug        string `json:"slug,omitempty"`
+	Provider    string `json:"provider,omitempty"`
+	TargetOS    string `json:"targetOS,omitempty"`
+	WindowsMode string `json:"windowsMode,omitempty"`
+	Class       string `json:"class,omitempty"`
+	ServerType  string `json:"serverType,omitempty"`
+}
+
+type CheckpointRun struct {
+	ID          string `json:"id,omitempty"`
+	ExitCode    *int   `json:"exitCode,omitempty"`
+	DurationMs  int64  `json:"durationMs,omitempty"`
+	Command     string `json:"command,omitempty"`
+	LogPath     string `json:"logPath,omitempty"`
+	ResultsPath string `json:"resultsPath,omitempty"`
+}
+
+type CheckpointWorkspace struct {
+	ManifestPath string `json:"manifestPath,omitempty"`
+	PatchPath    string `json:"patchPath,omitempty"`
+	ArchivePath  string `json:"archivePath,omitempty"`
+	ChangedFiles int    `json:"changedFiles,omitempty"`
+	DeletedFiles int    `json:"deletedFiles,omitempty"`
+	Bytes        int64  `json:"bytes,omitempty"`
+}
+
+type CheckpointArtifact struct {
+	Path string `json:"path,omitempty"`
+	URL  string `json:"url,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+type CheckpointProviderSnapshot struct {
+	Provider string `json:"provider,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+}
+
+type checkpointStore struct {
+	dir string
+}
+
+func defaultCheckpointStore() (checkpointStore, error) {
+	stateDir, err := crabboxStateDir()
+	if err != nil {
+		return checkpointStore{}, err
+	}
+	return checkpointStore{dir: filepath.Join(stateDir, "checkpoints")}, nil
+}
+
+func (s checkpointStore) Create(record CheckpointRecord) (CheckpointRecord, error) {
+	if strings.TrimSpace(record.ID) == "" {
+		id, err := newCheckpointID()
+		if err != nil {
+			return CheckpointRecord{}, err
+		}
+		record.ID = id
+	}
+	record.ID = strings.TrimSpace(record.ID)
+	if err := validateCheckpointID(record.ID); err != nil {
+		return CheckpointRecord{}, err
+	}
+	record.ParentID = strings.TrimSpace(record.ParentID)
+	if record.ParentID != "" {
+		if err := validateCheckpointID(record.ParentID); err != nil {
+			return CheckpointRecord{}, fmt.Errorf("parent id: %w", err)
+		}
+	}
+	if strings.TrimSpace(record.CreatedAt) == "" {
+		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
+		return CheckpointRecord{}, exit(2, "checkpoint createdAt must be RFC3339: %v", err)
+	}
+	path := s.path(record.ID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return CheckpointRecord{}, exit(2, "create checkpoint directory: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		return CheckpointRecord{}, exit(2, "checkpoint %s already exists", record.ID)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return CheckpointRecord{}, exit(2, "stat checkpoint %s: %v", path, err)
+	}
+	if err := writeCheckpointJSON(path, record); err != nil {
+		return CheckpointRecord{}, err
+	}
+	return record, nil
+}
+
+func (s checkpointStore) Read(id string) (CheckpointRecord, error) {
+	id = strings.TrimSpace(id)
+	if err := validateCheckpointID(id); err != nil {
+		return CheckpointRecord{}, err
+	}
+	data, err := os.ReadFile(s.path(id))
+	if errors.Is(err, os.ErrNotExist) {
+		return CheckpointRecord{}, exit(2, "checkpoint %s not found", id)
+	}
+	if err != nil {
+		return CheckpointRecord{}, exit(2, "read checkpoint %s: %v", id, err)
+	}
+	var record CheckpointRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return CheckpointRecord{}, exit(2, "parse checkpoint %s: %v", id, err)
+	}
+	if record.ID == "" {
+		record.ID = id
+	}
+	return record, nil
+}
+
+func (s checkpointStore) List() ([]CheckpointRecord, error) {
+	entries, err := os.ReadDir(s.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, exit(2, "read checkpoints directory: %v", err)
+	}
+	records := make([]CheckpointRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		record, err := s.Read(id)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		left, leftErr := time.Parse(time.RFC3339, records[i].CreatedAt)
+		right, rightErr := time.Parse(time.RFC3339, records[j].CreatedAt)
+		if leftErr == nil && rightErr == nil && !left.Equal(right) {
+			return left.After(right)
+		}
+		return records[i].ID > records[j].ID
+	})
+	return records, nil
+}
+
+func (s checkpointStore) path(id string) string {
+	return filepath.Join(s.dir, id+".json")
+}
+
+func writeCheckpointJSON(path string, record CheckpointRecord) error {
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".checkpoint-*.tmp")
+	if err != nil {
+		return exit(2, "create checkpoint temp file: %v", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return exit(2, "write checkpoint %s: %v", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return exit(2, "close checkpoint %s: %v", path, err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return exit(2, "chmod checkpoint %s: %v", path, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return exit(2, "write checkpoint %s: %v", path, err)
+	}
+	return nil
+}
+
+func newCheckpointID() (string, error) {
+	var raw [8]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return checkpointIDPrefix + hex.EncodeToString(raw[:]), nil
+}
+
+func validateCheckpointID(id string) error {
+	if !strings.HasPrefix(id, checkpointIDPrefix) || len(id) <= len(checkpointIDPrefix) {
+		return exit(2, "checkpoint id must start with %s", checkpointIDPrefix)
+	}
+	for _, r := range strings.TrimPrefix(id, checkpointIDPrefix) {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			continue
+		}
+		return exit(2, "checkpoint id contains unsafe character %q", r)
+	}
+	return nil
+}

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,8 +10,6 @@ import (
 	"strings"
 	"time"
 )
-
-const checkpointIDPrefix = "chk_"
 
 type CheckpointRecord struct {
 	ID               string                      `json:"id"`
@@ -99,15 +95,18 @@ func (s checkpointStore) Create(record CheckpointRecord) (CheckpointRecord, erro
 		}
 		record.ID = id
 	}
-	record.ID = strings.TrimSpace(record.ID)
-	if err := validateCheckpointID(record.ID); err != nil {
+	id, err := validateCheckpointID(record.ID)
+	if err != nil {
 		return CheckpointRecord{}, err
 	}
+	record.ID = id
 	record.ParentID = strings.TrimSpace(record.ParentID)
 	if record.ParentID != "" {
-		if err := validateCheckpointID(record.ParentID); err != nil {
+		parentID, err := validateCheckpointID(record.ParentID)
+		if err != nil {
 			return CheckpointRecord{}, fmt.Errorf("parent id: %w", err)
 		}
+		record.ParentID = parentID
 	}
 	if strings.TrimSpace(record.CreatedAt) == "" {
 		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -126,8 +125,8 @@ func (s checkpointStore) Create(record CheckpointRecord) (CheckpointRecord, erro
 }
 
 func (s checkpointStore) Read(id string) (CheckpointRecord, error) {
-	id = strings.TrimSpace(id)
-	if err := validateCheckpointID(id); err != nil {
+	id, err := validateCheckpointID(id)
+	if err != nil {
 		return CheckpointRecord{}, err
 	}
 	data, err := os.ReadFile(s.path(id))
@@ -209,26 +208,5 @@ func writeCheckpointJSON(path string, record CheckpointRecord) error {
 		return exit(2, "close checkpoint %s: %v", path, err)
 	}
 	created = true
-	return nil
-}
-
-func newCheckpointID() (string, error) {
-	var raw [8]byte
-	if _, err := rand.Read(raw[:]); err != nil {
-		return "", err
-	}
-	return checkpointIDPrefix + hex.EncodeToString(raw[:]), nil
-}
-
-func validateCheckpointID(id string) error {
-	if !strings.HasPrefix(id, checkpointIDPrefix) || len(id) <= len(checkpointIDPrefix) {
-		return exit(2, "checkpoint id must start with %s", checkpointIDPrefix)
-	}
-	for _, r := range strings.TrimPrefix(id, checkpointIDPrefix) {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
-			continue
-		}
-		return exit(2, "checkpoint id contains unsafe character %q", r)
-	}
 	return nil
 }

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckpointStoreCreateReadList(t *testing.T) {
+	store := checkpointStore{dir: t.TempDir()}
+	first, err := store.Create(CheckpointRecord{
+		ID:        "chk_first",
+		Name:      "first",
+		CreatedAt: "2026-05-09T10:00:00Z",
+		Repo: CheckpointRepo{
+			Root:      "/repo",
+			Name:      "crabbox",
+			RemoteURL: "https://github.com/openclaw/crabbox",
+			Branch:    "main",
+			Head:      "abc123",
+			BaseRef:   "main",
+		},
+		Lease: CheckpointLease{
+			ID:       "cbx_123",
+			Slug:     "blue-lobster",
+			Provider: "aws",
+			TargetOS: "linux",
+			Class:    "beast",
+		},
+		Workspace: CheckpointWorkspace{
+			ChangedFiles: 2,
+			DeletedFiles: 1,
+			Bytes:        42,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	if first.ID != "chk_first" {
+		t.Fatalf("id=%q", first.ID)
+	}
+	second, err := store.Create(CheckpointRecord{
+		ID:        "chk_second",
+		ParentID:  "chk_first",
+		Name:      "second",
+		CreatedAt: "2026-05-09T11:00:00Z",
+		Run: CheckpointRun{
+			ID:         "run_123",
+			DurationMs: 1500,
+			Command:    "go test ./...",
+		},
+		Artifacts: []CheckpointArtifact{{Path: "artifacts/blue-lobster/screenshot.png", Type: "screenshot"}},
+	})
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	got, err := store.Read(second.ID)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if got.ParentID != "chk_first" || got.Run.ID != "run_123" || len(got.Artifacts) != 1 {
+		t.Fatalf("unexpected checkpoint: %#v", got)
+	}
+
+	records, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records=%d want 2", len(records))
+	}
+	if records[0].ID != "chk_second" || records[1].ID != "chk_first" {
+		t.Fatalf("records ordered newest first: %#v", records)
+	}
+
+	data, err := os.ReadFile(filepath.Join(store.dir, "chk_second.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if raw["id"] != "chk_second" {
+		t.Fatalf("json id=%v", raw["id"])
+	}
+}
+
+func TestCheckpointStoreRejectsDuplicatesAndUnsafeIDs(t *testing.T) {
+	store := checkpointStore{dir: t.TempDir()}
+	if _, err := store.Create(CheckpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:00:00Z"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.Create(CheckpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+		t.Fatal("duplicate checkpoint succeeded")
+	}
+	if _, err := store.Create(CheckpointRecord{ID: "../bad", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+		t.Fatal("unsafe checkpoint id succeeded")
+	}
+	if _, err := store.Create(CheckpointRecord{ID: "chk_bad/slash", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+		t.Fatal("slash checkpoint id succeeded")
+	}
+	if _, err := store.Create(CheckpointRecord{ID: "chk_bad", ParentID: "../parent", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+		t.Fatal("unsafe parent id succeeded")
+	}
+}
+
+func TestCheckpointStoreFillsIDAndCreatedAt(t *testing.T) {
+	store := checkpointStore{dir: t.TempDir()}
+	record, err := store.Create(CheckpointRecord{Name: "generated"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !strings.HasPrefix(record.ID, checkpointIDPrefix) {
+		t.Fatalf("id=%q", record.ID)
+	}
+	if record.CreatedAt == "" {
+		t.Fatal("createdAt not filled")
+	}
+}

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -17,8 +17,8 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 		CreatedAt: "2026-05-09T10:00:00Z",
 		Repo: CheckpointRepo{
 			Root:      "/repo",
-			Name:      "crabbox",
-			RemoteURL: "https://github.com/openclaw/crabbox",
+			Name:      "my-app",
+			RemoteURL: "https://github.com/example-org/my-app",
 			Branch:    "main",
 			Head:      "abc123",
 			BaseRef:   "main",

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +106,42 @@ func TestCheckpointStoreRejectsDuplicatesAndUnsafeIDs(t *testing.T) {
 	}
 	if _, err := store.Create(CheckpointRecord{ID: "chk_bad", ParentID: "../parent", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
 		t.Fatal("unsafe parent id succeeded")
+	}
+}
+
+func TestCheckpointStoreConcurrentSameIDAllowsOneWriter(t *testing.T) {
+	store := checkpointStore{dir: t.TempDir()}
+	const workers = 64
+	start := make(chan struct{})
+	results := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			<-start
+			_, err := store.Create(CheckpointRecord{
+				ID:        "chk_race",
+				Name:      fmt.Sprintf("worker-%d", i),
+				CreatedAt: "2026-05-09T10:00:00Z",
+			})
+			results <- err
+		}(i)
+	}
+
+	close(start)
+	successes := 0
+	for i := 0; i < workers; i++ {
+		if err := <-results; err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful concurrent creates=%d, want 1", successes)
+	}
+	got, err := store.Read("chk_race")
+	if err != nil {
+		t.Fatalf("read raced checkpoint: %v", err)
+	}
+	if got.ID != "chk_race" || got.CreatedAt != "2026-05-09T10:00:00Z" {
+		t.Fatalf("unexpected raced checkpoint: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add typed checkpoint records for repo, lease, run, workspace, artifacts, and provider snapshot references
- persist checkpoints as append-only JSON files under Crabbox state
- list checkpoints newest-first and reject duplicate or unsafe checkpoint ids

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/cli
- git diff --check