### PR TITLE
fix(worker): retry aws lease cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
+- Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 
 ## 0.13.0 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.13.1 - Unreleased
 
+### Fixed
+
+- Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
+
 ## 0.13.0 - 2026-05-13
 
 ### Added

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -58,7 +58,7 @@ participate in Crabbox lease expiry, cleanup, or cost accounting.
 
 ## Cleanup
 
-Brokered cleanup is owned by the Durable Object alarm. `crabbox cleanup` refuses to run when a coordinator is configured, because sweeping provider resources behind the coordinator can delete live leases.
+Brokered cleanup is owned by the Durable Object alarm. `crabbox cleanup` refuses to run when a coordinator is configured, because sweeping provider resources behind the coordinator can delete live leases. When provider deletion fails during TTL cleanup, the coordinator keeps the lease active with cleanup retry metadata and schedules another alarm instead of marking the lease expired while the machine may still exist.
 
 Direct cleanup only deletes machines that are clearly safe:
 
@@ -67,6 +67,8 @@ Direct cleanup only deletes machines that are clearly safe:
 - expired ready/leased/active direct machines can be cleaned up manually;
 - expired inactive machines can be deleted;
 - stale active states older than expiry plus 12 hours can be deleted.
+
+Direct AWS security-group maintenance also prunes Crabbox-owned SSH ingress rules before adding the current source CIDRs, including old fallback ports that are no longer configured. It leaves non-Crabbox rules untouched.
 
 ## Cost Control
 

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -15,7 +15,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-const awsUbuntuOwner = "099720109477"
+const (
+	awsUbuntuOwner           = "099720109477"
+	awsSSHIngressDescription = "Crabbox SSH"
+)
 
 type AWSClient struct {
 	ec2    *ec2.Client
@@ -439,8 +442,10 @@ func (c *AWSClient) ensureSecurityGroup(ctx context.Context, cfg Config) (string
 		return "", err
 	}
 	var groupID string
+	var group *types.SecurityGroup
 	if len(existing.SecurityGroups) > 0 {
-		groupID = aws.ToString(existing.SecurityGroups[0].GroupId)
+		group = &existing.SecurityGroups[0]
+		groupID = aws.ToString(group.GroupId)
 	} else {
 		created, err := c.ec2.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
 			Description: aws.String("Crabbox ephemeral test runners"),
@@ -455,12 +460,116 @@ func (c *AWSClient) ensureSecurityGroup(ctx context.Context, cfg Config) (string
 		}
 		groupID = aws.ToString(created.GroupId)
 	}
-	for _, port := range sshPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts) {
+	ports := sshPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts)
+	if group != nil {
+		if err := c.pruneStaleSSHIngress(ctx, groupID, *group, ports, cfg.AWSSSHCIDRs); err != nil {
+			return "", err
+		}
+	}
+	for _, port := range ports {
 		if err := c.allowTCP(ctx, groupID, port, cfg.AWSSSHCIDRs); err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
 			return "", err
 		}
 	}
 	return groupID, nil
