### PR TITLE
fix(admin): audit expired aws leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.13.1 - Unreleased
 
+### Added
+
+- Added `crabbox admin lease-audit` so operators can compare expired brokered AWS lease records against live cloud instance state and fail automation when a record still maps to a live instance.
+
 ### Fixed
 
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,7 @@ crabbox share --id <lease-id-or-slug> [--user <email>] [--org] [--role use|manag
 crabbox unshare --id <lease-id-or-slug> [--user <email>] [--org] [--all] [--json]
 crabbox usage [--scope user|org|all] [--user <email>] [--org <name>] [--month YYYY-MM] [--json]
 crabbox admin leases [--state active|released|expired|failed] [--owner <email>] [--org <name>] [--json]
+crabbox admin lease-audit [--state expired] [--provider aws] [--fail-on-live] [--json]
 crabbox admin release <lease-id-or-slug> [--delete]
 crabbox admin delete <lease-id-or-slug> --force
 crabbox ssh --id <lease-id-or-slug> [--network auto|tailscale|public]
@@ -262,6 +263,7 @@ Trusted operator lease controls:
 
 ```sh
 crabbox admin leases --state active
+crabbox admin lease-audit --state expired --provider aws --fail-on-live
 crabbox admin release blue-lobster
 crabbox admin delete cbx_abcdef123456 --force
 ```

--- a/docs/commands/admin.md
+++ b/docs/commands/admin.md
@@ -5,6 +5,8 @@
 ```sh
 crabbox admin leases
 crabbox admin leases --state active --json
+crabbox admin lease-audit --state expired --provider aws
+crabbox admin lease-audit --fail-on-live
 crabbox admin release blue-lobster
 crabbox admin release blue-lobster --delete
 crabbox admin delete cbx_... --force
@@ -27,6 +29,24 @@ Flags:
 --owner <email>     filter by owner
 --org <name>        filter by org
 --limit <n>         default 100, maximum 500
+--json              print JSON
+```
+
+## lease-audit
+
+Check expired coordinator lease records against the backing cloud provider.
+The audit currently supports AWS leases and reports whether each expired
+`cloudID` is still present, missing, or could not be checked.
+
+Flags:
+
+```text
+--state <state>     default expired
+--provider <name>   default aws
+--owner <email>     filter by owner
+--org <name>        filter by org
+--limit <n>         default 100, maximum 500
+--fail-on-live      exit non-zero for live cloud instances or audit errors
 --json              print JSON
 ```
 

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -35,6 +35,7 @@ Trusted operator controls:
 
 ```sh
 crabbox admin leases --state active
+crabbox admin lease-audit --state expired --provider aws
 crabbox admin release blue-lobster
 crabbox admin delete cbx_... --force
 ```

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -41,6 +41,7 @@ GET  /v1/runners
 POST /v1/runners/sync
 GET  /v1/usage
 GET  /v1/admin/leases
+GET  /v1/admin/lease-audit
 POST /v1/admin/leases/{id-or-slug}/release
 POST /v1/admin/leases/{id-or-slug}/delete
 ```

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -34,6 +34,56 @@ func (a App) adminLeases(ctx context.Context, args []string) error {
 	return nil
 }
 
+func (a App) adminLeaseAudit(ctx context.Context, args []string) error {
+	fs := newFlagSet("admin lease-audit", a.Stderr)
+	state := fs.String("state", "expired", "filter by state")
+	provider := fs.String("provider", "aws", "filter by provider")
+	owner := fs.String("owner", "", "filter by owner")
+	org := fs.String("org", "", "filter by org")
+	limit := fs.Int("limit", 100, "maximum leases")
+	failOnLive := fs.Bool("fail-on-live", false, "exit non-zero when expired leases still have live cloud instances or audit errors")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	coord, err := configuredAdminCoordinator()
+	if err != nil {
+		return err
+	}
+	audits, err := coord.AdminLeaseAudit(ctx, *state, *provider, *owner, *org, *limit)
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		if err := json.NewEncoder(a.Stdout).Encode(audits); err != nil {
+			return err
+		}
+	} else {
+		for _, audit := range audits {
+			fmt.Fprintf(a.Stdout, "%-16s %-16s %-8s %-8s %-14s cloud=%-7s cloud_state=%s host=%s expires=%s cleanup=%s\n",
+				audit.LeaseID, blank(audit.Slug, "-"), audit.Provider, audit.State, audit.ServerType, audit.CloudStatus, blank(audit.CloudState, "-"), blank(audit.CloudHost, "-"), blank(audit.ExpiresAt, "-"), leaseAuditCleanupSummary(audit))
+		}
+	}
+	if *failOnLive {
+		for _, audit := range audits {
+			if audit.CloudStatus == "found" || audit.CloudStatus == "error" {
+				return exit(1, "lease audit found unreconciled cloud instances or audit errors")
+			}
+		}
+	}
+	return nil
+}
+
+func leaseAuditCleanupSummary(audit CoordinatorLeaseCloudAudit) string {
+	if audit.CleanupAttempts == 0 && audit.CleanupError == "" {
+		return "-"
+	}
+	if audit.CleanupError == "" {
+		return fmt.Sprintf("attempts=%d", audit.CleanupAttempts)
+	}
+	return fmt.Sprintf("attempts=%d error=%s", audit.CleanupAttempts, audit.CleanupError)
+}
+
 func (a App) adminRelease(ctx context.Context, args []string) error {
 	args, deleteAnywhere := extractBoolFlag(args, "delete")
 	args, jsonAnywhere := extractBoolFlag(args, "json")

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -201,6 +201,7 @@ Common Flows:
   crabbox cache stats --id blue-lobster
   crabbox usage --scope org
   crabbox admin leases --state active
+  crabbox admin lease-audit --state expired --provider aws
   crabbox warmup --actions-runner
   crabbox actions hydrate --id blue-lobster
   crabbox actions dispatch -f testbox_id=cbx_abcdef123456

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -316,11 +316,15 @@ type imagePromoteKongCmd struct {
 }
 
 type adminKongCmd struct {
-	Leases  adminLeasesKongCmd  `cmd:"" passthrough:"" help:"List coordinator lease records."`
-	Release adminReleaseKongCmd `cmd:"" passthrough:"" help:"Mark a lease released."`
-	Delete  adminDeleteKongCmd  `cmd:"" passthrough:"" help:"Delete the backing server and mark the lease released."`
+	Leases     adminLeasesKongCmd     `cmd:"" passthrough:"" help:"List coordinator lease records."`
+	LeaseAudit adminLeaseAuditKongCmd `cmd:"" name:"lease-audit" passthrough:"" help:"Check expired coordinator leases against cloud provider state."`
+	Release    adminReleaseKongCmd    `cmd:"" passthrough:"" help:"Mark a lease released."`
+	Delete     adminDeleteKongCmd     `cmd:"" passthrough:"" help:"Delete the backing server and mark the lease released."`
 }
 type adminLeasesKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type adminLeaseAuditKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type adminReleaseKongCmd struct {
@@ -482,6 +486,9 @@ func (c *imagePromoteKongCmd) Run(ctx context.Context, app App) error {
 
 func (c *adminLeasesKongCmd) Run(ctx context.Context, app App) error {
 	return app.adminLeases(ctx, c.Args)
+}
+func (c *adminLeaseAuditKongCmd) Run(ctx context.Context, app App) error {
+	return app.adminLeaseAudit(ctx, c.Args)
 }
 func (c *adminReleaseKongCmd) Run(ctx context.Context, app App) error {
 	return app.adminRelease(ctx, c.Args)

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -123,6 +123,29 @@ type CoordinatorMachine struct {
 	Labels     map[string]string `json:"labels"`
 }
 
+type CoordinatorLeaseCloudAudit struct {
+	LeaseID         string `json:"leaseID"`
+	Slug            string `json:"slug,omitempty"`
+	Provider        string `json:"provider"`
+	State           string `json:"state"`
+	TargetOS        string `json:"target,omitempty"`
+	Owner           string `json:"owner"`
+	Org             string `json:"org"`
+	Region          string `json:"region,omitempty"`
+	CloudID         string `json:"cloudID"`
+	Host            string `json:"host,omitempty"`
+	ServerType      string `json:"serverType,omitempty"`
+	ExpiresAt       string `json:"expiresAt,omitempty"`
+	CleanupAttempts int    `json:"cleanupAttempts,omitempty"`
+	CleanupError    string `json:"cleanupError,omitempty"`
+	CleanupRetryAt  string `json:"cleanupRetryAt,omitempty"`
+	CloudStatus     string `json:"cloudStatus"`
+	CloudState      string `json:"cloudState,omitempty"`
+	CloudHost       string `json:"cloudHost,omitempty"`
+	CloudServerType string `json:"cloudServerType,omitempty"`
+	Message         string `json:"message,omitempty"`
+}
+
 type CoordinatorUsageResponse struct {
 	Usage  CoordinatorUsageSummary `json:"usage"`
 	Limits CoordinatorCostLimits   `json:"limits"`
@@ -825,6 +848,34 @@ func (c *CoordinatorClient) AdminLeases(ctx context.Context, state, owner, org s
 	}
 	err := c.do(ctx, http.MethodGet, path, nil, &res)
 	return res.Leases, err
+}
+
+func (c *CoordinatorClient) AdminLeaseAudit(ctx context.Context, state, provider, owner, org string, limit int) ([]CoordinatorLeaseCloudAudit, error) {
+	var res struct {
+		Audits []CoordinatorLeaseCloudAudit `json:"audits"`
+	}
+	values := url.Values{}
+	if state != "" {
+		values.Set("state", state)
+	}
+	if provider != "" {
+		values.Set("provider", provider)
+	}
+	if owner != "" {
+		values.Set("owner", owner)
+	}
+	if org != "" {
+		values.Set("org", org)
+	}
+	if limit > 0 {
+		values.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/v1/admin/lease-audit"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	err := c.do(ctx, http.MethodGet, path, nil, &res)
+	return res.Audits, err
 }
 
 func (c *CoordinatorClient) AdminReleaseLease(ctx context.Context, id string, deleteServer bool) (CoordinatorLease, error) {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -225,6 +226,30 @@ func TestCoordinatorHTTPAddsAccessHeaders(t *testing.T) {
 	}
 	if err := client.Health(context.Background()); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCoordinatorAdminLeaseAudit(t *testing.T) {
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/admin/lease-audit" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"audits":[{"leaseID":"cbx_123","provider":"aws","state":"expired","target":"linux","owner":"alice@example.com","org":"example-org","cloudID":"i-123","cloudStatus":"found","cloudState":"running"}]}`))
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	audits, err := client.AdminLeaseAudit(context.Background(), "expired", "aws", "alice@example.com", "example-org", 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotQuery.Get("state") != "expired" || gotQuery.Get("provider") != "aws" || gotQuery.Get("owner") != "alice@example.com" || gotQuery.Get("org") != "example-org" || gotQuery.Get("limit") != "25" {
+		t.Fatalf("query=%v", gotQuery)
+	}
+	if len(audits) != 1 || audits[0].LeaseID != "cbx_123" || audits[0].CloudStatus != "found" {
+		t.Fatalf("audits=%#v", audits)
 	}
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -2605,6 +2605,14 @@ export class FleetDurableObject implements DurableObject {
     }
     try {
       const server = await this.awsLeaseServer(lease);
+      if (isAWSTerminalInstanceState(server.status)) {
+        return {
+          ...audit,
+          cloudStatus: "missing",
+          cloudState: server.status,
+          message: `aws instance is ${server.status}`,
+        };
+      }
       return {
         ...audit,
         cloudStatus: "found",
@@ -3697,6 +3705,10 @@ function isCloudNotFoundError(message: string): boolean {
     lower.includes("invalidinstanceid.notfound") ||
     lower.includes("does not exist")
   );
+}
+
+function isAWSTerminalInstanceState(state: string): boolean {
+  return state === "shutting-down" || state === "terminated";
 }
 
 function isAdminRoute(method: string, parts: string[]): boolean {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -191,6 +191,29 @@ interface CodePendingWebSocketFrame {
   chunks: string[];
 }
 
+interface LeaseCloudAudit {
+  leaseID: string;
+  slug?: string;
+  provider: Provider;
+  state: LeaseRecord["state"];
+  target: LeaseRecord["target"];
+  owner: string;
+  org: string;
+  region?: string;
+  cloudID: string;
+  host: string;
+  serverType: string;
+  expiresAt: string;
+  cleanupAttempts?: number;
+  cleanupError?: string;
+  cleanupRetryAt?: string;
+  cloudStatus: "found" | "missing" | "error";
+  cloudState?: string;
+  cloudHost?: string;
+  cloudServerType?: string;
+  message?: string;
+}
+
 type BridgeAttachment =
   | { kind: "webvnc-agent"; leaseID: string; id: string }
   | {
@@ -309,6 +332,9 @@ export class FleetDurableObject implements DurableObject {
       }
       if (method === "GET" && parts.join("/") === "v1/admin/leases") {
         return await this.adminLeases(request);
+      }
+      if (method === "GET" && parts.join("/") === "v1/admin/lease-audit") {
+        return await this.adminLeaseAudit(request);
       }
       if (parts[0] === "v1" && parts[1] === "admin" && parts[2] === "leases" && parts[3]) {
         return await this.adminLeaseRoute(request, parts[3], parts[4]);
@@ -2520,6 +2546,96 @@ export class FleetDurableObject implements DurableObject {
     return json({ leases: this.filterLeases(await this.leaseRecords(), request) });
   }
 
+  private async adminLeaseAudit(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const provider = (url.searchParams.get("provider") ?? "aws").trim().toLowerCase();
+    if (provider !== "aws") {
+      return json(
+        {
+          error: "unsupported_provider",
+          message: "lease audit currently supports provider=aws",
+        },
+        { status: 400 },
+      );
+    }
+    const state = url.searchParams.get("state") ?? "expired";
+    const owner = url.searchParams.get("owner") ?? "";
+    const org = url.searchParams.get("org") ?? "";
+    const limit = clampLimit(url.searchParams.get("limit"), 100);
+    const leases = (await this.leaseRecords())
+      .filter((lease) => lease.provider === "aws")
+      .filter((lease) => !state || lease.state === state)
+      .filter((lease) => !owner || lease.owner === owner)
+      .filter((lease) => !org || lease.org === org)
+      .filter((lease) => Boolean(lease.cloudID))
+      .toSorted((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit);
+    const audits = await Promise.all(leases.map((lease) => this.auditAWSLeaseCloud(lease)));
+    return json({ audits });
+  }
+
+  private async auditAWSLeaseCloud(lease: LeaseRecord): Promise<LeaseCloudAudit> {
+    const audit: LeaseCloudAudit = {
+      leaseID: lease.id,
+      provider: lease.provider,
+      state: lease.state,
+      target: lease.target,
+      owner: lease.owner,
+      org: lease.org,
+      cloudID: lease.cloudID,
+      host: lease.host,
+      serverType: lease.serverType,
+      expiresAt: lease.expiresAt,
+      cloudStatus: "error",
+    };
+    if (lease.slug) {
+      audit.slug = lease.slug;
+    }
+    if (lease.region) {
+      audit.region = lease.region;
+    }
+    if (lease.cleanupAttempts !== undefined) {
+      audit.cleanupAttempts = lease.cleanupAttempts;
+    }
+    if (lease.cleanupError) {
+      audit.cleanupError = lease.cleanupError;
+    }
+    if (lease.cleanupRetryAt) {
+      audit.cleanupRetryAt = lease.cleanupRetryAt;
+    }
+    try {
+      const server = await this.awsLeaseServer(lease);
+      return {
+        ...audit,
+        cloudStatus: "found",
+        cloudState: server.status,
+        cloudHost: server.host,
+        cloudServerType: server.serverType,
+      };
+    } catch (error) {
+      const message = errorMessage(error);
+      if (isCloudNotFoundError(message)) {
+        return { ...audit, cloudStatus: "missing", message };
+      }
+      return { ...audit, cloudStatus: "error", message };
+    }
+  }
+
+  private async awsLeaseServer(lease: LeaseRecord): Promise<ProviderMachine> {
+    const provider = this.provider("aws", lease.region);
+    if (provider.getServer) {
+      return await provider.getServer(lease.cloudID);
+    }
+    const machines = await provider.listCrabboxServers();
+    const server = machines.find(
+      (machine) => machine.cloudID === lease.cloudID || String(machine.id) === lease.cloudID,
+    );
+    if (!server) {
+      throw new Error(`aws instance not found: ${lease.cloudID}`);
+    }
+    return server;
+  }
+
   private async adminLeaseRoute(
     request: Request,
     leaseID: string,
@@ -3574,11 +3690,23 @@ function adminRouteError(request: Request, method: string, parts: string[]): Res
   return json({ error: "forbidden", message: "admin token required" }, { status: 403 });
 }
 
+function isCloudNotFoundError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("not found") ||
+    lower.includes("invalidinstanceid.notfound") ||
+    lower.includes("does not exist")
+  );
+}
+
 function isAdminRoute(method: string, parts: string[]): boolean {
   if (method === "GET" && parts.join("/") === "v1/pool") {
     return true;
   }
   if (method === "GET" && parts.join("/") === "v1/admin/leases") {
+    return true;
+  }
+  if (method === "GET" && parts.join("/") === "v1/admin/lease-audit") {
     return true;
   }
   if (parts[0] === "v1" && parts[1] === "admin" && parts[2] === "leases" && Boolean(parts[3])) {
@@ -4697,6 +4825,7 @@ function uniqueNonEmpty(values: Array<string | undefined>): string[] {
 
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
+  getServer?(id: string): Promise<ProviderMachine>;
   createServerWithFallback(
     config: ReturnType<typeof leaseConfig>,
     leaseID: string,
@@ -4880,6 +5009,10 @@ class AWSProvider implements CloudProvider {
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  getServer(id: string): Promise<ProviderMachine> {
+    return this.client.getServer(id);
   }
 
   async createServerWithFallback(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3025,6 +3025,18 @@ describe("fleet identity", () => {
       }),
     );
     storage.seed(
+      "lease:cbx_000000000004",
+      testLease({
+        id: "cbx_000000000004",
+        slug: "terminated-runner",
+        provider: "aws",
+        cloudID: "i-terminated",
+        region: "eu-west-1",
+        state: "expired",
+        createdAt: "2026-05-01T00:02:00.000Z",
+      }),
+    );
+    storage.seed(
       "lease:cbx_000000000003",
       testLease({
         id: "cbx_000000000003",
@@ -3046,7 +3058,7 @@ describe("fleet identity", () => {
           cloudID: id,
           region: "eu-west-1",
           name: `crabbox-${id}`,
-          status: "running",
+          status: id === "i-terminated" ? "terminated" : "running",
           serverType: "c7i.2xlarge",
           host: "192.0.2.20",
           labels: {},
@@ -3064,6 +3076,7 @@ describe("fleet identity", () => {
       audits: Array<{ leaseID: string; cloudStatus: string; cloudState?: string }>;
     };
     expect(body.audits).toMatchObject([
+      { leaseID: "cbx_000000000004", cloudStatus: "missing", cloudState: "terminated" },
       { leaseID: "cbx_000000000002", cloudStatus: "missing" },
       { leaseID: "cbx_000000000001", cloudStatus: "found", cloudState: "running" },
     ]);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -19,6 +19,7 @@ import type {
   Env,
   ExternalRunnerRecord,
   LeaseRecord,
+  ProviderMachine,
   ProvisioningAttempt,
   RunRecord,
 } from "../src/types";
@@ -2996,6 +2997,78 @@ describe("fleet identity", () => {
     expect(response.status).toBe(403);
   });
 
+  it("audits expired AWS leases against cloud state", async () => {
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "live-lobster",
+        provider: "aws",
+        cloudID: "i-live",
+        region: "eu-west-1",
+        state: "expired",
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        slug: "gone-lobster",
+        provider: "aws",
+        cloudID: "i-gone",
+        region: "eu-west-1",
+        state: "expired",
+        cleanupAttempts: 1,
+        cleanupError: "terminated",
+        createdAt: "2026-05-01T00:01:00.000Z",
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000003",
+      testLease({
+        id: "cbx_000000000003",
+        slug: "active-lobster",
+        provider: "aws",
+        cloudID: "i-active",
+        region: "eu-west-1",
+        state: "active",
+      }),
+    );
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, undefined, async (id) => {
+        if (id === "i-gone") {
+          throw new Error("aws instance not found: i-gone");
+        }
+        return {
+          provider: "aws",
+          id: 123,
+          cloudID: id,
+          region: "eu-west-1",
+          name: `crabbox-${id}`,
+          status: "running",
+          serverType: "c7i.2xlarge",
+          host: "192.0.2.20",
+          labels: {},
+        };
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("GET", "/v1/admin/lease-audit?state=expired&provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      audits: Array<{ leaseID: string; cloudStatus: string; cloudState?: string }>;
+    };
+    expect(body.audits).toMatchObject([
+      { leaseID: "cbx_000000000002", cloudStatus: "missing" },
+      { leaseID: "cbx_000000000001", cloudStatus: "found", cloudState: "running" },
+    ]);
+  });
+
   it("starts GitHub login and keeps polling secret server-side", async () => {
     const storage = new MemoryStorage();
     const fleet = new FleetDurableObject(
@@ -3381,10 +3454,26 @@ function fakeProvider(
     attempts?: ProvisioningAttempt[];
   } = {},
   onDelete?: (id: string) => Promise<void>,
+  onGet?: (id: string) => Promise<ProviderMachine> | ProviderMachine,
 ) {
   return {
     async listCrabboxServers() {
       return [];
+    },
+    async getServer(id: string) {
+      if (onGet) {
+        return await onGet(id);
+      }
+      return {
+        provider: result.provider ?? "hetzner",
+        id: 123,
+        cloudID: id,
+        name: `crabbox-${id}`,
+        status: "running",
+        serverType: result.serverType ?? "cpx62",
+        host: "192.0.2.10",
+        labels: {},
+      };
     },
     async createServerWithFallback(config: LeaseConfig, _leaseID: string, slug: string) {
       onCreate?.(config);


### PR DESCRIPTION
## Summary
- add admin `/v1/admin/lease-audit` for expired AWS lease cloud-state checks
- add `crabbox admin lease-audit` with JSON output and `--fail-on-live` for operator automation
- document the operator flow and add changelog coverage

## Verification
- `npm run check --prefix worker`
- `npm test --prefix worker -- fleet.test.ts`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- `go test ./internal/cli -run 'TestCoordinatorAdminLeaseAudit|TestCoordinatorHTTPAddsAccessHeaders' -count=1`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `./bin/crabbox help admin`\n\n## Notes\n- Full `go test ./...` and `go test ./internal/cli` did not complete promptly in this local lane; the focused coordinator tests and CLI build passed.\n- Live active lease list was empty after stopping the stale AWS lease.\n- Bounded `wrangler tail` completed with no sampled events.\n- CodeQL default setup is now enabled for this repo; it surfaced existing alerts on main that should be triaged separately.