### PR TITLE
chore(macos): add devtools image mint wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
+
 ## 0.16.0 - 2026-05-18
 
 ### Added

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -322,6 +322,41 @@ private prep hook only for organization-specific setup. Do not put Apple
 credentials, download tokens, or private package mirrors in this repository or
 in baked images.
 
+For the generic developer-tools image, prefer the small wrapper instead of
+remembering the lifecycle environment by hand:
+
+```bash
+scripts/mint-macos-devtools-image.sh
+```
+
+That default is no-spend: it runs coordinator, IAM, offering, quota, host list,
+and allocation dry-run checks, writes the usual lifecycle summary, and stops
+before lease creation. To mint from an already available host:
+
+```bash
+scripts/mint-macos-devtools-image.sh \
+  --region us-west-2 \
+  --type mac2.metal \
+  --use-existing
+```
+
+To allow paid host allocation when no reusable host exists:
+
+```bash
+scripts/mint-macos-devtools-image.sh \
+  --region us-west-2 \
+  --type mac2.metal \
+  --allocate
+```
+
+The wrapper sets `CRABBOX_MACOS_SOURCE_PREP_SCRIPT` to
+`scripts/install-macos-developer-tools.sh`, names images with the
+`crabbox-macos-devtools-<timestamp>` prefix, promotes the AMI after candidate
+proof, and keeps checkpoint fork proof enabled by default. Use
+`--no-promote` for a candidate-only run, `--no-checkpoint` to skip checkpoint
+fork proof, and `--release-host` only when the AWS Dedicated Host can be
+released safely.
+
 If an available EC2 Mac Dedicated Host already exists, the script still stops
 after preflight unless `CRABBOX_MACOS_RUN=1` or `CRABBOX_MACOS_ALLOCATE=1` is
 set.

--- a/scripts/mint-macos-devtools-image.sh
+++ b/scripts/mint-macos-devtools-image.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lifecycle_script="${CRABBOX_MACOS_LIFECYCLE_SCRIPT:-$ROOT/scripts/macos-image-lifecycle-smoke.sh}"
+prep_script="${CRABBOX_MACOS_SOURCE_PREP_SCRIPT:-$ROOT/scripts/install-macos-developer-tools.sh}"
+image_name="${CRABBOX_MACOS_IMAGE_NAME:-crabbox-macos-devtools-$(date -u +%Y%m%d-%H%M)}"
+run_existing="${CRABBOX_MACOS_RUN:-0}"
+allocate="${CRABBOX_MACOS_ALLOCATE:-0}"
+create_image="${CRABBOX_MACOS_CREATE_IMAGE:-1}"
+promote="${CRABBOX_MACOS_PROMOTE:-1}"
+checkpoint="${CRABBOX_MACOS_CHECKPOINT:-$create_image}"
+open_webvnc="${CRABBOX_MACOS_OPEN_WEBVNC:-0}"
+keep_lease="${CRABBOX_MACOS_KEEP_LEASE:-0}"
+release_host="${CRABBOX_MACOS_RELEASE_HOST:-0}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/mint-macos-devtools-image.sh [flags]
+
+Thin maintainer wrapper around scripts/macos-image-lifecycle-smoke.sh for the
+generic macOS developer-tools AMI.
+
+By default this only runs no-spend preflight checks. Paid work requires one of:
+  --use-existing   use an already available EC2 Mac Dedicated Host
+  --allocate       allocate a paid EC2 Mac Dedicated Host when needed
+
+Flags:
+  --region REGION       set CRABBOX_MACOS_REGION
+  --type TYPE           set CRABBOX_MACOS_TYPE, default mac2.metal
+  --name NAME           set CRABBOX_MACOS_IMAGE_NAME
+  --use-existing        continue with an available host
+  --allocate            allow paid host allocation when no host is available
+  --release-host        release the allocated host after proof
+  --keep-lease          keep leases alive for debugging
+  --open                open WebVNC during proof
+  --no-promote          create and smoke the candidate AMI but do not promote it
+  --no-checkpoint       skip checkpoint fork proof
+  -h, --help            show this help
+
+Useful env:
+  CRABBOX_BIN
+  CRABBOX_MACOS_REGIONS
+  CRABBOX_MACOS_REGION_PREFLIGHT
+  CRABBOX_MACOS_CREATE_IMAGE
+  CRABBOX_MACOS_ARTIFACT_DIR
+  CRABBOX_MACOS_HOST_WAIT_TIMEOUT
+  CRABBOX_MACOS_RELEASE_EXISTING_HOST
+USAGE
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --region)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      export CRABBOX_MACOS_REGION="$2"
+      shift 2
+      ;;
+    --type)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      export CRABBOX_MACOS_TYPE="$2"
+      shift 2
+      ;;
+    --name)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      image_name="$2"
+      shift 2
+      ;;
+    --use-existing)
+      run_existing=1
+      shift
+      ;;
+    --allocate)
+      allocate=1
+      shift
+      ;;
+    --release-host)
+      release_host=1
+      shift
+      ;;
+    --keep-lease)
+      keep_lease=1
+      shift
+      ;;
+    --open)
+      open_webvnc=1
+      shift
+      ;;
+    --no-promote)
+      promote=0
+      shift
+      ;;
+    --no-checkpoint)
+      checkpoint=0
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "$lifecycle_script" ]]; then
+  printf 'macOS lifecycle script is not executable: %s\n' "$lifecycle_script" >&2
+  exit 2
+fi
+if [[ ! -f "$prep_script" ]]; then
+  printf 'macOS developer-tools prep script not found: %s\n' "$prep_script" >&2
+  exit 2
+fi
+
+cat >&2 <<EOF
+macOS devtools image mint
+  image: $image_name
+  prep:  $prep_script
+  paid:  use_existing=$run_existing allocate=$allocate release_host=$release_host
+  proof: create_image=$create_image checkpoint=$checkpoint promote=$promote webvnc_open=$open_webvnc
+EOF
+
+export CRABBOX_MACOS_SOURCE_PREP_SCRIPT="$prep_script"
+export CRABBOX_MACOS_IMAGE_NAME="$image_name"
+export CRABBOX_MACOS_RUN="$run_existing"
+export CRABBOX_MACOS_ALLOCATE="$allocate"
+export CRABBOX_MACOS_CREATE_IMAGE="$create_image"
+export CRABBOX_MACOS_PROMOTE="$promote"
+export CRABBOX_MACOS_CHECKPOINT="$checkpoint"
+export CRABBOX_MACOS_OPEN_WEBVNC="$open_webvnc"
+export CRABBOX_MACOS_KEEP_LEASE="$keep_lease"
+export CRABBOX_MACOS_RELEASE_HOST="$release_host"
+
+exec "$lifecycle_script"

