### PR TITLE
[security] fix(islo): contain workdir paths under workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed signed portal user tokens so caller-provided admin claims are rejected instead of granting admin access. Thanks @Hinotoi-agent.
+- Fixed Islo workdir containment so absolute paths and parent-directory escapes are rejected before sandbox creation, sync, or run. Thanks @Hinotoi-agent.
 - Fixed Semaphore host configuration so dashboard URLs normalize to hosts while API paths, query strings, fragments, and user info are rejected. Thanks @stainlu.
 - Fixed WebVNC portal input focus so controller typing stays in the remote desktop and right-clicks no longer open the browser context menu.
 - Fixed Semaphore list output so locally claimed jobs show their lease slugs.

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -37,6 +37,10 @@ islo:
   diskGB: 20
 ```
 
+`islo.workdir` must be a relative directory name under `/workspace`. Absolute
+paths and `..` escapes are rejected before Crabbox prepares or syncs the
+sandbox workspace.
+
 Equivalent flags:
 
 ```sh
@@ -50,8 +54,9 @@ crabbox stop --provider islo <slug>
 
 - `warmup` creates a `crabbox-...` Islo sandbox and stores a local lease ID of
   the form `isb_<crabbox-sandbox-name>` plus a Crabbox slug.
-- `run` creates or reuses a sandbox, syncs the local Git-managed working set
-  into `/workspace/<islo.workdir>`, streams stdout/stderr from Islo's SSE exec
+- `run` creates or reuses a sandbox, validates `islo.workdir` as a relative
+  directory under `/workspace`, syncs the local Git-managed working set into
+  `/workspace/<islo.workdir>`, streams stdout/stderr from Islo's SSE exec
   endpoint, and returns the remote exit code.
 - `--sync-only` and `--checksum` are rejected because Islo does not expose a
   Crabbox SSH/rsync target. Large-sync guardrails still apply, and

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -66,12 +66,16 @@ Provider flags:
 --islo-disk-gb
 ```
 
+`--islo-workdir` / `islo.workdir` is interpreted as a relative directory below
+`/workspace`. Crabbox rejects absolute paths and `..` escapes before workspace
+preparation and sync.
+
 ## Lifecycle
 
 1. Create or resolve a Crabbox-owned Islo sandbox.
 2. Store a local lease ID with the `isb_` prefix and a friendly slug.
-3. Build the Crabbox sync manifest and upload a gzipped archive into
-   `/workspace/<islo.workdir>`.
+3. Validate the Islo workdir, build the Crabbox sync manifest, and upload a
+   gzipped archive into `/workspace/<islo.workdir>`.
 4. Execute commands through Islo's streaming exec endpoint in that workdir.
 5. Require an exit event before treating a stream as successful.
 6. Delete the sandbox on release unless kept.

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -145,6 +145,10 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 	if err := rejectIsloSyncOptions(req); err != nil {
 		return RunResult{}, err
 	}
+	workspace, err := isloWorkspacePath(b.cfg)
+	if err != nil {
+		return RunResult{}, err
+	}
 	started := b.now()
 	client, err := newIsloClient(b.cfg, b.rt)
 	if err != nil {
@@ -178,7 +182,6 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 	fmt.Fprintf(b.rt.Stderr, "provider=islo lease=%s sandbox=%s\n", leaseID, name)
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	workspace := isloWorkspacePath(b.cfg)
 	if !req.NoSync {
 		var err error
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, name, req)

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -301,14 +301,16 @@ func (b *isloBackend) Stop(ctx context.Context, req StopRequest) error {
 }
 
 func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Repo, reclaim bool) (string, string, string, error) {
+	workdir, err := isloRelativeWorkdir(b.cfg)
+	if err != nil {
+		return "", "", "", err
+	}
 	name := newIsloSandboxName(repo)
 	create := &gosdk.SandboxCreate{Name: stringValue(name)}
 	if b.cfg.Islo.Image != "" {
 		create.Image = stringValue(b.cfg.Islo.Image)
 	}
-	if b.cfg.Islo.Workdir != "" {
-		create.Workdir = stringValue(b.cfg.Islo.Workdir)
-	}
+	create.Workdir = stringValue(workdir)
 	if b.cfg.Islo.GatewayProfile != "" {
 		create.GatewayProfile = stringValue(b.cfg.Islo.GatewayProfile)
 	}

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -124,14 +124,35 @@ func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
 }
 
 func TestIsloWorkspacePathDefaultsUnderWorkspace(t *testing.T) {
-	if got := isloWorkspacePath(Config{}); got != "/workspace/crabbox" {
-		t.Fatalf("workspace=%q", got)
+	if got, err := isloWorkspacePath(Config{}); err != nil || got != "/workspace/crabbox" {
+		t.Fatalf("workspace=%q err=%v", got, err)
 	}
-	if got := isloWorkspacePath(Config{Islo: IsloConfig{Workdir: "repo"}}); got != "/workspace/repo" {
-		t.Fatalf("workspace=%q", got)
+	if got, err := isloWorkspacePath(Config{Islo: IsloConfig{Workdir: "repo"}}); err != nil || got != "/workspace/repo" {
+		t.Fatalf("workspace=%q err=%v", got, err)
 	}
-	if got := isloWorkspacePath(Config{Islo: IsloConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
-		t.Fatalf("workspace=%q", got)
+	if got, err := isloWorkspacePath(Config{Islo: IsloConfig{Workdir: "team/repo"}}); err != nil || got != "/workspace/team/repo" {
+		t.Fatalf("workspace=%q err=%v", got, err)
+	}
+}
+
+func TestIsloWorkspacePathRejectsEscapes(t *testing.T) {
+	for _, workdir := range []string{"/work/repo", "/etc", "../etc", "repo/../../../etc", ".", "./.."} {
+		t.Run(workdir, func(t *testing.T) {
+			if got, err := isloWorkspacePath(Config{Islo: IsloConfig{Workdir: workdir}}); err == nil {
+				t.Fatalf("workspace=%q, want error for workdir %q", got, workdir)
+			}
+		})
+	}
+}
+
+func TestIsloRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{Workdir: "../etc"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true})
+	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
+		t.Fatalf("Run err=%v, want workdir containment error", err)
 	}
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -156,6 +156,37 @@ func TestIsloRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
 	}
 }
 
+func TestIsloCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
+	client := &fakeIsloSyncClient{}
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{Workdir: "../etc"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false)
+	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
+		t.Fatalf("createSandbox err=%v, want workdir containment error", err)
+	}
+	if client.createRequest != nil {
+		t.Fatalf("CreateSandbox was called with %#v", client.createRequest)
+	}
+}
+
+func TestIsloCreateSandboxPassesRelativeWorkdirToProvider(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{Workdir: "team/repo"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.createRequest == nil || client.createRequest.Workdir == nil || *client.createRequest.Workdir != "team/repo" {
+		t.Fatalf("create workdir=%v", client.createRequest)
+	}
+}
+
 func TestIsloSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -358,10 +389,17 @@ type fakeIsloSyncClient struct {
 	uploaded          bytes.Buffer
 	uploadErr         error
 	closeUploadReader bool
+	createRequest     *gosdk.SandboxCreate
+	createName        string
 }
 
-func (f *fakeIsloSyncClient) CreateSandbox(context.Context, *gosdk.SandboxCreate) (*gosdk.SandboxResponse, error) {
-	return nil, nil
+func (f *fakeIsloSyncClient) CreateSandbox(_ context.Context, req *gosdk.SandboxCreate) (*gosdk.SandboxResponse, error) {
+	f.createRequest = req
+	name := f.createName
+	if name == "" {
+		name = "crabbox-test-abcdef"
+	}
+	return &gosdk.SandboxResponse{Name: name}, nil
 }
 
 func (f *fakeIsloSyncClient) GetSandbox(context.Context, string) (*gosdk.SandboxResponse, error) {

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -166,6 +166,14 @@ func createIsloSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest
 }
 
 func isloWorkspacePath(cfg Config) (string, error) {
+	workdir, err := isloRelativeWorkdir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return path.Join("/workspace", workdir), nil
+}
+
+func isloRelativeWorkdir(cfg Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.Islo.Workdir)
 	if workdir == "" {
 		workdir = "crabbox"
@@ -173,9 +181,9 @@ func isloWorkspacePath(cfg Config) (string, error) {
 	if strings.HasPrefix(workdir, "/") {
 		return "", exit(2, "islo workdir %q must be relative under /workspace", workdir)
 	}
-	workspace := path.Clean(path.Join("/workspace", workdir))
-	if workspace == "/workspace" || !strings.HasPrefix(workspace, "/workspace/") {
+	workdir = path.Clean(workdir)
+	if workdir == "." || workdir == ".." || strings.HasPrefix(workdir, "../") {
 		return "", exit(2, "islo workdir %q escapes /workspace", workdir)
 	}
-	return workspace, nil
+	return workdir, nil
 }

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -45,7 +45,10 @@ func (b *isloBackend) syncWorkspace(ctx context.Context, client isloAPI, name st
 		return nil, 0, err
 	}
 	preflightDuration := b.now().Sub(preflightStarted)
-	workspace := isloWorkspacePath(b.cfg)
+	workspace, err := isloWorkspacePath(b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
 	prepareStarted := b.now()
 	if err := b.prepareWorkspace(ctx, client, name, workspace); err != nil {
 		return nil, 0, err
@@ -162,13 +165,17 @@ func createIsloSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest
 	return archive, nil
 }
 
-func isloWorkspacePath(cfg Config) string {
+func isloWorkspacePath(cfg Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.Islo.Workdir)
 	if workdir == "" {
 		workdir = "crabbox"
 	}
 	if strings.HasPrefix(workdir, "/") {
-		return path.Clean(workdir)
+		return "", exit(2, "islo workdir %q must be relative under /workspace", workdir)
 	}
-	return path.Join("/workspace", workdir)
+	workspace := path.Clean(path.Join("/workspace", workdir))
+	if workspace == "/workspace" || !strings.HasPrefix(workspace, "/workspace/") {
+		return "", exit(2, "islo workdir %q escapes /workspace", workdir)
+	}
+	return workspace, nil
 }


### PR DESCRIPTION
## Summary

This PR hardens the Islo provider's workspace path boundary so repo-local configuration cannot steer delegated sync outside `/workspace`.

It specifically:

- rejects absolute `islo.workdir` values before Islo client setup or sandbox creation;
- rejects relative `..` values that clean outside `/workspace`;
- keeps valid nested relative workdirs such as `team/repo` working as `/workspace/team/repo`;
- adds regression coverage for the path escape and documents the enforced boundary.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Repo-controlled Islo workdir can escape `/workspace` | A repo-local config can direct Islo workspace preparation, deletion, and archive extraction at broad sandbox paths such as `/etc` | Medium |

## Before this PR

- Crabbox loaded repo-local `crabbox.yaml` / `.crabbox.yaml` and applied `islo.workdir` directly.
- `isloWorkspacePath()` accepted absolute paths such as `/etc`.
- Relative paths such as `../etc` were joined with `/workspace` and cleaned to `/etc`.
- Islo sync preparation then used that resolved path in `rm -rf <workspace> && mkdir -p <workspace>` when `sync.delete` was enabled.
- The behavior was not covered by a regression test.

## After this PR

- `islo.workdir` is validated as a relative directory under `/workspace`.
- Absolute paths are rejected.
- Cleaned paths that resolve to `/workspace` itself or outside `/workspace/` are rejected.
- `Run()` validates the path before Islo client setup or sandbox creation, so invalid config fails before provider-side side effects.
- The Islo tests now cover safe defaults, safe nested relative paths, absolute paths, dot/root-equivalent values, and `..` escapes.

## Why this matters

Islo delegated sync prepares the remote sandbox workdir before the user's command runs. A repository can carry Crabbox config, so the workdir value should not be able to redirect Crabbox's setup/deletion step at broad provider-side filesystem locations.

Without this guardrail, a malicious or compromised repository could include config such as:

```yaml
provider: islo
islo:
  workdir: ../etc
