### PR TITLE
feat: improve doctor diagnostics and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a no-spend macOS coordinator remediation audit helper that bundles provider identity, IAM policy, host quota, host allocation dry-run, guarded IAM apply dry-run, and guarded quota request dry-run evidence into `summary.json`.
 - Added Cloudflare runner readiness to `crabbox doctor --provider cloudflare` so runner URL, auth, and container bindings are checked without creating a sandbox. Thanks @altaywtf.
 - Added direct `crabbox doctor` readiness for all built-in providers without creating provider resources.
+- Added `crabbox doctor --json`, provider error classification and hints, direct-check timeout/API/mutation labels, optional `--doctor-probe-ssh`, and `scripts/live-doctor-smoke.sh` for maintainer live coverage checks.
 - Added `--slug` for `crabbox warmup`, fresh `crabbox run` leases, and `crabbox checkpoint fork`, plus `--label` for human-readable run history/timing metadata.
 
 ### Changed

--- a/cmd/crabbox/main_test.go
+++ b/cmd/crabbox/main_test.go
@@ -69,7 +69,8 @@ func TestDoctorCloudflareUsesRealProviderReadiness(t *testing.T) {
 	text := stdout.String()
 	if !strings.Contains(text, "ok      provider provider=cloudflare") ||
 		!strings.Contains(text, "runner="+server.URL) ||
-		!strings.Contains(text, "auth=configured") {
+		!strings.Contains(text, "auth=ready") ||
+		!strings.Contains(text, "api=readiness") {
 		t.Fatalf("doctor output missing Cloudflare readiness result: %q", text)
 	}
 }

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -10,6 +10,7 @@ crabbox doctor --provider aws
 crabbox doctor --profile live-qa --id blue-lobster
 crabbox doctor --provider hetzner --target linux
 crabbox doctor --provider ssh --target windows --windows-mode normal --static-host win-dev.local
+crabbox doctor --json
 ```
 
 ## What It Checks
@@ -22,8 +23,9 @@ ssh          SSH key path readable, key permissions sane, ssh-keygen on PATH
 tools        provider-applicable local tools are present and executable
 ```
 
-For `--provider ssh`, doctor validates that `static.host` is configured.
-Use `crabbox doctor --id <lease>` for a remote SSH/tool probe against a
+For `--provider ssh`, doctor validates that `static.host` is configured. Add
+`--doctor-probe-ssh` to run a short SSH reachability probe without creating a
+lease. Use `crabbox doctor --id <lease>` for a remote SSH/tool probe against a
 resolved target.
 
 When `CRABBOX_SSH_KEY` is explicitly set, doctor validates the private key
@@ -36,11 +38,12 @@ reports missing Worker secret names such as `AZURE_TENANT_ID` without exposing
 secret values. Static, Proxmox, and delegated providers skip this broker-secret check.
 Delegated providers can still run their own direct readiness checks; for example,
 Cloudflare validates the configured runner URL and bearer token against the
-authenticated runner readiness API. GCP, Proxmox, Daytona, and Blacksmith
-Testbox use cheap inventory/list checks when running in direct mode, as do the
-other built-in providers that expose non-mutating list APIs. Blacksmith Testbox
-reports runtime as provider-hydrated because GitHub Actions hydration is owned
-by Testbox.
+authenticated runner readiness API. Direct provider checks print stable fields
+such as `timeout=10s`, `api=list`, and `mutation=false` so scripts can tell
+what was checked. GCP uses an aggregated Compute Engine inventory query across
+zones, while the other built-in providers use their cheapest non-mutating list
+or readiness API. Blacksmith Testbox reports runtime as provider-hydrated
+because GitHub Actions hydration is owned by Testbox.
 
 When `--profile <name> --id <lease>` selects a profile with `doctor.enabled:
 true`, doctor runs that profile's remote prerequisite contract instead of the
@@ -78,12 +81,16 @@ tools:
   ok    tar
 ```
 
-Failures swap the leading `ok` for `fail` and add a remediation hint:
+Failures swap the leading `ok` for `failed` and add a class and remediation
+hint:
 
 ```text
-auth:
-  fail  broker token is missing - run `crabbox login`
+failed  provider provider=gcp class=auth hint=check_gcp_project_credentials_and_compute_instances_list ...
 ```
+
+`--json` prints the same checks as structured JSON with `ok`, `provider`, and
+`checks` fields. Each check includes `status`, `check`, `message`, and parsed
+`details` when available.
 
 Exit code is `0` on full success, `1` on any failure. Skips never change
 the exit code.
@@ -93,6 +100,8 @@ the exit code.
 ```text
 --provider hetzner|aws|azure|gcp|proxmox|ssh   provider to validate
 --profile <name>             configured profile for remote prereq checks
+--json                       print JSON
+--doctor-probe-ssh           probe static SSH reachability
 --target linux|macos|windows target OS for ssh provider checks
 --windows-mode normal|wsl2   when target=windows
 --static-host <host>         static SSH host

--- a/docs/features/doctor.md
+++ b/docs/features/doctor.md
@@ -62,7 +62,10 @@ diffable across runs.
   directly instead of treating a healthy coordinator as proof of runner
   readiness, using the runner's authenticated readiness endpoint. All built-in
   providers now expose provider-owned direct doctor checks; providers with list
-  APIs use non-mutating inventory checks when running in direct mode.
+  APIs use non-mutating inventory checks when running in direct mode. Direct
+  checks include stable `timeout`, `api`, and `mutation` fields; for example
+  GCP reports an aggregated Compute Engine list query, and Blacksmith Testbox
+  reports provider-owned runtime hydration.
 
 When auth is missing, doctor prints `crabbox login` as the next step.
 
@@ -74,7 +77,7 @@ When auth is missing, doctor prints `crabbox login` as the next step.
   joined client.
 - `crabbox doctor --id <lease>` runs an SSH transport/tool probe against the
   resolved target. The static provider check without `--id` only verifies that
-  `static.host` is configured.
+  `static.host` is configured unless `--doctor-probe-ssh` is set.
 
 DNS is checked before HTTPS so a broken DNS responder does not look like a
 broker outage.
@@ -147,8 +150,7 @@ tools:
 Failures swap the leading `ok` for `fail` and add a remediation hint:
 
 ```text
-auth:
-  fail  broker token is missing - run `crabbox login`
+failed  provider provider=gcp class=auth hint=check_gcp_project_credentials_and_compute_instances_list ...
 ```
 
 Skips swap `ok` for `skip` and explain why the check did not run:
@@ -161,12 +163,18 @@ network:
 Exit code is `0` on full success, `1` on any failure. Skips do not change
 the exit code.
 
+Use `--json` for automation. The JSON view contains the overall `ok` boolean,
+selected `provider`, and a `checks` array with each check's status, category,
+message, and parsed details.
+
 ## Adding A Check
 
 Doctor orchestration lives in `internal/cli/doctor.go`. Prefer provider-owned
 `DoctorProvider` implementations for direct provider checks. Keep each check
 explicit and cheap, and print stable `ok`, `failed`, `missing`, `skip`, or
-`warning` lines that remain easy to scan in terminal logs.
+`warning` lines that remain easy to scan in terminal logs. Maintainers can run
+`scripts/live-doctor-smoke.sh` after building `bin/crabbox` to exercise every
+built-in provider against the local machine and configured credentials.
 
 Rules for new checks:
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,11 +2,30 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+const doctorProviderTimeout = 10 * time.Second
+
+type doctorJSONOutput struct {
+	OK       bool              `json:"ok"`
+	Provider string            `json:"provider"`
+	Checks   []doctorJSONCheck `json:"checks"`
+}
+
+type doctorJSONCheck struct {
+	Status   string            `json:"status"`
+	Check    string            `json:"check"`
+	Provider string            `json:"provider,omitempty"`
+	Message  string            `json:"message,omitempty"`
+	Details  map[string]string `json:"details,omitempty"`
+}
 
 func (a App) doctor(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
@@ -14,6 +33,8 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	profile := fs.String("profile", defaults.Profile, "configured profile for remote prerequisite checks")
 	id := fs.String("id", "", "remote lease id to inspect")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	probeSSH := fs.Bool("doctor-probe-ssh", false, "probe static SSH reachability during doctor")
 	targetFlags := registerTargetFlags(fs, defaults)
 	providerFlags := registerProviderFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -29,12 +50,39 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		return err
 	}
 	ok := true
+	var checks []doctorJSONCheck
+	record := func(status, check, message string, details map[string]string) {
+		if *jsonOut {
+			item := doctorJSONCheck{Status: status, Check: check, Message: message, Details: details}
+			if details != nil {
+				item.Provider = details["provider"]
+			}
+			checks = append(checks, item)
+			return
+		}
+		if message == "" {
+			fmt.Fprintf(a.Stdout, "%-7s %s\n", status, check)
+			return
+		}
+		fmt.Fprintf(a.Stdout, "%-7s %-8s %s\n", status, check, message)
+	}
+	finish := func() error {
+		if *jsonOut {
+			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
+				return err
+			}
+		}
+		if !ok {
+			return exit(1, "doctor found problems")
+		}
+		return nil
+	}
 	if problem := configFilePermissionProblem(writableConfigPath()); problem != "" {
-		fmt.Fprintf(a.Stdout, "failed  config   %s: %s\n", writableConfigPath(), problem)
+		record("failed", "config", fmt.Sprintf("%s: %s", writableConfigPath(), problem), nil)
 		ok = false
 	} else if path := writableConfigPath(); path != "" {
 		if _, err := os.Stat(path); err == nil {
-			fmt.Fprintf(a.Stdout, "ok      config   %s permissions=0600\n", path)
+			record("ok", "config", fmt.Sprintf("%s permissions=0600", path), map[string]string{"path": path, "permissions": "0600"})
 		}
 	}
 	cfg.Provider = *provider
