### PR TITLE
fix: include Tensorlake slug in timing JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.
 - Fixed installed tagged builds so `crabbox --version` and proof metadata report the Go module build version instead of the development fallback. Thanks @stainlu.
 - Fixed native provider checkpoint creation so AWS, Azure, and GCP snapshot/image checkpoints flush source filesystem writes before calling the provider API.
+- Fixed Tensorlake timing JSON so delegated runs include the lease slug and reused sandboxes preserve the stored claim slug. Thanks @stainlu.
 
 ## 0.13.0 - 2026-05-13
 

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -145,6 +145,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
+			Slug:          slug,
 			SyncDelegated: true,
 			SyncMs:        syncDuration.Milliseconds(),
 			SyncPhases:    syncPhases,

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -76,11 +76,10 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxID, name)
 		acquired = true
 	} else {
-		leaseID, sandboxID, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
 		if err != nil {
 			return RunResult{}, err
 		}
-		slug = newLeaseSlug(leaseID)
 	}
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
@@ -207,7 +206,7 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -221,7 +220,7 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		ready := describeErr == nil && isReadyState(state)
 		view := StatusView{
 			ID:       leaseID,
-			Slug:     newLeaseSlug(leaseID),
+			Slug:     slug,
 			Provider: providerName,
 			TargetOS: targetLinux,
 			State:    state,
@@ -253,7 +252,7 @@ func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
 		return err
 	}
@@ -286,13 +285,13 @@ func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCL
 }
 
 // resolveLeaseID resolves a user-supplied identifier (slug, lease ID, or
-// raw Tensorlake sandbox ID) to a (leaseID, sandboxID) pair. Resolution is
+// raw Tensorlake sandbox ID) to a (leaseID, sandboxID, slug) tuple. Resolution is
 // strict: only locally-claimed Crabbox sandboxes are accepted, mirroring
 // islo. Raw IDs are accepted only when a matching `tlsbx_<id>` claim exists.
-func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, error) {
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
 	}
 	probes := []string{id}
 	if !strings.HasPrefix(id, leasePrefix) {
@@ -301,7 +300,7 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	for _, probe := range probes {
 		claim, ok, err := resolveLeaseClaimForProvider(probe, providerName)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		if !ok {
 			continue
@@ -309,12 +308,16 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 		if repoRoot != "" {
 			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
 				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-				return "", "", err
+				return "", "", "", err
 			}
 		}
-		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), nil
+		slug := claim.Slug
+		if strings.TrimSpace(slug) == "" {
+			slug = newLeaseSlug(claim.LeaseID)
+		}
+		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
 	}
-	return "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return "", "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -3,6 +3,7 @@ package tensorlake
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -447,6 +448,46 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	var ee ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code=7", err)
+	}
+}
+
+func TestRunTimingJSONIncludesSlug(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	sandboxID := "timingid0123456789"
+	leaseID := leasePrefix + sandboxID
+	defer removeLeaseClaim(leaseID)
+	runner := newRunner(map[string]scriptedReply{
+		"sbx create": {stdout: sandboxID + "\n"},
+		"sbx exec":   {stdout: "ok\n"},
+	}, nil)
+	var stderr bytes.Buffer
+	rt := newTestRuntime(runner)
+	rt.Stderr = &stderr
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
+	req := RunRequest{
+		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+		Command:    []string{"echo", "ok"},
+		NoSync:     true,
+		Keep:       true,
+		Reclaim:    true,
+		TimingJSON: true,
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	report := map[string]any{}
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		if strings.HasPrefix(line, "{") {
+			if err := json.Unmarshal([]byte(line), &report); err != nil {
+				t.Fatalf("decode timing JSON %q: %v", line, err)
+			}
+		}
+	}
+	if report["leaseId"] != leaseID {
+		t.Fatalf("leaseId=%v want %s in timing JSON:\n%s", report["leaseId"], leaseID, stderr.String())
+	}
+	if report["slug"] != newLeaseSlug(leaseID) {
+		t.Fatalf("slug=%v want %s in timing JSON:\n%s", report["slug"], newLeaseSlug(leaseID), stderr.String())
 	}
 }
 

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -170,14 +170,14 @@ func TestIsReadyState(t *testing.T) {
 }
 
 func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
