### PR TITLE
feat: add workspace checkpoint feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `crabbox list --refresh` so local Cloudflare claims can be checked against live runner state on demand.
 - Added brokered provider snapshot/image deletion for AWS EBS snapshots and AMIs, Azure managed disk snapshots and managed images, and GCP disk snapshots and machine images.
 - Added Modal and Tensorlake to the top-level provider docs and delegated sandbox configuration examples. Thanks @stainlu.
+- Added provider feature flags for workspace checkpoint, fork, restore, and native snapshot capabilities. Thanks @stainlu.
 
 ### Changed
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -166,6 +166,13 @@ Rules:
   - `FeatureDesktop`, `FeatureBrowser`, `FeatureCode` - lease can host a visible
     desktop, browser, or code-server instance.
   - `FeatureTailscale` - lease can join a tailnet via cloud-init/`--tailscale`.
+  - `FeatureCheckpoint` - backend can create a provider-aware workspace
+    checkpoint beyond Crabbox's generic local ledger.
+  - `FeatureFork` - backend can create a new workspace from a checkpoint or
+    snapshot without replaying a full generic sync.
+  - `FeatureRestore` - backend can restore a workspace to a previous checkpoint.
+  - `FeatureSnapshot` - backend can return a provider-native snapshot handle
+    that Crabbox can reference in checkpoint metadata.
 - `Coordinator` is `CoordinatorSupported` only when the Cloudflare Worker can
   provision your runners. Direct-only providers, including all delegated run
   backends and Static SSH, set `CoordinatorNever`.
@@ -174,6 +181,13 @@ Actions runner hydration is not a feature flag. Core checks for an SSH lease
 backend on `target=linux` instead. Setting `FeatureSSH` on a non-Linux-only
 provider is fine; setting `target=linux` on a backend that cannot satisfy it is
 not.
+
+Versioned workspace features describe provider depth, not the presence of
+Crabbox checkpoint commands. Core can always record a generic checkpoint from
+repo metadata, logs, and artifacts once that command exists. Providers should
+set checkpoint-related flags only when they can preserve or recreate state that
+the generic ledger cannot, such as sandbox filesystem state, VM snapshot ids, or
+copy-on-write forks.
 
 ## Step 5. Own Provider-Specific Flags
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -318,6 +318,10 @@ cli.FeatureDesktop
 cli.FeatureBrowser
 cli.FeatureCode
 cli.FeatureTailscale
+cli.FeatureCheckpoint
+cli.FeatureFork
+cli.FeatureRestore
+cli.FeatureSnapshot
 ```
 
 Actions runner hydration is intentionally not a provider feature. It is a core
@@ -329,6 +333,18 @@ SSH-over-Linux workflow. It requires:
 
 Only set `CoordinatorSupported` when the Crabbox coordinator can provision that
 provider. A direct-only SSH provider should use `CoordinatorNever`.
+
+Checkpoint-related features are reserved for versioned workspaces:
+
+- `FeatureCheckpoint`: provider can create a provider-aware checkpoint.
+- `FeatureFork`: provider can create a new workspace from a checkpoint.
+- `FeatureRestore`: provider can restore an existing workspace to a checkpoint.
+- `FeatureSnapshot`: provider can expose a native snapshot id for Crabbox
+  metadata.
+
+Do not set these flags for plain SSH access alone. Generic Git/archive/log
+checkpoints are core-owned and should work even when the provider advertises no
+native checkpoint features.
 
 ## Flags And Config
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -92,6 +92,10 @@ const (
 	FeatureBrowser     Feature = "browser"
 	FeatureCode        Feature = "code"
 	FeatureTailscale   Feature = "tailscale"
+	FeatureCheckpoint  Feature = "workspace-checkpoint"
+	FeatureFork        Feature = "workspace-fork"
+	FeatureRestore     Feature = "workspace-restore"
+	FeatureSnapshot    Feature = "provider-snapshot"
 )
 
 type FeatureSet []Feature


### PR DESCRIPTION
## Summary
- add provider feature constants for workspace checkpoint, fork, restore, and provider-native snapshot support
- document that generic checkpointing stays core-owned while provider flags describe deeper native state support
- clarify that plain SSH access alone should not advertise native checkpoint features

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/cli
- node scripts/build-docs-site.mjs
- git diff --check