### PR TITLE
feat(azure): support Windows desktop and WSL2 leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `crabbox run --keep-on-failure` so failed one-shot runs can leave the exact lease available for SSH inspection until idle/TTL expiry.
 - Added `provider: proxmox` for direct Proxmox VE Linux QEMU VM leases, including template clone, cloud-init SSH key injection, guest-agent bootstrap, docs, and cleanup support.
 - Added `scripts/proxmox-build-template.sh` to build a Crabbox-ready Ubuntu 24.04 Proxmox template from a public cloud image. Thanks @VACInc.
+- Added Azure native Windows desktop/VNC and Windows WSL2 lease support, matching the AWS Windows capability boundary. Thanks @jwmoss.
 - Added `crabbox azure login` so direct Azure users can persist the active `az login` subscription, tenant, and location without manually exporting service-principal environment variables. Thanks @galiniliev.
 - Added `azure.network` / `CRABBOX_AZURE_NETWORK` so Azure direct leases can SSH through private VNet addresses when using VPN/private-network access. Thanks @galiniliev.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ OpenClaw WSL2 test helper:
 
 ```sh
 CRABBOX_LIVE=1 scripts/openclaw-wsl2-tests.sh
-CRABBOX_LIVE=1 CRABBOX_OPENCLAW_WSL2_PROVIDER=azure scripts/openclaw-wsl2-tests.sh
 CRABBOX_LIVE=1 CRABBOX_OPENCLAW_WSL2_ID=blue-lobster scripts/openclaw-wsl2-tests.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Supported providers:
 - [AWS EC2](docs/providers/aws.md) (`provider: aws`): brokered or direct Linux,
   native Windows, Windows WSL2, and EC2 Mac.
 - [Azure](docs/providers/azure.md) (`provider: azure`): brokered or direct
-  Linux and native Windows VMs.
+  Linux, native Windows, and Windows WSL2 VMs.
 - [Google Cloud](docs/providers/gcp.md) (`provider: gcp`): brokered or direct
   Linux Compute Engine VMs.
 - [Hetzner Cloud](docs/providers/hetzner.md) (`provider: hetzner`): brokered or
@@ -112,8 +112,8 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Run observability.** Every coordinator-backed run gets an early `run_...` handle. Use `crabbox attach <run-id>` while it is active, `crabbox events <run-id> --after <seq> --limit <n>` for durable lifecycle/output events, and `crabbox logs <run-id>` for retained output after completion.
 - **Stable timing records.** `--timing-json` on `run`, `warmup`, and `actions hydrate` gives scripts one machine-readable sync/command/total timing schema across AWS, Hetzner, and Blacksmith Testboxes.
 - **Local-first workspace sync.** No clean-checkout requirement. Tracked + nonignored files only, fingerprint skip on no-op runs, sanity checks against suspicious mass deletions, optional shallow base-ref hydration for changed-test workflows.
-- **Brokered cloud.** Maintainers and agents share infra without sharing provider tokens. Hetzner, AWS EC2, Azure, and Google Cloud are managed providers; AWS also owns Windows WSL2 and EC2 Mac targets. Linux defaults to Spot unless capacity config says otherwise. Providers fall back across compatible instance families when capacity or quota rejects a request.
-- **Azure Linux and native Windows.** `provider: azure` provisions Linux and native Windows VMs in a configurable Azure subscription using `DefaultAzureCredential` in direct mode or service-principal secrets in the broker. Crabbox creates a shared resource group, vnet, subnet, and NSG on first use, then per-lease public IPs, NICs, and VMs. Linux uses cloud-init; Windows uses VM Agent Custom Script Extension to install OpenSSH/Git and configure the Crabbox user.
+- **Brokered cloud.** Maintainers and agents share infra without sharing provider tokens. Hetzner, AWS EC2, Azure, and Google Cloud are managed providers; AWS owns EC2 Mac targets. Linux defaults to Spot unless capacity config says otherwise. Providers fall back across compatible instance families when capacity or quota rejects a request.
+- **Azure Linux and Windows.** `provider: azure` provisions Linux, native Windows, and Windows WSL2 VMs in a configurable Azure subscription using `DefaultAzureCredential` in direct mode or service-principal secrets in the broker. Crabbox creates a shared resource group, vnet, subnet, and NSG on first use, then per-lease public IPs, NICs, and VMs. Linux uses cloud-init; Windows uses VM Agent Custom Script Extension to install OpenSSH/Git and configure the Crabbox user, with optional post-SSH desktop/VNC or WSL2 bootstrap.
 - **macOS and Windows static hosts.** `provider: ssh` reuses existing machines; it does not create macOS or Windows Crabbox boxes. macOS and Windows WSL2 use the POSIX rsync path; native Windows uses PowerShell plus tar archive sync.
 - **Blacksmith Testbox wrapper.** Set `provider: blacksmith-testbox` to delegate warmup/run/list/status/stop to the Blacksmith CLI while Crabbox keeps local slugs, repo claims, timing summaries, config conventions, and portal visibility for active external runners.
 - **Namespace Devbox SSH leases.** Set `provider: namespace-devbox` to create or reuse Namespace Devboxes through the `devbox` CLI, then let Crabbox sync the dirty checkout and run commands over SSH.
@@ -124,7 +124,7 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
 - **Trusted AWS images.** Operators can create AMIs from active brokered AWS leases and promote a known-good image as the coordinator default.
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type.
 - **GitHub Actions hydration.** `crabbox actions hydrate` registers a leased box as an ephemeral Actions runner, so the repo's own workflow installs runtimes, services, and secrets. Crabbox does not parse Actions YAML.
-- **Interactive desktop and browser leases.** `--browser` provisions Chrome or Chromium for headless automation, `--desktop` provisions visible UI with tunnel-only VNC takeover on managed Linux, AWS native Windows, and AWS EC2 Mac targets. `crabbox desktop doctor` checks session, VNC, input tooling, browser, ffmpeg, screen size, screenshot capture, and WebVNC portal state; `desktop click/paste/type/key` provide first-class input helpers so agents do not hand-roll brittle `xdotool` snippets. `desktop proof` launches a terminal smoke and captures metadata, screenshot, diagnostics, MP4, and a contact-sheet PNG in one bundle that can be published to a PR; MP4 capture is Linux/native Windows only for now. QA systems such as Mantis own scenario logic, screenshots, and PR evidence. Azure native Windows is SSH/sync/run only; use AWS for managed Windows desktop/WSL2 or `provider: ssh` for an existing Windows host.
+- **Interactive desktop and browser leases.** `--browser` provisions Chrome or Chromium for headless automation, `--desktop` provisions visible UI with tunnel-only VNC takeover on managed Linux, native Windows on AWS or Azure, and AWS EC2 Mac targets. `crabbox desktop doctor` checks session, VNC, input tooling, browser, ffmpeg, screen size, screenshot capture, and WebVNC portal state; `desktop click/paste/type/key` provide first-class input helpers so agents do not hand-roll brittle `xdotool` snippets. `desktop proof` launches a terminal smoke and captures metadata, screenshot, diagnostics, MP4, and a contact-sheet PNG in one bundle that can be published to a PR; MP4 capture is Linux/native Windows only for now. QA systems such as Mantis own scenario logic, screenshots, and PR evidence. Windows WSL2 is for POSIX sync/run/actions hydration, not a separate VNC desktop; existing Windows hosts belong on `provider: ssh`.
 - **Authenticated web portal.** Browser login opens owner-scoped and explicitly shared lease/run views with searchable, paginated tables, muted external-runner rows, compact provider/OS/access icons, relative sortable times, recent run logs/events, WebVNC, code-server, and Linux lease/run telemetry charts. `crabbox share` can grant a lease to one user or the owning org, and the lease page exposes the same sharing controls for owners/managers. WebVNC is preferred for human demos because it preloads the VNC password; `webvnc status` reports local daemon, tunnel, target reachability, bridge/viewer state, recent events, URL/password, and native VNC fallback, while `webvnc reset` restarts only the selected lease's WebVNC/input stack. Admin sessions can also see non-owned runner leases behind `mine`/`system` filters.
 - **Agent workspace evidence.** History, logs, events, telemetry, JUnit summaries, screenshots, recordings, artifacts, and PR publishing make autonomous work reviewable instead of only ephemeral terminal output.
 - **Hardened coordinator auth.** GitHub browser login, owner-scoped leases, admin-only routes, optional GitHub team allowlists, Cloudflare Access JWT verification, and service-token support keep normal use and operator automation separate.
@@ -163,7 +163,8 @@ Azure      standard  Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2, th
            large     Standard_D96ads_v6, Standard_D96ds_v6, then 64/48-vCPU fallbacks
            beast     Standard_D192ds_v6, Standard_D128ds_v6, then 96/64-vCPU fallbacks
 
-Azure Win  standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
+Azure Win/
+WSL2       standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_D2as_v6
            fast      Standard_D4ads_v6, Standard_D4ds_v6, Standard_D4ads_v5, Standard_D4ds_v5, Standard_D4as_v6
            large     Standard_D8ads_v6, Standard_D8ds_v6, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D8as_v6
            beast     Standard_D16ads_v6, Standard_D16ds_v6, Standard_D16ads_v5, Standard_D16ds_v5, Standard_D8ads_v6
@@ -310,6 +311,7 @@ OpenClaw WSL2 test helper:
 
 ```sh
 CRABBOX_LIVE=1 scripts/openclaw-wsl2-tests.sh
