### PR TITLE
fix: retry WebVNC take-control handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fixed WebVNC `--take-control` handoff links so the portal keeps retrying the automatic control claim until the opened viewer is registered as an observer.
 - Fixed WebVNC portal click forwarding so controller clicks reach the remote desktop while preserving focus and browser context-menu suppression.
 
 ## 0.14.0 - 2026-05-15

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -765,6 +765,11 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
         applyCollaborationState(state);
         return state;
       }
+      async function refreshCollaborationStateAndMaybeTakeControl() {
+        const state = await refreshCollaborationState();
+        await takeControlIfRequested(state);
+        return state;
+      }
       async function takeControl(label = "you took control") {
         const response = await fetch(controlURL, {
           method: "POST",
@@ -834,9 +839,11 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
             connected = true;
             retryAttempt = 0;
             setStatus("connected", "ok");
-            void refreshCollaborationState().then((state) => takeControlIfRequested(state)).then(focusVNC).catch(() => {});
+            void refreshCollaborationStateAndMaybeTakeControl().then(focusVNC).catch(() => {});
             window.clearInterval(statusTimer);
-            statusTimer = window.setInterval(refreshCollaborationState, 1500);
+            statusTimer = window.setInterval(() => {
+              void refreshCollaborationStateAndMaybeTakeControl().catch(() => {});
+            }, 1500);
           });
           rfb.addEventListener("clipboard", (event) => {
             remoteClipboardText = event.detail?.text || "";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2170,6 +2170,10 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain("you control");
     expect(pageBody).toContain('fragment.get("control") === "take"');
     expect(pageBody).toContain("takeControlIfRequested(state)");
+    expect(pageBody).toContain("refreshCollaborationStateAndMaybeTakeControl");
+    expect(pageBody).toContain(
+      "void refreshCollaborationStateAndMaybeTakeControl().catch(() => {})",
+    );
     expect(pageBody).toContain('aria-label="WebVNC display" tabindex="0"');
     expect(pageBody).toContain('screen.addEventListener("contextmenu"');
     expect(pageBody).toContain(


### PR DESCRIPTION
## Summary
- Keep WebVNC `#control=take` handoff links retrying the automatic control claim during collaboration polling until the opened viewer is registered.
- Add worker regression coverage for the retry path.
- Add changelog note for the user-visible WebVNC fix.

## Verification
- `npm test --prefix worker -- test/fleet.test.ts`
- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run build --prefix worker`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access --parallel-tests "npm test --prefix worker -- test/fleet.test.ts"`
