### PR TITLE
fix: validate Sprites work roots before create

### DIFF
--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -74,6 +74,9 @@ func validateSpritesOptions(cfg Config) error {
 	if cfg.Tailscale.Enabled {
 		return exit(2, "--tailscale is not supported for provider=sprites; Sprites exposes SSH through sprite proxy")
 	}
+	if err := cleanSpritesWorkRoot(cfg.Sprites.WorkRoot); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -144,6 +144,14 @@ func TestSpritesRejectsTailscale(t *testing.T) {
 	}
 }
 
+func TestSpritesRejectsUnsafeWorkRootBeforeBackend(t *testing.T) {
+	cfg := Config{Sprites: SpritesConfig{Token: "test-token", WorkRoot: "/tmp"}}
+	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestSpritesClientLifecycleRequests(t *testing.T) {
 	var sawCreate bool
 	var sawDelete bool


### PR DESCRIPTION
## Summary
- validate sprites.workRoot during Sprites backend configuration
- reject broad roots such as /tmp before any Sprite can be created
- add a regression for unsafe work roots failing before backend use

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/sprites ./internal/cli
- git diff --check