@@ -51,11 +99,11 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	for _, tool := range doctorLocalTools(providerDef.Spec()) {
 		path, err := exec.LookPath(tool)
 		if err != nil {
-			fmt.Fprintf(a.Stdout, "missing %-8s\n", tool)
+			record("missing", tool, "", map[string]string{"tool": tool})
 			ok = false
 			continue
 		}
-		fmt.Fprintf(a.Stdout, "ok      %-8s %s\n", tool, path)
+		record("ok", tool, path, map[string]string{"tool": tool, "path": path})
 	}
 	if *id != "" {
 		_, target, leaseID, err := a.resolveLeaseTarget(ctx, cfg, *id)
@@ -74,12 +122,16 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		}
 		out, err := runSSHCombinedOutput(ctx, target, remote)
 		if err != nil {
+			ok = false
 			if strings.TrimSpace(out) != "" {
-				fmt.Fprintf(a.Stdout, "failed  remote  %s\n%s\n", *id, strings.TrimSpace(out))
+				record("failed", "remote", fmt.Sprintf("%s\n%s", *id, strings.TrimSpace(out)), map[string]string{"id": *id})
+			}
+			if *jsonOut {
+				_ = json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: false, Provider: cfg.Provider, Checks: checks})
 			}
 			return exit(7, "remote doctor failed for %s: %v", *id, err)
 		}
