### PR TITLE
feat(scripts): add openclaw-config-compat.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
+- Added `scripts/openclaw-config-compat.sh`, an OpenClaw config compatibility smoke that leases a Linux box, installs a baseline OpenClaw version, stages a source-controlled config snapshot, then upgrades to a target version and reports whether `openclaw doctor` is required to migrate the config.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
 - Added `scripts/openclaw-config-compat.sh`, an OpenClaw config compatibility smoke that leases a Linux box, installs a baseline OpenClaw version, stages a source-controlled config snapshot, then upgrades to a target version and reports whether `openclaw doctor` is required to migrate the config.
+- Added five `scripts/fixtures/openclaw/<version>/openclaw.json` snapshots covering the queue, web-search, audio, channels, and runtime-mcp legacy-config-migration buckets, each lifted verbatim from OpenClaw's own migration tests and indexed by `scripts/fixtures/openclaw/README.md`.
 
 ### Changed
 

--- a/scripts/fixtures/openclaw/2026.4.1/openclaw.json
+++ b/scripts/fixtures/openclaw/2026.4.1/openclaw.json
@@ -1,0 +1,14 @@
+{
+  "mcp": {
+    "servers": {
+      "example-http": {
+        "type": "http",
+        "url": "https://mcp.example.com/sse"
+      },
+      "example-stdio": {
+        "type": "stdio",
+        "command": "/usr/local/bin/example-mcp"
+      }
+    }
+  }
+}

--- a/scripts/fixtures/openclaw/2026.4.25/openclaw.json
+++ b/scripts/fixtures/openclaw/2026.4.25/openclaw.json
@@ -1,0 +1,8 @@
+{
+  "audio": {
+    "transcription": {
+      "command": ["whisper-cli", "--model", "small", "{input}", "--input={input}"],
+      "timeoutSeconds": 30
+    }
+  }
+}

--- a/scripts/fixtures/openclaw/2026.4.27/openclaw.json
+++ b/scripts/fixtures/openclaw/2026.4.27/openclaw.json
@@ -1,0 +1,12 @@
+{
+  "messages": {
+    "queue": {
+      "mode": "queue",
+      "byChannel": {
+        "discord": "steer-backlog",
+        "telegram": "collect",
+        "slack": "steer"
+      }
+    }
+  }
+}

--- a/scripts/fixtures/openclaw/2026.5.12/openclaw.json
+++ b/scripts/fixtures/openclaw/2026.5.12/openclaw.json
@@ -1,0 +1,17 @@
+{
+  "tools": {
+    "web": {
+      "search": {
+        "apiKey": "brave-key",
+        "grok": {
+          "apiKey": "xai-key",
+          "model": "grok-4-search"
+        },
+        "kimi": {
+          "apiKey": "kimi-key",
+          "model": "kimi-k2.5"
+        }
+      }
+    }
+  }
+}

--- a/scripts/fixtures/openclaw/2026.5.3/openclaw.json
+++ b/scripts/fixtures/openclaw/2026.5.3/openclaw.json
@@ -1,0 +1,19 @@
+{
+  "routing": {
+    "allowFrom": ["+15555550123"],
+    "groupChat": {
+      "requireMention": false,
+      "historyLimit": 25,
+      "mentionPatterns": ["@bot"]
+    }
+  },
+  "channels": {
+    "whatsapp": {
+      "enabled": true
+    },
+    "telegram": {
+      "enabled": true,
+      "requireMention": true
+    }
+  }
+}

