### PR TITLE
fix: reject malformed Cloudflare runner URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed checkpoint archive restores so large archives stream over SSH without buffering the full tarball in memory and unpack through a per-restore remote temp file. Thanks @stainlu.
 - Fixed Daytona toolbox archive sync so failed remote extracts still remove the uploaded `/tmp/crabbox-*.tgz` archive. Thanks @stainlu.
 - Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files. Thanks @stainlu.
+- Fixed Cloudflare runner URL validation so configured runner URLs cannot include query or fragment components that corrupt API request paths. Thanks @stainlu.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -116,6 +116,39 @@ func TestCloudflareFlagsApply(t *testing.T) {
 	}
 }
 
+func TestCloudflareClientNormalizesBaseURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = " https://runner.example.com/base/ "
+	cfg.Cloudflare.Token = "token"
+	client, err := newCloudflareClient(cfg, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.baseURL != "https://runner.example.com/base" {
+		t.Fatalf("baseURL = %q, want normalized base URL", client.baseURL)
+	}
+}
+
+func TestCloudflareClientRejectsURLQueryAndFragment(t *testing.T) {
+	for _, rawURL := range []string{
+		"https://runner.example.com?token=leaky",
+		"https://runner.example.com/#sandbox",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			cfg := Config{}
+			cfg.Cloudflare.APIURL = rawURL
+			cfg.Cloudflare.Token = "token"
+			_, err := newCloudflareClient(cfg, Runtime{})
+			if err == nil {
+				t.Fatal("newCloudflareClient accepted URL query or fragment")
+			}
+			if !strings.Contains(err.Error(), "must not include query or fragment") {
+				t.Fatalf("error = %v, want query or fragment message", err)
+			}
+		})
+	}
+}
+
 func TestCloudflareCreateSandboxSendsInstanceType(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	var got createSandboxRequest

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -131,6 +131,8 @@ func TestCloudflareClientNormalizesBaseURL(t *testing.T) {
 
 func TestCloudflareClientRejectsURLQueryAndFragment(t *testing.T) {
 	for _, rawURL := range []string{
+		"https://runner.example.com?",
+		"https://runner.example.com/?",
 		"https://runner.example.com?token=leaky",
 		"https://runner.example.com/#sandbox",
 	} {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -82,7 +82,7 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
 		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
 		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, apiURL)
 	}
 	baseURL := strings.TrimRight(parsed.String(), "/")

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -82,12 +82,16 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
 		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, apiURL)
+	}
+	baseURL := strings.TrimRight(parsed.String(), "/")
 	httpClient := rt.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 	return &cloudflareClient{
-		baseURL:      strings.TrimRight(apiURL, "/"),
+		baseURL:      baseURL,
 		token:        token,
 		instanceType: instanceType,
 		http:         httpClient,


### PR DESCRIPTION
## Summary
- reject Cloudflare runner URLs that include query or fragment components
- store the parsed, trimmed runner base URL instead of raw config text
- cover normalization and rejection behavior in Cloudflare provider tests

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/cloudflare -count=1