### PR TITLE
fix: accept current providers in plugin schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed Islo exec-upload fallback cleanup so failed archive decodes or extracts still remove temporary upload files. Thanks @stainlu.
 - Fixed Cloudflare runner URL validation so configured runner URLs cannot include query or fragment components that corrupt API request paths. Thanks @stainlu.
 - Fixed Cloudflare stop so missing runner containers prune their stale local claims instead of leaving users to run cleanup manually. Thanks @stainlu.
+- Fixed the Crabbox plugin provider schema so current providers and aliases such as `modal`, `tensorlake`, and `cf` can be selected. Thanks @stainlu.
 - Fixed coordinator TTL cleanup so provider deletion failures keep leases active with retry metadata instead of silently expiring while cloud instances continue running.
 - Fixed direct AWS security-group maintenance so stale Crabbox-owned SSH ingress rules are pruned before adding the current source CIDRs.
 - Fixed E2B sync cleanup so remote upload archives are removed even when extraction fails. Thanks @stainlu.

--- a/index.js
+++ b/index.js
@@ -23,7 +23,35 @@ const envSchema = {
 
 const providerSchema = {
   type: "string",
-  enum: ["aws", "hetzner", "ssh", "blacksmith-testbox", "blacksmith", "namespace-devbox", "namespace", "semaphore", "sprites", "daytona", "islo", "e2b", "cloudflare"],
+  enum: [
+    "aws",
+    "azure",
+    "gcp",
+    "google",
+    "google-cloud",
+    "hetzner",
+    "proxmox",
+    "ssh",
+    "static",
+    "static-ssh",
+    "blacksmith-testbox",
+    "blacksmith",
+    "namespace-devbox",
+    "namespace",
+    "namespace-devboxes",
+    "semaphore",
+    "sem",
+    "sprites",
+    "daytona",
+    "islo",
+    "e2b",
+    "modal",
+    "tensorlake",
+    "tl",
+    "tensorlake-sbx",
+    "cloudflare",
+    "cf",
+  ],
 };
 
 function readConfig(api) {

--- a/index.test.js
+++ b/index.test.js
@@ -47,6 +47,42 @@ test("registers the Crabbox tool surface", () => {
   );
 });
 
+test("provider schema accepts current Crabbox providers and aliases", () => {
+  const tools = registerWithConfig({});
+  const providerEnum = getTool(tools, "crabbox_run").parameters.properties.provider.enum;
+  for (const provider of [
+    "aws",
+    "azure",
+    "gcp",
+    "google",
+    "google-cloud",
+    "hetzner",
+    "proxmox",
+    "ssh",
+    "static",
+    "static-ssh",
+    "blacksmith-testbox",
+    "blacksmith",
+    "namespace-devbox",
+    "namespace",
+    "namespace-devboxes",
+    "semaphore",
+    "sem",
+    "sprites",
+    "daytona",
+    "islo",
+    "e2b",
+    "modal",
+    "tensorlake",
+    "tl",
+    "tensorlake-sbx",
+    "cloudflare",
+    "cf",
+  ]) {
+    assert.ok(providerEnum.includes(provider), `${provider} missing from provider schema`);
+  }
+});
+
 test("crabbox_run executes the CLI without shell wrapping", async () => {
   const fake = createFakeCrabbox();
   const tools = registerWithConfig({ binary: fake.file });


### PR DESCRIPTION
## Summary
- expand the OpenClaw plugin provider enum to include current Crabbox providers and supported aliases
- add schema coverage so provider additions such as Modal, Tensorlake, and Cloudflare aliases are not silently rejected by plugin hosts

## Verification
- npm test
- npm run check