### PR TITLE
[codex] add provider-native checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 
 - Added `crabbox admin lease-audit` so operators can compare expired brokered AWS lease records against live cloud instance state and fail automation when a record still maps to a live instance.
-- Added `crabbox checkpoint` to create VM-level AWS AMI checkpoints for brokered Linux leases, fall back to local workspace archives on generic POSIX SSH leases, inspect/list/delete them, restore archives, or fork checkpoints into fresh leases.
-- Added brokered AWS AMI deletion, including deregistering the image and deleting referenced EBS snapshots.
+- Added `crabbox checkpoint` native disk-snapshot checkpoints for brokered AWS, Azure, and GCP Linux leases, optional provider image checkpoints via `--strategy image`, local workspace archives for generic POSIX SSH leases, inspect/list/delete flows, archive restore, and checkpoint forks into fresh leases.
+- Added brokered provider snapshot/image deletion for AWS EBS snapshots and AMIs, Azure managed disk snapshots and managed images, and GCP disk snapshots and machine images.
 
 ### Fixed
 
@@ -14,7 +14,7 @@
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
-- Fixed native AWS checkpoint creation so no-reboot AMI snapshots flush source filesystem writes before calling `CreateImage`.
+- Fixed native provider checkpoint creation so AWS, Azure, and GCP snapshot/image checkpoints flush source filesystem writes before calling the provider API.
 
 ## 0.13.0 - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added `crabbox checkpoint` native disk-snapshot checkpoints for brokered AWS, Azure, and GCP Linux leases, optional provider image checkpoints via `--strategy image`, local workspace archives for generic POSIX SSH leases, inspect/list/delete flows, archive restore, and checkpoint forks into fresh leases.
 - Added brokered provider snapshot/image deletion for AWS EBS snapshots and AMIs, Azure managed disk snapshots and managed images, and GCP disk snapshots and machine images.
 
+### Changed
+
+- Improved checkpoint documentation with clearer native vs archive distinction, workflow mechanics, security warnings, and command reference examples.
+
 ### Fixed
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -1,150 +1,239 @@
 # checkpoint
 
-`crabbox checkpoint` saves a useful remote state and starts fresh leases from it
-later.
+Save remote state, fork it into fresh leases later.
 
-Use it when setup is expensive or a bug is already staged: install
-dependencies once, pause a reproducer, keep generated fixtures, then fork that
-state for repeated test runs.
+**When to use**: Expensive setup (install deps once), paused bugs, generated
+fixtures. Fork the scenario for repeated test runs without repeating setup.
 
-The current native checkpoint backends are brokered AWS, Azure, and GCP Linux
-leases. The default `auto` mode creates the provider's boot-disk snapshot when
-the source lease supports it:
+## Two Checkpoint Types
 
-- AWS creates an EBS snapshot.
-- Azure creates a managed OS disk snapshot in the configured resource group.
-- GCP creates a Compute Engine persistent disk snapshot.
+**Native (provider snapshots)**
+- AWS/Azure/GCP: Creates VM disk snapshot at provider level
+- Preserves entire machine: packages, tools, caches, services
+- Stored in provider account (incurs storage costs)
+- Linux only
 
-Forking the checkpoint launches a new VM from that provider snapshot. Use
-`--strategy image` on AWS or GCP when you specifically want the older provider
-image primitive: AWS AMI or GCP machine image. Azure managed images require a
-stopped/generalized source VM, so active Azure leases use disk snapshots.
+**Archive (workspace tarball)**
+- Creates local tar of workdir
+- Portable across any SSH lease
+- Preserves files only, not machine state
 
-On providers without a real VM snapshot primitive, Crabbox falls back to
-`workspace-archive`: a local tar archive of the POSIX SSH lease workdir. This
-preserves files in the workspace, not the whole machine.
+Default `--mode auto`: native for AWS/Azure/GCP Linux, otherwise archive.
 
-`crabbox checkpoint` is different from `crabbox image promote`. A checkpoint is
-explicit: you fork it by ID when you want that prepared scenario. A promoted
-image changes the default AWS runner image for future brokered AWS leases.
+## Quick Start
+
+```sh
+# Create checkpoint from lease
+crabbox warmup --provider aws --class beast
+crabbox run --id blue-lobster --shell 'npm ci && npm test'
+crabbox checkpoint create --id blue-lobster --name after-npm-ci
+# Output: checkpoint created id=chk_abc123 kind=aws-ebs-snapshot
+
+# Fork checkpoint into new lease
+crabbox checkpoint fork chk_abc123 --class beast
+# Output: checkpoint forked id=chk_abc123 lease=cbx_xyz slug=purple-whale
+
+# Use forked lease
+crabbox run --id purple-whale -- npm test
+```
+
+**vs. `crabbox image promote`**: Checkpoints are explicit (fork by ID). Promoted
+images change the default AWS runner for all future leases.
 
 ## Create
 
+Create checkpoint from existing lease.
+
 ```sh
-crabbox checkpoint create --id <lease-id-or-slug> --name after-install
-crabbox checkpoint create --id <lease-id-or-slug> --mode native --wait
-crabbox checkpoint create --id <lease-id-or-slug> --strategy image
-crabbox checkpoint create --id <lease-id-or-slug> --mode archive
-crabbox checkpoint create --id <lease-id-or-slug> --workdir /work/cbx_123/my-app
+# Auto mode (native for AWS/Azure/GCP, archive otherwise)
+crabbox checkpoint create --id blue-lobster --name after-install
+
+# Force native (fails if unsupported)
+crabbox checkpoint create --id blue-lobster --mode native --wait
+
+# Force archive (portable tarball)
+crabbox checkpoint create --id blue-lobster --mode archive
+
+# Use image strategy instead of disk-snapshot (AWS/GCP only)
+crabbox checkpoint create --id blue-lobster --strategy image
+
+# Custom workdir
+crabbox checkpoint create --id blue-lobster --workdir /work/cbx_123/my-app
 ```
 
-Useful flags:
+**Flags**
 
-```text
---id <lease-id-or-slug>   lease to snapshot
---name <name>             human-readable name
---mode auto|native|archive default auto
---strategy auto|disk-snapshot|image default auto
---wait                    wait for native snapshot availability, default true
---wait-timeout <duration> default 45m
---no-reboot               AWS AMI CreateImage NoReboot when using --strategy image, default true
---workdir <path>          remote workdir, default is the repo workdir for the lease
---recipe-only             record metadata without archiving files
---reclaim                 claim the lease for the current repo
+```
+--id <lease>              Required. Lease ID or slug to snapshot
+--name <name>             Optional. Human-readable name
+--mode auto|native|archive Default auto
+--strategy auto|disk-snapshot|image Default auto (disk-snapshot for native)
+--wait                    Wait for snapshot completion, default true
+--wait-timeout <duration> Default 45m
+--no-reboot               Avoid reboot (AWS AMI only), default true
+--workdir <path>          Remote workdir, default is lease's repo workdir
+--recipe-only             Metadata only, no artifact creation
+--reclaim                 Claim lease for current repo
 ```
 
-Native Linux checkpoints clean cloud-init state before imaging so forked VMs
-can run fresh user-data and install their own per-lease SSH key.
+**Strategy details**
 
-Native provider checkpoints keep machine-level state: installed packages,
-toolchains, system caches, services, and files on the root volume. They may
-also keep secrets or one-off debugging state if those were written to disk, so
-create them from intentional leases and delete them when they are no longer
-needed.
+- `disk-snapshot`: EBS/Azure disk/GCP disk snapshot — faster, best for iteration
+- `image`: AMI/GCP machine image — slower, preserves full VM config
+- Azure managed images require stopped VMs, not created from active leases
 
-Workspace archives intentionally skip `.crabbox/env` and `.crabbox/scripts` so
-profile-backed secret helpers are not silently persisted.
+**What gets cleaned before native snapshot**
 
-`--recipe-only` records metadata only. It is useful for future workflow design,
-but current `restore` and `fork` commands require either `workspace-archive` or
-a native provider checkpoint.
+- `cloud-init clean --logs` — resets cloud-init for fresh SSH keys on fork
+- `sync` — flushes filesystem writes
+
+**⚠️ Security note**
+
+Native checkpoints capture full root volume: packages, caches, logs, secrets.
+Archive checkpoints capture workdir contents: build outputs, generated files.
+
+Both may contain secrets. Delete when no longer needed.
 
 ## List And Inspect
 
 ```sh
 crabbox checkpoint list
-crabbox checkpoint inspect chk_123
-crabbox checkpoint inspect chk_123 --json
+crabbox checkpoint inspect chk_abc123
+crabbox checkpoint inspect chk_abc123 --json
 ```
 
-Checkpoints live in the local Crabbox state directory under `checkpoints/`.
-For native checkpoints, that local record points at provider-side snapshot/image
-resources. Keep the local metadata and the provider resources together; if
-either side is deleted, the checkpoint cannot be forked normally.
+Checkpoints stored in `~/.local/state/crabbox/checkpoints/`.
+
+**Local metadata includes**:
+- Checkpoint ID, name, kind
+- Source lease ID, provider, region
+- Repo name, git head, workdir path
+- Creation timestamp
+- Native: provider resource ID (ami-xxx, snapshot-xxx)
+- Archive: tarball path and size
+
+**⚠️ Both parts required**: Native checkpoints need local metadata AND provider
+resource. Losing either side breaks fork. Archive checkpoints need local metadata
+AND tarball.
 
 ## Restore
 
+**Archive checkpoints only**. Uploads tarball to running lease, extracts to workdir.
+
 ```sh
-crabbox checkpoint restore chk_123 --id <lease-id-or-slug>
-crabbox checkpoint restore chk_123 --id <lease-id-or-slug> --clear=false
+crabbox checkpoint restore chk_abc123 --id target-lease
+crabbox checkpoint restore chk_abc123 --id target-lease --clear=false
 ```
 
-Restore uploads the local archive to the target and extracts it into the target
-lease's normal repo workdir by default. Use `--workdir` to restore somewhere
-else. VM-level checkpoints cannot restore onto an already-running lease; fork
-them into a new lease.
+**Flags**
+
+```
+--id <lease>     Required. Target lease ID or slug
+--clear          Clear target workdir before restore, default true
+--workdir <path> Custom restore path, default is lease's workdir
+```
+
+**Native checkpoints cannot restore**. Fork them instead (creates new lease from
+snapshot).
 
 ## Fork
 
+Create fresh lease from checkpoint. Works for both native and archive checkpoints.
+
 ```sh
-crabbox checkpoint fork chk_123 --class beast
+crabbox checkpoint fork chk_abc123 --class beast
+# Output: checkpoint forked id=chk_abc123 lease=cbx_xyz slug=purple-whale
 ```
 
-Fork leases a new SSH-backed box, restores the checkpoint, prints the lease id
-and slug, and keeps the lease by default. For native provider checkpoints, fork
-launches a fresh lease from the checkpoint snapshot or image, then moves the
-captured source workdir to the fork's normal per-lease workdir so
-`crabbox run --id <fork>` starts in the snapshotted scenario.
+**Flags**
 
-Fast test loop:
+```
+--class <class>  Lease class (standard, beast, etc.)
+--provider <p>   Provider (aws, azure, gcp, etc.)
+--keep           Keep lease running, default true
+```
+
+**What happens**
+
+Native checkpoints:
+1. Acquire lease from provider using checkpoint snapshot/image
+2. Wait for boot
+3. Relocate workdir: `/work/cbx_old/repo` → `/work/cbx_new/repo`
+4. Print lease ID and slug
+5. Keep lease running
+
+Archive checkpoints:
+1. Acquire standard new lease
+2. Upload tarball via SSH
+3. Extract to workdir
+4. Print lease ID and slug
+5. Keep lease running
+
+**Fast iteration example**
 
 ```sh
 crabbox warmup --provider aws --class beast
 crabbox run --id blue-lobster --shell 'npm ci && npm test'
 crabbox checkpoint create --id blue-lobster --name after-npm-ci
-crabbox checkpoint fork chk_123 --class beast
-crabbox run --id <forked-slug> -- npm test
-```
 
-Use `--mode archive` when you only need the workdir and want a portable local
-artifact. Use the default `auto` mode on AWS, Azure, or GCP when the machine
-setup itself is the expensive part.
+# Fork multiple times for parallel tests
+crabbox checkpoint fork chk_abc123 --class beast
+crabbox run --id purple-whale -- npm test
+
+crabbox checkpoint fork chk_abc123 --class beast
+crabbox run --id green-tiger -- npm run integration-test
+```
 
 ## Delete
 
+Delete checkpoint from provider and local storage.
+
 ```sh
-crabbox checkpoint delete chk_123
-crabbox checkpoint delete chk_123 --local-only
+crabbox checkpoint delete chk_abc123
+crabbox checkpoint delete chk_abc123 --local-only
 ```
 
-Deleting a native checkpoint removes the provider snapshot/image before
-removing the local checkpoint record. AWS snapshot checkpoints delete the EBS
-snapshot; AWS image checkpoints deregister the AMI and delete its EBS
-snapshots. Azure deletion removes the managed disk snapshot or managed image.
-GCP deletion removes the disk snapshot or machine image. Use `--local-only`
-only when the provider resource was already removed outside Crabbox.
+**Default behavior (native checkpoints)**
 
-AWS EBS snapshots, Azure managed disk snapshots, Azure managed images, GCP disk
-snapshots, and GCP machine images can incur storage cost while they exist.
-Prefer naming checkpoints after the scenario they preserve, inspect old
-checkpoints periodically, and delete stale ones.
+1. Delete provider resource (EBS snapshot, AMI, disk snapshot)
+2. For AMIs: deregister AMI, delete backing EBS snapshots
+3. Remove local checkpoint metadata
 
-## Boundary
+**Archive checkpoints**
 
-Native checkpoints are provider-specific. The default native backends are AWS
-EBS snapshots, Azure managed OS disk snapshots, and GCP persistent disk
-snapshots for brokered Linux leases. AWS AMI and GCP machine-image checkpoints
-remain available with `--strategy image`. Windows native checkpoints are not
-supported yet. Proxmox VM snapshots/clones and sandbox-provider snapshots fit
-the same command contract, but plain SSH targets still use workspace archives
-unless the target exposes a real snapshot API that Crabbox owns.
+1. Delete local tarball
+2. Remove local checkpoint metadata
+
+**Flags**
+
+```
+--local-only  Skip provider deletion, remove local metadata only
+```
+
+Use `--local-only` only when provider resource was already deleted outside
+Crabbox (manual cleanup, account migration, etc.).
+
+**⚠️ Storage costs**: Provider snapshots/images incur storage costs while they
+exist. Delete stale checkpoints periodically. Name checkpoints after scenarios
+they preserve to identify candidates for cleanup.
+
+## Provider Support
+
+**Native checkpoints (Linux only)**
+
+Default strategy `disk-snapshot`:
+- AWS: EBS snapshot
+- Azure: Managed OS disk snapshot
+- GCP: Persistent disk snapshot
+
+Opt-in strategy `--strategy image`:
+- AWS: AMI (Amazon Machine Image)
+- Azure: Not created from active VMs (requires stopped/generalized source)
+- GCP: Machine image
+
+**Archive checkpoints**
+
+All SSH-accessible leases. Portable across providers.
+
+**Future**: Proxmox VM snapshots, sandbox provider snapshots, storage-backed
+snapshots (ZFS, Btrfs, LVM) when Crabbox owns integration.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -7,11 +7,18 @@ Use it when setup is expensive or a bug is already staged: install
 dependencies once, pause a reproducer, keep generated fixtures, then fork that
 state for repeated test runs.
 
-The current native checkpoint backend is AWS Linux. On a brokered AWS Linux
-lease, the default `auto` mode creates an AMI, which is AWS's bootable machine
-image format. That AMI is backed by EBS snapshots, which are stored copies of
-the EC2 disk volumes. Forking the checkpoint launches a new AWS VM from that
-AMI.
+The current native checkpoint backends are brokered AWS, Azure, and GCP Linux
+leases. The default `auto` mode creates the provider's boot-disk snapshot when
+the source lease supports it:
+
+- AWS creates an EBS snapshot.
+- Azure creates a managed OS disk snapshot in the configured resource group.
+- GCP creates a Compute Engine persistent disk snapshot.
+
+Forking the checkpoint launches a new VM from that provider snapshot. Use
+`--strategy image` on AWS or GCP when you specifically want the older provider
+image primitive: AWS AMI or GCP machine image. Azure managed images require a
+stopped/generalized source VM, so active Azure leases use disk snapshots.
 
 On providers without a real VM snapshot primitive, Crabbox falls back to
 `workspace-archive`: a local tar archive of the POSIX SSH lease workdir. This
@@ -26,6 +33,7 @@ image changes the default AWS runner image for future brokered AWS leases.
 ```sh
 crabbox checkpoint create --id <lease-id-or-slug> --name after-install
 crabbox checkpoint create --id <lease-id-or-slug> --mode native --wait
+crabbox checkpoint create --id <lease-id-or-slug> --strategy image
 crabbox checkpoint create --id <lease-id-or-slug> --mode archive
 crabbox checkpoint create --id <lease-id-or-slug> --workdir /work/cbx_123/my-app
 ```
@@ -36,28 +44,30 @@ Useful flags:
 --id <lease-id-or-slug>   lease to snapshot
 --name <name>             human-readable name
 --mode auto|native|archive default auto
+--strategy auto|disk-snapshot|image default auto
 --wait                    wait for native snapshot availability, default true
 --wait-timeout <duration> default 45m
---no-reboot               AWS AMI CreateImage NoReboot, default true
+--no-reboot               AWS AMI CreateImage NoReboot when using --strategy image, default true
 --workdir <path>          remote workdir, default is the repo workdir for the lease
 --recipe-only             record metadata without archiving files
 --reclaim                 claim the lease for the current repo
 ```
 
-Native AWS checkpoints clean cloud-init state before imaging so forked VMs can
-run fresh user-data and install their own per-lease SSH key.
+Native Linux checkpoints clean cloud-init state before imaging so forked VMs
+can run fresh user-data and install their own per-lease SSH key.
 
-AWS AMI checkpoints keep machine-level state: installed packages, toolchains,
-system caches, services, and files on the root volume. They may also keep
-secrets or one-off debugging state if those were written to disk, so create
-them from intentional leases and delete them when they are no longer needed.
+Native provider checkpoints keep machine-level state: installed packages,
+toolchains, system caches, services, and files on the root volume. They may
+also keep secrets or one-off debugging state if those were written to disk, so
+create them from intentional leases and delete them when they are no longer
+needed.
 
 Workspace archives intentionally skip `.crabbox/env` and `.crabbox/scripts` so
 profile-backed secret helpers are not silently persisted.
 
 `--recipe-only` records metadata only. It is useful for future workflow design,
 but current `restore` and `fork` commands require either `workspace-archive` or
-`aws-ami`.
+a native provider checkpoint.
 
 ## List And Inspect
 
@@ -68,8 +78,8 @@ crabbox checkpoint inspect chk_123 --json
 ```
 
 Checkpoints live in the local Crabbox state directory under `checkpoints/`.
-For AWS AMI checkpoints, that local record points at provider-side AMI and EBS
-snapshot resources. Keep the local metadata and the AWS resources together; if
+For native checkpoints, that local record points at provider-side snapshot/image
+resources. Keep the local metadata and the provider resources together; if
 either side is deleted, the checkpoint cannot be forked normally.
 
 ## Restore
@@ -91,10 +101,10 @@ crabbox checkpoint fork chk_123 --class beast
 ```
 
 Fork leases a new SSH-backed box, restores the checkpoint, prints the lease id
-and slug, and keeps the lease by default. For AWS AMI checkpoints, fork launches
-a fresh AWS lease from the checkpoint image, then moves the captured source
-workdir to the fork's normal per-lease workdir so `crabbox run --id <fork>`
-starts in the snapshotted scenario.
+and slug, and keeps the lease by default. For native provider checkpoints, fork
+launches a fresh lease from the checkpoint snapshot or image, then moves the
+captured source workdir to the fork's normal per-lease workdir so
+`crabbox run --id <fork>` starts in the snapshotted scenario.
 
 Fast test loop:
 
@@ -107,8 +117,8 @@ crabbox run --id <forked-slug> -- npm test
 ```
 
 Use `--mode archive` when you only need the workdir and want a portable local
-artifact. Use the default `auto` mode on AWS when the machine setup itself is
-the expensive part.
+artifact. Use the default `auto` mode on AWS, Azure, or GCP when the machine
+setup itself is the expensive part.
 
 ## Delete
 
@@ -117,19 +127,24 @@ crabbox checkpoint delete chk_123
 crabbox checkpoint delete chk_123 --local-only
 ```
 
-Deleting an AWS AMI checkpoint deregisters the AMI and deletes the EBS
-snapshots referenced by that AMI before removing the local checkpoint record.
-Use `--local-only` only when the provider image was already removed outside
-Crabbox.
+Deleting a native checkpoint removes the provider snapshot/image before
+removing the local checkpoint record. AWS snapshot checkpoints delete the EBS
+snapshot; AWS image checkpoints deregister the AMI and delete its EBS
+snapshots. Azure deletion removes the managed disk snapshot or managed image.
+GCP deletion removes the disk snapshot or machine image. Use `--local-only`
+only when the provider resource was already removed outside Crabbox.
 
-AWS EBS snapshots can incur storage cost while they exist. Prefer naming
-checkpoints after the scenario they preserve, inspect old checkpoints
-periodically, and delete stale ones.
+AWS EBS snapshots, Azure managed disk snapshots, Azure managed images, GCP disk
+snapshots, and GCP machine images can incur storage cost while they exist.
+Prefer naming checkpoints after the scenario they preserve, inspect old
+checkpoints periodically, and delete stale ones.
 
 ## Boundary
 
-Native checkpoints are provider-specific. The current native backend is AWS
-Linux AMI snapshots. Windows native checkpoints are not supported yet. Proxmox
-VM snapshots/clones and sandbox-provider snapshots fit the same command
-contract, but plain SSH targets still use workspace archives unless the target
-exposes a real snapshot API that Crabbox owns.
+Native checkpoints are provider-specific. The default native backends are AWS
+EBS snapshots, Azure managed OS disk snapshots, and GCP persistent disk
+snapshots for brokered Linux leases. AWS AMI and GCP machine-image checkpoints
+remain available with `--strategy image`. Windows native checkpoints are not
+supported yet. Proxmox VM snapshots/clones and sandbox-provider snapshots fit
+the same command contract, but plain SSH targets still use workspace archives
+unless the target exposes a real snapshot API that Crabbox owns.

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -1,8 +1,8 @@
 # image
 
-`crabbox image` contains trusted operator controls for AWS runner images.
-Use it for base runner images, not per-scenario checkpoints. If you want to
-save one prepared lease and fork that exact scenario later, use
+`crabbox image` contains trusted operator controls for provider images. Use it
+for base runner images and explicit image cleanup, not per-scenario checkpoints.
+If you want to save one prepared lease and fork that exact scenario later, use
 [`crabbox checkpoint`](checkpoint.md).
 
 ```sh
@@ -10,6 +10,8 @@ crabbox image create --id cbx_... --name crabbox-runner-20260501-1246 --wait
 crabbox image promote ami-...
 crabbox image promote ami-... --json
 crabbox image delete ami-... --region eu-west-1
