### PR TITLE
fix: guard Sprites list pagination

### DIFF
--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -202,6 +202,40 @@ func TestSpritesClientLifecycleRequests(t *testing.T) {
 	}
 }
 
+func TestSpritesClientRejectsBadPagination(t *testing.T) {
+	for name, response := range map[string]spritesListResponse{
+		"missing token": {HasMore: true},
+		"repeated token": {
+			HasMore:               true,
+			NextContinuationToken: "same",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			requests := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/v1/sprites" {
+					t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+				}
+				requests++
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer srv.Close()
+
+			client := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+			_, err := client.ListSprites(context.Background(), "crabbox-")
+			if err == nil {
+				t.Fatal("expected pagination error")
+			}
+			if name == "repeated token" && requests != 2 {
+				t.Fatalf("requests=%d want 2", requests)
+			}
+			if name == "missing token" && requests != 1 {
+				t.Fatalf("requests=%d want 1", requests)
+			}
+		})
+	}
+}
+
 func TestSpritesEnsureCLIUsesSpriteBinary(t *testing.T) {
 	runner := &recordingRunner{}
 	backend := &spritesBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -87,6 +87,7 @@ func (c *spritesClient) GetSprite(ctx context.Context, name string) (spritesInfo
 func (c *spritesClient) ListSprites(ctx context.Context, prefix string) ([]spritesInfo, error) {
 	var all []spritesInfo
 	continuation := ""
+	seenContinuations := map[string]bool{}
 	for {
 		query := url.Values{}
 		query.Set("max_results", "50")
@@ -101,10 +102,18 @@ func (c *spritesClient) ListSprites(ctx context.Context, prefix string) ([]sprit
 			return nil, err
 		}
 		all = append(all, page.Sprites...)
-		if !page.HasMore || page.NextContinuationToken == "" {
+		if !page.HasMore {
 			return all, nil
 		}
-		continuation = page.NextContinuationToken
+		next := strings.TrimSpace(page.NextContinuationToken)
+		if next == "" {
+			return nil, fmt.Errorf("sprites list response has_more without next_continuation_token")
+		}
+		if seenContinuations[next] {
+			return nil, fmt.Errorf("sprites list response repeated continuation token %q", next)
+		}
+		seenContinuations[next] = true
+		continuation = next
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject Sprites list responses that report has_more without a continuation token
- detect repeated continuation tokens so list cannot spin forever
- add regression coverage for malformed pagination responses

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/sprites ./internal/cli
- git diff --check