+CRABBOX_LIVE=1 CRABBOX_OPENCLAW_WSL2_PROVIDER=azure scripts/openclaw-wsl2-tests.sh
 CRABBOX_LIVE=1 CRABBOX_OPENCLAW_WSL2_ID=blue-lobster scripts/openclaw-wsl2-tests.sh
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ crabbox CLI    -- HTTPS --> Fleet Durable Object  -->   Hetzner / AWS / Azure / 
    +------------ SSH + rsync to leased runner <--------------+
 ```
 
-The CLI is a Go binary. The broker is a Cloudflare Worker plus a single Durable Object. Brokered Linux runners are vanilla Ubuntu boxes prepared by cloud-init with SSH, Git, rsync, curl, jq, and `/work/crabbox`; AWS can also broker managed Windows/WSL2 and EC2 Mac desktop targets, while Azure can broker native Windows SSH/sync/run targets. Static hosts are existing SSH machines selected with `provider: ssh`. Project runtimes come from Actions hydration or repo-owned setup. Runners hold no broker credentials - they are leaf nodes.
+The CLI is a Go binary. The broker is a Cloudflare Worker plus a single Durable Object. Brokered Linux runners are vanilla Ubuntu boxes prepared by cloud-init with SSH, Git, rsync, curl, jq, and `/work/crabbox`; AWS can also broker managed Windows/WSL2 and EC2 Mac desktop targets, while Azure can broker native Windows SSH/sync/run, desktop/VNC, and Windows WSL2 targets. Static hosts are existing SSH machines selected with `provider: ssh`. Project runtimes come from Actions hydration or repo-owned setup. Runners hold no broker credentials - they are leaf nodes.
 
 ## A run, end to end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,7 +121,7 @@ Owned backends:
 - `hetzner-static`: pre-created warm machines.
 - `hetzner-ephemeral`: created per lease or overflow.
 - `aws`: one-time EC2 instances for burst capacity, managed Windows/WSL2, and EC2 Mac.
-- `azure`: one-time Azure VMs for Linux and native Windows SSH/sync/run.
+- `azure`: one-time Azure VMs for Linux and managed Windows/WSL2, including optional native Windows desktop/VNC.
 - `ssh-static`: manually managed machines reachable by SSH.
 
 Brokered backends, later:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,7 @@ crabbox init [--force]
 crabbox config show [--json]
 crabbox config path
 crabbox config set-broker --url <url> --token-stdin [--provider hetzner|aws|azure|gcp]
-crabbox warmup [--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--profile <name>] [--idle-timeout <duration>] [--timing-json]
+crabbox warmup [--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--windows-mode normal|wsl2] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--profile <name>] [--idle-timeout <duration>] [--timing-json]
 crabbox run [--id <lease-id-or-slug>] [--provider hetzner|aws|azure|gcp|proxmox|ssh|blacksmith-testbox|namespace-devbox|semaphore|sprites|daytona|islo|e2b] [--target linux|macos|windows] [--windows-mode normal|wsl2] [--desktop] [--browser] [--code] [--tailscale] [--network auto|tailscale|public] [--keep-on-failure] [--shell] [--script <file>|--script-stdin] [--fresh-pr <owner/repo#number>] [--allow-env <name>] [--env-from-profile <file>] [--checksum] [--debug] [--force-sync-large] [--preflight] [--capture-stdout <path>] [--capture-stderr <path>] [--capture-on-fail] [--download remote=local] [--timing-json] [--blacksmith-workflow <workflow>] -- <command...>
 crabbox job list
 crabbox job run [--id <lease-id-or-slug>] [--dry-run] [--no-hydrate] [--stop auto|always|success|failure|never] <name>
@@ -167,10 +167,13 @@ crabbox run --provider ssh --target windows --windows-mode normal --static-host 
 crabbox run --provider ssh --target windows --windows-mode wsl2 --static-host win-dev.local -- pnpm test
 ```
 
-Create managed AWS desktop boxes:
+Create managed cloud Windows boxes:
 
 ```sh
 crabbox warmup --provider aws --target windows --desktop
+crabbox warmup --provider azure --target windows --desktop
+crabbox warmup --provider aws --target windows --windows-mode wsl2
+crabbox warmup --provider azure --target windows --windows-mode wsl2
 CRABBOX_AWS_MAC_HOST_ID=h-... crabbox warmup --provider aws --target macos --desktop --market on-demand
 crabbox vnc --id blue-lobster
 crabbox screenshot --id blue-lobster --output desktop.png
@@ -179,12 +182,13 @@ crabbox screenshot --id blue-lobster --output desktop.png
 Managed provider targets are intentionally narrow:
 
 - Hetzner managed provisioning supports Linux only.
-- AWS supports Linux, native Windows (`--target windows --windows-mode normal`),
-  Windows WSL2 (`--target windows --windows-mode wsl2`), and EC2 Mac
-  (`--target macos`) when the Mac Dedicated Host is provided.
-- Azure supports Linux and native Windows (`--target windows --windows-mode
-  normal`). Azure Windows does not provide managed desktop, browser, WSL2, or
-  macOS targets.
+- AWS and Azure both support Linux, native Windows (`--target windows
+  --windows-mode normal`) with managed desktop/VNC, and Windows WSL2
+  (`--target windows --windows-mode wsl2`) for POSIX sync, run, and Actions
+  hydration. Use native Windows for desktop/VNC; use WSL2 for Linux tooling on
+  a Windows host.
+- AWS also supports EC2 Mac (`--target macos`) when the Mac Dedicated Host is
+  provided. Azure does not have a managed macOS target.
 - Existing macOS and Windows machines belong on `provider=ssh`.
 
 Use Tailscale as an optional network plane:

--- a/docs/commands/screenshot.md
+++ b/docs/commands/screenshot.md
@@ -18,7 +18,7 @@ non-interactive SSH sessions cannot capture the visible desktop. macOS uses
 `screencapture`.
 
 For Windows, the screenshot reflects the active console session in the
-Crabbox-created instance. Managed AWS Windows desktop leases enable auto-logon
+Crabbox-created instance. Managed AWS and Azure Windows desktop leases enable auto-logon
 for the generated `crabbox` user, store that password under
 `C:\ProgramData\crabbox`, and use it only on the instance to run the scheduled
 capture task.
@@ -31,7 +31,7 @@ crabbox-<slug-or-id>-screenshot.png
 
 Static macOS and Windows targets are existing host machines, not Crabbox-created
 desktops, so `screenshot` rejects those targets instead of capturing your local
-or home-host desktop by accident. Managed AWS Windows and AWS macOS desktop
+or home-host desktop by accident. Managed AWS/Azure Windows and AWS macOS desktop
 leases are Crabbox-created boxes and can be captured by lease id or slug.
 
 Flags:

--- a/docs/commands/vnc.md
+++ b/docs/commands/vnc.md
@@ -16,10 +16,11 @@ crabbox vnc --id blue-lobster --network tailscale
 crabbox vnc --id blue-lobster --open
 ```
 
-Managed AWS Windows and EC2 Mac desktop leases use the same command:
+Managed Windows and EC2 Mac desktop leases use the same command:
 
 ```sh
 crabbox warmup --provider aws --target windows --desktop
+crabbox warmup --provider azure --target windows --desktop
 crabbox vnc --id crimson-crab
 
 CRABBOX_AWS_MAC_HOST_ID=h-... \
@@ -85,7 +86,7 @@ Password locations:
 | Windows | `C:\ProgramData\crabbox\vnc.password` |
 | macOS | `/var/db/crabbox/vnc.password` |
 
-Managed AWS Windows leases also print the generated Windows console login:
+Managed AWS and Azure Windows leases also print the generated Windows console login:
 
 ```text
 password: Cb1!...
@@ -150,6 +151,7 @@ host's VNC or Screen Sharing prompt.
 | AWS Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
 | Azure Linux | Yes | Requires `--desktop`; same Linux desktop profile. |
 | AWS Windows | Yes | Requires `--target windows --desktop`; installs Git for Windows and TightVNC after EC2Launch enables OpenSSH. Spot or On-Demand follows the AWS capacity config. |
+| Azure Windows | Yes | Requires `--target windows --desktop`; installs Git for Windows and TightVNC after Custom Script Extension enables OpenSSH. Capacity follows the Azure class/SKU config. |
 | AWS macOS | Yes | Requires `--target macos --desktop --market on-demand` plus `CRABBOX_AWS_MAC_HOST_ID` or `aws.macHostId`. |
 | Static Linux | Host-managed | Requires an existing loopback VNC service on the host. |
 | Static macOS | Host-managed | Uses existing Screen Sharing or VNC. |

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -63,10 +63,9 @@ the updated PATH.
 
 With `--provider hetzner`, managed provisioning supports Linux only. Hetzner can
 run Windows through ISO/snapshot installation flows, but Crabbox does not manage
-that path today. Use `--provider aws --target windows` for managed Windows
-desktop or WSL2, `--provider azure --target windows` for native Windows
-SSH/sync/run, or `--provider ssh --target windows` for an existing Hetzner
-Windows host.
+that path today. Use `--provider aws --target windows` or
+`--provider azure --target windows` for managed Windows desktop or WSL2, or
+`--provider ssh --target windows` for an existing Hetzner Windows host.
 
 With `--provider aws --target windows --windows-mode normal --desktop`, Crabbox
 creates a real AWS Windows Server lease. EC2Launch user data installs OpenSSH
@@ -84,7 +83,11 @@ families for this mode. Commands and sync then use the POSIX WSL contract.
 With `--provider azure --target windows`, Crabbox creates a native Windows
 Server lease, uses the Azure VM Agent Custom Script Extension to install
 OpenSSH Server and Git for Windows, and configures the `crabbox` user for
-SSH/sync/run. Azure Windows does not provision VNC/browser/WSL2.
+SSH/sync/run. Add `--desktop` to run the shared Windows desktop bootstrap over
+SSH, install TightVNC, configure auto-logon, and expose VNC through the normal
+SSH tunnel. With `--windows-mode wsl2`, Crabbox enables WSL2 over SSH and then
+uses the POSIX WSL sync/run/actions contract. Azure Windows does not provision
+browser/code.
 
 With `--provider aws --target macos --desktop`, Crabbox launches an EC2 Mac
 instance on an already allocated Dedicated Host. Set `CRABBOX_AWS_MAC_HOST_ID`

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -35,7 +35,7 @@ Read when:
 - [Provider backends](../provider-backends.md): contract reference for backend interfaces and registration.
 - [Authoring a provider](provider-authoring.md): step-by-step guide to writing a new provider.
 - [AWS](aws.md): EC2 Linux, Windows, WSL2, EC2 Mac, capacity, AMIs, and security groups.
-- [Azure](azure.md): Azure Linux/native Windows, shared infra, capacity, and cleanup.
+- [Azure](azure.md): Azure Linux, Windows, WSL2, shared infra, capacity, and cleanup.
 - [Google Cloud](../providers/gcp.md): GCP Compute Engine Linux SSH leases.
 - [Hetzner](hetzner.md): Linux-only managed Hetzner behavior, classes, and cleanup.
 - [Proxmox](../providers/proxmox.md): direct Proxmox VE Linux QEMU VM clones.

--- a/docs/features/actions-hydration.md
+++ b/docs/features/actions-hydration.md
@@ -9,7 +9,7 @@ Read when:
 Actions hydration lets a repository reuse its existing GitHub Actions setup without putting repository-specific setup code in the Crabbox binary.
 
 Runner registration supports POSIX targets: brokered Hetzner/AWS/Azure/GCP
-Linux, direct Proxmox Linux, and AWS Windows WSL2. Static macOS and native Windows targets are for direct
+Linux, direct Proxmox Linux, and AWS/Azure Windows WSL2. Static macOS and native Windows targets are for direct
 `crabbox run` loops until platform-specific runner installation is added.
 
 The flow:

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -6,19 +6,22 @@ Read when:
 - debugging Azure VM capacity, quotas, images, or SSH readiness;
 - changing Azure provisioning code in the CLI.
 