-		fmt.Fprintf(a.Stdout, "ok      remote  %s\n%s\n", *id, out)
+		record("ok", "remote", fmt.Sprintf("%s\n%s", *id, out), map[string]string{"id": *id})
 	}
 	if os.Getenv("CRABBOX_SERVER_TYPE") == "" {
 		applyServerTypeFlagOverrides(&cfg, fs, "")
@@ -87,32 +139,35 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	useCoordinator := false
 	if shouldUseCoordinator(cfg, providerDef.Spec()) {
 		if coord, coordinatorConfigured, err := newTargetCoordinatorClient(cfg); err != nil {
-			fmt.Fprintf(a.Stdout, "failed  coord    %v\n", err)
+			record("failed", "coord", err.Error(), nil)
 			ok = false
 		} else if coordinatorConfigured {
 			useCoordinator = true
 			if err := coord.Health(ctx); err != nil {
-				fmt.Fprintf(a.Stdout, "failed  coord    %v\n", err)
+				record("failed", "coord", err.Error(), nil)
 				ok = false
 			} else {
-				fmt.Fprintf(a.Stdout, "ok      coord    %s access=%s\n", cfg.Coordinator, accessAuthState(cfg.Access))
+				record("ok", "coord", fmt.Sprintf("%s access=%s", cfg.Coordinator, accessAuthState(cfg.Access)), map[string]string{"url": cfg.Coordinator, "access": accessAuthState(cfg.Access)})
 				if whoami, err := coord.Whoami(ctx); err != nil {
-					fmt.Fprintf(a.Stdout, "failed  broker   %v\n", err)
+					record("failed", "broker", err.Error(), nil)
 					ok = false
 				} else {
-					fmt.Fprintf(a.Stdout, "ok      broker   auth=%s owner=%s org=%s default_type=%s\n", whoami.Auth, whoami.Owner, whoami.Org, cfg.ServerType)
+					record("ok", "broker", fmt.Sprintf("auth=%s owner=%s org=%s default_type=%s", whoami.Auth, whoami.Owner, whoami.Org, cfg.ServerType), map[string]string{"auth": whoami.Auth, "owner": whoami.Owner, "org": whoami.Org, "default_type": cfg.ServerType})
 				}
 				if coordinatorProviderReadinessSupported(cfg.Provider) {
 					readiness, err := coord.ProviderReadiness(ctx, cfg.Provider)
 					if err == nil {
 						if readiness.Configured {
-							fmt.Fprintf(a.Stdout, "ok      provider provider=%s coordinator_secrets=ready\n", readiness.Provider)
+							record("ok", "provider", fmt.Sprintf("provider=%s coordinator_secrets=ready", readiness.Provider), map[string]string{"provider": readiness.Provider, "coordinator_secrets": "ready"})
 						} else {
-							fmt.Fprintf(a.Stdout, "failed  provider provider=%s missing=%s\n", readiness.Provider, strings.Join(readiness.Missing, ","))
+							hint := doctorErrorHint(readiness.Provider, "config")
+							record("failed", "provider", fmt.Sprintf("provider=%s missing=%s class=config hint=%s", readiness.Provider, strings.Join(readiness.Missing, ","), hint), map[string]string{"provider": readiness.Provider, "missing": strings.Join(readiness.Missing, ","), "class": "config", "hint": hint})
 							ok = false
 						}
 					} else if !isCoordinatorNotFoundError(err) {
-						fmt.Fprintf(a.Stdout, "failed  provider %v\n", err)
+						class := doctorErrorClass(err)
+						hint := doctorErrorHint(cfg.Provider, class)
+						record("failed", "provider", fmt.Sprintf("provider=%s class=%s hint=%s %v", cfg.Provider, class, hint, err), map[string]string{"provider": cfg.Provider, "class": class, "hint": hint, "error": err.Error()})
 						ok = false
 					}
 				}
@@ -125,13 +180,13 @@ func (a App) doctor(ctx context.Context, args []string) error {
 					}
 					if machines, err := adminCoord.Pool(ctx, cfg); err != nil {
 						if isCoordinatorUnauthorized(err) {
-							fmt.Fprintf(a.Stdout, "warning admin    pool list unauthorized; user broker checks still passed\n")
+							record("warning", "admin", "pool list unauthorized; user broker checks still passed", nil)
 						} else {
-							fmt.Fprintf(a.Stdout, "failed  admin    %v\n", err)
+							record("failed", "admin", err.Error(), nil)
 							ok = false
 						}
 					} else {
-						fmt.Fprintf(a.Stdout, "ok      admin    provider=%s machines=%d\n", cfg.Provider, len(machines))
+						record("ok", "admin", fmt.Sprintf("provider=%s machines=%d", cfg.Provider, len(machines)), map[string]string{"provider": cfg.Provider, "machines": fmt.Sprintf("%d", len(machines))})
 					}
 				}
 			}
@@ -140,61 +195,59 @@ func (a App) doctor(ctx context.Context, args []string) error {
 
 	if os.Getenv("CRABBOX_SSH_KEY") != "" {
 		if _, err := os.Stat(cfg.SSHKey); err != nil {
-			fmt.Fprintf(a.Stdout, "missing ssh key %s\n", cfg.SSHKey)
+			record("missing", "ssh-key", cfg.SSHKey, map[string]string{"path": cfg.SSHKey})
 			ok = false
 		} else if _, err := publicKeyFor(cfg.SSHKey); err != nil {
-			fmt.Fprintf(a.Stdout, "missing ssh public key %s.pub\n", cfg.SSHKey)
+			record("missing", "ssh-key", cfg.SSHKey+".pub", map[string]string{"path": cfg.SSHKey + ".pub"})
 			ok = false
 		} else {
-			fmt.Fprintf(a.Stdout, "ok      ssh-key  %s\n", cfg.SSHKey)
+			record("ok", "ssh-key", cfg.SSHKey, map[string]string{"path": cfg.SSHKey})
 		}
 	} else {
-		fmt.Fprintf(a.Stdout, "ok      ssh-key  per-lease\n")
+		record("ok", "ssh-key", "per-lease", map[string]string{"mode": "per-lease"})
 	}
 
 	if useCoordinator {
-		if !ok {
-			return exit(1, "doctor found problems")
-		}
-		return nil
+		return finish()
 	}
 
 	doctorProvider, doctorSupported := providerDef.(DoctorProvider)
 	if doctorSupported {
 		doctor, err := doctorProvider.ConfigureDoctor(cfg, runtimeForApp(a))
 		if err != nil {
-			fmt.Fprintf(a.Stdout, "failed  provider provider=%s %v\n", providerDef.Name(), err)
+			class := doctorErrorClass(err)
+			hint := doctorErrorHint(providerDef.Name(), class)
+			record("failed", "provider", fmt.Sprintf("provider=%s class=%s hint=%s %v", providerDef.Name(), class, hint, err), map[string]string{"provider": providerDef.Name(), "class": class, "hint": hint, "error": err.Error()})
 			ok = false
 		} else {
-			result, err := doctor.Doctor(ctx, DoctorRequest{})
+			doctorCtx, cancel := context.WithTimeout(ctx, doctorProviderTimeout)
+			result, err := doctor.Doctor(doctorCtx, DoctorRequest{ProbeSSH: *probeSSH})
+			cancel()
 			if err != nil {
-				fmt.Fprintf(a.Stdout, "failed  provider provider=%s %v\n", doctor.Spec().Name, err)
+				class := doctorErrorClass(err)
+				hint := doctorErrorHint(doctor.Spec().Name, class)
+				record("failed", "provider", fmt.Sprintf("provider=%s class=%s hint=%s %v", doctor.Spec().Name, class, hint, err), map[string]string{"provider": doctor.Spec().Name, "class": class, "hint": hint, "error": err.Error(), "timeout": doctorProviderTimeout.String()})
 				ok = false
 			} else {
-				fmt.Fprintf(a.Stdout, "ok      provider provider=%s %s\n", result.Provider, result.Message)
+				message := fmt.Sprintf("provider=%s timeout=%s %s", result.Provider, doctorProviderTimeout, result.Message)
+				details := parseDoctorDetails(result.Message)
+				details["provider"] = result.Provider
+				details["timeout"] = doctorProviderTimeout.String()
+				record("ok", "provider", message, details)
 			}
 		}
-		if !ok {
-			return exit(1, "doctor found problems")
-		}
-		return nil
+		return finish()
 	}
 
 	if providerDef.Spec().Kind == ProviderKindDelegatedRun {
-		if !ok {
-			return exit(1, "doctor found problems")
-		}
 		if !doctorSupported {
-			fmt.Fprintf(a.Stdout, "skip    provider provider=%s direct_doctor=unsupported\n", providerDef.Name())
+			record("skip", "provider", fmt.Sprintf("provider=%s direct_doctor=unsupported", providerDef.Name()), map[string]string{"provider": providerDef.Name(), "direct_doctor": "unsupported"})
 		}
-		return nil
+		return finish()
 	}
 
-	if !ok {
-		return exit(1, "doctor found problems")
-	}
-	fmt.Fprintf(a.Stdout, "skip    provider provider=%s direct_doctor=unsupported\n", providerDef.Name())
-	return nil
+	record("skip", "provider", fmt.Sprintf("provider=%s direct_doctor=unsupported", providerDef.Name()), map[string]string{"provider": providerDef.Name(), "direct_doctor": "unsupported"})
+	return finish()
 }
 
 func doctorLocalTools(spec ProviderSpec) []string {
@@ -223,4 +276,91 @@ func doctorProviderUsesLocalArchive(provider string) bool {
 func coordinatorProviderReadinessSupported(provider string) bool {
 	p, err := ProviderFor(provider)
 	return err == nil && p.Spec().Coordinator == CoordinatorSupported
+}
+
+func parseDoctorDetails(message string) map[string]string {
+	details := make(map[string]string)
+	for _, field := range strings.Fields(message) {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok || key == "" {
+			continue
+		}
+		details[key] = value
+	}
+	return details
+}
+
+func doctorErrorClass(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "timed out") || strings.Contains(message, "timeout") || strings.Contains(message, "deadline"):
+		return "timeout"
+	case strings.Contains(message, "executable file not found") || strings.Contains(message, "not found in $path") || strings.Contains(message, "no such file"):
+		return "tool"
+	case strings.Contains(message, "missing") || strings.Contains(message, "required") || strings.Contains(message, "not configured") || strings.Contains(message, "empty config"):
+		return "config"
+	case strings.Contains(message, "unauthorized") || strings.Contains(message, "forbidden") || strings.Contains(message, "permission") || strings.Contains(message, "denied") || strings.Contains(message, "credential") || strings.Contains(message, "api key") || strings.Contains(message, "token") || strings.Contains(message, "401") || strings.Contains(message, "403"):
+		return "auth"
+	case strings.Contains(message, "connection refused") || strings.Contains(message, "no such host") || strings.Contains(message, "network") || strings.Contains(message, "dial") || strings.Contains(message, "tls"):
+		return "network"
+	default:
+		return "provider"
+	}
+}
+
+func doctorErrorHint(provider, class string) string {
+	if class == "timeout" {
+		return "retry_or_check_provider_status"
+	}
+	if class == "tool" {
+		return "install_provider_cli"
+	}
+	if class == "network" {
+		return "check_network_and_provider_endpoint"
+	}
+	switch provider {
+	case "aws":
+		return "check_aws_credentials_and_ec2_describe_instances"
+	case "azure":
+		return "check_azure_login_subscription_and_virtualmachines_read"
+	case "gcp":
+		return "check_gcp_project_credentials_and_compute_instances_list"
+	case "hetzner":
+		return "check_hcloud_token_and_servers_read"
+	case "proxmox":
+		return "check_proxmox_url_token_and_vm_audit"
+	case "blacksmith-testbox":
+		return "check_blacksmith_cli_auth_and_testbox_list"
+	case "daytona":
+		return "check_daytona_auth_profile_and_sandboxes_list"
+	case "e2b":
+		return "check_e2b_api_key_and_sandbox_list"
+	case "islo":
+		return "check_islo_api_key_and_sandbox_list"
+	case "modal":
+		return "check_modal_profile_and_sandbox_list"
+	case "namespace-devbox":
+		return "check_namespace_cli_auth_and_devbox_list"
+	case "semaphore":
+		return "check_semaphore_token_project_and_jobs_read"
+	case "sprites":
+		return "check_sprites_cli_auth_and_sprite_list"
+	case "tensorlake":
+		return "check_tensorlake_cli_auth_and_sbx_ls"
+	case "cloudflare":
+		return "check_cloudflare_readiness_url_and_credentials"
+	case "ssh":
+		return "check_static_host_user_key_and_network"
+	default:
+		if class == "config" {
+			return "check_crabbox_provider_config"
+		}
+		return "check_provider_auth_and_config"
+	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -104,11 +104,62 @@ func TestDoctorRunsDirectProviderCheckForCoordinatorNeverProvider(t *testing.T) 
 	if err != nil {
 		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "ok      provider provider=cloudflare direct_check=ready") {
+	if !strings.Contains(stdout.String(), "ok      provider provider=cloudflare timeout=10s direct_check=ready") {
 		t.Fatalf("doctor did not run direct provider check: %q", stdout.String())
 	}
 	if coordinatorCalled {
 		t.Fatalf("doctor checked coordinator for direct provider: %q", stdout.String())
+	}
+}
+
+func TestDoctorJSONCoordinatorOutput(t *testing.T) {
+	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
+		case "/v1/providers/aws/readiness":
+			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{Provider: "aws", Configured: true})
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "aws", "--json"})
+	if err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	var view doctorJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if !view.OK || view.Provider != "aws" {
+		t.Fatalf("view=%#v", view)
+	}
+	found := false
+	for _, check := range view.Checks {
+		if check.Check == "provider" && check.Details["provider"] == "aws" && check.Details["coordinator_secrets"] == "ready" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("provider readiness missing from JSON: %#v", view.Checks)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -154,7 +154,9 @@ type LocalCommandResult struct {
 	Stderr   string
 }
 
-type DoctorRequest struct{}
+type DoctorRequest struct {
+	ProbeSSH bool
+}
 
 type DoctorResult struct {
 	Provider string
@@ -164,14 +166,14 @@ type DoctorResult struct {
 func InventoryDoctorResult(provider string, leases int) DoctorResult {
 	return DoctorResult{
 		Provider: provider,
-		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready leases=%d runtime=unchecked", leases),
+		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=unchecked", leases),
 	}
 }
 
 func CLIDoctorResult(provider string, leases int, runtime string) DoctorResult {
 	return DoctorResult{
 		Provider: provider,
-		Message:  fmt.Sprintf("cli=ready inventory=ready leases=%d runtime=%s", leases, runtime),
+		Message:  fmt.Sprintf("cli=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=%s", leases, runtime),
 	}
 }
 

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -222,7 +222,7 @@ func (b *blacksmithBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 	}
 	return core.DoctorResult{
 		Provider: blacksmithTestboxProvider,
-		Message:  fmt.Sprintf("cli=ready inventory=ready leases=%d runtime=ci_hydrated_by_provider", len(servers)),
+		Message:  fmt.Sprintf("cli=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=ci_hydrated_by_provider", len(servers)),
 	}, nil
 }
 

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -607,7 +607,7 @@ func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "cli=ready inventory=ready leases=1 runtime=ci_hydrated_by_provider") {
+	if result.Provider != blacksmithTestboxProvider || !strings.Contains(result.Message, "cli=ready control_plane=ready inventory=ready api=list mutation=false leases=1 runtime=ci_hydrated_by_provider") {
 		t.Fatalf("result=%#v", result)
 	}
 	if len(runner.calls) != 1 {

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -48,7 +48,7 @@ func (b *cloudflareBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doctor
 	}
 	return DoctorResult{
 		Provider: providerName,
-		Message:  fmt.Sprintf("runner=%s auth=configured type=%s", client.baseURL, client.instanceType),
+		Message:  fmt.Sprintf("auth=ready control_plane=ready api=readiness mutation=false runner=%s type=%s runtime=ready", client.baseURL, client.instanceType),
 	}, nil
 }
 

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -203,7 +203,7 @@ func TestCloudflareDoctorChecksRunnerAuth(t *testing.T) {
 	if !sawAuth {
 		t.Fatal("doctor did not make authenticated runner request")
 	}
-	if result.Provider != providerName || !strings.Contains(result.Message, "auth=configured") || !strings.Contains(result.Message, "type=standard-4") {
+	if result.Provider != providerName || !strings.Contains(result.Message, "auth=ready") || !strings.Contains(result.Message, "api=readiness") || !strings.Contains(result.Message, "type=standard-4") {
 		t.Fatalf("doctor result = %#v", result)
 	}
 }

--- a/internal/providers/daytona/backend_doctor_test.go
+++ b/internal/providers/daytona/backend_doctor_test.go
@@ -72,7 +72,7 @@ func TestDaytonaDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != daytonaProvider || !strings.Contains(result.Message, "inventory=ready leases=1 runtime=unchecked") {
+	if result.Provider != daytonaProvider || !strings.Contains(result.Message, "inventory=ready api=list mutation=false leases=1 runtime=unchecked") {
 		t.Fatalf("result=%#v", result)
 	}
 	if fake.listCalls != 1 {

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -210,7 +210,7 @@ func (b *daytonaLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doct
 	}
 	return DoctorResult{
 		Provider: daytonaProvider,
-		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready leases=%d runtime=unchecked", len(servers)),
+		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=unchecked", len(servers)),
 	}, nil
 }
 

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -164,10 +164,9 @@ func (b *gcpLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (cor
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
-	return core.DoctorResult{
-		Provider: "gcp",
-		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready leases=%d runtime=unchecked", len(servers)),
-	}, nil
+	result := core.InventoryDoctorResult("gcp", len(servers))
+	result.Message += fmt.Sprintf(" project=%s zone=aggregated", b.Cfg.GCPProject)
+	return result, nil
 }
 
 func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -58,7 +58,7 @@ func TestGCPDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != "gcp" || !strings.Contains(result.Message, "inventory=ready leases=2 runtime=unchecked") {
+	if result.Provider != "gcp" || !strings.Contains(result.Message, "inventory=ready api=list mutation=false leases=2 runtime=unchecked") || !strings.Contains(result.Message, "zone=aggregated") {
 		t.Fatalf("result=%#v", result)
 	}
 	if fake.listCalls != 1 {

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -162,7 +162,7 @@ func (b *leaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.D
 	}
 	return core.DoctorResult{
 		Provider: "proxmox",
-		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready leases=%d runtime=unchecked", len(servers)),
+		Message:  fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=unchecked", len(servers)),
 	}, nil
 }
 

--- a/internal/providers/proxmox/backend_doctor_test.go
+++ b/internal/providers/proxmox/backend_doctor_test.go
@@ -54,7 +54,7 @@ func TestProxmoxDoctorListsInventoryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Provider != "proxmox" || !strings.Contains(result.Message, "inventory=ready leases=1 runtime=unchecked") {
+	if result.Provider != "proxmox" || !strings.Contains(result.Message, "inventory=ready api=list mutation=false leases=1 runtime=unchecked") {
 		t.Fatalf("result=%#v", result)
 	}
 	if fake.listCalls != 1 {

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -69,13 +69,26 @@ func (b *staticLeaseBackend) List(_ context.Context, req ListRequest) ([]LeaseVi
 	return []LeaseView{server}, nil
 }
 
-func (b *staticLeaseBackend) Doctor(_ context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+func (b *staticLeaseBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	if b.Cfg.Static.Host == "" {
 		return core.DoctorResult{}, exit(3, "missing static.host")
 	}
+	runtime := "unchecked"
+	api := "static_config"
+	if req.ProbeSSH {
+		_, target, _, err := staticLease(b.Cfg)
+		if err != nil {
+			return core.DoctorResult{}, err
+		}
+		if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "doctor", 10*time.Second); err != nil {
+			return core.DoctorResult{}, err
+		}
+		api = "ssh_probe"
+		runtime = "ssh_reachable"
+	}
 	return core.DoctorResult{
 		Provider: "ssh",
-		Message:  fmt.Sprintf("target=%s windows_mode=%s host=%s runtime=unchecked", b.Cfg.TargetOS, b.Cfg.WindowsMode, b.Cfg.Static.Host),
+		Message:  fmt.Sprintf("target=%s windows_mode=%s host=%s api=%s mutation=false runtime=%s", b.Cfg.TargetOS, b.Cfg.WindowsMode, b.Cfg.Static.Host, api, runtime),
 	}, nil
 }
 
@@ -101,6 +114,9 @@ func staticLease(cfg Config) (Server, SSHTarget, string, error) { return core.St
 func serverSlug(server Server) string                           { return core.ServerSlug(server) }
 func waitForSSH(ctx context.Context, target *SSHTarget, stderr io.Writer) error {
 	return core.WaitForSSH(ctx, target, stderr)
+}
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)

--- a/internal/providers/ssh/backend_doctor_test.go
+++ b/internal/providers/ssh/backend_doctor_test.go
@@ -1,0 +1,26 @@
+package ssh
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestStaticSSHDoctorDoesNotReportProbeWhenUnchecked(t *testing.T) {
+	cfg := Config{}
+	cfg.Static.Host = "example.test"
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{}).(*staticLeaseBackend)
+
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Message, "api=static_config") || strings.Contains(result.Message, "api=ssh_probe") {
+		t.Fatalf("result=%#v", result)
+	}
+	if !strings.Contains(result.Message, "runtime=unchecked") {
+		t.Fatalf("result=%#v", result)
+	}
+}

--- a/scripts/live-doctor-smoke.sh
+++ b/scripts/live-doctor-smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+bin="${CRABBOX_BIN:-./bin/crabbox}"
+providers=(
+  aws
+  azure
+  blacksmith-testbox
+  cloudflare
+  daytona
+  e2b
+  gcp
+  hetzner
+  islo
+  modal
+  namespace-devbox
+  proxmox
+  semaphore
+  sprites
+  ssh
+  tensorlake
+)
+
+if [[ ! -x "$bin" ]]; then
+  echo "missing crabbox binary: $bin" >&2
+  echo "build first: go build -trimpath -o bin/crabbox ./cmd/crabbox" >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+pass=0
+fail=0
+unsupported=0
+
+for provider in "${providers[@]}"; do
+  out="$tmpdir/$provider.out"
+  if "$bin" doctor --provider "$provider" --json >"$out" 2>&1; then
+    status="pass"
+    pass=$((pass + 1))
+  else
+    status="fail"
+    fail=$((fail + 1))
+  fi
+  if grep -q 'direct_doctor=unsupported' "$out"; then
+    unsupported=$((unsupported + 1))
+  fi
+  summary="$(tr '\n' ' ' <"$out" | sed 's/[[:space:]][[:space:]]*/ /g' | cut -c 1-220)"
+  printf '%-20s %s %s\n' "$provider" "$status" "$summary"
+done
+
+echo "summary pass=$pass fail=$fail unsupported=$unsupported"
+if [[ "$unsupported" -ne 0 || "$fail" -ne 0 ]]; then
+  if [[ "${CRABBOX_DOCTOR_SMOKE_ALLOW_FAILURES:-}" == "1" && "$unsupported" -eq 0 ]]; then
+    exit 0
+  fi
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- cover every built-in provider with a provider-owned doctor path, so unsupported direct doctor output is gone for registered providers
- add short classified provider failures, JSON output, provider timeout details, API/mutation labels, and opt-in static SSH probing
- add live all-provider smoke script plus docs, changelog, and focused tests

## Verification
- go test ./internal/cli ./internal/providers/cloudflare ./internal/providers/blacksmith ./internal/providers/gcp ./internal/providers/daytona ./internal/providers/proxmox ./internal/providers/ssh
- go test ./...
- go vet ./...
- node scripts/build-docs-site.mjs
- git diff --check
- go build -trimpath -o bin/crabbox ./cmd/crabbox
- CRABBOX_DOCTOR_SMOKE_ALLOW_FAILURES=1 scripts/live-doctor-smoke.sh

## Live smoke
- unsupported=0 across aws, azure, blacksmith-testbox, cloudflare, daytona, e2b, gcp, hetzner, islo, modal, namespace-devbox, proxmox, semaphore, sprites, ssh, tensorlake
- pass=6 fail=10 on this machine; failures were classified local config/auth/tool/API state, not unsupported providers
- strict script mode exits nonzero on provider failures; allow-failures mode is for coverage collection on partially configured machines
