### PR TITLE
feat(images): add developer image bakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed Windows developer-image prep so fresh Chocolatey and Node shims are visible in the active PowerShell session, and first-pass Docker feature installs exit cleanly before final tool verification.
 - Fixed Windows developer-image Docker Engine installation to use static Docker binaries instead of the stale DockerMsftProvider package feed.
 - Fixed Windows developer-image AMI prep to reset EC2Launch state before capture so candidate instances run per-lease user data and accept the new Crabbox SSH key.
+- Fixed Windows developer-image prep to leave Crabbox-managed OpenSSH in place instead of installing Chocolatey's OpenSSH package over the active lease transport.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
+- Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Changed the portal lease table filter bar from a long single-choice pill list to grouped state, provider, OS, kind, and admin ownership selectors.
+- Changed the macOS developer-tools mint wrapper to default to a full Xcode macOS 15 / Swift 6.2 toolchain on newer EC2 Mac host families, while keeping CLT-only image bakes explicit.
 
 ## 0.16.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed Windows developer-image warmup proof so the mint wrapper keeps the source lease alive with an SSH command instead of waiting on stale coordinator readiness.
 - Fixed Windows developer-image prep so fresh Chocolatey and Node shims are visible in the active PowerShell session, and first-pass Docker feature installs exit cleanly before final tool verification.
 - Fixed Windows developer-image Docker Engine installation to use static Docker binaries instead of the stale DockerMsftProvider package feed.
+- Fixed Windows developer-image AMI prep to reset EC2Launch state before capture so candidate instances run per-lease user data and accept the new Crabbox SSH key.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Fixed
 
 - Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
-- Fixed the Windows developer-image mint wrapper to use Crabbox's native PowerShell script upload instead of a manual base64 chunk transfer.
+- Fixed the Windows developer-image mint wrapper so the final PowerShell prep chunk decodes and runs inline instead of relying on a separate post-upload command.
 
 ## 0.16.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
 - Fixed the Windows developer-image mint wrapper so the final PowerShell prep chunk decodes and runs inline instead of relying on a separate post-upload command.
+- Fixed Windows developer-image prep so Docker Engine installation is deferred until after the required Containers feature reboot.
 
 ## 0.16.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed the Windows developer-image mint wrapper so the final PowerShell prep chunk decodes and runs inline instead of relying on a separate post-upload command.
 - Fixed Windows developer-image prep so Docker Engine installation is deferred until after the required Containers feature reboot.
 - Fixed Windows developer-image bakes so the Docker Containers feature can interrupt SSH without aborting the image mint, as long as the reboot marker is present.
+- Fixed Windows developer-image warmup proof so the mint wrapper keeps the source lease alive with an SSH command instead of waiting on stale coordinator readiness.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
 - Fixed the Windows developer-image mint wrapper so the final PowerShell prep chunk decodes and runs inline instead of relying on a separate post-upload command.
 - Fixed Windows developer-image prep so Docker Engine installation is deferred until after the required Containers feature reboot.
+- Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Changed the portal lease table filter bar from a long single-choice pill list to grouped state, provider, OS, kind, and admin ownership selectors.
 - Changed the macOS developer-tools mint wrapper to default to a full Xcode macOS 15 / Swift 6.2 toolchain on newer EC2 Mac host families, while keeping CLT-only image bakes explicit.
 
+### Fixed
+
+- Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
+
 ## 0.16.0 - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed Windows developer-image bakes so the Docker Containers feature can interrupt SSH without aborting the image mint, as long as the reboot marker is present.
 - Fixed Windows developer-image warmup proof so the mint wrapper keeps the source lease alive with an SSH command instead of waiting on stale coordinator readiness.
 - Fixed Windows developer-image prep so fresh Chocolatey and Node shims are visible in the active PowerShell session, and first-pass Docker feature installs exit cleanly before final tool verification.
+- Fixed Windows developer-image Docker Engine installation to use static Docker binaries instead of the stale DockerMsftProvider package feed.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed Windows developer-image Docker Engine installation to use static Docker binaries instead of the stale DockerMsftProvider package feed.
 - Fixed Windows developer-image AMI prep to reset EC2Launch state before capture so candidate instances run per-lease user data and accept the new Crabbox SSH key.
 - Fixed Windows developer-image prep to leave Crabbox-managed OpenSSH in place instead of installing Chocolatey's OpenSSH package over the active lease transport.
+- Fixed Windows developer-image minting to retry idempotent prep-script chunk uploads and require a stable post-reboot SSH window before the second prep pass.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
 - Fixed the Windows developer-image mint wrapper so the final PowerShell prep chunk decodes and runs inline instead of relying on a separate post-upload command.
 - Fixed Windows developer-image prep so Docker Engine installation is deferred until after the required Containers feature reboot.
+- Fixed Windows developer-image bakes so the Docker Containers feature can interrupt SSH without aborting the image mint, as long as the reboot marker is present.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed Windows developer-image prep so Docker Engine installation is deferred until after the required Containers feature reboot.
 - Fixed Windows developer-image bakes so the Docker Containers feature can interrupt SSH without aborting the image mint, as long as the reboot marker is present.
 - Fixed Windows developer-image warmup proof so the mint wrapper keeps the source lease alive with an SSH command instead of waiting on stale coordinator readiness.
+- Fixed Windows developer-image prep so fresh Chocolatey and Node shims are visible in the active PowerShell session, and first-pass Docker feature installs exit cleanly before final tool verification.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fixed Windows developer-image bootstrap readiness so setup completion is written before restarting SSH and native Windows bakes wait for a stable SSH window before continuing.
+- Fixed the Windows developer-image mint wrapper to use Crabbox's native PowerShell script upload instead of a manual base64 chunk transfer.
 
 ## 0.16.0 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Fixed Windows developer-image Docker Engine installation to use static Docker binaries instead of the stale DockerMsftProvider package feed.
 - Fixed Windows developer-image AMI prep to reset EC2Launch state before capture so candidate instances run per-lease user data and accept the new Crabbox SSH key.
 - Fixed Windows developer-image prep to leave Crabbox-managed OpenSSH in place instead of installing Chocolatey's OpenSSH package over the active lease transport.
-- Fixed Windows developer-image minting to retry idempotent prep-script chunk uploads and require a stable post-reboot SSH window before the second prep pass.
+- Fixed Windows developer-image minting to retry idempotent prep-script chunk uploads, run long prep through a detached scheduled task, and require a stable post-reboot SSH window before the second prep pass.
 - Fixed AWS developer-image bakes behind configured security groups so coordinator heartbeats still refresh the configured Crabbox SSH ports, and aligned the Worker Windows bootstrap ordering with the CLI path.
 
 ## 0.16.0 - 2026-05-18

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -16,6 +16,8 @@ Use names that identify owner, purpose, and UTC bake time:
 
 ```text
 crabbox-linux-desktop-browser-YYYYMMDD-HHMM
+crabbox-linux-devtools-YYYYMMDD-HHMM
+crabbox-windows-devtools-YYYYMMDD-HHMM
 crabbox-macos-arm64-YYYYMMDD-HHMM
 ```
 
@@ -33,6 +35,8 @@ Bake machine capabilities:
 - Chrome/Chromium for browser leases;
 - `ffmpeg`, `ffprobe`, `scrot`, `xdotool`, and other capture helpers;
 - Node 24, npm, corepack, pnpm;
+- Docker Engine plus the Compose and buildx plugins where the platform supports
+  them;
 - build-essential, Python, and common native-addon headers;
 - empty cache directories such as `/var/cache/crabbox/pnpm`.
 
@@ -171,6 +175,73 @@ crabbox run \
 
 Keep the previous promoted AMI available until at least one normal brokered
 lease and one relevant QA lane pass on the new image.
+
+## Linux And Windows Developer Images
+
+For generic AWS Linux and Windows developer AMIs, use the guarded wrapper
+instead of hand-running the prep and image commands:
+
+```bash
+scripts/mint-aws-devtools-image.sh --target linux
+scripts/mint-aws-devtools-image.sh --target windows
+```
+
+The default is a no-spend plan. Add `--run` only when the selected AWS account,
+region, quotas, and image name are correct:
+
+```bash
+scripts/mint-aws-devtools-image.sh \
+  --target linux \
+  --region us-west-2 \
+  --type m7i.large \
+  --run
+
+scripts/mint-aws-devtools-image.sh \
+  --target windows \
+  --region us-west-2 \
+  --type m7i.large \
+  --windows-mode normal \
+  --run
+```
+
+The Linux prep script installs common CLI/build tooling, GitHub CLI, Node 24,
+corepack/pnpm, Chrome or Chromium for browser lanes, desktop/VNC helpers, Docker
+Engine, Compose, buildx, and a small default Docker image set. The Windows prep
+script installs common CLI/build tooling, GitHub CLI, Node 24, corepack/pnpm,
+and Windows Server container support with Docker Engine. It deliberately avoids
+Docker Desktop because headless image bakes should not depend on a user-session
+desktop app or Docker Desktop licensing.
+
+Tune the default prebake set with environment variables:
+
+```bash
+CRABBOX_LINUX_DOCKER_IMAGES='hello-world ubuntu:24.04 node:24-bookworm'
+CRABBOX_WINDOWS_DOCKER_IMAGES='mcr.microsoft.com/windows/servercore:ltsc2022'
+CRABBOX_LINUX_BROWSER=0
+CRABBOX_LINUX_DESKTOP_TOOLS=0
+CRABBOX_WINDOWS_INSTALL_DOCKER=0
+```
+
+The wrapper always proves the source lease, candidate AMI, and promoted AMI
+before declaring success unless `--no-promote` is set. It writes warmup timing
+logs under `.crabbox/image-mint-<image-name>-*.log`, which is the evidence to
+compare before and after each bake.
+
+## Fast Boot Expectations
+
+Fast images come from moving stable machine setup into the AMI and keeping
+per-lease bootstrap tiny. Bake OS patches, developer tools, Docker, browser
+bits, cache directories, service enablement, and first-run suppression. Do not
+bake repository checkouts, package installs tied to one lockfile, browser login
+state, or secrets.
+
+For Blacksmith-like cold-start times on AWS, an AMI alone is not always enough.
+EBS snapshots hydrate lazily by default, so new regions or availability zones
+can still pay first-read penalties. For hot production lanes, keep capacity in
+the same region as the promoted AMI, track the wrapper timing logs, and enable
+AWS Fast Snapshot Restore on the backing snapshots in the availability zones
+where the image must boot immediately. Treat snapshot warmup as a separate
+provider-cost decision; do not enable it casually for every candidate image.
 
 ## macOS Images
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -360,10 +360,11 @@ requires an active Apple developer tools directory, a macOS SDK through
 waits for the portal bridge to report `connected=true`, collects desktop
 artifacts, creates a candidate AMI with a rebooting image capture, boots and
 smokes the candidate, then promotes and smokes the promoted image when
-`CRABBOX_MACOS_PROMOTE=1`. Command Line Tools are enough by default; full Xcode
-is not required unless `CRABBOX_MACOS_REQUIRE_XCODE=1` is set. For `mac2*`
-families the default gates are macOS 14+ and Swift tools 6.0+ because those are
-the launchable hosts commonly available today. For newer `mac-m*` families the
+`CRABBOX_MACOS_PROMOTE=1`. The generic lifecycle defaults to Command Line
+Tools-compatible checks; set `CRABBOX_MACOS_REQUIRE_XCODE=1` when the image must
+run SwiftPM, app, or SDK lanes that depend on Xcode.app. For `mac2*` families
+the default gates are macOS 14+ and Swift tools 6.0+ because those are the
+launchable hosts commonly available today. For newer `mac-m*` families the
 defaults are macOS 15+ and Swift tools 6.2+, which matches Swift package lanes
 that require `swift-tools-version: 6.2` and macOS 15 SDKs. Tune the toolchain
 gates with `CRABBOX_MACOS_REQUIRED_MAJOR` and
@@ -397,13 +398,15 @@ scripts/macos-image-lifecycle-smoke.sh
 ```
 
 The bundled developer-tool prep script keeps the image generic: it verifies
-Command Line Tools, installs Homebrew when missing, installs common developer
-packages such as Git, GitHub CLI, jq/yq, ripgrep, fd, ShellCheck, shfmt, Python,
-Node 24, and activates pnpm through corepack. It also creates `/usr/local/bin`
-shims so non-login SSH commands can find those tools after the AMI boots. Use a
-private prep hook only for organization-specific setup. Do not put Apple
-credentials, download tokens, or private package mirrors in this repository or
-in baked images.
+Command Line Tools by default, or selects an installed `/Applications/Xcode*.app`
+developer directory when `CRABBOX_MACOS_REQUIRE_XCODE=1`. It installs Homebrew
+when missing, installs common developer packages such as Git, GitHub CLI, jq/yq,
+ripgrep, fd, ShellCheck, shfmt, Python, Node 24, and activates pnpm through
+corepack. It also creates `/usr/local/bin` shims so non-login SSH commands can
+find those tools after the AMI boots. The script does not download Xcode;
+install Xcode in a private prep hook first if the base image does not already
+contain it. Do not put Apple credentials, download tokens, or private package
+mirrors in this repository or in baked images.
 
 For the generic developer-tools image, prefer the small wrapper instead of
 remembering the lifecycle environment by hand:
@@ -414,12 +417,18 @@ scripts/mint-macos-devtools-image.sh
 
 That default is no-spend: it runs coordinator, IAM, offering, quota, host list,
 and allocation dry-run checks, writes the usual lifecycle summary, and stops
-before lease creation. To mint from an already available host:
+before lease creation. The wrapper is intentionally stricter than the generic
+lifecycle: it defaults to `mac-m4.metal`, macOS 15+, Swift tools 6.2+, and full
+Xcode.app via `CRABBOX_MACOS_REQUIRE_XCODE=1`. For an older CLT-only image, set
+`CRABBOX_MACOS_TYPE=mac2.metal`, `CRABBOX_MACOS_REQUIRED_MAJOR=14`,
+`CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS=6.0`, and
+`CRABBOX_MACOS_REQUIRE_XCODE=0` explicitly. To mint from an already available
+host:
 
 ```bash
 scripts/mint-macos-devtools-image.sh \
   --region us-west-2 \
-  --type mac2.metal \
+  --type mac-m4.metal \
   --use-existing
 ```
 
@@ -428,7 +437,7 @@ To allow paid host allocation when no reusable host exists:
 ```bash
 scripts/mint-macos-devtools-image.sh \
   --region us-west-2 \
-  --type mac2.metal \
+  --type mac-m4.metal \
   --allocate
 ```
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -212,6 +212,11 @@ and Windows Server container support with Docker Engine. It deliberately avoids
 Docker Desktop because headless image bakes should not depend on a user-session
 desktop app or Docker Desktop licensing.
 
+Windows container support can require one reboot before Docker starts. The
+wrapper detects the prep script's reboot marker, reboots the source lease,
+waits for Crabbox readiness, reruns the prep script to pull the configured
+Docker images, and only then runs the source smoke and AMI capture.
+
 Tune the default prebake set with environment variables:
 
 ```bash

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -193,12 +193,14 @@ region, quotas, and image name are correct:
 scripts/mint-aws-devtools-image.sh \
   --target linux \
   --region us-west-2 \
+  --class standard \
   --type m7i.large \
   --run
 
 scripts/mint-aws-devtools-image.sh \
   --target windows \
   --region us-west-2 \
+  --class standard \
   --type m7i.large \
   --windows-mode normal \
   --run
