### PR TITLE
fix(security): constrain code bridge upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -324,8 +324,11 @@ func (b *codeBridge) Close(code websocket.StatusCode, reason string) {
 
 func (b *codeBridge) handleHTTP(ctx context.Context, msg codeProxyMessage) {
 	body, _ := base64.StdEncoding.DecodeString(msg.Body)
-	upstreamPath := codeUpstreamPath(msg.Path)
-	upstream := b.baseURL + upstreamPath
+	upstream, upstreamPath, err := b.upstreamURL("http", msg.Path)
+	if err != nil {
+		_ = b.writeJSON(ctx, codeProxyMessage{Type: "http", ID: msg.ID, Status: 400, Error: err.Error()})
+		return
+	}
 	req, err := http.NewRequestWithContext(ctx, msg.Method, upstream, bytes.NewReader(body))
 	if err != nil {
 		_ = b.writeJSON(ctx, codeProxyMessage{Type: "http", ID: msg.ID, Status: 502, Error: err.Error()})
@@ -396,7 +399,11 @@ func (b *codeBridge) handleHTTP(ctx context.Context, msg codeProxyMessage) {
 }
 
 func (b *codeBridge) openUpstreamWebSocket(ctx context.Context, msg codeProxyMessage) {
-	upstream := "ws" + strings.TrimPrefix(b.baseURL, "http") + codeUpstreamPath(msg.Path)
+	upstream, _, err := b.upstreamURL("ws", msg.Path)
+	if err != nil {
+		_ = b.writeJSON(ctx, codeProxyMessage{Type: "ws_close", ID: msg.ID, Code: int(websocket.StatusPolicyViolation), Reason: err.Error()})
+		return
+	}
 	b.trace("ws_open id=%s path=%s upstream=%s", msg.ID, msg.Path, upstream)
 	header, subprotocols := codeWebSocketDialHeaders(b.baseURL, msg.Headers)
 	b.trace("ws_open_headers id=%s cookie=%t origin=%q subprotocols=%d", msg.ID, header.Get("Cookie") != "", header.Get("Origin"), len(subprotocols))
@@ -593,10 +600,69 @@ func isRetryableCodeBridgeError(err error) bool {
 		strings.Contains(text, "tls: bad record MAC")
 }
 
-func codeUpstreamPath(path string) string {
-	u, err := url.Parse(path)
+func (b *codeBridge) upstreamURL(scheme, rawPath string) (string, string, error) {
+	upstreamPath, err := codeUpstreamPath(rawPath)
 	if err != nil {
-		return "/"
+		return "", "", err
+	}
+	upstream, err := codeBridgeUpstreamURL(b.baseURL, scheme, upstreamPath)
+	if err != nil {
+		return "", "", err
+	}
+	return upstream, upstreamPath, nil
+}
+
+func codeBridgeUpstreamURL(baseURL, scheme, upstreamPath string) (string, error) {
+	if scheme != "http" && scheme != "ws" {
+		return "", fmt.Errorf("unsupported upstream scheme %q", scheme)
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if base.Scheme != "http" || !codeBridgeLoopbackHost(base.Hostname()) {
+		return "", fmt.Errorf("code bridge upstream must be loopback HTTP")
+	}
+	parsed, err := url.Parse(upstreamPath)
+	if err != nil {
+		return "", err
+	}
+	if parsed.IsAbs() || parsed.Host != "" {
+		return "", fmt.Errorf("absolute upstream URLs are not allowed")
+	}
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+	base.Scheme = scheme
+	base.Path = parsed.Path
+	base.RawQuery = parsed.RawQuery
+	base.ForceQuery = parsed.ForceQuery
+	base.RawFragment = ""
+	base.Fragment = ""
+	return base.String(), nil
+}
+
+func codeBridgeLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func codeUpstreamPath(rawPath string) (string, error) {
+	u, err := url.Parse(rawPath)
+	if err != nil {
+		return "", err
+	}
+	if u.IsAbs() || u.Host != "" {
+		return "", fmt.Errorf("absolute upstream URLs are not allowed")
+	}
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	if !strings.HasPrefix(u.Path, "/") {
+		u.Path = "/" + u.Path
 	}
 	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 	if len(parts) >= 4 && parts[0] == "portal" && parts[1] == "leases" && parts[3] == "code" {
@@ -606,9 +672,9 @@ func codeUpstreamPath(path string) string {
 		} else {
 			u.Path = "/" + tail
 		}
-		return u.RequestURI()
+		return u.RequestURI(), nil
 	}
-	return u.RequestURI()
+	return u.RequestURI(), nil
 }
 
 func isCodeHTML(contentType string) bool {

--- a/internal/cli/code_test.go
+++ b/internal/cli/code_test.go
@@ -111,8 +111,35 @@ func TestCodeUpstreamPathStripsPortalLeasePrefix(t *testing.T) {
 		"/portal/leases/blue-lobster/code/proxy/3000/?q=hello+you": "/proxy/3000/?q=hello+you",
 	}
 	for input, want := range tests {
-		if got := codeUpstreamPath(input); got != want {
+		got, err := codeUpstreamPath(input)
+		if err != nil {
+			t.Fatalf("codeUpstreamPath(%q): %v", input, err)
+		}
+		if got != want {
 			t.Fatalf("codeUpstreamPath(%q)=%q want %q", input, got, want)
+		}
+	}
+}
+
+func TestCodeUpstreamPathRejectsAbsoluteURLs(t *testing.T) {
+	for _, input := range []string{"https://evil.example/socket", "//evil.example/socket"} {
+		if _, err := codeUpstreamPath(input); err == nil {
+			t.Fatalf("codeUpstreamPath(%q) expected error", input)
+		}
+	}
+}
+
+func TestCodeBridgeUpstreamURLPinsLoopbackHost(t *testing.T) {
+	got, err := codeBridgeUpstreamURL("http://127.0.0.1:8080", "ws", "/proxy/3000/?q=hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "ws://127.0.0.1:8080/proxy/3000/?q=hello" {
+		t.Fatalf("upstream url=%q", got)
+	}
+	for _, baseURL := range []string{"http://example.com:8080", "https://127.0.0.1:8080"} {
+		if _, err := codeBridgeUpstreamURL(baseURL, "http", "/"); err == nil {
+			t.Fatalf("codeBridgeUpstreamURL(%q) expected error", baseURL)
 		}
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1670,7 +1670,7 @@ func applyEnv(cfg *Config) {
 	cfg.AWSSGID = getenv("CRABBOX_AWS_SECURITY_GROUP_ID", cfg.AWSSGID)
 	cfg.AWSSubnetID = getenv("CRABBOX_AWS_SUBNET_ID", cfg.AWSSubnetID)
 	cfg.AWSProfile = getenv("CRABBOX_AWS_INSTANCE_PROFILE", cfg.AWSProfile)
-	cfg.AWSRootGB = int32(getenvInt("CRABBOX_AWS_ROOT_GB", int(cfg.AWSRootGB)))
+	cfg.AWSRootGB = getenvInt32("CRABBOX_AWS_ROOT_GB", cfg.AWSRootGB)
 	cfg.AWSMacHostID = getenv("CRABBOX_AWS_MAC_HOST_ID", cfg.AWSMacHostID)
 	if cidrs := os.Getenv("CRABBOX_AWS_SSH_CIDRS"); cidrs != "" {
 		cfg.AWSSSHCIDRs = splitCommaList(cidrs)
@@ -2141,6 +2141,18 @@ func getenvInt(name string, fallback int) int {
 		return fallback
 	}
 	return n
+}
+
+func getenvInt32(name string, fallback int32) int32 {
+	v := os.Getenv(name)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return fallback
+	}
+	return int32(n)
 }
 
 func getenvFloat(name string, fallback float64) float64 {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -990,6 +990,14 @@ func TestEnvHelperBranches(t *testing.T) {
 	if got := getenvInt("CRABBOX_MISSING_INT", 7); got != 7 {
 		t.Fatalf("missing int fallback=%d", got)
 	}
+	t.Setenv("CRABBOX_INT32", "2147483647")
+	t.Setenv("CRABBOX_INT32_OVERFLOW", "2147483648")
+	if got := getenvInt32("CRABBOX_INT32", 7); got != 2147483647 {
+		t.Fatalf("int32=%d", got)
+	}
+	if got := getenvInt32("CRABBOX_INT32_OVERFLOW", 7); got != 7 {
+		t.Fatalf("overflow int32 fallback=%d", got)
+	}
 
 	for _, tc := range []struct {
 		name  string


### PR DESCRIPTION
## Summary
- pin Code bridge HTTP/WebSocket upstream construction to loopback HTTP targets
- reject absolute browser-controlled upstream paths before proxying to code-server
- parse `CRABBOX_AWS_ROOT_GB` with an explicit int32 bound to avoid narrowing overflow

## Verification
- `go test ./internal/cli -run 'TestCode|TestWebCode|TestConnectCodeBridge|TestEnvHelperBranches' -count=1`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n\n## Notes\n- Intended to address CodeQL alerts https://github.com/openclaw/crabbox/security/code-scanning/14, https://github.com/openclaw/crabbox/security/code-scanning/15, and https://github.com/openclaw/crabbox/security/code-scanning/16.\n- Full local `go test ./internal/cli` stalled in this lane; CI should run the full package gate.