### PR TITLE
[security] fix: ignore identity headers for shared token auth

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,6 +108,7 @@ Conditional Worker secrets and settings:
 ```text
 AWS_SESSION_TOKEN optional
 CRABBOX_AWS_MAC_HOST_ID required only for brokered target=macos
+CRABBOX_SHARED_OWNER optional fixed owner identity for shared-token automation
 CRABBOX_ADMIN_TOKEN required for admin routes and image promotion
 CRABBOX_GITHUB_CLIENT_ID required for browser login
 CRABBOX_GITHUB_CLIENT_SECRET required for browser login

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,7 +65,7 @@ Rules:
 - Never accept secret values as command-line flag values.
 - Never log env values.
 - Redact known secret-looking strings in diagnostics.
-- `CRABBOX_SHARED_TOKEN` is stored as a Worker secret for trusted operator automation; local automation can use `CRABBOX_COORDINATOR_TOKEN`.
+- `CRABBOX_SHARED_TOKEN` is stored as a Worker secret for trusted operator automation; local automation can use `CRABBOX_COORDINATOR_TOKEN`. Shared-token requests do not trust caller-supplied `X-Crabbox-Owner` or `X-Crabbox-Org`; configure a fixed `CRABBOX_SHARED_OWNER` for that automation identity, or use verified Cloudflare Access / signed browser tokens for per-user identity.
 - `CRABBOX_ADMIN_TOKEN` is stored as a Worker secret for admin and image lifecycle routes; local admin commands use `CRABBOX_COORDINATOR_ADMIN_TOKEN` or `broker.adminToken`.
 - `CRABBOX_GITHUB_CLIENT_ID`, `CRABBOX_GITHUB_CLIENT_SECRET`, and `CRABBOX_SESSION_SECRET` are Worker secrets for browser login.
 - `CRABBOX_TAILSCALE_CLIENT_ID` and `CRABBOX_TAILSCALE_CLIENT_SECRET` are

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -30,6 +30,7 @@ export async function authenticateRequest(
   env: Pick<
     Env,
     | "CRABBOX_SHARED_TOKEN"
+    | "CRABBOX_SHARED_OWNER"
     | "CRABBOX_ADMIN_TOKEN"
     | "CRABBOX_SESSION_SECRET"
     | "CRABBOX_DEFAULT_ORG"
@@ -56,8 +57,8 @@ export async function authenticateRequest(
       authorized: true,
       admin: false,
       auth: "bearer",
-      owner: accessIdentity?.email ?? request.headers.get("x-crabbox-owner") ?? "unknown",
-      org: request.headers.get("x-crabbox-org") ?? env.CRABBOX_DEFAULT_ORG ?? "unknown",
+      owner: accessIdentity?.email ?? env.CRABBOX_SHARED_OWNER?.trim() ?? "unknown",
+      org: env.CRABBOX_DEFAULT_ORG ?? "unknown",
     };
   }
   const payload = await verifyUserToken(token, env).catch(() => undefined);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -58,6 +58,7 @@ export async function isAuthorized(
   env: Pick<
     Env,
     | "CRABBOX_SHARED_TOKEN"
+    | "CRABBOX_SHARED_OWNER"
     | "CRABBOX_ADMIN_TOKEN"
     | "CRABBOX_SESSION_SECRET"
     | "CRABBOX_DEFAULT_ORG"

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -28,6 +28,7 @@ export interface Env {
   CRABBOX_AZURE_NSG?: string;
   CRABBOX_AZURE_SSH_CIDRS?: string;
   CRABBOX_SHARED_TOKEN?: string;
+  CRABBOX_SHARED_OWNER?: string;
   CRABBOX_ADMIN_TOKEN?: string;
   CRABBOX_SESSION_SECRET?: string;
   CRABBOX_GITHUB_CLIENT_ID?: string;

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -25,9 +25,10 @@ describe("coordinator auth", () => {
     await expect(isAuthorized(allowed, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(true);
   });
 
-  it("keeps shared bearer token non-admin and requires a separate admin token", async () => {
+  it("keeps shared bearer token non-admin and ignores caller-supplied identity headers", async () => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SHARED_OWNER: "automation@example.com",
       CRABBOX_ADMIN_TOKEN: "admin",
       CRABBOX_DEFAULT_ORG: "openclaw",
     };
@@ -36,6 +37,7 @@ describe("coordinator auth", () => {
         headers: {
           authorization: "Bearer shared",
           "x-crabbox-owner": "operator@example.com",
+          "x-crabbox-org": "attacker-org",
           "cf-access-authenticated-user-email": "spoof@example.com",
         },
       }),
@@ -51,7 +53,8 @@ describe("coordinator auth", () => {
     expect(shared).toMatchObject({
       authorized: true,
       admin: false,
-      owner: "operator@example.com",
+      owner: "automation@example.com",
+      org: "openclaw",
     });
     expect(admin).toMatchObject({
       authorized: true,


### PR DESCRIPTION
## Summary

This PR hardens the coordinator shared-token identity boundary so a holder of `CRABBOX_SHARED_TOKEN` cannot choose arbitrary lease owner/org identities by sending trusted internal headers.

- Shared-token authentication no longer trusts caller-supplied `X-Crabbox-Owner` or `X-Crabbox-Org`.
- Shared-token automation can use a fixed `CRABBOX_SHARED_OWNER` identity, or a verified Cloudflare Access identity when Access JWT verification is configured.
- Signed GitHub user tokens and admin-token behavior remain separate.
- Regression coverage now locks the shared-token behavior so spoofed identity headers do not become the authenticated owner/org.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Shared-token owner/org header spoofing | A non-admin shared-token caller could impersonate another owner/org and reach owner/manage-scoped lease operations. | High |

## Before this PR

- `CRABBOX_SHARED_TOKEN` authenticated callers as non-admin but still accepted `X-Crabbox-Owner` and `X-Crabbox-Org` from the incoming request.
- Those trusted headers were then forwarded to the Fleet Durable Object as authenticated request context.
- Lease authorization compares the authenticated request owner/org against stored lease ownership, so a shared-token caller could choose a victim owner/org at request time.
- The existing auth test confirmed non-admin status but did not assert that user-controlled identity headers were ignored for shared-token requests.

## After this PR

- Shared-token requests use only server-controlled identity sources:
  - verified Cloudflare Access email when a valid Access JWT is configured and present;
  - otherwise the fixed `CRABBOX_SHARED_OWNER` Worker setting;
  - otherwise `unknown`.
- Shared-token requests use `CRABBOX_DEFAULT_ORG` for org context instead of caller-supplied `X-Crabbox-Org`.
- Admin-token requests keep their existing privileged behavior.
- The auth regression test now sends spoofed owner/org headers and verifies they do not override the shared-token identity.

## Explicit operator choice

Secure default / fixed automation identity:

```text
CRABBOX_SHARED_TOKEN=<secret>
CRABBOX_SHARED_OWNER=automation@example.com
CRABBOX_DEFAULT_ORG=openclaw
```

Per-user identity should come from a stronger identity source:

```text
CRABBOX_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com
CRABBOX_ACCESS_AUD=<access-audience>
```

With this model, a shared secret can authenticate automation, but it cannot mint arbitrary user identities by changing request headers. Deployments that need per-user attribution should use signed browser/user tokens or verified Cloudflare Access identity rather than trusting raw `X-Crabbox-*` headers from the public request.

## Why this matters

The shared coordinator token is intentionally non-admin, but owner/org identity is also a security boundary. Owner-equivalent access can read lease details, change sharing, create bridge tickets, and release or manage leases depending on the route and lease sharing state. Treating request headers as identity lets any shared-token holder cross that boundary.

## Attack flow

```text
Bearer CRABBOX_SHARED_TOKEN + X-Crabbox-Owner: victim@example.com
    -> authenticateRequest accepts caller-supplied identity headers
        -> requestWithAuthContext forwards victim owner/org as trusted context
            -> Fleet lease checks treat the request as the victim owner/org
                -> victim lease read/manage/ticket operations can be reached
