### PR TITLE
feat: add exe.dev sandbox provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.15.1 - Unreleased
 
+### Added
+
+- Added `provider: exe-dev` delegated runs against the stateless [exe.dev](https://exe.dev) `POST /exec` shell endpoint, including env-only auth via `EXE_API_KEY` / `CRABBOX_EXE_API_KEY`, `--exe-dev-url` for custom endpoints, docs, and no-live-credential tests.
+
 ## 0.15.0 - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `provider: exe-dev` delegated runs against the stateless [exe.dev](https://exe.dev) `POST /exec` shell endpoint, including env-only auth via `EXE_API_KEY` / `CRABBOX_EXE_API_KEY`, `--exe-dev-url` for custom endpoints, docs, and no-live-credential tests.
 
+### Fixed
+
+- Mapped exe.dev `HTTP 422` to a command-exit failure (per [exe.dev/docs/https-api](https://exe.dev/docs/https-api)) so non-zero exit codes from `POST /exec` surface as `crabbox run` exit codes instead of a generic API error. Documented the 30-second timeout, 64KB body limit, and JSON-response semantics in `docs/providers/exe-dev.md`.
+
 ## 0.15.0 - 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Supported providers:
   execution.
 - [E2B](docs/providers/e2b.md) (`provider: e2b`): delegated E2B sandbox
   execution.
+- [exe.dev](docs/providers/exe-dev.md) (`provider: exe-dev`): delegated
+  stateless `POST /exec` execution against [exe.dev](https://exe.dev).
 - [Modal](docs/providers/modal.md) (`provider: modal`): delegated Modal
   Sandbox execution through the local Python client.
 - [Tensorlake](docs/providers/tensorlake.md) (`provider: tensorlake`):

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -24,6 +24,7 @@ static SSH provider for existing machines.
 | [Daytona](daytona.md) | hybrid delegated run + SSH | Linux | Daytona snapshot sandboxes |
 | [Islo](islo.md) | delegated run | Linux | Islo-owned sandbox execution |
 | [E2B](e2b.md) | delegated run | Linux | E2B-owned sandbox execution |
+| [exe.dev](exe-dev.md) | delegated run | Linux | stateless `POST /exec` shell endpoint |
 | [Modal](modal.md) | delegated run | Linux | Modal Sandbox execution through the local Python client |
 | [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 | [Cloudflare](cloudflare.md) | delegated run | Linux | Cloudflare execution through a Worker and container runner |
@@ -64,6 +65,8 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
 - Daytona uses Daytona API and SDK/toolbox APIs.
 - Islo uses the Islo API and SDK auth.
 - E2B uses E2B's sandbox REST and envd APIs.
+- exe.dev uses a single bearer-authenticated `POST /exec` endpoint with the
+  command as the request body.
 - Modal uses the local Modal Python client and Modal Sandbox APIs.
 - Sprites uses the authenticated `sprite` CLI plus Sprites API.
 - Tensorlake uses the `tensorlake` CLI (`tensorlake sbx ...`) for sandbox lifecycle and command exec.
@@ -92,6 +95,7 @@ through the Sprites API and reaches SSH through `sprite proxy`.
 | Daytona | yes | yes | yes | no | archive via Daytona toolbox | no |
 | Islo | yes | yes | no | no | no | yes |
 | E2B | yes | yes | no | no | archive via E2B envd | no |
+| exe.dev | yes | no | no | no | no | no |
 | Modal | yes | yes | no | no | archive via Modal Sandbox exec | no |
 | Tensorlake | yes | yes | no | no | archive via `tensorlake sbx cp` | no |
 | Cloudflare | yes | yes | no | no | archive via Worker runner | no |

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -1,0 +1,95 @@
+# exe.dev Provider
+
+Read when:
+
+- choosing `provider: exe-dev`;
+- configuring the exe.dev exec endpoint;
+- changing `internal/providers/exedev`.
+
+[exe.dev](https://exe.dev) is a delegated run provider with a single stateless
+exec endpoint. Crabbox `POST`s the user command as the request body and streams
+the response back as stdout. There is no sandbox lifecycle: every `run`
+constructs a fresh request and the service owns the execution environment.
+
+## When To Use
+
+Use exe.dev for ad-hoc one-shot commands where you do not need workspace sync,
+SSH, or a long-lived sandbox. Use E2B, Modal, or a Daytona/Cloudflare backend
+when you need lease lifecycle, archive sync, or richer process transport.
+
+## Commands
+
+```sh
+crabbox run --provider exe-dev --no-sync -- whoami
+crabbox run --provider exe-dev --no-sync --shell 'uname -a && date'
+```
+
+`warmup`, `status`, `list`, and `stop` are not meaningful for a stateless exec
+service; the backend rejects them with a clear message rather than pretending to
+maintain sandboxes.
+
+## Auth
+
+```sh
+export EXE_API_KEY=...   # required
+```
+
+`CRABBOX_EXE_API_KEY` is also accepted and wins over `EXE_API_KEY`. The token
+is read from the environment only; the provider does not register a CLI flag
+for the key. Do not pass it as a command-line argument.
+
+The canonical exe.dev request shape is:
+
+```sh
+curl -X POST https://exe.dev/exec \
+  -H "Authorization: Bearer $EXE_API_KEY" \
+  -d 'whoami'
+```
+
+Crabbox sends the same `Authorization: Bearer $EXE_API_KEY` header and uses the
+command string as the request body.
+
+## Config
+
+```yaml
+provider: exe-dev
+target: linux
+exeDev:
+  apiUrl: https://exe.dev
+```
+
+Provider flags:
+
+```text
+--exe-dev-url
+```
+
+Environment overrides:
+
+```text
+CRABBOX_EXE_API_KEY  (or EXE_API_KEY)
+CRABBOX_EXE_API_URL  (or EXE_API_URL)
+```
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: no. `--no-sync` is required.
+- Provider sync: no.
+- Desktop/browser/code: no.
+- Actions hydration: no.
+- Coordinator: no.
+
+## Gotchas
+
+- exe.dev does not expose sandbox state, so `--id`, `--keep`, `--reclaim`,
+  `warmup`, `status`, and `stop` are rejected.
+- The provider must run with `--no-sync`; there is no documented file upload
+  endpoint, and the service does not maintain a working directory between
+  requests.
+- A 2xx response is treated as exit code 0. Non-2xx responses are surfaced as
+  `exeDevAPIError`, mirroring the error shape used by other delegated providers.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/exe-dev.md
+++ b/docs/providers/exe-dev.md
@@ -7,9 +7,12 @@ Read when:
 - changing `internal/providers/exedev`.
 
 [exe.dev](https://exe.dev) is a delegated run provider with a single stateless
-exec endpoint. Crabbox `POST`s the user command as the request body and streams
-the response back as stdout. There is no sandbox lifecycle: every `run`
-constructs a fresh request and the service owns the execution environment.
+exec endpoint (`POST /exec`, see <https://exe.dev/docs/https-api>). Crabbox
+`POST`s the user command as the request body and writes the response body to
+stdout. The exe.dev API always returns JSON output (equivalent to `--json`);
+the body is the SSH command output, streamed verbatim. There is no sandbox
+lifecycle: every `run` constructs a fresh request and the service owns the
+execution environment.
 
 ## When To Use
 
@@ -87,8 +90,19 @@ CRABBOX_EXE_API_URL  (or EXE_API_URL)
 - The provider must run with `--no-sync`; there is no documented file upload
   endpoint, and the service does not maintain a working directory between
   requests.
-- A 2xx response is treated as exit code 0. Non-2xx responses are surfaced as
-  `exeDevAPIError`, mirroring the error shape used by other delegated providers.
+- `/exec` has a 30-second server-side timeout (HTTP 504) and a 64KB request
+  body limit (HTTP 413). It has no stdin and no pty, so interactive commands
+  will not work.
+- Response responses are always JSON-formatted command output (the API enables
+  `--json` server-side). Pipe stdout through `jq` if you need to extract
+  individual fields.
+- Status mapping, per <https://exe.dev/docs/https-api>:
+  - `2xx` -> command exited 0.
+  - `422` -> command ran but exited non-zero; the body is streamed to stdout
+    and `crabbox` exits non-zero (surfaced as `exeDevCommandFailedError`).
+  - Other non-2xx (`400`, `401`, `403`, `404`, `405`, `413`, `429`, `500`,
+    `504`) are transport-level failures surfaced as `exeDevAPIError`,
+    mirroring the error shape used by other delegated providers.
 
 Related docs:
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -90,6 +90,7 @@ type Config struct {
 	Namespace           NamespaceConfig
 	Daytona             DaytonaConfig
 	E2B                 E2BConfig
+	ExeDev              ExeDevConfig
 	Islo                IsloConfig
 	Tensorlake          TensorlakeConfig
 	Modal               ModalConfig
@@ -185,6 +186,11 @@ type E2BConfig struct {
 	Template string
 	Workdir  string
 	User     string
+}
+
+type ExeDevConfig struct {
+	APIKey string
+	APIURL string
 }
 
 type IsloConfig struct {
@@ -494,6 +500,9 @@ func baseConfig() Config {
 			Template: "base",
 			Workdir:  "crabbox",
 		},
+		ExeDev: ExeDevConfig{
+			APIURL: "https://exe.dev",
+		},
 		Islo: IsloConfig{
 			BaseURL:  "https://api.islo.dev",
 			Image:    "docker.io/library/ubuntu:24.04",
@@ -574,6 +583,7 @@ type fileConfig struct {
 	Namespace        *fileNamespaceConfig               `yaml:"namespace,omitempty"`
 	Daytona          *fileDaytonaConfig                 `yaml:"daytona,omitempty"`
 	E2B              *fileE2BConfig                     `yaml:"e2b,omitempty"`
+	ExeDev           *fileExeDevConfig                  `yaml:"exeDev,omitempty"`
 	Islo             *fileIsloConfig                    `yaml:"islo,omitempty"`
 	Tensorlake       *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
 	Modal            *fileModalConfig                   `yaml:"modal,omitempty"`
@@ -758,6 +768,10 @@ type fileE2BConfig struct {
 	Template string `yaml:"template,omitempty"`
 	Workdir  string `yaml:"workdir,omitempty"`
 	User     string `yaml:"user,omitempty"`
+}
+
+type fileExeDevConfig struct {
+	APIURL string `yaml:"apiUrl,omitempty"`
 }
 
 type fileIsloConfig struct {
@@ -1524,6 +1538,11 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.E2B.User = file.E2B.User
 		}
 	}
+	if file.ExeDev != nil {
+		if file.ExeDev.APIURL != "" {
+			cfg.ExeDev.APIURL = file.ExeDev.APIURL
+		}
+	}
 	if file.Islo != nil {
 		if file.Islo.BaseURL != "" {
 			cfg.Islo.BaseURL = file.Islo.BaseURL
@@ -2159,6 +2178,8 @@ func applyEnv(cfg *Config) {
 	cfg.E2B.Template = getenv("CRABBOX_E2B_TEMPLATE", cfg.E2B.Template)
 	cfg.E2B.Workdir = getenv("CRABBOX_E2B_WORKDIR", cfg.E2B.Workdir)
 	cfg.E2B.User = getenv("CRABBOX_E2B_USER", cfg.E2B.User)
+	cfg.ExeDev.APIKey = getenv("CRABBOX_EXE_API_KEY", getenv("EXE_API_KEY", cfg.ExeDev.APIKey))
+	cfg.ExeDev.APIURL = getenv("CRABBOX_EXE_API_URL", getenv("EXE_API_URL", cfg.ExeDev.APIURL))
 	cfg.Islo.APIKey = getenv("CRABBOX_ISLO_API_KEY", getenv("ISLO_API_KEY", cfg.Islo.APIKey))
 	cfg.Islo.BaseURL = getenv("CRABBOX_ISLO_BASE_URL", getenv("ISLO_BASE_URL", cfg.Islo.BaseURL))
 	cfg.Islo.Image = getenv("CRABBOX_ISLO_IMAGE", cfg.Islo.Image)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -336,7 +336,7 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, or cloudflare"
+	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, exe-dev, modal, sprites, or cloudflare"
 }
 
 func providerHelpSSH() string {

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/cloudflare"
 	_ "github.com/openclaw/crabbox/internal/providers/daytona"
 	_ "github.com/openclaw/crabbox/internal/providers/e2b"
+	_ "github.com/openclaw/crabbox/internal/providers/exedev"
 	_ "github.com/openclaw/crabbox/internal/providers/gcp"
 	_ "github.com/openclaw/crabbox/internal/providers/hetzner"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -1,0 +1,149 @@
+package exedev
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func NewExeDevBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &exeDevBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type exeDevBackend struct {
+	spec   ProviderSpec
+	cfg    Config
+	rt     Runtime
+	client exeDevAPI
+}
+
+func (b *exeDevBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *exeDevBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s does not support warmup; exe.dev exec is stateless", providerName)
+}
+
+func (b *exeDevBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := rejectExeDevRunOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	if len(req.Command) == 0 {
+		return RunResult{}, exit(2, "missing command")
+	}
+	client, err := b.api()
+	if err != nil {
+		return RunResult{}, err
+	}
+	command := exeDevCommandString(req.Command, req.ShellMode)
+	if command == "" {
+		return RunResult{}, exit(2, "missing command")
+	}
+	started := b.now()
+	fmt.Fprintf(b.rt.Stderr, "running on %s %s\n", providerName, strings.Join(req.Command, " "))
+	exitCode, execErr := client.Exec(ctx, command, b.rt.Stdout, b.rt.Stderr)
+	commandDuration := b.now().Sub(started)
+	result := RunResult{
+		ExitCode: exitCode,
+		Command:  commandDuration,
+		Total:    commandDuration,
+	}
+	fmt.Fprintf(b.rt.Stderr, "%s run summary command=%s total=%s exit=%d\n", providerName, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:  providerName,
+			CommandMs: commandDuration.Milliseconds(),
+			TotalMs:   result.Total.Milliseconds(),
+			ExitCode:  result.ExitCode,
+		}); err != nil {
+			return result, err
+		}
+	}
+	if execErr != nil {
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, execErr)}
+	}
+	if result.ExitCode != 0 {
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
+	}
+	return result, nil
+}
+
+func (b *exeDevBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = ctx
+	_ = req
+	// exe.dev exec is stateless: there are no sandboxes to enumerate.
+	return nil, nil
+}
+
+func (b *exeDevBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	_ = ctx
+	_ = req
+	return StatusView{}, exit(2, "provider=%s does not support status; exe.dev exec is stateless", providerName)
+}
+
+func (b *exeDevBackend) Stop(ctx context.Context, req StopRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s does not support stop; exe.dev exec is stateless", providerName)
+}
+
+func (b *exeDevBackend) api() (exeDevAPI, error) {
+	if b.client != nil {
+		return b.client, nil
+	}
+	return newExeDevClient(b.cfg, b.rt)
+}
+
+func exeDevCommandString(command []string, shellMode bool) string {
+	if len(command) == 0 {
+		return ""
+	}
+	if shellMode {
+		return strings.Join(command, " ")
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		return shellScriptFromArgv(command)
+	}
+	return strings.Join(shellWords(command), " ")
+}
+
+func rejectExeDevRunOptions(req RunRequest) error {
+	if req.ID != "" {
+		return exit(2, "provider=%s does not maintain sandboxes; --id is not supported", providerName)
+	}
+	if req.Keep {
+		return exit(2, "provider=%s does not maintain sandboxes; --keep is not supported", providerName)
+	}
+	if req.Reclaim {
+		return exit(2, "provider=%s does not maintain sandboxes; --reclaim is not supported", providerName)
+	}
+	if !req.NoSync {
+		// exe.dev provides no sync surface (no upload endpoint documented).
+		// Mirror other delegated-only providers that do not implement archive
+		// sync by requiring --no-sync explicitly.
+		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
+	}
+	if req.SyncOnly {
+		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
+	}
+	if req.ChecksumSync {
+		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
+	}
+	if req.ForceSyncLarge {
+		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
+	}
+	if req.FullResync {
+		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
+	}
+	return nil
+}
+
+func (b *exeDevBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -2,6 +2,7 @@ package exedev
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -63,6 +64,14 @@ func (b *exeDevBackend) Run(ctx context.Context, req RunRequest) (RunResult, err
 		}
 	}
 	if execErr != nil {
+		var cmdFailed *exeDevCommandFailedError
+		if errors.As(execErr, &cmdFailed) {
+			// The remote command itself failed; the body has already been
+			// written to stdout. Surface a non-zero exit without wrapping the
+			// transport-level message, mirroring how other delegated providers
+			// propagate exit codes.
+			return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
+		}
 		return result, ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, execErr)}
 	}
 	if result.ExitCode != 0 {

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -47,6 +47,15 @@ func (b *exeDevBackend) Run(ctx context.Context, req RunRequest) (RunResult, err
 	fmt.Fprintf(b.rt.Stderr, "running on %s %s\n", providerName, strings.Join(req.Command, " "))
 	exitCode, execErr := client.Exec(ctx, command, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(started)
+	// Distinguish a transport-level failure (exeDevAPIError, network errors)
+	// from a remote command exit. exeDevCommandFailedError already carries the
+	// command's non-zero exit code in exitCode; everything else gets wrapped as
+	// a generic "run failed" with exit=1.
+	var cmdFailed *exeDevCommandFailedError
+	commandExited := execErr == nil || errors.As(execErr, &cmdFailed)
+	if !commandExited {
+		exitCode = 1
+	}
 	result := RunResult{
 		ExitCode: exitCode,
 		Command:  commandDuration,
@@ -63,21 +72,14 @@ func (b *exeDevBackend) Run(ctx context.Context, req RunRequest) (RunResult, err
 			return result, err
 		}
 	}
-	if execErr != nil {
-		var cmdFailed *exeDevCommandFailedError
-		if errors.As(execErr, &cmdFailed) {
-			// The remote command itself failed; the body has already been
-			// written to stdout. Surface a non-zero exit without wrapping the
-			// transport-level message, mirroring how other delegated providers
-			// propagate exit codes.
-			return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
-		}
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, execErr)}
+	var runErr error
+	switch {
+	case !commandExited:
+		runErr = ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, execErr)}
+	case result.ExitCode != 0:
+		runErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
 	}
-	if result.ExitCode != 0 {
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
-	}
-	return result, nil
+	return result, runErr
 }
 
 func (b *exeDevBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -252,6 +252,65 @@ func TestExeDevRunHappyPath(t *testing.T) {
 	}
 }
 
+func TestExeDevRunMaps422ToExitErrorWithoutTransportWrapper(t *testing.T) {
+	// 422 means the remote command ran but failed; Run() must surface "run
+	// exited N" (not "run failed: ..."), keep the body on stdout, and propagate
+	// the command's non-zero exit through ExitError.Code.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, "missing arguments\n")
+	}))
+	defer server.Close()
+
+	cfg := Config{Provider: providerName}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	var stdout bytes.Buffer
+	rt := Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: io.Discard}
+	backend := NewExeDevBackend(Provider{}.Spec(), cfg, rt).(*exeDevBackend)
+	result, err := backend.Run(context.Background(), RunRequest{Command: []string{"whoami"}, NoSync: true})
+	if err == nil {
+		t.Fatal("Run accepted 422 response")
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", result.ExitCode)
+	}
+	if !strings.Contains(err.Error(), "run exited") {
+		t.Fatalf("err = %v, want 'run exited' (not transport-wrapped)", err)
+	}
+	if strings.Contains(err.Error(), "run failed") {
+		t.Fatalf("err = %v, must not wrap as 'run failed'", err)
+	}
+	if !strings.Contains(stdout.String(), "missing arguments") {
+		t.Fatalf("stdout = %q, want command output body", stdout.String())
+	}
+}
+
+func TestExeDevRunMapsTransportFailureToRunFailed(t *testing.T) {
+	// Non-422 non-2xx responses (here: 504) are transport-level failures. Run()
+	// must surface them as "run failed: ..." with exit=1, not "run exited ...".
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "timeout", http.StatusGatewayTimeout)
+	}))
+	defer server.Close()
+
+	cfg := Config{Provider: providerName}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	rt := Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}
+	backend := NewExeDevBackend(Provider{}.Spec(), cfg, rt).(*exeDevBackend)
+	result, err := backend.Run(context.Background(), RunRequest{Command: []string{"whoami"}, NoSync: true})
+	if err == nil {
+		t.Fatal("Run accepted 504 response")
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", result.ExitCode)
+	}
+	if !strings.Contains(err.Error(), "run failed") {
+		t.Fatalf("err = %v, want 'run failed' transport wrapper", err)
+	}
+}
+
 func TestExeDevWarmupRejected(t *testing.T) {
 	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	err := backend.Warmup(context.Background(), WarmupRequest{})

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -136,6 +136,72 @@ func TestExeDevExecSurfacesNon2xxAsAPIError(t *testing.T) {
 	}
 }
 
