### PR TITLE
fix: preflight raw JS command runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Fixed
 
+- Fixed raw SSH-provider JS package command failures so Crabbox probes obvious `pnpm`, `npm`, `node`, `corepack`, `yarn`, and `bun` entrypoints before syncing and fails with hydration/setup guidance instead of an empty `exit 127` tail.
 - Fixed macOS image lifecycle region-preflight blockers so they preserve guarded IAM helper remediation commands from the region preflight evidence instead of falling back to manual account-match snippets.
 - Fixed macOS image lifecycle cleanup so script-allocated EC2 Mac Dedicated Hosts are released from failure traps when host release is requested.
 - Fixed EC2 Mac Dedicated Host allocation and release handling so paid host IDs returned by AWS are not retried in another availability zone after post-allocation describe failures, and failed `ReleaseHosts` results are surfaced instead of reported as released.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -448,6 +448,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	}
 	contextPrinted := false
 	preflightPrinted := false
+	rawJSRuntimePreflightDone := false
 	printContext := func(currentTarget SSHTarget) {
 		if contextPrinted {
 			return
@@ -469,6 +470,47 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		hydrateSupported := supportsActionsRunnerTarget(hydrateTarget)
 		printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
 		preflightPrinted = true
+	}
+	preflightRawJSRuntime := func(currentTarget SSHTarget) error {
+		if rawJSRuntimePreflightDone {
+			return nil
+		}
+		if hydratedByActions || script != nil || *syncOnly {
+			rawJSRuntimePreflightDone = true
+			return nil
+		}
+		if runEnvProvidesPath(envSelection.Effective, currentTarget) {
+			rawJSRuntimePreflightDone = true
+			return nil
+		}
+		tools := commandRuntimePreflightTools(command, *shellMode)
+		if len(tools) == 0 {
+			rawJSRuntimePreflightDone = true
+			return nil
+		}
+		missing, err := probeMissingRemoteTools(ctx, currentTarget, tools)
+		if err != nil {
+			return exit(5, "remote JS runtime preflight failed before sync: %v", err)
+		}
+		if len(missing) == 0 {
+			rawJSRuntimePreflightDone = true
+			return nil
+		}
+		if *keepOnFailure {
+			if acquired && !*keep {
+				keepFailedLease = true
+			}
+			printKeepOnFailureSSHHint(a.Stderr, cfg, leaseID, server, currentTarget)
+		}
+		hydrateTarget := currentTarget
+		if hydrateTarget.TargetOS == "" {
+			hydrateTarget.TargetOS = cfg.TargetOS
+		}
+		if hydrateTarget.WindowsMode == "" {
+			hydrateTarget.WindowsMode = cfg.WindowsMode
+		}
+		suggestion := rawJSRuntimeHydrateSuggestion(cfg, hydrateTarget, leaseID, acquired, *keep, *keepOnFailure)
+		return rawJSRuntimeMissingError(cfg, missing, command, *shellMode, suggestion)
 	}
 	if !*noSync {
 		syncStart := time.Now()
@@ -498,6 +540,9 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 				return recordFailure(err)
 			}
 			exitNodeEgressChecked = true
+		}
+		if err := preflightRawJSRuntime(target); err != nil {
+			return recordFailure(err)
 		}
 		recorder.CaptureTelemetryStart(ctx, target)
 		recorder.StartTelemetrySampler(ctx, target)
@@ -708,6 +753,9 @@ afterSync:
 			return recordFailure(exit(7, "create remote workdir: %v", err))
 		}
 	}
+	if err := preflightRawJSRuntime(target); err != nil {
+		return recordFailure(err)
+	}
 	if len(envSelection.Profile) > 0 {
 		profileEnvFile = runEnvProfilePath(firstNonBlank(recorder.runID, leaseID, "run"))
 		envHelperPath := ""
@@ -899,6 +947,8 @@ afterSync:
 			}
 			printKeepOnFailureSSHHint(a.Stderr, cfg, leaseID, server, target)
 		}
