### PR TITLE
[security] fix: require manage access for bridge tickets

### DIFF
--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1472,9 +1472,13 @@ export class FleetDurableObject implements DurableObject {
     if (request.method.toUpperCase() !== "POST") {
       return json({ error: "not_found" }, { status: 404 });
     }
-    const lease = await this.resolveLease(identifier, request, false);
+    const admin = isAdminRequest(request);
+    const lease = await this.resolveLease(identifier, request, admin);
     if (!lease) {
       return notFound();
+    }
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     if (lease.state !== "active") {
       return json({ error: "egress_unavailable", message: "lease is not active" }, { status: 409 });
@@ -1604,9 +1608,13 @@ export class FleetDurableObject implements DurableObject {
     if (request.method.toUpperCase() !== "POST") {
       return json({ error: "not_found" }, { status: 404 });
     }
-    const lease = await this.resolveLease(identifier, request, false);
+    const admin = isAdminRequest(request);
+    const lease = await this.resolveLease(identifier, request, admin);
     if (!lease) {
       return notFound();
+    }
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     const error = webVNCLeaseError(lease);
     if (error) {
@@ -1768,9 +1776,13 @@ export class FleetDurableObject implements DurableObject {
     if (request.method.toUpperCase() !== "POST") {
       return json({ error: "not_found" }, { status: 404 });
     }
-    const lease = await this.resolveLease(identifier, request, false);
+    const admin = isAdminRequest(request);
+    const lease = await this.resolveLease(identifier, request, admin);
     if (!lease) {
       return notFound();
+    }
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     const error = codeLeaseError(lease);
     if (error) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -204,7 +204,31 @@ describe("fleet lease identity and idle", () => {
         body: {},
       }),
     );
-    expect(friendTicket.status).toBe(200);
+    expect(friendTicket.status).toBe(403);
+
+    const ownerTicket = await fleet.fetch(
+      request("POST", "/v1/leases/blue-lobster/webvnc/ticket", {
+        headers: ownerHeaders,
+        body: {},
+      }),
+    );
+    expect(ownerTicket.status).toBe(200);
+
+    const friendCodeTicket = await fleet.fetch(
+      request("POST", "/v1/leases/blue-lobster/code/ticket", {
+        headers: friendHeaders,
+        body: {},
+      }),
+    );
+    expect(friendCodeTicket.status).toBe(403);
+
+    const friendEgressTicket = await fleet.fetch(
+      request("POST", "/v1/leases/blue-lobster/egress/ticket", {
+        headers: friendHeaders,
+        body: { role: "host" },
+      }),
+    );
+    expect(friendEgressTicket.status).toBe(403);
 
     const friendRelease = await fleet.fetch(
       request("POST", "/v1/leases/blue-lobster/release", {


### PR DESCRIPTION
## Summary

This PR hardens bridge ticket issuance so users with lease `use` visibility cannot mint lease-side bridge-agent tickets for Code, WebVNC, or Egress.

The patch changes the ticket endpoints to require owner/manage/admin access before issuing bridge tickets, matching the trust boundary already used by owner/manage lease operations. It also adds regression coverage proving that a `use`-shared user can still see the lease but cannot mint backend bridge tickets.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Use-role users could mint lease-side bridge tickets | A user with only shared `use` access could obtain Code/WebVNC/Egress agent tickets and replace or impersonate trusted lease-side bridges | High |

## Before this PR

- `POST /v1/leases/:id/code/ticket` resolved leases with visibility-only access.
- `POST /v1/leases/:id/webvnc/ticket` resolved leases with visibility-only access.
- `POST /v1/leases/:id/egress/ticket` resolved leases with visibility-only access.
- Lease visibility includes explicit user/org `use` shares.
- The returned tickets are accepted by the corresponding bridge-agent WebSocket routes.
- A `use` user could therefore obtain agent-side bridge tickets even though other owner/manage actions such as release remained forbidden.

## After this PR

- Code bridge tickets require owner/manage/admin access.
- WebVNC bridge tickets require owner/manage/admin access.
- Egress host/client bridge tickets require owner/manage/admin access.
- `use`-shared users receive `403 forbidden` from all three ticket-minting endpoints.
- Owners and managers can still mint bridge tickets for their leases.

## Why this matters

Bridge tickets are not passive viewer credentials. They admit the holder to trusted lease-side bridge-agent routes:

- Code bridge agents can replace the active code bridge and receive portal Code proxy traffic.
- WebVNC bridge agents can present or replace the desktop bridge seen by viewers.
- Egress host/client agents can replace either side of an egress tunnel session.

A lease `use` share is a lower-privilege collaboration role. It should allow using or viewing the shared lease, but it should not allow impersonating the backend bridge that owners and managers trust.

## How this differs from related auth PRs

This is distinct from the existing coordinator auth hardening work:

- #64 addressed signed user-token payloads carrying admin claims.
- #70 addresses shared-token callers selecting arbitrary owner/org identities with request headers.

This PR addresses a different authorization layer after identity has already been established: a correctly identified `use`-shared principal could mint bridge-agent tickets because the ticket routes checked lease visibility rather than lease manageability.

## Attack flow

```text
Owner shares a Code/WebVNC/Egress-enabled lease with attacker as role: use
    -> attacker calls /v1/leases/:id/code/ticket or /webvnc/ticket or /egress/ticket
        -> vulnerable code issues a bridge-agent ticket because the lease is visible
            -> attacker connects to the corresponding /agent, /host, or /client WebSocket
                -> trusted bridge state can be replaced or impersonated
```

## Affected code

| Issue | Files |
|-------|-------|
| Bridge tickets used visibility-only authorization | `worker/src/fleet.ts`, `worker/test/fleet.test.ts` |

## Root cause

- The ticket minting handlers used `resolveLease(identifier, request, false)`, which accepts any visible lease.
- `leaseAccessRole()` treats `use` shares as visible.
- The ticket handlers did not follow the existing `leaseManageableByRequest()` pattern used by owner/manage operations.
- The same ticket primitive is consumed by the bridge-agent WebSocket endpoints.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Use-role bridge ticket minting | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale:

- The attacker needs a valid account or token with `use` access to a shared lease, so privileges required are low.
- Exploitation is network-reachable and low-complexity once the lease is shared.
- Successful exploitation can compromise confidentiality and integrity of bridge traffic or bridge state for the affected lease.
- Availability impact is lower than confidentiality/integrity because the patch is focused on bridge impersonation/replacement rather than global coordinator shutdown.

## Safe reproduction steps

1. Seed or create an active lease with Code/WebVNC/Egress enabled.
2. Share that lease with `attacker@example.com` as `use`.
3. Send requests as `attacker@example.com` to:
   - `POST /v1/leases/:id/code/ticket`
   - `POST /v1/leases/:id/webvnc/ticket`
   - `POST /v1/leases/:id/egress/ticket` with `{ "role": "host" }`
4. On vulnerable code, each endpoint returns a bridge ticket.
5. With this PR, each endpoint returns `403 forbidden` for the `use` user while owner requests still succeed.

The regression test added here performs the safe local version of this flow without contacting a real coordinator.

## Expected vulnerable behavior

- A `use`-shared user can see the lease.
- The same user cannot release the lease.
- On vulnerable code, the same user can still mint bridge-agent tickets for Code, WebVNC, and Egress.

## Changes in this PR

- Adds owner/manage/admin authorization checks to Code ticket creation.
- Adds owner/manage/admin authorization checks to WebVNC ticket creation.
- Adds owner/manage/admin authorization checks to Egress ticket creation.
- Updates lease sharing regression coverage so `use` users are denied bridge tickets while owners remain allowed.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Authz hardening | `worker/src/fleet.ts` | Ticket creation now uses `isAdminRequest()` and `leaseManageableByRequest()` before minting bridge tickets. |
| Regression tests | `worker/test/fleet.test.ts` | `use`-shared users now assert 403 for WebVNC, Code, and Egress ticket creation; owner ticket creation remains allowed. |

## Maintainer impact

- Owners, managers, and admins can still mint bridge tickets.
- `use`-shared users can still view visible lease details and use lower-privilege shared surfaces.
- The patch intentionally changes only ticket minting authorization; it does not alter ticket formats, WebSocket handling, bridge protocol messages, or provider behavior.

## Fix rationale

Bridge tickets admit a client to trusted lease-side agent roles. Those roles are closer to lease management than passive use, because they can replace backend bridge state and influence traffic seen by owners or other users. Reusing `leaseManageableByRequest()` keeps this boundary consistent with existing owner/manage lease operations.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused Fleet regression test
- [x] Worker type check
- [x] Worker lint
- [x] Worker format check
- [x] Full Worker Vitest suite
- [x] Git whitespace check

Executed with:

- `npm test --prefix worker -- --run test/fleet.test.ts`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker`
- `git diff --check`

## Disclosure notes

- This PR is bounded to bridge ticket authorization for Code, WebVNC, and Egress.
- It does not claim a bypass of GitHub OAuth, Cloudflare Access, or admin-token checks.
- It is distinct from shared-token identity spoofing and signed-token admin-claim hardening because it applies after a principal is already correctly identified as a `use`-shared lease user.
- No unrelated files were changed.