@@ -227,10 +229,12 @@ CRABBOX_LINUX_DESKTOP_TOOLS=0
 CRABBOX_WINDOWS_INSTALL_DOCKER=0
 ```
 
-The wrapper always proves the source lease, candidate AMI, and promoted AMI
-before declaring success unless `--no-promote` is set. It writes warmup timing
-logs under `.crabbox/image-mint-<image-name>-*.log`, which is the evidence to
-compare before and after each bake.
+The wrapper defaults to `--class standard` even when an explicit instance type
+is provided, so image bakes do not accidentally consume the high-pressure beast
+class. It always proves the source lease, candidate AMI, and promoted AMI before
+declaring success unless `--no-promote` is set. It writes warmup timing logs
+under `.crabbox/image-mint-<image-name>-*.log`, which is the evidence to compare
+before and after each bake.
 
 ## Fast Boot Expectations
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -213,6 +213,9 @@ script installs common CLI/build tooling, GitHub CLI, Node 24, corepack/pnpm,
 and Windows Server container support with Docker Engine. It deliberately avoids
 Docker Desktop because headless image bakes should not depend on a user-session
 desktop app or Docker Desktop licensing.
+Windows developer bakes are headless by default for faster boot and fewer
+desktop-bootstrap moving parts. Pass `--desktop` only when the image is meant
+to back interactive desktop leases.
 
 Windows container support can require one reboot before Docker starts. The
 wrapper detects the prep script's reboot marker, reboots the source lease,

--- a/docs/features/prebaked-images.md
+++ b/docs/features/prebaked-images.md
@@ -33,8 +33,10 @@ Good prebake contents:
 - SSH, Git, rsync, curl, jq, and readiness helpers;
 - desktop/browser capabilities for `--desktop --browser` leases;
 - screenshot and recording tools such as `scrot`, `ffmpeg`, `xdotool`, and VNC;
-- Node 22, corepack/pnpm, build-essential, Python, and common native-addon
+- Node 24, corepack/pnpm, build-essential, Python, and common native-addon
   headers when the image targets browser/channel QA;
+- Docker Engine and common container plugin support when the target platform
+  supports headless Docker;
 - empty shared cache directories such as `/var/cache/crabbox/pnpm`.
 
 Bad prebake contents:
@@ -74,9 +76,10 @@ candidate smoke, promotion, rollback, and cleanup commands. At a high level:
 6. Run a normal brokered lease and the relevant QA lane.
 7. Keep the previous known-good AMI until the new image has real QA proof.
 
-For Mantis, image bake success is not just "Chrome exists." A useful image must
-reduce `crabbox.warmup` or `crabbox.remote_run` time in the Mantis timing
-report while keeping Slack/browser login state outside the image.
+Image bake success is not just "Chrome exists." A useful image must reduce
+`crabbox.warmup` or `crabbox.remote_run` time in timing evidence while keeping
+project credentials, browser login state, and repository artifacts outside the
+image.
 
 Related docs:
 

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -663,41 +663,54 @@ func (c *AWSClient) resolveLatestAmazonAMI(ctx context.Context, name, architectu
 }
 
 func (c *AWSClient) ensureSecurityGroup(ctx context.Context, cfg Config) (string, error) {
-	if cfg.AWSSGID != "" {
-		return cfg.AWSSGID, nil
-	}
-	vpcID, err := c.securityGroupVPC(ctx, cfg)
-	if err != nil {
-		return "", err
-	}
-	const name = "crabbox-runners"
-	existing, err := c.ec2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
-		Filters: []types.Filter{
-			{Name: aws.String("group-name"), Values: []string{name}},
-			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
-		},
-	})
-	if err != nil {
-		return "", err
-	}
 	var groupID string
 	var group *types.SecurityGroup
-	if len(existing.SecurityGroups) > 0 {
-		group = &existing.SecurityGroups[0]
-		groupID = aws.ToString(group.GroupId)
-	} else {
-		created, err := c.ec2.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
-			Description: aws.String("Crabbox ephemeral test runners"),
-			GroupName:   aws.String(name),
-			TagSpecifications: []types.TagSpecification{
-				{ResourceType: types.ResourceTypeSecurityGroup, Tags: awsTags(map[string]string{"Name": name, "crabbox": "true", "created_by": "crabbox"})},
-			},
-			VpcId: aws.String(vpcID),
+	if cfg.AWSSGID != "" {
+		groupID = cfg.AWSSGID
+		existing, err := c.ec2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			GroupIds: []string{groupID},
 		})
 		if err != nil {
 			return "", err
 		}
-		groupID = aws.ToString(created.GroupId)
+		if len(existing.SecurityGroups) > 0 {
+			group = &existing.SecurityGroups[0]
+		}
+	} else {
+		vpcID, err := c.securityGroupVPC(ctx, cfg)
+		if err != nil {
+			return "", err
+		}
+		const name = "crabbox-runners"
+		existing, err := c.ec2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []types.Filter{
+				{Name: aws.String("group-name"), Values: []string{name}},
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+			},
+		})
+		if err != nil {
+			return "", err
+		}
+		if len(existing.SecurityGroups) > 0 {
+			group = &existing.SecurityGroups[0]
+			groupID = aws.ToString(group.GroupId)
+		} else {
+			created, err := c.ec2.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+				Description: aws.String("Crabbox ephemeral test runners"),
+				GroupName:   aws.String(name),
+				TagSpecifications: []types.TagSpecification{
+					{ResourceType: types.ResourceTypeSecurityGroup, Tags: awsTags(map[string]string{"Name": name, "crabbox": "true", "created_by": "crabbox"})},
+				},
+				VpcId: aws.String(vpcID),
+			})
+			if err != nil {
+				return "", err
+			}
+			groupID = aws.ToString(created.GroupId)
+		}
+	}
+	if groupID == "" {
+		return "", exit(3, "aws security group id is empty")
 	}
 	ports := sshPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts)
 	if group != nil {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -289,6 +289,76 @@ func TestStaleAWSCrabboxSSHIngressPermissionsKeepsDefaultCIDR(t *testing.T) {
 	}
 }
 
+func TestEnsureAWSSecurityGroupRefreshesConfiguredGroupIngress(t *testing.T) {
+	var actions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		action := r.Form.Get("Action")
+		actions = append(actions, strings.Join([]string{
+			action,
+			r.Form.Get("GroupId"),
+			r.Form.Get("GroupId.1"),
+			r.Form.Get("IpPermissions.1.FromPort"),
+			r.Form.Get("IpPermissions.1.IpRanges.1.CidrIp"),
+		}, ":"))
+		switch action {
+		case "DescribeSecurityGroups":
+			writeEC2XML(w, `<DescribeSecurityGroupsResponse>
+  <securityGroupInfo>
+    <item>
+      <groupId>sg-fixed</groupId>
+      <ipPermissions>
+        <item>
+          <ipProtocol>tcp</ipProtocol>
+          <fromPort>2222</fromPort>
+          <toPort>2222</toPort>
+          <ipRanges>
+            <item>
+              <cidrIp>203.0.113.10/32</cidrIp>
+              <description>`+awsSSHIngressDescription+`</description>
+            </item>
+          </ipRanges>
+        </item>
+      </ipPermissions>
+    </item>
+  </securityGroupInfo>
+</DescribeSecurityGroupsResponse>`)
+		case "RevokeSecurityGroupIngress":
+			writeEC2XML(w, `<RevokeSecurityGroupIngressResponse />`)
+		case "AuthorizeSecurityGroupIngress":
+			writeEC2XML(w, `<AuthorizeSecurityGroupIngressResponse />`)
+		default:
+			writeEC2Error(w, "Unexpected", action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	groupID, err := testAWSClient(server.URL).ensureSecurityGroup(context.Background(), Config{
+		Provider:         "aws",
+		AWSSGID:          "sg-fixed",
+		SSHPort:          "2222",
+		SSHFallbackPorts: []string{"22"},
+		AWSSSHCIDRs:      []string{"198.51.100.77/32"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if groupID != "sg-fixed" {
+		t.Fatalf("groupID=%q, want sg-fixed", groupID)
+	}
+	if !slices.Contains(actions, "DescribeSecurityGroups::sg-fixed::") {
+		t.Fatalf("actions=%v, want configured group describe", actions)
+	}
+	if !slices.Contains(actions, "AuthorizeSecurityGroupIngress:sg-fixed::2222:198.51.100.77/32") {
+		t.Fatalf("actions=%v, want 2222 ingress authorization", actions)
+	}
+	if !slices.Contains(actions, "AuthorizeSecurityGroupIngress:sg-fixed::22:198.51.100.77/32") {
+		t.Fatalf("actions=%v, want 22 ingress authorization", actions)
+	}
+}
+
 func TestAWSMacOSFallbackResolvesAMIForEachInstanceType(t *testing.T) {
 	var imageQueries []string
 	var runImages []string
@@ -305,6 +375,12 @@ func TestAWSMacOSFallbackResolvesAMIForEachInstanceType(t *testing.T) {
 		switch action := params.Get("Action"); action {
 		case "DescribeKeyPairs":
 			writeEC2XML(w, `<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-test</keyName></item></keySet></DescribeKeyPairsResponse>`)
+		case "DescribeSecurityGroups":
+			writeEC2XML(w, `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-123</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>`)
+		case "RevokeSecurityGroupIngress":
+			writeEC2XML(w, `<RevokeSecurityGroupIngressResponse />`)
+		case "AuthorizeSecurityGroupIngress":
+			writeEC2XML(w, `<AuthorizeSecurityGroupIngressResponse />`)
 		case "DescribeImages":
 			architecture := params.Get("Filter.1.Value.1")
 			name := params.Get("Filter.2.Value.1")

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -58,12 +58,58 @@ exit $LASTEXITCODE`)
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: %s SSH command ended before completion; waiting for reboot/ready state: %v\n", phase, err)
 	}
-	if err := waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+	if err := waitForWindowsBootstrapSSHReady(ctx, target, stderr, bootstrapWaitTimeout(cfg)); err != nil {
 		return err
 	}
 	if cfg.Desktop && cfg.WindowsMode == windowsModeNormal {
 		return waitForManagedWindowsLoopbackVNC(ctx, target, stderr, 5*time.Minute)
 	}
+	return nil
+}
+
+func waitForWindowsBootstrapSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	if err := waitForSSHReady(ctx, target, stderr, "bootstrap", timeout); err != nil {
+		return err
+	}
+	const stableProbes = 3
+	const stableInterval = 10 * time.Second
+	stable := 1
+	for stable < stableProbes {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return exit(5, "timed out waiting for stable Windows SSH on %s during bootstrap; %s", target.Host, sshWaitNextAction("bootstrap"))
+		}
+		timer := time.NewTimer(minDuration(stableInterval, remaining))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return context.Cause(ctx)
+		case <-timer.C:
+		}
+		remaining = time.Until(deadline)
+		if remaining <= 0 {
+			return exit(5, "timed out waiting for stable Windows SSH on %s during bootstrap; %s", target.Host, sshWaitNextAction("bootstrap"))
+		}
+		if probeSSHReady(ctx, target, minDuration(10*time.Second, remaining)) {
+			stable++
+			continue
+		}
+		fmt.Fprintln(stderr, "Windows bootstrap SSH reached once but is still settling; waiting for stable ready-check")
+		stable = 0
+		remaining = time.Until(deadline)
+		if remaining <= 0 {
+			return exit(5, "timed out waiting for stable Windows SSH on %s during bootstrap; %s", target.Host, sshWaitNextAction("bootstrap"))
+		}
+		if err := waitForSSHReady(ctx, target, stderr, "bootstrap", remaining); err != nil {
+			return err
+		}
+		stable = 1
+	}
+	fmt.Fprintln(stderr, "Windows bootstrap SSH stable")
 	return nil
 }
 

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -267,6 +267,14 @@ func TestAzureWindowsBootstrapPowerShell(t *testing.T) {
 	if strings.Contains(got, "Restart-Computer") {
 		t.Fatalf("azure extension bootstrap must not restart inside Custom Script Extension")
 	}
+	setupIndex := strings.Index(got, "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath")
+	restartIndex := strings.Index(got, "Restart-Service sshd -Force")
+	if setupIndex < 0 || restartIndex < 0 {
+		t.Fatalf("azure bootstrap missing setup/restart markers")
+	}
+	if setupIndex > restartIndex {
+		t.Fatalf("azure bootstrap must mark setup complete before restarting sshd")
+	}
 }
 
 func TestAzureTagsMapReservedWindowsPrefix(t *testing.T) {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -450,6 +450,7 @@ Set-ItemProperty -Path $winlogon -Name DefaultPassword -Value $userPassword -Typ
 if (-not (Test-Path -LiteralPath $setupCompletePath)) {
   Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
 	  Restart-Computer -Force
+	  exit 0
 	}
 Restart-Service sshd
 	`

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -380,8 +380,8 @@ crabbox-ready
 	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
 	wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
 	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
-	Restart-Service sshd -Force
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	Restart-Service sshd -Force
 	`
 }
 
@@ -447,20 +447,20 @@ Set-ItemProperty -Path $winlogon -Name AutoAdminLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name ForceAutoLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name DefaultUserName -Value $user -Type String
 Set-ItemProperty -Path $winlogon -Name DefaultPassword -Value $userPassword -Type String
-Restart-Service sshd
 if (-not (Test-Path -LiteralPath $setupCompletePath)) {
   Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
 	  Restart-Computer -Force
 	}
+Restart-Service sshd
 	`
 }
 
 func windowsCoreBootstrapFinalizePowerShell() string {
 	return `
-	Restart-Service sshd -Force
 	git --version | Out-Null
 	tar --version | Out-Null
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	Restart-Service sshd -Force
 	`
 }
 
@@ -476,10 +476,10 @@ $usernamePath = Join-Path $base "windows.username"
 $passwordMirrorPath = $null
 $enforceKeyAuth = $true
 ` + windowsBootstrapCorePowerShell() + `
-Restart-Service sshd -Force
 git --version | Out-Null
 tar --version | Out-Null
 ` + setupComplete + `
+Restart-Service sshd -Force
 `
 }
 

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -284,6 +284,14 @@ func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
 			t.Fatalf("windows core bootstrap missing %q", want)
 		}
 	}
+	setupIndex := strings.Index(got, "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath")
+	restartIndex := strings.Index(got, "Restart-Service sshd -Force")
+	if setupIndex < 0 || restartIndex < 0 {
+		t.Fatalf("windows core bootstrap missing setup/restart markers")
+	}
+	if setupIndex > restartIndex {
+		t.Fatalf("windows core bootstrap must mark setup complete before restarting sshd")
+	}
 	for _, notWant := range []string{
 		"tightvnc-2.8.85-gpl-setup-64bit.msi",
 		`C:\ProgramData\crabbox\vnc.password`,

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -13,7 +13,10 @@ log() {
 
 need_root() {
   if [[ "$(id -u)" -ne 0 ]]; then
-    log "run through sudo or as root"
+    if command -v sudo >/dev/null 2>&1; then
+      exec sudo -E bash "$0" "$@"
+    fi
+    log "sudo is required when not running as root"
     exit 2
   fi
 }
@@ -154,7 +157,7 @@ print_versions() {
   docker compose version
 }
 
-need_root
+need_root "$@"
 export DEBIAN_FRONTEND=noninteractive
 cat >/etc/apt/apt.conf.d/80-crabbox-retries <<'APT'
 Acquire::Retries "8";

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pnpm_version="${CRABBOX_LINUX_PNPM_VERSION:-11.1.0}"
+node_major="${CRABBOX_LINUX_NODE_MAJOR:-24}"
+docker_images="${CRABBOX_LINUX_DOCKER_IMAGES:-hello-world ubuntu:24.04 node:24-bookworm}"
+install_desktop="${CRABBOX_LINUX_DESKTOP_TOOLS:-1}"
+install_browser="${CRABBOX_LINUX_BROWSER:-1}"
+
+log() {
+  printf 'linux-tools: %s\n' "$*" >&2
+}
+
+need_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    log "run through sudo or as root"
+    exit 2
+  fi
+}
+
+retry() {
+  local n=1
+  until "$@"; do
+    if [[ "$n" -ge 8 ]]; then
+      return 1
+    fi
+    sleep "$((n * 5))"
+    n="$((n + 1))"
+  done
+}
+
+apt_install() {
+  retry apt-get install -y --no-install-recommends "$@"
+}
+
+add_nodesource() {
+  if command -v node >/dev/null 2>&1 && node --version | grep -q "^v${node_major}\\."; then
+    return 0
+  fi
+  install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" |
+    gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  chmod 0644 /etc/apt/keyrings/nodesource.gpg
+  printf 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_%s.x nodistro main\n' "$node_major" \
+    >/etc/apt/sources.list.d/nodesource.list
+}
+
+add_docker_repo() {
+  if command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+  local codename arch
+  # shellcheck disable=SC1091
+  codename="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-}")"
+  arch="$(dpkg --print-architecture)"
+  if [[ -z "$codename" ]]; then
+    log "could not determine Debian/Ubuntu codename"
+    exit 2
+  fi
+  install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" |
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod 0644 /etc/apt/keyrings/docker.gpg
+  printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu %s stable\n' "$arch" "$codename" \
+    >/etc/apt/sources.list.d/docker.list
+}
+
+install_chrome_or_chromium() {
+  local browser_path=""
+  if [[ "$(dpkg --print-architecture)" == "amd64" ]]; then
+    install -d -m 0755 /etc/apt/keyrings
+    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub |
+      gpg --dearmor -o /etc/apt/keyrings/google-linux.gpg
+    chmod 0644 /etc/apt/keyrings/google-linux.gpg
+    printf 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google-linux.gpg] https://dl.google.com/linux/chrome/deb/ stable main\n' \
+      >/etc/apt/sources.list.d/google-chrome.list
+    if retry apt-get update && apt_install google-chrome-stable; then
+      browser_path="$(command -v google-chrome || true)"
+    else
+      rm -f /etc/apt/sources.list.d/google-chrome.list
+      retry apt-get update || true
+    fi
+  fi
+  if [[ -z "$browser_path" ]]; then
+    if apt-cache show chromium >/dev/null 2>&1 && apt_install chromium; then
+      browser_path="$(command -v chromium || true)"
+    elif apt-cache show chromium-browser >/dev/null 2>&1 && apt_install chromium-browser; then
+      browser_path="$(command -v chromium-browser || true)"
+    fi
+  fi
+  if [[ -n "$browser_path" ]]; then
+    install -d -m 0755 /etc/opt/chrome/policies/managed /etc/chromium/policies/managed
+    printf '%s\n' '{"DefaultBrowserSettingEnabled":false,"MetricsReportingEnabled":false,"PromotionalTabsEnabled":false}' \
+      >/etc/opt/chrome/policies/managed/crabbox.json
+    cp /etc/opt/chrome/policies/managed/crabbox.json /etc/chromium/policies/managed/crabbox.json
+    cat >/usr/local/bin/crabbox-browser <<EOF
+#!/bin/sh
+exec "$browser_path" --no-first-run --no-default-browser-check --disable-default-apps --window-size=1500,900 --window-position=80,80 "\$@"
+EOF
+    chmod 0755 /usr/local/bin/crabbox-browser
+    install -d -m 0755 /var/lib/crabbox
+    printf 'CHROME_BIN=/usr/local/bin/crabbox-browser\nBROWSER=/usr/local/bin/crabbox-browser\n' \
+      >/var/lib/crabbox/browser.env
+    chmod 0644 /var/lib/crabbox/browser.env
+  fi
+}
+
+install_node_pnpm() {
+  apt_install nodejs
+  corepack enable
+  corepack prepare "pnpm@$pnpm_version" --activate
+  command -v pnpm >/dev/null
+}
+
+install_docker() {
+  apt_install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  systemctl enable --now docker || service docker start
+  usermod -aG docker crabbox 2>/dev/null || true
+  docker version
+  docker compose version
+  if [[ -n "$docker_images" ]]; then
+    # shellcheck disable=SC2206
+    local images=($docker_images)
+    local image
+    for image in "${images[@]}"; do
+      retry docker pull "$image" || log "docker pull failed for $image; continuing"
+    done
+  fi
+}
+
+prepare_fast_boot() {
+  install -d -m 1777 /var/cache/crabbox /var/cache/crabbox/pnpm /var/cache/crabbox/npm /var/cache/crabbox/corepack /var/cache/crabbox/docker
+  systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+  systemctl mask apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+  cloud-init clean --logs --seed 2>/dev/null || true
+  sync
+}
+
+print_versions() {
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  printf 'os=%s %s\n' "${PRETTY_NAME:-unknown}" "$(uname -m)"
+  git --version
+  gh --version | head -n 1
+  jq --version
+  rg --version | head -n 1
+  fd --version || fdfind --version
+  python3 --version
+  node --version
+  npm --version
+  corepack --version
+  pnpm --version
+  docker --version
+  docker compose version
+}
+
+need_root
+export DEBIAN_FRONTEND=noninteractive
+cat >/etc/apt/apt.conf.d/80-crabbox-retries <<'APT'
+Acquire::Retries "8";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+APT
+
+apt_get_base=(apt-transport-https ca-certificates curl gnupg lsb-release software-properties-common)
+retry apt-get update
+apt_install "${apt_get_base[@]}"
+add_nodesource
+add_docker_repo
+retry apt-get update
+apt_install \
+  build-essential \
+  pkg-config \
+  git \
+  git-lfs \
+  gh \
+  jq \
+  yq \
+  ripgrep \
+  fd-find \
+  fzf \
+  coreutils \
+  tar \
+  sed \
+  findutils \
+  rsync \
+  unzip \
+  zip \
+  shellcheck \
+  shfmt \
+  python3 \
+  python3-pip \
+  python3-venv \
+  python3-dev \
+  netcat-openbsd \
+  iproute2 \
+  openssl
+
+if [[ ! -e /usr/local/bin/fd && -x /usr/bin/fdfind ]]; then
+  ln -sf /usr/bin/fdfind /usr/local/bin/fd
+fi
+
+if [[ "$install_desktop" == "1" ]]; then
+  apt_install xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation
+fi
+if [[ "$install_browser" == "1" ]]; then
+  install_chrome_or_chromium
+fi
+install_node_pnpm
+install_docker
+prepare_fast_boot
+print_versions

