### PR TITLE
fix: clean Islo exec upload temps after extract errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
-- Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files.
+- Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files. Thanks @stainlu.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
+- Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -257,6 +257,22 @@ func TestIsloSyncWorkspaceFallsBackToExecUpload(t *testing.T) {
 	}
 }
 
+func TestIsloFallbackExtractCommandCleansUploadsOnFailure(t *testing.T) {
+	cmd := isloFallbackExtractCommand("/tmp/crabbox-test.tgz.b64", "/tmp/crabbox-test.tgz", "/workspace/repo")
+	for _, want := range []string{
+		"base64 -d '/tmp/crabbox-test.tgz.b64' > '/tmp/crabbox-test.tgz'",
+		"tar -xzf '/tmp/crabbox-test.tgz' -C '/workspace/repo'",
+		"; status=$?; rm -f '/tmp/crabbox-test.tgz.b64' '/tmp/crabbox-test.tgz'; exit $status",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("command missing %q: %s", want, cmd)
+		}
+	}
+	if strings.Index(cmd, "rm -f '/tmp/crabbox-test.tgz.b64'") < strings.Index(cmd, "tar -xzf") {
+		t.Fatalf("cleanup should run after extract attempt: %s", cmd)
+	}
+}
+
 func TestIsloExecForwardsEnv(t *testing.T) {
 	client := &fakeIsloSyncClient{}
 	backend := &isloBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -119,12 +119,16 @@ func (b *isloBackend) uploadArchiveViaExec(ctx context.Context, client isloAPI, 
 			return fmt.Errorf("islo read archive for fallback upload: %w", readErr)
 		}
 	}
+	return b.execShell(ctx, client, name, isloFallbackExtractCommand(remoteB64, remoteArchive, workspace), io.Discard)
+}
+
+func isloFallbackExtractCommand(remoteB64, remoteArchive, workspace string) string {
 	extract := strings.Join([]string{
 		"if base64 -d " + shellQuote(remoteB64) + " > " + shellQuote(remoteArchive) + " 2>/dev/null; then :; else base64 --decode " + shellQuote(remoteB64) + " > " + shellQuote(remoteArchive) + "; fi",
 		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workspace),
-		"rm -f " + shellQuote(remoteB64) + " " + shellQuote(remoteArchive),
 	}, " && ")
-	return b.execShell(ctx, client, name, extract, io.Discard)
+	cleanup := "rm -f " + shellQuote(remoteB64) + " " + shellQuote(remoteArchive)
+	return extract + "; status=$?; " + cleanup + "; exit $status"
 }
 
 func (b *isloBackend) execShell(ctx context.Context, client isloAPI, name, command string, stdout io.Writer) error {


### PR DESCRIPTION
## Summary

- Clean Islo exec-upload fallback temp files even when base64 decode or tar extraction fails.
- Preserve the original extract/decode exit status after cleanup.
- Add focused command-shape coverage and an Unreleased changelog entry.

## Validation

- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/islo -run 'TestIsloFallbackExtractCommandCleansUploadsOnFailure|TestIsloSyncWorkspaceFallsBackToExecUpload|TestIsloSyncWorkspaceUploadsRepoArchive' -count=1`
- `env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/islo -count=1`
- `git diff --check`