--- a/scripts/fixtures/openclaw/README.md
+++ b/scripts/fixtures/openclaw/README.md
@@ -1,0 +1,93 @@
+# OpenClaw config compatibility fixtures
+
+Snapshots of `openclaw.json` known to load on a baseline OpenClaw version and
+known to trip `openclaw doctor`'s legacy-config rules on a later version. Each
+fixture is consumed by `scripts/openclaw-config-compat.sh`:
+
+```sh
+CRABBOX_LIVE=1 \
+  OPENCLAW_VERSION_X=2026.4.27 \
+  OPENCLAW_VERSION_Y=2026.5.18 \
+  OPENCLAW_FIXTURE=scripts/fixtures/openclaw/2026.4.27/openclaw.json \
+  scripts/openclaw-config-compat.sh
+```
+
+The five fixtures span the five top-level legacy-config-migration buckets
+OpenClaw groups itself by, so the suite covers each category of breakage
+the project's own doctor knows how to repair:
+
+| # | Bucket     | Fixture                              | Suggested X | Suggested Y |
+|---|------------|--------------------------------------|-------------|-------------|
+| 1 | queue      | `2026.4.27/openclaw.json`            | `2026.4.27` | `2026.5.18` |
+| 2 | web-search | `2026.5.12/openclaw.json`            | `2026.5.12` | `2026.5.18` |
+| 3 | audio      | `2026.4.25/openclaw.json`            | `2026.4.25` | `2026.5.18` |
+| 4 | channels   | `2026.5.3/openclaw.json`             | `2026.5.3`  | `2026.5.18` |
+| 5 | runtime    | `2026.4.1/openclaw.json` (mcp)       | `2026.4.1`  | `2026.5.18` |
+
+Strength of the X→Y boundary varies. Buckets 1 and 2 line up with a
+changelog-cited migration landing inside the npm-published version range, so
+the baseline really did accept the legacy shape natively. Buckets 3, 4, and 5
+document the legacy shape exactly as OpenClaw's own migration tests do, but
+the rename predates the earliest stable on npm; if phase 1 fails for those,
+the fixture is still valuable as documentation of the deprecated shape that
+doctor handles today. The script exits 2 in that case, with a clear message
+distinguishing fixture trouble from a real Y-regression.
+
+All five legacy shapes are lifted from OpenClaw's own migration tests, so the
+JSON matches verbatim what `migrateLegacyConfigForTest` exercises in CI.
+
+## 1. `messages.queue.mode = "queue"` (queue migration)
+
+- Migration rule: `src/commands/doctor/shared/legacy-config-migrations.queue.ts:8-49`
+- Test that proves doctor rewrites it: `src/commands/doctor/shared/legacy-config-migrate.test.ts:336-365`
+- Changelog evidence: `2026.4.29` made `steer` the default and demoted `"queue"`
+  to a retired mode. By `2026.5.x`, doctor maps `"queue"` → `"steer"` and
+  `"steer-backlog"` → `"followup"`.
+- Expected doctor output: `Moved deprecated messages.queue.mode "queue" → "steer"`.
+
+## 2. `tools.web.search.<provider>` (web-search migration)
+
+- Migration rule: `src/commands/doctor/shared/legacy-config-migrations.web-search.ts:11-19`
+- Test that proves doctor rewrites it: `src/commands/doctor/shared/legacy-web-search-migrate.test.ts:20-62`
+- Changelog evidence: `2026.5.14` introduced the canonical doctor migration
+  from `tools.web.search.<provider>` to
+  `plugins.entries.<plugin>.config.webSearch`. `2026.5.12` is the last stable
+  release on npm that still treats the legacy shape as canonical.
+- Expected doctor output: `Moved tools.web.search.grok → plugins.entries.xai.config.webSearch`, etc.
+
+## 3. `audio.transcription` (audio migration)
+
+- Migration rule: `src/commands/doctor/shared/legacy-config-migrations.audio.ts:36-60`
+- Test that proves doctor rewrites it: `src/commands/doctor/shared/legacy-config-migrate.test.ts:417-437`
+- Changelog evidence: `2026.4.26` adds the `{input}` → `{{MediaPath}}` placeholder
+  rewrite inside this migration. The whole `audio.transcription` shape predates
+  that release and now migrates to `tools.media.audio.models`.
+- Expected doctor output: `Moved audio.transcription → tools.media.audio.models`.
+
+## 4. `routing.allowFrom` and `routing.groupChat.*` (channels migration)
+
+- Migration rule: `src/commands/doctor/shared/legacy-config-migrations.channels.ts:384-410`
+- Test that proves the schema rejects these shapes today: `src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts:6-17`
+- Changelog evidence: `2026.5.4` restored the doctor migration "so upgrades
+  keep WhatsApp, Telegram, and iMessage group mention gates and history
+  settings instead of leaving configs invalid or silently blocked."
+- Expected doctor output: `Moved routing.allowFrom → channels.whatsapp.allowFrom`,
+  `Moved routing.groupChat.historyLimit → messages.groupChat.historyLimit`, etc.
+
+## 5. `mcp.servers.<name>.type` (runtime migration)
+
+- Migration rule: `src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts:12-19`
+- Migration logic: same file, lines 21-52
+- Alias map: `src/config/mcp-config-normalize.ts:6-11` maps `http` →
+  `streamable-http`, accepts `sse` and `stdio` as-is.
+- Expected doctor output: `Moved mcp.servers.example-http.type "http" → transport "streamable-http"`.
+
+## Adding a fixture
+
+1. Find the deprecated shape in `../openclaw/src/commands/doctor/shared/legacy-config-migrations.*.ts`.
+2. Copy the input from the matching test in `legacy-config-migrate.test.ts` (or
+   the per-bucket `legacy-*-migrate.test.ts`) verbatim — same field names, same
+   sample values — so the fixture is grounded in OpenClaw's own contract.
+3. Place it at `scripts/fixtures/openclaw/<baseline-version>/openclaw.json`.
+4. Add a row to the table above with a citation to the migration rule and
+   the matching test.

