### PR TITLE
feat: add Proxmox provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin/
 dist/
 artifacts/
-.crabbox/captures/
+.crabbox/
 node_modules/
 .wrangler/
 *.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `crabbox run --fresh-pr <owner/repo#number>` for fresh remote GitHub PR checkouts, with optional `--apply-local-patch`.
 - Added `crabbox run --preflight`, `--capture-stderr`, automatic failure bundles, env-forwarding summaries, and `CRABBOX_PHASE:<name>` timing markers for easier live/provider run debugging.
 - Added `crabbox run --keep-on-failure` so failed one-shot runs can leave the exact lease available for SSH inspection until idle/TTL expiry.
+- Added `provider: proxmox` for direct Proxmox VE Linux QEMU VM leases, including template clone, cloud-init SSH key injection, guest-agent bootstrap, docs, and cleanup support.
 - Added `crabbox azure login` so direct Azure users can persist the active `az login` subscription, tenant, and location without manually exporting service-principal environment variables. Thanks @galiniliev.
 - Added `azure.network` / `CRABBOX_AZURE_NETWORK` so Azure direct leases can SSH through private VNet addresses when using VPN/private-network access. Thanks @galiniliev.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ Supported providers:
   native Windows, Windows WSL2, and EC2 Mac.
 - [Azure](docs/providers/azure.md) (`provider: azure`): brokered or direct
   Linux and native Windows VMs.
+- [Google Cloud](docs/providers/gcp.md) (`provider: gcp`): brokered or direct
+  Linux Compute Engine VMs.
 - [Hetzner Cloud](docs/providers/hetzner.md) (`provider: hetzner`): brokered or
   direct Linux VMs.
+- [Proxmox](docs/providers/proxmox.md) (`provider: proxmox`): direct Linux QEMU
+  VM clones from private Proxmox VE templates.
 - [Static SSH](docs/providers/ssh.md) (`provider: ssh`): existing Linux, macOS,
   Windows, or WSL2 hosts.
 - [Blacksmith Testbox](docs/providers/blacksmith-testbox.md)
@@ -87,7 +91,7 @@ Every lease has a stable `cbx_...` ID and a friendly crustacean slug (`blue-lobs
 ```text
 your laptop                Cloudflare Worker            cloud provider
 -------------              ------------------           --------------
-crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS EC2 / Azure
+crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS / Azure / GCP
    |                         lease + cost state              |
    |                                                         |
    +------------ SSH + rsync to leased runner <--------------+
@@ -97,7 +101,7 @@ crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS EC2 / Azur
 - **Broker** — Cloudflare Worker at `crabbox.openclaw.ai` plus a single Durable Object. Owns provider credentials, serializes lease state, enforces active-lease and monthly spend caps, and expires stale leases by alarm. Auth is GitHub login or a shared bearer token.
 - **Runner** — a throwaway SSH machine prepared with SSH on the primary port, default `2222`, plus configured fallback ports and Crabbox's sync/run prerequisites. Linux uses Ubuntu with cloud-init and `/work/crabbox`; native Windows uses OpenSSH, Git for Windows, and `C:\crabbox`. No broker credentials live on the box. Project runtimes (Go, Node, Docker, services, secrets) come from your repo's GitHub Actions hydration, devcontainer, Nix, mise/asdf, or setup scripts — not from Crabbox.
 
-A direct-provider mode (`--provider hetzner|aws|azure` with local credentials) exists for debugging the broker itself; the brokered path is the default.
+A direct-provider mode (`--provider hetzner|aws|azure|gcp|proxmox` with local credentials) exists for debugging the broker itself or using private infrastructure; the brokered path is the default where supported.
 
 For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For the doc-to-code map, see [Source Map](docs/source-map.md).
 
@@ -108,12 +112,13 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Run observability.** Every coordinator-backed run gets an early `run_...` handle. Use `crabbox attach <run-id>` while it is active, `crabbox events <run-id> --after <seq> --limit <n>` for durable lifecycle/output events, and `crabbox logs <run-id>` for retained output after completion.
 - **Stable timing records.** `--timing-json` on `run`, `warmup`, and `actions hydrate` gives scripts one machine-readable sync/command/total timing schema across AWS, Hetzner, and Blacksmith Testboxes.
 - **Local-first workspace sync.** No clean-checkout requirement. Tracked + nonignored files only, fingerprint skip on no-op runs, sanity checks against suspicious mass deletions, optional shallow base-ref hydration for changed-test workflows.
-- **Brokered cloud.** Maintainers and agents share infra without sharing provider tokens. Hetzner, AWS EC2, and Azure are managed providers; AWS also owns Windows WSL2 and EC2 Mac targets. Linux defaults to Spot unless capacity config says otherwise. Providers fall back across compatible instance families when capacity or quota rejects a request.
+- **Brokered cloud.** Maintainers and agents share infra without sharing provider tokens. Hetzner, AWS EC2, Azure, and Google Cloud are managed providers; AWS also owns Windows WSL2 and EC2 Mac targets. Linux defaults to Spot unless capacity config says otherwise. Providers fall back across compatible instance families when capacity or quota rejects a request.
 - **Azure Linux and native Windows.** `provider: azure` provisions Linux and native Windows VMs in a configurable Azure subscription using `DefaultAzureCredential` in direct mode or service-principal secrets in the broker. Crabbox creates a shared resource group, vnet, subnet, and NSG on first use, then per-lease public IPs, NICs, and VMs. Linux uses cloud-init; Windows uses VM Agent Custom Script Extension to install OpenSSH/Git and configure the Crabbox user.
 - **macOS and Windows static hosts.** `provider: ssh` reuses existing machines; it does not create macOS or Windows Crabbox boxes. macOS and Windows WSL2 use the POSIX rsync path; native Windows uses PowerShell plus tar archive sync.
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, config conventions, and portal visibility for active external runners.
 - **Namespace Devbox SSH leases.** Set `provider: namespace-devbox` to create or reuse Namespace Devboxes through the `devbox` CLI, then let Crabbox sync the dirty checkout and run commands over SSH.
 - **Semaphore CI testbox.** Set `provider: semaphore` to lease a Semaphore CI job as a testbox. Same environment as your real pipelines.
+- **Proxmox VM clones.** Set `provider: proxmox` to clone Linux QEMU templates on a private Proxmox VE cluster, bootstrap them through the QEMU guest agent, and use normal Crabbox SSH sync/run/cleanup.
 - **Sprites SSH leases.** Set `provider: sprites` to create a Sprites microVM, bootstrap OpenSSH inside it, and let Crabbox sync/run through `sprite proxy` with `crabbox ssh` support.
 - **Daytona, Islo, and E2B sandboxes.** Set `provider: daytona` for Daytona SDK/toolbox execution from a snapshot with explicit SSH access when needed, `provider: islo` for delegated Islo sandbox execution through the Islo Go SDK, or `provider: e2b` for delegated E2B sandbox execution through E2B sandbox APIs.
 - **Trusted AWS images.** Operators can create AMIs from active brokered AWS leases and promote a known-good image as the coordinator default.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ guardrails so individual machines and CLIs never need to.
 ```text
 your laptop                Cloudflare Worker            cloud provider
 -------------              ------------------           --------------
-crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS EC2 / Azure
+crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS / Azure / GCP
    |                         lease + cost state              |
    |                                                         |
    +------------ SSH + rsync to leased runner <--------------+
@@ -87,7 +87,7 @@ Pick whichever matches your intent:
 - **Start here:** [Getting started](getting-started.md), [How Crabbox Works](how-it-works.md), [Concepts and glossary](concepts.md).
 - **Get the mental model:** [Architecture](architecture.md), [Orchestrator](orchestrator.md).
 - **Use the CLI:** [CLI](cli.md), [Commands](commands/README.md), [Features](features/README.md), [Configuration](features/configuration.md), [Jobs](features/jobs.md), [Actions hydration](features/actions-hydration.md), [Browser portal](features/portal.md), [Telemetry](features/telemetry.md).
-- **Pick or add a target:** [Provider reference](providers/README.md), [Providers feature overview](features/providers.md), [Provider authoring](features/provider-authoring.md), [Provider backends](provider-backends.md), [AWS](providers/aws.md), [Azure](providers/azure.md), [Hetzner](providers/hetzner.md), [Static SSH](providers/ssh.md), [Blacksmith Testbox](providers/blacksmith-testbox.md), [Namespace Devbox](providers/namespace-devbox.md), [Semaphore](providers/semaphore.md), [Sprites](providers/sprites.md), [Daytona](providers/daytona.md), [Islo](providers/islo.md), [E2B](providers/e2b.md), [Interactive desktop and VNC](features/interactive-desktop-vnc.md).
+- **Pick or add a target:** [Provider reference](providers/README.md), [Providers feature overview](features/providers.md), [Provider authoring](features/provider-authoring.md), [Provider backends](provider-backends.md), [AWS](providers/aws.md), [Azure](providers/azure.md), [Google Cloud](providers/gcp.md), [Hetzner](providers/hetzner.md), [Proxmox](providers/proxmox.md), [Static SSH](providers/ssh.md), [Blacksmith Testbox](providers/blacksmith-testbox.md), [Namespace Devbox](providers/namespace-devbox.md), [Semaphore](providers/semaphore.md), [Sprites](providers/sprites.md), [Daytona](providers/daytona.md), [Islo](providers/islo.md), [E2B](providers/e2b.md), [Interactive desktop and VNC](features/interactive-desktop-vnc.md).
 - **Operate it:** [Operations](operations.md), [Observability](observability.md), [Troubleshooting](troubleshooting.md), [Performance](performance.md).
 - **Set it up or audit it:** [Infrastructure](infrastructure.md), [Security](security.md), [Source Map](source-map.md), [MVP Plan](mvp-plan.md).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,16 +25,16 @@ Primary output goes to stdout. Progress, diagnostics, and errors go to stderr. J
 
 ```text
 crabbox doctor
-crabbox login [--url <url>] [--provider hetzner|aws|azure] [--no-browser]
-crabbox login --url <url> --token-stdin [--provider hetzner|aws|azure]
+crabbox login [--url <url>] [--provider hetzner|aws|azure|gcp] [--no-browser]
+crabbox login --url <url> --token-stdin [--provider hetzner|aws|azure|gcp]
 crabbox logout
 crabbox whoami [--json]
 crabbox init [--force]
 crabbox config show [--json]
 crabbox config path
-crabbox config set-broker --url <url> --token-stdin [--provider hetzner|aws|azure]
-crabbox warmup [--provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--profile <name>] [--idle-timeout <duration>] [--timing-json]
-crabbox run [--id <lease-id-or-slug>] [--provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--windows-mode normal|wsl2] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--keep-on-failure] [--shell] [--script <file>|--script-stdin] [--fresh-pr <owner/repo#number>] [--allow-env <name>] [--env-from-profile <file>] [--checksum] [--debug] [--force-sync-large] [--preflight] [--capture-stdout <path>] [--capture-stderr <path>] [--capture-on-fail] [--download remote=local] [--timing-json] [--blacksmith-workflow <workflow>] -- <command...>
+crabbox config set-broker --url <url> --token-stdin [--provider hetzner|aws|azure|gcp]
+crabbox warmup [--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--profile <name>] [--idle-timeout <duration>] [--timing-json]
+crabbox run [--id <lease-id-or-slug>] [--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--windows-mode normal|wsl2] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--keep-on-failure] [--shell] [--script <file>|--script-stdin] [--fresh-pr <owner/repo#number>] [--allow-env <name>] [--env-from-profile <file>] [--checksum] [--debug] [--force-sync-large] [--preflight] [--capture-stdout <path>] [--capture-stderr <path>] [--capture-on-fail] [--download remote=local] [--timing-json] [--blacksmith-workflow <workflow>] -- <command...>
 crabbox job list
 crabbox job run [--id <lease-id-or-slug>] [--dry-run] [--no-hydrate] [--stop auto|always|success|failure|never] <name>
 crabbox desktop launch --id <lease-id-or-slug> [--browser] [--url <url>] [--egress <profile>] [--webvnc] [--open] [-- <command...>]

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -62,7 +62,7 @@ and continue with the next candidate.
 ## Flags
 
 ```text
---provider hetzner|aws|azure|namespace-devbox  provider to sweep
+--provider hetzner|aws|azure|gcp|proxmox|namespace-devbox  provider to sweep
 --target linux|macos|windows  for AWS, restrict by target
 --windows-mode normal|wsl2    when target=windows
 --static-host <host>          ignored (provider=ssh has nothing to sweep)

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -15,7 +15,7 @@ Subcommands:
 ```text
 path
 show [--json]
-set-broker --url <url> [--token-stdin] [--admin-token-stdin] [--provider hetzner|aws|azure]
+set-broker --url <url> [--token-stdin] [--admin-token-stdin] [--provider hetzner|aws|azure|gcp]
 ```
 
 `config show` reports broker auth as `auth` and `admin_auth`, plus

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -31,9 +31,9 @@ and the matching `.pub` file. When unset, it skips that check because
 per-lease keys do not need a global key.
 
 When a coordinator is configured, doctor also asks the broker for secret
-readiness for managed brokered providers such as AWS, Azure, and Hetzner. It
+readiness for managed brokered providers such as AWS, Azure, GCP, and Hetzner. It
 reports missing Worker secret names such as `AZURE_TENANT_ID` without exposing
-secret values. Static and delegated providers skip this broker-secret check.
+secret values. Static, Proxmox, and delegated providers skip this broker-secret check.
 
 For the full list of checks, including how each one decides between
 `fail`, `skip`, and `ok`, see
@@ -76,7 +76,7 @@ the exit code.
 ## Flags
 
 ```text
---provider hetzner|aws|azure|ssh   provider to validate
+--provider hetzner|aws|azure|gcp|proxmox|ssh   provider to validate
 --target linux|macos|windows target OS for ssh provider checks
 --windows-mode normal|wsl2   when target=windows
 --static-host <host>         static SSH host

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -40,7 +40,7 @@ included.
 
 ```text
 --id <lease-id-or-slug>      lease to inspect; required for managed providers
---provider hetzner|aws|azure|ssh|namespace-devbox|semaphore|sprites|daytona   override the configured provider
+--provider hetzner|aws|azure|gcp|proxmox|ssh|namespace-devbox|semaphore|sprites|daytona   override the configured provider
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>         static SSH host for provider=ssh

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -40,7 +40,7 @@ lease view.
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
+--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -27,7 +27,7 @@ Flags:
 
 ```text
 --url <url>                 broker URL
---provider hetzner|aws|azure      default provider to store with the broker
+--provider hetzner|aws|azure|gcp  default provider to store with the broker
 --no-browser                print the GitHub login URL instead of opening it
 --token-stdin               read broker token from stdin for operator automation
 --json                      print JSON

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -182,7 +182,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
+--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/commands/ssh.md
+++ b/docs/commands/ssh.md
@@ -27,7 +27,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|azure|ssh|namespace-devbox|semaphore|sprites|daytona
+--provider hetzner|aws|azure|gcp|proxmox|ssh|namespace-devbox|semaphore|sprites|daytona
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -37,7 +37,7 @@ Flags:
 
 ```text
 --id <lease-id-or-slug>
---provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
+--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -32,7 +32,7 @@ host.
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
+--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -98,7 +98,7 @@ On success, `warmup` prints a concise total duration line. Add `--timing-json` t
 Flags:
 
 ```text
---provider hetzner|aws|azure|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
+--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -38,6 +38,7 @@ Read when:
 - [Azure](azure.md): Azure Linux/native Windows, shared infra, capacity, and cleanup.
 - [Google Cloud](../providers/gcp.md): GCP Compute Engine Linux SSH leases.
 - [Hetzner](hetzner.md): Linux-only managed Hetzner behavior, classes, and cleanup.
+- [Proxmox](../providers/proxmox.md): direct Proxmox VE Linux QEMU VM clones.
 - [Blacksmith Testbox](blacksmith-testbox.md): delegated Testbox backend behavior.
 - [Namespace Devbox](namespace-devbox.md): Namespace Devbox SSH leases with Crabbox sync/run.
 - [Namespace Devbox setup](namespace-devbox-setup.md): CLI install, auth token profile, and live checks.

--- a/docs/features/actions-hydration.md
+++ b/docs/features/actions-hydration.md
@@ -8,8 +8,8 @@ Read when:
 
 Actions hydration lets a repository reuse its existing GitHub Actions setup without putting repository-specific setup code in the Crabbox binary.
 
-Runner registration supports POSIX targets: brokered Hetzner/AWS/Azure Linux
-and AWS Windows WSL2. Static macOS and native Windows targets are for direct
+Runner registration supports POSIX targets: brokered Hetzner/AWS/Azure/GCP
+Linux, direct Proxmox Linux, and AWS Windows WSL2. Static macOS and native Windows targets are for direct
 `crabbox run` loops until platform-specific runner installation is added.
 
 The flow:

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -160,6 +160,35 @@ aws:
 Hetzner credentials and image come from broker-side config. Repos do not need
 a `hetzner:` block unless they pin a class or location.
 
+### Google Cloud
+
+```yaml
+provider: gcp
+gcp:
+  project: example-project
+  zone: europe-west2-a
+  network: default
+  rootGB: 400
+```
+
+### Proxmox
+
+```yaml
+provider: proxmox
+proxmox:
+  apiUrl: https://pve.example.test:8006
+  tokenId: crabbox@pve!ci
+  node: pve1
+  templateId: 9000
+  storage: local-lvm
+  bridge: vmbr0
+  user: crabbox
+  workRoot: /work/crabbox
+```
+
+Put `tokenSecret` in a private config file or use
+`CRABBOX_PROXMOX_TOKEN_SECRET`; do not pass it as a command-line flag.
+
 ### Static SSH
 
 ```yaml
@@ -452,6 +481,8 @@ provider-native:
 ```text
 HCLOUD_TOKEN / HETZNER_TOKEN
 AWS_PROFILE / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_CLOUD_PROJECT
+CRABBOX_PROXMOX_TOKEN_ID / CRABBOX_PROXMOX_TOKEN_SECRET
 DAYTONA_API_KEY / DAYTONA_JWT_TOKEN
 BLACKSMITH_*  (read by the Blacksmith CLI)
 ISLO_API_KEY  (read by the Islo SDK)

--- a/docs/features/doctor.md
+++ b/docs/features/doctor.md
@@ -99,7 +99,7 @@ modern version of these tools.
 Doctor stays local on purpose. It does not:
 
 - start a real lease or provision a server;
-- talk to AWS, Hetzner, Daytona, Islo, or any provider API;
+- talk to any cloud, Proxmox, or delegated provider API;
 - run `git ls-files` against the repo (that belongs in `crabbox sync-plan`);
 - estimate costs;
 - modify config or rotate keys.

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -59,7 +59,8 @@ the address is already on the tailnet.
 ## Public Reachability
 
 Brokered AWS Linux, AWS Windows, AWS Mac, Azure Linux, Azure native Windows,
-Hetzner Linux, Daytona, and Islo leases all expose at least one public address.
+Google Cloud, Hetzner Linux, Proxmox, Daytona, and Islo leases all expose at
+least one dialable address.
 Crabbox stores the public address on the server record and uses it whenever
 the network mode resolves to `public`.
 
@@ -69,6 +70,8 @@ limited to the configured CIDRs or the request source IP. Hetzner managed
 leases use the cloud firewall attached to the project; the broker keeps it
 limited to the operator's IPs. Azure managed leases use the configured network
 security group and `azure.sshCIDRs`.
+Proxmox uses the first non-loopback IPv4 address reported by the QEMU guest
+agent, so the address can be private if the selected bridge is private.
 
 If your client IP changes during a long warmup, the existing security group
 rule may not include the new IP. Re-running `crabbox status` adds the

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -2,7 +2,7 @@
 
 Read when:
 
-- changing Hetzner, AWS, Azure, Google Cloud, or Blacksmith Testbox provisioning;
+- changing Hetzner, AWS, Azure, Google Cloud, Proxmox, or Blacksmith Testbox provisioning;
 - adding a backend;
 - adjusting machine classes, fallback order, regions, or images.
 
@@ -28,6 +28,7 @@ ssh         Existing SSH host selected by static.host
 Direct provider backends can also run without the Crabbox coordinator:
 
 ```text
+proxmox    Proxmox VE QEMU VM clones exposed as SSH leases
 semaphore  Semaphore CI jobs exposed as SSH leases
 namespace  Namespace Devboxes exposed as SSH leases
 sprites    Sprites microVMs exposed as SSH leases through sprite proxy
@@ -43,6 +44,7 @@ e2b        E2B sandboxes with delegated command execution
 - [Azure](../providers/azure.md): Azure Linux/native Windows, shared infra, capacity, and cleanup.
 - [Google Cloud](../providers/gcp.md): GCP Compute Engine Linux SSH leases.
 - [Hetzner](../providers/hetzner.md): Linux-only managed provider behavior, classes, and cleanup.
+- [Proxmox](../providers/proxmox.md): direct Proxmox VE Linux QEMU VM clones.
 - [Static SSH](../providers/ssh.md): existing Linux, macOS, and Windows SSH hosts.
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Testbox backend behavior.
 - [Namespace Devbox](../providers/namespace-devbox.md): Namespace Devbox SSH leases with Crabbox sync/run.
@@ -131,7 +133,7 @@ large     L
 beast     XL
 ```
 
-Direct provider mode still exists when no coordinator is configured. It uses local AWS credentials, Azure credentials, Google Application Default Credentials, or `HCLOUD_TOKEN`/`HETZNER_TOKEN` and should stay secondary to the brokered path.
+Direct provider mode still exists when no coordinator is configured. It uses local AWS credentials, Azure credentials, Google Application Default Credentials, Proxmox API tokens, or `HCLOUD_TOKEN`/`HETZNER_TOKEN` and should stay secondary to the brokered path when a brokered provider is available.
 
 Tailscale is not a provider. Use `--tailscale` to add tailnet reachability to
 new managed Linux leases, or set a static host to a MagicDNS name/100.x address
@@ -156,6 +158,11 @@ has no Durable Object alarm; cleanup is best-effort through provider labels and
 manual `crabbox cleanup`. Direct AWS fallback can retry provider types, but the
 structured quota preflight and `provisioningAttempts` metadata belong to the
 brokered Worker path.
+
+Use `--provider proxmox` with `CRABBOX_PROXMOX_*` config for direct Proxmox
+smoke. Proxmox clones a configured Linux QEMU template, injects SSH via
+cloud-init, discovers the IP and bootstraps the VM through the QEMU guest agent,
+then uses normal Crabbox SSH sync/run/release.
 
 Crabbox can also wrap Blacksmith Testboxes with `provider: blacksmith-testbox`. That backend does not use the Crabbox broker or direct cloud credentials. It shells out to the authenticated Blacksmith CLI for `testbox warmup`, `run`, `status`, `list`, and `stop`, while Crabbox keeps local slugs, repo claims, config, and timing summaries. See [Blacksmith Testbox](blacksmith-testbox.md).
 
@@ -230,6 +237,7 @@ Related docs:
 - [Provider reference](../providers/README.md)
 - [AWS](../providers/aws.md)
 - [Hetzner](../providers/hetzner.md)
+- [Proxmox](../providers/proxmox.md)
 - [Tailscale](tailscale.md)
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md)
 - [Namespace Devbox](../providers/namespace-devbox.md)