-Azure is a managed provider for Linux and native Windows SSH leases. It
+Azure is a managed provider for Linux, native Windows, and Windows WSL2 leases. It
 creates VMs in a shared resource group, tags them with Crabbox lease
 metadata, and bootstraps the normal SSH/sync contract through cloud-init
-on Linux or Custom Script Extension on Windows. It works in direct mode with
-local Azure auth and in brokered mode through Worker-owned service principal
-secrets.
+on Linux or Custom Script Extension on Windows. Native Windows can also run
+the shared desktop/VNC bootstrap after SSH is reachable; WSL2 runs the shared
+Windows WSL2 bootstrap and then uses the POSIX sync/run contract through WSL.
+It works in direct mode with local Azure auth and in brokered mode through
+Worker-owned service principal secrets.
 
 ## Targets
 
 | Target | Managed | Notes |
 | --- | --- | --- |
 | Linux | Yes | Cloud-init bootstrap, SSH, rsync, optional desktop/browser/code. |
-| Windows | Yes | Native Windows SSH/sync/run only. No Azure desktop/browser/WSL2. |
+| Windows native | Yes | Native Windows SSH/sync/run and optional desktop/VNC. No Azure browser/code. |
+| Windows WSL2 | Yes | Nested-virtualization VM sizes; POSIX sync/run/actions hydration through WSL. |
 | macOS | No | Azure does not offer managed macOS; use AWS EC2 Mac or static SSH. |
 
 Examples:
@@ -27,6 +30,8 @@ Examples:
 crabbox warmup --provider azure --class beast
 crabbox run --provider azure --class standard -- pnpm test
 crabbox warmup --provider azure --target windows --class standard
+crabbox warmup --provider azure --target windows --desktop --class standard
+crabbox warmup --provider azure --target windows --windows-mode wsl2 --class standard
 crabbox warmup --provider azure --desktop --browser
 crabbox vnc --id blue-lobster --open
 ```
@@ -40,7 +45,8 @@ large     Standard_D96ads_v6, Standard_D96ds_v6, then D/F 64-vCPU and 48-vCPU fa
 beast     Standard_D192ds_v6, Standard_D128ds_v6, then D/F 96-vCPU and 64-vCPU fallbacks
 ```
 
-Native Windows uses the smaller AWS Windows class scale:
+Native Windows and WSL2 use the smaller AWS Windows class scale. The default
+candidate families support Azure nested virtualization for WSL2:
 
 ```text
 standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, then Standard_D2as_v6
@@ -55,8 +61,8 @@ SKU cannot be created. Spot leases fall back to on-demand when
 `capacity.fallback` starts with `on-demand`.
 
 Default Azure Linux class candidates mirror the vCPU scale of the AWS Linux
-class table. Default Azure native Windows candidates mirror the AWS native
-Windows class table. Crabbox asks Azure Resource SKUs whether the selected VM
+class table. Default Azure Windows candidates mirror the AWS native Windows
+class table. Crabbox asks Azure Resource SKUs whether the selected VM
 supports ephemeral OS disks; ephemeral-capable sizes use local OS disks,
 while exact `--type` requests for non-ephemeral sizes use managed
 `StandardSSD_LRS` OS disks.
@@ -154,10 +160,15 @@ back to the public IP. The default is `public`.
 
 ## Desktop
 
-Azure desktop leases use the standard Linux VNC path: Xvfb, a lightweight
+Azure Linux desktop leases use the standard VNC path: Xvfb, a lightweight
 desktop session, x11vnc bound to `127.0.0.1:5900`, and an SSH local tunnel
-created by `crabbox vnc`. Azure native Windows currently supports SSH, sync,
-and run only. Use AWS for managed Windows desktop or Windows WSL2.
+created by `crabbox vnc`. Azure native Windows desktop leases use the shared
+managed Windows bootstrap to install TightVNC, create the local `crabbox`
+administrator, enable auto-logon, and expose VNC only through an SSH tunnel.
+Azure WSL2 leases enable WSL, VirtualMachinePlatform, and HypervisorPlatform,
+update the WSL kernel, import the Ubuntu rootfs, and prepare the Linux-side
+`crabbox-ready` toolchain. Azure Windows still does not provision browser/code
+targets.
 
 ## Cleanup
 

--- a/docs/features/hetzner.md
+++ b/docs/features/hetzner.md
@@ -15,7 +15,7 @@ contract, and optionally adds Linux desktop/browser capability.
 | Target | Managed | Notes |
 | --- | --- | --- |
 | Linux | Yes | Cloud-init bootstrap, SSH, rsync, optional desktop/browser. |
-| Windows | No | Use AWS for managed Windows or `provider: ssh` for an existing Windows host. |
+| Windows | No | Use AWS or Azure for managed Windows or `provider: ssh` for an existing Windows host. |
 | macOS | No | Use AWS EC2 Mac or `provider: ssh` for an existing Mac. |
 
 Examples:

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -72,7 +72,7 @@ Scenario systems such as Mantis own:
 | Linux on Azure | Yes | Xvfb/XFCE/x11vnc over SSH tunnel | [Linux VNC](vnc-linux.md) |
 | AWS Windows | Yes | TightVNC over SSH tunnel | [Windows VNC](vnc-windows.md) |
 | AWS EC2 Mac | Yes | Screen Sharing/VNC over SSH tunnel | [macOS VNC](vnc-macos.md) |
-| Azure Windows | No | SSH/sync/run only | [Azure](azure.md) |
+| Azure Windows | Yes | TightVNC over SSH tunnel | [Windows VNC](vnc-windows.md) |
 | Static Linux | Host-managed | Existing loopback VNC service | [Linux VNC](vnc-linux.md) |
 | Static macOS | Host-managed | Existing Screen Sharing/VNC | [macOS VNC](vnc-macos.md) |
 | Static Windows | Host-managed | Existing VNC service | [Windows VNC](vnc-windows.md) |
@@ -237,7 +237,7 @@ often machine- and user-encrypted.
 ## Where To Go Next
 
 - [Linux VNC](vnc-linux.md): Hetzner/AWS/Azure Linux desktop services and static Linux.
-- [Windows VNC](vnc-windows.md): AWS Windows, native Windows static hosts, and WSL2 boundaries.
+- [Windows VNC](vnc-windows.md): AWS/Azure managed Windows, native Windows static hosts, and WSL2 boundaries.
 - [macOS VNC](vnc-macos.md): AWS EC2 Mac and static Mac Screen Sharing.
 - [AWS](aws.md): AWS target matrix, capacity, AMIs, and EC2 Mac host requirements.
 - [Hetzner](hetzner.md): Linux-only managed Hetzner behavior.

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -8,10 +8,10 @@ Read when:
 - adjusting SSH port fallbacks for restrictive operator networks.
 
 A Crabbox lease can be reachable through more than one network plane.
-Brokered Linux leases can join a Tailscale tailnet, brokered AWS Windows and
-EC2 Mac leases stay public, and static SSH targets can be on either depending
-on how the operator configured them. The CLI picks one plane per command and
-prints which it picked.
+Brokered Linux leases can join a Tailscale tailnet, brokered AWS/Azure Windows
+and EC2 Mac leases stay public, and static SSH targets can be on either
+depending on how the operator configured them. The CLI picks one plane per
+command and prints which it picked.
 
 ## Modes
 

--- a/docs/features/vnc-windows.md
+++ b/docs/features/vnc-windows.md
@@ -2,7 +2,7 @@
 
 Read when:
 
-- using managed AWS Windows desktop leases;
+- using managed AWS or Azure Windows desktop leases;
 - choosing between native Windows and WSL2;
 - preparing a static Windows host for Crabbox VNC.
 
@@ -12,8 +12,7 @@ Crabbox has two Windows execution contracts:
 - WSL2: POSIX commands through WSL, Linux-style sync, no separate managed VNC
   contract beyond the underlying Windows host.
 
-Managed Windows desktop support is AWS-only. Direct CLI provisioning and
-brokered coordinator provisioning use the same bootstrap contract.
+Managed native Windows desktop support is available on AWS and Azure.
 
 ## Managed AWS Windows
 
@@ -29,13 +28,35 @@ Bootstrap flow:
 - Crabbox installs Git for Windows and TightVNC.
 - Crabbox creates a local `crabbox` administrator.
 - Windows auto-logon starts a visible console session for that user.
-- TightVNC runs in that logged-in user session, with its HKCU password values
-  copied from the service configuration during startup.
-- The TightVNC service is also left startable and running as a fallback so
-  screenshots and WebVNC can connect even if the user-session startup task is
-  delayed.
+- TightVNC runs in that logged-in user session through the `CrabboxUserVNC`
+  logon scheduled task, with its HKCU password values copied from the service
+  configuration during startup.
+- The TightVNC service is disabled after seeding the per-user configuration, so
+  screenshots and WebVNC target the visible console session instead of the
+  service session.
 - The Windows first-network-discovery flyout is disabled during bootstrap so it
   does not cover screenshots.
+- The generated password is stored at
+  `C:\ProgramData\crabbox\vnc.password`.
+- VNC remains reachable only through the SSH tunnel.
+
+## Managed Azure Windows
+
+```sh
+crabbox warmup --provider azure --target windows --desktop
+crabbox vnc --id blue-lobster --open
+crabbox screenshot --id blue-lobster --output windows.png
+```
+
+Bootstrap flow:
+
+- Azure creates the VM, public IP, NIC, and OS disk.
+- Azure Custom Script Extension runs a minimal non-rebooting Crabbox SSH
+  bootstrap from `C:\AzureData\CustomData.bin`.
+- After SSH is reachable, Crabbox runs the shared Windows desktop bootstrap
+  over SSH as the `crabbox` administrator.
+- Crabbox installs Git for Windows and TightVNC, configures auto-logon, reboots
+  once, and waits for SSH/VNC readiness.
 - The generated password is stored at
   `C:\ProgramData\crabbox\vnc.password`.
 - VNC remains reachable only through the SSH tunnel.
@@ -53,18 +74,19 @@ Windows account and is not stored in coordinator history.
 
 ## WSL2
 
-Managed AWS WSL2 leases are Windows instances with nested virtualization
-enabled and an Ubuntu rootfs imported into WSL. Commands and sync use the POSIX
-WSL contract:
+Managed AWS and Azure WSL2 leases are Windows instances with nested
+virtualization enabled and an Ubuntu rootfs imported into WSL. Commands and
+sync use the POSIX WSL contract:
 
 ```sh
 crabbox warmup --provider aws --target windows --windows-mode wsl2
