### PR TITLE
fix: reject unsafe Tensorlake workdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed Modal sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.
 - Fixed native provider checkpoint creation so AWS, Azure, and GCP snapshot/image checkpoints flush source filesystem writes before calling the provider API.
 - Fixed Tensorlake timing JSON so delegated runs include the lease slug and reused sandboxes preserve the stored claim slug. Thanks @stainlu.
+- Fixed Tensorlake workdir validation so broad sandbox paths are rejected before sync or command execution. Thanks @stainlu.
 
 ## 0.13.0 - 2026-05-13
 

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 )
@@ -399,10 +400,15 @@ func tensorlakeWorkdir(cfg Config) (string, error) {
 	if workdir == "" {
 		workdir = "/workspace/crabbox"
 	}
-	if !strings.HasPrefix(workdir, "/") {
+	clean := path.Clean(workdir)
+	if !strings.HasPrefix(clean, "/") {
 		return "", exit(2, "tensorlake workdir %q must be an absolute path", workdir)
 	}
-	return workdir, nil
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
+		return "", exit(2, "tensorlake workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
 }
 
 func (b *tensorlakeBackend) now() time.Time {

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -82,6 +82,30 @@ func TestTensorlakeWorkdirRejectsRelative(t *testing.T) {
 	}
 }
 
+func TestTensorlakeWorkdirRejectsBroadPaths(t *testing.T) {
+	for _, workdir := range []string{"/", "/tmp", "/workspace", "/workspace/.."} {
+		t.Run(workdir, func(t *testing.T) {
+			cfg := newTestConfig()
+			cfg.Tensorlake.Workdir = workdir
+			if _, err := tensorlakeWorkdir(cfg); err == nil || !strings.Contains(err.Error(), "too broad") {
+				t.Fatalf("err=%v, want too broad rejection", err)
+			}
+		})
+	}
+}
+
+func TestTensorlakeWorkdirCleansDedicatedPath(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Tensorlake.Workdir = " /workspace/crabbox/../project "
+	got, err := tensorlakeWorkdir(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/workspace/project" {
+		t.Fatalf("workdir=%q want /workspace/project", got)
+	}
+}
+
 func TestTensorlakeWorkdirDefault(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Tensorlake.Workdir = ""


### PR DESCRIPTION
## Summary
- clean Tensorlake sandbox workdirs before use
- reject broad Tensorlake roots such as /, /tmp, /workspace, and /workspace/..
- add regression coverage for broad-path rejection and cleaned dedicated paths

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/tensorlake
- git diff --check

## Notes
- A broader local check, env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/tensorlake ./internal/cli, reproduced an unrelated current-main failure in internal/cli: TestRunCommandCleansEnvProfileWhenProbeFails times out waiting for the fake SSH probe and expects exit 7. The focused Tensorlake package passes.