### PR TITLE
feat(macos): support AWS macOS image runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 
-- Fixed direct AWS AMI checkpoint inspect, delete, and fork paths so recorded account and direct-backend metadata are honored even after coordinator configuration changes.
+- Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
 - Fixed recursive run artifact globs so `**` works on older Bash without crossing unintended path segments.
 
 ## 0.15.0 - 2026-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Fixed
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
-- Fixed direct AWS macOS AMI checkpoint forks so recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
+- Fixed direct AWS macOS AMI checkpoint forks so resolved and recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
 - Fixed AWS macOS native checkpoint selection so macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
+- Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.
 - Fixed recursive run artifact globs so `**` works on older Bash without crossing unintended path segments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - Clarified WebVNC docs to include coordinator-backed AWS macOS desktop leases in the supported portal bridge surface.
 
+### Fixed
+
+- Fixed direct AWS AMI checkpoint inspect, delete, and fork paths so recorded account and direct-backend metadata are honored even after coordinator configuration changes.
+- Fixed recursive run artifact globs so `**` works on older Bash without crossing unintended path segments.
+
 ## 0.15.0 - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed direct AWS macOS AMI checkpoint forks so resolved and recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
 - Fixed AWS macOS native checkpoint selection so brokered and direct macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
 - Fixed macOS image lifecycle smoke checkpoint forks so EC2 Mac host recycle waits require stable availability and retry once after transient host recycle failures.
+- Fixed macOS image lifecycle smoke checkpoint forks so forked macOS leases request desktop/WebVNC metadata before collecting WebVNC evidence.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
 - Fixed direct AWS macOS AMI checkpoint forks so resolved and recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
 - Fixed AWS macOS native checkpoint selection so brokered and direct macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
+- Fixed macOS image lifecycle smoke checkpoint forks so EC2 Mac host recycle waits require stable availability and retry once after transient host recycle failures.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
+- Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed recursive run artifact globs so `**` works on older Bash without crossing unintended path segments.
 
 ## 0.15.0 - 2026-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
+- Fixed direct AWS macOS AMI checkpoint forks so recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
 - Fixed AWS macOS native checkpoint selection so macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
 - Fixed direct AWS macOS AMI checkpoint forks so resolved and recorded EC2 Mac Dedicated Host pins are reused after coordinator routing is disabled.
-- Fixed AWS macOS native checkpoint selection so macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
+- Fixed AWS macOS native checkpoint selection so brokered and direct macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.1 - Unreleased
 
+### Added
+
+- Added an account-guarded EC2 Mac Dedicated Host quota request helper for turning macOS lifecycle smoke quota evidence into a dry-run or explicit AWS Service Quotas request.
+
 ## 0.15.0 - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Added `crabbox capsule` for local GitHub Actions failure replay manifests, including capture, inspect, replay, promotion, and documentation for how capsules compose with actions hydration and checkpoints. Thanks @zozo123.
 - Added AWS macOS support to native `crabbox checkpoint` snapshot/image creation and forks, including host-pin metadata and On-Demand fork defaults.
+- Added direct AWS AMI checkpoint creation so non-brokered AWS Linux/macOS leases can use `crabbox checkpoint create --mode native` or `--strategy image` without a coordinator.
 - Added `--take-control` for WebVNC portal handoffs so opened browser viewers can automatically become the keyboard and mouse controller after connecting.
 - Added `scripts/macos-image-lifecycle-smoke.sh` for guarded AWS EC2 Mac host allocation, source macOS lease boot, WebVNC bridge proof, AMI creation, candidate-image smoke, promotion, promoted-image smoke, cleanup, and durable `summary.json` evidence.
 - Added a no-spend macOS host region preflight helper for checking reusable EC2 Mac Dedicated Hosts, dry-run allocation readiness, and Dedicated Mac host quota across configured AWS regions before approving paid allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added an account-guarded EC2 Mac Dedicated Host quota request helper for turning macOS lifecycle smoke quota evidence into a dry-run or explicit AWS Service Quotas request.
+- Added a no-spend macOS coordinator remediation audit helper that bundles provider identity, IAM policy, host quota, host allocation dry-run, guarded IAM apply dry-run, and guarded quota request dry-run evidence into `summary.json`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an account-guarded EC2 Mac Dedicated Host quota request helper for turning macOS lifecycle smoke quota evidence into a dry-run or explicit AWS Service Quotas request.
 
+### Changed
+
+- Clarified WebVNC docs to include coordinator-backed AWS macOS desktop leases in the supported portal bridge surface.
+
 ## 0.15.0 - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
+- Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.
 - Fixed recursive run artifact globs so `**` works on older Bash without crossing unintended path segments.
 
 ## 0.15.0 - 2026-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed direct AWS AMI checkpoint create, inspect, delete, and fork paths so source instances are validated before host preparation and recorded account/direct-backend metadata is honored even after coordinator configuration changes.
+- Fixed AWS macOS native checkpoint selection so macOS checkpoints use AMI-backed snapshots by default instead of raw EBS snapshot forks that EC2 Mac cannot reliably relaunch.
 - Fixed macOS image lifecycle smoke summaries so paid EC2 Mac Dedicated Host allocation failures preserve stderr, blocker text, and remediation guidance instead of writing an empty blocker.
 - Fixed EC2 Mac Dedicated Host state parsing so live AWS `DescribeHosts` responses are recognized as reusable by macOS lifecycle smoke instead of falling through to a new host allocation path.
 - Fixed existing AWS macOS lease commands so `crabbox run --id ... --target macos` defaults the irrelevant capacity market to On-Demand instead of failing Spot validation before reaching the lease.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -58,6 +58,9 @@ crabbox checkpoint create --id blue-lobster --mode archive
 # Use image strategy instead of disk-snapshot (AWS Linux/macOS, GCP Linux)
 crabbox checkpoint create --id blue-lobster --strategy image
 