+crabbox warmup --provider azure --target windows --windows-mode wsl2
 crabbox actions hydrate --id blue-lobster
 crabbox run --id blue-lobster -- pnpm test
 ```
 
 Use native Windows mode when you need the Windows desktop. Use WSL2 when you
-need Linux tooling on Windows-capable AWS instance families.
+need Linux tooling on Windows-capable nested-virtualization VM families.
 
 OpenClaw maintainers can run the full OpenClaw test suite on a fresh WSL2 box
 with:

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -12,7 +12,7 @@ static SSH provider for existing machines.
 | Provider | Backend kind | Targets | Best for |
 | --- | --- | --- | --- |
 | [AWS](aws.md) | SSH lease | Linux, Windows, macOS | broad managed capacity, Windows, EC2 Mac |
-| [Azure](azure.md) | SSH lease | Linux, Windows | Azure-backed Linux and native Windows capacity |
+| [Azure](azure.md) | SSH lease | Linux, Windows | Azure-backed Linux and Windows capacity |
 | [Google Cloud](gcp.md) | SSH lease | Linux | GCP-backed Linux Compute Engine capacity |
 | [Hetzner](hetzner.md) | SSH lease | Linux | fast Linux capacity at low cost |
 | [Proxmox](proxmox.md) | SSH lease | Linux | private Proxmox VE QEMU VM templates |
@@ -73,7 +73,7 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | Provider | `run` | `warmup` | `ssh` | VNC/code | Crabbox sync | Provider sync |
 | --- | --- | --- | --- | --- | --- | --- |
 | AWS | yes | yes | yes | yes | yes | no |
-| Azure | yes | yes | yes | Linux VNC/code | yes | no |
+| Azure | yes | yes | yes | Linux/Windows VNC; Linux code | yes | no |
 | Google Cloud | yes | yes | yes | no | yes | no |
 | Hetzner | yes | yes | yes | Linux VNC/code | yes | no |
 | Proxmox | yes | yes | yes | no | yes | no |

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -15,7 +15,7 @@ desktop tunnels, and cleanup.
 
 Use AWS when you need:
 
-- managed Windows or WSL2 test machines;
+- managed Windows or WSL2 test machines on EC2 capacity;
 - EC2 Mac desktops through a configured Dedicated Host;
 - broad Linux capacity with Spot and On-Demand fallback;
 - coordinator-owned cloud credentials and cost accounting.

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -6,18 +6,19 @@ Read when:
 - debugging Azure VM capacity, quotas, images, or SSH readiness;
 - changing `internal/providers/azure` or the direct Azure provisioning code.
 
-Azure is a managed provider for Linux and native Windows SSH leases. Azure
+Azure is a managed provider for Linux, native Windows, and Windows WSL2 leases. Azure
 provisions the VM, public IP, NIC, and OS disk, then Crabbox owns SSH
-readiness, sync, command execution, results, and cleanup.
+readiness, optional desktop/VNC or WSL2 bootstrap, sync, command execution,
+results, and cleanup.
 
 ## When To Use
 
 Use Azure when the team's cloud capacity lives in an Azure subscription, or
 when Microsoft tooling, Entra ID, or Azure-specific networking constraints
 make AWS or Hetzner inappropriate. Use Hetzner for cheaper Linux-only
-capacity and AWS for Windows desktop, Windows WSL2, or macOS targets.
+capacity and AWS for macOS targets.
 
-Azure supports direct mode and brokered Linux/native Windows leases. Direct
+Azure supports direct mode and brokered Linux/native Windows/WSL2 leases. Direct
 mode uses local Azure credentials. Brokered mode uses the operator-owned
 Azure service principal configured on the Worker.
 
@@ -27,6 +28,8 @@ Azure service principal configured on the Worker.
 crabbox warmup --provider azure --class beast
 crabbox run --provider azure --class standard -- pnpm test
 crabbox warmup --provider azure --target windows --class standard
+crabbox warmup --provider azure --target windows --desktop --class standard
+crabbox warmup --provider azure --target windows --windows-mode wsl2 --class standard
 crabbox warmup --provider azure --desktop --browser
 crabbox ssh --provider azure --id blue-lobster
 crabbox stop --provider azure blue-lobster
@@ -153,15 +156,23 @@ See [Authenticate Go apps to Azure services with service principals](https://lea
    `osProfile.linuxConfiguration.ssh.publicKeys` for Linux. Native Windows
    uses a Windows Server small-disk Gen2 image, Windows `osProfile` fields
    (`adminPassword`, `computerName`, and `windowsConfiguration`), and a
-   Custom Script Extension that runs the Crabbox bootstrap saved in
-   `C:\AzureData\CustomData.bin`.
+   non-rebooting Custom Script Extension that runs the initial Crabbox SSH
+   bootstrap saved in `C:\AzureData\CustomData.bin`.
 6. Query Azure Resource SKUs for the VM size. If Azure reports ephemeral OS
    disk support, use a local ephemeral OS disk. Otherwise use a managed
    `StandardSSD_LRS` OS disk.
 7. Tag the VM, NIC, and public IP with Crabbox lease metadata.
-8. Wait for the public IP to allocate, then for SSH and `crabbox-ready`.
-9. Let core sync and run over SSH.
-10. On release/cleanup, cascade-delete VM → NIC → public IP → OS disk. The
+8. Wait for the public IP to allocate, then for SSH readiness.
+9. When `--desktop` is requested on native Windows, run the shared Windows
+   desktop bootstrap over SSH. That installs TightVNC, configures the
+   generated `crabbox` Windows login, enables auto-logon, reboots once, and
+   waits for SSH/VNC readiness.
+10. When `windows.mode=wsl2` is requested, run the shared Windows WSL2
+   bootstrap over SSH. That enables WSL/VirtualMachinePlatform/HypervisorPlatform,
+   reboots as needed, imports Ubuntu, and waits for the Linux-side
+   `crabbox-ready` check.
+11. Let core sync and run over SSH.
+12. On release/cleanup, cascade-delete VM → NIC → public IP → OS disk. The
    shared infra remains.
 
 ## Classes
@@ -175,7 +186,7 @@ large     Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D9
 beast     Standard_D192ds_v6, Standard_D128ds_v6, then D/F 96-vCPU and 64-vCPU fallbacks
 ```
 
-Default native Windows SKUs:
+Default native Windows and WSL2 SKUs:
 
 ```text
 standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, then Standard_D2as_v6
@@ -191,18 +202,21 @@ rejects a SKU for capacity or quota
 `capacity.fallback` starts with `on-demand`. Explicit `--type` is exact.
 The default Linux candidates mirror the AWS Linux class table's vCPU scale.
 The default Windows candidates mirror the AWS native Windows class table's
-vCPU scale. Azure native Windows support covers SSH, sync, and run; Windows
-WSL2 and macOS remain AWS or static-SSH targets.
+vCPU scale. Azure native Windows support covers SSH, sync, run, and optional
+desktop/VNC. Azure WSL2 support covers SSH, sync, run, and actions hydration
+through the POSIX WSL contract.
 
 ## Capabilities
 
 - SSH: yes.
 - Crabbox sync: yes.
-- Native Windows: yes for SSH, sync, and run.
-- Desktop / browser / code: Linux only on Azure.
+- Native Windows: yes for SSH, sync, run, and desktop/VNC.
+- Windows WSL2: yes for SSH, sync, run, and actions hydration.
+- Desktop: Linux and native Windows.
+- Browser / code: Linux only on Azure.
 - Tailscale: Linux managed leases.
-- Actions hydration: yes, Linux SSH leases.
-- Coordinator: yes, brokered Linux/native Windows leases.
+- Actions hydration: yes, Linux and Windows WSL2 leases.
+- Coordinator: yes, brokered Linux/native Windows/WSL2 leases.
 
 ## Gotchas
 
@@ -232,10 +246,10 @@ WSL2 and macOS remain AWS or static-SSH targets.
 - Azure costs are not hardcoded in Crabbox. Set `CRABBOX_COST_RATES_JSON`
   when you need exact Azure cost guardrails.
 - Azure native Windows uses Custom Script Extension because Windows custom
-  data is saved to disk but not executed by Azure provisioning. Do not add
-  rebooting bootstrap work to that extension path.
-- Azure does not provide managed Windows WSL2 or macOS through this provider.
-  Use AWS or `provider: ssh` for those targets.
+  data is saved to disk but not executed by Azure provisioning. Keep that
+  extension path non-rebooting; Windows desktop/VNC setup runs later over SSH.
+- Azure does not provide managed macOS through this provider. Use AWS or
+  `provider: ssh` for macOS targets.
 - Direct-mode cleanup is best effort. Use `crabbox cleanup --provider azure`
   to sweep expired direct leases.
 

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -18,7 +18,7 @@ Use Static SSH when:
 - you need a local Mac Studio, LAN host, VM, or persistent Windows box;
 - cloud provider cleanup and cost accounting do not apply.
 
-Use AWS or Hetzner when you want Crabbox to create and delete the machine.
+Use AWS, Azure, or Hetzner when you want Crabbox to create and delete the machine.
 
 ## Commands
 

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -135,7 +135,8 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 	if *noContactSheet {
 		*contactSheet = false
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	needsDesktop := artifactCollectNeedsDesktop(*screenshot, *video, *doctor, *webvncStatus)
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: needsDesktop})
 	if err != nil {
 		return err
 	}
@@ -315,6 +316,10 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "publish: crabbox artifacts publish --dir %s --pr <n>\n", strings.Join(readableShellWords([]string{dir}), " "))
 	return nil
+}
+
+func artifactCollectNeedsDesktop(screenshot, video, doctor, webvncStatus bool) bool {
+	return screenshot || video || doctor || webvncStatus
 }
 
 func (a App) finishArtifactCollectFailure(result *artifactCollectResult, jsonOut bool, err error, warning artifactWarning) error {

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -149,6 +149,22 @@ func TestArtifactStorageURLs(t *testing.T) {
 	}
 }
 
+func TestArtifactCollectNeedsDesktop(t *testing.T) {
+	if artifactCollectNeedsDesktop(false, false, false, false) {
+		t.Fatal("log-only artifact collection should not require desktop")
+	}
+	for name, args := range map[string][4]bool{
+		"screenshot":    {true, false, false, false},
+		"video":         {false, true, false, false},
+		"doctor":        {false, false, true, false},
+		"webvnc status": {false, false, false, true},
+	} {
+		if !artifactCollectNeedsDesktop(args[0], args[1], args[2], args[3]) {
+			t.Fatalf("%s artifact collection should require desktop", name)
+		}
+	}
+}
+
 func TestArtifactCloudflareEnvUsesGenericCredentials(t *testing.T) {
 	t.Setenv("CLOUDFLARE_API_TOKEN", "generic-token")
 	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "generic-account")

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -7,18 +7,39 @@ import (
 	"time"
 )
 
-func bootstrapAWSWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
-	if cfg.Provider != "aws" || cfg.TargetOS != targetWindows {
+func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
+	if cfg.TargetOS != targetWindows {
+		return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
+	}
+	if cfg.WindowsMode == windowsModeWSL2 {
+		bootstrapTarget := *target
+		bootstrapTarget.WindowsMode = windowsModeNormal
+		bootstrapTarget.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
+		if cfg.Provider == "aws" {
+			bootstrapTarget.User = "Administrator"
+			target.User = "Administrator"
+		}
+		return bootstrapManagedWindowsWSL2(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
+	}
+	if cfg.Provider == "azure" && cfg.WindowsMode == windowsModeNormal && cfg.Desktop {
+		bootstrapTarget := *target
+		return runWindowsDesktopBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
+	}
+	if cfg.Provider != "aws" {
 		return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
 	}
 	bootstrapTarget := *target
 	bootstrapTarget.User = "Administrator"
 	bootstrapTarget.WindowsMode = windowsModeNormal
 	bootstrapTarget.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
-	if cfg.WindowsMode == windowsModeWSL2 {
-		target.User = "Administrator"
-		return bootstrapAWSWindowsWSL2(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
-	}
+	return runWindowsDesktopBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
+}
+
+func bootstrapAWSWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
+	return bootstrapManagedWindowsDesktop(ctx, cfg, target, publicKey, stderr)
+}
+
+func runWindowsDesktopBootstrapOverSSH(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {
 	if err := waitForSSHReady(ctx, &bootstrapTarget, stderr, "windows openssh", 20*time.Minute); err != nil {
 		return err
 	}
@@ -33,14 +54,47 @@ exit $LASTEXITCODE`)
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: Windows bootstrap SSH command ended before completion; waiting for reboot/ready state: %v\n", err)
 	}
