### PR TITLE
docs(islo): document ssh access via islo ssh --setup

### DIFF
--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -58,12 +58,16 @@ crabbox stop --provider islo <slug>
   directory under `/workspace`, syncs the local Git-managed working set into
   `/workspace/<islo.workdir>`, streams stdout/stderr from Islo's SSE exec
   endpoint, and returns the remote exit code.
-- `--sync-only` and `--checksum` are rejected because Islo does not expose a
-  Crabbox SSH/rsync target. Large-sync guardrails still apply, and
-  `--force-sync-large` is honored for intentional large archive syncs.
+- `--sync-only` and `--checksum` are rejected because the Crabbox `provider:
+  islo` backend does not yet drive a Crabbox-managed SSH/rsync target. Large-sync
+  guardrails still apply, and `--force-sync-large` is honored for intentional
+  large archive syncs.
 - `list`, `status`, and `stop` use the Islo SDK and return core-rendered
   Crabbox views for Crabbox-created sandboxes only.
 
-Islo is not an SSH lease backend today. Commands that require a Crabbox SSH
-target, such as `ssh`, `vnc`, `code`, and Actions runner hydration, should use
-Hetzner, AWS, static SSH, or Daytona instead.
+Islo sandboxes are reachable interactively over SSH using Islo's own host alias
+(`ssh <sandbox-name>.islo` after `islo ssh --setup`); see
+[Provider: Islo → SSH access](../providers/islo.md#ssh-access) for the recipe.
+Crabbox itself is not yet wired to drive `crabbox ssh`, `vnc`, `code`, or
+Actions runner hydration through that path — for those, use Hetzner, AWS,
+static SSH, or Daytona.

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -82,17 +82,38 @@ preparation and sync.
 
 ## Capabilities
 
-- SSH: no.
+- SSH: not driven by Crabbox. Islo sandboxes are reachable from the host with
+  the OS `ssh` client via the `<sandbox-name>.islo` host alias after a one-time
+  `islo ssh --setup` (see [SSH access](#ssh-access) below). Crabbox itself does
+  not yet route `crabbox ssh`, sync, or run through that path.
 - Crabbox sync: yes, archive sync through the Islo API or chunked exec fallback.
 - Provider sync: no separate Islo CLI sync.
 - Desktop/browser/code: no Crabbox VNC/code surface.
 - Actions hydration: no.
 - Coordinator: no.
 
+## SSH access
+
+Islo provisions a per-sandbox SSH endpoint and configures `~/.ssh/config` for
+you. The sandbox name (the Crabbox-created `crabbox-...` name, or any other
+slug shown by `islo ls`) is the SSH host:
+
+```sh
+islo ssh --setup            # one-time, idempotent; edits ~/.ssh/config
+ssh <sandbox-name>.islo     # interactive shell on the sandbox
+ssh <sandbox-name>.islo pnpm test       # one-shot remote command
+```
+
+This is useful for ad-hoc inspection of a Crabbox-created Islo sandbox while
+`provider: islo` still uses the streaming exec endpoint for `crabbox run`.
+Certificates are minted automatically and cached by the Islo CLI; no key files
+need to be plumbed into Crabbox.
+
 ## Gotchas
 
-- `--sync-only` and `--checksum` are rejected because Islo does not expose a
-  Crabbox SSH/rsync target.
+- `--sync-only` and `--checksum` are rejected because the `provider: islo`
+  backend does not yet expose a Crabbox-managed SSH/rsync target, even though
+  the sandbox is independently reachable with `ssh <sandbox-name>.islo`.
 - Large-sync guardrails still apply. Use `--force-sync-large` when a large Islo
   archive sync is intentional.
 - `--shell` passes the raw shell string to the remote shell path.


### PR DESCRIPTION
## Summary

- Islo CLI now ships `islo ssh --setup`, which configures `~/.ssh/config` so any sandbox is reachable through the OS `ssh` client at `ssh <sandbox-name>.islo` (certificates minted and cached automatically by the Islo CLI).
- The Crabbox `provider: islo` backend itself is **unchanged** in this PR — it still drives `crabbox run` through the SSE exec endpoint and archive sync. Wiring `crabbox ssh`/rsync/Actions hydration into the new SSH path is a separate, larger change.
- Existing docs asserted *"Islo is not an SSH lease backend today"* and *"SSH: no"* without telling operators that an out-of-band SSH path into a Crabbox-created Islo sandbox already exists. This PR corrects `docs/providers/islo.md` and `docs/features/islo.md` and adds a short SSH-access recipe under the Islo provider page.

## Verification

Live check against `islo` CLI v`0.26.0-dev.115` and a Crabbox-created sandbox `openclaw-public`:

```
$ islo ssh --setup
✓ SSH config already configured
$ ssh openclaw-public.islo 'echo ok; uname -srm; whoami'
ok
Linux 6.16.9+ x86_64
islo
```

Docs gate (per `package.json` → `docs:check`):

- [x] `node scripts/check-docs-links.mjs` — 113 markdown files: internal links ok
- [x] `node scripts/check-command-docs.mjs` — 35 command docs: command surface ok
- [x] `node scripts/build-docs-site.mjs` — built `dist/docs-site`

## Test plan

- [ ] Maintainers confirm the new \"SSH access\" section is the recipe they want surfaced (vs. a follow-up that wires `provider: islo` directly into the Crabbox SSH/rsync path).
- [ ] Optional: file a follow-up issue for the larger `provider: islo` SSH-lease integration (`core.FeatureSSH`, per-lease key minting, `Acquire` returning a `LeaseTarget` over `<name>.islo`, swap archive sync for rsync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)