### PR TITLE
fix(windows): split bootstrap profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Fixed brokered Azure leases so the CLI only sends `azureOSDisk` when the user explicitly configures it, preserving the coordinator default while keeping new Azure leases checkpointable by default. Thanks @jwmoss.
+- Fixed managed Windows bootstraps so native Windows leases skip desktop/VNC setup unless `--desktop` is requested, while WSL2 leases keep their Windows core and Linux setup paths separate. Thanks @jwmoss.
 - Fixed WebVNC `--take-control` handoff links so the portal keeps retrying the automatic control claim until the opened viewer is registered as an observer.
 - Fixed WebVNC portal click forwarding so controller clicks reach the remote desktop while preserving focus and browser context-menu suppression.
 

--- a/docs/features/aws.md
+++ b/docs/features/aws.md
@@ -16,7 +16,7 @@ debugging.
 | Target | Managed | Notes |
 | --- | --- | --- |
 | Linux | Yes | Spot by default; On-Demand optional; cloud-init bootstrap. |
-| Windows native | Yes | EC2Launch, OpenSSH, Git for Windows, TightVNC, archive sync, first-network flyout suppression. |
+| Windows native | Yes | EC2Launch, OpenSSH, Git for Windows, archive sync; optional TightVNC/autologon with `--desktop`. |
 | Windows WSL2 | Yes | Nested virtualization on C8i/M8i/R8i families; POSIX sync through WSL. |
 | macOS | Yes | EC2 Mac Dedicated Host id required; On-Demand only. |
 

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -17,8 +17,8 @@ gcp         Google Cloud Compute Engine instances
 
 Brokered Hetzner leases are Linux targets. Brokered AWS supports Linux, native
 Windows Server, Windows WSL2, and EC2 Mac when a Dedicated Host is configured.
-Brokered Azure supports Linux and native Windows SSH/sync/run. Brokered GCP
-supports Linux SSH/sync/run. Static SSH still
+Brokered Azure supports Linux, native Windows, and Windows WSL2 SSH/sync/run.
+Brokered GCP supports Linux SSH/sync/run. Static SSH still
 exists for reusing existing macOS and Windows machines:
 
 ```text

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -73,9 +73,9 @@ tensorlake Tensorlake Firecracker sandboxes with delegated command execution
 - imports or reuses an EC2 key pair;
 - creates or reuses the `crabbox-runners` security group with SSH ingress limited to configured CIDRs or the request source IP;
 - launches one-time Linux Spot or On-Demand instances;
-- launches AWS Windows Server desktop leases with EC2Launch PowerShell user
-  data, OpenSSH, Git for Windows, TightVNC, and first-network flyout
-  suppression when `target=windows`;
+- launches AWS Windows Server leases with EC2Launch PowerShell user data, then a
+  post-SSH Crabbox bootstrap for OpenSSH/Git/user setup; `--desktop` adds
+  TightVNC, auto-logon, and first-network flyout suppression;
 - launches EC2 Mac leases only with an explicit Dedicated Host id
   (`CRABBOX_AWS_MAC_HOST_ID` or `aws.macHostId`) and On-Demand capacity;
 - tags instances, volumes, and Spot requests;

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -82,7 +82,7 @@ Brokered AWS credentials belong in the Worker, not on developer machines.
 | Target | Notes |
 | --- | --- |
 | Linux | Ubuntu bootstrap, SSH, rsync, optional desktop/browser/code. |
-| Windows native | EC2Launch, OpenSSH, Git for Windows, TightVNC, archive sync, first-network flyout suppression. |
+| Windows native | EC2Launch, OpenSSH, Git for Windows, archive sync; optional TightVNC/autologon with `--desktop`. |
 | Windows WSL2 | Nested virtualization families; POSIX sync and commands through WSL. |
 | macOS | Requires `CRABBOX_AWS_MAC_HOST_ID` or `aws.macHostId`; On-Demand only. |
 
@@ -93,7 +93,7 @@ Brokered AWS credentials belong in the Worker, not on developer machines.
 3. Launch EC2 instance, Spot request, Windows instance, or EC2 Mac host-backed
    instance.
 4. Tag instance, volumes, and Spot requests with Crabbox lease labels.
-5. Wait for SSH and `crabbox-ready`.
+5. Wait for SSH readiness, and for `crabbox-ready` on POSIX targets.
 6. Let core sync and run over SSH.
 7. Terminate on release, cleanup, or coordinator expiry.
 

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -23,7 +23,7 @@ func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSH
 	}
 	if cfg.Provider == "azure" && cfg.WindowsMode == windowsModeNormal && cfg.Desktop {
 		bootstrapTarget := *target
-		return runWindowsDesktopBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
+		return runWindowsBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr, "Windows desktop bootstrap")
 	}
 	if cfg.Provider != "aws" {
 		return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
@@ -32,18 +32,22 @@ func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSH
 	bootstrapTarget.User = "Administrator"
 	bootstrapTarget.WindowsMode = windowsModeNormal
 	bootstrapTarget.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
-	return runWindowsDesktopBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
+	phase := "Windows core bootstrap"
+	if cfg.Desktop {
+		phase = "Windows desktop bootstrap"
+	}
+	return runWindowsBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr, phase)
 }
 
 func bootstrapAWSWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
 	return bootstrapManagedWindowsDesktop(ctx, cfg, target, publicKey, stderr)
 }
 
-func runWindowsDesktopBootstrapOverSSH(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {
+func runWindowsBootstrapOverSSH(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer, phase string) error {
 	if err := waitForSSHReady(ctx, &bootstrapTarget, stderr, "windows openssh", 20*time.Minute); err != nil {
 		return err
 	}
-	fmt.Fprintln(stderr, "running Windows desktop bootstrap over SSH")
+	fmt.Fprintf(stderr, "running %s over SSH\n", phase)
 	remote := powershellCommand(`$ErrorActionPreference = "Stop"
 $path = "C:\ProgramData\crabbox-bootstrap.ps1"
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
@@ -52,7 +56,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File $path
 exit $LASTEXITCODE`)
 	err := runSSHInputQuiet(ctx, bootstrapTarget, remote, windowsBootstrapPowerShell(cfg, publicKey))
 	if err != nil {
-		fmt.Fprintf(stderr, "warning: Windows bootstrap SSH command ended before completion; waiting for reboot/ready state: %v\n", err)
+		fmt.Fprintf(stderr, "warning: %s SSH command ended before completion; waiting for reboot/ready state: %v\n", phase, err)
 	}
 	if err := waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
 		return err

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -223,97 +223,135 @@ foreach ($path in @("C:\Program Files\OpenSSH", "C:\Program Files\Git\cmd", "C:\
 }
 
 func windowsBootstrapPowerShell(cfg Config, publicKey string) string {
-	workRoot := cfg.WorkRoot
-	if workRoot == "" {
-		workRoot = `C:\crabbox`
+	script := windowsBootstrapHeaderPowerShell(cfg, publicKey, windowsBootstrapWorkRoot(cfg)) +
+		windowsManagedCorePreludePowerShell(cfg) +
+		windowsBootstrapCorePowerShell()
+	if cfg.WindowsMode == windowsModeWSL2 {
+		return script + windowsWSL2BootstrapPowerShell(cfg)
 	}
-	wslMode := cfg.WindowsMode == windowsModeWSL2
-	return windowsBootstrapHeaderPowerShell(cfg, publicKey, workRoot) + `
-$wslMode = $` + fmt.Sprint(wslMode) + `
-$wslDistro = "Crabbox"
-$wslRoot = "C:\ProgramData\crabbox\wsl\Crabbox"
-$wslRootfs = "C:\ProgramData\crabbox\wsl\ubuntu-noble-wsl-amd64.rootfs.tar.gz"
-$wslRootfsDownload = "$wslRootfs.download"
-$wslRootfsMinBytes = 100 * 1024 * 1024
-$wslSetup = "C:\ProgramData\crabbox\wsl\linux-setup.sh"
-$wslFeaturesMarker = "C:\ProgramData\crabbox\wsl-features-rebooted"
-$wslKernelMarker = "C:\ProgramData\crabbox\wsl-kernel-rebooted"
-$vncPasswordPath = "C:\ProgramData\crabbox\vnc.password"
-$windowsUsernamePath = "C:\ProgramData\crabbox\windows.username"
-$windowsPasswordPath = "C:\ProgramData\crabbox\windows.password"
-$passwordPath = $vncPasswordPath
-$usernamePath = $windowsUsernamePath
-$passwordMirrorPath = $windowsPasswordPath
-$enforceKeyAuth = $false
-$userVNCStartupPath = "C:\ProgramData\crabbox\start-user-vnc.ps1"
-$userVNCStartupCommandPath = Join-Path (Join-Path (Join-Path "C:\Users" $user) "AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup") "crabbox-user-vnc.cmd"
-$tightVNCInstaller = "$env:TEMP\tightvnc-2.8.85-gpl-setup-64bit.msi"
-function Restart-CrabboxBootstrap($MarkerPath) {
-  Set-Content -NoNewline -Encoding ASCII -Path $MarkerPath -Value (Get-Date).ToString("o")
-  Restart-Computer -Force
-  exit 0
+	if cfg.Desktop {
+		return script + windowsDesktopBootstrapPowerShell()
+	}
+	return script + windowsCoreBootstrapFinalizePowerShell()
 }