+crabbox image delete my-azure-image --provider azure --region westeurope
+crabbox image delete my-gcp-image --provider gcp --region europe-west1-b --project example-project
 ```
 
 Image commands require a configured coordinator and admin-token auth. Set
@@ -18,33 +20,37 @@ checks `CRABBOX_ADMIN_TOKEN`.
 They are intentionally not available to normal GitHub browser-login users.
 
 Image bytes live in the provider account, not in git or coordinator durable
-state. AWS images are AMIs backed by EBS snapshots. Crabbox stores only the
+state. AWS images are AMIs backed by EBS snapshots. Azure images are managed
+images. GCP images are Compute Engine machine images. Crabbox stores only the
 promoted AMI id and related metadata so future AWS leases can resolve the
 default image. Hetzner snapshots/images should live in the Hetzner project and
-be selected through `image`/`CRABBOX_HETZNER_IMAGE` until Crabbox grows
-Hetzner create/promote lifecycle commands.
+be selected through `image`/`CRABBOX_HETZNER_IMAGE` until Crabbox grows Hetzner
+create/promote lifecycle commands.
 
 An AMI is AWS's bootable machine image format. EBS snapshots are the stored disk
-snapshots that back the AMI. Deleting a candidate image should remove both the
-AMI registration and its EBS snapshots.
+snapshots that back the AMI. Deleting an AWS candidate image should remove both
+the AMI registration and its EBS snapshots.
 
 ## create
 
-Create an AWS AMI from an active AWS lease.
+Create a provider image from an active brokered AWS or GCP lease. Active Azure
+leases use `crabbox checkpoint` disk snapshots; Azure managed-image capture
+requires a stopped/generalized source VM.
 
 Flags:
 
 ```text
---id <cbx_id>        source lease; must be a canonical AWS lease ID
---name <name>        AMI name
---wait               poll until the AMI is available
+--id <cbx_id>        source lease; must be a canonical lease ID
+--name <name>        provider image name
+--wait               poll until the provider image is available
 --wait-timeout <d>   default 45m
---no-reboot          default true
+--no-reboot          AWS AMI CreateImage NoReboot, default true
 --json               print JSON
 ```
 
-The source lease must still be active in the coordinator. The Worker calls AWS
-`CreateImage` from the backing instance ID and tags the image as Crabbox-owned.
+The source lease must still be active in the coordinator. The Worker calls the
+provider image API from the backing cloud VM id and tags the image as
+Crabbox-owned.
 
 Recommended bake flow:
 
@@ -63,15 +69,15 @@ instead of relying only on the short smoke above.
 Failure handling:
 
 - If `--wait` times out, run `crabbox image create ... --json` or inspect the
-  AWS AMI state before retrying. AWS image creation can continue after the CLI
-  stops polling.
-- If the AMI enters a failed state, leave the current promoted image in place
-  and create a new image from a fresh lease.
+  provider image state before retrying. Provider image creation can continue
+  after the CLI stops polling.
+- If the image enters a failed state, leave the current promoted AWS image in
+  place and create a new image from a fresh lease.
 - If the source lease disappears, create a new warm lease and restart the bake;
-  image creation requires the backing AWS instance ID.
+  image creation requires the backing cloud VM ID.
 - If the baked image boots but never reaches `crabbox-ready`, do not promote it.
   Keep the previous promoted AMI and debug bootstrap on a normal lease first.
-- Cleanup of stale candidate AMIs is an AWS operator task. Promotion does not
+- Cleanup of stale candidate images is an operator task. Promotion does not
   delete old images or snapshots. Use `crabbox image delete` for explicit
   cleanup.
 - If a Mantis timing report does not improve after promotion, treat that as a
@@ -108,14 +114,17 @@ on the new image.
 
 ## delete
 
-Delete an AMI and its EBS snapshots:
+Delete a provider image:
 
 ```sh
 crabbox image delete ami-1234567890abcdef0 --region eu-west-1
+crabbox image delete my-managed-image --provider azure --region westeurope
+crabbox image delete my-machine-image --provider gcp --region europe-west1-b --project example-project
 ```
 
-Deletion deregisters the AMI, then deletes the EBS snapshots referenced by its
-block device mappings. It requires admin-token auth.
+AWS deletion deregisters the AMI, then deletes the EBS snapshots referenced by
+its block device mappings. Azure deletion removes the managed image. GCP
+deletion removes the machine image. It requires admin-token auth.
 
 Related docs:
 

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -1,152 +1,181 @@
 # Checkpoints
 
-Crabbox checkpoints make prepared remote state reusable.
+Crabbox checkpoints save prepared remote state for reuse.
 
-The product goal is fast access to known-good or known-interesting scenarios:
-dependencies installed, repositories synced, services warm, failure artifacts
-present, or a bug paused at a useful workspace state.
+**Goal**: Skip expensive setup. Install dependencies once, pause a bug at a useful
+state, keep generated fixtures, then fork that scenario for repeated test runs.
 
-Checkpoints are scenario handles. They do not change the default runner image
-for normal `warmup` or `run` commands. Use `crabbox checkpoint fork <id>` when
-you want a fresh lease from a saved scenario. Use `crabbox image promote` when
-you want future AWS leases to boot from a new default runner image.
+**Key distinction**: Checkpoints are explicit scenario handles, not default images.
+Use `crabbox checkpoint fork <id>` to start a fresh lease from a saved scenario.
+Use `crabbox image promote` to change the default AWS runner image for all future
+leases.
 
-## Tiers
+## Two Modes
 
-Crabbox treats checkpointing as tiered, because providers do not expose the same
-snapshot primitives.
+**Native (Provider Snapshots)**
+- Snapshots entire VM disk at provider level (AWS/Azure/GCP)
+- Preserves full machine state: packages, tools, caches, services, files
+- Fast to create and fork (leverages cloud-native snapshots)
+- Lives in provider account, incurs storage costs
+- Linux only (Windows not supported)
 
-- `recipe`: metadata only. Stores repo identity, lease/provider info and
-  workdir. Current restore/fork commands do not rebuild recipe checkpoints yet.
-- `aws-ebs-snapshot`: default AWS Linux checkpoint. Creates an EBS snapshot of
-  the source instance boot disk, then forks fresh leases from that snapshot.
-- `azure-os-disk-snapshot`: default Azure Linux checkpoint. Creates a managed
-  disk snapshot of the source VM OS disk, then forks fresh leases from that
-  snapshot.
-- `gcp-disk-snapshot`: default GCP Linux checkpoint. Creates a persistent disk
-  snapshot of the source instance boot disk, then forks fresh leases from that
-  snapshot.
-- `aws-ami`: AWS Linux image checkpoint. Creates an AMI from the backing EC2
-  instance, then forks fresh leases from that image. An AMI is AWS's bootable
-  machine image format; the disk contents are stored as EBS snapshots.
-- `azure-managed-image`: Azure managed images can be read/deleted and used from
-  imported records, but Crabbox does not create them from active leases because
-  Azure requires a stopped/generalized source VM.
-- `gcp-machine-image`: GCP Linux image checkpoint. Creates a Compute Engine
-  machine image from the source instance, then forks fresh leases from that
-  image.
-- `workspace-archive`: portable SSH fallback. Stores the remote workdir as a
-  local tarball and restores it to any compatible POSIX SSH lease. It preserves
-  workspace files, not the full machine.
-- `provider-native`: umbrella term for provider-owned images or snapshots.
-  Future backends such as Proxmox VM snapshots/clones fit here when Crabbox owns
-  create, fork, and delete semantics.
+**Archive (Workspace Tarball)**
+- Captures workdir files only, stores locally as tarball
+- Portable across any SSH-accessible lease
+- Does not preserve system packages or machine state
+- Excludes `.crabbox/env` and `.crabbox/scripts` by default
 
-The default `auto` mode uses the matching native disk snapshot when the source
-is a brokered AWS, Azure, or GCP Linux lease. Otherwise it falls back to
-`workspace-archive`. Use `--strategy image` on AWS or GCP when the provider
-image primitive is more useful than the boot-disk snapshot.
+Default `auto` mode: native for brokered AWS/Azure/GCP Linux leases, otherwise
+archive.
 
-## Current Flow
+## Native Checkpoint Strategies
 
-```sh
-crabbox warmup --class beast
-crabbox run --id blue-lobster --shell 'npm ci && npm test'
-crabbox checkpoint create --id blue-lobster --name after-npm-ci
-crabbox checkpoint fork chk_123 --class beast
-crabbox run --id <forked-lease> -- npm test
-```
+Native checkpoints use two provider primitives:
 
-`checkpoint create` records either a provider snapshot/image or a local workspace
-archive. `fork` creates a fresh lease from that checkpoint and keeps it
-available for more runs or SSH debugging.
+**Disk-Snapshot Strategy (default)**
+- AWS: EBS snapshot (`aws-ebs-snapshot`)
+- Azure: Managed OS disk snapshot (`azure-os-disk-snapshot`)
+- GCP: Persistent disk snapshot (`gcp-disk-snapshot`)
+- Faster to create, boots with fresh SSH keys
+- Best for iterative development
 
-For native Linux checkpoints, Crabbox flushes filesystem writes and resets
-cloud-init state before snapshot/image creation. On AWS and GCP disk-snapshot
-forks, new user-data can install a fresh per-lease SSH key. Azure disk-snapshot
-forks boot from a specialized OS disk and can inherit source machine identity;
-treat them as exact-clone snapshots until Crabbox grows a stronger Azure
-post-boot reset path. After the fork boots, Crabbox moves the snapshotted source
-workdir to the new lease's normal workdir so existing `crabbox run --id <fork>`
-workflows see the prepared scenario.
+**Image Strategy (opt-in with `--strategy image`)**
+- AWS: AMI (`aws-ami`)
+- Azure: Managed image (`azure-managed-image`) — read-only, not created from active VMs
+- GCP: Machine image (`gcp-machine-image`)
+- Slower but preserves complete VM configuration
+- Best for distribution or long-term storage
 
-## What Gets Preserved
+**Metadata-Only (`recipe`)**
+- Records lease/repo/workdir info without creating artifacts
+- Not yet supported by fork/restore commands
 
-Native provider checkpoints preserve machine-level state from the VM disk:
-system packages, installed tools, language runtimes, caches on disk, services,
-repository workdirs, and generated files. They can also preserve secrets if
-secrets were written to disk. Treat them like sensitive provider artifacts.
+## Security First
 
-Workspace archives preserve files under the selected workdir. They do not
-preserve installed OS packages, system services, remote caches outside the
-workdir, users, SSH host configuration, or other machine state.
+**⚠️ Native checkpoints may contain secrets**
 
-Both modes record local metadata such as checkpoint id, source lease, provider,
-repo name, git head, workdir, kind, and creation time under Crabbox's local
-state directory.
+Native snapshots capture full root volume state: system files, logs, caches,
+installed packages, and any secrets written to disk during setup. Treat them as
+sensitive provider artifacts.
 
-## When To Use It
+- Delete when no longer needed (storage costs accrue)
+- Do not create from ad-hoc debugging sessions with temporary secrets
+- Provider resources remain even if local metadata is lost
 
-Use a native provider checkpoint when machine setup is the slow part:
+**Workspace archives may contain secrets too**
+
+Archives capture workdir contents: build outputs, caches, logs, generated files.
+Crabbox excludes `.crabbox/env` and `.crabbox/scripts` by default but does not
+scan for credentials in arbitrary files.
+
+**Local metadata is required**
+
+Checkpoints store metadata locally (`~/.local/state/crabbox/checkpoints/`) with
+provider resource IDs and regions. Losing local metadata means you cannot fork
+by checkpoint ID. Deleting provider resources means local metadata is insufficient
+to fork.
+
+## Workflow
+
+**Basic flow**
 
 ```sh
 crabbox warmup --provider aws --class beast
-crabbox run --id blue-lobster --shell 'sudo apt-get update && sudo apt-get install -y heavy-tool && npm ci'
-crabbox checkpoint create --id blue-lobster --name heavy-tool-ready
-crabbox checkpoint fork chk_123 --class beast
+crabbox run --id blue-lobster --shell 'npm ci && npm test'
+crabbox checkpoint create --id blue-lobster --name after-npm-ci
+# Creates chk_abc123
+
+crabbox checkpoint fork chk_abc123 --class beast
+# Prints forked lease slug: purple-whale
+crabbox run --id purple-whale -- npm test
 ```
 
-The same flow works for brokered Azure and GCP Linux leases:
+**What happens on create**
+
+Native checkpoints:
+1. Flush filesystem writes (`sync`)
+2. Reset cloud-init state (allows fresh SSH keys on fork)
+3. Call provider snapshot/image API (EBS snapshot, AMI, etc.)
+4. Save local metadata with provider resource ID and region
+
+Archive checkpoints:
+1. SSH into lease
+2. Tar workdir (excluding `.crabbox/env` and `.crabbox/scripts`)
+3. Download tarball to `~/.local/state/crabbox/checkpoints/chk_*/workspace.tar.gz`
+4. Save local metadata
+
+**What happens on fork**
+
+Native checkpoints:
+1. Acquire new lease from provider using checkpoint snapshot/image
+2. Wait for boot
+3. Relocate snapshotted workdir to new lease's standard path
+   (`/work/cbx_old/repo` → `/work/cbx_new/repo`)
+4. Keep lease running for immediate use
+
+Archive checkpoints:
+1. Acquire standard new lease
+2. Upload tarball via SSH
+3. Extract to workdir
+4. Keep lease running
+
+**Azure disk-snapshot specifics**
+
+Azure disk-snapshot forks boot from a specialized OS disk and may inherit source
+machine identity. Treat them as exact-clone snapshots until Crabbox implements
+stronger post-boot reset. AWS and GCP disk-snapshots inject fresh user-data for
+per-lease SSH keys.
+
+## When To Use Checkpoints
+
+**Use native checkpoints when machine setup is slow**
+
+Expensive system packages, heavy toolchain installs, large dependency downloads:
 
 ```sh
-crabbox warmup --provider gcp --class beast
-crabbox run --id blue-lobster --shell 'sudo apt-get update && npm ci'
-crabbox checkpoint create --id blue-lobster --name gcp-ready
+crabbox warmup --provider aws --class beast
+crabbox run --id blue-lobster --shell 'sudo apt install -y cuda-toolkit && npm ci'
+crabbox checkpoint create --id blue-lobster --name cuda-ready
 crabbox checkpoint fork chk_123 --class beast
 ```
 
-Use a workspace archive when the repo state is the valuable part:
+Works identically for AWS, Azure, and GCP Linux leases.
+
+**Use workspace archives when repo state is valuable**
+
+Paused bugs, generated fixtures, build artifacts, test failures:
 
 ```sh
 crabbox checkpoint create --id blue-lobster --mode archive --name failing-fixtures
 crabbox checkpoint fork chk_123 --class standard
 ```
 
-Use a promoted image instead of a checkpoint when the prepared machine should
-become the normal base image for future AWS leases.
+Portable across all SSH-accessible leases.
 
-## Security Boundary
+**Use promoted images instead for default base images**
 
-Workspace archives may contain build outputs, caches, logs, repository data, and
-anything else in the workdir. Crabbox excludes `.crabbox/env` and
-`.crabbox/scripts` by default to avoid persisting profile-backed env helpers,
-but users should still treat checkpoint archives as sensitive local artifacts.
+If the prepared machine should become the standard image for all future AWS
+leases, use `crabbox image promote` instead of checkpoints. Checkpoints are
+explicit scenario handles; promoted images change the global default.
 
-Native checkpoints live in the provider account. The default AWS, Azure, and
-GCP checkpoint resources are boot-disk snapshots; `--strategy image` uses AWS
-AMIs or GCP machine images. They may contain the full root volume state.
-`crabbox checkpoint delete` removes the provider resource; keep long-lived
-checkpoints intentionally. Provider snapshot/image storage can incur cost while
-it exists.
+## Use Cases
 
-The local checkpoint record is also part of the checkpoint. For native
-checkpoints, it stores the provider resource id plus region/location/zone and
-project when needed. If the local record is lost, the provider resource still
-exists, but Crabbox cannot fork it by checkpoint id until equivalent metadata is
-restored. If the provider resource is deleted, the local record is no longer
-enough to fork.
+- Fast test iteration: `npm ci` once, fork for each test run
+- Heavy toolchains: Install CUDA, Android SDK, Xcode once
+- Paused debugging: Capture exact failure state, fork to investigate
+- Generated fixtures: Keep expensive setup data, fork for clean runs
+- CI optimization: Prebake common environments, fork in parallel jobs
+- Team sharing: Distribute snapshot IDs for consistent environments (native only)
 
-## Native Snapshot Direction
+## Future Expansion
 
-Additional native checkpointing should be added only when a backend can
-guarantee real semantics:
+Additional native checkpoint backends require:
 
-- create a stable snapshot from a lease or workspace;
-- fork that snapshot into a new lease;
-- restore or delete it predictably;
-- report cost, retention, and security boundaries.
+- Stable snapshot creation from active lease
+- Fork snapshot into new lease
+- Predictable restore/delete operations
+- Clear cost, retention, security boundaries
 
-Proxmox is the next natural backend because it has VM-level snapshot and clone
-semantics close to local hypervisor snapshots. Plain SSH providers should not
-advertise native checkpoint features unless the target host exposes a real
-snapshot API such as ZFS, Btrfs, or LVM and Crabbox owns that integration.
+Proxmox VM snapshots/clones are the next natural fit. Plain SSH providers should
+not expose native checkpoint features unless the target host provides a real
+snapshot API (ZFS, Btrfs, LVM) and Crabbox owns the integration.

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -18,17 +18,34 @@ snapshot primitives.
 
 - `recipe`: metadata only. Stores repo identity, lease/provider info and
   workdir. Current restore/fork commands do not rebuild recipe checkpoints yet.
-- `aws-ami`: VM-level AWS Linux checkpoint. Creates an AMI from the backing EC2
+- `aws-ebs-snapshot`: default AWS Linux checkpoint. Creates an EBS snapshot of
+  the source instance boot disk, then forks fresh leases from that snapshot.
+- `azure-os-disk-snapshot`: default Azure Linux checkpoint. Creates a managed
+  disk snapshot of the source VM OS disk, then forks fresh leases from that
+  snapshot.
+- `gcp-disk-snapshot`: default GCP Linux checkpoint. Creates a persistent disk
+  snapshot of the source instance boot disk, then forks fresh leases from that
+  snapshot.
+- `aws-ami`: AWS Linux image checkpoint. Creates an AMI from the backing EC2
   instance, then forks fresh leases from that image. An AMI is AWS's bootable
   machine image format; the disk contents are stored as EBS snapshots.
+- `azure-managed-image`: Azure managed images can be read/deleted and used from
+  imported records, but Crabbox does not create them from active leases because
+  Azure requires a stopped/generalized source VM.
+- `gcp-machine-image`: GCP Linux image checkpoint. Creates a Compute Engine
+  machine image from the source instance, then forks fresh leases from that
+  image.
 - `workspace-archive`: portable SSH fallback. Stores the remote workdir as a
   local tarball and restores it to any compatible POSIX SSH lease. It preserves
   workspace files, not the full machine.
-- `provider-native`: future provider-owned snapshots for other backends such as
-  Proxmox VM snapshots/clones and sandbox-provider snapshots.
+- `provider-native`: umbrella term for provider-owned images or snapshots.
+  Future backends such as Proxmox VM snapshots/clones fit here when Crabbox owns
+  create, fork, and delete semantics.
 
-The default `auto` mode uses `aws-ami` when the source is a brokered AWS Linux
-lease. Otherwise it falls back to `workspace-archive`.
+The default `auto` mode uses the matching native disk snapshot when the source
+is a brokered AWS, Azure, or GCP Linux lease. Otherwise it falls back to
+`workspace-archive`. Use `--strategy image` on AWS or GCP when the provider
+image primitive is more useful than the boot-disk snapshot.
 
 ## Current Flow
 
@@ -40,19 +57,22 @@ crabbox checkpoint fork chk_123 --class beast
 crabbox run --id <forked-lease> -- npm test
 ```
 
-`checkpoint create` records either a provider image or a local workspace
+`checkpoint create` records either a provider snapshot/image or a local workspace
 archive. `fork` creates a fresh lease from that checkpoint and keeps it
 available for more runs or SSH debugging.
 
-For AWS AMI checkpoints, Crabbox resets cloud-init state before image creation.
-That lets forked VMs run new user-data and install their own per-lease SSH key
-instead of inheriting the source lease key. After the fork boots, Crabbox moves
-the snapshotted source workdir to the new lease's normal workdir so existing
-`crabbox run --id <fork>` workflows see the prepared scenario.
+For native Linux checkpoints, Crabbox flushes filesystem writes and resets
+cloud-init state before snapshot/image creation. On AWS and GCP disk-snapshot
+forks, new user-data can install a fresh per-lease SSH key. Azure disk-snapshot
+forks boot from a specialized OS disk and can inherit source machine identity;
+treat them as exact-clone snapshots until Crabbox grows a stronger Azure
+post-boot reset path. After the fork boots, Crabbox moves the snapshotted source
+workdir to the new lease's normal workdir so existing `crabbox run --id <fork>`
+workflows see the prepared scenario.
 
 ## What Gets Preserved
 
-AWS AMI checkpoints preserve machine-level state from the EC2 root volume:
+Native provider checkpoints preserve machine-level state from the VM disk:
 system packages, installed tools, language runtimes, caches on disk, services,
 repository workdirs, and generated files. They can also preserve secrets if
 secrets were written to disk. Treat them like sensitive provider artifacts.
@@ -67,12 +87,21 @@ state directory.
 
 ## When To Use It
 
-Use an AWS AMI checkpoint when machine setup is the slow part:
+Use a native provider checkpoint when machine setup is the slow part:
 
 ```sh
 crabbox warmup --provider aws --class beast
 crabbox run --id blue-lobster --shell 'sudo apt-get update && sudo apt-get install -y heavy-tool && npm ci'
 crabbox checkpoint create --id blue-lobster --name heavy-tool-ready
+crabbox checkpoint fork chk_123 --class beast
+```
+
+The same flow works for brokered Azure and GCP Linux leases:
+
+```sh
+crabbox warmup --provider gcp --class beast
+crabbox run --id blue-lobster --shell 'sudo apt-get update && npm ci'
+crabbox checkpoint create --id blue-lobster --name gcp-ready
 crabbox checkpoint fork chk_123 --class beast
 ```
 
@@ -93,16 +122,18 @@ anything else in the workdir. Crabbox excludes `.crabbox/env` and
 `.crabbox/scripts` by default to avoid persisting profile-backed env helpers,
 but users should still treat checkpoint archives as sensitive local artifacts.
 
-AWS AMI checkpoints live in the provider account and are backed by EBS
-snapshots. They may contain the full root volume state. `crabbox checkpoint
-delete` deregisters the AMI and deletes its snapshots; keep long-lived
-checkpoints intentionally. EBS snapshots can incur storage cost while they
-exist.
+Native checkpoints live in the provider account. The default AWS, Azure, and
+GCP checkpoint resources are boot-disk snapshots; `--strategy image` uses AWS
+AMIs or GCP machine images. They may contain the full root volume state.
+`crabbox checkpoint delete` removes the provider resource; keep long-lived
+checkpoints intentionally. Provider snapshot/image storage can incur cost while
+it exists.
 
-The local checkpoint record is also part of the checkpoint. For AWS, it stores
-the AMI id and region. If the local record is lost, the AMI still exists in AWS,
-but Crabbox cannot fork it by checkpoint id until equivalent metadata is
-restored. If the AMI or EBS snapshots are deleted, the local record is no longer
+The local checkpoint record is also part of the checkpoint. For native
+checkpoints, it stores the provider resource id plus region/location/zone and
+project when needed. If the local record is lost, the provider resource still
+exists, but Crabbox cannot fork it by checkpoint id until equivalent metadata is
+restored. If the provider resource is deleted, the local record is no longer
 enough to fork.
 
 ## Native Snapshot Direction

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -65,7 +65,7 @@ This page maps user-facing behavior back to implementation files. Keep docs desc
   `internal/providers/modal`, `internal/providers/tensorlake`, plus shared helpers in `internal/providers/shared`
 - Worker Hetzner provider: `worker/src/hetzner.ts`
 - Worker AWS EC2 provider: `worker/src/aws.ts`
