### PR TITLE
fix: clean Daytona sync archives after extract errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
+- Fixed Daytona toolbox archive sync so failed remote extracts still remove the uploaded `/tmp/crabbox-*.tgz` archive.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -347,7 +347,7 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 	if b.cfg.Sync.Delete {
 		deletePrefix = "rm -rf " + shellQuote(workdir) + " && "
 	}
-	extractCommand := deletePrefix + "mkdir -p " + shellQuote(workdir) + " && tar -xzf " + shellQuote(archivePath) + " -C " + shellQuote(workdir) + " && rm -f " + shellQuote(archivePath)
+	extractCommand := daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix)
 	if response, err := sandbox.Process.ExecuteCommand(ctx, extractCommand); err != nil {
 		return nil, fmt.Errorf("daytona extract archive: %w", err)
 	} else if responseExitCode(response) != 0 {
@@ -373,6 +373,13 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 		{Name: "toolbox_sync", Ms: time.Since(start).Milliseconds()},
 	}
 	return phases, nil
+}
+
+func daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix string) string {
+	return deletePrefix +
+		"mkdir -p " + shellQuote(workdir) +
+		" && tar -xzf " + shellQuote(archivePath) + " -C " + shellQuote(workdir) +
+		"; status=$?; rm -f " + shellQuote(archivePath) + "; exit $status"
 }
 
 func createDaytonaSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -379,7 +379,7 @@ func daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix string) str
 	return deletePrefix +
 		"mkdir -p " + shellQuote(workdir) +
 		" && tar -xzf " + shellQuote(archivePath) + " -C " + shellQuote(workdir) +
-		"; status=$?; rm -f " + shellQuote(archivePath) + "; exit $status"
+		"; crabbox_status=$?; rm -f " + shellQuote(archivePath) + "; exit $crabbox_status"
 }
 
 func createDaytonaSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -71,6 +71,22 @@ func TestDaytonaToolboxUploadURL(t *testing.T) {
 	}
 }
 
+func TestDaytonaExtractArchiveCommandCleansArchiveOnFailure(t *testing.T) {
+	cmd := daytonaExtractArchiveCommand("/workspace/repo", "/tmp/crabbox-archive.tgz", "rm -rf '/workspace/repo' && ")
+	for _, want := range []string{
+		"rm -rf '/workspace/repo' && mkdir -p '/workspace/repo'",
+		"tar -xzf '/tmp/crabbox-archive.tgz' -C '/workspace/repo'",
+		"; status=$?; rm -f '/tmp/crabbox-archive.tgz'; exit $status",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("command missing %q: %s", want, cmd)
+		}
+	}
+	if strings.Index(cmd, "rm -f '/tmp/crabbox-archive.tgz'") < strings.Index(cmd, "tar -xzf") {
+		t.Fatalf("cleanup should run after extract attempt: %s", cmd)
+	}
+}
+
 func TestUploadDaytonaFileStreamDoesNotPrebuffer(t *testing.T) {
 	sourceReader, sourceWriter := io.Pipe()
 	requestStarted := make(chan struct{})

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -76,7 +76,7 @@ func TestDaytonaExtractArchiveCommandCleansArchiveOnFailure(t *testing.T) {
 	for _, want := range []string{
 		"rm -rf '/workspace/repo' && mkdir -p '/workspace/repo'",
 		"tar -xzf '/tmp/crabbox-archive.tgz' -C '/workspace/repo'",
-		"; status=$?; rm -f '/tmp/crabbox-archive.tgz'; exit $status",
+		"; crabbox_status=$?; rm -f '/tmp/crabbox-archive.tgz'; exit $crabbox_status",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Fatalf("command missing %q: %s", want, cmd)


### PR DESCRIPTION
## Summary

- Clean Daytona toolbox upload archives even when remote extraction fails.
- Factor the extract command so the original extract exit status is preserved after cleanup.
- Add focused command-shape coverage and an Unreleased changelog entry.

## Validation

- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/daytona -run 'TestDaytonaExtractArchiveCommandCleansArchiveOnFailure|TestUploadDaytonaFileStreamDoesNotPrebuffer|TestCreateDaytonaSyncArchiveWritesTempFile' -count=1`
- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/daytona -count=1`
- `git diff --check`
