### PR TITLE
fix: stream checkpoint archive restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
-- Fixed checkpoint archive restores so large archives stream over SSH without buffering the full tarball in memory and unpack through a per-restore remote temp file.
+- Fixed checkpoint archive restores so large archives stream over SSH without buffering the full tarball in memory and unpack through a per-restore remote temp file. Thanks @stainlu.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed installed tagged builds so `crabbox --version` and proof metadata report the Go module build version instead of the development fallback. Thanks @stainlu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
+- Fixed checkpoint archive restores so large archives stream over SSH without buffering the full tarball in memory and unpack through a per-restore remote temp file.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed installed tagged builds so `crabbox --version` and proof metadata report the Go module build version instead of the development fallback. Thanks @stainlu.

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1020,7 +1020,7 @@ func remoteCheckpointArchiveCommand(workdir string) string {
 func remoteCheckpointRestoreCommand(workdir string, clear bool) string {
 	var b strings.Builder
 	b.WriteString("set -eu\n")
-	b.WriteString("tmp=$(mktemp /tmp/crabbox-checkpoint.XXXXXX.tar.gz)\n")
+	b.WriteString("tmp=$(mktemp /tmp/crabbox-checkpoint.XXXXXX)\n")
 	b.WriteString("cleanup() { rm -f -- \"$tmp\"; }\n")
 	b.WriteString("trap cleanup EXIT INT TERM\n")
 	b.WriteString("cat > \"$tmp\"\n")

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -998,20 +998,14 @@ func restoreCheckpointArchive(ctx context.Context, target SSHTarget, localPath, 
 	if info.IsDir() {
 		return exit(2, "checkpoint archive is a directory: %s", localPath)
 	}
-	remotePath := "/tmp/crabbox-" + safeCaptureName(checkpointID) + ".tar.gz"
 	file, err := os.Open(localPath)
 	if err != nil {
 		return exit(2, "open checkpoint archive: %v", err)
 	}
 	defer func() { _ = file.Close() }()
-	if err := runSSHInput(ctx, target, "cat > "+shellQuote(remotePath), file, io.Discard, io.Discard); err != nil {
-		return exit(7, "upload checkpoint archive %s: %v", checkpointID, err)
-	}
-	if err := file.Close(); err != nil {
-		return err
-	}
-	if out, err := runSSHCombinedOutput(ctx, target, remoteCheckpointRestoreCommand(workdir, remotePath, clear)); err != nil {
-		return exit(7, "restore checkpoint %s: %v: %s", checkpointID, err, trimFailureDetail(out))
+	var stderr strings.Builder
+	if err := runSSHInputStream(ctx, target, remoteCheckpointRestoreCommand(workdir, clear), file, io.Discard, &stderr); err != nil {
+		return exit(7, "restore checkpoint %s: %v: %s", checkpointID, err, trimFailureDetail(stderr.String()))
 	}
 	return nil
 }
@@ -1023,9 +1017,13 @@ func remoteCheckpointArchiveCommand(workdir string) string {
 	return "bash -lc " + shellQuote(script)
 }
 
-func remoteCheckpointRestoreCommand(workdir, archivePath string, clear bool) string {
+func remoteCheckpointRestoreCommand(workdir string, clear bool) string {
 	var b strings.Builder
 	b.WriteString("set -eu\n")
+	b.WriteString("tmp=$(mktemp /tmp/crabbox-checkpoint.XXXXXX.tar.gz)\n")
+	b.WriteString("cleanup() { rm -f -- \"$tmp\"; }\n")
+	b.WriteString("trap cleanup EXIT INT TERM\n")
+	b.WriteString("cat > \"$tmp\"\n")
 	b.WriteString("mkdir -p ")
 	b.WriteString(shellQuote(workdir))
 	b.WriteByte('\n')
@@ -1036,11 +1034,7 @@ func remoteCheckpointRestoreCommand(workdir, archivePath string, clear bool) str
 	}
 	b.WriteString("tar -C ")
 	b.WriteString(shellQuote(workdir))
-	b.WriteString(" -xzf ")
-	b.WriteString(shellQuote(archivePath))
-	b.WriteByte('\n')
-	b.WriteString("rm -f -- ")
-	b.WriteString(shellQuote(archivePath))
+	b.WriteString(" -xzf \"$tmp\"")
 	return "bash -lc " + shellQuote(b.String())
 }
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -562,7 +562,7 @@ func TestRemoteCheckpointArchiveCommand(t *testing.T) {
 func TestRemoteCheckpointRestoreCommandClearsWorkdir(t *testing.T) {
 	cmd := remoteCheckpointRestoreCommand("/work/repo", true)
 	for _, want := range []string{
-		"mktemp /tmp/crabbox-checkpoint.XXXXXX.tar.gz",
+		"mktemp /tmp/crabbox-checkpoint.XXXXXX",
 		"trap cleanup EXIT INT TERM",
 		"cat > \"$tmp\"",
 		"mkdir -p",

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -560,15 +560,17 @@ func TestRemoteCheckpointArchiveCommand(t *testing.T) {
 }
 
 func TestRemoteCheckpointRestoreCommandClearsWorkdir(t *testing.T) {
-	cmd := remoteCheckpointRestoreCommand("/work/repo", "/tmp/chk.tar.gz", true)
+	cmd := remoteCheckpointRestoreCommand("/work/repo", true)
 	for _, want := range []string{
+		"mktemp /tmp/crabbox-checkpoint.XXXXXX.tar.gz",
+		"trap cleanup EXIT INT TERM",
+		"cat > \"$tmp\"",
 		"mkdir -p",
 		"/work/repo",
 		"find",
 		"-mindepth 1 -maxdepth 1 -exec rm -rf -- {} +",
 		"tar -C",
 		"-xzf",
-		"/tmp/chk.tar.gz",
 		"rm -f --",
 	} {
 		if !strings.Contains(cmd, want) {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -389,6 +389,34 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 	return lastErr
 }
 
+func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, input io.ReadSeeker, stdout, stderr io.Writer) error {
+	remote = wrapRemoteForTarget(target, remote)
+	if input == nil {
+		input = strings.NewReader("")
+	}
+	var lastErr error
+	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		if _, err := input.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		probe := target
+		probe.Port = port
+		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
+		cmd.Stdin = input
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		err := cmd.Run()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !shouldRetrySSHPort(err) {
+			return err
+		}
+	}
+	return lastErr
+}
+
 func runSSHStream(ctx context.Context, target SSHTarget, remote string, stdout, stderr io.Writer) int {
 	code, _ := runSSHStreamResult(ctx, target, remote, stdout, stderr)
 	return code


### PR DESCRIPTION
## Summary

- Stream checkpoint archive restores from disk instead of buffering the full tarball in memory.
- Extract archives through a per-restore remote `mktemp` path with cleanup instead of a predictable `/tmp/crabbox-<checkpoint>.tar.gz` name.
- Add focused command-shape coverage and an Unreleased changelog entry.

## Validation

- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/cli -run 'TestRemoteCheckpointRestoreCommandClearsWorkdir|TestCheckpoint|Test.*Checkpoint|TestRunSSH' -count=1`
- `env GOCACHE=/private/tmp/crabbox-gocache go test ./...`
- `git diff --check`
