### PR TITLE
fix: unify checkpoint store and add audit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `crabbox admin lease-audit` so operators can compare expired brokered AWS lease records against live cloud instance state and fail automation when a record still maps to a live instance.
 - Added `crabbox checkpoint` native disk-snapshot checkpoints for brokered AWS, Azure, and GCP Linux leases, optional provider image checkpoints via `--strategy image`, local workspace archives for generic POSIX SSH leases, inspect/list/delete flows, archive restore, and checkpoint forks into fresh leases.
+- Added checkpoint audit and cleanup management with `crabbox checkpoint list --verify`, `inspect --verify`, and `prune --older-than`.
 - Added `provider: cloudflare` delegated runs for Cloudflare Containers through a Worker runner, including archive sync, warm containers, local claim cleanup, and deployment docs. Thanks @altaywtf.
 - Added Cloudflare runner deploy-smoke tooling, CI coverage for the container runner Go module, and redacted `crabbox config show` output for Cloudflare runner auth.
 - Added `crabbox list --refresh` so local Cloudflare claims can be checked against live runner state on demand.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -98,7 +98,9 @@ Both may contain secrets. Delete when no longer needed.
 
 ```sh
 crabbox checkpoint list
+crabbox checkpoint list --verify
 crabbox checkpoint inspect chk_abc123
+crabbox checkpoint inspect chk_abc123 --verify
 crabbox checkpoint inspect chk_abc123 --json
 ```
 
@@ -115,6 +117,12 @@ Checkpoints stored in `~/.local/state/crabbox/checkpoints/`.
 **⚠️ Both parts required**: Native checkpoints need local metadata AND provider
 resource. Losing either side breaks fork. Archive checkpoints need local metadata
 AND tarball.
+
+`--verify` audits the second half of the checkpoint:
+
+- Archive checkpoints: confirms the local tarball still exists.
+- Native checkpoints: asks the coordinator to look up the provider snapshot or image.
+- JSON output includes `localState`, `providerState`, and `nextAction`.
 
 ## Restore
 
@@ -212,6 +220,30 @@ crabbox checkpoint delete chk_abc123 --local-only
 
 Use `--local-only` only when provider resource was already deleted outside
 Crabbox (manual cleanup, account migration, etc.).
+
+## Prune
+
+Delete old checkpoints by age, optionally scoped to native or archive
+checkpoints.
+
+```sh
+crabbox checkpoint prune --older-than 30d --dry-run
+crabbox checkpoint prune --older-than 30d --kind archive
+crabbox checkpoint prune --older-than 30d --kind native
+```
+
+**Flags**
+
+```
+--older-than <duration> Required. Delete checkpoints older than this duration
+--kind native|archive   Optional checkpoint kind filter
+--dry-run               Print matching checkpoints without deleting them
+--local-only            Skip provider deletion for native checkpoints
+```
+
+For native checkpoints, prune uses the same provider deletion path as
+`checkpoint delete`. Keep `--dry-run` in operator automation until the match set
+looks right.
 
 **⚠️ Storage costs**: Provider snapshots/images incur storage costs while they
 exist. Delete stale checkpoints periodically. Name checkpoints after scenarios

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -81,15 +82,17 @@ func (a App) checkpoint(ctx context.Context, args []string) error {
 	case "create":
 		return a.checkpointCreate(ctx, args[1:])
 	case "list":
-		return a.checkpointList(args[1:])
+		return a.checkpointList(ctx, args[1:])
 	case "inspect":
-		return a.checkpointInspect(args[1:])
+		return a.checkpointInspect(ctx, args[1:])
 	case "restore":
 		return a.checkpointRestore(ctx, args[1:])
 	case "fork":
 		return a.checkpointFork(ctx, args[1:])
 	case "delete":
-		return a.checkpointDelete(args[1:])
+		return a.checkpointDelete(ctx, args[1:])
+	case "prune":
+		return a.checkpointPrune(ctx, args[1:])
 	default:
 		return exit(2, "unknown checkpoint command %q", args[0])
 	}
