### PR TITLE
Improve motion GIF preview quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Improved `crabbox media preview` and `artifacts collect --gif` defaults to generate higher-quality 1000px/24fps GIFs with Floyd-Steinberg palette dithering and optional gifsicle optimization.
+- Improved `crabbox media preview` and `artifacts collect --gif` defaults to generate higher-quality 1000px/24fps GIFs with Floyd-Steinberg palette dithering and optional gifsicle optimization. Thanks @obviyus.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Improved `crabbox media preview` and `artifacts collect --gif` defaults to generate higher-quality 1000px/24fps GIFs with Floyd-Steinberg palette dithering and optional gifsicle optimization.
+
 ### Fixed
 
 - Fixed `crabbox webvnc daemon start` so it starts with a fresh bridge log and waits briefly for the bridge-ready marker before returning.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,7 @@ crabbox egress client --id <lease-id-or-slug> [--listen <addr>] [--ticket <ticke
 crabbox egress status --id <lease-id-or-slug>
 crabbox egress stop --id <lease-id-or-slug>
 crabbox media preview --input <video> --output <preview.gif> [--trimmed-video-output <change.mp4>]
-crabbox artifacts collect --id <lease-id-or-slug> [--output <dir>] [--run <run-id>] [--all] [--screenshot] [--video] [--gif] [--doctor] [--webvnc-status] [--metadata] [--duration <duration>] [--fps <n>] [--gif-width <px>] [--network auto|tailscale|public] [--json]
+crabbox artifacts collect --id <lease-id-or-slug> [--output <dir>] [--run <run-id>] [--all] [--screenshot] [--video] [--gif] [--doctor] [--webvnc-status] [--metadata] [--duration <duration>] [--fps <n>] [--gif-width <px>] [--gif-fps <n>] [--network auto|tailscale|public] [--json]
 crabbox artifacts video --id <lease-id-or-slug> [--output <path>] [--duration <duration>] [--fps <n>] [--no-contact-sheet]
 crabbox desktop record --id <lease-id-or-slug> [--output <path>] [--duration <duration>] [--fps <n>] [--no-contact-sheet]
 crabbox artifacts gif --input <video> --output <preview.gif> [--trimmed-video-output <change.mp4>]

--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -45,7 +45,8 @@ Useful flags:
 --metadata
 --duration <duration> default 10s
 --fps <n>             default 15
---gif-width <px>      default 640
+--gif-width <px>      default 1000
+--gif-fps <n>         default 24
 --contact-sheet       default true
 --no-contact-sheet
 --contact-sheet-output <path>

--- a/docs/commands/media.md
+++ b/docs/commands/media.md
@@ -20,7 +20,8 @@ By default the preview is motion-focused:
 
 - ffmpeg `freezedetect` finds leading and trailing static regions.
 - Crabbox keeps a little padding around the first and last moving frame.
-- The GIF is palette-optimized at 4 fps and 640 px wide.
+- The GIF is palette-optimized at 24 fps and 1000 px wide with Floyd-Steinberg dithering.
+- When `gifsicle` is on `PATH`, Crabbox runs `gifsicle -O3 --lossy=65 --gamma=1.2` after ffmpeg to reduce file size without dropping the higher-quality palette.
 - `--trimmed-video-output` writes an MP4 clip using the same motion window.
 
 If no motion is detected, Crabbox keeps the full source video instead of
@@ -32,15 +33,20 @@ Useful flags:
 --input <path>
 --output <path>
 --trimmed-video-output <path>
---width <px>              default 640
---fps <n>                 default 4
+--width <px>              default 1000
+--fps <n>                 default 24
 --trim-static             default true
 --no-trim-static
 --trim-padding <duration> default 750ms
 --freeze-duration <dur>   default 500ms
 --freeze-noise <level>    default -50dB
 --min-duration <duration> default 1500ms
+--gifsicle auto|off|required
+--gifsicle-lossy <n>      default 65
+--gifsicle-gamma <n>      default 1.2
 --json
 ```
 
-`ffmpeg` and `ffprobe` must be on `PATH`.
+`ffmpeg` and `ffprobe` must be on `PATH`. `gifsicle` is optional by default;
+use `--gifsicle required` when you want the command to fail instead of skipping
+that optimization pass.

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -91,7 +91,8 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 	metadata := fs.Bool("metadata", true, "write metadata.json")
 	duration := fs.Duration("duration", 10*time.Second, "video capture duration")
 	fps := fs.Float64("fps", 15, "video frames per second")
-	gifWidth := fs.Int("gif-width", 640, "trimmed GIF width")
+	gifWidth := fs.Int("gif-width", defaultMediaPreviewWidth, "trimmed GIF width")
+	gifFPS := fs.Float64("gif-fps", defaultMediaPreviewFPS, "trimmed GIF frames per second")
 	contactSheetFrames := fs.Int("contact-sheet-frames", 5, "number of sampled frames in the contact sheet")
 	contactSheetCols := fs.Int("contact-sheet-cols", 5, "contact sheet columns")
 	contactSheetWidth := fs.Int("contact-sheet-width", 320, "width of each contact sheet tile")
@@ -118,6 +119,9 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 	}
 	if *gifWidth <= 0 {
 		return exit(2, "artifacts collect --gif-width must be positive")
+	}
+	if *gifFPS <= 0 {
+		return exit(2, "artifacts collect --gif-fps must be positive")
 	}
 	if *contactSheetFrames <= 0 {
 		return exit(2, "artifacts collect --contact-sheet-frames must be positive")
@@ -277,18 +281,10 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 		if *gif {
 			gifPath := filepath.Join(dir, "screen.trimmed.gif")
 			trimmedPath := filepath.Join(dir, "screen.trimmed.mp4")
-			preview, err := createMediaPreview(ctx, mediaPreviewOptions{
-				Input:              path,
-				Output:             gifPath,
-				TrimmedVideoOutput: trimmedPath,
-				Width:              *gifWidth,
-				FPS:                4,
-				TrimStatic:         true,
-				TrimPadding:        750 * time.Millisecond,
-				FreezeDuration:     500 * time.Millisecond,
-				FreezeNoise:        "-50dB",
-				MinDuration:        1500 * time.Millisecond,
-			})
+			options := defaultMediaPreviewOptions(path, gifPath, trimmedPath)
+			options.Width = *gifWidth
+			options.FPS = *gifFPS
+			preview, err := createMediaPreview(ctx, options)
 			if err != nil {
 				return fail(err, artifactWarning{
 					Problem: rescueArtifactCaptureFailed,

--- a/internal/cli/media.go
+++ b/internal/cli/media.go
@@ -26,6 +26,7 @@ type mediaPreviewResult struct {
 	TrimmedStaticEdges       bool    `json:"trimmedStaticEdges"`
 	DetectedFreezeIntervals  int     `json:"detectedFreezeIntervals"`
 	DetectedMotionWindowNote string  `json:"detectedMotionWindowNote,omitempty"`
+	GifsicleOptimized        bool    `json:"gifsicleOptimized"`
 }
 
 type mediaContactSheetResult struct {
@@ -49,6 +50,9 @@ type mediaPreviewOptions struct {
 	FreezeDuration     time.Duration
 	FreezeNoise        string
 	MinDuration        time.Duration
+	GifsicleMode       string
+	GifsicleLossy      int
+	GifsicleGamma      float64
 	JSON               bool
 }
 
@@ -65,19 +69,48 @@ type mediaInterval struct {
 	End   float64
 }
 
+const (
+	defaultMediaPreviewWidth         = 1000
+	defaultMediaPreviewFPS           = 24
+	defaultMediaPreviewGifsicleMode  = "auto"
+	defaultMediaPreviewGifsicleLossy = 65
+	defaultMediaPreviewGifsicleGamma = 1.2
+)
+
+func defaultMediaPreviewOptions(input, output, trimmedVideoOutput string) mediaPreviewOptions {
+	return mediaPreviewOptions{
+		Input:              input,
+		Output:             output,
+		TrimmedVideoOutput: trimmedVideoOutput,
+		Width:              defaultMediaPreviewWidth,
+		FPS:                defaultMediaPreviewFPS,
+		TrimStatic:         true,
+		TrimPadding:        750 * time.Millisecond,
+		FreezeDuration:     500 * time.Millisecond,
+		FreezeNoise:        "-50dB",
+		MinDuration:        1500 * time.Millisecond,
+		GifsicleMode:       defaultMediaPreviewGifsicleMode,
+		GifsicleLossy:      defaultMediaPreviewGifsicleLossy,
+		GifsicleGamma:      defaultMediaPreviewGifsicleGamma,
+	}
+}
+
 func (a App) mediaPreview(ctx context.Context, args []string) error {
 	fs := newFlagSet("media preview", a.Stderr)
 	input := fs.String("input", "", "input MP4/video path")
 	output := fs.String("output", "", "output GIF preview path")
 	trimmedVideoOutput := fs.String("trimmed-video-output", "", "optional output MP4 trimmed to the same motion window")
-	width := fs.Int("width", 640, "preview width in pixels")
-	fps := fs.Float64("fps", 4, "preview frames per second")
+	width := fs.Int("width", defaultMediaPreviewWidth, "preview width in pixels")
+	fps := fs.Float64("fps", defaultMediaPreviewFPS, "preview frames per second")
 	trimStatic := fs.Bool("trim-static", true, "trim leading and trailing static regions before making the preview")
 	noTrimStatic := fs.Bool("no-trim-static", false, "disable static-region trimming")
 	trimPadding := fs.Duration("trim-padding", 750*time.Millisecond, "padding kept before first motion and after last motion")
 	freezeDuration := fs.Duration("freeze-duration", 500*time.Millisecond, "minimum still duration for ffmpeg freezedetect")
 	freezeNoise := fs.String("freeze-noise", "-50dB", "ffmpeg freezedetect noise threshold")
 	minDuration := fs.Duration("min-duration", 1500*time.Millisecond, "minimum preview duration after trimming")
+	gifsicleMode := fs.String("gifsicle", defaultMediaPreviewGifsicleMode, "gifsicle optimization: auto, off, or required")
+	gifsicleLossy := fs.Int("gifsicle-lossy", defaultMediaPreviewGifsicleLossy, "gifsicle lossy compression value")
+	gifsicleGamma := fs.Float64("gifsicle-gamma", defaultMediaPreviewGifsicleGamma, "gifsicle gamma value")
 	jsonOut := fs.Bool("json", false, "print machine-readable result metadata")
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -85,19 +118,18 @@ func (a App) mediaPreview(ctx context.Context, args []string) error {
 	if *noTrimStatic {
 		*trimStatic = false
 	}
-	opts := mediaPreviewOptions{
-		Input:              *input,
-		Output:             *output,
-		TrimmedVideoOutput: *trimmedVideoOutput,
-		Width:              *width,
-		FPS:                *fps,
-		TrimStatic:         *trimStatic,
-		TrimPadding:        *trimPadding,
-		FreezeDuration:     *freezeDuration,
-		FreezeNoise:        *freezeNoise,
-		MinDuration:        *minDuration,
-		JSON:               *jsonOut,
-	}
+	opts := defaultMediaPreviewOptions(*input, *output, *trimmedVideoOutput)
+	opts.Width = *width
+	opts.FPS = *fps
+	opts.TrimStatic = *trimStatic
+	opts.TrimPadding = *trimPadding
+	opts.FreezeDuration = *freezeDuration
+	opts.FreezeNoise = *freezeNoise
+	opts.MinDuration = *minDuration
+	opts.GifsicleMode = *gifsicleMode
+	opts.GifsicleLossy = *gifsicleLossy
+	opts.GifsicleGamma = *gifsicleGamma
+	opts.JSON = *jsonOut
 	result, err := createMediaPreview(ctx, opts)
 	if err != nil {
 		return err
@@ -136,6 +168,19 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 	}
 	if opts.MinDuration < 0 {
 		return mediaPreviewResult{}, exit(2, "media preview --min-duration must be non-negative")
+	}
+	gifsicleMode := strings.ToLower(strings.TrimSpace(opts.GifsicleMode))
+	if gifsicleMode == "" {
+		gifsicleMode = defaultMediaPreviewGifsicleMode
+	}
+	if gifsicleMode != "auto" && gifsicleMode != "off" && gifsicleMode != "required" {
+		return mediaPreviewResult{}, exit(2, "media preview --gifsicle must be auto, off, or required")
+	}
+	if opts.GifsicleLossy < 0 {
+		return mediaPreviewResult{}, exit(2, "media preview --gifsicle-lossy must be non-negative")
+	}
+	if opts.GifsicleGamma <= 0 {
+		return mediaPreviewResult{}, exit(2, "media preview --gifsicle-gamma must be positive")
 	}
 	if _, err := os.Stat(opts.Input); err != nil {
 		return mediaPreviewResult{}, exit(2, "read input video: %v", err)
@@ -180,6 +225,13 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 	if err := runMediaCommand(ctx, "ffmpeg", previewGIFArgs(opts.Input, palette, opts.Output, opts.Width, opts.FPS, start, previewDuration)...); err != nil {
 		return mediaPreviewResult{}, err
 	}
+	optimized := false
+	if gifsicleMode != "off" {
+		optimized, err = optimizeGIF(ctx, opts.Output, opts.GifsicleLossy, opts.GifsicleGamma, gifsicleMode == "required")
+		if err != nil {
+			return mediaPreviewResult{}, err
+		}
+	}
 	if opts.TrimmedVideoOutput != "" {
 		if err := os.MkdirAll(filepath.Dir(opts.TrimmedVideoOutput), 0o755); err != nil && filepath.Dir(opts.TrimmedVideoOutput) != "." {
 			return mediaPreviewResult{}, exit(2, "create trimmed video output directory: %v", err)
@@ -198,6 +250,7 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 		TrimmedStaticEdges:       trimmed,
 		DetectedFreezeIntervals:  freezeCount,
 		DetectedMotionWindowNote: note,
+		GifsicleOptimized:        optimized,
 	}, nil
 }
 
@@ -286,11 +339,40 @@ func previewGIFArgs(input, palette, output string, width int, fps, start, durati
 	args = appendTrimInputArgs(args, input, start, duration)
 	args = append(args,
 		"-i", palette,
-		"-lavfi", fmt.Sprintf("fps=%s,scale=%d:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3:diff_mode=rectangle", formatMediaSeconds(fps), width),
+		"-lavfi", fmt.Sprintf("fps=%s,scale=iw*sar:ih,scale=%d:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=floyd_steinberg", formatMediaSeconds(fps), width),
 		"-loop", "0",
 		output,
 	)
 	return args
+}
+
+func gifsicleOptimizeArgs(input, output string, lossy int, gamma float64) []string {
+	return []string{
+		"-O3",
+		fmt.Sprintf("--gamma=%s", formatMediaSeconds(gamma)),
+		fmt.Sprintf("--lossy=%d", lossy),
+		input,
+		"-o",
+		output,
+	}
+}
+
+func optimizeGIF(ctx context.Context, output string, lossy int, gamma float64, required bool) (bool, error) {
+	if _, err := exec.LookPath("gifsicle"); err != nil {
+		if required {
+			return false, exit(2, "gifsicle is required for media preview: %v", err)
+		}
+		return false, nil
+	}
+	temp := strings.TrimSuffix(output, filepath.Ext(output)) + ".optimized.gif"
+	defer os.Remove(temp)
+	if err := runMediaCommand(ctx, "gifsicle", gifsicleOptimizeArgs(output, temp, lossy, gamma)...); err != nil {
+		return false, err
+	}
+	if err := os.Rename(temp, output); err != nil {
+		return false, exit(2, "replace optimized GIF: %v", err)
+	}
+	return true, nil
 }
 
 func trimmedVideoArgs(input, output string, start, duration float64) []string {

--- a/internal/cli/media_test.go
+++ b/internal/cli/media_test.go
@@ -67,12 +67,28 @@ func TestPreviewCommandsUsePaletteGIFAndTrimWindow(t *testing.T) {
 		"-t 6.500",
 		"-i desktop.mp4",
 		"-i palette.png",
-		"paletteuse=dither=bayer",
+		"scale=iw*sar:ih,scale=640:-1:flags=lanczos",
+		"paletteuse=dither=floyd_steinberg",
 		"-loop 0",
 		"preview.gif",
 	} {
 		if !strings.Contains(gif, want) {
 			t.Fatalf("gif args missing %q:\n%s", want, gif)
+		}
+	}
+}
+
+func TestGifsicleOptimizeArgsUseHQDefaults(t *testing.T) {
+	got := strings.Join(gifsicleOptimizeArgs("preview.gif", "preview.optimized.gif", 65, 1.2), " ")
+	for _, want := range []string{
+		"-O3",
+		"--gamma=1.200",
+		"--lossy=65",
+		"preview.gif",
+		"-o preview.optimized.gif",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("gifsicle args missing %q:\n%s", want, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- raise motion GIF previews to 1000px/24fps with Floyd-Steinberg palette dithering
- optionally run `gifsicle -O3 --lossy=65 --gamma=1.2` when available
- keep `media preview` and `artifacts collect --gif` on one shared default preview configuration

## GIF comparison
| Before | After |
| --- | --- |
| ![Before low-quality GIF](https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-80194/pr-80194-gif-only/20260510-092333-510587000/telegram-user-crabbox-session-motion.gif) | ![After HQ GIF](https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-80194/pr-80194-hq-gif/20260510-093447-966301000/telegram-user-crabbox-session-motion-hq.gif) |
| 640px / 4fps / bayer dithering / 61 KB | 1000px / 24fps / Floyd-Steinberg + gifsicle / 118 KB |

## Verification
- `go test ./internal/cli`
- `go test ./...`
- `npm run docs:check`
- regenerated the Telegram Crabbox motion GIF from the same source recording and uploaded the HQ artifact