-	return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
+	if err := waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+		return err
+	}
+	if cfg.Desktop && cfg.WindowsMode == windowsModeNormal {
+		return waitForManagedWindowsLoopbackVNC(ctx, target, stderr, 5*time.Minute)
+	}
+	return nil
+}
+
+func waitForManagedWindowsLoopbackVNC(ctx context.Context, target *SSHTarget, stderr io.Writer, timeout time.Duration) error {
+	fmt.Fprintln(stderr, "waiting for Windows desktop VNC on 127.0.0.1:5900")
+	deadline := time.Now().Add(timeout)
+	for {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+			probe := *target
+			probe.Port = port
+			if err := probeLoopbackVNC(ctx, probe, "5", "1"); err == nil {
+				target.Port = port
+				fmt.Fprintln(stderr, "Windows desktop VNC ready")
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return exit(5, "managed Windows desktop did not expose VNC on 127.0.0.1:5900")
+		}
+		time.Sleep(5 * time.Second)
+	}
 }
 
 func BootstrapAWSWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
 	return bootstrapAWSWindowsDesktop(ctx, cfg, target, publicKey, stderr)
 }
 
-func bootstrapAWSWindowsWSL2(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {
+func BootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
+	return bootstrapManagedWindowsDesktop(ctx, cfg, target, publicKey, stderr)
+}
+
+func bootstrapManagedWindowsWSL2(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {
 	for attempt := 1; attempt <= 5; attempt++ {
 		if err := waitForSSHReady(ctx, &bootstrapTarget, stderr, "windows openssh", 20*time.Minute); err != nil {
 			return err

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -155,7 +155,7 @@ func azureVMSizeCandidatesForTargetModeClass(target, windowsMode, class string) 
 	case targetLinux:
 		return azureVMSizeCandidatesForClass(class)
 	case targetWindows:
-		if windowsMode == windowsModeNormal {
+		if windowsMode == windowsModeNormal || windowsMode == windowsModeWSL2 {
 			return azureWindowsVMSizeCandidatesForClass(class)
 		}
 		return []string{class}

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -105,8 +105,8 @@ func TestAzureVMSizeCandidatesForTargetModeClass(t *testing.T) {
 		t.Fatalf("windows target got %v want %v", windows, want)
 	}
 	wsl2 := azureVMSizeCandidatesForTargetModeClass(targetWindows, windowsModeWSL2, "standard")
-	if !reflect.DeepEqual(wsl2, []string{"standard"}) {
-		t.Fatalf("wsl2 target got %v want explicit fallback", wsl2)
+	if want := azureWindowsVMSizeCandidatesForClass("standard"); !reflect.DeepEqual(wsl2, want) {
+		t.Fatalf("wsl2 target got %v want %v", wsl2, want)
 	}
 }
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -132,6 +132,7 @@ $openSSHZip = "$env:TEMP\OpenSSH-Win64.zip"
 $gitInstaller = "$env:TEMP\Git-2.52.0-64-bit.exe"
 New-Item -ItemType Directory -Force -Path $base, $workRoot | Out-Null
 New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Type DWord -Value 1 -ErrorAction SilentlyContinue
 `
 }
 
@@ -388,6 +389,7 @@ New-ItemProperty -Force -Path $serverKey -Name AllowLoopback -PropertyType DWord
 New-ItemProperty -Force -Path $serverKey -Name AcceptHttpConnections -PropertyType DWord -Value 0 | Out-Null
 $exe = "C:\Program Files\TightVNC\tvnserver.exe"
 Get-Process tvnserver -ErrorAction SilentlyContinue | Where-Object { $_.SessionId -eq (Get-Process -Id $PID).SessionId } | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Milliseconds 500
 Start-Process -FilePath $exe -ArgumentList "-run" -WindowStyle Minimized
 '@
 Set-Content -Encoding UTF8 -LiteralPath $userVNCStartupPath -Value $userVNCStartup
@@ -395,9 +397,9 @@ New-Item -ItemType Directory -Force -Path (Split-Path -Parent $userVNCStartupCom
 Set-Content -Encoding ASCII -LiteralPath $userVNCStartupCommandPath -Value ('@echo off' + [Environment]::NewLine + 'powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "' + $userVNCStartupPath + '"' + [Environment]::NewLine)
 $startupTask = "CrabboxUserVNC"
 cmd.exe /c "schtasks.exe /Delete /TN $startupTask /F 2>NUL" | Out-Null
-schtasks.exe /Create /TN $startupTask /SC ONCE /ST ((Get-Date).AddMinutes(1).ToString("HH:mm")) /TR "powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File $userVNCStartupPath" /RU $user /IT /F | Out-Null
-Get-Service -Name tvnserver -ErrorAction SilentlyContinue | Set-Service -StartupType Manual
-Start-Service -Name tvnserver -ErrorAction SilentlyContinue
+schtasks.exe /Create /TN $startupTask /SC ONLOGON /TR "powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File $userVNCStartupPath" /RU $user /IT /F | Out-Null
+Get-Service -Name tvnserver -ErrorAction SilentlyContinue | Set-Service -StartupType Disabled
+Stop-Service -Name tvnserver -Force -ErrorAction SilentlyContinue
 $winlogon = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"
 Set-ItemProperty -Path $winlogon -Name AutoAdminLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name ForceAutoLogon -Value "1" -Type String
@@ -416,6 +418,10 @@ func azureWindowsBootstrapPowerShell(cfg Config, publicKey string) string {
 	if workRoot == "" {
 		workRoot = defaultWindowsWorkRoot
 	}
+	setupComplete := `Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")`
+	if cfg.Desktop {
+		setupComplete = ""
+	}
 	return windowsBootstrapHeaderPowerShell(cfg, publicKey, workRoot) + `
 $passwordPath = Join-Path $base "windows.password"
 $usernamePath = Join-Path $base "windows.username"
@@ -425,7 +431,7 @@ $enforceKeyAuth = $true
 Restart-Service sshd -Force
 git --version | Out-Null
 tar --version | Out-Null
-Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+` + setupComplete + `
 `
 }
 

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -232,14 +232,17 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 		"VALUE_OF_ALLOWLOOPBACK=1",
 		"CrabboxUserVNC",
 		"crabbox-user-vnc.cmd",
+		`AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup`,
 		"start-user-vnc.ps1",
 		"Set-TightVNCBinaryValue",
 		`reg.exe add "HKCU\Software\TightVNC\Server"`,
 		`$hex = -join ($bytes | ForEach-Object { $_.ToString("X2") })`,
 		"-run",
 		"NewNetworkWindowOff",
-		"Set-Service -StartupType Manual",
-		"Start-Service -Name tvnserver",
+		"DoNotOpenServerManagerAtLogon",
+		"/SC ONLOGON",
+		"Set-Service -StartupType Disabled",
+		"Stop-Service -Name tvnserver",
 		"New-CrabboxPassword",
 		"${userSID}:F",
 		`C:\ProgramData\crabbox\vnc.password`,
@@ -250,6 +253,15 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows user data missing %q", want)
 		}
+	}
+	if strings.Contains(got, "/SC ONCE") {
+		t.Fatalf("windows user data should not schedule user VNC as a one-shot task")
+	}
+	if strings.Contains(got, "Set-Service -StartupType Manual") {
+		t.Fatalf("windows user data should not keep the service VNC fallback enabled")
+	}
+	if strings.Contains(got, "Start-Service -Name tvnserver") {
+		t.Fatalf("windows user data should not start service-session VNC")
 	}
 }
 
@@ -288,6 +300,28 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows WSL2 bootstrap missing %q", want)
 		}
+	}
+}
+
+func TestAzureWindowsDesktopExtensionBootstrapLeavesRebootToSSHBootstrap(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Desktop = true
+	cfg.WorkRoot = `C:\crabbox`
+	got := azureWindowsBootstrapPowerShell(cfg, "ssh-rsa test")
+	if !strings.Contains(got, "PasswordAuthentication no") {
+		t.Fatalf("azure windows extension bootstrap should enforce key auth")
+	}
+	if strings.Contains(got, "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath") {
+		t.Fatalf("azure desktop extension bootstrap should not mark setup complete before desktop SSH bootstrap")
+	}
+	if strings.Contains(got, "Restart-Computer") {
+		t.Fatalf("azure extension bootstrap must not reboot")
+	}
+	if strings.Contains(got, "tightvnc") {
+		t.Fatalf("azure extension bootstrap should not install VNC")
 	}
 }
 

