### PR TITLE
fix: sync delegated runners after allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed delegated Blacksmith Testbox warmup/run flows so successful allocations refresh the coordinator runner portal instead of waiting for a later manual list.
 - Fixed Code bridge upstream URL handling so browser-controlled paths cannot select a non-loopback upstream target, and clamped `CRABBOX_AWS_ROOT_GB` parsing to valid `int32` values.
 - Fixed `crabbox admin lease-audit --fail-on-live` so recently terminated AWS instances returned by `DescribeInstances` do not fail cleanup automation as live resources.
 - Fixed checkpoint archive restores so large archives stream over SSH without buffering the full tarball in memory and unpack through a per-restore remote temp file. Thanks @stainlu.

--- a/internal/cli/pool_test.go
+++ b/internal/cli/pool_test.go
@@ -1,6 +1,11 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -136,6 +141,59 @@ func TestCoordinatorExternalRunnersFromBlacksmithListView(t *testing.T) {
 	}
 	if got.ID != "tbx_01kqyahxh67z6qtwtsdkt5xcst" || got.CreatedAt != "2026-05-06T09:45:16.000000Z" {
 		t.Fatalf("unexpected runner: %#v", got)
+	}
+}
+
+type testExternalRunnerJSONBackend struct {
+	view     any
+	requests []ListRequest
+}
+
+func (b *testExternalRunnerJSONBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "blacksmith-testbox"}
+}
+
+func (b *testExternalRunnerJSONBackend) ListJSON(_ context.Context, req ListRequest) (any, error) {
+	b.requests = append(b.requests, req)
+	return b.view, nil
+}
+
+func TestSyncExternalRunnersBestEffortPostsBlacksmithJSONList(t *testing.T) {
+	var posted struct {
+		Provider string                      `json:"provider"`
+		Runners  []CoordinatorExternalRunner `json:"runners"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/runners/sync" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatalf("decode sync body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(CoordinatorExternalRunnerSyncResponse{})
+	}))
+	defer server.Close()
+
+	backend := &testExternalRunnerJSONBackend{view: []map[string]string{
+		{
+			"id":      "tbx_01sync",
+			"status":  "ready",
+			"repo":    "example-org/example-repo",
+			"created": "2026-05-06T09:45:16.000000Z",
+		},
+	}}
+
+	app := App{Stderr: io.Discard}
+	app.syncExternalRunnersBestEffort(context.Background(), Config{Provider: "blacksmith-testbox", Coordinator: server.URL}, backend)
+
+	if len(backend.requests) != 1 || !backend.requests[0].All {
+		t.Fatalf("list requests=%#v, want one all request", backend.requests)
+	}
+	if posted.Provider != "blacksmith-testbox" || len(posted.Runners) != 1 {
+		t.Fatalf("posted=%#v", posted)
+	}
+	if got := posted.Runners[0]; got.ID != "tbx_01sync" || got.Provider != "blacksmith-testbox" {
+		t.Fatalf("runner=%#v", got)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -66,7 +66,11 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	}
 	options := leaseOptionsFromConfig(cfg)
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
-		return delegated.Warmup(ctx, WarmupRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim, ActionsRunner: *actionsRunner, TimingJSON: *timingJSON})
+		if err := delegated.Warmup(ctx, WarmupRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim, ActionsRunner: *actionsRunner, TimingJSON: *timingJSON}); err != nil {
+			return err
+		}
+		a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+		return nil
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
@@ -294,8 +298,11 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		if runReq.Preflight {
 			printDelegatedPreflightUnsupported(a.Stderr, backend.Spec().Name)
 		}
-		_, err := delegated.Run(ctx, runReq)
-		return err
+		result, runErr := delegated.Run(ctx, runReq)
+		if runErr == nil || result.Command > 0 || result.Total > 0 {
+			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+		}
+		return runErr
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -292,7 +292,7 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 	output := result.Stdout + result.Stderr
 	if err != nil {
 		b.cleanupFailedWarmup(ctx, beforeWarmup, output)
-		return "", "", exit(result.ExitCode, "blacksmith testbox warmup failed: %v", err)
+		return "", "", exit(result.ExitCode, "blacksmith testbox warmup failed: %v; if the delegated queue is unavailable, rerun with a coordinator-backed provider such as --provider aws", err)
 	}
 	leaseID := parseBlacksmithID(output)
 	if leaseID == "" {


### PR DESCRIPTION
## Summary
- refresh the coordinator external-runner portal after successful delegated warmup/run allocations
- add a regression test for Blacksmith JSON-list runner sync
- add a clearer Blacksmith outage hint that points users to coordinator-backed providers

## Verification
- go test ./internal/cli -run 'TestSyncExternalRunnersBestEffortPostsBlacksmithJSONList|TestCoordinatorExternalRunnersFromBlacksmithListView' -count=1\n- go test ./internal/providers/blacksmith -run 'TestBlacksmithWarmupFailure|TestBlacksmithWarmupArgs' -count=1\n- git diff --check\n\n## Notes\n- Broad `go test -timeout=30s ./internal/cli ./internal/providers/blacksmith` timed out in unrelated `TestInitProjectWritesExpectedFiles` while waiting on `git` repo discovery; the targeted regressions above passed.