-function Initialize-CrabboxWSL2 {
-  if (-not $wslMode) { return }
-  $needsFeatureReboot = $false
-  foreach ($feature in @("Microsoft-Windows-Subsystem-Linux", "VirtualMachinePlatform", "HypervisorPlatform")) {
-    $state = (Get-WindowsOptionalFeature -Online -FeatureName $feature -ErrorAction SilentlyContinue).State
-    if ($state -ne "Enabled") {
-      dism.exe /online /enable-feature /featurename:$feature /all /norestart | Out-Host
-      if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { throw "enable $feature failed with exit $LASTEXITCODE" }
-      $needsFeatureReboot = $true
-    }
-  }
-  bcdedit.exe /set hypervisorlaunchtype auto | Out-Host
-  if ($LASTEXITCODE -ne 0) { throw "bcdedit hypervisorlaunchtype failed with exit $LASTEXITCODE" }
-  if ($needsFeatureReboot -and -not (Test-Path -LiteralPath $wslFeaturesMarker)) {
-    Restart-CrabboxBootstrap $wslFeaturesMarker
-  }
-  if (-not (Test-Path -LiteralPath $wslKernelMarker)) {
-    wsl.exe --update --web-download | Out-Host
-    if ($LASTEXITCODE -ne 0) { throw "wsl --update --web-download failed with exit $LASTEXITCODE" }
-    Restart-CrabboxBootstrap $wslKernelMarker
-  }
-  wsl.exe --set-default-version 2 | Out-Host
-  if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version 2 failed with exit $LASTEXITCODE" }
-  $distros = (wsl.exe --list --quiet 2>$null) -join [Environment]::NewLine
-  if ($distros -notmatch "(?m)^$([Regex]::Escape($wslDistro))$") {
-    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $wslRoot), $wslRoot | Out-Null
-    if ((Test-Path -LiteralPath $wslRootfs) -and ((Get-Item -LiteralPath $wslRootfs).Length -lt $wslRootfsMinBytes)) {
-      Remove-Item -Force -LiteralPath $wslRootfs
-    }
-    if (-not (Test-Path -LiteralPath $wslRootfs)) {
-      Remove-Item -Force -LiteralPath $wslRootfsDownload -ErrorAction SilentlyContinue
-      Retry {
-        $expectedLength = 0
-        try {
-          $head = Invoke-WebRequest -Uri ` + psQuote(ubuntuWSLRootFSURL) + ` -Method Head -UseBasicParsing
-          if ($head.Headers.ContainsKey("Content-Length")) {
-            [void][Int64]::TryParse(($head.Headers["Content-Length"] | Select-Object -First 1), [ref]$expectedLength)
-          }
-        } catch {
-          $expectedLength = 0
-        }
-        if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
-          & curl.exe -fL --retry 8 --retry-delay 5 --connect-timeout 30 --speed-time 30 --speed-limit 1024 -o $wslRootfsDownload ` + psQuote(ubuntuWSLRootFSURL) + `
-          if ($LASTEXITCODE -ne 0) { throw "download WSL rootfs failed with exit $LASTEXITCODE" }
-        } else {
-          Invoke-WebRequest -Uri ` + psQuote(ubuntuWSLRootFSURL) + ` -OutFile $wslRootfsDownload -UseBasicParsing
-        }
-        $actualLength = (Get-Item -LiteralPath $wslRootfsDownload).Length
-        if ($actualLength -lt $wslRootfsMinBytes) { throw "downloaded WSL rootfs is incomplete" }
-        if ($expectedLength -gt 0 -and $actualLength -ne $expectedLength) {
-          throw "downloaded WSL rootfs is incomplete: $actualLength of $expectedLength bytes"
-        }
-      }
-      Move-Item -Force -LiteralPath $wslRootfsDownload -Destination $wslRootfs
-    }
-    wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2 | Out-Host
-    if ($LASTEXITCODE -ne 0) { throw "wsl --import failed with exit $LASTEXITCODE" }
-    wsl.exe --set-default $wslDistro | Out-Host
-    if ($LASTEXITCODE -ne 0) { throw "wsl --set-default failed with exit $LASTEXITCODE" }
-  }
-  $linuxSetup = @'
+
+func windowsBootstrapWorkRoot(cfg Config) string {
+	if cfg.WindowsMode == windowsModeWSL2 {
+		return defaultWindowsWorkRoot
+	}
+	if cfg.WorkRoot != "" {
+		return cfg.WorkRoot
+	}
+	return defaultWindowsWorkRoot
+}
+
+func windowsWSLWorkRoot(cfg Config) string {
+	if cfg.WorkRoot != "" {
+		return cfg.WorkRoot
+	}
+	return defaultPOSIXWorkRoot
+}
+
+func windowsManagedCorePreludePowerShell(cfg Config) string {
+	if cfg.WindowsMode == windowsModeNormal && cfg.Desktop {
+		return `
+	$vncPasswordPath = "C:\ProgramData\crabbox\vnc.password"
+	$windowsUsernamePath = "C:\ProgramData\crabbox\windows.username"
+	$windowsPasswordPath = "C:\ProgramData\crabbox\windows.password"
+	$passwordPath = $vncPasswordPath
+	$usernamePath = $windowsUsernamePath
+	$passwordMirrorPath = $windowsPasswordPath
+	$enforceKeyAuth = $false
+	$userVNCStartupPath = "C:\ProgramData\crabbox\start-user-vnc.ps1"
+	$userVNCStartupCommandPath = Join-Path (Join-Path (Join-Path "C:\Users" $user) "AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup") "crabbox-user-vnc.cmd"
+	$tightVNCInstaller = "$env:TEMP\tightvnc-2.8.85-gpl-setup-64bit.msi"
+	`
+	}
+	return `
+	$windowsUsernamePath = "C:\ProgramData\crabbox\windows.username"
+	$windowsPasswordPath = "C:\ProgramData\crabbox\windows.password"
+	$passwordPath = $windowsPasswordPath
+	$usernamePath = $windowsUsernamePath
+	$passwordMirrorPath = $null
+	$enforceKeyAuth = $false
+	`
+}
+
+func windowsWSL2BootstrapPowerShell(cfg Config) string {
+	workRoot := windowsWSLWorkRoot(cfg)
+	return `
+	$wslDistro = "Crabbox"
+	$wslRoot = "C:\ProgramData\crabbox\wsl\Crabbox"
+	$wslRootfs = "C:\ProgramData\crabbox\wsl\ubuntu-noble-wsl-amd64.rootfs.tar.gz"
+	$wslRootfsDownload = "$wslRootfs.download"
+	$wslRootfsMinBytes = 100 * 1024 * 1024
+	$wslSetup = "C:\ProgramData\crabbox\wsl\linux-setup.sh"
+	$wslFeaturesMarker = "C:\ProgramData\crabbox\wsl-features-rebooted"
+	$wslKernelMarker = "C:\ProgramData\crabbox\wsl-kernel-rebooted"
+	function Restart-CrabboxBootstrap($MarkerPath) {
+	  Set-Content -NoNewline -Encoding ASCII -Path $MarkerPath -Value (Get-Date).ToString("o")
+	  Restart-Computer -Force
+	  exit 0
+	}
+	$needsFeatureReboot = $false
+	foreach ($feature in @("Microsoft-Windows-Subsystem-Linux", "VirtualMachinePlatform", "HypervisorPlatform")) {
+	  $state = (Get-WindowsOptionalFeature -Online -FeatureName $feature -ErrorAction SilentlyContinue).State
+	  if ($state -ne "Enabled") {
+	    dism.exe /online /enable-feature /featurename:$feature /all /norestart | Out-Host
+	    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { throw "enable $feature failed with exit $LASTEXITCODE" }
+	    $needsFeatureReboot = $true
+	  }
+	}
+	bcdedit.exe /set hypervisorlaunchtype auto | Out-Host
+	if ($LASTEXITCODE -ne 0) { throw "bcdedit hypervisorlaunchtype failed with exit $LASTEXITCODE" }
+	if ($needsFeatureReboot -and -not (Test-Path -LiteralPath $wslFeaturesMarker)) {
+	  Restart-CrabboxBootstrap $wslFeaturesMarker
+	}
+	if (-not (Test-Path -LiteralPath $wslKernelMarker)) {
+	  wsl.exe --update --web-download | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --update --web-download failed with exit $LASTEXITCODE" }
+	  Restart-CrabboxBootstrap $wslKernelMarker
+	}
+	wsl.exe --set-default-version 2 | Out-Host
+	if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version 2 failed with exit $LASTEXITCODE" }
+	$distros = (wsl.exe --list --quiet 2>$null) -join [Environment]::NewLine
+	if ($distros -notmatch "(?m)^$([Regex]::Escape($wslDistro))$") {
+	  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $wslRoot), $wslRoot | Out-Null
+	  if ((Test-Path -LiteralPath $wslRootfs) -and ((Get-Item -LiteralPath $wslRootfs).Length -lt $wslRootfsMinBytes)) {
+	    Remove-Item -Force -LiteralPath $wslRootfs
+	  }
+	  if (-not (Test-Path -LiteralPath $wslRootfs)) {
+	    Remove-Item -Force -LiteralPath $wslRootfsDownload -ErrorAction SilentlyContinue
+	    Retry {
+	      $expectedLength = 0
+	      try {
+	        $head = Invoke-WebRequest -Uri ` + psQuote(ubuntuWSLRootFSURL) + ` -Method Head -UseBasicParsing
+	        if ($head.Headers.ContainsKey("Content-Length")) {
+	          [void][Int64]::TryParse(($head.Headers["Content-Length"] | Select-Object -First 1), [ref]$expectedLength)
+	        }
+	      } catch {
+	        $expectedLength = 0
+	      }
+	      if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
+	        & curl.exe -fL --retry 8 --retry-delay 5 --connect-timeout 30 --speed-time 30 --speed-limit 1024 -o $wslRootfsDownload ` + psQuote(ubuntuWSLRootFSURL) + `
+	        if ($LASTEXITCODE -ne 0) { throw "download WSL rootfs failed with exit $LASTEXITCODE" }
+	      } else {
+	        Invoke-WebRequest -Uri ` + psQuote(ubuntuWSLRootFSURL) + ` -OutFile $wslRootfsDownload -UseBasicParsing
+	      }
+	      $actualLength = (Get-Item -LiteralPath $wslRootfsDownload).Length
+	      if ($actualLength -lt $wslRootfsMinBytes) { throw "downloaded WSL rootfs is incomplete" }
+	      if ($expectedLength -gt 0 -and $actualLength -ne $expectedLength) {
+	        throw "downloaded WSL rootfs is incomplete: $actualLength of $expectedLength bytes"
+	      }
+	    }
+	    Move-Item -Force -LiteralPath $wslRootfsDownload -Destination $wslRootfs
+	  }
+	  wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2 | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --import failed with exit $LASTEXITCODE" }
+	  wsl.exe --set-default $wslDistro | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --set-default failed with exit $LASTEXITCODE" }
+	}
+	$linuxSetup = @'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p ` + shellQuote(workRoot) + ` /var/cache/crabbox/pnpm /var/cache/crabbox/npm /var/lib/crabbox
@@ -338,17 +376,21 @@ chmod 0755 /usr/local/bin/crabbox-ready
 touch /var/lib/crabbox/bootstrapped
 crabbox-ready
 '@
-  $linuxSetup = $linuxSetup.Replace(([string][char]13 + [string][char]10), ([string][char]10))
-  [IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
-  wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
-  if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
+	$linuxSetup = $linuxSetup.Replace(([string][char]13 + [string][char]10), ([string][char]10))
+	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
+	wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
+	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
+	Restart-Service sshd -Force
+	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	`
 }