--- a/internal/cli/capabilities.go
+++ b/internal/cli/capabilities.go
@@ -47,8 +47,11 @@ func validateRequestedCapabilities(cfg Config) error {
 	if cfg.Code && !featureSetHas(spec.Features, FeatureCode) {
 		return exit(2, "web code is not supported for provider=%s", provider.Name())
 	}
-	if cfg.Provider == "azure" && cfg.TargetOS == targetWindows && (cfg.Desktop || cfg.Browser || cfg.Code || cfg.Tailscale.Enabled) {
-		return exit(2, "provider=azure target=windows currently supports SSH, sync, and run; desktop/browser/code/tailscale require Linux or AWS Windows where supported")
+	if cfg.TargetOS == targetWindows && cfg.WindowsMode == windowsModeWSL2 && cfg.Desktop {
+		return exit(2, "target=windows --windows-mode wsl2 does not support desktop/VNC; use --windows-mode normal for desktop/VNC or omit --desktop for WSL2")
+	}
+	if cfg.Provider == "azure" && cfg.TargetOS == targetWindows && (cfg.Browser || cfg.Code || cfg.Tailscale.Enabled) {
+		return exit(2, "provider=azure target=windows currently supports SSH, sync, run, and desktop/VNC; browser/code/tailscale require Linux or AWS Windows where supported")
 	}
 	if cfg.Code && cfg.TargetOS != targetLinux {
 		return exit(2, "web code currently supports managed Linux leases only")

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -822,14 +822,18 @@ func egressClientBinaryForTarget(ctx context.Context, target SSHTarget) (string,
 }
 
 func scpBaseArgs(target SSHTarget) []string {
-	args := []string{
+	args := make([]string, 0, 16)
+	if target.TargetOS == targetWindows && target.WindowsMode != windowsModeWSL2 {
+		args = append(args, "-O")
+	}
+	args = append(args,
 		"-o", "BatchMode=yes",
 		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile=" + sshConfigFileValue(knownHostsFile(target)),
+		"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
 		"-o", "ConnectTimeout=10",
 		"-o", "ConnectionAttempts=3",
 		"-P", target.Port,
-	}
+	)
 	if target.Key != "" {
 		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
 	}

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -90,6 +91,21 @@ func TestEgressClientBinaryRejectsNonLinuxTargets(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "only supports Linux lease targets") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSCPBaseArgsUseLegacyProtocolForNativeWindows(t *testing.T) {
+	native := scpBaseArgs(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
+	if !slices.Contains(native, "-O") {
+		t.Fatalf("native Windows scp args should include -O for OpenSSH servers without SFTP subsystem: %v", native)
+	}
+	wsl2 := scpBaseArgs(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2})
+	if slices.Contains(wsl2, "-O") {
+		t.Fatalf("WSL2 scp args should not force legacy protocol: %v", wsl2)
+	}
+	linux := scpBaseArgs(SSHTarget{TargetOS: targetLinux})
+	if slices.Contains(linux, "-O") {
+		t.Fatalf("Linux scp args should not force legacy protocol: %v", linux)
 	}
 }
 

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -68,7 +68,7 @@ func (b *coordinatorLeaseBackend) acquireOnce(ctx context.Context, keep bool) (L
 	stopLeaseWatch := startCoordinatorLeaseWatch(waitCtx, b.coord, leaseID, cancelWait, b.rt.Stderr)
 	defer stopLeaseWatch()
 	bootstrapTarget := bootstrapNetworkTarget(cfg, server, target)
-	if err := bootstrapAWSWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
+	if err := bootstrapManagedWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
 		if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID); releaseErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: release failed after bootstrap error for %s: %v\n", leaseID, releaseErr)
 		}

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -31,6 +31,7 @@ func (testAzureProvider) Spec() ProviderSpec {
 		Targets: []TargetSpec{
 			{OS: targetLinux},
 			{OS: targetWindows, WindowsMode: windowsModeNormal},
+			{OS: targetWindows, WindowsMode: windowsModeWSL2},
 		},
 		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureTailscale},
 		Coordinator: CoordinatorSupported,

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -151,14 +151,11 @@ func unsupportedManagedTargetMessage(provider, target string) string {
 
 func unsupportedManagedTargetMessageForConfig(provider string, cfg Config) string {
 	target := cfg.TargetOS
-	if provider == "azure" && target == targetWindows && cfg.WindowsMode == windowsModeWSL2 {
-		return "provider=azure supports native Windows only; use provider=aws for managed Windows WSL2 or provider=ssh for existing Windows WSL2 hosts"
-	}
 	if provider == "azure" {
 		if target == targetMacOS {
-			return "provider=azure managed provisioning supports target=linux and native Windows only; use provider=aws with an EC2 Mac Dedicated Host or provider=ssh for existing macOS hosts"
+			return "provider=azure managed provisioning supports target=linux and Windows only; use provider=aws with an EC2 Mac Dedicated Host or provider=ssh for existing macOS hosts"
 		}
-		return "provider=azure managed provisioning supports target=linux and native Windows only"
+		return "provider=azure managed provisioning supports target=linux and Windows only"
 	}
 	switch target {
 	case targetWindows:

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -51,25 +51,49 @@ func TestValidateProviderTargetAllowsAWSNativeWindows(t *testing.T) {
 	}
 }
 
-func TestValidateProviderTargetAllowsAzureNativeWindowsOnly(t *testing.T) {
+func TestValidateProviderTargetAllowsAzureWindowsModes(t *testing.T) {
+	for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = "azure"
+			cfg.TargetOS = targetWindows
+			cfg.WindowsMode = mode
+			if err := validateProviderTarget(cfg); err != nil {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRequestedCapabilitiesAllowsAzureWindowsDesktop(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "azure"
 	cfg.TargetOS = targetWindows
 	cfg.WindowsMode = windowsModeNormal
-	if err := validateProviderTarget(cfg); err != nil {
-		t.Fatalf("native err=%v", err)
-	}
-
-	cfg.WindowsMode = windowsModeWSL2
-	err := validateProviderTarget(cfg)
-	if err == nil || !strings.Contains(err.Error(), "native Windows only") {
-		t.Fatalf("wsl2 err=%v", err)
+	cfg.Desktop = true
+	if err := validateRequestedCapabilities(cfg); err != nil {
+		t.Fatalf("desktop err=%v", err)
 	}
 }
 
-func TestValidateRequestedCapabilitiesRejectsAzureWindowsDesktop(t *testing.T) {
+func TestValidateRequestedCapabilitiesRejectsWindowsWSL2Desktop(t *testing.T) {
+	for _, provider := range []string{"aws", "azure"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = provider
+			cfg.TargetOS = targetWindows
+			cfg.WindowsMode = windowsModeWSL2
+			cfg.Desktop = true
+			err := validateRequestedCapabilities(cfg)
+			if err == nil || !strings.Contains(err.Error(), "does not support desktop/VNC") {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRequestedCapabilitiesRejectsAzureWindowsUnsupportedCapabilities(t *testing.T) {
 	for name, mutate := range map[string]func(*Config){
-		"desktop":   func(cfg *Config) { cfg.Desktop = true },
 		"browser":   func(cfg *Config) { cfg.Browser = true },
 		"code":      func(cfg *Config) { cfg.Code = true },
 		"tailscale": func(cfg *Config) { cfg.Tailscale.Enabled = true },
@@ -81,7 +105,7 @@ func TestValidateRequestedCapabilitiesRejectsAzureWindowsDesktop(t *testing.T) {
 			cfg.WindowsMode = windowsModeNormal
 			mutate(&cfg)
 			err := validateRequestedCapabilities(cfg)
-			if err == nil || !strings.Contains(err.Error(), "SSH, sync, and run") {
+			if err == nil || !strings.Contains(err.Error(), "browser/code/tailscale") {
 				t.Fatalf("err=%v", err)
 			}
 		})

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -75,7 +74,7 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool) (LeaseTa
 		return LeaseTarget{}, err
 	}
 	target := sshTargetFromConfig(cfg, azureServerHost(server, cfg.AzureNetwork))
-	if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+	if err := bootstrapManagedWindowsDesktop(ctx, cfg, &target, publicKey, b.RT.Stderr); err != nil {
 		_ = client.DeleteServer(context.Background(), server.CloudID)
 		return LeaseTarget{}, err
 	}
@@ -183,10 +182,9 @@ func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLeas
 func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
+	return core.BootstrapManagedWindowsDesktop(ctx, cfg, target, publicKey, stderr)
 }
-func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	return core.DeleteServer(ctx, cfg, server)
 }

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -21,6 +21,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Targets: []core.TargetSpec{
 			{OS: core.TargetLinux},
 			{OS: core.TargetWindows, WindowsMode: "normal"},
+			{OS: core.TargetWindows, WindowsMode: "wsl2"},
 		},
 		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode, core.FeatureTailscale},
 		Coordinator: core.CoordinatorSupported,

--- a/internal/providers/azure/provider_test.go
+++ b/internal/providers/azure/provider_test.go
@@ -55,6 +55,7 @@ func TestProviderSpec(t *testing.T) {
 	wantTargets := []core.TargetSpec{
 		{OS: core.TargetLinux},
 		{OS: core.TargetWindows, WindowsMode: "normal"},
+		{OS: core.TargetWindows, WindowsMode: "wsl2"},
 	}
 	if len(spec.Targets) != len(wantTargets) {
 		t.Fatalf("spec.Targets = %+v, want %+v", spec.Targets, wantTargets)

--- a/scripts/openclaw-wsl2-tests.sh
+++ b/scripts/openclaw-wsl2-tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
-  echo "set CRABBOX_LIVE=1 to create a Windows WSL2 lease" >&2
+  echo "set CRABBOX_LIVE=1 to create an AWS Windows WSL2 lease" >&2
   exit 2
 fi
 
@@ -10,23 +10,18 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cb="${CRABBOX_BIN:-$root/bin/crabbox}"
 repo="${CRABBOX_OPENCLAW_REPO:-${CRABBOX_LIVE_REPO:-/Users/steipete/Projects/openclaw}}"
 lease="${CRABBOX_OPENCLAW_WSL2_ID:-}"
-provider="${CRABBOX_OPENCLAW_WSL2_PROVIDER:-aws}"
 class="${CRABBOX_OPENCLAW_WSL2_CLASS:-beast}"
 market="${CRABBOX_OPENCLAW_WSL2_MARKET:-on-demand}"
 idle_timeout="${CRABBOX_OPENCLAW_WSL2_IDLE_TIMEOUT:-240m}"
 hydrate_wait="${CRABBOX_OPENCLAW_WSL2_HYDRATE_WAIT:-45m}"
 keep_alive="${CRABBOX_OPENCLAW_WSL2_KEEP_ALIVE_MINUTES:-240}"
-reclaim="${CRABBOX_OPENCLAW_WSL2_RECLAIM:-0}"
 stop_after="${CRABBOX_OPENCLAW_WSL2_STOP:-0}"
 test_command="${CRABBOX_OPENCLAW_TEST_COMMAND:-corepack enable && pnpm install --frozen-lockfile && CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test}"
 crabbox_target_args=(
-  --provider "$provider"
+  --provider aws
   --target windows
   --windows-mode wsl2
 )
-export CRABBOX_PROVIDER="$provider"
-export CRABBOX_TARGET=windows
-export CRABBOX_WINDOWS_MODE=wsl2
 
 if [[ ! -d "$repo/.git" ]]; then
   echo "OpenClaw repo not found: $repo" >&2
@@ -41,7 +36,7 @@ run_in_repo() {
 run_crabbox_wsl2() {
   (
     cd "$repo"
-    CRABBOX_PROVIDER="$provider" CRABBOX_TARGET=windows CRABBOX_WINDOWS_MODE=wsl2 "$cb" "$@"
+    CRABBOX_PROVIDER=aws CRABBOX_TARGET=windows CRABBOX_WINDOWS_MODE=wsl2 "$cb" "$@"
   )
 }
 
@@ -76,14 +71,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-hydrate_args=()
-if [[ "$reclaim" == "1" ]]; then
-  hydrate_args+=(--reclaim)
-fi
-
 run_crabbox_wsl2 actions hydrate \
   --id "$lease" \
-  "${hydrate_args[@]}" \
   --wait-timeout "$hydrate_wait" \
   --keep-alive-minutes "$keep_alive" \
   --timing-json

--- a/scripts/openclaw-wsl2-tests.sh
+++ b/scripts/openclaw-wsl2-tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
-  echo "set CRABBOX_LIVE=1 to create an AWS Windows WSL2 lease" >&2
+  echo "set CRABBOX_LIVE=1 to create a Windows WSL2 lease" >&2
   exit 2
 fi
 
@@ -10,18 +10,23 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cb="${CRABBOX_BIN:-$root/bin/crabbox}"
 repo="${CRABBOX_OPENCLAW_REPO:-${CRABBOX_LIVE_REPO:-/Users/steipete/Projects/openclaw}}"
 lease="${CRABBOX_OPENCLAW_WSL2_ID:-}"
+provider="${CRABBOX_OPENCLAW_WSL2_PROVIDER:-aws}"
 class="${CRABBOX_OPENCLAW_WSL2_CLASS:-beast}"
 market="${CRABBOX_OPENCLAW_WSL2_MARKET:-on-demand}"
 idle_timeout="${CRABBOX_OPENCLAW_WSL2_IDLE_TIMEOUT:-240m}"
 hydrate_wait="${CRABBOX_OPENCLAW_WSL2_HYDRATE_WAIT:-45m}"
 keep_alive="${CRABBOX_OPENCLAW_WSL2_KEEP_ALIVE_MINUTES:-240}"
+reclaim="${CRABBOX_OPENCLAW_WSL2_RECLAIM:-0}"
 stop_after="${CRABBOX_OPENCLAW_WSL2_STOP:-0}"
 test_command="${CRABBOX_OPENCLAW_TEST_COMMAND:-corepack enable && pnpm install --frozen-lockfile && CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test}"
 crabbox_target_args=(
-  --provider aws
+  --provider "$provider"
   --target windows
   --windows-mode wsl2
 )
+export CRABBOX_PROVIDER="$provider"
+export CRABBOX_TARGET=windows
+export CRABBOX_WINDOWS_MODE=wsl2
 
 if [[ ! -d "$repo/.git" ]]; then
   echo "OpenClaw repo not found: $repo" >&2
@@ -36,7 +41,7 @@ run_in_repo() {
 run_crabbox_wsl2() {
   (
     cd "$repo"
-    CRABBOX_PROVIDER=aws CRABBOX_TARGET=windows CRABBOX_WINDOWS_MODE=wsl2 "$cb" "$@"
+    CRABBOX_PROVIDER="$provider" CRABBOX_TARGET=windows CRABBOX_WINDOWS_MODE=wsl2 "$cb" "$@"
   )
 }
 
@@ -71,8 +76,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+hydrate_args=()
+if [[ "$reclaim" == "1" ]]; then
+  hydrate_args+=(--reclaim)
+fi
+
 run_crabbox_wsl2 actions hydrate \
   --id "$lease" \
+  "${hydrate_args[@]}" \
   --wait-timeout "$hydrate_wait" \
   --keep-alive-minutes "$keep_alive" \
   --timing-json

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -19,6 +19,7 @@ const API_VERSIONS = {
 };
 const DELETE_RETRY_ATTEMPTS = 13;
 const DELETE_RETRY_DELAY_MS = 15_000;
+const MIN_LRO_POLL_INTERVAL_MS = 15_000;
 const DEFAULT_AZURE_LINUX_IMAGE = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest";
 const DEFAULT_AZURE_WINDOWS_IMAGE =
   "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest";
@@ -603,8 +604,7 @@ export class AzureClient {
     const asyncURL =
       response.headers.get("azure-asyncoperation") ?? response.headers.get("location");
     if (!asyncURL) return;
-    const retryAfter = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
-    const interval = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 3_000;
+    const interval = azureLROPollIntervalMS(response.headers.get("retry-after"));
     const deadline = Date.now() + 20 * 60_000;
     while (Date.now() < deadline) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- LRO must wait between status reads.
@@ -778,6 +778,12 @@ function nextNSGPriority(used: Set<number>): number {
     }
   }
   throw new Error("azure nsg: no available security rule priorities");
+}
+
+export function azureLROPollIntervalMS(retryAfter: string | null): number {
+  const seconds = Number.parseInt(retryAfter ?? "", 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) return MIN_LRO_POLL_INTERVAL_MS;
+  return Math.max(seconds * 1000, MIN_LRO_POLL_INTERVAL_MS);
 }
 
 export function azureSupportsEphemeralOS(vmSize: string): boolean {

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -124,6 +124,7 @@ $openSSHZip = "$env:TEMP\\OpenSSH-Win64.zip"
 $gitInstaller = "$env:TEMP\\Git-2.52.0-64-bit.exe"
 New-Item -ItemType Directory -Force -Path $base, $workRoot | Out-Null
 New-Item -Path "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Network\\NewNetworkWindowOff" -Force | Out-Null
+Set-ItemProperty -Path "HKLM:\\SOFTWARE\\Microsoft\\ServerManager" -Name DoNotOpenServerManagerAtLogon -Type DWord -Value 1 -ErrorAction SilentlyContinue
 `;
 }
 
@@ -280,9 +281,9 @@ New-Item -ItemType Directory -Force -Path (Split-Path -Parent $userVNCStartupCom
 Set-Content -Encoding ASCII -LiteralPath $userVNCStartupCommandPath -Value ('@echo off' + [Environment]::NewLine + 'powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "' + $userVNCStartupPath + '"' + [Environment]::NewLine)
 $startupTask = "CrabboxUserVNC"
 cmd.exe /c "schtasks.exe /Delete /TN $startupTask /F 2>NUL" | Out-Null
-schtasks.exe /Create /TN $startupTask /SC ONCE /ST ((Get-Date).AddMinutes(1).ToString("HH:mm")) /TR "powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File $userVNCStartupPath" /RU $user /IT /F | Out-Null
-Get-Service -Name tvnserver -ErrorAction SilentlyContinue | Set-Service -StartupType Manual
-Start-Service -Name tvnserver -ErrorAction SilentlyContinue
+schtasks.exe /Create /TN $startupTask /SC ONLOGON /TR "powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File $userVNCStartupPath" /RU $user /IT /F | Out-Null
+Get-Service -Name tvnserver -ErrorAction SilentlyContinue | Set-Service -StartupType Disabled
+Stop-Service -Name tvnserver -Force -ErrorAction SilentlyContinue
 $winlogon = "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon"
 Set-ItemProperty -Path $winlogon -Name AutoAdminLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name ForceAutoLogon -Value "1" -Type String
@@ -298,6 +299,9 @@ if (-not (Test-Path -LiteralPath $setupCompletePath)) {
 }
 
 export function azureWindowsBootstrapPowerShell(config: LeaseConfig): string {
+  const setupComplete = config.desktop
+    ? ""
+    : `Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")`;
   return (
     windowsBootstrapHeaderPowerShell(config) +
     `
@@ -311,7 +315,7 @@ $enforceKeyAuth = $true
 Restart-Service sshd -Force
 git --version | Out-Null
 tar --version | Out-Null
-Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+${setupComplete}
 `
   );
 }

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -70,20 +70,25 @@ export function leaseConfig(input: LeaseRequest): LeaseConfig {
     target !== "linux" &&
     !(provider === "aws" && target === "windows") &&
     !(provider === "aws" && target === "macos") &&
-    !(provider === "azure" && target === "windows" && windowsMode === "normal")
+    !(provider === "azure" && target === "windows")
   ) {
     if (provider === "hetzner" || provider === "azure" || provider === "gcp") {
-      throw new Error(unsupportedManagedTargetMessage(provider, target, windowsMode));
+      throw new Error(unsupportedManagedTargetMessage(provider, target));
     }
     throw new Error(`unsupported target for brokered ${provider}: ${target}`);
   }
   if (
     provider === "azure" &&
     target === "windows" &&
-    (input.desktop || input.browser || input.code || input.tailscale)
+    (input.browser || input.code || input.tailscale)
   ) {
     throw new Error(
-      "brokered azure target=windows currently supports SSH, sync, and run; desktop/browser/code/tailscale require Linux or AWS Windows where supported",
+      "brokered azure target=windows currently supports SSH, sync, run, and desktop/VNC; browser/code/tailscale require Linux or AWS Windows where supported",
+    );
+  }
+  if (target === "windows" && windowsMode === "wsl2" && input.desktop) {
+    throw new Error(
+      "brokered target=windows windowsMode=wsl2 does not support desktop/VNC; use windowsMode=normal for desktop/VNC or omit desktop for WSL2",
     );
   }
   if (target === "macos") {
@@ -185,19 +190,12 @@ function defaultSSHUser(provider: Provider, target: TargetOS, windowsMode: Windo
   return "crabbox";
 }
 
-function unsupportedManagedTargetMessage(
-  provider: Provider,
-  target: TargetOS,
-  windowsMode: WindowsMode,
-): string {
-  if (provider === "azure" && target === "windows" && windowsMode === "wsl2") {
-    return "brokered azure supports native Windows only; use brokered aws for managed Windows WSL2 or provider=ssh for existing Windows WSL2 hosts";
-  }
+function unsupportedManagedTargetMessage(provider: Provider, target: TargetOS): string {
   if (provider === "azure") {
     if (target === "macos") {
-      return "brokered azure managed provisioning supports target=linux and native Windows only; use brokered aws with an EC2 Mac Dedicated Host or provider=ssh for existing macOS hosts";
+      return "brokered azure managed provisioning supports target=linux and Windows only; use brokered aws with an EC2 Mac Dedicated Host or provider=ssh for existing macOS hosts";
     }
-    return "brokered azure managed provisioning supports target=linux and native Windows only";
+    return "brokered azure managed provisioning supports target=linux and Windows only";
   }
   if (provider === "gcp") {
     if (target === "macos") {
@@ -370,7 +368,7 @@ export function azureVMSizeCandidatesForTargetClass(
   if (target === "linux") {
     return azureVMSizeCandidatesForClass(machineClass);
   }
-  if (target === "windows" && windowsMode === "normal") {
+  if (target === "windows" && (windowsMode === "normal" || windowsMode === "wsl2")) {
     return azureWindowsVMSizeCandidatesForClass(machineClass);
   }
   return [machineClass];

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   AzureClient,
   azureLabelsFromTags,
+  azureLROPollIntervalMS,
   azureSupportsEphemeralOS,
   azureTagsFromLabels,
   isRetryableDeleteError,
@@ -403,6 +404,12 @@ describe("azure provider", () => {
     await client.listCrabboxServers();
     await client.listCrabboxServers();
     expect(tokenMints).toBe(1);
+  });
+
+  it("uses a conservative Azure LRO polling floor to stay under Worker subrequest limits", () => {
+    expect(azureLROPollIntervalMS(null)).toBe(15_000);
+    expect(azureLROPollIntervalMS("3")).toBe(15_000);
+    expect(azureLROPollIntervalMS("30")).toBe(30_000);
   });
 
   it("drops crabbox-ssh-* rules and preserves operator rules", () => {

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -208,18 +208,22 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("crabbox-sshd-$port");
     expect(got).toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
     expect(got).toContain("NewNetworkWindowOff");
+    expect(got).toContain("DoNotOpenServerManagerAtLogon");
     expect(got).toContain("VALUE_OF_PASSWORD=$vncPassword");
     expect(got).toContain("VALUE_OF_ALLOWLOOPBACK=1");
     expect(got).toContain("CrabboxUserVNC");
     expect(got).toContain("crabbox-user-vnc.cmd");
+    expect(got).toContain("AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup");
     expect(got).toContain("start-user-vnc.ps1");
     expect(got).toContain("Set-TightVNCBinaryValue");
     expect(got).toContain('reg.exe add "HKCU\\Software\\TightVNC\\Server"');
     expect(got).toContain('$hex = -join ($bytes | ForEach-Object { $_.ToString("X2") })');
-    expect(got).toContain("Set-Service -StartupType Manual");
-    expect(got).toContain("Start-Service -Name tvnserver");
-    expect(got).not.toContain("Set-Service -StartupType Disabled");
-    expect(got).not.toContain("Stop-Service -Name tvnserver");
+    expect(got).toContain("/SC ONLOGON");
+    expect(got).toContain("Set-Service -StartupType Disabled");
+    expect(got).toContain("Stop-Service -Name tvnserver");
+    expect(got).not.toContain("/SC ONCE");
+    expect(got).not.toContain("Set-Service -StartupType Manual");
+    expect(got).not.toContain("Start-Service -Name tvnserver");
     expect(got).toContain("New-CrabboxPassword");
     expect(got).toContain("${userSID}:F");
     expect(got).toContain("C:\\ProgramData\\crabbox\\windows.username");
@@ -244,6 +248,22 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("PasswordAuthentication no");
     expect(got).toContain("Restart-Service sshd -Force");
     expect(got).toContain("Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath");
+    expect(got).not.toContain("Restart-Computer");
+    expect(got).not.toContain("tightvnc");
+  });
+
+  it("leaves Azure Windows desktop restart to the SSH bootstrap", () => {
+    const input = {
+      ...config,
+      provider: "azure",
+      target: "windows",
+      desktop: true,
+      workRoot: "C:\\crabbox",
+      sshPublicKey: "ssh-rsa test",
+    } as const;
+    const got = azureWindowsBootstrapPowerShell(input);
+    expect(got).toContain("PasswordAuthentication no");
+    expect(got).not.toContain("Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath");
     expect(got).not.toContain("Restart-Computer");
     expect(got).not.toContain("tightvnc");
   });

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -66,9 +66,9 @@ describe("machine class config", () => {
     expect(azureVMSizeCandidatesForTargetClass("windows", "standard")).toEqual(
       azureWindowsVMSizeCandidatesForClass("standard"),
     );
-    expect(azureVMSizeCandidatesForTargetClass("windows", "standard", "wsl2")).toEqual([
-      "standard",
-    ]);
+    expect(azureVMSizeCandidatesForTargetClass("windows", "standard", "wsl2")).toEqual(
+      azureWindowsVMSizeCandidatesForClass("standard"),
+    );
   });
 
   it("maps known classes to preferred GCP candidates", () => {
@@ -118,6 +118,9 @@ describe("machine class config", () => {
       expect(azureVMSizeCandidatesForClass(name)).toEqual(azureLinux[name]);
       expect(azureWindowsVMSizeCandidatesForClass(name)).toEqual(azureWindows[name]);
       expect(azureVMSizeCandidatesForTargetClass("windows", name)).toEqual(azureWindows[name]);
+      expect(azureVMSizeCandidatesForTargetClass("windows", name, "wsl2")).toEqual(
+        azureWindows[name],
+      );
       expect(awsInstanceTypeCandidatesForTargetClass("windows", name)).toEqual(awsWindows[name]);
       expect(awsInstanceTypeCandidatesForTargetClass("windows", name, "wsl2")).toEqual(
         awsWSL2[name],
@@ -299,21 +302,15 @@ describe("lease config", () => {
     const config = leaseConfig({
       provider: "azure",
       target: "windows",
+      desktop: true,
       sshPublicKey: "ssh-rsa test",
     });
     expect(config.serverType).toBe("Standard_D16ads_v6");
     expect(config.workRoot).toBe("C:\\crabbox");
     expect(config.windowsMode).toBe("normal");
     expect(config.sshUser).toBe("crabbox");
-    expect(() =>
-      leaseConfig({
-        provider: "azure",
-        target: "windows",
-        windowsMode: "wsl2",
-        sshPublicKey: "ssh-rsa test",
-      }),
-    ).toThrow("native Windows only");
-    for (const capability of ["desktop", "browser", "code", "tailscale"] as const) {
+    expect(config.desktop).toBe(true);
+    for (const capability of ["browser", "code", "tailscale"] as const) {
       expect(() =>
         leaseConfig({
           provider: "azure",
@@ -321,7 +318,7 @@ describe("lease config", () => {
           [capability]: true,
           sshPublicKey: "ssh-rsa test",
         }),
-      ).toThrow("SSH, sync, and run");
+      ).toThrow("browser/code/tailscale");
     }
   });
 
@@ -357,6 +354,37 @@ describe("lease config", () => {
     expect(wsl2.workRoot).toBe("/work/crabbox");
     expect(wsl2.windowsMode).toBe("wsl2");
     expect(wsl2.sshUser).toBe("Administrator");
+    expect(() =>
+      leaseConfig({
+        provider: "aws",
+        target: "windows",
+        windowsMode: "wsl2",
+        desktop: true,
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    ).toThrow("does not support desktop/VNC");
+  });
+
+  it("allows Azure Windows WSL2 leases", () => {
+    const wsl2 = leaseConfig({
+      provider: "azure",
+      target: "windows",
+      windowsMode: "wsl2",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(wsl2.serverType).toBe("Standard_D16ads_v6");
+    expect(wsl2.workRoot).toBe("/work/crabbox");
+    expect(wsl2.windowsMode).toBe("wsl2");
+    expect(wsl2.sshUser).toBe("crabbox");
+    expect(() =>
+      leaseConfig({
+        provider: "azure",
+        target: "windows",
+        windowsMode: "wsl2",
+        desktop: true,
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    ).toThrow("does not support desktop/VNC");
   });
 
   it("allows AWS macOS leases only with on-demand capacity", () => {


### PR DESCRIPTION
## Summary

Adds Azure parity for managed Windows targets:

- Azure native Windows can now use `--desktop` / VNC through the shared post-SSH Windows desktop bootstrap.
- Azure Windows WSL2 leases are accepted for POSIX sync/run and Actions hydration, matching the AWS WSL2 contract.
- `--target windows --windows-mode wsl2 --desktop` is rejected for both AWS and Azure because WSL2 is a POSIX run target, not the managed VNC desktop target.
- Docs now describe the shared support boundary: native Windows for desktop/VNC, WSL2 for Linux tooling on a Windows host.

Closes https://github.com/openclaw/crabbox/issues/80

## Maintainer rewrite

Rebased onto current `main`, kept the Proxmox template helper changes intact, removed the legacy project-specific helper change from this PR, and added the 0.12.0 changelog entry with contributor credit.

## Verification

Local:

```sh
go test ./internal/cli -run 'TestValidateRequestedCapabilities|TestValidateProviderTargetAllows|TestArtifactCollectNeedsDesktop|TestSCPBaseArgsUseLegacyProtocolForNativeWindows|TestAzureVMSizeCandidatesForTargetModeClass|TestAzureWindowsDesktopExtensionBootstrapLeavesRebootToSSHBootstrap|TestAWSUserDataWindowsProfile'
go test ./internal/providers/azure
npm test --prefix worker -- --run test/config.test.ts test/bootstrap.test.ts test/azure.test.ts
npm run docs:check
npm run check --prefix worker
npm run format:check --prefix worker
git diff --check main..HEAD
go test ./...
```

Live direct Azure, using a temporary config with broker env cleared:

```sh
CRABBOX_CONFIG=<tmp> CRABBOX_COORDINATOR= CRABBOX_COORDINATOR_TOKEN= ./bin/crabbox run \
  --provider azure --target windows --windows-mode wsl2 --class standard \
  --market on-demand --no-sync --preflight --timing-json -- \
  bash -lc 'echo CRABBOX_AZURE_WSL2_PR81_OK; uname -a; command -v rsync; command -v git; id'
```

Observed:

```text
leased cbx_7517bebdf301 slug=harbor-barnacle provider=azure type=Standard_D2ads_v6
CRABBOX_AZURE_WSL2_PR81_OK
Linux ... microsoft-standard-WSL2 ... Ubuntu 24.04 LTS
/usr/bin/rsync
/usr/bin/git
uid=0(root) gid=0(root)
exit=0
released cbx_7517bebdf301
```

```sh
CRABBOX_CONFIG=<tmp> CRABBOX_COORDINATOR= CRABBOX_COORDINATOR_TOKEN= ./bin/crabbox run \
  --provider azure --target windows --windows-mode normal --desktop --class standard \
  --market on-demand --no-sync --timing-json --shell -- \
  'Write-Output "CRABBOX_AZURE_WINDOWS_DESKTOP_PR81_OK"; $result = Test-NetConnection -ComputerName 127.0.0.1 -Port 5900; Write-Output ("vncTcp=" + $result.TcpTestSucceeded); if (-not $result.TcpTestSucceeded) { exit 7 }'
```

Observed:

```text
leased cbx_b60d5a9116d9 slug=quick-crayfish provider=azure type=Standard_D2ads_v6
Windows desktop VNC ready
CRABBOX_AZURE_WINDOWS_DESKTOP_PR81_OK
vncTcp=True
exit=0
released cbx_b60d5a9116d9
```

GitHub CI for `fcb470942da3c4ea3c2217773e1ff45d0811165c` is green.