-- Worker AWS AMI create/read/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`
+- Worker provider image create/read/delete/promote routes: `worker/src/fleet.ts`, `worker/src/aws.ts`, `worker/src/azure.ts`, `worker/src/gcp.ts`
 - Provider feature docs: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
 - Provider reference docs: `docs/providers/README.md`, `docs/providers/aws.md`, `docs/providers/azure.md`, `docs/providers/gcp.md`, `docs/providers/hetzner.md`, `docs/providers/proxmox.md`, `docs/providers/ssh.md`, `docs/providers/blacksmith-testbox.md`, `docs/providers/namespace-devbox.md`, `docs/providers/daytona.md`, `docs/providers/islo.md`, `docs/providers/semaphore.md`, `docs/providers/sprites.md`, `docs/providers/e2b.md`, `docs/providers/modal.md`, `docs/providers/tensorlake.md`
 - Provider/backend authoring guide: `docs/provider-backends.md`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -159,7 +159,7 @@ Commands:
   list        List Crabbox machines
   share       Share a lease with users or the owning org
   unshare     Remove lease sharing
-  image       Create or promote brokered AWS runner images
+  image       Create provider images and promote brokered AWS runner images
   usage       Show cost and usage estimates by user, org, or fleet
   admin       Lease admin controls for trusted operators
   actions     Register GitHub Actions runners or dispatch workflows

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -627,6 +627,9 @@ func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Serv
 	if _, ok := nativeCheckpointKind(cfg, server, target, strategy); !ok {
 		return CoordinatorImage{}, exit(2, "native checkpoints currently support brokered AWS, Azure, and GCP Linux leases only")
 	}
+	if server.Provider == "azure" && strategy == checkpointStrategyImage {
+		return CoordinatorImage{}, exit(2, "Azure managed images require a stopped/generalized source VM; use --strategy disk-snapshot for active Azure leases")
+	}
 	if name == "" {
 		name = defaultNativeImageName(leaseID, repoName)
 	}

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -23,6 +23,15 @@ const (
 	checkpointKindRecipe  = "recipe"
 	checkpointKindArchive = "workspace-archive"
 	checkpointKindAWSAMI  = "aws-ami"
+	checkpointKindAWSEBS  = "aws-ebs-snapshot"
+	checkpointKindAzure   = "azure-managed-image"
+	checkpointKindAzureOS = "azure-os-disk-snapshot"
+	checkpointKindGCP     = "gcp-machine-image"
+	checkpointKindGCPDisk = "gcp-disk-snapshot"
+
+	checkpointStrategyAuto         = "auto"
+	checkpointStrategyImage        = "image"
+	checkpointStrategyDiskSnapshot = "disk-snapshot"
 )
 
 type checkpointRecord struct {
@@ -42,9 +51,13 @@ type checkpointRecord struct {
 	Native         struct {
 		Provider string `json:"provider,omitempty"`
 		ImageID  string `json:"imageId,omitempty"`
+		Kind     string `json:"kind,omitempty"`
 		Name     string `json:"name,omitempty"`
 		State    string `json:"state,omitempty"`
 		Region   string `json:"region,omitempty"`
+		Project  string `json:"project,omitempty"`
+		Resource string `json:"resource,omitempty"`
+		Strategy string `json:"strategy,omitempty"`
 		NoReboot bool   `json:"noReboot,omitempty"`
 	} `json:"native,omitempty"`
 	Repo struct {
@@ -84,14 +97,14 @@ func (a App) checkpoint(ctx context.Context, args []string) error {
 
 func (a App) printCheckpointHelp() {
 	fmt.Fprintln(a.Stdout, `Usage:
-  crabbox checkpoint create --id <lease-id-or-slug> [--name <name>] [--mode auto|native|archive]
+  crabbox checkpoint create --id <lease-id-or-slug> [--name <name>] [--mode auto|native|archive] [--strategy auto|disk-snapshot|image]
   crabbox checkpoint list [--json]
   crabbox checkpoint inspect <checkpoint-id> [--json]
   crabbox checkpoint restore <checkpoint-id> --id <lease-id-or-slug> [--clear=false]
   crabbox checkpoint fork <checkpoint-id> [--class <class>] [--keep]
   crabbox checkpoint delete <checkpoint-id>
 
-Checkpoints use AWS AMI snapshots for brokered Linux leases and portable workspace archives elsewhere.`)
+Checkpoints use provider-native disk snapshots for brokered AWS, Azure, and GCP Linux leases, and portable workspace archives elsewhere.`)
 }
 
 func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
@@ -101,6 +114,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	id := fs.String("id", "", "lease id or slug")
 	name := fs.String("name", "", "checkpoint name")
 	mode := fs.String("mode", "auto", "checkpoint mode: auto, native, or archive")
+	strategy := fs.String("strategy", checkpointStrategyAuto, "native checkpoint strategy: auto, disk-snapshot, or image")
 	workdirOverride := fs.String("workdir", "", "remote workdir to archive")
 	recipeOnly := fs.Bool("recipe-only", false, "record metadata without archiving the remote workdir")
 	wait := fs.Bool("wait", true, "wait for native provider snapshot availability")
@@ -111,6 +125,9 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
+	}
+	if !validCheckpointStrategy(*strategy) {
+		return exit(2, "checkpoint strategy must be auto, disk-snapshot, or image")
 	}
 	setIDFromFirstArg(fs, id)
 	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
@@ -143,13 +160,14 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	defer func() {
 		cleanupUncommittedCheckpointDir(dir, recordWritten, err)
 	}()
