### PR TITLE
feat: add Tensorlake delegated-run provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `crabbox run --preflight`, `--capture-stderr`, automatic failure bundles, env-forwarding summaries, and `CRABBOX_PHASE:<name>` timing markers for easier live/provider run debugging.
 - Added `crabbox run --keep-on-failure` so failed one-shot runs can leave the exact lease available for SSH inspection until idle/TTL expiry.
 - Added `provider: proxmox` for direct Proxmox VE Linux QEMU VM leases, including template clone, cloud-init SSH key injection, guest-agent bootstrap, docs, and cleanup support.
+- Added `provider: tensorlake` delegated runs for Tensorlake Firecracker sandboxes through the `tensorlake` CLI, including archive sync, env allowlist forwarding, docs, and live-provider coverage. Thanks @zozo123.
 - Added `scripts/proxmox-build-template.sh` to build a Crabbox-ready Ubuntu 24.04 Proxmox template from a public cloud image. Thanks @VACInc.
 - Added Azure native Windows desktop/VNC and Windows WSL2 lease support, matching the AWS Windows capability boundary. Thanks @jwmoss.
 - Added `crabbox azure login` so direct Azure users can persist the active `az login` subscription, tenant, and location without manually exporting service-principal environment variables. Thanks @galiniliev.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -158,6 +158,7 @@ internal/providers/daytona
 internal/providers/islo
 internal/providers/e2b
 internal/providers/semaphore
+internal/providers/tensorlake
 ```
 
 Each provider package owns registration, provider name, aliases, spec,
@@ -193,6 +194,7 @@ internal/providers/daytona                # Daytona SSH + delegated SDK backend
 internal/providers/islo                   # Islo delegated backend
 internal/providers/e2b                    # E2B delegated backend
 internal/providers/semaphore              # Semaphore SSH lease backend
+internal/providers/tensorlake             # Tensorlake delegated CLI backend
 ```
 
 Provider packages may use small exported core helpers for claims, labels,

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -87,7 +87,7 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | Daytona | yes | yes | yes | no | archive via Daytona toolbox | no |
 | Islo | yes | yes | no | no | no | yes |
 | E2B | yes | yes | no | no | archive via E2B envd | no |
-| Tensorlake | requires `--no-sync` (v1) | yes | no | no | no (planned) | no |
+| Tensorlake | yes | yes | no | no | archive via `tensorlake sbx cp` | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
 Use AWS, Google Cloud, Hetzner, Proxmox, Static SSH, Namespace Devbox,

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -24,6 +24,7 @@ static SSH provider for existing machines.
 | [Daytona](daytona.md) | hybrid delegated run + SSH | Linux | Daytona snapshot sandboxes |
 | [Islo](islo.md) | delegated run | Linux | Islo-owned sandbox execution |
 | [E2B](e2b.md) | delegated run | Linux | E2B-owned sandbox execution |
+| [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 
 ## Shared Rules
 
@@ -62,6 +63,7 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
 - Islo uses the Islo API and SDK auth.
 - E2B uses E2B's sandbox REST and envd APIs.
 - Sprites uses the authenticated `sprite` CLI plus Sprites API.
+- Tensorlake uses the `tensorlake` CLI (`tensorlake sbx ...`) for sandbox lifecycle and command exec.
 
 Namespace Devbox and Semaphore are SSH lease providers that do not use the
 Crabbox coordinator. Namespace provisions through the authenticated `devbox`
@@ -85,6 +87,7 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | Daytona | yes | yes | yes | no | archive via Daytona toolbox | no |
 | Islo | yes | yes | no | no | no | yes |
 | E2B | yes | yes | no | no | archive via E2B envd | no |
+| Tensorlake | requires `--no-sync` (v1) | yes | no | no | no (planned) | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
 Use AWS, Google Cloud, Hetzner, Proxmox, Static SSH, Namespace Devbox,

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -30,8 +30,8 @@ AWS, Hetzner, Static SSH, or Daytona when you need Crabbox-native SSH access.
 
 ```sh
 crabbox warmup --provider tensorlake --tensorlake-image <image>
-crabbox run --provider tensorlake --no-sync -- pnpm test
-crabbox run --provider tensorlake --no-sync --id blue-lobster --shell 'pnpm install && pnpm test'
+crabbox run --provider tensorlake -- pnpm test
+crabbox run --provider tensorlake --id blue-lobster --shell 'pnpm install && pnpm test'
 crabbox status --provider tensorlake --id blue-lobster
 crabbox stop --provider tensorlake blue-lobster
 ```
@@ -55,11 +55,12 @@ target: linux
 tensorlake:
   apiUrl: https://api.tensorlake.ai
   cliPath: tensorlake
-  image: ""             # required for new sandboxes when no snapshot is given
-  snapshot: ""          # snapshot ID to restore from (alternative to image)
+  image: ""              # ubuntu-minimal default; pin a registered image otherwise
+  snapshot: ""           # snapshot ID to restore from (alternative to image)
   organizationId: ""
   projectId: ""
   namespace: ""
+  workdir: /workspace/crabbox  # absolute path; sync target and -w for exec
   cpus: 1.0
   memoryMB: 1024
   diskMB: 10240
@@ -77,6 +78,7 @@ Provider flags:
 --tensorlake-organization-id
 --tensorlake-project-id
 --tensorlake-namespace
+--tensorlake-workdir
 --tensorlake-cpus
 --tensorlake-memory-mb
 --tensorlake-disk-mb
@@ -93,20 +95,25 @@ config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
 
 1. `warmup` / `run` (without `--id`) generates a Crabbox-owned sandbox name
    (`crabbox-<repo-slug>-<random6>`) and runs `tensorlake sbx create` with the
-   configured CPU/memory/disk/image/snapshot.
-2. The local lease is stored with the `tlsbx_` prefix and a friendly slug.
-3. `run` invokes `tensorlake sbx exec <name> -- <command>` and streams
-   stdout/stderr back through Crabbox.
-4. On release the sandbox is terminated via `tensorlake sbx terminate <name>`
+   configured CPU/memory/disk/image/snapshot. The Tensorlake-assigned sandbox
+   ID is captured from stdout and used as the canonical identifier.
+2. The local lease is stored as `tlsbx_<sandbox-id>` with a friendly slug.
+3. By default `run` archive-syncs the working tree: `git ls-files`-driven
+   manifest → `tar -czf` locally → `tensorlake sbx cp` upload to
+   `/tmp/crabbox-sync-*.tgz` → `tensorlake sbx exec -- bash -lc 'tar -xzf …'`
+   into the configured workdir. Pass `--no-sync` to skip the archive step.
+4. The user command runs via `tensorlake sbx exec -w <workdir> <id> -- <cmd>`,
+   streaming stdout/stderr back through Crabbox.
+5. On release the sandbox is terminated via `tensorlake sbx terminate <id>`
    unless `--keep` was set.
 
 ## Capabilities
 
 - SSH: no (Tensorlake exposes `tensorlake sbx ssh` directly; Crabbox does not
-  proxy it yet).
-- Crabbox sync: not yet — v1 requires `--no-sync`. Archive sync via
-  `tensorlake sbx cp` plus an in-sandbox `tar -xzf` is the planned follow-up.
-- Provider sync: no.
+  proxy it).
+- Crabbox sync: yes — gzipped tar uploaded via `tensorlake sbx cp` and
+  extracted in-sandbox.
+- Provider sync: no separate Tensorlake sync command.
 - Desktop/browser/code: no Crabbox VNC/code surface.
 - Actions hydration: no.
 - Coordinator: no.
@@ -114,14 +121,18 @@ config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
 ## Gotchas
 
 - `--sync-only`, `--checksum`, `--force-sync-large`, `--capture-stdout`, and
-  `--download` are rejected by core for delegated providers, and `run` further
-  requires `--no-sync` until archive sync lands.
+  `--download` are rejected because Tensorlake doesn't expose Crabbox's
+  rsync semantics. Use `--no-sync` plus an explicit `--id` if you've already
+  primed the sandbox.
 - `--shell` wraps the command as `bash -lc '<joined args>'` before passing it