+# Direct AWS leases can force native AMI checkpoints without a coordinator
+crabbox checkpoint create --provider aws --id blue-lobster --mode native
+
 # Custom workdir
 crabbox checkpoint create --id blue-lobster --workdir /work/cbx_123/my-app
 ```
@@ -268,6 +271,11 @@ Opt-in strategy `--strategy image`:
 - AWS Linux/macOS: AMI (Amazon Machine Image)
 - Azure: Not created from active VMs (requires stopped/generalized source)
 - GCP Linux: Machine image
+
+Direct AWS Linux/macOS leases use AMIs for native checkpoints. `--mode auto`
+still falls back to workspace archives without a coordinator, while
+`--mode native` or `--strategy image` creates an AMI in the configured AWS
+region.
 
 AWS macOS checkpoint forks still require EC2 Mac Dedicated Host capacity. Brokered
 mode can discover a host; host-pinned checkpoints reuse the recorded `hostId`.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -82,7 +82,7 @@ crabbox checkpoint create --id blue-lobster --workdir /work/cbx_123/my-app
 
 **Strategy details**
 
-- `disk-snapshot`: EBS/Azure disk/GCP disk snapshot — faster, best for iteration
+- `disk-snapshot`: EBS/Azure disk/GCP disk snapshot; AWS macOS maps to AMI-backed checkpoints with backing EBS snapshots
 - `image`: AWS AMI/GCP machine image — slower, preserves full VM config
 - Azure managed images require stopped VMs, not created from active leases
 
@@ -258,7 +258,8 @@ they preserve to identify candidates for cleanup.
 **Native checkpoints**
 
 Default strategy `disk-snapshot`:
-- AWS Linux/macOS: EBS snapshot
+- AWS Linux: EBS snapshot
+- AWS macOS: AMI-backed checkpoint with backing EBS snapshots
 - Azure: Managed OS disk snapshot
 - GCP: Persistent disk snapshot
 
@@ -272,10 +273,12 @@ Opt-in strategy `--strategy image`:
 - Azure: Not created from active VMs (requires stopped/generalized source)
 - GCP Linux: Machine image
 
-Direct AWS Linux/macOS leases use AMIs for native checkpoints. `--mode auto`
-still falls back to workspace archives without a coordinator, while
-`--mode native` or `--strategy image` creates an AMI in the configured AWS
-region.
+AWS macOS uses AMI-backed native checkpoints even when `disk-snapshot` is
+requested, because relaunching EC2 Mac from a raw registered root EBS snapshot
+does not preserve enough AWS launch metadata. Direct AWS Linux/macOS leases use
+AMIs for native checkpoints. `--mode auto` still falls back to workspace
+archives without a coordinator, while `--mode native` or `--strategy image`
+creates an AMI in the configured AWS region.
 
 AWS macOS checkpoint forks still require EC2 Mac Dedicated Host capacity. Brokered
 mode can discover a host; host-pinned checkpoints reuse the recorded `hostId`.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -186,7 +186,8 @@ daemon stop
 
 Limitations:
 
-- Coordinator-backed Hetzner, AWS, and Azure Linux desktop leases are supported.
+- Coordinator-backed Hetzner, AWS, and Azure Linux desktop leases are supported,
+  along with coordinator-backed AWS macOS desktop leases.
 - Static SSH hosts are intentionally not supported yet because the portal cannot
   prove that host-managed VNC credentials and prompts are safe to expose.
 - Blacksmith Testbox still owns its own machine connectivity.

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -26,7 +26,9 @@ leases.
 - Excludes `.crabbox/env` and `.crabbox/scripts` by default
 
 Default `auto` mode: native for brokered AWS Linux/macOS leases and Azure/GCP
-Linux leases, otherwise archive.
+Linux leases, otherwise archive. Direct AWS leases can force native AMI
+checkpoints with `--mode native` or `--strategy image`; direct AWS `auto` keeps
+the archive fallback.
 
 ## Native Checkpoint Strategies
 
@@ -53,6 +55,8 @@ stateless Azure leases where native checkpoint/fork support is not needed.
 - GCP: Machine image (`gcp-machine-image`)
 - Slower but preserves complete VM configuration
 - Best for distribution or long-term storage
+- Direct AWS Linux/macOS leases use this strategy for native checkpoints because
+  AMIs can be forked directly through `CRABBOX_AWS_AMI`
 
 **Metadata-Only (`recipe`)**
 - Records lease/repo/workdir info without creating artifacts

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -35,7 +35,8 @@ the archive fallback.
 Native checkpoints use two provider primitives:
 
 **Disk-Snapshot Strategy (default)**
-- AWS: EBS snapshot (`aws-ebs-snapshot`)
+- AWS Linux: EBS snapshot (`aws-ebs-snapshot`)
+- AWS macOS: AMI-backed checkpoint (`aws-ami`) with AWS-managed backing EBS snapshots
 - Azure: Managed OS disk snapshot (`azure-os-disk-snapshot`)
 - GCP: Persistent disk snapshot (`gcp-disk-snapshot`)
 - Faster to create, boots with fresh SSH keys
@@ -57,6 +58,9 @@ stateless Azure leases where native checkpoint/fork support is not needed.
 - Best for distribution or long-term storage
 - Direct AWS Linux/macOS leases use this strategy for native checkpoints because
   AMIs can be forked directly through `CRABBOX_AWS_AMI`
+- AWS macOS uses this AMI-backed path even when `disk-snapshot` is requested,
+  because raw registered EC2 Mac root snapshots do not preserve enough AWS
+  launch metadata to be a reliable fork source.
 
 **Metadata-Only (`recipe`)**
 - Records lease/repo/workdir info without creating artifacts

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -232,6 +232,17 @@ If dry-run succeeds, run
 `crabbox admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2.metal`
 before real allocation. It prints the selected EC2 Mac Dedicated Host quota
 from AWS Service Quotas, which is the next useful no-spend blocker after IAM.
+For a single artifact bundle that captures identity, IAM policy, quota,
+allocation dry-run, local AWS profile matching, and quota request dry-run
+evidence, run:
+
+```bash
+scripts/macos-coordinator-remediation-audit.sh --region eu-west-1 --type mac2.metal --profile auto
+```
+
+The audit writes `summary.json` with `blocked` or `ready-for-paid-smoke`,
+artifact-relative evidence paths, blocker names, and exact remediation
+commands.
 
 Do not treat that host policy as the whole image bake policy. It only unblocks
 Dedicated Host allocation and release. The full paid lifecycle also needs the

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -267,6 +267,21 @@ with `ready-existing-host`, `ready-allocation`, or `blocked`; `ready-allocation`
 requires both a successful allocation dry-run and visible quota of at least one
 host for the selected type.
 
+When the only blocker is Dedicated Mac host quota, capture the same quota and
+coordinator identity evidence, then dry-run the AWS quota request before
+submitting it:
+
+```sh
+crabbox admin providers identity --provider aws --region eu-west-1 --json > provider-identity.json
+crabbox admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2.metal --json > mac-host-quota.json
+scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto
+scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto --apply
+```
+
+The helper refuses to submit unless the selected AWS profile belongs to the same
+account as the deployed coordinator identity. It exits without making an AWS
+request when the captured quota is already at or above the requested value.
+
 The guarded macOS image lifecycle smoke also runs that region preflight
 automatically when `CRABBOX_MACOS_REGIONS` or `CRABBOX_CAPACITY_REGIONS` is set
 and `CRABBOX_MACOS_REGION` is not set. It records the region-preflight JSON in

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -267,6 +267,18 @@ with `ready-existing-host`, `ready-allocation`, or `blocked`; `ready-allocation`
 requires both a successful allocation dry-run and visible quota of at least one
 host for the selected type.
 
+When the coordinator is blocked and you need a handoff bundle for the AWS
+account owner, run:
+
+```sh
+scripts/macos-coordinator-remediation-audit.sh --region eu-west-1 --type mac2.metal --profile auto
+```
+
+The audit is no-spend. It captures provider identity, the combined macOS IAM
+policy, EC2 Mac host quota, host allocation dry-run, guarded IAM apply dry-run,
+and guarded quota request dry-run evidence, then writes `summary.json` with the
+blockers and exact remediation commands.
+
 When the only blocker is Dedicated Mac host quota, capture the same quota and
 coordinator identity evidence, then dry-run the AWS quota request before
 submitting it:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.302.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/daytonaio/daytona/libs/api-client-go v0.177.0
 	github.com/daytonaio/daytona/libs/sdk-go v0.177.0
 	github.com/islo-labs/go-sdk v0.0.0-20260515061547-7c377773942c
@@ -44,7 +45,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -13,6 +13,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 const (
@@ -31,6 +32,7 @@ var awsSnapshotDeleteBackoff = []time.Duration{
 
 type AWSClient struct {
 	ec2    *ec2.Client
+	sts    *sts.Client
 	region string
 }
 
@@ -46,7 +48,7 @@ func newAWSClientForRegion(ctx context.Context, cfg Config, region string) (*AWS
 	if err != nil {
 		return nil, err
 	}
-	return &AWSClient{ec2: ec2.NewFromConfig(awsCfg), region: region}, nil
+	return &AWSClient{ec2: ec2.NewFromConfig(awsCfg), sts: sts.NewFromConfig(awsCfg), region: region}, nil
 }
 
 func NewAWSClient(ctx context.Context, cfg Config) (*AWSClient, error) {
@@ -400,6 +402,10 @@ func (c *AWSClient) DeleteServer(ctx context.Context, id string) error {
 }
 
 func (c *AWSClient) CreateImageCheckpoint(ctx context.Context, instanceID, name string, noReboot bool) (CoordinatorImage, error) {
+	accountID, err := c.CallerAccountID(ctx)
+	if err != nil {
+		return CoordinatorImage{}, err
+	}
 	tags := awsTagsWithName(map[string]string{
 		"crabbox":           "true",
 		"created_by":        "crabbox",
@@ -429,6 +435,7 @@ func (c *AWSClient) CreateImageCheckpoint(ctx context.Context, instanceID, name 
 		Kind:       checkpointKindAWSAMI,
 		Region:     c.region,
 		ResourceID: imageID,
+		AccountID:  accountID,
 		Direct:     true,
 	}, nil
 }
@@ -458,12 +465,21 @@ func (c *AWSClient) GetImageCheckpoint(ctx context.Context, imageID string) (Coo
 	}, nil
 }
 
-func (c *AWSClient) DeleteImageCheckpoint(ctx context.Context, imageID string, fallbackSnapshotIDs []string) error {
+func (c *AWSClient) DeleteImageCheckpoint(ctx context.Context, imageID string, fallbackSnapshotIDs []string, expectedAccountID string) error {
+	if err := c.GuardAccount(ctx, expectedAccountID); err != nil {
+		return err
+	}
 	out, err := c.ec2.DescribeImages(ctx, &ec2.DescribeImagesInput{
 		ImageIds: []string{imageID},
 	})
-	if err != nil && !strings.Contains(err.Error(), "InvalidAMIID.NotFound") {
-		return err
+	imageNotFound := err != nil && strings.Contains(err.Error(), "InvalidAMIID.NotFound")
+	if err != nil {
+		if !imageNotFound {
+			return err
+		}
+		if expectedAccountID == "" {
+			return exit(3, "cannot confirm direct AWS checkpoint delete for %s: image not found and checkpoint record has no accountId; switch to the original AWS account or use --local-only", imageID)
+		}
 	}
 	snapshotIDs := append([]string(nil), fallbackSnapshotIDs...)
 	if err == nil && len(out.Images) > 0 {
@@ -477,6 +493,36 @@ func (c *AWSClient) DeleteImageCheckpoint(ctx context.Context, imageID string, f
 		if err := c.deleteSnapshotWithRetry(ctx, snapshotID); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (c *AWSClient) CallerAccountID(ctx context.Context) (string, error) {
+	if c.sts == nil {
+		return "", exit(3, "aws sts client is unavailable")
+	}
+	out, err := c.sts.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+	accountID := aws.ToString(out.Account)
+	if accountID == "" {
+		return "", exit(3, "aws returned no caller account id")
+	}
+	return accountID, nil
+}
+
+func (c *AWSClient) GuardAccount(ctx context.Context, expectedAccountID string) error {
+	expectedAccountID = strings.TrimSpace(expectedAccountID)
+	if expectedAccountID == "" {
+		return nil
+	}
+	accountID, err := c.CallerAccountID(ctx)
+	if err != nil {
+		return err
+	}
+	if accountID != expectedAccountID {
+		return exit(3, "direct AWS checkpoint account mismatch: current account %s does not match checkpoint account %s", accountID, expectedAccountID)
 	}
 	return nil
 }

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -440,6 +440,17 @@ func (c *AWSClient) CreateImageCheckpoint(ctx context.Context, instanceID, name 
 	}, nil
 }
 
+func (c *AWSClient) ValidateImageCheckpointSource(ctx context.Context, instanceID string) (string, error) {
+	accountID, err := c.CallerAccountID(ctx)
+	if err != nil {
+		return "", err
+	}
+	if _, err := c.GetServer(ctx, instanceID); err != nil {
+		return "", err
+	}
+	return accountID, nil
+}
+
 func (c *AWSClient) GetImageCheckpoint(ctx context.Context, imageID string) (CoordinatorImage, error) {
 	out, err := c.ec2.DescribeImages(ctx, &ec2.DescribeImagesInput{
 		ImageIds: []string{imageID},

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -889,6 +889,9 @@ func awsInstanceToServer(instance types.Instance) Server {
 		Status:   string(instance.State.Name),
 		Labels:   labels,
 	}
+	if instance.Placement != nil {
+		server.HostID = aws.ToString(instance.Placement.HostId)
+	}
 	server.PublicNet.IPv4.IP = aws.ToString(instance.PublicIpAddress)
 	server.ServerType.Name = string(instance.InstanceType)
 	return server

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -20,6 +20,15 @@ const (
 	awsSSHIngressDescription = "Crabbox SSH"
 )
 
+var awsSnapshotDeleteBackoff = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+}
+
 type AWSClient struct {
 	ec2    *ec2.Client
 	region string
@@ -388,6 +397,140 @@ func (c *AWSClient) DeleteServer(ctx context.Context, id string) error {
 		InstanceIds: []string{id},
 	})
 	return err
+}
+
+func (c *AWSClient) CreateImageCheckpoint(ctx context.Context, instanceID, name string, noReboot bool) (CoordinatorImage, error) {
+	tags := awsTagsWithName(map[string]string{
+		"crabbox":           "true",
+		"created_by":        "crabbox",
+		"crabbox:source_id": instanceID,
+	}, name)
+	out, err := c.ec2.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId: aws.String(instanceID),
+		Name:       aws.String(name),
+		NoReboot:   aws.Bool(noReboot),
+		TagSpecifications: []types.TagSpecification{
+			{ResourceType: types.ResourceTypeImage, Tags: tags},
+			{ResourceType: types.ResourceTypeSnapshot, Tags: tags},
+		},
+	})
+	if err != nil {
+		return CoordinatorImage{}, err
+	}
+	imageID := aws.ToString(out.ImageId)
+	if imageID == "" {
+		return CoordinatorImage{}, exit(5, "aws returned no image id")
+	}
+	return CoordinatorImage{
+		ID:         imageID,
+		Name:       name,
+		State:      "pending",
+		Provider:   "aws",
+		Kind:       checkpointKindAWSAMI,
+		Region:     c.region,
+		ResourceID: imageID,
+		Direct:     true,
+	}, nil
+}
+
+func (c *AWSClient) GetImageCheckpoint(ctx context.Context, imageID string) (CoordinatorImage, error) {
+	out, err := c.ec2.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{imageID},
+	})
+	if err != nil {
+		return CoordinatorImage{}, err
+	}
+	if len(out.Images) == 0 {
+		return CoordinatorImage{}, exit(4, "aws image not found: %s", imageID)
+	}
+	image := out.Images[0]
+	return CoordinatorImage{
+		ID:           aws.ToString(image.ImageId),
+		Name:         aws.ToString(image.Name),
+		State:        string(image.State),
+		Provider:     "aws",
+		Kind:         checkpointKindAWSAMI,
+		Region:       c.region,
+		ResourceID:   aws.ToString(image.ImageId),
+		SnapshotIDs:  awsImageSnapshotIDs(image),
+		Direct:       true,
+		Architecture: string(image.Architecture),
+	}, nil
+}
+
+func (c *AWSClient) DeleteImageCheckpoint(ctx context.Context, imageID string, fallbackSnapshotIDs []string) error {
+	out, err := c.ec2.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{imageID},
+	})
+	if err != nil && !strings.Contains(err.Error(), "InvalidAMIID.NotFound") {
+		return err
+	}
+	snapshotIDs := append([]string(nil), fallbackSnapshotIDs...)
+	if err == nil && len(out.Images) > 0 {
+		snapshotIDs = append(snapshotIDs, awsImageSnapshotIDs(out.Images[0])...)
+	}
+	snapshotIDs = uniqueStrings(snapshotIDs)
+	if _, err := c.ec2.DeregisterImage(ctx, &ec2.DeregisterImageInput{ImageId: aws.String(imageID)}); err != nil && !strings.Contains(err.Error(), "InvalidAMIID.NotFound") {
+		return err
+	}
+	for _, snapshotID := range snapshotIDs {
+		if err := c.deleteSnapshotWithRetry(ctx, snapshotID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *AWSClient) deleteSnapshotWithRetry(ctx context.Context, snapshotID string) error {
+	var lastErr error
+	for attempt := 0; attempt <= len(awsSnapshotDeleteBackoff); attempt++ {
+		if _, err := c.ec2.DeleteSnapshot(ctx, &ec2.DeleteSnapshotInput{SnapshotId: aws.String(snapshotID)}); err != nil {
+			message := err.Error()
+			if strings.Contains(message, "InvalidSnapshot.NotFound") {
+				return nil
+			}
+			if !isRetryableAWSSnapshotDeleteError(message) {
+				return err
+			}
+			lastErr = err
+		} else {
+			return nil
+		}
+		if attempt >= len(awsSnapshotDeleteBackoff) {
+			break
+		}
+		timer := time.NewTimer(awsSnapshotDeleteBackoff[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+func awsImageSnapshotIDs(image types.Image) []string {
+	var snapshotIDs []string
+	for _, mapping := range image.BlockDeviceMappings {
+		if mapping.Ebs == nil {
+			continue
+		}
+		if snapshotID := aws.ToString(mapping.Ebs.SnapshotId); snapshotID != "" {
+			snapshotIDs = append(snapshotIDs, snapshotID)
+		}
+	}
+	return uniqueStrings(snapshotIDs)
+}
+
+func isRetryableAWSSnapshotDeleteError(message string) bool {
+	return strings.Contains(message, "InvalidSnapshot.InUse") ||
+		strings.Contains(message, "RequestLimitExceeded") ||
+		strings.Contains(message, "Throttl") ||
+		strings.Contains(message, "ServiceUnavailable") ||
+		strings.Contains(message, "InternalError") ||
+		strings.Contains(message, "http 5") ||
+		strings.Contains(strings.ToLower(message), "currently in use")
 }
 
 func (c *AWSClient) SetTags(ctx context.Context, id string, labels map[string]string) error {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 func TestApplyAWSRunInstanceTargetOptionsEnablesNestedVirtualizationForWSL2(t *testing.T) {
@@ -56,6 +58,83 @@ func TestRetryableAWSSnapshotDeleteError(t *testing.T) {
 	}
 	if isRetryableAWSSnapshotDeleteError("AuthFailure: not authorized") {
 		t.Fatal("AuthFailure should not be retryable")
+	}
+}
+
+func TestCreateImageCheckpointRecordsCallerAccount(t *testing.T) {
+	var sawCreate bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		switch action := r.Form.Get("Action"); action {
+		case "GetCallerIdentity":
+			writeSTSXML(w, `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account><Arn>arn:aws:iam::123456789012:user/test</Arn><UserId>AIDAEXAMPLE</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>`)
+		case "CreateImage":
+			sawCreate = true
+			writeEC2XML(w, `<CreateImageResponse><imageId>ami-12345678</imageId></CreateImageResponse>`)
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := testAWSClient(server.URL)
+	image, err := client.CreateImageCheckpoint(context.Background(), "i-1234567890abcdef0", "checkpoint", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawCreate {
+		t.Fatal("CreateImage was not called")
+	}
+	if image.AccountID != "123456789012" {
+		t.Fatalf("AccountID=%q, want caller account", image.AccountID)
+	}
+}
+
+func TestDeleteImageCheckpointRefusesNotFoundWithoutAccountID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if action := r.Form.Get("Action"); action != "DescribeImages" {
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+			return
+		}
+		writeEC2Error(w, "InvalidAMIID.NotFound", "image not found", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	err := testAWSClient(server.URL).DeleteImageCheckpoint(context.Background(), "ami-12345678", nil, "")
+	if err == nil || !strings.Contains(err.Error(), "checkpoint record has no accountId") {
+		t.Fatalf("err=%v, want account guard error", err)
+	}
+}
+
+func TestDeleteImageCheckpointRefusesAccountMismatchBeforeDescribe(t *testing.T) {
+	var describeHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		switch action := r.Form.Get("Action"); action {
+		case "GetCallerIdentity":
+			writeSTSXML(w, `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>999999999999</Account><Arn>arn:aws:iam::999999999999:user/test</Arn><UserId>AIDAEXAMPLE</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>`)
+		case "DescribeImages":
+			describeHits++
+			writeEC2XML(w, `<DescribeImagesResponse><imagesSet></imagesSet></DescribeImagesResponse>`)
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	err := testAWSClient(server.URL).DeleteImageCheckpoint(context.Background(), "ami-12345678", nil, "123456789012")
+	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("err=%v, want account mismatch", err)
+	}
+	if describeHits != 0 {
+		t.Fatalf("DescribeImages called %d time(s), want zero", describeHits)
 	}
 }
 
@@ -266,7 +345,25 @@ func TestAWSMacOSAMIQueryForInstanceType(t *testing.T) {
 	}
 }
 
+func testAWSClient(endpoint string) *AWSClient {
+	cfg := aws.Config{
+		Region:       "eu-west-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "secret", ""),
+		BaseEndpoint: aws.String(endpoint),
+	}
+	return &AWSClient{
+		ec2:    ec2.NewFromConfig(cfg),
+		sts:    sts.NewFromConfig(cfg),
+		region: "eu-west-1",
+	}
+}
+
 func writeEC2XML(w http.ResponseWriter, body string) {
+	w.Header().Set("content-type", "text/xml")
+	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` + body))
+}
+
+func writeSTSXML(w http.ResponseWriter, body string) {
 	w.Header().Set("content-type", "text/xml")
 	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` + body))
 }

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -92,6 +92,68 @@ func TestCreateImageCheckpointRecordsCallerAccount(t *testing.T) {
 	}
 }
 
+func TestValidateImageCheckpointSourceChecksAccountAndInstance(t *testing.T) {
+	var actions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		action := r.Form.Get("Action")
+		actions = append(actions, action)
+		switch action {
+		case "GetCallerIdentity":
+			writeSTSXML(w, `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account><Arn>arn:aws:iam::123456789012:user/test</Arn><UserId>AIDAEXAMPLE</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>`)
+		case "DescribeInstances":
+			writeEC2XML(w, `<DescribeInstancesResponse><reservationSet><item><instancesSet><item><instanceId>i-1234567890abcdef0</instanceId><instanceType>t3.micro</instanceType><ipAddress>203.0.113.44</ipAddress><instanceState><name>running</name></instanceState></item></instancesSet></item></reservationSet></DescribeInstancesResponse>`)
+		case "CreateImage":
+			t.Fatal("CreateImage must not be part of source validation")
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	accountID, err := testAWSClient(server.URL).ValidateImageCheckpointSource(context.Background(), "i-1234567890abcdef0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accountID != "123456789012" {
+		t.Fatalf("accountID=%q, want caller account", accountID)
+	}
+	if got := strings.Join(actions, ","); got != "GetCallerIdentity,DescribeInstances" {
+		t.Fatalf("actions=%s, want GetCallerIdentity,DescribeInstances", got)
+	}
+}
+
+func TestValidateImageCheckpointSourceRejectsMissingInstance(t *testing.T) {
+	var sawDescribe bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		switch action := r.Form.Get("Action"); action {
+		case "GetCallerIdentity":
+			writeSTSXML(w, `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account><Arn>arn:aws:iam::123456789012:user/test</Arn><UserId>AIDAEXAMPLE</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>`)
+		case "DescribeInstances":
+			sawDescribe = true
+			writeEC2XML(w, `<DescribeInstancesResponse><reservationSet></reservationSet></DescribeInstancesResponse>`)
+		case "CreateImage":
+			t.Fatal("CreateImage must not run when the source instance is missing")
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	_, err := testAWSClient(server.URL).ValidateImageCheckpointSource(context.Background(), "i-missing")
+	if err == nil || !strings.Contains(err.Error(), "aws instance not found") {
+		t.Fatalf("err=%v, want missing instance validation error", err)
+	}
+	if !sawDescribe {
+		t.Fatal("DescribeInstances was not called")
+	}
+}
+
 func TestDeleteImageCheckpointRefusesNotFoundWithoutAccountID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -42,6 +42,19 @@ func TestApplyAWSRunInstanceTargetOptionsLeavesNativeWindowsDefault(t *testing.T
 	}
 }
 
+func TestAWSInstanceToServerPreservesHostID(t *testing.T) {
+	server := awsInstanceToServer(types.Instance{
+		InstanceId:   aws.String("i-1234567890abcdef0"),
+		InstanceType: types.InstanceTypeMac2Metal,
+		Placement:    &types.Placement{HostId: aws.String("h-000000000001")},
+		State:        &types.InstanceState{Name: types.InstanceStateNameRunning},
+	})
+
+	if server.HostID != "h-000000000001" {
+		t.Fatalf("HostID=%q, want h-000000000001", server.HostID)
+	}
+}
+
 func TestRetryableAWSSnapshotDeleteError(t *testing.T) {
 	for _, message := range []string{
 		"InvalidSnapshot.InUse: snapshot is currently in use by ami-123",

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -40,6 +40,25 @@ func TestApplyAWSRunInstanceTargetOptionsLeavesNativeWindowsDefault(t *testing.T
 	}
 }
 
+func TestRetryableAWSSnapshotDeleteError(t *testing.T) {
+	for _, message := range []string{
+		"InvalidSnapshot.InUse: snapshot is currently in use by ami-123",
+		"RequestLimitExceeded: request rate exceeded",
+		"ThrottlingException: slow down",
+		"ServiceUnavailable: try again",
+		"InternalError: internal failure",
+		"http 500: server error",
+		"Snapshot snap-123 is currently in use",
+	} {
+		if !isRetryableAWSSnapshotDeleteError(message) {
+			t.Fatalf("message %q should be retryable", message)
+		}
+	}
+	if isRetryableAWSSnapshotDeleteError("AuthFailure: not authorized") {
+		t.Fatal("AuthFailure should not be retryable")
+	}
+}
+
 func TestStaleAWSCrabboxSSHIngressPermissionsPrunesOnlyOwnedCIDRs(t *testing.T) {
 	group := types.SecurityGroup{
 		IpPermissions: []types.IpPermission{

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1210,7 +1210,10 @@ func nativeCheckpointForkWorkdir(cfg Config, leaseID, repoName, override string)
 
 func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record checkpointRecord) error {
 	cfg.Provider = firstNonBlank(record.Native.Provider, checkpointProviderForKind(record.Kind), record.Provider)
-	if cfg.CoordAdminToken != "" {
+	if record.Native.Direct {
+		cfg.Coordinator = ""
+		cfg.CoordToken = ""
+	} else if cfg.CoordAdminToken != "" {
 		cfg.CoordToken = cfg.CoordAdminToken
 	}
 	switch record.Kind {

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1104,11 +1104,11 @@ func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, serve
 	if name == "" {
 		name = defaultNativeImageName(leaseID, repoName)
 	}
-	if err := prepareNativeImageSource(ctx, target); err != nil {
-		return CoordinatorImage{}, err
-	}
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
+		return CoordinatorImage{}, err
+	}
+	if err := prepareNativeImageSource(ctx, target); err != nil {
 		return CoordinatorImage{}, err
 	}
 	image, err := client.CreateImageCheckpoint(ctx, server.CloudID, name, noReboot)

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -712,7 +712,7 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 			return audit, nil
 		}
 		if cfg, ok := directAWSCheckpointConfig(record); ok {
-			return verifyDirectAWSCheckpoint(ctx, audit, cfg, providerID), nil
+			return verifyDirectAWSCheckpoint(ctx, audit, cfg, providerID, record.Native.AccountID), nil
 		}
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
@@ -743,12 +743,22 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 	}
 }
 
-func verifyDirectAWSCheckpoint(ctx context.Context, audit checkpointAudit, cfg Config, providerID string) checkpointAudit {
+func verifyDirectAWSCheckpoint(ctx context.Context, audit checkpointAudit, cfg Config, providerID, expectedAccountID string) checkpointAudit {
 	client, clientErr := newAWSClient(ctx, cfg)
 	if clientErr != nil {
 		audit.ProviderState = "unknown"
 		audit.NextAction = "check_auth_or_provider"
 		audit.Error = clientErr.Error()
+		return audit
+	}
+	return verifyDirectAWSCheckpointWithClient(ctx, audit, client, providerID, expectedAccountID)
+}
+
+func verifyDirectAWSCheckpointWithClient(ctx context.Context, audit checkpointAudit, client *AWSClient, providerID, expectedAccountID string) checkpointAudit {
+	if guardErr := client.GuardAccount(ctx, expectedAccountID); guardErr != nil {
+		audit.ProviderState = "unknown"
+		audit.NextAction = "check_auth_or_provider"
+		audit.Error = guardErr.Error()
 		return audit
 	}
 	image, imageErr := client.GetImageCheckpoint(ctx, providerID)

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -541,6 +541,9 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 			if err != nil {
 				return err
 			}
+			if err := client.GuardAccount(ctx, record.Native.AccountID); err != nil {
+				return err
+			}
 			if len(record.Native.SnapshotIDs) == 0 {
 				if image, err := client.GetImageCheckpoint(ctx, providerID); err == nil && len(image.SnapshotIDs) > 0 {
 					record.Native.SnapshotIDs = image.SnapshotIDs

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1122,7 +1122,7 @@ func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, serve
 		return CoordinatorImage{}, err
 	}
 	if wait {
-		waited, err := waitForDirectAWSImage(ctx, client, image.ID, waitTimeout, a.Stderr)
+		waited, err := waitForDirectAWSImage(ctx, client, image.ID, image.AccountID, waitTimeout, a.Stderr)
 		if err != nil {
 			return image, err
 		}
@@ -1131,13 +1131,16 @@ func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, serve
 	return image, nil
 }
 
-func waitForDirectAWSImage(ctx context.Context, client *AWSClient, imageID string, timeout time.Duration, stderr io.Writer) (CoordinatorImage, error) {
+func waitForDirectAWSImage(ctx context.Context, client *AWSClient, imageID, accountID string, timeout time.Duration, stderr io.Writer) (CoordinatorImage, error) {
 	deadline := time.Now().Add(timeout)
 	var last CoordinatorImage
 	for {
 		image, err := client.GetImageCheckpoint(ctx, imageID)
 		if err != nil {
 			return CoordinatorImage{}, err
+		}
+		if image.AccountID == "" {
+			image.AccountID = accountID
 		}
 		last = image
 		state := strings.ToLower(image.State)

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -58,6 +58,7 @@ type checkpointRecord struct {
 		Name        string   `json:"name,omitempty"`
 		State       string   `json:"state,omitempty"`
 		Region      string   `json:"region,omitempty"`
+		AccountID   string   `json:"accountId,omitempty"`
 		Project     string   `json:"project,omitempty"`
 		Resource    string   `json:"resource,omitempty"`
 		SnapshotIDs []string `json:"snapshotIds,omitempty"`
@@ -548,7 +549,7 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 					}
 				}
 			}
-			if err := client.DeleteImageCheckpoint(ctx, providerID, record.Native.SnapshotIDs); err != nil {
+			if err := client.DeleteImageCheckpoint(ctx, providerID, record.Native.SnapshotIDs, record.Native.AccountID); err != nil {
 				return err
 			}
 			return store.Delete(id)
@@ -820,6 +821,7 @@ func applyNativeImageCheckpointRecord(record *checkpointRecord, image Coordinato
 	record.Native.Name = image.Name
 	record.Native.State = image.State
 	record.Native.Region = image.Region
+	record.Native.AccountID = image.AccountID
 	record.Native.Project = image.Project
 	record.Native.Resource = image.ResourceID
 	record.Native.SnapshotIDs = image.SnapshotIDs

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1124,6 +1124,9 @@ func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, serve
 	if err != nil {
 		return CoordinatorImage{}, err
 	}
+	if _, err := client.ValidateImageCheckpointSource(ctx, server.CloudID); err != nil {
+		return CoordinatorImage{}, err
+	}
 	if err := prepareNativeImageSource(ctx, target); err != nil {
 		return CoordinatorImage{}, err
 	}

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -972,6 +972,9 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 		if kind, ok := nativeCheckpointKind(cfg, server, target, checkpointStrategyDiskSnapshot); ok {
 			return kind
 		}
+		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyDiskSnapshot); ok {
+			return kind
+		}
 		return "unsupported"
 	case "archive", "workspace", "workspace-archive":
 		return checkpointKindArchive
@@ -1028,6 +1031,9 @@ func directAWSNativeCheckpointKind(cfg Config, server Server, target SSHTarget, 
 	targetOS := firstNonBlank(target.TargetOS, cfg.TargetOS)
 	if targetOS != targetLinux && targetOS != targetMacOS {
 		return "", false
+	}
+	if targetOS == targetMacOS {
+		return checkpointKindAWSAMI, true
 	}
 	if normalizeCheckpointStrategy(strategy) != checkpointStrategyImage {
 		return "", false

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1269,6 +1269,10 @@ func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record check
 		cfg.WindowsMode = record.WindowsMode
 	}
 	if cfg.Provider == "aws" && cfg.TargetOS == targetMacOS {
+		if record.Native.Direct && record.HostID != "" {
+			cfg.HostID = record.HostID
+			cfg.AWSMacHostID = record.HostID
+		}
 		if !flagWasSet(fs, "market") {
 			cfg.Capacity.Market = "on-demand"
 		}

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -52,16 +52,18 @@ type checkpointRecord struct {
 	ArchivePath    string `json:"archivePath,omitempty"`
 	ArchiveBytes   int64  `json:"archiveBytes,omitempty"`
 	Native         struct {
-		Provider string `json:"provider,omitempty"`
-		ImageID  string `json:"imageId,omitempty"`
-		Kind     string `json:"kind,omitempty"`
-		Name     string `json:"name,omitempty"`
-		State    string `json:"state,omitempty"`
-		Region   string `json:"region,omitempty"`
-		Project  string `json:"project,omitempty"`
-		Resource string `json:"resource,omitempty"`
-		Strategy string `json:"strategy,omitempty"`
-		NoReboot bool   `json:"noReboot,omitempty"`
+		Provider    string   `json:"provider,omitempty"`
+		ImageID     string   `json:"imageId,omitempty"`
+		Kind        string   `json:"kind,omitempty"`
+		Name        string   `json:"name,omitempty"`
+		State       string   `json:"state,omitempty"`
+		Region      string   `json:"region,omitempty"`
+		Project     string   `json:"project,omitempty"`
+		Resource    string   `json:"resource,omitempty"`
+		SnapshotIDs []string `json:"snapshotIds,omitempty"`
+		Direct      bool     `json:"direct,omitempty"`
+		Strategy    string   `json:"strategy,omitempty"`
+		NoReboot    bool     `json:"noReboot,omitempty"`
 	} `json:"native,omitempty"`
 	Repo struct {
 		Root      string `json:"root,omitempty"`
@@ -533,6 +535,24 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 	}
 	providerID := nativeCheckpointDeleteID(record)
 	if isNativeCheckpointKind(record.Kind) && providerID != "" && !localOnly {
+		if cfg, ok := directAWSCheckpointConfig(record); ok {
+			client, err := newAWSClient(ctx, cfg)
+			if err != nil {
+				return err
+			}
+			if len(record.Native.SnapshotIDs) == 0 {
+				if image, err := client.GetImageCheckpoint(ctx, providerID); err == nil && len(image.SnapshotIDs) > 0 {
+					record.Native.SnapshotIDs = image.SnapshotIDs
+					if writeErr := store.Write(record); writeErr != nil {
+						return writeErr
+					}
+				}
+			}
+			if err := client.DeleteImageCheckpoint(ctx, providerID, record.Native.SnapshotIDs); err != nil {
+				return err
+			}
+			return store.Delete(id)
+		}
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
 			return err
@@ -692,6 +712,29 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 		}
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
+			if cfg, ok := directAWSCheckpointConfig(record); ok {
+				client, clientErr := newAWSClient(ctx, cfg)
+				if clientErr != nil {
+					audit.ProviderState = "unknown"
+					audit.NextAction = "check_auth_or_provider"
+					audit.Error = clientErr.Error()
+					return audit, nil
+				}
+				image, imageErr := client.GetImageCheckpoint(ctx, providerID)
+				if imageErr != nil {
+					if strings.Contains(imageErr.Error(), "InvalidAMIID.NotFound") || strings.Contains(imageErr.Error(), "aws image not found") {
+						audit.ProviderState = "missing"
+						audit.NextAction = "delete_local"
+						return audit, nil
+					}
+					audit.ProviderState = "unknown"
+					audit.NextAction = "check_auth_or_provider"
+					audit.Error = imageErr.Error()
+					return audit, nil
+				}
+				applyCheckpointImageAudit(&audit, image)
+				return audit, nil
+			}
 			audit.ProviderState = "unknown"
 			audit.NextAction = "configure_admin_auth"
 			audit.Error = err.Error()
@@ -709,21 +752,41 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 			audit.Error = err.Error()
 			return audit, nil
 		}
-		audit.ProviderState = blank(image.State, "unknown")
-		switch strings.ToLower(image.State) {
-		case "available", "ready", "succeeded", "completed":
-			audit.NextAction = "fork_or_delete"
-		case "failed", "invalid":
-			audit.NextAction = "delete"
-		default:
-			audit.NextAction = "wait_or_delete"
-		}
+		applyCheckpointImageAudit(&audit, image)
 		return audit, nil
 	default:
 		audit.LocalState = "metadata_only"
 		audit.ProviderState = "not_applicable"
 		audit.NextAction = "inspect"
 		return audit, nil
+	}
+}
+
+func directAWSCheckpointConfig(record checkpointRecord) (Config, bool) {
+	provider := firstNonBlank(record.Native.Provider, checkpointProviderForKind(record.Kind), record.Provider)
+	if provider != "aws" || record.Kind != checkpointKindAWSAMI || !record.Native.Direct {
+		return Config{}, false
+	}
+	cfg, err := loadConfig()
+	if err != nil || cfg.Coordinator != "" {
+		return Config{}, false
+	}
+	cfg.Provider = "aws"
+	if record.Native.Region != "" {
+		cfg.AWSRegion = record.Native.Region
+	}
+	return cfg, true
+}
+
+func applyCheckpointImageAudit(audit *checkpointAudit, image CoordinatorImage) {
+	audit.ProviderState = blank(image.State, "unknown")
+	switch strings.ToLower(image.State) {
+	case "available", "ready", "succeeded", "completed":
+		audit.NextAction = "fork_or_delete"
+	case "failed", "invalid":
+		audit.NextAction = "delete"
+	default:
+		audit.NextAction = "wait_or_delete"
 	}
 }
 
@@ -755,6 +818,8 @@ func applyNativeImageCheckpointRecord(record *checkpointRecord, image Coordinato
 	record.Native.Region = image.Region
 	record.Native.Project = image.Project
 	record.Native.Resource = image.ResourceID
+	record.Native.SnapshotIDs = image.SnapshotIDs
+	record.Native.Direct = image.Direct
 	record.Native.Strategy = checkpointStrategyForKind(record.Kind)
 	record.Native.NoReboot = noReboot
 }
@@ -860,14 +925,30 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
 			return kind
 		}
+		if !isAutoCheckpointStrategy(strategy) {
+			if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+				return kind
+			}
+		}
 		return checkpointKindArchive
 	case "native", "provider-native", "vm":
 		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
 			return kind
 		}
+		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+			return kind
+		}
+		if isAutoCheckpointStrategy(strategy) {
+			if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
+				return kind
+			}
+		}
 		return "unsupported"
 	case "ami", "image":
 		if kind, ok := nativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
+			return kind
+		}
+		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
 			return kind
 		}
 		return "unsupported"
@@ -921,6 +1002,29 @@ func nativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy 
 	}
 }
 
+func directAWSNativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
+	if cfg.Coordinator != "" || server.Provider != "aws" || server.CloudID == "" || isWindowsNativeTarget(target) {
+		return "", false
+	}
+	targetOS := firstNonBlank(target.TargetOS, cfg.TargetOS)
+	if targetOS != targetLinux && targetOS != targetMacOS {
+		return "", false
+	}
+	if normalizeCheckpointStrategy(strategy) != checkpointStrategyImage {
+		return "", false
+	}
+	return checkpointKindAWSAMI, true
+}
+
+func isAutoCheckpointStrategy(strategy string) bool {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", checkpointStrategyAuto:
+		return true
+	default:
+		return false
+	}
+}
+
 func normalizeCheckpointStrategy(strategy string) string {
 	switch strings.ToLower(strings.TrimSpace(strategy)) {
 	case "", checkpointStrategyAuto, "snapshot", "disk":
@@ -955,6 +1059,9 @@ func checkpointStrategyForKind(kind string) string {
 }
 
 func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName, strategy string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
+	if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, strategy); ok && kind == checkpointKindAWSAMI {
+		return a.createDirectAWSAMICheckpoint(ctx, cfg, server, target, leaseID, name, repoName, noReboot, wait, waitTimeout)
+	}
 	if cfg.Coordinator == "" {
 		return CoordinatorImage{}, exit(2, "native checkpoints require a configured coordinator")
 	}
@@ -991,6 +1098,59 @@ func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Serv
 
 func (a App) createAWSAMICheckpoint(ctx context.Context, cfg Config, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
 	return a.createNativeCheckpoint(ctx, cfg, Server{Provider: "aws", CloudID: leaseID}, target, leaseID, name, repoName, checkpointStrategyImage, noReboot, wait, waitTimeout)
+}
+
+func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
+	if name == "" {
+		name = defaultNativeImageName(leaseID, repoName)
+	}
+	if err := prepareNativeImageSource(ctx, target); err != nil {
+		return CoordinatorImage{}, err
+	}
+	client, err := newAWSClient(ctx, cfg)
+	if err != nil {
+		return CoordinatorImage{}, err
+	}
+	image, err := client.CreateImageCheckpoint(ctx, server.CloudID, name, noReboot)
+	if err != nil {
+		return CoordinatorImage{}, err
+	}
+	if wait {
+		waited, err := waitForDirectAWSImage(ctx, client, image.ID, waitTimeout, a.Stderr)
+		if err != nil {
+			return image, err
+		}
+		return waited, nil
+	}
+	return image, nil
+}
+
+func waitForDirectAWSImage(ctx context.Context, client *AWSClient, imageID string, timeout time.Duration, stderr io.Writer) (CoordinatorImage, error) {
+	deadline := time.Now().Add(timeout)
+	var last CoordinatorImage
+	for {
+		image, err := client.GetImageCheckpoint(ctx, imageID)
+		if err != nil {
+			return CoordinatorImage{}, err
+		}
+		last = image
+		state := strings.ToLower(image.State)
+		if state == "available" || state == "ready" || state == "succeeded" || state == "completed" {
+			return image, nil
+		}
+		if state == "failed" || state == "invalid" {
+			return CoordinatorImage{}, exit(5, "image %s failed", imageID)
+		}
+		if time.Now().After(deadline) {
+			return CoordinatorImage{}, exit(5, "timed out waiting for image %s; last state=%s", imageID, last.State)
+		}
+		_, _ = fmt.Fprintf(stderr, "waiting image=%s state=%s\n", imageID, blank(image.State, "pending"))
+		select {
+		case <-ctx.Done():
+			return CoordinatorImage{}, ctx.Err()
+		case <-time.After(15 * time.Second):
+		}
+	}
 }
 
 func defaultNativeImageName(leaseID, repoName string) string {

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -993,6 +993,9 @@ func nativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy 
 		if targetOS != targetLinux && targetOS != targetMacOS {
 			return "", false
 		}
+		if targetOS == targetMacOS {
+			return checkpointKindAWSAMI, true
+		}
 		if strategy == checkpointStrategyImage {
 			return checkpointKindAWSAMI, true
 		}

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -768,7 +768,7 @@ func directAWSCheckpointConfig(record checkpointRecord) (Config, bool) {
 		return Config{}, false
 	}
 	cfg, err := loadConfig()
-	if err != nil || cfg.Coordinator != "" {
+	if err != nil {
 		return Config{}, false
 	}
 	cfg.Provider = "aws"

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -710,31 +710,11 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 			audit.NextAction = "delete_local"
 			return audit, nil
 		}
+		if cfg, ok := directAWSCheckpointConfig(record); ok {
+			return verifyDirectAWSCheckpoint(ctx, audit, cfg, providerID), nil
+		}
 		coord, err := configuredAdminCoordinator()
 		if err != nil {
-			if cfg, ok := directAWSCheckpointConfig(record); ok {
-				client, clientErr := newAWSClient(ctx, cfg)
-				if clientErr != nil {
-					audit.ProviderState = "unknown"
-					audit.NextAction = "check_auth_or_provider"
-					audit.Error = clientErr.Error()
-					return audit, nil
-				}
-				image, imageErr := client.GetImageCheckpoint(ctx, providerID)
-				if imageErr != nil {
-					if strings.Contains(imageErr.Error(), "InvalidAMIID.NotFound") || strings.Contains(imageErr.Error(), "aws image not found") {
-						audit.ProviderState = "missing"
-						audit.NextAction = "delete_local"
-						return audit, nil
-					}
-					audit.ProviderState = "unknown"
-					audit.NextAction = "check_auth_or_provider"
-					audit.Error = imageErr.Error()
-					return audit, nil
-				}
-				applyCheckpointImageAudit(&audit, image)
-				return audit, nil
-			}
 			audit.ProviderState = "unknown"
 			audit.NextAction = "configure_admin_auth"
 			audit.Error = err.Error()
@@ -760,6 +740,30 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 		audit.NextAction = "inspect"
 		return audit, nil
 	}
+}
+
+func verifyDirectAWSCheckpoint(ctx context.Context, audit checkpointAudit, cfg Config, providerID string) checkpointAudit {
+	client, clientErr := newAWSClient(ctx, cfg)
+	if clientErr != nil {
+		audit.ProviderState = "unknown"
+		audit.NextAction = "check_auth_or_provider"
+		audit.Error = clientErr.Error()
+		return audit
+	}
+	image, imageErr := client.GetImageCheckpoint(ctx, providerID)
+	if imageErr != nil {
+		if strings.Contains(imageErr.Error(), "InvalidAMIID.NotFound") || strings.Contains(imageErr.Error(), "aws image not found") {
+			audit.ProviderState = "missing"
+			audit.NextAction = "delete_local"
+			return audit
+		}
+		audit.ProviderState = "unknown"
+		audit.NextAction = "check_auth_or_provider"
+		audit.Error = imageErr.Error()
+		return audit
+	}
+	applyCheckpointImageAudit(&audit, image)
+	return audit
 }
 
 func directAWSCheckpointConfig(record checkpointRecord) (Config, bool) {

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -440,6 +440,26 @@ func TestDirectAWSCheckpointConfigRequiresNoCoordinator(t *testing.T) {
 	}
 }
 
+func TestCreateDirectAWSAMICheckpointValidatesConfigBeforePreparingSource(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = ""
+	cfg.AWSRegion = ""
+	target := SSHTarget{User: "nobody", Host: "127.0.0.1", Port: "1", TargetOS: targetMacOS}
+	app := App{Stderr: io.Discard}
+
+	_, err := app.createDirectAWSAMICheckpoint(context.Background(), cfg, Server{Provider: "aws", CloudID: "i-123"}, target, "cbx_test", "", "repo", false, false, time.Minute)
+	if err == nil {
+		t.Fatal("expected missing AWS region error")
+	}
+	if !strings.Contains(err.Error(), "CRABBOX_AWS_REGION or AWS_REGION is required") {
+		t.Fatalf("err=%v, want AWS config validation before source preparation", err)
+	}
+	if strings.Contains(err.Error(), "prepare native checkpoint source") {
+		t.Fatalf("source was prepared before AWS config validation: %v", err)
+	}
+}
+
 func TestApplyNativeImageCheckpointRecordPersistsSnapshotIDs(t *testing.T) {
 	record := checkpointRecord{Kind: checkpointKindArchive, Provider: "aws"}
 	applyNativeImageCheckpointRecord(&record, CoordinatorImage{

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -958,6 +958,31 @@ func TestApplyAWSAMICheckpointForkConfigRecomputesServerType(t *testing.T) {
 	}
 }
 
+func TestApplyAWSAMICheckpointForkConfigKeepsDirectRecordsOffCoordinator(t *testing.T) {
+	fs := newFlagSet("checkpoint fork", io.Discard)
+	_ = fs.String("type", "", "provider type")
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = "https://coordinator.example"
+	cfg.CoordToken = "user-token"
+	cfg.CoordAdminToken = "admin-token"
+	record := checkpointRecord{Kind: checkpointKindAWSAMI, TargetOS: targetLinux, WindowsMode: windowsModeNormal}
+	record.Native.Provider = "aws"
+	record.Native.ImageID = "ami-12345678"
+	record.Native.Region = "eu-west-1"
+	record.Native.Direct = true
+
+	if err := applyAWSAMICheckpointForkConfig(&cfg, fs, record); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Coordinator != "" || cfg.CoordToken != "" {
+		t.Fatalf("direct checkpoint fork kept coordinator: coordinator=%q token=%q", cfg.Coordinator, cfg.CoordToken)
+	}
+	if cfg.AWSAMI != "ami-12345678" || cfg.AWSRegion != "eu-west-1" {
+		t.Fatalf("direct AWS image config not applied: %#v", cfg)
+	}
+}
+
 func TestApplyAWSAMICheckpointForkConfigHonorsClassOverride(t *testing.T) {
 	fs := newFlagSet("checkpoint fork", io.Discard)
 	class := fs.String("class", "standard", "provider class")

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -444,6 +444,36 @@ func TestDirectAWSCheckpointConfigUsesDirectMarker(t *testing.T) {
 	}
 }
 
+func TestVerifyDirectAWSCheckpointRefusesAccountMismatchBeforeNotFound(t *testing.T) {
+	var describeHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		switch action := r.Form.Get("Action"); action {
+		case "GetCallerIdentity":
+			writeSTSXML(w, `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>999999999999</Account><Arn>arn:aws:iam::999999999999:user/test</Arn><UserId>AIDAEXAMPLE</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>`)
+		case "DescribeImages":
+			describeHits++
+			writeEC2Error(w, "InvalidAMIID.NotFound", "image not found", http.StatusBadRequest)
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	audit := verifyDirectAWSCheckpointWithClient(context.Background(), checkpointAudit{}, testAWSClient(server.URL), "ami-12345678", "123456789012")
+	if audit.ProviderState != "unknown" || audit.NextAction != "check_auth_or_provider" {
+		t.Fatalf("audit=%#v, want account mismatch auth/provider state", audit)
+	}
+	if !strings.Contains(audit.Error, "account mismatch") {
+		t.Fatalf("error=%q, want account mismatch", audit.Error)
+	}
+	if describeHits != 0 {
+		t.Fatalf("DescribeImages called %d time(s), want zero", describeHits)
+	}
+}
+
 func TestCreateDirectAWSAMICheckpointValidatesConfigBeforePreparingSource(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -464,6 +464,28 @@ func TestCreateDirectAWSAMICheckpointValidatesConfigBeforePreparingSource(t *tes
 	}
 }
 
+func TestWaitForDirectAWSImagePreservesAccountID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		if action := r.Form.Get("Action"); action != "DescribeImages" {
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+			return
+		}
+		writeEC2XML(w, `<DescribeImagesResponse><imagesSet><item><imageId>ami-12345678</imageId><name>checkpoint</name><imageState>available</imageState></item></imagesSet></DescribeImagesResponse>`)
+	}))
+	defer server.Close()
+
+	image, err := waitForDirectAWSImage(context.Background(), testAWSClient(server.URL), "ami-12345678", "123456789012", time.Second, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if image.AccountID != "123456789012" {
+		t.Fatalf("AccountID=%q, want preserved caller account", image.AccountID)
+	}
+}
+
 func TestApplyNativeImageCheckpointRecordPersistsSnapshotIDs(t *testing.T) {
 	record := checkpointRecord{Kind: checkpointKindArchive, Provider: "aws"}
 	applyNativeImageCheckpointRecord(&record, CoordinatorImage{

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -473,6 +473,7 @@ func TestApplyNativeImageCheckpointRecordPersistsSnapshotIDs(t *testing.T) {
 		Provider:    "aws",
 		Kind:        checkpointKindAWSAMI,
 		Region:      "eu-west-1",
+		AccountID:   "123456789012",
 		ResourceID:  "ami-12345678",
 		SnapshotIDs: []string{"snap-1", "snap-2"},
 		Direct:      true,
@@ -483,6 +484,9 @@ func TestApplyNativeImageCheckpointRecordPersistsSnapshotIDs(t *testing.T) {
 	}
 	if got := strings.Join(record.Native.SnapshotIDs, ","); got != "snap-1,snap-2" {
 		t.Fatalf("snapshot IDs=%q, want snap-1,snap-2", got)
+	}
+	if record.Native.AccountID != "123456789012" {
+		t.Fatalf("AccountID=%q, want caller account", record.Native.AccountID)
 	}
 	if !record.Native.Direct {
 		t.Fatal("direct marker was not persisted")

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -400,8 +400,8 @@ func TestCheckpointCreateModeNativeSupportsDirectAWSAMI(t *testing.T) {
 	if got := checkpointCreateMode("image", "", cfg, server, target, false); got != checkpointKindAWSAMI {
 		t.Fatalf("image mode=%q, want %q", got, checkpointKindAWSAMI)
 	}
-	if got := checkpointCreateMode("snapshot", "", cfg, server, target, false); got != "unsupported" {
-		t.Fatalf("snapshot mode=%q, want unsupported", got)
+	if got := checkpointCreateMode("snapshot", "", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("snapshot mode=%q, want %q", got, checkpointKindAWSAMI)
 	}
 }
 
@@ -555,6 +555,21 @@ func TestCheckpointCreateModeNativeUsesResolvedProvider(t *testing.T) {
 	server := Server{Provider: "hetzner", CloudID: "123"}
 	if got := checkpointCreateMode("native", "", cfg, server, SSHTarget{TargetOS: targetLinux}, false); got != "unsupported" {
 		t.Fatalf("mode=%q, want unsupported", got)
+	}
+}
+
+func TestCheckpointCreateModeDirectAWSMacOSDiskSnapshotUsesAMI(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = ""
+	cfg.TargetOS = targetMacOS
+	server := Server{Provider: "aws", CloudID: "i-1234567890abcdef0"}
+	target := SSHTarget{TargetOS: targetMacOS}
+
+	for _, mode := range []string{"native", "snapshot"} {
+		if got := checkpointCreateMode(mode, checkpointStrategyDiskSnapshot, cfg, server, target, false); got != checkpointKindAWSAMI {
+			t.Fatalf("mode=%s got %q, want %q", mode, got, checkpointKindAWSAMI)
+		}
 	}
 }
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -377,6 +377,94 @@ func TestCheckpointCreateModeAutoFallsBackForDirectAWS(t *testing.T) {
 	}
 }
 
+func TestCheckpointCreateModeNativeSupportsDirectAWSAMI(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = ""
+	cfg.TargetOS = targetMacOS
+	server := Server{Provider: "aws", CloudID: "i-123"}
+	target := SSHTarget{TargetOS: targetMacOS}
+
+	if got := checkpointCreateMode("native", "", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("native mode=%q, want %q", got, checkpointKindAWSAMI)
+	}
+	if got := checkpointCreateMode("native", "image", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("native image mode=%q, want %q", got, checkpointKindAWSAMI)
+	}
+	if got := checkpointCreateMode("auto", "image", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("auto image mode=%q, want %q", got, checkpointKindAWSAMI)
+	}
+	if got := checkpointCreateMode("image", "", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("image mode=%q, want %q", got, checkpointKindAWSAMI)
+	}
+	if got := checkpointCreateMode("snapshot", "", cfg, server, target, false); got != "unsupported" {
+		t.Fatalf("snapshot mode=%q, want unsupported", got)
+	}
+}
+
+func TestDirectAWSCheckpointConfigRequiresNoCoordinator(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(cfgPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	record := checkpointRecord{
+		Kind:     checkpointKindAWSAMI,
+		Provider: "aws",
+	}
+	record.Native.Provider = "aws"
+	record.Native.Region = "eu-west-1"
+	record.Native.Direct = true
+
+	cfg, ok := directAWSCheckpointConfig(record)
+	if !ok {
+		t.Fatal("direct AWS checkpoint config not detected")
+	}
+	if cfg.AWSRegion != "eu-west-1" {
+		t.Fatalf("AWSRegion=%q, want record region", cfg.AWSRegion)
+	}
+
+	if err := os.WriteFile(cfgPath, []byte("provider: aws\ncoordinator: https://coordinator.example\naws:\n  region: us-east-1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := directAWSCheckpointConfig(record); ok {
+		t.Fatal("coordinator-backed config should not use direct AWS cleanup")
+	}
+
+	if err := os.WriteFile(cfgPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record.Native.Direct = false
+	if _, ok := directAWSCheckpointConfig(record); ok {
+		t.Fatal("brokered AWS checkpoint should not use direct AWS cleanup")
+	}
+}
+
+func TestApplyNativeImageCheckpointRecordPersistsSnapshotIDs(t *testing.T) {
+	record := checkpointRecord{Kind: checkpointKindArchive, Provider: "aws"}
+	applyNativeImageCheckpointRecord(&record, CoordinatorImage{
+		ID:          "ami-12345678",
+		Name:        "checkpoint",
+		State:       "available",
+		Provider:    "aws",
+		Kind:        checkpointKindAWSAMI,
+		Region:      "eu-west-1",
+		ResourceID:  "ami-12345678",
+		SnapshotIDs: []string{"snap-1", "snap-2"},
+		Direct:      true,
+	}, true)
+
+	if record.Kind != checkpointKindAWSAMI {
+		t.Fatalf("Kind=%q, want %q", record.Kind, checkpointKindAWSAMI)
+	}
+	if got := strings.Join(record.Native.SnapshotIDs, ","); got != "snap-1,snap-2" {
+		t.Fatalf("snapshot IDs=%q, want snap-1,snap-2", got)
+	}
+	if !record.Native.Direct {
+		t.Fatal("direct marker was not persisted")
+	}
+}
+
 func TestCheckpointCreateModeNativeUsesResolvedProvider(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -986,6 +986,41 @@ func TestApplyAWSAMICheckpointForkConfigKeepsDirectRecordsOffCoordinator(t *test
 	}
 }
 
+func TestApplyAWSAMICheckpointForkConfigPreservesDirectMacHostPin(t *testing.T) {
+	fs := newFlagSet("checkpoint fork", io.Discard)
+	_ = fs.String("type", "", "provider type")
+	_ = fs.String("market", "spot", "capacity market")
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = "https://coordinator.example"
+	cfg.TargetOS = targetLinux
+	record := checkpointRecord{
+		Kind:        checkpointKindAWSAMI,
+		TargetOS:    targetMacOS,
+		WindowsMode: windowsModeNormal,
+		ServerType:  "mac2.metal",
+		HostID:      "h-000000000001",
+	}
+	record.Native.Provider = "aws"
+	record.Native.ImageID = "ami-12345678"
+	record.Native.Region = "eu-west-1"
+	record.Native.Direct = true
+
+	if err := applyAWSAMICheckpointForkConfig(&cfg, fs, record); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Coordinator != "" {
+		t.Fatalf("direct checkpoint fork kept coordinator: %q", cfg.Coordinator)
+	}
+	if cfg.HostID != "h-000000000001" || cfg.AWSMacHostID != "h-000000000001" {
+		t.Fatalf("host pin not preserved: hostID=%q awsMacHostID=%q", cfg.HostID, cfg.AWSMacHostID)
+	}
+	if cfg.Capacity.Market != "on-demand" {
+		t.Fatalf("market=%q, want on-demand", cfg.Capacity.Market)
+	}
+}
+
 func TestApplyAWSAMICheckpointForkConfigHonorsClassOverride(t *testing.T) {
 	fs := newFlagSet("checkpoint fork", io.Discard)
 	class := fs.String("class", "standard", "provider class")

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -327,7 +327,7 @@ func TestCheckpointCreateModePrefersDiskSnapshotLinuxNative(t *testing.T) {
 	}
 }
 
-func TestCheckpointCreateModeSupportsAWSMacOSNativeSnapshots(t *testing.T) {
+func TestCheckpointCreateModeSupportsAWSMacOSAMIBackedCheckpoints(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"
 	cfg.Coordinator = "https://coordinator.example"
@@ -336,11 +336,14 @@ func TestCheckpointCreateModeSupportsAWSMacOSNativeSnapshots(t *testing.T) {
 	server := Server{Provider: "aws", CloudID: "i-123"}
 	target := SSHTarget{TargetOS: targetMacOS}
 
-	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindAWSEBS {
-		t.Fatalf("mode=%q, want %q", got, checkpointKindAWSEBS)
+	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("mode=%q, want %q", got, checkpointKindAWSAMI)
 	}
 	if got := checkpointCreateMode("native", "image", cfg, server, target, false); got != checkpointKindAWSAMI {
 		t.Fatalf("image strategy mode=%q, want %q", got, checkpointKindAWSAMI)
+	}
+	if got := checkpointCreateMode("snapshot", "", cfg, server, target, false); got != checkpointKindAWSAMI {
+		t.Fatalf("snapshot mode=%q, want %q", got, checkpointKindAWSAMI)
 	}
 }
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -702,6 +702,65 @@ func TestCheckpointInspectVerifyResourceOnlyNativeDoesNotUseCoordinator(t *testi
 	}
 }
 
+func TestCheckpointInspectVerifyDirectAWSUsesLocalPathBeforeCoordinator(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_AWS_REGION", "")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+
+	var coordinatorHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coordinatorHits++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin")
+	cfgPath := filepath.Join(t.TempDir(), "crabbox.yaml")
+	if err := os.WriteFile(cfgPath, []byte("provider: aws\ncoordinator: "+server.URL+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:        "chk_direct_aws",
+		Kind:      checkpointKindAWSAMI,
+		Provider:  "aws",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		TargetOS:  targetMacOS,
+	}
+	record.Native.Provider = "aws"
+	record.Native.ImageID = "ami-12345678"
+	record.Native.Region = "not a valid region"
+	record.Native.Direct = true
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointInspect(context.Background(), []string{record.ID, "--verify", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var audit checkpointAudit
+	if err := json.Unmarshal(stdout.Bytes(), &audit); err != nil {
+		t.Fatal(err)
+	}
+	if coordinatorHits != 0 {
+		t.Fatalf("direct AWS verification hit coordinator %d time(s)", coordinatorHits)
+	}
+	if audit.ProviderState != "unknown" || audit.NextAction != "check_auth_or_provider" {
+		t.Fatalf("audit=%#v", audit)
+	}
+	if audit.Error == "" {
+		t.Fatal("expected local AWS verification error")
+	}
+}
+
 func TestCheckpointDeleteResourceOnlyNativeDeletesProviderResource(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -402,7 +402,7 @@ func TestCheckpointCreateModeNativeSupportsDirectAWSAMI(t *testing.T) {
 	}
 }
 
-func TestDirectAWSCheckpointConfigRequiresNoCoordinator(t *testing.T) {
+func TestDirectAWSCheckpointConfigUsesDirectMarker(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "crabbox.yaml")
 	if err := os.WriteFile(cfgPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -427,8 +427,12 @@ func TestDirectAWSCheckpointConfigRequiresNoCoordinator(t *testing.T) {
 	if err := os.WriteFile(cfgPath, []byte("provider: aws\ncoordinator: https://coordinator.example\naws:\n  region: us-east-1\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := directAWSCheckpointConfig(record); ok {
-		t.Fatal("coordinator-backed config should not use direct AWS cleanup")
+	cfg, ok = directAWSCheckpointConfig(record)
+	if !ok {
+		t.Fatal("direct AWS checkpoint should still use direct cleanup when a coordinator is configured later")
+	}
+	if cfg.Coordinator == "" {
+		t.Fatal("expected loaded config to preserve coordinator for unrelated settings")
 	}
 
 	if err := os.WriteFile(cfgPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -173,6 +173,7 @@ type CoordinatorImage struct {
 	Provider     string   `json:"provider,omitempty"`
 	Kind         string   `json:"kind,omitempty"`
 	Region       string   `json:"region,omitempty"`
+	AccountID    string   `json:"accountId,omitempty"`
 	Project      string   `json:"project,omitempty"`
 	ResourceID   string   `json:"resourceID,omitempty"`
 	SnapshotIDs  []string `json:"snapshotIds,omitempty"`

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -167,19 +167,21 @@ type CoordinatorProviderReadiness struct {
 }
 
 type CoordinatorImage struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	State        string `json:"state"`
-	Provider     string `json:"provider,omitempty"`
-	Kind         string `json:"kind,omitempty"`
-	Region       string `json:"region,omitempty"`
-	Project      string `json:"project,omitempty"`
-	ResourceID   string `json:"resourceID,omitempty"`
-	Target       string `json:"target,omitempty"`
-	WindowsMode  string `json:"windowsMode,omitempty"`
-	ServerType   string `json:"serverType,omitempty"`
-	Architecture string `json:"architecture,omitempty"`
-	PromotedAt   string `json:"promotedAt,omitempty"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	State        string   `json:"state"`
+	Provider     string   `json:"provider,omitempty"`
+	Kind         string   `json:"kind,omitempty"`
+	Region       string   `json:"region,omitempty"`
+	Project      string   `json:"project,omitempty"`
+	ResourceID   string   `json:"resourceID,omitempty"`
+	SnapshotIDs  []string `json:"snapshotIds,omitempty"`
+	Direct       bool     `json:"direct,omitempty"`
+	Target       string   `json:"target,omitempty"`
+	WindowsMode  string   `json:"windowsMode,omitempty"`
+	ServerType   string   `json:"serverType,omitempty"`
+	Architecture string   `json:"architecture,omitempty"`
+	PromotedAt   string   `json:"promotedAt,omitempty"`
 }
 
 type CoordinatorMacHost struct {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -42,6 +42,10 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 }
 
 func applyLeaseCreateFlags(cfg *Config, fs *flag.FlagSet, values leaseCreateFlagValues) error {
+	return applyLeaseCreateFlagsForLease(cfg, fs, values, "")
+}
+
+func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCreateFlagValues, existingLeaseID string) error {
 	cfg.Provider = *values.Provider
 	cfg.Profile = *values.Profile
 	cfg.Class = *values.Class
@@ -51,6 +55,9 @@ func applyLeaseCreateFlags(cfg *Config, fs *flag.FlagSet, values leaseCreateFlag
 	}
 	if err := applyNetworkFlagOverrides(cfg, fs, values.Network); err != nil {
 		return err
+	}
+	if existingLeaseID != "" && cfg.Provider == "aws" && cfg.TargetOS == targetMacOS && !flagWasSet(fs, "market") {
+		cfg.Capacity.Market = "on-demand"
 	}
 	if err := applyCapacityMarketFlag(cfg, fs, *values.Market); err != nil {
 		return err

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -726,6 +726,31 @@ func TestRunArtifactCollectScriptWarnsOnEmptyMatches(t *testing.T) {
 	}
 }
 
+func TestRunArtifactCollectScriptRecursiveGlobIncludesZeroDepthMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".artifacts", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".artifacts", "result.xml"), []byte("<root />\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".artifacts", "nested", "result.xml"), []byte("<nested />\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+	script := runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{".artifacts/**/*.xml"})
+	if out, err := exec.Command("bash", "-lc", script).CombinedOutput(); err != nil {
+		t.Fatalf("collect script failed: %v\n%s", err, out)
+	}
+	names := tarGzNames(t, archivePath)
+	if !stringSliceContains(names, ".artifacts/result.xml") {
+		t.Fatalf("archive missing zero-depth recursive match: %#v", names)
+	}
+	if !stringSliceContains(names, ".artifacts/nested/result.xml") {
+		t.Fatalf("archive missing nested recursive match: %#v", names)
+	}
+}
+
 func tarGzNames(t *testing.T, path string) []string {
 	t.Helper()
 	file, err := os.Open(path)

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -751,6 +751,44 @@ func TestRunArtifactCollectScriptRecursiveGlobIncludesZeroDepthMatches(t *testin
 	}
 }
 
