### PR TITLE
fix: handle Hetzner private_net arrays

### DIFF
--- a/internal/cli/hcloud.go
+++ b/internal/cli/hcloud.go
@@ -19,6 +19,36 @@ type HetznerClient struct {
 	Client *http.Client
 }
 
+type privateNet struct {
+	IPv4 struct {
+		IP string `json:"ip"`
+	} `json:"ipv4"`
+}
+
+func (n *privateNet) UnmarshalJSON(data []byte) error {
+	var single struct {
+		IPv4 struct {
+			IP string `json:"ip"`
+		} `json:"ipv4"`
+	}
+	if err := json.Unmarshal(data, &single); err == nil {
+		*n = privateNet(single)
+		return nil
+	}
+	var list []struct {
+		IPv4 struct {
+			IP string `json:"ip"`
+		} `json:"ipv4"`
+	}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+	if len(list) > 0 {
+		*n = privateNet(list[0])
+	}
+	return nil
+}
+
 type Server struct {
 	CloudID   string
 	Provider  string
@@ -31,11 +61,7 @@ type Server struct {
 			IP string `json:"ip"`
 		} `json:"ipv4"`
 	} `json:"public_net"`
-	PrivateNet struct {
-		IPv4 struct {
-			IP string `json:"ip"`
-		} `json:"ipv4"`
-	} `json:"private_net"`
+	PrivateNet privateNet `json:"private_net"`
 	ServerType struct {
 		Name string `json:"name"`
 	} `json:"server_type"`

--- a/internal/cli/hcloud_test.go
+++ b/internal/cli/hcloud_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestServerUnmarshalsHetznerPrivateNetArray(t *testing.T) {
+	data := []byte(`{
+		"id": 123,
+		"name": "crabbox-blue-lobster",
+		"status": "running",
+		"labels": {"crabbox": "true"},
+		"public_net": {"ipv4": {"ip": "203.0.113.10"}},
+		"private_net": [
+			{"ipv4": {"ip": "10.0.0.5"}}
+		],
+		"server_type": {"name": "cpx22"}
+	}`)
+
+	var server Server
+	if err := json.Unmarshal(data, &server); err != nil {
+		t.Fatalf("unmarshal server: %v", err)
+	}
+	if server.PrivateNet.IPv4.IP != "10.0.0.5" {
+		t.Fatalf("private IP: got %q", server.PrivateNet.IPv4.IP)
+	}
+}
+
+func TestServerUnmarshalsObjectPrivateNet(t *testing.T) {
+	data := []byte(`{
+		"id": 123,
+		"private_net": {"ipv4": {"ip": "10.0.0.6"}}
+	}`)
+
+	var server Server
+	if err := json.Unmarshal(data, &server); err != nil {
+		t.Fatalf("unmarshal server: %v", err)
+	}
+	if server.PrivateNet.IPv4.IP != "10.0.0.6" {
+		t.Fatalf("private IP: got %q", server.PrivateNet.IPv4.IP)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes direct Hetzner provisioning when the Hetzner API returns `private_net` as an array.

Recent Crabbox releases decode `Server.PrivateNet` as an object-shaped field. Hetzner returns `private_net` as an array, so direct Hetzner runs can create the server and then fail while unmarshalling the response:

```text
json: cannot unmarshal array into Go struct field Server.server.private_net
```

This keeps the existing `server.PrivateNet.IPv4.IP` access pattern but makes the decoder accept both object-shaped and array-shaped JSON.

## Validation

- Added `TestServerUnmarshalsHetznerPrivateNetArray`
- Added `TestServerUnmarshalsObjectPrivateNet`
- `go test ./internal/cli -run 'TestServerUnmarshals'`
- `go test ./internal/cli -run 'TestServerUnmarshals|TestAzureResolvesPrivateNetworkTarget|TestProxmox'`
- `go test ./internal/providers/hetzner`
- Verified a patched `0.13.0-dev` binary can provision direct Hetzner with `--script-stdin`, `--env-from-profile`, and `--allow-env OPENAI_API_KEY`; the run completed and released the lease cleanly.

## Notes

- No config or secret handling changes.
- `go test ./internal/cli` broadly timed out locally in `TestRunCommandCleansEnvProfileWhenProbeFails`; the focused regression and touched-provider checks above passed.