-  to `tensorlake sbx exec`.
-- IDs accepted by `--id` and `stop`: Crabbox slugs, `tlsbx_<name>` lease IDs,
-  and Crabbox-created sandbox names. Sandboxes whose name does not start with
-  `crabbox-` are rejected to avoid touching unrelated workloads in the
-  Tensorlake account.
+  to `tensorlake sbx exec`. Plain commands containing shell metacharacters
+  (`&&`, `|`, `>`, etc.) or leading `KEY=VALUE` env assignments are also
+  auto-wrapped.
+- `tensorlake.workdir` must be absolute (default `/workspace/crabbox`). It's
+  used as both the sync target and the `-w` working directory for exec.
+- IDs accepted by `--id` and `stop`: Crabbox slugs and `tlsbx_<sandbox-id>`
+  lease IDs that have a local Crabbox claim. Sandboxes without a local claim
+  are rejected (matches the islo/Crabbox-owned-only safety pattern).
 - The `tensorlake` CLI authenticates from `TENSORLAKE_API_KEY` in env; never
   pass `--api-key` on the command line because process listings expose argv.
 

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -1,0 +1,130 @@
+# Tensorlake Provider
+
+Read when:
+
+- choosing `provider: tensorlake`;
+- configuring Tensorlake sandbox image, snapshot, sizing, or organization;
+- changing `internal/providers/tensorlake`.
+
+Tensorlake is a delegated run provider. Crabbox shells out to the `tensorlake`
+CLI (`tensorlake sbx ...`) for sandbox lifecycle and command exec. Tensorlake
+owns the Firecracker MicroVM and command transport; Crabbox owns local config,
+repo claims, slugs, timing summaries, and normalized list/status rendering.
+
+## When To Use
+
+Use Tensorlake when the remote sandbox should be a Tensorlake Firecracker
+MicroVM and command execution should happen through `tensorlake sbx exec`. Use
+AWS, Hetzner, Static SSH, or Daytona when you need Crabbox-native SSH access.
+
+## Prerequisites
+
+- The `tensorlake` CLI must be on `PATH` (or pointed at via
+  `--tensorlake-cli` / `tensorlake.cliPath`). Install it via
+  `pip install tensorlake` — the wheel ships a Rust `tensorlake` binary at
+  `<env>/bin/tensorlake`.
+- A Tensorlake API key. Crabbox passes it through to the CLI via the
+  `TENSORLAKE_API_KEY` environment variable; it is never placed on `argv`.
+
+## Commands
+
+```sh
+crabbox warmup --provider tensorlake --tensorlake-image <image>
+crabbox run --provider tensorlake --no-sync -- pnpm test
+crabbox run --provider tensorlake --no-sync --id blue-lobster --shell 'pnpm install && pnpm test'
+crabbox status --provider tensorlake --id blue-lobster
+crabbox stop --provider tensorlake blue-lobster
+```
+
+## Auth
+
+```sh
+export TENSORLAKE_API_KEY=tl_apiKey_...
+```
+
+`TENSORLAKE_API_URL` (or `tensorlake.apiUrl`) can override the default
+`https://api.tensorlake.ai`. `TENSORLAKE_ORGANIZATION_ID` and
+`TENSORLAKE_PROJECT_ID` select the org/project when your account spans more
+than one.
+
+## Config
+
+```yaml
+provider: tensorlake
+target: linux
+tensorlake:
+  apiUrl: https://api.tensorlake.ai
+  cliPath: tensorlake
+  image: ""             # required for new sandboxes when no snapshot is given
+  snapshot: ""          # snapshot ID to restore from (alternative to image)
+  organizationId: ""
+  projectId: ""
+  namespace: ""
+  cpus: 1.0
+  memoryMB: 1024
+  diskMB: 10240
+  timeoutSecs: 0
+  noInternet: false
+```
+
+Provider flags:
+
+```text
+--tensorlake-api-url
+--tensorlake-cli
+--tensorlake-image
+--tensorlake-snapshot
+--tensorlake-organization-id
+--tensorlake-project-id
+--tensorlake-namespace
+--tensorlake-cpus
+--tensorlake-memory-mb
+--tensorlake-disk-mb
+--tensorlake-timeout-secs
+--tensorlake-no-internet
+```
+
+Environment overrides (`CRABBOX_TENSORLAKE_*` and the corresponding
+`TENSORLAKE_*` variables read by the CLI itself) take precedence over file
+config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
+`TENSORLAKE_API_KEY`.
+
+## Lifecycle
+
+1. `warmup` / `run` (without `--id`) generates a Crabbox-owned sandbox name
+   (`crabbox-<repo-slug>-<random6>`) and runs `tensorlake sbx create` with the
+   configured CPU/memory/disk/image/snapshot.
+2. The local lease is stored with the `tlsbx_` prefix and a friendly slug.
+3. `run` invokes `tensorlake sbx exec <name> -- <command>` and streams
+   stdout/stderr back through Crabbox.
+4. On release the sandbox is terminated via `tensorlake sbx terminate <name>`
+   unless `--keep` was set.
+
+## Capabilities
+
+- SSH: no (Tensorlake exposes `tensorlake sbx ssh` directly; Crabbox does not
+  proxy it yet).
+- Crabbox sync: not yet — v1 requires `--no-sync`. Archive sync via
+  `tensorlake sbx cp` plus an in-sandbox `tar -xzf` is the planned follow-up.
+- Provider sync: no.
+- Desktop/browser/code: no Crabbox VNC/code surface.
+- Actions hydration: no.
+- Coordinator: no.
+
+## Gotchas
+
+- `--sync-only`, `--checksum`, `--force-sync-large`, `--capture-stdout`, and
+  `--download` are rejected by core for delegated providers, and `run` further
+  requires `--no-sync` until archive sync lands.
+- `--shell` wraps the command as `bash -lc '<joined args>'` before passing it
+  to `tensorlake sbx exec`.
+- IDs accepted by `--id` and `stop`: Crabbox slugs, `tlsbx_<name>` lease IDs,
+  and Crabbox-created sandbox names. Sandboxes whose name does not start with
+  `crabbox-` are rejected to avoid touching unrelated workloads in the
+  Tensorlake account.
+- The `tensorlake` CLI authenticates from `TENSORLAKE_API_KEY` in env; never
+  pass `--api-key` on the command line because process listings expose argv.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -91,6 +91,18 @@ Environment overrides (`CRABBOX_TENSORLAKE_*` and the corresponding
 config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
 `TENSORLAKE_API_KEY`.
 
+Run-time environment forwarding uses the normal Crabbox allowlist:
+
+```sh
+crabbox run --provider tensorlake --allow-env API_TOKEN -- printenv API_TOKEN
+crabbox run --provider tensorlake --env-from-profile ~/.my-live.profile --allow-env API_TOKEN -- npm test
+```
+
+Crabbox prints only redacted presence/length metadata. For Tensorlake it writes
+the allowed values to a temporary local shell profile, uploads that file into
+`/tmp`, sources it for the command, and removes both copies best-effort after
+the run. Values are not placed on the local `tensorlake` process argv.
+
 ## Lifecycle
 
 1. `warmup` / `run` (without `--id`) generates a Crabbox-owned sandbox name
@@ -105,7 +117,8 @@ config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
 4. The user command runs via `tensorlake sbx exec -w <workdir> <id> -- <cmd>`,
    streaming stdout/stderr back through Crabbox.
 5. On release the sandbox is terminated via `tensorlake sbx terminate <id>`
-   unless `--keep` was set.
+   unless `--keep` was set. `--keep-on-failure` retains newly-created failed
+   sandboxes and prints a rerun/stop hint.
 
 ## Capabilities
 
@@ -128,6 +141,9 @@ config. The API key is sourced from `CRABBOX_TENSORLAKE_API_KEY` or
   to `tensorlake sbx exec`. Plain commands containing shell metacharacters
   (`&&`, `|`, `>`, etc.) or leading `KEY=VALUE` env assignments are also
   auto-wrapped.
+- Forwarded environment values are written to a temporary in-sandbox profile
+  for the duration of the command. Avoid forwarding broad wildcard allowlists
+  unless you trust the sandbox and command.
 - `tensorlake.workdir` must be absolute (default `/workspace/crabbox`). It's
   used as both the sync target and the `-w` working directory for exec.
 - IDs accepted by `--id` and `stop`: Crabbox slugs and `tlsbx_<sandbox-id>`

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -45,6 +45,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Daytona provider backend and SDK/toolbox wrapper: `internal/providers/daytona`
 - Islo delegated backend and SDK wrapper: `internal/providers/islo`
 - E2B delegated backend and REST/envd wrapper: `internal/providers/e2b`
+- Tensorlake delegated backend and `tensorlake` CLI wrapper: `internal/providers/tensorlake`
 - Provider backend interfaces, registry, and request/result types:
   `internal/cli/provider_backend.go`
 - Built-in provider registration packages:
@@ -53,19 +54,19 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
   `internal/providers/gcp`, `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/namespace`, `internal/providers/daytona`, `internal/providers/islo`,
   `internal/providers/semaphore`, `internal/providers/sprites`, `internal/providers/e2b`,
-  `internal/providers/all`
+  `internal/providers/tensorlake`, `internal/providers/all`
 - Built-in provider backend implementations:
   `internal/providers/aws`, `internal/providers/azure`, `internal/providers/gcp`,
   `internal/providers/hetzner`, `internal/providers/proxmox`,
   `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/namespace`, `internal/providers/daytona`, `internal/providers/islo`,
   `internal/providers/semaphore`, `internal/providers/sprites`, `internal/providers/e2b`,
-  plus shared helpers in `internal/providers/shared`
+  `internal/providers/tensorlake`, plus shared helpers in `internal/providers/shared`
 - Worker Hetzner provider: `worker/src/hetzner.ts`
 - Worker AWS EC2 provider: `worker/src/aws.ts`
 - Worker AWS AMI create/read/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`
 - Provider feature docs: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
-- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/gcp.md`, `docs/providers/hetzner.md`, `docs/providers/proxmox.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/namespace-devbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/semaphore.md`, `docs/providers/sprites.md`, `docs/providers/e2b.md`
+- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/gcp.md`, `docs/providers/hetzner.md`, `docs/providers/proxmox.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/namespace-devbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/semaphore.md`, `docs/providers/sprites.md`, `docs/providers/e2b.md`, `docs/providers/tensorlake.md`
 - Provider/backend authoring guide: `docs/provider-backends.md`
 - CLI cloud-init bootstrap: `internal/cli/bootstrap.go`
 - Worker cloud-init bootstrap: `worker/src/bootstrap.ts`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	Daytona            DaytonaConfig
 	E2B                E2BConfig
 	Islo               IsloConfig
+	Tensorlake         TensorlakeConfig
 	Semaphore          SemaphoreConfig
 	Sprites            SpritesConfig
 	Tailscale          TailscaleConfig
@@ -178,6 +179,22 @@ type IsloConfig struct {
 	VCPUs          int
 	MemoryMB       int
 	DiskGB         int
+}
+
+type TensorlakeConfig struct {
+	APIKey         string
+	APIURL         string
+	CLIPath        string
+	Image          string
+	Snapshot       string
+	OrganizationID string
+	ProjectID      string
+	Namespace      string
+	CPUs           float64
+	MemoryMB       int
+	DiskMB         int
+	TimeoutSecs    int
+	NoInternet     bool
 }
 
 type ProxmoxConfig struct {
@@ -417,6 +434,13 @@ func baseConfig() Config {
 			MemoryMB: 4096,
 			DiskGB:   20,
 		},
+		Tensorlake: TensorlakeConfig{
+			APIURL:   "https://api.tensorlake.ai",
+			CLIPath:  "tensorlake",
+			CPUs:     1.0,
+			MemoryMB: 1024,
+			DiskMB:   10240,
+		},
 		Proxmox: ProxmoxConfig{
 			User:      "crabbox",
 			WorkRoot:  defaultPOSIXWorkRoot,
@@ -471,6 +495,7 @@ type fileConfig struct {
 	Daytona          *fileDaytonaConfig       `yaml:"daytona,omitempty"`
 	E2B              *fileE2BConfig           `yaml:"e2b,omitempty"`
 	Islo             *fileIsloConfig          `yaml:"islo,omitempty"`
+	Tensorlake       *fileTensorlakeConfig    `yaml:"tensorlake,omitempty"`
 	Semaphore        *fileSemaphoreConfig     `yaml:"semaphore,omitempty"`
 	Sprites          *fileSpritesConfig       `yaml:"sprites,omitempty"`
 	Tailscale        *fileTailscaleConfig     `yaml:"tailscale,omitempty"`
@@ -654,6 +679,21 @@ type fileIsloConfig struct {
 	VCPUs          int    `yaml:"vcpus,omitempty"`
 	MemoryMB       int    `yaml:"memoryMB,omitempty"`
 	DiskGB         int    `yaml:"diskGB,omitempty"`
+}
+
+type fileTensorlakeConfig struct {
+	APIURL         string  `yaml:"apiUrl,omitempty"`
+	CLIPath        string  `yaml:"cliPath,omitempty"`
+	Image          string  `yaml:"image,omitempty"`
+	Snapshot       string  `yaml:"snapshot,omitempty"`
+	OrganizationID string  `yaml:"organizationId,omitempty"`
+	ProjectID      string  `yaml:"projectId,omitempty"`
+	Namespace      string  `yaml:"namespace,omitempty"`
+	CPUs           float64 `yaml:"cpus,omitempty"`
+	MemoryMB       int     `yaml:"memoryMB,omitempty"`
+	DiskMB         int     `yaml:"diskMB,omitempty"`
+	TimeoutSecs    int     `yaml:"timeoutSecs,omitempty"`
+	NoInternet     *bool   `yaml:"noInternet,omitempty"`
 }
 
 type fileSemaphoreConfig struct {
@@ -1276,6 +1316,44 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.Islo.DiskGB = file.Islo.DiskGB
 		}
 	}
+	if file.Tensorlake != nil {
+		if file.Tensorlake.APIURL != "" {
+			cfg.Tensorlake.APIURL = file.Tensorlake.APIURL
+		}
+		if file.Tensorlake.CLIPath != "" {
+			cfg.Tensorlake.CLIPath = file.Tensorlake.CLIPath
+		}
+		if file.Tensorlake.Image != "" {
+			cfg.Tensorlake.Image = file.Tensorlake.Image
+		}
+		if file.Tensorlake.Snapshot != "" {
+			cfg.Tensorlake.Snapshot = file.Tensorlake.Snapshot
+		}
+		if file.Tensorlake.OrganizationID != "" {
+			cfg.Tensorlake.OrganizationID = file.Tensorlake.OrganizationID
+		}
+		if file.Tensorlake.ProjectID != "" {
+			cfg.Tensorlake.ProjectID = file.Tensorlake.ProjectID
+		}
+		if file.Tensorlake.Namespace != "" {
+			cfg.Tensorlake.Namespace = file.Tensorlake.Namespace
+		}
+		if file.Tensorlake.CPUs > 0 {
+			cfg.Tensorlake.CPUs = file.Tensorlake.CPUs
+		}
+		if file.Tensorlake.MemoryMB > 0 {
+			cfg.Tensorlake.MemoryMB = file.Tensorlake.MemoryMB
+		}
+		if file.Tensorlake.DiskMB > 0 {
+			cfg.Tensorlake.DiskMB = file.Tensorlake.DiskMB
+		}
+		if file.Tensorlake.TimeoutSecs > 0 {
+			cfg.Tensorlake.TimeoutSecs = file.Tensorlake.TimeoutSecs
+		}
+		if file.Tensorlake.NoInternet != nil {
+			cfg.Tensorlake.NoInternet = *file.Tensorlake.NoInternet
+		}
+	}
 	if file.Semaphore != nil {
 		if file.Semaphore.Host != "" {
 			cfg.Semaphore.Host = file.Semaphore.Host
@@ -1674,6 +1752,21 @@ func applyEnv(cfg *Config) {
 	cfg.Islo.VCPUs = getenvInt("CRABBOX_ISLO_VCPUS", cfg.Islo.VCPUs)
 	cfg.Islo.MemoryMB = getenvInt("CRABBOX_ISLO_MEMORY_MB", cfg.Islo.MemoryMB)
 	cfg.Islo.DiskGB = getenvInt("CRABBOX_ISLO_DISK_GB", cfg.Islo.DiskGB)
+	cfg.Tensorlake.APIKey = getenv("CRABBOX_TENSORLAKE_API_KEY", getenv("TENSORLAKE_API_KEY", cfg.Tensorlake.APIKey))
+	cfg.Tensorlake.APIURL = getenv("CRABBOX_TENSORLAKE_API_URL", getenv("TENSORLAKE_API_URL", cfg.Tensorlake.APIURL))
+	cfg.Tensorlake.CLIPath = getenv("CRABBOX_TENSORLAKE_CLI", cfg.Tensorlake.CLIPath)
+	cfg.Tensorlake.Image = getenv("CRABBOX_TENSORLAKE_IMAGE", cfg.Tensorlake.Image)
+	cfg.Tensorlake.Snapshot = getenv("CRABBOX_TENSORLAKE_SNAPSHOT", cfg.Tensorlake.Snapshot)
+	cfg.Tensorlake.OrganizationID = getenv("CRABBOX_TENSORLAKE_ORGANIZATION_ID", getenv("TENSORLAKE_ORGANIZATION_ID", cfg.Tensorlake.OrganizationID))
+	cfg.Tensorlake.ProjectID = getenv("CRABBOX_TENSORLAKE_PROJECT_ID", getenv("TENSORLAKE_PROJECT_ID", cfg.Tensorlake.ProjectID))
+	cfg.Tensorlake.Namespace = getenv("CRABBOX_TENSORLAKE_NAMESPACE", getenv("INDEXIFY_NAMESPACE", cfg.Tensorlake.Namespace))
+	cfg.Tensorlake.CPUs = getenvFloat("CRABBOX_TENSORLAKE_CPUS", cfg.Tensorlake.CPUs)
+	cfg.Tensorlake.MemoryMB = getenvInt("CRABBOX_TENSORLAKE_MEMORY_MB", cfg.Tensorlake.MemoryMB)
+	cfg.Tensorlake.DiskMB = getenvInt("CRABBOX_TENSORLAKE_DISK_MB", cfg.Tensorlake.DiskMB)
+	cfg.Tensorlake.TimeoutSecs = getenvInt("CRABBOX_TENSORLAKE_TIMEOUT_SECS", cfg.Tensorlake.TimeoutSecs)
+	if v, ok := getenvBool("CRABBOX_TENSORLAKE_NO_INTERNET"); ok {
+		cfg.Tensorlake.NoInternet = v
+	}
 	cfg.Semaphore.Host = getenv("CRABBOX_SEMAPHORE_HOST", getenv("SEMAPHORE_HOST", cfg.Semaphore.Host))
 	cfg.Semaphore.Token = getenv("CRABBOX_SEMAPHORE_TOKEN", getenv("SEMAPHORE_API_TOKEN", cfg.Semaphore.Token))
 	cfg.Semaphore.Project = getenv("CRABBOX_SEMAPHORE_PROJECT", getenv("SEMAPHORE_PROJECT", cfg.Semaphore.Project))
@@ -1975,6 +2068,18 @@ func getenvInt(name string, fallback int) int {
 		return fallback
 	}
 	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+func getenvFloat(name string, fallback float64) float64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.ParseFloat(v, 64)
 	if err != nil {
 		return fallback
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -190,6 +190,7 @@ type TensorlakeConfig struct {
 	OrganizationID string
 	ProjectID      string
 	Namespace      string
+	Workdir        string
 	CPUs           float64
 	MemoryMB       int
 	DiskMB         int
@@ -437,6 +438,7 @@ func baseConfig() Config {
 		Tensorlake: TensorlakeConfig{
 			APIURL:   "https://api.tensorlake.ai",
 			CLIPath:  "tensorlake",
+			Workdir:  "/workspace/crabbox",
 			CPUs:     1.0,
 			MemoryMB: 1024,
 			DiskMB:   10240,
@@ -689,6 +691,7 @@ type fileTensorlakeConfig struct {
 	OrganizationID string  `yaml:"organizationId,omitempty"`
 	ProjectID      string  `yaml:"projectId,omitempty"`
 	Namespace      string  `yaml:"namespace,omitempty"`
+	Workdir        string  `yaml:"workdir,omitempty"`
 	CPUs           float64 `yaml:"cpus,omitempty"`
 	MemoryMB       int     `yaml:"memoryMB,omitempty"`
 	DiskMB         int     `yaml:"diskMB,omitempty"`
@@ -1338,6 +1341,9 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 		if file.Tensorlake.Namespace != "" {
 			cfg.Tensorlake.Namespace = file.Tensorlake.Namespace
 		}
+		if file.Tensorlake.Workdir != "" {
+			cfg.Tensorlake.Workdir = file.Tensorlake.Workdir
+		}
 		if file.Tensorlake.CPUs > 0 {
 			cfg.Tensorlake.CPUs = file.Tensorlake.CPUs
 		}
@@ -1760,6 +1766,7 @@ func applyEnv(cfg *Config) {
 	cfg.Tensorlake.OrganizationID = getenv("CRABBOX_TENSORLAKE_ORGANIZATION_ID", getenv("TENSORLAKE_ORGANIZATION_ID", cfg.Tensorlake.OrganizationID))
 	cfg.Tensorlake.ProjectID = getenv("CRABBOX_TENSORLAKE_PROJECT_ID", getenv("TENSORLAKE_PROJECT_ID", cfg.Tensorlake.ProjectID))
 	cfg.Tensorlake.Namespace = getenv("CRABBOX_TENSORLAKE_NAMESPACE", getenv("INDEXIFY_NAMESPACE", cfg.Tensorlake.Namespace))
+	cfg.Tensorlake.Workdir = getenv("CRABBOX_TENSORLAKE_WORKDIR", cfg.Tensorlake.Workdir)
 	cfg.Tensorlake.CPUs = getenvFloat("CRABBOX_TENSORLAKE_CPUS", cfg.Tensorlake.CPUs)
 	cfg.Tensorlake.MemoryMB = getenvInt("CRABBOX_TENSORLAKE_MEMORY_MB", cfg.Tensorlake.MemoryMB)
 	cfg.Tensorlake.DiskMB = getenvInt("CRABBOX_TENSORLAKE_DISK_MB", cfg.Tensorlake.DiskMB)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -75,6 +75,25 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_ISLO_VCPUS",
 		"CRABBOX_ISLO_MEMORY_MB",
 		"CRABBOX_ISLO_DISK_GB",
+		"CRABBOX_TENSORLAKE_API_KEY",
+		"TENSORLAKE_API_KEY",
+		"CRABBOX_TENSORLAKE_API_URL",
+		"TENSORLAKE_API_URL",
+		"CRABBOX_TENSORLAKE_CLI",
+		"CRABBOX_TENSORLAKE_IMAGE",
+		"CRABBOX_TENSORLAKE_SNAPSHOT",
+		"CRABBOX_TENSORLAKE_ORGANIZATION_ID",
+		"TENSORLAKE_ORGANIZATION_ID",
+		"CRABBOX_TENSORLAKE_PROJECT_ID",
+		"TENSORLAKE_PROJECT_ID",
+		"CRABBOX_TENSORLAKE_NAMESPACE",
+		"INDEXIFY_NAMESPACE",
+		"CRABBOX_TENSORLAKE_WORKDIR",
+		"CRABBOX_TENSORLAKE_CPUS",
+		"CRABBOX_TENSORLAKE_MEMORY_MB",
+		"CRABBOX_TENSORLAKE_DISK_MB",
+		"CRABBOX_TENSORLAKE_TIMEOUT_SECS",
+		"CRABBOX_TENSORLAKE_NO_INTERNET",
 		"CRABBOX_SEMAPHORE_HOST",
 		"SEMAPHORE_HOST",
 		"CRABBOX_SEMAPHORE_TOKEN",
@@ -249,6 +268,20 @@ islo:
   vcpus: 4
   memoryMB: 8192
   diskGB: 40
+tensorlake:
+  apiUrl: https://api.tensorlake.example.test
+  cliPath: /usr/local/bin/tl
+  image: ubuntu-22.04
+  snapshot: snap-tl
+  organizationId: org-tl
+  projectId: proj-tl
+  namespace: ns-tl
+  workdir: /workspace/crabbox-test
+  cpus: 4
+  memoryMB: 8192
+  diskMB: 30000
+  timeoutSecs: 1800
+  noInternet: true
 proxmox:
   apiUrl: https://pve.example.test:8006
   tokenId: crabbox@pve!test
@@ -373,6 +406,9 @@ ssh:
 	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
 		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
+	}
+	if cfg.Tensorlake.APIURL != "https://api.tensorlake.example.test" || cfg.Tensorlake.CLIPath != "/usr/local/bin/tl" || cfg.Tensorlake.Image != "ubuntu-22.04" || cfg.Tensorlake.Snapshot != "snap-tl" || cfg.Tensorlake.OrganizationID != "org-tl" || cfg.Tensorlake.ProjectID != "proj-tl" || cfg.Tensorlake.Namespace != "ns-tl" || cfg.Tensorlake.Workdir != "/workspace/crabbox-test" || cfg.Tensorlake.CPUs != 4 || cfg.Tensorlake.MemoryMB != 8192 || cfg.Tensorlake.DiskMB != 30000 || cfg.Tensorlake.TimeoutSecs != 1800 || !cfg.Tensorlake.NoInternet {
+		t.Fatalf("tensorlake config not loaded: %#v", cfg.Tensorlake)
 	}
 	if cfg.Proxmox.APIURL != "https://pve.example.test:8006" || cfg.Proxmox.TokenID != "crabbox@pve!test" || cfg.Proxmox.TokenSecret != "proxmox-secret" || cfg.Proxmox.Node != "pve1" || cfg.Proxmox.TemplateID != 9000 || cfg.Proxmox.Storage != "local-lvm" || cfg.Proxmox.Pool != "crabbox" || cfg.Proxmox.Bridge != "vmbr1" || cfg.Proxmox.User != "runner" || cfg.Proxmox.WorkRoot != "/work/proxmox" || cfg.Proxmox.FullClone || !cfg.Proxmox.InsecureTLS {
 		t.Fatalf("proxmox config not loaded: %#v", cfg.Proxmox)
@@ -505,6 +541,25 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_ISLO_VCPUS", "8")
 	t.Setenv("CRABBOX_ISLO_MEMORY_MB", "16384")
 	t.Setenv("CRABBOX_ISLO_DISK_GB", "80")
+	t.Setenv("TENSORLAKE_API_KEY", "tl-api-file")
+	t.Setenv("CRABBOX_TENSORLAKE_API_KEY", "tl-api-env")
+	t.Setenv("TENSORLAKE_API_URL", "https://api.tl-file.example")
+	t.Setenv("CRABBOX_TENSORLAKE_API_URL", "https://api.tl-env.example")
+	t.Setenv("CRABBOX_TENSORLAKE_CLI", "/opt/tl/bin/tensorlake")
+	t.Setenv("CRABBOX_TENSORLAKE_IMAGE", "ubuntu:tl-env")
+	t.Setenv("CRABBOX_TENSORLAKE_SNAPSHOT", "snap-tl-env")
+	t.Setenv("TENSORLAKE_ORGANIZATION_ID", "org-tl-file")
+	t.Setenv("CRABBOX_TENSORLAKE_ORGANIZATION_ID", "org-tl-env")
+	t.Setenv("TENSORLAKE_PROJECT_ID", "proj-tl-file")
+	t.Setenv("CRABBOX_TENSORLAKE_PROJECT_ID", "proj-tl-env")
+	t.Setenv("INDEXIFY_NAMESPACE", "ns-tl-file")
+	t.Setenv("CRABBOX_TENSORLAKE_NAMESPACE", "ns-tl-env")
+	t.Setenv("CRABBOX_TENSORLAKE_WORKDIR", "/workspace/tl-env")
+	t.Setenv("CRABBOX_TENSORLAKE_CPUS", "2.5")
+	t.Setenv("CRABBOX_TENSORLAKE_MEMORY_MB", "4096")
+	t.Setenv("CRABBOX_TENSORLAKE_DISK_MB", "20480")
+	t.Setenv("CRABBOX_TENSORLAKE_TIMEOUT_SECS", "900")
+	t.Setenv("CRABBOX_TENSORLAKE_NO_INTERNET", "true")
 	t.Setenv("CRABBOX_PROXMOX_API_URL", "https://pve-env.example:8006")
 	t.Setenv("CRABBOX_PROXMOX_TOKEN_ID", "runner@pve!env")
 	t.Setenv("CRABBOX_PROXMOX_TOKEN_SECRET", "proxmox-env-secret")
@@ -617,6 +672,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {
 		t.Fatalf("unexpected islo env: %#v", cfg.Islo)
+	}
+	if cfg.Tensorlake.APIKey != "tl-api-env" || cfg.Tensorlake.APIURL != "https://api.tl-env.example" || cfg.Tensorlake.CLIPath != "/opt/tl/bin/tensorlake" || cfg.Tensorlake.Image != "ubuntu:tl-env" || cfg.Tensorlake.Snapshot != "snap-tl-env" || cfg.Tensorlake.OrganizationID != "org-tl-env" || cfg.Tensorlake.ProjectID != "proj-tl-env" || cfg.Tensorlake.Namespace != "ns-tl-env" || cfg.Tensorlake.Workdir != "/workspace/tl-env" || cfg.Tensorlake.CPUs != 2.5 || cfg.Tensorlake.MemoryMB != 4096 || cfg.Tensorlake.DiskMB != 20480 || cfg.Tensorlake.TimeoutSecs != 900 || !cfg.Tensorlake.NoInternet {
+		t.Fatalf("unexpected tensorlake env: %#v", cfg.Tensorlake)
 	}
 	if cfg.Proxmox.APIURL != "https://pve-env.example:8006" || cfg.Proxmox.TokenID != "runner@pve!env" || cfg.Proxmox.TokenSecret != "proxmox-env-secret" || cfg.Proxmox.Node != "pve-env" || cfg.Proxmox.TemplateID != 9100 || cfg.Proxmox.Storage != "ceph-env" || cfg.Proxmox.Pool != "pool-env" || cfg.Proxmox.Bridge != "vmbr2" || cfg.Proxmox.User != "runner-env" || cfg.Proxmox.WorkRoot != "/work/proxmox-env" || cfg.Proxmox.FullClone || !cfg.Proxmox.InsecureTLS {
 		t.Fatalf("unexpected proxmox env: %#v", cfg.Proxmox)

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -14,4 +14,5 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"
+	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"
 )

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -1,0 +1,317 @@
+package tensorlake
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func NewTensorlakeBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &tensorlakeBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type tensorlakeBackend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func (b *tensorlakeBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	started := b.now()
+	cli, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, name, slug, err := b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, name)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: tensorlake warmup keeps the sandbox until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := rejectSyncOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	cli, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		return RunResult{}, err
+	}
+	leaseID, name := "", ""
+	acquired := false
+	if req.ID == "" {
+		var slug string
+		leaseID, name, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
+		if err != nil {
+			return RunResult{}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, name)
+		acquired = true
+	} else {
+		leaseID, name, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	if acquired && !req.Keep {
+		defer func() {
+			if termErr := cli.terminate(context.Background(), name); termErr != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: tensorlake terminate failed for %s: %v\n", name, termErr)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s\n", providerName, leaseID, name)
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	commandStart := b.now()
+	exitCode, runErr := cli.execStream(ctx, name, "", command, b.rt.Stdout, b.rt.Stderr)
+	commandDuration := b.now().Sub(commandStart)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+	}
+	fmt.Fprintf(b.rt.Stderr, "tensorlake run summary command=%s total=%s exit=%d\n",
+		result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:    providerName,
+			LeaseID:     leaseID,
+			SyncSkipped: true,
+			CommandMs:   result.Command.Milliseconds(),
+			TotalMs:     result.Total.Milliseconds(),
+			ExitCode:    exitCode,
+		}); err != nil {
+			return result, err
+		}
+	}
+	if runErr != nil {
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("tensorlake run failed: %v", runErr)}
+	}
+	if exitCode != 0 {
+		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("tensorlake run exited %d", exitCode)}
+	}
+	return result, nil
+}
+
+func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	cli, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	ids, err := cli.listIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(ids))
+	for _, id := range ids {
+		// `sbx ls -q` returns IDs only; we don't know which are crabbox-owned
+		// without describing each. Cross-reference with local claims instead.
+		claim, ok, err := resolveLeaseClaim(id)
+		if err != nil {
+			continue
+		}
+		if !ok || claim.Provider != providerName {
+			// Try matching by lease prefix on the canonical name as well.
+			if leaseClaim, leaseOK, _ := resolveLeaseClaim(leasePrefix + id); leaseOK && leaseClaim.Provider == providerName {
+				claim = leaseClaim
+				ok = true
+			}
+		}
+		if !ok || claim.Provider != providerName {
+			continue
+		}
+		servers = append(servers, Server{
+			Provider: providerName,
+			CloudID:  id,
+			Name:     strings.TrimPrefix(claim.LeaseID, leasePrefix),
+			Status:   "",
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    claim.LeaseID,
+				"slug":     claim.Slug,
+				"target":   targetLinux,
+			},
+		})
+	}
+	return servers, nil
+}
+
+func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	cli, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, name, err := resolveLeaseID(req.ID, "", false, 0)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deadline := b.now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = b.now().Add(5 * time.Minute)
+	}
+	for {
+		_, describeErr := cli.describe(ctx, name)
+		view := StatusView{
+			ID:       leaseID,
+			Slug:     newLeaseSlug(leaseID),
+			Provider: providerName,
+			TargetOS: targetLinux,
+			ServerID: name,
+			Network:  NetworkPublic,
+			Ready:    describeErr == nil,
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    leaseID,
+			},
+		}
+		if describeErr == nil {
+			view.State = statusViewReady
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for tensorlake sandbox %s to become ready", name)
+		}
+		select {
+		case <-ctx.Done():
+			return StatusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
+	cli, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, name, err := resolveLeaseID(req.ID, "", false, 0)
+	if err != nil {
+		return err
+	}
+	if err := cli.terminate(ctx, name); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, name)
+	return nil
+}
+
+func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool) (string, string, string, error) {
+	name := newSandboxName(repo)
+	if err := cli.createSandbox(ctx, name); err != nil {
+		return "", "", "", err
+	}
+	leaseID := leasePrefix + name
+	slug := newLeaseSlug(leaseID)
+	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		_ = cli.terminate(context.Background(), name)
+		return "", "", "", err
+	}
+	return leaseID, name, slug, nil
+}
+
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox name, lease id, or slug")
+	}
+	if strings.HasPrefix(id, leasePrefix) {
+		name := strings.TrimPrefix(id, leasePrefix)
+		if !isCrabboxSandboxName(name) {
+			return "", "", exit(4, "tensorlake lease %q is not a Crabbox-owned sandbox", id)
+		}
+		return id, name, nil
+	}
+	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+		return "", "", err
+	} else if ok && claim.Provider == providerName {
+		if repoRoot != "" {
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
+				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+				return "", "", err
+			}
+		}
+		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), nil
+	}
+	if !isCrabboxSandboxName(id) {
+		return "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; pass a Crabbox slug or %s<crabbox-sandbox-name>", id, leasePrefix)
+	}
+	return leasePrefix + id, id, nil
+}
+
+func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func newSandboxName(repo Repo) string {
+	base := normalizeLeaseSlug(repo.Name)
+	if base == "" {
+		base = "crabbox"
+	}
+	base = strings.TrimPrefix(base, strings.TrimSuffix(namePrefix, "-")+"-")
+	return namePrefix + base + "-" + randomSuffix()
+}
+
+func isCrabboxSandboxName(name string) bool {
+	return strings.HasPrefix(normalizeLeaseSlug(name), namePrefix)
+}
+
+func randomSuffix() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func buildCommand(command []string, shellMode bool) ([]string, error) {
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if shellMode {
+		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
+	}
+	return command, nil
+}
+
+func (b *tensorlakeBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -52,7 +52,11 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 }
 
 func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectSyncOptions(req); err != nil {
+	if err := rejectIncompatibleSyncOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	workdir, err := tensorlakeWorkdir(b.cfg)
+	if err != nil {
 		return RunResult{}, err
 	}
 	started := b.now()
@@ -85,13 +89,27 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			removeLeaseClaim(leaseID)
 		}()
 	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s\n", providerName, leaseID, sandboxID)
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		var err error
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, cli, sandboxID, req, workdir)
+		if err != nil {
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, cli, sandboxID, workdir); err != nil {
+		return RunResult{}, err
+	}
+
 	command, err := buildCommand(req.Command, req.ShellMode)
 	if err != nil {
 		return RunResult{}, err
 	}
 	commandStart := b.now()
-	exitCode, runErr := cli.execStream(ctx, sandboxID, "", command, b.rt.Stdout, b.rt.Stderr)
+	exitCode, runErr := cli.execStream(ctx, sandboxID, workdir, command, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(commandStart)
 	result := RunResult{
 		ExitCode:      exitCode,
@@ -99,16 +117,24 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		Total:         b.now().Sub(started),
 		SyncDelegated: true,
 	}
-	fmt.Fprintf(b.rt.Stderr, "tensorlake run summary command=%s total=%s exit=%d\n",
-		result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "tensorlake run summary sync_skipped=true command=%s total=%s exit=%d\n",
+			result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "tensorlake run summary sync=%s command=%s total=%s exit=%d\n",
+			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	}
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider:    providerName,
-			LeaseID:     leaseID,
-			SyncSkipped: true,
-			CommandMs:   result.Command.Milliseconds(),
-			TotalMs:     result.Total.Milliseconds(),
-			ExitCode:    exitCode,
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     result.Command.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      exitCode,
 		}); err != nil {
 			return result, err
 		}
@@ -327,7 +353,27 @@ func buildCommand(command []string, shellMode bool) ([]string, error) {
 	if shellMode {
 		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
 	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	}
 	return command, nil
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
+}
+
+// tensorlakeWorkdir returns the configured absolute workspace path inside the
+// sandbox, validating that it isn't relative or empty.
+func tensorlakeWorkdir(cfg Config) (string, error) {
+	workdir := strings.TrimSpace(cfg.Tensorlake.Workdir)
+	if workdir == "" {
+		workdir = "/workspace/crabbox"
+	}
+	if !strings.HasPrefix(workdir, "/") {
+		return "", exit(2, "tensorlake workdir %q must be an absolute path", workdir)
+	}
+	return workdir, nil
 }
 
 func (b *tensorlakeBackend) now() time.Time {

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -64,10 +65,10 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	if err != nil {
 		return RunResult{}, err
 	}
-	leaseID, sandboxID := "", ""
+	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
 	if req.ID == "" {
-		var slug, name string
+		var name string
 		leaseID, sandboxID, name, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
@@ -79,9 +80,14 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		if err != nil {
 			return RunResult{}, err
 		}
+		slug = newLeaseSlug(leaseID)
 	}
-	if acquired && !req.Keep {
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
 		defer func() {
+			if !shouldStop {
+				return
+			}
 			if termErr := cli.terminate(context.Background(), sandboxID); termErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: tensorlake terminate failed for %s: %v\n", sandboxID, termErr)
 				return
@@ -107,6 +113,17 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	command, err := buildCommand(req.Command, req.ShellMode)
 	if err != nil {
 		return RunResult{}, err
+	}
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	if len(req.Env) > 0 {
+		envPath, cleanup, err := b.uploadEnvProfile(ctx, cli, sandboxID, req.Env)
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer cleanup()
+		command = wrapCommandWithEnvProfile(command, envPath)
 	}
 	commandStart := b.now()
 	exitCode, runErr := cli.execStream(ctx, sandboxID, workdir, command, b.rt.Stdout, b.rt.Stderr)
@@ -140,9 +157,11 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		}
 	}
 	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, ExitError{Code: 1, Message: fmt.Sprintf("tensorlake run failed: %v", runErr)}
 	}
 	if exitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("tensorlake run exited %d", exitCode)}
 	}
 	return result, nil
@@ -310,6 +329,16 @@ func newSandboxName(repo Repo) string {
 		base = "crabbox"
 	}
 	base = strings.TrimPrefix(base, strings.TrimSuffix(namePrefix, "-")+"-")
+	maxBase := maxSandboxNameLen - len(namePrefix) - 1 - sandboxNameSuffixLen
+	if maxBase < 1 {
+		maxBase = 1
+	}
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+	}
+	if base == "" {
+		base = "crabbox"
+	}
 	return namePrefix + base + "-" + randomSuffix()
 }
 

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -29,11 +29,11 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if err != nil {
 		return err
 	}
-	leaseID, name, slug, err := b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
+	leaseID, sandboxID, name, slug, err := b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, name)
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxID, name)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: tensorlake warmup keeps the sandbox until explicit stop\n")
 	}
@@ -60,38 +60,38 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	if err != nil {
 		return RunResult{}, err
 	}
-	leaseID, name := "", ""
+	leaseID, sandboxID := "", ""
 	acquired := false
 	if req.ID == "" {
-		var slug string
-		leaseID, name, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
+		var slug, name string
+		leaseID, sandboxID, name, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, name)
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxID, name)
 		acquired = true
 	} else {
-		leaseID, name, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		leaseID, sandboxID, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
 		if err != nil {
 			return RunResult{}, err
 		}
 	}
 	if acquired && !req.Keep {
 		defer func() {
-			if termErr := cli.terminate(context.Background(), name); termErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: tensorlake terminate failed for %s: %v\n", name, termErr)
+			if termErr := cli.terminate(context.Background(), sandboxID); termErr != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: tensorlake terminate failed for %s: %v\n", sandboxID, termErr)
 				return
 			}
 			removeLeaseClaim(leaseID)
 		}()
 	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s\n", providerName, leaseID, name)
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s\n", providerName, leaseID, sandboxID)
 	command, err := buildCommand(req.Command, req.ShellMode)
 	if err != nil {
 		return RunResult{}, err
 	}
 	commandStart := b.now()
-	exitCode, runErr := cli.execStream(ctx, name, "", command, b.rt.Stdout, b.rt.Stderr)
+	exitCode, runErr := cli.execStream(ctx, sandboxID, "", command, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(commandStart)
 	result := RunResult{
 		ExitCode:      exitCode,
@@ -134,32 +134,22 @@ func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	}
 	servers := make([]Server, 0, len(ids))
 	for _, id := range ids {
-		// `sbx ls -q` returns IDs only; we don't know which are crabbox-owned
-		// without describing each. Cross-reference with local claims instead.
-		claim, ok, err := resolveLeaseClaim(id)
-		if err != nil {
-			continue
-		}
-		if !ok || claim.Provider != providerName {
-			// Try matching by lease prefix on the canonical name as well.
-			if leaseClaim, leaseOK, _ := resolveLeaseClaim(leasePrefix + id); leaseOK && leaseClaim.Provider == providerName {
-				claim = leaseClaim
-				ok = true
-			}
-		}
-		if !ok || claim.Provider != providerName {
+		leaseID := leasePrefix + id
+		claim, ok, err := resolveLeaseClaim(leaseID)
+		if err != nil || !ok || claim.Provider != providerName {
 			continue
 		}
 		servers = append(servers, Server{
 			Provider: providerName,
 			CloudID:  id,
-			Name:     strings.TrimPrefix(claim.LeaseID, leasePrefix),
-			Status:   "",
+			Name:     id,
+			Status:   "running",
 			Labels: map[string]string{
 				"provider": providerName,
 				"lease":    claim.LeaseID,
 				"slug":     claim.Slug,
 				"target":   targetLinux,
+				"state":    "running",
 			},
 		})
 	}
@@ -171,7 +161,7 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, name, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, err := resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -180,28 +170,29 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		deadline = b.now().Add(5 * time.Minute)
 	}
 	for {
-		_, describeErr := cli.describe(ctx, name)
+		out, describeErr := cli.describe(ctx, sandboxID)
+		state := parseDescribeState(out)
+		ready := describeErr == nil && isReadyState(state)
 		view := StatusView{
 			ID:       leaseID,
 			Slug:     newLeaseSlug(leaseID),
 			Provider: providerName,
 			TargetOS: targetLinux,
-			ServerID: name,
+			State:    state,
+			ServerID: sandboxID,
 			Network:  NetworkPublic,
-			Ready:    describeErr == nil,
+			Ready:    ready,
 			Labels: map[string]string{
 				"provider": providerName,
 				"lease":    leaseID,
+				"state":    state,
 			},
-		}
-		if describeErr == nil {
-			view.State = statusViewReady
 		}
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
 		if b.now().After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for tensorlake sandbox %s to become ready", name)
+			return StatusView{}, exit(5, "timed out waiting for tensorlake sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-ctx.Done():
@@ -216,47 +207,59 @@ func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, name, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, err := resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
 		return err
 	}
-	if err := cli.terminate(ctx, name); err != nil {
+	if err := cli.terminate(ctx, sandboxID); err != nil {
 		return err
 	}
 	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, name)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool) (string, string, string, error) {
+// createSandbox returns (leaseID, sandboxID, name, slug, err). The Tensorlake
+// CLI returns the assigned sandbox ID on stdout; that ID is the canonical
+// identifier we key the local claim by. The Crabbox-prefixed name is set on
+// the Tensorlake side for human-readable `tensorlake sbx ls` output but is
+// not used for subsequent API calls.
+func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool) (string, string, string, string, error) {
 	name := newSandboxName(repo)
-	if err := cli.createSandbox(ctx, name); err != nil {
-		return "", "", "", err
+	sandboxID, err := cli.createSandbox(ctx, name)
+	if err != nil {
+		return "", "", "", "", err
 	}
-	leaseID := leasePrefix + name
+	leaseID := leasePrefix + sandboxID
 	slug := newLeaseSlug(leaseID)
 	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		_ = cli.terminate(context.Background(), name)
-		return "", "", "", err
+		_ = cli.terminate(context.Background(), sandboxID)
+		return "", "", "", "", err
 	}
-	return leaseID, name, slug, nil
+	return leaseID, sandboxID, name, slug, nil
 }
 
+// resolveLeaseID resolves a user-supplied identifier (slug, lease ID, or
+// raw Tensorlake sandbox ID) to a (leaseID, sandboxID) pair. Resolution is
+// strict: only locally-claimed Crabbox sandboxes are accepted, mirroring
+// islo. Raw IDs are accepted only when a matching `tlsbx_<id>` claim exists.
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox name, lease id, or slug")
+		return "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
 	}
-	if strings.HasPrefix(id, leasePrefix) {
-		name := strings.TrimPrefix(id, leasePrefix)
-		if !isCrabboxSandboxName(name) {
-			return "", "", exit(4, "tensorlake lease %q is not a Crabbox-owned sandbox", id)
+	probes := []string{id}
+	if !strings.HasPrefix(id, leasePrefix) {
+		probes = append(probes, leasePrefix+id)
+	}
+	for _, probe := range probes {
+		claim, ok, err := resolveLeaseClaim(probe)
+		if err != nil {
+			return "", "", err
 		}
-		return id, name, nil
-	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
-		return "", "", err
-	} else if ok && claim.Provider == providerName {
+		if !ok || claim.Provider != providerName {
+			continue
+		}
 		if repoRoot != "" {
 			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
 				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
@@ -265,10 +268,7 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 		}
 		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), nil
 	}
-	if !isCrabboxSandboxName(id) {
-		return "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; pass a Crabbox slug or %s<crabbox-sandbox-name>", id, leasePrefix)
-	}
-	return leasePrefix + id, id, nil
+	return "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
@@ -287,8 +287,29 @@ func newSandboxName(repo Repo) string {
 	return namePrefix + base + "-" + randomSuffix()
 }
 
-func isCrabboxSandboxName(name string) bool {
-	return strings.HasPrefix(normalizeLeaseSlug(name), namePrefix)
+// parseDescribeState extracts the Status field from `tensorlake sbx describe`
+// stdout. The CLI prints key/value lines like "Status: running"; an empty
+// string is returned when no Status line is present.
+func parseDescribeState(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), "status") {
+			return strings.ToLower(strings.TrimSpace(value))
+		}
+	}
+	return ""
+}
+
+func isReadyState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "running", "ready", "started", "active":
+		return true
+	default:
+		return false
+	}
 }
 
 func randomSuffix() string {

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -1,8 +1,12 @@
 package tensorlake
 
 import (
+	"context"
+	"errors"
+	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -13,8 +17,7 @@ func TestProviderSpec(t *testing.T) {
 	if p.Name() != "tensorlake" {
 		t.Fatalf("Name=%q want tensorlake", p.Name())
 	}
-	aliases := p.Aliases()
-	if len(aliases) == 0 {
+	if len(p.Aliases()) == 0 {
 		t.Fatalf("expected aliases, got none")
 	}
 	spec := p.Spec()
@@ -57,41 +60,63 @@ func TestBuildCommandRejectsEmpty(t *testing.T) {
 	}
 }
 
-func TestIsCrabboxSandboxName(t *testing.T) {
-	cases := map[string]bool{
-		"crabbox-foo-abc123": true,
-		"crabbox-x-1":        true,
-		"my-app-001":         false,
-		"":                   false,
+func TestParseSandboxIDPicksAlphanumericLine(t *testing.T) {
+	cases := map[string]string{
+		"3pryjysezwsnlex226i5h":                                 "3pryjysezwsnlex226i5h",
+		"  561sdfohklnysghdfbgrz  ":                             "561sdfohklnysghdfbgrz",
+		"sandbox created\n3pryjysezwsnlex226i5h\nfollowup line": "3pryjysezwsnlex226i5h",
+		"": "",
+		"some warning that contains UPPERCASE and is not the id": "",
 	}
-	for name, want := range cases {
-		if got := isCrabboxSandboxName(name); got != want {
-			t.Errorf("isCrabboxSandboxName(%q)=%v want %v", name, got, want)
+	for input, want := range cases {
+		if got := parseSandboxID(input); got != want {
+			t.Errorf("parseSandboxID(%q)=%q want %q", input, got, want)
 		}
 	}
 }
 
-func TestResolveLeaseIDRejectsForeignSandboxes(t *testing.T) {
-	_, _, err := resolveLeaseID("not-a-crabbox-sandbox", "", false, 0)
+func TestParseDescribeStateExtractsStatus(t *testing.T) {
+	out := strings.Join([]string{
+		"ID:              3pryjysezwsnlex226i5h",
+		"Name:            crabbox-app-aaa111",
+		"Status:          running",
+		"Image:           ubuntu-minimal",
+	}, "\n")
+	if got := parseDescribeState(out); got != "running" {
+		t.Fatalf("state=%q want running", got)
+	}
+	if got := parseDescribeState(""); got != "" {
+		t.Fatalf("empty input should return empty, got %q", got)
+	}
+}
+
+func TestIsReadyState(t *testing.T) {
+	cases := map[string]bool{
+		"running":    true,
+		"  Running ": true,
+		"ready":      true,
+		"starting":   false,
+		"terminated": false,
+		"":           false,
+	}
+	for state, want := range cases {
+		if got := isReadyState(state); got != want {
+			t.Errorf("isReadyState(%q)=%v want %v", state, got, want)
+		}
+	}
+}
+
+func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
+	_, _, err := resolveLeaseID("not-a-known-slug", "", false, 0)
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection of unclaimed sandbox", err)
 	}
 }
 
-func TestResolveLeaseIDAcceptsLeasePrefix(t *testing.T) {
-	lease, name, err := resolveLeaseID("tlsbx_crabbox-app-aaa111", "", false, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lease != "tlsbx_crabbox-app-aaa111" || name != "crabbox-app-aaa111" {
-		t.Fatalf("lease=%q name=%q", lease, name)
-	}
-}
-
-func TestResolveLeaseIDRejectsForeignLeasePrefix(t *testing.T) {
-	_, _, err := resolveLeaseID("tlsbx_someone-elses-sandbox", "", false, 0)
-	if err == nil || !strings.Contains(err.Error(), "not a Crabbox-owned sandbox") {
-		t.Fatalf("err=%v, want rejection", err)
+func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
+	_, _, err := resolveLeaseID("tlsbx_unknown123", "", false, 0)
+	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v, want rejection without local claim", err)
 	}
 }
 
@@ -107,9 +132,6 @@ func TestNewSandboxNameUsesRepoName(t *testing.T) {
 	if !strings.HasPrefix(name, "crabbox-carbbox-") {
 		t.Fatalf("name=%q does not start with crabbox-carbbox-", name)
 	}
-	if !isCrabboxSandboxName(name) {
-		t.Fatalf("isCrabboxSandboxName(%q)=false", name)
-	}
 }
 
 func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
@@ -122,3 +144,293 @@ func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
 		t.Fatalf("name=%q does not start with crabbox-app-", name)
 	}
 }
+
+// recordingCommandRunner is a fake CommandRunner that records every call and
+// replies with a scripted (stdout, stderr, exit, err) tuple keyed by the
+// subcommand sequence (e.g. "sbx create", "sbx exec", "sbx terminate").
+type recordingCommandRunner struct {
+	mu      sync.Mutex
+	calls   []core.LocalCommandRequest
+	scripts map[string]scriptedReply
+}
+
+type scriptedReply struct {
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+}
+
+func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, req)
+	r.mu.Unlock()
+	key := scriptKey(req.Args)
+	reply := r.scripts[key]
+	if req.Stdout != nil && reply.stdout != "" {
+		_, _ = io.WriteString(req.Stdout, reply.stdout)
+	}
+	if req.Stderr != nil && reply.stderr != "" {
+		_, _ = io.WriteString(req.Stderr, reply.stderr)
+	}
+	res := core.LocalCommandResult{
+		ExitCode: reply.exitCode,
+		Stdout:   reply.stdout,
+		Stderr:   reply.stderr,
+	}
+	return res, reply.err
+}
+
+// scriptKey extracts the `sbx <verb>` portion of an argv slice, ignoring
+// global flags so test scripts can match by subcommand alone.
+func scriptKey(args []string) string {
+	for i, a := range args {
+		if a == "sbx" && i+1 < len(args) {
+			return "sbx " + args[i+1]
+		}
+	}
+	return ""
+}
+
+func newTestRuntime(runner *recordingCommandRunner) Runtime {
+	return Runtime{
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+		Exec:   runner,
+	}
+}
+
+func newTestConfig() Config {
+	cfg := Config{}
+	cfg.Tensorlake.APIKey = "tl_apiKey_test"
+	cfg.Tensorlake.APIURL = "https://api.tensorlake.ai"
+	cfg.Tensorlake.CLIPath = "tensorlake"
+	cfg.Tensorlake.CPUs = 1.0
+	cfg.Tensorlake.MemoryMB = 1024
+	cfg.Tensorlake.DiskMB = 10240
+	return cfg
+}
+
+func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
+	runner := &recordingCommandRunner{
+		scripts: map[string]scriptedReply{
+			"sbx create":    {stdout: "3pryjysezwsnlex226i5h\n"},
+			"sbx exec":      {stdout: "hello\n"},
+			"sbx terminate": {stdout: "3pryjysezwsnlex226i5h\n"},
+		},
+	}
+	cfg := newTestConfig()
+	rt := newTestRuntime(runner)
+	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, rt).(*tensorlakeBackend)
+	repoRoot := t.TempDir()
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+		Command: []string{"echo", "hello"},
+		NoSync:  true,
+	}
+	defer func() {
+		// Best-effort cleanup of the lease claim store side effects.
+		_ = req
+	}()
+	result, err := backend.Run(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d want 0", result.ExitCode)
+	}
+	verbs := callVerbs(runner)
+	want := []string{"sbx create", "sbx exec", "sbx terminate"}
+	if !reflect.DeepEqual(verbs, want) {
+		t.Fatalf("verbs=%v want %v", verbs, want)
+	}
+	// `sbx exec` must target the captured sandbox ID, not the human name.
+	execCall := findCall(runner, "sbx exec")
+	if execCall == nil {
+		t.Fatalf("missing sbx exec call")
+	}
+	if !containsArg(execCall.Args, "3pryjysezwsnlex226i5h") {
+		t.Fatalf("exec args=%v missing sandbox id", execCall.Args)
+	}
+	if !containsArg(execCall.Args, "echo") || !containsArg(execCall.Args, "hello") {
+		t.Fatalf("exec args=%v missing user command", execCall.Args)
+	}
+	// API key must flow via env, never argv.
+	if containsArgPrefix(execCall.Args, "tl_apiKey_") {
+		t.Fatalf("API key leaked into argv: %v", execCall.Args)
+	}
+	if !containsEnv(execCall.Env, "TENSORLAKE_API_KEY=tl_apiKey_test") {
+		t.Fatalf("env missing TENSORLAKE_API_KEY: %v", execCall.Env)
+	}
+}
+
+func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
+	exitErr := &fakeExitError{code: 7}
+	runner := &recordingCommandRunner{
+		scripts: map[string]scriptedReply{
+			"sbx create":    {stdout: "abc123def456ghi789\n"},
+			"sbx exec":      {stderr: "boom\n", exitCode: 7, err: exitErr},
+			"sbx terminate": {stdout: "abc123def456ghi789\n"},
+		},
+	}
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+		Command: []string{"false"},
+		NoSync:  true,
+	}
+	result, err := backend.Run(context.Background(), req)
+	if result.ExitCode != 7 {
+		t.Fatalf("exit=%d want 7", result.ExitCode)
+	}
+	var ee ExitError
+	if !errors.As(err, &ee) || ee.Code != 7 {
+		t.Fatalf("err=%v want ExitError code=7", err)
+	}
+}
+
+func TestRunRequiresNoSync(t *testing.T) {
+	runner := &recordingCommandRunner{}
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+		Command: []string{"echo"},
+		NoSync:  false,
+	}
+	if _, err := backend.Run(context.Background(), req); err == nil {
+		t.Fatalf("expected error when --no-sync is missing")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("CLI was invoked despite sync rejection: %d calls", len(runner.calls))
+	}
+}
+
+func TestKeepRetainsSandbox(t *testing.T) {
+	runner := &recordingCommandRunner{
+		scripts: map[string]scriptedReply{
+			"sbx create": {stdout: "keepid01234567890ab\n"},
+			"sbx exec":   {stdout: "hi\n"},
+		},
+	}
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+		Command: []string{"echo", "hi"},
+		NoSync:  true,
+		Keep:    true,
+		Reclaim: true,
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if findCall(runner, "sbx terminate") != nil {
+		t.Fatalf("sbx terminate called despite Keep=true")
+	}
+}
+
+func TestStopRejectsUnclaimedID(t *testing.T) {
+	runner := &recordingCommandRunner{}
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	err := backend.Stop(context.Background(), StopRequest{ID: "not-claimed-anywhere"})
+	if err == nil {
+		t.Fatalf("expected rejection of unclaimed sandbox")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("CLI invoked for unclaimed sandbox: %d calls", len(runner.calls))
+	}
+}
+
+func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
+	runner := &recordingCommandRunner{
+		scripts: map[string]scriptedReply{
+			"sbx create": {stdout: "sizingid01234567890\n"},
+			"sbx exec":   {stdout: "ok\n"},
+		},
+	}
+	cfg := newTestConfig()
+	cfg.Tensorlake.CPUs = 2.5
+	cfg.Tensorlake.MemoryMB = 8192
+	cfg.Tensorlake.DiskMB = 20000
+	cfg.Tensorlake.Image = "ubuntu-22.04"
+	cfg.Tensorlake.NoInternet = true
+	cfg.Tensorlake.OrganizationID = "org_xyz"
+	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, newTestRuntime(runner)).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+		Command: []string{"echo", "ok"},
+		NoSync:  true,
+		Keep:    true,
+		Reclaim: true,
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	create := findCall(runner, "sbx create")
+	if create == nil {
+		t.Fatalf("missing sbx create call")
+	}
+	for _, want := range []string{"-c", "2.5", "-m", "8192", "--disk_mb", "20000", "-i", "ubuntu-22.04", "-N"} {
+		if !containsArg(create.Args, want) {
+			t.Errorf("create args=%v missing %q", create.Args, want)
+		}
+	}
+	// global flag
+	if !containsArg(create.Args, "--organization") || !containsArg(create.Args, "org_xyz") {
+		t.Errorf("create args=%v missing --organization org_xyz", create.Args)
+	}
+}
+
+func callVerbs(r *recordingCommandRunner) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	verbs := make([]string, 0, len(r.calls))
+	for _, c := range r.calls {
+		if v := scriptKey(c.Args); v != "" {
+			verbs = append(verbs, v)
+		}
+	}
+	return verbs
+}
+
+func findCall(r *recordingCommandRunner, verb string) *core.LocalCommandRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.calls {
+		if scriptKey(r.calls[i].Args) == verb {
+			return &r.calls[i]
+		}
+	}
+	return nil
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPrefix(args []string, prefix string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+type fakeExitError struct{ code int }
+
+func (e *fakeExitError) Error() string { return "exit" }
+func (e *fakeExitError) ExitCode() int { return e.code }

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -1,6 +1,7 @@
 package tensorlake
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -205,6 +206,17 @@ func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
 	}
 }
 
+func TestNewSandboxNameFitsTensorlakeLimit(t *testing.T) {
+	repo := Repo{Name: strings.Repeat("very-long-repo-name-", 8)}
+	name := newSandboxName(repo)
+	if len(name) > 63 {
+		t.Fatalf("name len=%d want <=63: %q", len(name), name)
+	}
+	if strings.HasSuffix(name, "-") || !strings.HasPrefix(name, "crabbox-") {
+		t.Fatalf("invalid sandbox name: %q", name)
+	}
+}
+
 // recordingCommandRunner is a fake CommandRunner that records every call and
 // replies from a per-verb queue of scripted (stdout, stderr, exit, err)
 // tuples. Replies are popped in order; if the queue for a verb is empty, the
@@ -339,6 +351,55 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	}
 }
 
+func TestRunForwardsEnvViaUploadedProfile(t *testing.T) {
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create":    {stdout: "envid0123456789012\n"},
+		"sbx exec":      {stdout: "ok\n"},
+		"sbx cp":        {stdout: ""},
+		"sbx terminate": {stdout: "envid0123456789012\n"},
+	}, nil)
+	var stderr bytes.Buffer
+	rt := newTestRuntime(runner)
+	rt.Stderr = &stderr
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+		Command:    []string{"printenv", "SECRET_TOKEN"},
+		NoSync:     true,
+		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
+		EnvSummary: true,
+		Options:    core.LeaseOptions{EnvAllow: []string{"SECRET_TOKEN"}},
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	verbs := callVerbs(runner)
+	want := []string{"sbx create", "sbx exec", "sbx cp", "sbx exec", "sbx exec", "sbx terminate"}
+	if !reflect.DeepEqual(verbs, want) {
+		t.Fatalf("verbs=%v want %v", verbs, want)
+	}
+	if strings.Contains(stderr.String(), "super-secret") {
+		t.Fatalf("secret leaked in stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "SECRET_TOKEN=set len=12 secret=true") {
+		t.Fatalf("missing redacted env summary: %s", stderr.String())
+	}
+	cp := findCall(runner, "sbx cp")
+	if cp == nil || containsArgSubstring(cp.Args, "super-secret") {
+		t.Fatalf("env upload leaked secret in argv: %#v", cp)
+	}
+	userExec := findCallN(runner, "sbx exec", 1)
+	if userExec == nil {
+		t.Fatalf("missing user exec")
+	}
+	if containsArgSubstring(userExec.Args, "super-secret") {
+		t.Fatalf("secret leaked in exec argv: %v", userExec.Args)
+	}
+	if !containsArg(userExec.Args, "bash") || !containsArg(userExec.Args, "-lc") || !containsArgSubstring(userExec.Args, "/tmp/crabbox-env-") {
+		t.Fatalf("exec args=%v missing env profile wrapper", userExec.Args)
+	}
+}
+
 func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	exitErr := &fakeExitError{code: 7}
 	runner := newRunner(
@@ -368,6 +429,47 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	var ee ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code=7", err)
+	}
+}
+
+func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
+	sandboxID := "failkeep" + randomSuffix() + randomSuffix()
+	defer removeLeaseClaim(leasePrefix + sandboxID)
+	runner := newRunner(
+		map[string]scriptedReply{
+			"sbx create": {stdout: sandboxID + "\n"},
+		},
+		map[string][]scriptedReply{
+			"sbx exec": {
+				{stdout: ""},
+				{stderr: "boom\n", exitCode: 7},
+			},
+		},
+	)
+	var stderr bytes.Buffer
+	rt := newTestRuntime(runner)
+	rt.Stderr = &stderr
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:          Repo{Name: "carbbox", Root: t.TempDir()},
+		Command:       []string{"false"},
+		NoSync:        true,
+		KeepOnFailure: true,
+		Reclaim:       true,
+	}
+	result, err := backend.Run(context.Background(), req)
+	if result.ExitCode != 7 {
+		t.Fatalf("exit=%d want 7", result.ExitCode)
+	}
+	var ee ExitError
+	if !errors.As(err, &ee) || ee.Code != 7 {
+		t.Fatalf("err=%v want ExitError code=7", err)
+	}
+	if findCall(runner, "sbx terminate") != nil {
+		t.Fatalf("sbx terminate called despite --keep-on-failure")
+	}
+	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=tlsbx_"+sandboxID) {
+		t.Fatalf("missing keep-on-failure hint: %s", stderr.String())
 	}
 }
 
@@ -566,6 +668,15 @@ func containsArg(args []string, want string) bool {
 func containsArgPrefix(args []string, prefix string) bool {
 	for _, a := range args {
 		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgSubstring(args []string, needle string) bool {
+	for _, a := range args {
+		if strings.Contains(a, needle) {
 			return true
 		}
 	}

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -1,0 +1,124 @@
+package tensorlake
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpec(t *testing.T) {
+	p := Provider{}
+	if p.Name() != "tensorlake" {
+		t.Fatalf("Name=%q want tensorlake", p.Name())
+	}
+	aliases := p.Aliases()
+	if len(aliases) == 0 {
+		t.Fatalf("expected aliases, got none")
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%v want delegated run", spec.Kind)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%v want never", spec.Coordinator)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want [{linux}]", spec.Targets)
+	}
+}
+
+func TestBuildCommandShellMode(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm install && pnpm test"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"bash", "-lc", "pnpm install && pnpm test"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command=%#v want %#v", got, want)
+	}
+}
+
+func TestBuildCommandPassThrough(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm", "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"pnpm", "test"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command=%#v want %#v", got, want)
+	}
+}
+
+func TestBuildCommandRejectsEmpty(t *testing.T) {
+	if _, err := buildCommand(nil, false); err == nil {
+		t.Fatalf("expected error for empty command")
+	}
+}
+
+func TestIsCrabboxSandboxName(t *testing.T) {
+	cases := map[string]bool{
+		"crabbox-foo-abc123": true,
+		"crabbox-x-1":        true,
+		"my-app-001":         false,
+		"":                   false,
+	}
+	for name, want := range cases {
+		if got := isCrabboxSandboxName(name); got != want {
+			t.Errorf("isCrabboxSandboxName(%q)=%v want %v", name, got, want)
+		}
+	}
+}
+
+func TestResolveLeaseIDRejectsForeignSandboxes(t *testing.T) {
+	_, _, err := resolveLeaseID("not-a-crabbox-sandbox", "", false, 0)
+	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v, want rejection of unclaimed sandbox", err)
+	}
+}
+
+func TestResolveLeaseIDAcceptsLeasePrefix(t *testing.T) {
+	lease, name, err := resolveLeaseID("tlsbx_crabbox-app-aaa111", "", false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease != "tlsbx_crabbox-app-aaa111" || name != "crabbox-app-aaa111" {
+		t.Fatalf("lease=%q name=%q", lease, name)
+	}
+}
+
+func TestResolveLeaseIDRejectsForeignLeasePrefix(t *testing.T) {
+	_, _, err := resolveLeaseID("tlsbx_someone-elses-sandbox", "", false, 0)
+	if err == nil || !strings.Contains(err.Error(), "not a Crabbox-owned sandbox") {
+		t.Fatalf("err=%v, want rejection", err)
+	}
+}
+
+func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
+	if _, _, err := resolveLeaseID("", "", false, 0); err == nil {
+		t.Fatalf("expected error for empty id")
+	}
+}
+
+func TestNewSandboxNameUsesRepoName(t *testing.T) {
+	repo := Repo{Name: "carbbox"}
+	name := newSandboxName(repo)
+	if !strings.HasPrefix(name, "crabbox-carbbox-") {
+		t.Fatalf("name=%q does not start with crabbox-carbbox-", name)
+	}
+	if !isCrabboxSandboxName(name) {
+		t.Fatalf("isCrabboxSandboxName(%q)=false", name)
+	}
+}
+
+func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
+	repo := Repo{Name: "crabbox-app"}
+	name := newSandboxName(repo)
+	if strings.HasPrefix(name, "crabbox-crabbox-") {
+		t.Fatalf("name=%q double-prefixed", name)
+	}
+	if !strings.HasPrefix(name, "crabbox-app-") {
+		t.Fatalf("name=%q does not start with crabbox-app-", name)
+	}
+}

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -11,6 +14,8 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func osExec(name string, args ...string) *osexec.Cmd { return osexec.Command(name, args...) }
 
 func TestProviderSpec(t *testing.T) {
 	p := Provider{}
@@ -29,6 +34,61 @@ func TestProviderSpec(t *testing.T) {
 	}
 	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
 		t.Fatalf("targets=%#v want [{linux}]", spec.Targets)
+	}
+}
+
+func TestProviderForResolvesNameAndAliases(t *testing.T) {
+	for _, name := range []string{"tensorlake", "tl", "tensorlake-sbx"} {
+		got, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q) err=%v", name, err)
+		}
+		if got.Name() != "tensorlake" {
+			t.Fatalf("ProviderFor(%q).Name()=%q want tensorlake", name, got.Name())
+		}
+	}
+}
+
+func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm install && pnpm test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "bash" || got[1] != "-lc" {
+		t.Fatalf("command=%#v want bash -lc wrapping", got)
+	}
+	if !strings.Contains(got[2], "pnpm install") || !strings.Contains(got[2], "pnpm test") {
+		t.Fatalf("command=%#v missing user input", got)
+	}
+}
+
+func TestBuildCommandAutoWrapsLeadingEnvAssignment(t *testing.T) {
+	got, err := buildCommand([]string{"FOO=bar", "pnpm", "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "bash" {
+		t.Fatalf("command=%#v want bash wrapping for FOO=bar", got)
+	}
+}
+
+func TestTensorlakeWorkdirRejectsRelative(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Tensorlake.Workdir = "relative/path"
+	if _, err := tensorlakeWorkdir(cfg); err == nil {
+		t.Fatalf("expected rejection of relative workdir")
+	}
+}
+
+func TestTensorlakeWorkdirDefault(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Tensorlake.Workdir = ""
+	got, err := tensorlakeWorkdir(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/workspace/crabbox" {
+		t.Fatalf("default=%q want /workspace/crabbox", got)
 	}
 }
 
@@ -146,12 +206,14 @@ func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
 }
 
 // recordingCommandRunner is a fake CommandRunner that records every call and
-// replies with a scripted (stdout, stderr, exit, err) tuple keyed by the
-// subcommand sequence (e.g. "sbx create", "sbx exec", "sbx terminate").
+// replies from a per-verb queue of scripted (stdout, stderr, exit, err)
+// tuples. Replies are popped in order; if the queue for a verb is empty, the
+// last reply (or zero value) is reused.
 type recordingCommandRunner struct {
-	mu      sync.Mutex
-	calls   []core.LocalCommandRequest
-	scripts map[string]scriptedReply
+	mu       sync.Mutex
+	calls    []core.LocalCommandRequest
+	scripts  map[string][]scriptedReply
+	defaults map[string]scriptedReply
 }
 
 type scriptedReply struct {
@@ -164,9 +226,15 @@ type scriptedReply struct {
 func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.mu.Lock()
 	r.calls = append(r.calls, req)
-	r.mu.Unlock()
 	key := scriptKey(req.Args)
-	reply := r.scripts[key]
+	var reply scriptedReply
+	if queue := r.scripts[key]; len(queue) > 0 {
+		reply = queue[0]
+		r.scripts[key] = queue[1:]
+	} else if def, ok := r.defaults[key]; ok {
+		reply = def
+	}
+	r.mu.Unlock()
 	if req.Stdout != nil && reply.stdout != "" {
 		_, _ = io.WriteString(req.Stdout, reply.stdout)
 	}
@@ -179,6 +247,10 @@ func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandReq
 		Stderr:   reply.stderr,
 	}
 	return res, reply.err
+}
+
+func newRunner(defaults map[string]scriptedReply, sequenced map[string][]scriptedReply) *recordingCommandRunner {
+	return &recordingCommandRunner{defaults: defaults, scripts: sequenced}
 }
 
 // scriptKey extracts the `sbx <verb>` portion of an argv slice, ignoring
@@ -212,13 +284,11 @@ func newTestConfig() Config {
 }
 
 func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
-	runner := &recordingCommandRunner{
-		scripts: map[string]scriptedReply{
-			"sbx create":    {stdout: "3pryjysezwsnlex226i5h\n"},
-			"sbx exec":      {stdout: "hello\n"},
-			"sbx terminate": {stdout: "3pryjysezwsnlex226i5h\n"},
-		},
-	}
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create":    {stdout: "3pryjysezwsnlex226i5h\n"},
+		"sbx exec":      {stdout: "hello\n"},
+		"sbx terminate": {stdout: "3pryjysezwsnlex226i5h\n"},
+	}, nil)
 	cfg := newTestConfig()
 	rt := newTestRuntime(runner)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, rt).(*tensorlakeBackend)
@@ -240,20 +310,25 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 		t.Fatalf("exit=%d want 0", result.ExitCode)
 	}
 	verbs := callVerbs(runner)
-	want := []string{"sbx create", "sbx exec", "sbx terminate"}
+	// With --no-sync we still prepare the workdir (mkdir) before the user's command.
+	want := []string{"sbx create", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
 		t.Fatalf("verbs=%v want %v", verbs, want)
 	}
 	// `sbx exec` must target the captured sandbox ID, not the human name.
-	execCall := findCall(runner, "sbx exec")
+	// The user-command exec is the second exec call (the first is the mkdir prepare).
+	execCall := findCallN(runner, "sbx exec", 1)
 	if execCall == nil {
-		t.Fatalf("missing sbx exec call")
+		t.Fatalf("missing user-command sbx exec call")
 	}
 	if !containsArg(execCall.Args, "3pryjysezwsnlex226i5h") {
 		t.Fatalf("exec args=%v missing sandbox id", execCall.Args)
 	}
 	if !containsArg(execCall.Args, "echo") || !containsArg(execCall.Args, "hello") {
 		t.Fatalf("exec args=%v missing user command", execCall.Args)
+	}
+	if !containsArg(execCall.Args, "-w") || !containsArg(execCall.Args, "/workspace/crabbox") {
+		t.Fatalf("exec args=%v missing -w workdir", execCall.Args)
 	}
 	// API key must flow via env, never argv.
 	if containsArgPrefix(execCall.Args, "tl_apiKey_") {
@@ -266,13 +341,20 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 
 func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	exitErr := &fakeExitError{code: 7}
-	runner := &recordingCommandRunner{
-		scripts: map[string]scriptedReply{
+	runner := newRunner(
+		map[string]scriptedReply{
 			"sbx create":    {stdout: "abc123def456ghi789\n"},
-			"sbx exec":      {stderr: "boom\n", exitCode: 7, err: exitErr},
 			"sbx terminate": {stdout: "abc123def456ghi789\n"},
 		},
-	}
+		map[string][]scriptedReply{
+			// First exec is the mkdir prepare (succeeds); second is the user
+			// command (exits 7).
+			"sbx exec": {
+				{stdout: ""},
+				{stderr: "boom\n", exitCode: 7, err: exitErr},
+			},
+		},
+	)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	req := RunRequest{
 		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
@@ -289,29 +371,71 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	}
 }
 
-func TestRunRequiresNoSync(t *testing.T) {
-	runner := &recordingCommandRunner{}
+func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create":    {stdout: "syncidaaaaaaaaaaaaaa\n"},
+		"sbx exec":      {stdout: "ok\n"},
+		"sbx cp":        {stdout: ""},
+		"sbx terminate": {stdout: "syncidaaaaaaaaaaaaaa\n"},
+	}, nil)
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	repoRoot := newGitRepo(t)
+	if err := os.WriteFile(filepath.Join(repoRoot, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	req := RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+		Command: []string{"echo", "ok"},
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	verbs := callVerbs(runner)
+	// Expected order: create → mkdir-prepare exec → cp upload → tar-extract exec → user exec → terminate
+	want := []string{"sbx create", "sbx exec", "sbx cp", "sbx exec", "sbx exec", "sbx terminate"}
+	if !reflect.DeepEqual(verbs, want) {
+		t.Fatalf("verbs=%v want %v", verbs, want)
+	}
+	cp := findCall(runner, "sbx cp")
+	if cp == nil {
+		t.Fatalf("missing sbx cp call")
+	}
+	if !containsArgPrefix(cp.Args, "syncidaaaaaaaaaaaaaa:/tmp/crabbox-sync-") {
+		t.Fatalf("cp args=%v missing remote dest", cp.Args)
+	}
+}
+
+func TestRunSkipsSyncWithNoSync(t *testing.T) {
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create":    {stdout: "nosyncidaaaaaaaaaaaa\n"},
+		"sbx exec":      {stdout: "ok\n"},
+		"sbx terminate": {stdout: "nosyncidaaaaaaaaaaaa\n"},
+	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	req := RunRequest{
 		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
-		Command: []string{"echo"},
-		NoSync:  false,
+		Command: []string{"echo", "ok"},
+		NoSync:  true,
 	}
-	if _, err := backend.Run(context.Background(), req); err == nil {
-		t.Fatalf("expected error when --no-sync is missing")
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
 	}
-	if len(runner.calls) != 0 {
-		t.Fatalf("CLI was invoked despite sync rejection: %d calls", len(runner.calls))
+	if findCall(runner, "sbx cp") != nil {
+		t.Fatalf("sbx cp called despite --no-sync")
+	}
+	verbs := callVerbs(runner)
+	// With --no-sync we still prepare the workdir (mkdir) before the user's command.
+	want := []string{"sbx create", "sbx exec", "sbx exec", "sbx terminate"}
+	if !reflect.DeepEqual(verbs, want) {
+		t.Fatalf("verbs=%v want %v", verbs, want)
 	}
 }
 
 func TestKeepRetainsSandbox(t *testing.T) {
-	runner := &recordingCommandRunner{
-		scripts: map[string]scriptedReply{
-			"sbx create": {stdout: "keepid01234567890ab\n"},
-			"sbx exec":   {stdout: "hi\n"},
-		},
-	}
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create": {stdout: "keepid01234567890ab\n"},
+		"sbx exec":   {stdout: "hi\n"},
+	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	req := RunRequest{
 		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
@@ -329,7 +453,7 @@ func TestKeepRetainsSandbox(t *testing.T) {
 }
 
 func TestStopRejectsUnclaimedID(t *testing.T) {
-	runner := &recordingCommandRunner{}
+	runner := newRunner(nil, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	err := backend.Stop(context.Background(), StopRequest{ID: "not-claimed-anywhere"})
 	if err == nil {
@@ -341,12 +465,10 @@ func TestStopRejectsUnclaimedID(t *testing.T) {
 }
 
 func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
-	runner := &recordingCommandRunner{
-		scripts: map[string]scriptedReply{
-			"sbx create": {stdout: "sizingid01234567890\n"},
-			"sbx exec":   {stdout: "ok\n"},
-		},
-	}
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create": {stdout: "sizingid01234567890\n"},
+		"sbx exec":   {stdout: "ok\n"},
+	}, nil)
 	cfg := newTestConfig()
 	cfg.Tensorlake.CPUs = 2.5
 	cfg.Tensorlake.MemoryMB = 8192
@@ -393,14 +515,43 @@ func callVerbs(r *recordingCommandRunner) []string {
 }
 
 func findCall(r *recordingCommandRunner, verb string) *core.LocalCommandRequest {
+	return findCallN(r, verb, 0)
+}
+
+// findCallN returns the (n+1)-th call to verb (zero-indexed). Returns nil
+// when fewer than n+1 calls exist.
+func findCallN(r *recordingCommandRunner, verb string, n int) *core.LocalCommandRequest {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	seen := 0
 	for i := range r.calls {
 		if scriptKey(r.calls[i].Args) == verb {
-			return &r.calls[i]
+			if seen == n {
+				return &r.calls[i]
+			}
+			seen++
 		}
 	}
 	return nil
+}
+
+// newGitRepo creates a temp directory, runs `git init` + an empty commit so
+// `git ls-files` (used by core.BuildSyncManifest) has something to walk.
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", root},
+		{"-C", root, "config", "user.email", "test@example.com"},
+		{"-C", root, "config", "user.name", "test"},
+		{"-C", root, "commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		cmd := osExec("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return root
 }
 
 func containsArg(args []string, want string) bool {

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -102,7 +102,9 @@ func (c *tensorlakeCLI) runStreamed(ctx context.Context, sub []string, args []st
 	return res.ExitCode, nil
 }
 
-func (c *tensorlakeCLI) createSandbox(ctx context.Context, name string) error {
+// createSandbox runs `tensorlake sbx create` and returns the
+// Tensorlake-assigned sandbox ID parsed from stdout.
+func (c *tensorlakeCLI) createSandbox(ctx context.Context, name string) (string, error) {
 	args := []string{}
 	if c.cfg.Tensorlake.CPUs > 0 {
 		args = append(args, "-c", trimFloat(c.cfg.Tensorlake.CPUs))
@@ -125,9 +127,47 @@ func (c *tensorlakeCLI) createSandbox(ctx context.Context, name string) error {
 	if c.cfg.Tensorlake.NoInternet {
 		args = append(args, "-N")
 	}
-	args = append(args, name)
-	_, err := c.runQuiet(ctx, []string{"sbx", "create"}, args)
-	return err
+	if strings.TrimSpace(name) != "" {
+		args = append(args, name)
+	}
+	out, err := c.runQuiet(ctx, []string{"sbx", "create"}, args)
+	if err != nil {
+		return "", err
+	}
+	id := parseSandboxID(out)
+	if id == "" {
+		return "", fmt.Errorf("tensorlake sbx create: empty sandbox id in output %q", out)
+	}
+	return id, nil
+}
+
+// parseSandboxID extracts a sandbox ID from `tensorlake sbx create` stdout.
+// The CLI prints just the ID on a single line on success.
+func parseSandboxID(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if isLikelySandboxID(line) {
+			return line
+		}
+	}
+	return ""
+}
+
+// isLikelySandboxID returns true for the lowercase-alphanumeric token format
+// Tensorlake uses for sandbox IDs (e.g. "3pryjysezwsnlex226i5h").
+func isLikelySandboxID(s string) bool {
+	if len(s) < 12 || len(s) > 40 {
+		return false
+	}
+	for _, r := range s {
+		if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'z') {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *tensorlakeCLI) execStream(ctx context.Context, name, workdir string, command []string, stdout, stderr io.Writer) (int, error) {

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type tensorlakeCLI struct {
@@ -180,6 +178,28 @@ func (c *tensorlakeCLI) execStream(ctx context.Context, name, workdir string, co
 	return c.runStreamed(ctx, []string{"sbx", "exec"}, args, stdout, stderr)
 }
 
+// execShell runs `bash -lc <command>` inside the sandbox and returns an error
+// for non-zero exits. Used for sync helpers (mkdir, tar, cleanup) where we
+// don't care about streaming output back to the user.
+func (c *tensorlakeCLI) execShell(ctx context.Context, name, command string) error {
+	code, err := c.runStreamed(ctx, []string{"sbx", "exec"}, []string{name, "bash", "-lc", command}, io.Discard, io.Discard)
+	if err != nil {
+		return fmt.Errorf("tensorlake exec %q: %w", command, err)
+	}
+	if code != 0 {
+		return exit(code, "tensorlake exec %q exited %d", command, code)
+	}
+	return nil
+}
+
+// uploadFile pushes a local file into the sandbox via `tensorlake sbx cp`.
+func (c *tensorlakeCLI) uploadFile(ctx context.Context, name, localPath, remotePath string) error {
+	src := localPath
+	dst := name + ":" + remotePath
+	_, err := c.runQuiet(ctx, []string{"sbx", "cp"}, []string{src, dst})
+	return err
+}
+
 func (c *tensorlakeCLI) terminate(ctx context.Context, name string) error {
 	_, err := c.runQuiet(ctx, []string{"sbx", "terminate"}, []string{name})
 	return err
@@ -225,17 +245,4 @@ func tensorlakeError(action string, exitCode int, stdout, stderr *bytes.Buffer, 
 func trimFloat(v float64) string {
 	s := strconv.FormatFloat(v, 'f', -1, 64)
 	return s
-}
-
-// rejectSyncOptions refuses Crabbox sync flags that have no Tensorlake-side
-// implementation in v1. Archive sync via `tensorlake sbx cp` + tar is a
-// follow-up; for now the user must pass --no-sync.
-func rejectSyncOptions(req RunRequest) error {
-	if err := core.RejectDelegatedSyncOptions(providerName, req); err != nil {
-		return err
-	}
-	if !req.NoSync {
-		return exit(2, "provider=tensorlake requires --no-sync; archive sync via tensorlake sbx cp is not implemented yet")
-	}
-	return nil
 }

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -1,0 +1,201 @@
+package tensorlake
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type tensorlakeCLI struct {
+	cfg Config
+	rt  Runtime
+}
+
+func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
+	if strings.TrimSpace(cfg.Tensorlake.APIKey) == "" {
+		return nil, exit(2, "provider=tensorlake requires TENSORLAKE_API_KEY")
+	}
+	if rt.Exec == nil {
+		return nil, exit(2, "provider=tensorlake requires Runtime.Exec")
+	}
+	return &tensorlakeCLI{cfg: cfg, rt: rt}, nil
+}
+
+func (c *tensorlakeCLI) binary() string {
+	return blank(strings.TrimSpace(c.cfg.Tensorlake.CLIPath), defaultCLIPath)
+}
+
+func (c *tensorlakeCLI) globalArgs() []string {
+	var args []string
+	if v := strings.TrimSpace(c.cfg.Tensorlake.APIURL); v != "" {
+		args = append(args, "--api-url", v)
+	}
+	if v := strings.TrimSpace(c.cfg.Tensorlake.OrganizationID); v != "" {
+		args = append(args, "--organization", v)
+	}
+	if v := strings.TrimSpace(c.cfg.Tensorlake.ProjectID); v != "" {
+		args = append(args, "--project", v)
+	}
+	if v := strings.TrimSpace(c.cfg.Tensorlake.Namespace); v != "" {
+		args = append(args, "--namespace", v)
+	}
+	return args
+}
+
+func (c *tensorlakeCLI) env() []string {
+	env := append([]string{}, os.Environ()...)
+	env = append(env, "TENSORLAKE_API_KEY="+c.cfg.Tensorlake.APIKey)
+	if v := strings.TrimSpace(c.cfg.Tensorlake.APIURL); v != "" {
+		env = append(env, "TENSORLAKE_API_URL="+v)
+	}
+	return env
+}
+
+// runQuiet runs a tensorlake CLI subcommand and captures stdout/stderr.
+// Returns trimmed stdout on success, or an error on non-zero exit.
+func (c *tensorlakeCLI) runQuiet(ctx context.Context, sub []string, args []string) (string, error) {
+	full := append([]string{}, c.globalArgs()...)
+	full = append(full, sub...)
+	full = append(full, args...)
+	var stdout, stderr bytes.Buffer
+	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   c.binary(),
+		Args:   full,
+		Env:    c.env(),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return strings.TrimSpace(stdout.String()), tensorlakeError(strings.Join(sub, " "), res.ExitCode, &stdout, &stderr, err)
+	}
+	if res.ExitCode != 0 {
+		return strings.TrimSpace(stdout.String()), tensorlakeError(strings.Join(sub, " "), res.ExitCode, &stdout, &stderr, nil)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// runStreamed runs a tensorlake CLI subcommand and streams output to the
+// provided writers. Non-zero exit codes are reported via the int return,
+// not as an error — callers must propagate them as the wrapped command's
+// exit. Errors are reserved for transport-level failures (binary missing,
+// I/O errors).
+func (c *tensorlakeCLI) runStreamed(ctx context.Context, sub []string, args []string, stdout, stderr io.Writer) (int, error) {
+	full := append([]string{}, c.globalArgs()...)
+	full = append(full, sub...)
+	full = append(full, args...)
+	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   c.binary(),
+		Args:   full,
+		Env:    c.env(),
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+	if err != nil && res.ExitCode == 0 {
+		return res.ExitCode, fmt.Errorf("tensorlake %s: %w", strings.Join(sub, " "), err)
+	}
+	return res.ExitCode, nil
+}
+
+func (c *tensorlakeCLI) createSandbox(ctx context.Context, name string) error {
+	args := []string{}
+	if c.cfg.Tensorlake.CPUs > 0 {
+		args = append(args, "-c", trimFloat(c.cfg.Tensorlake.CPUs))
+	}
+	if c.cfg.Tensorlake.MemoryMB > 0 {
+		args = append(args, "-m", strconv.Itoa(c.cfg.Tensorlake.MemoryMB))
+	}
+	if c.cfg.Tensorlake.DiskMB > 0 {
+		args = append(args, "--disk_mb", strconv.Itoa(c.cfg.Tensorlake.DiskMB))
+	}
+	if c.cfg.Tensorlake.TimeoutSecs > 0 {
+		args = append(args, "-t", strconv.Itoa(c.cfg.Tensorlake.TimeoutSecs))
+	}
+	if v := strings.TrimSpace(c.cfg.Tensorlake.Snapshot); v != "" {
+		args = append(args, "-s", v)
+	}
+	if v := strings.TrimSpace(c.cfg.Tensorlake.Image); v != "" {
+		args = append(args, "-i", v)
+	}
+	if c.cfg.Tensorlake.NoInternet {
+		args = append(args, "-N")
+	}
+	args = append(args, name)
+	_, err := c.runQuiet(ctx, []string{"sbx", "create"}, args)
+	return err
+}
+
+func (c *tensorlakeCLI) execStream(ctx context.Context, name, workdir string, command []string, stdout, stderr io.Writer) (int, error) {
+	args := []string{}
+	if v := strings.TrimSpace(workdir); v != "" {
+		args = append(args, "-w", v)
+	}
+	args = append(args, name)
+	args = append(args, command...)
+	return c.runStreamed(ctx, []string{"sbx", "exec"}, args, stdout, stderr)
+}
+
+func (c *tensorlakeCLI) terminate(ctx context.Context, name string) error {
+	_, err := c.runQuiet(ctx, []string{"sbx", "terminate"}, []string{name})
+	return err
+}
+
+func (c *tensorlakeCLI) describe(ctx context.Context, name string) (string, error) {
+	return c.runQuiet(ctx, []string{"sbx", "describe"}, []string{name})
+}
+
+func (c *tensorlakeCLI) listIDs(ctx context.Context) ([]string, error) {
+	out, err := c.runQuiet(ctx, []string{"sbx", "ls"}, []string{"-q"})
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	ids := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			ids = append(ids, line)
+		}
+	}
+	return ids, nil
+}
+
+func tensorlakeError(action string, exitCode int, stdout, stderr *bytes.Buffer, runErr error) error {
+	tail := strings.TrimSpace(stderr.String())
+	if tail == "" {
+		tail = strings.TrimSpace(stdout.String())
+	}
+	if len(tail) > 4096 {
+		tail = tail[:4096]
+	}
+	if runErr != nil {
+		return fmt.Errorf("tensorlake %s (exit=%d): %v: %s", action, exitCode, runErr, tail)
+	}
+	return fmt.Errorf("tensorlake %s exited %d: %s", action, exitCode, tail)
+}
+
+func trimFloat(v float64) string {
+	s := strconv.FormatFloat(v, 'f', -1, 64)
+	return s
+}
+
+// rejectSyncOptions refuses Crabbox sync flags that have no Tensorlake-side
+// implementation in v1. Archive sync via `tensorlake sbx cp` + tar is a
+// follow-up; for now the user must pass --no-sync.
+func rejectSyncOptions(req RunRequest) error {
+	if err := core.RejectDelegatedSyncOptions(providerName, req); err != nil {
+		return err
+	}
+	if !req.NoSync {
+		return exit(2, "provider=tensorlake requires --no-sync; archive sync via tensorlake sbx cp is not implemented yet")
+	}
+	return nil
+}

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -1,0 +1,80 @@
+package tensorlake
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type TensorlakeConfig = core.TensorlakeConfig
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+type LocalCommandRequest = core.LocalCommandRequest
+
+const (
+	providerName     = "tensorlake"
+	leasePrefix      = "tlsbx_"
+	namePrefix       = "crabbox-"
+	defaultAPIURL    = "https://api.tensorlake.ai"
+	defaultCLIPath   = "tensorlake"
+	defaultCPUs      = 1
+	defaultMemoryMB  = 1024
+	defaultDiskMB    = 10240
+	defaultWorkdir   = "/workspace"
+	targetLinux      = core.TargetLinux
+	NetworkPublic    = core.NetworkPublic
+	statusViewReady  = "running"
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -41,6 +41,9 @@ const (
 	targetLinux     = core.TargetLinux
 	NetworkPublic   = core.NetworkPublic
 	statusViewReady = "running"
+
+	maxSandboxNameLen    = 63
+	sandboxNameSuffixLen = 6
 )
 
 func exit(code int, format string, args ...any) core.ExitError {
@@ -53,6 +56,14 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -29,18 +29,18 @@ type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
 
 const (
-	providerName     = "tensorlake"
-	leasePrefix      = "tlsbx_"
-	namePrefix       = "crabbox-"
-	defaultAPIURL    = "https://api.tensorlake.ai"
-	defaultCLIPath   = "tensorlake"
-	defaultCPUs      = 1
-	defaultMemoryMB  = 1024
-	defaultDiskMB    = 10240
-	defaultWorkdir   = "/workspace"
-	targetLinux      = core.TargetLinux
-	NetworkPublic    = core.NetworkPublic
-	statusViewReady  = "running"
+	providerName    = "tensorlake"
+	leasePrefix     = "tlsbx_"
+	namePrefix      = "crabbox-"
+	defaultAPIURL   = "https://api.tensorlake.ai"
+	defaultCLIPath  = "tensorlake"
+	defaultCPUs     = 1
+	defaultMemoryMB = 1024
+	defaultDiskMB   = 10240
+	defaultWorkdir  = "/workspace"
+	targetLinux     = core.TargetLinux
+	NetworkPublic   = core.NetworkPublic
+	statusViewReady = "running"
 )
 
 func exit(code int, format string, args ...any) core.ExitError {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -78,3 +78,29 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes []string) (core.SyncManifest, error) {
+	return core.BuildSyncManifest(root, excludes)
+}
+
+func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+type SyncManifest = core.SyncManifest

--- a/internal/providers/tensorlake/env.go
+++ b/internal/providers/tensorlake/env.go
@@ -1,0 +1,86 @@
+package tensorlake
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+func (b *tensorlakeBackend) uploadEnvProfile(ctx context.Context, cli *tensorlakeCLI, sandboxID string, env map[string]string) (string, func(), error) {
+	if len(env) == 0 {
+		return "", func() {}, nil
+	}
+	file, err := os.CreateTemp("", "crabbox-tensorlake-env-*.sh")
+	if err != nil {
+		return "", nil, fmt.Errorf("create tensorlake env profile: %w", err)
+	}
+	localPath := file.Name()
+	cleanupLocal := func() { _ = os.Remove(localPath) }
+	keep := false
+	defer func() {
+		_ = file.Close()
+		if !keep {
+			cleanupLocal()
+		}
+	}()
+	if _, err := file.WriteString(formatTensorlakeShellEnvFile(env)); err != nil {
+		return "", nil, fmt.Errorf("write tensorlake env profile: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return "", nil, fmt.Errorf("close tensorlake env profile: %w", err)
+	}
+	remotePath := "/tmp/crabbox-env-" + randomSuffix() + ".sh"
+	if err := cli.uploadFile(ctx, sandboxID, localPath, remotePath); err != nil {
+		return "", nil, err
+	}
+	keep = true
+	cleanup := func() {
+		cleanupLocal()
+		if err := cli.execShell(context.Background(), sandboxID, "rm -f "+shellQuote(remotePath)); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: tensorlake env profile cleanup failed for %s: %v\n", sandboxID, err)
+		}
+	}
+	return remotePath, cleanup, nil
+}
+
+func formatTensorlakeShellEnvFile(env map[string]string) string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if validTensorlakeEnvName(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("set -a\n")
+	for _, key := range keys {
+		fmt.Fprintf(&b, "%s=%s\n", key, shellQuote(env[key]))
+	}
+	b.WriteString("set +a\n")
+	return b.String()
+}
+
+func wrapCommandWithEnvProfile(command []string, envPath string) []string {
+	script := ". " + shellQuote(envPath) + "\n"
+	if len(command) == 3 && command[0] == "bash" && command[1] == "-lc" {
+		script += command[2]
+	} else {
+		script += "exec " + shellScriptFromArgv(command)
+	}
+	return []string{"bash", "-lc", script}
+}
+
+func validTensorlakeEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/providers/tensorlake/flags.go
+++ b/internal/providers/tensorlake/flags.go
@@ -1,0 +1,79 @@
+package tensorlake
+
+import "flag"
+
+type tensorlakeFlagValues struct {
+	APIURL         *string
+	CLIPath        *string
+	Image          *string
+	Snapshot       *string
+	OrganizationID *string
+	ProjectID      *string
+	Namespace      *string
+	CPUs           *float64
+	MemoryMB       *int
+	DiskMB         *int
+	TimeoutSecs    *int
+	NoInternet     *bool
+}
+
+func RegisterTensorlakeProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return tensorlakeFlagValues{
+		APIURL:         fs.String("tensorlake-api-url", defaults.Tensorlake.APIURL, "Tensorlake API base URL"),
+		CLIPath:        fs.String("tensorlake-cli", defaults.Tensorlake.CLIPath, "Path to the tensorlake CLI binary"),
+		Image:          fs.String("tensorlake-image", defaults.Tensorlake.Image, "Tensorlake sandbox image name"),
+		Snapshot:       fs.String("tensorlake-snapshot", defaults.Tensorlake.Snapshot, "Tensorlake snapshot ID to restore from"),
+		OrganizationID: fs.String("tensorlake-organization-id", defaults.Tensorlake.OrganizationID, "Tensorlake organization ID"),
+		ProjectID:      fs.String("tensorlake-project-id", defaults.Tensorlake.ProjectID, "Tensorlake project ID"),
+		Namespace:      fs.String("tensorlake-namespace", defaults.Tensorlake.Namespace, "Tensorlake namespace"),
+		CPUs:           fs.Float64("tensorlake-cpus", defaults.Tensorlake.CPUs, "Tensorlake sandbox CPU count"),
+		MemoryMB:       fs.Int("tensorlake-memory-mb", defaults.Tensorlake.MemoryMB, "Tensorlake sandbox memory in MB"),
+		DiskMB:         fs.Int("tensorlake-disk-mb", defaults.Tensorlake.DiskMB, "Tensorlake sandbox root disk in MB"),
+		TimeoutSecs:    fs.Int("tensorlake-timeout-secs", defaults.Tensorlake.TimeoutSecs, "Tensorlake sandbox lifetime timeout in seconds"),
+		NoInternet:     fs.Bool("tensorlake-no-internet", defaults.Tensorlake.NoInternet, "Block outbound internet from the sandbox"),
+	}
+}
+
+func ApplyTensorlakeProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(tensorlakeFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "tensorlake-api-url") {
+		cfg.Tensorlake.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "tensorlake-cli") {
+		cfg.Tensorlake.CLIPath = *v.CLIPath
+	}
+	if flagWasSet(fs, "tensorlake-image") {
+		cfg.Tensorlake.Image = *v.Image
+	}
+	if flagWasSet(fs, "tensorlake-snapshot") {
+		cfg.Tensorlake.Snapshot = *v.Snapshot
+	}
+	if flagWasSet(fs, "tensorlake-organization-id") {
+		cfg.Tensorlake.OrganizationID = *v.OrganizationID
+	}
+	if flagWasSet(fs, "tensorlake-project-id") {
+		cfg.Tensorlake.ProjectID = *v.ProjectID
+	}
+	if flagWasSet(fs, "tensorlake-namespace") {
+		cfg.Tensorlake.Namespace = *v.Namespace
+	}
+	if flagWasSet(fs, "tensorlake-cpus") {
+		cfg.Tensorlake.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "tensorlake-memory-mb") {
+		cfg.Tensorlake.MemoryMB = *v.MemoryMB
+	}
+	if flagWasSet(fs, "tensorlake-disk-mb") {
+		cfg.Tensorlake.DiskMB = *v.DiskMB
+	}
+	if flagWasSet(fs, "tensorlake-timeout-secs") {
+		cfg.Tensorlake.TimeoutSecs = *v.TimeoutSecs
+	}
+	if flagWasSet(fs, "tensorlake-no-internet") {
+		cfg.Tensorlake.NoInternet = *v.NoInternet
+	}
+	return nil
+}

--- a/internal/providers/tensorlake/flags.go
+++ b/internal/providers/tensorlake/flags.go
@@ -10,6 +10,7 @@ type tensorlakeFlagValues struct {
 	OrganizationID *string
 	ProjectID      *string
 	Namespace      *string
+	Workdir        *string
 	CPUs           *float64
 	MemoryMB       *int
 	DiskMB         *int
@@ -26,6 +27,7 @@ func RegisterTensorlakeProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		OrganizationID: fs.String("tensorlake-organization-id", defaults.Tensorlake.OrganizationID, "Tensorlake organization ID"),
 		ProjectID:      fs.String("tensorlake-project-id", defaults.Tensorlake.ProjectID, "Tensorlake project ID"),
 		Namespace:      fs.String("tensorlake-namespace", defaults.Tensorlake.Namespace, "Tensorlake namespace"),
+		Workdir:        fs.String("tensorlake-workdir", defaults.Tensorlake.Workdir, "Absolute working directory inside the sandbox (also used as sync target)"),
 		CPUs:           fs.Float64("tensorlake-cpus", defaults.Tensorlake.CPUs, "Tensorlake sandbox CPU count"),
 		MemoryMB:       fs.Int("tensorlake-memory-mb", defaults.Tensorlake.MemoryMB, "Tensorlake sandbox memory in MB"),
 		DiskMB:         fs.Int("tensorlake-disk-mb", defaults.Tensorlake.DiskMB, "Tensorlake sandbox root disk in MB"),
@@ -59,6 +61,9 @@ func ApplyTensorlakeProviderFlags(cfg *Config, fs *flag.FlagSet, values any) err
 	}
 	if flagWasSet(fs, "tensorlake-namespace") {
 		cfg.Tensorlake.Namespace = *v.Namespace
+	}
+	if flagWasSet(fs, "tensorlake-workdir") {
+		cfg.Tensorlake.Workdir = *v.Workdir
 	}
 	if flagWasSet(fs, "tensorlake-cpus") {
 		cfg.Tensorlake.CPUs = *v.CPUs

--- a/internal/providers/tensorlake/provider.go
+++ b/internal/providers/tensorlake/provider.go
@@ -1,0 +1,38 @@
+package tensorlake
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"tl", "tensorlake-sbx"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    nil,
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterTensorlakeProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyTensorlakeProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewTensorlakeBackend(p.Spec(), cfg, rt), nil
+}

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -1,0 +1,140 @@
+package tensorlake
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+// rejectIncompatibleSyncOptions refuses Crabbox sync flags whose semantics
+// can't be honored on top of `tensorlake sbx cp`. SyncOnly and ChecksumSync
+// require Crabbox-side rsync semantics that the Tensorlake CLI doesn't
+// expose. ForceSyncLarge is rejected by the core delegated-sync gate before
+// we get here, so we don't repeat that check.
+func rejectIncompatibleSyncOptions(req RunRequest) error {
+	if req.SyncOnly {
+		return exit(2, "provider=tensorlake uses archive sync; --sync-only is not supported")
+	}
+	if req.ChecksumSync {
+		return exit(2, "provider=tensorlake uses archive sync; --checksum is not supported")
+	}
+	return nil
+}
+
+// syncWorkspace builds a gzipped tar archive of the repo, uploads it via
+// `tensorlake sbx cp`, and extracts it into the configured workdir. Returns
+// per-phase timings so warmup/run summaries can break the sync down the same
+// way islo and daytona do.
+func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	manifestStart := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStart)
+
+	preflightStart := b.now()
+	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStart)
+
+	prepareStart := b.now()
+	if err := b.prepareWorkspace(ctx, cli, sandboxID, workdir); err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStart)
+
+	archiveStart := b.now()
+	archive, err := createTensorlakeSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := b.now().Sub(archiveStart)
+
+	uploadStart := b.now()
+	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
+	if err := cli.uploadFile(ctx, sandboxID, archive.Name(), remoteArchive); err != nil {
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStart)
+
+	extractStart := b.now()
+	if err := b.extractRemoteArchive(ctx, cli, sandboxID, remoteArchive, workdir); err != nil {
+		// Best-effort cleanup of the remote archive even when extract fails.
+		_ = cli.execShell(context.Background(), sandboxID, "rm -f "+shellQuote(remoteArchive))
+		return nil, 0, err
+	}
+	extractDuration := b.now().Sub(extractStart)
+
+	total := b.now().Sub(start)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "extract", Ms: extractDuration.Milliseconds()},
+		{Name: "tensorlake_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func (b *tensorlakeBackend) prepareWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID, workdir string) error {
+	command := "mkdir -p " + shellQuote(workdir)
+	if b.cfg.Sync.Delete {
+		command = "rm -rf " + shellQuote(workdir) + " && " + command
+	}
+	return cli.execShell(ctx, sandboxID, command)
+}
+
+func (b *tensorlakeBackend) extractRemoteArchive(ctx context.Context, cli *tensorlakeCLI, sandboxID, remoteArchive, workdir string) error {
+	cmd := strings.Join([]string{
+		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
+		"rm -f " + shellQuote(remoteArchive),
+	}, " && ")
+	return cli.execShell(ctx, sandboxID, cmd)
+}
+
+func createTensorlakeSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
+	var input bytes.Buffer
+	input.Write(manifest.NUL())
+	archive, err := os.CreateTemp("", "crabbox-tensorlake-sync-*.tgz")
+	if err != nil {
+		return nil, fmt.Errorf("create sync archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
+	cmd.Stdin = &input
+	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
+	cmd.Stdout = archive
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	keep = true
+	return archive, nil
+}


### PR DESCRIPTION
## Summary

- Adds `provider: tensorlake` as a delegated Linux run provider backed by the `tensorlake sbx ...` CLI.
- Registers aliases `tl` and `tensorlake-sbx`, provider flags, config file/env wiring, docs, and provider registration.
- Uses the Tensorlake-assigned sandbox ID as the canonical local claim (`tlsbx_<id>`) while keeping Crabbox-prefixed sandbox names for readable Tensorlake listings.
- Supports archive sync through `tensorlake sbx cp` plus in-sandbox `tar`, absolute workdirs, timing phases, redacted env allowlist forwarding, `--keep-on-failure`, `--id` reuse, and explicit stop/list/status flows.

## Maintainer fixups

- Rebased on current `main` and resolved provider/config docs drift.
- Added a changelog entry with contributor credit.
- Added secret-safe Tensorlake env forwarding via a temporary uploaded shell profile, so forwarded values are not placed on the local `tensorlake` process argv.
- Added keep-on-failure parity for failed delegated runs.
- Capped generated Tensorlake sandbox names to the CLI's 63-character limit.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `node scripts/build-docs-site.mjs`
- Live Tensorlake: temp git repo, archive sync, `--env-from-profile` + `--allow-env`, command exec, timing JSON, automatic terminate.
- Live Tensorlake: `--keep-on-failure` retained a failed sandbox, reran with `--id`, then `crabbox stop --provider tensorlake` released it.
