### PR TITLE
feat: add Proxmox template helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `crabbox run --preflight`, `--capture-stderr`, automatic failure bundles, env-forwarding summaries, and `CRABBOX_PHASE:<name>` timing markers for easier live/provider run debugging.
 - Added `crabbox run --keep-on-failure` so failed one-shot runs can leave the exact lease available for SSH inspection until idle/TTL expiry.
 - Added `provider: proxmox` for direct Proxmox VE Linux QEMU VM leases, including template clone, cloud-init SSH key injection, guest-agent bootstrap, docs, and cleanup support.
+- Added `scripts/proxmox-build-template.sh` to build a Crabbox-ready Ubuntu 24.04 Proxmox template from a public cloud image. Thanks @VACInc.
 - Added `crabbox azure login` so direct Azure users can persist the active `az login` subscription, tenant, and location without manually exporting service-principal environment variables. Thanks @galiniliev.
 - Added `azure.network` / `CRABBOX_AZURE_NETWORK` so Azure direct leases can SSH through private VNet addresses when using VPN/private-network access. Thanks @galiniliev.
 

--- a/docs/providers/proxmox.md
+++ b/docs/providers/proxmox.md
@@ -55,6 +55,48 @@ Crabbox sets:
 If the guest agent does not report an IPv4 address or cannot execute the
 bootstrap script, provisioning fails and the cloned VM is deleted.
 
+## Template Build Helper
+
+For a reproducible starting point, Crabbox includes a Proxmox-node helper that
+builds an Ubuntu 24.04 cloud-image template with cloud-init, OpenSSH, the QEMU
+guest agent, and common sync/runtime tools preinstalled.
+
+Run it from a Crabbox checkout on a Proxmox VE node as root:
+
+```sh
+CRABBOX_PROXMOX_TEMPLATE_ID=9400 \
+CRABBOX_PROXMOX_TEMPLATE_NAME=crabbox-ubuntu-2404 \
+CRABBOX_PROXMOX_STORAGE=local-lvm \
+CRABBOX_PROXMOX_BRIDGE=vmbr0 \
+CRABBOX_PROXMOX_USER=crabbox \
+./scripts/proxmox-build-template.sh
+```
+
+The helper downloads the public Ubuntu Noble cloud image, optionally verifies
+`CRABBOX_PROXMOX_IMAGE_SHA256`, customizes a local copy, imports it into the
+selected Proxmox storage, attaches a cloud-init drive, and converts the VM to a
+template. It does not use Proxmox API tokens, Crabbox coordinator tokens, or
+lease SSH keys, and it does not bake secrets into the image.
+
+If the VMID already exists, the helper stops before changing it. Set
+`CRABBOX_PROXMOX_REPLACE_TEMPLATE=1` only when you intentionally want to destroy
+and rebuild that local template.
+
+The resulting config looks like:
+
+```yaml
+provider: proxmox
+proxmox:
+  node: pve1
+  templateId: 9400
+  storage: local-lvm
+  bridge: vmbr0
+  user: crabbox
+```
+
+The helper requires Proxmox's `qm` and `pvesm` commands plus `qemu-img`,
+`virt-customize`, `sha256sum`, and either `curl` or `wget`.
+
 ## Quick Start
 
 Create an API token in Proxmox and give it permission to clone, configure,