```

## Affected code

| Issue | Files |
|-------|-------|
| Shared-token owner/org header spoofing | `worker/src/auth.ts`, `worker/src/types.ts`, `worker/src/index.ts`, `worker/test/http.test.ts`, `docs/security.md`, `docs/operations.md` |

## Root cause

Shared-token owner/org header spoofing:

- `authenticateRequest()` treated `X-Crabbox-Owner` and `X-Crabbox-Org` as trusted identity input for `CRABBOX_SHARED_TOKEN` requests.
- Those headers are only trustworthy after the coordinator has constructed them from an authenticated identity; they should not be accepted directly from a non-admin bearer-token caller.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Shared-token owner/org header spoofing | 8.8 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` |

Rationale:

- The issue requires possession of the shared coordinator token, so Privileges Required is Low.
- Once held, exploitation is network-reachable and low-complexity with no user interaction.
- Impact can include cross-owner confidentiality/integrity/availability effects for lease records and owner/manage-scoped operations.

## Safe reproduction steps

1. Configure the Worker auth environment with a shared token and default org.
2. Send a request using `Authorization: Bearer <CRABBOX_SHARED_TOKEN>` plus attacker-controlled identity headers such as:

   ```text
   X-Crabbox-Owner: victim@example.com
   X-Crabbox-Org: victim-org
   ```