--- a/scripts/install-macos-developer-tools.sh
+++ b/scripts/install-macos-developer-tools.sh
@@ -5,6 +5,8 @@ brew_update="${CRABBOX_MACOS_BREW_UPDATE:-1}"
 pnpm_version="${CRABBOX_MACOS_PNPM_VERSION:-11.1.0}"
 node_formula="${CRABBOX_MACOS_NODE_FORMULA:-node@24}"
 python_formula="${CRABBOX_MACOS_PYTHON_FORMULA:-python@3.13}"
+require_xcode="${CRABBOX_MACOS_REQUIRE_XCODE:-0}"
+xcode_developer_dir="${CRABBOX_MACOS_XCODE_DEVELOPER_DIR:-}"
 default_formulas=(
   git
   git-lfs
@@ -29,8 +31,26 @@ log() {
   printf 'macos-tools: %s\n' "$*" >&2
 }
 
-require_command_line_tools() {
+select_full_xcode() {
+  local candidate
+  if [[ -n "$xcode_developer_dir" ]]; then
+    sudo xcode-select -s "$xcode_developer_dir"
+    return
+  fi
+  for candidate in /Applications/Xcode*.app/Contents/Developer; do
+    [[ -d "$candidate" ]] || continue
+    if [[ -x "$candidate/usr/bin/xcodebuild" && -d "$candidate/Platforms/MacOSX.platform/Developer/SDKs" ]]; then
+      sudo xcode-select -s "$candidate"
+      return
+    fi
+  done
+}
+
+require_developer_tools() {
   local developer_dir
+  if [[ "$require_xcode" == "1" ]]; then
+    select_full_xcode || true
+  fi
   developer_dir="$(xcode-select -p 2>/dev/null || true)"
   if [[ -z "$developer_dir" ]]; then
     log "xcode-select has no active developer directory"
@@ -43,6 +63,23 @@ require_command_line_tools() {
   xcrun --sdk macosx --show-sdk-path >/dev/null
   xcrun --find clang >/dev/null
   xcrun --find swift >/dev/null
+  if [[ "$require_xcode" == "1" ]]; then
+    case "$developer_dir" in
+      *CommandLineTools*)
+        log "full Xcode developer directory required, got Command Line Tools: $developer_dir"
+        log "install Xcode.app first or set CRABBOX_MACOS_XCODE_DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer"
+        return 1
+        ;;
+    esac
+    if [[ ! -x "$developer_dir/usr/bin/xcodebuild" || ! -d "$developer_dir/Platforms/MacOSX.platform/Developer/SDKs" ]]; then
+      log "active developer directory is not a full Xcode.app: $developer_dir"
+      return 1
+    fi
+    sudo xcodebuild -license accept >/dev/null 2>&1 || true
+    sudo xcodebuild -runFirstLaunch >/dev/null 2>&1 || true
+    xcodebuild -version
+    xcodebuild -showsdks | grep -E 'macOS|macosx' >/dev/null
+  fi
   log "developer tools: $developer_dir"
 }
 
@@ -213,7 +250,7 @@ print_versions() {
   pnpm --version
 }
 
-require_command_line_tools
+require_developer_tools
 install_homebrew
 install_formulas
 install_node_and_pnpm

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -1,0 +1,176 @@
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$NodeVersion = $env:CRABBOX_WINDOWS_NODE_VERSION
+if (-not $NodeVersion) { $NodeVersion = "24.11.1" }
+$PnpmVersion = $env:CRABBOX_WINDOWS_PNPM_VERSION
+if (-not $PnpmVersion) { $PnpmVersion = "11.1.0" }
+$DockerImages = $env:CRABBOX_WINDOWS_DOCKER_IMAGES
+if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:ltsc2022" }
+$InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
+if (-not $InstallDocker) { $InstallDocker = "1" }
+
+function Write-Log {
+  param([string]$Message)
+  Write-Host "windows-tools: $Message"
+}
+
+function Retry {
+  param([scriptblock]$ScriptBlock)
+  for ($i = 1; $i -le 8; $i++) {
+    try {
+      & $ScriptBlock
+      return
+    } catch {
+      if ($i -eq 8) { throw }
+      Start-Sleep -Seconds ($i * 5)
+    }
+  }
+}
+
+function Add-MachinePath {
+  param([string]$Path)
+  $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+  if ($machinePath -notlike "*$Path*") {
+    [Environment]::SetEnvironmentVariable("Path", "$machinePath;$Path", "Machine")
+  }
+  if ($env:Path -notlike "*$Path*") {
+    $env:Path = "$env:Path;$Path"
+  }
+}
+
+function Install-Chocolatey {
+  if (Get-Command choco.exe -ErrorAction SilentlyContinue) { return }
+  Write-Log "installing Chocolatey"
+  Set-ExecutionPolicy Bypass -Scope Process -Force
+  Invoke-Expression ((New-Object Net.WebClient).DownloadString("https://community.chocolatey.org/install.ps1"))
+  Add-MachinePath "C:\ProgramData\chocolatey\bin"
+}
+
+function Install-ChocoPackage {
+  param([string[]]$Packages)
+  Retry { choco install -y --no-progress @Packages }
+}
+
+function Install-Node {
+  if (Get-Command node.exe -ErrorAction SilentlyContinue) {
+    $current = (& node --version).TrimStart("v")
+    if ($current -eq $NodeVersion) { return }
+  }
+  $arch = "x64"
+  $msi = Join-Path $env:TEMP "node-v$NodeVersion-$arch.msi"
+  $url = "https://nodejs.org/dist/v$NodeVersion/node-v$NodeVersion-$arch.msi"
+  Write-Log "installing Node $NodeVersion"
+  Retry { Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing }
+  Start-Process -FilePath "msiexec.exe" -ArgumentList "/i", $msi, "/qn", "/norestart" -Wait
+  Add-MachinePath "C:\Program Files\nodejs"
+}
+
+function Enable-CorepackPnpm {
+  Write-Log "activating pnpm $PnpmVersion"
+  & corepack enable
+  & corepack prepare "pnpm@$PnpmVersion" --activate
+}
+
+function Install-DockerEngine {
+  if ($InstallDocker -ne "1") { return }
+  Write-Log "installing Windows container support and Docker Engine"
+  $restartRequired = $false
+  $feature = Get-WindowsFeature -Name Containers -ErrorAction SilentlyContinue
+  if ($feature -and -not $feature.Installed) {
+    $result = Install-WindowsFeature -Name Containers
+    $result | Out-Host
+    if ($result.RestartNeeded -and $result.RestartNeeded -ne "No") {
+      $restartRequired = $true
+    }
+  }
+  if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+  }
+  if (-not (Get-Module -ListAvailable -Name DockerMsftProvider)) {
+    Install-Module -Name DockerMsftProvider -Repository PSGallery -Force | Out-Null
+  }
+  if (-not (Get-Service -Name docker -ErrorAction SilentlyContinue)) {
+    Install-Package -Name docker -ProviderName DockerMsftProvider -Force | Out-Null
+  }
+  Set-Service -Name docker -StartupType Automatic
+  try {
+    Start-Service docker
+    & docker version
+  } catch {
+    if (-not $restartRequired) { throw }
+    Write-Log "Docker service will be verified after the image-create reboot"
+    return
+  }
+  foreach ($image in ($DockerImages -split "\s+")) {
+    if (-not $image) { continue }
+    try {
+      Retry { & docker pull $image }
+    } catch {
+      Write-Log "docker pull failed for $image; continuing"
+    }
+  }
+}
+
+function Prepare-Caches {
+  $dirs = @(
+    "C:\ProgramData\crabbox\cache",
+    "C:\ProgramData\crabbox\cache\npm",
+    "C:\ProgramData\crabbox\cache\pnpm",
+    "C:\ProgramData\crabbox\cache\corepack",
+    "C:\ProgramData\crabbox\cache\docker"
+  )
+  foreach ($dir in $dirs) {
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+  }
+  [Environment]::SetEnvironmentVariable("npm_config_cache", "C:\ProgramData\crabbox\cache\npm", "Machine")
+  [Environment]::SetEnvironmentVariable("PNPM_HOME", "C:\ProgramData\crabbox\pnpm", "Machine")
+  Add-MachinePath "C:\ProgramData\crabbox\pnpm"
+}
+
+function Disable-FirstBootNoise {
+  Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\ServerManager" -Name DoNotOpenServerManagerAtLogon -Type DWord -Value 1 -ErrorAction SilentlyContinue
+  New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
+}
+
+Install-Chocolatey
+Install-ChocoPackage @(
+  "git",
+  "git-lfs",
+  "gh",
+  "jq",
+  "yq",
+  "ripgrep",
+  "fd",
+  "fzf",
+  "7zip",
+  "python313",
+  "curl",
+  "wget",
+  "openssh",
+  "vcredist-all"
+)
+Install-Node
+Enable-CorepackPnpm
+Install-DockerEngine
+Prepare-Caches
+Disable-FirstBootNoise
+
+Write-Log "versions"
+Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List
+git --version
+gh --version | Select-Object -First 1
+jq --version
+rg --version | Select-Object -First 1
+fd --version
+python --version
+node --version
+npm --version
+corepack --version
+pnpm --version
+if (Get-Command docker.exe -ErrorAction SilentlyContinue) {
+  docker --version
+}
+
+Write-Log "complete"

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -214,7 +214,6 @@ Install-ChocoPackage @(
   "python313",
   "curl",
   "wget",
-  "openssh",
   "vcredist-all"
 )
 Refresh-SessionPath

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -10,6 +10,7 @@ $DockerImages = $env:CRABBOX_WINDOWS_DOCKER_IMAGES
 if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:ltsc2022" }
 $InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
 if (-not $InstallDocker) { $InstallDocker = "1" }
+$RebootMarker = "C:\ProgramData\crabbox\image-prep-reboot-required"
 
 function Write-Log {
   param([string]$Message)
@@ -100,8 +101,13 @@ function Install-DockerEngine {
     & docker version
   } catch {
     if (-not $restartRequired) { throw }
-    Write-Log "Docker service will be verified after the image-create reboot"
+    New-Item -ItemType Directory -Force -Path (Split-Path $RebootMarker) | Out-Null
+    Set-Content -Path $RebootMarker -Value "Containers feature requires reboot before Docker service verification"
+    Write-Log "Docker service will be verified after reboot"
     return
+  }
+  if (Test-Path $RebootMarker) {
+    Remove-Item -Force $RebootMarker
   }
   foreach ($image in ($DockerImages -split "\s+")) {
     if (-not $image) { continue }

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -86,6 +86,12 @@ function Install-DockerEngine {
       $restartRequired = $true
     }
   }
+  if ($restartRequired) {
+    New-Item -ItemType Directory -Force -Path (Split-Path $RebootMarker) | Out-Null
+    Set-Content -Path $RebootMarker -Value "Containers feature requires reboot before Docker Engine installation"
+    Write-Log "Docker Engine will be installed after reboot"
+    return
+  }
   if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
   }

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -6,6 +6,8 @@ $NodeVersion = $env:CRABBOX_WINDOWS_NODE_VERSION
 if (-not $NodeVersion) { $NodeVersion = "24.11.1" }
 $PnpmVersion = $env:CRABBOX_WINDOWS_PNPM_VERSION
 if (-not $PnpmVersion) { $PnpmVersion = "11.1.0" }
+$DockerVersion = $env:CRABBOX_WINDOWS_DOCKER_VERSION
+if (-not $DockerVersion) { $DockerVersion = "29.5.1" }
 $DockerImages = $env:CRABBOX_WINDOWS_DOCKER_IMAGES
 if (-not $DockerImages) { $DockerImages = "mcr.microsoft.com/windows/servercore:ltsc2022" }
 $InstallDocker = $env:CRABBOX_WINDOWS_INSTALL_DOCKER
@@ -54,6 +56,7 @@ function Refresh-SessionPath {
   Add-MachinePath "C:\Python313\Scripts"
   Add-MachinePath "C:\Program Files\nodejs"
   Add-MachinePath "C:\ProgramData\crabbox\pnpm"
+  Add-MachinePath "C:\Program Files\docker"
 }
 
 function Install-Chocolatey {
@@ -89,6 +92,24 @@ function Enable-CorepackPnpm {
   & corepack prepare "pnpm@$PnpmVersion" --activate
 }
 
+function Install-StaticDockerEngine {
+  $dockerBin = Join-Path $env:ProgramFiles "docker"
+  $dockerd = Join-Path $dockerBin "dockerd.exe"
+  $dockerExe = Join-Path $dockerBin "docker.exe"
+  if (-not (Test-Path $dockerd) -or -not (Test-Path $dockerExe)) {
+    $zip = Join-Path $env:TEMP "docker-$DockerVersion.zip"
+    $url = "https://download.docker.com/win/static/stable/x86_64/docker-$DockerVersion.zip"
+    Write-Log "installing Docker Engine $DockerVersion"
+    Retry { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing }
+    Expand-Archive -Path $zip -DestinationPath $env:ProgramFiles -Force
+  }
+  Add-MachinePath $dockerBin
+  Refresh-SessionPath
+  if (-not (Get-Service -Name docker -ErrorAction SilentlyContinue)) {
+    & $dockerd --register-service
+  }
+}
+
 function Install-DockerEngine {
   if ($InstallDocker -ne "1") { return }
   Write-Log "installing Windows container support and Docker Engine"
@@ -109,15 +130,7 @@ function Install-DockerEngine {
     Write-Log "Docker Engine will be installed after reboot"
     return
   }
-  if (-not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
-    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
-  }
-  if (-not (Get-Module -ListAvailable -Name DockerMsftProvider)) {
-    Install-Module -Name DockerMsftProvider -Repository PSGallery -Force | Out-Null
-  }
-  if (-not (Get-Service -Name docker -ErrorAction SilentlyContinue)) {
-    Install-Package -Name docker -ProviderName DockerMsftProvider -Force | Out-Null
-  }
+  Install-StaticDockerEngine
   Set-Service -Name docker -StartupType Automatic
   try {
     Start-Service docker

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -176,6 +176,30 @@ function Disable-FirstBootNoise {
   New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force | Out-Null
 }
 
+function Reset-EC2LaunchForImage {
+  $ec2Launch = @(
+    "C:\Program Files\Amazon\EC2Launch\EC2Launch.exe",
+    "C:\ProgramData\Amazon\EC2Launch\EC2Launch.exe"
+  ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+  if ($ec2Launch) {
+    Write-Log "resetting EC2Launch v2 state for AMI boot"
+    & $ec2Launch reset --block
+    if ($LASTEXITCODE -ne 0) {
+      & $ec2Launch reset
+    }
+    if ($LASTEXITCODE -ne 0) {
+      throw "EC2Launch reset failed with exit code $LASTEXITCODE"
+    }
+  } else {
+    $initialize = "C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1"
+    if (Test-Path $initialize) {
+      Write-Log "scheduling EC2Launch v1 initialize for AMI boot"
+      & powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File $initialize -Schedule
+    }
+  }
+  Remove-Item -Force "C:\ProgramData\crabbox\setup-complete" -ErrorAction SilentlyContinue
+}
+
 Install-Chocolatey
 Install-ChocoPackage @(
   "git",
@@ -206,6 +230,8 @@ if (Test-Path $RebootMarker) {
   Write-Log "reboot required before final verification"
   exit 0
 }
+
+Reset-EC2LaunchForImage
 
 Write-Log "versions"
 Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -41,6 +41,21 @@ function Add-MachinePath {
   }
 }
 
+function Refresh-SessionPath {
+  $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $paths = @($machinePath, $userPath) | Where-Object { $_ }
+  if ($paths.Count -gt 0) {
+    $env:Path = ($paths -join ";")
+  }
+  Add-MachinePath "C:\ProgramData\chocolatey\bin"
+  Add-MachinePath "C:\Program Files\Git\cmd"
+  Add-MachinePath "C:\Python313"
+  Add-MachinePath "C:\Python313\Scripts"
+  Add-MachinePath "C:\Program Files\nodejs"
+  Add-MachinePath "C:\ProgramData\crabbox\pnpm"
+}
+
 function Install-Chocolatey {
   if (Get-Command choco.exe -ErrorAction SilentlyContinue) { return }
   Write-Log "installing Chocolatey"
@@ -165,11 +180,19 @@ Install-ChocoPackage @(
   "openssh",
   "vcredist-all"
 )
+Refresh-SessionPath
 Install-Node
+Refresh-SessionPath
 Enable-CorepackPnpm
 Install-DockerEngine
 Prepare-Caches
 Disable-FirstBootNoise
+Refresh-SessionPath
+
+if (Test-Path $RebootMarker) {
+  Write-Log "reboot required before final verification"
+  exit 0
+}
 
 Write-Log "versions"
 Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List

--- a/scripts/install-windows-developer-tools.ps1
+++ b/scripts/install-windows-developer-tools.ps1
@@ -80,6 +80,8 @@ function Install-DockerEngine {
   $restartRequired = $false
   $feature = Get-WindowsFeature -Name Containers -ErrorAction SilentlyContinue
   if ($feature -and -not $feature.Installed) {
+    New-Item -ItemType Directory -Force -Path (Split-Path $RebootMarker) | Out-Null
+    Set-Content -Path $RebootMarker -Value "Containers feature installation may interrupt SSH and requires a reboot before Docker Engine installation"
     $result = Install-WindowsFeature -Name Containers
     $result | Out-Host
     if ($result.RestartNeeded -and $result.RestartNeeded -ne "No") {

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -643,6 +643,7 @@ test("macOS lifecycle smoke uses stricter defaults for mac-m host families", asy
     CRABBOX_MACOS_ALLOCATE: "1",
     CRABBOX_MACOS_CREATE_IMAGE: "0",
     CRABBOX_MACOS_TYPE: "mac-m4.metal",
+    CRABBOX_MACOS_REQUIRE_XCODE: "1",
     CRABBOX_MACOS_ARTIFACT_DIR: run.artifacts,
     CRABBOX_MACOS_IMAGE_NAME: "m4-toolchain",
     CRABBOX_MACOS_WEBVNC_START_GRACE: "0s",
@@ -652,6 +653,9 @@ test("macOS lifecycle smoke uses stricter defaults for mac-m host families", asy
   const fakeLog = await readFile(run.fakeLog, "utf8");
   assert.match(fakeLog, /required_macos_major=15/);
   assert.match(fakeLog, /required_swift_tools=6\.2/);
+  assert.match(fakeLog, /require_xcode=1/);
+  assert.match(fakeLog, /full Xcode developer directory required/);
+  assert.match(fakeLog, /xcodebuild -version/);
 });
 
 test("macOS lifecycle smoke runs source prep before the source smoke", async () => {

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRABBOX_BIN="${CRABBOX_BIN:-$ROOT/bin/crabbox}"
+target="${CRABBOX_IMAGE_TARGET:-linux}"
+region="${CRABBOX_IMAGE_REGION:-${CRABBOX_AWS_REGION:-}}"
+server_type="${CRABBOX_IMAGE_TYPE:-}"
+image_name="${CRABBOX_IMAGE_NAME:-}"
+ttl="${CRABBOX_IMAGE_TTL:-2h}"
+idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
+wait_timeout="${CRABBOX_IMAGE_WAIT_TIMEOUT:-60m}"
+run="${CRABBOX_IMAGE_RUN:-0}"
+promote="${CRABBOX_IMAGE_PROMOTE:-1}"
+keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
+desktop="${CRABBOX_IMAGE_DESKTOP:-1}"
+browser="${CRABBOX_IMAGE_BROWSER:-auto}"
+windows_mode="${CRABBOX_WINDOWS_MODE:-normal}"
+prep_script="${CRABBOX_IMAGE_PREP_SCRIPT:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/mint-aws-devtools-image.sh --target linux|windows [flags]
+
+Mint and optionally promote AWS developer-tool AMIs for normal Crabbox leases.
+By default this prints the plan and exits before paid work. Add --run to create
+source/candidate leases and image artifacts.
+
+Flags:
+  --target TARGET       linux or windows
+  --region REGION       AWS region
+  --type TYPE           AWS instance type
+  --name NAME           image name
+  --run                 allow paid lease/image work
+  --no-promote          smoke candidate only
+  --keep-lease          keep proof leases alive
+  --no-desktop          do not request desktop bootstrap
+  --no-browser          do not request browser bootstrap on Linux
+  --windows-mode MODE   normal or wsl2, default normal
+  --prep-script PATH    override target prep script
+  -h, --help            show this help
+
+Useful env:
+  CRABBOX_BIN
+  CRABBOX_IMAGE_RUN
+  CRABBOX_IMAGE_PROMOTE
+  CRABBOX_IMAGE_KEEP_LEASE
+  CRABBOX_IMAGE_WAIT_TIMEOUT
+USAGE
+}
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --target)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      target="$2"
+      shift 2
+      ;;
+    --region)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      region="$2"
+      shift 2
+      ;;
+    --type)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      server_type="$2"
+      shift 2
+      ;;
+    --name)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      image_name="$2"
+      shift 2
+      ;;
+    --run)
+      run=1
+      shift
+      ;;
+    --no-promote)
+      promote=0
+      shift
+      ;;
+    --keep-lease)
+      keep_lease=1
+      shift
+      ;;
+    --no-desktop)
+      desktop=0
+      shift
+      ;;
+    --no-browser)
+      browser=0
+      shift
+      ;;
+    --windows-mode)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      windows_mode="$2"
+      shift 2
+      ;;
+    --prep-script)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      prep_script="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$target" in
+  linux | windows) ;;
+  *)
+    printf 'target must be linux or windows, got %s\n' "$target" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$image_name" ]]; then
+  image_name="crabbox-${target}-devtools-$(date -u +%Y%m%d-%H%M)"
+fi
+if [[ -z "$prep_script" ]]; then
+  if [[ "$target" == "windows" ]]; then
+    prep_script="$ROOT/scripts/install-windows-developer-tools.ps1"
+  else
+    prep_script="$ROOT/scripts/install-linux-developer-tools.sh"
+  fi
+fi
+if [[ "$browser" == "auto" ]]; then
+  if [[ "$target" == "linux" ]]; then
+    browser=1
+  else
+    browser=0
+  fi
+fi
+
+if [[ ! -x "$CRABBOX_BIN" ]]; then
+  printf 'CRABBOX_BIN is not executable: %s\n' "$CRABBOX_BIN" >&2
+  exit 2
+fi
+if [[ ! -f "$prep_script" ]]; then
+  printf 'prep script not found: %s\n' "$prep_script" >&2
+  exit 2
+fi
+
+source_lease=""
+candidate_lease=""
+promoted_lease=""
+
+cleanup() {
+  [[ "$keep_lease" == "1" ]] && return 0
+  for lease in "$promoted_lease" "$candidate_lease" "$source_lease"; do
+    [[ -n "$lease" ]] || continue
+    "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" || true
+  done
+}
+trap cleanup EXIT
+
+run_cmd() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+warmup_args() {
+  printf '%s\0' warmup --provider aws --target "$target" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
+  [[ -n "$region" ]] && printf '%s\0' --region "$region"
+  [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
+  [[ "$desktop" == "1" ]] && printf '%s\0' --desktop
+  [[ "$browser" == "1" ]] && printf '%s\0' --browser
+  [[ "$target" == "windows" ]] && printf '%s\0' --windows-mode "$windows_mode"
+}
+
+lease_from_log() {
+  node -e '
+const fs = require("fs");
+const text = fs.readFileSync(process.argv[1], "utf8");
+for (const line of text.trim().split(/\n/).reverse()) {
+  try {
+    const json = JSON.parse(line);
+    if (json.leaseId) {
+      console.log(json.leaseId);
+      process.exit(0);
+    }
+  } catch {}
+}
+process.exit(1);
+' "$1"
+}
+
+warmup() {
+  local label="$1"
+  local log=".crabbox/image-mint-${image_name}-${label}.log"
+  mkdir -p .crabbox
+  local -a args
+  while IFS= read -r -d '' arg; do args+=("$arg"); done < <(warmup_args)
+  printf 'warming %s lease\n' "$label" >&2
+  if [[ "$label" == "candidate" ]]; then
+    CRABBOX_AWS_AMI="$2" run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
+  else
+    run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
+  fi
+  lease_from_log "$log"
+}
+
+smoke_script() {
+  if [[ "$target" == "windows" ]]; then
+    cat <<'POWERSHELL'
+$ErrorActionPreference = "Stop"
+Write-Output "devtools-smoke-ok"
+Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List
+git --version
+gh --version | Select-Object -First 1
+jq --version
+rg --version | Select-Object -First 1
+fd --version
+python --version
+node --version
+npm --version
+corepack --version
+pnpm --version
+docker --version
+docker version
+POWERSHELL
+  else
+    cat <<'SHELL'
+set -euo pipefail
+echo devtools-smoke-ok
+uname -a
+command -v git
+command -v gh
+command -v jq
+command -v rg
+command -v fd
+command -v python3
+command -v node
+command -v npm
+command -v corepack
+command -v pnpm
+command -v docker
+docker version
+docker compose version
+test -d /var/cache/crabbox/pnpm
+SHELL
+  fi
+}
+
+smoke() {
+  local lease="$1"
+  local script
+  script="$(smoke_script)"
+  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --shell -- "$script"
+}
+
+cat >&2 <<EOF
+AWS devtools image mint
+  target: $target
+  image:  $image_name
+  region: ${region:-auto}
+  type:   ${server_type:-auto}
+  prep:   $prep_script
+  proof:  desktop=$desktop browser=$browser promote=$promote
+  paid:   run=$run keep_lease=$keep_lease
+EOF
+
+if [[ "$run" != "1" ]]; then
+  printf 'dry plan only; add --run to create source/candidate leases and AMIs.\n'
+  exit 0
+fi
+
+source_lease="$(warmup source)"
+run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$source_lease" --no-sync --script "$prep_script"
+smoke "$source_lease"
+
+image_json="$("$CRABBOX_BIN" image create --id "$source_lease" --name "$image_name" --no-reboot=false --wait --wait-timeout "$wait_timeout" --json)"
+printf '%s\n' "$image_json" | jq .
+ami_id="$(printf '%s\n' "$image_json" | jq -r '.id // .image.id // empty')"
+if [[ -z "$ami_id" ]]; then
+  printf 'image create did not return an AMI id\n' >&2
+  exit 1
+fi
+
+if [[ "$keep_lease" != "1" ]]; then
+  run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$source_lease"
+  source_lease=""
+fi
+
+candidate_lease="$(warmup candidate "$ami_id")"
+smoke "$candidate_lease"
+printf 'candidate AMI smoke passed: %s\n' "$ami_id"
+
+if [[ "$promote" != "1" ]]; then
+  exit 0
+fi
+
+promote_args=(image promote "$ami_id" --target "$target" --json)
+[[ -n "$region" ]] && promote_args+=(--region "$region")
+run_cmd "$CRABBOX_BIN" "${promote_args[@]}"
+
+if [[ "$keep_lease" != "1" ]]; then
+  run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
+  candidate_lease=""
+fi
+
+promoted_lease="$(warmup promoted)"
+smoke "$promoted_lease"
+printf 'promoted %s developer image passed: %s\n' "$target" "$ami_id"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -282,10 +282,18 @@ smoke() {
 run_prep() {
   local lease="$1"
   if [[ "$target" == "windows" ]]; then
-    local encoded command
+    local encoded chunk_size offset chunk remote_b64 remote_script command
     encoded="$(base64 <"$prep_script" | tr -d '\n')"
-    command="powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"\$__crabboxPrep = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$encoded')); Invoke-Expression \$__crabboxPrep\""
-    printf '+ %q run --provider aws --target windows --id %q --no-sync --shell -- <encoded powershell prep %s bytes>\n' "$CRABBOX_BIN" "$lease" "${#encoded}"
+    chunk_size=1800
+    remote_b64='C:\ProgramData\crabbox\image-prep.b64'
+    remote_script='C:\ProgramData\crabbox\image-prep.ps1'
+    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "New-Item -ItemType Directory -Force -Path 'C:\\ProgramData\\crabbox' | Out-Null; Set-Content -Path '$remote_b64' -Value '' -NoNewline"
+    for ((offset = 0; offset < ${#encoded}; offset += chunk_size)); do
+      chunk="${encoded:offset:chunk_size}"
+      run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "Add-Content -Path '$remote_b64' -Value '$chunk' -NoNewline"
+    done
+    command="\$__crabboxPrep = Get-Content -Raw '$remote_b64'; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'"
+    printf '+ %q run --provider aws --target windows --id %q --no-sync --shell -- <chunked powershell prep %s bytes>\n' "$CRABBOX_BIN" "$lease" "${#encoded}"
     "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"
     return
   fi

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -241,6 +241,7 @@ corepack --version
 pnpm --version
 docker --version
 docker version
+docker image inspect mcr.microsoft.com/windows/servercore:ltsc2022 | Out-Null
 POWERSHELL
   else
     cat <<'SHELL'
@@ -258,8 +259,14 @@ command -v npm
 command -v corepack
 command -v pnpm
 command -v docker
-docker version
-docker compose version
+docker_probe='docker version && docker compose version && docker image inspect hello-world ubuntu:24.04 node:24-bookworm >/dev/null'
+if ! sh -c "$docker_probe"; then
+  if command -v sg >/dev/null 2>&1 && getent group docker | grep -Eq "(^|,)$(whoami)(,|$)"; then
+    sg docker -c "$docker_probe"
+  else
+    sudo sh -c "$docker_probe"
+  fi
+fi
 test -d /var/cache/crabbox/pnpm
 SHELL
   fi

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -279,6 +279,19 @@ smoke() {
   run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --shell -- "$script"
 }
 
+run_prep() {
+  local lease="$1"
+  if [[ "$target" == "windows" ]]; then
+    local encoded command
+    encoded="$(base64 <"$prep_script" | tr -d '\n')"
+    command="powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"\$__crabboxPrep = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('$encoded')); Invoke-Expression \$__crabboxPrep\""
+    printf '+ %q run --provider aws --target windows --id %q --no-sync --shell -- <encoded powershell prep %s bytes>\n' "$CRABBOX_BIN" "$lease" "${#encoded}"
+    "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"
+    return
+  fi
+  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"
+}
+
 windows_reboot_required() {
   local lease="$1"
   local output
@@ -297,7 +310,7 @@ reboot_windows_source_if_needed() {
   run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- 'shutdown /r /t 5 /f; Write-Output "reboot scheduled"'
   sleep "$reboot_settle_seconds"
   run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$reboot_wait_timeout"
-  run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --script "$prep_script"
+  run_prep "$lease"
   if windows_reboot_required "$lease"; then
     printf 'Windows prep still requires reboot after one reboot cycle\n' >&2
     exit 1
@@ -322,7 +335,7 @@ if [[ "$run" != "1" ]]; then
 fi
 
 source_lease="$(warmup source)"
-run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$source_lease" --no-sync --script "$prep_script"
+run_prep "$source_lease"
 reboot_windows_source_if_needed "$source_lease"
 smoke "$source_lease"
 

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -196,6 +196,32 @@ run_cmd() {
   "$@"
 }
 
+duration_seconds() {
+  case "$1" in
+    *h) printf '%s\n' "$((${1%h} * 3600))" ;;
+    *m) printf '%s\n' "$((${1%m} * 60))" ;;
+    *s) printf '%s\n' "${1%s}" ;;
+    *) printf '%s\n' "$1" ;;
+  esac
+}
+
+wait_windows_ssh_probe() {
+  local lease="$1"
+  local timeout_value="$2"
+  local deadline
+  deadline=$((SECONDS + $(duration_seconds "$timeout_value")))
+  while true; do
+    if run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- 'Write-Output "windows-ssh-ready"' >&2; then
+      return 0
+    fi
+    if ((SECONDS >= deadline)); then
+      printf 'Windows SSH probe did not succeed within %s\n' "$timeout_value" >&2
+      return 1
+    fi
+    sleep 15
+  done
+}
+
 warmup_args() {
   printf '%s\0' warmup --provider aws --target "$target" --class "$server_class" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
@@ -251,7 +277,7 @@ warmup() {
   fi
   if [[ "$target" == "windows" ]]; then
     sleep "$windows_warmup_settle_seconds"
-    if ! run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$windows_warmup_wait_timeout" >&2; then
+    if ! wait_windows_ssh_probe "$lease" "$windows_warmup_wait_timeout"; then
       [[ "$keep_lease" == "1" ]] || run_cmd "$CRABBOX_BIN" stop --provider aws --target windows "$lease" >&2 || true
       return 1
     fi
@@ -354,7 +380,7 @@ windows_reboot_required() {
 recover_windows_prep_disconnect() {
   local lease="$1"
   printf 'Windows prep command disconnected; checking whether a planned Docker reboot is pending\n' >&2
-  if ! run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$reboot_wait_timeout" >&2; then
+  if ! wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"; then
     return 1
   fi
   if windows_reboot_required "$lease"; then
@@ -373,7 +399,7 @@ reboot_windows_source_if_needed() {
   printf 'Windows source lease requires reboot before Docker image pull/proof\n' >&2
   run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- 'shutdown /r /t 5 /f; Write-Output "reboot scheduled"'
   sleep "$reboot_settle_seconds"
-  run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$reboot_wait_timeout"
+  wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"
   run_prep "$lease"
   if windows_reboot_required "$lease"; then
     printf 'Windows prep still requires reboot after one reboot cycle\n' >&2

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -231,16 +231,30 @@ warmup() {
   [[ -n "$region" ]] && env_args+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
   [[ "$label" == "candidate" ]] && env_args+=(CRABBOX_AWS_AMI="$2")
   printf 'warming %s lease\n' "$label" >&2
+  local warmup_status=0
   if [[ "${#env_args[@]}" -gt 0 ]]; then
-    run_cmd env "${env_args[@]}" "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
+    run_cmd env "${env_args[@]}" "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2 || warmup_status=$?
   else
-    run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
+    run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2 || warmup_status=$?
   fi
   local lease
-  lease="$(lease_from_log "$log")"
+  lease="$(lease_from_log "$log" || true)"
+  if [[ "$warmup_status" -ne 0 ]]; then
+    if [[ -n "$lease" && "$keep_lease" != "1" ]]; then
+      run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2 || true
+    fi
+    return "$warmup_status"
+  fi
+  if [[ -z "$lease" ]]; then
+    printf 'warmup did not return a lease id for %s\n' "$label" >&2
+    return 1
+  fi
   if [[ "$target" == "windows" ]]; then
     sleep "$windows_warmup_settle_seconds"
-    run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$windows_warmup_wait_timeout" >&2
+    if ! run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$windows_warmup_wait_timeout" >&2; then
+      [[ "$keep_lease" == "1" ]] || run_cmd "$CRABBOX_BIN" stop --provider aws --target windows "$lease" >&2 || true
+      return 1
+    fi
   fi
   printf '%s\n' "$lease"
 }

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -10,6 +10,8 @@ image_name="${CRABBOX_IMAGE_NAME:-}"
 ttl="${CRABBOX_IMAGE_TTL:-2h}"
 idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
 wait_timeout="${CRABBOX_IMAGE_WAIT_TIMEOUT:-60m}"
+reboot_wait_timeout="${CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT:-25m}"
+reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
 run="${CRABBOX_IMAGE_RUN:-0}"
 promote="${CRABBOX_IMAGE_PROMOTE:-1}"
 keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
@@ -17,6 +19,7 @@ desktop="${CRABBOX_IMAGE_DESKTOP:-1}"
 browser="${CRABBOX_IMAGE_BROWSER:-auto}"
 windows_mode="${CRABBOX_WINDOWS_MODE:-normal}"
 prep_script="${CRABBOX_IMAGE_PREP_SCRIPT:-}"
+windows_reboot_marker='C:\ProgramData\crabbox\image-prep-reboot-required'
 
 usage() {
   cat <<'USAGE'
@@ -46,6 +49,8 @@ Useful env:
   CRABBOX_IMAGE_PROMOTE
   CRABBOX_IMAGE_KEEP_LEASE
   CRABBOX_IMAGE_WAIT_TIMEOUT
+  CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT
+  CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS
 USAGE
 }
 
@@ -260,6 +265,31 @@ smoke() {
   run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --shell -- "$script"
 }
 
+windows_reboot_required() {
+  local lease="$1"
+  local output
+  output="$("$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "if (Test-Path '$windows_reboot_marker') { Write-Output 'crabbox-reboot-required' } else { Write-Output 'crabbox-reboot-not-required' }")"
+  printf '%s\n' "$output"
+  grep -q 'crabbox-reboot-required' <<<"$output"
+}
+
+reboot_windows_source_if_needed() {
+  local lease="$1"
+  [[ "$target" == "windows" ]] || return 0
+  if ! windows_reboot_required "$lease"; then
+    return 0
+  fi
+  printf 'Windows source lease requires reboot before Docker image pull/proof\n' >&2
+  run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- 'shutdown /r /t 5 /f; Write-Output "reboot scheduled"'
+  sleep "$reboot_settle_seconds"
+  run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$reboot_wait_timeout"
+  run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --script "$prep_script"
+  if windows_reboot_required "$lease"; then
+    printf 'Windows prep still requires reboot after one reboot cycle\n' >&2
+    exit 1
+  fi
+}
+
 cat >&2 <<EOF
 AWS devtools image mint
   target: $target
@@ -278,6 +308,7 @@ fi
 
 source_lease="$(warmup source)"
 run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$source_lease" --no-sync --script "$prep_script"
+reboot_windows_source_if_needed "$source_lease"
 smoke "$source_lease"
 
 image_json="$("$CRABBOX_BIN" image create --id "$source_lease" --name "$image_name" --no-reboot=false --wait --wait-timeout "$wait_timeout" --json)"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -318,7 +318,21 @@ smoke() {
 run_prep() {
   local lease="$1"
   if [[ "$target" == "windows" ]]; then
-    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --script "$prep_script"
+    local encoded chunk_size offset chunk remote_b64 remote_script command decode_and_run
+    encoded="$(base64 <"$prep_script" | tr -d '\n')"
+    chunk_size=1800
+    remote_b64='C:\ProgramData\crabbox\image-prep.b64'
+    remote_script='C:\ProgramData\crabbox\image-prep.ps1'
+    decode_and_run="; \$__crabboxPrep = Get-Content -Raw '$remote_b64'; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'; exit \$LASTEXITCODE"
+    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "New-Item -ItemType Directory -Force -Path 'C:\\ProgramData\\crabbox' | Out-Null; Set-Content -Path '$remote_b64' -Value '' -NoNewline"
+    for ((offset = 0; offset < ${#encoded}; offset += chunk_size)); do
+      chunk="${encoded:offset:chunk_size}"
+      command="Add-Content -Path '$remote_b64' -Value '$chunk' -NoNewline"
+      if ((offset + chunk_size >= ${#encoded})); then
+        command+="$decode_and_run"
+      fi
+      run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"
+    done
     return
   fi
   run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -338,10 +338,10 @@ wait_windows_prep_task() {
     status=0
     output="$("$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$status_command" 2>&1)" || status=$?
     printf '%s\n' "$output" >&2
-    if grep -q 'crabbox-prep-done' <<<"$output"; then
+    if grep -qx 'crabbox-prep-done' <<<"$output"; then
       return 0
     fi
-    if grep -q 'crabbox-prep-failed' <<<"$output"; then
+    if grep -qx 'crabbox-prep-failed' <<<"$output"; then
       return 1
     fi
     if ((SECONDS >= deadline)); then

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -13,6 +13,7 @@ idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
 wait_timeout="${CRABBOX_IMAGE_WAIT_TIMEOUT:-60m}"
 reboot_wait_timeout="${CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT:-25m}"
 reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
+reboot_ready_settle_seconds="${CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS:-180}"
 windows_warmup_wait_timeout="${CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT:-15m}"
 windows_warmup_settle_seconds="${CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS:-90}"
 run="${CRABBOX_IMAGE_RUN:-0}"
@@ -56,6 +57,7 @@ Useful env:
   CRABBOX_IMAGE_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS
+  CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS
   CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT
   CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS
 USAGE
@@ -222,6 +224,35 @@ wait_windows_ssh_probe() {
   done
 }
 
+wait_windows_reboot_ready() {
+  local lease="$1"
+  wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"
+  if ((reboot_ready_settle_seconds > 0)); then
+    printf 'Windows SSH responded after reboot; settling for %ss before continuing\n' "$reboot_ready_settle_seconds" >&2
+    sleep "$reboot_ready_settle_seconds"
+    wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"
+  fi
+}
+
+run_windows_shell_retry() {
+  local lease="$1"
+  local label="$2"
+  local command="$3"
+  local attempt
+  for attempt in 1 2 3; do
+    if run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"; then
+      return 0
+    fi
+    if ((attempt == 3)); then
+      break
+    fi
+    printf 'Windows command failed during %s; waiting for SSH before retry %s/3\n' "$label" "$((attempt + 1))" >&2
+    wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"
+    sleep 15
+  done
+  return 1
+}
+
 warmup_args() {
   printf '%s\0' warmup --provider aws --target "$target" --class "$server_class" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
@@ -344,25 +375,28 @@ smoke() {
 run_prep() {
   local lease="$1"
   if [[ "$target" == "windows" ]]; then
-    local encoded chunk_size offset chunk remote_b64 remote_script command decode_and_run
+    local encoded chunk_size offset chunk remote_dir remote_script command decode_and_run part_index part_name
     encoded="$(base64 <"$prep_script" | tr -d '\n')"
     chunk_size=1800
-    remote_b64='C:\ProgramData\crabbox\image-prep.b64'
+    remote_dir='C:\ProgramData\crabbox'
     remote_script='C:\ProgramData\crabbox\image-prep.ps1'
-    decode_and_run="; \$__crabboxPrep = Get-Content -Raw '$remote_b64'; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'; exit \$LASTEXITCODE"
-    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "New-Item -ItemType Directory -Force -Path 'C:\\ProgramData\\crabbox' | Out-Null; Set-Content -Path '$remote_b64' -Value '' -NoNewline"
+    decode_and_run="; \$__crabboxParts = Get-ChildItem -Path '$remote_dir' -Filter 'image-prep.part-*' | Sort-Object Name; \$__crabboxPrep = (\$__crabboxParts | ForEach-Object { Get-Content -Raw \$_.FullName }) -join ''; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'; exit \$LASTEXITCODE"
+    run_windows_shell_retry "$lease" "prep upload init" "New-Item -ItemType Directory -Force -Path '$remote_dir' | Out-Null; Remove-Item -Path '$remote_dir\\image-prep.part-*' -Force -ErrorAction SilentlyContinue"
+    part_index=0
     for ((offset = 0; offset < ${#encoded}; offset += chunk_size)); do
       chunk="${encoded:offset:chunk_size}"
-      command="Add-Content -Path '$remote_b64' -Value '$chunk' -NoNewline"
+      printf -v part_name 'image-prep.part-%05d' "$part_index"
+      command="Set-Content -Path '$remote_dir\\$part_name' -Value '$chunk' -NoNewline"
       if ((offset + chunk_size >= ${#encoded})); then
         command+="$decode_and_run"
       fi
-      if ! run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"; then
+      if ! run_windows_shell_retry "$lease" "prep upload $part_name" "$command"; then
         if ((offset + chunk_size >= ${#encoded})) && recover_windows_prep_disconnect "$lease"; then
           return 0
         fi
         return 1
       fi
+      part_index=$((part_index + 1))
     done
     return
   fi
@@ -402,7 +436,7 @@ reboot_windows_source_if_needed() {
   printf 'Windows source lease requires reboot before Docker image pull/proof\n' >&2
   run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- 'shutdown /r /t 5 /f; Write-Output "reboot scheduled"'
   sleep "$reboot_settle_seconds"
-  wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"
+  wait_windows_reboot_ready "$lease"
   run_prep "$lease"
   if windows_reboot_required "$lease"; then
     printf 'Windows prep still requires reboot after one reboot cycle\n' >&2

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -11,6 +11,7 @@ image_name="${CRABBOX_IMAGE_NAME:-}"
 ttl="${CRABBOX_IMAGE_TTL:-2h}"
 idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
 wait_timeout="${CRABBOX_IMAGE_WAIT_TIMEOUT:-60m}"
+prep_wait_timeout="${CRABBOX_IMAGE_PREP_WAIT_TIMEOUT:-90m}"
 reboot_wait_timeout="${CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT:-25m}"
 reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
 reboot_ready_settle_seconds="${CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS:-180}"
@@ -55,6 +56,7 @@ Useful env:
   CRABBOX_IMAGE_PROMOTE
   CRABBOX_IMAGE_KEEP_LEASE
   CRABBOX_IMAGE_WAIT_TIMEOUT
+  CRABBOX_IMAGE_PREP_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS
   CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS
@@ -253,6 +255,106 @@ run_windows_shell_retry() {
   return 1
 }
 
+windows_prep_start_command() {
+  cat <<'POWERSHELL'
+$dir = 'C:\ProgramData\crabbox'
+$runner = Join-Path $dir 'image-prep-runner.ps1'
+$script = Join-Path $dir 'image-prep.ps1'
+$log = Join-Path $dir 'image-prep.log'
+$exitFile = Join-Path $dir 'image-prep.exit'
+$done = Join-Path $dir 'image-prep.done'
+$failed = Join-Path $dir 'image-prep.failed'
+Remove-Item -Force $log,$exitFile,$done,$failed -ErrorAction SilentlyContinue
+@'
+$dir = 'C:\ProgramData\crabbox'
+$script = Join-Path $dir 'image-prep.ps1'
+$log = Join-Path $dir 'image-prep.log'
+$exitFile = Join-Path $dir 'image-prep.exit'
+$done = Join-Path $dir 'image-prep.done'
+$failed = Join-Path $dir 'image-prep.failed'
+$ErrorActionPreference = 'Continue'
+Remove-Item -Force $exitFile,$done,$failed -ErrorAction SilentlyContinue
+& powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $script *>&1 | Tee-Object -FilePath $log
+$code = $LASTEXITCODE
+if ($null -eq $code) { $code = 0 }
+Set-Content -Path $exitFile -Value $code
+if ($code -eq 0) {
+  Set-Content -Path $done -Value 'ok'
+} else {
+  Set-Content -Path $failed -Value $code
+}
+exit $code
+'@ | Set-Content -Path $runner -Encoding UTF8
+Unregister-ScheduledTask -TaskName 'CrabboxImagePrep' -Confirm:$false -ErrorAction SilentlyContinue
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ('-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}"' -f $runner)
+$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit (New-TimeSpan -Hours 2)
+Register-ScheduledTask -TaskName 'CrabboxImagePrep' -Action $action -Principal $principal -Settings $settings -Force | Out-Null
+Start-ScheduledTask -TaskName 'CrabboxImagePrep'
+Write-Output 'crabbox-prep-started'
+POWERSHELL
+}
+
+windows_prep_status_command() {
+  cat <<'POWERSHELL'
+$dir = 'C:\ProgramData\crabbox'
+$log = Join-Path $dir 'image-prep.log'
+$exitFile = Join-Path $dir 'image-prep.exit'
+$done = Join-Path $dir 'image-prep.done'
+$failed = Join-Path $dir 'image-prep.failed'
+if (Test-Path $done) {
+  Write-Output 'crabbox-prep-done'
+  if (Test-Path $exitFile) { Get-Content $exitFile }
+  if (Test-Path $log) { Get-Content $log -Tail 80 }
+  exit 0
+}
+if (Test-Path $failed) {
+  Write-Output 'crabbox-prep-failed'
+  if (Test-Path $exitFile) { Get-Content $exitFile }
+  if (Test-Path $log) { Get-Content $log -Tail 120 }
+  exit 0
+}
+$task = Get-ScheduledTask -TaskName 'CrabboxImagePrep' -ErrorAction SilentlyContinue
+if ($task) {
+  $info = Get-ScheduledTaskInfo -TaskName 'CrabboxImagePrep' -ErrorAction SilentlyContinue
+  if ($info) {
+    Write-Output ("crabbox-prep-state={0} result={1}" -f $task.State,$info.LastTaskResult)
+  } else {
+    Write-Output ("crabbox-prep-state={0}" -f $task.State)
+  }
+}
+if (Test-Path $log) { Get-Content $log -Tail 30 }
+Write-Output 'crabbox-prep-running'
+exit 0
+POWERSHELL
+}
+
+wait_windows_prep_task() {
+  local lease="$1"
+  local status_command output status deadline
+  status_command="$(windows_prep_status_command)"
+  deadline=$((SECONDS + $(duration_seconds "$prep_wait_timeout")))
+  while true; do
+    status=0
+    output="$("$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$status_command" 2>&1)" || status=$?
+    printf '%s\n' "$output" >&2
+    if grep -q 'crabbox-prep-done' <<<"$output"; then
+      return 0
+    fi
+    if grep -q 'crabbox-prep-failed' <<<"$output"; then
+      return 1
+    fi
+    if ((SECONDS >= deadline)); then
+      printf 'Windows prep task did not finish within %s\n' "$prep_wait_timeout" >&2
+      return 1
+    fi
+    if [[ "$status" -ne 0 ]]; then
+      printf 'Windows prep status unavailable; waiting for SSH before next poll\n' >&2
+    fi
+    sleep 30
+  done
+}
+
 warmup_args() {
   printf '%s\0' warmup --provider aws --target "$target" --class "$server_class" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
@@ -380,7 +482,7 @@ run_prep() {
     chunk_size=1800
     remote_dir='C:\ProgramData\crabbox'
     remote_script='C:\ProgramData\crabbox\image-prep.ps1'
-    decode_and_run="; \$__crabboxParts = Get-ChildItem -Path '$remote_dir' -Filter 'image-prep.part-*' | Sort-Object Name; \$__crabboxPrep = (\$__crabboxParts | ForEach-Object { Get-Content -Raw \$_.FullName }) -join ''; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'; exit \$LASTEXITCODE"
+    decode_and_run="; \$__crabboxParts = Get-ChildItem -Path '$remote_dir' -Filter 'image-prep.part-*' | Sort-Object Name; \$__crabboxPrep = (\$__crabboxParts | ForEach-Object { Get-Content -Raw \$_.FullName }) -join ''; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); Write-Output 'crabbox-prep-uploaded'"
     run_windows_shell_retry "$lease" "prep upload init" "New-Item -ItemType Directory -Force -Path '$remote_dir' | Out-Null; Remove-Item -Path '$remote_dir\\image-prep.part-*' -Force -ErrorAction SilentlyContinue"
     part_index=0
     for ((offset = 0; offset < ${#encoded}; offset += chunk_size)); do
@@ -398,6 +500,8 @@ run_prep() {
       fi
       part_index=$((part_index + 1))
     done
+    run_windows_shell_retry "$lease" "prep task start" "$(windows_prep_start_command)"
+    wait_windows_prep_task "$lease"
     return
   fi
   run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -6,6 +6,7 @@ CRABBOX_BIN="${CRABBOX_BIN:-$ROOT/bin/crabbox}"
 target="${CRABBOX_IMAGE_TARGET:-linux}"
 region="${CRABBOX_IMAGE_REGION:-${CRABBOX_AWS_REGION:-}}"
 server_type="${CRABBOX_IMAGE_TYPE:-}"
+server_class="${CRABBOX_IMAGE_CLASS:-standard}"
 image_name="${CRABBOX_IMAGE_NAME:-}"
 ttl="${CRABBOX_IMAGE_TTL:-2h}"
 idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
@@ -32,6 +33,7 @@ source/candidate leases and image artifacts.
 Flags:
   --target TARGET       linux or windows
   --region REGION       AWS region
+  --class CLASS         Crabbox machine class, default standard
   --type TYPE           AWS instance type
   --name NAME           image name
   --run                 allow paid lease/image work
@@ -69,6 +71,11 @@ while [[ "$#" -gt 0 ]]; do
     --type)
       [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
       server_type="$2"
+      shift 2
+      ;;
+    --class)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      server_class="$2"
       shift 2
       ;;
     --name)
@@ -174,7 +181,7 @@ run_cmd() {
 }
 
 warmup_args() {
-  printf '%s\0' warmup --provider aws --target "$target" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
+  printf '%s\0' warmup --provider aws --target "$target" --class "$server_class" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
   [[ "$desktop" == "1" ]] && printf '%s\0' --desktop
   [[ "$browser" == "1" ]] && printf '%s\0' --browser
@@ -295,6 +302,7 @@ AWS devtools image mint
   target: $target
   image:  $image_name
   region: ${region:-auto}
+  class:  $server_class
   type:   ${server_type:-auto}
   prep:   $prep_script
   proof:  desktop=$desktop browser=$browser promote=$promote

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -331,7 +331,12 @@ run_prep() {
       if ((offset + chunk_size >= ${#encoded})); then
         command+="$decode_and_run"
       fi
-      run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"
+      if ! run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"; then
+        if ((offset + chunk_size >= ${#encoded})) && recover_windows_prep_disconnect "$lease"; then
+          return 0
+        fi
+        return 1
+      fi
     done
     return
   fi
@@ -344,6 +349,19 @@ windows_reboot_required() {
   output="$("$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "if (Test-Path '$windows_reboot_marker') { Write-Output 'crabbox-reboot-required' } else { Write-Output 'crabbox-reboot-not-required' }")"
   printf '%s\n' "$output"
   grep -q 'crabbox-reboot-required' <<<"$output"
+}
+
+recover_windows_prep_disconnect() {
+  local lease="$1"
+  printf 'Windows prep command disconnected; checking whether a planned Docker reboot is pending\n' >&2
+  if ! run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$reboot_wait_timeout" >&2; then
+    return 1
+  fi
+  if windows_reboot_required "$lease"; then
+    return 0
+  fi
+  printf 'Windows prep command failed and no reboot marker was found\n' >&2
+  return 1
 }
 
 reboot_windows_source_if_needed() {

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -170,7 +170,6 @@ run_cmd() {
 
 warmup_args() {
   printf '%s\0' warmup --provider aws --target "$target" --market on-demand --ttl "$ttl" --idle-timeout "$idle_timeout" --timing-json
-  [[ -n "$region" ]] && printf '%s\0' --region "$region"
   [[ -n "$server_type" ]] && printf '%s\0' --type "$server_type"
   [[ "$desktop" == "1" ]] && printf '%s\0' --desktop
   [[ "$browser" == "1" ]] && printf '%s\0' --browser
@@ -200,9 +199,12 @@ warmup() {
   mkdir -p .crabbox
   local -a args
   while IFS= read -r -d '' arg; do args+=("$arg"); done < <(warmup_args)
+  local -a env_args=()
+  [[ -n "$region" ]] && env_args+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
+  [[ "$label" == "candidate" ]] && env_args+=(CRABBOX_AWS_AMI="$2")
   printf 'warming %s lease\n' "$label" >&2
-  if [[ "$label" == "candidate" ]]; then
-    CRABBOX_AWS_AMI="$2" run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
+  if [[ "${#env_args[@]}" -gt 0 ]]; then
+    run_cmd env "${env_args[@]}" "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
   else
     run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
   fi

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -13,6 +13,8 @@ idle_timeout="${CRABBOX_IMAGE_IDLE_TIMEOUT:-30m}"
 wait_timeout="${CRABBOX_IMAGE_WAIT_TIMEOUT:-60m}"
 reboot_wait_timeout="${CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT:-25m}"
 reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
+windows_warmup_wait_timeout="${CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT:-15m}"
+windows_warmup_settle_seconds="${CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS:-90}"
 run="${CRABBOX_IMAGE_RUN:-0}"
 promote="${CRABBOX_IMAGE_PROMOTE:-1}"
 keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
@@ -54,6 +56,8 @@ Useful env:
   CRABBOX_IMAGE_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_WAIT_TIMEOUT
   CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS
+  CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT
+  CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS
 USAGE
 }
 
@@ -232,7 +236,13 @@ warmup() {
   else
     run_cmd "$CRABBOX_BIN" "${args[@]}" 2>&1 | tee "$log" >&2
   fi
-  lease_from_log "$log"
+  local lease
+  lease="$(lease_from_log "$log")"
+  if [[ "$target" == "windows" ]]; then
+    sleep "$windows_warmup_settle_seconds"
+    run_cmd "$CRABBOX_BIN" status --provider aws --target windows --id "$lease" --wait --wait-timeout "$windows_warmup_wait_timeout" >&2
+  fi
+  printf '%s\n' "$lease"
 }
 
 smoke_script() {

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -16,7 +16,7 @@ reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
 run="${CRABBOX_IMAGE_RUN:-0}"
 promote="${CRABBOX_IMAGE_PROMOTE:-1}"
 keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
-desktop="${CRABBOX_IMAGE_DESKTOP:-1}"
+desktop="${CRABBOX_IMAGE_DESKTOP:-auto}"
 browser="${CRABBOX_IMAGE_BROWSER:-auto}"
 windows_mode="${CRABBOX_WINDOWS_MODE:-normal}"
 prep_script="${CRABBOX_IMAGE_PREP_SCRIPT:-}"
@@ -39,6 +39,7 @@ Flags:
   --run                 allow paid lease/image work
   --no-promote          smoke candidate only
   --keep-lease          keep proof leases alive
+  --desktop             request desktop bootstrap
   --no-desktop          do not request desktop bootstrap
   --no-browser          do not request browser bootstrap on Linux
   --windows-mode MODE   normal or wsl2, default normal
@@ -95,6 +96,10 @@ while [[ "$#" -gt 0 ]]; do
       keep_lease=1
       shift
       ;;
+    --desktop)
+      desktop=1
+      shift
+      ;;
     --no-desktop)
       desktop=0
       shift
@@ -148,6 +153,13 @@ if [[ "$browser" == "auto" ]]; then
     browser=1
   else
     browser=0
+  fi
+fi
+if [[ "$desktop" == "auto" ]]; then
+  if [[ "$target" == "windows" ]]; then
+    desktop=0
+  else
+    desktop=1
   fi
 fi
 

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -379,14 +379,17 @@ windows_reboot_required() {
 
 recover_windows_prep_disconnect() {
   local lease="$1"
-  printf 'Windows prep command disconnected; checking whether a planned Docker reboot is pending\n' >&2
-  if ! wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"; then
-    return 1
-  fi
-  if windows_reboot_required "$lease"; then
-    return 0
-  fi
-  printf 'Windows prep command failed and no reboot marker was found\n' >&2
+  printf 'Windows prep command failed or disconnected; checking whether a planned Docker reboot is pending\n' >&2
+  for _ in 1 2 3; do
+    if ! wait_windows_ssh_probe "$lease" "$reboot_wait_timeout"; then
+      return 1
+    fi
+    if windows_reboot_required "$lease"; then
+      return 0
+    fi
+    sleep 30
+  done
+  printf 'Windows prep command failed or disconnected and no reboot marker was found\n' >&2
   return 1
 }
 

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -331,17 +331,18 @@ POWERSHELL
 
 wait_windows_prep_task() {
   local lease="$1"
-  local status_command output status deadline
+  local status_command output normalized status deadline
   status_command="$(windows_prep_status_command)"
   deadline=$((SECONDS + $(duration_seconds "$prep_wait_timeout")))
   while true; do
     status=0
     output="$("$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$status_command" 2>&1)" || status=$?
     printf '%s\n' "$output" >&2
-    if grep -qx 'crabbox-prep-done' <<<"$output"; then
+    normalized="${output//$'\r'/}"
+    if grep -qx 'crabbox-prep-done' <<<"$normalized"; then
       return 0
     fi
-    if grep -qx 'crabbox-prep-failed' <<<"$output"; then
+    if grep -qx 'crabbox-prep-failed' <<<"$normalized"; then
       return 1
     fi
     if ((SECONDS >= deadline)); then

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -318,19 +318,7 @@ smoke() {
 run_prep() {
   local lease="$1"
   if [[ "$target" == "windows" ]]; then
-    local encoded chunk_size offset chunk remote_b64 remote_script command
-    encoded="$(base64 <"$prep_script" | tr -d '\n')"
-    chunk_size=1800
-    remote_b64='C:\ProgramData\crabbox\image-prep.b64'
-    remote_script='C:\ProgramData\crabbox\image-prep.ps1'
-    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "New-Item -ItemType Directory -Force -Path 'C:\\ProgramData\\crabbox' | Out-Null; Set-Content -Path '$remote_b64' -Value '' -NoNewline"
-    for ((offset = 0; offset < ${#encoded}; offset += chunk_size)); do
-      chunk="${encoded:offset:chunk_size}"
-      run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "Add-Content -Path '$remote_b64' -Value '$chunk' -NoNewline"
-    done
-    command="\$__crabboxPrep = Get-Content -Raw '$remote_b64'; [IO.File]::WriteAllBytes('$remote_script', [Convert]::FromBase64String(\$__crabboxPrep)); powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File '$remote_script'"
-    printf '+ %q run --provider aws --target windows --id %q --no-sync --shell -- <chunked powershell prep %s bytes>\n' "$CRABBOX_BIN" "$lease" "${#encoded}"
-    "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --shell -- "$command"
+    run_cmd "$CRABBOX_BIN" run --provider aws --target windows --id "$lease" --no-sync --script "$prep_script"
     return
   fi
   run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -158,7 +158,8 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.match(log, /--windows-mode normal/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- powershell/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
   assert.doesNotMatch(log, /image promote/);
 });
@@ -190,5 +191,6 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- powershell/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
+  assert.match(log, /FromBase64String/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -158,7 +158,8 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.match(log, /--windows-mode normal/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- powershell/);
+  assert.match(log, /FromBase64String/);
   assert.doesNotMatch(log, /image promote/);
 });
 
@@ -189,5 +190,5 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- powershell/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -125,6 +125,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.match(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-west-2/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
+  assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
   assert.match(log, /image create --id cbx_source --name crabbox-linux-devtools-/);
   assert.match(log, /image promote ami-devtools --target linux --json --region us-west-2/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const script = path.join(scriptDir, "mint-aws-devtools-image.sh");
+
+async function setupFakeCrabbox() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "crabbox-aws-image-mint-test-"));
+  const log = path.join(dir, "fake.log");
+  const fake = path.join(dir, "crabbox");
+  const linuxPrep = path.join(dir, "linux.sh");
+  const windowsPrep = path.join(dir, "windows.ps1");
+  await writeFile(linuxPrep, "#!/usr/bin/env bash\nexit 0\n");
+  await chmod(linuxPrep, 0o755);
+  await writeFile(windowsPrep, "exit 0\n");
+  await writeFile(
+    fake,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+case "$1" in
+  warmup)
+    count_file="\${CRABBOX_FAKE_LOG}.count"
+    count=0
+    [[ -f "$count_file" ]] && count="$(cat "$count_file")"
+    count="$((count + 1))"
+    printf '%s\\n' "$count" >"$count_file"
+    case "$count" in
+      1) printf '{"leaseId":"cbx_source"}\\n' ;;
+      2) printf '{"leaseId":"cbx_candidate"}\\n' ;;
+      *) printf '{"leaseId":"cbx_promoted"}\\n' ;;
+    esac
+    ;;
+  run)
+    printf 'devtools-smoke-ok\\n'
+    ;;
+  image)
+    if [[ "$2" == "create" ]]; then
+      printf '{"id":"ami-devtools"}\\n'
+    elif [[ "$2" == "promote" ]]; then
+      printf '{"image":{"id":"ami-devtools"}}\\n'
+    fi
+    ;;
+  stop)
+    printf 'stopped %s\\n' "\${*: -1}"
+    ;;
+esac
+`,
+  );
+  await chmod(fake, 0o755);
+  return { dir, fake, log, linuxPrep, windowsPrep };
+}
+
+function runScript(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [script, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("AWS devtools mint wrapper defaults to dry plan", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(["--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /dry plan only/);
+  await assert.rejects(readFile(fake.log, "utf8"));
+});
+
+test("AWS devtools mint wrapper runs linux source candidate and promoted proof", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(
+    ["--target", "linux", "--region", "us-west-2", "--type", "m7i.large", "--run", "--prep-script", fake.linuxPrep],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /candidate AMI smoke passed: ami-devtools/);
+  assert.match(result.stdout, /promoted linux developer image passed: ami-devtools/);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /warmup --provider aws --target linux/);
+  assert.match(log, /--browser/);
+  assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
+  assert.match(log, /image create --id cbx_source --name crabbox-linux-devtools-/);
+  assert.match(log, /image promote ami-devtools --target linux --json --region us-west-2/);
+});
+
+test("AWS devtools mint wrapper maps windows flags", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(
+    [
+      "--target",
+      "windows",
+      "--region",
+      "us-east-1",
+      "--type",
+      "m7i.large",
+      "--windows-mode",
+      "normal",
+      "--run",
+      "--no-promote",
+      "--prep-script",
+      fake.windowsPrep,
+    ],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /warmup --provider aws --target windows/);
+  assert.match(log, /--windows-mode normal/);
+  assert.doesNotMatch(log, /--browser/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
+  assert.doesNotMatch(log, /image promote/);
+});

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -38,6 +38,19 @@ case "$1" in
     esac
     ;;
   run)
+    if [[ "$*" == *"Test-Path 'C:\\ProgramData\\crabbox\\image-prep-reboot-required'"* ]]; then
+      if [[ "\${CRABBOX_FAKE_WINDOWS_REBOOT:-0}" == "1" && ! -f "\${CRABBOX_FAKE_LOG}.rebooted" ]]; then
+        printf 'crabbox-reboot-required\\n'
+      else
+        printf 'crabbox-reboot-not-required\\n'
+      fi
+      exit 0
+    fi
+    if [[ "$*" == *"shutdown /r"* ]]; then
+      touch "\${CRABBOX_FAKE_LOG}.rebooted"
+      printf 'reboot scheduled\\n'
+      exit 0
+    fi
     printf 'devtools-smoke-ok\\n'
     ;;
   image)
@@ -49,6 +62,9 @@ case "$1" in
     ;;
   stop)
     printf 'stopped %s\\n' "\${*: -1}"
+    ;;
+  status)
+    printf 'ready\\n'
     ;;
 esac
 `,
@@ -142,4 +158,34 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
   assert.doesNotMatch(log, /image promote/);
+});
+
+test("AWS devtools mint wrapper reboots windows source when prep requires it", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(
+    [
+      "--target",
+      "windows",
+      "--region",
+      "us-east-1",
+      "--type",
+      "m7i.large",
+      "--run",
+      "--no-promote",
+      "--prep-script",
+      fake.windowsPrep,
+    ],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_FAKE_WINDOWS_REBOOT: "1",
+      CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
+  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -168,7 +168,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /--desktop/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
-  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 15m/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
@@ -202,7 +202,7 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   const log = await readFile(fake.log, "utf8");
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
-  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
 });
@@ -234,7 +234,7 @@ test("AWS devtools mint wrapper recovers windows prep disconnects with reboot ma
   assert.equal(result.code, 0, result.stderr);
   assert.match(result.stderr, /Windows prep command disconnected; checking whether a planned Docker reboot is pending/);
   const log = await readFile(fake.log, "utf8");
-  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /image create --id cbx_source --name crabbox-windows-devtools-/);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -165,9 +165,9 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 15m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
-  assert.doesNotMatch(log, /Add-Content/);
-  assert.doesNotMatch(log, /FromBase64String/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
+  assert.match(log, /FromBase64String/);
   assert.doesNotMatch(log, /image promote/);
 });
 
@@ -199,9 +199,8 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
-  assert.doesNotMatch(log, /Add-Content/);
-  assert.doesNotMatch(log, /FromBase64String/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
+  assert.match(log, /FromBase64String/);
 });
 
 test("AWS devtools mint wrapper cleans up lease when warmup fails after allocation", async () => {

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -36,6 +36,9 @@ case "$1" in
       2) printf '{"leaseId":"cbx_candidate"}\\n' ;;
       *) printf '{"leaseId":"cbx_promoted"}\\n' ;;
     esac
+    if [[ "\${CRABBOX_FAKE_WARMUP_FAIL_AFTER_LEASE:-0}" == "1" ]]; then
+      exit 23
+    fi
     ;;
   run)
     if [[ "$*" == *"Test-Path 'C:\\ProgramData\\crabbox\\image-prep-reboot-required'"* ]]; then
@@ -198,4 +201,17 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
+});
+
+test("AWS devtools mint wrapper cleans up lease when warmup fails after allocation", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(["--target", "linux", "--run", "--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_FAKE_WARMUP_FAIL_AFTER_LEASE: "1",
+  });
+  assert.equal(result.code, 23, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /warmup --provider aws --target linux/);
+  assert.match(log, /stop --provider aws --target linux cbx_source/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -121,6 +121,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
       CRABBOX_BIN: fake.fake,
       CRABBOX_FAKE_LOG: fake.log,
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -170,7 +171,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Set-Content/);
   assert.match(log, /FromBase64String/);
   assert.doesNotMatch(log, /image promote/);
 });
@@ -195,6 +196,7 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
       CRABBOX_FAKE_LOG: fake.log,
       CRABBOX_FAKE_WINDOWS_REBOOT: "1",
       CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
     },
   );
@@ -203,11 +205,11 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Set-Content/);
   assert.match(log, /FromBase64String/);
 });
 
-test("AWS devtools mint wrapper recovers windows prep disconnects with reboot marker", async () => {
+test("AWS devtools mint wrapper retries windows prep upload disconnects", async () => {
   const fake = await setupFakeCrabbox();
   const result = await runScript(
     [
@@ -228,11 +230,12 @@ test("AWS devtools mint wrapper recovers windows prep disconnects with reboot ma
       CRABBOX_FAKE_WINDOWS_PREP_DISCONNECT: "1",
       CRABBOX_FAKE_WINDOWS_REBOOT: "1",
       CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
     },
   );
   assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stderr, /Windows prep command failed or disconnected; checking whether a planned Docker reboot is pending/);
+  assert.match(result.stderr, /Windows command failed during prep upload image-prep\.part-/);
   const log = await readFile(fake.log, "utf8");
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -58,6 +58,15 @@ case "$1" in
       touch "\${CRABBOX_FAKE_LOG}.prep-disconnected"
       exit 255
     fi
+    if [[ "$*" == *"Start-ScheduledTask"* ]]; then
+      touch "\${CRABBOX_FAKE_LOG}.prep-started"
+      printf 'crabbox-prep-started\\n'
+      exit 0
+    fi
+    if [[ "$*" == *"image-prep.done"* ]]; then
+      printf 'crabbox-prep-done\\n0\\n'
+      exit 0
+    fi
     printf 'devtools-smoke-ok\\n'
     ;;
   image)
@@ -122,6 +131,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
       CRABBOX_FAKE_LOG: fake.log,
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_PREP_WAIT_TIMEOUT: "5s",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -198,6 +208,7 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
       CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_PREP_WAIT_TIMEOUT: "5s",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -232,6 +243,7 @@ test("AWS devtools mint wrapper retries windows prep upload disconnects", async 
       CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS: "0",
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_PREP_WAIT_TIMEOUT: "5s",
     },
   );
   assert.equal(result.code, 0, result.stderr);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -165,9 +165,9 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 15m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
-  assert.match(log, /FromBase64String/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
+  assert.doesNotMatch(log, /Add-Content/);
+  assert.doesNotMatch(log, /FromBase64String/);
   assert.doesNotMatch(log, /image promote/);
 });
 
@@ -199,8 +199,9 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
-  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
-  assert.match(log, /FromBase64String/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
+  assert.doesNotMatch(log, /Add-Content/);
+  assert.doesNotMatch(log, /FromBase64String/);
 });
 
 test("AWS devtools mint wrapper cleans up lease when warmup fails after allocation", async () => {

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -113,6 +113,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
     {
       CRABBOX_BIN: fake.fake,
       CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -150,6 +151,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
     {
       CRABBOX_BIN: fake.fake,
       CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -159,6 +161,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /--desktop/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
+  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 15m/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
@@ -185,6 +188,7 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
       CRABBOX_FAKE_LOG: fake.log,
       CRABBOX_FAKE_WINDOWS_REBOOT: "1",
       CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
     },
   );
   assert.equal(result.code, 0, result.stderr);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -121,6 +121,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   const log = await readFile(fake.log, "utf8");
   assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args warmup --provider aws --target linux/);
   assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI=ami-devtools args warmup --provider aws --target linux/);
+  assert.match(log, /--class standard/);
   assert.match(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-west-2/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -156,6 +156,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   const log = await readFile(fake.log, "utf8");
   assert.match(log, /env CRABBOX_AWS_REGION=us-east-1 AWS_REGION=us-east-1 CRABBOX_AWS_AMI= args warmup --provider aws --target windows/);
   assert.match(log, /--windows-mode normal/);
+  assert.doesNotMatch(log, /--desktop/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- New-Item/);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -23,7 +23,7 @@ async function setupFakeCrabbox() {
     fake,
     `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+printf 'env CRABBOX_AWS_REGION=%s AWS_REGION=%s CRABBOX_AWS_AMI=%s args %s\\n' "\${CRABBOX_AWS_REGION:-}" "\${AWS_REGION:-}" "\${CRABBOX_AWS_AMI:-}" "$*" >>"\${CRABBOX_FAKE_LOG:?}"
 case "$1" in
   warmup)
     count_file="\${CRABBOX_FAKE_LOG}.count"
@@ -103,8 +103,10 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.match(result.stdout, /candidate AMI smoke passed: ami-devtools/);
   assert.match(result.stdout, /promoted linux developer image passed: ami-devtools/);
   const log = await readFile(fake.log, "utf8");
-  assert.match(log, /warmup --provider aws --target linux/);
+  assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args warmup --provider aws --target linux/);
+  assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI=ami-devtools args warmup --provider aws --target linux/);
   assert.match(log, /--browser/);
+  assert.doesNotMatch(log, /warmup .*--region us-west-2/);
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
   assert.match(log, /image create --id cbx_source --name crabbox-linux-devtools-/);
   assert.match(log, /image promote ami-devtools --target linux --json --region us-west-2/);
@@ -134,9 +136,10 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   );
   assert.equal(result.code, 0, result.stderr);
   const log = await readFile(fake.log, "utf8");
-  assert.match(log, /warmup --provider aws --target windows/);
+  assert.match(log, /env CRABBOX_AWS_REGION=us-east-1 AWS_REGION=us-east-1 CRABBOX_AWS_AMI= args warmup --provider aws --target windows/);
   assert.match(log, /--windows-mode normal/);
   assert.doesNotMatch(log, /--browser/);
+  assert.doesNotMatch(log, /warmup .*--region us-east-1/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --script/);
   assert.doesNotMatch(log, /image promote/);
 });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -232,7 +232,7 @@ test("AWS devtools mint wrapper recovers windows prep disconnects with reboot ma
     },
   );
   assert.equal(result.code, 0, result.stderr);
-  assert.match(result.stderr, /Windows prep command disconnected; checking whether a planned Docker reboot is pending/);
+  assert.match(result.stderr, /Windows prep command failed or disconnected; checking whether a planned Docker reboot is pending/);
   const log = await readFile(fake.log, "utf8");
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -54,6 +54,10 @@ case "$1" in
       printf 'reboot scheduled\\n'
       exit 0
     fi
+    if [[ "$*" == *"FromBase64String"* && "\${CRABBOX_FAKE_WINDOWS_PREP_DISCONNECT:-0}" == "1" && ! -f "\${CRABBOX_FAKE_LOG}.prep-disconnected" ]]; then
+      touch "\${CRABBOX_FAKE_LOG}.prep-disconnected"
+      exit 255
+    fi
     printf 'devtools-smoke-ok\\n'
     ;;
   image)
@@ -201,6 +205,39 @@ test("AWS devtools mint wrapper reboots windows source when prep requires it", a
   assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
   assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- Add-Content/);
   assert.match(log, /FromBase64String/);
+});
+
+test("AWS devtools mint wrapper recovers windows prep disconnects with reboot marker", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(
+    [
+      "--target",
+      "windows",
+      "--region",
+      "us-east-1",
+      "--type",
+      "m7i.large",
+      "--run",
+      "--no-promote",
+      "--prep-script",
+      fake.windowsPrep,
+    ],
+    {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_FAKE_WINDOWS_PREP_DISCONNECT: "1",
+      CRABBOX_FAKE_WINDOWS_REBOOT: "1",
+      CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS: "0",
+      CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stderr, /Windows prep command disconnected; checking whether a planned Docker reboot is pending/);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /status --provider aws --target windows --id cbx_source --wait --wait-timeout 25m/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- if \(Test-Path/);
+  assert.match(log, /run --provider aws --target windows --id cbx_source --no-sync --shell -- shutdown \/r \/t 5 \/f/);
+  assert.match(log, /image create --id cbx_source --name crabbox-windows-devtools-/);
 });
 
 test("AWS devtools mint wrapper cleans up lease when warmup fails after allocation", async () => {

--- a/scripts/mint-macos-devtools-image.sh
+++ b/scripts/mint-macos-devtools-image.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 lifecycle_script="${CRABBOX_MACOS_LIFECYCLE_SCRIPT:-$ROOT/scripts/macos-image-lifecycle-smoke.sh}"
 prep_script="${CRABBOX_MACOS_SOURCE_PREP_SCRIPT:-$ROOT/scripts/install-macos-developer-tools.sh}"
 image_name="${CRABBOX_MACOS_IMAGE_NAME:-crabbox-macos-devtools-$(date -u +%Y%m%d-%H%M)}"
+instance_type="${CRABBOX_MACOS_TYPE:-mac-m4.metal}"
 run_existing="${CRABBOX_MACOS_RUN:-0}"
 allocate="${CRABBOX_MACOS_ALLOCATE:-0}"
 create_image="${CRABBOX_MACOS_CREATE_IMAGE:-1}"
@@ -13,6 +14,9 @@ checkpoint="${CRABBOX_MACOS_CHECKPOINT:-$create_image}"
 open_webvnc="${CRABBOX_MACOS_OPEN_WEBVNC:-0}"
 keep_lease="${CRABBOX_MACOS_KEEP_LEASE:-0}"
 release_host="${CRABBOX_MACOS_RELEASE_HOST:-0}"
+required_macos_major="${CRABBOX_MACOS_REQUIRED_MAJOR:-15}"
+required_swift_tools="${CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS:-6.2}"
+require_xcode="${CRABBOX_MACOS_REQUIRE_XCODE:-1}"
 
 usage() {
   cat <<'USAGE'
@@ -27,7 +31,7 @@ By default this only runs no-spend preflight checks. Paid work requires one of:
 
 Flags:
   --region REGION       set CRABBOX_MACOS_REGION
-  --type TYPE           set CRABBOX_MACOS_TYPE, default mac2.metal
+  --type TYPE           set CRABBOX_MACOS_TYPE, default mac-m4.metal
   --name NAME           set CRABBOX_MACOS_IMAGE_NAME
   --use-existing        continue with an available host
   --allocate            allow paid host allocation when no host is available
@@ -43,6 +47,9 @@ Useful env:
   CRABBOX_MACOS_REGIONS
   CRABBOX_MACOS_REGION_PREFLIGHT
   CRABBOX_MACOS_CREATE_IMAGE
+  CRABBOX_MACOS_REQUIRED_MAJOR
+  CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS
+  CRABBOX_MACOS_REQUIRE_XCODE
   CRABBOX_MACOS_ARTIFACT_DIR
   CRABBOX_MACOS_HOST_WAIT_TIMEOUT
   CRABBOX_MACOS_RELEASE_EXISTING_HOST
@@ -58,7 +65,7 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --type)
       [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
-      export CRABBOX_MACOS_TYPE="$2"
+      instance_type="$2"
       shift 2
       ;;
     --name)
@@ -119,12 +126,15 @@ cat >&2 <<EOF
 macOS devtools image mint
   image: $image_name
   prep:  $prep_script
+  type:  $instance_type
   paid:  use_existing=$run_existing allocate=$allocate release_host=$release_host
   proof: create_image=$create_image checkpoint=$checkpoint promote=$promote webvnc_open=$open_webvnc
+  tools: macos>=$required_macos_major swift>=$required_swift_tools require_xcode=$require_xcode
 EOF
 
 export CRABBOX_MACOS_SOURCE_PREP_SCRIPT="$prep_script"
 export CRABBOX_MACOS_IMAGE_NAME="$image_name"
+export CRABBOX_MACOS_TYPE="$instance_type"
 export CRABBOX_MACOS_RUN="$run_existing"
 export CRABBOX_MACOS_ALLOCATE="$allocate"
 export CRABBOX_MACOS_CREATE_IMAGE="$create_image"
@@ -133,5 +143,8 @@ export CRABBOX_MACOS_CHECKPOINT="$checkpoint"
 export CRABBOX_MACOS_OPEN_WEBVNC="$open_webvnc"
 export CRABBOX_MACOS_KEEP_LEASE="$keep_lease"
 export CRABBOX_MACOS_RELEASE_HOST="$release_host"
+export CRABBOX_MACOS_REQUIRED_MAJOR="$required_macos_major"
+export CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS="$required_swift_tools"
+export CRABBOX_MACOS_REQUIRE_XCODE="$require_xcode"
 
 exec "$lifecycle_script"

--- a/scripts/mint-macos-devtools-image.test.js
+++ b/scripts/mint-macos-devtools-image.test.js
@@ -35,6 +35,9 @@ const keys = [
   "CRABBOX_MACOS_OPEN_WEBVNC",
   "CRABBOX_MACOS_KEEP_LEASE",
   "CRABBOX_MACOS_RELEASE_HOST",
+  "CRABBOX_MACOS_REQUIRED_MAJOR",
+  "CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS",
+  "CRABBOX_MACOS_REQUIRE_XCODE",
 ];
 const out = {};
 for (const key of keys) out[key] = process.env[key] || "";
@@ -79,6 +82,7 @@ test("mint wrapper defaults to no-spend promoted developer-tools proof", async (
   const env = JSON.parse(await readFile(fake.envPath, "utf8"));
   assert.equal(env.CRABBOX_MACOS_SOURCE_PREP_SCRIPT, fake.prepPath);
   assert.match(env.CRABBOX_MACOS_IMAGE_NAME, /^crabbox-macos-devtools-/);
+  assert.equal(env.CRABBOX_MACOS_TYPE, "mac-m4.metal");
   assert.equal(env.CRABBOX_MACOS_RUN, "0");
   assert.equal(env.CRABBOX_MACOS_ALLOCATE, "0");
   assert.equal(env.CRABBOX_MACOS_CREATE_IMAGE, "1");
@@ -86,7 +90,11 @@ test("mint wrapper defaults to no-spend promoted developer-tools proof", async (
   assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "1");
   assert.equal(env.CRABBOX_MACOS_OPEN_WEBVNC, "0");
   assert.equal(env.CRABBOX_MACOS_RELEASE_HOST, "0");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_MAJOR, "15");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS, "6.2");
+  assert.equal(env.CRABBOX_MACOS_REQUIRE_XCODE, "1");
   assert.match(result.stderr, /paid:\s+use_existing=0 allocate=0 release_host=0/);
+  assert.match(result.stderr, /tools:\s+macos>=15 swift>=6\.2 require_xcode=1/);
 });
 
 test("mint wrapper maps explicit paid-work flags to lifecycle env", async () => {
@@ -126,6 +134,9 @@ test("mint wrapper maps explicit paid-work flags to lifecycle env", async () => 
   assert.equal(env.CRABBOX_MACOS_OPEN_WEBVNC, "1");
   assert.equal(env.CRABBOX_MACOS_PROMOTE, "0");
   assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "0");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_MAJOR, "15");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS, "6.2");
+  assert.equal(env.CRABBOX_MACOS_REQUIRE_XCODE, "1");
 });
 
 test("mint wrapper preserves source-only checkpoint default", async () => {
@@ -141,4 +152,24 @@ test("mint wrapper preserves source-only checkpoint default", async () => {
   assert.equal(env.CRABBOX_MACOS_CREATE_IMAGE, "0");
   assert.equal(env.CRABBOX_MACOS_CHECKPOINT, "0");
   assert.match(result.stderr, /proof:\s+create_image=0 checkpoint=0 promote=1/);
+});
+
+test("mint wrapper preserves explicit macOS toolchain overrides", async () => {
+  const fake = await setupFakeLifecycle();
+  const result = await runWrapper([], {
+    CRABBOX_FAKE_ENV_PATH: fake.envPath,
+    CRABBOX_MACOS_LIFECYCLE_SCRIPT: fake.lifecyclePath,
+    CRABBOX_MACOS_SOURCE_PREP_SCRIPT: fake.prepPath,
+    CRABBOX_MACOS_TYPE: "mac2.metal",
+    CRABBOX_MACOS_REQUIRED_MAJOR: "14",
+    CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS: "6.0",
+    CRABBOX_MACOS_REQUIRE_XCODE: "0",
+  });
+  assert.equal(result.code, 0, result.stderr);
+  const env = JSON.parse(await readFile(fake.envPath, "utf8"));
+  assert.equal(env.CRABBOX_MACOS_TYPE, "mac2.metal");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_MAJOR, "14");
+  assert.equal(env.CRABBOX_MACOS_REQUIRED_SWIFT_TOOLS, "6.0");
+  assert.equal(env.CRABBOX_MACOS_REQUIRE_XCODE, "0");
+  assert.match(result.stderr, /tools:\s+macos>=14 swift>=6\.0 require_xcode=0/);
 });

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1038,22 +1038,32 @@ export class EC2SpotClient {
   }
 
   private async ensureSecurityGroup(config: LeaseConfig): Promise<string> {
-    if (config.awsSGID || this.env.CRABBOX_AWS_SECURITY_GROUP_ID) {
-      return config.awsSGID || this.env.CRABBOX_AWS_SECURITY_GROUP_ID || "";
-    }
-    const vpcID = await this.securityGroupVPC(config);
-    const name = "crabbox-runners";
-    const existing = await this.ec2("DescribeSecurityGroups", {
-      "Filter.1.Name": "group-name",
-      "Filter.1.Value.1": name,
-      "Filter.2.Name": "vpc-id",
-      "Filter.2.Value.1": vpcID,
-    });
-    const group = items(record(existing["securityGroupInfo"])["item"])[0];
-    let groupID = asString(record(group)["groupId"]);
-    if (!groupID) {
-      const created = await this.ec2("CreateSecurityGroup", createSecurityGroupParams(name, vpcID));
-      groupID = asString(record(created)["groupId"]);
+    const configuredGroupID = config.awsSGID || this.env.CRABBOX_AWS_SECURITY_GROUP_ID || "";
+    let group: unknown;
+    let groupID = configuredGroupID;
+    if (groupID) {
+      const existing = await this.ec2("DescribeSecurityGroups", {
+        "GroupId.1": groupID,
+      });
+      group = items(record(existing["securityGroupInfo"])["item"])[0];
+    } else {
+      const vpcID = await this.securityGroupVPC(config);
+      const name = "crabbox-runners";
+      const existing = await this.ec2("DescribeSecurityGroups", {
+        "Filter.1.Name": "group-name",
+        "Filter.1.Value.1": name,
+        "Filter.2.Name": "vpc-id",
+        "Filter.2.Value.1": vpcID,
+      });
+      group = items(record(existing["securityGroupInfo"])["item"])[0];
+      groupID = asString(record(group)["groupId"]);
+      if (!groupID) {
+        const created = await this.ec2(
+          "CreateSecurityGroup",
+          createSecurityGroupParams(name, vpcID),
+        );
+        groupID = asString(record(created)["groupId"]);
+      }
     }
     if (!groupID) {
       throw new Error("aws security group id is empty");

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -369,8 +369,8 @@ crabbox-ready
 	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
 	wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
 	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
-	Restart-Service sshd -Force
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	Restart-Service sshd -Force
 	`;
 }
 
@@ -434,20 +434,21 @@ Set-ItemProperty -Path $winlogon -Name AutoAdminLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name ForceAutoLogon -Value "1" -Type String
 Set-ItemProperty -Path $winlogon -Name DefaultUserName -Value $user -Type String
 Set-ItemProperty -Path $winlogon -Name DefaultPassword -Value $userPassword -Type String
-Restart-Service sshd
 if (-not (Test-Path -LiteralPath $setupCompletePath)) {
   Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
 	  Restart-Computer -Force
+	  exit 0
 	}
+Restart-Service sshd
 	`;
 }
 
 function windowsCoreBootstrapFinalizePowerShell(): string {
   return `
-	Restart-Service sshd -Force
 	git --version | Out-Null
 	tar --version | Out-Null
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	Restart-Service sshd -Force
 	`;
 }
 

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -114,6 +114,81 @@ describe("aws provider", () => {
     ).toEqual([{ cidr: "203.0.113.10/32", family: "ipv4", port: "2222" }]);
   });
 
+  it("refreshes configured AWS security groups with current SSH ingress", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        calls.push(
+          [
+            action,
+            params.get("GroupId") ?? params.get("GroupId.1") ?? "",
+            params.get("IpPermissions.1.FromPort") ?? "",
+            params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "",
+          ].join(":"),
+        );
+        if (action === "DescribeSecurityGroups") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse>
+  <securityGroupInfo>
+    <item>
+      <groupId>sg-fixed</groupId>
+      <ipPermissions>
+        <item>
+          <ipProtocol>tcp</ipProtocol>
+          <fromPort>2222</fromPort>
+          <toPort>2222</toPort>
+          <ipRanges>
+            <item>
+              <cidrIp>203.0.113.10/32</cidrIp>
+              <description>Crabbox SSH</description>
+            </item>
+          </ipRanges>
+        </item>
+      </ipPermissions>
+    </item>
+  </securityGroupInfo>
+</DescribeSecurityGroupsResponse>`);
+        }
+        if (action === "RevokeSecurityGroupIngress") {
+          return ec2XMLResponse("<RevokeSecurityGroupIngressResponse />");
+        }
+        if (action === "AuthorizeSecurityGroupIngress") {
+          return ec2XMLResponse("<AuthorizeSecurityGroupIngressResponse />");
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-fixed",
+      } as never,
+      "eu-west-1",
+    );
+
+    await client.refreshSSHIngress(
+      leaseConfig({
+        provider: "aws",
+        target: "windows",
+        awsSSHCIDRs: ["198.51.100.77/32"],
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    );
+
+    expect(calls).toContain("DescribeSecurityGroups:sg-fixed::");
+    expect(calls).toContain("AuthorizeSecurityGroupIngress:sg-fixed:2222:198.51.100.77/32");
+    expect(calls).toContain("AuthorizeSecurityGroupIngress:sg-fixed:22:198.51.100.77/32");
+    expect(calls).not.toContain("DescribeVpcs:::");
+  });
+
   it("does not tag Spot request resources for On-Demand launches", () => {
     const spotParams: Record<string, string> = {};
     addRunInstancesTagSpecifications(spotParams, { crabbox: "true", Name: "crabbox-cbx" }, "spot");
@@ -410,6 +485,10 @@ describe("aws provider", () => {
         const body = await request.clone().text();
         const params = new URLSearchParams(body);
         const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
         if (action === "DescribeKeyPairs") {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
@@ -523,6 +602,10 @@ describe("aws provider", () => {
         const body = await request.clone().text();
         const params = new URLSearchParams(body);
         const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
         if (action === "DescribeKeyPairs") {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
@@ -585,6 +668,7 @@ describe("aws provider", () => {
         AWS_ACCESS_KEY_ID: "test",
         AWS_SECRET_ACCESS_KEY: "secret",
         CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
       } as never,
       "eu-west-1",
     );
@@ -621,6 +705,10 @@ describe("aws provider", () => {
         const body = await request.clone().text();
         const params = new URLSearchParams(body);
         const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
         if (action === "DescribeKeyPairs") {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
@@ -679,6 +767,7 @@ describe("aws provider", () => {
         AWS_ACCESS_KEY_ID: "test",
         AWS_SECRET_ACCESS_KEY: "secret",
         CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
       } as never,
       "eu-west-1",
     );
@@ -715,6 +804,10 @@ describe("aws provider", () => {
         }
         const params = new URLSearchParams(await request.clone().text());
         const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
         if (action === "DescribeKeyPairs") {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
@@ -756,6 +849,7 @@ describe("aws provider", () => {
         AWS_ACCESS_KEY_ID: "test",
         AWS_SECRET_ACCESS_KEY: "secret",
         CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
       } as never,
       "us-west-2",
     );
@@ -796,6 +890,13 @@ describe("aws provider", () => {
         const body = await request.clone().text();
         const params = Object.fromEntries(new URLSearchParams(body));
         const action = params.Action ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(
+          action,
+          new URLSearchParams(body),
+        );
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
         if (action === "DescribeKeyPairs") {
           return ec2XMLResponse("<DescribeKeyPairsResponse />");
         }
@@ -865,6 +966,7 @@ describe("aws provider", () => {
         AWS_ACCESS_KEY_ID: "test",
         AWS_SECRET_ACCESS_KEY: "secret",
         CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
         CRABBOX_AWS_SUBNET_ID: "subnet-123",
       } as never,
       "eu-west-1",
@@ -1211,6 +1313,25 @@ describe("aws provider", () => {
     ]);
   });
 });
+
+function ec2ConfiguredSecurityGroupResponse(
+  action: string,
+  params: URLSearchParams,
+): Response | undefined {
+  if (action === "DescribeSecurityGroups") {
+    const groupID = params.get("GroupId.1") ?? params.get("GroupId") ?? "sg-123";
+    return ec2XMLResponse(
+      `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
+    );
+  }
+  if (action === "RevokeSecurityGroupIngress") {
+    return ec2XMLResponse("<RevokeSecurityGroupIngressResponse />");
+  }
+  if (action === "AuthorizeSecurityGroupIngress") {
+    return ec2XMLResponse("<AuthorizeSecurityGroupIngressResponse />");
+  }
+  return undefined;
+}
 
 function ec2XMLResponse(body: string, status = 200): Response {
   return new Response(body, { status, headers: { "content-type": "application/xml" } });

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -230,6 +230,13 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("C:\\ProgramData\\crabbox\\windows.username");
     expect(got).toContain("AutoAdminLogon");
     expect(got).toContain("Restart-Computer -Force");
+    expect(got).toContain("exit 0");
+    const setupIndex = got.indexOf(
+      "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
+    );
+    const restartIndex = got.indexOf("Restart-Computer -Force");
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(setupIndex).toBeLessThan(restartIndex);
   });
 
   it("builds Windows core bootstrap without desktop/VNC", () => {
@@ -244,6 +251,12 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("$passwordPath = $windowsPasswordPath");
     expect(got).toContain("Restart-Service sshd -Force");
     expect(got).toContain("Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath");
+    const setupIndex = got.indexOf(
+      "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
+    );
+    const restartIndex = got.indexOf("Restart-Service sshd -Force");
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(setupIndex).toBeLessThan(restartIndex);
     expect(got).not.toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
     expect(got).not.toContain("C:\\ProgramData\\crabbox\\vnc.password");
     expect(got).not.toContain("CrabboxUserVNC");
@@ -274,6 +287,12 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2");
     expect(got).toContain("wsl.exe --set-default $wslDistro");
     expect(got).toContain("test -w '/work/crabbox'");
+    const setupIndex = got.indexOf(
+      "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
+    );
+    const restartIndex = got.lastIndexOf("Restart-Service sshd -Force");
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(setupIndex).toBeLessThan(restartIndex);
     expect(got).not.toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
     expect(got).not.toContain("C:\\ProgramData\\crabbox\\vnc.password");
     expect(got).not.toContain("CrabboxUserVNC");


### PR DESCRIPTION
## Summary

- add Linux developer-image prep with Node 24, pnpm, GitHub CLI, desktop/browser helpers, Docker Engine, Compose, buildx, and cached base Docker images
- add Windows developer-image prep with Chocolatey tooling, Node 24, pnpm, and headless Windows Server Docker Engine support
- add a guarded AWS developer-image mint wrapper that defaults to a no-spend plan, proves source/candidate/promoted AMIs, records warmup timing logs, cleans up failed warmup leases, and handles Windows reboot/settle behavior before AMI capture
- tighten the macOS developer-tools image wrapper so the default dev image contract is macOS 15+, Swift tools 6.2+, full Xcode.app, and a newer EC2 Mac host family, while leaving CLT-only bakes explicit
- document Linux/Windows/macOS developer-image bakes, Docker expectations, full-Xcode macOS requirements, and fast-boot tradeoffs for AWS AMIs and Fast Snapshot Restore

## Verification

- `bash -n scripts/install-macos-developer-tools.sh scripts/mint-macos-devtools-image.sh scripts/macos-image-lifecycle-smoke.sh scripts/install-linux-developer-tools.sh scripts/mint-aws-devtools-image.sh`
- `shellcheck scripts/install-macos-developer-tools.sh scripts/mint-macos-devtools-image.sh scripts/macos-image-lifecycle-smoke.sh scripts/install-linux-developer-tools.sh scripts/mint-aws-devtools-image.sh`
- `node --test scripts/mint-macos-devtools-image.test.js scripts/macos-image-lifecycle-smoke.test.js scripts/mint-aws-devtools-image.test.js`
- `go test ./internal/cli`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `git diff --check`
- GitHub checks: Go, Worker, Docs, Release Check, CodeQL, Socket, and Analyze jobs all passing on `9624a95aac861f6c3a73ffe83a7f59ccc1677959`

## Live image proof

- Linux candidate bake passed in `eu-west-1`:
  - source lease: `cbx_b308cea5ed2c` / `silver-barnacle`
  - candidate AMI: `ami-0f0239a3397d28259`
  - candidate lease: `cbx_f480eff8d093` / `crimson-hermit`
  - candidate warmup: `76.155s`
  - smoke run: `run_154595fab130`
  - verified: Git, GitHub CLI, jq, ripgrep, fd, Python, Node 24.15.0, npm, corepack, pnpm 11.1.0, Docker 29.5.0, Docker Compose 5.1.3, and prebaked `hello-world`, `ubuntu:24.04`, `node:24-bookworm` images
- Windows candidate bake passed in `us-west-2`:
  - source lease: `cbx_804e2eb8ef50` / `violet-hermit`
  - source smoke run: `run_989bb2cf0864`
  - candidate AMI: `ami-07a874a66c4393f58`
  - candidate lease: `cbx_5457cdd04481` / `brisk-hermit`
  - candidate warmup: `254.946s`
  - readiness probe run: `run_346eb4b67ca5`
  - candidate smoke run: `run_18e6f79f665b`
  - verified: Windows Server 2022, Git, GitHub CLI, jq, ripgrep, fd, Python 3.13.13, Node 24.11.1, npm 11.6.2, corepack, pnpm 11.1.3, Docker 29.5.1 daemon, and prebaked `mcr.microsoft.com/windows/servercore:ltsc2022`

## Notes

- The AWS mint wrapper is dry-run by default; `--run` is required before it creates leases or AMIs.
- Linux and Windows proof bakes were run with `--no-promote`; image promotion remains an explicit operator step.
- macOS full app proof still needs a newly baked full-Xcode image; the previous host had Command Line Tools only, macOS 14.8.5, Swift 6.0.3, and no usable `xcodebuild`, which is not enough for Swift tools 6.2 / macOS 15 SDK lanes.