--- a/scripts/proxmox-build-template.sh
+++ b/scripts/proxmox-build-template.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Build a Crabbox-ready Proxmox VE QEMU template from a public Ubuntu cloud image.
+
+Run this on a Proxmox VE node as root. It creates a local VM template only; it
+does not use Crabbox API tokens, inject lease SSH keys, or bake secrets into the
+image.
+
+Environment:
+  CRABBOX_PROXMOX_TEMPLATE_ID        VMID to create (default: 9400)
+  CRABBOX_PROXMOX_TEMPLATE_NAME      Template name (default: crabbox-ubuntu-2404)
+  CRABBOX_PROXMOX_STORAGE            Target Proxmox storage (default: local-lvm)
+  CRABBOX_PROXMOX_BRIDGE             Network bridge (default: vmbr0)
+  CRABBOX_PROXMOX_USER               Cloud-init user Crabbox configures (default: crabbox)
+  CRABBOX_PROXMOX_IMAGE_URL          Cloud image URL
+  CRABBOX_PROXMOX_IMAGE_SHA256       Optional expected image sha256
+  CRABBOX_PROXMOX_CORES              Template vCPU count (default: 2)
+  CRABBOX_PROXMOX_MEMORY_MB          Template memory in MiB (default: 4096)
+  CRABBOX_PROXMOX_DISK_SIZE          Final root disk size, qm syntax (default: 32G)
+  CRABBOX_PROXMOX_REPLACE_TEMPLATE   Destroy an existing VM/template first when set to 1
+
+Example:
+  CRABBOX_PROXMOX_STORAGE=local-lvm ./scripts/proxmox-build-template.sh
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+template_id="${CRABBOX_PROXMOX_TEMPLATE_ID:-9400}"
+template_name="${CRABBOX_PROXMOX_TEMPLATE_NAME:-crabbox-ubuntu-2404}"
+storage="${CRABBOX_PROXMOX_STORAGE:-local-lvm}"
+bridge="${CRABBOX_PROXMOX_BRIDGE:-vmbr0}"
+vm_user="${CRABBOX_PROXMOX_USER:-crabbox}"
+image_url="${CRABBOX_PROXMOX_IMAGE_URL:-https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img}"
+image_sha256="${CRABBOX_PROXMOX_IMAGE_SHA256:-}"
+cores="${CRABBOX_PROXMOX_CORES:-2}"
+memory_mb="${CRABBOX_PROXMOX_MEMORY_MB:-4096}"
+disk_size="${CRABBOX_PROXMOX_DISK_SIZE:-32G}"
+replace_template="${CRABBOX_PROXMOX_REPLACE_TEMPLATE:-0}"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+fetch_image() {
+  local url="$1"
+  local dest="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL --retry 3 --output "$dest" "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$dest" "$url"
+  else
+    die "missing curl or wget"
+  fi
+}
+
+if [[ "${EUID}" -ne 0 ]]; then
+  die "run this script on a Proxmox VE node as root"
+fi
+
+is_uint "$template_id" || die "CRABBOX_PROXMOX_TEMPLATE_ID must be numeric"
+is_uint "$cores" || die "CRABBOX_PROXMOX_CORES must be numeric"
+is_uint "$memory_mb" || die "CRABBOX_PROXMOX_MEMORY_MB must be numeric"
+
+need_cmd qm
+need_cmd pvesm
+need_cmd virt-customize
+need_cmd qemu-img
+need_cmd sha256sum
+need_cmd awk
+
+if qm status "$template_id" >/dev/null 2>&1; then
+  if [[ "$replace_template" == "1" ]]; then
+    printf 'destroying existing VM/template %s before rebuild\n' "$template_id" >&2
+    qm destroy "$template_id" --purge 1
+  else
+    die "VMID $template_id already exists; set CRABBOX_PROXMOX_REPLACE_TEMPLATE=1 to rebuild it"
+  fi
+fi
+
+workdir="$(mktemp -d /var/tmp/crabbox-proxmox-template.XXXXXX)"
+cleanup() {
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+source_image="$workdir/source.img"
+custom_image="$workdir/${template_name}.qcow2"
+
+printf 'downloading %s\n' "$image_url" >&2
+fetch_image "$image_url" "$source_image"
+
+if [[ -n "$image_sha256" ]]; then
+  printf '%s  %s\n' "$image_sha256" "$source_image" | sha256sum -c -
+fi
+
+printf 'customizing image packages and services\n' >&2
+qemu-img convert -O qcow2 "$source_image" "$custom_image"
+virt-customize -a "$custom_image" \
+  --install cloud-init,qemu-guest-agent,openssh-server,ca-certificates,curl,git,jq,rsync,tar \
+  --run-command 'systemctl enable cloud-init qemu-guest-agent ssh || true' \
+  --run-command 'cloud-init clean --logs'
+
+printf 'creating Proxmox template VMID=%s name=%s storage=%s bridge=%s\n' "$template_id" "$template_name" "$storage" "$bridge" >&2
+qm create "$template_id" \
+  --name "$template_name" \
+  --memory "$memory_mb" \
+  --cores "$cores" \
+  --net0 "virtio,bridge=${bridge}" \
+  --serial0 socket \
+  --vga serial0 \
+  --agent enabled=1 \
+  --ostype l26 \
+  --scsihw virtio-scsi-pci
+
+qm importdisk "$template_id" "$custom_image" "$storage"
+
+disk_volume="$(pvesm list "$storage" --vmid "$template_id" | awk -v id="$template_id" 'NR > 1 && $1 ~ ("vm-" id "-disk-") { print $1; exit }')"
+if [[ -z "$disk_volume" ]]; then
+  qm destroy "$template_id" --purge 1
+  die "could not find imported disk volume for VMID $template_id on storage $storage"
+fi
+
+qm set "$template_id" --scsi0 "${disk_volume},discard=on"
+qm set "$template_id" --ide2 "${storage}:cloudinit"
+qm set "$template_id" --boot c --bootdisk scsi0
+qm set "$template_id" --ipconfig0 ip=dhcp --ciuser "$vm_user"
+qm resize "$template_id" scsi0 "$disk_size"
+qm template "$template_id"
+
+cat <<EOF
+Created Crabbox Proxmox template:
+  templateId: $template_id
+  name: $template_name
+  storage: $storage
+  user: $vm_user
+
+Crabbox config:
+  provider: proxmox
+  proxmox:
+    node: <your-proxmox-node>
+    templateId: $template_id
+    storage: $storage
+    bridge: $bridge
+    user: $vm_user
+EOF


### PR DESCRIPTION
## Summary

- Rewrites the original Proxmox-provider PR down to the remaining useful piece after `provider: proxmox` landed on `main`.
- Adds `scripts/proxmox-build-template.sh`, a root-only Proxmox-node helper that builds a Crabbox-ready Ubuntu 24.04 QEMU template from the public cloud image.
- Documents the helper in the Proxmox provider guide and credits @VACInc in the changelog.

## Why This Shape

The provider implementation from this PR was superseded by the current `main` implementation. Replaying it would reintroduce stale config names and older provider behavior. This rewrite keeps the reusable template-build workflow and aligns it with current Crabbox Proxmox config:

- `CRABBOX_PROXMOX_USER` / `proxmox.user`
- `CRABBOX_PROXMOX_INSECURE_TLS`
- current template clone/bootstrap lifecycle

The helper does not use API tokens, coordinator tokens, lease SSH keys, or bake secrets into the image.

## Verification

Local:

```text
bash -n scripts/proxmox-build-template.sh
./scripts/proxmox-build-template.sh --help
shellcheck scripts/proxmox-build-template.sh
npm run docs:check
node scripts/check-docs-links.mjs
node scripts/build-docs-site.mjs
go test ./internal/cli ./internal/providers/proxmox
git diff --cached --check
```

Live Crabbox E2E:

```text
./bin/crabbox run --provider aws --class standard --ttl 30m --idle-timeout 10m --preflight --timing-json -- bash -lc '<template-helper smoke>'
```

Result:

```text
lease=cbx_c2e751d29d49 slug=crimson-shrimp provider=aws type=c7a.8xlarge
sync candidate: 370 files, 3.4 MiB
remote preflight workspace=raw workdir=/work/crabbox/cbx_c2e751d29d49/crabbox hydrate_supported=true
helper-negative-rc=1
proxmox-template-helper-e2e-ok
exit=0
```

That live run synced this rewritten branch to a fresh remote VM, validated the helper is executable, syntax-clean, prints the expected help/config surface, docs/changelog mention it, and fails safely on a non-Proxmox host.

## Not Tested

- Running the template builder on a real Proxmox VE node from this checkout. No `CRABBOX_PROXMOX_*` credentials or reachable Proxmox node are available in this environment.