--- a/docs/features/tailscale.md
+++ b/docs/features/tailscale.md
@@ -7,8 +7,9 @@ Read when:
 - changing SSH, VNC, or coordinator bootstrap behavior.
 
 Tailscale is an optional Crabbox reachability layer. It is not a provider.
-Providers still own machines: Hetzner, AWS, Azure, static SSH hosts, and Blacksmith
-Testbox. Tailscale only changes which host Crabbox dials for SSH-backed work.
+Providers still own machines: Hetzner, AWS, Azure, Google Cloud, Proxmox,
+static SSH hosts, and Blacksmith Testbox. Tailscale only changes which host
+Crabbox dials for SSH-backed work.
 
 V1 support:
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -147,12 +147,17 @@ Built-in providers live under `internal/providers/<name>`:
 internal/providers/all
 internal/providers/hetzner
 internal/providers/aws
+internal/providers/azure
+internal/providers/gcp
+internal/providers/proxmox
 internal/providers/ssh
 internal/providers/blacksmith
 internal/providers/namespace
 internal/providers/sprites
 internal/providers/daytona
 internal/providers/islo
+internal/providers/e2b
+internal/providers/semaphore
 ```
 
 Each provider package owns registration, provider name, aliases, spec,
@@ -176,13 +181,18 @@ internal/cli/provider_coordinator.go      # brokered coordinator lease wrapper
 internal/cli/provider_labels.go           # shared direct-provider label helpers
 internal/providers/shared                 # shared direct SSH retry/touch/cleanup helpers
 internal/providers/aws                    # AWS SSH lease backend
+internal/providers/azure                  # Azure SSH lease backend
+internal/providers/gcp                    # Google Cloud SSH lease backend
 internal/providers/hetzner                # Hetzner SSH lease backend
+internal/providers/proxmox                # Proxmox VE SSH lease backend
 internal/providers/ssh                    # static SSH backend
 internal/providers/blacksmith             # Blacksmith delegated backend
 internal/providers/namespace              # Namespace Devbox SSH backend
 internal/providers/sprites                # Sprites SSH backend
 internal/providers/daytona                # Daytona SSH + delegated SDK backend
 internal/providers/islo                   # Islo delegated backend
+internal/providers/e2b                    # E2B delegated backend
+internal/providers/semaphore              # Semaphore SSH lease backend
 ```
 
 Provider packages may use small exported core helpers for claims, labels,

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -15,6 +15,7 @@ static SSH provider for existing machines.
 | [Azure](azure.md) | SSH lease | Linux, Windows | Azure-backed Linux and native Windows capacity |
 | [Google Cloud](gcp.md) | SSH lease | Linux | GCP-backed Linux Compute Engine capacity |
 | [Hetzner](hetzner.md) | SSH lease | Linux | fast Linux capacity at low cost |