+func TestExeDevExecMaps422ToCommandFailure(t *testing.T) {
+	// Per https://exe.dev/docs/https-api, HTTP 422 means the command ran but
+	// returned a non-zero exit code. The body should be streamed to stdout
+	// and the call should return a non-zero exit with exeDevCommandFailedError.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, "missing arguments\n")
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	client, err := newExeDevClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	code, err := client.Exec(context.Background(), "new", &stdout, io.Discard)
+	if err == nil {
+		t.Fatal("Exec accepted 422 response")
+	}
+	cmdErr, ok := err.(*exeDevCommandFailedError)
+	if !ok {
+		t.Fatalf("err = %T, want *exeDevCommandFailedError", err)
+	}
+	if !strings.Contains(cmdErr.Body, "missing arguments") {
+		t.Fatalf("body = %q, want missing arguments snippet", cmdErr.Body)
+	}
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stdout.String(), "missing arguments") {
+		t.Fatalf("stdout = %q, want command output body", stdout.String())
+	}
+}
+
+func TestExeDevExecSurfaces504AsAPIError(t *testing.T) {
+	// Per https://exe.dev/docs/https-api, HTTP 504 means the command exceeded
+	// the 30s timeout. It should surface as a transport-level API error rather
+	// than a clean exit, so callers can distinguish it from command failures.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "timeout", http.StatusGatewayTimeout)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	client, err := newExeDevClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Exec(context.Background(), "sleep 60", io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("Exec accepted 504 response")
+	}
+	apiErr, ok := err.(*exeDevAPIError)
+	if !ok {
+		t.Fatalf("err = %T, want *exeDevAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504", apiErr.StatusCode)
+	}
+}
+
 func TestExeDevRunRequiresNoSync(t *testing.T) {
 	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	_, err := backend.Run(context.Background(), RunRequest{Command: []string{"whoami"}})

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -1,0 +1,237 @@
+package exedev
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExeDevProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName {
+		t.Fatalf("spec.Name = %q, want %q", spec.Name, providerName)
+	}
+	if spec.Kind != "delegated-run" {
+		t.Fatalf("spec.Kind = %q, want delegated-run", spec.Kind)
+	}
+	aliases := Provider{}.Aliases()
+	if len(aliases) != 2 || aliases[0] != "exe" || aliases[1] != "exedev" {
+		t.Fatalf("aliases = %#v, want [exe exedev]", aliases)
+	}
+}
+
+func TestExeDevClientRequiresAPIKey(t *testing.T) {
+	cfg := Config{}
+	cfg.ExeDev.APIURL = "https://exe.dev"
+	if _, err := newExeDevClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newExeDevClient accepted empty API key")
+	}
+}
+
+func TestExeDevClientRejectsBareHTTPURL(t *testing.T) {
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = "http://exe.dev"
+	if _, err := newExeDevClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newExeDevClient accepted plaintext http URL")
+	}
+}
+
+func TestExeDevTokenFlagIsNotRegistered(t *testing.T) {
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "secret-key"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterExeDevProviderFlags(fs, cfg)
+	if fs.Lookup("exe-dev-key") != nil || fs.Lookup("exe-dev-token") != nil || fs.Lookup("exe-api-key") != nil {
+		t.Fatal("exe.dev API key surfaced as a flag")
+	}
+	if fs.Lookup("exe-dev-url") == nil {
+		t.Fatal("exe-dev-url flag missing")
+	}
+}
+
+func TestExeDevExecSendsBearerAndBody(t *testing.T) {
+	var (
+		gotAuth   string
+		gotMethod string
+		gotPath   string
+		gotBody   string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = io.WriteString(w, "root\n")
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	client, err := newExeDevClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code, err := client.Exec(context.Background(), "whoami", &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/exec" {
+		t.Fatalf("path = %q, want /exec", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth header = %q, want bearer test-key", gotAuth)
+	}
+	if gotBody != "whoami" {
+		t.Fatalf("body = %q, want whoami", gotBody)
+	}
+	if stdout.String() != "root\n" {
+		t.Fatalf("stdout = %q, want root\\n", stdout.String())
+	}
+}
+
+func TestExeDevExecSurfacesNon2xxAsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized request", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.ExeDev.APIKey = "wrong-key"
+	cfg.ExeDev.APIURL = server.URL
+	client, err := newExeDevClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, err := client.Exec(context.Background(), "whoami", io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("Exec accepted 401 response")
+	}
+	apiErr, ok := err.(*exeDevAPIError)
+	if !ok {
+		t.Fatalf("err = %T, want *exeDevAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Body, "unauthorized request") {
+		t.Fatalf("body = %q, want unauthorized request snippet", apiErr.Body)
+	}
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+}
+
+func TestExeDevRunRequiresNoSync(t *testing.T) {
+	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), RunRequest{Command: []string{"whoami"}})
+	if err == nil {
+		t.Fatal("Run accepted request without --no-sync")
+	}
+	if !strings.Contains(err.Error(), "--no-sync") {
+		t.Fatalf("err = %v, want --no-sync hint", err)
+	}
+}
+
+func TestExeDevRunRejectsLeaseFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		req  RunRequest
+		want string
+	}{
+		{name: "id", req: RunRequest{ID: "foo", NoSync: true, Command: []string{"whoami"}}, want: "--id"},
+		{name: "keep", req: RunRequest{Keep: true, NoSync: true, Command: []string{"whoami"}}, want: "--keep"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			_, err := backend.Run(context.Background(), tc.req)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %s rejection", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestExeDevRunHappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "root\n")
+	}))
+	defer server.Close()
+
+	cfg := Config{Provider: providerName}
+	cfg.ExeDev.APIKey = "test-key"
+	cfg.ExeDev.APIURL = server.URL
+	rt := Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}
+	backend := NewExeDevBackend(Provider{}.Spec(), cfg, rt).(*exeDevBackend)
+	result, err := backend.Run(context.Background(), RunRequest{Command: []string{"whoami"}, NoSync: true})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+}
+
+func TestExeDevWarmupRejected(t *testing.T) {
+	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), WarmupRequest{})
+	if err == nil || !strings.Contains(err.Error(), "warmup") {
+		t.Fatalf("Warmup err = %v, want warmup rejection", err)
+	}
+}
+
+func TestExeDevStopRejected(t *testing.T) {
+	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Stop(context.Background(), StopRequest{})
+	if err == nil || !strings.Contains(err.Error(), "stop") {
+		t.Fatalf("Stop err = %v, want stop rejection", err)
+	}
+}
+
+func TestExeDevStatusRejected(t *testing.T) {
+	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	if _, err := backend.Status(context.Background(), StatusRequest{}); err == nil {
+		t.Fatal("Status should reject without sandboxes")
+	}
+}
+
+func TestExeDevListEmpty(t *testing.T) {
+	backend := &exeDevBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	servers, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err = %v", err)
+	}
+	if len(servers) != 0 {
+		t.Fatalf("List len = %d, want 0", len(servers))
+	}
+}
+
+func TestExeDevFlagsApply(t *testing.T) {
+	cfg := Config{Provider: providerName}
+	cfg.ExeDev.APIURL = "https://exe.dev"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := RegisterExeDevProviderFlags(fs, cfg)
+	if err := fs.Parse([]string{"--exe-dev-url", "https://exe.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyExeDevProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ExeDev.APIURL != "https://exe.example.com" {
+		t.Fatalf("APIURL = %q, want https://exe.example.com", cfg.ExeDev.APIURL)
+	}
+}

--- a/internal/providers/exedev/client.go
+++ b/internal/providers/exedev/client.go
@@ -34,6 +34,20 @@ func (e *exeDevAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
+// exeDevCommandFailedError signals that the exe.dev API ran the command
+// successfully (HTTP 422 per https://exe.dev/docs/https-api) but the command
+// itself exited non-zero. The body carries the error message from the command.
+type exeDevCommandFailedError struct {
+	Body string
+}
+
+func (e *exeDevCommandFailedError) Error() string {
+	if e.Body == "" {
+		return "command failed"
+	}
+	return "command failed: " + e.Body
+}
+
 func newExeDevClient(cfg Config, rt Runtime) (exeDevAPI, error) {
 	apiKey := strings.TrimSpace(cfg.ExeDev.APIKey)
 	if apiKey == "" {
@@ -64,26 +78,38 @@ func (c *exeDevClient) Exec(ctx context.Context, command string, stdout, stderr 
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "text/plain")
-	req.Header.Set("Accept", "application/octet-stream, text/plain, application/json")
+	req.Header.Set("Accept", "application/json, text/plain, application/octet-stream")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return 1, err
 	}
 	defer resp.Body.Close()
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	// Per https://exe.dev/docs/https-api, HTTP 422 means the command ran but
+	// returned a non-zero exit code; the response body contains the error
+	// message. Treat it as a command failure (the body is still part of the
+	// command's output) rather than a transport-level API error.
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		if _, err := io.Copy(stdout, bytes.NewReader(data)); err != nil {
+			return 1, fmt.Errorf("read exe.dev exec body: %w", err)
+		}
+		return 1, &exeDevCommandFailedError{Body: strings.TrimSpace(string(data))}
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return 1, &exeDevAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
 	}
-	if stdout == nil {
-		stdout = io.Discard
-	}
 	if _, err := io.Copy(stdout, resp.Body); err != nil {
 		return 1, fmt.Errorf("read exe.dev exec body: %w", err)
 	}
-	// exe.dev does not document a separate exit-code surface, so a 2xx response
-	// is treated as a successful command run; non-2xx is surfaced through
-	// exeDevAPIError above. If the service later returns an exit code via a
-	// trailer/header, parse it here.
+	// Per https://exe.dev/docs/https-api, JSON output is always enabled for
+	// API responses (equivalent to --json) and the returned body is the ssh
+	// command output. A 2xx response means the command exited 0; 422 (handled
+	// above) means non-zero exit; all other non-2xx statuses are transport
+	// errors surfaced through exeDevAPIError.
 	return 0, nil
 }
 

--- a/internal/providers/exedev/client.go
+++ b/internal/providers/exedev/client.go
@@ -1,0 +1,96 @@
+package exedev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type exeDevAPI interface {
+	Exec(ctx context.Context, command string, stdout, stderr io.Writer) (int, error)
+}
+
+type exeDevClient struct {
+	apiKey     string
+	apiURL     string
+	httpClient *http.Client
+}
+
+type exeDevAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *exeDevAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+func newExeDevClient(cfg Config, rt Runtime) (exeDevAPI, error) {
+	apiKey := strings.TrimSpace(cfg.ExeDev.APIKey)
+	if apiKey == "" {
+		return nil, exit(2, "provider=%s requires EXE_API_KEY", providerName)
+	}
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.ExeDev.APIURL, "https://exe.dev")), "/")
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &exeDevClient{apiKey: apiKey, apiURL: apiURL, httpClient: httpClient}, nil
+}
+
+func (c *exeDevClient) Exec(ctx context.Context, command string, stdout, stderr io.Writer) (int, error) {
+	if strings.TrimSpace(command) == "" {
+		return 1, errors.New("empty command")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+"/exec", bytes.NewReader([]byte(command)))
+	if err != nil {
+		return 1, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Accept", "application/octet-stream, text/plain, application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 1, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return 1, &exeDevAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if _, err := io.Copy(stdout, resp.Body); err != nil {
+		return 1, fmt.Errorf("read exe.dev exec body: %w", err)
+	}
+	// exe.dev does not document a separate exit-code surface, so a 2xx response
+	// is treated as a successful command run; non-2xx is surfaced through
+	// exeDevAPIError above. If the service later returns an exit code via a
+	// trailer/header, parse it here.
+	return 0, nil
+}
+
+func isLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/providers/exedev/client.go
+++ b/internal/providers/exedev/client.go
@@ -87,10 +87,6 @@ func (c *exeDevClient) Exec(ctx context.Context, command string, stdout, stderr 
 	if stdout == nil {
 		stdout = io.Discard
 	}
-	// Per https://exe.dev/docs/https-api, HTTP 422 means the command ran but
-	// returned a non-zero exit code; the response body contains the error
-	// message. Treat it as a command failure (the body is still part of the
-	// command's output) rather than a transport-level API error.
 	if resp.StatusCode == http.StatusUnprocessableEntity {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		if _, err := io.Copy(stdout, bytes.NewReader(data)); err != nil {

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -1,0 +1,71 @@
+package exedev
+
+import (
+	"flag"
+	"io"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ExeDevConfig = core.ExeDevConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type ExitError = core.ExitError
+type FeatureSet = core.FeatureSet
+type Feature = core.Feature
+type timingReport = core.TimingReport
+
+const (
+	providerName = "exe-dev"
+	targetLinux  = core.TargetLinux
+
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellWords(words []string) []string {
+	return core.ShellWords(words)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}

--- a/internal/providers/exedev/flags.go
+++ b/internal/providers/exedev/flags.go
@@ -1,0 +1,35 @@
+package exedev
+
+import "flag"
+
+type exeDevFlagValues struct {
+	APIURL *string
+}
+
+// RegisterExeDevProviderFlags exposes exe.dev-specific flags. The API key is
+// intentionally not surfaced as a flag because secrets must not be passed as
+// command-line arguments; it is sourced from EXE_API_KEY / CRABBOX_EXE_API_KEY.
+func RegisterExeDevProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return exeDevFlagValues{
+		APIURL: fs.String("exe-dev-url", defaults.ExeDev.APIURL, "exe.dev API URL"),
+	}
+}
+
+func ApplyExeDevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == providerName {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s", providerName)
+		}
+	}
+	v, ok := values.(exeDevFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "exe-dev-url") {
+		cfg.ExeDev.APIURL = *v.APIURL
+	}
+	return nil
+}

--- a/internal/providers/exedev/provider.go
+++ b/internal/providers/exedev/provider.go
@@ -1,0 +1,38 @@
+package exedev
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"exe", "exedev"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    nil,
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterExeDevProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyExeDevProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewExeDevBackend(p.Spec(), cfg, rt), nil
+}


### PR DESCRIPTION
## Summary

Adds an `exe-dev` delegated-run provider that targets [exe.dev](https://exe.dev). Each `crabbox run` issues a single `POST /exec` with `Authorization: Bearer $EXE_API_KEY` and the user command as the request body, streaming the response back as stdout. The endpoint is stateless, so `warmup`, `status`, `list`, and `stop` are rejected with clear messages and `--no-sync` is required.

## Env

- `EXE_API_KEY` (or `CRABBOX_EXE_API_KEY`) — required, sourced from env only (no CLI flag).
- `EXE_API_URL` (or `CRABBOX_EXE_API_URL`) — optional override, defaults to `https://exe.dev`.

## Reference

```sh
curl -X POST https://exe.dev/exec \
  -H "Authorization: Bearer $EXE_API_KEY" \
  -d 'whoami'
```

See <https://exe.dev>.