```

On vulnerable code, that resolves to `/etc` and reaches the workspace preparation path.

## How this differs from related E2B workdir fixes

This is a same-family variant of the E2B workspace hardening already merged in:

- https://github.com/openclaw/crabbox/pull/50
- https://github.com/openclaw/crabbox/pull/55

Those PRs hardened E2B-specific workspace handling. This PR addresses the remaining Islo-specific implementation, which has a separate `isloWorkspacePath()` helper and delegated archive-sync flow.

The failure mode is similar, but the vulnerable code path is different:

- E2B fix: `internal/providers/e2b/...`
- This fix: `internal/providers/islo/...`

## Attack flow

```text
repo-local .crabbox.yaml / crabbox.yaml
    -> islo.workdir: ../etc
        -> isloWorkspacePath() cleans /workspace/../etc to /etc
            -> prepareWorkspace() builds rm -rf '/etc' && mkdir -p '/etc'
                -> delegated sync can delete or overwrite broad sandbox paths
```

## Affected code

| Issue | Files |
|-------|-------|
| Islo workdir escape | `internal/providers/islo/sync.go`, `internal/providers/islo/backend.go`, `internal/providers/islo/backend_test.go` |
| Documentation boundary | `docs/features/islo.md`, `docs/providers/islo.md` |

## Root cause

Issue: Islo workdir escape

- The Islo provider treated `islo.workdir` as a path component but did not enforce containment under `/workspace`.
- `path.Join("/workspace", workdir)` was used without checking whether the cleaned result stayed under the intended root.
- Absolute paths were accepted outright.
- The same resolved path was later used by workspace preparation, upload, extraction, and command execution.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Islo workdir escape | 7.1 Medium | `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H` |

Rationale:

- Exploitation requires a user/operator to run Crabbox from a repository containing malicious Crabbox config.
- The impact is bounded to the delegated Islo sandbox environment, but can affect integrity and availability of broad sandbox paths before the intended command runs.

## Safe reproduction steps

1. On vulnerable code, consider this repo-local config:

   ```yaml
   provider: islo
   islo:
     workdir: ../etc
   sync:
     delete: true
   ```

2. The previous path resolver would compute:

   ```text
   /workspace/../etc -> /etc
   ```

3. The workspace preparation command would then target the escaped path:

   ```sh
   rm -rf '/etc' && mkdir -p '/etc'
   ```

4. This PR's regression coverage exercises the same condition safely in unit tests, without running destructive commands against a real sandbox.

## Expected vulnerable behavior

Before this PR:

- `islo.workdir: ../etc` resolved to `/etc`.
- `islo.workdir: /etc` was accepted directly.
- `prepareWorkspace()` used the escaped path in the generated remote shell command.

After this PR:

- both absolute values and cleaned escapes return a validation error before provider-side setup.

## Changes in this PR

- Changes `isloWorkspacePath()` to return `(string, error)`.
- Rejects absolute Islo workdir values.
- Rejects cleaned paths that resolve to `/workspace` itself or outside `/workspace/`.
- Propagates validation errors through both `Run()` and `syncWorkspace()`.
- Validates `Run()` early, before Islo client setup or sandbox creation.
- Adds regression tests for safe values and unsafe absolute/escape values.
- Updates Islo documentation to state that workdirs are relative under `/workspace`.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Islo provider | `internal/providers/islo/sync.go` | Added workspace containment validation and error return |
| Islo run flow | `internal/providers/islo/backend.go` | Validates workdir before provider setup and propagates validation errors |
| Tests | `internal/providers/islo/backend_test.go` | Added safe-path and escape-path regression coverage |
| Docs | `docs/features/islo.md`, `docs/providers/islo.md` | Documented the relative-under-`/workspace` boundary |

## Maintainer impact

- The patch is limited to the Islo provider and Islo docs.
- Valid relative workdirs continue to work.
- Nested relative workdirs such as `team/repo` remain supported.
- Absolute Islo workdirs now fail fast with a clear validation error.
- E2B and other providers are not changed.

## Fix rationale

The Islo docs already describe sync into `/workspace/<islo.workdir>`, and the CLI flag help describes the value as an Islo sandbox working directory under `/workspace`. Enforcing that boundary in code makes the documented model true and prevents repo-local config from controlling broad filesystem deletion or extraction targets.

The containment check is intentionally small and local to the Islo path helper, so future call sites get the same validation automatically.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `go test ./internal/providers/islo ./internal/cli ./internal/providers/e2b -count=1`
- [x] `go test ./... -count=1`
- [x] `git diff --check`
- [x] `node scripts/build-docs-site.mjs`
- [x] Independent pre-commit review of the final diff

Executed with:

```sh
gofmt -w internal/providers/islo/backend.go internal/providers/islo/backend_test.go internal/providers/islo/sync.go
go test ./internal/providers/islo ./internal/cli ./internal/providers/e2b -count=1
go test ./... -count=1
git diff --check
node scripts/build-docs-site.mjs
```

## Token usage

- discovery tokens: partial/unknown; delegated discovery agents were used, but full-session accounting is not available in one reliable total
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact local validation commands are listed above; no real secrets or credentials are included in this PR body

## Disclosure notes

- This PR is intentionally bounded to the Islo delegated-sync workdir containment issue.
- It does not claim that command execution inside a deliberately chosen sandbox workdir is unexpected.
- The issue is the missing containment boundary before Crabbox prepares/deletes/uploads the workdir.
- No unrelated provider behavior is changed.