+| [Proxmox](proxmox.md) | SSH lease | Linux | private Proxmox VE QEMU VM templates |
 | [Static SSH](ssh.md) | SSH lease | Linux, macOS, Windows | reusing an existing host |
 | [Blacksmith Testbox](blacksmith-testbox.md) | delegated run | Linux | existing Blacksmith Testbox workflows |
 | [Namespace Devbox](namespace-devbox.md) | SSH lease | Linux | Namespace-managed dev environments with Crabbox sync |
@@ -53,8 +54,9 @@ credentials, cost state, cleanup alarms, and lease accounting.
 Direct mode is for local operator debugging or non-brokered setups. It uses local
 provider credentials and best-effort cleanup through provider labels.
 
-Delegated providers do not use the Crabbox coordinator:
+Proxmox and delegated providers do not use the Crabbox coordinator:
 
+- Proxmox clones private QEMU VM templates through the Proxmox VE REST API.
 - Blacksmith uses the authenticated Blacksmith CLI.
 - Daytona uses Daytona API and SDK/toolbox APIs.
 - Islo uses the Islo API and SDK auth.
@@ -74,6 +76,7 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | Azure | yes | yes | yes | Linux VNC/code | yes | no |
 | Google Cloud | yes | yes | yes | no | yes | no |
 | Hetzner | yes | yes | yes | Linux VNC/code | yes | no |
+| Proxmox | yes | yes | yes | no | yes | no |
 | Static SSH | yes | resolves host | yes | host-dependent | yes | no |
 | Blacksmith Testbox | yes | yes | no | no | no | yes |
 | Namespace Devbox | yes | yes | yes | no | yes | no |
@@ -84,8 +87,8 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | E2B | yes | yes | no | no | archive via E2B envd | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
-Use AWS, Google Cloud, Hetzner, Static SSH, Namespace Devbox, Semaphore, or Sprites for that
-path.
+Use AWS, Google Cloud, Hetzner, Proxmox, Static SSH, Namespace Devbox,
+Semaphore, or Sprites for that path.
 
 ## Implementation
 

