### PR TITLE
feat: streamline Azure login and fix Windows sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@
 
 ### Added
 
+- Added `crabbox azure login` so direct Azure users can persist the active `az login` subscription, tenant, and location without manually exporting service-principal environment variables. Thanks @galiniliev.
+- Added `azure.network` / `CRABBOX_AZURE_NETWORK` so Azure direct leases can SSH through private VNet addresses when using VPN/private-network access. Thanks @galiniliev.
+
 ### Changed
 
 - Documented Islo's `islo ssh --setup` host-alias flow for ad-hoc SSH access to Islo sandboxes. Thanks @zozo123.
+- Documented Azure CLI login setup, private-network SSH selection, and regional constraints for reused Azure VNet/subnet/NSG resources. Thanks @galiniliev.
 
 ### Fixed
 
 - Fixed shared-token coordinator auth so caller-supplied `X-Crabbox-Owner` and `X-Crabbox-Org` headers cannot select the authenticated owner/org. Thanks @Hinotoi-agent.
 - Fixed Code, WebVNC, and Egress bridge ticket creation so `use`-shared lease users cannot mint lease-side bridge-agent tickets without manage access. Thanks @Hinotoi-agent.
+- Fixed Windows SSH sync by disabling unsupported OpenSSH ControlMaster multiplexing and preferring WSL rsync/path conversion when available. Thanks @galiniliev.
 
 ## 0.11.0 - 2026-05-11
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -39,4 +39,5 @@ Command docs live here, one file per top-level command. Keep `docs/cli.md` as th
 - [inspect](inspect.md)
 - [stop](stop.md)
 - [cleanup](cleanup.md)
+- [azure](azure.md)
 - [config](config.md)