-	_, _, err := resolveLeaseID("not-a-known-slug", "", false, 0)
+	_, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0)
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection of unclaimed sandbox", err)
 	}
 }
 
 func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
-	_, _, err := resolveLeaseID("tlsbx_unknown123", "", false, 0)
+	_, _, _, err := resolveLeaseID("tlsbx_unknown123", "", false, 0)
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection without local claim", err)
 	}
@@ -191,17 +191,35 @@ func TestResolveLeaseIDUsesTensorlakeClaimWhenSlugCollides(t *testing.T) {
 	if err := claimLeaseForRepoProvider("tlsbx_tensorlake123456", "Blue Lobster", providerName, "/repo-b", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	leaseID, sandboxID, err := resolveLeaseID("blue-lobster", "", false, 0)
+	leaseID, sandboxID, slug, err := resolveLeaseID("blue-lobster", "", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if leaseID != "tlsbx_tensorlake123456" || sandboxID != "tensorlake123456" {
 		t.Fatalf("lease=%q sandbox=%q", leaseID, sandboxID)
 	}
+	if slug != "Blue Lobster" {
+		t.Fatalf("slug=%q", slug)
+	}
+}
+
+func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "tlsbx_tensorlake123456"
+	if err := claimLeaseForRepoProvider(leaseID, "", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	_, _, slug, err := resolveLeaseID(leaseID, "", false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != newLeaseSlug(leaseID) {
+		t.Fatalf("slug=%q want %q", slug, newLeaseSlug(leaseID))
+	}
 }
 
 func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
-	if _, _, err := resolveLeaseID("", "", false, 0); err == nil {
+	if _, _, _, err := resolveLeaseID("", "", false, 0); err == nil {
 		t.Fatalf("expected error for empty id")
 	}
 }
@@ -488,6 +506,45 @@ func TestRunTimingJSONIncludesSlug(t *testing.T) {
 	}
 	if report["slug"] != newLeaseSlug(leaseID) {
 		t.Fatalf("slug=%v want %s in timing JSON:\n%s", report["slug"], newLeaseSlug(leaseID), stderr.String())
+	}
+}
+
+func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	sandboxID := "reuseid01234567890"
+	leaseID := leasePrefix + sandboxID
+	if err := claimLeaseForRepoProvider(leaseID, "custom-slug", providerName, repoRoot, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	defer removeLeaseClaim(leaseID)
+	runner := newRunner(map[string]scriptedReply{
+		"sbx exec": {stdout: "ok\n"},
+	}, nil)
+	var stderr bytes.Buffer
+	rt := newTestRuntime(runner)
+	rt.Stderr = &stderr
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
+	req := RunRequest{
+		ID:         "custom-slug",
+		Repo:       Repo{Name: "carbbox", Root: repoRoot},
+		Command:    []string{"echo", "ok"},
+		NoSync:     true,
+		TimingJSON: true,
+	}
+	if _, err := backend.Run(context.Background(), req); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	report := map[string]any{}
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		if strings.HasPrefix(line, "{") {
+			if err := json.Unmarshal([]byte(line), &report); err != nil {
+				t.Fatalf("decode timing JSON %q: %v", line, err)
+			}
+		}
+	}
+	if report["slug"] != "custom-slug" {
+		t.Fatalf("slug=%v want custom-slug in timing JSON:\n%s", report["slug"], stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- include the Tensorlake lease slug in run timing JSON
- keep Tensorlake warmup/run timing output consistent with other delegated providers
- add regression coverage that parses emitted timing JSON and checks leaseId plus slug

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/tensorlake
- git diff --check