--- a/docs/providers/proxmox.md
+++ b/docs/providers/proxmox.md
@@ -1,0 +1,182 @@
+# Proxmox Provider
+
+Read when:
+
+- choosing `provider: proxmox`;
+- setting up a Proxmox VE VM template for Crabbox;
+- debugging Proxmox API tokens, clone tasks, guest agent IP discovery, or cleanup;
+- changing `internal/providers/proxmox` or `internal/cli/proxmox.go`.
+
+Proxmox is a direct SSH lease provider for Linux QEMU VMs. Crabbox clones a
+configured Proxmox template, injects a per-lease SSH key through cloud-init,
+uses the QEMU guest agent to discover the VM IP and run the Crabbox bootstrap,
+then uses the normal SSH sync/run/release path.
+
+It is direct-only today. The Crabbox coordinator does not broker Proxmox
+credentials or capacity yet.
+
+## When To Use
+
+Use Proxmox when:
+
+- your test capacity lives on a private Proxmox VE cluster;
+- you want reusable local or lab infrastructure instead of public cloud VMs;
+- your template already supports cloud-init and the QEMU guest agent.
+
+Use AWS, Azure, Google Cloud, or Hetzner when you need brokered shared-team
+leases. Use Static SSH when you already have a running host and do not want
+Crabbox to clone or delete VMs.
+
+Provider name:
+
+```text
+proxmox
+```
+
+## Template Requirements
+
+The configured template must be a Linux QEMU VM template with:
+
+- cloud-init drive configured;
+- QEMU guest agent installed and enabled;
+- DHCP networking or equivalent IP config;
+- outbound package access for `apt-get`;
+- enough permissions for the guest agent to run bootstrap commands as root.
+
+Crabbox sets:
+
+- `ciuser` to `proxmox.user` or `CRABBOX_PROXMOX_USER`;
+- `sshkeys` to the generated per-lease public key;
+- `ipconfig0=ip=dhcp`;
+- `agent=enabled=1`;
+- `description` with Crabbox lease labels for list/touch/cleanup;
+- `tags=crabbox`.
+
+If the guest agent does not report an IPv4 address or cannot execute the
+bootstrap script, provisioning fails and the cloned VM is deleted.
+
+## Quick Start
+
+Create an API token in Proxmox and give it permission to clone, configure,
+start, stop, delete, and inspect VMs on the target node/storage.
+
+```sh
+export CRABBOX_PROXMOX_API_URL=https://pve.example.test:8006
+export CRABBOX_PROXMOX_TOKEN_ID='crabbox@pve!ci'
+export CRABBOX_PROXMOX_TOKEN_SECRET='<token-secret>'
+export CRABBOX_PROXMOX_NODE=pve1
+export CRABBOX_PROXMOX_TEMPLATE_ID=9000
+
+crabbox warmup --provider proxmox --keep
+crabbox run --provider proxmox --no-sync -- echo proxmox-ok
+crabbox ssh --provider proxmox --id blue-crab
+crabbox stop --provider proxmox blue-crab
+crabbox cleanup --provider proxmox
+```
+
+For self-signed private clusters, set `CRABBOX_PROXMOX_INSECURE_TLS=1` or pass
+`--proxmox-insecure-tls`.
+
+## Config
+
+```yaml
+provider: proxmox
+target: linux
+proxmox:
+  apiUrl: https://pve.example.test:8006
+  tokenId: crabbox@pve!ci
+  tokenSecret: <token-secret>
+  node: pve1
+  templateId: 9000
+  storage: local-lvm
+  pool: crabbox
+  bridge: vmbr0
+  user: crabbox
+  workRoot: /work/crabbox
+  fullClone: true
+  insecureTLS: false
+```
+
+Secret values should live in `~/.profile`, a private config file with `0600`
+permissions, or your shell secret manager. Avoid passing token secrets as CLI
+arguments.
+
+Environment:
+
+```text
+CRABBOX_PROXMOX_API_URL
+CRABBOX_PROXMOX_TOKEN_ID
+CRABBOX_PROXMOX_TOKEN_SECRET
+CRABBOX_PROXMOX_NODE
+CRABBOX_PROXMOX_TEMPLATE_ID
+CRABBOX_PROXMOX_STORAGE
+CRABBOX_PROXMOX_POOL
+CRABBOX_PROXMOX_BRIDGE
+CRABBOX_PROXMOX_USER
+CRABBOX_PROXMOX_WORK_ROOT
+CRABBOX_PROXMOX_FULL_CLONE
+CRABBOX_PROXMOX_INSECURE_TLS
+```
+
+Provider flags mirror the non-secret config fields:
+
+```text
+--proxmox-api-url
+--proxmox-node
+--proxmox-template-id
+--proxmox-storage
+--proxmox-pool
+--proxmox-bridge
+--proxmox-user
+--proxmox-work-root
+--proxmox-full-clone
+--proxmox-insecure-tls
+```
+
+`--proxmox-token-secret` is intentionally not a flag so secrets do not appear in
+shell history or process argv.
+
+## Lifecycle
+
+1. Allocate a Crabbox lease ID and friendly slug.
+2. Ask Proxmox for the next VMID.
+3. Clone `proxmox.templateId` on `proxmox.node`.
+4. Configure cloud-init SSH user/key, DHCP, optional bridge/storage/pool, and
+   Crabbox labels in the VM description.
+5. Start the VM and wait for the QEMU guest agent.
+6. Discover the first non-loopback IPv4 address from the guest agent.
+7. Run the Crabbox Linux bootstrap through guest-agent exec.
+8. Wait for SSH and `/usr/local/bin/crabbox-ready`.
+9. Touch labels during runs and delete the VM on release unless the lease is kept.
+
+Cleanup reads Crabbox labels from VM descriptions and only deletes expired
+Crabbox-managed VMs.
+
+## Troubleshooting
+
+`proxmox tokenId/tokenSecret are required`
+
+Set `CRABBOX_PROXMOX_TOKEN_ID` and `CRABBOX_PROXMOX_TOKEN_SECRET`, or put them
+under `proxmox:` in a private Crabbox config file.
+
+`timeout waiting for proxmox qemu guest agent`
+
+Install and enable `qemu-guest-agent` in the template, then shut down and convert
+the VM to a template again.
+
+`no guest ipv4 address reported by qemu guest agent`
+
+Check DHCP, bridge selection, VLANs, and whether the guest agent can see the
+interface. If you override `--proxmox-bridge`, make sure the template NIC can
+boot on that bridge.
+
+`proxmox guest bootstrap exit=...`
+
+The VM booted and the guest agent ran, but apt/bootstrap failed. SSH into a kept
+lease if available, or check the Proxmox task and guest logs.
+
+## Related
+
+- [Provider reference](README.md)
+- [Provider backends](../provider-backends.md)
+- [Providers overview](../features/providers.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -36,6 +36,8 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Direct Hetzner provider: `internal/providers/hetzner`, with API client helpers in `internal/cli/hcloud.go`
 - Direct AWS provider: `internal/providers/aws`, with API client helpers in `internal/cli/aws.go`
 - Direct Azure provider: `internal/providers/azure`, with API client helpers in `internal/cli/azure.go`
+- Direct Google Cloud provider: `internal/providers/gcp`, with API client helpers in `internal/cli/gcp.go`
+- Direct Proxmox provider: `internal/providers/proxmox`, with API client helpers in `internal/cli/proxmox.go`
 - Static SSH macOS/Windows provider: `internal/providers/ssh`, with target mapping helpers in `internal/cli/static.go`
 - Blacksmith Testbox backend and argument/parsing helpers: `internal/providers/blacksmith`
 - Namespace Devbox SSH lease backend and CLI wrapper: `internal/providers/namespace`
@@ -47,14 +49,14 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
   `internal/cli/provider_backend.go`
 - Built-in provider registration packages:
   `internal/providers/hetzner`, `internal/providers/aws`,
-  `internal/providers/azure`,
-  `internal/providers/ssh`, `internal/providers/blacksmith`,
+  `internal/providers/azure`, `internal/providers/proxmox`,
+  `internal/providers/gcp`, `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/namespace`, `internal/providers/daytona`, `internal/providers/islo`,
   `internal/providers/semaphore`, `internal/providers/sprites`, `internal/providers/e2b`,
   `internal/providers/all`
 - Built-in provider backend implementations:
-  `internal/providers/aws`, `internal/providers/azure`,
-  `internal/providers/hetzner`,
+  `internal/providers/aws`, `internal/providers/azure`, `internal/providers/gcp`,
+  `internal/providers/hetzner`, `internal/providers/proxmox`,
   `internal/providers/ssh`, `internal/providers/blacksmith`,
   `internal/providers/namespace`, `internal/providers/daytona`, `internal/providers/islo`,
   `internal/providers/semaphore`, `internal/providers/sprites`, `internal/providers/e2b`,
@@ -63,7 +65,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
 - Worker AWS EC2 provider: `worker/src/aws.ts`
 - Worker AWS AMI create/read/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`
 - Provider feature docs: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
-- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/hetzner.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/namespace-devbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/semaphore.md`, `docs/providers/sprites.md`, `docs/providers/e2b.md`
+- Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/gcp.md`, `docs/providers/hetzner.md`, `docs/providers/proxmox.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/namespace-devbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/semaphore.md`, `docs/providers/sprites.md`, `docs/providers/e2b.md`
 - Provider/backend authoring guide: `docs/provider-backends.md`
 - CLI cloud-init bootstrap: `internal/cli/bootstrap.go`
 - Worker cloud-init bootstrap: `worker/src/bootstrap.ts`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -228,7 +228,7 @@ Environment:
   CRABBOX_ACCESS_CLIENT_ID     Cloudflare Access service token client ID
   CRABBOX_ACCESS_CLIENT_SECRET Cloudflare Access service token client secret
   CRABBOX_ACCESS_TOKEN         Cloudflare Access JWT for protected routes
-  CRABBOX_PROVIDER             hetzner, aws, azure, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, or sprites
+  CRABBOX_PROVIDER             hetzner, aws, azure, gcp, proxmox, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, or sprites
   CRABBOX_TARGET               linux, macos, or windows
   CRABBOX_WINDOWS_MODE         normal or wsl2
   CRABBOX_DESKTOP              Provision or require desktop/VNC capability
@@ -246,6 +246,7 @@ Environment:
   CRABBOX_CAPACITY_MARKET      spot or on-demand
   CRABBOX_CAPACITY_REGIONS     Comma-separated AWS region fallback candidates
   HCLOUD_TOKEN/HETZNER_TOKEN   Direct Hetzner mode
+  CRABBOX_PROXMOX_API_URL      Proxmox VE API URL, e.g. https://pve.local:8006
 
 Aliases:
   crabbox release <id-or-slug> Alias for stop

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -21,7 +21,7 @@ const defaultCoordinatorURL = "https://crabbox.openclaw.ai"
 func (a App) login(ctx context.Context, args []string) error {
 	fs := newFlagSet("login", a.Stderr)
 	brokerURL := fs.String("url", "", "broker URL")
-	provider := fs.String("provider", "", "default provider: hetzner, aws, or azure")
+	provider := fs.String("provider", "", "default brokered provider: hetzner, aws, azure, or gcp")
 	tokenStdin := fs.Bool("token-stdin", false, "read broker token from stdin")
 	noBrowser := fs.Bool("no-browser", false, "print GitHub login URL instead of opening a browser")
 	jsonOut := fs.Bool("json", false, "print JSON")

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	GCPRootGB          int64
 	gcpRootGBExplicit  bool
 	GCPServiceAccount  string
+	Proxmox            ProxmoxConfig
 	SSHUser            string
 	SSHKey             string
 	SSHPort            string
@@ -179,6 +180,21 @@ type IsloConfig struct {
 	DiskGB         int
 }
 
+type ProxmoxConfig struct {
+	APIURL      string
+	TokenID     string
+	TokenSecret string
+	Node        string
+	TemplateID  int
+	Storage     string
+	Pool        string
+	Bridge      string
+	User        string
+	WorkRoot    string
+	FullClone   bool
+	InsecureTLS bool
+}
+
 type SemaphoreConfig struct {
 	Host        string
 	Token       string
@@ -280,6 +296,7 @@ func loadConfig() (Config, error) {
 	}
 	applyEnv(&cfg)
 	canonicalizeConfigProvider(&cfg)
+	applyProviderConfigDefaults(&cfg)
 	normalizeTargetConfig(&cfg)
 	if err := validateTargetConfig(cfg); err != nil {
 		return Config{}, err
@@ -297,6 +314,18 @@ func canonicalizeConfigProvider(cfg *Config) {
 	provider, err := ProviderFor(cfg.Provider)
 	if err == nil {
 		cfg.Provider = provider.Name()
+	}
+}
+
+func applyProviderConfigDefaults(cfg *Config) {
+	if cfg.Provider != "proxmox" {
+		return
+	}
+	if cfg.Proxmox.User != "" {
+		cfg.SSHUser = cfg.Proxmox.User
+	}
+	if cfg.Proxmox.WorkRoot != "" {
+		cfg.WorkRoot = cfg.Proxmox.WorkRoot
 	}
 }
 
@@ -388,6 +417,11 @@ func baseConfig() Config {
 			MemoryMB: 4096,
 			DiskGB:   20,
 		},
+		Proxmox: ProxmoxConfig{
+			User:      "crabbox",
+			WorkRoot:  defaultPOSIXWorkRoot,
+			FullClone: true,
+		},
 		Sprites: SpritesConfig{
 			APIURL:   "https://api.sprites.dev",
 			WorkRoot: "/home/sprite/crabbox",
@@ -426,6 +460,7 @@ type fileConfig struct {
 	AWS              *fileAWSConfig           `yaml:"aws,omitempty"`
 	Azure            *fileAzureConfig         `yaml:"azure,omitempty"`
 	GCP              *fileGCPConfig           `yaml:"gcp,omitempty"`
+	Proxmox          *fileProxmoxConfig       `yaml:"proxmox,omitempty"`
 	SSH              *fileSSHConfig           `yaml:"ssh,omitempty"`
 	Sync             *fileSyncConfig          `yaml:"sync,omitempty"`
 	Env              *fileEnvConfig           `yaml:"env,omitempty"`
@@ -508,6 +543,21 @@ type fileGCPConfig struct {
 	SSHCIDRs       []string `yaml:"sshCIDRs,omitempty"`
 	RootGB         int64    `yaml:"rootGB,omitempty"`
 	ServiceAccount string   `yaml:"serviceAccount,omitempty"`
+}
+
+type fileProxmoxConfig struct {
+	APIURL      string `yaml:"apiUrl,omitempty"`
+	TokenID     string `yaml:"tokenId,omitempty"`
+	TokenSecret string `yaml:"tokenSecret,omitempty"`
+	Node        string `yaml:"node,omitempty"`
+	TemplateID  int    `yaml:"templateId,omitempty"`
+	Storage     string `yaml:"storage,omitempty"`
+	Pool        string `yaml:"pool,omitempty"`
+	Bridge      string `yaml:"bridge,omitempty"`
+	User        string `yaml:"user,omitempty"`
+	WorkRoot    string `yaml:"workRoot,omitempty"`
+	FullClone   *bool  `yaml:"fullClone,omitempty"`
+	InsecureTLS *bool  `yaml:"insecureTLS,omitempty"`
 }
 
 type fileSSHConfig struct {
@@ -967,6 +1017,44 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 		}
 		if file.GCP.ServiceAccount != "" {
 			cfg.GCPServiceAccount = file.GCP.ServiceAccount
+		}
+	}
+	if file.Proxmox != nil {
+		if file.Proxmox.APIURL != "" {
+			cfg.Proxmox.APIURL = file.Proxmox.APIURL
+		}
+		if file.Proxmox.TokenID != "" {
+			cfg.Proxmox.TokenID = file.Proxmox.TokenID
+		}
+		if file.Proxmox.TokenSecret != "" {
+			cfg.Proxmox.TokenSecret = file.Proxmox.TokenSecret
+		}
+		if file.Proxmox.Node != "" {
+			cfg.Proxmox.Node = file.Proxmox.Node
+		}
+		if file.Proxmox.TemplateID > 0 {
+			cfg.Proxmox.TemplateID = file.Proxmox.TemplateID
+		}
+		if file.Proxmox.Storage != "" {
+			cfg.Proxmox.Storage = file.Proxmox.Storage
+		}
+		if file.Proxmox.Pool != "" {
+			cfg.Proxmox.Pool = file.Proxmox.Pool
+		}
+		if file.Proxmox.Bridge != "" {
+			cfg.Proxmox.Bridge = file.Proxmox.Bridge
+		}
+		if file.Proxmox.User != "" {
+			cfg.Proxmox.User = file.Proxmox.User
+		}
+		if file.Proxmox.WorkRoot != "" {
+			cfg.Proxmox.WorkRoot = file.Proxmox.WorkRoot
+		}
+		if file.Proxmox.FullClone != nil {
+			cfg.Proxmox.FullClone = *file.Proxmox.FullClone
+		}
+		if file.Proxmox.InsecureTLS != nil {
+			cfg.Proxmox.InsecureTLS = *file.Proxmox.InsecureTLS
 		}
 	}
 	if file.SSH != nil {
@@ -1504,6 +1592,22 @@ func applyEnv(cfg *Config) {
 	if cidrs := os.Getenv("CRABBOX_GCP_SSH_CIDRS"); cidrs != "" {
 		cfg.GCPSSHCIDRs = splitCommaList(cidrs)
 	}
+	cfg.Proxmox.APIURL = getenv("CRABBOX_PROXMOX_API_URL", cfg.Proxmox.APIURL)
+	cfg.Proxmox.TokenID = getenv("CRABBOX_PROXMOX_TOKEN_ID", cfg.Proxmox.TokenID)
+	cfg.Proxmox.TokenSecret = getenv("CRABBOX_PROXMOX_TOKEN_SECRET", cfg.Proxmox.TokenSecret)
+	cfg.Proxmox.Node = getenv("CRABBOX_PROXMOX_NODE", cfg.Proxmox.Node)
+	cfg.Proxmox.TemplateID = getenvInt("CRABBOX_PROXMOX_TEMPLATE_ID", cfg.Proxmox.TemplateID)
+	cfg.Proxmox.Storage = getenv("CRABBOX_PROXMOX_STORAGE", cfg.Proxmox.Storage)
+	cfg.Proxmox.Pool = getenv("CRABBOX_PROXMOX_POOL", cfg.Proxmox.Pool)
+	cfg.Proxmox.Bridge = getenv("CRABBOX_PROXMOX_BRIDGE", cfg.Proxmox.Bridge)
+	cfg.Proxmox.User = getenv("CRABBOX_PROXMOX_USER", cfg.Proxmox.User)
+	cfg.Proxmox.WorkRoot = getenv("CRABBOX_PROXMOX_WORK_ROOT", cfg.Proxmox.WorkRoot)
+	if value, ok := getenvBool("CRABBOX_PROXMOX_FULL_CLONE"); ok {
+		cfg.Proxmox.FullClone = value
+	}
+	if value, ok := getenvBool("CRABBOX_PROXMOX_INSECURE_TLS"); ok {
+		cfg.Proxmox.InsecureTLS = value
+	}
 	cfg.SSHUser = getenv("CRABBOX_SSH_USER", cfg.SSHUser)
 	cfg.SSHKey = getenv("CRABBOX_SSH_KEY", cfg.SSHKey)
 	cfg.SSHPort = getenv("CRABBOX_SSH_PORT", cfg.SSHPort)
@@ -1712,6 +1816,9 @@ func serverTypeForConfig(cfg Config) string {
 	if cfg.Provider == "gcp" {
 		return gcpMachineTypeCandidatesForClass(cfg.Class)[0]
 	}
+	if cfg.Provider == "proxmox" {
+		return proxmoxServerTypeForConfig(cfg)
+	}
 	return serverTypeForClass(cfg.Class)
 }
 
@@ -1740,7 +1847,17 @@ func serverTypeForProviderClass(provider, class string) string {
 	if provider == "gcp" {
 		return gcpMachineTypeCandidatesForClass(class)[0]
 	}
+	if provider == "proxmox" {
+		return "template"
+	}
 	return serverTypeForClass(class)
+}
+
+func proxmoxServerTypeForConfig(cfg Config) string {
+	if cfg.Proxmox.TemplateID > 0 {
+		return "template-" + strconv.Itoa(cfg.Proxmox.TemplateID)
+	}
+	return "template"
 }
 
 func namespaceDevboxSizeForConfig(cfg Config) string {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -141,6 +141,20 @@ func (a App) configShow(args []string) error {
 			"sshCIDRs":       cfg.GCPSSHCIDRs,
 			"serviceAccount": cfg.GCPServiceAccount,
 		},
+		"proxmox": map[string]any{
+			"apiUrl":      cfg.Proxmox.APIURL,
+			"auth":        tokenState(cfg.Proxmox.TokenSecret),
+			"tokenId":     cfg.Proxmox.TokenID,
+			"node":        cfg.Proxmox.Node,
+			"templateId":  cfg.Proxmox.TemplateID,
+			"storage":     cfg.Proxmox.Storage,
+			"pool":        cfg.Proxmox.Pool,
+			"bridge":      cfg.Proxmox.Bridge,
+			"user":        cfg.Proxmox.User,
+			"workRoot":    cfg.Proxmox.WorkRoot,
+			"fullClone":   cfg.Proxmox.FullClone,
+			"insecureTLS": cfg.Proxmox.InsecureTLS,
+		},
 	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(view)
@@ -170,6 +184,7 @@ func (a App) configShow(args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "aws region=%s root_gb=%d ssh_cidrs=%s\n", cfg.AWSRegion, cfg.AWSRootGB, blank(strings.Join(cfg.AWSSSHCIDRs, ","), "-"))
 	fmt.Fprintf(a.Stdout, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
+	fmt.Fprintf(a.Stdout, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(cfg.Proxmox.APIURL, "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
 	return nil
 }
 
@@ -234,7 +249,7 @@ func durationString(d time.Duration) string {
 func (a App) configSetBroker(args []string) error {
 	fs := newFlagSet("config set-broker", a.Stderr)
 	url := fs.String("url", "", "broker URL")
-	provider := fs.String("provider", "", "default provider: hetzner, aws, azure, or gcp")
+	provider := fs.String("provider", "", "default brokered provider: hetzner, aws, azure, or gcp")
 	tokenStdin := fs.Bool("token-stdin", false, "read broker token from stdin")
 	adminTokenStdin := fs.Bool("admin-token-stdin", false, "read broker admin token from stdin")
 	if err := parseFlags(fs, args); err != nil {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -249,6 +249,19 @@ islo:
   vcpus: 4
   memoryMB: 8192
   diskGB: 40
+proxmox:
+  apiUrl: https://pve.example.test:8006
+  tokenId: crabbox@pve!test
+  tokenSecret: proxmox-secret
+  node: pve1
+  templateId: 9000
+  storage: local-lvm
+  pool: crabbox
+  bridge: vmbr1
+  user: runner
+  workRoot: /work/proxmox
+  fullClone: false
+  insecureTLS: true
 semaphore:
   host: semaphore.example.test
   token: semaphore-token
@@ -360,6 +373,9 @@ ssh:
 	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
 		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
+	}
+	if cfg.Proxmox.APIURL != "https://pve.example.test:8006" || cfg.Proxmox.TokenID != "crabbox@pve!test" || cfg.Proxmox.TokenSecret != "proxmox-secret" || cfg.Proxmox.Node != "pve1" || cfg.Proxmox.TemplateID != 9000 || cfg.Proxmox.Storage != "local-lvm" || cfg.Proxmox.Pool != "crabbox" || cfg.Proxmox.Bridge != "vmbr1" || cfg.Proxmox.User != "runner" || cfg.Proxmox.WorkRoot != "/work/proxmox" || cfg.Proxmox.FullClone || !cfg.Proxmox.InsecureTLS {
+		t.Fatalf("proxmox config not loaded: %#v", cfg.Proxmox)
 	}
 	if cfg.Semaphore.Host != "semaphore.example.test" || cfg.Semaphore.Token != "semaphore-token" || cfg.Semaphore.Project != "crabbox" || cfg.Semaphore.Machine != "f1-standard-4" || cfg.Semaphore.OSImage != "ubuntu2404" || cfg.Semaphore.IdleTimeout != "15m" {
 		t.Fatalf("semaphore config not loaded: %#v", cfg.Semaphore)
@@ -489,6 +505,18 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_ISLO_VCPUS", "8")
 	t.Setenv("CRABBOX_ISLO_MEMORY_MB", "16384")
 	t.Setenv("CRABBOX_ISLO_DISK_GB", "80")
+	t.Setenv("CRABBOX_PROXMOX_API_URL", "https://pve-env.example:8006")
+	t.Setenv("CRABBOX_PROXMOX_TOKEN_ID", "runner@pve!env")
+	t.Setenv("CRABBOX_PROXMOX_TOKEN_SECRET", "proxmox-env-secret")
+	t.Setenv("CRABBOX_PROXMOX_NODE", "pve-env")
+	t.Setenv("CRABBOX_PROXMOX_TEMPLATE_ID", "9100")
+	t.Setenv("CRABBOX_PROXMOX_STORAGE", "ceph-env")
+	t.Setenv("CRABBOX_PROXMOX_POOL", "pool-env")
+	t.Setenv("CRABBOX_PROXMOX_BRIDGE", "vmbr2")
+	t.Setenv("CRABBOX_PROXMOX_USER", "runner-env")
+	t.Setenv("CRABBOX_PROXMOX_WORK_ROOT", "/work/proxmox-env")
+	t.Setenv("CRABBOX_PROXMOX_FULL_CLONE", "false")
+	t.Setenv("CRABBOX_PROXMOX_INSECURE_TLS", "true")
 	t.Setenv("SEMAPHORE_HOST", "semaphore-file.example.test")
 	t.Setenv("CRABBOX_SEMAPHORE_HOST", "semaphore-env.example.test")
 	t.Setenv("SEMAPHORE_API_TOKEN", "semaphore-token-file")
@@ -589,6 +617,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {
 		t.Fatalf("unexpected islo env: %#v", cfg.Islo)
+	}
+	if cfg.Proxmox.APIURL != "https://pve-env.example:8006" || cfg.Proxmox.TokenID != "runner@pve!env" || cfg.Proxmox.TokenSecret != "proxmox-env-secret" || cfg.Proxmox.Node != "pve-env" || cfg.Proxmox.TemplateID != 9100 || cfg.Proxmox.Storage != "ceph-env" || cfg.Proxmox.Pool != "pool-env" || cfg.Proxmox.Bridge != "vmbr2" || cfg.Proxmox.User != "runner-env" || cfg.Proxmox.WorkRoot != "/work/proxmox-env" || cfg.Proxmox.FullClone || !cfg.Proxmox.InsecureTLS {
+		t.Fatalf("unexpected proxmox env: %#v", cfg.Proxmox)
 	}
 	if cfg.Semaphore.Host != "semaphore-env.example.test" || cfg.Semaphore.Token != "semaphore-token-env" || cfg.Semaphore.Project != "semaphore-project-env" || cfg.Semaphore.Machine != "f1-standard-env" || cfg.Semaphore.OSImage != "ubuntu-env" || cfg.Semaphore.IdleTimeout != "22m" {
 		t.Fatalf("unexpected semaphore env: %#v", cfg.Semaphore)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,7 +10,7 @@ import (
 
 func (a App) doctor(ctx context.Context, args []string) error {
 	fs := newFlagSet("doctor", a.Stderr)
-	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, azure, or ssh")
+	provider := fs.String("provider", defaultConfig().Provider, "provider: hetzner, aws, azure, gcp, proxmox, or ssh")
 	id := fs.String("id", "", "remote lease id to inspect")
 	targetFlags := registerTargetFlags(fs, defaultConfig())
 	if err := parseFlags(fs, args); err != nil {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -19,7 +19,9 @@ func TestCoordinatorProviderReadinessSupported(t *testing.T) {
 	}{
 		{provider: "aws", want: true},
 		{provider: "azure", want: true},
+		{provider: "gcp", want: true},
 		{provider: "hetzner", want: true},
+		{provider: "proxmox", want: false},
 		{provider: "daytona", want: false},
 		{provider: "islo", want: false},
 		{provider: "e2b", want: false},

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -65,6 +65,7 @@ func applyLeaseCreateFlags(cfg *Config, fs *flag.FlagSet, values leaseCreateFlag
 	if err := applyProviderFlags(cfg, fs, values.ProviderFlags); err != nil {
 		return err
 	}
+	applyProviderConfigDefaults(cfg)
 	if err := validateProviderTarget(*cfg); err != nil {
 		return err
 	}
@@ -102,6 +103,10 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 	}
 	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
 		return Config{}, err
+	}
+	applyProviderConfigDefaults(&cfg)
+	if !cfg.ServerTypeExplicit {
+		cfg.ServerType = serverTypeForConfig(cfg)
 	}
 	return cfg, nil
 }

--- a/internal/cli/pool.go
+++ b/internal/cli/pool.go
@@ -305,7 +305,7 @@ func coordinatorMachineOrphanField(labels map[string]string, activeLeaseIDs map[
 func (a App) cleanup(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("machine cleanup", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, azure, gcp, or namespace-devbox")
+	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, azure, gcp, proxmox, or namespace-devbox")
 	dryRun := fs.Bool("dry-run", false, "only print")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -324,11 +324,11 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: hetzner, aws, azure, gcp, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, or sprites"
+	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, or sprites"
 }
 
 func providerHelpSSH() string {
-	return "provider: hetzner, aws, azure, gcp, ssh, namespace-devbox, semaphore, daytona, or sprites"
+	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, namespace-devbox, semaphore, daytona, or sprites"
 }
 
 func isBlacksmithProvider(provider string) bool {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -173,6 +175,34 @@ func TestLeaseCreateFlagsApplySelectedProviderFlags(t *testing.T) {
 	}
 }
 
+func TestLeaseCreateFlagsReapplyProxmoxDefaultsAfterProviderOverride(t *testing.T) {
+	defaults := baseConfig()
+	defaults.Provider = "hetzner"
+	defaults.Proxmox.TemplateID = 9000
+	defaults.Proxmox.User = "runner"
+	defaults.Proxmox.WorkRoot = "/work/proxmox"
+	defaults.ServerType = serverTypeForConfig(defaults)
+
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := parseFlags(fs, []string{"--provider", "proxmox"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SSHUser != "runner" {
+		t.Fatalf("ssh user=%q want proxmox default", cfg.SSHUser)
+	}
+	if cfg.WorkRoot != "/work/proxmox" {
+		t.Fatalf("work root=%q want proxmox default", cfg.WorkRoot)
+	}
+	if cfg.ServerType != "template-9000" {
+		t.Fatalf("server type=%q want template-9000", cfg.ServerType)
+	}
+}
+
 func TestLeaseCreateFlagsDeriveGCPTypeForAlias(t *testing.T) {
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)
@@ -189,6 +219,40 @@ func TestLeaseCreateFlagsDeriveGCPTypeForAlias(t *testing.T) {
 	}
 	if cfg.ServerType != "c4-standard-32" {
 		t.Fatalf("server type=%q want gcp default", cfg.ServerType)
+	}
+}
+
+func TestLoadLeaseTargetConfigReappliesProxmoxDefaultsAfterProviderOverride(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := os.WriteFile(configPath, []byte(`provider: hetzner
+proxmox:
+  templateId: 9000
+  user: runner
+  workRoot: /work/proxmox
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := defaultConfig()
+	fs := newFlagSet("test", io.Discard)
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, "proxmox", targetFlags, networkFlags, leaseTargetConfigOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SSHUser != "runner" {
+		t.Fatalf("ssh user=%q want proxmox default", cfg.SSHUser)
+	}
+	if cfg.WorkRoot != "/work/proxmox" {
+		t.Fatalf("work root=%q want proxmox default", cfg.WorkRoot)
+	}
+	if cfg.ServerType != "template-9000" {
+		t.Fatalf("server type=%q want template-9000", cfg.ServerType)
 	}
 }
 

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -22,7 +22,7 @@ func testRuntimeWithRunner(r CommandRunner) Runtime {
 }
 
 func TestProviderRegistryCanonicalAndAliases(t *testing.T) {
-	for _, name := range []string{"hetzner", "aws", "azure", "gcp", "google", "google-cloud", "ssh", "static", "static-ssh", "blacksmith", "blacksmith-testbox", "namespace", "namespace-devbox", "daytona", "islo", "e2b", "sprites"} {
+	for _, name := range []string{"hetzner", "aws", "azure", "gcp", "google", "google-cloud", "proxmox", "ssh", "static", "static-ssh", "blacksmith", "blacksmith-testbox", "namespace", "namespace-devbox", "daytona", "islo", "e2b", "sprites"} {
 		if _, err := ProviderFor(name); err != nil {
 			t.Fatalf("ProviderFor(%q): %v", name, err)
 		}
@@ -71,6 +71,15 @@ func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 		t.Fatalf("backend=%T, want ssh lease backend", backend)
 	}
 
+	cfg.Provider = "proxmox"
+	backend, err = loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
+	if err != nil {
+		t.Fatalf("load proxmox backend: %v", err)
+	}
+	if _, ok := backend.(SSHLeaseBackend); !ok {
+		t.Fatalf("backend=%T, want ssh lease backend", backend)
+	}
+
 	cfg.Provider = "e2b"
 	backend, err = loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
 	if err != nil {
@@ -110,6 +119,35 @@ func TestProviderFlagsApplyNamespaceWithoutCoreEdits(t *testing.T) {
 	}
 	if cfg.Namespace.Image != "crabbox-ready" || cfg.Namespace.Size != "L" || cfg.Namespace.WorkRoot != "/workspaces/test" {
 		t.Fatalf("namespace flags not applied: %#v", cfg.Namespace)
+	}
+}
+
+func TestProviderFlagsApplyProxmoxWithoutSecrets(t *testing.T) {
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	provider := fs.String("provider", defaults.Provider, "")
+	values := registerProviderFlags(fs, defaults)
+	if err := parseFlags(fs, []string{
+		"--provider", "proxmox",
+		"--proxmox-api-url", "https://pve.example.test:8006",
+		"--proxmox-node", "pve1",
+		"--proxmox-template-id", "9000",
+		"--proxmox-user", "runner",
+		"--proxmox-work-root", "/work/test",
+		"--proxmox-insecure-tls",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	cfg.Provider = *provider
+	if err := applyProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Proxmox.APIURL != "https://pve.example.test:8006" || cfg.Proxmox.Node != "pve1" || cfg.Proxmox.TemplateID != 9000 || cfg.Proxmox.User != "runner" || cfg.SSHUser != "runner" || cfg.WorkRoot != "/work/test" || !cfg.Proxmox.InsecureTLS {
+		t.Fatalf("proxmox flags not applied: %#v", cfg.Proxmox)
+	}
+	if cfg.ServerType != "template-9000" {
+		t.Fatalf("server type=%q want template-9000", cfg.ServerType)
 	}
 }
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -12,6 +12,10 @@ func ServerTypeForProviderClass(provider, class string) string {
 	return serverTypeForProviderClass(provider, class)
 }
 
+func ProxmoxServerTypeForConfig(cfg Config) string {
+	return proxmoxServerTypeForConfig(cfg)
+}
+
 func Exit(code int, format string, args ...any) ExitError {
 	return exit(code, format, args...)
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -10,6 +10,7 @@ func init() {
 	RegisterProvider(testAWSProvider{})
 	RegisterProvider(testAzureProvider{})
 	RegisterProvider(testGCPProvider{})
+	RegisterProvider(testProxmoxProvider{})
 	RegisterProvider(testStaticSSHProvider{})
 	RegisterProvider(testBlacksmithProvider{})
 	RegisterProvider(testNamespaceProvider{})
@@ -111,6 +112,70 @@ func (testAWSProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 }
 func (p testAWSProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testProxmoxProvider struct{}
+
+func (testProxmoxProvider) Name() string      { return "proxmox" }
+func (testProxmoxProvider) Aliases() []string { return nil }
+func (testProxmoxProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "proxmox",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testProxmoxProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return testProxmoxFlagValues{
+		APIURL:      fs.String("proxmox-api-url", defaults.Proxmox.APIURL, "Proxmox VE API URL"),
+		Node:        fs.String("proxmox-node", defaults.Proxmox.Node, "Proxmox VE node name"),
+		TemplateID:  fs.Int("proxmox-template-id", defaults.Proxmox.TemplateID, "Proxmox QEMU template VMID"),
+		User:        fs.String("proxmox-user", defaults.Proxmox.User, "Proxmox VM user"),
+		WorkRoot:    fs.String("proxmox-work-root", defaults.Proxmox.WorkRoot, "Proxmox VM work root"),
+		InsecureTLS: fs.Bool("proxmox-insecure-tls", defaults.Proxmox.InsecureTLS, "allow self-signed Proxmox TLS certificates"),
+	}
+}
+func (testProxmoxProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(testProxmoxFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "proxmox-api-url") {
+		cfg.Proxmox.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "proxmox-node") {
+		cfg.Proxmox.Node = *v.Node
+	}
+	if flagWasSet(fs, "proxmox-template-id") {
+		cfg.Proxmox.TemplateID = *v.TemplateID
+		cfg.ServerType = proxmoxServerTypeForConfig(*cfg)
+	}
+	if flagWasSet(fs, "proxmox-user") {
+		cfg.Proxmox.User = *v.User
+		cfg.SSHUser = *v.User
+	}
+	if flagWasSet(fs, "proxmox-work-root") {
+		cfg.Proxmox.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if flagWasSet(fs, "proxmox-insecure-tls") {
+		cfg.Proxmox.InsecureTLS = *v.InsecureTLS
+	}
+	return nil
+}
+func (p testProxmoxProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testProxmoxFlagValues struct {
+	APIURL      *string
+	Node        *string
+	TemplateID  *int
+	User        *string
+	WorkRoot    *string
+	InsecureTLS *bool
 }
 
 type testStaticSSHProvider struct{}

--- a/internal/cli/providers_common.go
+++ b/internal/cli/providers_common.go
@@ -63,6 +63,17 @@ func touchDirectLeaseBestEffort(ctx context.Context, cfg Config, server Server, 
 		}
 		return server
 	}
+	if cfg.Provider == "proxmox" || server.Provider == "proxmox" {
+		client, err := NewProxmoxClient(cfg)
+		if err != nil {
+			fmt.Fprintf(stderr, "warning: direct touch state=%s: %v\n", state, err)
+			return server
+		}
+		if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
+			fmt.Fprintf(stderr, "warning: direct touch state=%s: %v\n", state, err)
+		}
+		return server
+	}
 	client, err := newHetznerClient()
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: direct touch state=%s: %v\n", state, err)

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -1,0 +1,596 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ProxmoxClient struct {
+	BaseURL     string
+	TokenID     string
+	TokenSecret string
+	Node        string
+	Client      *http.Client
+}
+
+type ProxmoxError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *ProxmoxError) Error() string {
+	return fmt.Sprintf("proxmox %s %s: http %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+}
+
+func NewProxmoxClient(cfg Config) (*ProxmoxClient, error) {
+	apiURL := strings.TrimSpace(cfg.Proxmox.APIURL)
+	if apiURL == "" {
+		return nil, exit(3, "proxmox apiUrl is required (set proxmox.apiUrl or CRABBOX_PROXMOX_API_URL)")
+	}
+	apiURL = strings.TrimRight(apiURL, "/")
+	apiURL = strings.TrimSuffix(apiURL, "/api2/json")
+	if cfg.Proxmox.TokenID == "" || cfg.Proxmox.TokenSecret == "" {
+		return nil, exit(3, "proxmox tokenId/tokenSecret are required (set proxmox.tokenId/tokenSecret or CRABBOX_PROXMOX_TOKEN_ID/CRABBOX_PROXMOX_TOKEN_SECRET)")
+	}
+	if cfg.Proxmox.Node == "" {
+		return nil, exit(3, "proxmox node is required (set proxmox.node or CRABBOX_PROXMOX_NODE)")
+	}
+	if cfg.Proxmox.TemplateID <= 0 {
+		return nil, exit(3, "proxmox templateId is required (set proxmox.templateId or CRABBOX_PROXMOX_TEMPLATE_ID)")
+	}
+	client := &http.Client{Timeout: 60 * time.Second}
+	if cfg.Proxmox.InsecureTLS {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // User opt-in for self-signed private Proxmox clusters.
+		client.Transport = transport
+	}
+	return &ProxmoxClient{
+		BaseURL:     apiURL,
+		TokenID:     cfg.Proxmox.TokenID,
+		TokenSecret: cfg.Proxmox.TokenSecret,
+		Node:        cfg.Proxmox.Node,
+		Client:      client,
+	}, nil
+}
+
+func (c *ProxmoxClient) do(ctx context.Context, method, path string, form url.Values, out any) error {
+	var body io.Reader
+	if form != nil {
+		body = strings.NewReader(form.Encode())
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+"/api2/json"+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "PVEAPIToken="+c.TokenID+"="+c.TokenSecret)
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &ProxmoxError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: summarizeJSON(data)}
+	}
+	if out == nil {
+		return nil
+	}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	if len(envelope.Data) == 0 || bytes.Equal(envelope.Data, []byte("null")) {
+		return nil
+	}
+	return json.Unmarshal(envelope.Data, out)
+}
+
+func (c *ProxmoxClient) nextID(ctx context.Context) (int, error) {
+	var raw any
+	if err := c.do(ctx, http.MethodGet, "/cluster/nextid", nil, &raw); err != nil {
+		return 0, err
+	}
+	switch v := raw.(type) {
+	case float64:
+		return int(v), nil
+	case string:
+		id, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("parse proxmox nextid %q: %w", v, err)
+		}
+		return id, nil
+	default:
+		return 0, fmt.Errorf("unexpected proxmox nextid response: %#v", raw)
+	}
+}
+
+type proxmoxVM struct {
+	VMID     int    `json:"vmid"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Template int    `json:"template"`
+}
+
+func (c *ProxmoxClient) listQEMU(ctx context.Context) ([]proxmoxVM, error) {
+	var vms []proxmoxVM
+	if err := c.do(ctx, http.MethodGet, "/nodes/"+url.PathEscape(c.Node)+"/qemu", nil, &vms); err != nil {
+		return nil, err
+	}
+	return vms, nil
+}
+
+func (c *ProxmoxClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
+	vms, err := c.listQEMU(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(vms))
+	for _, vm := range vms {
+		if vm.Template != 0 || !strings.HasPrefix(vm.Name, "crabbox-") {
+			continue
+		}
+		server, err := c.GetServer(ctx, strconv.Itoa(vm.VMID))
+		if err != nil {
+			if IsProxmoxNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if isCrabboxProxmoxLease(server) {
+			servers = append(servers, server)
+		}
+	}
+	return servers, nil
+}
+
+func (c *ProxmoxClient) CreateServer(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool) (Server, error) {
+	if cfg.TargetOS != targetLinux {
+		return Server{}, exit(2, "proxmox provider currently supports target=linux only")
+	}
+	vmid, err := c.nextID(ctx)
+	if err != nil {
+		return Server{}, err
+	}
+	name := leaseProviderName(leaseID, slug)
+	full := "1"
+	if !cfg.Proxmox.FullClone {
+		full = "0"
+	}
+	clone := url.Values{
+		"newid": {strconv.Itoa(vmid)},
+		"name":  {name},
+		"full":  {full},
+	}
+	if cfg.Proxmox.Storage != "" {
+		clone.Set("storage", cfg.Proxmox.Storage)
+	}
+	if cfg.Proxmox.Pool != "" {
+		clone.Set("pool", cfg.Proxmox.Pool)
+	}
+	var upid string
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/clone", url.PathEscape(c.Node), cfg.Proxmox.TemplateID), clone, &upid); err != nil {
+		return Server{}, err
+	}
+	clonedVMID := strconv.Itoa(vmid)
+	cleanupClone := func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		_ = c.DeleteServer(cleanupCtx, clonedVMID)
+	}
+	if err := c.waitTask(ctx, upid); err != nil {
+		cleanupClone()
+		return Server{}, err
+	}
+
+	now := time.Now().UTC()
+	labels := directLeaseLabels(cfg, leaseID, slug, "proxmox", "", keep, now)
+	labels["node"] = cfg.Proxmox.Node
+	labels["template_id"] = strconv.Itoa(cfg.Proxmox.TemplateID)
+	description := proxmoxDescription(labels)
+	config := url.Values{
+		"ciuser":      {cfg.SSHUser},
+		"sshkeys":     {publicKey},
+		"ipconfig0":   {"ip=dhcp"},
+		"agent":       {"enabled=1"},
+		"description": {description},
+		"tags":        {"crabbox"},
+	}
+	if cfg.Proxmox.Bridge != "" {
+		config.Set("net0", "virtio,bridge="+cfg.Proxmox.Bridge)
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), config, nil); err != nil {
+		cleanupClone()
+		return Server{}, err
+	}
+	if err := c.startVM(ctx, vmid); err != nil {
+		cleanupClone()
+		return Server{}, err
+	}
+	if err := c.bootstrapGuest(ctx, vmid, cfg); err != nil {
+		cleanupClone()
+		return Server{}, err
+	}
+	server, err := c.GetServer(ctx, clonedVMID)
+	if err != nil {
+		cleanupClone()
+		return Server{}, err
+	}
+	return server, nil
+}
+
+func (c *ProxmoxClient) startVM(ctx context.Context, vmid int) error {
+	var upid string
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/status/start", url.PathEscape(c.Node), vmid), url.Values{}, &upid); err != nil {
+		return err
+	}
+	return c.waitTask(ctx, upid)
+}
+
+func (c *ProxmoxClient) stopVM(ctx context.Context, vmid int) error {
+	var upid string
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/status/stop", url.PathEscape(c.Node), vmid), url.Values{}, &upid); err != nil {
+		if IsProxmoxNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return c.waitTask(ctx, upid)
+}
+
+func (c *ProxmoxClient) DeleteServer(ctx context.Context, id string) error {
+	vmid, err := strconv.Atoi(strings.TrimSpace(id))
+	if err != nil {
+		server, err := c.GetServer(ctx, id)
+		if err != nil {
+			if IsProxmoxNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		vmid = int(server.ID)
+	}
+	_ = c.stopVM(ctx, vmid)
+	q := url.Values{}
+	q.Set("purge", "1")
+	var upid string
+	if err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/nodes/%s/qemu/%d?%s", url.PathEscape(c.Node), vmid, q.Encode()), nil, &upid); err != nil {
+		if IsProxmoxNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return c.waitTask(ctx, upid)
+}
+
+func (c *ProxmoxClient) GetServer(ctx context.Context, id string) (Server, error) {
+	vmid, err := strconv.Atoi(strings.TrimSpace(id))
+	if err != nil {
+		return c.getServerByName(ctx, id)
+	}
+	var status proxmoxVM
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", url.PathEscape(c.Node), vmid), nil, &status); err != nil {
+		return Server{}, err
+	}
+	labels := map[string]string{}
+	var config map[string]any
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), nil, &config); err == nil {
+		if desc, ok := config["description"].(string); ok {
+			labels = proxmoxDescriptionLabels(desc)
+		}
+		if status.Name == "" {
+			if name, ok := config["name"].(string); ok {
+				status.Name = name
+			}
+		}
+	}
+	ip, _ := c.guestIPv4(ctx, vmid)
+	server := proxmoxVMToServer(c.Node, status, labels, ip)
+	if server.Name == "" {
+		server.Name = "vm-" + strconv.Itoa(vmid)
+	}
+	return server, nil
+}
+
+func (c *ProxmoxClient) getServerByName(ctx context.Context, name string) (Server, error) {
+	vms, err := c.listQEMU(ctx)
+	if err != nil {
+		return Server{}, err
+	}
+	for _, vm := range vms {
+		if vm.Name == name {
+			return c.GetServer(ctx, strconv.Itoa(vm.VMID))
+		}
+	}
+	return Server{}, &ProxmoxError{Method: http.MethodGet, Path: "/nodes/" + c.Node + "/qemu/" + name, StatusCode: http.StatusNotFound, Body: "not found"}
+}
+
+func (c *ProxmoxClient) SetLabels(ctx context.Context, id string, labels map[string]string) error {
+	vmid, err := strconv.Atoi(strings.TrimSpace(id))
+	if err != nil {
+		server, err := c.GetServer(ctx, id)
+		if err != nil {
+			return err
+		}
+		vmid = int(server.ID)
+	}
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), url.Values{"description": {proxmoxDescription(labels)}}, nil)
+}
+
+type proxmoxTaskStatus struct {
+	Status     string `json:"status"`
+	ExitStatus string `json:"exitstatus"`
+}
+
+func (c *ProxmoxClient) waitTask(ctx context.Context, upid string) error {
+	if upid == "" {
+		return nil
+	}
+	path := fmt.Sprintf("/nodes/%s/tasks/%s/status", url.PathEscape(c.Node), url.PathEscape(upid))
+	deadline := time.Now().Add(15 * time.Minute)
+	for {
+		var status proxmoxTaskStatus
+		if err := c.do(ctx, http.MethodGet, path, nil, &status); err != nil {
+			return err
+		}
+		if status.Status == "stopped" {
+			if status.ExitStatus == "" || status.ExitStatus == "OK" {
+				return nil
+			}
+			return fmt.Errorf("proxmox task %s failed: %s", upid, status.ExitStatus)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for proxmox task %s", upid)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+type proxmoxAgentExecStart struct {
+	PID int `json:"pid"`
+}
+
+type proxmoxAgentExecStatus struct {
+	Exited   bool   `json:"exited"`
+	ExitCode int    `json:"exitcode"`
+	OutData  string `json:"out-data"`
+	ErrData  string `json:"err-data"`
+}
+
+func (c *ProxmoxClient) bootstrapGuest(ctx context.Context, vmid int, cfg Config) error {
+	if err := c.waitGuestAgent(ctx, vmid); err != nil {
+		return err
+	}
+	script := proxmoxBootstrapScript(cfg)
+	var start proxmoxAgentExecStart
+	form := url.Values{
+		"command":    {"/bin/bash"},
+		"input-data": {script},
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", url.PathEscape(c.Node), vmid), form, &start); err != nil {
+		return fmt.Errorf("proxmox guest bootstrap: %w", err)
+	}
+	return c.waitGuestExec(ctx, vmid, start.PID)
+}
+
+func (c *ProxmoxClient) waitGuestAgent(ctx context.Context, vmid int) error {
+	deadline := time.Now().Add(10 * time.Minute)
+	for {
+		if _, err := c.guestIPv4(ctx, vmid); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for proxmox qemu guest agent on vmid=%d", vmid)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+func (c *ProxmoxClient) waitGuestExec(ctx context.Context, vmid, pid int) error {
+	if pid == 0 {
+		return fmt.Errorf("proxmox guest exec returned empty pid")
+	}
+	path := fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec-status?pid=%d", url.PathEscape(c.Node), vmid, pid)
+	deadline := time.Now().Add(15 * time.Minute)
+	for {
+		var status proxmoxAgentExecStatus
+		if err := c.do(ctx, http.MethodGet, path, nil, &status); err != nil {
+			return err
+		}
+		if status.Exited {
+			if status.ExitCode == 0 {
+				return nil
+			}
+			return fmt.Errorf("proxmox guest bootstrap exit=%d stderr=%s stdout=%s", status.ExitCode, strings.TrimSpace(status.ErrData), strings.TrimSpace(status.OutData))
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for proxmox guest bootstrap pid=%d", pid)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+type proxmoxAgentInterface struct {
+	Name        string `json:"name"`
+	IPAddresses []struct {
+		Type    string `json:"ip-address-type"`
+		Address string `json:"ip-address"`
+	} `json:"ip-addresses"`
+}
+
+func (c *ProxmoxClient) guestIPv4(ctx context.Context, vmid int) (string, error) {
+	var res struct {
+		Result []proxmoxAgentInterface `json:"result"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/nodes/%s/qemu/%d/agent/network-get-interfaces", url.PathEscape(c.Node), vmid), nil, &res); err != nil {
+		return "", err
+	}
+	for _, iface := range res.Result {
+		name := strings.ToLower(iface.Name)
+		if name == "lo" || strings.HasPrefix(name, "docker") || strings.HasPrefix(name, "veth") {
+			continue
+		}
+		for _, addr := range iface.IPAddresses {
+			if addr.Type != "ipv4" || addr.Address == "" || strings.HasPrefix(addr.Address, "127.") {
+				continue
+			}
+			if ip := net.ParseIP(addr.Address); ip != nil && ip.To4() != nil {
+				return addr.Address, nil
+			}
+		}
+	}
+	return "", errors.New("no guest ipv4 address reported by qemu guest agent")
+}
+
+func proxmoxVMToServer(node string, vm proxmoxVM, labels map[string]string, ip string) Server {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if labels["node"] == "" {
+		labels["node"] = node
+	}
+	server := Server{
+		Provider: "proxmox",
+		CloudID:  strconv.Itoa(vm.VMID),
+		ID:       int64(vm.VMID),
+		Name:     vm.Name,
+		Status:   vm.Status,
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = ip
+	server.PrivateNet.IPv4.IP = ip
+	server.ServerType.Name = blank(labels["server_type"], blank(labels["template_id"], "template"))
+	return server
+}
+
+func isCrabboxProxmoxLease(server Server) bool {
+	if server.Labels == nil {
+		return false
+	}
+	if server.Labels["crabbox"] != "true" {
+		return false
+	}
+	if provider := server.Labels["provider"]; provider != "" && provider != "proxmox" {
+		return false
+	}
+	return true
+}
+
+func IsCrabboxProxmoxLease(server Server) bool {
+	return isCrabboxProxmoxLease(server)
+}
+
+func IsProxmoxNotFound(err error) bool {
+	var proxErr *ProxmoxError
+	return errors.As(err, &proxErr) && proxErr.StatusCode == http.StatusNotFound
+}
+
+func proxmoxDescription(labels map[string]string) string {
+	var b strings.Builder
+	b.WriteString("crabbox labels\n")
+	for _, key := range sortedLabelKeys(labels) {
+		fmt.Fprintf(&b, "%s=%s\n", key, labels[key])
+	}
+	return b.String()
+}
+
+func proxmoxDescriptionLabels(desc string) map[string]string {
+	labels := map[string]string{}
+	for _, line := range strings.Split(desc, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "crabbox labels" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		labels[key] = strings.TrimSpace(value)
+	}
+	return labels
+}
+
+func sortedLabelKeys(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func proxmoxBootstrapScript(cfg Config) string {
+	return fmt.Sprintf(`set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p %[1]s /var/cache/crabbox/pnpm /var/cache/crabbox/npm /var/lib/crabbox
+cat >/etc/apt/apt.conf.d/80-crabbox-retries <<'APT'
+Acquire::Retries "8";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+APT
+retry() {
+  n=1
+  until "$@"; do
+    if [ "$n" -ge 8 ]; then
+      return 1
+    fi
+    sleep $((n * 5))
+    n=$((n + 1))
+  done
+}
+retry apt-get update
+retry apt-get install -y --no-install-recommends openssh-server ca-certificates curl git rsync jq
+chown -R %[2]s:%[2]s %[1]s /var/cache/crabbox || true
+cat >/usr/local/bin/crabbox-ready <<'READY'
+#!/usr/bin/env bash
+set -euo pipefail
+git --version >/dev/null
+rsync --version >/dev/null
+curl --version >/dev/null
+jq --version >/dev/null
+test -w %[1]s
+READY
+chmod 0755 /usr/local/bin/crabbox-ready
+systemctl enable ssh || true
+systemctl restart ssh || systemctl restart ssh.socket || true
+touch /var/lib/crabbox/bootstrapped
+/usr/local/bin/crabbox-ready
+`, shellQuote(cfg.WorkRoot), shellQuote(cfg.SSHUser))
+}

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -220,7 +220,7 @@ func (c *ProxmoxClient) CreateServer(ctx context.Context, cfg Config, publicKey,
 	if cfg.Proxmox.Bridge != "" {
 		config.Set("net0", "virtio,bridge="+cfg.Proxmox.Bridge)
 	}
-	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), config, nil); err != nil {
+	if err := c.configureVM(ctx, vmid, config); err != nil {
 		cleanupClone()
 		return Server{}, err
 	}
@@ -335,7 +335,15 @@ func (c *ProxmoxClient) SetLabels(ctx context.Context, id string, labels map[str
 		}
 		vmid = int(server.ID)
 	}
-	return c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), url.Values{"description": {proxmoxDescription(labels)}}, nil)
+	return c.configureVM(ctx, vmid, url.Values{"description": {proxmoxDescription(labels)}})
+}
+
+func (c *ProxmoxClient) configureVM(ctx context.Context, vmid int, form url.Values) error {
+	var upid string
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/config", url.PathEscape(c.Node), vmid), form, &upid); err != nil {
+		return err
+	}
+	return c.waitTask(ctx, upid)
 }
 
 type proxmoxTaskStatus struct {
@@ -389,7 +397,7 @@ func (c *ProxmoxClient) bootstrapGuest(ctx context.Context, vmid int, cfg Config
 	script := proxmoxBootstrapScript(cfg)
 	var start proxmoxAgentExecStart
 	form := url.Values{
-		"command":    {"/bin/bash"},
+		"command":    {"/bin/bash", "-s"},
 		"input-data": {script},
 	}
 	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", url.PathEscape(c.Node), vmid), form, &start); err != nil {

--- a/internal/cli/proxmox_test.go
+++ b/internal/cli/proxmox_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProxmoxDescriptionRoundTrip(t *testing.T) {
+	labels := map[string]string{
+		"crabbox": "true",
+		"lease":   "cbx_123456abcdef",
+		"slug":    "blue-crab",
+	}
+	got := proxmoxDescriptionLabels(proxmoxDescription(labels))
+	if got["crabbox"] != "true" || got["lease"] != "cbx_123456abcdef" || got["slug"] != "blue-crab" {
+		t.Fatalf("labels=%#v", got)
+	}
+}
+
+func TestNewProxmoxClientStripsAPIPathAndUsesTokenAuth(t *testing.T) {
+	var auth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		if r.URL.Path != "/api2/json/cluster/nextid" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": "123"})
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Proxmox.APIURL = server.URL + "/api2/json"
+	cfg.Proxmox.TokenID = "runner@pve!crabbox"
+	cfg.Proxmox.TokenSecret = "secret"
+	cfg.Proxmox.Node = "pve1"
+	cfg.Proxmox.TemplateID = 9000
+	client, err := NewProxmoxClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := client.nextID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != 123 {
+		t.Fatalf("id=%d", id)
+	}
+	if auth != "PVEAPIToken=runner@pve!crabbox=secret" {
+		t.Fatalf("auth=%q", auth)
+	}
+}
+
+func TestProxmoxCreateServerFlow(t *testing.T) {
+	var forms []url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "PVEAPIToken=runner@pve!crabbox=secret" {
+			t.Fatalf("auth=%q", r.Header.Get("Authorization"))
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/cluster/nextid":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": 101})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/9000/clone":
+			forms = append(forms, readForm(t, r))
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:clone"})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api2/json/nodes/pve1/tasks/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"status": "stopped", "exitstatus": "OK"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/config":
+			forms = append(forms, readForm(t, r))
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": nil})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/status/start":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:start"})
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/agent/network-get-interfaces":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"result": []any{
+				map[string]any{"name": "lo", "ip-addresses": []any{map[string]any{"ip-address-type": "ipv4", "ip-address": "127.0.0.1"}}},
+				map[string]any{"name": "eth0", "ip-addresses": []any{map[string]any{"ip-address-type": "ipv4", "ip-address": "192.0.2.44"}}},
+			}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/agent/exec":
+			forms = append(forms, readForm(t, r))
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"pid": 77}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/agent/exec-status":
+			if r.URL.Query().Get("pid") != "77" {
+				t.Fatalf("pid=%s", r.URL.Query().Get("pid"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"exited": true, "exitcode": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/status/current":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"vmid": 101, "name": "crabbox-blue-crab-12345678", "status": "running"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/config":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"description": "crabbox labels\ncrabbox=true\nprovider=proxmox\nlease=cbx_123456abcdef\nslug=blue-crab\nserver_type=template-9000\n"}})
+		default:
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "proxmox"
+	cfg.Proxmox.APIURL = server.URL
+	cfg.Proxmox.TokenID = "runner@pve!crabbox"
+	cfg.Proxmox.TokenSecret = "secret"
+	cfg.Proxmox.Node = "pve1"
+	cfg.Proxmox.TemplateID = 9000
+	cfg.Proxmox.Storage = "local-lvm"
+	cfg.Proxmox.Pool = "ci"
+	cfg.Proxmox.Bridge = "vmbr1"
+	cfg.ServerType = proxmoxServerTypeForConfig(cfg)
+	client, err := NewProxmoxClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := client.CreateServer(ctx, cfg, "ssh-ed25519 AAAA test", "cbx_123456abcdef", "blue-crab", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CloudID != "101" || got.PublicNet.IPv4.IP != "192.0.2.44" || got.Labels["lease"] != "cbx_123456abcdef" {
+		t.Fatalf("server=%#v", got)
+	}
+	if forms[0].Get("newid") != "101" || forms[0].Get("storage") != "local-lvm" || forms[0].Get("pool") != "ci" {
+		t.Fatalf("clone form=%v", forms[0])
+	}
+	if forms[1].Get("ciuser") != "crabbox" || !strings.Contains(forms[1].Get("sshkeys"), "ssh-ed25519") || forms[1].Get("net0") != "virtio,bridge=vmbr1" {
+		t.Fatalf("config form=%v", forms[1])
+	}
+	if forms[2].Get("command") != "/bin/bash" || !strings.Contains(forms[2].Get("input-data"), "crabbox-ready") {
+		t.Fatalf("exec form=%v", forms[2])
+	}
+}
+
+func TestProxmoxCreateServerCleansUpCloneOnConfigFailure(t *testing.T) {
+	stopped := false
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/cluster/nextid":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": 101})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/9000/clone":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:clone"})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api2/json/nodes/pve1/tasks/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"status": "stopped", "exitstatus": "OK"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/config":
+			http.Error(w, "permission denied", http.StatusForbidden)
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/status/stop":
+			stopped = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:stop"})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api2/json/nodes/pve1/qemu/101":
+			if r.URL.Query().Get("purge") != "1" {
+				t.Fatalf("purge=%s", r.URL.Query().Get("purge"))
+			}
+			deleted = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:delete"})
+		default:
+			t.Fatalf("%s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "proxmox"
+	cfg.Proxmox.APIURL = server.URL
+	cfg.Proxmox.TokenID = "runner@pve!crabbox"
+	cfg.Proxmox.TokenSecret = "secret"
+	cfg.Proxmox.Node = "pve1"
+	cfg.Proxmox.TemplateID = 9000
+	client, err := NewProxmoxClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := client.CreateServer(ctx, cfg, "ssh-ed25519 AAAA test", "cbx_123456abcdef", "blue-crab", false); err == nil {
+		t.Fatal("expected config failure")
+	}
+	if !stopped || !deleted {
+		t.Fatalf("cleanup stopped=%v deleted=%v", stopped, deleted)
+	}
+}
+
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	if err := r.ParseForm(); err != nil {
+		t.Fatal(err)
+	}
+	return r.Form
+}

