### PR TITLE
feat: add exe-dev doctor readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added an account-guarded EC2 Mac Dedicated Host quota request helper for turning macOS lifecycle smoke quota evidence into a dry-run or explicit AWS Service Quotas request.
 - Added a no-spend macOS coordinator remediation audit helper that bundles provider identity, IAM policy, host quota, host allocation dry-run, guarded IAM apply dry-run, and guarded quota request dry-run evidence into `summary.json`.
 - Added `provider: exe-dev` for exe.dev VM SSH leases through the exe.dev SSH API, including Crabbox sync/run, `crabbox ssh`, and provider docs.
+- Added direct `crabbox doctor --provider exe-dev` readiness through the exe.dev inventory API without creating VMs.
 - Added Cloudflare runner readiness to `crabbox doctor --provider cloudflare` so runner URL, auth, and container bindings are checked without creating a sandbox. Thanks @altaywtf.
 - Added direct `crabbox doctor` readiness for all built-in providers without creating provider resources.
 - Added `crabbox doctor --json`, provider error classification and hints, direct-check timeout/API/mutation labels, optional `--doctor-probe-ssh`, and `scripts/live-doctor-smoke.sh` for maintainer live coverage checks.

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -14,6 +14,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"cloudflare",
 		"daytona",
 		"e2b",
+		"exe-dev",
 		"gcp",
 		"hetzner",
 		"islo",

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -84,6 +84,14 @@ func (b *exeDevLeaseBackend) List(ctx context.Context, req ListRequest) ([]Lease
 	return b.listServers(ctx, req.All)
 }
 
+func (b *exeDevLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return cliDoctorResult(providerName, len(servers), "unchecked"), nil
+}
+
 func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
 	name := strings.TrimSpace(req.Lease.Server.Name)
 	if name == "" {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -49,6 +49,30 @@ func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
 	}
 }
 
+func TestExeDevDoctorListsInventory(t *testing.T) {
+	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		got := strings.Join(req.Args, " ")
+		if !strings.Contains(got, "exe.dev ls --l --json") {
+			t.Fatalf("args=%v", req.Args)
+		}
+		if strings.Contains(got, " new ") || strings.Contains(got, " rm ") {
+			t.Fatalf("doctor used mutating command: %v", req.Args)
+		}
+		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running"}]}`}, nil
+	}}
+	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Provider != providerName || !strings.Contains(result.Message, "cli=ready") || !strings.Contains(result.Message, "api=list") || !strings.Contains(result.Message, "leases=1") {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
 func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		got := strings.Join(req.Args, " ")

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -14,6 +14,8 @@ type ExeDevConfig = core.ExeDevConfig
 type ProviderSpec = core.ProviderSpec
 type Runtime = core.Runtime
 type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
 type AcquireRequest = core.AcquireRequest
 type ResolveRequest = core.ResolveRequest
 type ListRequest = core.ListRequest
@@ -104,4 +106,8 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 
 func bootstrapWaitTimeout(cfg Config) time.Duration {
 	return core.BootstrapWaitTimeout(cfg)
+}
+
+func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {
+	return core.CLIDoctorResult(provider, leases, runtime)
 }

--- a/internal/providers/exedev/provider.go
+++ b/internal/providers/exedev/provider.go
@@ -45,3 +45,15 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	}
 	return NewExeDevLeaseBackend(p.Spec(), cfg, rt), nil
 }
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "exe.dev doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/scripts/live-doctor-smoke.sh
+++ b/scripts/live-doctor-smoke.sh
@@ -9,6 +9,7 @@ providers=(
   cloudflare
   daytona
   e2b
+  exe-dev
   gcp
   hetzner
   islo


### PR DESCRIPTION
## Summary
- add a provider-owned exe.dev doctor path that runs the existing list-only SSH control API
- include exe-dev in built-in doctor coverage tests and live doctor smoke coverage
- add changelog entry for exe-dev doctor readiness

## Verification
- go test ./internal/providers/exedev ./internal/providers/all ./internal/cli
- go test ./...
- go vet ./...
- git diff --check
- go build -trimpath -o bin/crabbox ./cmd/crabbox
- CRABBOX_DOCTOR_SMOKE_ALLOW_FAILURES=1 scripts/live-doctor-smoke.sh
- codex-review --parallel-tests "go test ./... && go vet ./... && git diff --check"

## Live smoke
- unsupported=0 across current built-in providers, including exe-dev
- pass=5 fail=12 on this machine; failures were provider config/auth/control-plane state, not unsupported doctor coverage
