### PR TITLE
fix: report Namespace prepare failures

### DIFF
--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -195,7 +195,7 @@ func (b *namespaceLeaseBackend) prepareDevbox(ctx context.Context, name string) 
 	}
 	out, err := b.commandOutput(ctx, []string{"prepare", name})
 	if err != nil {
-		return SSHTarget{}, configureErr
+		return SSHTarget{}, err
 	}
 	var result namespacePrepareResult
 	if err := json.Unmarshal([]byte(extractJSONObject(out)), &result); err != nil {

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -130,13 +130,31 @@ func TestNamespaceLifecycleCommandFallbacks(t *testing.T) {
 	}
 }
 
+func TestNamespacePrepareReportsPrepareFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	runner := &namespaceRecordingRunner{failAll: true}
+	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+
+	_, err := backend.prepareDevbox(context.Background(), "crabbox-blue-lobster-deadbeef")
+	if err == nil || !strings.Contains(err.Error(), "namespace devbox failed") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.calls) != 2 || runner.calls[0] != "devbox configure-ssh" || runner.calls[1] != "devbox prepare crabbox-blue-lobster-deadbeef" {
+		t.Fatalf("prepare calls=%#v", runner.calls)
+	}
+}
+
 type namespaceRecordingRunner struct {
 	calls     []string
+	failAll   bool
 	failFirst bool
 }
 
 func (r *namespaceRecordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	r.calls = append(r.calls, req.Name+" "+strings.Join(req.Args, " "))
+	if r.failAll {
+		return LocalCommandResult{ExitCode: 2}, errors.New("unsupported")
+	}
 	if r.failFirst {
 		r.failFirst = false
 		return LocalCommandResult{ExitCode: 2}, errors.New("unsupported")


### PR DESCRIPTION
## Summary
- return the actual devbox prepare error when SSH config setup and prepare both fail
- avoid hiding prepare failures behind the earlier local SSH-config miss
- add regression coverage for the fallback path

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/namespace ./internal/cli
- git diff --check