--- a/internal/cli/proxmox_test.go
+++ b/internal/cli/proxmox_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -58,6 +59,7 @@ func TestNewProxmoxClientStripsAPIPathAndUsesTokenAuth(t *testing.T) {
 
 func TestProxmoxCreateServerFlow(t *testing.T) {
 	var forms []url.Values
+	var events []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "PVEAPIToken=runner@pve!crabbox=secret" {
 			t.Fatalf("auth=%q", r.Header.Get("Authorization"))
@@ -67,13 +69,26 @@ func TestProxmoxCreateServerFlow(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": 101})
 		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/9000/clone":
 			forms = append(forms, readForm(t, r))
+			events = append(events, "clone")
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:clone"})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api2/json/nodes/pve1/tasks/"):
+			switch {
+			case strings.Contains(r.URL.Path, "clone"):
+				events = append(events, "wait-clone")
+			case strings.Contains(r.URL.Path, "config"):
+				events = append(events, "wait-config")
+			case strings.Contains(r.URL.Path, "start"):
+				events = append(events, "wait-start")
+			default:
+				t.Fatalf("unexpected task path %s", r.URL.Path)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"status": "stopped", "exitstatus": "OK"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/config":
 			forms = append(forms, readForm(t, r))
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": nil})
+			events = append(events, "config")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:config"})
 		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/status/start":
+			events = append(events, "start")
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": "UPID:pve1:start"})
 		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/nodes/pve1/qemu/101/agent/network-get-interfaces":
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"result": []any{
@@ -128,8 +143,15 @@ func TestProxmoxCreateServerFlow(t *testing.T) {
 	if forms[1].Get("ciuser") != "crabbox" || !strings.Contains(forms[1].Get("sshkeys"), "ssh-ed25519") || forms[1].Get("net0") != "virtio,bridge=vmbr1" {
 		t.Fatalf("config form=%v", forms[1])
 	}
-	if forms[2].Get("command") != "/bin/bash" || !strings.Contains(forms[2].Get("input-data"), "crabbox-ready") {
+	if got := forms[2]["command"]; !reflect.DeepEqual(got, []string{"/bin/bash", "-s"}) {
+		t.Fatalf("exec command=%v want [/bin/bash -s]", got)
+	}
+	if !strings.Contains(forms[2].Get("input-data"), "crabbox-ready") {
 		t.Fatalf("exec form=%v", forms[2])
+	}
+	wantEvents := []string{"clone", "wait-clone", "config", "wait-config", "start", "wait-start"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events=%v want %v", events, wantEvents)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1399,6 +1399,13 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	if cfg.Provider == "azure" || server.Provider == "azure" {
 		return deleteAzureServer(ctx, cfg, server)
 	}
+	if cfg.Provider == "proxmox" || server.Provider == "proxmox" {
+		client, err := NewProxmoxClient(cfg)
+		if err != nil {
+			return err
+		}
+		return client.DeleteServer(ctx, server.CloudID)
+	}
 	client, err := newHetznerClient()
 	if err != nil {
 		return err

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,3 +1,3 @@
 package cli
 
-var version = "0.11.1-dev"
+var version = "0.12.0-dev"

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/hetzner"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
+	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -1,0 +1,236 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type Config = core.Config
+type Runtime = core.Runtime
+type ProviderSpec = core.ProviderSpec
+type Backend = core.Backend
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type CleanupRequest = core.CleanupRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+
+type leaseBackend struct{ shared.DirectSSHBackend }
+
+func NewLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = "proxmox"
+	if cfg.Proxmox.User != "" {
+		cfg.SSHUser = cfg.Proxmox.User
+	}
+	if cfg.Proxmox.WorkRoot != "" {
+		cfg.WorkRoot = cfg.Proxmox.WorkRoot
+	}
+	return &leaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt}}
+}
+
+func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+		return b.acquireOnce(ctx, req.Keep)
+	})
+}
+
+func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool) (LeaseTarget, error) {
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	leaseID := newLeaseID()
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	slug := allocateDirectLeaseSlug(leaseID, servers)
+	cfg := b.Cfg
+	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = providerKeyForLease(leaseID)
+	cfg.ServerType = proxmoxServerTypeForConfig(cfg)
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=proxmox lease=%s slug=%s node=%s template=%d keep=%v\n",
+		leaseID, slug, cfg.Proxmox.Node, cfg.Proxmox.TemplateID, keep)
+	server, err := client.CreateServer(ctx, cfg, publicKey, leaseID, slug, keep)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if server.PublicNet.IPv4.IP == "" {
+		cloudID := server.CloudID
+		server, err = client.GetServer(ctx, server.CloudID)
+		if err != nil {
+			_ = client.DeleteServer(context.Background(), cloudID)
+			return LeaseTarget{}, err
+		}
+	}
+	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+		_ = client.DeleteServer(context.Background(), server.CloudID)
+		return LeaseTarget{}, err
+	}
+	server.Labels["state"] = "ready"
+	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
+		fmt.Fprintf(b.RT.Stderr, "warning: set proxmox labels: %v\n", err)
+	}
+	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s node=%s ip=%s\n", leaseID, server.DisplayID(), cfg.Proxmox.Node, server.PublicNet.IPv4.IP)
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.ID != "" {
+		if _, err := strconv.Atoi(req.ID); err == nil || strings.HasPrefix(req.ID, "crabbox-") {
+			server, err := client.GetServer(ctx, req.ID)
+			if err != nil {
+				if !core.IsProxmoxNotFound(err) {
+					return LeaseTarget{}, err
+				}
+			} else {
+				if !isCrabboxLease(server) {
+					return LeaseTarget{}, exit(4, "lease/server not found: %s (VM exists but is not Crabbox-managed)", req.ID)
+				}
+				return b.targetForServer(server), nil
+			}
+		}
+	}
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
+		return LeaseTarget{}, err
+	} else if leaseID != "" {
+		target := b.targetForServer(server)
+		target.LeaseID = leaseID
+		return target, nil
+	}
+	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+}
+
+func (b *leaseBackend) targetForServer(server Server) LeaseTarget {
+	cfg := b.Cfg
+	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	leaseID := core.Blank(server.Labels["lease"], server.CloudID)
+	useStoredTestboxKey(&target, leaseID)
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+}
+
+func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return nil, err
+	}
+	return client.ListCrabboxServers(ctx)
+}
+
+func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return err
+	}
+	id := req.Lease.Server.CloudID
+	if id == "" {
+		id = req.Lease.LeaseID
+	}
+	if err := client.DeleteServer(ctx, id); err != nil {
+		return err
+	}
+	removeLeaseClaim(req.Lease.LeaseID)
+	return nil
+}
+
+func (b *leaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return Server{}, err
+	}
+	server := req.Lease.Server
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
+	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
+		return Server{}, err
+	}
+	return server, nil
+}
+
+func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+	if err != nil {
+		return err
+	}
+	client, err := newClient(b.Cfg)
+	if err != nil {
+		return err
+	}
+	for _, server := range servers {
+		shouldDelete, reason := core.ShouldCleanupServer(server, time.Now().UTC())
+		if !shouldDelete {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
+		if req.DryRun {
+			continue
+		}
+		if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newClient(cfg Config) (*core.ProxmoxClient, error) { return core.NewProxmoxClient(cfg) }
+func newLeaseID() string                                { return core.NewLeaseID() }
+func allocateDirectLeaseSlug(id string, servers []Server) string {
+	return core.AllocateDirectLeaseSlug(id, servers)
+}
+func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
+	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
+}
+func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
+func proxmoxServerTypeForConfig(cfg Config) string {
+	return core.ProxmoxServerTypeForConfig(cfg)
+}
+func sshTargetFromConfig(cfg Config, host string) SSHTarget {
+	return core.SSHTargetFromConfig(cfg, host)
+}
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+}
+func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
+func findServerByAlias(servers []Server, id string) (Server, string, error) {
+	return core.FindServerByAlias(servers, id)
+}
+func isCrabboxLease(server Server) bool { return core.IsCrabboxProxmoxLease(server) }
+func removeLeaseClaim(leaseID string)   { core.RemoveLeaseClaim(leaseID) }
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func useStoredTestboxKey(target *SSHTarget, leaseID string) {
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			target.Key = keyPath
+		}
+	}
+}