+		hydrateSuggestion := rawJSRuntimeHydrateSuggestion(cfg, target, leaseID, acquired, *keep, *keepOnFailure)
+		printCommandNotFoundHint(a.Stderr, cfg, target, leaseID, command, *shellMode, code, hydratedByActions, hydrateSuggestion)
 		printFailureTail(a.Stderr, "stdout", stdoutTail, *captureStdout)
 		printFailureTail(a.Stderr, "stderr", stderrTail, *captureStderr)
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
@@ -1010,27 +1060,342 @@ func shouldSeedRemotePruneManifest(hydratedByActions, fullResync bool) bool {
 }
 
 func commandNeedsHydrationHint(command []string, shellMode bool) bool {
-	if len(command) == 0 {
-		return false
+	return len(commandRuntimePreflightTools(command, shellMode)) > 0
+}
+
+func rawJSRuntimeHydrateSuggestion(cfg Config, target SSHTarget, leaseID string, acquired, keep, keepOnFailure bool) string {
+	if strings.TrimSpace(cfg.Actions.Workflow) == "" {
+		return ""
 	}
-	words := command
-	if shellMode || len(command) == 1 {
-		words = strings.Fields(strings.Join(command, " "))
+	if !acquired || keep || keepOnFailure {
+		return hydrateCommandSuggestion(cfg, target, leaseID, supportsActionsRunnerTarget(target))
 	}
-	for len(words) > 0 && words[0] == "env" {
-		words = words[1:]
-		for len(words) > 0 && strings.Contains(words[0], "=") {
-			words = words[1:]
+	return "rerun with --keep and then hydrate the kept lease"
+}
+
+func commandRuntimePreflightTools(command []string, shellMode bool) []string {
+	words := commandWords(command, shellMode)
+	if shellWordsContainFailureFallback(words) {
+		return nil
+	}
+	var tools []string
+	for len(words) > 0 {
+		segment, rest := nextShellCommandSegment(words)
+		tool, skip := commandSegmentRuntimePreflightTool(segment)
+		if skip {
+			if len(tools) == 0 {
+				return nil
+			}
+			return tools
 		}
+		if tool != "" {
+			tools = appendUniqueStrings(tools, tool)
+		}
+		words = rest
 	}
-	for _, word := range words {
-		word = strings.Trim(word, "'\";|&()")
-		switch word {
-		case "pnpm", "npm", "node", "npx", "corepack", "yarn", "bun":
+	return tools
+}
+
+func commandSegmentRuntimePreflightTool(words []string) (tool string, skip bool) {
+	var customPath bool
+	words, customPath = stripCommandEnvPrefixes(words)
+	if customPath {
+		return "", true
+	}
+	words = stripSudoCommandPrefix(words)
+	words, customPath = stripCommandEnvPrefixes(words)
+	if customPath {
+		return "", true
+	}
+	if len(words) == 0 {
+		return "", false
+	}
+	first := cleanCommandWord(words[0])
+	if strings.Contains(first, "/") && !strings.HasPrefix(first, "/") {
+		return "", true
+	}
+	base := commandBase(first)
+	if commandSegmentSetsPath(base, words[1:]) {
+		return "", true
+	}
+	if commandSegmentSetsUpJSRuntime(base, words[1:]) {
+		return "", true
+	}
+	switch base {
+	case "pnpm", "npm", "npx", "corepack", "yarn", "bun":
+		return first, false
+	case "node":
+		return first, false
+	}
+	if commandMayInstallRuntime(base) {
+		return "", true
+	}
+	return "", false
+}
+
+func runEnvProvidesPath(env map[string]string, target SSHTarget) bool {
+	for key := range env {
+		if key == "PATH" || isWindowsNativeTarget(target) && strings.EqualFold(key, "PATH") {
 			return true
 		}
 	}
 	return false
+}
+
+func stripCommandEnvPrefixes(words []string) ([]string, bool) {
+	for len(words) > 0 && commandBase(cleanCommandWord(words[0])) == "env" {
+		var customPath bool
+		words, customPath = stripEnvCommandPrefix(words[1:])
+		if customPath {
+			return nil, true
+		}
+	}
+	for len(words) > 0 && shellAssignmentWord(words[0]) {
+		if shellAssignmentKey(words[0]) == "PATH" {
+			return nil, true
+		}
+		words = words[1:]
+	}
+	return words, false
+}
+
+func commandSegmentSetsPath(base string, args []string) bool {
+	if base != "export" {
+		return false
+	}
+	for _, arg := range args {
+		if shellAssignmentWord(cleanCommandWord(arg)) && shellAssignmentKey(cleanCommandWord(arg)) == "PATH" {
+			return true
+		}
+	}
+	return false
+}
+
+func commandSegmentSetsUpJSRuntime(base string, args []string) bool {
+	switch base {
+	case "corepack":
+		return len(args) > 0 && (cleanCommandWord(args[0]) == "enable" || cleanCommandWord(args[0]) == "prepare")
+	case "npm":
+		if len(args) == 0 {
+			return false
+		}
+		action := cleanCommandWord(args[0])
+		if action != "install" && action != "i" && action != "add" {
+			return false
+		}
+		for _, arg := range args[1:] {
+			arg = cleanCommandWord(arg)
+			if arg == "-g" || arg == "--global" || strings.HasPrefix(arg, "--location=global") {
+				return true
+			}
+		}
+	case "yarn":
+		return len(args) >= 2 && cleanCommandWord(args[0]) == "global" && cleanCommandWord(args[1]) == "add"
+	}
+	return false
+}
+
+func stripSudoCommandPrefix(words []string) []string {
+	if len(words) == 0 || commandBase(cleanCommandWord(words[0])) != "sudo" {
+		return words
+	}
+	words = words[1:]
+	for len(words) > 0 {
+		word := cleanCommandWord(words[0])
+		if word == "--" {
+			return words[1:]
+		}
+		if word == "-E" || word == "-n" || word == "-S" || word == "-H" || word == "-k" || word == "-v" {
+			words = words[1:]
+			continue
+		}
+		if word == "-u" || word == "-g" || word == "-C" || word == "-p" || word == "-h" {
+			if len(words) < 2 {
+				return nil
+			}
+			words = words[2:]
+			continue
+		}
+		if strings.HasPrefix(word, "-u") || strings.HasPrefix(word, "-g") || strings.HasPrefix(word, "-C") || strings.HasPrefix(word, "-p") || strings.HasPrefix(word, "-h") {
+			words = words[1:]
+			continue
+		}
+		if strings.HasPrefix(word, "-") {
+			return nil
+		}
+		return words
+	}
+	return nil
+}
+
+func nextShellCommandSegment(words []string) ([]string, []string) {
+	for i, word := range words {
+		if isShellCommandSeparator(word) {
+			return words[:i], words[i+1:]
+		}
+	}
+	return words, nil
+}
+
+func isShellCommandSeparator(word string) bool {
+	switch strings.TrimSpace(word) {
+	case "&&", ";", "|":
+		return true
+	default:
+		return false
+	}
+}
+
+func commandMayInstallRuntime(base string) bool {
+	switch base {
+	case "apt", "apt-get", "apk", "brew", "dnf", "yum", "curl", "wget", "mise", "asdf", "volta", "nvm", "source", ".", "bash", "sh", "zsh":
+		return true
+	default:
+		return false
+	}
+}
+
+func shellWordsContainFailureFallback(words []string) bool {
+	for _, word := range words {
+		if strings.TrimSpace(word) == "||" {
+			return true
+		}
+	}
+	return false
+}
+
+func stripEnvCommandPrefix(words []string) ([]string, bool) {
+	for len(words) > 0 {
+		word := cleanCommandWord(words[0])
+		if shellAssignmentWord(word) {
+			if shellAssignmentKey(word) == "PATH" {
+				return nil, true
+			}
+			words = words[1:]
+			continue
+		}
+		if word == "--" {
+			return words[1:], false
+		}
+		if word == "-u" || word == "--unset" || word == "-C" || word == "--chdir" {
+			if len(words) < 2 {
+				return nil, false
+			}
+			words = words[2:]
+			continue
+		}
+		if word == "-S" || word == "--split-string" {
+			return nil, false
+		}
+		if strings.HasPrefix(word, "--unset=") || strings.HasPrefix(word, "--chdir=") {
+			words = words[1:]
+			continue
+		}
+		if word == "-i" || word == "-" || word == "--ignore-environment" || word == "-0" || word == "--null" {
+			words = words[1:]
+			continue
+		}
+		if strings.HasPrefix(word, "-") {
+			return nil, false
+		}
+		return words, false
+	}
+	return nil, false
+}
+
+func commandWords(command []string, shellMode bool) []string {
+	if len(command) == 0 {
+		return nil
+	}
+	if shellMode || len(command) == 1 {
+		return shellCommandWords(strings.Join(command, " "))
+	}
+	return append([]string(nil), command...)
+}
+
+func shellCommandWords(value string) []string {
+	var words []string
+	var current strings.Builder
+	var quote rune
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		words = append(words, current.String())
+		current.Reset()
+	}
+	for i, r := range value {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			continue
+		}
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			flush()
+			continue
+		}
+		if i > 0 && ((value[i-1] == '&' && r == '&') || (value[i-1] == '|' && r == '|')) {
+			continue
+		}
+		if r == ';' || r == '|' {
+			flush()
+			if r == '|' && i+1 < len(value) && value[i+1] == '|' {
+				words = append(words, "||")
+				continue
+			}
+			words = append(words, string(r))
+			continue
+		}
+		if r == '&' && i+1 < len(value) && value[i+1] == '&' {
+			flush()
+			words = append(words, "&&")
+			continue
+		}
+		current.WriteRune(r)
+	}
+	flush()
+	return words
+}
+
+func shellAssignmentWord(word string) bool {
+	if strings.HasPrefix(word, "-") {
+		return false
+	}
+	idx := strings.Index(word, "=")
+	if idx <= 0 {
+		return false
+	}
+	name := word[:idx]
+	for i, r := range name {
+		if !(r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func shellAssignmentKey(word string) string {
+	key, _, _ := strings.Cut(word, "=")
+	return key
+}
+
+func cleanCommandWord(word string) string {
+	word = strings.TrimSpace(word)
+	return strings.Trim(word, "'\";|&()")
+}
+
+func commandBase(word string) string {
+	if idx := strings.LastIndex(word, "/"); idx >= 0 {
+		word = word[idx+1:]
+	}
+	return word
 }
 
 func gitHydrateBaseSHA(repo Repo, baseRef string) string {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -232,6 +232,117 @@ func hydrateCommandSuggestion(cfg Config, target SSHTarget, leaseID string, supp
 	return command
 }
 
+func probeMissingRemoteTools(ctx context.Context, target SSHTarget, tools []string) ([]string, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	command := remoteMissingToolsCommand(tools)
+	if isWindowsNativeTarget(target) {
+		command = windowsRemoteMissingToolsCommand(tools)
+	}
+	out, err := runSSHCombinedOutput(ctx, target, command)
+	if err != nil {
+		return nil, err
+	}
+	return parseMissingRemoteToolsOutput(out), nil
+}
+
+const missingRemoteToolPrefix = "__crabbox_missing_tool__:"
+
+func remoteMissingToolsCommand(tools []string) string {
+	var b strings.Builder
+	b.WriteString("for tool in")
+	for _, tool := range tools {
+		b.WriteString(" ")
+		b.WriteString(shellQuote(tool))
+	}
+	b.WriteString(`; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf '` + missingRemoteToolPrefix + `%s\n' "$tool"
+  fi
+done
+`)
+	return "bash -lc " + shellQuote(b.String())
+}
+
+func windowsRemoteMissingToolsCommand(tools []string) string {
+	var b strings.Builder
+	b.WriteString("foreach ($tool in @(")
+	for i, tool := range tools {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(psQuote(tool))
+	}
+	b.WriteString(`)) {
+  if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+    Write-Output (` + psQuote(missingRemoteToolPrefix) + ` + $tool)
+  }
+}
+`)
+	return powershellCommand(b.String())
+}
+
+func parseMissingRemoteToolsOutput(value string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, line := range strings.Split(value, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, missingRemoteToolPrefix) {
+			continue
+		}
+		line = strings.TrimPrefix(line, missingRemoteToolPrefix)
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	return out
+}
+
+func rawJSRuntimeMissingError(cfg Config, missing []string, command []string, shellMode bool, hydrateSuggestion string) error {
+	parts := []string{
+		fmt.Sprintf("remote raw workspace missing JS runtime tool(s): %s", strings.Join(missing, ",")),
+		fmt.Sprintf("command starts with %q and would fail before project code runs", commandStartForMessage(command, shellMode)),
+	}
+	if hydrateSuggestion != "" {
+		parts = append(parts, "hydrate first: "+hydrateSuggestion)
+	} else if strings.TrimSpace(cfg.Actions.Workflow) == "" {
+		parts = append(parts, "configure actions.workflow and hydrate the lease first")
+	}
+	parts = append(parts, "or include Node/Corepack/package-manager setup before the command")
+	parts = append(parts, "or choose a provider/image with the JS toolchain")
+	return exit(5, "%s", strings.Join(parts, "; "))
+}
+
+func printCommandNotFoundHint(w io.Writer, cfg Config, target SSHTarget, leaseID string, command []string, shellMode bool, exitCode int, hydrated bool, hydrateSuggestion string) {
+	if w == nil || exitCode != 127 || hydrated {
+		return
+	}
+	tools := commandRuntimePreflightTools(command, shellMode)
+	if len(tools) == 0 {
+		return
+	}
+	suggestion := ""
+	if strings.TrimSpace(cfg.Actions.Workflow) != "" && hydrateSuggestion != "" {
+		suggestion = "; hydrate first: " + hydrateSuggestion
+	}
+	fmt.Fprintf(w, "hint: exit 127 usually means command not found; JS runtime tool(s) needed: %s%s; or include runtime setup before the command\n", strings.Join(tools, ","), suggestion)
+}
+
+func commandStartForMessage(command []string, shellMode bool) string {
+	tools := commandRuntimePreflightTools(command, shellMode)
+	if len(tools) > 0 {
+		return tools[0]
+	}
+	words := commandWords(command, shellMode)
+	if len(words) == 0 {
+		return ""
+	}
+	return commandBase(cleanCommandWord(words[0]))
+}
+
 func remoteCapabilityPreflightCommand(workdir string, env map[string]string, envFiles []string, tools []string) string {
 	script := `printf 'user=%s\n' "$(id -un 2>/dev/null || whoami 2>/dev/null || printf unknown)"
 printf 'cwd=%s\n' "$(pwd -P 2>/dev/null || pwd)"

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -115,10 +115,11 @@ func (b runEnvProfileTestBackend) Acquire(context.Context, AcquireRequest) (Leas
 	return LeaseTarget{
 		Server: Server{Provider: b.spec.Name},
 		SSH: SSHTarget{
-			User:     "crabbox",
-			Host:     "127.0.0.1",
-			Port:     os.Getenv("CRABBOX_FAKE_SSH_PORT"),
-			TargetOS: targetLinux,
+			User:           "crabbox",
+			Host:           "127.0.0.1",
+			Port:           os.Getenv("CRABBOX_FAKE_SSH_PORT"),
+			TargetOS:       targetLinux,
+			SSHConfigProxy: os.Getenv("CRABBOX_FAKE_SSH_PROXY") == "1",
 		},
 		LeaseID: "cbx_env_profile_test",
 	}, nil
@@ -427,6 +428,154 @@ exit 0
 	}
 	if !strings.Contains(string(logData), "rm -f --") || !strings.Contains(string(logData), ".crabbox/env/cbx_env_profile_test.env") {
 		t.Fatalf("cleanup command missing from ssh log:\n%s", logData)
+	}
+}
+
+func TestRunCommandHardFailsMissingJSRuntimeBeforeCommand(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	logPath := filepath.Join(dir, "ssh.log")
+	script := `#!/bin/sh
+cmd=""
+for arg do
+  cmd="$arg"
+done
+printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *"command -v"*) printf '` + missingRemoteToolPrefix + `pnpm\n' ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--keep-on-failure",
+		"--", "pnpm", "test:docs",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("error=%v, want exit 5", err)
+	}
+	for _, want := range []string{
+		"remote raw workspace missing JS runtime tool(s): pnpm",
+		"command starts with \"pnpm\"",
+		"would fail before project code runs",
+	} {
+		if !strings.Contains(exitErr.Message, want) {
+			t.Fatalf("message missing %q in %q", want, exitErr.Message)
+		}
+	}
+	if strings.Contains(stderr.String(), "running on ") {
+		t.Fatalf("remote command should not start after JS preflight failure:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=cbx_env_profile_test") {
+		t.Fatalf("keep-on-failure hint missing:\n%s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "releasing cbx_env_profile_test") {
+		t.Fatalf("preflight failure should keep lease:\n%s", stderr.String())
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(logData), "pnpm test:docs") {
+		t.Fatalf("user command reached ssh log:\n%s", logData)
+	}
+}
+
+func TestRunCommandSyncOnlyIgnoresJSCommandRuntime(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	logPath := filepath.Join(dir, "ssh.log")
+	script := `#!/bin/sh
+cmd=""
+for arg do
+  cmd="$arg"
+done
+printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *"command -v"*) printf 'pnpm\n' ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--sync-only",
+		"--", "pnpm", "test",
+	})
+	if err != nil {
+		t.Fatalf("sync-only should ignore command runtime: %v", err)
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(logData), "command -v") {
+		t.Fatalf("sync-only should not probe command runtime:\n%s", logData)
+	}
+}
+
+func TestRunCommandSkipsJSRuntimePreflightWithForwardedPATH(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	logPath := filepath.Join(dir, "ssh.log")
+	script := `#!/bin/sh
+cmd=""
+for arg do
+  cmd="$arg"
+done
+printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *"command -v"*) printf '` + missingRemoteToolPrefix + `pnpm\n' ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--allow-env", "PATH",
+		"--", "pnpm", "test",
+	})
+	if err != nil {
+		t.Fatalf("forwarded PATH should skip hard runtime preflight: %v", err)
+	}
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(logData), "command -v") {
+		t.Fatalf("forwarded PATH should skip command runtime probe:\n%s", logData)
+	}
+	if !strings.Contains(string(logData), "pnpm") {
+		t.Fatalf("user command missing from ssh log:\n%s", logData)
 	}
 }
 
@@ -1329,8 +1478,191 @@ func TestCommandNeedsHydrationHint(t *testing.T) {
 	if !commandNeedsHydrationHint([]string{"env NODE_OPTIONS=--max-old-space-size=4096 pnpm test"}, true) {
 		t.Fatal("expected shell pnpm command to need hydration hint")
 	}
+	if !commandNeedsHydrationHint([]string{"pnpm", "test:docs"}, false) {
+		t.Fatal("expected pnpm docs command to need hydration hint")
+	}
+	if !commandNeedsHydrationHint([]string{"node", "scripts/check.mjs"}, false) {
+		t.Fatal("expected node script command to need hydration hint")
+	}
 	if commandNeedsHydrationHint([]string{"go", "test", "./..."}, false) {
 		t.Fatal("go test should not need hydration hint")
+	}
+}
+
+func TestCommandRuntimePreflightToolsFocusesEntrypoint(t *testing.T) {
+	if got := strings.Join(commandRuntimePreflightTools([]string{"env CI=1 pnpm test"}, true), ","); got != "pnpm" {
+		t.Fatalf("tools=%q want pnpm", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"env -u NODE_OPTIONS pnpm test"}, true), ","); got != "pnpm" {
+		t.Fatalf("tools=%q want pnpm through env -u", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"env", "--unset=NODE_OPTIONS", "pnpm", "test"}, false), ","); got != "pnpm" {
+		t.Fatalf("tools=%q want pnpm through env --unset", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"/usr/bin/env", "pnpm", "test"}, false), ","); got != "pnpm" {
+		t.Fatalf("tools=%q want pnpm through /usr/bin/env", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"/opt/node/bin/pnpm", "test"}, false), ","); got != "/opt/node/bin/pnpm" {
+		t.Fatalf("tools=%q want explicit pnpm path", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"./scripts/pnpm", "test"}, false), ","); got != "" {
+		t.Fatalf("repo-relative wrapper should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"env PATH=/opt/node/bin:$PATH pnpm test"}, true), ","); got != "" {
+		t.Fatalf("custom PATH command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"export PATH=/opt/node/bin:$PATH; pnpm test"}, true), ","); got != "" {
+		t.Fatalf("export PATH setup should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"bash", "-lc", "source ~/.nvm/nvm.sh && pnpm test"}, false), ","); got != "" {
+		t.Fatalf("bash setup wrapper should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"sudo apt-get update && sudo apt-get install -y nodejs npm && npm test"}, true), ","); got != "" {
+		t.Fatalf("sudo runtime setup command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"corepack enable && pnpm install"}, true), ","); got != "" {
+		t.Fatalf("corepack setup command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"npm install -g pnpm && pnpm test"}, true), ","); got != "" {
+		t.Fatalf("npm global setup command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"cd web && pnpm test"}, true), ","); got != "pnpm" {
+		t.Fatalf("shell cd prefix should still preflight pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"echo starting; pnpm install"}, true), ","); got != "pnpm" {
+		t.Fatalf("shell echo prefix should still preflight pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{`echo "ok&&pnpm"`}, true), ","); got != "" {
+		t.Fatalf("quoted shell separator should not expose pnpm preflight, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"echo 'ok; pnpm'"}, true), ","); got != "" {
+		t.Fatalf("quoted semicolon should not expose pnpm preflight, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"node --version && pnpm test"}, true), ","); got != "node,pnpm" {
+		t.Fatalf("multi-segment JS command should preflight node and pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"pnpm test && bash scripts/post.sh"}, true), ","); got != "pnpm" {
+		t.Fatalf("later setup wrapper should not erase earlier pnpm preflight, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"pnpm test && curl -fsSL https://example.invalid/setup.sh | bash"}, true), ","); got != "pnpm" {
+		t.Fatalf("later installer command should not erase earlier pnpm preflight, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"sudo", "-E", "pnpm", "test"}, false), ","); got != "pnpm" {
+		t.Fatalf("sudo JS command should preflight pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"sudo", "env", "CI=1", "pnpm", "test"}, false), ","); got != "pnpm" {
+		t.Fatalf("sudo env JS command should preflight pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"sudo", "CI=1", "pnpm", "test"}, false), ","); got != "pnpm" {
+		t.Fatalf("sudo assignment JS command should preflight pnpm, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"apt-get update && apt-get install -y nodejs npm && npm test"}, true), ","); got != "" {
+		t.Fatalf("runtime setup command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"pnpm --version || npm --version"}, true), ","); got != "" {
+		t.Fatalf("shell fallback command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"pnpm --version||npm --version"}, true), ","); got != "" {
+		t.Fatalf("compact shell fallback command should not be preflight-blocked, got %q", got)
+	}
+	if got := strings.Join(commandRuntimePreflightTools([]string{"pnpm", "--version", "||", "npm", "--version"}, false), ","); got != "" {
+		t.Fatalf("argv fallback command should not be preflight-blocked, got %q", got)
+	}
+}
+
+func TestRunEnvProvidesPathHandlesWindowsCasing(t *testing.T) {
+	if !runEnvProvidesPath(map[string]string{"PATH": "/opt/node/bin"}, SSHTarget{TargetOS: targetLinux}) {
+		t.Fatal("POSIX PATH should skip runtime preflight")
+	}
+	if runEnvProvidesPath(map[string]string{"Path": "/opt/node/bin"}, SSHTarget{TargetOS: targetLinux}) {
+		t.Fatal("POSIX Path should not skip runtime preflight")
+	}
+	if !runEnvProvidesPath(map[string]string{"Path": `C:\node`}, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}) {
+		t.Fatal("native Windows Path should skip runtime preflight")
+	}
+}
+
+func TestRemoteMissingToolsCommandUsesLoginShell(t *testing.T) {
+	got := remoteMissingToolsCommand([]string{"pnpm"})
+	if !strings.HasPrefix(got, "bash -lc ") {
+		t.Fatalf("command=%q want bash -lc wrapper", got)
+	}
+	if !strings.Contains(got, "command -v") {
+		t.Fatalf("command=%q want command -v probe", got)
+	}
+	if !strings.Contains(got, missingRemoteToolPrefix) {
+		t.Fatalf("command=%q want missing tool sentinel", got)
+	}
+}
+
+func TestParseMissingRemoteToolsOutputIgnoresShellNoise(t *testing.T) {
+	got := strings.Join(parseMissingRemoteToolsOutput("Welcome\n"+missingRemoteToolPrefix+"pnpm\nwarning\n"+missingRemoteToolPrefix+"pnpm\n"), ",")
+	if got != "pnpm" {
+		t.Fatalf("missing=%q want pnpm", got)
+	}
+}
+
+func TestRawJSRuntimeMissingErrorMessage(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	err := rawJSRuntimeMissingError(cfg, []string{"pnpm"}, []string{"pnpm", "test:docs"}, false, "crabbox actions hydrate --id cbx_123 --provider aws")
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("error=%v, want exit 5", err)
+	}
+	for _, want := range []string{
+		"remote raw workspace missing JS runtime tool(s): pnpm",
+		"command starts with \"pnpm\"",
+		"hydrate first: crabbox actions hydrate --id cbx_123 --provider aws",
+		"include Node/Corepack/package-manager setup",
+		"provider/image with the JS toolchain",
+	} {
+		if !strings.Contains(exitErr.Message, want) {
+			t.Fatalf("message missing %q in %q", want, exitErr.Message)
+		}
+	}
+}
+
+func TestRawJSRuntimeHydrateSuggestionAvoidsReleasedLease(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	target := SSHTarget{TargetOS: targetLinux}
+	got := rawJSRuntimeHydrateSuggestion(cfg, target, "cbx_released", true, false, false)
+	if strings.Contains(got, "cbx_released") || !strings.Contains(got, "--keep") {
+		t.Fatalf("suggestion=%q should not target released lease", got)
+	}
+	got = rawJSRuntimeHydrateSuggestion(cfg, target, "cbx_kept", true, true, false)
+	if !strings.Contains(got, "cbx_kept") {
+		t.Fatalf("suggestion=%q should target kept lease", got)
+	}
+}
+
+func TestPrintCommandNotFoundHint(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	var out bytes.Buffer
+	printCommandNotFoundHint(&out, cfg, SSHTarget{TargetOS: targetLinux}, "cbx_123", []string{"pnpm", "test"}, false, 127, false, "crabbox actions hydrate --id cbx_123 --provider aws")
+	got := out.String()
+	for _, want := range []string{"exit 127", "pnpm", "crabbox actions hydrate --id cbx_123"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("hint missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestPrintCommandNotFoundHintAvoidsReleasedLease(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	var out bytes.Buffer
+	suggestion := rawJSRuntimeHydrateSuggestion(cfg, SSHTarget{TargetOS: targetLinux}, "cbx_released", true, false, false)
+	printCommandNotFoundHint(&out, cfg, SSHTarget{TargetOS: targetLinux}, "cbx_released", []string{"pnpm", "test"}, false, 127, false, suggestion)
+	got := out.String()
+	if strings.Contains(got, "cbx_released") || !strings.Contains(got, "--keep") {
+		t.Fatalf("hint should avoid released lease and suggest --keep, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Summary:
- preflight raw direct-provider runs for obvious JS runtime entrypoints before sync/run
- print actionable hydration/setup/Testbox guidance for missing Node/Corepack/pnpm-style tools
- add focused CLI tests for detection, skip paths, and command-not-found guidance

Verification:
- go test ./internal/cli
- git diff --check
- codex-review clean with go test ./internal/cli