--- a/scripts/openclaw-config-compat.sh
+++ b/scripts/openclaw-config-compat.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Verify that an OpenClaw config snapshot known-good on version X still loads
+# on version Y, and surface whether `openclaw doctor` is required to migrate
+# it.
+#
+# Phases (all run on the same leased Linux box):
+#   1. Install OpenClaw X, stage the fixture into the state dir, run the
+#      smoke command. Must succeed — this is the load-bearing assumption that
+#      the fixture is valid for its declared baseline version. Failure exits
+#      2; nothing has been learned about Y.
+#   2. Upgrade to OpenClaw Y via `npm i -g openclaw@<y>`. Re-run the smoke
+#      command WITHOUT invoking doctor. Snapshot the state-dir hash.
+#   3. Run `openclaw doctor --non-interactive --yes`. Diff the state-dir hash
+#      to detect mutations; capture doctor output.
+#   4. Re-run the smoke command (post-doctor). Record pass/fail.
+#
+# Exit codes:
+#   0  Clean upgrade — phase 2 passed. Doctor output is informational.
+#   3  Migration required — phase 2 failed, phase 4 passed (doctor fixed it).
+#   4  Regression — phase 2 AND phase 4 failed (doctor cannot recover).
+#   2  Bad fixture, infra error, or unsatisfied precondition.
+#
+# Required:
+#   CRABBOX_LIVE=1                 acknowledge that this leases a real box
+#   OPENCLAW_VERSION_X=<semver>    baseline version the fixture was authored for
+#   OPENCLAW_VERSION_Y=<semver>    target version under test (use "latest" for HEAD)
+#
+# Optional:
+#   OPENCLAW_FIXTURE=<path>        config snapshot to copy to the box; default
+#                                  scripts/fixtures/openclaw/$OPENCLAW_VERSION_X/openclaw.json
+#   OPENCLAW_SMOKE_CMD=<cmd>       remote command that returns 0 iff the
+#                                  config loads cleanly; default
+#                                  `openclaw doctor --lint --json` (non-mutating)
+#   OPENCLAW_STATE_DIR=<remote>    state dir on the box; default $HOME/.openclaw
+#   OPENCLAW_COMPAT_ID=<lease>     reuse an existing lease instead of warmup
+#   OPENCLAW_COMPAT_PROVIDER=<p>   crabbox provider; default aws
+#   OPENCLAW_COMPAT_CLASS=<class>  crabbox machine class; default fast
+#   OPENCLAW_COMPAT_IDLE=<dur>     lease idle timeout; default 60m
+#   OPENCLAW_COMPAT_STOP=1|0       stop the lease on exit; default 1
+#   CRABBOX_BIN=<path>             crabbox binary; default $repo/bin/crabbox
+
+set -euo pipefail
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  echo "set CRABBOX_LIVE=1 to lease a real box" >&2
+  exit 2
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cb="${CRABBOX_BIN:-$root/bin/crabbox}"
+
+vx="${OPENCLAW_VERSION_X:?set OPENCLAW_VERSION_X=<baseline semver>}"
+vy="${OPENCLAW_VERSION_Y:?set OPENCLAW_VERSION_Y=<target semver or latest>}"
+fixture="${OPENCLAW_FIXTURE:-$root/scripts/fixtures/openclaw/${vx}/openclaw.json}"
+smoke="${OPENCLAW_SMOKE_CMD:-openclaw doctor --lint --json}"
+state_dir="${OPENCLAW_STATE_DIR:-\$HOME/.openclaw}"
+lease="${OPENCLAW_COMPAT_ID:-}"
+provider="${OPENCLAW_COMPAT_PROVIDER:-aws}"
+class="${OPENCLAW_COMPAT_CLASS:-fast}"
+idle="${OPENCLAW_COMPAT_IDLE:-60m}"
+stop_after="${OPENCLAW_COMPAT_STOP:-1}"
+
+if [[ ! -f "$fixture" ]]; then
+  echo "missing fixture: $fixture" >&2
+  echo "set OPENCLAW_FIXTURE=<path> or place a snapshot at the default location" >&2
+  exit 2
+fi
+
+if [[ ! -x "$cb" ]]; then
+  echo "crabbox binary not found at $cb; build it or set CRABBOX_BIN" >&2
+  exit 2
+fi
+
+on_box() { "$cb" run --id "$lease" --shell -- "$1"; }
+on_box_ok() { "$cb" run --id "$lease" --shell -- "$1" >/dev/null 2>&1; }
+on_box_capture() { "$cb" run --id "$lease" --shell -- "$1" 2>&1; }
+
+extract_lease() {
+  sed -n 's/.*\(cbx_[a-f0-9]\{12\}\).*/\1/p' | head -1
+}
+
+if [[ -z "$lease" ]]; then
+  echo "==> warming up $provider/$class lease"
+  if ! out="$("$cb" warmup \
+    --provider "$provider" \
+    --class "$class" \
+    --idle-timeout "$idle" \
+    --timing-json 2>&1)"; then
+    printf '%s\n' "$out" >&2
+    echo "warmup failed" >&2
+    exit 2
+  fi
+  printf '%s\n' "$out"
+  lease="$(printf '%s\n' "$out" | extract_lease)"
+fi
+
+if [[ -z "$lease" ]]; then
+  echo "could not resolve lease id" >&2
+  exit 2
+fi
+
+cleanup() {
+  if [[ "$stop_after" == "1" ]]; then
+    "$cb" stop "$lease" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "==> lease=$lease  X=$vx  Y=$vy"
+echo "    fixture=$fixture"
+echo "    smoke=$smoke"
+echo "    state_dir=$state_dir"
+
+stage_fixture() {
+  local remote_path="$state_dir/openclaw.json"
+  # Upload fixture as base64 over stdin to avoid quoting hell with secrets/JSON.
+  local b64
+  b64="$(base64 < "$fixture" | tr -d '\n')"
+  on_box "
+    set -e
+    mkdir -p $state_dir
+    printf '%s' '$b64' | base64 -d > $remote_path
+    chmod 600 $remote_path
+  "
+}
+
+state_hash() {
+  on_box_capture "
+    if [ ! -d $state_dir ]; then echo MISSING; exit 0; fi
+    find $state_dir -type f -print0 \
+      | sort -z \
+      | xargs -0 sha256sum 2>/dev/null \
+      | sha256sum \
+      | awk '{print \$1}'
+  " | tail -n1
+}
+
+# Phase 1: install vX, stage fixture, smoke must pass.
+echo
+echo "==> phase 1: install openclaw@${vx} + smoke (must pass)"
+if ! on_box "npm i -g openclaw@${vx}"; then
+  echo "FAIL[phase1]: could not install openclaw@${vx}" >&2
+  exit 2
+fi
+stage_fixture
+if ! on_box_ok "$smoke"; then
+  echo "FAIL[phase1]: fixture rejected by its own baseline ${vx}." >&2
+  echo "  The fixture is not actually valid for X — fix the fixture, not openclaw." >&2
+  echo "  smoke output:" >&2
+  on_box_capture "$smoke" >&2 || true
+  exit 2
+fi
+echo "    phase 1: pass"
+
+# Phase 2: upgrade to vY, no doctor, re-smoke.
+echo
+echo "==> phase 2: upgrade to openclaw@${vy}, smoke WITHOUT doctor"
+if ! on_box "npm i -g openclaw@${vy}"; then
+  echo "FAIL[phase2]: could not install openclaw@${vy}" >&2
+  exit 2
+fi
+hash_before="$(state_hash)"
+echo "    state-dir hash (pre-doctor): $hash_before"
+if on_box_ok "$smoke"; then
+  phase2=pass
+  echo "    phase 2: pass (no migration needed)"
+else
+  phase2=fail
+  echo "    phase 2: fail (config does not load on ${vy} without doctor)"
+  echo "    --- smoke output ---"
+  on_box_capture "$smoke" || true
+  echo "    --------------------"
+fi
+
+# Phase 3: doctor.
+echo
+echo "==> phase 3: openclaw doctor --non-interactive --yes"
+doctor_out="$(on_box_capture "openclaw doctor --non-interactive --yes" || true)"
+hash_after="$(state_hash)"
+if [[ "$hash_before" == "$hash_after" ]]; then
+  doctor_changed=no
+  echo "    state-dir hash unchanged ($hash_after) — doctor made no mutations"
+else
+  doctor_changed=yes
+  echo "    state-dir MUTATED: $hash_before -> $hash_after"
+fi
+echo "    --- doctor output ---"
+printf '%s\n' "$doctor_out"
+echo "    ---------------------"
+
+# Phase 4: smoke after doctor.
+echo
+echo "==> phase 4: smoke AFTER doctor"
+if on_box_ok "$smoke"; then
+  phase4=pass
+  echo "    phase 4: pass"
+else
+  phase4=fail
+  echo "    phase 4: fail"
+  echo "    --- smoke output ---"
+  on_box_capture "$smoke" || true
+  echo "    --------------------"
+fi
+
+# Decision.
+echo
+echo "==> summary"
+echo "    X=$vx -> Y=$vy"
+echo "    phase 2 (Y, no doctor): $phase2"
+echo "    doctor changed state  : $doctor_changed"
+echo "    phase 4 (Y, +doctor)  : $phase4"
+
+if [[ "$phase2" == "pass" ]]; then
+  echo "RESULT: clean upgrade"
+  exit 0
+fi
+if [[ "$phase4" == "pass" ]]; then
+  echo "RESULT: migration required — doctor fixes ${vx} -> ${vy} on its own"
+  exit 3
+fi
+echo "RESULT: REGRESSION — config valid on ${vx} fails on ${vy}, doctor cannot recover" >&2
+exit 4


### PR DESCRIPTION
## Summary

Adds `scripts/openclaw-config-compat.sh`, a four-phase smoke that takes a source-controlled OpenClaw config fixture, proves it loads on the version it was authored for, then surfaces whether `openclaw doctor` is required to keep it loading after an upgrade.

- Phase 1 installs OpenClaw X, stages the fixture into `~/.openclaw/openclaw.json` on the leased box, and runs a configurable smoke command (`openclaw doctor --lint --json` by default). If this fails the script exits 2 — the fixture is bad, no signal about Y was produced.
- Phase 2 upgrades to OpenClaw Y via `npm i -g openclaw@<y>` and re-runs the smoke command without touching doctor. The state-dir hash is captured here.
- Phase 3 runs `openclaw doctor --non-interactive --yes`, captures its output, and diffs the state-dir hash to report whether doctor actually mutated anything.
- Phase 4 re-runs the smoke command post-doctor.

Exit codes distinguish the four interesting outcomes: 0 = clean upgrade, 3 = migration required and doctor handled it, 4 = regression that doctor could not recover, 2 = bad fixture or infra error.

Everything sensitive (path quoting, the JSON fixture itself) goes over a base64-decoded stdin to the box, so fixtures with quotes or large payloads do not blow up the shell. The script gates on `CRABBOX_LIVE=1`, matches the convention of `scripts/openclaw-wsl2-tests.sh`, and stops the lease on exit unless `OPENCLAW_COMPAT_STOP=0` is set.

## Test plan

- [ ] `bash -n scripts/openclaw-config-compat.sh` — syntax check (done locally).
- [ ] Live smoke against an AWS Linux lease with a known-good fixture for the current OpenClaw release: expect exit 0 and "clean upgrade."
- [ ] Live smoke with a deliberately stale fixture against a newer OpenClaw: expect either exit 3 (doctor migrates) or exit 4 (regression) with the doctor diff in the output.
- [ ] Live smoke with a hand-broken fixture against its own baseline: expect exit 2 ("fixture rejected by its own baseline").
- [ ] `CRABBOX_LIVE` unset: expect exit 2 with the live-mode reminder.