-	switch checkpointCreateMode(*mode, cfg, server, target, *recipeOnly) {
+	createKind := checkpointCreateMode(*mode, *strategy, cfg, server, target, *recipeOnly)
+	switch createKind {
 	case checkpointKindRecipe:
 		record.Kind = checkpointKindRecipe
-	case checkpointKindAWSAMI:
-		image, err := a.createAWSAMICheckpoint(ctx, cfg, target, leaseID, record.Name, repo.Name, *noReboot, *wait, *waitTimeout)
+	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk:
+		image, err := a.createNativeCheckpoint(ctx, cfg, server, target, leaseID, record.Name, repo.Name, checkpointStrategyForKind(createKind), *noReboot, *wait, *waitTimeout)
 		if image.ID != "" {
-			applyAWSAMIImageCheckpointRecord(&record, image, *noReboot)
+			applyNativeImageCheckpointRecord(&record, image, *noReboot)
 		}
 		if err != nil {
 			if record.Native.ImageID != "" {
@@ -179,8 +197,8 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	recordWritten = true
-	if record.Kind == checkpointKindAWSAMI {
-		fmt.Fprintf(a.Stdout, "checkpoint created id=%s kind=%s image=%s state=%s region=%s workdir=%s\n", record.ID, record.Kind, record.Native.ImageID, record.Native.State, blank(record.Native.Region, "-"), record.Workdir)
+	if isNativeCheckpointKind(record.Kind) {
+		fmt.Fprintf(a.Stdout, "checkpoint created id=%s kind=%s resource=%s state=%s region=%s workdir=%s\n", record.ID, record.Kind, record.Native.ImageID, record.Native.State, blank(record.Native.Region, "-"), record.Workdir)
 		return nil
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint created id=%s kind=%s bytes=%s workdir=%s\n", record.ID, record.Kind, humanBytes(record.ArchiveBytes), record.Workdir)
@@ -206,8 +224,8 @@ func (a App) checkpointList(args []string) error {
 	}
 	for _, record := range records {
 		extra := fmt.Sprintf("bytes=%s", humanBytes(record.ArchiveBytes))
-		if record.Kind == checkpointKindAWSAMI {
-			extra = fmt.Sprintf("image=%s state=%s region=%s", blank(record.Native.ImageID, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"))
+		if isNativeCheckpointKind(record.Kind) {
+			extra = fmt.Sprintf("resource=%s state=%s region=%s", blank(record.Native.ImageID, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"))
 		}
 		fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s created=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, record.CreatedAt)
 	}
@@ -232,9 +250,15 @@ func (a App) checkpointInspect(args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "id=%s\nkind=%s\nname=%s\ncreated=%s\nprovider=%s\nlease=%s\nrepo=%s\nhead=%s\nworkdir=%s\narchive=%s\nbytes=%s\n",
 		record.ID, record.Kind, blank(record.Name, "-"), record.CreatedAt, blank(record.Provider, "-"), blank(record.LeaseID, "-"), blank(record.Repo.Name, "-"), blank(record.Repo.Head, "-"), blank(record.Workdir, "-"), blank(record.ArchivePath, "-"), humanBytes(record.ArchiveBytes))
-	if record.Kind == checkpointKindAWSAMI {
-		fmt.Fprintf(a.Stdout, "image=%s\nimage_name=%s\nimage_state=%s\nimage_region=%s\nno_reboot=%t\n",
-			blank(record.Native.ImageID, "-"), blank(record.Native.Name, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"), record.Native.NoReboot)
+	if isNativeCheckpointKind(record.Kind) {
+		fmt.Fprintf(a.Stdout, "resource=%s\nresource_name=%s\nresource_state=%s\nresource_region=%s\nstrategy=%s\nno_reboot=%t\n",
+			blank(record.Native.ImageID, "-"), blank(record.Native.Name, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"), blank(record.Native.Strategy, checkpointStrategyImage), record.Native.NoReboot)
+		if record.Native.Project != "" {
+			fmt.Fprintf(a.Stdout, "image_project=%s\n", record.Native.Project)
+		}
+		if record.Native.Resource != "" {
+			fmt.Fprintf(a.Stdout, "image_resource=%s\n", record.Native.Resource)
+		}
 	}
 	return nil
 }
@@ -260,7 +284,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		return err
 	}
 	if record.Kind != checkpointKindArchive {
-		if record.Kind == checkpointKindAWSAMI {
+		if isNativeCheckpointKind(record.Kind) {
 			return exit(2, "checkpoint %s is a VM image; use crabbox checkpoint fork %s to create a lease from it", record.ID, record.ID)
 		}
 		return exit(2, "checkpoint %s has kind=%s; restore requires %s", record.ID, record.Kind, checkpointKindArchive)
@@ -319,11 +343,11 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
 		return err
 	}
-	if record.Kind == checkpointKindAWSAMI {
-		applyAWSAMICheckpointForkConfig(&cfg, fs, record)
+	if isNativeCheckpointKind(record.Kind) {
+		applyNativeCheckpointForkConfig(&cfg, fs, record)
 	}
-	if record.Kind != checkpointKindArchive && record.Kind != checkpointKindAWSAMI {
-		return exit(2, "checkpoint %s has kind=%s; fork requires %s or %s", record.ID, record.Kind, checkpointKindArchive, checkpointKindAWSAMI)
+	if record.Kind != checkpointKindArchive && !isNativeCheckpointKind(record.Kind) {
+		return exit(2, "checkpoint %s has kind=%s; fork requires %s or a native image checkpoint", record.ID, record.Kind, checkpointKindArchive)
 	}
 	repo, err := findRepo()
 	if err != nil {
@@ -361,7 +385,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 			fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 		}
 	}
-	if record.Kind == checkpointKindAWSAMI {
+	if isNativeCheckpointKind(record.Kind) {
 		workdir := nativeCheckpointForkWorkdir(cfg, leaseID, repo.Name, *workdirOverride)
 		if err := relocateNativeCheckpointWorkdir(ctx, target, record.Workdir, workdir); err != nil {
 			a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
@@ -399,12 +423,12 @@ func (a App) checkpointDelete(args []string) error {
 	if err != nil {
 		return err
 	}
-	if record.Kind == checkpointKindAWSAMI && record.Native.ImageID != "" && !*localOnly {
+	if isNativeCheckpointKind(record.Kind) && record.Native.ImageID != "" && !*localOnly {
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
 			return err
 		}
-		if err := coord.DeleteImage(context.Background(), record.Native.ImageID, record.Native.Region); err != nil {
+		if err := coord.DeleteImage(context.Background(), record.Native.ImageID, nativeCoordinatorImageRef(record)); err != nil {
 			return err
 		}
 	}
@@ -419,14 +443,41 @@ func (a App) checkpointDelete(args []string) error {
 	return nil
 }
 
-func applyAWSAMIImageCheckpointRecord(record *checkpointRecord, image CoordinatorImage, noReboot bool) {
-	record.Kind = checkpointKindAWSAMI
-	record.Native.Provider = "aws"
+func applyNativeImageCheckpointRecord(record *checkpointRecord, image CoordinatorImage, noReboot bool) {
+	record.Kind = checkpointKindForProviderImage(image)
+	record.Native.Provider = firstNonBlank(image.Provider, checkpointProviderForKind(record.Kind), record.Provider)
 	record.Native.ImageID = image.ID
+	record.Native.Kind = image.Kind
 	record.Native.Name = image.Name
 	record.Native.State = image.State
 	record.Native.Region = image.Region
+	record.Native.Project = image.Project
+	record.Native.Resource = image.ResourceID
+	record.Native.Strategy = checkpointStrategyForKind(record.Kind)
 	record.Native.NoReboot = noReboot
+}
+
+func applyAWSAMIImageCheckpointRecord(record *checkpointRecord, image CoordinatorImage, noReboot bool) {
+	applyNativeImageCheckpointRecord(record, image, noReboot)
+}
+
+func checkpointKindForProviderImage(image CoordinatorImage) string {
+	switch image.Kind {
+	case checkpointKindAWSEBS:
+		return checkpointKindAWSEBS
+	case checkpointKindAzureOS:
+		return checkpointKindAzureOS
+	case checkpointKindGCPDisk:
+		return checkpointKindGCPDisk
+	}
+	switch image.Provider {
+	case "azure":
+		return checkpointKindAzure
+	case "gcp":
+		return checkpointKindGCP
+	default:
+		return checkpointKindAWSAMI
+	}
 }
 
 func newCheckpointRecord(repo Repo, cfg Config, server Server, target SSHTarget, leaseID, workdir, name string) (checkpointRecord, string, error) {
@@ -474,27 +525,32 @@ func newCheckpointID() (string, error) {
 	return checkpointIDPrefix + hex.EncodeToString(raw[:]), nil
 }
 
-func checkpointCreateMode(mode string, cfg Config, server Server, target SSHTarget, recipeOnly bool) string {
+func checkpointCreateMode(mode, strategy string, cfg Config, server Server, target SSHTarget, recipeOnly bool) string {
 	if recipeOnly {
 		return checkpointKindRecipe
 	}
+	normalizedStrategy := normalizeCheckpointStrategy(strategy)
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "", "auto":
-		if cfg.Coordinator != "" && server.Provider == "aws" && server.CloudID != "" && !isWindowsNativeTarget(target) && firstNonBlank(target.TargetOS, cfg.TargetOS) == targetLinux {
-			return checkpointKindAWSAMI
+		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+			return kind
 		}
 		return checkpointKindArchive
-	case "native", "provider-native", "vm", "ami":
-		if server.Provider != "aws" {
-			return "unsupported"
+	case "native", "provider-native", "vm":
+		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+			return kind
 		}
-		if server.CloudID == "" {
-			return "unsupported"
+		return "unsupported"
+	case "ami", "image":
+		if kind, ok := nativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
+			return kind
 		}
-		if isWindowsNativeTarget(target) || firstNonBlank(target.TargetOS, cfg.TargetOS) != targetLinux {
-			return "unsupported"
+		return "unsupported"
+	case "snapshot", "disk-snapshot", "disk":
+		if kind, ok := nativeCheckpointKind(cfg, server, target, checkpointStrategyDiskSnapshot); ok {
+			return kind
 		}
-		return checkpointKindAWSAMI
+		return "unsupported"
 	case "archive", "workspace", "workspace-archive":
 		return checkpointKindArchive
 	case "recipe":
@@ -504,29 +560,89 @@ func checkpointCreateMode(mode string, cfg Config, server Server, target SSHTarg
 	}
 }
 
-func (a App) createAWSAMICheckpoint(ctx context.Context, cfg Config, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
-	if cfg.Coordinator == "" {
-		return CoordinatorImage{}, exit(2, "native AWS checkpoints require a configured coordinator")
+func nativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
+	if cfg.Coordinator == "" || server.CloudID == "" || isWindowsNativeTarget(target) || firstNonBlank(target.TargetOS, cfg.TargetOS) != targetLinux {
+		return "", false
 	}
-	if isWindowsNativeTarget(target) || firstNonBlank(target.TargetOS, cfg.TargetOS) != targetLinux {
-		return CoordinatorImage{}, exit(2, "native AWS checkpoints currently support Linux leases only")
+	strategy = normalizeCheckpointStrategy(strategy)
+	switch server.Provider {
+	case "aws":
+		if strategy == checkpointStrategyImage {
+			return checkpointKindAWSAMI, true
+		}
+		return checkpointKindAWSEBS, true
+	case "azure":
+		if strategy == checkpointStrategyImage {
+			return checkpointKindAzure, true
+		}
+		return checkpointKindAzureOS, true
+	case "gcp":
+		if strategy == checkpointStrategyImage {
+			return checkpointKindGCP, true
+		}
+		return checkpointKindGCPDisk, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeCheckpointStrategy(strategy string) string {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", checkpointStrategyAuto, "snapshot", "disk":
+		return checkpointStrategyDiskSnapshot
+	case checkpointStrategyImage, "ami", "machine-image", "managed-image":
+		return checkpointStrategyImage
+	case checkpointStrategyDiskSnapshot, "disk_snapshot":
+		return checkpointStrategyDiskSnapshot
+	default:
+		return checkpointStrategyDiskSnapshot
+	}
+}
+
+func validCheckpointStrategy(strategy string) bool {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", checkpointStrategyAuto, checkpointStrategyDiskSnapshot, checkpointStrategyImage, "snapshot", "disk", "ami", "machine-image", "managed-image", "disk_snapshot":
+		return true
+	default:
+		return false
+	}
+}
+
+func checkpointStrategyForKind(kind string) string {
+	switch kind {
+	case checkpointKindAWSAMI, checkpointKindAzure, checkpointKindGCP:
+		return checkpointStrategyImage
+	case checkpointKindAWSEBS, checkpointKindAzureOS, checkpointKindGCPDisk:
+		return checkpointStrategyDiskSnapshot
+	default:
+		return ""
+	}
+}
+
+func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName, strategy string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
+	if cfg.Coordinator == "" {
+		return CoordinatorImage{}, exit(2, "native checkpoints require a configured coordinator")
+	}
+	strategy = normalizeCheckpointStrategy(strategy)
+	if _, ok := nativeCheckpointKind(cfg, server, target, strategy); !ok {
+		return CoordinatorImage{}, exit(2, "native checkpoints currently support brokered AWS, Azure, and GCP Linux leases only")
 	}
 	if name == "" {
-		name = defaultAWSAMIName(leaseID, repoName)
+		name = defaultNativeImageName(leaseID, repoName)
 	}
 	coord, err := configuredAdminCoordinator()
 	if err != nil {
 		return CoordinatorImage{}, err
 	}
-	if err := prepareAWSAMICloudInit(ctx, target); err != nil {
+	if err := prepareNativeLinuxImageSource(ctx, target); err != nil {
 		return CoordinatorImage{}, err
 	}
-	image, err := coord.CreateImage(ctx, leaseID, name, noReboot)
+	image, err := coord.CreateImage(ctx, leaseID, name, noReboot, strategy)
 	if err != nil {
 		return CoordinatorImage{}, err
 	}
 	if wait {
-		waited, err := waitForImage(ctx, coord, image.ID, image.Region, waitTimeout, a.Stderr)
+		waited, err := waitForImage(ctx, coord, image.ID, imageRefFromCoordinatorImage(image), waitTimeout, a.Stderr)
 		if err != nil {
 			return image, err
 		}
@@ -535,7 +651,11 @@ func (a App) createAWSAMICheckpoint(ctx context.Context, cfg Config, target SSHT
 	return image, nil
 }
 
-func defaultAWSAMIName(leaseID, repoName string) string {
+func (a App) createAWSAMICheckpoint(ctx context.Context, cfg Config, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
+	return a.createNativeCheckpoint(ctx, cfg, Server{Provider: "aws", CloudID: leaseID}, target, leaseID, name, repoName, checkpointStrategyImage, noReboot, wait, waitTimeout)
+}
+
+func defaultNativeImageName(leaseID, repoName string) string {
 	repoName = strings.TrimSpace(repoName)
 	if repoName == "" {
 		repoName = "workspace"
@@ -547,10 +667,10 @@ func defaultAWSAMIName(leaseID, repoName string) string {
 	return base
 }
 
-func prepareAWSAMICloudInit(ctx context.Context, target SSHTarget) error {
+func prepareNativeLinuxImageSource(ctx context.Context, target SSHTarget) error {
 	command := remotePrepareAWSAMICommand()
 	if out, err := runSSHCombinedOutput(ctx, target, "bash -lc "+shellQuote(command)); err != nil {
-		return exit(7, "prepare AWS AMI source cloud-init: %v: %s", err, trimFailureDetail(out))
+		return exit(7, "prepare native checkpoint source cloud-init: %v: %s", err, trimFailureDetail(out))
 	}
 	return nil
 }
@@ -571,11 +691,50 @@ func nativeCheckpointForkWorkdir(cfg Config, leaseID, repoName, override string)
 	return remoteJoin(cfg, leaseID, repoName)
 }
 
-func applyAWSAMICheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record checkpointRecord) {
-	cfg.Provider = "aws"
-	cfg.AWSAMI = record.Native.ImageID
-	if record.Native.Region != "" {
-		cfg.AWSRegion = record.Native.Region
+func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record checkpointRecord) {
+	cfg.Provider = firstNonBlank(record.Native.Provider, checkpointProviderForKind(record.Kind), record.Provider)
+	if cfg.CoordAdminToken != "" {
+		cfg.CoordToken = cfg.CoordAdminToken
+	}
+	switch record.Kind {
+	case checkpointKindAWSAMI:
+		cfg.AWSAMI = record.Native.ImageID
+		if record.Native.Region != "" {
+			cfg.AWSRegion = record.Native.Region
+		}
+	case checkpointKindAWSEBS:
+		cfg.AWSSnapshot = record.Native.ImageID
+		if record.Native.Region != "" {
+			cfg.AWSRegion = record.Native.Region
+		}
+	case checkpointKindAzure:
+		cfg.AzureImage = firstNonBlank(record.Native.Resource, record.Native.ImageID)
+		if record.Native.Region != "" {
+			cfg.AzureLocation = record.Native.Region
+		}
+	case checkpointKindAzureOS:
+		cfg.AzureSnapshot = firstNonBlank(record.Native.Resource, record.Native.ImageID)
+		if record.Native.Region != "" {
+			cfg.AzureLocation = record.Native.Region
+		}
+	case checkpointKindGCP:
+		cfg.GCPMachineImage = firstNonBlank(record.Native.Resource, record.Native.ImageID)
+		if record.Native.Region != "" {
+			cfg.GCPZone = record.Native.Region
+		}
+		if record.Native.Project != "" {
+			cfg.GCPProject = record.Native.Project
+			cfg.gcpProjectExplicit = true
+		}
+	case checkpointKindGCPDisk:
+		cfg.GCPSnapshot = firstNonBlank(record.Native.Resource, record.Native.ImageID)
+		if record.Native.Region != "" {
+			cfg.GCPZone = record.Native.Region
+		}
+		if record.Native.Project != "" {
+			cfg.GCPProject = record.Native.Project
+			cfg.gcpProjectExplicit = true
+		}
 	}
 	if record.TargetOS != "" {
 		cfg.TargetOS = record.TargetOS
@@ -586,6 +745,36 @@ func applyAWSAMICheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record check
 	if !flagWasSet(fs, "type") {
 		cfg.ServerTypeExplicit = false
 		cfg.ServerType = serverTypeForConfig(*cfg)
+	}
+}
+
+func applyAWSAMICheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record checkpointRecord) {
+	applyNativeCheckpointForkConfig(cfg, fs, record)
+}
+
+func nativeCoordinatorImageRef(record checkpointRecord) CoordinatorImageRef {
+	return CoordinatorImageRef{
+		Provider: firstNonBlank(record.Native.Provider, record.Provider),
+		Region:   record.Native.Region,
+		Project:  record.Native.Project,
+		Kind:     firstNonBlank(record.Native.Kind, record.Kind),
+	}
+}
+
+func isNativeCheckpointKind(kind string) bool {
+	return kind == checkpointKindAWSAMI || kind == checkpointKindAWSEBS || kind == checkpointKindAzure || kind == checkpointKindAzureOS || kind == checkpointKindGCP || kind == checkpointKindGCPDisk
+}
+
+func checkpointProviderForKind(kind string) string {
+	switch kind {
+	case checkpointKindAWSAMI, checkpointKindAWSEBS:
+		return "aws"
+	case checkpointKindAzure, checkpointKindAzureOS:
+		return "azure"
+	case checkpointKindGCP, checkpointKindGCPDisk:
+		return "gcp"
+	default:
+		return ""
 	}
 }
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -225,6 +225,36 @@ func TestCreateAWSAMICheckpointValidatesAdminBeforeCloudInit(t *testing.T) {
 	}
 }
 
+func TestCreateNativeCheckpointRejectsAzureImageBeforeAdminAndCloudInit(t *testing.T) {
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "https://coordinator.example")
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "")
+	t.Setenv("CRABBOX_ADMIN_TOKEN", "")
+	cfg := baseConfig()
+	cfg.Coordinator = "https://coordinator.example"
+	cfg.TargetOS = targetLinux
+
+	_, err := (App{Stdout: io.Discard, Stderr: io.Discard}).createNativeCheckpoint(
+		context.Background(),
+		cfg,
+		Server{Provider: "azure", CloudID: "crabbox-source"},
+		SSHTarget{TargetOS: targetLinux},
+		"cbx_123",
+		"",
+		"repo",
+		checkpointStrategyImage,
+		true,
+		false,
+		0,
+	)
+	if err == nil {
+		t.Fatal("expected Azure image strategy to fail")
+	}
+	if !strings.Contains(err.Error(), "Azure managed images require") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestRemotePrepareAWSAMICommandFlushesFilesystem(t *testing.T) {
 	cmd := remotePrepareAWSAMICommand()
 	for _, want := range []string{"cloud-init clean --logs", "sync"} {

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -136,15 +136,42 @@ func TestDefaultCheckpointRestoreWorkdirUsesTargetLease(t *testing.T) {
 	}
 }
 
-func TestCheckpointCreateModePrefersAWSAMILinuxNative(t *testing.T) {
+func TestCheckpointCreateModePrefersDiskSnapshotLinuxNative(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "hetzner"
 	cfg.Coordinator = "https://coordinator.example"
 	cfg.TargetOS = targetLinux
 	server := Server{Provider: "aws", CloudID: "i-123"}
 	target := SSHTarget{TargetOS: targetLinux}
-	if got := checkpointCreateMode("auto", cfg, server, target, false); got != checkpointKindAWSAMI {
+	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindAWSEBS {
 		t.Fatalf("mode=%q", got)
+	}
+	if got := checkpointCreateMode("native", "image", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("image strategy mode=%q", got)
+	}
+	if got := checkpointCreateMode("image", "", cfg, server, target, false); got != checkpointKindAWSAMI || checkpointStrategyForKind(got) != checkpointStrategyImage {
+		t.Fatalf("legacy image mode=%q strategy=%q", got, checkpointStrategyForKind(got))
+	}
+}
+
+func TestCheckpointCreateModeSupportsAzureAndGCPNative(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Coordinator = "https://coordinator.example"
+	cfg.TargetOS = targetLinux
+	target := SSHTarget{TargetOS: targetLinux}
+	for _, tc := range []struct {
+		provider string
+		want     string
+	}{
+		{provider: "azure", want: checkpointKindAzureOS},
+		{provider: "gcp", want: checkpointKindGCPDisk},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			server := Server{Provider: tc.provider, CloudID: "vm-123"}
+			if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != tc.want {
+				t.Fatalf("mode=%q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -155,7 +182,7 @@ func TestCheckpointCreateModeAutoFallsBackForDirectAWS(t *testing.T) {
 	cfg.TargetOS = targetLinux
 	server := Server{Provider: "aws", CloudID: "i-123"}
 	target := SSHTarget{TargetOS: targetLinux}
-	if got := checkpointCreateMode("auto", cfg, server, target, false); got != checkpointKindArchive {
+	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindArchive {
 		t.Fatalf("mode=%q, want archive", got)
 	}
 }
@@ -165,7 +192,7 @@ func TestCheckpointCreateModeNativeUsesResolvedProvider(t *testing.T) {
 	cfg.Provider = "aws"
 	cfg.TargetOS = targetLinux
 	server := Server{Provider: "hetzner", CloudID: "123"}
-	if got := checkpointCreateMode("native", cfg, server, SSHTarget{TargetOS: targetLinux}, false); got != "unsupported" {
+	if got := checkpointCreateMode("native", "", cfg, server, SSHTarget{TargetOS: targetLinux}, false); got != "unsupported" {
 		t.Fatalf("mode=%q, want unsupported", got)
 	}
 }
@@ -174,7 +201,7 @@ func TestCheckpointCreateModeFallsBackToArchiveForSSH(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "ssh"
 	cfg.TargetOS = targetLinux
-	if got := checkpointCreateMode("auto", cfg, Server{Provider: "ssh"}, SSHTarget{TargetOS: targetLinux}, false); got != checkpointKindArchive {
+	if got := checkpointCreateMode("auto", "", cfg, Server{Provider: "ssh"}, SSHTarget{TargetOS: targetLinux}, false); got != checkpointKindArchive {
 		t.Fatalf("mode=%q", got)
 	}
 }
@@ -322,6 +349,7 @@ func TestApplyAWSAMICheckpointForkConfigRecomputesServerType(t *testing.T) {
 	cfg.Class = "beast"
 	cfg.ServerType = "ccx63"
 	cfg.ServerTypeExplicit = true
+	cfg.CoordAdminToken = "admin-token"
 	record := checkpointRecord{Kind: checkpointKindAWSAMI, TargetOS: targetLinux, WindowsMode: windowsModeNormal}
 	record.Native.ImageID = "ami-12345678"
 	record.Native.Region = "eu-west-1"
@@ -330,6 +358,9 @@ func TestApplyAWSAMICheckpointForkConfigRecomputesServerType(t *testing.T) {
 
 	if cfg.Provider != "aws" || cfg.AWSAMI != "ami-12345678" || cfg.AWSRegion != "eu-west-1" {
 		t.Fatalf("aws config not applied: %#v", cfg)
+	}
+	if cfg.CoordToken != "admin-token" {
+		t.Fatalf("coord token=%q, want admin token for native checkpoint fork", cfg.CoordToken)
 	}
 	if cfg.ServerTypeExplicit {
 		t.Fatal("ServerTypeExplicit=true, want false")
@@ -356,6 +387,90 @@ func TestApplyAWSAMICheckpointForkConfigPreservesExplicitTypeFlag(t *testing.T) 
 
 	if cfg.ServerType != "c7a.4xlarge" || !cfg.ServerTypeExplicit {
 		t.Fatalf("explicit type not preserved: type=%q explicit=%t", cfg.ServerType, cfg.ServerTypeExplicit)
+	}
+}
+
+func TestApplyNativeCheckpointForkConfigForAzureAndGCP(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		record checkpointRecord
+		check  func(t *testing.T, cfg Config)
+	}{
+		{
+			name: "azure",
+			record: func() checkpointRecord {
+				record := checkpointRecord{Kind: checkpointKindAzure, TargetOS: targetLinux}
+				record.Native.ImageID = "checkpoint-azure"
+				record.Native.Resource = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/images/checkpoint-azure"
+				record.Native.Region = "eastus"
+				return record
+			}(),
+			check: func(t *testing.T, cfg Config) {
+				if cfg.Provider != "azure" || cfg.AzureLocation != "eastus" || cfg.AzureImage == "" {
+					t.Fatalf("azure config not applied: %#v", cfg)
+				}
+			},
+		},
+		{
+			name: "azure disk snapshot",
+			record: func() checkpointRecord {
+				record := checkpointRecord{Kind: checkpointKindAzureOS, TargetOS: targetLinux}
+				record.Native.ImageID = "checkpoint-azure"
+				record.Native.Resource = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint-azure"
+				record.Native.Region = "eastus"
+				return record
+			}(),
+			check: func(t *testing.T, cfg Config) {
+				if cfg.Provider != "azure" || cfg.AzureLocation != "eastus" || cfg.AzureSnapshot == "" {
+					t.Fatalf("azure snapshot config not applied: %#v", cfg)
+				}
+			},
+		},
+		{
+			name: "gcp",
+			record: func() checkpointRecord {
+				record := checkpointRecord{Kind: checkpointKindGCP, TargetOS: targetLinux}
+				record.Native.ImageID = "checkpoint-gcp"
+				record.Native.Resource = "projects/proj/global/machineImages/checkpoint-gcp"
+				record.Native.Region = "us-central1-a"
+				record.Native.Project = "proj"
+				return record
+			}(),
+			check: func(t *testing.T, cfg Config) {
+				if cfg.Provider != "gcp" || cfg.GCPZone != "us-central1-a" || cfg.GCPProject != "proj" || cfg.GCPMachineImage == "" || !cfg.gcpProjectExplicit {
+					t.Fatalf("gcp config not applied: %#v", cfg)
+				}
+			},
+		},
+		{
+			name: "gcp disk snapshot",
+			record: func() checkpointRecord {
+				record := checkpointRecord{Kind: checkpointKindGCPDisk, TargetOS: targetLinux}
+				record.Native.ImageID = "checkpoint-gcp"
+				record.Native.Resource = "projects/proj/global/snapshots/checkpoint-gcp"
+				record.Native.Region = "us-central1-a"
+				record.Native.Project = "proj"
+				return record
+			}(),
+			check: func(t *testing.T, cfg Config) {
+				if cfg.Provider != "gcp" || cfg.GCPZone != "us-central1-a" || cfg.GCPProject != "proj" || cfg.GCPSnapshot == "" || !cfg.gcpProjectExplicit {
+					t.Fatalf("gcp snapshot config not applied: %#v", cfg)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newFlagSet("checkpoint fork", io.Discard)
+			_ = fs.String("type", "", "provider type")
+			cfg := defaultConfig()
+			cfg.Provider = "hetzner"
+			cfg.Class = "standard"
+			applyNativeCheckpointForkConfig(&cfg, fs, tc.record)
+			tc.check(t, cfg)
+			if cfg.ServerTypeExplicit {
+				t.Fatal("ServerTypeExplicit=true, want false")
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -34,7 +34,7 @@ type crabboxKongCLI struct {
 	List       listKongCmd       `cmd:"" passthrough:"" help:"List Crabbox machines."`
 	Share      shareKongCmd      `cmd:"" passthrough:"" help:"Share a lease with users or the owning org."`
 	Unshare    unshareKongCmd    `cmd:"" passthrough:"" help:"Remove lease sharing."`
-	Image      imageKongCmd      `cmd:"" help:"Create or promote brokered AWS runner images."`
+	Image      imageKongCmd      `cmd:"" help:"Create provider images and promote brokered AWS runner images."`
 	Usage      usageKongCmd      `cmd:"" passthrough:"" help:"Show cost and usage estimates by user, org, or fleet."`
 	Admin      adminKongCmd      `cmd:"" help:"Lease admin controls for trusted operators."`
 	Actions    actionsKongCmd    `cmd:"" help:"Register GitHub Actions runners or dispatch workflows."`
@@ -306,9 +306,9 @@ type cacheWarmKongCmd struct {
 }
 
 type imageKongCmd struct {
-	Create  imageCreateKongCmd  `cmd:"" passthrough:"" help:"Create an AMI from a brokered AWS lease."`
+	Create  imageCreateKongCmd  `cmd:"" passthrough:"" help:"Create a provider image from a brokered lease."`
 	Promote imagePromoteKongCmd `cmd:"" passthrough:"" help:"Promote an AMI for brokered AWS runners."`
-	Delete  imageDeleteKongCmd  `cmd:"" passthrough:"" help:"Delete an AWS AMI and its EBS snapshots."`
+	Delete  imageDeleteKongCmd  `cmd:"" passthrough:"" help:"Delete a provider image."`
 }
 type imageCreateKongCmd struct {
 	Args []string `arg:"" optional:""`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Image              string
 	AWSRegion          string
 	AWSAMI             string
+	AWSSnapshot        string
 	AWSSGID            string
 	AWSSubnetID        string
 	AWSProfile         string
@@ -44,6 +45,7 @@ type Config struct {
 	AzureLocation      string
 	AzureResourceGroup string
 	AzureImage         string
+	AzureSnapshot      string
 	AzureVNet          string
 	AzureSubnet        string
 	AzureNSG           string
@@ -55,6 +57,8 @@ type Config struct {
 	gcpZoneExplicit    bool
 	GCPImage           string
 	gcpImageExplicit   bool
+	GCPMachineImage    string
+	GCPSnapshot        string
 	GCPNetwork         string
 	gcpNetworkExplicit bool
 	GCPSubnet          string

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -168,8 +168,19 @@ type CoordinatorImage struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
 	State      string `json:"state"`
+	Provider   string `json:"provider,omitempty"`
+	Kind       string `json:"kind,omitempty"`
 	Region     string `json:"region,omitempty"`
+	Project    string `json:"project,omitempty"`
+	ResourceID string `json:"resourceID,omitempty"`
 	PromotedAt string `json:"promotedAt,omitempty"`
+}
+
+type CoordinatorImageRef struct {
+	Provider string
+	Region   string
+	Project  string
+	Kind     string
 }
 
 type CoordinatorGitHubLoginStart struct {
@@ -535,6 +546,7 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 		"image":                           cfg.Image,
 		"awsRegion":                       cfg.AWSRegion,
 		"awsAMI":                          cfg.AWSAMI,
+		"awsSnapshot":                     cfg.AWSSnapshot,
 		"awsSGID":                         cfg.AWSSGID,
 		"awsSubnetID":                     cfg.AWSSubnetID,
 		"awsProfile":                      cfg.AWSProfile,
@@ -543,6 +555,7 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 		"awsMacHostID":                    cfg.AWSMacHostID,
 		"azureLocation":                   cfg.AzureLocation,
 		"azureImage":                      cfg.AzureImage,
+		"azureSnapshot":                   cfg.AzureSnapshot,
 		"sshUser":                         cfg.SSHUser,
 		"sshPort":                         cfg.SSHPort,
 		"sshFallbackPorts":                cfg.SSHFallbackPorts,
@@ -574,6 +587,12 @@ func addCoordinatorGCPFields(req map[string]any, cfg Config) {
 	}
 	if cfg.GCPImage != "" && (cfg.gcpImageExplicit || cfg.GCPImage != base.GCPImage) {
 		req["gcpImage"] = cfg.GCPImage
+	}
+	if cfg.GCPMachineImage != "" {
+		req["gcpMachineImage"] = cfg.GCPMachineImage
+	}
+	if cfg.GCPSnapshot != "" {
+		req["gcpSnapshot"] = cfg.GCPSnapshot
 	}
 	if cfg.GCPNetwork != "" && (cfg.gcpNetworkExplicit || cfg.GCPNetwork != base.GCPNetwork) {
 		req["gcpNetwork"] = cfg.GCPNetwork
@@ -894,49 +913,65 @@ func (c *CoordinatorClient) AdminDeleteLease(ctx context.Context, id string) (Co
 	return res.Lease, err
 }
 
-func (c *CoordinatorClient) CreateImage(ctx context.Context, leaseID, name string, noReboot bool) (CoordinatorImage, error) {
+func (c *CoordinatorClient) CreateImage(ctx context.Context, leaseID, name string, noReboot bool, strategies ...string) (CoordinatorImage, error) {
 	var res struct {
 		Image CoordinatorImage `json:"image"`
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/images", map[string]any{
+	req := map[string]any{
 		"leaseID":  leaseID,
 		"name":     name,
 		"noReboot": noReboot,
-	}, &res)
+	}
+	if len(strategies) > 0 && strings.TrimSpace(strategies[0]) != "" {
+		req["strategy"] = strings.TrimSpace(strategies[0])
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/images", req, &res)
 	return res.Image, err
 }
 
-func (c *CoordinatorClient) Image(ctx context.Context, imageID string, region ...string) (CoordinatorImage, error) {
+func (c *CoordinatorClient) Image(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorImage, error) {
 	var res struct {
 		Image CoordinatorImage `json:"image"`
 	}
-	err := c.do(ctx, http.MethodGet, imagePath(imageID, "", region...), nil, &res)
+	err := c.do(ctx, http.MethodGet, imagePath(imageID, "", refs...), nil, &res)
 	return res.Image, err
 }
 
-func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, region ...string) (CoordinatorImage, error) {
+func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorImage, error) {
 	var res struct {
 		Image CoordinatorImage `json:"image"`
 	}
-	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote", region...), map[string]any{}, &res)
+	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote", refs...), map[string]any{}, &res)
 	return res.Image, err
 }
 
-func (c *CoordinatorClient) DeleteImage(ctx context.Context, imageID string, region ...string) error {
-	return c.do(ctx, http.MethodDelete, imagePath(imageID, "", region...), nil, nil)
+func (c *CoordinatorClient) DeleteImage(ctx context.Context, imageID string, refs ...CoordinatorImageRef) error {
+	return c.do(ctx, http.MethodDelete, imagePath(imageID, "", refs...), nil, nil)
 }
 
-func imagePath(imageID, action string, region ...string) string {
+func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {
 	path := "/v1/images/" + url.PathEscape(imageID)
 	if action != "" {
 		path += "/" + url.PathEscape(action)
 	}
-	selected := ""
-	if len(region) > 0 {
-		selected = strings.TrimSpace(region[0])
+	values := url.Values{}
+	if len(refs) > 0 {
+		ref := refs[0]
+		if strings.TrimSpace(ref.Provider) != "" {
+			values.Set("provider", strings.TrimSpace(ref.Provider))
+		}
+		if strings.TrimSpace(ref.Region) != "" {
+			values.Set("region", strings.TrimSpace(ref.Region))
+		}
+		if strings.TrimSpace(ref.Project) != "" {
+			values.Set("project", strings.TrimSpace(ref.Project))
+		}
+		if strings.TrimSpace(ref.Kind) != "" {
+			values.Set("kind", strings.TrimSpace(ref.Kind))
+		}
 	}
-	if selected != "" {
-		path += "?region=" + url.QueryEscape(selected)
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
 	}
 	return path
 }

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -467,11 +467,14 @@ func TestCoordinatorLeaseWatchCancelsWhenLeaseReleased(t *testing.T) {
 func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 	var body struct {
 		Provider           string   `json:"provider"`
+		AWSSnapshot        string   `json:"awsSnapshot"`
 		AWSSSHCIDRs        []string `json:"awsSSHCIDRs"`
 		AzureLocation      string   `json:"azureLocation"`
 		AzureImage         string   `json:"azureImage"`
+		AzureSnapshot      string   `json:"azureSnapshot"`
 		GCPProject         string   `json:"gcpProject"`
 		GCPZone            string   `json:"gcpZone"`
+		GCPSnapshot        string   `json:"gcpSnapshot"`
 		GCPNetwork         string   `json:"gcpNetwork"`
 		GCPTags            []string `json:"gcpTags"`
 		GCPSSHCIDRs        []string `json:"gcpSSHCIDRs"`
@@ -497,9 +500,11 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 		Provider:           "google",
 		ServerType:         "t3.small",
 		ServerTypeExplicit: true,
+		AWSSnapshot:        "snap-123",
 		AWSSSHCIDRs:        []string{"198.51.100.7/32"},
 		AzureLocation:      "eastus",
 		AzureImage:         "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+		AzureSnapshot:      "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint",
 		GCPProject:         "crabbox-project",
 		gcpProjectExplicit: true,
 		GCPZone:            "europe-west2-b",
@@ -507,6 +512,7 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 		GCPNetwork:         "crabbox-net",
 		GCPTags:            []string{"crabbox-ci"},
 		GCPSSHCIDRs:        []string{"198.51.100.11/32"},
+		GCPSnapshot:        "projects/crabbox-project/global/snapshots/checkpoint",
 		GCPRootGB:          900,
 		SSHFallbackPorts:   []string{"22", "2022"},
 		Capacity: CapacityConfig{
@@ -530,6 +536,9 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 	}
 	if body.AzureImage != "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest" {
 		t.Fatalf("azureImage=%q", body.AzureImage)
+	}
+	if body.AWSSnapshot != "snap-123" || body.AzureSnapshot == "" || body.GCPSnapshot == "" {
+		t.Fatalf("snapshot fields not forwarded: aws=%q azure=%q gcp=%q", body.AWSSnapshot, body.AzureSnapshot, body.GCPSnapshot)
 	}
 	if body.GCPProject != "crabbox-project" || body.GCPZone != "europe-west2-b" || body.GCPNetwork != "crabbox-net" || body.GCPRootGB != 900 {
 		t.Fatalf("unexpected gcp body: %#v", body)
@@ -834,6 +843,9 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 			_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","name":"openclaw-crabbox-test","state":"pending","region":"eu-west-1"}}`))
 		case "/v1/images/ami-12345678":
 			if r.Method == http.MethodDelete {
+				if got := r.URL.Query().Get("kind"); got != "aws-ami" {
+					t.Fatalf("delete kind=%q", got)
+				}
 				_, _ = w.Write([]byte(`{"imageID":"ami-12345678","deleted":true}`))
 				return
 			}
@@ -863,7 +875,7 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678"); err != nil || promoted.PromotedAt == "" {
 		t.Fatalf("promoted=%#v err=%v", promoted, err)
 	}
-	if err := client.DeleteImage(context.Background(), "ami-12345678"); err != nil {
+	if err := client.DeleteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "eu-west-1", Kind: "aws-ami"}); err != nil {
 		t.Fatalf("delete image: %v", err)
 	}
 }

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -5,33 +5,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
 func (a App) imageCreate(ctx context.Context, args []string) error {
 	fs := newFlagSet("image create", a.Stderr)
-	id := fs.String("id", "", "AWS lease id to image")
-	name := fs.String("name", "", "AMI name")
-	wait := fs.Bool("wait", false, "wait until the AMI is available")
+	id := fs.String("id", "", "lease id to image")
+	name := fs.String("name", "", "provider image name")
+	wait := fs.Bool("wait", false, "wait until the provider image is available")
 	waitTimeout := fs.Duration("wait-timeout", 45*time.Minute, "maximum wait duration")
-	noReboot := fs.Bool("no-reboot", true, "avoid rebooting the source instance while creating the AMI")
+	noReboot := fs.Bool("no-reboot", true, "avoid rebooting the source AWS instance while creating the AMI")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if *id == "" || *name == "" {
-		return exit(2, "usage: crabbox image create --id <cbx_id> --name <ami-name> [--wait]")
+		return exit(2, "usage: crabbox image create --id <cbx_id> --name <image-name> [--wait]")
 	}
 	coord, err := configuredAdminCoordinator()
 	if err != nil {
 		return err
 	}
-	image, err := coord.CreateImage(ctx, *id, *name, *noReboot)
+	image, err := coord.CreateImage(ctx, *id, *name, *noReboot, checkpointStrategyImage)
 	if err != nil {
 		return err
 	}
 	if *wait {
-		image, err = waitForImage(ctx, coord, image.ID, image.Region, *waitTimeout, a.Stderr)
+		image, err = waitForImage(ctx, coord, image.ID, imageRefFromCoordinatorImage(image), *waitTimeout, a.Stderr)
 		if err != nil {
 			return err
 		}
@@ -57,7 +58,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	image, err := coord.PromoteImage(ctx, fs.Arg(0), *region)
+	image, err := coord.PromoteImage(ctx, fs.Arg(0), CoordinatorImageRef{Provider: "aws", Region: *region})
 	if err != nil {
 		return err
 	}
@@ -70,37 +71,45 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 
 func (a App) imageDelete(ctx context.Context, args []string) error {
 	fs := newFlagSet("image delete", a.Stderr)
-	region := fs.String("region", "", "AWS region containing the AMI")
+	provider := fs.String("provider", "aws", "image provider: aws, azure, or gcp")
+	region := fs.String("region", "", "region, location, or zone containing the image")
+	project := fs.String("project", "", "GCP project containing the image")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image delete <ami-id> [--region <region>]")
+		return exit(2, "usage: crabbox image delete <image-id> [--provider aws|azure|gcp] [--region <region>] [--project <project>]")
+	}
+	normalizedProvider := normalizeProviderName(*provider)
+	if normalizedProvider != "aws" && normalizedProvider != "azure" && normalizedProvider != "gcp" {
+		return exit(2, "unsupported image provider %q; use aws, azure, or gcp", *provider)
 	}
 	coord, err := configuredAdminCoordinator()
 	if err != nil {
 		return err
 	}
-	if err := coord.DeleteImage(ctx, fs.Arg(0), *region); err != nil {
+	ref := CoordinatorImageRef{Provider: normalizedProvider, Region: *region, Project: *project}
+	if err := coord.DeleteImage(ctx, fs.Arg(0), ref); err != nil {
 		return err
 	}
-	fmt.Fprintf(a.Stdout, "deleted image=%s region=%s\n", fs.Arg(0), blank(*region, "-"))
+	fmt.Fprintf(a.Stdout, "deleted image=%s provider=%s region=%s project=%s\n", fs.Arg(0), normalizedProvider, blank(*region, "-"), blank(*project, "-"))
 	return nil
 }
 
-func waitForImage(ctx context.Context, coord *CoordinatorClient, imageID, region string, timeout time.Duration, stderr io.Writer) (CoordinatorImage, error) {
+func waitForImage(ctx context.Context, coord *CoordinatorClient, imageID string, ref CoordinatorImageRef, timeout time.Duration, stderr io.Writer) (CoordinatorImage, error) {
 	deadline := time.Now().Add(timeout)
 	var last CoordinatorImage
 	for {
-		image, err := coord.Image(ctx, imageID, region)
+		image, err := coord.Image(ctx, imageID, ref)
 		if err != nil {
 			return CoordinatorImage{}, err
 		}
 		last = image
-		if image.State == "available" {
+		state := strings.ToLower(image.State)
+		if state == "available" || state == "ready" || state == "succeeded" || state == "completed" {
 			return image, nil
 		}
-		if image.State == "failed" {
+		if state == "failed" || state == "invalid" {
 			return CoordinatorImage{}, exit(5, "image %s failed", imageID)
 		}
 		if time.Now().After(deadline) {
@@ -112,5 +121,14 @@ func waitForImage(ctx context.Context, coord *CoordinatorClient, imageID, region
 			return CoordinatorImage{}, ctx.Err()
 		case <-time.After(15 * time.Second):
 		}
+	}
+}
+
+func imageRefFromCoordinatorImage(image CoordinatorImage) CoordinatorImageRef {
+	return CoordinatorImageRef{
+		Provider: image.Provider,
+		Region:   image.Region,
+		Project:  image.Project,
+		Kind:     image.Kind,
 	}
 }

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -120,6 +120,17 @@ func isCoordinatorStaleInstanceCleanedSignal(err error) bool {
 func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
 	lease, err := b.coord.GetLease(ctx, req.ID)
 	if err != nil {
+		if b.cfg.CoordAdminToken != "" && (isCoordinatorNotFoundError(err) || isCoordinatorUnauthorized(err)) {
+			adminCoord, adminErr := b.adminCoordinatorClient()
+			if adminErr != nil {
+				return LeaseTarget{}, err
+			}
+			lease, adminErr = adminCoord.GetLease(ctx, req.ID)
+			if adminErr == nil {
+				server, target, leaseID := leaseToServerTarget(lease, b.cfg)
+				return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: adminCoord}, nil
+			}
+		}
 		return LeaseTarget{}, err
 	}
 	server, target, leaseID := leaseToServerTarget(lease, b.cfg)
@@ -261,10 +272,27 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 		return exit(2, "missing coordinator lease id")
 	}
 	if err := releaseCoordinatorLease(ctx, b.coord, req.Lease.LeaseID); err != nil {
+		if b.cfg.CoordAdminToken != "" && (isCoordinatorNotFoundError(err) || isCoordinatorUnauthorized(err)) {
+			adminCoord, adminErr := b.adminCoordinatorClient()
+			if adminErr != nil {
+				return err
+			}
+			if _, adminErr = adminCoord.AdminReleaseLease(ctx, req.Lease.LeaseID, true); adminErr == nil {
+				removeLeaseClaim(req.Lease.LeaseID)
+				return nil
+			}
+		}
 		return err
 	}
 	removeLeaseClaim(req.Lease.LeaseID)
 	return nil
+}
+
+func (b *coordinatorLeaseBackend) adminCoordinatorClient() (*CoordinatorClient, error) {
+	cfg := b.cfg
+	cfg.CoordToken = cfg.CoordAdminToken
+	coord, _, err := newCoordinatorClient(cfg)
+	return coord, err
 }
 
 func (b *coordinatorLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -114,6 +114,106 @@ func TestCoordinatorListJSONFallsBackWhenAdminTokenMissing(t *testing.T) {
 	}
 }
 
+func TestCoordinatorResolveFallsBackToAdminToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_admin" {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Header.Get("Authorization") {
+		case "Bearer user-token":
+			http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+		case "Bearer admin-token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID:                 "cbx_admin",
+				Slug:               "green-shrimp",
+				Provider:           "aws",
+				TargetOS:           targetLinux,
+				CloudID:            "i-admin",
+				Host:               "203.0.113.44",
+				SSHUser:            "crabbox",
+				SSHPort:            "2222",
+				SSHFallbackPorts:   []string{"22"},
+				WorkRoot:           "/work/crabbox",
+				State:              "active",
+				ServerType:         "t3.small",
+				IdleTimeoutSeconds: 600,
+			}})
+		default:
+			t.Fatalf("unexpected auth %q", r.Header.Get("Authorization"))
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		Provider:        "aws",
+		TargetOS:        targetLinux,
+		Coordinator:     server.URL,
+		CoordToken:      "user-token",
+		CoordAdminToken: "admin-token",
+	}
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "cbx_admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_admin" || lease.SSH.Host != "203.0.113.44" || lease.Coordinator == nil {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if lease.Coordinator.Token != "admin-token" {
+		t.Fatalf("coordinator token=%q, want admin token", lease.Coordinator.Token)
+	}
+}
+
+func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
+	adminReleased := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/admin/leases/cbx_admin/release" && r.URL.Path != "/v1/leases/cbx_admin/release" {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Header.Get("Authorization") {
+		case "Bearer user-token":
+			http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+		case "Bearer admin-token":
+			if r.URL.Path != "/v1/admin/leases/cbx_admin/release" {
+				t.Fatalf("admin release path=%s", r.URL.Path)
+			}
+			adminReleased = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_admin", Provider: "aws", State: "released"}})
+		default:
+			t.Fatalf("unexpected auth %q", r.Header.Get("Authorization"))
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		Provider:        "aws",
+		TargetOS:        targetLinux,
+		Coordinator:     server.URL,
+		CoordToken:      "user-token",
+		CoordAdminToken: "admin-token",
+	}
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+
+	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_admin"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !adminReleased {
+		t.Fatal("admin release was not called")
+	}
+}
+
 func TestCoordinatorAcquireReleasesStaleInstanceLease(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -35,7 +35,7 @@ extract_lease() {
 }
 
 extract_slug() {
-  sed -n 's/.*slug=\([^ ]*\).*/\1/p' | rg -v '^-$' | head -1
+  sed -n 's/.*slug=\([^ ]*\).*/\1/p' | rg -v '^-$' | tail -1
 }
 
 stop_lease() {

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -118,72 +118,35 @@ export class EC2SpotClient {
     attempts?: ProvisioningAttempt[];
   }> {
     await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
-    const imageID = await this.resolveAMI(config);
-    const securityGroupID = await this.ensureSecurityGroup(config);
-    const candidates = awsLaunchCandidates(config);
-    const failures: string[] = [];
-    const attempts: ProvisioningAttempt[] = [];
-    const quotaCache = new Map<string, number | undefined>();
-    for (const serverType of candidates) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
-      const preflight = await this.quotaPreflightAttempt(
-        serverType,
-        config.capacityMarket,
-        quotaCache,
-      );
-      if (preflight) {
-        attempts.push(preflight);
-        failures.push(`${serverType}: ${preflight.message}`);
-        continue;
-      }
-      try {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback must stay sequential.
-        const server = await this.createServer(
-          { ...config, serverType },
-          leaseID,
-          slug,
-          owner,
-          imageID,
-          securityGroupID,
-        );
-        const result: {
-          server: ProviderMachine;
-          serverType: string;
-          market?: string;
-          attempts?: ProvisioningAttempt[];
-        } = { server, serverType, market: config.capacityMarket };
-        if (attempts.length > 0) {
-          result.attempts = attempts;
-        }
-        return result;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        attempts.push({
-          region: this.region,
-          serverType,
-          market: config.capacityMarket,
-          category: awsProvisioningErrorCategory(message) || "fatal",
-          message: conciseAWSProvisioningMessage(message),
-        });
-        failures.push(`${serverType}: ${message}`);
-        if (!isRetryableAWSProvisioningError(message)) {
-          break;
-        }
-      }
-    }
-    if (config.capacityMarket === "spot" && config.capacityFallback.startsWith("on-demand")) {
+    let transientImageID = "";
+    try {
+      const imageID = config.awsSnapshot
+        ? await (async () => {
+            transientImageID = await this.registerSnapshotImage(config.awsSnapshot, leaseID);
+            return this.waitForImageAvailable(transientImageID);
+          })()
+        : await this.resolveAMI(config);
+      const securityGroupID = await this.ensureSecurityGroup(config);
+      const candidates = awsLaunchCandidates(config);
+      const failures: string[] = [];
+      const attempts: ProvisioningAttempt[] = [];
+      const quotaCache = new Map<string, number | undefined>();
       for (const serverType of candidates) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
-        const preflight = await this.quotaPreflightAttempt(serverType, "on-demand", quotaCache);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
+        const preflight = await this.quotaPreflightAttempt(
+          serverType,
+          config.capacityMarket,
+          quotaCache,
+        );
         if (preflight) {
           attempts.push(preflight);
-          failures.push(`on-demand ${serverType}: ${preflight.message}`);
+          failures.push(`${serverType}: ${preflight.message}`);
           continue;
         }
         try {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback must stay sequential.
           const server = await this.createServer(
-            { ...config, capacityMarket: "on-demand", serverType },
+            { ...config, serverType },
             leaseID,
             slug,
             owner,
@@ -195,7 +158,7 @@ export class EC2SpotClient {
             serverType: string;
             market?: string;
             attempts?: ProvisioningAttempt[];
-          } = { server, serverType, market: "on-demand" };
+          } = { server, serverType, market: config.capacityMarket };
           if (attempts.length > 0) {
             result.attempts = attempts;
           }
@@ -205,23 +168,72 @@ export class EC2SpotClient {
           attempts.push({
             region: this.region,
             serverType,
-            market: "on-demand",
+            market: config.capacityMarket,
             category: awsProvisioningErrorCategory(message) || "fatal",
             message: conciseAWSProvisioningMessage(message),
           });
-          failures.push(`on-demand ${serverType}: ${message}`);
+          failures.push(`${serverType}: ${message}`);
           if (!isRetryableAWSProvisioningError(message)) {
             break;
           }
         }
       }
+      if (config.capacityMarket === "spot" && config.capacityFallback.startsWith("on-demand")) {
+        for (const serverType of candidates) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
+          const preflight = await this.quotaPreflightAttempt(serverType, "on-demand", quotaCache);
+          if (preflight) {
+            attempts.push(preflight);
+            failures.push(`on-demand ${serverType}: ${preflight.message}`);
+            continue;
+          }
+          try {
+            // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
+            const server = await this.createServer(
+              { ...config, capacityMarket: "on-demand", serverType },
+              leaseID,
+              slug,
+              owner,
+              imageID,
+              securityGroupID,
+            );
+            const result: {
+              server: ProviderMachine;
+              serverType: string;
+              market?: string;
+              attempts?: ProvisioningAttempt[];
+            } = { server, serverType, market: "on-demand" };
+            if (attempts.length > 0) {
+              result.attempts = attempts;
+            }
+            return result;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            attempts.push({
+              region: this.region,
+              serverType,
+              market: "on-demand",
+              category: awsProvisioningErrorCategory(message) || "fatal",
+              message: conciseAWSProvisioningMessage(message),
+            });
+            failures.push(`on-demand ${serverType}: ${message}`);
+            if (!isRetryableAWSProvisioningError(message)) {
+              break;
+            }
+          }
+        }
+      }
+      if (config.serverTypeExplicit) {
+        throw new Error(
+          `requested exact AWS instance type ${config.serverType} failed; remove --type to allow class fallback: ${failures.join("; ")}`,
+        );
+      }
+      throw new Error(failures.join("; "));
+    } finally {
+      if (transientImageID) {
+        await this.ec2("DeregisterImage", { ImageId: transientImageID }).catch(() => undefined);
+      }
     }
-    if (config.serverTypeExplicit) {
-      throw new Error(
-        `requested exact AWS instance type ${config.serverType} failed; remove --type to allow class fallback: ${failures.join("; ")}`,
-      );
-    }
-    throw new Error(failures.join("; "));
   }
 
   async getServer(instanceID: string): Promise<ProviderMachine> {
@@ -265,6 +277,39 @@ export class EC2SpotClient {
     await this.ec2("TerminateInstances", { "InstanceId.1": instanceID });
   }
 
+  async createDiskSnapshot(instanceID: string, name: string): Promise<ProviderImage> {
+    const source = await this.instanceRootVolumeMetadata(instanceID);
+    const root = await this.ec2("CreateSnapshot", {
+      VolumeId: source.volumeID,
+      Description: `Crabbox checkpoint from ${instanceID}`,
+      "TagSpecification.1.ResourceType": "snapshot",
+      "TagSpecification.1.Tag.1.Key": "crabbox",
+      "TagSpecification.1.Tag.1.Value": "true",
+      "TagSpecification.1.Tag.2.Key": "created_by",
+      "TagSpecification.1.Tag.2.Value": "crabbox",
+      "TagSpecification.1.Tag.3.Key": "Name",
+      "TagSpecification.1.Tag.3.Value": name,
+      "TagSpecification.1.Tag.4.Key": "crabbox_root_device_name",
+      "TagSpecification.1.Tag.4.Value": source.rootDeviceName,
+      "TagSpecification.1.Tag.5.Key": "crabbox_architecture",
+      "TagSpecification.1.Tag.5.Value": source.architecture,
+    });
+    const snapshotID = asString(root["snapshotId"]);
+    if (!snapshotID) {
+      throw new Error("aws returned no snapshot id");
+    }
+    return {
+      id: snapshotID,
+      name,
+      state: asString(root["status"]) || "pending",
+      provider: "aws",
+      kind: "aws-ebs-snapshot",
+      region: this.region,
+      resourceID: snapshotID,
+      snapshots: [snapshotID],
+    };
+  }
+
   async createImage(instanceID: string, name: string, noReboot: boolean): Promise<ProviderImage> {
     const params: Record<string, string> = {
       InstanceId: instanceID,
@@ -283,10 +328,21 @@ export class EC2SpotClient {
     if (!imageID) {
       throw new Error("aws returned no image id");
     }
-    return { id: imageID, name, state: "pending", region: this.region };
+    return {
+      id: imageID,
+      name,
+      state: "pending",
+      provider: "aws",
+      kind: "aws-ami",
+      region: this.region,
+      resourceID: imageID,
+    };
   }
 
   async getImage(imageID: string): Promise<ProviderImage> {
+    if (imageID.startsWith("snap-")) {
+      return await this.getSnapshot(imageID);
+    }
     const root = await this.ec2("DescribeImages", {
       "ImageId.1": imageID,
     });
@@ -299,12 +355,19 @@ export class EC2SpotClient {
       id,
       name: asString(image["name"]),
       state: asString(image["imageState"]),
+      provider: "aws",
+      kind: "aws-ami",
       region: this.region,
+      resourceID: id,
       snapshots: imageSnapshotIDs(image),
     };
   }
 
   async deleteImage(imageID: string): Promise<void> {
+    if (imageID.startsWith("snap-")) {
+      await this.deleteSnapshotWithRetry(imageID);
+      return;
+    }
     const image = await this.getImage(imageID);
     await this.ec2("DeregisterImage", { ImageId: imageID }).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -315,6 +378,115 @@ export class EC2SpotClient {
     for (const snapshotID of image.snapshots ?? []) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- EBS snapshot deletes are independent cleanup calls.
       await this.deleteSnapshotWithRetry(snapshotID);
+    }
+  }
+
+  private async getSnapshot(snapshotID: string): Promise<ProviderImage> {
+    const root = await this.ec2("DescribeSnapshots", {
+      "SnapshotId.1": snapshotID,
+    });
+    const snapshot = record(items(record(root["snapshotSet"])["item"])[0]);
+    const id = asString(snapshot["snapshotId"]);
+    if (!id) {
+      throw new Error(`aws snapshot not found: ${snapshotID}`);
+    }
+    return {
+      id,
+      name: tagValue(snapshot, "Name") || id,
+      state: asString(snapshot["status"]),
+      provider: "aws",
+      kind: "aws-ebs-snapshot",
+      region: this.region,
+      resourceID: id,
+      snapshots: [id],
+    };
+  }
+
+  private async instanceRootVolumeMetadata(instanceID: string): Promise<{
+    volumeID: string;
+    rootDeviceName: string;
+    architecture: string;
+  }> {
+    const root = await this.ec2("DescribeInstances", {
+      "InstanceId.1": instanceID,
+    });
+    for (const reservation of reservations(root)) {
+      for (const instance of items(record(record(reservation)["instancesSet"])["item"])) {
+        const inst = record(instance);
+        const rootDevice = asString(inst["rootDeviceName"]) || "/dev/sda1";
+        for (const mapping of items(record(inst["blockDeviceMapping"])["item"])) {
+          const map = record(mapping);
+          if (asString(map["deviceName"]) !== rootDevice) continue;
+          const volumeID = asString(record(map["ebs"])["volumeId"]);
+          if (volumeID) {
+            return {
+              volumeID,
+              rootDeviceName: rootDevice,
+              architecture: asString(inst["architecture"]) || "x86_64",
+            };
+          }
+        }
+      }
+    }
+    throw new Error(`aws root volume not found for instance ${instanceID}`);
+  }
+
+  private async registerSnapshotImage(snapshotID: string, leaseID: string): Promise<string> {
+    const name = `crabbox-${leaseID.replaceAll("_", "-")}-${Date.now()}`;
+    const metadata = await this.snapshotBootMetadata(snapshotID);
+    const root = await this.ec2("RegisterImage", {
+      Name: name,
+      Architecture: metadata.architecture,
+      RootDeviceName: metadata.rootDeviceName,
+      VirtualizationType: "hvm",
+      EnaSupport: "true",
+      "BlockDeviceMapping.1.DeviceName": metadata.rootDeviceName,
+      "BlockDeviceMapping.1.Ebs.SnapshotId": snapshotID,
+      "BlockDeviceMapping.1.Ebs.DeleteOnTermination": "true",
+      "BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+      "TagSpecification.1.ResourceType": "image",
+      "TagSpecification.1.Tag.1.Key": "crabbox",
+      "TagSpecification.1.Tag.1.Value": "true",
+      "TagSpecification.1.Tag.2.Key": "created_by",
+      "TagSpecification.1.Tag.2.Value": "crabbox",
+      "TagSpecification.1.Tag.3.Key": "transient_checkpoint_snapshot",
+      "TagSpecification.1.Tag.3.Value": snapshotID,
+    });
+    const imageID = asString(root["imageId"]);
+    if (!imageID) {
+      throw new Error("aws returned no transient image id");
+    }
+    return imageID;
+  }
+
+  private async snapshotBootMetadata(snapshotID: string): Promise<{
+    rootDeviceName: string;
+    architecture: string;
+  }> {
+    const root = await this.ec2("DescribeSnapshots", {
+      "SnapshotId.1": snapshotID,
+    });
+    const snapshot = record(items(record(root["snapshotSet"])["item"])[0]);
+    return {
+      rootDeviceName: tagValue(snapshot, "crabbox_root_device_name") || "/dev/sda1",
+      architecture: tagValue(snapshot, "crabbox_architecture") || "x86_64",
+    };
+  }
+
+  private async waitForImageAvailable(imageID: string): Promise<string> {
+    const deadline = Date.now() + 600_000;
+    for (;;) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- EC2 AMI availability is eventually consistent.
+      const image = await this.getImage(imageID);
+      if (image.state === "available") return imageID;
+      if (image.state === "failed" || image.state === "invalid") {
+        throw new Error(`aws transient image ${imageID} is ${image.state}`);
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for AWS transient image ${imageID}`);
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- polling interval.
+      await sleep(5_000);
     }
   }
 
@@ -777,6 +949,14 @@ function imageSnapshotIDs(image: Record<string, unknown>): string[] {
     .map((mapping) => asString(record(record(mapping)["ebs"])["snapshotId"]))
     .filter((snapshotID) => snapshotID !== "");
   return [...new Set(snapshots)];
+}
+
+function tagValue(resource: Record<string, unknown>, key: string): string {
+  for (const tag of items(record(resource["tagSet"])["item"])) {
+    const item = record(tag);
+    if (asString(item["key"]) === key) return asString(item["value"]);
+  }
+  return "";
 }
 
 function isRetryableSnapshotDeleteError(message: string): boolean {

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -7,7 +7,7 @@ import {
 } from "./config";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
-import type { Env, ProviderMachine } from "./types";
+import type { Env, ProviderImage, ProviderMachine } from "./types";
 
 const ADDRESS_SPACE = "10.42.0.0/16";
 const SUBNET_CIDR = "10.42.0.0/24";
@@ -37,7 +37,22 @@ interface AzureVM {
   properties?: {
     provisioningState?: string;
     hardwareProfile?: { vmSize?: string };
+    storageProfile?: { osDisk?: { managedDisk?: { id?: string }; osType?: string } };
   };
+}
+
+interface AzureManagedImage {
+  id?: string;
+  name?: string;
+  location?: string;
+  properties?: { provisioningState?: string };
+}
+
+interface AzureSnapshot {
+  id?: string;
+  name?: string;
+  location?: string;
+  properties?: { provisioningState?: string; completionPercent?: number };
 }
 
 interface AzurePublicIP {
@@ -389,30 +404,45 @@ export class AzureClient {
         },
       },
     );
-    const image = parseImageRef(this.imageForConfig(config));
     const customData = btoa(
       config.target === "windows" ? azureWindowsBootstrapPowerShell(config) : cloudInit(config),
     );
-    const osDisk: Record<string, unknown> = {
-      name: `${name}-osdisk`,
-      createOption: "FromImage",
-    };
-    if (await this.supportsEphemeralOS(config.serverType, location)) {
-      osDisk["caching"] = "ReadOnly";
-      osDisk["diffDiskSettings"] = { option: "Local" };
-    } else {
-      osDisk["caching"] = "ReadWrite";
-      osDisk["managedDisk"] = { storageAccountType: "StandardSSD_LRS" };
-    }
+    const storageProfile: Record<string, unknown> = {};
     const vmProperties: Record<string, unknown> = {
       hardwareProfile: { vmSize: config.serverType },
-      storageProfile: {
-        imageReference: image,
-        osDisk,
-      },
-      osProfile: this.osProfile(config, name, leaseID, customData),
+      storageProfile,
       networkProfile: { networkInterfaces: [{ id: nicID }] },
     };
+    if (config.azureSnapshot) {
+      const diskID = await this.createDiskFromSnapshot(
+        config.azureSnapshot,
+        `${name}-osdisk`,
+        location,
+        tags,
+      );
+      storageProfile["osDisk"] = {
+        createOption: "Attach",
+        managedDisk: { id: diskID },
+        osType: config.target === "windows" ? "Windows" : "Linux",
+        caching: "ReadWrite",
+      };
+    } else {
+      const image = azureImageReference(this.imageForConfig(config));
+      const osDisk: Record<string, unknown> = {
+        name: `${name}-osdisk`,
+        createOption: "FromImage",
+      };
+      if (await this.supportsEphemeralOS(config.serverType, location)) {
+        osDisk["caching"] = "ReadOnly";
+        osDisk["diffDiskSettings"] = { option: "Local" };
+      } else {
+        osDisk["caching"] = "ReadWrite";
+        osDisk["managedDisk"] = { storageAccountType: "StandardSSD_LRS" };
+      }
+      storageProfile["imageReference"] = image;
+      storageProfile["osDisk"] = osDisk;
+      vmProperties["osProfile"] = this.osProfile(config, name, leaseID, customData);
+    }
     if (config.capacityMarket === "spot") {
       vmProperties["priority"] = "Spot";
       vmProperties["evictionPolicy"] = "Delete";
@@ -422,6 +452,9 @@ export class AzureClient {
       tags,
       properties: vmProperties,
     });
+    if (config.azureSnapshot && config.target !== "windows") {
+      await this.installLinuxSSHKeyExtension(location, name, tags, config);
+    }
     if (config.target === "windows") {
       await this.installWindowsBootstrapExtension(location, name, tags);
     }
@@ -502,6 +535,184 @@ export class AzureClient {
           },
         },
       },
+    );
+  }
+
+  private async installLinuxSSHKeyExtension(
+    location: string,
+    vmName: string,
+    tags: Record<string, string>,
+    config: LeaseConfig,
+  ): Promise<void> {
+    const user = shellQuote(config.sshUser || "crabbox");
+    const key = shellQuote(config.sshPublicKey);
+    const command = [
+      "set -eu",
+      `user=${user}`,
+      `key=${key}`,
+      `if ! id "$user" >/dev/null 2>&1; then useradd -m -s /bin/bash "$user"; fi`,
+      `home=$(getent passwd "$user" | cut -d: -f6)`,
+      `install -d -m 700 -o "$user" -g "$user" "$home/.ssh"`,
+      `printf '%s\\n' "$key" > "$home/.ssh/authorized_keys"`,
+      `chown "$user:$user" "$home/.ssh/authorized_keys"`,
+      `chmod 600 "$home/.ssh/authorized_keys"`,
+      `if command -v cloud-init >/dev/null 2>&1; then cloud-init clean --logs || true; fi`,
+    ].join("; ");
+    await this.arm(
+      "PUT",
+      `${vmPath(this.resourceGroup, vmName)}/extensions/crabbox-bootstrap`,
+      API_VERSIONS.compute,
+      {
+        location,
+        tags,
+        properties: {
+          publisher: "Microsoft.Azure.Extensions",
+          type: "CustomScript",
+          typeHandlerVersion: "2.1",
+          autoUpgradeMinorVersion: true,
+          settings: { timestamp: Math.trunc(Date.now() / 1000) },
+          protectedSettings: {
+            commandToExecute: `/bin/sh -c ${shellQuote(command)}`,
+          },
+        },
+      },
+    );
+  }
+
+  async createDiskSnapshot(vmName: string, name: string): Promise<ProviderImage> {
+    const vm = await this.arm<AzureVM>(
+      "GET",
+      vmPath(this.resourceGroup, vmName),
+      API_VERSIONS.compute,
+    );
+    const sourceDiskID = vm.properties?.storageProfile?.osDisk?.managedDisk?.id;
+    if (!sourceDiskID) {
+      throw new Error(`azure os disk not found for vm ${vmName}`);
+    }
+    const location = vm.location || this.defaultLocation;
+    const snapshot = await this.arm<AzureSnapshot>(
+      "PUT",
+      azureSnapshotPath(this.resourceGroup, name),
+      API_VERSIONS.disks,
+      {
+        location,
+        tags: { crabbox: "true", managed_by: "crabbox" },
+        properties: {
+          creationData: {
+            createOption: "Copy",
+            sourceResourceId: sourceDiskID,
+          },
+        },
+      },
+    );
+    return azureSnapshotProviderImage(snapshot, name, location);
+  }
+
+  async getImage(name: string, kind?: string): Promise<ProviderImage> {
+    if (kind === "azure-os-disk-snapshot") {
+      return await this.getDiskSnapshot(name);
+    }
+    const imageName = azureResourceName(name);
+    if (kind === "azure-managed-image") {
+      const image = await this.arm<AzureManagedImage>(
+        "GET",
+        azureImagePath(this.resourceGroup, imageName),
+        API_VERSIONS.compute,
+      );
+      return azureProviderImage(image, imageName, image.location || this.defaultLocation);
+    }
+    const image = await this.arm<AzureManagedImage>(
+      "GET",
+      azureImagePath(this.resourceGroup, imageName),
+      API_VERSIONS.compute,
+    ).catch((error) => {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    });
+    if (!image) return await this.getDiskSnapshot(name);
+    return azureProviderImage(image, imageName, image.location || this.defaultLocation);
+  }
+
+  async deleteImage(name: string, kind?: string): Promise<void> {
+    if (kind === "azure-os-disk-snapshot") {
+      await this.deleteDiskSnapshot(name);
+      return;
+    }
+    const imageName = azureResourceName(name);
+    if (kind === "azure-managed-image") {
+      await this.arm(
+        "DELETE",
+        azureImagePath(this.resourceGroup, imageName),
+        API_VERSIONS.compute,
+      ).catch((error) => {
+        if (isNotFound(error)) return undefined;
+        throw error;
+      });
+      return;
+    }
+    const image = await this.arm(
+      "DELETE",
+      azureImagePath(this.resourceGroup, imageName),
+      API_VERSIONS.compute,
+    ).catch((error) => {
+      if (isNotFound(error)) return "not-found";
+      throw error;
+    });
+    if (image !== "not-found") return;
+    await this.deleteDiskSnapshot(name);
+  }
+
+  private async getDiskSnapshot(name: string): Promise<ProviderImage> {
+    const snapshot = await this.arm<AzureSnapshot>(
+      "GET",
+      azureSnapshotPath(this.resourceGroup, azureResourceName(name)),
+      API_VERSIONS.disks,
+    );
+    return azureSnapshotProviderImage(
+      snapshot,
+      azureResourceName(name),
+      snapshot.location || this.defaultLocation,
+    );
+  }
+
+  private async deleteDiskSnapshot(name: string): Promise<void> {
+    await this.arm(
+      "DELETE",
+      azureSnapshotPath(this.resourceGroup, azureResourceName(name)),
+      API_VERSIONS.disks,
+    ).catch((error) => {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    });
+  }
+
+  private async createDiskFromSnapshot(
+    snapshotID: string,
+    diskName: string,
+    location: string,
+    tags: Record<string, string>,
+  ): Promise<string> {
+    const sourceResourceId = snapshotID.startsWith("/subscriptions/")
+      ? snapshotID
+      : `/subscriptions/${this.subscription}${azureSnapshotPath(this.resourceGroup, snapshotID)}`;
+    const disk = await this.arm<{ id?: string }>(
+      "PUT",
+      `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${diskName}`,
+      API_VERSIONS.disks,
+      {
+        location,
+        tags,
+        properties: {
+          creationData: {
+            createOption: "Copy",
+            sourceResourceId,
+          },
+        },
+      },
+    );
+    return (
+      disk.id ??
+      `/subscriptions/${this.subscription}/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${diskName}`
     );
   }
 
@@ -687,6 +898,20 @@ function networkPath(rg: string, kind: string, name: string): string {
   return `/resourceGroups/${rg}/providers/Microsoft.Network/${kind}/${name}`;
 }
 
+function azureImageReference(value: string):
+  | { id: string }
+  | {
+      publisher: string;
+      offer: string;
+      sku: string;
+      version: string;
+    } {
+  if (value.startsWith("/subscriptions/")) {
+    return { id: value };
+  }
+  return parseImageRef(value);
+}
+
 function parseImageRef(value: string): {
   publisher: string;
   offer: string;
@@ -698,6 +923,59 @@ function parseImageRef(value: string): {
     throw new Error(`azure image must be Publisher:Offer:SKU:Version, got ${value}`);
   }
   return { publisher: parts[0]!, offer: parts[1]!, sku: parts[2]!, version: parts[3]! };
+}
+
+function azureImagePath(rg: string, name: string): string {
+  return `/resourceGroups/${rg}/providers/Microsoft.Compute/images/${name}`;
+}
+
+function azureSnapshotPath(rg: string, name: string): string {
+  return `/resourceGroups/${rg}/providers/Microsoft.Compute/snapshots/${name}`;
+}
+
+function azureResourceName(value: string): string {
+  return value.slice(value.lastIndexOf("/") + 1);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+function azureProviderImage(
+  image: AzureManagedImage,
+  fallbackName: string,
+  location: string,
+): ProviderImage {
+  const out: ProviderImage = {
+    id: image.name ?? fallbackName,
+    name: image.name ?? fallbackName,
+    state: image.properties?.provisioningState?.toLowerCase() || "succeeded",
+    provider: "azure",
+    kind: "azure-managed-image",
+    region: location,
+  };
+  if (image.id) out.resourceID = image.id;
+  return out;
+}
+
+function azureSnapshotProviderImage(
+  snapshot: AzureSnapshot,
+  fallbackName: string,
+  location: string,
+): ProviderImage {
+  const out: ProviderImage = {
+    id: snapshot.name ?? fallbackName,
+    name: snapshot.name ?? fallbackName,
+    state: snapshot.properties?.provisioningState?.toLowerCase() || "succeeded",
+    provider: "azure",
+    kind: "azure-os-disk-snapshot",
+    region: location,
+  };
+  if (snapshot.id) {
+    out.resourceID = snapshot.id;
+    out.snapshots = [snapshot.id];
+  }
+  return out;
 }
 
 function toMachine(vm: AzureVM, ip: string): ProviderMachine {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -21,6 +21,7 @@ export interface LeaseConfig {
   image: string;
   awsRegion: string;
   awsAMI: string;
+  awsSnapshot: string;
   awsSGID: string;
   awsSubnetID: string;
   awsProfile: string;
@@ -29,9 +30,12 @@ export interface LeaseConfig {
   awsMacHostID: string;
   azureLocation: string;
   azureImage: string;
+  azureSnapshot: string;
   gcpProject: string;
   gcpZone: string;
   gcpImage: string;
+  gcpMachineImage: string;
+  gcpSnapshot: string;
   gcpNetwork: string;
   gcpSubnet: string;
   gcpTags: string[];
@@ -135,6 +139,7 @@ export function leaseConfig(input: LeaseRequest): LeaseConfig {
     image: input.image ?? "ubuntu-24.04",
     awsRegion: input.awsRegion ?? "eu-west-1",
     awsAMI: input.awsAMI ?? "",
+    awsSnapshot: input.awsSnapshot ?? "",
     awsSGID: input.awsSGID ?? "",
     awsSubnetID: input.awsSubnetID ?? "",
     awsProfile: input.awsProfile ?? "",
@@ -143,9 +148,12 @@ export function leaseConfig(input: LeaseRequest): LeaseConfig {
     awsMacHostID: input.awsMacHostID ?? "",
     azureLocation: input.azureLocation ?? "",
     azureImage: input.azureImage ?? "",
+    azureSnapshot: input.azureSnapshot ?? "",
     gcpProject: input.gcpProject ?? "",
     gcpZone: input.gcpZone ?? "",
     gcpImage: input.gcpImage ?? "",
+    gcpMachineImage: input.gcpMachineImage ?? "",
+    gcpSnapshot: input.gcpSnapshot ?? "",
     gcpNetwork: input.gcpNetwork ?? "",
     gcpSubnet: input.gcpSubnet ?? "",
     gcpTags: uniqueStrings(input.gcpTags ?? []),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3076,6 +3076,15 @@ export class FleetDurableObject implements DurableObject {
       );
     }
     const strategy = checkpointStrategy(input.strategy);
+    if (!strategy) {
+      return json(
+        {
+          error: "invalid_strategy",
+          message: "checkpoint strategy must be auto, disk-snapshot, or image",
+        },
+        { status: 400 },
+      );
+    }
     if (lease.provider === "azure" && strategy === "image") {
       return json(
         {
@@ -3750,7 +3759,7 @@ function hasNativeLeaseSource(config: LeaseConfig): boolean {
   );
 }
 
-function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot" {
+function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot" | undefined {
   switch ((value ?? "").trim().toLowerCase()) {
     case "image":
     case "ami":
@@ -3762,8 +3771,10 @@ function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot
     case "snapshot":
     case "disk":
     case "disk-snapshot":
-    default:
+    case "disk_snapshot":
       return "disk-snapshot";
+    default:
+      return undefined;
   }
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -8,7 +8,7 @@ import {
   isRetryableAWSProvisioningError,
 } from "./aws";
 import { AzureClient } from "./azure";
-import { azureLocationFor, leaseConfig, validCIDRs } from "./config";
+import { azureLocationFor, leaseConfig, validCIDRs, type LeaseConfig } from "./config";
 import { GCPClient } from "./gcp";
 import { HetznerClient } from "./hetzner";
 import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
@@ -841,10 +841,19 @@ export class FleetDurableObject implements DurableObject {
     const org = requestOrg(request, this.env);
     const input = await readJson<LeaseRequest>(request);
     const config = leaseConfig(input);
+    if (!isAdminRequest(request) && hasNativeLeaseSource(config)) {
+      return json(
+        {
+          error: "admin_required",
+          message: "native snapshot/image lease sources require admin-token auth",
+        },
+        { status: 403 },
+      );
+    }
     if (config.provider === "aws" && config.awsSSHCIDRs.length === 0) {
       config.awsSSHCIDRs = requestSourceCIDRs(request);
     }
-    if (config.provider === "aws" && !config.awsAMI) {
+    if (config.provider === "aws" && !config.awsAMI && !config.awsSnapshot) {
       const promoted = await this.promotedAWSImage();
       config.awsAMI = promoted?.id ?? "";
       if (promoted?.region) {
@@ -3043,6 +3052,7 @@ export class FleetDurableObject implements DurableObject {
       id?: string;
       name?: string;
       noReboot?: boolean;
+      strategy?: string;
     }>(request);
     const leaseID = input.leaseID ?? input.id ?? "";
     const name = input.name ?? "";
@@ -3056,49 +3066,88 @@ export class FleetDurableObject implements DurableObject {
     if (!lease) {
       return notFound();
     }
-    if (lease.provider !== "aws" || !lease.cloudID) {
+    if (!lease.cloudID || !providerSupportsNativeImages(lease.provider)) {
       return json(
-        { error: "unsupported_provider", message: "only AWS leases can be imaged" },
+        {
+          error: "unsupported_provider",
+          message: "native images are supported for AWS, Azure, and GCP leases",
+        },
         { status: 400 },
       );
     }
-    const image = await this.provider("aws", lease.region).createImage(
+    const strategy = checkpointStrategy(input.strategy);
+    if (lease.provider === "azure" && strategy === "image") {
+      return json(
+        {
+          error: "unsupported_strategy",
+          message:
+            "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases",
+        },
+        { status: 400 },
+      );
+    }
+    const image = await this.provider(
+      lease.provider,
+      lease.region,
+      lease.providerProject,
+    ).createImage(
       lease.cloudID,
-      name,
+      providerImageResourceName(lease.provider, name, leaseID),
       input.noReboot ?? true,
+      strategy,
     );
     return json({ image }, { status: 201 });
   }
 
   private async imageRoute(request: Request, imageID: string, action?: string): Promise<Response> {
     const method = request.method.toUpperCase();
-    if (!validImageID(imageID)) {
+    const decodedImageID = decodeImageRouteID(imageID);
+    if (!validImageRouteID(decodedImageID)) {
       return json({ error: "invalid_image_id" }, { status: 400 });
     }
-    const region = new URL(request.url).searchParams.get("region") ?? undefined;
+    const url = new URL(request.url);
+    const provider = providerFromQuery(url.searchParams.get("provider"));
+    if (!provider) {
+      return json(
+        { error: "unsupported_provider", message: "image provider must be aws, azure, or gcp" },
+        { status: 400 },
+      );
+    }
+    const region = url.searchParams.get("region") ?? undefined;
+    const project = url.searchParams.get("project") ?? undefined;
+    const kind = url.searchParams.get("kind") ?? undefined;
     if (method === "GET" && action === undefined) {
-      const image = await this.provider("aws", region).getImage(imageID);
+      const image = await this.provider(provider, region, project).getImage(decodedImageID, kind);
       return json({ image });
     }
     if (method === "DELETE" && action === undefined) {
-      const promoted = await this.state.storage.get<PromotedImageRecord>(promotedAWSImageKey());
-      if (promoted?.id === imageID) {
+      const promoted =
+        provider === "aws"
+          ? await this.state.storage.get<PromotedImageRecord>(promotedAWSImageKey())
+          : undefined;
+      if (promoted?.id === decodedImageID) {
         return json(
           {
             error: "image_promoted",
-            message: `image ${imageID} is the promoted AWS image; promote another image before deleting it`,
+            message: `image ${decodedImageID} is the promoted AWS image; promote another image before deleting it`,
           },
           { status: 409 },
         );
       }
-      await this.provider("aws", region).deleteImage(imageID);
-      return json({ imageID, deleted: true });
+      await this.provider(provider, region, project).deleteImage(decodedImageID, kind);
+      return json({ imageID: decodedImageID, deleted: true });
     }
     if (method === "POST" && action === "promote") {
-      const image = await this.provider("aws", region).getImage(imageID);
+      if (provider !== "aws") {
+        return json(
+          { error: "unsupported_provider", message: "image promotion is currently AWS-only" },
+          { status: 400 },
+        );
+      }
+      const image = await this.provider("aws", region).getImage(decodedImageID);
       if (image.state !== "available") {
         return json(
-          { error: "image_not_available", message: `image ${imageID} is ${image.state}` },
+          { error: "image_not_available", message: `image ${decodedImageID} is ${image.state}` },
           { status: 409 },
         );
       }
@@ -3675,12 +3724,84 @@ function validEgressSessionID(value: string | undefined): value is string {
   return typeof value === "string" && /^egress_[A-Za-z0-9_.:-]{6,80}$/.test(value);
 }
 
-function validImageID(value: string | undefined): value is string {
-  return typeof value === "string" && /^ami-[a-f0-9]{8,32}$/.test(value);
+function validImageRouteID(value: string | undefined): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_./:-]{1,512}$/.test(value);
+}
+
+function decodeImageRouteID(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return "";
+  }
 }
 
 function validImageName(value: string): boolean {
   return /^[A-Za-z0-9()[\]./_ -]{3,128}$/.test(value);
+}
+
+function providerSupportsNativeImages(provider: Provider): boolean {
+  return provider === "aws" || provider === "azure" || provider === "gcp";
+}
+
+function hasNativeLeaseSource(config: LeaseConfig): boolean {
+  return Boolean(
+    config.awsSnapshot || config.azureSnapshot || config.gcpMachineImage || config.gcpSnapshot,
+  );
+}
+
+function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot" {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "image":
+    case "ami":
+    case "machine-image":
+    case "managed-image":
+      return "image";
+    case "":
+    case "auto":
+    case "snapshot":
+    case "disk":
+    case "disk-snapshot":
+    default:
+      return "disk-snapshot";
+  }
+}
+
+function providerFromQuery(value: string | null): Provider | undefined {
+  const provider = (value ?? "").trim().toLowerCase();
+  if (!provider) return "aws";
+  if (provider === "azure" || provider === "gcp" || provider === "aws") {
+    return provider;
+  }
+  return undefined;
+}
+
+function providerImageResourceName(provider: Provider, name: string, leaseID: string): string {
+  if (provider === "aws") {
+    return name;
+  }
+  const allowed = provider === "gcp" ? /[^a-z0-9-]/g : /[^a-z0-9_.-]/g;
+  const normalized = name.trim().toLowerCase().replaceAll(allowed, "-");
+  const trimmed =
+    provider === "gcp"
+      ? normalized
+          .replaceAll(/^[^a-z]+/g, "")
+          .replaceAll(/-+/g, "-")
+          .replaceAll(/-+$/g, "")
+      : normalized
+          .replaceAll(/^[^a-z]+/g, "")
+          .replaceAll(/-+/g, "-")
+          .replaceAll(/[-.]+$/g, "");
+  const fallback = leaseID.toLowerCase().replaceAll(/[^a-z0-9-]/g, "-");
+  const maxLength = provider === "gcp" ? 63 : 80;
+  const truncated = (trimmed || `checkpoint-${fallback}`).slice(0, maxLength);
+  return provider === "gcp"
+    ? truncated.replaceAll(/-+$/g, "")
+    : truncated.replaceAll(/[-.]+$/g, "");
+}
+
+function unsupportedProviderImageLifecycle(provider: Provider) {
+  return () => Promise.reject(new Error(`${provider} images are not supported`));
 }
 
 function validCrabboxProviderKey(value: string | undefined): value is string {
@@ -4869,9 +4990,14 @@ interface CloudProvider {
     attempts?: ProvisioningAttempt[];
   }>;
   deleteServer(id: string): Promise<void>;
-  createImage(instanceID: string, name: string, noReboot: boolean): Promise<ProviderImage>;
-  getImage(imageID: string): Promise<ProviderImage>;
-  deleteImage(imageID: string): Promise<void>;
+  createImage(
+    instanceID: string,
+    name: string,
+    noReboot: boolean,
+    strategy: "image" | "disk-snapshot",
+  ): Promise<ProviderImage>;
+  getImage(imageID: string, kind?: string): Promise<ProviderImage>;
+  deleteImage(imageID: string, kind?: string): Promise<void>;
   deleteSSHKey(name: string): Promise<void>;
   hourlyPriceUSD(
     serverType: string,
@@ -4915,17 +5041,9 @@ class HetznerProvider implements CloudProvider {
     await this.client.deleteServer(Number(id));
   }
 
-  createImage(): Promise<ProviderImage> {
-    throw new Error("hetzner images are not supported");
-  }
-
-  getImage(): Promise<ProviderImage> {
-    throw new Error("hetzner images are not supported");
-  }
-
-  deleteImage(): Promise<void> {
-    throw new Error("hetzner images are not supported");
-  }
+  createImage = unsupportedProviderImageLifecycle("hetzner");
+  getImage = unsupportedProviderImageLifecycle("hetzner");
+  deleteImage = unsupportedProviderImageLifecycle("hetzner");
 
   async deleteSSHKey(name: string): Promise<void> {
     await this.client.deleteSSHKey(name);
@@ -4968,16 +5086,28 @@ class AzureProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
-  createImage(): Promise<ProviderImage> {
-    throw new Error("azure images are not supported");
+  createImage(
+    instanceID: string,
+    name: string,
+    _noReboot: boolean,
+    strategy: "image" | "disk-snapshot",
+  ): Promise<ProviderImage> {
+    if (strategy === "image") {
+      return Promise.reject(
+        new Error(
+          "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases",
+        ),
+      );
+    }
+    return this.client.createDiskSnapshot(instanceID, name);
   }
 
-  getImage(): Promise<ProviderImage> {
-    throw new Error("azure images are not supported");
+  getImage(imageID: string, kind?: string): Promise<ProviderImage> {
+    return this.client.getImage(imageID, kind);
   }
 
-  deleteImage(): Promise<void> {
-    throw new Error("azure images are not supported");
+  deleteImage(imageID: string, kind?: string): Promise<void> {
+    return this.client.deleteImage(imageID, kind);
   }
 
   async deleteSSHKey(): Promise<void> {
@@ -5018,16 +5148,23 @@ class GCPProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
-  createImage(): Promise<ProviderImage> {
-    throw new Error("gcp images are not supported");
+  createImage(
+    instanceID: string,
+    name: string,
+    _noReboot: boolean,
+    strategy: "image" | "disk-snapshot",
+  ): Promise<ProviderImage> {
+    return strategy === "image"
+      ? this.client.createImage(instanceID, name)
+      : this.client.createDiskSnapshot(instanceID, name);
   }
 
-  getImage(): Promise<ProviderImage> {
-    throw new Error("gcp images are not supported");
+  getImage(imageID: string, kind?: string): Promise<ProviderImage> {
+    return this.client.getImage(imageID, kind);
   }
 
-  deleteImage(): Promise<void> {
-    throw new Error("gcp images are not supported");
+  deleteImage(imageID: string, kind?: string): Promise<void> {
+    return this.client.deleteImage(imageID, kind);
   }
 
   deleteSSHKey(): Promise<void> {
@@ -5143,8 +5280,15 @@ class AWSProvider implements CloudProvider {
     await this.client.deleteServer(id);
   }
 
-  createImage(instanceID: string, name: string, noReboot: boolean): Promise<ProviderImage> {
-    return this.client.createImage(instanceID, name, noReboot);
+  createImage(
+    instanceID: string,
+    name: string,
+    noReboot: boolean,
+    strategy: "image" | "disk-snapshot",
+  ): Promise<ProviderImage> {
+    return strategy === "image"
+      ? this.client.createImage(instanceID, name, noReboot)
+      : this.client.createDiskSnapshot(instanceID, name);
   }
 
   getImage(imageID: string): Promise<ProviderImage> {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -2,7 +2,7 @@ import { cloudInit } from "./bootstrap";
 import { gcpMachineTypeCandidatesForClass, sshPorts, validCIDRs, type LeaseConfig } from "./config";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
-import type { Env, ProviderMachine, ProvisioningAttempt } from "./types";
+import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
 
 const computeBaseURL = "https://compute.googleapis.com/compute/v1";
 const tokenURL = "https://oauth2.googleapis.com/token";
@@ -24,6 +24,10 @@ interface GCPInstance {
   networkInterfaces?: {
     accessConfigs?: { natIP?: string }[];
   }[];
+  disks?: {
+    boot?: boolean;
+    source?: string;
+  }[];
 }
 
 interface GCPAggregatedInstanceList {
@@ -34,6 +38,20 @@ interface GCPOperation {
   name?: string;
   status?: string;
   error?: { errors?: { code?: string; message?: string }[] };
+}
+
+interface GCPMachineImage {
+  id?: string;
+  name?: string;
+  selfLink?: string;
+  status?: string;
+}
+
+interface GCPSnapshot {
+  id?: string;
+  name?: string;
+  selfLink?: string;
+  status?: string;
 }
 
 export class GCPClient {
@@ -196,6 +214,7 @@ export class GCPClient {
     }
     await this.ensureFirewall(config);
     const name = leaseProviderName(leaseID, slug);
+    const project = config.gcpProject || this.project;
     const labels = gcpLabels(
       leaseProviderLabels(config, leaseID, slug, owner, "gcp", new Date(), {
         market: config.capacityMarket,
@@ -206,18 +225,6 @@ export class GCPClient {
       labels,
       machineType: `zones/${this.zone}/machineTypes/${config.serverType}`,
       tags: { items: gcpEffectiveTags(this.tags, config.gcpTags) },
-      disks: [
-        {
-          boot: true,
-          autoDelete: true,
-          type: "PERSISTENT",
-          initializeParams: {
-            sourceImage: config.gcpImage || this.image,
-            diskSizeGb: config.gcpRootGB || this.rootGB,
-            diskType: `zones/${this.zone}/diskTypes/pd-balanced`,
-          },
-        },
-      ],
       metadata: {
         items: [
           { key: "enable-oslogin", value: "FALSE" },
@@ -233,6 +240,28 @@ export class GCPClient {
         },
       ],
     };
+    if (!config.gcpMachineImage) {
+      const initializeParams: Record<string, unknown> = config.gcpSnapshot
+        ? { sourceSnapshot: gcpSnapshotRef(config.gcpSnapshot, project) }
+        : {
+            sourceImage: config.gcpImage || this.image,
+            diskSizeGb: config.gcpRootGB || this.rootGB,
+          };
+      if (config.gcpSnapshot && config.gcpRootGB > 0) {
+        initializeParams["diskSizeGb"] = config.gcpRootGB;
+      }
+      instance["disks"] = [
+        {
+          boot: true,
+          autoDelete: true,
+          type: "PERSISTENT",
+          initializeParams: {
+            ...initializeParams,
+            diskType: `zones/${this.zone}/diskTypes/pd-balanced`,
+          },
+        },
+      ];
+    }
     if (config.gcpServiceAccount || this.serviceAccount) {
       instance["serviceAccounts"] = [
         {
@@ -250,7 +279,10 @@ export class GCPClient {
       };
     }
     try {
-      const op = await this.gcp<GCPOperation>("POST", `/zones/${this.zone}/instances`, instance);
+      const path = config.gcpMachineImage
+        ? `/zones/${this.zone}/instances?sourceMachineImage=${encodeURIComponent(gcpMachineImageRef(config.gcpMachineImage, project))}`
+        : `/zones/${this.zone}/instances`;
+      const op = await this.gcp<GCPOperation>("POST", path, instance);
       await this.waitZoneOperation(op);
       return await this.getServer(name);
     } catch (error) {
@@ -291,6 +323,106 @@ export class GCPClient {
 
   async deleteSSHKey(): Promise<void> {
     // GCP stores per-instance SSH metadata; nothing global to clean up.
+  }
+
+  async createImage(instanceName: string, name: string): Promise<ProviderImage> {
+    const op = await this.gcp<GCPOperation>("POST", "/global/machineImages", {
+      name,
+      sourceInstance: `zones/${this.zone}/instances/${instanceName}`,
+      description: `Crabbox checkpoint from ${instanceName}`,
+    });
+    await this.waitGlobalOperation(op);
+    return await this.getImage(name);
+  }
+
+  async createDiskSnapshot(instanceName: string, name: string): Promise<ProviderImage> {
+    const instance = await this.gcp<GCPInstance>(
+      "GET",
+      `/zones/${this.zone}/instances/${instanceName}`,
+    );
+    const sourceDisk = instance.disks?.find((disk) => disk.boot)?.source;
+    if (!sourceDisk) {
+      throw new Error(`gcp boot disk not found for instance ${instanceName}`);
+    }
+    const diskName = lastPathPart(sourceDisk);
+    const op = await this.gcp<GCPOperation>(
+      "POST",
+      `/zones/${this.zone}/disks/${diskName}/createSnapshot`,
+      {
+        name,
+        description: `Crabbox checkpoint from ${instanceName}`,
+        labels: { crabbox: "true", managed_by: "crabbox" },
+      },
+    );
+    await this.waitZoneOperation(op);
+    return await this.getImage(name, "gcp-disk-snapshot");
+  }
+
+  async getImage(name: string, kind?: string): Promise<ProviderImage> {
+    const imageName = lastPathPart(name);
+    if (kind === "gcp-disk-snapshot") {
+      return await this.getDiskSnapshot(name);
+    }
+    if (kind === "gcp-machine-image") {
+      const image = await this.gcp<GCPMachineImage>("GET", `/global/machineImages/${imageName}`);
+      return gcpMachineProviderImage(image, imageName, this.zone, this.project);
+    }
+    const image = await this.gcp<GCPMachineImage>(
+      "GET",
+      `/global/machineImages/${imageName}`,
+    ).catch((error) => {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    });
+    if (!image) return await this.getDiskSnapshot(name);
+    return gcpMachineProviderImage(image, imageName, this.zone, this.project);
+  }
+
+  async deleteImage(name: string, kind?: string): Promise<void> {
+    const imageName = lastPathPart(name);
+    if (kind === "gcp-disk-snapshot") {
+      await this.deleteDiskSnapshot(name);
+      return;
+    }
+    const op = await this.gcp<GCPOperation>("DELETE", `/global/machineImages/${imageName}`).catch(
+      (error) => {
+        if (isNotFound(error)) return undefined;
+        throw error;
+      },
+    );
+    if (op) {
+      await this.waitGlobalOperation(op);
+      return;
+    }
+    if (kind === "gcp-machine-image") return;
+    await this.deleteDiskSnapshot(name);
+  }
+
+  private async deleteDiskSnapshot(name: string): Promise<void> {
+    const snapshotOp = await this.gcp<GCPOperation>(
+      "DELETE",
+      `/global/snapshots/${lastPathPart(name)}`,
+    ).catch((error) => {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    });
+    if (snapshotOp) await this.waitGlobalOperation(snapshotOp);
+  }
+
+  private async getDiskSnapshot(name: string): Promise<ProviderImage> {
+    const snapshotName = lastPathPart(name);
+    const snapshot = await this.gcp<GCPSnapshot>("GET", `/global/snapshots/${snapshotName}`);
+    return {
+      id: snapshot.name ?? snapshotName,
+      name: snapshot.name ?? snapshotName,
+      state: (snapshot.status ?? "READY").toLowerCase(),
+      provider: "gcp",
+      kind: "gcp-disk-snapshot",
+      region: this.zone,
+      project: this.project,
+      resourceID: snapshot.selfLink ?? gcpSnapshotRef(snapshotName, this.project),
+      snapshots: [snapshot.selfLink ?? gcpSnapshotRef(snapshotName, this.project)],
+    };
   }
 
   hourlyPriceUSD(): Promise<number | undefined> {
@@ -553,6 +685,24 @@ function lastPathPart(value: string): string {
   return value.slice(value.lastIndexOf("/") + 1);
 }
 
+function gcpMachineProviderImage(
+  image: GCPMachineImage,
+  fallbackName: string,
+  zone: string,
+  project: string,
+): ProviderImage {
+  return {
+    id: image.name ?? fallbackName,
+    name: image.name ?? fallbackName,
+    state: (image.status ?? "READY").toLowerCase(),
+    provider: "gcp",
+    kind: "gcp-machine-image",
+    region: zone,
+    project,
+    resourceID: image.selfLink ?? gcpMachineImageRef(fallbackName, project),
+  };
+}
+
 export function gcpFirewallNameForNetwork(network: string): string {
   const name = lastPathPart(network.trim());
   if (!name || name === "default") return firewallName;
@@ -614,6 +764,20 @@ function fnv32Hex(value: string): string {
 
 function regionFromZone(zone: string): string {
   return zone.slice(0, zone.lastIndexOf("-")) || zone;
+}
+
+function gcpMachineImageRef(value: string, project: string): string {
+  if (value.includes("/")) {
+    return value;
+  }
+  return `projects/${project}/global/machineImages/${value}`;
+}
+
+function gcpSnapshotRef(value: string, project: string): string {
+  if (value.includes("/")) {
+    return value;
+  }
+  return `projects/${project}/global/snapshots/${value}`;
 }
 
 function numberFromEnv(value: string | undefined, fallback: number): number {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -103,6 +103,7 @@ export interface LeaseRequest {
   image?: string;
   awsRegion?: string;
   awsAMI?: string;
+  awsSnapshot?: string;
   awsSGID?: string;
   awsSubnetID?: string;
   awsProfile?: string;
@@ -111,9 +112,12 @@ export interface LeaseRequest {
   awsMacHostID?: string;
   azureLocation?: string;
   azureImage?: string;
+  azureSnapshot?: string;
   gcpProject?: string;
   gcpZone?: string;
   gcpImage?: string;
+  gcpMachineImage?: string;
+  gcpSnapshot?: string;
   gcpNetwork?: string;
   gcpSubnet?: string;
   gcpTags?: string[];
@@ -259,7 +263,11 @@ export interface ProviderImage {
   id: string;
   name: string;
   state: string;
+  provider?: Provider;
+  kind?: string;
   region?: string;
+  project?: string;
+  resourceID?: string;
   snapshots?: string[];
 }
 

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -17,6 +17,7 @@ import {
   isAWSInstanceNotFoundError,
   staleCrabboxSSHIngressRules,
 } from "../src/aws";
+import { leaseConfig } from "../src/config";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -218,6 +219,220 @@ describe("aws provider", () => {
         "eu-west-1",
       ),
     ).toBe("eu-west-1b");
+  });
+
+  it("waits for transient AMIs before launching from EBS snapshots", async () => {
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as EC2SpotClient & {
+      ensureSSHKey: () => Promise<void>;
+      registerSnapshotImage: () => Promise<string>;
+      waitForImageAvailable: (imageID: string) => Promise<string>;
+      ensureSecurityGroup: () => Promise<string>;
+      createServer: (...args: unknown[]) => Promise<{
+        provider: "aws";
+        id: number;
+        cloudID: string;
+        name: string;
+        status: string;
+        serverType: string;
+        host: string;
+        labels: Record<string, string>;
+      }>;
+    };
+    const calls: string[] = [];
+    client.ensureSSHKey = async () => {
+      calls.push("ensure-key");
+    };
+    client.registerSnapshotImage = async () => {
+      calls.push("register-snapshot");
+      return "ami-transient";
+    };
+    client.waitForImageAvailable = async (imageID: string) => {
+      calls.push(`wait:${imageID}`);
+      return imageID;
+    };
+    client.ensureSecurityGroup = async () => {
+      calls.push("security-group");
+      return "sg-123";
+    };
+    client.createServer = async (...args: unknown[]) => {
+      calls.push(`launch:${String(args[4])}`);
+      return {
+        provider: "aws",
+        id: 1,
+        cloudID: "i-123",
+        name: "crabbox-blue-lobster",
+        status: "running",
+        serverType: "t3.small",
+        host: "192.0.2.10",
+        labels: {},
+      };
+    };
+
+    await client.createServerWithFallback(
+      leaseConfig({
+        provider: "aws",
+        serverType: "t3.small",
+        serverTypeExplicit: true,
+        awsSnapshot: "snap-000000000001",
+        sshPublicKey: "ssh-ed25519 test",
+        capacity: { market: "on-demand" },
+      }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "owner",
+    );
+
+    expect(calls).toEqual([
+      "ensure-key",
+      "register-snapshot",
+      "wait:ami-transient",
+      "security-group",
+      "launch:ami-transient",
+    ]);
+  });
+
+  it("deregisters transient AMIs when snapshot image waiting fails", async () => {
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as EC2SpotClient & {
+      ensureSSHKey: () => Promise<void>;
+      registerSnapshotImage: () => Promise<string>;
+      waitForImageAvailable: (imageID: string) => Promise<string>;
+      ec2: (action: string, params?: Record<string, string>) => Promise<unknown>;
+    };
+    const calls: string[] = [];
+    client.ensureSSHKey = async () => {
+      calls.push("ensure-key");
+    };
+    client.registerSnapshotImage = async () => {
+      calls.push("register-snapshot");
+      return "ami-transient";
+    };
+    client.waitForImageAvailable = async (imageID: string) => {
+      calls.push(`wait:${imageID}`);
+      throw new Error("timed out waiting");
+    };
+    client.ec2 = async (action, params) => {
+      calls.push(`${action}:${params?.ImageId ?? ""}`);
+      return {};
+    };
+
+    await expect(
+      client.createServerWithFallback(
+        leaseConfig({
+          provider: "aws",
+          serverType: "t3.small",
+          serverTypeExplicit: true,
+          awsSnapshot: "snap-000000000001",
+          sshPublicKey: "ssh-ed25519 test",
+          capacity: { market: "on-demand" },
+        }),
+        "cbx_123456789abc",
+        "blue-lobster",
+        "owner",
+      ),
+    ).rejects.toThrow("timed out waiting");
+
+    expect(calls).toEqual([
+      "ensure-key",
+      "register-snapshot",
+      "wait:ami-transient",
+      "DeregisterImage:ami-transient",
+    ]);
+  });
+
+  it("registers snapshot AMIs with stored boot metadata", async () => {
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as EC2SpotClient & {
+      registerSnapshotImage: (snapshotID: string, leaseID: string) => Promise<string>;
+      ec2: (action: string, params?: Record<string, string>) => Promise<Record<string, unknown>>;
+    };
+    const registerParams: Record<string, string>[] = [];
+    client.ec2 = async (action, params = {}) => {
+      if (action === "DescribeSnapshots") {
+        return {
+          snapshotSet: {
+            item: {
+              snapshotId: "snap-000000000001",
+              tagSet: {
+                item: [
+                  { key: "crabbox_root_device_name", value: "/dev/xvda" },
+                  { key: "crabbox_architecture", value: "arm64" },
+                ],
+              },
+            },
+          },
+        };
+      }
+      if (action === "RegisterImage") {
+        registerParams.push(params);
+        return { imageId: "ami-transient" };
+      }
+      throw new Error(`unexpected ${action}`);
+    };
+
+    const imageID = await client.registerSnapshotImage("snap-000000000001", "cbx_123456789abc");
+
+    expect(imageID).toBe("ami-transient");
+    expect(registerParams[0]).toMatchObject({
+      Architecture: "arm64",
+      RootDeviceName: "/dev/xvda",
+      "BlockDeviceMapping.1.DeviceName": "/dev/xvda",
+    });
+  });
+
+  it("stores source boot metadata on EBS snapshot checkpoints", async () => {
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    ) as unknown as EC2SpotClient & {
+      createDiskSnapshot: (instanceID: string, name: string) => Promise<unknown>;
+      ec2: (action: string, params?: Record<string, string>) => Promise<Record<string, unknown>>;
+    };
+    const snapshotParams: Record<string, string>[] = [];
+    client.ec2 = async (action, params = {}) => {
+      if (action === "DescribeInstances") {
+        return {
+          reservationSet: {
+            item: {
+              instancesSet: {
+                item: {
+                  rootDeviceName: "/dev/xvda",
+                  architecture: "arm64",
+                  blockDeviceMapping: {
+                    item: {
+                      deviceName: "/dev/xvda",
+                      ebs: { volumeId: "vol-000000000001" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+      }
+      if (action === "CreateSnapshot") {
+        snapshotParams.push(params);
+        return { snapshotId: "snap-000000000001", status: "pending" };
+      }
+      throw new Error(`unexpected ${action}`);
+    };
+
+    await client.createDiskSnapshot("i-000000000001", "checkpoint");
+
+    expect(snapshotParams[0]).toMatchObject({
+      VolumeId: "vol-000000000001",
+      "TagSpecification.1.Tag.4.Key": "crabbox_root_device_name",
+      "TagSpecification.1.Tag.4.Value": "/dev/xvda",
+      "TagSpecification.1.Tag.5.Key": "crabbox_architecture",
+      "TagSpecification.1.Tag.5.Value": "arm64",
+    });
   });
 
   it("maps AWS instance types to vCPU quota units", () => {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -22,6 +22,10 @@ const baseEnv: Env = {
   AZURE_SUBSCRIPTION_ID: "sub",
 };
 
+function isAzureLoginURL(value: string): boolean {
+  return new URL(value).hostname === "login.microsoftonline.com";
+}
+
 function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
   return {
     provider: "azure",
@@ -177,7 +181,7 @@ describe("azure provider", () => {
     const deletes: string[] = [];
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
@@ -214,7 +218,7 @@ describe("azure provider", () => {
     const deletes: string[] = [];
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
@@ -270,7 +274,7 @@ describe("azure provider", () => {
     const bodies: unknown[] = [];
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
@@ -409,7 +413,7 @@ describe("azure provider", () => {
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
       const pathname = new URL(url).pathname;
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
@@ -509,7 +513,7 @@ describe("azure provider", () => {
     let nsgBody: { properties?: { securityRules?: Array<{ name?: string }> } } | undefined;
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
@@ -554,7 +558,7 @@ describe("azure provider", () => {
     let tokenMints = 0;
     const fakeFetch = ((input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         tokenMints += 1;
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), {
@@ -598,7 +602,7 @@ describe("azure provider", () => {
     const client = new AzureClient(baseEnv);
     const fakeFetch = ((input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("login.microsoftonline.com")) {
+      if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -97,6 +97,81 @@ describe("azure provider", () => {
     expect(azureLabelsFromTags(tags).windows_mode).toBe("normal");
   });
 
+  it("reads and deletes managed images by explicit kind", async () => {
+    const client = new AzureClient(baseEnv);
+    const calls: Array<{ method: string; pathname: string }> = [];
+    client.fetcher = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (url.hostname === "login.microsoftonline.com") {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      calls.push({ method: init?.method ?? "GET", pathname: url.pathname });
+      if (url.pathname.endsWith("/images/checkpoint-azure") && init?.method !== "DELETE") {
+        return Response.json({
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/images/checkpoint-azure",
+          name: "checkpoint-azure",
+          location: "eastus",
+          properties: { provisioningState: "Succeeded" },
+        });
+      }
+      return new Response(null, { status: 204 });
+    };
+
+    const image = await client.getImage("checkpoint-azure", "azure-managed-image");
+    await client.deleteImage("checkpoint-azure", "azure-managed-image");
+
+    expect(image).toMatchObject({
+      id: "checkpoint-azure",
+      provider: "azure",
+      kind: "azure-managed-image",
+      state: "succeeded",
+    });
+    expect(calls.map((call) => `${call.method} ${call.pathname}`)).toEqual([
+      "GET /subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/images/checkpoint-azure",
+      "DELETE /subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/images/checkpoint-azure",
+    ]);
+  });
+
+  it("routes kind-specific snapshot reads and deletes to Azure snapshots", async () => {
+    const client = new AzureClient(baseEnv);
+    const calls: Array<{ method: string; pathname: string }> = [];
+    client.fetcher = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (url.hostname === "login.microsoftonline.com") {
+        return Response.json({ access_token: "tkn", expires_in: 3600 });
+      }
+      calls.push({ method: init?.method ?? "GET", pathname: url.pathname });
+      if (url.pathname.endsWith("/snapshots/checkpoint-azure")) {
+        return Response.json({
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+          name: "checkpoint-azure",
+          location: "eastus",
+          properties: { provisioningState: "Succeeded" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const image = await client.getImage(
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+      "azure-os-disk-snapshot",
+    );
+    await client.deleteImage(
+      "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+      "azure-os-disk-snapshot",
+    );
+
+    expect(image).toMatchObject({
+      id: "checkpoint-azure",
+      provider: "azure",
+      kind: "azure-os-disk-snapshot",
+    });
+    expect(calls.map((call) => `${call.method} ${call.pathname}`)).toEqual([
+      "GET /subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+      "DELETE /subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+    ]);
+  });
+
   it("continues deleting per-lease resources after a delete failure", async () => {
     const client = new AzureClient(baseEnv);
     const deletes: string[] = [];
@@ -326,6 +401,95 @@ describe("azure provider", () => {
       JSON.stringify(body).includes("CustomScriptExtension"),
     );
     expect(JSON.stringify(extensionBody)).toContain("AzureData\\\\CustomData.bin");
+  });
+
+  it("installs an SSH key extension when forking Linux VMs from OS disk snapshots", async () => {
+    const client = new AzureClient(baseEnv);
+    const bodies: unknown[] = [];
+    const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const pathname = new URL(url).pathname;
+      if (url.includes("login.microsoftonline.com")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
+        );
+      }
+      if (init?.body) bodies.push(JSON.parse(String(init.body)));
+      if (pathname.endsWith("/resourceGroups/crabbox-leases")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (pathname.endsWith("/virtualNetworks/crabbox-vnet")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (pathname.endsWith("/networkSecurityGroups/crabbox-nsg") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              tags: { managed_by: "crabbox" },
+              properties: { securityRules: [] },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes("/publicIPAddresses/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ properties: { ipAddress: "192.0.2.10" } }), {
+            status: 200,
+          }),
+        );
+      }
+      if (url.includes("/virtualMachines/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "crabbox-blue-lobster",
+              tags: { crabbox: "true" },
+              properties: {
+                provisioningState: "Succeeded",
+                hardwareProfile: { vmSize: "Standard_D2ads_v6" },
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+    client.fetcher = fakeFetch;
+
+    await client.createServerWithFallback(
+      testLeaseConfig({
+        azureSnapshot:
+          "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+        capacityMarket: "on-demand",
+        sshPublicKey: "ssh-ed25519 snapshot-key",
+      }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "owner",
+    );
+
+    const vmBody = bodies.find(
+      (body): body is { properties: { osProfile?: unknown; storageProfile?: unknown } } =>
+        typeof body === "object" &&
+        body !== null &&
+        "properties" in body &&
+        JSON.stringify(body).includes("Attach"),
+    );
+    expect(vmBody?.properties.osProfile).toBeUndefined();
+    const extensionBody = bodies.find((body) => JSON.stringify(body).includes("authorized_keys"));
+    expect(extensionBody).toMatchObject({
+      properties: {
+        publisher: "Microsoft.Azure.Extensions",
+        type: "CustomScript",
+      },
+    });
+    expect(JSON.stringify(extensionBody)).toContain("ssh-ed25519 snapshot-key");
   });
 
   it("honors CRABBOX_AZURE_* overrides", () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2503,6 +2503,69 @@ describe("fleet lease identity and idle", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "unsupported_strategy" });
   });
 
+  it("rejects invalid native image strategies", async () => {
+    let created = false;
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onCreateImage() {
+          created = true;
+        },
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-000000000001",
+      }),
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000001", name: "After Install", strategy: "snapshopt" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(created).toBe(false);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_strategy" });
+  });
+
+  it("keeps accepting disk_snapshot as a native image strategy alias", async () => {
+    let strategy = "";
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onCreateImage(_sourceID, _name, receivedStrategy) {
+          strategy = receivedStrategy;
+        },
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-000000000001",
+      }),
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000001", name: "After Install", strategy: "disk_snapshot" },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(strategy).toBe("disk-snapshot");
+  });
+
   it("deletes provider-native images using provider query routing", async () => {
     let azureDeleted = "";
     let azureDeletedKind = "";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2223,7 +2223,7 @@ describe("fleet lease identity and idle", () => {
     const created = await fleet.fetch(
       request("POST", "/v1/images", {
         headers: { "x-crabbox-admin": "true" },
-        body: { leaseID: "cbx_000000000001", name: "openclaw-crabbox-test" },
+        body: { leaseID: "cbx_000000000001", name: "openclaw-crabbox-test", strategy: "image" },
       }),
     );
     expect(created.status).toBe(201);
@@ -2283,6 +2283,100 @@ describe("fleet lease identity and idle", () => {
     expect(body.lease.region).toBe("us-east-2");
   });
 
+  it("passes provider-native checkpoint snapshot fields into new leases", async () => {
+    let awsConfig: LeaseConfig | undefined;
+    let azureConfig: LeaseConfig | undefined;
+    let gcpConfig: LeaseConfig | undefined;
+    const fleet = testFleet(new MemoryStorage(), {
+      aws: fakeProvider(
+        (config) => {
+          awsConfig = config;
+        },
+        { provider: "aws", region: "us-east-2" },
+      ),
+      azure: fakeProvider(
+        (config) => {
+          azureConfig = config;
+        },
+        { provider: "azure", region: "eastus" },
+      ),
+      gcp: fakeProvider(
+        (config) => {
+          gcpConfig = config;
+        },
+        { provider: "gcp", region: "us-central1-a" },
+      ),
+    });
+
+    const aws = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          provider: "aws",
+          awsRegion: "us-east-2",
+          awsSnapshot: "snap-000000000001",
+          sshPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com",
+        },
+      }),
+    );
+    const azure = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          provider: "azure",
+          azureLocation: "eastus",
+          azureSnapshot:
+            "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+          sshPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com",
+        },
+      }),
+    );
+    const gcp = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          provider: "gcp",
+          gcpProject: "proj",
+          gcpZone: "us-central1-a",
+          gcpSnapshot: "projects/proj/global/snapshots/checkpoint-gcp",
+          sshPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com",
+        },
+      }),
+    );
+
+    expect(aws.status).toBe(201);
+    expect(azure.status).toBe(201);
+    expect(gcp.status).toBe(201);
+    expect(awsConfig?.awsSnapshot).toBe("snap-000000000001");
+    expect(azureConfig?.azureSnapshot).toBe(
+      "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+    );
+    expect(gcpConfig?.gcpSnapshot).toBe("projects/proj/global/snapshots/checkpoint-gcp");
+  });
+
+  it("rejects snapshot-backed lease fields for non-admin users", async () => {
+    let created = false;
+    const fleet = testFleet(new MemoryStorage(), {
+      aws: fakeProvider(() => {
+        created = true;
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          provider: "aws",
+          awsSnapshot: "snap-000000000001",
+          sshPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(created).toBe(false);
+    await expect(response.json()).resolves.toMatchObject({ error: "admin_required" });
+  });
+
   it("deletes AWS images through admin routes", async () => {
     let deleted = "";
     const fleet = testFleet(new MemoryStorage(), {
@@ -2308,6 +2402,181 @@ describe("fleet lease identity and idle", () => {
     );
     expect(allowed.status).toBe(200);
     expect(deleted).toBe("ami-000000000001");
+  });
+
+  it("creates Azure and GCP native disk snapshots through admin routes by default", async () => {
+    const storage = new MemoryStorage();
+    const createdNames: string[] = [];
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        region: "eastus",
+        imageRegion: "eastus",
+        onCreateImage: (_instanceID, name, strategy) =>
+          createdNames.push(`azure:${strategy}:${name}`),
+      }),
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        region: "us-central1-a",
+        imageRegion: "us-central1-a",
+        onCreateImage: (_instanceID, name, strategy) =>
+          createdNames.push(`gcp:${strategy}:${name}`),
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        provider: "azure",
+        cloudID: "crabbox-azure",
+        region: "eastus",
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000003",
+      testLease({
+        id: "cbx_000000000003",
+        provider: "gcp",
+        cloudID: "crabbox-gcp",
+        region: "us-central1-a",
+        providerProject: "proj",
+      }),
+    );
+
+    const azure = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000002", name: "After Install" },
+      }),
+    );
+    const longGCPName = `${"a".repeat(62)} b`;
+    const gcp = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000003", name: longGCPName },
+      }),
+    );
+    expect(azure.status).toBe(201);
+    expect(gcp.status).toBe(201);
+    await expect(azure.json()).resolves.toMatchObject({
+      image: { id: "checkpoint-azure", provider: "azure", kind: "azure-os-disk-snapshot" },
+    });
+    await expect(gcp.json()).resolves.toMatchObject({
+      image: { id: "checkpoint-gcp", provider: "gcp", kind: "gcp-disk-snapshot" },
+    });
+    expect(createdNames).toEqual([
+      "azure:disk-snapshot:after-install",
+      `gcp:disk-snapshot:${"a".repeat(62)}`,
+    ]);
+  });
+
+  it("rejects Azure managed image creation from active leases", async () => {
+    let created = false;
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        onCreateImage() {
+          created = true;
+        },
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        provider: "azure",
+        cloudID: "crabbox-azure",
+        region: "eastus",
+      }),
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000002", name: "After Install", strategy: "image" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(created).toBe(false);
+    await expect(response.json()).resolves.toMatchObject({ error: "unsupported_strategy" });
+  });
+
+  it("deletes provider-native images using provider query routing", async () => {
+    let azureDeleted = "";
+    let azureDeletedKind = "";
+    let gcpDeleted = "";
+    let gcpDeletedKind = "";
+    const fleet = testFleet(new MemoryStorage(), {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        onDeleteImage(imageID, kind) {
+          azureDeleted = imageID;
+          azureDeletedKind = kind ?? "";
+        },
+      }),
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onDeleteImage(imageID, kind) {
+          gcpDeleted = imageID;
+          gcpDeletedKind = kind ?? "";
+        },
+      }),
+    });
+
+    const azureResource =
+      "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint-azure";
+    const gcpResource = "projects/proj/global/snapshots/checkpoint-gcp";
+    const azure = await fleet.fetch(
+      request(
+        "DELETE",
+        `/v1/images/${encodeURIComponent(azureResource)}?provider=azure&region=eastus&kind=azure-os-disk-snapshot`,
+        {
+          headers: { "x-crabbox-admin": "true" },
+          body: {},
+        },
+      ),
+    );
+    const gcp = await fleet.fetch(
+      request(
+        "DELETE",
+        `/v1/images/${encodeURIComponent(gcpResource)}?provider=gcp&region=us-central1-a&project=proj&kind=gcp-disk-snapshot`,
+        {
+          headers: { "x-crabbox-admin": "true" },
+          body: {},
+        },
+      ),
+    );
+
+    expect(azure.status).toBe(200);
+    expect(gcp.status).toBe(200);
+    expect(azureDeleted).toBe(azureResource);
+    expect(azureDeletedKind).toBe("azure-os-disk-snapshot");
+    expect(gcpDeleted).toBe(gcpResource);
+    expect(gcpDeletedKind).toBe("gcp-disk-snapshot");
+  });
+
+  it("rejects invalid image provider query routing", async () => {
+    let deleted = "";
+    const fleet = testFleet(new MemoryStorage(), {
+      aws: fakeProvider(undefined, {
+        onDeleteImage(imageID) {
+          deleted = imageID;
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("DELETE", "/v1/images/checkpoint-azure?provider=azuer", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(deleted).toBe("");
+    await expect(response.json()).resolves.toMatchObject({ error: "unsupported_provider" });
   });
 
   it("rejects deleting the promoted AWS image", async () => {
@@ -3556,14 +3825,19 @@ function testFleet(
 function fakeProvider(
   onCreate?: (config: LeaseConfig) => void,
   result: {
-    provider?: "hetzner" | "aws" | "gcp";
+    provider?: "hetzner" | "aws" | "azure" | "gcp";
     serverType?: string;
     cloudID?: string;
     region?: string;
     imageRegion?: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
-    onDeleteImage?: (imageID: string) => void;
+    onCreateImage?: (
+      instanceID: string,
+      name: string,
+      strategy?: "image" | "disk-snapshot",
+    ) => void;
+    onDeleteImage?: (imageID: string, kind?: string) => void;
   } = {},
   onDelete?: (id: string) => Promise<void>,
   onGet?: (id: string) => Promise<ProviderMachine> | ProviderMachine,
@@ -3602,8 +3876,10 @@ function fakeProvider(
             result.provider === "aws"
               ? (result.region ?? "eu-west-2")
               : result.provider === "gcp"
-                ? "us-central1-a"
-                : undefined,
+                ? (result.region ?? "us-central1-a")
+                : result.provider === "azure"
+                  ? (result.region ?? "eastus")
+                  : undefined,
           labels: {},
         },
         serverType: result.serverType ?? "cpx62",
@@ -3614,25 +3890,77 @@ function fakeProvider(
     async deleteServer(id: string) {
       await onDelete?.(id);
     },
-    async createImage(_instanceID: string, name: string) {
-      return {
-        id: "ami-000000000001",
-        name,
-        state: "pending",
-        region: result.imageRegion ?? "eu-west-1",
-      };
-    },
-    async getImage(imageID: string) {
+    async createImage(
+      instanceID: string,
+      name: string,
+      _noReboot = true,
+      strategy: "image" | "disk-snapshot" = "disk-snapshot",
+    ) {
+      result.onCreateImage?.(instanceID, name, strategy);
+      const provider = result.provider ?? "aws";
+      const imageID =
+        provider === "azure"
+          ? "checkpoint-azure"
+          : provider === "gcp"
+            ? "checkpoint-gcp"
+            : strategy === "disk-snapshot"
+              ? "snap-000000000001"
+              : "ami-000000000001";
       return {
         id: imageID,
-        name: "openclaw-crabbox-test",
-        state: "available",
+        name,
+        state: "pending",
+        provider,
+        kind:
+          strategy === "disk-snapshot"
+            ? provider === "azure"
+              ? "azure-os-disk-snapshot"
+              : provider === "gcp"
+                ? "gcp-disk-snapshot"
+                : "aws-ebs-snapshot"
+            : provider === "azure"
+              ? "azure-managed-image"
+              : provider === "gcp"
+                ? "gcp-machine-image"
+                : "aws-ami",
         region: result.imageRegion ?? "eu-west-1",
+        project: provider === "gcp" ? "proj" : undefined,
+        resourceID:
+          strategy === "disk-snapshot"
+            ? provider === "azure"
+              ? `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/${imageID}`
+              : provider === "gcp"
+                ? `projects/proj/global/snapshots/${imageID}`
+                : imageID
+            : provider === "azure"
+              ? `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/images/${imageID}`
+              : provider === "gcp"
+                ? `projects/proj/global/machineImages/${imageID}`
+                : imageID,
+        snapshots: [imageID],
+      };
+    },
+    async getImage(imageID: string, kind?: string) {
+      const provider = result.provider ?? "aws";
+      return {
+        id: imageID,
+        name: "crabbox-runner-test",
+        state: "available",
+        provider,
+        kind:
+          kind ??
+          (provider === "azure"
+            ? "azure-managed-image"
+            : provider === "gcp"
+              ? "gcp-machine-image"
+              : "aws-ami"),
+        region: result.imageRegion ?? "eu-west-1",
+        project: provider === "gcp" ? "proj" : undefined,
         snapshots: ["snap-000000000001"],
       };
     },
-    async deleteImage(imageID: string) {
-      result.onDeleteImage?.(imageID);
+    async deleteImage(imageID: string, kind?: string) {
+      result.onDeleteImage?.(imageID, kind);
     },
     async deleteSSHKey() {},
     async hourlyPriceUSD() {

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -78,6 +78,233 @@ describe("gcp provider", () => {
     ]);
   });
 
+  it("creates and deletes machine images through Compute Engine", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const calls: Array<{ method: string; path: string; body: unknown }> = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      calls.push({ method: init?.method ?? "GET", path: url.pathname + url.search, body });
+      if (url.pathname.endsWith("/global/operations/op-1/wait")) {
+        return Response.json({ name: "op-1", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/global/machineImages/checkpoint-gcp") && init?.method === "GET") {
+        return Response.json({
+          name: "checkpoint-gcp",
+          selfLink: "projects/default-project/global/machineImages/checkpoint-gcp",
+          status: "READY",
+        });
+      }
+      return Response.json({ name: "op-1", status: "PENDING" });
+    };
+
+    const image = await client.createImage("crabbox-source", "checkpoint-gcp");
+    await client.deleteImage("checkpoint-gcp");
+
+    expect(image).toMatchObject({
+      id: "checkpoint-gcp",
+      provider: "gcp",
+      kind: "gcp-machine-image",
+      state: "ready",
+    });
+    expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      "POST /compute/v1/projects/default-project/global/machineImages",
+      "POST /compute/v1/projects/default-project/global/operations/op-1/wait",
+      "GET /compute/v1/projects/default-project/global/machineImages/checkpoint-gcp",
+      "DELETE /compute/v1/projects/default-project/global/machineImages/checkpoint-gcp",
+      "POST /compute/v1/projects/default-project/global/operations/op-1/wait",
+    ]);
+    expect(calls[0]?.body).toMatchObject({
+      name: "checkpoint-gcp",
+      sourceInstance: "zones/us-central1-a/instances/crabbox-source",
+    });
+  });
+
+  it("routes kind-specific snapshot reads and deletes to GCP snapshots", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const calls: Array<{ method: string; path: string }> = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      calls.push({ method: init?.method ?? "GET", path: url.pathname + url.search });
+      if (url.pathname.endsWith("/global/operations/op-1/wait")) {
+        return Response.json({ name: "op-1", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/global/snapshots/checkpoint-gcp") && init?.method !== "DELETE") {
+        return Response.json({
+          name: "checkpoint-gcp",
+          selfLink: "projects/default-project/global/snapshots/checkpoint-gcp",
+          status: "READY",
+        });
+      }
+      return Response.json({ name: "op-1", status: "PENDING" });
+    };
+
+    const image = await client.getImage(
+      "projects/default-project/global/snapshots/checkpoint-gcp",
+      "gcp-disk-snapshot",
+    );
+    await client.deleteImage(
+      "projects/default-project/global/snapshots/checkpoint-gcp",
+      "gcp-disk-snapshot",
+    );
+
+    expect(image).toMatchObject({
+      id: "checkpoint-gcp",
+      provider: "gcp",
+      kind: "gcp-disk-snapshot",
+    });
+    expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      "GET /compute/v1/projects/default-project/global/snapshots/checkpoint-gcp",
+      "DELETE /compute/v1/projects/default-project/global/snapshots/checkpoint-gcp",
+      "POST /compute/v1/projects/default-project/global/operations/op-1/wait",
+    ]);
+  });
+
+  it("creates instances from machine images without boot disk initialization", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const calls: Array<{
+      method: string;
+      path: string;
+      body: Record<string, unknown> | undefined;
+    }> = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+      calls.push({ method, path: url.pathname + url.search, body });
+      if (url.pathname.endsWith("/global/firewalls/crabbox-ssh") && method === "GET") {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.pathname.endsWith("/global/operations/op-firewall/wait")) {
+        return Response.json({ name: "op-firewall", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/zones/us-central1-a/operations/op-instance/wait")) {
+        return Response.json({ name: "op-instance", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/global/firewalls") && method === "POST") {
+        return Response.json({ name: "op-firewall", status: "PENDING" });
+      }
+      if (url.pathname.endsWith("/zones/us-central1-a/instances") && method === "POST") {
+        return Response.json({ name: "op-instance", status: "PENDING" });
+      }
+      if (url.pathname.includes("/zones/us-central1-a/instances/crabbox-blue-lobster-")) {
+        return Response.json({
+          id: "123",
+          name: url.pathname.split("/").pop(),
+          status: "RUNNING",
+          machineType: "zones/us-central1-a/machineTypes/e2-micro",
+          networkInterfaces: [{ accessConfigs: [{ natIP: "192.0.2.5" }] }],
+        });
+      }
+      return Response.json({});
+    };
+
+    const config = leaseConfig({
+      provider: "gcp",
+      serverType: "e2-micro",
+      gcpMachineImage: "checkpoint-gcp",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    const server = await client.createServer(
+      config,
+      "cbx_123456789abc",
+      "blue-lobster",
+      "alice@example.com",
+    );
+
+    const createCall = calls.find(
+      (call) => call.method === "POST" && call.path.includes("/zones/us-central1-a/instances?"),
+    );
+    expect(server.host).toBe("192.0.2.5");
+    expect(createCall?.path).toContain(
+      "sourceMachineImage=projects%2Fdefault-project%2Fglobal%2FmachineImages%2Fcheckpoint-gcp",
+    );
+    expect(createCall?.body).not.toHaveProperty("disks");
+    expect(String(createCall?.body?.name)).toMatch(/^crabbox-blue-lobster-/);
+  });
+
+  it("creates instances from disk snapshots without forcing default disk size", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const calls: Array<{
+      method: string;
+      path: string;
+      body: Record<string, unknown> | undefined;
+    }> = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+      calls.push({ method, path: url.pathname + url.search, body });
+      if (url.pathname.endsWith("/global/firewalls/crabbox-ssh") && method === "GET") {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.pathname.endsWith("/global/operations/op-firewall/wait")) {
+        return Response.json({ name: "op-firewall", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/zones/us-central1-a/operations/op-instance/wait")) {
+        return Response.json({ name: "op-instance", status: "DONE" });
+      }
+      if (url.pathname.endsWith("/global/firewalls") && method === "POST") {
+        return Response.json({ name: "op-firewall", status: "PENDING" });
+      }
+      if (url.pathname.endsWith("/zones/us-central1-a/instances") && method === "POST") {
+        return Response.json({ name: "op-instance", status: "PENDING" });
+      }
+      if (url.pathname.includes("/zones/us-central1-a/instances/crabbox-blue-lobster-")) {
+        return Response.json({
+          id: "123",
+          name: url.pathname.split("/").pop(),
+          status: "RUNNING",
+          machineType: "zones/us-central1-a/machineTypes/e2-micro",
+          networkInterfaces: [{ accessConfigs: [{ natIP: "192.0.2.5" }] }],
+        });
+      }
+      return Response.json({});
+    };
+
+    await client.createServer(
+      leaseConfig({
+        provider: "gcp",
+        serverType: "e2-micro",
+        gcpSnapshot: "checkpoint-gcp",
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "alice@example.com",
+    );
+
+    const createCall = calls.find(
+      (call) => call.method === "POST" && call.path.endsWith("/zones/us-central1-a/instances"),
+    );
+    const disks = createCall?.body?.disks as Array<{ initializeParams?: Record<string, unknown> }>;
+    expect(disks[0]?.initializeParams).toMatchObject({
+      sourceSnapshot: "projects/default-project/global/snapshots/checkpoint-gcp",
+      diskType: "zones/us-central1-a/diskTypes/pd-balanced",
+    });
+    expect(disks[0]?.initializeParams).not.toHaveProperty("diskSizeGb");
+  });
+
   it("keeps exact GCP types eligible for zone fallback", async () => {
     const attempts: string[] = [];
     const original = GCPClient.prototype.createServer;

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-04-30",
   "workers_dev": true,
-  "preview_urls": false,
+  "preview_urls": true,
   "assets": {
     "directory": "./public",
   },
@@ -42,6 +42,33 @@
         "class_name": "FleetDurableObject",
       },
     ],
+  },
+  "previews": {
+    "vars": {
+      "CRABBOX_PUBLIC_URL": "https://crabbox.openclaw.ai",
+      "CRABBOX_DEFAULT_ORG": "openclaw",
+      "CRABBOX_GITHUB_ALLOWED_ORG": "openclaw",
+      "CRABBOX_ACCESS_TEAM_DOMAIN": "crabbox-openclaw.cloudflareaccess.com",
+      "CRABBOX_ACCESS_AUD": "2c79b4c28dd40029b75b1e8d36d9a945ddc864dd40a34e50f6538bae8a3633ea",
+      "CRABBOX_AWS_REGION": "eu-west-1",
+      "CRABBOX_CAPACITY_REGIONS": "eu-west-1,eu-west-2,eu-central-1,us-east-1,us-west-2",
+      "CRABBOX_CAPACITY_HINTS": "1",
+      "CRABBOX_CAPACITY_LARGE_CLASSES": "beast",
+      "CRABBOX_ARTIFACTS_BACKEND": "r2",
+      "CRABBOX_ARTIFACTS_BUCKET": "openclaw-crabbox-artifacts",
+      "CRABBOX_ARTIFACTS_PREFIX": "crabbox-artifacts",
+      "CRABBOX_ARTIFACTS_BASE_URL": "https://artifacts.openclaw.ai",
+      "CRABBOX_ARTIFACTS_REGION": "auto",
+      "CRABBOX_ARTIFACTS_ENDPOINT_URL": "https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com",
+    },
+    "durable_objects": {
+      "bindings": [
+        {
+          "name": "FLEET",
+          "class_name": "FleetDurableObject",
+        },
+      ],
+    },
   },
   "migrations": [
     {


### PR DESCRIPTION
## Summary

- add provider-native checkpoint/image support for AWS, Azure, and GCP brokered Linux leases
- support disk-snapshot and full-image strategies, native checkpoint fork/delete, and provider-aware image delete routes
- document checkpoint/image behavior, update changelog/source map, and enable Worker preview URL config
- add Go and Worker regression coverage for checkpoint routing, AWS images, Azure snapshots/images, and GCP snapshots/machine images

## Validation

- `go test ./...`
- `npm test --prefix worker -- --run fleet.test.ts gcp.test.ts azure.test.ts aws.test.ts`
- `npm run docs:check`
- live AWS E2E: created native AMI checkpoint `chk_dd7d0c5a4a3f861d`, forked lease `cbx_8caff7811d52`, verified `/opt/crabbox-checkpoint-e2e-marker` survived, released source/fork leases, removed AMI `ami-02988e7af6fd5998b` and matching snapshots

## Notes

Azure/GCP live E2E is blocked by environment credentials, not local tests: the deployed Worker is missing Azure/GCP provider secrets, the Google `services@openclaw.org` login has no visible GCP project access, and the available Azure login hits a disabled guest user in an old tenant. AWS live cleanup also exposed an IAM policy gap: the coordinator can create AMIs but needs `ec2:DeregisterImage` and snapshot delete permission for native checkpoint deletion through the Worker route.
