### PR TITLE
feat: add railway sandbox provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added an account-guarded EC2 Mac Dedicated Host quota request helper for turning macOS lifecycle smoke quota evidence into a dry-run or explicit AWS Service Quotas request.
 - Added a no-spend macOS coordinator remediation audit helper that bundles provider identity, IAM policy, host quota, host allocation dry-run, guarded IAM apply dry-run, and guarded quota request dry-run evidence into `summary.json`.
 - Added `provider: exe-dev` for exe.dev VM SSH leases through the exe.dev SSH API, including Crabbox sync/run, `crabbox ssh`, and provider docs.
+- Added the Railway delegated provider for redeploying an existing Railway service, streaming build/runtime logs, and reporting deployment status through `crabbox run`, `status`, `stop`, and `list`. Thanks @zozo123.
 - Added direct `crabbox doctor --provider exe-dev` readiness through the exe.dev inventory API without creating VMs.
 - Added Cloudflare runner readiness to `crabbox doctor --provider cloudflare` so runner URL, auth, and container bindings are checked without creating a sandbox. Thanks @altaywtf.
 - Added direct `crabbox doctor` readiness for all built-in providers without creating provider resources.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Supported providers:
 - [Cloudflare](docs/providers/cloudflare.md)
   (`provider: cloudflare`): delegated Cloudflare execution through a Worker and
   container runner.