-` + windowsBootstrapCorePowerShell() + `
-Initialize-CrabboxWSL2
-if (-not (Test-Path -LiteralPath "C:\Program Files\TightVNC\tvnserver.exe")) {
-  Retry { Invoke-WebRequest -Uri ` + psQuote(tightVNCMSIURL) + ` -OutFile $tightVNCInstaller -UseBasicParsing }
-  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
-  Start-Process -FilePath msiexec.exe -ArgumentList @(
+
+func windowsDesktopBootstrapPowerShell() string {
+	return `
+	if (-not (Test-Path -LiteralPath "C:\Program Files\TightVNC\tvnserver.exe")) {
+	  Retry { Invoke-WebRequest -Uri ` + psQuote(tightVNCMSIURL) + ` -OutFile $tightVNCInstaller -UseBasicParsing }
+	  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
+	  Start-Process -FilePath msiexec.exe -ArgumentList @(
     "/i", $tightVNCInstaller, "/quiet", "/norestart",
     "ADDLOCAL=Server",
     "SERVER_REGISTER_AS_SERVICE=1",
@@ -408,16 +450,22 @@ Set-ItemProperty -Path $winlogon -Name DefaultPassword -Value $userPassword -Typ
 Restart-Service sshd
 if (-not (Test-Path -LiteralPath $setupCompletePath)) {
   Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
-  Restart-Computer -Force
+	  Restart-Computer -Force
+	}
+	`
 }
-`
+
+func windowsCoreBootstrapFinalizePowerShell() string {
+	return `
+	Restart-Service sshd -Force
+	git --version | Out-Null
+	tar --version | Out-Null
+	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	`
 }
 
 func azureWindowsBootstrapPowerShell(cfg Config, publicKey string) string {
-	workRoot := cfg.WorkRoot
-	if workRoot == "" {
-		workRoot = defaultWindowsWorkRoot
-	}
+	workRoot := windowsBootstrapWorkRoot(cfg)
 	setupComplete := `Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")`
 	if cfg.Desktop {
 		setupComplete = ""

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -206,6 +206,7 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 	cfg.Provider = "aws"
 	cfg.TargetOS = targetWindows
 	cfg.WindowsMode = windowsModeNormal
+	cfg.Desktop = true
 	cfg.WorkRoot = `C:\crabbox`
 	userData := awsUserData(cfg, "ssh-ed25519 test")
 	if !strings.Contains(userData, "version: 1.1") || !strings.Contains(userData, "task: enableOpenSsh") {
@@ -265,6 +266,37 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 	}
 }
 
+func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.WorkRoot = `C:\crabbox`
+	got := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
+	for _, want := range []string{
+		"OpenSSH-Win64.zip",
+		"Git-2.52.0-64-bit.exe",
+		"$passwordPath = $windowsPasswordPath",
+		"Restart-Service sshd -Force",
+		"Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("windows core bootstrap missing %q", want)
+		}
+	}
+	for _, notWant := range []string{
+		"tightvnc-2.8.85-gpl-setup-64bit.msi",
+		`C:\ProgramData\crabbox\vnc.password`,
+		"CrabboxUserVNC",
+		"AutoAdminLogon",
+		"Restart-Computer -Force",
+	} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("windows core bootstrap should not include %q", notWant)
+		}
+	}
+}
+
 func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "aws"