--- a/docs/commands/azure.md
+++ b/docs/commands/azure.md
@@ -1,0 +1,67 @@
+# azure
+
+`crabbox azure` groups Azure provider setup commands.
+
+## azure login
+
+`crabbox azure login` detects the active Azure subscription from the `az` CLI,
+validates credentials through `DefaultAzureCredential`, and stores subscription,
+tenant, and location in the user config. After this, direct-mode Azure commands
+work without any `export AZURE_*` environment variables.
+
+### Prerequisites
+
+1. Install the [Azure CLI](https://aka.ms/installazurecli).
+2. Run `az login` and select the subscription you want Crabbox to use.
+
+### Usage
+
+```sh
+# Use the active az CLI subscription and default location (eastus):
+crabbox azure login
+
+# Pick a specific subscription:
+crabbox azure login --subscription 00000000-0000-0000-0000-000000000000
+
+# Pick a specific location:
+crabbox azure login --location westus2
+
+# JSON output:
+crabbox azure login --json
+```
+
+After login succeeds, `crabbox warmup --provider azure` and
+`crabbox run --provider azure` work immediately.
+
+### Flags
+
+```text
+--subscription <id|name>    Azure subscription ID or name (default: active az CLI subscription)
+--location <location>       Azure location for provisioning (default: eastus)
+--json                      Print JSON output
+```
+
+### What it does
+
+1. Runs `az account show` to detect the active subscription ID, tenant ID,
+   and subscription name.
+2. Validates that `DefaultAzureCredential` can acquire a token for Azure
+   Resource Manager.
+3. Writes `azure.subscriptionId`, `azure.tenantId`, and `azure.location`
+   to the user config file (e.g. `~/.config/crabbox/config.yaml`).
+4. Sets `provider: azure` if no default provider is configured.
+
+### Auto-resolve
+
+Even without running `crabbox azure login`, if the user config or environment
+does not contain a subscription ID, Crabbox will attempt to detect it from
+`az account show` at runtime. This makes `az login` + `crabbox warmup
+--provider azure` work with zero configuration, though `crabbox azure login`
+is recommended for a persistent setup.
+
+Related docs:
+
+- [Azure provider](../providers/azure.md)
+- [Azure feature guide](../features/azure.md)
+- [login (broker)](login.md)
+- [config](config.md)

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -124,6 +124,10 @@ The first acquire in an empty subscription creates:
 
 These resources are created with `createOrUpdate` and reused across leases.
 Per-lease provisioning creates only the public IP, NIC, VM, and OS disk.
+The shared vnet, subnet, and NSG are Azure regional resources. When reusing an
+existing shared resource group, set `azure.location` / `CRABBOX_AZURE_LOCATION`
+to the same region as the existing vnet and NSG, or choose distinct
+`azure.vnet`, `azure.subnet`, and `azure.nsg` names for a new region.
 
 Azure pricing is not hardcoded. Use `CRABBOX_COST_RATES_JSON` for exact
 Azure cost guardrails.

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -100,6 +100,7 @@ CRABBOX_AZURE_VNET
 CRABBOX_AZURE_SUBNET
 CRABBOX_AZURE_NSG
 CRABBOX_AZURE_SSH_CIDRS
+CRABBOX_AZURE_NETWORK
 ```
 
 The service principal needs the
@@ -126,6 +127,26 @@ Per-lease provisioning creates only the public IP, NIC, VM, and OS disk.
 
 Azure pricing is not hardcoded. Use `CRABBOX_COST_RATES_JSON` for exact
 Azure cost guardrails.
+
+## VPN / Private Network
+
+When connecting through a VPN to the Azure virtual network, set
+`azure.network: private` in config or `CRABBOX_AZURE_NETWORK=private` in the
+environment. This tells Crabbox to use the VM's NIC private IP (e.g.
+`10.42.0.4`) instead of the public IP for SSH connectivity.
+
+```yaml
+azure:
+  network: private
+```
+
+```sh
+export CRABBOX_AZURE_NETWORK=private
+crabbox warmup --provider azure
+```
+
+When `network` is `private` and the NIC has no private IP yet, Crabbox falls
+back to the public IP. The default is `public`.
 
 ## Desktop
 

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -61,6 +61,21 @@ supports ephemeral OS disks; ephemeral-capable sizes use local OS disks,
 while exact `--type` requests for non-ephemeral sizes use managed
 `StandardSSD_LRS` OS disks.
 
+## Quick Start With `az login`
+
+The simplest setup uses the Azure CLI — no environment variables needed:
+
+```sh
+az login
+crabbox azure login
+crabbox warmup --provider azure
+```
+
+`crabbox azure login` detects the active subscription from the `az` CLI,
+validates credentials through `DefaultAzureCredential`, and stores subscription,
+tenant, and location in user config. See the
+[azure command docs](../commands/azure.md) for flags and details.
+
 ## Direct Auth And Env
 
 Service principal env vars consumed by `DefaultAzureCredential`:

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -53,6 +53,7 @@ azure:
   subnet: crabbox-subnet
   nsg: crabbox-nsg
   sshCIDRs: []
+  network: public
 ```
 
 `subscriptionId`, `tenantId`, and `clientId` may be set in config or sourced
@@ -76,7 +77,12 @@ CRABBOX_AZURE_VNET
 CRABBOX_AZURE_SUBNET
 CRABBOX_AZURE_NSG
 CRABBOX_AZURE_SSH_CIDRS
+CRABBOX_AZURE_NETWORK
 ```
+
+`CRABBOX_AZURE_NETWORK` selects the IP used for SSH: `public` (default) uses
+the VM public IP, `private` uses the NIC private IP from the vnet. Use
+`private` when connecting through a VPN to the Azure virtual network.
 
 `AZURE_*` are the standard service principal env vars consumed by
 `DefaultAzureCredential`. Crabbox does not read or print the client secret.

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -214,6 +214,11 @@ WSL2 and macOS remain AWS or static-SSH targets.
 - The first acquire in an empty subscription pays the cost of creating the
   shared resource group, vnet, and NSG. Subsequent acquires only create
   per-lease resources.
+- Shared Azure network resources are regional. If `crabbox-nsg` or
+  `crabbox-vnet` already exists in `westcentralus`, a later acquire configured
+  for `eastus` must either set `azure.location: westcentralus` to reuse that
+  shared infra or use different `azure.vnet` / `azure.subnet` / `azure.nsg`
+  names for the new region.
 - If you already have a resource group / vnet / NSG with the configured
   names, Crabbox will refuse to mutate them unless they carry
   `managed_by=crabbox` as a tag. Either tag them to adopt, choose

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -94,6 +94,21 @@ until the required service-principal secrets are present.
 
 ## Auth
 
+The simplest setup uses the Azure CLI — no environment variables needed:
+
+```sh
+az login
+crabbox azure login
+crabbox warmup --provider azure
+```
+
+`crabbox azure login` detects the active subscription, validates credentials,
+and stores subscription ID, tenant ID, and location in user config. After this,
+`DefaultAzureCredential` picks up the `az login` session automatically.
+
+For service-principal setups (CI, automation, shared environments), use
+environment variables:
+
 If `azure.tenantId` and `azure.clientId` (or `CRABBOX_AZURE_TENANT_ID` /
 `CRABBOX_AZURE_CLIENT_ID`) are configured and `AZURE_CLIENT_SECRET` is set
 in the environment, Crabbox builds a `ClientSecretCredential` from those

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -213,6 +213,7 @@ Global:
 Config:
   crabbox login [--url <url>] [--provider aws|azure|hetzner] [--no-browser]
   crabbox login --url <url> --token-stdin [--provider aws|azure|hetzner]
+  crabbox azure login [--subscription <id>] [--location <loc>] [--json]
   crabbox config path
   crabbox config show [--json]
   crabbox config set-broker --url <url> --token-stdin [--provider aws|azure|hetzner]

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -169,6 +169,7 @@ Commands:
   inspect     Print lease/provider details; add --json for scripts
   stop        Release a lease or delete a direct-provider machine
   cleanup     Sweep expired direct-provider machines or local provider state
+  azure       Azure provider setup and login
   config      Show or update user config
 
 Common Flows:

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -608,7 +608,7 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 			return Server{}, err
 		}
 	}
-	return azureVMToServer(vmResp.VirtualMachine, ""), nil
+	return azureVMToServer(vmResp.VirtualMachine, "", ""), nil
 }
 
 func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string) (*armcompute.OSProfile, error) {
@@ -719,7 +719,7 @@ func (c *AzureClient) WaitForServerIP(ctx context.Context, name string) (Server,
 			if err != nil {
 				return Server{}, err
 			}
-			return azureVMToServer(vm.VirtualMachine, *pip.Properties.IPAddress), nil
+			return azureVMToServer(vm.VirtualMachine, *pip.Properties.IPAddress, c.nicPrivateIP(ctx, name)), nil
 		}
 		if time.Now().After(deadline) {
 			return Server{}, fmt.Errorf("timeout waiting for public ip on %s", name)
@@ -742,7 +742,7 @@ func (c *AzureClient) GetServer(ctx context.Context, name string) (Server, error
 	if pip, err := c.pipc.Get(ctx, c.ResourceGroup, pipName, nil); err == nil && pip.Properties != nil && pip.Properties.IPAddress != nil {
 		ip = *pip.Properties.IPAddress
 	}
-	return azureVMToServer(vm.VirtualMachine, ip), nil
+	return azureVMToServer(vm.VirtualMachine, ip, c.nicPrivateIP(ctx, name)), nil
 }
 
 func (c *AzureClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
@@ -770,7 +770,11 @@ func (c *AzureClient) ListCrabboxServers(ctx context.Context) ([]Server, error) 
 					ip = *pip.Properties.IPAddress
 				}
 			}
-			servers = append(servers, azureVMToServer(*vm, ip))
+			privateIP := ""
+			if vm.Name != nil {
+				privateIP = c.nicPrivateIP(ctx, *vm.Name)
+			}
+			servers = append(servers, azureVMToServer(*vm, ip, privateIP))
 		}
 	}
 	return servers, nil
@@ -862,7 +866,25 @@ func (c *AzureClient) SetTags(ctx context.Context, name string, labels map[strin
 	return nil
 }
 
-func azureVMToServer(vm armcompute.VirtualMachine, ip string) Server {
+// nicPrivateIP reads the private IP from the NIC associated with a VM.
+func (c *AzureClient) nicPrivateIP(ctx context.Context, vmName string) string {
+	nicName := vmName + "-nic"
+	nic, err := c.nicc.Get(ctx, c.ResourceGroup, nicName, nil)
+	if err != nil {
+		return ""
+	}
+	if nic.Properties == nil {
+		return ""
+	}
+	for _, ipCfg := range nic.Properties.IPConfigurations {
+		if ipCfg.Properties != nil && ipCfg.Properties.PrivateIPAddress != nil {
+			return *ipCfg.Properties.PrivateIPAddress
+		}
+	}
+	return ""
+}
+
+func azureVMToServer(vm armcompute.VirtualMachine, ip, privateIP string) Server {
 	s := Server{
 		Provider: "azure",
 		Labels:   map[string]string{},
@@ -878,6 +900,7 @@ func azureVMToServer(vm armcompute.VirtualMachine, ip string) Server {
 		s.ServerType.Name = string(*vm.Properties.HardwareProfile.VMSize)
 	}
 	s.PublicNet.IPv4.IP = ip
+	s.PrivateNet.IPv4.IP = privateIP
 	for k, v := range vm.Tags {
 		if v != nil {
 			s.Labels[azureTagToLabelKey(k)] = *v
@@ -885,6 +908,16 @@ func azureVMToServer(vm armcompute.VirtualMachine, ip string) Server {
 	}
 	normalizeAzureWindowsModeLabel(s.Labels)
 	return s
+}
+
+// AzureServerHost returns the SSH host for an Azure server based on the
+// configured network preference. When network is "private" and a private IP
+// is available, it returns the private IP; otherwise it returns the public IP.
+func AzureServerHost(server Server, network string) string {
+	if strings.EqualFold(network, "private") && server.PrivateNet.IPv4.IP != "" {
+		return server.PrivateNet.IPv4.IP
+	}
+	return server.PublicNet.IPv4.IP
 }
 
 func azureLabelsToTags(labels map[string]string) map[string]*string {

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -57,9 +57,16 @@ type AzureClient struct {
 type azureImageRef struct{ Publisher, Offer, SKU, Version string }
 
 func NewAzureClient(ctx context.Context, cfg Config) (*AzureClient, error) {
-	_ = ctx
 	if cfg.AzureSubscription == "" {
-		return nil, exit(3, "AZURE_SUBSCRIPTION_ID is required for direct azure provider")
+		info, err := azAccountShow(ctx, "")
+		if err != nil {
+			return nil, exit(3, "AZURE_SUBSCRIPTION_ID is required for direct azure provider (or run 'az login' and 'crabbox azure login'): %v", err)
+		}
+		cfg.AzureSubscription = info.ID
+		if cfg.AzureTenant == "" {
+			cfg.AzureTenant = info.TenantID
+		}
+		fmt.Fprintf(os.Stderr, "using azure subscription from az cli: %s (%s)\n", info.Name, info.ID)
 	}
 	if cfg.AzureLocation == "" {
 		return nil, exit(3, "azure location is required (set azure.location or CRABBOX_AZURE_LOCATION)")

--- a/internal/cli/azure_cli.go
+++ b/internal/cli/azure_cli.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type azAccountInfo struct {
+	ID       string `json:"id"`
+	TenantID string `json:"tenantId"`
+	Name     string `json:"name"`
+}
+
+// azAccountShow runs "az account show" and returns the active subscription.
+// If subscription is non-empty it passes --subscription to select a specific one.
+func azAccountShow(ctx context.Context, subscription string) (azAccountInfo, error) {
+	azPath, err := exec.LookPath("az")
+	if err != nil {
+		return azAccountInfo{}, fmt.Errorf("az CLI not found on PATH; install it from https://aka.ms/installazurecli")
+	}
+	args := []string{"account", "show", "--output", "json"}
+	if subscription != "" {
+		args = append(args, "--subscription", subscription)
+	}
+	cmd := exec.CommandContext(ctx, azPath, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := strings.TrimSpace(string(exitErr.Stderr))
+			if stderr != "" {
+				return azAccountInfo{}, fmt.Errorf("az account show: %s", stderr)
+			}
+		}
+		return azAccountInfo{}, fmt.Errorf("az account show: %w", err)
+	}
+	var info azAccountInfo
+	if err := json.Unmarshal(out, &info); err != nil {
+		return azAccountInfo{}, fmt.Errorf("az account show: parse output: %w", err)
+	}
+	if info.ID == "" {
+		return azAccountInfo{}, fmt.Errorf("az account show: subscription ID is empty; run 'az login' first")
+	}
+	return info, nil
+}

--- a/internal/cli/azure_cli_test.go
+++ b/internal/cli/azure_cli_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestAzAccountInfoParsesValidJSON(t *testing.T) {
+	t.Parallel()
+	input := `{"id":"00000000-0000-0000-0000-000000000001","tenantId":"00000000-0000-0000-0000-000000000002","name":"My Subscription"}`
+	var info azAccountInfo
+	if err := json.Unmarshal([]byte(input), &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.ID != "00000000-0000-0000-0000-000000000001" {
+		t.Fatalf("got ID=%q", info.ID)
+	}
+	if info.TenantID != "00000000-0000-0000-0000-000000000002" {
+		t.Fatalf("got TenantID=%q", info.TenantID)
+	}
+	if info.Name != "My Subscription" {
+		t.Fatalf("got Name=%q", info.Name)
+	}
+}
+
+func TestAzAccountInfoRejectsEmptySubscription(t *testing.T) {
+	t.Parallel()
+	input := `{"id":"","tenantId":"tenant","name":"empty"}`
+	var info azAccountInfo
+	if err := json.Unmarshal([]byte(input), &info); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.ID != "" {
+		t.Fatalf("expected empty ID")
+	}
+}
+
+func TestAzAccountShowRequiresAzOnPath(t *testing.T) {
+	t.Parallel()
+	t.Setenv("PATH", "")
+	_, err := azAccountShow(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error when az is not on PATH")
+	}
+	if got := err.Error(); got == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}

--- a/internal/cli/azure_cli_test.go
+++ b/internal/cli/azure_cli_test.go
@@ -37,7 +37,6 @@ func TestAzAccountInfoRejectsEmptySubscription(t *testing.T) {
 }
 
 func TestAzAccountShowRequiresAzOnPath(t *testing.T) {
-	t.Parallel()
 	t.Setenv("PATH", "")
 	_, err := azAccountShow(context.Background(), "")
 	if err == nil {

--- a/internal/cli/azure_login.go
+++ b/internal/cli/azure_login.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+func (a App) azureLogin(ctx context.Context, args []string) error {
+	fs := newFlagSet("azure login", a.Stderr)
+	subscription := fs.String("subscription", "", "Azure subscription ID or name (default: active az CLI subscription)")
+	location := fs.String("location", "eastus", "Azure location for provisioning")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+
+	info, err := azAccountShow(ctx, *subscription)
+	if err != nil {
+		return exit(3, "%v", err)
+	}
+
+	fmt.Fprintf(a.Stderr, "validating azure credentials for subscription %q (%s)...\n", info.Name, info.ID)
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return exit(3, "azure credential: %v", err)
+	}
+	_, err = cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	if err != nil {
+		return exit(3, "azure token acquisition failed: %v\nRun 'az login' to authenticate.", err)
+	}
+
+	path := writableConfigPath()
+	if path == "" {
+		return exit(2, "user config directory is unavailable")
+	}
+	file, err := readFileConfig(path)
+	if err != nil {
+		return err
+	}
+	if file.Azure == nil {
+		file.Azure = &fileAzureConfig{}
+	}
+	file.Azure.SubscriptionID = info.ID
+	file.Azure.TenantID = info.TenantID
+	if *location != "" {
+		file.Azure.Location = *location
+	}
+	if file.Provider == "" {
+		file.Provider = "azure"
+	}
+	written, err := writeUserFileConfig(file)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		result := map[string]string{
+			"subscription": info.ID,
+			"tenant":       info.TenantID,
+			"name":         info.Name,
+			"location":     *location,
+			"configPath":   written,
+		}
+		enc := json.NewEncoder(a.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(a.Stdout, "ok  subscription=%s (%s) tenant=%s location=%s\n", info.ID, info.Name, info.TenantID, *location)
+	fmt.Fprintf(a.Stdout, "config written to %s\n", written)
+	fmt.Fprintf(a.Stdout, "\nYou can now run:\n  crabbox warmup --provider azure\n  crabbox run --provider azure -- <command>\n")
+	return nil
+}

--- a/internal/cli/azure_login_test.go
+++ b/internal/cli/azure_login_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAzureLoginWritesConfigFields(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+
+	file := fileConfig{}
+	if file.Azure == nil {
+		file.Azure = &fileAzureConfig{}
+	}
+	file.Azure.SubscriptionID = "00000000-0000-0000-0000-000000000001"
+	file.Azure.TenantID = "00000000-0000-0000-0000-000000000002"
+	file.Azure.Location = "westus2"
+	file.Provider = "azure"
+
+	written, err := writeUserFileConfig(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if written != cfgPath {
+		t.Fatalf("got path=%q want %q", written, cfgPath)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var readBack fileConfig
+	if err := yaml.Unmarshal(data, &readBack); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if readBack.Provider != "azure" {
+		t.Fatalf("got provider=%q want azure", readBack.Provider)
+	}
+	if readBack.Azure == nil {
+		t.Fatal("azure config section is nil")
+	}
+	if readBack.Azure.SubscriptionID != "00000000-0000-0000-0000-000000000001" {
+		t.Fatalf("got subscriptionId=%q", readBack.Azure.SubscriptionID)
+	}
+	if readBack.Azure.TenantID != "00000000-0000-0000-0000-000000000002" {
+		t.Fatalf("got tenantId=%q", readBack.Azure.TenantID)
+	}
+	if readBack.Azure.Location != "westus2" {
+		t.Fatalf("got location=%q", readBack.Azure.Location)
+	}
+}
+
+func TestAzureLoginPreservesExistingConfig(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+
+	initial := fileConfig{
+		Provider: "hetzner",
+		Broker:   &fileBrokerConfig{URL: "https://crabbox.openclaw.ai", Token: "tok"},
+	}
+	data, _ := yaml.Marshal(initial)
+	if err := os.WriteFile(cfgPath, data, 0o600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	file, err := readFileConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if file.Azure == nil {
+		file.Azure = &fileAzureConfig{}
+	}
+	file.Azure.SubscriptionID = "sub-1"
+	file.Azure.TenantID = "tenant-1"
+	file.Azure.Location = "eastus"
+	// Don't overwrite provider since it's already set
+	if _, err := writeUserFileConfig(file); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	readBack, err := readFileConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if readBack.Provider != "hetzner" {
+		t.Fatalf("provider was overwritten: got %q", readBack.Provider)
+	}
+	if readBack.Broker == nil || readBack.Broker.Token != "tok" {
+		t.Fatal("broker config was lost")
+	}
+	if readBack.Azure == nil || readBack.Azure.SubscriptionID != "sub-1" {
+		t.Fatal("azure config was not written")
+	}
+}

--- a/internal/cli/azure_login_test.go
+++ b/internal/cli/azure_login_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAzureLoginWritesConfigFields(t *testing.T) {
-	t.Parallel()
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "config.yaml")
 	t.Setenv("CRABBOX_CONFIG", cfgPath)
@@ -57,7 +56,6 @@ func TestAzureLoginWritesConfigFields(t *testing.T) {
 }
 
 func TestAzureLoginPreservesExistingConfig(t *testing.T) {
-	t.Parallel()
 	tmp := t.TempDir()
 	cfgPath := filepath.Join(tmp, "config.yaml")
 	t.Setenv("CRABBOX_CONFIG", cfgPath)

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -392,3 +392,24 @@ func TestAzureCredentialForConfigFallsBackToDefault(t *testing.T) {
 		t.Fatalf("got %T, want *azidentity.DefaultAzureCredential", cred)
 	}
 }
+
+func TestNewAzureClientAutoResolvesSubscription(t *testing.T) {
+	// When az CLI is not available and no subscription is set, NewAzureClient
+	// should return an error mentioning both AZURE_SUBSCRIPTION_ID and az login.
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "")
+	t.Setenv("CRABBOX_AZURE_SUBSCRIPTION_ID", "")
+	t.Setenv("PATH", "")
+
+	cfg := defaultConfig()
+	cfg.Provider = "azure"
+	cfg.AzureSubscription = ""
+	cfg.AzureLocation = "eastus"
+
+	_, err := NewAzureClient(t.Context(), cfg)
+	if err == nil {
+		t.Fatal("expected error when no subscription and no az CLI")
+	}
+	if !strings.Contains(err.Error(), "az login") {
+		t.Fatalf("error should mention 'az login': %v", err)
+	}
+}

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -209,7 +209,7 @@ func TestAzureTagsMapReservedWindowsPrefix(t *testing.T) {
 	}
 	server := azureVMToServer(armcompute.VirtualMachine{
 		Tags: stringMapToPtrMap(tags),
-	}, "")
+	}, "", "")
 	if server.Labels["windows_mode"] != "normal" {
 		t.Fatalf("windows_mode label not restored: %#v", server.Labels)
 	}
@@ -411,5 +411,46 @@ func TestNewAzureClientAutoResolvesSubscription(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "az login") {
 		t.Fatalf("error should mention 'az login': %v", err)
+	}
+}
+
+func TestAzureServerHostSelectsPrivateIP(t *testing.T) {
+	t.Parallel()
+	server := Server{}
+	server.PublicNet.IPv4.IP = "20.168.181.119"
+	server.PrivateNet.IPv4.IP = "10.42.0.4"
+
+	if got := AzureServerHost(server, "public"); got != "20.168.181.119" {
+		t.Fatalf("public network: got %q, want public IP", got)
+	}
+	if got := AzureServerHost(server, "private"); got != "10.42.0.4" {
+		t.Fatalf("private network: got %q, want private IP", got)
+	}
+	if got := AzureServerHost(server, ""); got != "20.168.181.119" {
+		t.Fatalf("empty network: got %q, want public IP", got)
+	}
+	if got := AzureServerHost(server, "PRIVATE"); got != "10.42.0.4" {
+		t.Fatalf("case-insensitive: got %q, want private IP", got)
+	}
+}
+
+func TestAzureServerHostFallsBackToPublicWhenNoPrivateIP(t *testing.T) {
+	t.Parallel()
+	server := Server{}
+	server.PublicNet.IPv4.IP = "20.168.181.119"
+
+	if got := AzureServerHost(server, "private"); got != "20.168.181.119" {
+		t.Fatalf("private with no private IP: got %q, want public IP fallback", got)
+	}
+}
+
+func TestAzureVMToServerSetsPrivateIP(t *testing.T) {
+	t.Parallel()
+	server := azureVMToServer(armcompute.VirtualMachine{}, "1.2.3.4", "10.0.0.5")
+	if server.PublicNet.IPv4.IP != "1.2.3.4" {
+		t.Fatalf("public IP: got %q", server.PublicNet.IPv4.IP)
+	}
+	if server.PrivateNet.IPv4.IP != "10.0.0.5" {
+		t.Fatalf("private IP: got %q", server.PrivateNet.IPv4.IP)
 	}
 }

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -48,6 +48,7 @@ type crabboxKongCLI struct {
 	Stop       stopKongCmd       `cmd:"" passthrough:"" help:"Release a lease or delete a direct-provider machine."`
 	Release    releaseKongCmd    `cmd:"" passthrough:"" help:"Alias for stop."`
 	Cleanup    cleanupKongCmd    `cmd:"" passthrough:"" help:"Sweep expired direct-provider machines or local provider state."`
+	Azure      azureKongCmd      `cmd:"" help:"Azure provider setup and login."`
 	Config     configKongCmd     `cmd:"" help:"Show or update user config."`
 	Pool       poolKongCmd       `cmd:"" help:"Alias commands for machine pools."`
 	Machine    machineKongCmd    `cmd:"" help:"Alias commands for direct-provider machines."`
@@ -113,7 +114,7 @@ func normalizeKongHelpArgs(args []string) []string {
 
 func isKongCommandGroup(command string) bool {
 	switch command {
-	case "actions", "admin", "artifacts", "cache", "config", "desktop", "image", "job", "machine", "media", "pool":
+	case "actions", "admin", "artifacts", "azure", "cache", "config", "desktop", "image", "job", "machine", "media", "pool":
 		return true
 	default:
 		return false
@@ -349,6 +350,13 @@ type configKongCmd struct {
 	Show      configShowKongCmd      `cmd:"" passthrough:"" help:"Print merged config without secret values."`
 	SetBroker configSetBrokerKongCmd `cmd:"" name:"set-broker" passthrough:"" help:"Store broker URL and optional tokens in user config."`
 }
+
+type azureKongCmd struct {
+	Login azureLoginKongCmd `cmd:"" passthrough:"" help:"Detect subscription from az CLI, validate credentials, store in user config."`
+}
+type azureLoginKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
 type configPathKongCmd struct{}
 type configShowKongCmd struct {
 	Args []string `arg:"" optional:""`
@@ -505,6 +513,10 @@ func (c *configShowKongCmd) Run(app App) error {
 }
 func (c *configSetBrokerKongCmd) Run(app App) error {
 	return app.configSetBroker(c.Args)
+}
+
+func (c *azureLoginKongCmd) Run(ctx context.Context, app App) error {
+	return app.azureLogin(ctx, c.Args)
 }
 
 func (c *poolListKongCmd) Run(ctx context.Context, app App) error {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	AzureSubnet        string
 	AzureNSG           string
 	AzureSSHCIDRs      []string
+	AzureNetwork       string
 	GCPProject         string
 	gcpProjectExplicit bool
 	GCPZone            string
@@ -494,6 +495,7 @@ type fileAzureConfig struct {
 	Subnet         string   `yaml:"subnet,omitempty"`
 	NSG            string   `yaml:"nsg,omitempty"`
 	SSHCIDRs       []string `yaml:"sshCIDRs,omitempty"`
+	Network        string   `yaml:"network,omitempty"`
 }
 
 type fileGCPConfig struct {
@@ -927,6 +929,9 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 		}
 		if len(file.Azure.SSHCIDRs) > 0 {
 			cfg.AzureSSHCIDRs = file.Azure.SSHCIDRs
+		}
+		if file.Azure.Network != "" {
+			cfg.AzureNetwork = file.Azure.Network
 		}
 	}
 	if file.GCP != nil {
@@ -1461,6 +1466,7 @@ func applyEnv(cfg *Config) {
 	if cidrs := os.Getenv("CRABBOX_AZURE_SSH_CIDRS"); cidrs != "" {
 		cfg.AzureSSHCIDRs = splitCommaList(cidrs)
 	}
+	cfg.AzureNetwork = getenv("CRABBOX_AZURE_NETWORK", cfg.AzureNetwork)
 	if project := os.Getenv("CRABBOX_GCP_PROJECT"); project != "" {
 		cfg.GCPProject = project
 		cfg.gcpProjectExplicit = true

--- a/internal/cli/hcloud.go
+++ b/internal/cli/hcloud.go
@@ -31,6 +31,11 @@ type Server struct {
 			IP string `json:"ip"`
 		} `json:"ipv4"`
 	} `json:"public_net"`
+	PrivateNet struct {
+		IPv4 struct {
+			IP string `json:"ip"`
+		} `json:"ipv4"`
+	} `json:"private_net"`
 	ServerType struct {
 		Name string `json:"name"`
 	} `json:"server_type"`

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -620,7 +620,11 @@ func ensureTrailingSlash(path string) string {
 // rsyncLocalPath converts a Windows drive path like C:/foo to /c/foo so that
 // MSYS2/Cygwin rsync does not interpret the colon as a remote host separator.
 func rsyncLocalPath(path string) string {
-	if runtime.GOOS != "windows" {
+	return rsyncLocalPathForGOOS(runtime.GOOS, path)
+}
+
+func rsyncLocalPathForGOOS(goos, path string) string {
+	if goos != "windows" {
 		return path
 	}
 	path = strings.ReplaceAll(path, `\`, "/")

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -532,7 +532,7 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	if opts.Debug {
 		args = append(args, "--stats", "--itemize-changes", "--progress")
 	}
-	args = append(args, ensureTrailingSlash(src), target.User+"@"+target.Host+":"+dst+"/")
+	args = append(args, ensureTrailingSlash(rsyncLocalPath(src)), target.User+"@"+target.Host+":"+dst+"/")
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, "rsync", args...)
 	if opts.UseFilesFrom {
@@ -610,6 +610,20 @@ func ensureTrailingSlash(path string) string {
 		return path
 	}
 	return path + "/"
+}
+
+// rsyncLocalPath converts a Windows drive path like C:/foo to /c/foo so that
+// MSYS2/Cygwin rsync does not interpret the colon as a remote host separator.
+func rsyncLocalPath(path string) string {
+	if runtime.GOOS != "windows" {
+		return path
+	}
+	path = strings.ReplaceAll(path, `\`, "/")
+	if len(path) >= 2 && path[1] == ':' {
+		drive := strings.ToLower(string(path[0]))
+		return "/" + drive + path[2:]
+	}
+	return path
 }
 
 func shellQuote(s string) string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -534,7 +534,12 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	}
 	args = append(args, ensureTrailingSlash(rsyncLocalPath(src)), target.User+"@"+target.Host+":"+dst+"/")
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, "rsync", args...)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = windowsRsyncCommand(ctx, target, args)
+	} else {
+		cmd = exec.CommandContext(ctx, "rsync", args...)
+	}
 	if opts.UseFilesFrom {
 		cmd.Stdin = bytes.NewReader(opts.FilesFrom)
 	}
@@ -622,6 +627,57 @@ func rsyncLocalPath(path string) string {
 	if len(path) >= 2 && path[1] == ':' {
 		drive := strings.ToLower(string(path[0]))
 		return "/" + drive + path[2:]
+	}
+	return path
+}
+
+// windowsRsyncCommand builds an exec.Cmd for rsync on Windows.
+// MSYS2/Cygwin rsync has broken signal handling with Windows SSH child
+// processes, so we prefer WSL rsync when available. The SSH key is copied
+// into WSL /tmp with correct permissions, and local source paths are
+// converted from /c/... to /mnt/c/... for WSL's filesystem mount.
+func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *exec.Cmd {
+	if _, err := exec.LookPath("wsl"); err != nil {
+		// No WSL — fall back to native rsync with MSYS2 workarounds.
+		cmd := exec.CommandContext(ctx, "rsync", args...)
+		cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
+		return cmd
+	}
+	// Convert args for WSL: source paths /c/... -> /mnt/c/... and
+	// SSH key paths need copying with chmod 600.
+	wslArgs := make([]string, len(args))
+	for i, arg := range args {
+		wslArgs[i] = windowsToWSLPath(arg)
+	}
+	if target.Key != "" {
+		wslKey := "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
+		cpCmd := exec.Command("wsl", "bash", "-c",
+			fmt.Sprintf("cp %s %s 2>/dev/null; chmod 600 %s 2>/dev/null",
+				shellQuote(windowsToWSLPath(target.Key)),
+				shellQuote(wslKey),
+				shellQuote(wslKey)))
+		_ = cpCmd.Run()
+		// Replace key path in the -e ssh string
+		for i, arg := range wslArgs {
+			if strings.Contains(arg, windowsToWSLPath(target.Key)) {
+				wslArgs[i] = strings.ReplaceAll(arg, windowsToWSLPath(target.Key), wslKey)
+			}
+		}
+	}
+	return exec.CommandContext(ctx, "wsl", append([]string{"rsync"}, wslArgs...)...)
+}
+
+// windowsToWSLPath converts a POSIX-ified Windows path (/c/Users/...)
+// to a WSL mount path (/mnt/c/Users/...). Passes through other paths.
+func windowsToWSLPath(path string) string {
+	path = strings.ReplaceAll(path, `\`, "/")
+	if len(path) >= 2 && path[1] == ':' {
+		drive := strings.ToLower(string(path[0]))
+		return "/mnt/" + drive + path[2:]
+	}
+	// /c/foo -> /mnt/c/foo
+	if len(path) >= 3 && path[0] == '/' && path[2] == '/' && path[1] >= 'a' && path[1] <= 'z' {
+		return "/mnt" + path
 	}
 	return path
 }

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -634,8 +634,8 @@ func rsyncLocalPath(path string) string {
 // windowsRsyncCommand builds an exec.Cmd for rsync on Windows.
 // MSYS2/Cygwin rsync has broken signal handling with Windows SSH child
 // processes, so we prefer WSL rsync when available. The SSH key is copied
-// into WSL /tmp with correct permissions, and local source paths are
-// converted from /c/... to /mnt/c/... for WSL's filesystem mount.
+// into WSL /tmp with correct permissions, and paths within args are
+// converted to WSL mount paths.
 func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *exec.Cmd {
 	if _, err := exec.LookPath("wsl"); err != nil {
 		// No WSL — fall back to native rsync with MSYS2 workarounds.
@@ -643,43 +643,85 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
 		return cmd
 	}
-	// Convert args for WSL: source paths /c/... -> /mnt/c/... and
-	// SSH key paths need copying with chmod 600.
-	wslArgs := make([]string, len(args))
-	for i, arg := range args {
-		wslArgs[i] = windowsToWSLPath(arg)
-	}
+
+	// Prepare WSL key: copy with correct permissions.
+	wslKey := ""
+	knownHostsPath := ""
 	if target.Key != "" {
-		wslKey := "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
+		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
+		knownHostsPath = filepath.Join(filepath.Dir(target.Key), "known_hosts")
 		cpCmd := exec.Command("wsl", "bash", "-c",
-			fmt.Sprintf("cp %s %s 2>/dev/null; chmod 600 %s 2>/dev/null",
-				shellQuote(windowsToWSLPath(target.Key)),
+			fmt.Sprintf("mkdir -p /tmp && cp %s %s 2>/dev/null; chmod 600 %s 2>/dev/null",
+				shellQuote(windowsToWSLMountPath(target.Key)),
 				shellQuote(wslKey),
 				shellQuote(wslKey)))
 		_ = cpCmd.Run()
-		// Replace key path in the -e ssh string
-		for i, arg := range wslArgs {
-			if strings.Contains(arg, windowsToWSLPath(target.Key)) {
-				wslArgs[i] = strings.ReplaceAll(arg, windowsToWSLPath(target.Key), wslKey)
-			}
+	}
+
+	// Convert all args: replace Windows paths inside strings (including
+	// the -e "ssh ..." arg which embeds key and known_hosts paths).
+	wslArgs := make([]string, len(args))
+	for i, arg := range args {
+		converted := windowsToWSLPath(arg)
+		// Replace key path with WSL temp copy inside -e string
+		if wslKey != "" && target.Key != "" {
+			keyWSL := windowsToWSLMountPath(target.Key)
+			converted = strings.ReplaceAll(converted, keyWSL, wslKey)
 		}
+		// Replace known_hosts path
+		if knownHostsPath != "" {
+			khWSL := windowsToWSLMountPath(knownHostsPath)
+			wslKH := wslKey + "-known_hosts"
+			converted = strings.ReplaceAll(converted, khWSL, wslKH)
+		}
+		wslArgs[i] = converted
 	}
 	return exec.CommandContext(ctx, "wsl", append([]string{"rsync"}, wslArgs...)...)
 }
 
-// windowsToWSLPath converts a POSIX-ified Windows path (/c/Users/...)
-// to a WSL mount path (/mnt/c/Users/...). Passes through other paths.
-func windowsToWSLPath(path string) string {
+// windowsToWSLMountPath converts a single Windows path to WSL /mnt/ form.
+func windowsToWSLMountPath(path string) string {
 	path = strings.ReplaceAll(path, `\`, "/")
 	if len(path) >= 2 && path[1] == ':' {
 		drive := strings.ToLower(string(path[0]))
 		return "/mnt/" + drive + path[2:]
 	}
-	// /c/foo -> /mnt/c/foo
 	if len(path) >= 3 && path[0] == '/' && path[2] == '/' && path[1] >= 'a' && path[1] <= 'z' {
 		return "/mnt" + path
 	}
 	return path
+}
+
+// windowsToWSLPath converts Windows paths found anywhere in a string to
+// WSL mount paths. Handles both C:\... and /c/... formats embedded in
+// larger strings (like the -e "ssh -i C:\path\key ..." argument).
+func windowsToWSLPath(s string) string {
+	s = strings.ReplaceAll(s, `\`, "/")
+	// Replace drive-letter paths: C:/... -> /mnt/c/...
+	for i := 0; i < len(s)-2; i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') && s[i+1] == ':' && s[i+2] == '/' {
+			// Only replace if at start of string or preceded by a non-path char
+			if i == 0 || s[i-1] == ' ' || s[i-1] == '\'' || s[i-1] == '"' || s[i-1] == '=' {
+				drive := strings.ToLower(string(c))
+				s = s[:i] + "/mnt/" + drive + s[i+2:]
+				i += 4 // skip past /mnt/X
+			}
+		}
+	}
+	// Also handle /c/... -> /mnt/c/... (from rsyncLocalPath conversion)
+	for i := 0; i < len(s)-2; i++ {
+		if s[i] == '/' && s[i+1] >= 'a' && s[i+1] <= 'z' && s[i+2] == '/' {
+			if i == 0 || s[i-1] == ' ' || s[i-1] == '\'' || s[i-1] == '"' || s[i-1] == '=' {
+				// Avoid converting remote paths like crabbox@host:/work
+				if i == 0 || s[i-1] != ':' {
+					s = s[:i] + "/mnt" + s[i:]
+					i += 4
+				}
+			}
+		}
+	}
+	return s
 }
 
 func shellQuote(s string) string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -443,6 +443,11 @@ func sshBaseArgsWithOptions(target SSHTarget, connectTimeout, connectionAttempts
 	}
 	if target.AuthSecret {
 		args = append(args, "-o", "ControlMaster=no")
+	} else if runtime.GOOS == "windows" {
+		// Windows OpenSSH does not support Unix domain sockets for
+		// connection multiplexing; ControlMaster causes
+		// "getsockname failed: Not a socket" errors.
+		args = append(args, "-o", "ControlMaster=no")
 	} else {
 		args = append(args,
 			"-o", "ControlMaster=auto",

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -485,10 +485,10 @@ func TestRsyncLocalPathConvertsWindowsDrivePath(t *testing.T) {
 		t.Skip("Windows-only test")
 	}
 	tests := map[string]string{
-		"C:/OpenClaw/crabbox":  "/c/OpenClaw/crabbox",
-		"D:\\Users\\test":      "/d/Users/test",
-		"/already/posix":       "/already/posix",
-		"relative/path":        "relative/path",
+		"C:/OpenClaw/crabbox": "/c/OpenClaw/crabbox",
+		"D:\\Users\\test":     "/d/Users/test",
+		"/already/posix":      "/already/posix",
+		"relative/path":       "relative/path",
 	}
 	for in, want := range tests {
 		got := rsyncLocalPath(in)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -498,6 +498,25 @@ func TestRsyncLocalPathConvertsWindowsDrivePath(t *testing.T) {
 	}
 }
 
+func TestWindowsToWSLPath(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+	tests := map[string]string{
+		"/c/OpenClaw/crabbox":          "/mnt/c/OpenClaw/crabbox",
+		"C:/Users/test":                "/mnt/c/Users/test",
+		"/work/crabbox":                "/work/crabbox",
+		"crabbox@10.0.0.1:/work/":      "crabbox@10.0.0.1:/work/",
+	}
+	for in, want := range tests {
+		got := windowsToWSLPath(in)
+		if got != want {
+			t.Errorf("windowsToWSLPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestRemotePruneSyncManifestDeletesOnlyManagedPaths(t *testing.T) {
 	got := remotePruneSyncManifest("/work/repo")
 	for _, want := range []string{

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -475,6 +476,25 @@ func TestSSHPortCandidatesUseConfiguredFallbacks(t *testing.T) {
 	}
 	if got := sshPortCandidates("2222", []string{}); strings.Join(got, ",") != "2222" {
 		t.Fatalf("sshPortCandidates(disabled fallback)=%v want [2222]", got)
+	}
+}
+
+func TestRsyncLocalPathConvertsWindowsDrivePath(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only test")
+	}
+	tests := map[string]string{
+		"C:/OpenClaw/crabbox":  "/c/OpenClaw/crabbox",
+		"D:\\Users\\test":      "/d/Users/test",
+		"/already/posix":       "/already/posix",
+		"relative/path":        "relative/path",
+	}
+	for in, want := range tests {
+		got := rsyncLocalPath(in)
+		if got != want {
+			t.Errorf("rsyncLocalPath(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -503,16 +503,19 @@ func TestWindowsToWSLPath(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only test")
 	}
-	tests := map[string]string{
-		"/c/OpenClaw/crabbox":          "/mnt/c/OpenClaw/crabbox",
-		"C:/Users/test":                "/mnt/c/Users/test",
-		"/work/crabbox":                "/work/crabbox",
-		"crabbox@10.0.0.1:/work/":      "crabbox@10.0.0.1:/work/",
+	tests := []struct {
+		in, want string
+	}{
+		{"C:/Users/test", "/mnt/c/Users/test"},
+		{"'ssh' '-i' 'C:/Users/galini/key' '-o' 'UserKnownHostsFile=C:/Users/galini/known_hosts'",
+			"'ssh' '-i' '/mnt/c/Users/galini/key' '-o' 'UserKnownHostsFile=/mnt/c/Users/galini/known_hosts'"},
+		{"/work/crabbox", "/work/crabbox"},
+		{"crabbox@10.0.0.1:/work/", "crabbox@10.0.0.1:/work/"},
 	}
-	for in, want := range tests {
-		got := windowsToWSLPath(in)
-		if got != want {
-			t.Errorf("windowsToWSLPath(%q) = %q, want %q", in, got, want)
+	for _, tc := range tests {
+		got := windowsToWSLPath(tc.in)
+		if got != tc.want {
+			t.Errorf("windowsToWSLPath(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -481,9 +480,6 @@ func TestSSHPortCandidatesUseConfiguredFallbacks(t *testing.T) {
 
 func TestRsyncLocalPathConvertsWindowsDrivePath(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-only test")
-	}
 	tests := map[string]string{
 		"C:/OpenClaw/crabbox": "/c/OpenClaw/crabbox",
 		"D:\\Users\\test":     "/d/Users/test",
@@ -491,22 +487,28 @@ func TestRsyncLocalPathConvertsWindowsDrivePath(t *testing.T) {
 		"relative/path":       "relative/path",
 	}
 	for in, want := range tests {
-		got := rsyncLocalPath(in)
+		got := rsyncLocalPathForGOOS("windows", in)
 		if got != want {
 			t.Errorf("rsyncLocalPath(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
 
+func TestRsyncLocalPathPassesThroughNonWindowsPath(t *testing.T) {
+	t.Parallel()
+	if got := rsyncLocalPathForGOOS("linux", "C:/OpenClaw/crabbox"); got != "C:/OpenClaw/crabbox" {
+		t.Fatalf("non-Windows rsyncLocalPath = %q", got)
+	}
+}
+
 func TestWindowsToWSLPath(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-only test")
-	}
 	tests := []struct {
 		in, want string
 	}{
 		{"C:/Users/test", "/mnt/c/Users/test"},
+		{`D:\Users\test`, "/mnt/d/Users/test"},
+		{"/c/OpenClaw/crabbox", "/mnt/c/OpenClaw/crabbox"},
 		{"'ssh' '-i' 'C:/Users/galini/key' '-o' 'UserKnownHostsFile=C:/Users/galini/known_hosts'",
 			"'ssh' '-i' '/mnt/c/Users/galini/key' '-o' 'UserKnownHostsFile=/mnt/c/Users/galini/known_hosts'"},
 		{"/work/crabbox", "/work/crabbox"},

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -74,7 +74,7 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool) (LeaseTa
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	target := sshTargetFromConfig(cfg, azureServerHost(server, cfg.AzureNetwork))
 	if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
 		_ = client.DeleteServer(context.Background(), server.CloudID)
 		return LeaseTarget{}, err
@@ -100,7 +100,7 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 			return LeaseTarget{}, exit(4, "lease/server not found: %s (vm exists but is not Crabbox-managed)", req.ID)
 		}
 		leaseID := blank(server.Labels["lease"], req.ID)
-		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+		target := sshTargetFromConfig(b.Cfg, azureServerHost(server, b.Cfg.AzureNetwork))
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
@@ -111,7 +111,7 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
 		return LeaseTarget{}, err
 	} else if leaseID != "" {
-		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+		target := sshTargetFromConfig(b.Cfg, azureServerHost(server, b.Cfg.AzureNetwork))
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
@@ -202,3 +202,6 @@ func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
 func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
+func azureServerHost(server Server, network string) string {
+	return core.AzureServerHost(server, network)
+}

--- a/scripts/check-command-docs.mjs
+++ b/scripts/check-command-docs.mjs
@@ -83,7 +83,7 @@ console.log(`checked ${commands.length} command docs: command surface ok`);
 function readHelpCommands() {
   const appPath = path.join(root, "internal", "cli", "app.go");
   const app = fs.readFileSync(appPath, "utf8");
-  const match = app.match(/Commands:\n([\s\S]*?)\n\nCommon Flows:/);
+  const match = app.match(/Commands:\r?\n([\s\S]*?)\r?\n\r?\nCommon Flows:/);
   if (!match) {
     fail(`could not find Commands block in ${rel(appPath)}`);
   }


### PR DESCRIPTION
## Summary

This PR improves Azure direct-mode setup and fixes several Windows SSH/rsync sync issues.

The main Azure change is that users can now authenticate with the Azure CLI instead of configuring service-principal environment variables. After `az login`, users can run `crabbox azure login` to persist the active subscription, tenant, and location into Crabbox config, or Crabbox can auto-resolve the active subscription from `az account show` at runtime.

This also adds Azure private-network selection for VPN/private VNet use, and documents the regional constraints around shared Azure network infrastructure.

## Significant Changes

### Azure CLI login flow

- Added `crabbox azure login`.
- Uses `az account show` to detect the active Azure subscription, tenant, and subscription name.
- Validates Azure access through `DefaultAzureCredential`.
- Writes Azure subscription ID, tenant ID, and location to the Crabbox user config.
- Sets `provider: azure` when no provider is already configured.
- Supports `--subscription <id|name>`, `--location <region>`, and `--json`.
- Direct Azure usage no longer requires users to manually export `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, or `AZURE_CLIENT_SECRET` for the common `az login` workflow.
- If no subscription is configured, direct Azure provisioning now attempts to auto-resolve the active Azure CLI subscription before failing.

### Azure private network support

- Added `azure.network` config and `CRABBOX_AZURE_NETWORK`.
- Supports Azure SSH host selection through public or private VM addresses.
- When `azure.network: private` is configured, Crabbox uses the VM NIC private IP when available.
- Falls back to the public IP if no private IP has been discovered yet.
- Azure server records now include `private_net.ipv4.ip`.
- Azure acquire and resolve paths now select the SSH host through the Azure network preference instead of always using the public IP.

### Azure docs

- Added Azure command docs for `crabbox azure login`.
- Updated provider and feature docs to describe the `az login` setup path.
- Documented `CRABBOX_AZURE_NETWORK` and `azure.network`.
- Clarified that shared Azure vnet/subnet/NSG resources are regional. Reusing default shared resource names requires `azure.location` to match the existing resource region, or distinct vnet/subnet/NSG names must be used for a new region.

### Windows SSH and rsync fixes

- Disabled SSH `ControlMaster` on Windows.
  - Windows OpenSSH does not support the Unix-domain socket behavior used by SSH multiplexing.
  - This avoids errors such as `getsockname failed: Not a socket`.
- Fixed Windows local path handling for native rsync.
  - Converts Windows drive paths like `C:\OpenClaw\crabbox` / `C:/OpenClaw/crabbox` into rsync-safe `/c/OpenClaw/crabbox` form.
  - Prevents rsync from interpreting the drive-letter colon as a remote-host separator.
- Added a Windows WSL rsync execution path.
  - Prefers WSL rsync when `wsl.exe` is available to avoid MSYS2/Cygwin rsync signal-handling issues with Windows SSH child processes.
  - Converts Windows paths to WSL mount paths such as `/mnt/c/...`.
  - Converts paths embedded inside the rsync `-e "ssh ..."` argument, including SSH key and known_hosts paths.
  - Copies the SSH private key into WSL `/tmp` and applies `chmod 600` so WSL OpenSSH can use it safely.
- Added Windows-focused tests for rsync path conversion and WSL path conversion.

### Test fixes

- Removed `t.Parallel()` from Azure tests that call `t.Setenv`.
- This avoids Go test runner panics caused by combining parallel tests with process-wide environment mutation.

## Verification

```sh
go test ./internal/cli -run "Azure|AzAccount|RsyncLocalPath|WindowsToWSLPath" -count=1
go test ./internal/providers/azure -count=1
```

Also manually validated Azure config behavior locally with:

```sh
crabbox pool list
```

using Azure provider config and `azure.network: private`.