+}
+
+func (c *AWSClient) pruneStaleSSHIngress(ctx context.Context, groupID string, group types.SecurityGroup, ports []string, cidrs []string) error {
+	stalePermissions := staleAWSCrabboxSSHIngressPermissions(group, ports, cidrs)
+	if len(stalePermissions) == 0 {
+		return nil
+	}
+	_, err := c.ec2.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
+		GroupId:       aws.String(groupID),
+		IpPermissions: stalePermissions,
+	})
+	if err != nil && strings.Contains(err.Error(), "InvalidPermission.NotFound") {
+		return nil
+	}
+	return err
+}
+
+func staleAWSCrabboxSSHIngressPermissions(group types.SecurityGroup, ports []string, cidrs []string) []types.IpPermission {
+	desiredPorts := map[int32]struct{}{}
+	for _, port := range ports {
+		p, ok := parsePort32(port)
+		if ok {
+			desiredPorts[p] = struct{}{}
+		}
+	}
+	if len(desiredPorts) == 0 {
+		return nil
+	}
+	desiredCIDRs := awsSSHDesiredCIDRs(cidrs)
+	var stale []types.IpPermission
+	for _, permission := range group.IpPermissions {
+		if !isTCPPortPermission(permission, desiredPorts) {
+			continue
+		}
+		staleIPv4 := staleAWSIpRanges(permission.IpRanges, desiredCIDRs)
+		staleIPv6 := staleAWSIpv6Ranges(permission.Ipv6Ranges, desiredCIDRs)
+		if len(staleIPv4) == 0 && len(staleIPv6) == 0 {
+			continue
+		}
+		stale = append(stale, types.IpPermission{
+			FromPort:   permission.FromPort,
+			IpProtocol: permission.IpProtocol,
+			IpRanges:   staleIPv4,
+			Ipv6Ranges: staleIPv6,
+			ToPort:     permission.ToPort,
+		})
+	}
+	return stale
+}
+
+func awsSSHDesiredCIDRs(cidrs []string) map[string]struct{} {
+	desired := map[string]struct{}{}
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr != "" {
+			desired[cidr] = struct{}{}
+		}
+	}
+	if len(desired) == 0 {
+		desired["0.0.0.0/0"] = struct{}{}
+	}
+	return desired
+}
+
+func isTCPPortPermission(permission types.IpPermission, desiredPorts map[int32]struct{}) bool {
+	if aws.ToString(permission.IpProtocol) != "tcp" || permission.FromPort == nil || permission.ToPort == nil || *permission.FromPort != *permission.ToPort {
+		return false
+	}
+	_, ok := desiredPorts[*permission.FromPort]
+	return ok
+}
+
+func staleAWSIpRanges(ranges []types.IpRange, desiredCIDRs map[string]struct{}) []types.IpRange {
+	stale := make([]types.IpRange, 0, len(ranges))
+	for _, r := range ranges {
+		if aws.ToString(r.Description) != awsSSHIngressDescription {
+			continue
+		}
+		cidr := aws.ToString(r.CidrIp)
+		if _, ok := desiredCIDRs[cidr]; !ok {
+			stale = append(stale, types.IpRange{CidrIp: r.CidrIp, Description: r.Description})
+		}
+	}
+	return stale
+}
+
+func staleAWSIpv6Ranges(ranges []types.Ipv6Range, desiredCIDRs map[string]struct{}) []types.Ipv6Range {
+	stale := make([]types.Ipv6Range, 0, len(ranges))
+	for _, r := range ranges {
+		if aws.ToString(r.Description) != awsSSHIngressDescription {
+			continue
+		}
+		cidr := aws.ToString(r.CidrIpv6)
+		if _, ok := desiredCIDRs[cidr]; !ok {
+			stale = append(stale, types.Ipv6Range{CidrIpv6: r.CidrIpv6, Description: r.Description})
+		}
+	}
+	return stale
 }
 
 func (c *AWSClient) defaultVPC(ctx context.Context) (string, error) {
@@ -500,11 +609,11 @@ func (c *AWSClient) allowTCP(ctx context.Context, groupID, port string, cidrs []
 	ranges := make([]types.IpRange, 0, len(cidrs))
 	for _, cidr := range cidrs {
 		if strings.TrimSpace(cidr) != "" {
-			ranges = append(ranges, types.IpRange{CidrIp: aws.String(cidr), Description: aws.String("Crabbox SSH")})
+			ranges = append(ranges, types.IpRange{CidrIp: aws.String(cidr), Description: aws.String(awsSSHIngressDescription)})
 		}
 	}
 	if len(ranges) == 0 {
-		ranges = append(ranges, types.IpRange{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String("Crabbox SSH")})
+		ranges = append(ranges, types.IpRange{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String(awsSSHIngressDescription)})
 	}
 	_, err := c.ec2.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String(groupID),

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -503,11 +503,13 @@ func staleAWSCrabboxSSHIngressPermissions(group types.SecurityGroup, ports []str
 	desiredCIDRs := awsSSHDesiredCIDRs(cidrs)
 	var stale []types.IpPermission
 	for _, permission := range group.IpPermissions {
-		if !isTCPPortPermission(permission, desiredPorts) {
+		port, ok := exactTCPPermissionPort(permission)
+		if !ok {
 			continue
 		}
-		staleIPv4 := staleAWSIpRanges(permission.IpRanges, desiredCIDRs)
-		staleIPv6 := staleAWSIpv6Ranges(permission.Ipv6Ranges, desiredCIDRs)
+		_, keepPort := desiredPorts[port]
+		staleIPv4 := staleAWSIpRanges(permission.IpRanges, desiredCIDRs, keepPort)
+		staleIPv6 := staleAWSIpv6Ranges(permission.Ipv6Ranges, desiredCIDRs, keepPort)
 		if len(staleIPv4) == 0 && len(staleIPv6) == 0 {
 			continue
 		}
@@ -536,36 +538,37 @@ func awsSSHDesiredCIDRs(cidrs []string) map[string]struct{} {
 	return desired
 }
 
-func isTCPPortPermission(permission types.IpPermission, desiredPorts map[int32]struct{}) bool {
+func exactTCPPermissionPort(permission types.IpPermission) (int32, bool) {
 	if aws.ToString(permission.IpProtocol) != "tcp" || permission.FromPort == nil || permission.ToPort == nil || *permission.FromPort != *permission.ToPort {
-		return false
+		return 0, false
 	}
-	_, ok := desiredPorts[*permission.FromPort]
-	return ok
+	return *permission.FromPort, true
 }
 
-func staleAWSIpRanges(ranges []types.IpRange, desiredCIDRs map[string]struct{}) []types.IpRange {
+func staleAWSIpRanges(ranges []types.IpRange, desiredCIDRs map[string]struct{}, keepPort bool) []types.IpRange {
 	stale := make([]types.IpRange, 0, len(ranges))
 	for _, r := range ranges {
 		if aws.ToString(r.Description) != awsSSHIngressDescription {
 			continue
 		}
 		cidr := aws.ToString(r.CidrIp)
-		if _, ok := desiredCIDRs[cidr]; !ok {
+		_, keepCIDR := desiredCIDRs[cidr]
+		if !keepPort || !keepCIDR {
 			stale = append(stale, types.IpRange{CidrIp: r.CidrIp, Description: r.Description})
 		}
 	}
 	return stale
 }
 
-func staleAWSIpv6Ranges(ranges []types.Ipv6Range, desiredCIDRs map[string]struct{}) []types.Ipv6Range {
+func staleAWSIpv6Ranges(ranges []types.Ipv6Range, desiredCIDRs map[string]struct{}, keepPort bool) []types.Ipv6Range {
 	stale := make([]types.Ipv6Range, 0, len(ranges))
 	for _, r := range ranges {
 		if aws.ToString(r.Description) != awsSSHIngressDescription {
 			continue
 		}
 		cidr := aws.ToString(r.CidrIpv6)
-		if _, ok := desiredCIDRs[cidr]; !ok {
+		_, keepCIDR := desiredCIDRs[cidr]
+		if !keepPort || !keepCIDR {
 			stale = append(stale, types.Ipv6Range{CidrIpv6: r.CidrIpv6, Description: r.Description})
 		}
 	}

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -29,5 +30,68 @@ func TestApplyAWSRunInstanceTargetOptionsLeavesNativeWindowsDefault(t *testing.T
 	})
 	if input.CpuOptions != nil {
 		t.Fatalf("CpuOptions=%#v, want nil", input.CpuOptions)
+	}
+}
+
+func TestStaleAWSCrabboxSSHIngressPermissionsPrunesOnlyOwnedCIDRs(t *testing.T) {
+	group := types.SecurityGroup{
+		IpPermissions: []types.IpPermission{
+			{
+				FromPort:   aws.Int32(22),
+				ToPort:     aws.Int32(22),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("203.0.113.10/32"), Description: aws.String(awsSSHIngressDescription)},
+					{CidrIp: aws.String("198.51.100.20/32"), Description: aws.String(awsSSHIngressDescription)},
+					{CidrIp: aws.String("192.0.2.30/32"), Description: aws.String("operator access")},
+				},
+				Ipv6Ranges: []types.Ipv6Range{
+					{CidrIpv6: aws.String("2001:db8::1/128"), Description: aws.String(awsSSHIngressDescription)},
+				},
+			},
+			{
+				FromPort:   aws.Int32(443),
+				ToPort:     aws.Int32(443),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("198.51.100.20/32"), Description: aws.String(awsSSHIngressDescription)},
+				},
+			},
+		},
+	}
+
+	stale := staleAWSCrabboxSSHIngressPermissions(group, []string{"22"}, []string{"203.0.113.10/32"})
+	if len(stale) != 1 {
+		t.Fatalf("len(stale)=%d, want 1: %#v", len(stale), stale)
+	}
+	permission := stale[0]
+	if got := aws.ToInt32(permission.FromPort); got != 22 {
+		t.Fatalf("FromPort=%d, want 22", got)
+	}
+	if len(permission.IpRanges) != 1 || aws.ToString(permission.IpRanges[0].CidrIp) != "198.51.100.20/32" {
+		t.Fatalf("IpRanges=%#v, want only stale Crabbox IPv4 range", permission.IpRanges)
+	}
+	if len(permission.Ipv6Ranges) != 1 || aws.ToString(permission.Ipv6Ranges[0].CidrIpv6) != "2001:db8::1/128" {
+		t.Fatalf("Ipv6Ranges=%#v, want only stale Crabbox IPv6 range", permission.Ipv6Ranges)
+	}
+}
+
+func TestStaleAWSCrabboxSSHIngressPermissionsKeepsDefaultCIDR(t *testing.T) {
+	group := types.SecurityGroup{
+		IpPermissions: []types.IpPermission{
+			{
+				FromPort:   aws.Int32(22),
+				ToPort:     aws.Int32(22),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("0.0.0.0/0"), Description: aws.String(awsSSHIngressDescription)},
+				},
+			},
+		},
+	}
+
+	stale := staleAWSCrabboxSSHIngressPermissions(group, []string{"22"}, nil)
+	if len(stale) != 0 {
+		t.Fatalf("stale=%#v, want none for default fallback CIDR", stale)
 	}
 }

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -37,8 +37,8 @@ func TestStaleAWSCrabboxSSHIngressPermissionsPrunesOnlyOwnedCIDRs(t *testing.T) 
 	group := types.SecurityGroup{
 		IpPermissions: []types.IpPermission{
 			{
-				FromPort:   aws.Int32(22),
-				ToPort:     aws.Int32(22),
+				FromPort:   aws.Int32(2222),
+				ToPort:     aws.Int32(2222),
 				IpProtocol: aws.String("tcp"),
 				IpRanges: []types.IpRange{
 					{CidrIp: aws.String("203.0.113.10/32"), Description: aws.String(awsSSHIngressDescription)},
@@ -50,29 +50,42 @@ func TestStaleAWSCrabboxSSHIngressPermissionsPrunesOnlyOwnedCIDRs(t *testing.T) 
 				},
 			},
 			{
-				FromPort:   aws.Int32(443),
-				ToPort:     aws.Int32(443),
+				FromPort:   aws.Int32(22),
+				ToPort:     aws.Int32(22),
 				IpProtocol: aws.String("tcp"),
 				IpRanges: []types.IpRange{
 					{CidrIp: aws.String("198.51.100.20/32"), Description: aws.String(awsSSHIngressDescription)},
 				},
 			},
+			{
+				FromPort:   aws.Int32(443),
+				ToPort:     aws.Int32(443),
+				IpProtocol: aws.String("tcp"),
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("198.51.100.20/32"), Description: aws.String("operator access")},
+				},
+			},
 		},
 	}
 
-	stale := staleAWSCrabboxSSHIngressPermissions(group, []string{"22"}, []string{"203.0.113.10/32"})
-	if len(stale) != 1 {
-		t.Fatalf("len(stale)=%d, want 1: %#v", len(stale), stale)
+	stale := staleAWSCrabboxSSHIngressPermissions(group, []string{"2222"}, []string{"203.0.113.10/32"})
+	if len(stale) != 2 {
+		t.Fatalf("len(stale)=%d, want 2: %#v", len(stale), stale)
 	}
-	permission := stale[0]
-	if got := aws.ToInt32(permission.FromPort); got != 22 {
-		t.Fatalf("FromPort=%d, want 22", got)
+	byPort := map[int32]types.IpPermission{}
+	for _, permission := range stale {
+		byPort[aws.ToInt32(permission.FromPort)] = permission
 	}
-	if len(permission.IpRanges) != 1 || aws.ToString(permission.IpRanges[0].CidrIp) != "198.51.100.20/32" {
-		t.Fatalf("IpRanges=%#v, want only stale Crabbox IPv4 range", permission.IpRanges)
+	currentPort := byPort[2222]
+	if len(currentPort.IpRanges) != 1 || aws.ToString(currentPort.IpRanges[0].CidrIp) != "198.51.100.20/32" {
+		t.Fatalf("IpRanges=%#v, want only stale Crabbox IPv4 range on current port", currentPort.IpRanges)
 	}
-	if len(permission.Ipv6Ranges) != 1 || aws.ToString(permission.Ipv6Ranges[0].CidrIpv6) != "2001:db8::1/128" {
-		t.Fatalf("Ipv6Ranges=%#v, want only stale Crabbox IPv6 range", permission.Ipv6Ranges)
+	if len(currentPort.Ipv6Ranges) != 1 || aws.ToString(currentPort.Ipv6Ranges[0].CidrIpv6) != "2001:db8::1/128" {
+		t.Fatalf("Ipv6Ranges=%#v, want only stale Crabbox IPv6 range on current port", currentPort.Ipv6Ranges)
+	}
+	removedPort := byPort[22]
+	if len(removedPort.IpRanges) != 1 || aws.ToString(removedPort.IpRanges[0].CidrIp) != "198.51.100.20/32" {
+		t.Fatalf("removed port IpRanges=%#v, want Crabbox ranges pruned from removed port", removedPort.IpRanges)
 	}
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1043,6 +1043,7 @@ export class FleetDurableObject implements DurableObject {
     lease.updatedAt = now.toISOString();
     lease.lastTouchedAt = now.toISOString();
     lease.expiresAt = recomputeLeaseExpiresAt(lease, now).toISOString();
+    clearLeaseCleanupMetadata(lease);
     await this.putLease(lease);
     await this.scheduleAlarm();
   }
@@ -2995,10 +2996,7 @@ export class FleetDurableObject implements DurableObject {
         lease.state = "expired";
         lease.updatedAt = nowISO;
         lease.endedAt = nowISO;
-        delete lease.cleanupAttempts;
-        delete lease.cleanupError;
-        delete lease.cleanupFailedAt;
-        delete lease.cleanupRetryAt;
+        clearLeaseCleanupMetadata(lease);
         await this.putLease(lease);
       }),
     );
@@ -3301,10 +3299,7 @@ export class FleetDurableObject implements DurableObject {
     lease.updatedAt = now;
     lease.releasedAt = now;
     lease.endedAt = now;
-    delete lease.cleanupAttempts;
-    delete lease.cleanupError;
-    delete lease.cleanupFailedAt;
-    delete lease.cleanupRetryAt;
+    clearLeaseCleanupMetadata(lease);
     if (options.keep !== undefined) {
       lease.keep = options.keep;
     }
@@ -4530,12 +4525,23 @@ function activeSlugCollision(
 }
 
 function nextLeaseAlarmTime(lease: LeaseRecord): number {
+  const now = Date.now();
   const expiresAt = Date.parse(lease.expiresAt);
   const cleanupRetryAt = Date.parse(lease.cleanupRetryAt ?? "");
-  if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt > Date.now()) {
-    return cleanupRetryAt;
+  if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt > now) {
+    if (Number.isFinite(expiresAt) && expiresAt <= now) {
+      return cleanupRetryAt;
+    }
+    return Math.min(expiresAt, cleanupRetryAt);
   }
   return expiresAt;
+}
+
+function clearLeaseCleanupMetadata(lease: LeaseRecord): void {
+  delete lease.cleanupAttempts;
+  delete lease.cleanupError;
+  delete lease.cleanupFailedAt;
+  delete lease.cleanupRetryAt;
 }
 
 function normalizeShareUser(value: string | undefined): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -70,6 +70,7 @@ const maxExternalRunnerSyncItems = 200;
 const webVNCTicketTTLSeconds = 120;
 const codeTicketTTLSeconds = 120;
 const egressTicketTTLSeconds = 120;
+const leaseCleanupRetryDelayMs = 5 * 60 * 1000;
 const maxPendingWebVNCBytes = 1024 * 1024;
 const maxCodeRequestBytes = 10 * 1024 * 1024;
 const maxCodeWebSocketFrameChunkBytes = 15 * 1024;
@@ -2972,11 +2973,32 @@ export class FleetDurableObject implements DurableObject {
     );
     await Promise.all(
       expired.map(async (lease) => {
-        await this.deleteLeaseServer(lease).catch(() => undefined);
+        const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
+        if (Number.isFinite(retryAt) && retryAt > now) {
+          return;
+        }
         const nowISO = new Date().toISOString();
+        try {
+          await this.deleteLeaseServer(lease);
+        } catch (error) {
+          lease.cleanupAttempts = (lease.cleanupAttempts ?? 0) + 1;
+          lease.cleanupError = errorMessage(error);
+          lease.cleanupFailedAt = nowISO;
+          lease.cleanupRetryAt = new Date(now + leaseCleanupRetryDelayMs).toISOString();
+          lease.updatedAt = nowISO;
+          await this.putLease(lease);
+          console.warn(
+            `lease cleanup failed lease=${lease.id} provider=${lease.provider} cloud=${lease.cloudID}: ${lease.cleanupError}`,
+          );
+          return;
+        }
         lease.state = "expired";
         lease.updatedAt = nowISO;
         lease.endedAt = nowISO;
+        delete lease.cleanupAttempts;
+        delete lease.cleanupError;
+        delete lease.cleanupFailedAt;
+        delete lease.cleanupRetryAt;
         await this.putLease(lease);
       }),
     );
@@ -2986,7 +3008,7 @@ export class FleetDurableObject implements DurableObject {
     const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
     const activeExpiries = [...leases.values()]
       .filter((lease) => lease.state === "active")
-      .map((lease) => Date.parse(lease.expiresAt))
+      .map((lease) => nextLeaseAlarmTime(lease))
       .filter((time) => Number.isFinite(time));
     if (activeExpiries.length === 0) {
       await this.state.storage.deleteAlarm();
@@ -3279,6 +3301,10 @@ export class FleetDurableObject implements DurableObject {
     lease.updatedAt = now;
     lease.releasedAt = now;
     lease.endedAt = now;
+    delete lease.cleanupAttempts;
+    delete lease.cleanupError;
+    delete lease.cleanupFailedAt;
+    delete lease.cleanupRetryAt;
     if (options.keep !== undefined) {
       lease.keep = options.keep;
     }
@@ -4501,6 +4527,15 @@ function activeSlugCollision(
       lease.org === org &&
       normalizeLeaseSlug(lease.slug) === slug,
   );
+}
+
+function nextLeaseAlarmTime(lease: LeaseRecord): number {
+  const expiresAt = Date.parse(lease.expiresAt);
+  const cleanupRetryAt = Date.parse(lease.cleanupRetryAt ?? "");
+  if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt > Date.now()) {
+    return cleanupRetryAt;
+  }
+  return expiresAt;
 }
 
 function normalizeShareUser(value: string | undefined): string {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -207,6 +207,10 @@ export interface LeaseRecord {
   expiresAt: string;
   telemetry?: LeaseTelemetry;
   telemetryHistory?: LeaseTelemetry[];
+  cleanupAttempts?: number;
+  cleanupError?: string;
+  cleanupFailedAt?: string;
+  cleanupRetryAt?: string;
   releasedAt?: string;
   endedAt?: string;
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -171,6 +171,62 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBeUndefined();
   });
 
+  it("schedules the real expiry before stale cleanup retry metadata", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        cleanupAttempts: 1,
+        cleanupError: "previous failure",
+        cleanupFailedAt: new Date(Date.now() - 60_000).toISOString(),
+        cleanupRetryAt: new Date(Date.now() + 300_000).toISOString(),
+        expiresAt,
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(storage.alarm()).toBe(Date.parse(expiresAt));
+  });
+
+  it("clears cleanup retry metadata when an active lease heartbeats", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        owner: "peter@example.com",
+        org: "openclaw",
+        cleanupAttempts: 1,
+        cleanupError: "previous failure",
+        cleanupFailedAt: new Date(Date.now() - 60_000).toISOString(),
+        cleanupRetryAt: new Date(Date.now() + 300_000).toISOString(),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_000000000001/heartbeat", {
+        headers: {
+          "x-crabbox-owner": "peter@example.com",
+          "x-crabbox-org": "openclaw",
+        },
+        body: { idleTimeoutSeconds: 120 },
+      }),
+    );
+
+    expect(heartbeat.status).toBe(200);
+    const { lease } = (await heartbeat.json()) as { lease: LeaseRecord };
+    expect(lease.cleanupAttempts).toBeUndefined();
+    expect(lease.cleanupError).toBeUndefined();
+    expect(lease.cleanupRetryAt).toBeUndefined();
+    expect(storage.alarm()).toBe(Date.parse(lease.expiresAt));
+  });
+
   it("creates leases through the public route with slug and idle metadata", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -29,6 +29,7 @@ afterEach(() => {
 
 class MemoryStorage {
   private readonly values = new Map<string, unknown>();
+  private alarmTime: number | undefined;
 
   async get<T>(key: string): Promise<T | undefined> {
     return this.values.get(key) as T | undefined;
@@ -42,9 +43,13 @@ class MemoryStorage {
     this.values.delete(key);
   }
 
-  async deleteAlarm(): Promise<void> {}
+  async deleteAlarm(): Promise<void> {
+    this.alarmTime = undefined;
+  }
 
-  async setAlarm(_time: number): Promise<void> {}
+  async setAlarm(time: number): Promise<void> {
+    this.alarmTime = time;
+  }
 
   async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
     const matches = new Map<string, T>();
@@ -62,6 +67,10 @@ class MemoryStorage {
 
   value<T>(key: string): T | undefined {
     return this.values.get(key) as T | undefined;
+  }
+
+  alarm(): number | undefined {
+    return this.alarmTime;
   }
 }
 
@@ -100,6 +109,68 @@ class FakeWebSocket {
 }
 
 describe("fleet lease identity and idle", () => {
+  it("keeps expired leases active when provider cleanup fails and retries later", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async () => {
+        throw new Error("aws terminate throttled");
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-000000000001",
+        region: "eu-west-1",
+        expiresAt: "2026-05-01T00:00:01.000Z",
+      }),
+    );
+
+    await fleet.alarm();
+
+    const lease = storage.value<LeaseRecord>("lease:cbx_000000000001");
+    expect(lease?.state).toBe("active");
+    expect(lease?.cleanupAttempts).toBe(1);
+    expect(lease?.cleanupError).toContain("aws terminate throttled");
+    expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(Date.now());
+    expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
+  });
+
+  it("expires leases only after provider cleanup succeeds", async () => {
+    const storage = new MemoryStorage();
+    let deletes = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async () => {
+        deletes += 1;
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-000000000001",
+        region: "eu-west-1",
+        cleanupAttempts: 2,
+        cleanupError: "previous failure",
+        cleanupFailedAt: "2026-05-01T00:00:10.000Z",
+        cleanupRetryAt: "2026-05-01T00:05:10.000Z",
+        expiresAt: "2026-05-01T00:00:01.000Z",
+      }),
+    );
+
+    await fleet.alarm();
+
+    const lease = storage.value<LeaseRecord>("lease:cbx_000000000001");
+    expect(deletes).toBe(1);
+    expect(lease?.state).toBe("expired");
+    expect(lease?.cleanupAttempts).toBeUndefined();
+    expect(lease?.cleanupError).toBeUndefined();
+    expect(lease?.cleanupRetryAt).toBeUndefined();
+    expect(storage.alarm()).toBeUndefined();
+  });
+
   it("creates leases through the public route with slug and idle metadata", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {
@@ -3253,6 +3324,7 @@ function fakeProvider(
     market?: string;
     attempts?: ProvisioningAttempt[];
   } = {},
+  onDelete?: (id: string) => Promise<void>,
 ) {
   return {
     async listCrabboxServers() {
@@ -3282,7 +3354,9 @@ function fakeProvider(
         attempts: result.attempts,
       };
     },
-    async deleteServer() {},
+    async deleteServer(id: string) {
+      await onDelete?.(id);
+    },
     async createImage(_instanceID: string, name: string) {
       return { id: "ami-000000000001", name, state: "pending", region: "eu-west-1" };
     },


### PR DESCRIPTION
## Summary
- keep leases active and retry when coordinator TTL cleanup cannot delete the provider resource
- prune stale Crabbox-owned AWS SSH ingress rules in the direct CLI path before adding current CIDRs
- document both fixes in the unreleased changelog

## Verification
- npm test --prefix worker -- fleet.test.ts
- npm run format:check --prefix worker
- npm run check --prefix worker
- npm run lint --prefix worker
- npm run build --prefix worker
- go test ./internal/cli -run 'TestApplyAWS|TestStaleAWS'\n- deployed Worker preview to production coordinator and checked /v1/health\n- verified stale AWS instances were terminated and stale runner security-group rules were removed in affected regions\n