### PR TITLE
fix: clean Modal sync archives after extract errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.
 - Fixed installed tagged builds so `crabbox --version` and proof metadata report the Go module build version instead of the development fallback. Thanks @stainlu.
+- Fixed Modal sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.
 - Fixed native provider checkpoint creation so AWS, Azure, and GCP snapshot/image checkpoints flush source filesystem writes before calling the provider API.
 - Fixed Tensorlake timing JSON so delegated runs include the lease slug and reused sandboxes preserve the stored claim slug. Thanks @stainlu.
 

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -380,16 +380,9 @@ func containsVerb(verbs []string, want string) bool {
 func newGitRepo(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-	for _, args := range [][]string{
-		{"init", "-q", root},
-		{"-C", root, "config", "user.email", "test@example.com"},
-		{"-C", root, "config", "user.name", "test"},
-		{"-C", root, "commit", "-q", "--allow-empty", "-m", "init"},
-	} {
-		cmd := osexec.Command("git", args...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v: %s", args, err, out)
-		}
+	cmd := osexec.Command("git", "init", "-q", root)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
 	}
 	return root
 }

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -190,6 +193,30 @@ func TestRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
 	}
 }
 
+func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
+	fake := &fakeModalAPI{execCodes: []int{0, 7, 0}}
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	repoRoot := newGitRepo(t)
+	if err := os.WriteFile(filepath.Join(repoRoot, "hello.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "sb-123", RunRequest{
+		Repo: Repo{Name: "repo", Root: repoRoot},
+	}, "/workspace/crabbox")
+	if err == nil {
+		t.Fatalf("expected extract failure")
+	}
+	verbs := fake.verbs
+	want := []string{"exec", "upload", "exec", "exec"}
+	if !reflect.DeepEqual(verbs, want) {
+		t.Fatalf("verbs=%v want %v", verbs, want)
+	}
+	cleanup := strings.Join(fake.execCommands[2], " ")
+	if !strings.Contains(cleanup, "rm -f '/tmp/crabbox-modal-sync-") {
+		t.Fatalf("cleanup command missing remote archive removal: %v", fake.execCommands[2])
+	}
+}
+
 func TestKeepOnFailureRetainsSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeModalAPI{execCodes: []int{0, 7}}
@@ -348,4 +375,21 @@ func containsVerb(verbs []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", root},
+		{"-C", root, "config", "user.email", "test@example.com"},
+		{"-C", root, "config", "user.name", "test"},
+		{"-C", root, "commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		cmd := osexec.Command("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return root
 }

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -56,6 +56,7 @@ func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandb
 		"rm -f " + shellQuote(remoteArchive),
 	}, " && ")
 	if err := b.execShell(ctx, client, sandboxID, extract, io.Discard); err != nil {
+		_ = b.execShell(context.Background(), client, sandboxID, "rm -f "+shellQuote(remoteArchive), io.Discard)
 		return nil, 0, err
 	}
 	uploadDuration := b.now().Sub(uploadStarted)


### PR DESCRIPTION
## Summary
- clean up uploaded Modal sync archives when remote extraction fails
- keep successful extract behavior unchanged
- add a regression test that forces extraction failure and verifies cleanup still runs

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/modal
- git diff --check