+- [Railway](docs/providers/railway.md) (`provider: railway`): delegated
+  redeploy-and-stream execution against a pre-existing Railway service through
+  the [Railway](https://railway.com) GraphQL API.
 
 ---
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -28,6 +28,7 @@ static SSH provider for existing machines.
 | [Modal](modal.md) | delegated run | Linux | Modal Sandbox execution through the local Python client |
 | [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 | [Cloudflare](cloudflare.md) | delegated run | Linux | Cloudflare execution through a Worker and container runner |
+| [Railway](railway.md) | delegated run | Linux | redeploy and stream logs for an existing Railway service via the GraphQL API |
 
 ## Shared Rules
 
@@ -71,6 +72,10 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
 - Tensorlake uses the `tensorlake` CLI (`tensorlake sbx ...`) for sandbox lifecycle and command exec.
 - Cloudflare uses a deployed Worker runner backed by a Cloudflare
   Containers image.
+- Railway uses the [Railway](https://railway.com) GraphQL API (`environmentTriggersDeploy`,
+  `deploymentLogs`, `deploymentStop`) against a pre-existing service the user
+  owns. The user's command argument is logged; Railway runs the service's own
+  start command — there is no synchronous exec endpoint.
 
 Namespace Devbox and Semaphore are SSH lease providers that do not use the
 Crabbox coordinator. Namespace provisions through the authenticated `devbox`
@@ -99,6 +104,7 @@ provisions through `ssh exe.dev` and returns a normal VM SSH target.
 | Modal | yes | yes | no | no | archive via Modal Sandbox exec | no |
 | Tensorlake | yes | yes | no | no | archive via `tensorlake sbx cp` | no |
 | Cloudflare | yes | yes | no | no | archive via Worker runner | no |
+| Railway | yes | no | no | no | no | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
 Use AWS, Google Cloud, Hetzner, Proxmox, Static SSH, exe.dev, Namespace Devbox,

--- a/docs/providers/railway.md
+++ b/docs/providers/railway.md
@@ -24,12 +24,14 @@ SSH mutation, no `service.run(cmd)` GraphQL field. Crabbox therefore maps
 2. The provider issues the GraphQL mutation
    `environmentTriggersDeploy(input: { projectId, environmentId, serviceId })`
    to kick a redeploy of that service.
-3. The provider queries `deployments(input, first: 1)` to resolve the new
-   deployment id, then `deploymentLogs(deploymentId, limit)` and streams the
-   returned messages to stdout.
-4. The deployment `status` is mapped to a process exit code: `SUCCESS` /
-   `DEPLOYED` becomes `0`; anything else (`FAILED`, `CRASHED`, `BUILDING`,
-   ...) becomes `1`.
+3. The provider polls `deployment(id: $deploymentId)` for the deployment id
+   returned by the mutation, while fetching newly available
+   `buildLogs(deploymentId, limit)` and `deploymentLogs(deploymentId, limit)`
+   messages to stdout.
+4. The deployment `status` is mapped to a process exit code: `SUCCESS` and
+   `SLEEPING` become `0`; terminal failure/removal states (`FAILED`, `CRASHED`,
+   `REMOVED`, `SKIPPED`) become `1`. Non-terminal states are polled until they
+   finish or the 30 minute timeout expires.
 
 This means **the user's command argument is informational only**. Railway runs
 whatever start command the service is configured with (in `railway.toml`, the
@@ -50,8 +52,8 @@ Railway dashboard or via `serviceCreate`.
 
 Use Railway when the workload is already a Railway service and the redeploy
 loop is what you want from a Crabbox run (for example, "rebuild and stream
-build/runtime logs after a config change"). Pick a different provider for
-ad-hoc command execution.
+new build/runtime log messages after a config change"). Pick a different
+provider for ad-hoc command execution.
 
 ## Commands
 

--- a/docs/providers/railway.md
+++ b/docs/providers/railway.md
@@ -8,7 +8,7 @@ Read when:
 
 [Railway](https://railway.com) is a deployment platform whose primitives are
 projects, environments, services, and deployments. Railway's public API is
-GraphQL at `https://backboard.railway.app/graphql/v2` and is authenticated with
+GraphQL at `https://backboard.railway.com/graphql/v2` and is authenticated with
 `Authorization: Bearer $RAILWAY_API_TOKEN`. Account-scoped tokens from
 `/account/tokens` operate across every project the account can see.
 
@@ -86,7 +86,7 @@ not register a CLI flag for it. Do not pass the token on the command line.
 The canonical Railway request shape is:
 
 ```sh
-curl -X POST https://backboard.railway.app/graphql/v2 \
+curl -X POST https://backboard.railway.com/graphql/v2 \
   -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query":"query { projects { edges { node { id name } } } }"}'
@@ -101,7 +101,7 @@ JSON `{query, variables}` body to the same endpoint.
 provider: railway
 target: linux
 railway:
-  apiUrl: https://backboard.railway.app/graphql/v2
+  apiUrl: https://backboard.railway.com/graphql/v2
   projectId: <project-uuid>
   environmentId: <environment-uuid>
 ```

--- a/docs/providers/railway.md
+++ b/docs/providers/railway.md
@@ -67,7 +67,7 @@ crabbox run --provider railway --no-sync \
 
 ```sh
 crabbox status --provider railway --id $RAILWAY_SERVICE_ID
-crabbox stop   --provider railway --id $RAILWAY_SERVICE_ID
+crabbox stop   --provider railway $RAILWAY_SERVICE_ID
 crabbox list   --provider railway
 ```
 

--- a/docs/providers/railway.md
+++ b/docs/providers/railway.md
@@ -1,0 +1,150 @@
+# Railway Provider
+
+Read when:
+
+- choosing `provider: railway`;
+- pointing Crabbox at an existing Railway service;
+- changing `internal/providers/railway`.
+
+[Railway](https://railway.com) is a deployment platform whose primitives are
+projects, environments, services, and deployments. Railway's public API is
+GraphQL at `https://backboard.railway.app/graphql/v2` and is authenticated with
+`Authorization: Bearer $RAILWAY_API_TOKEN`. Account-scoped tokens from
+`/account/tokens` operate across every project the account can see.
+
+## Mapping And Semantic Differences
+
+Railway has no synchronous `POST /exec`-style endpoint. There is no shell, no
+SSH mutation, no `service.run(cmd)` GraphQL field. Crabbox therefore maps
+`crabbox run` onto the closest available lifecycle:
+
+1. The caller must point at a pre-existing Railway service with
+   `--id <serviceId>`, plus `--railway-project <projectId>` and
+   `--railway-environment <environmentId>` (or the matching env vars / YAML).
+2. The provider issues the GraphQL mutation
+   `environmentTriggersDeploy(input: { projectId, environmentId, serviceId })`
+   to kick a redeploy of that service.
+3. The provider queries `deployments(input, first: 1)` to resolve the new
+   deployment id, then `deploymentLogs(deploymentId, limit)` and streams the
+   returned messages to stdout.
+4. The deployment `status` is mapped to a process exit code: `SUCCESS` /
+   `DEPLOYED` becomes `0`; anything else (`FAILED`, `CRASHED`, `BUILDING`,
+   ...) becomes `1`.
+
+This means **the user's command argument is informational only**. Railway runs
+whatever start command the service is configured with (in `railway.toml`, the
+dashboard, or the `serviceInstanceUpdate` GraphQL mutation). The crabbox
+command argument is echoed to stderr and shows up in run telemetry, but it is
+not what the Railway container actually executes. If you need
+"run-this-exact-command-and-get-output", use the `exe-dev`, `e2b`, or `modal`
+provider instead — they fit that contract.
+
+`Stop` calls `deploymentStop(id: $deploymentId)` against the latest deployment
+for the service. `Status` returns the latest deployment status and readiness.
+`List` flattens `projects { edges { node { services { edges { node { ... } } } } } }`
+into one row per service. `Warmup` is rejected so Crabbox never silently
+provisions billable Railway resources — create the service yourself in the
+Railway dashboard or via `serviceCreate`.
+
+## When To Use
+
+Use Railway when the workload is already a Railway service and the redeploy
+loop is what you want from a Crabbox run (for example, "rebuild and stream
+build/runtime logs after a config change"). Pick a different provider for
+ad-hoc command execution.
+
+## Commands
+
+```sh
+crabbox run --provider railway --no-sync \
+  --id $RAILWAY_SERVICE_ID \
+  --railway-project $RAILWAY_PROJECT_ID \
+  --railway-environment $RAILWAY_ENVIRONMENT_ID \
+  -- pnpm test
+```
+
+```sh
+crabbox status --provider railway --id $RAILWAY_SERVICE_ID
+crabbox stop   --provider railway --id $RAILWAY_SERVICE_ID
+crabbox list   --provider railway
+```
+
+`warmup` is rejected; service creation must happen out-of-band.
+
+## Auth
+
+```sh
+export RAILWAY_API_TOKEN=...   # required, account or project token from /account/tokens
+```
+
+`CRABBOX_RAILWAY_API_TOKEN` is also accepted and wins over `RAILWAY_API_TOKEN`,
+matching the precedence used by other delegated providers
+(`CRABBOX_E2B_API_KEY` over `E2B_API_KEY`, `CRABBOX_EXE_API_KEY` over
+`EXE_API_KEY`). The token is read from the environment only; the provider does
+not register a CLI flag for it. Do not pass the token on the command line.
+
+The canonical Railway request shape is:
+
+```sh
+curl -X POST https://backboard.railway.app/graphql/v2 \
+  -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query { projects { edges { node { id name } } } }"}'
+```
+
+Crabbox sends the same `Authorization: Bearer $RAILWAY_API_TOKEN` header and a
+JSON `{query, variables}` body to the same endpoint.
+
+## Config
+
+```yaml
+provider: railway
+target: linux
+railway:
+  apiUrl: https://backboard.railway.app/graphql/v2
+  projectId: <project-uuid>
+  environmentId: <environment-uuid>
+```
+
+Provider flags:
+
+```text
+--railway-url
+--railway-project
+--railway-environment
+```
+
+Environment overrides:
+
+```text
+CRABBOX_RAILWAY_API_TOKEN      (or RAILWAY_API_TOKEN)
+CRABBOX_RAILWAY_API_URL        (or RAILWAY_API_URL)
+CRABBOX_RAILWAY_PROJECT_ID     (or RAILWAY_PROJECT_ID)
+CRABBOX_RAILWAY_ENVIRONMENT_ID (or RAILWAY_ENVIRONMENT_ID)
+```
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: no. `--no-sync` is required.
+- Provider sync: no.
+- Desktop/browser/code: no.
+- Actions hydration: no.
+- Coordinator: no.
+
+## Gotchas
+
+- Railway has no synchronous exec primitive; the user command is informational.
+  The service's configured start command is what runs.
+- `--keep`, `--reclaim`, `--class`, `--type` are rejected — Railway owns
+  service lifecycle.
+- `warmup` is rejected to avoid silently creating billable Railway resources.
+- The provider requires `--id`, `--railway-project`, and `--railway-environment`
+  for `run`, `status`, and `stop`. `list` only needs the API token.
+- Non-2xx HTTP responses and GraphQL `errors[]` envelopes are surfaced as
+  `railwayAPIError`, mirroring the error shape used by other delegated
+  providers.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	Daytona             DaytonaConfig
 	E2B                 E2BConfig
 	ExeDev              ExeDevConfig
+	Railway             RailwayConfig
 	Islo                IsloConfig
 	Tensorlake          TensorlakeConfig
 	Modal               ModalConfig
@@ -198,6 +199,13 @@ type ExeDevConfig struct {
 	User        string
 	WorkRoot    string
 	NoEmail     bool
+}
+
+type RailwayConfig struct {
+	APIToken      string
+	APIURL        string
+	ProjectID     string
+	EnvironmentID string
 }
 
 type IsloConfig struct {
@@ -539,6 +547,9 @@ func baseConfig() Config {
 			Disk:        "10GB",
 			NoEmail:     true,
 		},
+		Railway: RailwayConfig{
+			APIURL: "https://backboard.railway.com/graphql/v2",
+		},
 		Islo: IsloConfig{
 			BaseURL:  "https://api.islo.dev",
 			Image:    "docker.io/library/ubuntu:24.04",
@@ -620,6 +631,7 @@ type fileConfig struct {
 	Daytona          *fileDaytonaConfig                 `yaml:"daytona,omitempty"`
 	E2B              *fileE2BConfig                     `yaml:"e2b,omitempty"`
 	ExeDev           *fileExeDevConfig                  `yaml:"exeDev,omitempty"`
+	Railway          *fileRailwayConfig                 `yaml:"railway,omitempty"`
 	Islo             *fileIsloConfig                    `yaml:"islo,omitempty"`
 	Tensorlake       *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
 	Modal            *fileModalConfig                   `yaml:"modal,omitempty"`
@@ -816,6 +828,12 @@ type fileExeDevConfig struct {
 	User        string `yaml:"user,omitempty"`
 	WorkRoot    string `yaml:"workRoot,omitempty"`
 	NoEmail     *bool  `yaml:"noEmail,omitempty"`
+}
+
+type fileRailwayConfig struct {
+	APIURL        string `yaml:"apiUrl,omitempty"`
+	ProjectID     string `yaml:"projectId,omitempty"`
+	EnvironmentID string `yaml:"environmentId,omitempty"`
 }
 
 type fileIsloConfig struct {
@@ -1611,6 +1629,17 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.ExeDev.NoEmail = *file.ExeDev.NoEmail
 		}
 	}
+	if file.Railway != nil {
+		if file.Railway.APIURL != "" {
+			cfg.Railway.APIURL = file.Railway.APIURL
+		}
+		if file.Railway.ProjectID != "" {
+			cfg.Railway.ProjectID = file.Railway.ProjectID
+		}
+		if file.Railway.EnvironmentID != "" {
+			cfg.Railway.EnvironmentID = file.Railway.EnvironmentID
+		}
+	}
 	if file.Islo != nil {
 		if file.Islo.BaseURL != "" {
 			cfg.Islo.BaseURL = file.Islo.BaseURL
@@ -2257,6 +2286,10 @@ func applyEnv(cfg *Config) {
 	if value, ok := getenvBool("CRABBOX_EXE_DEV_NO_EMAIL"); ok {
 		cfg.ExeDev.NoEmail = value
 	}
+	cfg.Railway.APIToken = getenv("CRABBOX_RAILWAY_API_TOKEN", getenv("RAILWAY_API_TOKEN", cfg.Railway.APIToken))
+	cfg.Railway.APIURL = getenv("CRABBOX_RAILWAY_API_URL", getenv("RAILWAY_API_URL", cfg.Railway.APIURL))
+	cfg.Railway.ProjectID = getenv("CRABBOX_RAILWAY_PROJECT_ID", getenv("RAILWAY_PROJECT_ID", cfg.Railway.ProjectID))
+	cfg.Railway.EnvironmentID = getenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", getenv("RAILWAY_ENVIRONMENT_ID", cfg.Railway.EnvironmentID))
 	cfg.Islo.APIKey = getenv("CRABBOX_ISLO_API_KEY", getenv("ISLO_API_KEY", cfg.Islo.APIKey))
 	cfg.Islo.BaseURL = getenv("CRABBOX_ISLO_BASE_URL", getenv("ISLO_BASE_URL", cfg.Islo.BaseURL))
 	cfg.Islo.Image = getenv("CRABBOX_ISLO_IMAGE", cfg.Islo.Image)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -139,6 +139,14 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_EXE_DEV_USER",
 		"CRABBOX_EXE_DEV_WORK_ROOT",
 		"CRABBOX_EXE_DEV_NO_EMAIL",
+		"CRABBOX_RAILWAY_API_TOKEN",
+		"RAILWAY_API_TOKEN",
+		"CRABBOX_RAILWAY_API_URL",
+		"RAILWAY_API_URL",
+		"CRABBOX_RAILWAY_PROJECT_ID",
+		"RAILWAY_PROJECT_ID",
+		"CRABBOX_RAILWAY_ENVIRONMENT_ID",
+		"RAILWAY_ENVIRONMENT_ID",
 	} {
 		t.Setenv(key, "")
 	}
@@ -312,6 +320,10 @@ e2b:
   template: crabbox-ready
   workdir: work/repo
   user: sandbox
+railway:
+  apiUrl: https://railway.example.test/graphql/v2
+  projectId: project-file
+  environmentId: environment-file
 islo:
   baseUrl: https://islo.example.test
   image: docker.io/library/ubuntu:24.04
@@ -467,6 +479,9 @@ ssh:
 	}
 	if cfg.E2B.APIURL != "https://api.e2b.example.test" || cfg.E2B.Domain != "e2b.example.test" || cfg.E2B.Template != "crabbox-ready" || cfg.E2B.Workdir != "work/repo" || cfg.E2B.User != "sandbox" {
 		t.Fatalf("e2b config not loaded: %#v", cfg.E2B)
+	}
+	if cfg.Railway.APIURL != "https://railway.example.test/graphql/v2" || cfg.Railway.ProjectID != "project-file" || cfg.Railway.EnvironmentID != "environment-file" {
+		t.Fatalf("railway config not loaded: %#v", cfg.Railway)
 	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
 		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
@@ -645,6 +660,14 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_E2B_TEMPLATE", "template-env")
 	t.Setenv("CRABBOX_E2B_WORKDIR", "env-workdir")
 	t.Setenv("CRABBOX_E2B_USER", "sandbox-env")
+	t.Setenv("RAILWAY_API_TOKEN", "railway-token-file")
+	t.Setenv("CRABBOX_RAILWAY_API_TOKEN", "railway-token-env")
+	t.Setenv("RAILWAY_API_URL", "https://railway-file.example/graphql/v2")
+	t.Setenv("CRABBOX_RAILWAY_API_URL", "https://railway-env.example/graphql/v2")
+	t.Setenv("RAILWAY_PROJECT_ID", "railway-project-file")
+	t.Setenv("CRABBOX_RAILWAY_PROJECT_ID", "railway-project-env")
+	t.Setenv("RAILWAY_ENVIRONMENT_ID", "railway-environment-file")
+	t.Setenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", "railway-environment-env")
 	t.Setenv("ISLO_API_KEY", "islo-api-file")
 	t.Setenv("CRABBOX_ISLO_API_KEY", "islo-api-env")
 	t.Setenv("ISLO_BASE_URL", "https://islo-file.example")
@@ -797,6 +820,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.E2B.APIKey != "e2b-api-env" || cfg.E2B.APIURL != "https://api.e2b-env.example" || cfg.E2B.Domain != "e2b-env.example" || cfg.E2B.Template != "template-env" || cfg.E2B.Workdir != "env-workdir" || cfg.E2B.User != "sandbox-env" {
 		t.Fatalf("unexpected e2b env: %#v", cfg.E2B)
+	}
+	if cfg.Railway.APIToken != "railway-token-env" || cfg.Railway.APIURL != "https://railway-env.example/graphql/v2" || cfg.Railway.ProjectID != "railway-project-env" || cfg.Railway.EnvironmentID != "railway-environment-env" {
+		t.Fatalf("unexpected railway env: %#v", cfg.Railway)
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {
 		t.Fatalf("unexpected islo env: %#v", cfg.Islo)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -382,7 +382,7 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, or cloudflare"
+	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, railway, or cloudflare"
 }
 
 func providerHelpSSH() string {

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/modal"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
+	_ "github.com/openclaw/crabbox/internal/providers/railway"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -21,6 +21,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"modal",
 		"namespace-devbox",
 		"proxmox",
+		"railway",
 		"semaphore",
 		"sprites",
 		"ssh",

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -15,11 +15,12 @@ import (
 // reaches a terminal state. The interval grows exponentially with jitter so a
 // long deployment doesn't hammer the API while a short one still feels snappy.
 const (
-	railwayPollInitialInterval = 5 * time.Second
-	railwayPollMaxInterval     = 30 * time.Second
-	railwayPollOverallTimeout  = 30 * time.Minute
-	railwayPollJitterFraction  = 0.2
-	railwayPollLogLimit        = 500
+	railwayPollInitialInterval  = 5 * time.Second
+	railwayPollMaxInterval      = 30 * time.Second
+	railwayPollOverallTimeout   = 30 * time.Minute
+	railwayDeployResolveTimeout = 2 * time.Minute
+	railwayPollJitterFraction   = 0.2
+	railwayPollLogLimit         = 500
 )
 
 // railwayPollRand seeds a private rand.Source on first use so jitter doesn't
@@ -62,6 +63,8 @@ type railwayBackend struct {
 	pollInitialOverride time.Duration
 	// pollOverallOverride lets tests shorten the overall poll timeout.
 	pollOverallOverride time.Duration
+	// deployResolveOverride lets tests shorten boolean-trigger deployment resolution.
+	deployResolveOverride time.Duration
 }
 
 func (b *railwayBackend) Spec() ProviderSpec { return b.spec }
@@ -97,16 +100,17 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 	started := b.now()
 	fmt.Fprintf(b.rt.Stderr, "running on %s service=%s command=%s (start command is owned by the Railway service)\n", providerName, req.ID, strings.Join(req.Command, " "))
 
+	previousDeployment, _ := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
 	deploymentID, err := client.TriggerDeploy(ctx, projectID, environmentID, req.ID)
 	if err != nil {
 		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy failed: %v", providerName, err)}
 	}
 	deploymentID = strings.TrimSpace(deploymentID)
 	if deploymentID == "" {
-		// Without an id we cannot poll the deployment we just created vs. the
-		// prior one — surface this as a hard error rather than silently returning
-		// 0 (the legacy behaviour, which masked failing deploys).
-		return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy returned no deployment id", providerName)}
+		deploymentID, err = b.resolveTriggeredDeployment(ctx, client, projectID, environmentID, req.ID, previousDeployment.ID)
+		if err != nil {
+			return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s resolve triggered deployment failed: %v", providerName, err)}
+		}
 	}
 
 	logs := &railwayLogStreamer{out: b.rt.Stdout}
@@ -137,6 +141,45 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s deployment status=%s", providerName, finalStatus)}
 	}
 	return result, nil
+}
+
+func (b *railwayBackend) resolveTriggeredDeployment(ctx context.Context, client railwayAPI, projectID, environmentID, serviceID, previousID string) (string, error) {
+	overall := railwayDeployResolveTimeout
+	if b.deployResolveOverride > 0 {
+		overall = b.deployResolveOverride
+	}
+	deadlineCtx, cancel := context.WithTimeout(ctx, overall)
+	defer cancel()
+
+	interval := railwayPollInitialInterval
+	if b.pollInitialOverride > 0 {
+		interval = b.pollInitialOverride
+	}
+	for {
+		deployment, err := client.LatestDeployment(deadlineCtx, projectID, environmentID, serviceID)
+		if err != nil {
+			if deadlineCtx.Err() != nil {
+				return "", fmt.Errorf("deployment resolution cancelled: %w", deadlineCtx.Err())
+			}
+			return "", err
+		}
+		deploymentID := strings.TrimSpace(deployment.ID)
+		if deploymentID != "" && deploymentID != strings.TrimSpace(previousID) {
+			return deploymentID, nil
+		}
+		sleepFor := railwayJitter(interval)
+		select {
+		case <-deadlineCtx.Done():
+			return "", fmt.Errorf("deployment resolution cancelled: %w", deadlineCtx.Err())
+		case <-time.After(sleepFor):
+		}
+		if interval < railwayPollMaxInterval {
+			interval *= 2
+			if interval > railwayPollMaxInterval {
+				interval = railwayPollMaxInterval
+			}
+		}
+	}
 }
 
 // pollDeployment polls a specific deployment until it reaches a terminal state
@@ -309,7 +352,7 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 		Slug:       service.Name,
 		Provider:   providerName,
 		TargetOS:   targetLinux,
-		State:      strings.ToLower(string(deployment.Status.Normalized())),
+		State:      deployment.Status.State(),
 		ServerID:   service.ID,
 		ServerType: "railway-service",
 		Network:    networkPublic,

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -100,13 +100,16 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 	started := b.now()
 	fmt.Fprintf(b.rt.Stderr, "running on %s service=%s command=%s (start command is owned by the Railway service)\n", providerName, req.ID, strings.Join(req.Command, " "))
 
-	previousDeployment, _ := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	previousDeployment, previousErr := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
 	deploymentID, err := client.TriggerDeploy(ctx, projectID, environmentID, req.ID)
 	if err != nil {
 		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy failed: %v", providerName, err)}
 	}
 	deploymentID = strings.TrimSpace(deploymentID)
 	if deploymentID == "" {
+		if previousErr != nil {
+			return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s read latest deployment before trigger failed: %v", providerName, previousErr)}
+		}
 		deploymentID, err = b.resolveTriggeredDeployment(ctx, client, projectID, environmentID, req.ID, previousDeployment.ID)
 		if err != nil {
 			return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s resolve triggered deployment failed: %v", providerName, err)}
@@ -260,7 +263,7 @@ func (s *railwayLogStreamer) Flush(ctx context.Context, client railwayAPI, deplo
 }
 
 func printNewRailwayLogs(out io.Writer, lines []string, seen []string) []string {
-	start := commonRailwayLogPrefix(seen, lines)
+	start := overlappingRailwayLogLines(seen, lines)
 	for _, line := range lines[start:] {
 		fmt.Fprintln(out, line)
 	}
@@ -269,17 +272,25 @@ func printNewRailwayLogs(out io.Writer, lines []string, seen []string) []string 
 	return next
 }
 
-func commonRailwayLogPrefix(a, b []string) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
+func overlappingRailwayLogLines(previous, current []string) int {
+	n := len(previous)
+	if len(current) < n {
+		n = len(current)
 	}
-	for i := 0; i < n; i++ {
-		if a[i] != b[i] {
-			return i
+	for overlap := n; overlap > 0; overlap-- {
+		match := true
+		previousStart := len(previous) - overlap
+		for i := 0; i < overlap; i++ {
+			if previous[previousStart+i] != current[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return overlap
 		}
 	}
-	return n
+	return 0
 }
 
 func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -443,6 +443,12 @@ func rejectRailwayRunOptions(req RunRequest) error {
 	if req.FullResync {
 		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
 	}
+	if req.ShellMode {
+		return exit(2, "provider=%s runs the Railway service start command; --shell is not supported", providerName)
+	}
+	if len(req.Env) > 0 || req.EnvSummary {
+		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
+	}
 	return nil
 }
 

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -3,6 +3,7 @@ package railway
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"strings"
 	"sync"
@@ -108,18 +109,11 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 		return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy returned no deployment id", providerName)}
 	}
 
-	finalStatus, pollErr := b.pollDeployment(ctx, client, deploymentID)
+	logs := &railwayLogStreamer{out: b.rt.Stdout}
+	finalStatus, pollErr := b.pollDeployment(ctx, client, deploymentID, logs)
 	if pollErr != nil {
 		commandDuration := b.now().Sub(started)
 		return RunResult{ExitCode: 1, Command: commandDuration, Total: commandDuration}, ExitError{Code: 1, Message: fmt.Sprintf("%s deployment %s polling failed: %v", providerName, deploymentID, pollErr)}
-	}
-
-	logs, err := client.DeploymentLogs(ctx, deploymentID, railwayPollLogLimit)
-	if err != nil {
-		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s fetch logs failed: %v", providerName, err)}
-	}
-	for _, line := range logs {
-		fmt.Fprintln(b.rt.Stdout, line)
 	}
 
 	commandDuration := b.now().Sub(started)
@@ -148,7 +142,7 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 // pollDeployment polls a specific deployment until it reaches a terminal state
 // or the overall timeout / parent context expires. Returns the final observed
 // status on success.
-func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, deploymentID string) (railwayDeploymentStatus, error) {
+func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, deploymentID string, logs *railwayLogStreamer) (railwayDeploymentStatus, error) {
 	overall := railwayPollOverallTimeout
 	if b.pollOverallOverride > 0 {
 		overall = b.pollOverallOverride
@@ -173,7 +167,17 @@ func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, 
 			return "", err
 		}
 		if dep.Status.IsTerminal() {
+			if logs != nil {
+				if err := logs.Flush(deadlineCtx, client, deploymentID); err != nil {
+					return "", err
+				}
+			}
 			return dep.Status, nil
+		}
+		if logs != nil {
+			if err := logs.Flush(deadlineCtx, client, deploymentID); err != nil {
+				return "", err
+			}
 		}
 		// Backoff with ±jitter, capped at railwayPollMaxInterval.
 		sleepFor := railwayJitter(interval)
@@ -189,6 +193,50 @@ func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, 
 			}
 		}
 	}
+}
+
+type railwayLogStreamer struct {
+	out            io.Writer
+	buildSeen      []string
+	deploymentSeen []string
+}
+
+func (s *railwayLogStreamer) Flush(ctx context.Context, client railwayAPI, deploymentID string) error {
+	buildLogs, err := client.BuildLogs(ctx, deploymentID, railwayPollLogLimit)
+	if err != nil {
+		return fmt.Errorf("fetch build logs: %w", err)
+	}
+	s.buildSeen = printNewRailwayLogs(s.out, buildLogs, s.buildSeen)
+
+	deploymentLogs, err := client.DeploymentLogs(ctx, deploymentID, railwayPollLogLimit)
+	if err != nil {
+		return fmt.Errorf("fetch deployment logs: %w", err)
+	}
+	s.deploymentSeen = printNewRailwayLogs(s.out, deploymentLogs, s.deploymentSeen)
+	return nil
+}
+
+func printNewRailwayLogs(out io.Writer, lines []string, seen []string) []string {
+	start := commonRailwayLogPrefix(seen, lines)
+	for _, line := range lines[start:] {
+		fmt.Fprintln(out, line)
+	}
+	next := make([]string, len(lines))
+	copy(next, lines)
+	return next
+}
+
+func commonRailwayLogPrefix(a, b []string) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
 }
 
 func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -265,7 +313,7 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 		ServerID:   service.ID,
 		ServerType: "railway-service",
 		Network:    networkPublic,
-		Ready:      deployment.Status.Normalized() == railwayStatusSuccess,
+		Ready:      deployment.Status.IsReady(),
 		Labels:     map[string]string{"projectId": service.ProjectID},
 	}
 	return view, nil

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -457,7 +457,7 @@ func rejectRailwayRunOptions(req RunRequest) error {
 	if req.ShellMode {
 		return exit(2, "provider=%s runs the Railway service start command; --shell is not supported", providerName)
 	}
-	if len(req.Env) > 0 || req.EnvSummary {
+	if req.EnvSummary {
 		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
 	}
 	return nil

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -315,6 +315,17 @@ func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView
 	return servers, nil
 }
 
+func (b *railwayBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if _, _, err := b.requireProjectEnv(); err != nil {
+		return DoctorResult{}, err
+	}
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
 func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
 	if req.ID == "" {
 		return StatusView{}, exit(2, "provider=%s status requires --id <railway-service-id>", providerName)

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -3,9 +3,47 @@ package railway
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
+	"sync"
 	"time"
 )
+
+// Polling configuration for Run(). Railway has no synchronous exec endpoint,
+// so we trigger a deploy and then poll the new deployment's status until it
+// reaches a terminal state. The interval grows exponentially with jitter so a
+// long deployment doesn't hammer the API while a short one still feels snappy.
+const (
+	railwayPollInitialInterval = 5 * time.Second
+	railwayPollMaxInterval     = 30 * time.Second
+	railwayPollOverallTimeout  = 30 * time.Minute
+	railwayPollJitterFraction  = 0.2
+	railwayPollLogLimit        = 500
+)
+
+// railwayPollRand seeds a private rand.Source on first use so jitter doesn't
+// rely on the global generator (which other tests may reseed) while staying
+// dependency-free.
+var (
+	railwayPollRandOnce sync.Once
+	railwayPollRand     *rand.Rand
+	railwayPollRandMu   sync.Mutex
+)
+
+func railwayJitter(d time.Duration) time.Duration {
+	railwayPollRandOnce.Do(func() {
+		railwayPollRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	})
+	railwayPollRandMu.Lock()
+	defer railwayPollRandMu.Unlock()
+	// Centered jitter in [-fraction, +fraction] * d.
+	delta := (railwayPollRand.Float64()*2 - 1) * railwayPollJitterFraction
+	jittered := time.Duration(float64(d) * (1 + delta))
+	if jittered <= 0 {
+		return d
+	}
+	return jittered
+}
 
 func NewRailwayBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -17,6 +55,12 @@ type railwayBackend struct {
 	cfg    Config
 	rt     Runtime
 	client railwayAPI
+
+	// pollOverride lets tests shrink the polling interval without changing the
+	// production defaults. When zero, railwayPollInitialInterval is used.
+	pollInitialOverride time.Duration
+	// pollOverallOverride lets tests shorten the overall poll timeout.
+	pollOverallOverride time.Duration
 }
 
 func (b *railwayBackend) Spec() ProviderSpec { return b.spec }
@@ -38,13 +82,9 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 	if req.ID == "" {
 		return RunResult{}, exit(2, "provider=%s requires --id <railway-service-id>", providerName)
 	}
-	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
-	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
-	if projectID == "" {
-		return RunResult{}, exit(2, "provider=%s requires --railway-project or RAILWAY_PROJECT_ID", providerName)
-	}
-	if environmentID == "" {
-		return RunResult{}, exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
+	projectID, environmentID, err := b.requireProjectEnv()
+	if err != nil {
+		return RunResult{}, err
 	}
 	if len(req.Command) == 0 {
 		return RunResult{}, exit(2, "missing command")
@@ -55,30 +95,40 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 	}
 	started := b.now()
 	fmt.Fprintf(b.rt.Stderr, "running on %s service=%s command=%s (start command is owned by the Railway service)\n", providerName, req.ID, strings.Join(req.Command, " "))
-	if _, err := client.TriggerDeploy(ctx, projectID, environmentID, req.ID); err != nil {
+
+	deploymentID, err := client.TriggerDeploy(ctx, projectID, environmentID, req.ID)
+	if err != nil {
 		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy failed: %v", providerName, err)}
 	}
-	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
-	if err != nil {
-		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s fetch deployment failed: %v", providerName, err)}
+	deploymentID = strings.TrimSpace(deploymentID)
+	if deploymentID == "" {
+		// Without an id we cannot poll the deployment we just created vs. the
+		// prior one — surface this as a hard error rather than silently returning
+		// 0 (the legacy behaviour, which masked failing deploys).
+		return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy returned no deployment id", providerName)}
 	}
-	if deployment.ID == "" {
-		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s deployment id missing", providerName)}
+
+	finalStatus, pollErr := b.pollDeployment(ctx, client, deploymentID)
+	if pollErr != nil {
+		commandDuration := b.now().Sub(started)
+		return RunResult{ExitCode: 1, Command: commandDuration, Total: commandDuration}, ExitError{Code: 1, Message: fmt.Sprintf("%s deployment %s polling failed: %v", providerName, deploymentID, pollErr)}
 	}
-	logs, err := client.DeploymentLogs(ctx, deployment.ID, 0)
+
+	logs, err := client.DeploymentLogs(ctx, deploymentID, railwayPollLogLimit)
 	if err != nil {
 		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s fetch logs failed: %v", providerName, err)}
 	}
 	for _, line := range logs {
 		fmt.Fprintln(b.rt.Stdout, line)
 	}
+
 	commandDuration := b.now().Sub(started)
 	result := RunResult{
-		ExitCode: railwayExitCode(deployment.Status),
+		ExitCode: finalStatus.ExitCode(),
 		Command:  commandDuration,
 		Total:    commandDuration,
 	}
-	fmt.Fprintf(b.rt.Stderr, "%s run summary command=%s total=%s exit=%d status=%s\n", providerName, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode, deployment.Status)
+	fmt.Fprintf(b.rt.Stderr, "%s run summary command=%s total=%s exit=%d status=%s\n", providerName, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode, finalStatus)
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
 			Provider:  providerName,
@@ -90,9 +140,55 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 		}
 	}
 	if result.ExitCode != 0 {
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s deployment status=%s", providerName, deployment.Status)}
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s deployment status=%s", providerName, finalStatus)}
 	}
 	return result, nil
+}
+
+// pollDeployment polls a specific deployment until it reaches a terminal state
+// or the overall timeout / parent context expires. Returns the final observed
+// status on success.
+func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, deploymentID string) (railwayDeploymentStatus, error) {
+	overall := railwayPollOverallTimeout
+	if b.pollOverallOverride > 0 {
+		overall = b.pollOverallOverride
+	}
+	deadlineCtx, cancel := context.WithTimeout(ctx, overall)
+	defer cancel()
+
+	initial := railwayPollInitialInterval
+	if b.pollInitialOverride > 0 {
+		initial = b.pollInitialOverride
+	}
+	interval := initial
+
+	for {
+		dep, err := client.Deployment(deadlineCtx, deploymentID)
+		if err != nil {
+			// Bubble up context errors as-is so the caller can tell timeout from
+			// transport failures.
+			if deadlineCtx.Err() != nil {
+				return "", fmt.Errorf("polling cancelled: %w", deadlineCtx.Err())
+			}
+			return "", err
+		}
+		if dep.Status.IsTerminal() {
+			return dep.Status, nil
+		}
+		// Backoff with ±jitter, capped at railwayPollMaxInterval.
+		sleepFor := railwayJitter(interval)
+		select {
+		case <-deadlineCtx.Done():
+			return "", fmt.Errorf("polling cancelled: %w", deadlineCtx.Err())
+		case <-time.After(sleepFor):
+		}
+		if interval < railwayPollMaxInterval {
+			interval *= 2
+			if interval > railwayPollMaxInterval {
+				interval = railwayPollMaxInterval
+			}
+		}
+	}
 }
 
 func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -121,33 +217,55 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 	if req.ID == "" {
 		return StatusView{}, exit(2, "provider=%s status requires --id <railway-service-id>", providerName)
 	}
-	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
-	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
-	if projectID == "" || environmentID == "" {
+	projectID, environmentID, err := b.requireProjectEnv()
+	if err != nil {
+		// Status accepts the legacy combined message because callers historically
+		// piped --id-only requests through here.
 		return StatusView{}, exit(2, "provider=%s status requires --railway-project and --railway-environment", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
 		return StatusView{}, err
 	}
-	service, err := client.GetService(ctx, req.ID)
-	if err != nil {
-		return StatusView{}, err
+
+	// GetService and LatestDeployment are independent reads; fan them out in
+	// parallel so a slow Railway region doesn't double the wall-clock cost of
+	// a status check. Done with a WaitGroup rather than errgroup because the
+	// repository does not depend on golang.org/x/sync.
+	var (
+		wg         sync.WaitGroup
+		service    railwayService
+		deployment railwayDeployment
+		serviceErr error
+		deployErr  error
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		service, serviceErr = client.GetService(ctx, req.ID)
+	}()
+	go func() {
+		defer wg.Done()
+		deployment, deployErr = client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	}()
+	wg.Wait()
+	if serviceErr != nil {
+		return StatusView{}, serviceErr
 	}
-	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
-	if err != nil {
-		return StatusView{}, err
+	if deployErr != nil {
+		return StatusView{}, deployErr
 	}
+
 	view := StatusView{
 		ID:         service.ID,
 		Slug:       service.Name,
 		Provider:   providerName,
 		TargetOS:   targetLinux,
-		State:      strings.ToLower(deployment.Status),
+		State:      strings.ToLower(string(deployment.Status.Normalized())),
 		ServerID:   service.ID,
 		ServerType: "railway-service",
 		Network:    networkPublic,
-		Ready:      railwayReady(deployment.Status),
+		Ready:      deployment.Status.Normalized() == railwayStatusSuccess,
 		Labels:     map[string]string{"projectId": service.ProjectID},
 	}
 	return view, nil
@@ -157,9 +275,8 @@ func (b *railwayBackend) Stop(ctx context.Context, req StopRequest) error {
 	if req.ID == "" {
 		return exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
 	}
-	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
-	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
-	if projectID == "" || environmentID == "" {
+	projectID, environmentID, err := b.requireProjectEnv()
+	if err != nil {
 		return exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
 	}
 	client, err := b.api()
@@ -181,6 +298,21 @@ func (b *railwayBackend) api() (railwayAPI, error) {
 		return b.client, nil
 	}
 	return newRailwayClient(b.cfg, b.rt)
+}
+
+// requireProjectEnv reads and trims the Railway project + environment ids and
+// returns a CLI-facing exit error when either is missing. Callers route the
+// error directly out to the user.
+func (b *railwayBackend) requireProjectEnv() (string, string, error) {
+	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
+	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
+	if projectID == "" {
+		return "", "", exit(2, "provider=%s requires --railway-project or RAILWAY_PROJECT_ID", providerName)
+	}
+	if environmentID == "" {
+		return "", "", exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
+	}
+	return projectID, environmentID, nil
 }
 
 func rejectRailwayRunOptions(req RunRequest) error {
@@ -210,24 +342,6 @@ func rejectRailwayRunOptions(req RunRequest) error {
 		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
 	}
 	return nil
-}
-
-func railwayExitCode(status string) int {
-	switch strings.ToUpper(strings.TrimSpace(status)) {
-	case "SUCCESS", "DEPLOYED":
-		return 0
-	case "":
-		return 0
-	}
-	return 1
-}
-
-func railwayReady(status string) bool {
-	switch strings.ToUpper(strings.TrimSpace(status)) {
-	case "SUCCESS", "DEPLOYED":
-		return true
-	}
-	return false
 }
 
 func (b *railwayBackend) now() time.Time {

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -1,0 +1,238 @@
+package railway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func NewRailwayBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &railwayBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type railwayBackend struct {
+	spec   ProviderSpec
+	cfg    Config
+	rt     Runtime
+	client railwayAPI
+}
+
+func (b *railwayBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *railwayBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	_ = ctx
+	_ = req
+	// Warmup is rejected because Railway services and projects must be created
+	// out-of-band (the provider would otherwise leak billable resources if a
+	// warmup were triggered accidentally). Use the Railway dashboard or CLI to
+	// create the service, then point crabbox at it with --id <serviceId>.
+	return exit(2, "provider=%s does not support warmup; create the Railway service out-of-band", providerName)
+}
+
+func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := rejectRailwayRunOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	if req.ID == "" {
+		return RunResult{}, exit(2, "provider=%s requires --id <railway-service-id>", providerName)
+	}
+	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
+	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
+	if projectID == "" {
+		return RunResult{}, exit(2, "provider=%s requires --railway-project or RAILWAY_PROJECT_ID", providerName)
+	}
+	if environmentID == "" {
+		return RunResult{}, exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
+	}
+	if len(req.Command) == 0 {
+		return RunResult{}, exit(2, "missing command")
+	}
+	client, err := b.api()
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	fmt.Fprintf(b.rt.Stderr, "running on %s service=%s command=%s (start command is owned by the Railway service)\n", providerName, req.ID, strings.Join(req.Command, " "))
+	if _, err := client.TriggerDeploy(ctx, projectID, environmentID, req.ID); err != nil {
+		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy failed: %v", providerName, err)}
+	}
+	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	if err != nil {
+		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s fetch deployment failed: %v", providerName, err)}
+	}
+	if deployment.ID == "" {
+		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s deployment id missing", providerName)}
+	}
+	logs, err := client.DeploymentLogs(ctx, deployment.ID, 0)
+	if err != nil {
+		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s fetch logs failed: %v", providerName, err)}
+	}
+	for _, line := range logs {
+		fmt.Fprintln(b.rt.Stdout, line)
+	}
+	commandDuration := b.now().Sub(started)
+	result := RunResult{
+		ExitCode: railwayExitCode(deployment.Status),
+		Command:  commandDuration,
+		Total:    commandDuration,
+	}
+	fmt.Fprintf(b.rt.Stderr, "%s run summary command=%s total=%s exit=%d status=%s\n", providerName, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode, deployment.Status)
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:  providerName,
+			CommandMs: commandDuration.Milliseconds(),
+			TotalMs:   result.Total.Milliseconds(),
+			ExitCode:  result.ExitCode,
+		}); err != nil {
+			return result, err
+		}
+	}
+	if result.ExitCode != 0 {
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s deployment status=%s", providerName, deployment.Status)}
+	}
+	return result, nil
+}
+
+func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := b.api()
+	if err != nil {
+		return nil, err
+	}
+	services, err := client.ListServices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(services))
+	for _, s := range services {
+		servers = append(servers, Server{
+			CloudID:  s.ID,
+			Provider: providerName,
+			Name:     s.Name,
+			Labels:   map[string]string{"projectId": s.ProjectID},
+		})
+	}
+	return servers, nil
+}
+
+func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	if req.ID == "" {
+		return StatusView{}, exit(2, "provider=%s status requires --id <railway-service-id>", providerName)
+	}
+	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
+	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
+	if projectID == "" || environmentID == "" {
+		return StatusView{}, exit(2, "provider=%s status requires --railway-project and --railway-environment", providerName)
+	}
+	client, err := b.api()
+	if err != nil {
+		return StatusView{}, err
+	}
+	service, err := client.GetService(ctx, req.ID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	view := StatusView{
+		ID:         service.ID,
+		Slug:       service.Name,
+		Provider:   providerName,
+		TargetOS:   targetLinux,
+		State:      strings.ToLower(deployment.Status),
+		ServerID:   service.ID,
+		ServerType: "railway-service",
+		Network:    networkPublic,
+		Ready:      railwayReady(deployment.Status),
+		Labels:     map[string]string{"projectId": service.ProjectID},
+	}
+	return view, nil
+}
+
+func (b *railwayBackend) Stop(ctx context.Context, req StopRequest) error {
+	if req.ID == "" {
+		return exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+	}
+	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
+	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
+	if projectID == "" || environmentID == "" {
+		return exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
+	}
+	client, err := b.api()
+	if err != nil {
+		return err
+	}
+	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, req.ID)
+	if err != nil {
+		return err
+	}
+	if deployment.ID == "" {
+		return exit(5, "provider=%s service=%s has no deployment to stop", providerName, req.ID)
+	}
+	return client.StopDeployment(ctx, deployment.ID)
+}
+
+func (b *railwayBackend) api() (railwayAPI, error) {
+	if b.client != nil {
+		return b.client, nil
+	}
+	return newRailwayClient(b.cfg, b.rt)
+}
+
+func rejectRailwayRunOptions(req RunRequest) error {
+	if req.Keep {
+		return exit(2, "provider=%s lifecycle is owned by Railway; --keep is not supported", providerName)
+	}
+	if req.Reclaim {
+		return exit(2, "provider=%s lifecycle is owned by Railway; --reclaim is not supported", providerName)
+	}
+	if !req.NoSync {
+		// Railway does not expose a workspace-sync surface; mirror other
+		// delegated-only providers and require --no-sync explicitly so callers
+		// understand the deploy runs whatever the service is already configured
+		// to run.
+		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
+	}
+	if req.SyncOnly {
+		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
+	}
+	if req.ChecksumSync {
+		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
+	}
+	if req.ForceSyncLarge {
+		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
+	}
+	if req.FullResync {
+		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
+	}
+	return nil
+}
+
+func railwayExitCode(status string) int {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "SUCCESS", "DEPLOYED":
+		return 0
+	case "":
+		return 0
+	}
+	return 1
+}
+
+func railwayReady(status string) bool {
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "SUCCESS", "DEPLOYED":
+		return true
+	}
+	return false
+}
+
+func (b *railwayBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -218,6 +218,36 @@ func TestRailwayClientSurfacesGraphQLErrorsAsAPIError(t *testing.T) {
 	}
 }
 
+func TestRailwayClientDecodesLargeLogResponse(t *testing.T) {
+	message := strings.Repeat("x", 2<<20)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"deploymentLogs": []map[string]string{{"message": message}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logs, err := client.DeploymentLogs(context.Background(), "dep-1", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("logs len=%d, want 1", len(logs))
+	}
+	if logs[0] != message {
+		t.Fatalf("log len=%d, want %d", len(logs[0]), len(message))
+	}
+}
+
 func TestRailwayRunRequiresNoSync(t *testing.T) {
 	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	_, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", Command: []string{"pnpm", "test"}})
@@ -261,8 +291,7 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 		{name: "keep", req: RunRequest{ID: "svc-1", Keep: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--keep"},
 		{name: "reclaim", req: RunRequest{ID: "svc-1", Reclaim: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--reclaim"},
 		{name: "shell", req: RunRequest{ID: "svc-1", ShellMode: true, NoSync: true, Command: []string{"pnpm test"}}, want: "--shell"},
-		{name: "env", req: RunRequest{ID: "svc-1", NoSync: true, Env: map[string]string{"TOKEN": "secret"}, Command: []string{"pnpm", "test"}}, want: "environment"},
-		{name: "env summary", req: RunRequest{ID: "svc-1", NoSync: true, EnvSummary: true, Command: []string{"pnpm", "test"}}, want: "environment"},
+		{name: "env summary", req: RunRequest{ID: "svc-1", NoSync: true, Env: map[string]string{"TOKEN": "secret"}, EnvSummary: true, Command: []string{"pnpm", "test"}}, want: "environment"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
@@ -271,6 +300,18 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 				t.Fatalf("err = %v, want %s rejection", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestRailwayRunAllowsImplicitDefaultEnv(t *testing.T) {
+	err := rejectRailwayRunOptions(RunRequest{
+		ID:      "svc-1",
+		NoSync:  true,
+		Env:     map[string]string{"CI": "true"},
+		Command: []string{"pnpm", "test"},
+	})
+	if err != nil {
+		t.Fatalf("rejectRailwayRunOptions err: %v", err)
 	}
 }
 

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -122,6 +122,28 @@ func TestRailwayClientSendsBearerAndGraphQLBody(t *testing.T) {
 	}
 }
 
+func TestRailwayClientAcceptsBooleanTriggerDeployResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"data":{"environmentTriggersDeploy":true}}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployID, err := client.TriggerDeploy(context.Background(), "proj-1", "env-1", "svc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deployID != "" {
+		t.Fatalf("deployID = %q, want empty fallback marker", deployID)
+	}
+}
+
 func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden by token", http.StatusForbidden)
@@ -241,6 +263,8 @@ type fakeRailwayAPI struct {
 	logs                 []string
 	logsForID            string
 	deployment           railwayDeployment
+	latestDeployments    []railwayDeployment
+	latestCalls          int
 	// pollStatuses, when non-empty, is the sequence of statuses returned by
 	// Deployment() one call at a time. The last entry is replayed forever so
 	// callers can model "many non-terminal polls then a terminal one".
@@ -282,6 +306,14 @@ func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, deploymentID string, 
 func (f *fakeRailwayAPI) LatestDeployment(_ context.Context, _, _, _ string) (railwayDeployment, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.latestCalls++
+	if len(f.latestDeployments) > 0 {
+		idx := f.latestCalls - 1
+		if idx >= len(f.latestDeployments) {
+			idx = len(f.latestDeployments) - 1
+		}
+		return f.latestDeployments[idx], nil
+	}
 	return f.deployment, nil
 }
 
@@ -341,12 +373,13 @@ func newRailwayBackendForTest(api *fakeRailwayAPI) *railwayBackend {
 	cfg.Railway.EnvironmentID = "env-1"
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
 	return &railwayBackend{
-		spec:                Provider{}.Spec(),
-		cfg:                 cfg,
-		rt:                  rt,
-		client:              api,
-		pollInitialOverride: time.Millisecond,
-		pollOverallOverride: 5 * time.Second,
+		spec:                  Provider{}.Spec(),
+		cfg:                   cfg,
+		rt:                    rt,
+		client:                api,
+		pollInitialOverride:   time.Millisecond,
+		pollOverallOverride:   5 * time.Second,
+		deployResolveOverride: 5 * time.Second,
 	}
 }
 
@@ -415,6 +448,33 @@ func TestRailwayRunPollsDeployingThenSuccess(t *testing.T) {
 	}
 }
 
+func TestRailwayRunResolvesDeploymentWhenTriggerReturnsNoID(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID: "",
+		latestDeployments: []railwayDeployment{
+			{ID: "dep-old", Status: railwayStatusSuccess},
+			{ID: "dep-old", Status: railwayStatusSuccess},
+			{ID: "dep-new", Status: railwayStatusQueued},
+		},
+		pollStatuses: []railwayDeploymentStatus{railwayStatusSuccess},
+		logs:         []string{"ok"},
+	}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if api.logsForID != "dep-new" {
+		t.Fatalf("logs fetched for id=%q, want dep-new", api.logsForID)
+	}
+	if api.latestCalls < 3 {
+		t.Fatalf("latest calls = %d, want fallback polling", api.latestCalls)
+	}
+}
+
 func TestRailwayRunTreatsSleepingAsSuccessfulTerminalStatus(t *testing.T) {
 	api := &fakeRailwayAPI{
 		deployID:     "dep-1",
@@ -471,6 +531,7 @@ func TestRailwayLogStreamerPrintsChangedSnapshots(t *testing.T) {
 func TestRailwayRunReturnsErrorWhenTriggerYieldsEmptyID(t *testing.T) {
 	api := &fakeRailwayAPI{deployID: ""}
 	backend := newRailwayBackendForTest(api)
+	backend.deployResolveOverride = 25 * time.Millisecond
 	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
 	if err == nil {
 		t.Fatal("Run accepted empty deployment id from TriggerDeploy")
@@ -478,8 +539,8 @@ func TestRailwayRunReturnsErrorWhenTriggerYieldsEmptyID(t *testing.T) {
 	if result.ExitCode == 0 {
 		t.Fatalf("exit code = %d, want non-zero on empty deployment id", result.ExitCode)
 	}
-	if !strings.Contains(err.Error(), "no deployment id") {
-		t.Fatalf("err = %v, want 'no deployment id' message", err)
+	if !strings.Contains(err.Error(), "resolve triggered deployment") {
+		t.Fatalf("err = %v, want deployment resolution message", err)
 	}
 }
 
@@ -531,6 +592,17 @@ func TestRailwayDeploymentStatusEnum(t *testing.T) {
 				t.Fatalf("ExitCode() = %d, want %d", got, tc.exitCode)
 			}
 		})
+	}
+}
+
+func TestRailwayDeploymentStatusStateMapsTerminalFailures(t *testing.T) {
+	for _, status := range []railwayDeploymentStatus{railwayStatusFailed, railwayStatusCrashed, railwayStatusRemoved, railwayStatusSkipped} {
+		if got := status.State(); got != "failed" {
+			t.Fatalf("%s State() = %q, want failed", status, got)
+		}
+	}
+	if got := railwayStatusSleeping.State(); got != "sleeping" {
+		t.Fatalf("SLEEPING State() = %q, want sleeping", got)
 	}
 }
 
@@ -623,6 +695,29 @@ func TestRailwayStatusReturnsView(t *testing.T) {
 	}
 	if view.Provider != providerName {
 		t.Fatalf("view.Provider = %q, want %q", view.Provider, providerName)
+	}
+}
+
+func TestRailwayStatusMapsTerminalFailureState(t *testing.T) {
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: railwayStatusCrashed},
+	}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "svc-1"})
+	if err != nil {
+		t.Fatalf("Status err: %v", err)
+	}
+	if view.State != "failed" {
+		t.Fatalf("view.State = %q, want failed", view.State)
+	}
+	if view.Ready {
+		t.Fatal("CRASHED deployment should not be ready")
 	}
 }
 

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -278,6 +278,7 @@ type fakeRailwayAPI struct {
 	triggerErr      error
 	logsErr         error
 	listErr         error
+	latestErr       error
 }
 
 func (f *fakeRailwayAPI) TriggerDeploy(_ context.Context, projectID, environmentID, serviceID string) (string, error) {
@@ -307,6 +308,9 @@ func (f *fakeRailwayAPI) LatestDeployment(_ context.Context, _, _, _ string) (ra
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.latestCalls++
+	if f.latestErr != nil {
+		return railwayDeployment{}, f.latestErr
+	}
 	if len(f.latestDeployments) > 0 {
 		idx := f.latestCalls - 1
 		if idx >= len(f.latestDeployments) {
@@ -475,6 +479,43 @@ func TestRailwayRunResolvesDeploymentWhenTriggerReturnsNoID(t *testing.T) {
 	}
 }
 
+func TestRailwayRunRequiresPreviousDeploymentReadWhenTriggerReturnsNoID(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:  "",
+		latestErr: fmt.Errorf("latest unavailable"),
+	}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted boolean trigger fallback without a trusted previous deployment")
+	}
+	if result.ExitCode == 0 {
+		t.Fatalf("exit code = %d, want non-zero on failed previous deployment read", result.ExitCode)
+	}
+	if !strings.Contains(err.Error(), "read latest deployment before trigger failed") {
+		t.Fatalf("err = %v, want previous deployment read message", err)
+	}
+	if api.triggerServiceID != "svc-1" {
+		t.Fatalf("trigger service = %q, want svc-1", api.triggerServiceID)
+	}
+}
+
+func TestRailwayRunIgnoresPreviousDeploymentReadErrorWhenTriggerReturnsID(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:     "dep-1",
+		latestErr:    fmt.Errorf("latest unavailable"),
+		pollStatuses: []railwayDeploymentStatus{railwayStatusSuccess},
+	}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+}
+
 func TestRailwayRunTreatsSleepingAsSuccessfulTerminalStatus(t *testing.T) {
 	api := &fakeRailwayAPI{
 		deployID:     "dep-1",
@@ -516,14 +557,14 @@ func TestRailwayRunStreamsBuildAndDeploymentLogsWithoutDuplicates(t *testing.T) 
 	}
 }
 
-func TestRailwayLogStreamerPrintsChangedSnapshots(t *testing.T) {
+func TestRailwayLogStreamerPrintsRollingWindowsOnce(t *testing.T) {
 	var stdout strings.Builder
 	var seen []string
-	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2"}, seen)
-	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2"}, seen)
 	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2", "build 3"}, seen)
-	seen = printNewRailwayLogs(&stdout, []string{"build 1", "changed 2", "build 3"}, seen)
-	if got := stdout.String(); got != "build 1\nbuild 2\nbuild 3\nchanged 2\nbuild 3\n" {
+	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2", "build 3"}, seen)
+	seen = printNewRailwayLogs(&stdout, []string{"build 2", "build 3", "build 4"}, seen)
+	seen = printNewRailwayLogs(&stdout, []string{"build 3", "build 4", "build 5"}, seen)
+	if got := stdout.String(); got != "build 1\nbuild 2\nbuild 3\nbuild 4\nbuild 5\n" {
 		t.Fatalf("stdout = %q", got)
 	}
 }
@@ -758,5 +799,23 @@ func TestRailwayFlagsApply(t *testing.T) {
 	}
 	if cfg.Railway.ProjectID != "proj-x" || cfg.Railway.EnvironmentID != "env-x" {
 		t.Fatalf("project=%q env=%q", cfg.Railway.ProjectID, cfg.Railway.EnvironmentID)
+	}
+}
+
+func TestRailwayFlagsRejectUnsupportedSizingForAliases(t *testing.T) {
+	for _, provider := range []string{providerName, "rail", "railwayapp"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := Config{Provider: provider}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			fs.String("class", "", "class")
+			values := RegisterRailwayProviderFlags(fs, cfg)
+			if err := fs.Parse([]string{"--class", "beast"}); err != nil {
+				t.Fatal(err)
+			}
+			err := ApplyRailwayProviderFlags(&cfg, fs, values)
+			if err == nil || !strings.Contains(err.Error(), "--class is not supported") {
+				t.Fatalf("err = %v, want class rejection", err)
+			}
+		})
 	}
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -27,7 +27,7 @@ func TestRailwayProviderSpec(t *testing.T) {
 
 func TestRailwayClientRequiresAPIToken(t *testing.T) {
 	cfg := Config{}
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
 		t.Fatal("newRailwayClient accepted empty API token")
 	}
@@ -36,7 +36,7 @@ func TestRailwayClientRequiresAPIToken(t *testing.T) {
 func TestRailwayClientRejectsBareHTTPURL(t *testing.T) {
 	cfg := Config{}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "http://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "http://backboard.railway.com/graphql/v2"
 	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
 		t.Fatal("newRailwayClient accepted plaintext http URL")
 	}
@@ -278,7 +278,7 @@ func TestRailwayRunHappyPath(t *testing.T) {
 	}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
@@ -302,7 +302,7 @@ func TestRailwayRunFailedDeploymentMapsToExit1(t *testing.T) {
 	}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
@@ -335,7 +335,7 @@ func TestRailwayStopCallsDeploymentStop(t *testing.T) {
 	api := &fakeRailwayAPI{deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"}}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
@@ -354,7 +354,7 @@ func TestRailwayStatusReturnsView(t *testing.T) {
 	}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
@@ -377,7 +377,7 @@ func TestRailwayListEnumeratesServices(t *testing.T) {
 	}}
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
 	servers, err := backend.List(context.Background(), ListRequest{})
 	if err != nil {
@@ -393,7 +393,7 @@ func TestRailwayListEnumeratesServices(t *testing.T) {
 
 func TestRailwayFlagsApply(t *testing.T) {
 	cfg := Config{Provider: providerName}
-	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterRailwayProviderFlags(fs, cfg)
 	if err := fs.Parse([]string{"--railway-url", "https://example.com/graphql/v2", "--railway-project", "proj-x", "--railway-environment", "env-x"}); err != nil {

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -260,6 +260,9 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 	}{
 		{name: "keep", req: RunRequest{ID: "svc-1", Keep: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--keep"},
 		{name: "reclaim", req: RunRequest{ID: "svc-1", Reclaim: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--reclaim"},
+		{name: "shell", req: RunRequest{ID: "svc-1", ShellMode: true, NoSync: true, Command: []string{"pnpm test"}}, want: "--shell"},
+		{name: "env", req: RunRequest{ID: "svc-1", NoSync: true, Env: map[string]string{"TOKEN": "secret"}, Command: []string{"pnpm", "test"}}, want: "environment"},
+		{name: "env summary", req: RunRequest{ID: "svc-1", NoSync: true, EnvSummary: true, Command: []string{"pnpm", "test"}}, want: "environment"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
@@ -268,6 +271,25 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 				t.Fatalf("err = %v, want %s rejection", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestRailwayClientRejectsFalseStopDeploymentResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"data":{"deploymentStop":false}}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.StopDeployment(context.Background(), "dep-1")
+	if err == nil || !strings.Contains(err.Error(), "deploymentStop returned false") {
+		t.Fatalf("err = %v, want false stop error", err)
 	}
 }
 

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -236,6 +236,8 @@ type fakeRailwayAPI struct {
 	triggerEnvironmentID string
 	triggerServiceID     string
 	deployID             string
+	buildLogs            []string
+	buildLogsForID       string
 	logs                 []string
 	logsForID            string
 	deployment           railwayDeployment
@@ -261,6 +263,13 @@ func (f *fakeRailwayAPI) TriggerDeploy(_ context.Context, projectID, environment
 	f.triggerEnvironmentID = environmentID
 	f.triggerServiceID = serviceID
 	return f.deployID, f.triggerErr
+}
+
+func (f *fakeRailwayAPI) BuildLogs(_ context.Context, deploymentID string, _ int) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.buildLogsForID = deploymentID
+	return f.buildLogs, nil
 }
 
 func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, deploymentID string, _ int) ([]string, error) {
@@ -347,6 +356,7 @@ func TestRailwayRunHappyPath(t *testing.T) {
 		// Trigger returns dep-1; the poll loop sees one non-terminal status before
 		// terminating on SUCCESS; logs are then fetched against that exact id.
 		pollStatuses: []railwayDeploymentStatus{railwayStatusDeploying, railwayStatusSuccess},
+		buildLogs:    []string{"building image"},
 		logs:         []string{"+ pnpm test", "PASS suite (1.2s)"},
 	}
 	backend := newRailwayBackendForTest(api)
@@ -362,6 +372,9 @@ func TestRailwayRunHappyPath(t *testing.T) {
 	}
 	if api.logsForID != "dep-1" {
 		t.Fatalf("logs fetched for id=%q, want dep-1 (new deployment, not stale)", api.logsForID)
+	}
+	if api.buildLogsForID != "dep-1" {
+		t.Fatalf("build logs fetched for id=%q, want dep-1 (new deployment, not stale)", api.buildLogsForID)
 	}
 	if api.pollCalls < 2 {
 		t.Fatalf("poll calls = %d, want at least 2 (DEPLOYING then SUCCESS)", api.pollCalls)
@@ -399,6 +412,59 @@ func TestRailwayRunPollsDeployingThenSuccess(t *testing.T) {
 	}
 	if api.pollCalls != 4 {
 		t.Fatalf("poll calls = %d, want 4 (queued, building, deploying, success)", api.pollCalls)
+	}
+}
+
+func TestRailwayRunTreatsSleepingAsSuccessfulTerminalStatus(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:     "dep-1",
+		pollStatuses: []railwayDeploymentStatus{railwayStatusSleeping},
+		logs:         []string{"service is sleeping"},
+	}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if api.pollCalls != 1 {
+		t.Fatalf("poll calls = %d, want 1 for terminal SLEEPING", api.pollCalls)
+	}
+}
+
+func TestRailwayRunStreamsBuildAndDeploymentLogsWithoutDuplicates(t *testing.T) {
+	var stdout strings.Builder
+	api := &fakeRailwayAPI{
+		deployID:     "dep-1",
+		pollStatuses: []railwayDeploymentStatus{railwayStatusDeploying, railwayStatusSuccess},
+		buildLogs:    []string{"build line"},
+		logs:         []string{"deploy line"},
+	}
+	backend := newRailwayBackendForTest(api)
+	backend.rt.Stdout = &stdout
+	if _, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}}); err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	out := stdout.String()
+	if strings.Count(out, "build line") != 1 {
+		t.Fatalf("stdout = %q, want build line once", out)
+	}
+	if strings.Count(out, "deploy line") != 1 {
+		t.Fatalf("stdout = %q, want deploy line once", out)
+	}
+}
+
+func TestRailwayLogStreamerPrintsChangedSnapshots(t *testing.T) {
+	var stdout strings.Builder
+	var seen []string
+	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2"}, seen)
+	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2"}, seen)
+	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2", "build 3"}, seen)
+	seen = printNewRailwayLogs(&stdout, []string{"build 1", "changed 2", "build 3"}, seen)
+	if got := stdout.String(); got != "build 1\nbuild 2\nbuild 3\nchanged 2\nbuild 3\n" {
+		t.Fatalf("stdout = %q", got)
 	}
 }
 
@@ -448,6 +514,7 @@ func TestRailwayDeploymentStatusEnum(t *testing.T) {
 		{railwayStatusCrashed, true, 1},
 		{railwayStatusRemoved, true, 1},
 		{railwayStatusSkipped, true, 1},
+		{railwayStatusSleeping, true, 0},
 		{railwayStatusQueued, false, 1},
 		{railwayStatusInitializing, false, 1},
 		{railwayStatusBuilding, false, 1},
@@ -455,7 +522,6 @@ func TestRailwayDeploymentStatusEnum(t *testing.T) {
 		{railwayStatusWaiting, false, 1},
 		{railwayStatusNeedsApproval, false, 1},
 		{railwayStatusRemoving, false, 1},
-		{railwayStatusSleeping, false, 1},
 	} {
 		t.Run(string(tc.status), func(t *testing.T) {
 			if got := tc.status.IsTerminal(); got != tc.isTerminal {

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestRailwayProviderSpec(t *testing.T) {
@@ -228,61 +231,125 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 }
 
 type fakeRailwayAPI struct {
+	mu                   sync.Mutex
 	triggerProjectID     string
 	triggerEnvironmentID string
 	triggerServiceID     string
 	deployID             string
 	logs                 []string
+	logsForID            string
 	deployment           railwayDeployment
-	services             []railwayService
-	service              railwayService
-	stopID               string
-	triggerErr           error
-	logsErr              error
-	listErr              error
+	// pollStatuses, when non-empty, is the sequence of statuses returned by
+	// Deployment() one call at a time. The last entry is replayed forever so
+	// callers can model "many non-terminal polls then a terminal one".
+	pollStatuses    []railwayDeploymentStatus
+	pollCalls       int
+	deploymentErr   error
+	deploymentBlock chan struct{}
+	services        []railwayService
+	service         railwayService
+	stopID          string
+	triggerErr      error
+	logsErr         error
+	listErr         error
 }
 
 func (f *fakeRailwayAPI) TriggerDeploy(_ context.Context, projectID, environmentID, serviceID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.triggerProjectID = projectID
 	f.triggerEnvironmentID = environmentID
 	f.triggerServiceID = serviceID
 	return f.deployID, f.triggerErr
 }
 
-func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, _ string, _ int) ([]string, error) {
+func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, deploymentID string, _ int) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.logsForID = deploymentID
 	return f.logs, f.logsErr
 }
 
 func (f *fakeRailwayAPI) LatestDeployment(_ context.Context, _, _, _ string) (railwayDeployment, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return f.deployment, nil
 }
 
+func (f *fakeRailwayAPI) Deployment(ctx context.Context, deploymentID string) (railwayDeployment, error) {
+	// Optional gate that lets a test hold the call open so the polling loop can
+	// observe context-deadline cancellation.
+	f.mu.Lock()
+	block := f.deploymentBlock
+	f.mu.Unlock()
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return railwayDeployment{}, ctx.Err()
+		}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pollCalls++
+	if f.deploymentErr != nil {
+		return railwayDeployment{}, f.deploymentErr
+	}
+	if len(f.pollStatuses) == 0 {
+		return railwayDeployment{ID: deploymentID, Status: f.deployment.Status}, nil
+	}
+	idx := f.pollCalls - 1
+	if idx >= len(f.pollStatuses) {
+		idx = len(f.pollStatuses) - 1
+	}
+	return railwayDeployment{ID: deploymentID, Status: f.pollStatuses[idx]}, nil
+}
+
 func (f *fakeRailwayAPI) StopDeployment(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.stopID = id
 	return nil
 }
 
 func (f *fakeRailwayAPI) ListServices(_ context.Context) ([]railwayService, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return f.services, f.listErr
 }
 
 func (f *fakeRailwayAPI) GetService(_ context.Context, _ string) (railwayService, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	return f.service, nil
 }
 
-func TestRailwayRunHappyPath(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:   "dep-1",
-		deployment: railwayDeployment{ID: "dep-1", Status: "SUCCESS"},
-		logs:       []string{"+ pnpm test", "PASS suite (1.2s)"},
-	}
+func newRailwayBackendForTest(api *fakeRailwayAPI) *railwayBackend {
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
-	backend := &railwayBackend{spec: Provider{}.Spec(), cfg: cfg, rt: rt, client: api}
+	return &railwayBackend{
+		spec:                Provider{}.Spec(),
+		cfg:                 cfg,
+		rt:                  rt,
+		client:              api,
+		pollInitialOverride: time.Millisecond,
+		pollOverallOverride: 5 * time.Second,
+	}
+}
+
+func TestRailwayRunHappyPath(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID: "dep-1",
+		// Trigger returns dep-1; the poll loop sees one non-terminal status before
+		// terminating on SUCCESS; logs are then fetched against that exact id.
+		pollStatuses: []railwayDeploymentStatus{railwayStatusDeploying, railwayStatusSuccess},
+		logs:         []string{"+ pnpm test", "PASS suite (1.2s)"},
+	}
+	backend := newRailwayBackendForTest(api)
 	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
 	if err != nil {
 		t.Fatalf("Run error: %v", err)
@@ -293,26 +360,149 @@ func TestRailwayRunHappyPath(t *testing.T) {
 	if api.triggerServiceID != "svc-1" || api.triggerProjectID != "proj-1" || api.triggerEnvironmentID != "env-1" {
 		t.Fatalf("trigger called with svc=%q proj=%q env=%q", api.triggerServiceID, api.triggerProjectID, api.triggerEnvironmentID)
 	}
+	if api.logsForID != "dep-1" {
+		t.Fatalf("logs fetched for id=%q, want dep-1 (new deployment, not stale)", api.logsForID)
+	}
+	if api.pollCalls < 2 {
+		t.Fatalf("poll calls = %d, want at least 2 (DEPLOYING then SUCCESS)", api.pollCalls)
+	}
 }
 
 func TestRailwayRunFailedDeploymentMapsToExit1(t *testing.T) {
 	api := &fakeRailwayAPI{
-		deployID:   "dep-1",
-		deployment: railwayDeployment{ID: "dep-1", Status: "FAILED"},
+		deployID:     "dep-1",
+		pollStatuses: []railwayDeploymentStatus{railwayStatusFailed},
 	}
-	cfg := Config{Provider: providerName}
-	cfg.Railway.APIToken = "test-token"
-	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
-	cfg.Railway.ProjectID = "proj-1"
-	cfg.Railway.EnvironmentID = "env-1"
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
-	backend := &railwayBackend{spec: Provider{}.Spec(), cfg: cfg, rt: rt, client: api}
+	backend := newRailwayBackendForTest(api)
 	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
 	if err == nil {
 		t.Fatal("Run accepted FAILED deployment status")
 	}
 	if result.ExitCode != 1 {
 		t.Fatalf("exit code = %d, want 1", result.ExitCode)
+	}
+}
+
+func TestRailwayRunPollsDeployingThenSuccess(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:     "dep-new",
+		pollStatuses: []railwayDeploymentStatus{railwayStatusQueued, railwayStatusBuilding, railwayStatusDeploying, railwayStatusSuccess},
+		logs:         []string{"ok"},
+	}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err != nil {
+		t.Fatalf("Run err: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if api.pollCalls != 4 {
+		t.Fatalf("poll calls = %d, want 4 (queued, building, deploying, success)", api.pollCalls)
+	}
+}
+
+func TestRailwayRunReturnsErrorWhenTriggerYieldsEmptyID(t *testing.T) {
+	api := &fakeRailwayAPI{deployID: ""}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted empty deployment id from TriggerDeploy")
+	}
+	if result.ExitCode == 0 {
+		t.Fatalf("exit code = %d, want non-zero on empty deployment id", result.ExitCode)
+	}
+	if !strings.Contains(err.Error(), "no deployment id") {
+		t.Fatalf("err = %v, want 'no deployment id' message", err)
+	}
+}
+
+func TestRailwayRunPollingHonorsContextDeadline(t *testing.T) {
+	block := make(chan struct{})
+	api := &fakeRailwayAPI{
+		deployID:        "dep-1",
+		pollStatuses:    []railwayDeploymentStatus{railwayStatusBuilding},
+		deploymentBlock: block,
+	}
+	backend := newRailwayBackendForTest(api)
+	backend.pollInitialOverride = time.Millisecond
+	backend.pollOverallOverride = 25 * time.Millisecond
+	defer close(block) // unblock at the end of the test so the goroutine exits cleanly
+	_, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted hung deployment status")
+	}
+	if !strings.Contains(err.Error(), "polling") && !strings.Contains(err.Error(), "deadline") {
+		t.Fatalf("err = %v, want polling/deadline message", err)
+	}
+}
+
+func TestRailwayDeploymentStatusEnum(t *testing.T) {
+	for _, tc := range []struct {
+		status     railwayDeploymentStatus
+		isTerminal bool
+		exitCode   int
+	}{
+		{railwayStatusSuccess, true, 0},
+		{railwayStatusFailed, true, 1},
+		{railwayStatusCrashed, true, 1},
+		{railwayStatusRemoved, true, 1},
+		{railwayStatusSkipped, true, 1},
+		{railwayStatusQueued, false, 1},
+		{railwayStatusInitializing, false, 1},
+		{railwayStatusBuilding, false, 1},
+		{railwayStatusDeploying, false, 1},
+		{railwayStatusWaiting, false, 1},
+		{railwayStatusNeedsApproval, false, 1},
+		{railwayStatusRemoving, false, 1},
+		{railwayStatusSleeping, false, 1},
+	} {
+		t.Run(string(tc.status), func(t *testing.T) {
+			if got := tc.status.IsTerminal(); got != tc.isTerminal {
+				t.Fatalf("IsTerminal() = %v, want %v", got, tc.isTerminal)
+			}
+			if got := tc.status.ExitCode(); got != tc.exitCode {
+				t.Fatalf("ExitCode() = %d, want %d", got, tc.exitCode)
+			}
+		})
+	}
+}
+
+func TestRailwayDeploymentStatusNormalizesOnUnmarshal(t *testing.T) {
+	var dep railwayDeployment
+	if err := json.Unmarshal([]byte(`{"id":"d","status":"  success  "}`), &dep); err != nil {
+		t.Fatal(err)
+	}
+	if dep.Status != railwayStatusSuccess {
+		t.Fatalf("status = %q, want SUCCESS (trim+upper-cased)", dep.Status)
+	}
+	if !dep.Status.IsTerminal() {
+		t.Fatal("normalized SUCCESS must be terminal")
+	}
+}
+
+// failingDeploymentClient lets the polling-error test thread a fake error
+// through Deployment() without bypassing the fakeRailwayAPI mutex.
+type failingDeploymentClient struct {
+	*fakeRailwayAPI
+	err error
+}
+
+func (f *failingDeploymentClient) Deployment(_ context.Context, _ string) (railwayDeployment, error) {
+	return railwayDeployment{}, f.err
+}
+
+func TestRailwayRunSurfacesPollingTransportError(t *testing.T) {
+	api := &fakeRailwayAPI{deployID: "dep-1"}
+	wrapped := &failingDeploymentClient{fakeRailwayAPI: api, err: fmt.Errorf("network broken")}
+	backend := newRailwayBackendForTest(api)
+	backend.client = wrapped
+	_, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted polling transport failure")
+	}
+	if !strings.Contains(err.Error(), "network broken") {
+		t.Fatalf("err = %v, want surfaced transport error", err)
 	}
 }
 

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -144,6 +144,25 @@ func TestRailwayClientAcceptsBooleanTriggerDeployResponse(t *testing.T) {
 	}
 }
 
+func TestRailwayClientRejectsFalseBooleanTriggerDeployResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"data":{"environmentTriggersDeploy":false}}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.TriggerDeploy(context.Background(), "proj-1", "env-1", "svc-1")
+	if err == nil || !strings.Contains(err.Error(), "environmentTriggersDeploy returned false") {
+		t.Fatalf("err = %v, want false trigger error", err)
+	}
+}
+
 func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden by token", http.StatusForbidden)

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -824,6 +824,48 @@ func TestRailwayListEnumeratesServices(t *testing.T) {
 	}
 }
 
+func TestRailwayDoctorRequiresProjectEnvironment(t *testing.T) {
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: &fakeRailwayAPI{}}
+	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err == nil || !strings.Contains(err.Error(), "--railway-project") {
+		t.Fatalf("err = %v, want missing project rejection", err)
+	}
+}
+
+func TestRailwayDoctorRequiresToken(t *testing.T) {
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err == nil || !strings.Contains(err.Error(), "RAILWAY_API_TOKEN") {
+		t.Fatalf("err = %v, want missing token rejection", err)
+	}
+}
+
+func TestRailwayDoctorListsServices(t *testing.T) {
+	api := &fakeRailwayAPI{services: []railwayService{
+		{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+	}}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor err: %v", err)
+	}
+	if result.Provider != providerName || !strings.Contains(result.Message, "inventory=ready") || !strings.Contains(result.Message, "leases=1") {
+		t.Fatalf("Doctor result = %#v", result)
+	}
+}
+
 func TestRailwayFlagsApply(t *testing.T) {
 	cfg := Config{Provider: providerName}
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -1,0 +1,411 @@
+package railway
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRailwayProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName {
+		t.Fatalf("spec.Name = %q, want %q", spec.Name, providerName)
+	}
+	if spec.Kind != "delegated-run" {
+		t.Fatalf("spec.Kind = %q, want delegated-run", spec.Kind)
+	}
+	aliases := Provider{}.Aliases()
+	if len(aliases) != 2 || aliases[0] != "rail" || aliases[1] != "railwayapp" {
+		t.Fatalf("aliases = %#v, want [rail railwayapp]", aliases)
+	}
+}
+
+func TestRailwayClientRequiresAPIToken(t *testing.T) {
+	cfg := Config{}
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newRailwayClient accepted empty API token")
+	}
+}
+
+func TestRailwayClientRejectsBareHTTPURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "http://backboard.railway.app/graphql/v2"
+	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newRailwayClient accepted plaintext http URL")
+	}
+}
+
+func TestRailwayTokenFlagIsNotRegistered(t *testing.T) {
+	cfg := Config{}
+	cfg.Railway.APIToken = "secret-token"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterRailwayProviderFlags(fs, cfg)
+	for _, name := range []string{"railway-token", "railway-api-token", "railway-key", "railway-api-key"} {
+		if fs.Lookup(name) != nil {
+			t.Fatalf("railway API token surfaced as a flag --%s", name)
+		}
+	}
+	if fs.Lookup("railway-url") == nil {
+		t.Fatal("railway-url flag missing")
+	}
+	if fs.Lookup("railway-project") == nil {
+		t.Fatal("railway-project flag missing")
+	}
+	if fs.Lookup("railway-environment") == nil {
+		t.Fatal("railway-environment flag missing")
+	}
+}
+
+func TestRailwayClientSendsBearerAndGraphQLBody(t *testing.T) {
+	var (
+		gotAuth        string
+		gotContentType string
+		gotMethod      string
+		gotQuery       string
+		gotVariables   map[string]any
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		gotQuery = payload.Query
+		gotVariables = payload.Variables
+		_, _ = io.WriteString(w, `{"data":{"environmentTriggersDeploy":"dep-1"}}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployID, err := client.TriggerDeploy(context.Background(), "proj-1", "env-1", "svc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("auth header = %q, want Bearer test-token", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", gotContentType)
+	}
+	if !strings.Contains(gotQuery, "environmentTriggersDeploy") {
+		t.Fatalf("query missing environmentTriggersDeploy mutation: %s", gotQuery)
+	}
+	input, _ := gotVariables["input"].(map[string]any)
+	if input["projectId"] != "proj-1" || input["environmentId"] != "env-1" || input["serviceId"] != "svc-1" {
+		t.Fatalf("variables = %#v, want proj-1/env-1/svc-1", gotVariables)
+	}
+	if deployID != "dep-1" {
+		t.Fatalf("deployID = %q, want dep-1", deployID)
+	}
+}
+
+func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden by token", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "wrong-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.TriggerDeploy(context.Background(), "p", "e", "s")
+	if err == nil {
+		t.Fatal("TriggerDeploy accepted 403 response")
+	}
+	apiErr, ok := err.(*railwayAPIError)
+	if !ok {
+		t.Fatalf("err = %T, want *railwayAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Body, "forbidden by token") {
+		t.Fatalf("body = %q, want forbidden snippet", apiErr.Body)
+	}
+}
+
+func TestRailwayClientSurfacesGraphQLErrorsAsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"errors":[{"message":"Project not found"}]}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = server.URL
+	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.TriggerDeploy(context.Background(), "p", "e", "s")
+	if err == nil {
+		t.Fatal("TriggerDeploy accepted GraphQL error envelope")
+	}
+	apiErr, ok := err.(*railwayAPIError)
+	if !ok {
+		t.Fatalf("err = %T, want *railwayAPIError", err)
+	}
+	if !strings.Contains(apiErr.Body, "Project not found") {
+		t.Fatalf("err body = %q, want Project not found", apiErr.Body)
+	}
+}
+
+func TestRailwayRunRequiresNoSync(t *testing.T) {
+	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted request without --no-sync")
+	}
+	if !strings.Contains(err.Error(), "--no-sync") {
+		t.Fatalf("err = %v, want --no-sync hint", err)
+	}
+}
+
+func TestRailwayRunRequiresServiceID(t *testing.T) {
+	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil || !strings.Contains(err.Error(), "--id") {
+		t.Fatalf("err = %v, want --id rejection", err)
+	}
+}
+
+func TestRailwayRunRequiresProjectAndEnvironment(t *testing.T) {
+	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1", Command: []string{"pnpm", "test"}})
+	if err == nil || !strings.Contains(err.Error(), "--railway-project") {
+		t.Fatalf("err = %v, want --railway-project rejection", err)
+	}
+	cfg := Config{}
+	cfg.Railway.ProjectID = "proj-1"
+	backend2 := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err = backend2.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1", Command: []string{"pnpm", "test"}})
+	if err == nil || !strings.Contains(err.Error(), "--railway-environment") {
+		t.Fatalf("err = %v, want --railway-environment rejection", err)
+	}
+}
+
+func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		req  RunRequest
+		want string
+	}{
+		{name: "keep", req: RunRequest{ID: "svc-1", Keep: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--keep"},
+		{name: "reclaim", req: RunRequest{ID: "svc-1", Reclaim: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--reclaim"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			_, err := backend.Run(context.Background(), tc.req)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %s rejection", err, tc.want)
+			}
+		})
+	}
+}
+
+type fakeRailwayAPI struct {
+	triggerProjectID     string
+	triggerEnvironmentID string
+	triggerServiceID     string
+	deployID             string
+	logs                 []string
+	deployment           railwayDeployment
+	services             []railwayService
+	service              railwayService
+	stopID               string
+	triggerErr           error
+	logsErr              error
+	listErr              error
+}
+
+func (f *fakeRailwayAPI) TriggerDeploy(_ context.Context, projectID, environmentID, serviceID string) (string, error) {
+	f.triggerProjectID = projectID
+	f.triggerEnvironmentID = environmentID
+	f.triggerServiceID = serviceID
+	return f.deployID, f.triggerErr
+}
+
+func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, _ string, _ int) ([]string, error) {
+	return f.logs, f.logsErr
+}
+
+func (f *fakeRailwayAPI) LatestDeployment(_ context.Context, _, _, _ string) (railwayDeployment, error) {
+	return f.deployment, nil
+}
+
+func (f *fakeRailwayAPI) StopDeployment(_ context.Context, id string) error {
+	f.stopID = id
+	return nil
+}
+
+func (f *fakeRailwayAPI) ListServices(_ context.Context) ([]railwayService, error) {
+	return f.services, f.listErr
+}
+
+func (f *fakeRailwayAPI) GetService(_ context.Context, _ string) (railwayService, error) {
+	return f.service, nil
+}
+
+func TestRailwayRunHappyPath(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:   "dep-1",
+		deployment: railwayDeployment{ID: "dep-1", Status: "SUCCESS"},
+		logs:       []string{"+ pnpm test", "PASS suite (1.2s)"},
+	}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	backend := &railwayBackend{spec: Provider{}.Spec(), cfg: cfg, rt: rt, client: api}
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode)
+	}
+	if api.triggerServiceID != "svc-1" || api.triggerProjectID != "proj-1" || api.triggerEnvironmentID != "env-1" {
+		t.Fatalf("trigger called with svc=%q proj=%q env=%q", api.triggerServiceID, api.triggerProjectID, api.triggerEnvironmentID)
+	}
+}
+
+func TestRailwayRunFailedDeploymentMapsToExit1(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployID:   "dep-1",
+		deployment: railwayDeployment{ID: "dep-1", Status: "FAILED"},
+	}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	backend := &railwayBackend{spec: Provider{}.Spec(), cfg: cfg, rt: rt, client: api}
+	result, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", NoSync: true, Command: []string{"pnpm", "test"}})
+	if err == nil {
+		t.Fatal("Run accepted FAILED deployment status")
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", result.ExitCode)
+	}
+}
+
+func TestRailwayWarmupRejected(t *testing.T) {
+	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), WarmupRequest{})
+	if err == nil || !strings.Contains(err.Error(), "warmup") {
+		t.Fatalf("Warmup err = %v, want warmup rejection", err)
+	}
+}
+
+func TestRailwayStopRequiresID(t *testing.T) {
+	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	if err := backend.Stop(context.Background(), StopRequest{}); err == nil {
+		t.Fatal("Stop accepted empty service id")
+	}
+}
+
+func TestRailwayStopCallsDeploymentStop(t *testing.T) {
+	api := &fakeRailwayAPI{deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"}}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	if err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
+		t.Fatalf("Stop err: %v", err)
+	}
+	if api.stopID != "dep-1" {
+		t.Fatalf("stop called with id=%q, want dep-1", api.stopID)
+	}
+}
+
+func TestRailwayStatusReturnsView(t *testing.T) {
+	api := &fakeRailwayAPI{
+		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		deployment: railwayDeployment{ID: "dep-1", Status: "SUCCESS"},
+	}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	cfg.Railway.ProjectID = "proj-1"
+	cfg.Railway.EnvironmentID = "env-1"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "svc-1"})
+	if err != nil {
+		t.Fatalf("Status err: %v", err)
+	}
+	if view.ID != "svc-1" || view.Slug != "api" || !view.Ready {
+		t.Fatalf("view = %#v, want svc-1/api/ready", view)
+	}
+	if view.Provider != providerName {
+		t.Fatalf("view.Provider = %q, want %q", view.Provider, providerName)
+	}
+}
+
+func TestRailwayListEnumeratesServices(t *testing.T) {
+	api := &fakeRailwayAPI{services: []railwayService{
+		{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
+		{ID: "svc-2", Name: "worker", ProjectID: "proj-1"},
+	}}
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIToken = "test-token"
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	servers, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err: %v", err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("List len = %d, want 2", len(servers))
+	}
+	if servers[0].CloudID != "svc-1" || servers[1].Name != "worker" {
+		t.Fatalf("List = %#v", servers)
+	}
+}
+
+func TestRailwayFlagsApply(t *testing.T) {
+	cfg := Config{Provider: providerName}
+	cfg.Railway.APIURL = "https://backboard.railway.app/graphql/v2"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := RegisterRailwayProviderFlags(fs, cfg)
+	if err := fs.Parse([]string{"--railway-url", "https://example.com/graphql/v2", "--railway-project", "proj-x", "--railway-environment", "env-x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyRailwayProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Railway.APIURL != "https://example.com/graphql/v2" {
+		t.Fatalf("APIURL = %q", cfg.Railway.APIURL)
+	}
+	if cfg.Railway.ProjectID != "proj-x" || cfg.Railway.EnvironmentID != "env-x" {
+		t.Fatalf("project=%q env=%q", cfg.Railway.ProjectID, cfg.Railway.EnvironmentID)
+	}
+}

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -406,7 +406,16 @@ func (c *railwayClient) StopDeployment(ctx context.Context, deploymentID string)
 	if deploymentID == "" {
 		return fmt.Errorf("stopDeployment: deploymentId is required")
 	}
-	return c.do(ctx, deploymentStopMutation, map[string]any{"id": deploymentID}, nil)
+	var out struct {
+		DeploymentStop bool `json:"deploymentStop"`
+	}
+	if err := c.do(ctx, deploymentStopMutation, map[string]any{"id": deploymentID}, &out); err != nil {
+		return err
+	}
+	if !out.DeploymentStop {
+		return fmt.Errorf("deploymentStop returned false")
+	}
+	return nil
 }
 
 // railwayListServicesPageSize bounds the number of projects (and the services

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -20,6 +20,7 @@ import (
 // service; Stop calls deploymentStop on that latest deployment.
 type railwayAPI interface {
 	TriggerDeploy(ctx context.Context, projectID, environmentID, serviceID string) (string, error)
+	BuildLogs(ctx context.Context, deploymentID string, limit int) ([]string, error)
 	DeploymentLogs(ctx context.Context, deploymentID string, limit int) ([]string, error)
 	LatestDeployment(ctx context.Context, projectID, environmentID, serviceID string) (railwayDeployment, error)
 	Deployment(ctx context.Context, deploymentID string) (railwayDeployment, error)
@@ -62,7 +63,7 @@ type railwayDeployment struct {
 
 // railwayDeploymentStatus mirrors Railway's GraphQL DeploymentStatus enum.
 // Values: https://docs.railway.com (verified via docs.railway.com/integrations/api/manage-deployments).
-// Terminal states represent a completed deployment (SUCCESS/FAILED/CRASHED/REMOVED/SKIPPED);
+// Terminal states represent a completed deployment (SUCCESS/SLEEPING/FAILED/CRASHED/REMOVED/SKIPPED);
 // the remaining values are still progressing and must be polled.
 type railwayDeploymentStatus string
 
@@ -106,6 +107,7 @@ func (s railwayDeploymentStatus) Normalized() railwayDeploymentStatus {
 func (s railwayDeploymentStatus) IsTerminal() bool {
 	switch s.Normalized() {
 	case railwayStatusSuccess,
+		railwayStatusSleeping,
 		railwayStatusFailed,
 		railwayStatusCrashed,
 		railwayStatusRemoved,
@@ -115,12 +117,21 @@ func (s railwayDeploymentStatus) IsTerminal() bool {
 	return false
 }
 
-// ExitCode maps a terminal deployment status to a process exit code: 0 for
-// SUCCESS, 1 for every other terminal state. Non-terminal statuses also map to
-// 1 because they only reach this function when the polling loop bails out (for
-// example on context cancellation).
+// IsReady reports whether the latest deployment represents a usable service.
+func (s railwayDeploymentStatus) IsReady() bool {
+	switch s.Normalized() {
+	case railwayStatusSuccess, railwayStatusSleeping:
+		return true
+	}
+	return false
+}
+
+// ExitCode maps a terminal deployment status to a process exit code: 0 for a
+// usable deployment, 1 for every other terminal state. Non-terminal statuses
+// also map to 1 because they only reach this function when the polling loop
+// bails out (for example on context cancellation).
 func (s railwayDeploymentStatus) ExitCode() int {
-	if s.Normalized() == railwayStatusSuccess {
+	if s.IsReady() {
 		return 0
 	}
 	return 1
@@ -311,6 +322,38 @@ const deploymentLogsQuery = `query crabboxDeploymentLogs($deploymentId: String!,
     message
   }
 }`
+
+const buildLogsQuery = `query crabboxBuildLogs($deploymentId: String!, $limit: Int) {
+  buildLogs(deploymentId: $deploymentId, limit: $limit) {
+    message
+  }
+}`
+
+func (c *railwayClient) BuildLogs(ctx context.Context, deploymentID string, limit int) ([]string, error) {
+	if deploymentID == "" {
+		return nil, fmt.Errorf("buildLogs: deploymentId is required")
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	vars := map[string]any{
+		"deploymentId": deploymentID,
+		"limit":        limit,
+	}
+	var out struct {
+		BuildLogs []struct {
+			Message string `json:"message"`
+		} `json:"buildLogs"`
+	}
+	if err := c.do(ctx, buildLogsQuery, vars, &out); err != nil {
+		return nil, err
+	}
+	messages := make([]string, 0, len(out.BuildLogs))
+	for _, l := range out.BuildLogs {
+		messages = append(messages, l.Message)
+	}
+	return messages, nil
+}
 
 func (c *railwayClient) DeploymentLogs(ctx context.Context, deploymentID string, limit int) ([]string, error) {
 	if deploymentID == "" {

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -126,6 +126,17 @@ func (s railwayDeploymentStatus) IsReady() bool {
 	return false
 }
 
+// State returns the generic Crabbox status state. Railway has several terminal
+// failure statuses; expose them as "failed" so status --wait can stop promptly.
+func (s railwayDeploymentStatus) State() string {
+	switch s.Normalized() {
+	case railwayStatusFailed, railwayStatusCrashed, railwayStatusRemoved, railwayStatusSkipped:
+		return "failed"
+	default:
+		return strings.ToLower(string(s.Normalized()))
+	}
+}
+
 // ExitCode maps a terminal deployment status to a process exit code: 0 for a
 // usable deployment, 1 for every other terminal state. Non-terminal statuses
 // also map to 1 because they only reach this function when the polling loop
@@ -235,10 +246,9 @@ func (c *railwayClient) TriggerDeploy(ctx context.Context, projectID, environmen
 	if err := c.do(ctx, triggerDeployMutation, vars, &out); err != nil {
 		return "", err
 	}
-	// Railway's environmentTriggersDeploy historically returns the new deployment
-	// id as a bare string. Some schema versions wrap it in a Deployment object;
-	// accept either so callers always receive the id of the deployment they just
-	// triggered (which they then poll for terminal status).
+	// Railway's environmentTriggersDeploy can return the new deployment id as a
+	// bare string, wrap it in a Deployment object, or return a boolean success
+	// marker. The boolean case falls back to LatestDeployment in Run().
 	var maybeID string
 	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeID); err == nil {
 		return strings.TrimSpace(maybeID), nil

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -35,6 +35,8 @@ type railwayClient struct {
 	httpClient *http.Client
 }
 
+const railwayMaxGraphQLResponseBytes = 16 << 20
+
 type railwayAPIError struct {
 	StatusCode int
 	Status     string
@@ -199,9 +201,12 @@ func (c *railwayClient) do(ctx context.Context, query string, vars map[string]an
 		return err
 	}
 	defer resp.Body.Close()
-	data, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, railwayMaxGraphQLResponseBytes+1))
 	if readErr != nil {
 		return readErr
+	}
+	if len(data) > railwayMaxGraphQLResponseBytes {
+		return fmt.Errorf("railway response exceeds %d bytes", railwayMaxGraphQLResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -64,7 +64,7 @@ func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
 	if apiToken == "" {
 		return nil, exit(2, "provider=%s requires RAILWAY_API_TOKEN", providerName)
 	}
-	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Railway.APIURL, "https://backboard.railway.app/graphql/v2")), "/")
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Railway.APIURL, "https://backboard.railway.com/graphql/v2")), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -1,0 +1,338 @@
+package railway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// railwayAPI is the minimal Railway GraphQL surface the provider needs.
+//
+// Railway has no synchronous exec endpoint, so the provider models a "sandbox"
+// as a Railway service inside a project. Run triggers a redeploy via
+// environmentTriggersDeploy and surfaces deployment logs; List enumerates
+// services across visible projects; Status fetches the latest deployment for a
+// service; Stop calls deploymentStop on that latest deployment.
+type railwayAPI interface {
+	TriggerDeploy(ctx context.Context, projectID, environmentID, serviceID string) (string, error)
+	DeploymentLogs(ctx context.Context, deploymentID string, limit int) ([]string, error)
+	LatestDeployment(ctx context.Context, projectID, environmentID, serviceID string) (railwayDeployment, error)
+	StopDeployment(ctx context.Context, deploymentID string) error
+	ListServices(ctx context.Context) ([]railwayService, error)
+	GetService(ctx context.Context, serviceID string) (railwayService, error)
+}
+
+type railwayClient struct {
+	apiToken   string
+	apiURL     string
+	httpClient *http.Client
+}
+
+type railwayAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *railwayAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+type railwayService struct {
+	ID        string
+	Name      string
+	ProjectID string
+}
+
+type railwayDeployment struct {
+	ID        string
+	Status    string
+	URL       string
+	CreatedAt string
+}
+
+func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
+	apiToken := strings.TrimSpace(cfg.Railway.APIToken)
+	if apiToken == "" {
+		return nil, exit(2, "provider=%s requires RAILWAY_API_TOKEN", providerName)
+	}
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Railway.APIURL, "https://backboard.railway.app/graphql/v2")), "/")
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &railwayClient{apiToken: apiToken, apiURL: apiURL, httpClient: httpClient}, nil
+}
+
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type graphqlError struct {
+	Message string `json:"message"`
+}
+
+type graphqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphqlError  `json:"errors,omitempty"`
+}
+
+func (c *railwayClient) do(ctx context.Context, query string, vars map[string]any, out any) error {
+	body, err := json.Marshal(graphqlRequest{Query: query, Variables: vars})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+	}
+	var envelope graphqlResponse
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("decode railway response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return &railwayAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.Join(msgs, "; ")}
+	}
+	if out != nil {
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("decode railway data: %w", err)
+		}
+	}
+	return nil
+}
+
+const triggerDeployMutation = `mutation crabboxTriggerDeploy($input: EnvironmentTriggersDeployInput!) {
+  environmentTriggersDeploy(input: $input)
+}`
+
+func (c *railwayClient) TriggerDeploy(ctx context.Context, projectID, environmentID, serviceID string) (string, error) {
+	if projectID == "" || environmentID == "" || serviceID == "" {
+		return "", fmt.Errorf("triggerDeploy: projectId, environmentId, and serviceId are required")
+	}
+	var out struct {
+		EnvironmentTriggersDeploy json.RawMessage `json:"environmentTriggersDeploy"`
+	}
+	vars := map[string]any{
+		"input": map[string]any{
+			"projectId":     projectID,
+			"environmentId": environmentID,
+			"serviceId":     serviceID,
+		},
+	}
+	if err := c.do(ctx, triggerDeployMutation, vars, &out); err != nil {
+		return "", err
+	}
+	// The deployment id is not always returned in the trigger payload; callers
+	// resolve the active deployment via LatestDeployment afterwards. Surface the
+	// raw response if it happens to be a string so tests can inspect it.
+	var maybeID string
+	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeID); err == nil {
+		return maybeID, nil
+	}
+	return "", nil
+}
+
+const latestDeploymentQuery = `query crabboxLatestDeployment($input: DeploymentListInput!) {
+  deployments(input: $input, first: 1) {
+    edges {
+      node {
+        id
+        status
+        url
+        createdAt
+      }
+    }
+  }
+}`
+
+func (c *railwayClient) LatestDeployment(ctx context.Context, projectID, environmentID, serviceID string) (railwayDeployment, error) {
+	vars := map[string]any{
+		"input": map[string]any{
+			"projectId":     projectID,
+			"environmentId": environmentID,
+			"serviceId":     serviceID,
+		},
+	}
+	var out struct {
+		Deployments struct {
+			Edges []struct {
+				Node railwayDeployment `json:"node"`
+			} `json:"edges"`
+		} `json:"deployments"`
+	}
+	if err := c.do(ctx, latestDeploymentQuery, vars, &out); err != nil {
+		return railwayDeployment{}, err
+	}
+	if len(out.Deployments.Edges) == 0 {
+		return railwayDeployment{}, nil
+	}
+	return out.Deployments.Edges[0].Node, nil
+}
+
+const deploymentLogsQuery = `query crabboxDeploymentLogs($deploymentId: String!, $limit: Int) {
+  deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
+    message
+  }
+}`
+
+func (c *railwayClient) DeploymentLogs(ctx context.Context, deploymentID string, limit int) ([]string, error) {
+	if deploymentID == "" {
+		return nil, fmt.Errorf("deploymentLogs: deploymentId is required")
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	vars := map[string]any{
+		"deploymentId": deploymentID,
+		"limit":        limit,
+	}
+	var out struct {
+		DeploymentLogs []struct {
+			Message string `json:"message"`
+		} `json:"deploymentLogs"`
+	}
+	if err := c.do(ctx, deploymentLogsQuery, vars, &out); err != nil {
+		return nil, err
+	}
+	messages := make([]string, 0, len(out.DeploymentLogs))
+	for _, l := range out.DeploymentLogs {
+		messages = append(messages, l.Message)
+	}
+	return messages, nil
+}
+
+const deploymentStopMutation = `mutation crabboxDeploymentStop($id: String!) {
+  deploymentStop(id: $id)
+}`
+
+func (c *railwayClient) StopDeployment(ctx context.Context, deploymentID string) error {
+	if deploymentID == "" {
+		return fmt.Errorf("stopDeployment: deploymentId is required")
+	}
+	return c.do(ctx, deploymentStopMutation, map[string]any{"id": deploymentID}, nil)
+}
+
+const projectsQuery = `query crabboxProjects {
+  projects {
+    edges {
+      node {
+        id
+        name
+        services {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+func (c *railwayClient) ListServices(ctx context.Context) ([]railwayService, error) {
+	var out struct {
+		Projects struct {
+			Edges []struct {
+				Node struct {
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					Services struct {
+						Edges []struct {
+							Node struct {
+								ID   string `json:"id"`
+								Name string `json:"name"`
+							} `json:"node"`
+						} `json:"edges"`
+					} `json:"services"`
+				} `json:"node"`
+			} `json:"edges"`
+		} `json:"projects"`
+	}
+	if err := c.do(ctx, projectsQuery, nil, &out); err != nil {
+		return nil, err
+	}
+	var services []railwayService
+	for _, p := range out.Projects.Edges {
+		for _, s := range p.Node.Services.Edges {
+			services = append(services, railwayService{
+				ID:        s.Node.ID,
+				Name:      s.Node.Name,
+				ProjectID: p.Node.ID,
+			})
+		}
+	}
+	return services, nil
+}
+
+const serviceQuery = `query crabboxService($id: String!) {
+  service(id: $id) {
+    id
+    name
+    projectId
+  }
+}`
+
+func (c *railwayClient) GetService(ctx context.Context, serviceID string) (railwayService, error) {
+	if serviceID == "" {
+		return railwayService{}, fmt.Errorf("getService: serviceId is required")
+	}
+	var out struct {
+		Service struct {
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			ProjectID string `json:"projectId"`
+		} `json:"service"`
+	}
+	if err := c.do(ctx, serviceQuery, map[string]any{"id": serviceID}, &out); err != nil {
+		return railwayService{}, err
+	}
+	if out.Service.ID == "" {
+		return railwayService{}, fmt.Errorf("service %s not found", serviceID)
+	}
+	return railwayService{ID: out.Service.ID, Name: out.Service.Name, ProjectID: out.Service.ProjectID}, nil
+}
+
+func isLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -259,6 +259,13 @@ func (c *railwayClient) TriggerDeploy(ctx context.Context, projectID, environmen
 	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeObject); err == nil {
 		return strings.TrimSpace(maybeObject.ID), nil
 	}
+	var maybeOK bool
+	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeOK); err == nil {
+		if !maybeOK {
+			return "", fmt.Errorf("environmentTriggersDeploy returned false")
+		}
+		return "", nil
+	}
 	return "", nil
 }
 

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -22,6 +22,7 @@ type railwayAPI interface {
 	TriggerDeploy(ctx context.Context, projectID, environmentID, serviceID string) (string, error)
 	DeploymentLogs(ctx context.Context, deploymentID string, limit int) ([]string, error)
 	LatestDeployment(ctx context.Context, projectID, environmentID, serviceID string) (railwayDeployment, error)
+	Deployment(ctx context.Context, deploymentID string) (railwayDeployment, error)
 	StopDeployment(ctx context.Context, deploymentID string) error
 	ListServices(ctx context.Context) ([]railwayService, error)
 	GetService(ctx context.Context, serviceID string) (railwayService, error)
@@ -53,10 +54,76 @@ type railwayService struct {
 }
 
 type railwayDeployment struct {
-	ID        string
-	Status    string
-	URL       string
-	CreatedAt string
+	ID        string                  `json:"id"`
+	Status    railwayDeploymentStatus `json:"status"`
+	URL       string                  `json:"url"`
+	CreatedAt string                  `json:"createdAt"`
+}
+
+// railwayDeploymentStatus mirrors Railway's GraphQL DeploymentStatus enum.
+// Values: https://docs.railway.com (verified via docs.railway.com/integrations/api/manage-deployments).
+// Terminal states represent a completed deployment (SUCCESS/FAILED/CRASHED/REMOVED/SKIPPED);
+// the remaining values are still progressing and must be polled.
+type railwayDeploymentStatus string
+
+const (
+	railwayStatusQueued        railwayDeploymentStatus = "QUEUED"
+	railwayStatusInitializing  railwayDeploymentStatus = "INITIALIZING"
+	railwayStatusBuilding      railwayDeploymentStatus = "BUILDING"
+	railwayStatusDeploying     railwayDeploymentStatus = "DEPLOYING"
+	railwayStatusWaiting       railwayDeploymentStatus = "WAITING"
+	railwayStatusNeedsApproval railwayDeploymentStatus = "NEEDS_APPROVAL"
+	railwayStatusRemoving      railwayDeploymentStatus = "REMOVING"
+	railwayStatusSleeping      railwayDeploymentStatus = "SLEEPING"
+	railwayStatusSuccess       railwayDeploymentStatus = "SUCCESS"
+	railwayStatusFailed        railwayDeploymentStatus = "FAILED"
+	railwayStatusCrashed       railwayDeploymentStatus = "CRASHED"
+	railwayStatusRemoved       railwayDeploymentStatus = "REMOVED"
+	railwayStatusSkipped       railwayDeploymentStatus = "SKIPPED"
+)
+
+// UnmarshalJSON normalizes the incoming string (trim + upper-case) so callers
+// can compare against the typed constants without worrying about whitespace or
+// casing quirks in upstream responses.
+func (s *railwayDeploymentStatus) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = railwayDeploymentStatus(strings.ToUpper(strings.TrimSpace(raw)))
+	return nil
+}
+
+// Normalized returns the trim+upper-case form of s so ad-hoc string values
+// (e.g. plumbed from configuration) compare equal to the typed constants.
+func (s railwayDeploymentStatus) Normalized() railwayDeploymentStatus {
+	return railwayDeploymentStatus(strings.ToUpper(strings.TrimSpace(string(s))))
+}
+
+// IsTerminal reports whether the deployment has reached a final state and will
+// not transition further without a new trigger. Non-terminal statuses must be
+// polled.
+func (s railwayDeploymentStatus) IsTerminal() bool {
+	switch s.Normalized() {
+	case railwayStatusSuccess,
+		railwayStatusFailed,
+		railwayStatusCrashed,
+		railwayStatusRemoved,
+		railwayStatusSkipped:
+		return true
+	}
+	return false
+}
+
+// ExitCode maps a terminal deployment status to a process exit code: 0 for
+// SUCCESS, 1 for every other terminal state. Non-terminal statuses also map to
+// 1 because they only reach this function when the polling loop bails out (for
+// example on context cancellation).
+func (s railwayDeploymentStatus) ExitCode() int {
+	if s.Normalized() == railwayStatusSuccess {
+		return 0
+	}
+	return 1
 }
 
 func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
@@ -157,12 +224,19 @@ func (c *railwayClient) TriggerDeploy(ctx context.Context, projectID, environmen
 	if err := c.do(ctx, triggerDeployMutation, vars, &out); err != nil {
 		return "", err
 	}
-	// The deployment id is not always returned in the trigger payload; callers
-	// resolve the active deployment via LatestDeployment afterwards. Surface the
-	// raw response if it happens to be a string so tests can inspect it.
+	// Railway's environmentTriggersDeploy historically returns the new deployment
+	// id as a bare string. Some schema versions wrap it in a Deployment object;
+	// accept either so callers always receive the id of the deployment they just
+	// triggered (which they then poll for terminal status).
 	var maybeID string
 	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeID); err == nil {
-		return maybeID, nil
+		return strings.TrimSpace(maybeID), nil
+	}
+	var maybeObject struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(out.EnvironmentTriggersDeploy, &maybeObject); err == nil {
+		return strings.TrimSpace(maybeObject.ID), nil
 	}
 	return "", nil
 }
@@ -179,6 +253,34 @@ const latestDeploymentQuery = `query crabboxLatestDeployment($input: DeploymentL
     }
   }
 }`
+
+// deploymentQuery fetches a single deployment by ID. Verified against
+// docs.railway.com/integrations/api/manage-deployments: the GraphQL schema
+// exposes `deployment(id: String!): Deployment`.
+const deploymentQuery = `query crabboxDeployment($id: String!) {
+  deployment(id: $id) {
+    id
+    status
+    url
+    createdAt
+  }
+}`
+
+func (c *railwayClient) Deployment(ctx context.Context, deploymentID string) (railwayDeployment, error) {
+	if strings.TrimSpace(deploymentID) == "" {
+		return railwayDeployment{}, fmt.Errorf("deployment: deploymentId is required")
+	}
+	var out struct {
+		Deployment railwayDeployment `json:"deployment"`
+	}
+	if err := c.do(ctx, deploymentQuery, map[string]any{"id": deploymentID}, &out); err != nil {
+		return railwayDeployment{}, err
+	}
+	if out.Deployment.ID == "" {
+		return railwayDeployment{}, fmt.Errorf("deployment %s not found", deploymentID)
+	}
+	return out.Deployment, nil
+}
 
 func (c *railwayClient) LatestDeployment(ctx context.Context, projectID, environmentID, serviceID string) (railwayDeployment, error) {
 	vars := map[string]any{
@@ -247,13 +349,21 @@ func (c *railwayClient) StopDeployment(ctx context.Context, deploymentID string)
 	return c.do(ctx, deploymentStopMutation, map[string]any{"id": deploymentID}, nil)
 }
 
-const projectsQuery = `query crabboxProjects {
-  projects {
+// railwayListServicesPageSize bounds the number of projects (and the services
+// inside each project) returned by ListServices so a long-lived token does not
+// pull megabytes of unrelated metadata in a single call. Railway's GraphQL
+// connections accept `first: Int` on the projects edge as well as on the
+// nested services edge; if a future schema rev drops support there, the inner
+// `first:` argument becomes inert and we fall back to a client-side cap below.
+const railwayListServicesPageSize = 50
+
+const projectsQuery = `query crabboxProjects($first: Int) {
+  projects(first: $first) {
     edges {
       node {
         id
         name
-        services {
+        services(first: $first) {
           edges {
             node {
               id
@@ -285,7 +395,7 @@ func (c *railwayClient) ListServices(ctx context.Context) ([]railwayService, err
 			} `json:"edges"`
 		} `json:"projects"`
 	}
-	if err := c.do(ctx, projectsQuery, nil, &out); err != nil {
+	if err := c.do(ctx, projectsQuery, map[string]any{"first": railwayListServicesPageSize}, &out); err != nil {
 		return nil, err
 	}
 	var services []railwayService
@@ -296,6 +406,12 @@ func (c *railwayClient) ListServices(ctx context.Context) ([]railwayService, err
 				Name:      s.Node.Name,
 				ProjectID: p.Node.ID,
 			})
+			// Client-side cap: defends against a Railway schema rev that ignores
+			// `first:` on the services connection, which would otherwise let a
+			// single project flood the result.
+			if len(services) >= railwayListServicesPageSize*railwayListServicesPageSize {
+				return services, nil
+			}
 		}
 	}
 	return services, nil

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -1,0 +1,51 @@
+package railway
+
+import (
+	"flag"
+	"io"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type RailwayConfig = core.RailwayConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type ExitError = core.ExitError
+type FeatureSet = core.FeatureSet
+type Feature = core.Feature
+type timingReport = core.TimingReport
+
+const (
+	providerName = "railway"
+	targetLinux  = core.TargetLinux
+
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -20,6 +20,8 @@ type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
 type Server = core.Server
 type Repo = core.Repo
 type ExitError = core.ExitError
@@ -48,4 +50,8 @@ func blank(value, fallback string) string {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/railway/flags.go
+++ b/internal/providers/railway/flags.go
@@ -1,6 +1,9 @@
 package railway
 
-import "flag"
+import (
+	"flag"
+	"strings"
+)
 
 type railwayFlagValues struct {
 	APIURL        *string
@@ -21,7 +24,7 @@ func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if cfg.Provider == providerName {
+	if isRailwayProviderName(cfg.Provider) {
 		if flagWasSet(fs, "class") {
 			return exit(2, "--class is not supported for provider=%s", providerName)
 		}
@@ -43,4 +46,13 @@ func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 		cfg.Railway.EnvironmentID = *v.EnvironmentID
 	}
 	return nil
+}
+
+func isRailwayProviderName(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case providerName, "rail", "railwayapp":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/providers/railway/flags.go
+++ b/internal/providers/railway/flags.go
@@ -1,0 +1,46 @@
+package railway
+
+import "flag"
+
+type railwayFlagValues struct {
+	APIURL        *string
+	ProjectID     *string
+	EnvironmentID *string
+}
+
+// RegisterRailwayProviderFlags exposes railway-specific flags. The API token is
+// intentionally not surfaced as a flag because secrets must not be passed as
+// command-line arguments; it is sourced from RAILWAY_API_TOKEN /
+// CRABBOX_RAILWAY_API_TOKEN.
+func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return railwayFlagValues{
+		APIURL:        fs.String("railway-url", defaults.Railway.APIURL, "Railway GraphQL API URL"),
+		ProjectID:     fs.String("railway-project", defaults.Railway.ProjectID, "Railway project ID containing the target service"),
+		EnvironmentID: fs.String("railway-environment", defaults.Railway.EnvironmentID, "Railway environment ID to deploy into"),
+	}
+}
+
+func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == providerName {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s", providerName)
+		}
+	}
+	v, ok := values.(railwayFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "railway-url") {
+		cfg.Railway.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "railway-project") {
+		cfg.Railway.ProjectID = *v.ProjectID
+	}
+	if flagWasSet(fs, "railway-environment") {
+		cfg.Railway.EnvironmentID = *v.EnvironmentID
+	}
+	return nil
+}

--- a/internal/providers/railway/provider.go
+++ b/internal/providers/railway/provider.go
@@ -36,3 +36,15 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewRailwayBackend(p.Spec(), cfg, rt), nil
 }
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "railway doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/internal/providers/railway/provider.go
+++ b/internal/providers/railway/provider.go
@@ -1,0 +1,38 @@
+package railway
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"rail", "railwayapp"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    nil,
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterRailwayProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyRailwayProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewRailwayBackend(p.Spec(), cfg, rt), nil
+}


### PR DESCRIPTION
## Summary

Adds a `railway` delegated-run provider that targets [Railway](https://railway.com). Railway exposes no synchronous exec primitive, so `crabbox run --provider railway --id <serviceId>` issues `environmentTriggersDeploy(input: { projectId, environmentId, serviceId })` against an existing Railway service, then streams `deploymentLogs` to stdout and maps the final `deployment.status` to a process exit code. `list` flattens `projects { edges { node { services { ... } } } }`, `status` returns the latest deployment for a service, and `stop` calls `deploymentStop` on it; `warmup` is rejected so the provider never silently creates billable Railway resources.

## Env

- `RAILWAY_API_TOKEN` (or `CRABBOX_RAILWAY_API_TOKEN`, which wins) — required, env-only, no CLI flag, matching the precedence pattern used by `EXE_API_KEY` / `CRABBOX_EXE_API_KEY` and `E2B_API_KEY` / `CRABBOX_E2B_API_KEY`.
- `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID` — required for `run`, `status`, and `stop` (also exposed via `--railway-project` and `--railway-environment`).
- `RAILWAY_API_URL` — optional override, defaults to `https://backboard.railway.app/graphql/v2`.

## Railway primitive mapping

| Crabbox operation | Railway GraphQL |
| --- | --- |
| `run` | `environmentTriggersDeploy` -> `deployments(input, first: 1)` -> `deploymentLogs(deploymentId, limit)` |
| `list` | `projects { edges { node { services { edges { node { id name } } } } } }` |
| `status` | `service(id)` + `deployments(input, first: 1)` |
| `stop` | `deploymentStop(id)` against the latest deployment |
| `warmup` | rejected (services are created out-of-band) |

The user-supplied command argument is informational: Railway runs whatever start command the service is already configured with, since the GraphQL API does not accept an ad-hoc command. See [`docs/providers/railway.md`](docs/providers/railway.md) for the full semantic discussion.

## Reference

```sh
curl -X POST https://backboard.railway.app/graphql/v2 \
  -H "Authorization: Bearer $RAILWAY_API_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"query":"query { projects { edges { node { id name } } } }"}'
```

See <https://railway.com>.