@@ -103,6 +106,7 @@ func (a App) printCheckpointHelp() {
   crabbox checkpoint restore <checkpoint-id> --id <lease-id-or-slug> [--clear=false]
   crabbox checkpoint fork <checkpoint-id> [--class <class>] [--keep]
   crabbox checkpoint delete <checkpoint-id>
+  crabbox checkpoint prune --older-than <duration> [--kind native|archive] [--dry-run]
 
 Checkpoints use provider-native disk snapshots for brokered AWS, Azure, and GCP Linux leases, and portable workspace archives elsewhere.`)
 }
@@ -156,6 +160,16 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return err
+	}
+	var paths checkpointPaths
+	record, paths, err = store.Reserve(record)
+	if err != nil {
+		return err
+	}
+	dir = paths.Dir
 	recordWritten := false
 	defer func() {
 		cleanupUncommittedCheckpointDir(dir, recordWritten, err)
@@ -171,7 +185,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		}
 		if err != nil {
 			if record.Native.ImageID != "" {
-				if writeErr := writeCheckpointRecord(dir, record); writeErr != nil {
+				if writeErr := store.Write(record); writeErr != nil {
 					return writeErr
 				}
 				recordWritten = true
@@ -182,8 +196,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		if err := ensureCheckpointArchiveTarget(target); err != nil {
 			return err
 		}
-		archivePath := filepath.Join(dir, checkpointArchive)
-		bytes, err := createCheckpointArchive(ctx, target, workdir, archivePath)
+		bytes, err := createCheckpointArchive(ctx, target, workdir, paths.Archive)
 		if err != nil {
 			return err
 		}
@@ -193,7 +206,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	default:
 		return exit(2, "checkpoint mode must be auto, native, or archive")
 	}
-	if err := writeCheckpointRecord(dir, record); err != nil {
+	if err := store.Write(record); err != nil {
 		return err
 	}
 	recordWritten = true
@@ -205,15 +218,53 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	return nil
 }
 
-func (a App) checkpointList(args []string) error {
+type checkpointAudit struct {
+	Record        checkpointRecord `json:"record"`
+	LocalState    string           `json:"localState"`
+	ProviderState string           `json:"providerState,omitempty"`
+	NextAction    string           `json:"nextAction"`
+	Error         string           `json:"error,omitempty"`
+}
+
+func (a App) checkpointList(ctx context.Context, args []string) error {
 	fs := newFlagSet("checkpoint list", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
+	verify := fs.Bool("verify", false, "verify local artifacts and provider resources")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
-	records, err := listCheckpointRecords()
+	store, err := defaultCheckpointStore()
 	if err != nil {
 		return err
+	}
+	records, err := store.List()
+	if err != nil {
+		return err
+	}
+	if *verify {
+		audits, err := a.verifyCheckpointRecords(ctx, store, records)
+		if err != nil {
+			return err
+		}
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(audits)
+		}
+		if len(audits) == 0 {
+			fmt.Fprintln(a.Stdout, "no checkpoints")
+			return nil
+		}
+		for _, audit := range audits {
+			record := audit.Record
+			extra := fmt.Sprintf("local=%s", audit.LocalState)
+			if audit.ProviderState != "" {
+				extra += fmt.Sprintf(" provider=%s", audit.ProviderState)
+			}
+			if audit.Error != "" {
+				extra += fmt.Sprintf(" error=%q", audit.Error)
+			}
+			fmt.Fprintf(a.Stdout, "%s kind=%s name=%q repo=%s lease=%s %s next=%s created=%s\n", record.ID, record.Kind, record.Name, record.Repo.Name, blank(record.LeaseID, "-"), extra, audit.NextAction, record.CreatedAt)
+		}
+		return nil
 	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(records)
@@ -232,35 +283,59 @@ func (a App) checkpointList(args []string) error {
 	return nil
 }
 
-func (a App) checkpointInspect(args []string) error {
+func (a App) checkpointInspect(ctx context.Context, args []string) error {
 	fs := newFlagSet("checkpoint inspect", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
+	verify := fs.Bool("verify", false, "verify local artifact or provider resource")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
 		return exit(2, "usage: crabbox checkpoint inspect <checkpoint-id>")
 	}
-	record, _, err := readCheckpointRecord(fs.Arg(0))
+	store, err := defaultCheckpointStore()
 	if err != nil {
 		return err
+	}
+	record, _, err := store.Read(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	if *verify {
+		audit, err := a.verifyCheckpointRecord(ctx, store, record)
+		if err != nil {
+			return err
+		}
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(audit)
+		}
+		printCheckpointInspect(a.Stdout, record)
+		fmt.Fprintf(a.Stdout, "local_state=%s\nprovider_state=%s\nnext_action=%s\n", audit.LocalState, blank(audit.ProviderState, "-"), audit.NextAction)
+		if audit.Error != "" {
+			fmt.Fprintf(a.Stdout, "verify_error=%s\n", audit.Error)
+		}
+		return nil
 	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(record)
 	}
-	fmt.Fprintf(a.Stdout, "id=%s\nkind=%s\nname=%s\ncreated=%s\nprovider=%s\nlease=%s\nrepo=%s\nhead=%s\nworkdir=%s\narchive=%s\nbytes=%s\n",
+	printCheckpointInspect(a.Stdout, record)
+	return nil
+}
+
+func printCheckpointInspect(stdout io.Writer, record checkpointRecord) {
+	fmt.Fprintf(stdout, "id=%s\nkind=%s\nname=%s\ncreated=%s\nprovider=%s\nlease=%s\nrepo=%s\nhead=%s\nworkdir=%s\narchive=%s\nbytes=%s\n",
 		record.ID, record.Kind, blank(record.Name, "-"), record.CreatedAt, blank(record.Provider, "-"), blank(record.LeaseID, "-"), blank(record.Repo.Name, "-"), blank(record.Repo.Head, "-"), blank(record.Workdir, "-"), blank(record.ArchivePath, "-"), humanBytes(record.ArchiveBytes))
 	if isNativeCheckpointKind(record.Kind) {
-		fmt.Fprintf(a.Stdout, "resource=%s\nresource_name=%s\nresource_state=%s\nresource_region=%s\nstrategy=%s\nno_reboot=%t\n",
+		fmt.Fprintf(stdout, "resource=%s\nresource_name=%s\nresource_state=%s\nresource_region=%s\nstrategy=%s\nno_reboot=%t\n",
 			blank(record.Native.ImageID, "-"), blank(record.Native.Name, "-"), blank(record.Native.State, "-"), blank(record.Native.Region, "-"), blank(record.Native.Strategy, checkpointStrategyImage), record.Native.NoReboot)
 		if record.Native.Project != "" {
-			fmt.Fprintf(a.Stdout, "image_project=%s\n", record.Native.Project)
+			fmt.Fprintf(stdout, "image_project=%s\n", record.Native.Project)
 		}
 		if record.Native.Resource != "" {
-			fmt.Fprintf(a.Stdout, "image_resource=%s\n", record.Native.Resource)
+			fmt.Fprintf(stdout, "image_resource=%s\n", record.Native.Resource)
 		}
 	}
-	return nil
 }
 
 func (a App) checkpointRestore(ctx context.Context, args []string) error {
@@ -279,7 +354,11 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 	if fs.NArg() != 1 {
 		return exit(2, "usage: crabbox checkpoint restore <checkpoint-id> --id <lease-id-or-slug>")
 	}
-	record, dir, err := readCheckpointRecord(fs.Arg(0))
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return err
+	}
+	record, paths, err := store.Read(fs.Arg(0))
 	if err != nil {
 		return err
 	}
@@ -311,7 +390,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 	if workdir == "" {
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
-	if err := restoreCheckpointArchive(ctx, target, filepath.Join(dir, record.ArchivePath), record.ID, workdir, *clear); err != nil {
+	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint restored id=%s lease=%s workdir=%s\n", record.ID, leaseID, workdir)
@@ -332,7 +411,11 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if fs.NArg() != 1 {
 		return exit(2, "usage: crabbox checkpoint fork <checkpoint-id> [--class <class>]")
 	}
-	record, dir, err := readCheckpointRecord(fs.Arg(0))
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return err
+	}
+	record, paths, err := store.Read(fs.Arg(0))
 	if err != nil {
 		return err
 	}
@@ -398,7 +481,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if workdir == "" {
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
-	if err := restoreCheckpointArchive(ctx, target, filepath.Join(dir, record.ArchivePath), record.ID, workdir, *clear); err != nil {
+	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
 		a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		return err
 	}
@@ -406,7 +489,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	return nil
 }
 
-func (a App) checkpointDelete(args []string) error {
+func (a App) checkpointDelete(ctx context.Context, args []string) error {
 	fs := newFlagSet("checkpoint delete", a.Stderr)
 	localOnly := fs.Bool("local-only", false, "delete only the local checkpoint record")
 	if err := parseInterspersedFlags(fs, args); err != nil {
@@ -419,28 +502,227 @@ func (a App) checkpointDelete(args []string) error {
 	if err != nil {
 		return err
 	}
-	record, _, err := readCheckpointRecord(id)
+	store, err := defaultCheckpointStore()
 	if err != nil {
 		return err
 	}
-	if isNativeCheckpointKind(record.Kind) && record.Native.ImageID != "" && !*localOnly {
+	if err := deleteCheckpoint(ctx, store, id, *localOnly); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.Stdout, "checkpoint deleted id=%s\n", id)
+	return nil
+}
+
+func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, localOnly bool) error {
+	record, _, err := store.Read(id)
+	if err != nil {
+		return err
+	}
+	if isNativeCheckpointKind(record.Kind) && record.Native.ImageID != "" && !localOnly {
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
 			return err
 		}
-		if err := coord.DeleteImage(context.Background(), record.Native.ImageID, nativeCoordinatorImageRef(record)); err != nil {
+		if err := coord.DeleteImage(ctx, record.Native.ImageID, nativeCoordinatorImageRef(record)); err != nil {
 			return err
 		}
 	}
-	dir, err := checkpointDir(id)
+	return store.Delete(id)
+}
+
+func (a App) checkpointPrune(ctx context.Context, args []string) error {
+	fs := newFlagSet("checkpoint prune", a.Stderr)
+	olderThan := fs.String("older-than", "", "delete checkpoints older than this duration")
+	kind := fs.String("kind", "", "checkpoint kind filter: native or archive")
+	dryRun := fs.Bool("dry-run", false, "print checkpoints that would be deleted")
+	localOnly := fs.Bool("local-only", false, "delete local checkpoint records without deleting provider resources")
+	if err := parseInterspersedFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return exit(2, "usage: crabbox checkpoint prune --older-than <duration> [--kind native|archive] [--dry-run]")
+	}
+	pruneAge, err := parseCheckpointPruneDuration(*olderThan)
 	if err != nil {
 		return err
 	}
-	if err := os.RemoveAll(dir); err != nil {
-		return exit(2, "delete checkpoint %s: %v", id, err)
+	if pruneAge <= 0 {
+		return exit(2, "usage: crabbox checkpoint prune --older-than <duration> [--kind native|archive] [--dry-run]")
 	}
-	fmt.Fprintf(a.Stdout, "checkpoint deleted id=%s\n", id)
+	kindFilter := strings.TrimSpace(*kind)
+	if kindFilter != "" && kindFilter != "native" && kindFilter != "archive" {
+		return exit(2, "--kind must be native or archive")
+	}
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return err
+	}
+	records, err := store.List()
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-pruneAge)
+	matched := 0
+	for _, record := range records {
+		created, err := time.Parse(time.RFC3339, record.CreatedAt)
+		if err != nil {
+			return exit(2, "checkpoint %s has invalid createdAt: %v", record.ID, err)
+		}
+		if !created.Before(cutoff) || !checkpointMatchesPruneKind(record, kindFilter) {
+			continue
+		}
+		matched++
+		if *dryRun {
+			fmt.Fprintf(a.Stdout, "would delete id=%s kind=%s created=%s\n", record.ID, record.Kind, record.CreatedAt)
+			continue
+		}
+		if err := deleteCheckpoint(ctx, store, record.ID, *localOnly); err != nil {
+			return err
+		}
+		fmt.Fprintf(a.Stdout, "checkpoint pruned id=%s kind=%s created=%s\n", record.ID, record.Kind, record.CreatedAt)
+	}
+	if matched == 0 {
+		fmt.Fprintln(a.Stdout, "no checkpoints matched prune criteria")
+	}
 	return nil
+}
+
+func parseCheckpointPruneDuration(value string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, nil
+	}
+	if strings.HasSuffix(trimmed, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(trimmed, "d"))
+		if err != nil || days <= 0 {
+			return 0, exit(2, "--older-than day duration must be a positive integer")
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	duration, err := time.ParseDuration(trimmed)
+	if err != nil {
+		return 0, exit(2, "parse --older-than: %v", err)
+	}
+	return duration, nil
+}
+
+func checkpointMatchesPruneKind(record checkpointRecord, kind string) bool {
+	switch kind {
+	case "":
+		return true
+	case "native":
+		return isNativeCheckpointKind(record.Kind)
+	case "archive":
+		return record.Kind == checkpointKindArchive
+	default:
+		return false
+	}
+}
+
+func (a App) verifyCheckpointRecords(ctx context.Context, store checkpointStore, records []checkpointRecord) ([]checkpointAudit, error) {
+	audits := make([]checkpointAudit, 0, len(records))
+	for _, record := range records {
+		audit, err := a.verifyCheckpointRecord(ctx, store, record)
+		if err != nil {
+			return nil, err
+		}
+		audits = append(audits, audit)
+	}
+	return audits, nil
+}
+
+func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, record checkpointRecord) (checkpointAudit, error) {
+	audit := checkpointAudit{
+		Record:     record,
+		LocalState: "metadata_available",
+		NextAction: "inspect",
+	}
+	paths, err := store.Paths(record.ID)
+	if err != nil {
+		return checkpointAudit{}, err
+	}
+	switch {
+	case record.Kind == checkpointKindArchive:
+		archivePath := checkpointArchivePath(paths, record)
+		info, err := os.Stat(archivePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				audit.LocalState = "missing_archive"
+				audit.ProviderState = "not_applicable"
+				audit.NextAction = "delete_or_recreate"
+				return audit, nil
+			}
+			return checkpointAudit{}, exit(2, "stat checkpoint archive %s: %v", record.ID, err)
+		}
+		if info.IsDir() {
+			audit.LocalState = "invalid_archive"
+			audit.ProviderState = "not_applicable"
+			audit.NextAction = "delete_or_recreate"
+			return audit, nil
+		}
+		audit.LocalState = "available"
+		audit.ProviderState = "not_applicable"
+		audit.NextAction = "restore_or_fork"
+		return audit, nil
+	case isNativeCheckpointKind(record.Kind):
+		if record.Native.ImageID == "" {
+			audit.ProviderState = "missing_ref"
+			audit.NextAction = "delete_local"
+			return audit, nil
+		}
+		coord, err := configuredAdminCoordinator()
+		if err != nil {
+			audit.ProviderState = "unknown"
+			audit.NextAction = "configure_admin_auth"
+			audit.Error = err.Error()
+			return audit, nil
+		}
+		image, err := coord.Image(ctx, record.Native.ImageID, nativeCoordinatorImageRef(record))
+		if err != nil {
+			if coordinatorStatusCode(err) == 404 {
+				audit.ProviderState = "missing"
+				audit.NextAction = "delete_local"
+				return audit, nil
+			}
+			audit.ProviderState = "unknown"
+			audit.NextAction = "check_auth_or_provider"
+			audit.Error = err.Error()
+			return audit, nil
+		}
+		audit.ProviderState = blank(image.State, "unknown")
+		switch strings.ToLower(image.State) {
+		case "available", "ready", "succeeded", "completed":
+			audit.NextAction = "fork_or_delete"
+		case "failed", "invalid":
+			audit.NextAction = "delete"
+		default:
+			audit.NextAction = "wait_or_delete"
+		}
+		return audit, nil
+	default:
+		audit.LocalState = "metadata_only"
+		audit.ProviderState = "not_applicable"
+		audit.NextAction = "inspect"
+		return audit, nil
+	}
+}
+
+func checkpointArchivePath(paths checkpointPaths, record checkpointRecord) string {
+	if record.ArchivePath == "" {
+		return paths.Archive
+	}
+	if filepath.IsAbs(record.ArchivePath) {
+		return record.ArchivePath
+	}
+	return filepath.Join(paths.Dir, record.ArchivePath)
+}
+
+func coordinatorStatusCode(err error) int {
+	var httpErr CoordinatorHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode
+	}
+	return 0
 }
 
 func applyNativeImageCheckpointRecord(record *checkpointRecord, image CoordinatorImage, noReboot bool) {
@@ -836,98 +1118,6 @@ func validateCheckpointID(value string) (string, error) {
 		return "", exit(2, "checkpoint id contains unsafe character %q", r)
 	}
 	return id, nil
-}
-
-func checkpointRootDir() (string, error) {
-	stateDir, err := crabboxStateDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(stateDir, "checkpoints"), nil
-}
-
-func checkpointDir(id string) (string, error) {
-	id, err := validateCheckpointID(id)
-	if err != nil {
-		return "", err
-	}
-	root, err := checkpointRootDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(root, id), nil
-}
-
-func writeCheckpointRecord(dir string, record checkpointRecord) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return exit(2, "create checkpoint directory: %v", err)
-	}
-	data, err := json.MarshalIndent(record, "", "  ")
-	if err != nil {
-		return exit(2, "encode checkpoint %s: %v", record.ID, err)
-	}
-	data = append(data, '\n')
-	path := filepath.Join(dir, checkpointMetaFile)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return exit(2, "write checkpoint %s: %v", record.ID, err)
-	}
-	return nil
-}
-
-func readCheckpointRecord(id string) (checkpointRecord, string, error) {
-	dir, err := checkpointDir(id)
-	if err != nil {
-		return checkpointRecord{}, "", err
-	}
-	data, err := os.ReadFile(filepath.Join(dir, checkpointMetaFile))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return checkpointRecord{}, "", exit(2, "checkpoint %s not found", id)
-		}
-		return checkpointRecord{}, "", exit(2, "read checkpoint %s: %v", id, err)
-	}
-	var record checkpointRecord
-	if err := json.Unmarshal(data, &record); err != nil {
-		return checkpointRecord{}, "", exit(2, "parse checkpoint %s: %v", id, err)
-	}
-	if record.ID == "" {
-		record.ID = filepath.Base(dir)
-	}
-	return record, dir, nil
-}
-
-func listCheckpointRecords() ([]checkpointRecord, error) {
-	root, err := checkpointRootDir()
-	if err != nil {
-		return nil, err
-	}
-	entries, err := os.ReadDir(root)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, exit(2, "read checkpoints: %v", err)
-	}
-	records := []checkpointRecord{}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		record, _, err := readCheckpointRecord(entry.Name())
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, record)
-	}
-	sort.Slice(records, func(i, j int) bool {
-		left, leftErr := time.Parse(time.RFC3339, records[i].CreatedAt)
-		right, rightErr := time.Parse(time.RFC3339, records[j].CreatedAt)
-		if leftErr == nil && rightErr == nil && !left.Equal(right) {
-			return left.After(right)
-		}
-		return records[i].ID > records[j].ID
-	})
-	return records, nil
 }
 
 func ensureCheckpointArchiveTarget(target SSHTarget) error {

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -164,6 +164,13 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	createKind := checkpointCreateMode(*mode, *strategy, cfg, server, target, *recipeOnly)
+	switch createKind {
+	case checkpointKindRecipe, checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindArchive:
+		record.Kind = createKind
+	default:
+		return exit(2, "checkpoint mode must be auto, native, or archive")
+	}
 	var paths checkpointPaths
 	record, paths, err = store.Reserve(record)
 	if err != nil {
@@ -174,10 +181,8 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	defer func() {
 		cleanupUncommittedCheckpointDir(dir, recordWritten, err)
 	}()
-	createKind := checkpointCreateMode(*mode, *strategy, cfg, server, target, *recipeOnly)
 	switch createKind {
 	case checkpointKindRecipe:
-		record.Kind = checkpointKindRecipe
 	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk:
 		image, err := a.createNativeCheckpoint(ctx, cfg, server, target, leaseID, record.Name, repo.Name, checkpointStrategyForKind(createKind), *noReboot, *wait, *waitTimeout)
 		if image.ID != "" {
@@ -200,11 +205,8 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		if err != nil {
 			return err
 		}
-		record.Kind = checkpointKindArchive
 		record.ArchivePath = checkpointArchive
 		record.ArchiveBytes = bytes
-	default:
-		return exit(2, "checkpoint mode must be auto, native, or archive")
 	}
 	if err := store.Write(record); err != nil {
 		return err
@@ -426,11 +428,15 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
 		return err
 	}
-	if isNativeCheckpointKind(record.Kind) {
-		applyNativeCheckpointForkConfig(&cfg, fs, record)
-	}
-	if record.Kind != checkpointKindArchive && !isNativeCheckpointKind(record.Kind) {
+	nativeCheckpoint := isNativeCheckpointKind(record.Kind)
+	if record.Kind != checkpointKindArchive && !nativeCheckpoint {
 		return exit(2, "checkpoint %s has kind=%s; fork requires %s or a native image checkpoint", record.ID, record.Kind, checkpointKindArchive)
+	}
+	if nativeCheckpoint {
+		if nativeCheckpointResourceID(record) == "" {
+			return exit(2, "checkpoint %s is pending; native provider resource is not recorded yet", record.ID)
+		}
+		applyNativeCheckpointForkConfig(&cfg, fs, record)
 	}
 	repo, err := findRepo()
 	if err != nil {
@@ -474,7 +480,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 			a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 			return err
 		}
-		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), record.Native.ImageID, workdir)
+		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), nativeCheckpointResourceID(record), workdir)
 		return nil
 	}
 	workdir := strings.TrimSpace(*workdirOverride)
@@ -518,12 +524,13 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 	if err != nil {
 		return err
 	}
-	if isNativeCheckpointKind(record.Kind) && record.Native.ImageID != "" && !localOnly {
+	providerID := nativeCheckpointDeleteID(record)
+	if isNativeCheckpointKind(record.Kind) && providerID != "" && !localOnly {
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
 			return err
 		}
-		if err := coord.DeleteImage(ctx, record.Native.ImageID, nativeCoordinatorImageRef(record)); err != nil {
+		if err := coord.DeleteImage(ctx, providerID, nativeCoordinatorImageRef(record)); err != nil {
 			return err
 		}
 	}
@@ -665,7 +672,13 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 		audit.NextAction = "restore_or_fork"
 		return audit, nil
 	case isNativeCheckpointKind(record.Kind):
-		if record.Native.ImageID == "" {
+		providerID := strings.TrimSpace(record.Native.ImageID)
+		if providerID == "" {
+			if nativeCheckpointResourceID(record) != "" {
+				audit.ProviderState = "unverified_ref"
+				audit.NextAction = "fork_or_delete_local"
+				return audit, nil
+			}
 			audit.ProviderState = "missing_ref"
 			audit.NextAction = "delete_local"
 			return audit, nil
@@ -677,7 +690,7 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 			audit.Error = err.Error()
 			return audit, nil
 		}
-		image, err := coord.Image(ctx, record.Native.ImageID, nativeCoordinatorImageRef(record))
+		image, err := coord.Image(ctx, providerID, nativeCoordinatorImageRef(record))
 		if err != nil {
 			if coordinatorStatusCode(err) == 404 {
 				audit.ProviderState = "missing"
@@ -741,6 +754,27 @@ func applyNativeImageCheckpointRecord(record *checkpointRecord, image Coordinato
 
 func applyAWSAMIImageCheckpointRecord(record *checkpointRecord, image CoordinatorImage, noReboot bool) {
 	applyNativeImageCheckpointRecord(record, image, noReboot)
+}
+
+func nativeCheckpointResourceID(record checkpointRecord) string {
+	switch record.Kind {
+	case checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk:
+		return firstNonBlank(record.Native.Resource, record.Native.ImageID)
+	default:
+		return record.Native.ImageID
+	}
+}
+
+func nativeCheckpointDeleteID(record checkpointRecord) string {
+	if imageID := strings.TrimSpace(record.Native.ImageID); imageID != "" {
+		return imageID
+	}
+	switch record.Kind {
+	case checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk:
+		return strings.TrimSpace(record.Native.Resource)
+	default:
+		return ""
+	}
 }
 
 func checkpointKindForProviderImage(image CoordinatorImage) string {
@@ -1039,7 +1073,7 @@ func applyAWSAMICheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record check
 
 func nativeCoordinatorImageRef(record checkpointRecord) CoordinatorImageRef {
 	return CoordinatorImageRef{
-		Provider: firstNonBlank(record.Native.Provider, record.Provider),
+		Provider: firstNonBlank(record.Native.Provider, checkpointProviderForKind(record.Kind), record.Provider),
 		Region:   record.Native.Region,
 		Project:  record.Native.Project,
 		Kind:     firstNonBlank(record.Native.Kind, record.Kind),

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -3,80 +3,20 @@ package cli
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 )
 
-type CheckpointRecord struct {
-	ID               string                      `json:"id"`
-	ParentID         string                      `json:"parentId,omitempty"`
-	Name             string                      `json:"name,omitempty"`
-	Notes            string                      `json:"notes,omitempty"`
-	CreatedAt        string                      `json:"createdAt"`
-	CreatedBy        string                      `json:"createdBy,omitempty"`
-	Repo             CheckpointRepo              `json:"repo"`
-	Lease            CheckpointLease             `json:"lease,omitempty"`
-	Run              CheckpointRun               `json:"run,omitempty"`
-	Workspace        CheckpointWorkspace         `json:"workspace,omitempty"`
-	Artifacts        []CheckpointArtifact        `json:"artifacts,omitempty"`
-	ProviderSnapshot *CheckpointProviderSnapshot `json:"providerSnapshot,omitempty"`
-}
-
-type CheckpointRepo struct {
-	Root      string `json:"root,omitempty"`
-	Name      string `json:"name,omitempty"`
-	RemoteURL string `json:"remoteUrl,omitempty"`
-	Branch    string `json:"branch,omitempty"`
-	Head      string `json:"head,omitempty"`
-	BaseRef   string `json:"baseRef,omitempty"`
-}
-
-type CheckpointLease struct {
-	ID          string `json:"id,omitempty"`
-	Slug        string `json:"slug,omitempty"`
-	Provider    string `json:"provider,omitempty"`
-	TargetOS    string `json:"targetOS,omitempty"`
-	WindowsMode string `json:"windowsMode,omitempty"`
-	Class       string `json:"class,omitempty"`
-	ServerType  string `json:"serverType,omitempty"`
-}
-
-type CheckpointRun struct {
-	ID          string `json:"id,omitempty"`
-	ExitCode    *int   `json:"exitCode,omitempty"`
-	DurationMs  int64  `json:"durationMs,omitempty"`
-	Command     string `json:"command,omitempty"`
-	LogPath     string `json:"logPath,omitempty"`
-	ResultsPath string `json:"resultsPath,omitempty"`
-}
-
-type CheckpointWorkspace struct {
-	ManifestPath string `json:"manifestPath,omitempty"`
-	PatchPath    string `json:"patchPath,omitempty"`
-	ArchivePath  string `json:"archivePath,omitempty"`
-	ChangedFiles int    `json:"changedFiles,omitempty"`
-	DeletedFiles int    `json:"deletedFiles,omitempty"`
-	Bytes        int64  `json:"bytes,omitempty"`
-}
-
-type CheckpointArtifact struct {
-	Path string `json:"path,omitempty"`
-	URL  string `json:"url,omitempty"`
-	Type string `json:"type,omitempty"`
-}
-
-type CheckpointProviderSnapshot struct {
-	Provider string `json:"provider,omitempty"`
-	ID       string `json:"id,omitempty"`
-	Kind     string `json:"kind,omitempty"`
-}
-
 type checkpointStore struct {
-	dir string
+	root string
+}
+
+type checkpointPaths struct {
+	Dir     string
+	Meta    string
+	Archive string
 }
 
 func defaultCheckpointStore() (checkpointStore, error) {
@@ -84,83 +24,145 @@ func defaultCheckpointStore() (checkpointStore, error) {
 	if err != nil {
 		return checkpointStore{}, err
 	}
-	return checkpointStore{dir: filepath.Join(stateDir, "checkpoints")}, nil
+	return checkpointStore{root: filepath.Join(stateDir, "checkpoints")}, nil
 }
 
-func (s checkpointStore) Create(record CheckpointRecord) (CheckpointRecord, error) {
-	if strings.TrimSpace(record.ID) == "" {
+func checkpointDir(id string) (string, error) {
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		return "", err
+	}
+	paths, err := store.Paths(id)
+	if err != nil {
+		return "", err
+	}
+	return paths.Dir, nil
+}
+
+func (s checkpointStore) Paths(id string) (checkpointPaths, error) {
+	id, err := validateCheckpointID(id)
+	if err != nil {
+		return checkpointPaths{}, err
+	}
+	dir := filepath.Join(s.root, id)
+	return checkpointPaths{
+		Dir:     dir,
+		Meta:    filepath.Join(dir, checkpointMetaFile),
+		Archive: filepath.Join(dir, checkpointArchive),
+	}, nil
+}
+
+func (s checkpointStore) Reserve(record checkpointRecord) (checkpointRecord, checkpointPaths, error) {
+	if record.ID == "" {
 		id, err := newCheckpointID()
 		if err != nil {
-			return CheckpointRecord{}, err
+			return checkpointRecord{}, checkpointPaths{}, err
 		}
 		record.ID = id
 	}
 	id, err := validateCheckpointID(record.ID)
 	if err != nil {
-		return CheckpointRecord{}, err
+		return checkpointRecord{}, checkpointPaths{}, err
 	}
 	record.ID = id
-	record.ParentID = strings.TrimSpace(record.ParentID)
-	if record.ParentID != "" {
-		parentID, err := validateCheckpointID(record.ParentID)
-		if err != nil {
-			return CheckpointRecord{}, fmt.Errorf("parent id: %w", err)
-		}
-		record.ParentID = parentID
-	}
-	if strings.TrimSpace(record.CreatedAt) == "" {
+	if record.CreatedAt == "" {
 		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
 	}
 	if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
-		return CheckpointRecord{}, exit(2, "checkpoint createdAt must be RFC3339: %v", err)
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint createdAt must be RFC3339: %v", err)
 	}
-	path := s.path(record.ID)
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return CheckpointRecord{}, exit(2, "create checkpoint directory: %v", err)
+	paths, err := s.Paths(record.ID)
+	if err != nil {
+		return checkpointRecord{}, checkpointPaths{}, err
 	}
-	if err := writeCheckpointJSON(path, record); err != nil {
-		return CheckpointRecord{}, err
+	if err := os.MkdirAll(s.root, 0o700); err != nil {
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "create checkpoint root: %v", err)
 	}
+	if err := os.Mkdir(paths.Dir, 0o700); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint %s already exists", record.ID)
+		}
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "create checkpoint %s: %v", record.ID, err)
+	}
+	return record, paths, nil
+}
+
+func (s checkpointStore) Create(record checkpointRecord) (checkpointRecord, error) {
+	record, paths, err := s.Reserve(record)
+	if err != nil {
+		return checkpointRecord{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(paths.Dir)
+		}
+	}()
+	if err := s.Write(record); err != nil {
+		return checkpointRecord{}, err
+	}
+	committed = true
 	return record, nil
 }
 
-func (s checkpointStore) Read(id string) (CheckpointRecord, error) {
-	id, err := validateCheckpointID(id)
+func (s checkpointStore) Write(record checkpointRecord) error {
+	paths, err := s.Paths(record.ID)
 	if err != nil {
-		return CheckpointRecord{}, err
+		return err
 	}
-	data, err := os.ReadFile(s.path(id))
-	if errors.Is(err, os.ErrNotExist) {
-		return CheckpointRecord{}, exit(2, "checkpoint %s not found", id)
+	if err := os.MkdirAll(paths.Dir, 0o700); err != nil {
+		return exit(2, "create checkpoint directory: %v", err)
 	}
+	data, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
-		return CheckpointRecord{}, exit(2, "read checkpoint %s: %v", id, err)
+		return exit(2, "encode checkpoint %s: %v", record.ID, err)
 	}
-	var record CheckpointRecord
+	data = append(data, '\n')
+	if err := os.WriteFile(paths.Meta, data, 0o600); err != nil {
+		return exit(2, "write checkpoint %s: %v", record.ID, err)
+	}
+	return nil
+}
+
+func (s checkpointStore) Read(id string) (checkpointRecord, checkpointPaths, error) {
+	paths, err := s.Paths(id)
+	if err != nil {
+		return checkpointRecord{}, checkpointPaths{}, err
+	}
+	data, err := os.ReadFile(paths.Meta)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint %s not found", id)
+		}
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "read checkpoint %s: %v", id, err)
+	}
+	var record checkpointRecord
 	if err := json.Unmarshal(data, &record); err != nil {
-		return CheckpointRecord{}, exit(2, "parse checkpoint %s: %v", id, err)
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "parse checkpoint %s: %v", id, err)
 	}
+	dirID := filepath.Base(paths.Dir)
 	if record.ID == "" {
-		record.ID = id
+		record.ID = dirID
+	} else if record.ID != dirID {
+		return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint %s metadata id mismatch: %s", dirID, record.ID)
 	}
-	return record, nil
+	return record, paths, nil
 }
 
-func (s checkpointStore) List() ([]CheckpointRecord, error) {
-	entries, err := os.ReadDir(s.dir)
+func (s checkpointStore) List() ([]checkpointRecord, error) {
+	entries, err := os.ReadDir(s.root)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, exit(2, "read checkpoints directory: %v", err)
+		return nil, exit(2, "read checkpoints: %v", err)
 	}
-	records := make([]CheckpointRecord, 0, len(entries))
+	records := []checkpointRecord{}
 	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+		if !entry.IsDir() {
 			continue
 		}
-		id := strings.TrimSuffix(entry.Name(), ".json")
-		record, err := s.Read(id)
+		record, _, err := s.Read(entry.Name())
 		if err != nil {
 			return nil, err
 		}
@@ -177,36 +179,13 @@ func (s checkpointStore) List() ([]CheckpointRecord, error) {
 	return records, nil
 }
 
-func (s checkpointStore) path(id string) string {
-	return filepath.Join(s.dir, id+".json")
-}
-
-func writeCheckpointJSON(path string, record CheckpointRecord) error {
-	data, err := json.MarshalIndent(record, "", "  ")
+func (s checkpointStore) Delete(id string) error {
+	paths, err := s.Paths(id)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return exit(2, "checkpoint %s already exists", record.ID)
-		}
-		return exit(2, "create checkpoint %s: %v", path, err)
+	if err := os.RemoveAll(paths.Dir); err != nil {
+		return exit(2, "delete checkpoint %s: %v", id, err)
 	}
-	created := false
-	defer func() {
-		if !created {
-			_ = os.Remove(path)
-		}
-	}()
-	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		return exit(2, "write checkpoint %s: %v", path, err)
-	}
-	if err := file.Close(); err != nil {
-		return exit(2, "close checkpoint %s: %v", path, err)
-	}
-	created = true
 	return nil
 }

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -84,6 +84,10 @@ func (s checkpointStore) Reserve(record checkpointRecord) (checkpointRecord, che
 		}
 		return checkpointRecord{}, checkpointPaths{}, exit(2, "create checkpoint %s: %v", record.ID, err)
 	}
+	if err := s.writeMetadata(record, paths); err != nil {
+		_ = os.RemoveAll(paths.Dir)
+		return checkpointRecord{}, checkpointPaths{}, err
+	}
 	return record, paths, nil
 }
 
@@ -113,6 +117,10 @@ func (s checkpointStore) Write(record checkpointRecord) error {
 	if err := os.MkdirAll(paths.Dir, 0o700); err != nil {
 		return exit(2, "create checkpoint directory: %v", err)
 	}
+	return s.writeMetadata(record, paths)
+}
+
+func (s checkpointStore) writeMetadata(record checkpointRecord, paths checkpointPaths) error {
 	data, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return exit(2, "encode checkpoint %s: %v", record.ID, err)

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -67,6 +67,38 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 	}
 }
 
+func TestCheckpointStoreReserveWritesMetadata(t *testing.T) {
+	store := checkpointStore{root: t.TempDir()}
+	record, paths, err := store.Reserve(checkpointRecord{
+		ID:        "chk_pending",
+		Kind:      checkpointKindAWSAMI,
+		CreatedAt: "2026-05-09T10:00:00Z",
+		Workdir:   "/work/cbx_1/my-app",
+	})
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if _, err := os.Stat(paths.Meta); err != nil {
+		t.Fatalf("stat metadata: %v", err)
+	}
+
+	got, _, err := store.Read("chk_pending")
+	if err != nil {
+		t.Fatalf("read reserved checkpoint: %v", err)
+	}
+	if got.ID != record.ID || got.Kind != checkpointKindAWSAMI {
+		t.Fatalf("unexpected reserved checkpoint: %#v", got)
+	}
+
+	records, err := store.List()
+	if err != nil {
+		t.Fatalf("list reserved checkpoint: %v", err)
+	}
+	if len(records) != 1 || records[0].ID != "chk_pending" {
+		t.Fatalf("records=%#v", records)
+	}
+}
+
 func TestCheckpointStoreRejectsDuplicatesAndUnsafeIDs(t *testing.T) {
 	store := checkpointStore{root: t.TempDir()}
 	if _, err := store.Create(checkpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:00:00Z"}); err != nil {

--- a/internal/cli/checkpoint_store_test.go
+++ b/internal/cli/checkpoint_store_test.go
@@ -10,31 +10,13 @@ import (
 )
 
 func TestCheckpointStoreCreateReadList(t *testing.T) {
-	store := checkpointStore{dir: t.TempDir()}
-	first, err := store.Create(CheckpointRecord{
+	store := checkpointStore{root: t.TempDir()}
+	first, err := store.Create(checkpointRecord{
 		ID:        "chk_first",
 		Name:      "first",
+		Kind:      checkpointKindArchive,
 		CreatedAt: "2026-05-09T10:00:00Z",
-		Repo: CheckpointRepo{
-			Root:      "/repo",
-			Name:      "my-app",
-			RemoteURL: "https://github.com/example-org/my-app",
-			Branch:    "main",
-			Head:      "abc123",
-			BaseRef:   "main",
-		},
-		Lease: CheckpointLease{
-			ID:       "cbx_123",
-			Slug:     "blue-lobster",
-			Provider: "aws",
-			TargetOS: "linux",
-			Class:    "beast",
-		},
-		Workspace: CheckpointWorkspace{
-			ChangedFiles: 2,
-			DeletedFiles: 1,
-			Bytes:        42,
-		},
+		Workdir:   "/work/cbx_1/my-app",
 	})
 	if err != nil {
 		t.Fatalf("create first: %v", err)
@@ -42,27 +24,22 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 	if first.ID != "chk_first" {
 		t.Fatalf("id=%q", first.ID)
 	}
-	second, err := store.Create(CheckpointRecord{
+	second, err := store.Create(checkpointRecord{
 		ID:        "chk_second",
-		ParentID:  "chk_first",
 		Name:      "second",
+		Kind:      checkpointKindArchive,
 		CreatedAt: "2026-05-09T11:00:00Z",
-		Run: CheckpointRun{
-			ID:         "run_123",
-			DurationMs: 1500,
-			Command:    "go test ./...",
-		},
-		Artifacts: []CheckpointArtifact{{Path: "artifacts/blue-lobster/screenshot.png", Type: "screenshot"}},
+		Workdir:   "/work/cbx_2/my-app",
 	})
 	if err != nil {
 		t.Fatalf("create second: %v", err)
 	}
 
-	got, err := store.Read(second.ID)
+	got, _, err := store.Read(second.ID)
 	if err != nil {
 		t.Fatalf("read second: %v", err)
 	}
-	if got.ParentID != "chk_first" || got.Run.ID != "run_123" || len(got.Artifacts) != 1 {
+	if got.ID != "chk_second" || got.Workdir != "/work/cbx_2/my-app" {
 		t.Fatalf("unexpected checkpoint: %#v", got)
 	}
 
@@ -77,7 +54,7 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 		t.Fatalf("records ordered newest first: %#v", records)
 	}
 
-	data, err := os.ReadFile(filepath.Join(store.dir, "chk_second.json"))
+	data, err := os.ReadFile(filepath.Join(store.root, "chk_second", checkpointMetaFile))
 	if err != nil {
 		t.Fatalf("read file: %v", err)
 	}
@@ -91,33 +68,70 @@ func TestCheckpointStoreCreateReadList(t *testing.T) {
 }
 
 func TestCheckpointStoreRejectsDuplicatesAndUnsafeIDs(t *testing.T) {
-	store := checkpointStore{dir: t.TempDir()}
-	if _, err := store.Create(CheckpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:00:00Z"}); err != nil {
+	store := checkpointStore{root: t.TempDir()}
+	if _, err := store.Create(checkpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:00:00Z"}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if _, err := store.Create(CheckpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+	if _, err := store.Create(checkpointRecord{ID: "chk_ok", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
 		t.Fatal("duplicate checkpoint succeeded")
 	}
-	if _, err := store.Create(CheckpointRecord{ID: "../bad", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+	if _, err := store.Create(checkpointRecord{ID: "../bad", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
 		t.Fatal("unsafe checkpoint id succeeded")
 	}
-	if _, err := store.Create(CheckpointRecord{ID: "chk_bad/slash", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
+	if _, err := store.Create(checkpointRecord{ID: "chk_bad/slash", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
 		t.Fatal("slash checkpoint id succeeded")
 	}
-	if _, err := store.Create(CheckpointRecord{ID: "chk_bad", ParentID: "../parent", CreatedAt: "2026-05-09T10:01:00Z"}); err == nil {
-		t.Fatal("unsafe parent id succeeded")
+}
+
+func TestCheckpointStoreRejectsMetadataIDMismatch(t *testing.T) {
+	store := checkpointStore{root: t.TempDir()}
+	record, err := store.Create(checkpointRecord{
+		ID:        "chk_source",
+		Kind:      checkpointKindArchive,
+		CreatedAt: "2026-05-09T10:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	source, err := store.Paths(record.ID)
+	if err != nil {
+		t.Fatalf("source paths: %v", err)
+	}
+	target, err := store.Paths("chk_copy")
+	if err != nil {
+		t.Fatalf("target paths: %v", err)
+	}
+	if err := os.MkdirAll(target.Dir, 0o700); err != nil {
+		t.Fatalf("create copied dir: %v", err)
+	}
+	data, err := os.ReadFile(source.Meta)
+	if err != nil {
+		t.Fatalf("read source metadata: %v", err)
+	}
+	if err := os.WriteFile(target.Meta, data, 0o600); err != nil {
+		t.Fatalf("write copied metadata: %v", err)
+	}
+
+	if _, _, err := store.Read("chk_copy"); err == nil {
+		t.Fatal("expected metadata id mismatch")
+	}
+	if err := store.Delete("chk_copy"); err != nil {
+		t.Fatalf("delete copied dir: %v", err)
+	}
+	if _, _, err := store.Read("chk_source"); err != nil {
+		t.Fatalf("source checkpoint removed: %v", err)
 	}
 }
 
 func TestCheckpointStoreConcurrentSameIDAllowsOneWriter(t *testing.T) {
-	store := checkpointStore{dir: t.TempDir()}
+	store := checkpointStore{root: t.TempDir()}
 	const workers = 64
 	start := make(chan struct{})
 	results := make(chan error, workers)
 	for i := 0; i < workers; i++ {
 		go func(i int) {
 			<-start
-			_, err := store.Create(CheckpointRecord{
+			_, err := store.Create(checkpointRecord{
 				ID:        "chk_race",
 				Name:      fmt.Sprintf("worker-%d", i),
 				CreatedAt: "2026-05-09T10:00:00Z",
@@ -136,7 +150,7 @@ func TestCheckpointStoreConcurrentSameIDAllowsOneWriter(t *testing.T) {
 	if successes != 1 {
 		t.Fatalf("successful concurrent creates=%d, want 1", successes)
 	}
-	got, err := store.Read("chk_race")
+	got, _, err := store.Read("chk_race")
 	if err != nil {
 		t.Fatalf("read raced checkpoint: %v", err)
 	}
@@ -146,8 +160,8 @@ func TestCheckpointStoreConcurrentSameIDAllowsOneWriter(t *testing.T) {
 }
 
 func TestCheckpointStoreFillsIDAndCreatedAt(t *testing.T) {
-	store := checkpointStore{dir: t.TempDir()}
-	record, err := store.Create(CheckpointRecord{Name: "generated"})
+	store := checkpointStore{root: t.TempDir()}
+	record, err := store.Create(checkpointRecord{Name: "generated"})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateCheckpointID(t *testing.T) {
@@ -25,11 +27,7 @@ func TestValidateCheckpointID(t *testing.T) {
 
 func TestCheckpointRecordRoundTripAndListOrder(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	firstDir, err := checkpointDir("chk_first")
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondDir, err := checkpointDir("chk_second")
+	store, err := defaultCheckpointStore()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,20 +41,20 @@ func TestCheckpointRecordRoundTripAndListOrder(t *testing.T) {
 	second := first
 	second.ID = "chk_second"
 	second.CreatedAt = "2026-05-13T11:00:00Z"
-	if err := writeCheckpointRecord(firstDir, first); err != nil {
+	if _, err := store.Create(first); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeCheckpointRecord(secondDir, second); err != nil {
+	if _, err := store.Create(second); err != nil {
 		t.Fatal(err)
 	}
-	records, err := listCheckpointRecords()
+	records, err := store.List()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(records) != 2 || records[0].ID != "chk_second" || records[1].ID != "chk_first" {
 		t.Fatalf("unexpected order: %#v", records)
 	}
-	got, _, err := readCheckpointRecord("chk_first")
+	got, _, err := store.Read("chk_first")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +96,7 @@ func TestCheckpointDeleteReturnsMetadataReadError(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	var stdout bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: io.Discard}
-	if err := app.checkpointDelete([]string{"chk_missing"}); err == nil {
+	if err := app.checkpointDelete(context.Background(), []string{"chk_missing"}); err == nil {
 		t.Fatal("expected missing checkpoint delete to fail")
 	}
 	if stdout.String() != "" {
@@ -119,11 +117,134 @@ func TestCheckpointDeleteKeepsCorruptRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
-	if err := app.checkpointDelete([]string{"chk_corrupt"}); err == nil {
+	if err := app.checkpointDelete(context.Background(), []string{"chk_corrupt"}); err == nil {
 		t.Fatal("expected corrupt checkpoint delete to fail")
 	}
 	if _, err := os.Stat(dir); err != nil {
 		t.Fatalf("corrupt checkpoint dir removed: %v", err)
+	}
+}
+
+func TestCheckpointInspectVerifyArchiveStates(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{
+		ID:          "chk_archive",
+		Kind:        checkpointKindArchive,
+		CreatedAt:   "2026-05-13T10:00:00Z",
+		ArchivePath: checkpointArchive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := store.Paths(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointInspect(context.Background(), []string{record.ID, "--verify", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var audit checkpointAudit
+	if err := json.Unmarshal(stdout.Bytes(), &audit); err != nil {
+		t.Fatal(err)
+	}
+	if audit.LocalState != "available" || audit.ProviderState != "not_applicable" || audit.NextAction != "restore_or_fork" {
+		t.Fatalf("audit=%#v", audit)
+	}
+
+	if err := os.Remove(paths.Archive); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if err := app.checkpointInspect(context.Background(), []string{record.ID, "--verify", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &audit); err != nil {
+		t.Fatal(err)
+	}
+	if audit.LocalState != "missing_archive" || audit.NextAction != "delete_or_recreate" {
+		t.Fatalf("missing archive audit=%#v", audit)
+	}
+}
+
+func TestCheckpointPruneDryRunAndDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldRecord, err := store.Create(checkpointRecord{
+		ID:        "chk_old",
+		Kind:      checkpointKindArchive,
+		CreatedAt: time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(checkpointRecord{
+		ID:        "chk_new",
+		Kind:      checkpointKindArchive,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointPrune(context.Background(), []string{"--older-than", "24h", "--kind", "archive", "--dry-run"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "would delete id=chk_old") {
+		t.Fatalf("dry-run stdout=%q", stdout.String())
+	}
+	if _, _, err := store.Read(oldRecord.ID); err != nil {
+		t.Fatalf("dry-run deleted checkpoint: %v", err)
+	}
+
+	stdout.Reset()
+	if err := app.checkpointPrune(context.Background(), []string{"--older-than", "24h", "--kind", "archive"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "checkpoint pruned id=chk_old") {
+		t.Fatalf("prune stdout=%q", stdout.String())
+	}
+	if _, _, err := store.Read(oldRecord.ID); err == nil {
+		t.Fatal("old checkpoint still exists")
+	}
+	if _, _, err := store.Read("chk_new"); err != nil {
+		t.Fatalf("new checkpoint removed: %v", err)
+	}
+}
+
+func TestCheckpointPruneRejectsOperands(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(checkpointRecord{
+		ID:        "chk_old",
+		Kind:      checkpointKindArchive,
+		CreatedAt: time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointPrune(context.Background(), []string{"chk_old", "--older-than", "24h"}); err == nil {
+		t.Fatal("expected unexpected operand error")
+	}
+	if _, _, err := store.Read("chk_old"); err != nil {
+		t.Fatalf("checkpoint removed after invalid prune command: %v", err)
 	}
 }
 
@@ -337,11 +458,11 @@ func TestCheckpointForkReleasesLeaseWhenKeepFalse(t *testing.T) {
 		Workdir:     remoteJoin(cfg, backend.leaseID, repo.Name),
 	}
 	record.Native.ImageID = "ami-12345678"
-	dir, err := checkpointDir(record.ID)
+	store, err := defaultCheckpointStore()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := writeCheckpointRecord(dir, record); err != nil {
+	if _, err := store.Create(record); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -476,6 +478,145 @@ func TestCheckpointForkReleasesLeaseWhenKeepFalse(t *testing.T) {
 	}
 	if backend.releaseCount != 1 {
 		t.Fatalf("releaseCount=%d, want 1", backend.releaseCount)
+	}
+}
+
+func TestCheckpointForkRejectsPendingNativeCheckpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:        "chk_pending_native",
+		Kind:      checkpointKindAWSEBS,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		TargetOS:  targetLinux,
+	}
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err = app.checkpointFork(context.Background(), []string{record.ID})
+	if err == nil {
+		t.Fatal("expected pending native checkpoint fork to fail")
+	}
+	if !strings.Contains(err.Error(), "pending") {
+		t.Fatalf("err=%v, want pending checkpoint error", err)
+	}
+}
+
+func TestCheckpointInspectVerifyResourceOnlyNativeDoesNotUseCoordinator(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:        "chk_resource_only",
+		Kind:      checkpointKindGCPDisk,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		TargetOS:  targetLinux,
+	}
+	record.Native.Resource = "projects/proj/global/snapshots/checkpoint"
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointInspect(context.Background(), []string{record.ID, "--verify", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var audit checkpointAudit
+	if err := json.Unmarshal(stdout.Bytes(), &audit); err != nil {
+		t.Fatal(err)
+	}
+	if audit.ProviderState != "unverified_ref" || audit.NextAction != "fork_or_delete_local" {
+		t.Fatalf("audit=%#v", audit)
+	}
+}
+
+func TestCheckpointDeleteResourceOnlyNativeDeletesProviderResource(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+
+	var deleteRequest string
+	var deleteProvider string
+	var deleteKind string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleteRequest = r.Method + " " + r.RequestURI
+		deleteProvider = r.URL.Query().Get("provider")
+		deleteKind = r.URL.Query().Get("kind")
+		_, _ = w.Write([]byte(`{"deleted":true}`))
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin")
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:        "chk_resource_delete",
+		Kind:      checkpointKindAzureOS,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		TargetOS:  targetLinux,
+	}
+	record.Native.Resource = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint"
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointDelete(context.Background(), []string{record.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if deleteProvider != "azure" {
+		t.Fatalf("provider query=%q", deleteProvider)
+	}
+	if deleteKind != "azure-os-disk-snapshot" {
+		t.Fatalf("kind query=%q", deleteKind)
+	}
+	if !strings.HasPrefix(deleteRequest, "DELETE /v1/images/%2Fsubscriptions%2Fsub%2FresourceGroups%2Frg%2Fproviders%2FMicrosoft.Compute%2Fsnapshots%2Fcheckpoint?") {
+		t.Fatalf("delete request=%q", deleteRequest)
+	}
+	if _, _, err := store.Read(record.ID); err == nil {
+		t.Fatal("delete kept checkpoint")
+	}
+}
+
+func TestNativeCheckpointResourceIDAllowsAzureGCPResourceOnlyRecords(t *testing.T) {
+	aws := checkpointRecord{Kind: checkpointKindAWSAMI}
+	aws.Native.Resource = "ami-resource-only"
+	if got := nativeCheckpointResourceID(aws); got != "" {
+		t.Fatalf("aws resource-only ref=%q, want empty", got)
+	}
+	aws.Native.ImageID = "ami-12345678"
+	if got := nativeCheckpointResourceID(aws); got != "ami-12345678" {
+		t.Fatalf("aws ref=%q", got)
+	}
+
+	azure := checkpointRecord{Kind: checkpointKindAzureOS}
+	azure.Native.Resource = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/checkpoint"
+	if got := nativeCheckpointResourceID(azure); got != azure.Native.Resource {
+		t.Fatalf("azure ref=%q", got)
+	}
+
+	gcp := checkpointRecord{Kind: checkpointKindGCPDisk}
+	gcp.Native.Resource = "projects/proj/global/snapshots/checkpoint"
+	if got := nativeCheckpointResourceID(gcp); got != gcp.Native.Resource {
+		t.Fatalf("gcp ref=%q", got)
 	}
 }
 

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -361,6 +361,7 @@ type checkpointKongCmd struct {
 	Restore checkpointRestoreKongCmd `cmd:"" passthrough:"" help:"Restore a checkpoint onto an existing lease."`
 	Fork    checkpointForkKongCmd    `cmd:"" passthrough:"" help:"Lease a new box from a checkpoint."`
 	Delete  checkpointDeleteKongCmd  `cmd:"" passthrough:"" help:"Delete a checkpoint and provider snapshot."`
+	Prune   checkpointPruneKongCmd   `cmd:"" passthrough:"" help:"Delete checkpoints matching age and kind filters."`
 }
 type checkpointCreateKongCmd struct {
 	Args []string `arg:"" optional:""`
@@ -378,6 +379,9 @@ type checkpointForkKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type checkpointDeleteKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type checkpointPruneKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 
@@ -546,10 +550,10 @@ func (c *checkpointCreateKongCmd) Run(ctx context.Context, app App) error {
 	return app.checkpointCreate(ctx, stripKongCommandPath(c.Args, "checkpoint", "create"))
 }
 func (c *checkpointListKongCmd) Run(ctx context.Context, app App) error {
-	return app.checkpointList(stripKongCommandPath(c.Args, "checkpoint", "list"))
+	return app.checkpointList(ctx, stripKongCommandPath(c.Args, "checkpoint", "list"))
 }
 func (c *checkpointInspectKongCmd) Run(ctx context.Context, app App) error {
-	return app.checkpointInspect(stripKongCommandPath(c.Args, "checkpoint", "inspect"))
+	return app.checkpointInspect(ctx, stripKongCommandPath(c.Args, "checkpoint", "inspect"))
 }
 func (c *checkpointRestoreKongCmd) Run(ctx context.Context, app App) error {
 	return app.checkpointRestore(ctx, stripKongCommandPath(c.Args, "checkpoint", "restore"))
@@ -558,7 +562,10 @@ func (c *checkpointForkKongCmd) Run(ctx context.Context, app App) error {
 	return app.checkpointFork(ctx, stripKongCommandPath(c.Args, "checkpoint", "fork"))
 }
 func (c *checkpointDeleteKongCmd) Run(ctx context.Context, app App) error {
-	return app.checkpointDelete(stripKongCommandPath(c.Args, "checkpoint", "delete"))
+	return app.checkpointDelete(ctx, stripKongCommandPath(c.Args, "checkpoint", "delete"))
+}
+func (c *checkpointPruneKongCmd) Run(ctx context.Context, app App) error {
+	return app.checkpointPrune(ctx, stripKongCommandPath(c.Args, "checkpoint", "prune"))
 }
 
 func (c *configPathKongCmd) Run(ctx context.Context, app App) error {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3126,7 +3126,18 @@ export class FleetDurableObject implements DurableObject {
     const project = url.searchParams.get("project") ?? undefined;
     const kind = url.searchParams.get("kind") ?? undefined;
     if (method === "GET" && action === undefined) {
-      const image = await this.provider(provider, region, project).getImage(decodedImageID, kind);
+      let image: ProviderImage;
+      try {
+        image = await this.provider(provider, region, project).getImage(decodedImageID, kind);
+      } catch (error) {
+        if (isProviderImageNotFound(error)) {
+          return json(
+            { error: "not_found", message: `image ${decodedImageID} not found` },
+            { status: 404 },
+          );
+        }
+        throw error;
+      }
       return json({ image });
     }
     if (method === "DELETE" && action === undefined) {
@@ -3756,6 +3767,18 @@ function providerSupportsNativeImages(provider: Provider): boolean {
 function hasNativeLeaseSource(config: LeaseConfig): boolean {
   return Boolean(
     config.awsSnapshot || config.azureSnapshot || config.gcpMachineImage || config.gcpSnapshot,
+  );
+}
+
+function isProviderImageNotFound(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    message.includes("InvalidAMIID.NotFound") ||
+    message.includes("InvalidSnapshot.NotFound") ||
+    message.includes("ResourceNotFound") ||
+    message.includes("aws image not found") ||
+    message.includes("aws snapshot not found") ||
+    message.includes("http 404")
   );
 }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2620,6 +2620,26 @@ describe("fleet lease identity and idle", () => {
     expect(gcpDeletedKind).toBe("gcp-disk-snapshot");
   });
 
+  it("maps missing provider-native images to 404", async () => {
+    const fleet = testFleet(new MemoryStorage(), {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onGetImage() {
+          throw new Error("aws DescribeImages: http 400: InvalidAMIID.NotFound");
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("GET", "/v1/images/ami-000000000001?provider=aws", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: "not_found" });
+  });
+
   it("rejects invalid image provider query routing", async () => {
     let deleted = "";
     const fleet = testFleet(new MemoryStorage(), {
@@ -3900,6 +3920,7 @@ function fakeProvider(
       name: string,
       strategy?: "image" | "disk-snapshot",
     ) => void;
+    onGetImage?: (imageID: string, kind?: string) => Promise<ProviderImage> | ProviderImage;
     onDeleteImage?: (imageID: string, kind?: string) => void;
   } = {},
   onDelete?: (id: string) => Promise<void>,
@@ -4004,6 +4025,9 @@ function fakeProvider(
       };
     },
     async getImage(imageID: string, kind?: string) {
+      if (result.onGetImage) {
+        return await result.onGetImage(imageID, kind);
+      }
       const provider = result.provider ?? "aws";
       return {
         id: imageID,


### PR DESCRIPTION
## Summary
- unify checkpoint storage on the canonical checkpoint metadata model and directory-backed checkpoint records
- add checkpoint audit and cleanup management: `list --verify`, `inspect --verify`, and `prune --older-than`
- make native checkpoint audit/delete handle provider missing states, resource-only Azure/GCP refs, and pending checkpoint metadata safely
- return 404 for missing provider images in the broker image route

## Verification
- codex-review clean: no accepted/actionable findings reported
- go test ./... && go vet ./...
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm test --prefix worker
- npm run docs:check
- live checkpoint CLI test with isolated state: archive verify/list/prune, metadata mismatch, pending native fork rejection, resource-only GCP verify, Azure resource-only delete through mock coordinator

Closes https://github.com/openclaw/crabbox/issues/102
