### PR TITLE
fix: prune stale Cloudflare claims on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed Daytona toolbox archive sync so failed remote extracts still remove the uploaded `/tmp/crabbox-*.tgz` archive. Thanks @stainlu.
 - Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files. Thanks @stainlu.
 - Fixed Cloudflare runner URL validation so configured runner URLs cannot include query or fragment components that corrupt API request paths. Thanks @stainlu.
+- Fixed Cloudflare stop so missing runner containers prune their stale local claims instead of leaving users to run cleanup manually. Thanks @stainlu.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -280,6 +280,11 @@ func (b *cloudflareBackend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if err := client.destroySandbox(ctx, sandboxID); err != nil {
+		if cloudflareNotFoundError(err) {
+			removeLeaseClaim(leaseID)
+			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, leaseID)
+			return nil
+		}
 		return err
 	}
 	removeLeaseClaim(leaseID)
@@ -300,7 +305,7 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 	for _, claim := range claims {
 		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			if cloudflareNotFoundError(err) {
 				if req.DryRun {
 					fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
 					continue
@@ -328,6 +333,14 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d checked=%d\n", providerName, removed, len(claims))
 	}
 	return nil
+}
+
+func cloudflareNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "404") || strings.Contains(text, "not found")
 }
 
 func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflareClient, repo Repo, reclaim bool) (string, cloudflareContainer, string, error) {

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -543,6 +543,42 @@ func TestCloudflareStatusPrunesExpiredClaim(t *testing.T) {
 	}
 }
 
+func TestCloudflareStopPrunesMissingClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/sandboxes/cbx_missing" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	if err := claimLeaseForRepoProvider("cbx_missing", "stale-claim", providerName, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	backend := cloudflareBackend{
+		cfg: Config{
+			Provider: providerName,
+			Cloudflare: CloudflareConfig{
+				APIURL: server.URL,
+				Token:  "token",
+			},
+		},
+		rt: Runtime{HTTP: server.Client(), Stdout: &stdout},
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: "stale-claim"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := resolveLeaseClaimForProvider("stale-claim", providerName); err != nil || ok {
+		t.Fatalf("claim resolved after stale stop ok=%t err=%v", ok, err)
+	}
+	if !strings.Contains(stdout.String(), "removed stale cloudflare claim cbx_missing reason=not-found") {
+		t.Fatalf("stdout = %q, want stale claim removal", stdout.String())
+	}
+}
+
 func TestCloudflareRemoteDiskCheckRejectsZeroOrUnknownAvailable(t *testing.T) {
 	for _, tc := range []struct {
 		name   string


### PR DESCRIPTION
## Summary
- make Cloudflare stop prune the local claim when the runner reports the container is missing
- reuse the not-found check in Cloudflare cleanup
- add a regression test for stopping a stale local claim

## Verification
- env GOCACHE=/private/tmp/crabbox-gocache go test ./internal/providers/cloudflare -count=1