--- a/internal/providers/proxmox/provider.go
+++ b/internal/providers/proxmox/provider.go
@@ -1,0 +1,98 @@
+package proxmox
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return "proxmox" }
+func (Provider) Aliases() []string { return nil }
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        "proxmox",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+type flagValues struct {
+	APIURL      *string
+	Node        *string
+	TemplateID  *int
+	Storage     *string
+	Pool        *string
+	Bridge      *string
+	User        *string
+	WorkRoot    *string
+	FullClone   *bool
+	InsecureTLS *bool
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		APIURL:      fs.String("proxmox-api-url", defaults.Proxmox.APIURL, "Proxmox VE API URL"),
+		Node:        fs.String("proxmox-node", defaults.Proxmox.Node, "Proxmox VE node name"),
+		TemplateID:  fs.Int("proxmox-template-id", defaults.Proxmox.TemplateID, "Proxmox QEMU template VMID"),
+		Storage:     fs.String("proxmox-storage", defaults.Proxmox.Storage, "Proxmox clone storage"),
+		Pool:        fs.String("proxmox-pool", defaults.Proxmox.Pool, "Proxmox pool for cloned VMs"),
+		Bridge:      fs.String("proxmox-bridge", defaults.Proxmox.Bridge, "Proxmox bridge for net0 override"),
+		User:        fs.String("proxmox-user", defaults.Proxmox.User, "cloud-init SSH user for cloned VMs"),
+		WorkRoot:    fs.String("proxmox-work-root", defaults.Proxmox.WorkRoot, "remote work root for Proxmox VMs"),
+		FullClone:   fs.Bool("proxmox-full-clone", defaults.Proxmox.FullClone, "create full Proxmox clones"),
+		InsecureTLS: fs.Bool("proxmox-insecure-tls", defaults.Proxmox.InsecureTLS, "allow self-signed Proxmox TLS certificates"),
+	}
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "proxmox-api-url") {
+		cfg.Proxmox.APIURL = *v.APIURL
+	}
+	if core.FlagWasSet(fs, "proxmox-node") {
+		cfg.Proxmox.Node = *v.Node
+	}
+	if core.FlagWasSet(fs, "proxmox-template-id") {
+		cfg.Proxmox.TemplateID = *v.TemplateID
+		cfg.ServerType = core.ProxmoxServerTypeForConfig(*cfg)
+	}
+	if core.FlagWasSet(fs, "proxmox-storage") {
+		cfg.Proxmox.Storage = *v.Storage
+	}
+	if core.FlagWasSet(fs, "proxmox-pool") {
+		cfg.Proxmox.Pool = *v.Pool
+	}
+	if core.FlagWasSet(fs, "proxmox-bridge") {
+		cfg.Proxmox.Bridge = *v.Bridge
+	}
+	if core.FlagWasSet(fs, "proxmox-user") {
+		cfg.Proxmox.User = *v.User
+		cfg.SSHUser = *v.User
+	}
+	if core.FlagWasSet(fs, "proxmox-work-root") {
+		cfg.Proxmox.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if core.FlagWasSet(fs, "proxmox-full-clone") {
+		cfg.Proxmox.FullClone = *v.FullClone
+	}
+	if core.FlagWasSet(fs, "proxmox-insecure-tls") {
+		cfg.Proxmox.InsecureTLS = *v.InsecureTLS
+	}
+	return nil
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewLeaseBackend(p.Spec(), cfg, rt), nil
+}


### PR DESCRIPTION
## Summary

- add a direct `provider: proxmox` backend for Linux Proxmox VE QEMU VM clones
- support Proxmox config/env/flags, cloud-init SSH key injection, QEMU guest-agent bootstrap, list/status/stop/touch/cleanup, and provider registration
- document Proxmox setup, lifecycle, troubleshooting, command/provider references, and changelog entry for 0.12.0 Unreleased

## Notes

- Proxmox is direct-only in this PR; the coordinator does not broker Proxmox API tokens or capacity.
- Secrets stay in config/env only. There is intentionally no `--proxmox-token-secret` flag.
- Provisioning is covered by fake Proxmox API tests, including clone/config/start/guest-agent/bootstrap and cleanup after clone-time failures. I did not run a live Proxmox smoke because this checkout has no Proxmox cluster credentials.

## Verification

- `go test ./internal/cli ./internal/providers/proxmox`
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