+func TestRunArtifactCollectScriptRecursiveGlobPreservesPathSegments(t *testing.T) {
+	dir := t.TempDir()
+	for _, path := range []string{
+		filepath.Join("foo", "bar"),
+		filepath.Join("foo", "x", "bar"),
+		filepath.Join("foo", "bar", "baz"),
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join("foo", "bar", "file.txt"):       "zero depth\n",
+		filepath.Join("foo", "x", "bar", "file.txt"):  "nested\n",
+		filepath.Join("foo", "bar", "baz", "qux.txt"): "outside\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+	script := runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{"foo/**/bar/*.txt"})
+	if out, err := exec.Command("bash", "-lc", script).CombinedOutput(); err != nil {
+		t.Fatalf("collect script failed: %v\n%s", err, out)
+	}
+	names := tarGzNames(t, archivePath)
+	if !stringSliceContains(names, "foo/bar/file.txt") {
+		t.Fatalf("archive missing zero-depth path match: %#v", names)
+	}
+	if !stringSliceContains(names, "foo/x/bar/file.txt") {
+		t.Fatalf("archive missing nested path match: %#v", names)
+	}
+	if stringSliceContains(names, "foo/bar/baz/qux.txt") {
+		t.Fatalf("archive included path outside requested segment glob: %#v", names)
+	}
+}
+
 func tarGzNames(t *testing.T, path string) []string {
 	t.Helper()
 	file, err := os.Open(path)

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -789,6 +789,22 @@ func TestRunArtifactCollectScriptRecursiveGlobPreservesPathSegments(t *testing.T
 	}
 }
 
+func TestArtifactGlobSearchRootUsesLiteralPrefix(t *testing.T) {
+	tests := map[string]string{
+		".artifacts/**/*.xml": ".artifacts",
+		"foo/**/bar/*.txt":    "foo",
+		"foo/bar*.txt":        "foo",
+		"foo*/*.txt":          ".",
+		"**/*.xml":            ".",
+		"result.xml":          ".",
+	}
+	for glob, want := range tests {
+		if got := artifactGlobSearchRoot(glob); got != want {
+			t.Fatalf("artifactGlobSearchRoot(%q)=%q, want %q", glob, got, want)
+		}
+	}
+}
+
 func tarGzNames(t *testing.T, path string) []string {
 	t.Helper()
 	file, err := os.Open(path)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -213,7 +213,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if err := applySelectedProfileConfig(&cfg); err != nil {
 		return err
 	}
-	if err := applyLeaseCreateFlags(&cfg, fs, leaseFlags); err != nil {
+	if err := applyLeaseCreateFlagsForLease(&cfg, fs, leaseFlags, *leaseIDFlag); err != nil {
 		return err
 	}
 	expansion, err := expandRunProfile(cfg, *presetName, *scenario, presetVars, command, *shellMode, *preflight, artifactGlobs, *proofTemplate)

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -101,7 +101,11 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	for _, glob := range globs {
 		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
 		if strings.Contains(glob, "**") {
-			b.WriteString("while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"./$rel\" == " + glob + " || \"$rel\" == " + strings.TrimPrefix(glob, "./") + " ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
+			matches := []string{`"./$rel" == ` + glob, `"$rel" == ` + strings.TrimPrefix(glob, "./")}
+			if zeroDepth := strings.ReplaceAll(glob, "**/", ""); zeroDepth != glob {
+				matches = append(matches, ` "./$rel" == `+zeroDepth, `"$rel" == `+strings.TrimPrefix(zeroDepth, "./"))
+			}
+			b.WriteString("while IFS= read -r -d '' f; do rel=${f#./}; if [[ " + strings.Join(matches, " || ") + " ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
 		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -101,14 +101,38 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	for _, glob := range globs {
 		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
 		if strings.Contains(glob, "**") {
-			matches := []string{`"./$rel" == ` + glob, `"$rel" == ` + strings.TrimPrefix(glob, "./")}
-			if zeroDepth := strings.ReplaceAll(glob, "**/", ""); zeroDepth != glob {
-				matches = append(matches, ` "./$rel" == `+zeroDepth, `"$rel" == `+strings.TrimPrefix(zeroDepth, "./"))
-			}
-			b.WriteString("while IFS= read -r -d '' f; do rel=${f#./}; if [[ " + strings.Join(matches, " || ") + " ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
 		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
+	return b.String()
+}
+
+func artifactGlobRegex(glob string) string {
+	var b strings.Builder
+	b.WriteByte('^')
+	for i := 0; i < len(glob); {
+		if strings.HasPrefix(glob[i:], "**/") {
+			b.WriteString("(.*/)?")
+			i += 3
+			continue
+		}
+		if strings.HasPrefix(glob[i:], "**") {
+			b.WriteString(".*")
+			i += 2
+			continue
+		}
+		switch glob[i] {
+		case '*':
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(glob[i])))
+		}
+		i++
+	}
+	b.WriteByte('$')
 	return b.String()
 }
 

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -95,10 +95,14 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	b.WriteString("set -euo pipefail\n")
 	b.WriteString("cd " + shellQuote(workdir) + "\n")
 	b.WriteString("mkdir -p .crabbox\n")
-	b.WriteString("shopt -s globstar nullglob dotglob\n")
+	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("files=()\n")
+	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 0; rel=${f#./}; case \"$rel\" in .git|.git/*|.crabbox|.crabbox/*|" + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
 	for _, glob := range globs {
-		b.WriteString("for f in " + glob + "; do { [ -f \"$f\" ] || [ -L \"$f\" ]; } || continue; rel=${f#./}; case \"$rel\" in .git|.git/*|.crabbox|.crabbox/*|" + remotePath + ") continue;; esac; files+=(\"$rel\"); done\n")
+		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
+		if strings.Contains(glob, "**") {
+			b.WriteString("while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"./$rel\" == " + glob + " || \"$rel\" == " + strings.TrimPrefix(glob, "./") + " ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
+		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
 	return b.String()

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -105,7 +105,7 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_artifact_file \"$f\"; done\n")
 			}
 			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path ./.git -o -path ./.git/* -o -path ./.crabbox -o -path ./.crabbox/* -o -path .git -o -path .git/* -o -path .crabbox -o -path .crabbox/* \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -101,11 +101,43 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	for _, glob := range globs {
 		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
 		if strings.Contains(glob, "**") {
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find . \\( -type f -o -type l \\) -print0)\n")
+			if strings.Contains(glob, "**/") {
+				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_artifact_file \"$f\"; done\n")
+			}
+			searchRoot := artifactGlobSearchRoot(glob)
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path ./.git -o -path ./.git/* -o -path ./.crabbox -o -path ./.crabbox/* -o -path .git -o -path .git/* -o -path .crabbox -o -path .crabbox/* \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
 	return b.String()
+}
+
+func artifactGlobSearchRoot(glob string) string {
+	glob = strings.TrimSpace(filepath.ToSlash(glob))
+	glob = strings.TrimPrefix(glob, "./")
+	if glob == "" {
+		return "."
+	}
+	firstMeta := strings.IndexAny(glob, "*?")
+	if firstMeta < 0 {
+		dir := filepath.ToSlash(filepath.Dir(glob))
+		if dir == "" {
+			return "."
+		}
+		return dir
+	}
+	prefix := strings.TrimRight(glob[:firstMeta], "/")
+	if prefix == "" {
+		return "."
+	}
+	dir := filepath.ToSlash(filepath.Dir(prefix))
+	if dir == "." && strings.HasSuffix(glob[:firstMeta], "/") {
+		return prefix
+	}
+	if dir == "." && !strings.Contains(prefix, "/") {
+		return "."
+	}
+	return dir
 }
 
 func artifactGlobRegex(glob string) string {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1573,6 +1573,36 @@ func TestApplyCapacityMarketFlag(t *testing.T) {
 	}
 }
 
+func TestApplyLeaseCreateFlagsForExistingAWSMacOSLeaseDefaultsOnDemand(t *testing.T) {
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, defaultConfig())
+	if err := parseFlags(fs, []string{"--provider", "aws", "--target", "macos"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	cfg.Coordinator = "https://broker.example.test"
+	if err := applyLeaseCreateFlagsForLease(&cfg, fs, values, "cbx_123"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Capacity.Market != "on-demand" {
+		t.Fatalf("market=%s want on-demand", cfg.Capacity.Market)
+	}
+}
+
+func TestApplyLeaseCreateFlagsForExistingAWSMacOSLeaseRejectsExplicitSpot(t *testing.T) {
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, defaultConfig())
+	if err := parseFlags(fs, []string{"--provider", "aws", "--target", "macos", "--market", "spot"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	cfg.Coordinator = "https://broker.example.test"
+	err := applyLeaseCreateFlagsForLease(&cfg, fs, values, "cbx_123")
+	if err == nil || !strings.Contains(err.Error(), "requires --market on-demand") {
+		t.Fatalf("err=%v, want explicit spot rejection", err)
+	}
+}
+
 func TestApplyServerTypeFlagOverridesUsesTargetAwareAWSDefaults(t *testing.T) {
 	tests := []struct {
 		name string

--- a/scripts/apply-macos-image-iam-policy.sh
+++ b/scripts/apply-macos-image-iam-policy.sh
@@ -106,26 +106,43 @@ aws_account_for_profile() {
 
 if [[ "$profile" == "auto" ]]; then
   selected_profile=""
+  selected_default=0
   checked_profiles=0
-  while IFS= read -r candidate_profile; do
-    [[ -n "$candidate_profile" ]] || continue
+  if candidate_account="$(aws_account_for_profile "" 2>/dev/null)"; then
     checked_profiles=$((checked_profiles + 1))
-    if candidate_account="$(aws_account_for_profile "$candidate_profile" 2>/dev/null)"; then
-      printf 'checked_profile=%s account=%s\n' "$candidate_profile" "$candidate_account" >&2
-      if [[ "$candidate_account" == "$coordinator_account" ]]; then
-        selected_profile="$candidate_profile"
-        break
-      fi
-    else
-      printf 'checked_profile=%s status=unusable\n' "$candidate_profile" >&2
+    printf 'checked_profile=default-credentials account=%s\n' "$candidate_account" >&2
+    if [[ "$candidate_account" == "$coordinator_account" ]]; then
+      selected_default=1
     fi
-  done < <(aws configure list-profiles)
+  else
+    checked_profiles=$((checked_profiles + 1))
+    printf 'checked_profile=default-credentials status=unusable\n' >&2
+  fi
+  if [[ "$selected_default" != "1" ]]; then
+    while IFS= read -r candidate_profile; do
+      [[ -n "$candidate_profile" ]] || continue
+      checked_profiles=$((checked_profiles + 1))
+      if candidate_account="$(aws_account_for_profile "$candidate_profile" 2>/dev/null)"; then
+        printf 'checked_profile=%s account=%s\n' "$candidate_profile" "$candidate_account" >&2
+        if [[ "$candidate_account" == "$coordinator_account" ]]; then
+          selected_profile="$candidate_profile"
+          break
+        fi
+      else
+        printf 'checked_profile=%s status=unusable\n' "$candidate_profile" >&2
+      fi
+    done < <(aws configure list-profiles)
+  fi
 
-  if [[ -z "$selected_profile" ]]; then
+  if [[ -z "$selected_profile" && "$selected_default" != "1" ]]; then
     printf 'refusing to apply IAM policy: no local AWS profile matches coordinator account %s after checking %s profile(s)\n' "$coordinator_account" "$checked_profiles" >&2
     exit 1
   fi
-  profile="$selected_profile"
+  if [[ "$selected_default" == "1" ]]; then
+    profile=""
+  else
+    profile="$selected_profile"
+  fi
 fi
 
 aws_base=(aws)

--- a/scripts/apply-macos-image-iam-policy.test.js
+++ b/scripts/apply-macos-image-iam-policy.test.js
@@ -133,6 +133,18 @@ test("IAM apply helper auto-selects matching profile", async () => {
   assert.match(result.stdout, /dry-run: aws --profile prod iam put-user-policy/);
 });
 
+test("IAM apply helper auto-selects default credentials", async () => {
+  const ctx = await setup("user", "123456789012");
+  const result = await runApply(ctx, ["--profile", "auto"], {
+    CRABBOX_FAKE_AWS_PROFILES: "",
+  });
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /checked_profile=default-credentials account=123456789012/);
+  assert.doesNotMatch(result.stdout, /aws_profile=/);
+  assert.match(result.stdout, /dry-run: aws iam put-user-policy/);
+});
+
 test("IAM apply helper reports when auto profile has no match", async () => {
   const ctx = await setup("user", "123456789012");
   const result = await runApply(ctx, ["--profile", "auto"], {
@@ -142,9 +154,10 @@ test("IAM apply helper reports when auto profile has no match", async () => {
   });
 
   assert.equal(result.code, 1);
+  assert.match(result.stderr, /checked_profile=default-credentials account=999999999999/);
   assert.match(result.stderr, /checked_profile=default status=unusable/);
   assert.match(result.stderr, /checked_profile=prod account=999999999999/);
-  assert.match(result.stderr, /no local AWS profile matches coordinator account 123456789012 after checking 2 profile\(s\)/);
+  assert.match(result.stderr, /no local AWS profile matches coordinator account 123456789012 after checking 3 profile\(s\)/);
   const log = await readFile(ctx.log, "utf8");
   assert.doesNotMatch(log, /put-user-policy/);
 });

--- a/scripts/macos-coordinator-remediation-audit.sh
+++ b/scripts/macos-coordinator-remediation-audit.sh
@@ -153,7 +153,7 @@ if [[ "$quota_status" == "0" ]] && jq -e 'any(.[]; (.value // 0) >= 1)' "$artifa
 fi
 
 helper_profile_ok=true
-if grep -q 'no local AWS profile matches coordinator account' "$artifact_dir/evidence/iam-apply-dry-run.err" "$artifact_dir/evidence/quota-request-dry-run.err" 2>/dev/null; then
+if grep -Eq 'no local AWS profile matches coordinator account|local AWS account .* does not match coordinator account' "$artifact_dir/evidence/iam-apply-dry-run.err" "$artifact_dir/evidence/quota-request-dry-run.err" 2>/dev/null; then
   helper_profile_ok=false
 fi
 

--- a/scripts/macos-coordinator-remediation-audit.sh
+++ b/scripts/macos-coordinator-remediation-audit.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRABBOX_BIN="${CRABBOX_BIN:-$ROOT/bin/crabbox}"
+CRABBOX_REMEDIATION_BIN="${CRABBOX_REMEDIATION_BIN:-crabbox}"
+CRABBOX_MACOS_IAM_APPLY_COMMAND="${CRABBOX_MACOS_IAM_APPLY_COMMAND:-$ROOT/scripts/apply-macos-image-iam-policy.sh}"
+CRABBOX_MACOS_QUOTA_REQUEST_COMMAND="${CRABBOX_MACOS_QUOTA_REQUEST_COMMAND:-$ROOT/scripts/request-macos-host-quota.sh}"
+CRABBOX_MACOS_IAM_APPLY_DISPLAY_COMMAND="${CRABBOX_MACOS_IAM_APPLY_DISPLAY_COMMAND:-scripts/apply-macos-image-iam-policy.sh}"
+CRABBOX_MACOS_QUOTA_REQUEST_DISPLAY_COMMAND="${CRABBOX_MACOS_QUOTA_REQUEST_DISPLAY_COMMAND:-scripts/request-macos-host-quota.sh}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/macos-coordinator-remediation-audit.sh [--region <aws-region>] [--type <mac-host-type>] [--artifact-dir <dir>] [--profile <aws-profile|auto>]
+
+Collect a no-spend AWS macOS coordinator remediation bundle:
+provider identity, combined IAM policy, EC2 Mac Dedicated Host quota,
+allocation dry-run, guarded IAM apply dry-run, guarded quota request dry-run,
+and a summary.json with explicit blockers.
+
+Options:
+  --region <region>       AWS region to inspect; default CRABBOX_MACOS_REGION or eu-west-1
+  --type <instance-type>  EC2 Mac host type; default CRABBOX_MACOS_TYPE or mac2.metal
+  --artifact-dir <dir>    output directory for evidence
+  --profile <name|auto>   AWS profile for guarded remediation helper dry-runs; default auto
+  -h, --help              show this help
+USAGE
+}
+
+region="${CRABBOX_MACOS_REGION:-eu-west-1}"
+instance_type="${CRABBOX_MACOS_TYPE:-mac2.metal}"
+artifact_dir="${CRABBOX_MACOS_REMEDIATION_AUDIT_DIR:-}"
+profile="${CRABBOX_MACOS_REMEDIATION_PROFILE:-auto}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)
+      region="${2:?missing value for --region}"
+      shift 2
+      ;;
+    --type)
+      instance_type="${2:?missing value for --type}"
+      shift 2
+      ;;
+    --artifact-dir)
+      artifact_dir="${2:?missing value for --artifact-dir}"
+      shift 2
+      ;;
+    --profile)
+      profile="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+need jq
+if [[ ! -x "$CRABBOX_BIN" ]]; then
+  printf 'CRABBOX_BIN is not executable: %s\n' "$CRABBOX_BIN" >&2
+  exit 2
+fi
+if [[ ! -x "$CRABBOX_MACOS_IAM_APPLY_COMMAND" ]]; then
+  printf 'CRABBOX_MACOS_IAM_APPLY_COMMAND is not executable: %s\n' "$CRABBOX_MACOS_IAM_APPLY_COMMAND" >&2
+  exit 2
+fi
+if [[ ! -x "$CRABBOX_MACOS_QUOTA_REQUEST_COMMAND" ]]; then
+  printf 'CRABBOX_MACOS_QUOTA_REQUEST_COMMAND is not executable: %s\n' "$CRABBOX_MACOS_QUOTA_REQUEST_COMMAND" >&2
+  exit 2
+fi
+
+if [[ -z "$artifact_dir" ]]; then
+  artifact_dir="$ROOT/.crabbox/macos-remediation-audit/$(date -u +%Y%m%d-%H%M%S)"
+fi
+mkdir -p "$artifact_dir/evidence"
+
+run_capture() {
+  local name="$1"
+  shift
+  local status=0
+  "$@" >"$artifact_dir/evidence/$name.out" 2>"$artifact_dir/evidence/$name.err" || status=$?
+  printf '%s\n' "$status" >"$artifact_dir/evidence/$name.status"
+}
+
+run_capture provider-identity "$CRABBOX_BIN" admin providers identity --provider aws --region "$region" --json
+run_capture macos-image-policy "$CRABBOX_BIN" admin providers policy --provider aws --target macos
+run_capture mac-host-quota "$CRABBOX_BIN" admin hosts quota --provider aws --target macos --region "$region" --type "$instance_type" --json
+run_capture mac-host-dry-run "$CRABBOX_BIN" admin hosts allocate --provider aws --target macos --region "$region" --type "$instance_type" --dry-run --json
+
+if [[ "$(cat "$artifact_dir/evidence/provider-identity.status")" == "0" && "$(cat "$artifact_dir/evidence/macos-image-policy.status")" == "0" ]]; then
+  run_capture iam-apply-dry-run "$CRABBOX_MACOS_IAM_APPLY_COMMAND" --identity "$artifact_dir/evidence/provider-identity.out" --policy "$artifact_dir/evidence/macos-image-policy.out" --profile "$profile"
+else
+  printf 'skipped; provider identity or policy capture failed\n' >"$artifact_dir/evidence/iam-apply-dry-run.err"
+  printf '1\n' >"$artifact_dir/evidence/iam-apply-dry-run.status"
+  : >"$artifact_dir/evidence/iam-apply-dry-run.out"
+fi
+
+if [[ "$(cat "$artifact_dir/evidence/provider-identity.status")" == "0" && "$(cat "$artifact_dir/evidence/mac-host-quota.status")" == "0" ]]; then
+  run_capture quota-request-dry-run "$CRABBOX_MACOS_QUOTA_REQUEST_COMMAND" --identity "$artifact_dir/evidence/provider-identity.out" --quota "$artifact_dir/evidence/mac-host-quota.out" --region "$region" --profile "$profile"
+else
+  printf 'skipped; provider identity or quota capture failed\n' >"$artifact_dir/evidence/quota-request-dry-run.err"
+  printf '1\n' >"$artifact_dir/evidence/quota-request-dry-run.status"
+  : >"$artifact_dir/evidence/quota-request-dry-run.out"
+fi
+
+status_json() {
+	local name="$1"
+	local status
+	status="$(cat "$artifact_dir/evidence/$name.status")"
+	jq -n \
+		--argjson status "$status" \
+		--arg out "evidence/$name.out" \
+		--arg err "evidence/$name.err" \
+		--arg stdout "$(cat "$artifact_dir/evidence/$name.out" 2>/dev/null || true)" \
+		--arg stderr "$(cat "$artifact_dir/evidence/$name.err" 2>/dev/null || true)" \
+		'{
+        status: $status,
+        stdout: $out,
+        stderr: $err,
+        stdoutText: $stdout,
+        stderrText: $stderr
+      }'
+}
+
+provider_identity_status="$(cat "$artifact_dir/evidence/provider-identity.status")"
+policy_status="$(cat "$artifact_dir/evidence/macos-image-policy.status")"
+quota_status="$(cat "$artifact_dir/evidence/mac-host-quota.status")"
+dry_status="$(cat "$artifact_dir/evidence/mac-host-dry-run.status")"
+iam_status="$(cat "$artifact_dir/evidence/iam-apply-dry-run.status")"
+quota_request_status="$(cat "$artifact_dir/evidence/quota-request-dry-run.status")"
+
+host_dry_ok=false
+if [[ "$dry_status" == "0" ]] && jq -e 'any(.[]; .ok == true)' "$artifact_dir/evidence/mac-host-dry-run.out" >/dev/null 2>&1; then
+  host_dry_ok=true
+fi
+quota_ok=false
+if [[ "$quota_status" == "0" ]] && jq -e 'any(.[]; (.value // 0) >= 1)' "$artifact_dir/evidence/mac-host-quota.out" >/dev/null 2>&1; then
+  quota_ok=true
+fi
+
+helper_profile_ok=true
+if grep -q 'no local AWS profile matches coordinator account' "$artifact_dir/evidence/iam-apply-dry-run.err" "$artifact_dir/evidence/quota-request-dry-run.err" 2>/dev/null; then
+  helper_profile_ok=false
+fi
+
+commands_json="$(
+	printf '%s\n' \
+		"$CRABBOX_REMEDIATION_BIN admin providers identity --provider aws --region $region" \
+		"$CRABBOX_REMEDIATION_BIN admin providers identity --provider aws --region $region --json > provider-identity.json" \
+		"$CRABBOX_REMEDIATION_BIN admin providers policy --provider aws --target macos > macos-image-policy.json" \
+		"$CRABBOX_MACOS_IAM_APPLY_DISPLAY_COMMAND --identity provider-identity.json --policy macos-image-policy.json --profile $profile" \
+		"$CRABBOX_MACOS_IAM_APPLY_DISPLAY_COMMAND --identity provider-identity.json --policy macos-image-policy.json --profile $profile --apply" \
+		"$CRABBOX_REMEDIATION_BIN admin hosts quota --provider aws --target macos --region $region --type $instance_type --json > mac-host-quota.json" \
+		"$CRABBOX_MACOS_QUOTA_REQUEST_DISPLAY_COMMAND --identity provider-identity.json --quota mac-host-quota.json --region $region --profile $profile" \
+		"$CRABBOX_MACOS_QUOTA_REQUEST_DISPLAY_COMMAND --identity provider-identity.json --quota mac-host-quota.json --region $region --profile $profile --apply" |
+    jq -R . |
+    jq -s .
+)"
+
+blockers_json="$(
+  jq -n \
+    --argjson providerIdentityOK "$([[ "$provider_identity_status" == "0" ]] && echo true || echo false)" \
+    --argjson policyOK "$([[ "$policy_status" == "0" ]] && echo true || echo false)" \
+    --argjson dryOK "$host_dry_ok" \
+    --argjson quotaOK "$quota_ok" \
+    --argjson iamOK "$([[ "$iam_status" == "0" ]] && echo true || echo false)" \
+    --argjson quotaRequestOK "$([[ "$quota_request_status" == "0" ]] && echo true || echo false)" \
+    --argjson profileOK "$helper_profile_ok" \
+    --arg dryText "$(cat "$artifact_dir/evidence/mac-host-dry-run.out" "$artifact_dir/evidence/mac-host-dry-run.err" 2>/dev/null || true)" \
+    --arg quotaText "$(cat "$artifact_dir/evidence/mac-host-quota.out" "$artifact_dir/evidence/mac-host-quota.err" 2>/dev/null || true)" \
+    '[
+      (if $providerIdentityOK then empty else "provider-identity" end),
+      (if $policyOK then empty else "provider-policy" end),
+      (if $dryOK then empty
+       elif ($dryText | contains("UnauthorizedOperation")) then "host-iam"
+       else "host-dry-run" end),
+      (if $quotaOK then empty
+       elif ($quotaText | contains("\"value\":0") or contains("\"value\": 0")) then "host-quota"
+       else "host-quota-visibility" end),
+      (if $profileOK then empty else "local-coordinator-aws-profile" end),
+      (if $iamOK then empty else "iam-apply-dry-run" end),
+      (if $quotaRequestOK then empty else "quota-request-dry-run" end)
+    ] | unique'
+)"
+
+result="blocked"
+if [[ "$host_dry_ok" == "true" && "$quota_ok" == "true" ]]; then
+  result="ready-for-paid-smoke"
+fi
+
+jq -n \
+  --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg result "$result" \
+  --arg region "$region" \
+  --arg instanceType "$instance_type" \
+  --arg artifactRoot "." \
+  --argjson blockers "$blockers_json" \
+  --argjson commands "$commands_json" \
+  --argjson hostDryRunOK "$host_dry_ok" \
+  --argjson quotaOK "$quota_ok" \
+  --argjson helperProfileOK "$helper_profile_ok" \
+  --argjson providerIdentity "$(status_json provider-identity)" \
+  --argjson macosImagePolicy "$(status_json macos-image-policy)" \
+  --argjson macHostQuota "$(status_json mac-host-quota)" \
+  --argjson macHostDryRun "$(status_json mac-host-dry-run)" \
+  --argjson iamApplyDryRun "$(status_json iam-apply-dry-run)" \
+  --argjson quotaRequestDryRun "$(status_json quota-request-dry-run)" \
+  '{
+    generatedAt: $generatedAt,
+    result: $result,
+    region: $region,
+    instanceType: $instanceType,
+    artifactRoot: $artifactRoot,
+    ready: {
+      hostDryRun: $hostDryRunOK,
+      hostQuota: $quotaOK,
+      localCoordinatorAWSProfile: $helperProfileOK
+    },
+    blockers: $blockers,
+    remediation: {
+      commands: $commands
+    },
+    evidence: {
+      providerIdentity: $providerIdentity,
+      macosImagePolicy: $macosImagePolicy,
+      macHostQuota: $macHostQuota,
+      macHostDryRun: $macHostDryRun,
+      iamApplyDryRun: $iamApplyDryRun,
+      quotaRequestDryRun: $quotaRequestDryRun
+    }
+  }' >"$artifact_dir/summary.json"
+
+printf 'macOS coordinator remediation audit: %s\n' "$artifact_dir/summary.json"
+if [[ "$result" == "blocked" ]]; then
+  exit 1
+fi

--- a/scripts/macos-coordinator-remediation-audit.sh
+++ b/scripts/macos-coordinator-remediation-audit.sh
@@ -198,8 +198,8 @@ blockers_json="$(
 )"
 
 result="blocked"
-if [[ "$host_dry_ok" == "true" && "$quota_ok" == "true" ]]; then
-  result="ready-for-paid-smoke"
+if [[ "$host_dry_ok" == "true" && "$quota_ok" == "true" ]] && jq -e 'length == 0' <<<"$blockers_json" >/dev/null; then
+	result="ready-for-paid-smoke"
 fi
 
 jq -n \

--- a/scripts/macos-coordinator-remediation-audit.test.js
+++ b/scripts/macos-coordinator-remediation-audit.test.js
@@ -192,3 +192,22 @@ test("macOS coordinator remediation audit blocks when required evidence failed",
   assert.ok(summary.blockers.includes("iam-apply-dry-run"));
   assert.ok(summary.blockers.includes("quota-request-dry-run"));
 });
+
+test("macOS coordinator remediation audit reports explicit profile account mismatch", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runAudit(ctx, {
+    CRABBOX_FAKE_DRY_OK: "1",
+    CRABBOX_FAKE_QUOTA_VALUE: "1",
+    CRABBOX_FAKE_AWS_ACCOUNT: "999999999999",
+    CRABBOX_MACOS_REMEDIATION_PROFILE: "prod",
+  });
+
+  assert.equal(result.code, 1, result.stdout + result.stderr);
+  const summary = JSON.parse(await readFile(path.join(ctx.artifacts, "summary.json"), "utf8"));
+  assert.equal(summary.result, "blocked");
+  assert.equal(summary.ready.hostDryRun, true);
+  assert.equal(summary.ready.hostQuota, true);
+  assert.equal(summary.ready.localCoordinatorAWSProfile, false);
+  assert.ok(summary.blockers.includes("local-coordinator-aws-profile"));
+  assert.match(summary.evidence.iamApplyDryRun.stderrText, /does not match coordinator account/);
+});

--- a/scripts/macos-coordinator-remediation-audit.test.js
+++ b/scripts/macos-coordinator-remediation-audit.test.js
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const auditScript = path.join(scriptDir, "macos-coordinator-remediation-audit.sh");
+
+async function setup(account = "123456789012") {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crabbox-macos-remediation-audit-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const fakeAWS = path.join(bin, "aws");
+  const artifacts = path.join(dir, "artifacts");
+  await mkdir(bin);
+  await writeFile(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2 $3" == "admin providers identity" ]]; then
+  printf '{"account":"%s","arn":"arn:aws:iam::%s:user/crabbox-runner","region":"eu-west-1","policyTarget":{"type":"user","name":"crabbox-runner","source":"iam-user"}}\\n' "${account}" "${account}"
+  exit 0
+fi
+if [[ "$1 $2 $3" == "admin providers policy" ]]; then
+  printf '{"Statement":[{"Action":["ec2:RunInstances","ec2:AllocateHosts"]}]}\\n'
+  exit 0
+fi
+if [[ "$1 $2 $3" == "admin hosts quota" ]]; then
+  value="\${CRABBOX_FAKE_QUOTA_VALUE:-0}"
+  printf '[{"serviceCode":"ec2","quotaCode":"L-5D8DADF5","quotaName":"Running Dedicated mac2 Hosts","value":%s,"adjustable":true,"unit":"None"}]\\n' "$value"
+  exit 0
+fi
+if [[ "$1 $2 $3" == "admin hosts allocate" ]]; then
+  if [[ "\${CRABBOX_FAKE_DRY_OK:-0}" == "1" ]]; then
+    printf '[{"region":"eu-west-1","availabilityZone":"eu-west-1a","instanceType":"mac2.metal","ok":true,"message":"DryRunOperation"}]\\n'
+  else
+    printf '[{"region":"eu-west-1","availabilityZone":"eu-west-1a","instanceType":"mac2.metal","ok":false,"message":"UnauthorizedOperation: coordinator AWS identity needs EC2 Mac host lifecycle permissions, including ec2:AllocateHosts and ec2:CreateTags"}]\\n'
+  fi
+  exit 0
+fi
+printf 'unexpected crabbox args: %s\\n' "$*" >&2
+exit 2
+`,
+  );
+  await writeFile(
+    fakeAWS,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "configure" && "$2" == "list-profiles" ]]; then
+  printf '%s\\n' \${CRABBOX_FAKE_AWS_PROFILES:-default}
+  exit 0
+fi
+profile=""
+if [[ "\${1:-}" == "--profile" ]]; then
+  profile="$2"
+  shift 2
+fi
+if [[ "$1" == "sts" && "$2" == "get-caller-identity" ]]; then
+  if [[ -n "\${CRABBOX_FAKE_MATCH_PROFILE:-}" && "$profile" == "\${CRABBOX_FAKE_MATCH_PROFILE}" ]]; then
+    printf '%s\\n' "${account}"
+  else
+    printf '%s\\n' "\${CRABBOX_FAKE_AWS_ACCOUNT:-${account}}"
+  fi
+  exit 0
+fi
+if [[ "$1" == "iam" || "$1" == "service-quotas" ]]; then
+  printf '{"ok":true}\\n'
+  exit 0
+fi
+printf 'unexpected aws args: %s\\n' "$*" >&2
+exit 2
+`,
+  );
+  await chmod(fakeCrabbox, 0o755);
+  await chmod(fakeAWS, 0o755);
+  return { dir, bin, fakeCrabbox, artifacts };
+}
+
+function runAudit(ctx, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "bash",
+      [
+        auditScript,
+        "--artifact-dir",
+        ctx.artifacts,
+        "--region",
+        "eu-west-1",
+        "--type",
+        "mac2.metal",
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PATH: `${ctx.bin}:${process.env.PATH}`,
+          CRABBOX_BIN: ctx.fakeCrabbox,
+          ...env,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("macOS coordinator remediation audit records IAM, quota, and local profile blockers", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runAudit(ctx, {
+    CRABBOX_FAKE_AWS_ACCOUNT: "999999999999",
+    CRABBOX_FAKE_AWS_PROFILES: "default\nprod",
+  });
+
+  assert.equal(result.code, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /macOS coordinator remediation audit:/);
+  const summary = JSON.parse(await readFile(path.join(ctx.artifacts, "summary.json"), "utf8"));
+  assert.equal(summary.result, "blocked");
+  assert.equal(summary.ready.hostDryRun, false);
+  assert.equal(summary.ready.hostQuota, false);
+  assert.equal(summary.ready.localCoordinatorAWSProfile, false);
+  assert.ok(summary.blockers.includes("host-iam"));
+	assert.ok(summary.blockers.includes("host-quota"));
+	assert.ok(summary.blockers.includes("local-coordinator-aws-profile"));
+	assert.ok(
+		summary.remediation.commands.includes(
+			"scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto",
+		),
+	);
+	assert.ok(
+		summary.remediation.commands.includes(
+			"scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto",
+		),
+	);
+	assert.doesNotMatch(summary.remediation.commands.join("\n"), new RegExp(repoRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.equal(summary.evidence.providerIdentity.stdout, "evidence/provider-identity.out");
+	assert.equal(summary.evidence.macHostDryRun.status, 0);
+	assert.match(summary.evidence.macHostDryRun.stdoutText, /UnauthorizedOperation/);
+});
+
+test("macOS coordinator remediation audit reports ready when dry-run, quota, and account guard pass", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runAudit(ctx, {
+    CRABBOX_FAKE_DRY_OK: "1",
+    CRABBOX_FAKE_QUOTA_VALUE: "1",
+    CRABBOX_FAKE_AWS_PROFILES: "",
+  });
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  const summary = JSON.parse(await readFile(path.join(ctx.artifacts, "summary.json"), "utf8"));
+  assert.equal(summary.result, "ready-for-paid-smoke");
+  assert.equal(summary.ready.hostDryRun, true);
+  assert.equal(summary.ready.hostQuota, true);
+  assert.equal(summary.ready.localCoordinatorAWSProfile, true);
+  assert.deepEqual(summary.blockers, []);
+  assert.match(summary.evidence.iamApplyDryRun.stdoutText, /dry-run: aws iam put-user-policy/);
+  assert.match(summary.evidence.quotaRequestDryRun.stdoutText, /quota already sufficient/);
+});

--- a/scripts/macos-coordinator-remediation-audit.test.js
+++ b/scripts/macos-coordinator-remediation-audit.test.js
@@ -22,6 +22,10 @@ async function setup(account = "123456789012") {
     `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1 $2 $3" == "admin providers identity" ]]; then
+  if [[ "\${CRABBOX_FAKE_IDENTITY_FAIL:-0}" == "1" ]]; then
+    printf 'identity failed\\n' >&2
+    exit 1
+  fi
   printf '{"account":"%s","arn":"arn:aws:iam::%s:user/crabbox-runner","region":"eu-west-1","policyTarget":{"type":"user","name":"crabbox-runner","source":"iam-user"}}\\n' "${account}" "${account}"
   exit 0
 fi
@@ -169,4 +173,22 @@ test("macOS coordinator remediation audit reports ready when dry-run, quota, and
   assert.deepEqual(summary.blockers, []);
   assert.match(summary.evidence.iamApplyDryRun.stdoutText, /dry-run: aws iam put-user-policy/);
   assert.match(summary.evidence.quotaRequestDryRun.stdoutText, /quota already sufficient/);
+});
+
+test("macOS coordinator remediation audit blocks when required evidence failed", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runAudit(ctx, {
+    CRABBOX_FAKE_DRY_OK: "1",
+    CRABBOX_FAKE_QUOTA_VALUE: "1",
+    CRABBOX_FAKE_IDENTITY_FAIL: "1",
+  });
+
+  assert.equal(result.code, 1, result.stdout + result.stderr);
+  const summary = JSON.parse(await readFile(path.join(ctx.artifacts, "summary.json"), "utf8"));
+  assert.equal(summary.result, "blocked");
+  assert.equal(summary.ready.hostDryRun, true);
+  assert.equal(summary.ready.hostQuota, true);
+  assert.ok(summary.blockers.includes("provider-identity"));
+  assert.ok(summary.blockers.includes("iam-apply-dry-run"));
+  assert.ok(summary.blockers.includes("quota-request-dry-run"));
 });

--- a/scripts/macos-host-region-preflight.sh
+++ b/scripts/macos-host-region-preflight.sh
@@ -6,6 +6,7 @@ CRABBOX_BIN="${CRABBOX_BIN:-$ROOT/bin/crabbox}"
 CRABBOX_REMEDIATION_BIN="${CRABBOX_REMEDIATION_BIN:-crabbox}"
 CRABBOX_REGION_PREFLIGHT_COMMAND="${CRABBOX_REGION_PREFLIGHT_COMMAND:-scripts/macos-host-region-preflight.sh}"
 CRABBOX_MACOS_IAM_APPLY_COMMAND="${CRABBOX_MACOS_IAM_APPLY_COMMAND:-scripts/apply-macos-image-iam-policy.sh}"
+CRABBOX_MACOS_QUOTA_REQUEST_COMMAND="${CRABBOX_MACOS_QUOTA_REQUEST_COMMAND:-scripts/request-macos-host-quota.sh}"
 CRABBOX_MACOS_KNOWN_TYPES="mac2.metal,mac2-m2.metal,mac2-m2pro.metal,mac-m4.metal,mac-m4pro.metal,mac-m4max.metal,mac2-m1ultra.metal,mac-m3ultra.metal,mac1.metal"
 
 if [[ -n "${CRABBOX_MACOS_TYPE:-}" ]]; then
@@ -111,7 +112,13 @@ done
 done
 
 instance_types_json="$(printf '%s\n' "${instance_types[@]}" | jq -R . | jq -s .)"
-remediation_region="${regions[0]}"
+read -r remediation_region remediation_type < <(
+  jq -s -r '
+    ([.[] | select(.dryRun.ok == true and .quota.ok == false)][0] // .[0])
+    | [.region, .instanceType]
+    | @tsv
+  ' "$tmp"
+)
 blocker_commands_json="$(
   printf '%s\n' \
     "$CRABBOX_REMEDIATION_BIN admin providers identity --provider aws --region $remediation_region" \
@@ -119,6 +126,9 @@ blocker_commands_json="$(
     "$CRABBOX_REMEDIATION_BIN admin providers policy --provider aws --target macos > macos-image-policy.json" \
     "$CRABBOX_MACOS_IAM_APPLY_COMMAND --identity provider-identity.json --policy macos-image-policy.json --profile auto" \
     "$CRABBOX_MACOS_IAM_APPLY_COMMAND --identity provider-identity.json --policy macos-image-policy.json --profile auto --apply" \
+    "$CRABBOX_REMEDIATION_BIN admin hosts quota --provider aws --target macos --region $remediation_region --type $remediation_type --json > mac-host-quota.json" \
+    "$CRABBOX_MACOS_QUOTA_REQUEST_COMMAND --identity provider-identity.json --quota mac-host-quota.json --region $remediation_region --profile auto" \
+    "$CRABBOX_MACOS_QUOTA_REQUEST_COMMAND --identity provider-identity.json --quota mac-host-quota.json --region $remediation_region --profile auto --apply" \
     "$CRABBOX_REGION_PREFLIGHT_COMMAND" |
     jq -R . |
     jq -s .

--- a/scripts/macos-host-region-preflight.test.js
+++ b/scripts/macos-host-region-preflight.test.js
@@ -203,9 +203,40 @@ test("macOS host region preflight blocks when dry-run succeeds but quota is unav
     "crabbox admin providers policy --provider aws --target macos > macos-image-policy.json",
     "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto",
     "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto --apply",
+    "crabbox admin hosts quota --provider aws --target macos --region us-west-2 --type mac2.metal --json > mac-host-quota.json",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region us-west-2 --profile auto",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region us-west-2 --profile auto --apply",
     "scripts/macos-host-region-preflight.sh",
   ]);
   assert.match(summary.regions[0].quota.output, /Running Dedicated mac2 Hosts/);
+});
+
+test("macOS host region preflight points quota remediation at the dry-run-ready candidate", async () => {
+  const run = await setupRun();
+  const result = await runPreflight({
+    CRABBOX_BIN: run.fake,
+    CRABBOX_MACOS_REGIONS: "eu-central-1,us-west-2",
+    CRABBOX_FAKE_DRY_REGION: "us-west-2",
+    CRABBOX_FAKE_QUOTA_ZERO_REGION: "us-west-2",
+  });
+
+  assert.equal(result.code, 1);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.result, "blocked");
+  assert.equal(summary.regions[0].dryRun.status, 1);
+  assert.equal(summary.regions[1].dryRun.ok, true);
+  assert.equal(summary.regions[1].quota.ok, false);
+  assert.deepEqual(summary.blocker.commands, [
+    "crabbox admin providers identity --provider aws --region us-west-2",
+    "crabbox admin providers identity --provider aws --region us-west-2 --json > provider-identity.json",
+    "crabbox admin providers policy --provider aws --target macos > macos-image-policy.json",
+    "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto",
+    "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto --apply",
+    "crabbox admin hosts quota --provider aws --target macos --region us-west-2 --type mac2.metal --json > mac-host-quota.json",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region us-west-2 --profile auto",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region us-west-2 --profile auto --apply",
+    "scripts/macos-host-region-preflight.sh",
+  ]);
 });
 
 test("macOS host region preflight blocks when every region is unavailable", async () => {
@@ -229,6 +260,9 @@ test("macOS host region preflight blocks when every region is unavailable", asyn
     "crabbox admin providers policy --provider aws --target macos > macos-image-policy.json",
     "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto",
     "scripts/apply-macos-image-iam-policy.sh --identity provider-identity.json --policy macos-image-policy.json --profile auto --apply",
+    "crabbox admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2.metal --json > mac-host-quota.json",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto --apply",
     "scripts/macos-host-region-preflight.sh",
   ]);
 });

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -937,7 +937,17 @@ else
 
   summary_phase="host-allocation"
   allocate_log="$evidence_dir/mac-host-allocate.json"
-  run_tee "$allocate_log" "$CRABBOX_BIN" admin hosts allocate --provider aws --target macos --region "$region" --type "$instance_type" --force --json
+  set +e
+  capture_preflight_command host-allocation "mac host allocation" "$allocate_log" "$CRABBOX_BIN" admin hosts allocate --provider aws --target macos --region "$region" --type "$instance_type" --force --json
+  allocate_status=$?
+  set -e
+  if [[ "$allocate_status" -ne 0 ]]; then
+    preflight_blocker_from_stderr "mac host allocation" "${allocate_log}.stderr"
+    blocker_remediation="Retry the allocation if AWS reports a transient service error. If dry-run still succeeds but paid allocation keeps failing, use an existing available EC2 Mac Dedicated Host or try another host family/region with non-zero quota."
+    printf 'macOS lifecycle blocked during paid work: %s\n' "$blocker_message" >&2
+    write_summary blocked host-allocation
+    exit 1
+  fi
   allocated_host="$(jq -r '.[0].id // empty' "$allocate_log")"
   if [[ -z "$allocated_host" ]]; then
     blocker_message="mac host allocation did not return a host id"

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -19,6 +19,7 @@ idle_timeout="${CRABBOX_MACOS_IDLE_TIMEOUT:-30m}"
 image_wait_timeout="${CRABBOX_MACOS_IMAGE_WAIT_TIMEOUT:-60m}"
 host_wait_timeout="${CRABBOX_MACOS_HOST_WAIT_TIMEOUT:-5h}"
 host_wait_interval="${CRABBOX_MACOS_HOST_WAIT_INTERVAL:-2m}"
+host_available_stable_count="${CRABBOX_MACOS_HOST_AVAILABLE_STABLE_COUNT:-2}"
 webvnc_wait_timeout="${CRABBOX_MACOS_WEBVNC_WAIT_TIMEOUT:-2m}"
 webvnc_wait_interval="${CRABBOX_MACOS_WEBVNC_WAIT_INTERVAL:-5s}"
 webvnc_start_grace="${CRABBOX_MACOS_WEBVNC_START_GRACE:-3s}"
@@ -100,6 +101,15 @@ run_tee() {
   printf ' %q' "$@"
   printf '\n'
   "$@" | tee "$out"
+}
+
+run_tee_combined() {
+  local out="$1"
+  shift
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@" > >(tee "$out") 2> >(tee -a "$out" >&2)
 }
 
 preflight_blocker_from_stderr() {
@@ -669,18 +679,28 @@ wait_for_host_available() {
   local host="$1"
   local label="$2"
   [[ -n "$host" ]] || return 0
-  local timeout_seconds interval_seconds deadline state log
+  local available_count available_needed timeout_seconds interval_seconds deadline state log
   log="$(log_for_label host-wait "$label")"
   : >"$log"
   timeout_seconds="$(duration_seconds "$host_wait_timeout")"
   interval_seconds="$(duration_seconds "$host_wait_interval")"
+  available_needed="$host_available_stable_count"
+  if ! [[ "$available_needed" =~ ^[0-9]+$ ]] || [[ "$available_needed" -lt 1 ]]; then
+    available_needed=1
+  fi
+  available_count=0
   deadline="$(($(date +%s) + timeout_seconds))"
-  log_line "$log" "waiting for EC2 Mac Dedicated Host $host to become available after $label lease stop; timeout=$host_wait_timeout interval=$host_wait_interval"
+  log_line "$log" "waiting for EC2 Mac Dedicated Host $host to become stably available after $label lease stop; timeout=$host_wait_timeout interval=$host_wait_interval stable_count=$available_needed"
   while true; do
     state="$(mac_host_state "$host")"
     if [[ "$state" == "available" ]]; then
-      log_line "$log" "host $host is available"
-      return 0
+      available_count="$((available_count + 1))"
+      log_line "$log" "host $host is available ($available_count/$available_needed)"
+      if [[ "$available_count" -ge "$available_needed" ]]; then
+        return 0
+      fi
+    else
+      available_count=0
     fi
     if [[ "$(date +%s)" -ge "$deadline" ]]; then
       log_line "$log" "timed out waiting for EC2 Mac Dedicated Host $host to become available; last state=${state:-missing}" >&2
@@ -807,9 +827,30 @@ create_checkpoint_from_source() {
 smoke_checkpoint_fork() {
   [[ "$checkpoint" == "1" ]] || return 0
   [[ -n "$checkpoint_id" ]] || return 0
+  local attempt max_attempts status
+  max_attempts="${CRABBOX_MACOS_CHECKPOINT_FORK_ATTEMPTS:-2}"
+  if ! [[ "$max_attempts" =~ ^[0-9]+$ ]] || [[ "$max_attempts" -lt 1 ]]; then
+    max_attempts=1
+  fi
   summary_phase="checkpoint-fork"
   checkpoint_fork_log="$evidence_dir/checkpoint-fork.log"
-  run_tee "$checkpoint_fork_log" "$CRABBOX_BIN" checkpoint fork "$checkpoint_id"
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if [[ "$attempt" -gt 1 ]]; then
+      printf 'retrying checkpoint fork attempt %s/%s after host wait\n' "$attempt" "$max_attempts"
+      wait_for_host_available "$allocated_host" checkpoint
+    fi
+    set +e
+    run_tee_combined "$checkpoint_fork_log" "$CRABBOX_BIN" checkpoint fork "$checkpoint_id"
+    status=$?
+    set -e
+    if [[ "$status" -eq 0 ]]; then
+      break
+    fi
+    if [[ "$attempt" -eq "$max_attempts" ]]; then
+      blocker_message="checkpoint fork failed after $max_attempts attempt(s)"
+      return "$status"
+    fi
+  done
   checkpoint_fork_lease="$(checkpoint_fork_lease_from_log "$checkpoint_fork_log")"
   checkpoint_fork_lease_id="$checkpoint_fork_lease"
   if [[ -z "$checkpoint_fork_lease" ]]; then

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -11,6 +11,7 @@ region_preflight="${CRABBOX_MACOS_REGION_PREFLIGHT:-auto}"
 region_preflight_script="${CRABBOX_MACOS_REGION_PREFLIGHT_SCRIPT:-$ROOT/scripts/macos-host-region-preflight.sh}"
 region_preflight_command="${CRABBOX_MACOS_REGION_PREFLIGHT_COMMAND:-scripts/macos-host-region-preflight.sh}"
 iam_apply_command="${CRABBOX_MACOS_IAM_APPLY_COMMAND:-scripts/apply-macos-image-iam-policy.sh}"
+quota_request_command="${CRABBOX_MACOS_QUOTA_REQUEST_COMMAND:-scripts/request-macos-host-quota.sh}"
 instance_type="${CRABBOX_MACOS_TYPE:-mac2.metal}"
 image_name="${CRABBOX_MACOS_IMAGE_NAME:-crabbox-macos-arm64-$(date -u +%Y%m%d-%H%M)}"
 ttl="${CRABBOX_MACOS_TTL:-2h}"
@@ -917,6 +918,12 @@ else
   if ! jq -e 'any(.[]; (.value // 0) >= 1)' "$quota_log" >/dev/null; then
     blocker_message="EC2 Mac Dedicated Host quota is below 1 for $instance_type in $region"
     blocker_remediation="Request or raise the AWS EC2 Mac Dedicated Host quota for the selected host family in $region, then rerun the no-spend Mac host preflight."
+    blocker_commands="$(printf '%s\n' \
+      "$CRABBOX_REMEDIATION_BIN admin providers identity --provider aws --region $region --json > provider-identity.json" \
+      "$CRABBOX_REMEDIATION_BIN admin hosts quota --provider aws --target macos --region $region --type $instance_type --json > mac-host-quota.json" \
+      "$quota_request_command --identity provider-identity.json --quota mac-host-quota.json --region $region --profile auto" \
+      "$quota_request_command --identity provider-identity.json --quota mac-host-quota.json --region $region --profile auto --apply" \
+      "$region_preflight_command")"
     printf 'macOS lifecycle blocked before paid work: %s\n' "$blocker_message" >&2
     write_summary blocked host-quota
     exit 1

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -840,7 +840,7 @@ smoke_checkpoint_fork() {
       wait_for_host_available "$allocated_host" checkpoint
     fi
     set +e
-    run_tee_combined "$checkpoint_fork_log" "$CRABBOX_BIN" checkpoint fork "$checkpoint_id"
+    run_tee_combined "$checkpoint_fork_log" "$CRABBOX_BIN" checkpoint fork "$checkpoint_id" --desktop
     status=$?
     set -e
     if [[ "$status" -eq 0 ]]; then

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -793,7 +793,7 @@ create_checkpoint_from_source() {
     --id "$source_lease" \
     --name "$image_name-checkpoint" \
     --mode native \
-    --strategy disk-snapshot \
+    --strategy image \
     --wait \
     --wait-timeout "$image_wait_timeout"
   checkpoint_id="$(checkpoint_id_from_log "$checkpoint_create_log")"

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -95,6 +95,10 @@ if [[ "$1" == "admin" && ( "$2" == "mac-hosts" || "$2" == "hosts" ) ]]; then
         fi
       else
         : >"$state_dir/host"
+        if [[ "\${CRABBOX_FAKE_ALLOCATE_FAIL:-0}" == "1" ]]; then
+          printf 'coordinator POST /v1/admin/hosts?provider=aws&region=%s&target=macos: http 502: {"error":"mac_host_allocation_failed","message":"aws AllocateHosts: http 500: service unavailable"}\\n' "$region" >&2
+          exit 1
+        fi
         printf '[{"id":"h-mock","instanceType":"%s","state":"available"}]\\n' "$type"
       fi
       ;;
@@ -443,6 +447,35 @@ test("macOS lifecycle smoke blocks on missing Mac host quota before paid work", 
   const fakeLog = await readFile(run.fakeLog, "utf8");
   assert.match(fakeLog, /^admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2\.metal --json$/m);
   assert.doesNotMatch(fakeLog, /^admin hosts allocate --provider aws --target macos --region eu-west-1 --type mac2\.metal --force --json$/m);
+});
+
+test("macOS lifecycle smoke records paid host allocation failures", async () => {
+  const run = await setupRun();
+  const result = await runLifecycle({
+    CRABBOX_BIN: run.fake,
+    CRABBOX_FAKE_LOG: run.fakeLog,
+    CRABBOX_FAKE_STATE: run.fakeState,
+    CRABBOX_FAKE_NO_HOST: "1",
+    CRABBOX_FAKE_ALLOCATE_FAIL: "1",
+    CRABBOX_MACOS_ALLOCATE: "1",
+    CRABBOX_MACOS_ARTIFACT_DIR: run.artifacts,
+    CRABBOX_MACOS_IMAGE_NAME: "allocation-blocked",
+    CRABBOX_MACOS_WEBVNC_START_GRACE: "0s",
+  });
+
+  assert.equal(result.code, 1, result.stdout + result.stderr);
+  const summary = await readJSON(path.join(run.artifacts, "summary.json"));
+  assert.equal(summary.result, "blocked");
+  assert.equal(summary.phase, "host-allocation");
+  assert.match(summary.blocker.message, /mac host allocation failed/);
+  assert.match(summary.blocker.message, /AllocateHosts/);
+  assert.match(summary.blocker.remediation, /Retry the allocation/);
+  assert.equal(summary.evidence.hostAllocate, "evidence/mac-host-allocate.json");
+  await assertSummaryFileContains(run.artifacts, summary.evidence.hostAllocate, /mac_host_allocation_failed/);
+
+  const fakeLog = await readFile(run.fakeLog, "utf8");
+  assert.match(fakeLog, /^admin hosts allocate --provider aws --target macos --region eu-west-1 --type mac2\.metal --force --json$/m);
+  assert.doesNotMatch(fakeLog, /^warmup /m);
 });
 
 test("macOS lifecycle smoke selects a dry-run-ready configured region before paid work", async () => {

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -430,6 +430,13 @@ test("macOS lifecycle smoke blocks on missing Mac host quota before paid work", 
   assert.equal(summary.result, "blocked");
   assert.equal(summary.phase, "host-quota");
   assert.match(summary.blocker.message, /quota is below 1/);
+  assert.deepEqual(summary.blocker.commands, [
+    "crabbox admin providers identity --provider aws --region eu-west-1 --json > provider-identity.json",
+    "crabbox admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2.metal --json > mac-host-quota.json",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto",
+    "scripts/request-macos-host-quota.sh --identity provider-identity.json --quota mac-host-quota.json --region eu-west-1 --profile auto --apply",
+    "scripts/macos-host-region-preflight.sh",
+  ]);
   await assertSummaryFileContains(run.artifacts, summary.evidence.hostQuota, /Running Dedicated mac2 Hosts/);
   assert.equal(summary.evidence.hostAllocate, null);
 

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -617,7 +617,7 @@ test("macOS lifecycle smoke preserves full mock lifecycle evidence", async () =>
   assert.equal((fakeLog.match(/^webvnc daemon start\b/gm) ?? []).length, 4);
   assert.equal((fakeLog.match(/^webvnc status\b/gm) ?? []).length, 4);
   assert.match(fakeLog, /^checkpoint create --id cbx_source --name full-checkpoint --mode native --strategy image --wait --wait-timeout 60m$/m);
-  assert.match(fakeLog, /^checkpoint fork chk_macos$/m);
+  assert.match(fakeLog, /^checkpoint fork chk_macos --desktop$/m);
   assert.match(fakeLog, /^checkpoint delete chk_macos$/m);
   assert.match(fakeLog, /^admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2\.metal --json$/m);
   assert.match(fakeLog, /^admin hosts release h-mock --provider aws --target macos --region eu-west-1 --force$/m);
@@ -648,7 +648,7 @@ test("macOS lifecycle smoke retries checkpoint fork after transient host recycle
   await assertSummaryFileContains(run.artifacts, summary.evidence.checkpointFork, /cbx_checkpoint/);
 
   const fakeLog = await readFile(run.fakeLog, "utf8");
-  assert.equal((fakeLog.match(/^checkpoint fork chk_macos$/gm) ?? []).length, 2);
+  assert.equal((fakeLog.match(/^checkpoint fork chk_macos --desktop$/gm) ?? []).length, 2);
 });
 
 test("macOS lifecycle smoke forwards the selected region into warmup", async () => {

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -164,6 +164,11 @@ case "$1" in
     if [[ "$2" == "create" ]]; then
       printf 'checkpoint created id=chk_macos kind=aws-ami resource=ami-checkpoint state=available region=%s workdir=/Users/ec2-user/crabbox/crabbox\\n' "$region"
     elif [[ "$2" == "fork" ]]; then
+      if [[ "\${CRABBOX_FAKE_CHECKPOINT_FORK_FAIL_ONCE:-0}" == "1" && ! -f "$state_dir/checkpoint-fork-failed" ]]; then
+        : >"$state_dir/checkpoint-fork-failed"
+        printf 'coordinator POST /v1/leases: http 500: transient host recycle\\n' >&2
+        exit 42
+      fi
       printf 'checkpoint forked id=%s lease=cbx_checkpoint slug=checkpoint image=ami-checkpoint workdir=/Users/ec2-user/crabbox/crabbox\\n' "$3"
     elif [[ "$2" == "delete" ]]; then
       printf 'checkpoint deleted id=%s kind=aws-ami\\n' "$3"
@@ -183,7 +188,7 @@ function runLifecycle(env) {
   return new Promise((resolve, reject) => {
     const child = spawn("bash", [lifecycleScript], {
       cwd: repoRoot,
-      env: { ...process.env, ...env },
+      env: { ...process.env, CRABBOX_MACOS_HOST_WAIT_INTERVAL: "0s", ...env },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -616,6 +621,34 @@ test("macOS lifecycle smoke preserves full mock lifecycle evidence", async () =>
   assert.match(fakeLog, /^checkpoint delete chk_macos$/m);
   assert.match(fakeLog, /^admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2\.metal --json$/m);
   assert.match(fakeLog, /^admin hosts release h-mock --provider aws --target macos --region eu-west-1 --force$/m);
+});
+
+test("macOS lifecycle smoke retries checkpoint fork after transient host recycle", async () => {
+  const run = await setupRun();
+  const result = await runLifecycle({
+    CRABBOX_BIN: run.fake,
+    CRABBOX_FAKE_LOG: run.fakeLog,
+    CRABBOX_FAKE_STATE: run.fakeState,
+    CRABBOX_FAKE_NO_HOST: "1",
+    CRABBOX_FAKE_CHECKPOINT_FORK_FAIL_ONCE: "1",
+    CRABBOX_MACOS_ALLOCATE: "1",
+    CRABBOX_MACOS_ARTIFACT_DIR: run.artifacts,
+    CRABBOX_MACOS_IMAGE_NAME: "checkpoint-fork-retry",
+    CRABBOX_MACOS_WEBVNC_START_GRACE: "0s",
+  });
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stdout + result.stderr, /retrying checkpoint fork attempt 2\/2/);
+
+  const summary = await readJSON(path.join(run.artifacts, "summary.json"));
+  assert.equal(summary.result, "passed");
+  assert.equal(summary.phase, "candidate");
+  assert.equal(summary.leases.checkpointFork, "cbx_checkpoint");
+  await assertSummaryFileContains(run.artifacts, summary.evidence.hostWait.checkpointFork, /stable_count=2/);
+  await assertSummaryFileContains(run.artifacts, summary.evidence.checkpointFork, /cbx_checkpoint/);
+
+  const fakeLog = await readFile(run.fakeLog, "utf8");
+  assert.equal((fakeLog.match(/^checkpoint fork chk_macos$/gm) ?? []).length, 2);
 });
 
 test("macOS lifecycle smoke forwards the selected region into warmup", async () => {

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -162,11 +162,11 @@ case "$1" in
     ;;
   checkpoint)
     if [[ "$2" == "create" ]]; then
-      printf 'checkpoint created id=chk_macos kind=aws-ebs-snapshot resource=snap-mock state=available region=%s workdir=/Users/ec2-user/crabbox/crabbox\\n' "$region"
+      printf 'checkpoint created id=chk_macos kind=aws-ami resource=ami-checkpoint state=available region=%s workdir=/Users/ec2-user/crabbox/crabbox\\n' "$region"
     elif [[ "$2" == "fork" ]]; then
-      printf 'checkpoint forked id=%s lease=cbx_checkpoint slug=checkpoint image=snap-mock workdir=/Users/ec2-user/crabbox/crabbox\\n' "$3"
+      printf 'checkpoint forked id=%s lease=cbx_checkpoint slug=checkpoint image=ami-checkpoint workdir=/Users/ec2-user/crabbox/crabbox\\n' "$3"
     elif [[ "$2" == "delete" ]]; then
-      printf 'checkpoint deleted id=%s kind=aws-ebs-snapshot\\n' "$3"
+      printf 'checkpoint deleted id=%s kind=aws-ami\\n' "$3"
     fi
     ;;
   stop)
@@ -611,7 +611,7 @@ test("macOS lifecycle smoke preserves full mock lifecycle evidence", async () =>
   assert.equal((fakeLog.match(/^warmup\b/gm) ?? []).length, 3);
   assert.equal((fakeLog.match(/^webvnc daemon start\b/gm) ?? []).length, 4);
   assert.equal((fakeLog.match(/^webvnc status\b/gm) ?? []).length, 4);
-  assert.match(fakeLog, /^checkpoint create --id cbx_source --name full-checkpoint --mode native --strategy disk-snapshot --wait --wait-timeout 60m$/m);
+  assert.match(fakeLog, /^checkpoint create --id cbx_source --name full-checkpoint --mode native --strategy image --wait --wait-timeout 60m$/m);
   assert.match(fakeLog, /^checkpoint fork chk_macos$/m);
   assert.match(fakeLog, /^checkpoint delete chk_macos$/m);
   assert.match(fakeLog, /^admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2\.metal --json$/m);

--- a/scripts/request-macos-host-quota.sh
+++ b/scripts/request-macos-host-quota.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/request-macos-host-quota.sh --quota <mac-host-quota.json> --region <aws-region> [--identity <provider-identity.json>] [--profile <aws-profile|auto>] [--desired-value <number>] [--apply]
+
+Safely prepares or submits an AWS Service Quotas request for the selected EC2
+Mac Dedicated Host family. The script is dry-run by default and refuses to
+write unless --apply is passed with a provider identity whose AWS account
+matches the local AWS caller.
+
+Options:
+  --quota <file>          JSON from crabbox admin hosts quota --json
+  --region <region>       AWS region where the quota should be raised
+  --identity <file>       provider-identity.json from lifecycle evidence
+  --profile <name|auto>   AWS profile to use for sts/service-quotas commands
+  --desired-value <n>     requested quota value; default 1
+  --apply                 submit aws service-quotas request-service-quota-increase
+  -h, --help              show this help
+USAGE
+}
+
+quota_file=""
+identity_file=""
+region=""
+profile=""
+desired_value="1"
+apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quota)
+      quota_file="${2:?missing value for --quota}"
+      shift 2
+      ;;
+    --identity)
+      identity_file="${2:?missing value for --identity}"
+      shift 2
+      ;;
+    --region)
+      region="${2:?missing value for --region}"
+      shift 2
+      ;;
+    --profile)
+      profile="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    --desired-value)
+      desired_value="${2:?missing value for --desired-value}"
+      shift 2
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$quota_file" || -z "$region" ]]; then
+  usage >&2
+  exit 2
+fi
+if [[ ! -s "$quota_file" ]]; then
+  echo "quota file is missing or empty: $quota_file" >&2
+  exit 2
+fi
+if [[ "$apply" == 1 && -z "$identity_file" ]]; then
+  echo "refusing to submit quota request without --identity account guard" >&2
+  exit 2
+fi
+if [[ -n "$identity_file" && ! -s "$identity_file" ]]; then
+  echo "identity file is missing or empty: $identity_file" >&2
+  exit 2
+fi
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required" >&2
+  exit 127
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 127
+fi
+if ! jq -e -n --arg value "$desired_value" '$value | test("^[0-9]+([.][0-9]+)?$")' >/dev/null; then
+  echo "desired value must be numeric: $desired_value" >&2
+  exit 2
+fi
+
+quota_json="$(
+  jq -c '
+    map(select((.serviceCode // "") != "" and (.quotaCode // "") != ""))
+    | .[0] // empty
+  ' "$quota_file"
+)"
+if [[ -z "$quota_json" ]]; then
+  echo "quota file does not contain a visible EC2 Mac host quota" >&2
+  exit 1
+fi
+
+service_code="$(printf '%s\n' "$quota_json" | jq -r '.serviceCode')"
+quota_code="$(printf '%s\n' "$quota_json" | jq -r '.quotaCode')"
+quota_name="$(printf '%s\n' "$quota_json" | jq -r '.quotaName // "unknown quota"')"
+current_value="$(printf '%s\n' "$quota_json" | jq -r '(.value // 0) | tostring')"
+adjustable="$(printf '%s\n' "$quota_json" | jq -r '(.adjustable // false) | tostring')"
+
+if jq -e -n --argjson current "$current_value" --argjson desired "$desired_value" '$current >= $desired' >/dev/null; then
+  printf 'quota already sufficient: %s current=%s desired=%s region=%s\n' "$quota_name" "$current_value" "$desired_value" "$region"
+  exit 0
+fi
+
+if [[ "$adjustable" != "true" ]]; then
+  printf 'quota is not adjustable: %s (%s)\n' "$quota_name" "$quota_code" >&2
+  exit 1
+fi
+
+coordinator_account=""
+if [[ -n "$identity_file" ]]; then
+  coordinator_account="$(jq -r '.account // empty' "$identity_file")"
+  if [[ -z "$coordinator_account" ]]; then
+    echo "identity file does not include .account" >&2
+    exit 2
+  fi
+fi
+
+aws_account_for_profile() {
+  local profile_name="$1"
+  local -a account_cmd=(aws)
+  if [[ -n "$profile_name" ]]; then
+    account_cmd+=(--profile "$profile_name")
+  fi
+  "${account_cmd[@]}" sts get-caller-identity --query Account --output text
+}
+
+if [[ "$profile" == "auto" ]]; then
+  if [[ -z "$coordinator_account" ]]; then
+    echo "profile auto requires --identity" >&2
+    exit 2
+  fi
+  selected_profile=""
+  selected_default=0
+  checked_profiles=0
+  if candidate_account="$(aws_account_for_profile "" 2>/dev/null)"; then
+    checked_profiles=$((checked_profiles + 1))
+    printf 'checked_profile=default-credentials account=%s\n' "$candidate_account" >&2
+    if [[ "$candidate_account" == "$coordinator_account" ]]; then
+      selected_default=1
+    fi
+  else
+    checked_profiles=$((checked_profiles + 1))
+    printf 'checked_profile=default-credentials status=unusable\n' >&2
+  fi
+  if [[ "$selected_default" != "1" ]]; then
+    while IFS= read -r candidate_profile; do
+      [[ -n "$candidate_profile" ]] || continue
+      checked_profiles=$((checked_profiles + 1))
+      if candidate_account="$(aws_account_for_profile "$candidate_profile" 2>/dev/null)"; then
+        printf 'checked_profile=%s account=%s\n' "$candidate_profile" "$candidate_account" >&2
+        if [[ "$candidate_account" == "$coordinator_account" ]]; then
+          selected_profile="$candidate_profile"
+          break
+        fi
+      else
+        printf 'checked_profile=%s status=unusable\n' "$candidate_profile" >&2
+      fi
+    done < <(aws configure list-profiles)
+  fi
+
+  if [[ -z "$selected_profile" && "$selected_default" != "1" ]]; then
+    printf 'refusing to request quota: no local AWS profile matches coordinator account %s after checking %s profile(s)\n' "$coordinator_account" "$checked_profiles" >&2
+    exit 1
+  fi
+  if [[ "$selected_default" == "1" ]]; then
+    profile=""
+  else
+    profile="$selected_profile"
+  fi
+fi
+
+aws_base=(aws)
+if [[ -n "$profile" ]]; then
+  aws_base+=(--profile "$profile")
+fi
+
+if [[ -n "$coordinator_account" ]]; then
+  local_account="$("${aws_base[@]}" sts get-caller-identity --query Account --output text)"
+  if [[ "$local_account" != "$coordinator_account" ]]; then
+    printf 'refusing to request quota: local AWS account %s does not match coordinator account %s\n' "$local_account" "$coordinator_account" >&2
+    exit 1
+  fi
+else
+  local_account="$("${aws_base[@]}" sts get-caller-identity --query Account --output text)"
+fi
+
+cmd=(
+  "${aws_base[@]}"
+  service-quotas request-service-quota-increase
+  --service-code "$service_code"
+  --quota-code "$quota_code"
+  --desired-value "$desired_value"
+  --region "$region"
+)
+
+printf 'quota=%s\n' "$quota_name"
+printf 'quota_code=%s\n' "$quota_code"
+printf 'region=%s\n' "$region"
+printf 'current_value=%s\n' "$current_value"
+printf 'desired_value=%s\n' "$desired_value"
+printf 'local_account=%s\n' "$local_account"
+if [[ -n "$coordinator_account" ]]; then
+  printf 'coordinator_account=%s\n' "$coordinator_account"
+fi
+if [[ -n "$profile" ]]; then
+  printf 'aws_profile=%s\n' "$profile"
+fi
+
+if [[ "$apply" != 1 ]]; then
+  printf 'dry-run:'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  printf 'rerun with --apply to submit the quota increase request.\n'
+  exit 0
+fi
+
+printf '+'
+printf ' %q' "${cmd[@]}"
+printf '\n'
+"${cmd[@]}"

--- a/scripts/request-macos-host-quota.test.js
+++ b/scripts/request-macos-host-quota.test.js
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const quotaScript = path.join(scriptDir, "request-macos-host-quota.sh");
+
+async function setup(account = "123456789012", quotaValue = 0, adjustable = true) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crabbox-quota-request-test-"));
+  const bin = path.join(dir, "bin");
+  const log = path.join(dir, "aws.log");
+  const aws = path.join(bin, "aws");
+  await mkdir(bin);
+  await writeFile(
+    aws,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+if [[ "$1" == "configure" && "$2" == "list-profiles" ]]; then
+  printf '%s\\n' \${CRABBOX_FAKE_AWS_PROFILES:-default}
+  exit 0
+fi
+profile=""
+if [[ "\${1:-}" == "--profile" ]]; then
+  profile="$2"
+  shift 2
+fi
+if [[ "$1" == "sts" && "$2" == "get-caller-identity" ]]; then
+  if [[ -n "\${CRABBOX_FAKE_UNUSABLE_PROFILE:-}" && "$profile" == "\${CRABBOX_FAKE_UNUSABLE_PROFILE}" ]]; then
+    printf 'profile is unusable\\n' >&2
+    exit 254
+  fi
+  if [[ -n "\${CRABBOX_FAKE_MATCH_PROFILE:-}" && "$profile" == "\${CRABBOX_FAKE_MATCH_PROFILE}" ]]; then
+    printf '%s\\n' "${account}"
+  else
+    printf '%s\\n' "\${CRABBOX_FAKE_AWS_ACCOUNT:-${account}}"
+  fi
+  exit 0
+fi
+if [[ "$1" == "service-quotas" && "$2" == "request-service-quota-increase" ]]; then
+  printf '{"RequestedQuota":{"Id":"case-123"}}\\n'
+  exit 0
+fi
+printf 'unexpected aws args: %s\\n' "$*" >&2
+exit 2
+`,
+  );
+  await chmod(aws, 0o755);
+  const identity = path.join(dir, "provider-identity.json");
+  const quota = path.join(dir, "mac-host-quota.json");
+  await writeFile(
+    identity,
+    JSON.stringify({
+      account,
+      arn: `arn:aws:iam::${account}:user/crabbox-runner`,
+      region: "eu-west-1",
+      policyTarget: { type: "user", name: "crabbox-runner", source: "iam-user" },
+    }),
+  );
+  await writeFile(
+    quota,
+    JSON.stringify([
+      {
+        serviceCode: "ec2",
+        quotaCode: "L-5D8DADF5",
+        quotaName: "Running Dedicated mac2 Hosts",
+        value: quotaValue,
+        adjustable,
+        unit: "None",
+      },
+    ]),
+  );
+  return { dir, bin, log, identity, quota };
+}
+
+function runQuota(ctx, args = [], env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "bash",
+      [quotaScript, "--quota", ctx.quota, "--region", "eu-west-1", ...args],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, PATH: `${ctx.bin}:${process.env.PATH}`, ...env },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("quota request helper dry-runs the Service Quotas request", async () => {
+  const ctx = await setup();
+  const result = await runQuota(ctx, ["--identity", ctx.identity, "--desired-value", "1"]);
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /quota=Running Dedicated mac2 Hosts/);
+  assert.match(result.stdout, /current_value=0/);
+  assert.match(result.stdout, /desired_value=1/);
+  assert.match(result.stdout, /coordinator_account=123456789012/);
+  assert.match(result.stdout, /dry-run: aws service-quotas request-service-quota-increase/);
+  assert.match(result.stdout, /--quota-code L-5D8DADF5/);
+  assert.match(result.stdout, /--region eu-west-1/);
+
+  const log = await readFile(ctx.log, "utf8");
+  assert.match(log, /sts get-caller-identity/);
+  assert.doesNotMatch(log, /request-service-quota-increase/);
+});
+
+test("quota request helper submits only with --apply and account guard", async () => {
+  const ctx = await setup();
+  const result = await runQuota(ctx, ["--identity", ctx.identity, "--profile", "prod", "--apply"]);
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  const log = await readFile(ctx.log, "utf8");
+  assert.match(log, /--profile prod sts get-caller-identity --query Account --output text/);
+  assert.match(log, /--profile prod service-quotas request-service-quota-increase --service-code ec2 --quota-code L-5D8DADF5 --desired-value 1 --region eu-west-1/);
+});
+
+test("quota request helper auto-selects a matching profile", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runQuota(ctx, ["--identity", ctx.identity, "--profile", "auto"], {
+    CRABBOX_FAKE_AWS_ACCOUNT: "999999999999",
+    CRABBOX_FAKE_AWS_PROFILES: "default\nprod",
+    CRABBOX_FAKE_MATCH_PROFILE: "prod",
+  });
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /checked_profile=default account=999999999999/);
+  assert.match(result.stderr, /checked_profile=prod account=123456789012/);
+  assert.match(result.stdout, /aws_profile=prod/);
+  assert.match(result.stdout, /dry-run: aws --profile prod service-quotas request-service-quota-increase/);
+});
+
+test("quota request helper auto-selects default credentials", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runQuota(ctx, ["--identity", ctx.identity, "--profile", "auto"], {
+    CRABBOX_FAKE_AWS_PROFILES: "",
+  });
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /checked_profile=default-credentials account=123456789012/);
+  assert.doesNotMatch(result.stdout, /aws_profile=/);
+  assert.match(result.stdout, /dry-run: aws service-quotas request-service-quota-increase/);
+});
+
+test("quota request helper refuses mismatched accounts", async () => {
+  const ctx = await setup("123456789012");
+  const result = await runQuota(ctx, ["--identity", ctx.identity, "--apply"], {
+    CRABBOX_FAKE_AWS_ACCOUNT: "999999999999",
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /local AWS account 999999999999 does not match coordinator account 123456789012/);
+  const log = await readFile(ctx.log, "utf8");
+  assert.doesNotMatch(log, /request-service-quota-increase/);
+});
+
+test("quota request helper exits cleanly when quota is already sufficient", async () => {
+  const ctx = await setup("123456789012", 2);
+  const result = await runQuota(ctx, ["--desired-value", "1"]);
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /quota already sufficient/);
+  const log = await readFile(ctx.log, "utf8").catch(() => "");
+  assert.equal(log, "");
+});
+
+test("quota request helper exits cleanly when non-adjustable quota is already sufficient", async () => {
+  const ctx = await setup("123456789012", 2, false);
+  const result = await runQuota(ctx, ["--desired-value", "1"]);
+
+  assert.equal(result.code, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /quota already sufficient/);
+  const log = await readFile(ctx.log, "utf8").catch(() => "");
+  assert.equal(log, "");
+});
+
+test("quota request helper refuses non-adjustable quotas", async () => {
+  const ctx = await setup("123456789012", 0, false);
+  const result = await runQuota(ctx);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /quota is not adjustable/);
+});

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1156,7 +1156,7 @@ export class EC2SpotClient {
     const properties = record(host["hostProperties"]);
     const macHost: AWSMacHost = {
       id: asString(host["hostId"]),
-      state: asString(host["hostState"]),
+      state: asString(host["hostState"] ?? host["state"]),
       region: this.region,
       availabilityZone: asString(host["availabilityZone"]),
       instanceType: asString(properties["instanceType"] ?? host["instanceType"]),
@@ -1426,7 +1426,9 @@ export function awsMacHostIDFromDescribeHosts(
       const hostID = asString(host["hostId"]);
       return hostID && hostID !== excludedHostID;
     });
-  const available = hosts.find((host) => asString(host["hostState"]) === "available");
+  const available = hosts.find(
+    (host) => asString(host["hostState"] ?? host["state"]) === "available",
+  );
   return asString((available ?? hosts[0] ?? {})["hostId"]);
 }
 

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -196,6 +196,16 @@ describe("aws provider", () => {
         "h-stale",
       ),
     ).toBe("h-usable");
+    expect(
+      awsMacHostIDFromDescribeHosts({
+        hostSet: {
+          item: [
+            { hostId: "h-stale", state: "released" },
+            { hostId: "h-live", state: "available" },
+          ],
+        },
+      }),
+    ).toBe("h-live");
   });
 
   it("parses EC2 host id sets from AllocateHosts responses", () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2718,7 +2718,7 @@ describe("fleet lease identity and idle", () => {
           <hostSet>
             <item>
               <hostId>h-000000000001</hostId>
-              <hostState>available</hostState>
+              <state>available</state>
               <availabilityZone>eu-west-1a</availabilityZone>
               <autoPlacement>off</autoPlacement>
               <allocationTime>2026-05-15T00:00:00Z</allocationTime>


### PR DESCRIPTION
## Summary

Adds AWS macOS image-run support and the remediation surface needed to run brokered macOS image bakes with WebVNC and AMI-backed checkpoint proof.

- Adds provider-neutral host/provider admin commands and config (`admin hosts`, `admin providers`, `CRABBOX_HOST_ID`) while keeping AWS compatibility aliases.
- Adds guarded EC2 Mac Dedicated Host quota/IAM remediation helpers plus no-spend coordinator audit evidence for quota, allocation dry-run, IAM dry-run, quota-request dry-run, blockers, and next commands.
- Adds direct AWS AMI checkpoint creation for non-brokered AWS Linux/macOS leases using `crabbox checkpoint create --mode native` / `--strategy image` without a coordinator.
- Preserves direct AMI account, backing snapshot, resolved host, and direct-backend metadata through create/wait/inspect/delete/fork so private AMIs and macOS forks route through the correct AWS account/provider path.
- Maps brokered and direct AWS macOS native snapshot requests to AMI-backed checkpoints because raw EC2 Mac root EBS snapshots do not relaunch reliably.
- Hardens the macOS lifecycle smoke around reusable host detection, existing lease commands, paid allocation blockers, WebVNC evidence, checkpoints, cleanup, and artifact-relative summaries.
- Updates checkpoint/WebVNC/infrastructure docs and keeps release notes under `0.15.1 - Unreleased`.

## Validation

Head: `252814a7b402be1155ab9449cabaae095de9df3d`.

- GitHub PR checks are green: Analyze actions/go/javascript-typescript, CodeQL, Docs, Go, Plugin, Release Check, Socket project/report checks, Worker.
- `node --test scripts/macos-image-lifecycle-smoke.test.js`
- `go test ./internal/cli -run 'TestRunArtifactCollectScriptRecursiveGlob|TestArtifactGlobSearchRootUsesLiteralPrefix|TestDeleteImageCheckpointRefusesAccountMismatchBeforeDescribe|TestCheckpointDelete|TestApplyAWSAMICheckpointForkConfig' -count=1`
- `go test ./internal/cli -run 'TestRunArtifactCollectScriptExcludesEnvProfiles|TestRunArtifactCollectScriptRecursiveGlob|TestArtifactGlobSearchRootUsesLiteralPrefix|TestDeleteImageCheckpointRefusesAccountMismatchBeforeDescribe|TestCheckpointDelete|TestApplyAWSAMICheckpointForkConfig' -count=1`
- `go build -trimpath -ldflags "-s -w -X github.com/openclaw/crabbox/internal/cli.version=0.15.1-dev" -o bin/crabbox ./cmd/crabbox`
- `git diff --check`
- `codex review --base origin/main` found artifact glob and direct checkpoint delete guard issues; both are fixed in pushed follow-up commits.
- `codex review --commit HEAD` is clean on the latest review-fix commit.

## Live macOS proof

Completed in `eu-west-1` on an existing `mac2.metal` host, then repeated through the brokered coordinator path after rebasing and review fixes.

- Source brokered macOS lease booted on macOS 14.8.5 / Darwin 23.6.0 arm64.
- Source WebVNC bridge connected and collected doctor, metadata, screenshot, and WebVNC status artifacts.
- Native checkpoint creation produced an AMI-backed checkpoint; checkpoint inspect/delete worked, including remote AMI cleanup.
- Checkpoint fork with `--desktop` booted macOS 14.8.5 / Darwin 23.6.0 arm64, connected WebVNC, collected artifacts, and released cleanly.
- Candidate AMI booted a fresh macOS lease, connected WebVNC, collected artifacts, and released cleanly. Candidate bootstrap was slow, just under the 45 minute wait window, but completed without a product failure.
- Proof AMIs and brokered leases created by the final run were cleaned up after validation.

## Infra notes

- Paid `mac-m4.metal` allocation dry-run/quota looked ready in `eu-west-1`, but real AWS `AllocateHosts` returned HTTP 500 in both available zones and created no usable host.
- Other checked regions/types did not have usable quota for this account during validation, so the passing live proof uses `eu-west-1 mac2.metal`.