--- a/scripts/mint-macos-devtools-image.test.js
+++ b/scripts/mint-macos-devtools-image.test.js
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const wrapperScript = path.join(scriptDir, "mint-macos-devtools-image.sh");
+
+async function setupFakeLifecycle() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crabbox-macos-mint-test-"));
+  const envPath = path.join(dir, "env.json");
+  const prepPath = path.join(dir, "prep.sh");
+  const lifecyclePath = path.join(dir, "lifecycle.sh");
+  await writeFile(prepPath, "#!/usr/bin/env bash\nexit 0\n");
+  await chmod(prepPath, 0o755);
+  await writeFile(
+    lifecyclePath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+node -e '
+const fs = require("node:fs");
+const keys = [
+  "CRABBOX_MACOS_SOURCE_PREP_SCRIPT",
+  "CRABBOX_MACOS_IMAGE_NAME",
+  "CRABBOX_MACOS_REGION",
+  "CRABBOX_MACOS_TYPE",
+  "CRABBOX_MACOS_RUN",
+  "CRABBOX_MACOS_ALLOCATE",
+  "CRABBOX_MACOS_CREATE_IMAGE",
+  "CRABBOX_MACOS_PROMOTE",
+  "CRABBOX_MACOS_CHECKPOINT",
+  "CRABBOX_MACOS_OPEN_WEBVNC",
+  "CRABBOX_MACOS_KEEP_LEASE",
+  "CRABBOX_MACOS_RELEASE_HOST",
+];
+const out = {};
+for (const key of keys) out[key] = process.env[key] || "";
+fs.writeFileSync(process.env.CRABBOX_FAKE_ENV_PATH, JSON.stringify(out, null, 2));
+'
+`,
+  );
+  await chmod(lifecyclePath, 0o755);
+  return { dir, envPath, prepPath, lifecyclePath };
+}
+
+function runWrapper(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [wrapperScript, ...args], {
+      cwd: path.resolve(scriptDir, ".."),
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("mint wrapper defaults to no-spend promoted developer-tools proof", async () => {
+  const fake = await setupFakeLifecycle();
+  const result = await runWrapper([], {
+    CRABBOX_FAKE_ENV_PATH: fake.envPath,
+    CRABBOX_MACOS_LIFECYCLE_SCRIPT: fake.lifecyclePath,
+    CRABBOX_MACOS_SOURCE_PREP_SCRIPT: fake.prepPath,
+  });
+  assert.equal(result.code, 0, result.stderr);
+  const env = JSON.parse(await readFile(fake.envPath, "utf8"));
+  assert.equal(env.CRABBOX_MACOS_SOURCE_PREP_SCRIPT, fake.prepPath);
+  assert.match(env.CRABBOX_MACOS_IMAGE_NAME, /^crabbox-macos-devtools-/);
+  assert.equal(env.CRABBOX_MACOS_RUN, "0");
+  assert.equal(env.CRABBOX_MACOS_ALLOCATE, "0");
+  assert.equal(env.CRABBOX_MACOS_CREATE_IMAGE, "1");
+  assert.equal(env.CRABBOX_MACOS_PROMOTE, "1");
+  assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "1");
+  assert.equal(env.CRABBOX_MACOS_OPEN_WEBVNC, "0");
+  assert.equal(env.CRABBOX_MACOS_RELEASE_HOST, "0");
+  assert.match(result.stderr, /paid:\s+use_existing=0 allocate=0 release_host=0/);
+});
+
+test("mint wrapper maps explicit paid-work flags to lifecycle env", async () => {
+  const fake = await setupFakeLifecycle();
+  const result = await runWrapper(
+    [
+      "--region",
+      "us-west-2",
+      "--type",
+      "mac2.metal",
+      "--name",
+      "crabbox-macos-devtools-test",
+      "--use-existing",
+      "--allocate",
+      "--release-host",
+      "--keep-lease",
+      "--open",
+      "--no-promote",
+      "--no-checkpoint",
+    ],
+    {
+      CRABBOX_FAKE_ENV_PATH: fake.envPath,
+      CRABBOX_MACOS_LIFECYCLE_SCRIPT: fake.lifecyclePath,
+      CRABBOX_MACOS_SOURCE_PREP_SCRIPT: fake.prepPath,
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const env = JSON.parse(await readFile(fake.envPath, "utf8"));
+  assert.equal(env.CRABBOX_MACOS_IMAGE_NAME, "crabbox-macos-devtools-test");
+  assert.equal(env.CRABBOX_MACOS_REGION, "us-west-2");
+  assert.equal(env.CRABBOX_MACOS_TYPE, "mac2.metal");
+  assert.equal(env.CRABBOX_MACOS_RUN, "1");
+  assert.equal(env.CRABBOX_MACOS_ALLOCATE, "1");
+  assert.equal(env.CRABBOX_MACOS_CREATE_IMAGE, "1");
+  assert.equal(env.CRABBOX_MACOS_RELEASE_HOST, "1");
+  assert.equal(env.CRABBOX_MACOS_KEEP_LEASE, "1");
+  assert.equal(env.CRABBOX_MACOS_OPEN_WEBVNC, "1");
+  assert.equal(env.CRABBOX_MACOS_PROMOTE, "0");
+  assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "0");
+});
+
+test("mint wrapper preserves source-only checkpoint default", async () => {
+  const fake = await setupFakeLifecycle();
+  const result = await runWrapper([], {
+    CRABBOX_FAKE_ENV_PATH: fake.envPath,
+    CRABBOX_MACOS_LIFECYCLE_SCRIPT: fake.lifecyclePath,
+    CRABBOX_MACOS_SOURCE_PREP_SCRIPT: fake.prepPath,
+    CRABBOX_MACOS_CREATE_IMAGE: "0",
+  });
+  assert.equal(result.code, 0, result.stderr);
+  const env = JSON.parse(await readFile(fake.envPath, "utf8"));
+  assert.equal(env.CRABBOX_MACOS_CREATE_IMAGE, "0");
+  assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "0");
+  assert.match(result.stderr, /proof:\s+create_image=0 checkpoint=0 promote=1/);
+});


### PR DESCRIPTION
## Summary
- add a thin macOS developer-tools image mint wrapper around the existing lifecycle smoke script
- keep no-spend preflight as the default and require explicit --use-existing or --allocate before paid host work
- document the wrapper in the image bake runbook and add an Unreleased changelog entry

## Verification
- bash -n scripts/mint-macos-devtools-image.sh scripts/install-macos-developer-tools.sh scripts/macos-image-lifecycle-smoke.sh
- shellcheck scripts/mint-macos-devtools-image.sh
- node --test scripts/mint-macos-devtools-image.test.js