@@ -273,7 +305,8 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 	cfg.WorkRoot = `/work/crabbox`
 	got := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
-		"$wslMode = $true",
+		`$workRoot = 'C:\crabbox'`,
+		`C:\ProgramData\crabbox\windows.password`,
 		"Microsoft-Windows-Subsystem-Linux",
 		"VirtualMachinePlatform",
 		"HypervisorPlatform",
@@ -299,6 +332,16 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows WSL2 bootstrap missing %q", want)
+		}
+	}
+	for _, notWant := range []string{
+		"tightvnc-2.8.85-gpl-setup-64bit.msi",
+		`C:\ProgramData\crabbox\vnc.password`,
+		"CrabboxUserVNC",
+		"AutoAdminLogon",
+	} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("windows WSL2 bootstrap should not include %q", notWant)
 		}
 	}
 }

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -6,6 +6,8 @@ const gitForWindowsSetupURL =
   "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/Git-2.52.0-64-bit.exe";
 const openSSHWin64ZipURL =
   "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.3.0p2-Preview/OpenSSH-Win64.zip";
+const ubuntuWSLRootFSURL =
+  "https://cloud-images.ubuntu.com/wsl/releases/24.04/current/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz";
 
 export function awsUserData(config: LeaseConfig): string {
   if (config.target === "windows") {
@@ -215,26 +217,169 @@ foreach ($path in @("C:\\Program Files\\OpenSSH", "C:\\Program Files\\Git\\cmd",
 }
 
 export function windowsBootstrapPowerShell(config: LeaseConfig): string {
-  return (
-    windowsBootstrapHeaderPowerShell(config) +
-    `
-$vncPasswordPath = "C:\\ProgramData\\crabbox\\vnc.password"
-$windowsUsernamePath = "C:\\ProgramData\\crabbox\\windows.username"
-$windowsPasswordPath = "C:\\ProgramData\\crabbox\\windows.password"
-$passwordPath = $vncPasswordPath
-$usernamePath = $windowsUsernamePath
-$passwordMirrorPath = $windowsPasswordPath
-$enforceKeyAuth = $false
-$userVNCStartupPath = "C:\\ProgramData\\crabbox\\start-user-vnc.ps1"
-$userVNCStartupCommandPath = Join-Path (Join-Path (Join-Path "C:\\Users" $user) "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup") "crabbox-user-vnc.cmd"
-$tightVNCInstaller = "$env:TEMP\\tightvnc-2.8.85-gpl-setup-64bit.msi"
-` +
-    windowsBootstrapCorePowerShell() +
-    `
-if (-not (Test-Path -LiteralPath "C:\\Program Files\\TightVNC\\tvnserver.exe")) {
-  Retry { Invoke-WebRequest -Uri ${psQuote(tightVNCMSIURL)} -OutFile $tightVNCInstaller -UseBasicParsing }
-  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
-  Start-Process -FilePath msiexec.exe -ArgumentList @(
+  const script =
+    windowsBootstrapHeaderPowerShell({ ...config, workRoot: windowsBootstrapWorkRoot(config) }) +
+    windowsManagedCorePreludePowerShell(config) +
+    windowsBootstrapCorePowerShell();
+  if (config.windowsMode === "wsl2") {
+    return script + windowsWSL2BootstrapPowerShell(config);
+  }
+  if (config.desktop) {
+    return script + windowsDesktopBootstrapPowerShell();
+  }
+  return script + windowsCoreBootstrapFinalizePowerShell();
+}
+
+function windowsBootstrapWorkRoot(config: LeaseConfig): string {
+  if (config.windowsMode === "wsl2") {
+    return "C:\\crabbox";
+  }
+  return config.workRoot || "C:\\crabbox";
+}
+
+function windowsWSLWorkRoot(config: LeaseConfig): string {
+  return config.workRoot || "/work/crabbox";
+}
+
+function windowsManagedCorePreludePowerShell(config: LeaseConfig): string {
+  if (config.windowsMode === "normal" && config.desktop) {
+    return `
+	$vncPasswordPath = "C:\\ProgramData\\crabbox\\vnc.password"
+	$windowsUsernamePath = "C:\\ProgramData\\crabbox\\windows.username"
+	$windowsPasswordPath = "C:\\ProgramData\\crabbox\\windows.password"
+	$passwordPath = $vncPasswordPath
+	$usernamePath = $windowsUsernamePath
+	$passwordMirrorPath = $windowsPasswordPath
+	$enforceKeyAuth = $false
+	$userVNCStartupPath = "C:\\ProgramData\\crabbox\\start-user-vnc.ps1"
+	$userVNCStartupCommandPath = Join-Path (Join-Path (Join-Path "C:\\Users" $user) "AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup") "crabbox-user-vnc.cmd"
+	$tightVNCInstaller = "$env:TEMP\\tightvnc-2.8.85-gpl-setup-64bit.msi"
+	`;
+  }
+  return `
+	$windowsUsernamePath = "C:\\ProgramData\\crabbox\\windows.username"
+	$windowsPasswordPath = "C:\\ProgramData\\crabbox\\windows.password"
+	$passwordPath = $windowsPasswordPath
+	$usernamePath = $windowsUsernamePath
+	$passwordMirrorPath = $null
+	$enforceKeyAuth = $false
+	`;
+}
+
+function windowsWSL2BootstrapPowerShell(config: LeaseConfig): string {
+  const workRoot = windowsWSLWorkRoot(config);
+  return `
+	$wslDistro = "Crabbox"
+	$wslRoot = "C:\\ProgramData\\crabbox\\wsl\\Crabbox"
+	$wslRootfs = "C:\\ProgramData\\crabbox\\wsl\\ubuntu-noble-wsl-amd64.rootfs.tar.gz"
+	$wslRootfsDownload = "$wslRootfs.download"
+	$wslRootfsMinBytes = 100 * 1024 * 1024
+	$wslSetup = "C:\\ProgramData\\crabbox\\wsl\\linux-setup.sh"
+	$wslFeaturesMarker = "C:\\ProgramData\\crabbox\\wsl-features-rebooted"
+	$wslKernelMarker = "C:\\ProgramData\\crabbox\\wsl-kernel-rebooted"
+	function Restart-CrabboxBootstrap($MarkerPath) {
+	  Set-Content -NoNewline -Encoding ASCII -Path $MarkerPath -Value (Get-Date).ToString("o")
+	  Restart-Computer -Force
+	  exit 0
+	}
+	$needsFeatureReboot = $false
+	foreach ($feature in @("Microsoft-Windows-Subsystem-Linux", "VirtualMachinePlatform", "HypervisorPlatform")) {
+	  $state = (Get-WindowsOptionalFeature -Online -FeatureName $feature -ErrorAction SilentlyContinue).State
+	  if ($state -ne "Enabled") {
+	    dism.exe /online /enable-feature /featurename:$feature /all /norestart | Out-Host
+	    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { throw "enable $feature failed with exit $LASTEXITCODE" }
+	    $needsFeatureReboot = $true
+	  }
+	}
+	bcdedit.exe /set hypervisorlaunchtype auto | Out-Host
+	if ($LASTEXITCODE -ne 0) { throw "bcdedit hypervisorlaunchtype failed with exit $LASTEXITCODE" }
+	if ($needsFeatureReboot -and -not (Test-Path -LiteralPath $wslFeaturesMarker)) {
+	  Restart-CrabboxBootstrap $wslFeaturesMarker
+	}
+	if (-not (Test-Path -LiteralPath $wslKernelMarker)) {
+	  wsl.exe --update --web-download | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --update --web-download failed with exit $LASTEXITCODE" }
+	  Restart-CrabboxBootstrap $wslKernelMarker
+	}
+	wsl.exe --set-default-version 2 | Out-Host
+	if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version 2 failed with exit $LASTEXITCODE" }
+	$distros = (wsl.exe --list --quiet 2>$null) -join [Environment]::NewLine
+	if ($distros -notmatch "(?m)^$([Regex]::Escape($wslDistro))$") {
+	  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $wslRoot), $wslRoot | Out-Null
+	  if ((Test-Path -LiteralPath $wslRootfs) -and ((Get-Item -LiteralPath $wslRootfs).Length -lt $wslRootfsMinBytes)) {
+	    Remove-Item -Force -LiteralPath $wslRootfs
+	  }
+	  if (-not (Test-Path -LiteralPath $wslRootfs)) {
+	    Remove-Item -Force -LiteralPath $wslRootfsDownload -ErrorAction SilentlyContinue
+	    Retry {
+	      $expectedLength = 0
+	      try {
+	        $head = Invoke-WebRequest -Uri ${psQuote(ubuntuWSLRootFSURL)} -Method Head -UseBasicParsing
+	        if ($head.Headers.ContainsKey("Content-Length")) {
+	          [void][Int64]::TryParse(($head.Headers["Content-Length"] | Select-Object -First 1), [ref]$expectedLength)
+	        }
+	      } catch {
+	        $expectedLength = 0
+	      }
+	      if (Get-Command curl.exe -ErrorAction SilentlyContinue) {
+	        & curl.exe -fL --retry 8 --retry-delay 5 --connect-timeout 30 --speed-time 30 --speed-limit 1024 -o $wslRootfsDownload ${psQuote(ubuntuWSLRootFSURL)}
+	        if ($LASTEXITCODE -ne 0) { throw "download WSL rootfs failed with exit $LASTEXITCODE" }
+	      } else {
+	        Invoke-WebRequest -Uri ${psQuote(ubuntuWSLRootFSURL)} -OutFile $wslRootfsDownload -UseBasicParsing
+	      }
+	      $actualLength = (Get-Item -LiteralPath $wslRootfsDownload).Length
+	      if ($actualLength -lt $wslRootfsMinBytes) { throw "downloaded WSL rootfs is incomplete" }
+	      if ($expectedLength -gt 0 -and $actualLength -ne $expectedLength) {
+	        throw "downloaded WSL rootfs is incomplete: $actualLength of $expectedLength bytes"
+	      }
+	    }
+	    Move-Item -Force -LiteralPath $wslRootfsDownload -Destination $wslRootfs
+	  }
+	  wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2 | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --import failed with exit $LASTEXITCODE" }
+	  wsl.exe --set-default $wslDistro | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "wsl --set-default failed with exit $LASTEXITCODE" }
+	}
+	$linuxSetup = @'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p ${shellQuote(workRoot)} /var/cache/crabbox/pnpm /var/cache/crabbox/npm /var/lib/crabbox
+cat >/etc/apt/apt.conf.d/80-crabbox-retries <<'APT'
+Acquire::Retries "8";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+APT
+rm -rf /var/lib/apt/lists/*
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl git rsync jq
+cat >/usr/local/bin/crabbox-ready <<'READY'
+#!/usr/bin/env bash
+set -euo pipefail
+git --version >/dev/null
+rsync --version >/dev/null
+curl --version >/dev/null
+jq --version >/dev/null
+test -w ${shellQuote(workRoot)}
+READY
+chmod 0755 /usr/local/bin/crabbox-ready
+touch /var/lib/crabbox/bootstrapped
+crabbox-ready
+'@
+	$linuxSetup = $linuxSetup.Replace(([string][char]13 + [string][char]10), ([string][char]10))
+	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
+	wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
+	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
+	Restart-Service sshd -Force
+	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	`;
+}
+
+function windowsDesktopBootstrapPowerShell(): string {
+  return `
+	if (-not (Test-Path -LiteralPath "C:\\Program Files\\TightVNC\\tvnserver.exe")) {
+	  Retry { Invoke-WebRequest -Uri ${psQuote(tightVNCMSIURL)} -OutFile $tightVNCInstaller -UseBasicParsing }
+	  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
+	  Start-Process -FilePath msiexec.exe -ArgumentList @(
     "/i", $tightVNCInstaller, "/quiet", "/norestart",
     "ADDLOCAL=Server",
     "SERVER_REGISTER_AS_SERVICE=1",
@@ -292,18 +437,27 @@ Set-ItemProperty -Path $winlogon -Name DefaultPassword -Value $userPassword -Typ
 Restart-Service sshd
 if (-not (Test-Path -LiteralPath $setupCompletePath)) {
   Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
-  Restart-Computer -Force
+	  Restart-Computer -Force
+	}
+	`;
 }
-`
-  );
+
+function windowsCoreBootstrapFinalizePowerShell(): string {
+  return `
+	Restart-Service sshd -Force
+	git --version | Out-Null
+	tar --version | Out-Null
+	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	`;
 }
 
 export function azureWindowsBootstrapPowerShell(config: LeaseConfig): string {
+  const coreConfig = { ...config, workRoot: windowsBootstrapWorkRoot(config) };
   const setupComplete = config.desktop
     ? ""
     : `Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")`;
   return (
-    windowsBootstrapHeaderPowerShell(config) +
+    windowsBootstrapHeaderPowerShell(coreConfig) +
     `
 $passwordPath = Join-Path $base "windows.password"
 $usernamePath = Join-Path $base "windows.username"

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -193,6 +193,7 @@ describe("cloud-init bootstrap", () => {
     const input = {
       ...config,
       target: "windows",
+      desktop: true,
       workRoot: "C:\\crabbox",
     } as const;
     expect(awsUserData(input)).toContain("version: 1.1");
@@ -229,6 +230,54 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("C:\\ProgramData\\crabbox\\windows.username");
     expect(got).toContain("AutoAdminLogon");
     expect(got).toContain("Restart-Computer -Force");
+  });
+
+  it("builds Windows core bootstrap without desktop/VNC", () => {
+    const input = {
+      ...config,
+      target: "windows",
+      workRoot: "C:\\crabbox",
+    } as const;
+    const got = windowsBootstrapPowerShell(input);
+    expect(got).toContain("OpenSSH-Win64.zip");
+    expect(got).toContain("Git-2.52.0-64-bit.exe");
+    expect(got).toContain("$passwordPath = $windowsPasswordPath");
+    expect(got).toContain("Restart-Service sshd -Force");
+    expect(got).toContain("Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath");
+    expect(got).not.toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
+    expect(got).not.toContain("C:\\ProgramData\\crabbox\\vnc.password");
+    expect(got).not.toContain("CrabboxUserVNC");
+    expect(got).not.toContain("AutoAdminLogon");
+    expect(got).not.toContain("Restart-Computer -Force");
+  });
+
+  it("builds Windows WSL2 bootstrap without desktop/VNC", () => {
+    const input = {
+      ...config,
+      target: "windows",
+      windowsMode: "wsl2",
+      workRoot: "/work/crabbox",
+    } as const;
+    const got = windowsBootstrapPowerShell(input);
+    expect(got).toContain("$workRoot = 'C:\\crabbox'");
+    expect(got).toContain("C:\\ProgramData\\crabbox\\windows.password");
+    expect(got).toContain("Microsoft-Windows-Subsystem-Linux");
+    expect(got).toContain("VirtualMachinePlatform");
+    expect(got).toContain("HypervisorPlatform");
+    expect(got).toContain("bcdedit.exe /set hypervisorlaunchtype auto");
+    expect(got).toContain("wsl.exe --update --web-download");
+    expect(got).toContain("wsl.exe --set-default-version 2");
+    expect(got).toContain("ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz");
+    expect(got).toContain("$wslRootfsMinBytes = 100 * 1024 * 1024");
+    expect(got).toContain("curl.exe -fL --retry 8");
+    expect(got).toContain("downloaded WSL rootfs is incomplete");
+    expect(got).toContain("wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2");
+    expect(got).toContain("wsl.exe --set-default $wslDistro");
+    expect(got).toContain("test -w '/work/crabbox'");
+    expect(got).not.toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
+    expect(got).not.toContain("C:\\ProgramData\\crabbox\\vnc.password");
+    expect(got).not.toContain("CrabboxUserVNC");
+    expect(got).not.toContain("AutoAdminLogon");
   });
 
   it("builds Azure Windows extension bootstrap without restart", () => {


### PR DESCRIPTION
## Summary

Splits managed Windows bootstrap generation into explicit core, desktop, and WSL2 profiles.

- Native Windows without `--desktop` now runs only the core Windows user/OpenSSH/Git/tar setup and writes the setup marker.
- Native Windows with `--desktop` keeps the TightVNC, per-user VNC startup, `CrabboxUserVNC`, auto-logon, and VNC readiness behavior.
- Windows WSL2 keeps the WSL optional feature, kernel update, rootfs import, and Linux `crabbox-ready` setup without writing Windows VNC/autologon artifacts.
- The Cloudflare Worker bootstrap generator now mirrors the CLI generator contract.
- AWS docs now describe TightVNC/autologon as optional `--desktop` behavior, not default native Windows behavior.

Improves https://github.com/openclaw/crabbox/pull/81 by tightening the Windows desktop vs WSL2 boundary that PR added for Azure. It also fixes the same WSL2/VNC boundary for AWS from https://github.com/openclaw/crabbox/pull/23 and keeps the AWS desktop VNC behavior from https://github.com/openclaw/crabbox/pull/14 isolated to desktop leases.

## Implementation Notes

- `internal/cli/bootstrap.go`
  - `windowsBootstrapPowerShell` now composes a shared core script and selects one profile tail.
  - Added helpers for Windows host work root vs WSL Linux work root.
  - Moved WSL2 setup into `windowsWSL2BootstrapPowerShell`.
  - Moved TightVNC/autologon setup into `windowsDesktopBootstrapPowerShell`.
  - Added `windowsCoreBootstrapFinalizePowerShell` for no-desktop native Windows.
- `internal/cli/aws_windows_bootstrap.go`
  - Generalized the post-SSH bootstrap runner and made phase labels profile-specific.
  - VNC readiness is only checked for native Windows desktop.
- `worker/src/bootstrap.ts`
  - Mirrors the CLI bootstrap profile split for coordinator-created leases.
- Tests
  - Added Go and Worker assertions that core and WSL2 bootstraps exclude VNC/autologon artifacts.
- Docs
  - Updated AWS docs to describe TightVNC/autologon as optional `--desktop` behavior.

## Validation

Local:

```sh
go vet ./...
go test ./...
go build -trimpath -o bin/crabbox ./cmd/crabbox
git diff --check
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm test --prefix worker
npm run build --prefix worker
```

Branch live integration, direct mode:

| Provider | Profile | Type | Warmup | Result |
| --- | --- | --- | ---: | --- |
| AWS | Native core, no desktop/VNC | `m7i.large` | `2m56.944s` | `aws-core-no-vnc-ok` |
| AWS | Native desktop/VNC | `m7i.large` | `3m52.877s` | `aws-desktop-vnc-ok` |
| AWS | WSL2, no desktop/VNC | `m8i.large` | `5m48.834s` | `aws-wsl2-no-vnc-ok` |
| Azure | Native core, no desktop/VNC | `Standard_D2ads_v6` | `4m50.301s` | `azure-core-no-vnc-ok` |
| Azure | Native desktop/VNC | `Standard_D2ads_v6` | `5m55.272s` | `azure-desktop-vnc-ok` |
| Azure | WSL2, no desktop/VNC | `Standard_D2ads_v6` | `8m34.526s` | `azure-wsl2-no-vnc-ok` |

Old-vs-new baseline, direct mode:

| Provider | Profile | Upstream warmup | Branch warmup | Branch delta | Artifact result |
| --- | --- | ---: | ---: | ---: | --- |
| AWS | Native core, no desktop | `3m58.477s` | `2m56.944s` | `61.533s faster` | Upstream created VNC artifacts; branch did not. |
| AWS | Native desktop/VNC | `3m48.659s` | `3m52.877s` | `4.218s slower` | Both created VNC artifacts and reached VNC readiness. |
| AWS | WSL2 | `6m53.604s` | `5m48.834s` | `64.770s faster` | Upstream created Windows VNC files; branch did not. |
| Azure | Native core, no desktop | `3m40.705s` | `4m50.301s` | `69.596s slower` | Both were clean of VNC artifacts. |
| Azure | Native desktop/VNC | `4m04.178s` | `5m55.272s` | `111.094s slower` | Both created VNC artifacts and reached VNC readiness. |
| Azure | WSL2 | `7m28.962s` | `8m34.526s` | `65.564s slower` | Upstream created Windows VNC files; branch did not. |

AWS performance improvement from the fix:

- AWS native no-desktop now runs `Windows core bootstrap` instead of upstream's `Windows desktop bootstrap`.
- AWS native no-desktop improved from `3m58.477s` to `2m56.944s`, a `61.533s` improvement in the live sample.
- AWS WSL2 improved from `6m53.604s` to `5m48.834s`, a `64.770s` improvement in the live sample, while also removing unsupported Windows VNC files.

Cleanup:

- Stopped all six branch live validation leases.
- Stopped all six upstream baseline leases. The Azure WSL2 upstream release required live Azure resource cleanup because the old CLI tried a coordinator release path for that slug; post-cleanup Azure resource lookup by lease returned no rows.
- `bin/crabbox list --provider aws --target windows` returned no rows after cleanup.
- `bin/crabbox list --provider azure --target windows` returned no rows after cleanup.

## Risk

- Coordinator mode was validated through the mirrored Worker generator tests and dry-run Worker build, not by deploying a live Worker preview.
- Fresh WSL2 hosts still require the expected Windows feature/kernel reboot loop; this PR isolates that behavior but does not remove it.
