### PR TITLE
fix: reject unsafe Namespace work roots

### DIFF
--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -207,6 +207,18 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 	}
 }
 
+func TestNamespaceRejectsUnsafeWorkRoot(t *testing.T) {
+	for _, workRoot := range []string{"/", "/workspaces", "/tmp", "relative"} {
+		cfg := Config{Namespace: NamespaceConfig{WorkRoot: workRoot}}
+		if err := validateNamespaceConfig(cfg); err == nil {
+			t.Fatalf("expected %q to be rejected", workRoot)
+		}
+	}
+	if err := validateNamespaceConfig(Config{Namespace: NamespaceConfig{WorkRoot: "/workspaces/crabbox"}}); err != nil {
+		t.Fatalf("valid work root rejected: %v", err)
+	}
+}
+
 func TestNamespaceLifecycleCommandFallbacks(t *testing.T) {
 	runner := &namespaceRecordingRunner{failFirst: true}
 	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}

--- a/internal/providers/namespace/flags.go
+++ b/internal/providers/namespace/flags.go
@@ -2,6 +2,7 @@ package namespace
 
 import (
 	"flag"
+	"path"
 	"strings"
 	"time"
 )
@@ -82,6 +83,9 @@ func validateNamespaceConfig(cfg Config) error {
 	if cfg.Namespace.VolumeSizeGB < 0 {
 		return exit(2, "namespace volume size must be non-negative")
 	}
+	if err := cleanNamespaceWorkRoot(namespaceWorkRoot(cfg)); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -92,4 +96,16 @@ func applyNamespaceDuration(target *time.Duration, value string) {
 	if parsed, err := time.ParseDuration(value); err == nil && parsed > 0 {
 		*target = parsed
 	}
+}
+
+func cleanNamespaceWorkRoot(workRoot string) error {
+	clean := path.Clean(strings.TrimSpace(workRoot))
+	if clean == "" || !strings.HasPrefix(clean, "/") {
+		return exit(2, "namespace.workRoot %q must resolve to an absolute path", workRoot)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspaces":
+		return exit(2, "namespace.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- validate Namespace Devbox work roots during provider config
- reject broad roots such as /, /workspaces, and /tmp before create/prepare flows
- add regression coverage for invalid and valid work-root values

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/namespace ./internal/cli
- git diff --check