3. On vulnerable code, `authenticateRequest()` returns an authenticated non-admin context with the spoofed owner/org.
4. With a victim lease present, owner/org checks can then treat the request as belonging to the victim owner/org.

The regression test in this PR exercises this safely at the auth boundary and verifies the spoofed headers are ignored.

## Expected vulnerable behavior

- A non-admin shared-token caller should not be able to select another user's owner/org identity with request headers.
- Vulnerable code accepted those headers and converted them into trusted internal auth context.

## Changes in this PR

- Stop using request-supplied `X-Crabbox-Owner` and `X-Crabbox-Org` for shared-token identity.
- Add `CRABBOX_SHARED_OWNER` as a fixed Worker-side automation owner for shared-token deployments.
- Keep verified Cloudflare Access identity as the preferred per-request owner source when Access JWT verification is configured.
- Add/adjust Worker auth regression coverage for spoofed shared-token owner/org headers.
- Document the shared-token identity model and config implications.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Auth hardening | `worker/src/auth.ts` | Shared-token auth now derives identity from verified Access or fixed Worker config, not caller headers. |
| Types / API surface | `worker/src/types.ts`, `worker/src/index.ts` | Added `CRABBOX_SHARED_OWNER` to the Worker env typing/auth pick list. |
| Regression test | `worker/test/http.test.ts` | Shared-token test now sends spoofed owner/org headers and asserts fixed identity is used. |
| Documentation | `docs/security.md`, `docs/operations.md` | Documented shared-token identity behavior and `CRABBOX_SHARED_OWNER`. |

## Maintainer impact

- This is a narrow coordinator-auth change; provider code, lease lifecycle, portal rendering, and bridge implementations are otherwise unchanged.
- Deployments using shared-token automation with caller-supplied owner/org headers should move to `CRABBOX_SHARED_OWNER`, verified Cloudflare Access identity, signed user tokens, or the admin token where explicit operator impersonation is intended.
- The change keeps the shared token non-admin while preventing it from acting as an arbitrary owner-selection primitive.

## Suggested fix rationale

- `X-Crabbox-*` headers are internal trusted context after authentication, not public identity input for non-admin bearer callers.
- A fixed Worker-side automation identity preserves shared-token automation without allowing arbitrary owner/org impersonation.
- Verified Access and signed user tokens remain the right boundary for per-user identity because they bind identity cryptographically or through the configured identity provider.

## Reference patterns from other software

- GitHub Actions and GitLab CI distinguish shared automation credentials from per-user identity and protected resource access.
- Kubernetes and Keycloak similarly separate service-account privileges from arbitrary end-user impersonation unless explicit impersonation permissions are granted.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused auth regression test
- [x] Worker formatting check
- [x] Worker lint
- [x] Worker typecheck
- [x] Full Worker Vitest suite
- [x] Git whitespace check

Executed with:

- `npm ci --prefix worker`
- `npm test --prefix worker -- --run test/http.test.ts`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `git diff --check`

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: This PR was prepared from local code review and regression validation; exact token accounting was not available from the local tooling.

## Disclosure notes

- This PR is bounded to shared-token identity spoofing through trusted owner/org headers.
- It does not claim a bypass for signed GitHub user tokens; those already bind owner/org in the token payload.
- It does not change admin-token behavior, where administrative deployment operators are already privileged.
- I did not find a repository `SECURITY.md`, so this is submitted directly as a security-labeled hardening PR.
- No unrelated files were changed.
