### PR TITLE
feat: add runpod provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: runpod` for RunPod CPU pod SSH leases through the RunPod GraphQL API, including Crabbox sync/run, `crabbox ssh`, `crabbox doctor`, and provider docs.
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `provider: runpod` for RunPod CPU pod SSH leases through the RunPod GraphQL API, including Crabbox sync/run, `crabbox ssh`, `crabbox doctor`, and provider docs.
+- Added `provider: runpod` for RunPod public TCP SSH leases through the RunPod REST API, including Crabbox sync/run, `crabbox ssh`, `crabbox doctor`, and provider docs. Thanks @zozo123.
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Supported providers:
 - [Railway](docs/providers/railway.md) (`provider: railway`): delegated
   redeploy-and-stream execution against a pre-existing Railway service through
   the [Railway](https://railway.com) GraphQL API.
+- [RunPod](docs/providers/runpod.md) (`provider: runpod`): RunPod CPU pods
+  provisioned through the [RunPod](https://runpod.io) GraphQL API and exposed
+  as normal SSH leases with Crabbox sync.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Supported providers:
 - [Railway](docs/providers/railway.md) (`provider: railway`): delegated
   redeploy-and-stream execution against a pre-existing Railway service through
   the [Railway](https://railway.com) GraphQL API.
-- [RunPod](docs/providers/runpod.md) (`provider: runpod`): RunPod CPU pods
-  provisioned through the [RunPod](https://runpod.io) GraphQL API and exposed
-  as normal SSH leases with Crabbox sync.
+- [RunPod](docs/providers/runpod.md) (`provider: runpod`): RunPod pods
+  provisioned through the [RunPod](https://runpod.io) REST API and exposed as
+  normal SSH leases with Crabbox sync.
 
 ---
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -29,6 +29,7 @@ static SSH provider for existing machines.
 | [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 | [Cloudflare](cloudflare.md) | delegated run | Linux | Cloudflare execution through a Worker and container runner |
 | [Railway](railway.md) | delegated run | Linux | redeploy and stream logs for an existing Railway service via the GraphQL API |
+| [RunPod](runpod.md) | SSH lease | Linux | disposable RunPod CPU pods provisioned via the GraphQL API and accessed over public SSH |
 
 ## Shared Rules
 
@@ -76,6 +77,10 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
   `deploymentLogs`, `deploymentStop`) against a pre-existing service the user
   owns. The user's command argument is logged; Railway runs the service's own
   start command — there is no synchronous exec endpoint.
+- RunPod uses the [RunPod](https://runpod.io) GraphQL API (`deployCpuPod`,
+  `pod`, `podTerminate`) to provision a CPU pod that exposes SSH on port 22.
+  Once `pod.runtime.ports` reports the public TCP mapping, Crabbox reuses its
+  normal SSH sync/run path against `root@<pod-ip>:<public-port>`.
 
 Namespace Devbox and Semaphore are SSH lease providers that do not use the
 Crabbox coordinator. Namespace provisions through the authenticated `devbox`
@@ -105,10 +110,11 @@ provisions through `ssh exe.dev` and returns a normal VM SSH target.
 | Tensorlake | yes | yes | no | no | archive via `tensorlake sbx cp` | no |
 | Cloudflare | yes | yes | no | no | archive via Worker runner | no |
 | Railway | yes | no | no | no | no | no |
+| RunPod | yes | yes | yes | no | yes | no |
 
 Actions runner hydration requires a normal SSH lease on Linux and is core-over-SSH.
 Use AWS, Google Cloud, Hetzner, Proxmox, Static SSH, exe.dev, Namespace Devbox,
-Semaphore, or Sprites for that path.
+Semaphore, Sprites, or RunPod for that path.
 
 ## Implementation
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -29,7 +29,7 @@ static SSH provider for existing machines.
 | [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 | [Cloudflare](cloudflare.md) | delegated run | Linux | Cloudflare execution through a Worker and container runner |
 | [Railway](railway.md) | delegated run | Linux | redeploy and stream logs for an existing Railway service via the GraphQL API |
-| [RunPod](runpod.md) | SSH lease | Linux | disposable RunPod CPU pods provisioned via the GraphQL API and accessed over public SSH |
+| [RunPod](runpod.md) | SSH lease | Linux | disposable RunPod pods provisioned via the REST API and accessed over public SSH |
 
 ## Shared Rules
 
@@ -77,9 +77,9 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
   `deploymentLogs`, `deploymentStop`) against a pre-existing service the user
   owns. The user's command argument is logged; Railway runs the service's own
   start command — there is no synchronous exec endpoint.
-- RunPod uses the [RunPod](https://runpod.io) GraphQL API (`deployCpuPod`,
-  `pod`, `podTerminate`) to provision a CPU pod that exposes SSH on port 22.
-  Once `pod.runtime.ports` reports the public TCP mapping, Crabbox reuses its
+- RunPod uses the [RunPod](https://runpod.io) REST API (`/v1/pods`) to
+  provision a pod that exposes SSH on port 22. Once `publicIp` and
+  `portMappings["22"]` report the public TCP mapping, Crabbox reuses its
   normal SSH sync/run path against `root@<pod-ip>:<public-port>`.
 
 Namespace Devbox and Semaphore are SSH lease providers that do not use the

--- a/docs/providers/runpod.md
+++ b/docs/providers/runpod.md
@@ -1,0 +1,167 @@
+# RunPod Provider
+
+Read when:
+
+- choosing `provider: runpod`;
+- pointing Crabbox at a RunPod CPU (or GPU) pod;
+- changing `internal/providers/runpod`.
+
+[RunPod](https://runpod.io) is a GPU/CPU cloud whose primitives are pods, GPU
+types, CPU flavors, templates, and machines. RunPod's public API is GraphQL at
+`https://api.runpod.io/graphql` and is authenticated with
+`Authorization: Bearer $RUNPOD_API_KEY`. The same key is accepted as a query
+parameter (`?api_key=...`), but Crabbox only sends the header form.
+
+## SSH Lease Shape
+
+A RunPod pod has a static public IP and a NAT-mapped public port for each
+exposed private port. When the pod is created with `startSsh: true` and
+`ports: "22/tcp"`, RunPod reports the mapping via the pod's
+`runtime.ports[]` connection once the pod reaches `RUNNING`:
+
+```json
+{
+  "ip": "203.0.113.7",
+  "privatePort": 22,
+  "publicPort": 41010,
+  "isIpPublic": true,
+  "type": "tcp"
+}
+```
+
+Crabbox provisions the pod through `deployCpuPod`, polls `pod(input: {podId})`
+until `runtime.ports` exposes a public port-22 mapping, and then hands the
+caller a normal `SSHTarget` pointed at `root@<ip>:<publicPort>`. From that
+point on, Crabbox uses its existing SSH sync, run, status, ssh, and stop paths
+— there is no parallel RunPod-specific exec surface.
+
+Public-key SSH authentication is the only supported RunPod auth method. Upload
+your ED25519 public key under the RunPod settings page once; RunPod injects it
+into every pod you launch. Crabbox does not manage the public key.
+
+## Pod Lifecycle
+
+`Acquire` deploys a CPU pod whose name follows the standard Crabbox
+`crabbox-<slug>-<leaseSuffix>` pattern, then waits for `runtime.ports` to
+expose a public TCP mapping for port 22. `Resolve` looks up an existing pod by
+lease id, pod id, or pod name. `List` enumerates the caller's pods via
+`myself { pods { … } }` and filters to the `crabbox-` prefix unless `--all` is
+set. `ReleaseLease` calls `podTerminate(input: {podId})`. `Doctor` runs
+`myself` (auth check) and `myself.pods` (inventory check) without ever calling
+a mutation — it is safe to run on every CI.
+
+## Defaults And Cost Discipline
+
+The defaults pick the cheapest documented CPU flavor (`cpu3c-2-4`,
+compute-optimized, 2 vCPU / 4 GB RAM) on the `runpod/base:0.6.2` image with a
+10 GB container disk and `cloudType: ALL`. Override any of these via flags,
+env vars, or YAML before pointing the provider at a GPU SKU — GPU pods cost
+substantially more per hour. Pods are terminated immediately on
+`ReleaseLease`; if `--keep` is set, the pod stays up and accrues cost until
+the caller terminates it. Run `crabbox list --provider runpod` to spot leaked
+pods.
+
+## Commands
+
+```sh
+crabbox warmup --provider runpod
+crabbox run --provider runpod -- pnpm test
+crabbox ssh --provider runpod
+crabbox status --provider runpod
+crabbox stop --provider runpod $LEASE_ID
+crabbox list --provider runpod
+```
+
+## Auth
+
+```sh
+export RUNPOD_API_KEY=...   # required, from https://www.runpod.io/console/user/settings
+```
+
+`CRABBOX_RUNPOD_API_KEY` is also accepted and wins over `RUNPOD_API_KEY`,
+matching the precedence other direct providers use. The key is read from the
+environment only; the provider does not register a CLI flag for it. Do not
+pass the key on the command line.
+
+The canonical RunPod request shape is:
+
+```sh
+curl -X POST https://api.runpod.io/graphql \
+  -H "Authorization: Bearer $RUNPOD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query { myself { id email } }"}'
+```
+
+Crabbox sends the same `Authorization: Bearer $RUNPOD_API_KEY` header and a
+JSON `{query, variables}` body to the same endpoint.
+
+## Config
+
+```yaml
+provider: runpod
+target: linux
+runpod:
+  apiUrl: https://api.runpod.io/graphql
+  cloudType: ALL          # ALL | SECURE | COMMUNITY
+  instanceId: cpu3c-2-4   # cheapest documented CPU flavor
+  image: runpod/base:0.6.2
+  templateId: ""          # optional
+  diskGB: 10
+  user: root
+  workRoot: /tmp/crabbox
+```
+
+Provider flags:
+
+```text
+--runpod-url
+--runpod-cloud-type
+--runpod-instance-id
+--runpod-image
+--runpod-template-id
+--runpod-disk-gb
+--runpod-user
+--runpod-work-root
+```
+
+Environment overrides:
+
+```text
+CRABBOX_RUNPOD_API_KEY      (or RUNPOD_API_KEY)
+CRABBOX_RUNPOD_API_URL      (or RUNPOD_API_URL)
+CRABBOX_RUNPOD_CLOUD_TYPE   (or RUNPOD_CLOUD_TYPE)
+CRABBOX_RUNPOD_INSTANCE_ID  (or RUNPOD_INSTANCE_ID)
+CRABBOX_RUNPOD_IMAGE        (or RUNPOD_IMAGE)
+CRABBOX_RUNPOD_TEMPLATE_ID  (or RUNPOD_TEMPLATE_ID)
+CRABBOX_RUNPOD_DISK_GB
+CRABBOX_RUNPOD_USER
+CRABBOX_RUNPOD_WORK_ROOT
+```
+
+## Capabilities
+
+- SSH: yes (public IP + NAT-mapped port 22).
+- Crabbox sync: yes (standard rsync-over-SSH).
+- Provider sync: no.
+- Desktop/browser/code: no.
+- Actions hydration: yes (Linux SSH lease).
+- Coordinator: no — RunPod runs in direct-only mode.
+
+## Gotchas
+
+- A funded RunPod account is required. `deployCpuPod` returns
+  `Your account balance is too low to rent a pod. Please add funds to your account.`
+  when `clientBalance == 0`. `crabbox doctor --provider runpod` succeeds on a
+  zero-balance account because it only reads `myself` and the pod list — the
+  balance shortfall only surfaces when an `Acquire` runs.
+- You must upload your ED25519 public key to RunPod once before any pod
+  bootstrap will accept your SSH session.
+- The pod's public port for SSH is allocated at runtime and changes between
+  pods; never hard-code `--ssh-port`.
+- `--class` and `--type` are rejected for this provider; use
+  `--runpod-instance-id` and `--runpod-image` instead.
+- `--tailscale` is rejected; RunPod pods expose only public SSH.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/runpod.md
+++ b/docs/providers/runpod.md
@@ -3,21 +3,20 @@
 Read when:
 
 - choosing `provider: runpod`;
-- pointing Crabbox at a RunPod CPU (or GPU) pod;
+- pointing Crabbox at a RunPod pod;
 - changing `internal/providers/runpod`.
 
 [RunPod](https://runpod.io) is a GPU/CPU cloud whose primitives are pods, GPU
-types, CPU flavors, templates, and machines. RunPod's public API is GraphQL at
-`https://api.runpod.io/graphql` and is authenticated with
-`Authorization: Bearer $RUNPOD_API_KEY`. The same key is accepted as a query
-parameter (`?api_key=...`), but Crabbox only sends the header form.
+types, CPU flavors, templates, and machines. Crabbox uses the RunPod REST API
+at `https://rest.runpod.io/v1` with `Authorization: Bearer $RUNPOD_API_KEY`.
 
 ## SSH Lease Shape
 
-A RunPod pod has a static public IP and a NAT-mapped public port for each
-exposed private port. When the pod is created with `startSsh: true` and
-`ports: "22/tcp"`, RunPod reports the mapping via the pod's
-`runtime.ports[]` connection once the pod reaches `RUNNING`:
+A RunPod pod can expose a public IP and a NAT-mapped public port for each
+exposed private port. Crabbox creates pods with `ports: ["22/tcp"]` and
+`supportPublicIp: true`. RunPod reports the mapping as `publicIp` plus
+`portMappings["22"]`; older responses may also expose the same data through
+`runtime.ports[]`:
 
 ```json
 {
@@ -29,11 +28,12 @@ exposed private port. When the pod is created with `startSsh: true` and
 }
 ```
 
-Crabbox provisions the pod through `deployCpuPod`, polls `pod(input: {podId})`
-until `runtime.ports` exposes a public port-22 mapping, and then hands the
-caller a normal `SSHTarget` pointed at `root@<ip>:<publicPort>`. From that
-point on, Crabbox uses its existing SSH sync, run, status, ssh, and stop paths
-— there is no parallel RunPod-specific exec surface.
+Crabbox provisions the pod through `POST /v1/pods`, polls `GET /v1/pods/{id}`
+until public TCP port 22 is available, and then hands the caller a normal
+`SSHTarget` pointed at `root@<ip>:<publicPort>`. From that point on, Crabbox
+uses its existing SSH sync, run, status, ssh, and stop paths — there is no
+parallel RunPod-specific exec surface. RunPod's basic SSH proxy is not used
+because it does not support the SCP/SFTP behavior rsync needs.
 
 Public-key SSH authentication is the only supported RunPod auth method. Upload
 your ED25519 public key under the RunPod settings page once; RunPod injects it
@@ -41,25 +41,26 @@ into every pod you launch. Crabbox does not manage the public key.
 
 ## Pod Lifecycle
 
-`Acquire` deploys a CPU pod whose name follows the standard Crabbox
+`Acquire` deploys a pod whose name follows the standard Crabbox
 `crabbox-<slug>-<leaseSuffix>` pattern, then waits for `runtime.ports` to
 expose a public TCP mapping for port 22. `Resolve` looks up an existing pod by
 lease id, pod id, or pod name. `List` enumerates the caller's pods via
-`myself { pods { … } }` and filters to the `crabbox-` prefix unless `--all` is
-set. `ReleaseLease` calls `podTerminate(input: {podId})`. `Doctor` runs
-`myself` (auth check) and `myself.pods` (inventory check) without ever calling
-a mutation — it is safe to run on every CI.
+`GET /v1/pods` and filters to the `crabbox-` prefix unless `--all` is set.
+`ReleaseLease` calls `DELETE /v1/pods/{id}`. `Doctor` runs read-only pod list
+checks without ever creating a pod — it is safe to run on every CI.
 
 ## Defaults And Cost Discipline
 
-The defaults pick the cheapest documented CPU flavor (`cpu3c-2-4`,
-compute-optimized, 2 vCPU / 4 GB RAM) on the `runpod/base:0.6.2` image with a
-10 GB container disk and `cloudType: ALL`. Override any of these via flags,
-env vars, or YAML before pointing the provider at a GPU SKU — GPU pods cost
-substantially more per hour. Pods are terminated immediately on
-`ReleaseLease`; if `--keep` is set, the pod stays up and accrues cost until
-the caller terminates it. Run `crabbox list --provider runpod` to spot leaked
-pods.
+The defaults pick secure-cloud GPU pods on the RunPod PyTorch image with a 20
+GB container disk because that path exposes the public TCP SSH mapping Crabbox
+needs for rsync. `instanceId` may be a comma-separated GPU priority list; the
+default starts with `NVIDIA L4,NVIDIA RTX 4000 Ada Generation,NVIDIA RTX A4000`
+and continues through common 24 GB fallback GPUs. Override any of these via
+flags, env vars, or YAML if you need a different GPU type or a CPU flavor;
+verify that the selected shape exposes public TCP SSH before relying on it.
+Pods are terminated immediately on `ReleaseLease`; if `--keep` is set, the pod
+stays up and accrues cost until the caller terminates it. Run
+`crabbox list --provider runpod` to spot leaked pods.
 
 ## Commands
 
@@ -83,17 +84,15 @@ matching the precedence other direct providers use. The key is read from the
 environment only; the provider does not register a CLI flag for it. Do not
 pass the key on the command line.
 
-The canonical RunPod request shape is:
+The canonical RunPod auth check is:
 
 ```sh
-curl -X POST https://api.runpod.io/graphql \
-  -H "Authorization: Bearer $RUNPOD_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query { myself { id email } }"}'
+curl https://rest.runpod.io/v1/pods \
+  -H "Authorization: Bearer $RUNPOD_API_KEY"
 ```
 
-Crabbox sends the same `Authorization: Bearer $RUNPOD_API_KEY` header and a
-JSON `{query, variables}` body to the same endpoint.
+Crabbox sends the same `Authorization: Bearer $RUNPOD_API_KEY` header to REST
+pod endpoints.
 
 ## Config
 
@@ -101,12 +100,12 @@ JSON `{query, variables}` body to the same endpoint.
 provider: runpod
 target: linux
 runpod:
-  apiUrl: https://api.runpod.io/graphql
-  cloudType: ALL          # ALL | SECURE | COMMUNITY
-  instanceId: cpu3c-2-4   # cheapest documented CPU flavor
-  image: runpod/base:0.6.2
+  apiUrl: https://rest.runpod.io/v1
+  cloudType: SECURE       # SECURE | COMMUNITY
+  instanceId: NVIDIA L4,NVIDIA RTX 4000 Ada Generation,NVIDIA RTX A4000,NVIDIA GeForce RTX 3090,NVIDIA GeForce RTX 4090,NVIDIA RTX A5000,NVIDIA RTX A4500
+  image: runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04
   templateId: ""          # optional
-  diskGB: 10
+  diskGB: 20
   user: root
   workRoot: /tmp/crabbox
 ```
@@ -149,15 +148,15 @@ CRABBOX_RUNPOD_WORK_ROOT
 
 ## Gotchas
 
-- A funded RunPod account is required. `deployCpuPod` returns
-  `Your account balance is too low to rent a pod. Please add funds to your account.`
-  when `clientBalance == 0`. `crabbox doctor --provider runpod` succeeds on a
-  zero-balance account because it only reads `myself` and the pod list — the
+- A funded RunPod account is required. `crabbox doctor --provider runpod`
+  succeeds on a zero-balance account because it only reads the pod list — the
   balance shortfall only surfaces when an `Acquire` runs.
 - You must upload your ED25519 public key to RunPod once before any pod
   bootstrap will accept your SSH session.
 - The pod's public port for SSH is allocated at runtime and changes between
   pods; never hard-code `--ssh-port`.
+- RunPod's basic SSH proxy is not a Crabbox transport because rsync needs
+  SCP/SFTP support.
 - `--class` and `--type` are rejected for this provider; use
   `--runpod-instance-id` and `--runpod-image` instead.
 - `--tailscale` is rejected; RunPod pods expose only public SSH.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -246,7 +246,7 @@ Environment:
   CRABBOX_ACCESS_CLIENT_ID     Cloudflare Access service token client ID
   CRABBOX_ACCESS_CLIENT_SECRET Cloudflare Access service token client secret
   CRABBOX_ACCESS_TOKEN         Cloudflare Access JWT for protected routes
-  CRABBOX_PROVIDER             hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, or cloudflare
+  CRABBOX_PROVIDER             hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, runpod, or cloudflare
   CRABBOX_TARGET               linux, macos, or windows
   CRABBOX_WINDOWS_MODE         normal or wsl2
   CRABBOX_DESKTOP              Provision or require desktop/VNC capability

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -162,6 +162,23 @@ func TestResolveLeaseClaimForProviderSkipsSlugCollision(t *testing.T) {
 	}
 }
 
+func TestResolveLeaseClaimForProviderFallsBackToUnscopedLookup(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if err := claimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveLeaseClaimForProvider("blue-lobster", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || claim.LeaseID != "tbx_abc123" {
+		t.Fatalf("unexpected unscoped claim ok=%t claim=%#v", ok, claim)
+	}
+	if claim, ok, err := resolveLeaseClaimForProvider("blue-lobster", "runpod"); err != nil || ok || claim.LeaseID != "" {
+		t.Fatalf("provider mismatch resolved ok=%t claim=%#v err=%v", ok, claim, err)
+	}
+}
+
 func TestResolveLeaseClaimFallbacks(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	if claim, ok, err := resolveLeaseClaim(""); err != nil || ok || claim.LeaseID != "" {
@@ -191,5 +208,26 @@ func TestResolveLeaseClaimFallbacks(t *testing.T) {
 	}
 	if claim, ok, err := resolveLeaseClaim("not-blue-lobster"); err != nil || ok || claim.LeaseID != "" {
 		t.Fatalf("unmatched slug resolved ok=%t claim=%#v err=%v", ok, claim, err)
+	}
+}
+
+func TestClaimStateDirFallbackAndMissingClaim(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	dir, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(dir, home) || filepath.Base(dir) != "state" {
+		t.Fatalf("state dir=%q should live under home %q and end in state", dir, home)
+	}
+	claim, err := readLeaseClaim("cbx_missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID != "" {
+		t.Fatalf("missing claim=%#v", claim)
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	E2B                 E2BConfig
 	ExeDev              ExeDevConfig
 	Railway             RailwayConfig
+	Runpod              RunpodConfig
 	Islo                IsloConfig
 	Tensorlake          TensorlakeConfig
 	Modal               ModalConfig
@@ -206,6 +207,18 @@ type RailwayConfig struct {
 	APIURL        string
 	ProjectID     string
 	EnvironmentID string
+}
+
+type RunpodConfig struct {
+	APIKey     string
+	APIURL     string
+	CloudType  string
+	InstanceID string
+	Image      string
+	TemplateID string
+	DiskGB     int
+	User       string
+	WorkRoot   string
 }
 
 type IsloConfig struct {
@@ -551,6 +564,13 @@ func baseConfig() Config {
 		Railway: RailwayConfig{
 			APIURL: "https://backboard.railway.com/graphql/v2",
 		},
+		Runpod: RunpodConfig{
+			APIURL:     "https://api.runpod.io/graphql",
+			CloudType:  "ALL",
+			InstanceID: "cpu3c-2-4",
+			Image:      "runpod/base:0.6.2",
+			DiskGB:     10,
+		},
 		Islo: IsloConfig{
 			BaseURL:  "https://api.islo.dev",
 			Image:    "docker.io/library/ubuntu:24.04",
@@ -633,6 +653,7 @@ type fileConfig struct {
 	E2B              *fileE2BConfig                     `yaml:"e2b,omitempty"`
 	ExeDev           *fileExeDevConfig                  `yaml:"exeDev,omitempty"`
 	Railway          *fileRailwayConfig                 `yaml:"railway,omitempty"`
+	Runpod           *fileRunpodConfig                  `yaml:"runpod,omitempty"`
 	Islo             *fileIsloConfig                    `yaml:"islo,omitempty"`
 	Tensorlake       *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
 	Modal            *fileModalConfig                   `yaml:"modal,omitempty"`
@@ -835,6 +856,17 @@ type fileRailwayConfig struct {
 	APIURL        string `yaml:"apiUrl,omitempty"`
 	ProjectID     string `yaml:"projectId,omitempty"`
 	EnvironmentID string `yaml:"environmentId,omitempty"`
+}
+
+type fileRunpodConfig struct {
+	APIURL     string `yaml:"apiUrl,omitempty"`
+	CloudType  string `yaml:"cloudType,omitempty"`
+	InstanceID string `yaml:"instanceId,omitempty"`
+	Image      string `yaml:"image,omitempty"`
+	TemplateID string `yaml:"templateId,omitempty"`
+	DiskGB     int    `yaml:"diskGB,omitempty"`
+	User       string `yaml:"user,omitempty"`
+	WorkRoot   string `yaml:"workRoot,omitempty"`
 }
 
 type fileIsloConfig struct {
@@ -1642,6 +1674,32 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.Railway.EnvironmentID = file.Railway.EnvironmentID
 		}
 	}
+	if file.Runpod != nil {
+		if file.Runpod.APIURL != "" {
+			cfg.Runpod.APIURL = file.Runpod.APIURL
+		}
+		if file.Runpod.CloudType != "" {
+			cfg.Runpod.CloudType = file.Runpod.CloudType
+		}
+		if file.Runpod.InstanceID != "" {
+			cfg.Runpod.InstanceID = file.Runpod.InstanceID
+		}
+		if file.Runpod.Image != "" {
+			cfg.Runpod.Image = file.Runpod.Image
+		}
+		if file.Runpod.TemplateID != "" {
+			cfg.Runpod.TemplateID = file.Runpod.TemplateID
+		}
+		if file.Runpod.DiskGB != 0 {
+			cfg.Runpod.DiskGB = file.Runpod.DiskGB
+		}
+		if file.Runpod.User != "" {
+			cfg.Runpod.User = file.Runpod.User
+		}
+		if file.Runpod.WorkRoot != "" {
+			cfg.Runpod.WorkRoot = file.Runpod.WorkRoot
+		}
+	}
 	if file.Islo != nil {
 		if file.Islo.BaseURL != "" {
 			cfg.Islo.BaseURL = file.Islo.BaseURL
@@ -2295,6 +2353,15 @@ func applyEnv(cfg *Config) {
 	cfg.Railway.APIURL = getenv("CRABBOX_RAILWAY_API_URL", getenv("RAILWAY_API_URL", cfg.Railway.APIURL))
 	cfg.Railway.ProjectID = getenv("CRABBOX_RAILWAY_PROJECT_ID", getenv("RAILWAY_PROJECT_ID", cfg.Railway.ProjectID))
 	cfg.Railway.EnvironmentID = getenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", getenv("RAILWAY_ENVIRONMENT_ID", cfg.Railway.EnvironmentID))
+	cfg.Runpod.APIKey = getenv("CRABBOX_RUNPOD_API_KEY", getenv("RUNPOD_API_KEY", cfg.Runpod.APIKey))
+	cfg.Runpod.APIURL = getenv("CRABBOX_RUNPOD_API_URL", getenv("RUNPOD_API_URL", cfg.Runpod.APIURL))
+	cfg.Runpod.CloudType = getenv("CRABBOX_RUNPOD_CLOUD_TYPE", getenv("RUNPOD_CLOUD_TYPE", cfg.Runpod.CloudType))
+	cfg.Runpod.InstanceID = getenv("CRABBOX_RUNPOD_INSTANCE_ID", getenv("RUNPOD_INSTANCE_ID", cfg.Runpod.InstanceID))
+	cfg.Runpod.Image = getenv("CRABBOX_RUNPOD_IMAGE", getenv("RUNPOD_IMAGE", cfg.Runpod.Image))
+	cfg.Runpod.TemplateID = getenv("CRABBOX_RUNPOD_TEMPLATE_ID", getenv("RUNPOD_TEMPLATE_ID", cfg.Runpod.TemplateID))
+	cfg.Runpod.DiskGB = getenvInt("CRABBOX_RUNPOD_DISK_GB", cfg.Runpod.DiskGB)
+	cfg.Runpod.User = getenv("CRABBOX_RUNPOD_USER", cfg.Runpod.User)
+	cfg.Runpod.WorkRoot = getenv("CRABBOX_RUNPOD_WORK_ROOT", cfg.Runpod.WorkRoot)
 	cfg.Islo.APIKey = getenv("CRABBOX_ISLO_API_KEY", getenv("ISLO_API_KEY", cfg.Islo.APIKey))
 	cfg.Islo.BaseURL = getenv("CRABBOX_ISLO_BASE_URL", getenv("ISLO_BASE_URL", cfg.Islo.BaseURL))
 	cfg.Islo.Image = getenv("CRABBOX_ISLO_IMAGE", cfg.Islo.Image)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -565,11 +565,11 @@ func baseConfig() Config {
 			APIURL: "https://backboard.railway.com/graphql/v2",
 		},
 		Runpod: RunpodConfig{
-			APIURL:     "https://api.runpod.io/graphql",
-			CloudType:  "ALL",
-			InstanceID: "cpu3c-2-4",
-			Image:      "runpod/base:0.6.2",
-			DiskGB:     10,
+			APIURL:     "https://rest.runpod.io/v1",
+			CloudType:  "SECURE",
+			InstanceID: "NVIDIA L4,NVIDIA RTX 4000 Ada Generation,NVIDIA RTX A4000,NVIDIA GeForce RTX 3090,NVIDIA GeForce RTX 4090,NVIDIA RTX A5000,NVIDIA RTX A4500",
+			Image:      "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
+			DiskGB:     20,
 		},
 		Islo: IsloConfig{
 			BaseURL:  "https://api.islo.dev",

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1157,6 +1157,45 @@ func TestConfigHelperBranches(t *testing.T) {
 	}
 }
 
+func TestConfigHelperErrorBranches(t *testing.T) {
+	t.Run("unavailable user config dir", func(t *testing.T) {
+		t.Setenv("CRABBOX_CONFIG", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+		t.Setenv("HOME", "")
+		if _, err := writeUserFileConfig(fileConfig{Profile: "missing-home"}); err == nil {
+			t.Fatal("expected unavailable user config dir error")
+		}
+	})
+
+	t.Run("config parent is file", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "not-dir")
+		if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CRABBOX_CONFIG", filepath.Join(parent, "config.yaml"))
+		if _, err := writeUserFileConfig(fileConfig{Profile: "mkdir-fails"}); err == nil {
+			t.Fatal("expected config directory create error")
+		}
+	})
+
+	t.Run("config path is directory", func(t *testing.T) {
+		path := t.TempDir()
+		t.Setenv("CRABBOX_CONFIG", path)
+		if _, err := writeUserFileConfig(fileConfig{Profile: "write-fails"}); err == nil {
+			t.Fatal("expected config write error")
+		}
+	})
+}
+
+func TestWindowsWSLWorkRoot(t *testing.T) {
+	if got := windowsWSLWorkRoot(Config{}); got != defaultPOSIXWorkRoot {
+		t.Fatalf("windowsWSLWorkRoot default=%q want %q", got, defaultPOSIXWorkRoot)
+	}
+	if got := windowsWSLWorkRoot(Config{WorkRoot: "/work/custom"}); got != "/work/custom" {
+		t.Fatalf("windowsWSLWorkRoot custom=%q", got)
+	}
+}
+
 func TestEnvHelperBranches(t *testing.T) {
 	t.Setenv("CRABBOX_INT", "42")
 	t.Setenv("CRABBOX_BAD_INT", "oops")

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -324,6 +324,15 @@ railway:
   apiUrl: https://railway.example.test/graphql/v2
   projectId: project-file
   environmentId: environment-file
+runpod:
+  apiUrl: https://runpod.example.test/graphql
+  cloudType: SECURE
+  instanceId: cpu5c-2-4
+  image: runpod/base:custom
+  templateId: tpl-file
+  diskGB: 25
+  user: runpod-user
+  workRoot: /workspaces/runpod-test
 islo:
   baseUrl: https://islo.example.test
   image: docker.io/library/ubuntu:24.04
@@ -482,6 +491,9 @@ ssh:
 	}
 	if cfg.Railway.APIURL != "https://railway.example.test/graphql/v2" || cfg.Railway.ProjectID != "project-file" || cfg.Railway.EnvironmentID != "environment-file" {
 		t.Fatalf("railway config not loaded: %#v", cfg.Railway)
+	}
+	if cfg.Runpod.APIURL != "https://runpod.example.test/graphql" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "cpu5c-2-4" || cfg.Runpod.Image != "runpod/base:custom" || cfg.Runpod.TemplateID != "tpl-file" || cfg.Runpod.DiskGB != 25 || cfg.Runpod.User != "runpod-user" || cfg.Runpod.WorkRoot != "/workspaces/runpod-test" {
+		t.Fatalf("runpod config not loaded: %#v", cfg.Runpod)
 	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
 		t.Fatalf("islo config not loaded: %#v", cfg.Islo)
@@ -668,6 +680,21 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_RAILWAY_PROJECT_ID", "railway-project-env")
 	t.Setenv("RAILWAY_ENVIRONMENT_ID", "railway-environment-file")
 	t.Setenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", "railway-environment-env")
+	t.Setenv("RUNPOD_API_KEY", "runpod-key-file")
+	t.Setenv("CRABBOX_RUNPOD_API_KEY", "runpod-key-env")
+	t.Setenv("RUNPOD_API_URL", "https://runpod-file.example/graphql")
+	t.Setenv("CRABBOX_RUNPOD_API_URL", "https://runpod-env.example/graphql")
+	t.Setenv("RUNPOD_CLOUD_TYPE", "COMMUNITY")
+	t.Setenv("CRABBOX_RUNPOD_CLOUD_TYPE", "SECURE")
+	t.Setenv("RUNPOD_INSTANCE_ID", "cpu3g-2-4")
+	t.Setenv("CRABBOX_RUNPOD_INSTANCE_ID", "cpu5m-2-4")
+	t.Setenv("RUNPOD_IMAGE", "runpod/base:file")
+	t.Setenv("CRABBOX_RUNPOD_IMAGE", "runpod/base:env")
+	t.Setenv("RUNPOD_TEMPLATE_ID", "tpl-file")
+	t.Setenv("CRABBOX_RUNPOD_TEMPLATE_ID", "tpl-env")
+	t.Setenv("CRABBOX_RUNPOD_DISK_GB", "30")
+	t.Setenv("CRABBOX_RUNPOD_USER", "runpod-env-user")
+	t.Setenv("CRABBOX_RUNPOD_WORK_ROOT", "/work/runpod-env")
 	t.Setenv("ISLO_API_KEY", "islo-api-file")
 	t.Setenv("CRABBOX_ISLO_API_KEY", "islo-api-env")
 	t.Setenv("ISLO_BASE_URL", "https://islo-file.example")
@@ -823,6 +850,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Railway.APIToken != "railway-token-env" || cfg.Railway.APIURL != "https://railway-env.example/graphql/v2" || cfg.Railway.ProjectID != "railway-project-env" || cfg.Railway.EnvironmentID != "railway-environment-env" {
 		t.Fatalf("unexpected railway env: %#v", cfg.Railway)
+	}
+	if cfg.Runpod.APIKey != "runpod-key-env" || cfg.Runpod.APIURL != "https://runpod-env.example/graphql" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "cpu5m-2-4" || cfg.Runpod.Image != "runpod/base:env" || cfg.Runpod.TemplateID != "tpl-env" || cfg.Runpod.DiskGB != 30 || cfg.Runpod.User != "runpod-env-user" || cfg.Runpod.WorkRoot != "/work/runpod-env" {
+		t.Fatalf("unexpected runpod env: %#v", cfg.Runpod)
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {
 		t.Fatalf("unexpected islo env: %#v", cfg.Islo)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1216,6 +1216,17 @@ func TestEnvHelperBranches(t *testing.T) {
 	if got := getenvInt32("CRABBOX_INT32_OVERFLOW", 7); got != 7 {
 		t.Fatalf("overflow int32 fallback=%d", got)
 	}
+	t.Setenv("CRABBOX_FLOAT", "1.5")
+	t.Setenv("CRABBOX_BAD_FLOAT", "oops")
+	if got := getenvFloat("CRABBOX_FLOAT", 7); got != 1.5 {
+		t.Fatalf("float=%f", got)
+	}
+	if got := getenvFloat("CRABBOX_BAD_FLOAT", 7); got != 7 {
+		t.Fatalf("bad float fallback=%f", got)
+	}
+	if got := getenvFloat("CRABBOX_MISSING_FLOAT", 7); got != 7 {
+		t.Fatalf("missing float fallback=%f", got)
+	}
 
 	for _, tc := range []struct {
 		name  string
@@ -1244,6 +1255,16 @@ func TestEnvHelperBranches(t *testing.T) {
 	t.Setenv("CRABBOX_LIST", "CI,NODE_OPTIONS")
 	if list, ok := getenvList("CRABBOX_LIST"); !ok || len(list) != 2 || list[1] != "NODE_OPTIONS" {
 		t.Fatalf("getenvList=%v ok=%t", list, ok)
+	}
+}
+
+func TestFileProfileEnvConfigUnmarshalRejectsNonMapping(t *testing.T) {
+	var cfg struct {
+		Env fileProfileEnvConfig `yaml:"env"`
+	}
+	err := yaml.Unmarshal([]byte("env: []\n"), &cfg)
+	if err == nil || !strings.Contains(err.Error(), "profile env must be a mapping") {
+		t.Fatalf("err=%v", err)
 	}
 }
 
@@ -1301,6 +1322,97 @@ func TestNamespaceDevboxSizeForConfig(t *testing.T) {
 				t.Fatalf("size=%q want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestConfigServerTypeHelperBranches(t *testing.T) {
+	if got := proxmoxServerTypeForConfig(Config{}); got != "template" {
+		t.Fatalf("proxmox default=%q", got)
+	}
+	if got := proxmoxServerTypeForConfig(Config{Proxmox: ProxmoxConfig{TemplateID: 9000}}); got != "template-9000" {
+		t.Fatalf("proxmox template=%q", got)
+	}
+	for _, tc := range []struct {
+		class string
+		want  string
+	}{
+		{class: "standard", want: "S"},
+		{class: "fast", want: "M"},
+		{class: "beast", want: "XL"},
+	} {
+		if got := namespaceDevboxSizeForClass(tc.class); got != tc.want {
+			t.Fatalf("namespaceDevboxSizeForClass(%q)=%q want %q", tc.class, got, tc.want)
+		}
+	}
+}
+
+func TestApplyFileConfigCloudProviderBranches(t *testing.T) {
+	enabled := true
+	disabled := false
+	cfg := Config{}
+	applyFileConfig(&cfg, fileConfig{
+		TargetOS:         targetLinux,
+		Desktop:          &enabled,
+		Browser:          &disabled,
+		Code:             &enabled,
+		ServerType:       "custom-type",
+		CoordinatorToken: "coord-token",
+		HostID:           "",
+		Broker: &fileBrokerConfig{
+			Provider: "aws",
+			Access:   &fileAccessConfig{ClientID: "access-id", ClientSecret: "access-secret", Token: "access-token"},
+		},
+		Hetzner: &fileHetznerConfig{Location: "fsn1", Image: "ubuntu-24.04", SSHKey: "hetzner-key"},
+		AWS: &fileAWSConfig{
+			Region:          "eu-central-1",
+			AMI:             "ami-test",
+			SecurityGroupID: "sg-test",
+			SubnetID:        "subnet-test",
+			InstanceProfile: "profile-test",
+			RootGB:          123,
+			SSHCIDRs:        []string{"198.51.100.1/32"},
+			MacHostID:       "h-mac",
+		},
+		Azure: &fileAzureConfig{
+			SubscriptionID: "sub",
+			TenantID:       "tenant",
+			ClientID:       "client",
+			Location:       "westeurope",
+			ResourceGroup:  "rg",
+			Image:          "ubuntu",
+			OSDisk:         "ephemeral",
+			VNet:           "vnet",
+			Subnet:         "subnet",
+			NSG:            "nsg",
+			SSHCIDRs:       []string{"198.51.100.2/32"},
+			Network:        "public",
+		},
+		GCP: &fileGCPConfig{
+			Project:        "project",
+			Zone:           "europe-west1-b",
+			Image:          "ubuntu",
+			Network:        "net",
+			Subnet:         "subnet",
+			Tags:           []string{"crabbox"},
+			SSHCIDRs:       []string{"198.51.100.3/32"},
+			RootGB:         456,
+			ServiceAccount: "runner@example.iam.gserviceaccount.com",
+		},
+	})
+	if !cfg.Desktop || cfg.Browser || !cfg.Code || cfg.TargetOS != targetLinux || cfg.ServerType != "custom-type" {
+		t.Fatalf("top-level config not applied: %#v", cfg)
+	}
+	if cfg.Provider != "aws" || cfg.Access.ClientID != "access-id" || cfg.CoordToken != "coord-token" {
+		t.Fatalf("broker/access config not applied: provider=%s access=%#v token=%s", cfg.Provider, cfg.Access, cfg.CoordToken)
+	}
+	if cfg.Location != "fsn1" || cfg.ProviderKey != "hetzner-key" || cfg.HostID != "h-mac" || cfg.AWSRootGB != 123 {
+		t.Fatalf("hetzner/aws config not applied: location=%s key=%s host=%s root=%d", cfg.Location, cfg.ProviderKey, cfg.HostID, cfg.AWSRootGB)
+	}
+	if cfg.AzureOSDisk != "ephemeral" || !cfg.AzureOSDiskExplicit || cfg.AzureNetwork != "public" {
+		t.Fatalf("azure config not applied: %#v", cfg)
+	}
+	if cfg.GCPProject != "project" || !cfg.gcpProjectExplicit || cfg.GCPRootGB != 456 || cfg.GCPServiceAccount == "" {
+		t.Fatalf("gcp config not applied: %#v", cfg)
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -325,10 +325,10 @@ railway:
   projectId: project-file
   environmentId: environment-file
 runpod:
-  apiUrl: https://runpod.example.test/graphql
+  apiUrl: https://runpod.example.test/v1
   cloudType: SECURE
-  instanceId: cpu5c-2-4
-  image: runpod/base:custom
+  instanceId: NVIDIA L4
+  image: runpod/pytorch:custom
   templateId: tpl-file
   diskGB: 25
   user: runpod-user
@@ -492,7 +492,7 @@ ssh:
 	if cfg.Railway.APIURL != "https://railway.example.test/graphql/v2" || cfg.Railway.ProjectID != "project-file" || cfg.Railway.EnvironmentID != "environment-file" {
 		t.Fatalf("railway config not loaded: %#v", cfg.Railway)
 	}
-	if cfg.Runpod.APIURL != "https://runpod.example.test/graphql" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "cpu5c-2-4" || cfg.Runpod.Image != "runpod/base:custom" || cfg.Runpod.TemplateID != "tpl-file" || cfg.Runpod.DiskGB != 25 || cfg.Runpod.User != "runpod-user" || cfg.Runpod.WorkRoot != "/workspaces/runpod-test" {
+	if cfg.Runpod.APIURL != "https://runpod.example.test/v1" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "NVIDIA L4" || cfg.Runpod.Image != "runpod/pytorch:custom" || cfg.Runpod.TemplateID != "tpl-file" || cfg.Runpod.DiskGB != 25 || cfg.Runpod.User != "runpod-user" || cfg.Runpod.WorkRoot != "/workspaces/runpod-test" {
 		t.Fatalf("runpod config not loaded: %#v", cfg.Runpod)
 	}
 	if cfg.Islo.BaseURL != "https://islo.example.test" || cfg.Islo.Image != "docker.io/library/ubuntu:24.04" || cfg.Islo.Workdir != "crabbox" || cfg.Islo.GatewayProfile != "default" || cfg.Islo.SnapshotName != "snap-ready" || cfg.Islo.VCPUs != 4 || cfg.Islo.MemoryMB != 8192 || cfg.Islo.DiskGB != 40 {
@@ -682,14 +682,14 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", "railway-environment-env")
 	t.Setenv("RUNPOD_API_KEY", "runpod-key-file")
 	t.Setenv("CRABBOX_RUNPOD_API_KEY", "runpod-key-env")
-	t.Setenv("RUNPOD_API_URL", "https://runpod-file.example/graphql")
-	t.Setenv("CRABBOX_RUNPOD_API_URL", "https://runpod-env.example/graphql")
+	t.Setenv("RUNPOD_API_URL", "https://runpod-file.example/v1")
+	t.Setenv("CRABBOX_RUNPOD_API_URL", "https://runpod-env.example/v1")
 	t.Setenv("RUNPOD_CLOUD_TYPE", "COMMUNITY")
 	t.Setenv("CRABBOX_RUNPOD_CLOUD_TYPE", "SECURE")
-	t.Setenv("RUNPOD_INSTANCE_ID", "cpu3g-2-4")
-	t.Setenv("CRABBOX_RUNPOD_INSTANCE_ID", "cpu5m-2-4")
-	t.Setenv("RUNPOD_IMAGE", "runpod/base:file")
-	t.Setenv("CRABBOX_RUNPOD_IMAGE", "runpod/base:env")
+	t.Setenv("RUNPOD_INSTANCE_ID", "NVIDIA RTX A4000")
+	t.Setenv("CRABBOX_RUNPOD_INSTANCE_ID", "NVIDIA L4")
+	t.Setenv("RUNPOD_IMAGE", "runpod/pytorch:file")
+	t.Setenv("CRABBOX_RUNPOD_IMAGE", "runpod/pytorch:env")
 	t.Setenv("RUNPOD_TEMPLATE_ID", "tpl-file")
 	t.Setenv("CRABBOX_RUNPOD_TEMPLATE_ID", "tpl-env")
 	t.Setenv("CRABBOX_RUNPOD_DISK_GB", "30")
@@ -851,7 +851,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	if cfg.Railway.APIToken != "railway-token-env" || cfg.Railway.APIURL != "https://railway-env.example/graphql/v2" || cfg.Railway.ProjectID != "railway-project-env" || cfg.Railway.EnvironmentID != "railway-environment-env" {
 		t.Fatalf("unexpected railway env: %#v", cfg.Railway)
 	}
-	if cfg.Runpod.APIKey != "runpod-key-env" || cfg.Runpod.APIURL != "https://runpod-env.example/graphql" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "cpu5m-2-4" || cfg.Runpod.Image != "runpod/base:env" || cfg.Runpod.TemplateID != "tpl-env" || cfg.Runpod.DiskGB != 30 || cfg.Runpod.User != "runpod-env-user" || cfg.Runpod.WorkRoot != "/work/runpod-env" {
+	if cfg.Runpod.APIKey != "runpod-key-env" || cfg.Runpod.APIURL != "https://runpod-env.example/v1" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "NVIDIA L4" || cfg.Runpod.Image != "runpod/pytorch:env" || cfg.Runpod.TemplateID != "tpl-env" || cfg.Runpod.DiskGB != 30 || cfg.Runpod.User != "runpod-env-user" || cfg.Runpod.WorkRoot != "/work/runpod-env" {
 		t.Fatalf("unexpected runpod env: %#v", cfg.Runpod)
 	}
 	if cfg.Islo.APIKey != "islo-api-env" || cfg.Islo.BaseURL != "https://islo-env.example" || cfg.Islo.Image != "ubuntu:env" || cfg.Islo.Workdir != "env-workdir" || cfg.Islo.GatewayProfile != "env-gateway" || cfg.Islo.SnapshotName != "env-snapshot" || cfg.Islo.VCPUs != 8 || cfg.Islo.MemoryMB != 16384 || cfg.Islo.DiskGB != 80 {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -69,6 +69,39 @@ func TestInitProjectWritesExpectedFiles(t *testing.T) {
 	}
 }
 
+func TestWriteInitFileBranches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "file.txt")
+	if err := writeInitFile(path, "first", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeInitFile(path, "second", false); err == nil {
+		t.Fatal("expected existing file error")
+	}
+	if err := writeInitFile(path, "second", true); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "second" {
+		t.Fatalf("content=%q", data)
+	}
+
+	parent := filepath.Join(t.TempDir(), "not-dir")
+	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeInitFile(filepath.Join(parent, "file.txt"), "x", false); err == nil {
+		t.Fatal("expected create directory error")
+	}
+
+	dirPath := t.TempDir()
+	if err := writeInitFile(dirPath, "x", true); err == nil {
+		t.Fatal("expected write directory error")
+	}
+}
+
 func TestSubcommandHelpExitsZero(t *testing.T) {
 	var stderr bytes.Buffer
 	app := App{Stdout: &bytes.Buffer{}, Stderr: &stderr}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -382,7 +382,7 @@ func normalizeProviderName(name string) string {
 }
 
 func providerHelpAll() string {
-	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, railway, or cloudflare"
+	return "provider: hetzner, aws, azure, gcp, proxmox, ssh, exe-dev, blacksmith-testbox, namespace-devbox, semaphore, daytona, islo, e2b, modal, sprites, railway, runpod, or cloudflare"
 }
 
 func providerHelpSSH() string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -296,6 +296,10 @@ func runSSHQuiet(ctx context.Context, target SSHTarget, remote string) error {
 	return runSSHQuietWithOptions(ctx, target, remote, "10", "3")
 }
 
+func RunSSHQuiet(ctx context.Context, target SSHTarget, remote string) error {
+	return runSSHQuiet(ctx, target, remote)
+}
+
 func runSSHQuietWithOptions(ctx context.Context, target SSHTarget, remote, connectTimeout, connectionAttempts string) error {
 	remote = wrapRemoteForTarget(target, remote)
 	var lastErr error

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
 	_ "github.com/openclaw/crabbox/internal/providers/railway"
+	_ "github.com/openclaw/crabbox/internal/providers/runpod"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -22,6 +22,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"namespace-devbox",
 		"proxmox",
 		"railway",
+		"runpod",
 		"semaphore",
 		"sprites",
 		"ssh",

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -1,0 +1,489 @@
+package runpod
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Polling configuration for waiting on a freshly deployed pod to expose its
+// public SSH port. RunPod typically reports runtime.ports within tens of
+// seconds for CPU pods; cap at 10 minutes to stay well under bootstrap
+// timeouts while leaving slack for cold scheduler regions.
+const (
+	runpodSSHPollInitial = 3 * time.Second
+	runpodSSHPollMax     = 15 * time.Second
+	runpodSSHPollTimeout = 10 * time.Minute
+	runpodPollJitter     = 0.2
+)
+
+var (
+	runpodPollRandOnce sync.Once
+	runpodPollRand     *rand.Rand
+	runpodPollRandMu   sync.Mutex
+)
+
+func runpodJitter(d time.Duration) time.Duration {
+	runpodPollRandOnce.Do(func() {
+		runpodPollRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	})
+	runpodPollRandMu.Lock()
+	defer runpodPollRandMu.Unlock()
+	delta := (runpodPollRand.Float64()*2 - 1) * runpodPollJitter
+	jittered := time.Duration(float64(d) * (1 + delta))
+	if jittered <= 0 {
+		return d
+	}
+	return jittered
+}
+
+type runpodLeaseBackend struct {
+	spec   ProviderSpec
+	cfg    Config
+	rt     Runtime
+	client runpodAPI
+
+	pollInitialOverride time.Duration
+	pollTimeoutOverride time.Duration
+}
+
+func NewRunpodLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	applyRunpodDefaults(&cfg)
+	return &runpodLeaseBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *runpodLeaseBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	client, err := b.api()
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	leaseID := newLeaseID()
+	cfg := b.configForRun()
+	servers, err := b.listServersFromClient(ctx, client, true)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	name := leaseProviderName(leaseID, slug)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s instance=%s disk=%dGB keep=%v\n",
+		providerName, leaseID, slug, name, cfg.Runpod.Image, cfg.Runpod.InstanceID, cfg.Runpod.DiskGB, req.Keep)
+
+	pod, err := client.DeployCpuPod(ctx, runpodDeployInput{
+		Name:              name,
+		ImageName:         cfg.Runpod.Image,
+		InstanceID:        cfg.Runpod.InstanceID,
+		CloudType:         cfg.Runpod.CloudType,
+		TemplateID:        cfg.Runpod.TemplateID,
+		ContainerDiskInGb: cfg.Runpod.DiskGB,
+		Ports:             "22/tcp",
+		StartSSH:          true,
+	})
+	if err != nil {
+		return LeaseTarget{}, exit(1, "runpod deployCpuPod failed: %v", err)
+	}
+
+	ready, err := b.waitForPodSSH(ctx, client, pod.ID)
+	if err != nil {
+		if !req.Keep {
+			_ = client.TerminatePod(context.Background(), pod.ID)
+		}
+		return LeaseTarget{}, err
+	}
+
+	lease, err := b.prepareLease(ctx, cfg, ready, leaseID, slug, req.Keep, true)
+	if err != nil {
+		if !req.Keep {
+			_ = client.TerminatePod(context.Background(), pod.ID)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			_ = client.TerminatePod(context.Background(), pod.ID)
+		}
+		return LeaseTarget{}, err
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s pod=%s state=ready\n", leaseID, pod.ID)
+	return lease, nil
+}
+
+func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	cfg := b.configForRun()
+	client, err := b.api()
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	pod, leaseID, slug, err := b.resolvePod(ctx, client, req.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.ReleaseOnly {
+		return LeaseTarget{Server: runpodServer(pod, leaseID, slug, cfg, true), LeaseID: leaseID}, nil
+	}
+	lease, err := b.prepareLease(ctx, cfg, pod, leaseID, slug, true, false)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" {
+		if err := claimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *runpodLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	client, err := b.api()
+	if err != nil {
+		return nil, err
+	}
+	return b.listServersFromClient(ctx, client, req.All)
+}
+
+func (b *runpodLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	// Doctor performs a read-only auth verification that never creates a pod.
+	// Surface clearer messaging than the generic newRunpodClient error so the
+	// missing-key case is obvious without staring at a stack trace.
+	if strings.TrimSpace(b.cfg.Runpod.APIKey) == "" {
+		return DoctorResult{}, exit(2, "provider=%s requires RUNPOD_API_KEY (CRABBOX_RUNPOD_API_KEY also accepted)", providerName)
+	}
+	client, err := b.api()
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	if _, err := client.Whoami(ctx); err != nil {
+		return DoctorResult{}, exit(1, "runpod auth check failed: %v", err)
+	}
+	pods, err := client.ListPods(ctx)
+	if err != nil {
+		return DoctorResult{}, exit(1, "runpod list pods failed: %v", err)
+	}
+	return inventoryDoctorResult(providerName, len(pods)), nil
+}
+
+func (b *runpodLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	client, err := b.api()
+	if err != nil {
+		return err
+	}
+	podID := strings.TrimSpace(req.Lease.Server.CloudID)
+	if podID == "" {
+		// Fall back to a fresh resolve so release works against legacy lease
+		// records that only carry the lease id.
+		pod, _, _, err := b.resolvePod(ctx, client, req.Lease.LeaseID)
+		if err != nil {
+			return err
+		}
+		podID = pod.ID
+	}
+	if podID == "" {
+		return exit(2, "provider=%s release requires a pod id", providerName)
+	}
+	if err := client.TerminatePod(ctx, podID); err != nil {
+		return exit(1, "runpod terminate pod %s failed: %v", podID, err)
+	}
+	removeLeaseClaim(req.Lease.LeaseID)
+	return nil
+}
+
+func (b *runpodLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	server.Labels = touchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	return server, nil
+}
+
+func (b *runpodLeaseBackend) api() (runpodAPI, error) {
+	if b.client != nil {
+		return b.client, nil
+	}
+	return newRunpodClient(b.cfg, b.rt)
+}
+
+func (b *runpodLeaseBackend) configForRun() Config {
+	cfg := b.cfg
+	applyRunpodDefaults(&cfg)
+	return cfg
+}
+
+func applyRunpodDefaults(cfg *Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetLinux
+	}
+	if cfg.Runpod.APIURL == "" {
+		cfg.Runpod.APIURL = "https://api.runpod.io/graphql"
+	}
+	if cfg.Runpod.CloudType == "" {
+		cfg.Runpod.CloudType = "ALL"
+	}
+	if cfg.Runpod.InstanceID == "" {
+		// Cheapest documented CPU flavor at the time of writing: cpu3c
+		// (compute-optimized) with 2 vCPU and 4 GB RAM. Documented in
+		// docs/providers/runpod.md so callers can override knowingly.
+		cfg.Runpod.InstanceID = "cpu3c-2-4"
+	}
+	if cfg.Runpod.Image == "" {
+		cfg.Runpod.Image = "runpod/base:0.6.2"
+	}
+	if cfg.Runpod.DiskGB <= 0 {
+		cfg.Runpod.DiskGB = 10
+	}
+	if cfg.Runpod.WorkRoot == "" {
+		if !isDefaultWorkRoot(cfg.WorkRoot) {
+			cfg.Runpod.WorkRoot = cfg.WorkRoot
+		} else {
+			cfg.Runpod.WorkRoot = "/tmp/crabbox"
+		}
+	}
+	if cfg.Runpod.User != "" {
+		cfg.SSHUser = cfg.Runpod.User
+	} else if cfg.SSHUser == "" || cfg.SSHUser == "crabbox" {
+		cfg.SSHUser = blank(os.Getenv("USER"), "root")
+		// runpod pods always boot with root as the SSH user; if a generic env
+		// override hasn't kicked in, fall through to root.
+		if cfg.SSHUser == "" {
+			cfg.SSHUser = "root"
+		}
+	}
+	if cfg.Runpod.WorkRoot != "" {
+		cfg.WorkRoot = cfg.Runpod.WorkRoot
+	}
+	cfg.SSHPort = ""
+	cfg.SSHFallbackPorts = nil
+	cfg.ServerType = cfg.Runpod.InstanceID
+}
+
+func (b *runpodLeaseBackend) waitForPodSSH(ctx context.Context, client runpodAPI, podID string) (runpodPod, error) {
+	overall := runpodSSHPollTimeout
+	if b.pollTimeoutOverride > 0 {
+		overall = b.pollTimeoutOverride
+	}
+	initial := runpodSSHPollInitial
+	if b.pollInitialOverride > 0 {
+		initial = b.pollInitialOverride
+	}
+	deadlineCtx, cancel := context.WithTimeout(ctx, overall)
+	defer cancel()
+	interval := initial
+	for {
+		pod, err := client.GetPod(deadlineCtx, podID)
+		if err != nil {
+			if deadlineCtx.Err() != nil {
+				return runpodPod{}, fmt.Errorf("runpod pod %s ssh wait cancelled: %w", podID, deadlineCtx.Err())
+			}
+			return runpodPod{}, err
+		}
+		host, port := pod.SSHEndpoint()
+		if host != "" && port != 0 {
+			return pod, nil
+		}
+		sleepFor := runpodJitter(interval)
+		select {
+		case <-deadlineCtx.Done():
+			return runpodPod{}, fmt.Errorf("runpod pod %s ssh endpoint not exposed within %s", podID, overall)
+		case <-time.After(sleepFor):
+		}
+		if interval < runpodSSHPollMax {
+			interval *= 2
+			if interval > runpodSSHPollMax {
+				interval = runpodSSHPollMax
+			}
+		}
+	}
+}
+
+func (b *runpodLeaseBackend) prepareLease(ctx context.Context, cfg Config, pod runpodPod, leaseID, slug string, keep, wait bool) (LeaseTarget, error) {
+	server := runpodServer(pod, leaseID, slug, cfg, keep)
+	target := runpodSSHTarget(cfg, pod)
+	if wait {
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "runpod pod ssh", bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+		server.Status = "ready"
+		if server.Labels != nil {
+			server.Labels["state"] = "ready"
+		}
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *runpodLeaseBackend) resolvePod(ctx context.Context, client runpodAPI, identifier string) (runpodPod, string, string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return runpodPod{}, "", "", exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
+	}
+	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+		return runpodPod{}, "", "", err
+	} else if ok {
+		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		name := leaseProviderName(claim.LeaseID, slug)
+		pod, err := b.findPodByName(ctx, client, name)
+		return pod, claim.LeaseID, slug, err
+	}
+	if strings.HasPrefix(identifier, "cbx_") {
+		pod, ok, err := b.findPodByLeaseName(ctx, client, identifier)
+		if err != nil {
+			return runpodPod{}, "", "", err
+		}
+		if ok {
+			leaseID, slug := runpodLeaseIdentity(pod.Name)
+			return pod, leaseID, slug, nil
+		}
+		slug := newLeaseSlug(identifier)
+		pod, err = b.findPodByName(ctx, client, leaseProviderName(identifier, slug))
+		return pod, identifier, slug, err
+	}
+	// Identifier is treated as a raw RunPod pod ID first, then as a pod name
+	// fallback (pod ids are opaque short strings without dashes; pod names we
+	// own start with "crabbox-").
+	if pod, err := client.GetPod(ctx, identifier); err == nil {
+		leaseID, slug := runpodLeaseIdentity(pod.Name)
+		return pod, leaseID, slug, nil
+	}
+	pod, err := b.findPodByName(ctx, client, identifier)
+	if err != nil {
+		return runpodPod{}, "", "", err
+	}
+	leaseID, slug := runpodLeaseIdentity(pod.Name)
+	return pod, leaseID, slug, nil
+}
+
+func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI, name string) (runpodPod, error) {
+	pods, err := client.ListPods(ctx)
+	if err != nil {
+		return runpodPod{}, err
+	}
+	normalized := normalizeLeaseSlug(name)
+	for _, pod := range pods {
+		if pod.Name == name || normalizeLeaseSlug(pod.Name) == normalized || pod.ID == name {
+			return pod, nil
+		}
+	}
+	return runpodPod{}, exit(4, "runpod pod not found: %s", name)
+}
+
+func (b *runpodLeaseBackend) findPodByLeaseName(ctx context.Context, client runpodAPI, leaseID string) (runpodPod, bool, error) {
+	pods, err := client.ListPods(ctx)
+	if err != nil {
+		return runpodPod{}, false, err
+	}
+	for _, pod := range pods {
+		if id, _ := runpodLeaseIdentity(pod.Name); id == leaseID {
+			return pod, true, nil
+		}
+	}
+	return runpodPod{}, false, nil
+}
+
+func (b *runpodLeaseBackend) listServersFromClient(ctx context.Context, client runpodAPI, all bool) ([]LeaseView, error) {
+	pods, err := client.ListPods(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cfg := b.configForRun()
+	servers := make([]Server, 0, len(pods))
+	for _, pod := range pods {
+		if !all && !strings.HasPrefix(pod.Name, "crabbox-") {
+			continue
+		}
+		leaseID, slug := runpodLeaseIdentity(pod.Name)
+		servers = append(servers, runpodServer(pod, leaseID, slug, cfg, true))
+	}
+	return servers, nil
+}
+
+func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Server {
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	labels["name"] = pod.Name
+	state := pod.DesiredStatus
+	if state == "" {
+		state = "unknown"
+	}
+	labels["state"] = strings.ToLower(state)
+	labels["work_root"] = cfg.WorkRoot
+	labels["pod_id"] = pod.ID
+	if pod.MachineID != "" {
+		labels["machine_id"] = pod.MachineID
+	}
+	if pod.Machine.PodHostID != "" {
+		labels["pod_host_id"] = pod.Machine.PodHostID
+	}
+	host, port := pod.SSHEndpoint()
+	if host != "" {
+		labels["ssh_host"] = host
+	}
+	if port != 0 {
+		labels["ssh_port"] = strconv.Itoa(port)
+	}
+	server := Server{
+		CloudID:  pod.ID,
+		Provider: providerName,
+		Name:     pod.Name,
+		Status:   labels["state"],
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = host
+	server.ServerType.Name = cfg.Runpod.InstanceID
+	return server
+}
+
+func runpodSSHTarget(cfg Config, pod runpodPod) SSHTarget {
+	host, port := pod.SSHEndpoint()
+	target := sshTargetFromConfig(cfg, host)
+	if port != 0 {
+		target.Port = strconv.Itoa(port)
+	}
+	target.TargetOS = targetLinux
+	target.NetworkKind = networkPublic
+	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"
+	return target
+}
+
+// runpodLeaseIdentity infers the (leaseID, slug) pair from a pod name that
+// follows the leaseProviderName layout (crabbox-<slug>-<leaseSuffix>). For
+// pods we did not name we synthesize an identity so List/Resolve still work.
+func runpodLeaseIdentity(name string) (string, string) {
+	name = strings.TrimSpace(name)
+	const prefix = "crabbox-"
+	if !strings.HasPrefix(name, prefix) {
+		slug := normalizeLeaseSlug(blank(name, "manual"))
+		return "rpod_" + slug, slug
+	}
+	rest := strings.TrimPrefix(name, prefix)
+	idx := strings.LastIndex(rest, "-")
+	if idx <= 0 || idx == len(rest)-1 {
+		slug := normalizeLeaseSlug(rest)
+		return "rpod_" + slug, slug
+	}
+	hash := rest[idx+1:]
+	if len(hash) != 8 || !isLowerHex(hash) {
+		slug := normalizeLeaseSlug(rest)
+		return "rpod_" + slug, slug
+	}
+	slug := normalizeLeaseSlug(rest[:idx])
+	return "rpod_" + hash, slug
+}
+
+func isLowerHex(value string) bool {
+	for _, r := range value {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') {
+			continue
+		}
+		return false
+	}
+	return value != ""
+}

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Polling configuration for waiting on a freshly deployed pod to expose its
-// public SSH port. RunPod typically reports runtime.ports within tens of
-// seconds for CPU pods; cap at 10 minutes to stay well under bootstrap
-// timeouts while leaving slack for cold scheduler regions.
+// public SSH port. RunPod typically reports publicIp/portMappings within tens
+// of seconds; cap at 10 minutes to stay under bootstrap timeouts while leaving
+// slack for cold scheduler regions.
 const (
 	runpodSSHPollInitial = 3 * time.Second
 	runpodSSHPollMax     = 15 * time.Second
@@ -52,6 +52,14 @@ type runpodLeaseBackend struct {
 	pollTimeoutOverride time.Duration
 }
 
+type runpodSSHEndpoint struct {
+	Host   string
+	Port   int
+	User   string
+	Kind   string
+	Public bool
+}
+
 func NewRunpodLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
 	applyRunpodDefaults(&cfg)
@@ -79,7 +87,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s instance=%s disk=%dGB keep=%v\n",
 		providerName, leaseID, slug, name, cfg.Runpod.Image, cfg.Runpod.InstanceID, cfg.Runpod.DiskGB, req.Keep)
 
-	pod, err := client.DeployCpuPod(ctx, runpodDeployInput{
+	pod, err := client.DeployPod(ctx, runpodDeployInput{
 		Name:              name,
 		ImageName:         cfg.Runpod.Image,
 		InstanceID:        cfg.Runpod.InstanceID,
@@ -90,7 +98,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		StartSSH:          true,
 	})
 	if err != nil {
-		return LeaseTarget{}, exit(1, "runpod deployCpuPod failed: %v", err)
+		return LeaseTarget{}, exit(1, "runpod create pod failed: %v", err)
 	}
 
 	ready, err := b.waitForPodSSH(ctx, client, pod.ID)
@@ -225,22 +233,19 @@ func applyRunpodDefaults(cfg *Config) {
 		cfg.TargetOS = targetLinux
 	}
 	if cfg.Runpod.APIURL == "" {
-		cfg.Runpod.APIURL = "https://api.runpod.io/graphql"
+		cfg.Runpod.APIURL = "https://rest.runpod.io/v1"
 	}
 	if cfg.Runpod.CloudType == "" {
-		cfg.Runpod.CloudType = "ALL"
+		cfg.Runpod.CloudType = "SECURE"
 	}
 	if cfg.Runpod.InstanceID == "" {
-		// Cheapest documented CPU flavor at the time of writing: cpu3c
-		// (compute-optimized) with 2 vCPU and 4 GB RAM. Documented in
-		// docs/providers/runpod.md so callers can override knowingly.
-		cfg.Runpod.InstanceID = "cpu3c-2-4"
+		cfg.Runpod.InstanceID = "NVIDIA L4,NVIDIA RTX 4000 Ada Generation,NVIDIA RTX A4000,NVIDIA GeForce RTX 3090,NVIDIA GeForce RTX 4090,NVIDIA RTX A5000,NVIDIA RTX A4500"
 	}
 	if cfg.Runpod.Image == "" {
-		cfg.Runpod.Image = "runpod/base:0.6.2"
+		cfg.Runpod.Image = "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04"
 	}
 	if cfg.Runpod.DiskGB <= 0 {
-		cfg.Runpod.DiskGB = 10
+		cfg.Runpod.DiskGB = 20
 	}
 	if cfg.Runpod.WorkRoot == "" {
 		if !isDefaultWorkRoot(cfg.WorkRoot) {
@@ -287,8 +292,8 @@ func (b *runpodLeaseBackend) waitForPodSSH(ctx context.Context, client runpodAPI
 			}
 			return runpodPod{}, err
 		}
-		host, port := pod.SSHEndpoint()
-		if host != "" && port != 0 {
+		endpoint := pod.SSHEndpoint()
+		if endpoint.Host != "" && endpoint.Port != 0 && (endpoint.Public || strings.EqualFold(pod.DesiredStatus, "RUNNING")) {
 			return pod, nil
 		}
 		sleepFor := runpodJitter(interval)
@@ -310,6 +315,15 @@ func (b *runpodLeaseBackend) prepareLease(ctx context.Context, cfg Config, pod r
 	server := runpodServer(pod, leaseID, slug, cfg, keep)
 	target := runpodSSHTarget(cfg, pod)
 	if wait {
+		bootstrapTarget := target
+		bootstrapTarget.ReadyCheck = "true"
+		if err := waitForSSHReady(ctx, &bootstrapTarget, b.rt.Stderr, "runpod pod ssh", bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+		target.Port = bootstrapTarget.Port
+		if err := b.bootstrapRunpodTools(ctx, target); err != nil {
+			return LeaseTarget{}, err
+		}
 		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "runpod pod ssh", bootstrapWaitTimeout(cfg)); err != nil {
 			return LeaseTarget{}, err
 		}
@@ -319,6 +333,35 @@ func (b *runpodLeaseBackend) prepareLease(ctx context.Context, cfg Config, pod r
 		}
 	}
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *runpodLeaseBackend) bootstrapRunpodTools(ctx context.Context, target SSHTarget) error {
+	if b.rt.Stderr != nil {
+		fmt.Fprintln(b.rt.Stderr, "bootstrapping runpod pod tools")
+	}
+	if err := runSSHQuiet(ctx, target, runpodBootstrapToolsCommand()); err != nil {
+		return exit(1, "runpod pod tool bootstrap failed: %v", err)
+	}
+	return nil
+}
+
+func runpodBootstrapToolsCommand() string {
+	return strings.Join([]string{
+		"set -e",
+		"if command -v git >/dev/null 2>&1 && command -v rsync >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then exit 0; fi",
+		"SUDO=; if [ \"$(id -u)\" != 0 ]; then SUDO=sudo; fi",
+		"if command -v apt-get >/dev/null 2>&1; then",
+		"  $SUDO apt-get update >/tmp/crabbox-runpod-apt-update.log 2>&1",
+		"  $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git rsync tar >/tmp/crabbox-runpod-apt-install.log 2>&1",
+		"elif command -v dnf >/dev/null 2>&1; then",
+		"  $SUDO dnf install -y git rsync tar >/tmp/crabbox-runpod-dnf-install.log 2>&1",
+		"elif command -v yum >/dev/null 2>&1; then",
+		"  $SUDO yum install -y git rsync tar >/tmp/crabbox-runpod-yum-install.log 2>&1",
+		"elif command -v apk >/dev/null 2>&1; then",
+		"  $SUDO apk add --no-cache git rsync tar >/tmp/crabbox-runpod-apk-install.log 2>&1",
+		"fi",
+		"command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null",
+	}, "\n")
 }
 
 func (b *runpodLeaseBackend) resolvePod(ctx context.Context, client runpodAPI, identifier string) (runpodPod, string, string, error) {
@@ -422,12 +465,18 @@ func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Se
 	if pod.Machine.PodHostID != "" {
 		labels["pod_host_id"] = pod.Machine.PodHostID
 	}
-	host, port := pod.SSHEndpoint()
-	if host != "" {
-		labels["ssh_host"] = host
+	endpoint := pod.SSHEndpoint()
+	if endpoint.Host != "" {
+		labels["ssh_host"] = endpoint.Host
 	}
-	if port != 0 {
-		labels["ssh_port"] = strconv.Itoa(port)
+	if endpoint.Port != 0 {
+		labels["ssh_port"] = strconv.Itoa(endpoint.Port)
+	}
+	if endpoint.User != "" {
+		labels["ssh_user"] = endpoint.User
+	}
+	if endpoint.Kind != "" {
+		labels["ssh_kind"] = endpoint.Kind
 	}
 	server := Server{
 		CloudID:  pod.ID,
@@ -436,16 +485,21 @@ func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Se
 		Status:   labels["state"],
 		Labels:   labels,
 	}
-	server.PublicNet.IPv4.IP = host
+	if endpoint.Public {
+		server.PublicNet.IPv4.IP = endpoint.Host
+	}
 	server.ServerType.Name = cfg.Runpod.InstanceID
 	return server
 }
 
 func runpodSSHTarget(cfg Config, pod runpodPod) SSHTarget {
-	host, port := pod.SSHEndpoint()
-	target := sshTargetFromConfig(cfg, host)
-	if port != 0 {
-		target.Port = strconv.Itoa(port)
+	endpoint := pod.SSHEndpoint()
+	target := sshTargetFromConfig(cfg, endpoint.Host)
+	if endpoint.Port != 0 {
+		target.Port = strconv.Itoa(endpoint.Port)
+	}
+	if endpoint.User != "" {
+		target.User = endpoint.User
 	}
 	target.TargetOS = targetLinux
 	target.NetworkKind = networkPublic

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -1,0 +1,399 @@
+package runpod
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunpodProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName {
+		t.Fatalf("spec.Name = %q, want %q", spec.Name, providerName)
+	}
+	if spec.Kind != "ssh-lease" {
+		t.Fatalf("spec.Kind = %q, want ssh-lease", spec.Kind)
+	}
+	aliases := Provider{}.Aliases()
+	if len(aliases) != 2 || aliases[0] != "run-pod" || aliases[1] != "runpodio" {
+		t.Fatalf("aliases = %#v, want [run-pod runpodio]", aliases)
+	}
+}
+
+func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {
+	for _, name := range []string{"runpod", "Run-Pod", "  runpodio  ", "RUNPOD"} {
+		if !isRunpodProviderName(name) {
+			t.Fatalf("isRunpodProviderName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "exe-dev", "railway", "runpods"} {
+		if isRunpodProviderName(name) {
+			t.Fatalf("isRunpodProviderName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestRunpodClientRequiresAPIKey(t *testing.T) {
+	cfg := Config{}
+	cfg.Runpod.APIURL = "https://api.runpod.io/graphql"
+	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newRunpodClient accepted empty API key")
+	}
+}
+
+func TestRunpodClientRejectsBareHTTPURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Runpod.APIKey = "test-key"
+	cfg.Runpod.APIURL = "http://api.runpod.io/graphql"
+	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newRunpodClient accepted plaintext http URL")
+	}
+}
+
+func TestRunpodClientAllowsLoopbackHTTPURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Runpod.APIKey = "test-key"
+	cfg.Runpod.APIURL = "http://127.0.0.1:8080/graphql"
+	if _, err := newRunpodClient(cfg, Runtime{}); err != nil {
+		t.Fatalf("loopback http rejected: %v", err)
+	}
+}
+
+func TestRunpodTokenFlagIsNotRegistered(t *testing.T) {
+	cfg := Config{}
+	cfg.Runpod.APIKey = "secret-key"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterRunpodProviderFlags(fs, cfg)
+	for _, name := range []string{"runpod-token", "runpod-api-token", "runpod-key", "runpod-api-key"} {
+		if fs.Lookup(name) != nil {
+			t.Fatalf("runpod API key surfaced as a flag --%s", name)
+		}
+	}
+	for _, name := range []string{"runpod-url", "runpod-cloud-type", "runpod-instance-id", "runpod-image", "runpod-template-id", "runpod-disk-gb", "runpod-user", "runpod-work-root"} {
+		if fs.Lookup(name) == nil {
+			t.Fatalf("%s flag missing", name)
+		}
+	}
+}
+
+func TestRunpodFlagsRejectGenericClassAndType(t *testing.T) {
+	for _, args := range [][]string{
+		{"--class", "beast"},
+		{"--type", "ubuntu:24.04"},
+	} {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		fs.String("class", "", "")
+		fs.String("type", "", "")
+		values := RegisterRunpodProviderFlags(fs, Config{})
+		if err := fs.Parse(args); err != nil {
+			t.Fatal(err)
+		}
+		cfg := Config{Provider: providerName}
+		err := ApplyRunpodProviderFlags(&cfg, fs, values)
+		if err == nil || !strings.Contains(err.Error(), "not supported for provider=runpod") {
+			t.Fatalf("args=%v err=%v", args, err)
+		}
+	}
+}
+
+func TestRunpodConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
+	for name, cfg := range map[string]Config{
+		"macos target": {TargetOS: "macos"},
+		"tailscale":    {TargetOS: targetLinux, Tailscale: TailscaleConfig{Enabled: true}},
+		"network":      {TargetOS: targetLinux, Network: "tailscale"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Provider{}.Configure(cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestRunpodDefaultsPickCheapCPUFlavorAndPreserveCustomWorkRoot(t *testing.T) {
+	cfg := Config{}
+	applyRunpodDefaults(&cfg)
+	if cfg.Runpod.InstanceID != "cpu3c-2-4" {
+		t.Fatalf("default instanceId = %q, want cpu3c-2-4 (cheapest documented CPU flavor)", cfg.Runpod.InstanceID)
+	}
+	if cfg.Runpod.CloudType != "ALL" {
+		t.Fatalf("default cloudType = %q, want ALL", cfg.Runpod.CloudType)
+	}
+	if cfg.Runpod.DiskGB != 10 {
+		t.Fatalf("default diskGB = %d, want 10", cfg.Runpod.DiskGB)
+	}
+
+	cfg = Config{WorkRoot: "/custom/crabbox"}
+	applyRunpodDefaults(&cfg)
+	if cfg.WorkRoot != "/custom/crabbox" || cfg.Runpod.WorkRoot != "/custom/crabbox" {
+		t.Fatalf("workRoot=%q runpod.workRoot=%q", cfg.WorkRoot, cfg.Runpod.WorkRoot)
+	}
+
+	cfg = Config{WorkRoot: "/custom/crabbox", Runpod: RunpodConfig{WorkRoot: "/runpod/crabbox"}}
+	applyRunpodDefaults(&cfg)
+	if cfg.WorkRoot != "/runpod/crabbox" || cfg.Runpod.WorkRoot != "/runpod/crabbox" {
+		t.Fatalf("workRoot=%q runpod.workRoot=%q", cfg.WorkRoot, cfg.Runpod.WorkRoot)
+	}
+}
+
+func TestRunpodSSHEndpointPicksPublicPort22(t *testing.T) {
+	pod := runpodPod{Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
+		{IP: "10.0.0.1", PrivatePort: 8888, PublicPort: 41234, IsIPPublic: true, Type: "tcp"},
+		{IP: "203.0.113.5", PrivatePort: 22, PublicPort: 32100, IsIPPublic: true, Type: "tcp"},
+		{IP: "203.0.113.5", PrivatePort: 22, PublicPort: 32101, IsIPPublic: true, Type: "tcp"},
+	}}}
+	host, port := pod.SSHEndpoint()
+	if host != "203.0.113.5" || port != 32100 {
+		t.Fatalf("host=%q port=%d, want 203.0.113.5:32100", host, port)
+	}
+
+	pod = runpodPod{Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
+		{IP: "10.0.0.1", PrivatePort: 22, PublicPort: 32100, IsIPPublic: false, Type: "tcp"},
+	}}}
+	host, port = pod.SSHEndpoint()
+	if host != "" || port != 0 {
+		t.Fatalf("expected no public ssh endpoint, got %q:%d", host, port)
+	}
+
+	pod = runpodPod{Runtime: nil}
+	host, port = pod.SSHEndpoint()
+	if host != "" || port != 0 {
+		t.Fatalf("nil runtime should yield empty endpoint, got %q:%d", host, port)
+	}
+}
+
+func TestRunpodSSHTargetUsesPublicPortAndUser(t *testing.T) {
+	cfg := Config{Runpod: RunpodConfig{User: "root", WorkRoot: "/tmp/crabbox"}}
+	applyRunpodDefaults(&cfg)
+	pod := runpodPod{Name: "crabbox-blue-12345678", ID: "pod_abc", Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
+		{IP: "203.0.113.7", PrivatePort: 22, PublicPort: 41010, IsIPPublic: true, Type: "tcp"},
+	}}}
+	target := runpodSSHTarget(cfg, pod)
+	if target.Host != "203.0.113.7" || target.Port != "41010" {
+		t.Fatalf("target=%#v", target)
+	}
+	if target.User != "root" {
+		t.Fatalf("target user=%q, want root", target.User)
+	}
+	if target.TargetOS != targetLinux || target.NetworkKind != networkPublic {
+		t.Fatalf("target=%#v", target)
+	}
+}
+
+func TestRunpodLeaseIdentityHandlesNamedAndManualPods(t *testing.T) {
+	leaseID, slug := runpodLeaseIdentity("crabbox-blue-12345678")
+	if leaseID != "rpod_12345678" || slug != "blue" {
+		t.Fatalf("leaseID=%q slug=%q", leaseID, slug)
+	}
+	leaseID, slug = runpodLeaseIdentity("manual-pod")
+	if leaseID != "rpod_manual-pod" || slug != "manual-pod" {
+		t.Fatalf("leaseID=%q slug=%q", leaseID, slug)
+	}
+	leaseID, slug = runpodLeaseIdentity("")
+	if leaseID != "rpod_manual" || slug != "manual" {
+		t.Fatalf("leaseID=%q slug=%q", leaseID, slug)
+	}
+}
+
+func TestRunpodDoctorChecksAuthAndListPods(t *testing.T) {
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("auth = %q, want Bearer test-key", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content-type = %q", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		queries = append(queries, payload.Query)
+		if strings.Contains(payload.Query, "myself") && !strings.Contains(payload.Query, "pods") {
+			_, _ = io.WriteString(w, `{"data":{"myself":{"id":"user_x","email":"a@b","clientBalance":0,"signedTermsOfService":true}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"myself":{"pods":[]}}}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Runpod.APIKey = "test-key"
+	cfg.Runpod.APIURL = server.URL
+	doctor, err := Provider{}.ConfigureDoctor(cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("doctor returned err: %v", err)
+	}
+	if result.Provider != providerName {
+		t.Fatalf("provider=%q", result.Provider)
+	}
+	if len(queries) != 2 {
+		t.Fatalf("queries=%v, want 2 (whoami + list)", queries)
+	}
+	if !strings.Contains(queries[0], "myself") {
+		t.Fatalf("first query = %q, want whoami", queries[0])
+	}
+}
+
+func TestRunpodDoctorReportsMissingAPIKey(t *testing.T) {
+	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = doctor.Doctor(context.Background(), DoctorRequest{})
+	if err == nil || !strings.Contains(err.Error(), "RUNPOD_API_KEY") {
+		t.Fatalf("err=%v, want clear missing-key message", err)
+	}
+}
+
+type fakeRunpodAPI struct {
+	mu          sync.Mutex
+	whoamiCalls int
+	listCalls   int
+	deployCalls []runpodDeployInput
+	terminated  []string
+	listPods    []runpodPod
+	getPod      func(string) (runpodPod, error)
+	deployPod   runpodPod
+}
+
+func (f *fakeRunpodAPI) Whoami(_ context.Context) (runpodMyself, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.whoamiCalls++
+	return runpodMyself{ID: "user_x", Email: "a@b"}, nil
+}
+func (f *fakeRunpodAPI) DeployCpuPod(_ context.Context, input runpodDeployInput) (runpodPod, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deployCalls = append(f.deployCalls, input)
+	return f.deployPod, nil
+}
+func (f *fakeRunpodAPI) GetPod(_ context.Context, podID string) (runpodPod, error) {
+	if f.getPod != nil {
+		return f.getPod(podID)
+	}
+	return f.deployPod, nil
+}
+func (f *fakeRunpodAPI) ListPods(_ context.Context) ([]runpodPod, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls++
+	return f.listPods, nil
+}
+func (f *fakeRunpodAPI) TerminatePod(_ context.Context, podID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminated = append(f.terminated, podID)
+	return nil
+}
+
+func TestRunpodListFiltersCrabboxPodsByDefault(t *testing.T) {
+	fake := &fakeRunpodAPI{listPods: []runpodPod{
+		{ID: "pod_a", Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING"},
+		{ID: "pod_b", Name: "manual-pod", DesiredStatus: "RUNNING"},
+	}}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].Name != "crabbox-blue-12345678" || views[0].Provider != providerName {
+		t.Fatalf("views=%#v", views)
+	}
+	views, err = backend.List(context.Background(), ListRequest{All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestRunpodWaitForPodSSHReturnsWhenPublicPortReady(t *testing.T) {
+	calls := 0
+	fake := &fakeRunpodAPI{getPod: func(id string) (runpodPod, error) {
+		calls++
+		if calls < 2 {
+			return runpodPod{ID: id, Name: "crabbox-blue-12345678", DesiredStatus: "PROVISIONING"}, nil
+		}
+		return runpodPod{ID: id, Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING", Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
+			{IP: "203.0.113.9", PrivatePort: 22, PublicPort: 41200, IsIPPublic: true, Type: "tcp"},
+		}}}, nil
+	}}
+	backend := &runpodLeaseBackend{
+		cfg:                 Config{Runpod: RunpodConfig{APIKey: "k"}},
+		rt:                  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		client:              fake,
+		pollInitialOverride: 10 * time.Millisecond,
+		pollTimeoutOverride: 2 * time.Second,
+	}
+	pod, err := backend.waitForPodSSH(context.Background(), fake, "pod_a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := pod.SSHEndpoint()
+	if host != "203.0.113.9" || port != 41200 {
+		t.Fatalf("host=%q port=%d", host, port)
+	}
+}
+
+func TestRunpodReleaseLeaseTerminatesPod(t *testing.T) {
+	fake := &fakeRunpodAPI{}
+	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	req := ReleaseLeaseRequest{Lease: LeaseTarget{Server: Server{CloudID: "pod_z"}, LeaseID: "rpod_abcdef12"}}
+	if err := backend.ReleaseLease(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.terminated) != 1 || fake.terminated[0] != "pod_z" {
+		t.Fatalf("terminated=%v", fake.terminated)
+	}
+}
+
+func TestRunpodClientSendsBearerAndGraphQLBody(t *testing.T) {
+	var (
+		gotAuth        string
+		gotContentType string
+		gotMethod      string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		_, _ = io.WriteString(w, `{"data":{"myself":{"id":"user_x","email":"a@b","clientBalance":0,"signedTermsOfService":true}}}`)
+	}))
+	defer server.Close()
+	cfg := Config{}
+	cfg.Runpod.APIKey = "test-key"
+	cfg.Runpod.APIURL = server.URL
+	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Whoami(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method=%q", gotMethod)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth=%q", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("content-type=%q", gotContentType)
+	}
+}

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -42,7 +42,7 @@ func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {
 
 func TestRunpodClientRequiresAPIKey(t *testing.T) {
 	cfg := Config{}
-	cfg.Runpod.APIURL = "https://api.runpod.io/graphql"
+	cfg.Runpod.APIURL = "https://rest.runpod.io/v1"
 	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
 		t.Fatal("newRunpodClient accepted empty API key")
 	}
@@ -51,7 +51,7 @@ func TestRunpodClientRequiresAPIKey(t *testing.T) {
 func TestRunpodClientRejectsBareHTTPURL(t *testing.T) {
 	cfg := Config{}
 	cfg.Runpod.APIKey = "test-key"
-	cfg.Runpod.APIURL = "http://api.runpod.io/graphql"
+	cfg.Runpod.APIURL = "http://rest.runpod.io/v1"
 	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
 		t.Fatal("newRunpodClient accepted plaintext http URL")
 	}
@@ -60,7 +60,7 @@ func TestRunpodClientRejectsBareHTTPURL(t *testing.T) {
 func TestRunpodClientAllowsLoopbackHTTPURL(t *testing.T) {
 	cfg := Config{}
 	cfg.Runpod.APIKey = "test-key"
-	cfg.Runpod.APIURL = "http://127.0.0.1:8080/graphql"
+	cfg.Runpod.APIURL = "http://127.0.0.1:8080/v1"
 	if _, err := newRunpodClient(cfg, Runtime{}); err != nil {
 		t.Fatalf("loopback http rejected: %v", err)
 	}
@@ -119,17 +119,20 @@ func TestRunpodConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
 	}
 }
 
-func TestRunpodDefaultsPickCheapCPUFlavorAndPreserveCustomWorkRoot(t *testing.T) {
+func TestRunpodDefaultsPickPublicSSHGPUAndPreserveCustomWorkRoot(t *testing.T) {
 	cfg := Config{}
 	applyRunpodDefaults(&cfg)
-	if cfg.Runpod.InstanceID != "cpu3c-2-4" {
-		t.Fatalf("default instanceId = %q, want cpu3c-2-4 (cheapest documented CPU flavor)", cfg.Runpod.InstanceID)
+	if cfg.Runpod.APIURL != "https://rest.runpod.io/v1" {
+		t.Fatalf("default apiUrl = %q, want REST API", cfg.Runpod.APIURL)
 	}
-	if cfg.Runpod.CloudType != "ALL" {
-		t.Fatalf("default cloudType = %q, want ALL", cfg.Runpod.CloudType)
+	if cfg.Runpod.InstanceID != "NVIDIA L4,NVIDIA RTX 4000 Ada Generation,NVIDIA RTX A4000,NVIDIA GeForce RTX 3090,NVIDIA GeForce RTX 4090,NVIDIA RTX A5000,NVIDIA RTX A4500" {
+		t.Fatalf("default instanceId = %q, want GPU priority list", cfg.Runpod.InstanceID)
 	}
-	if cfg.Runpod.DiskGB != 10 {
-		t.Fatalf("default diskGB = %d, want 10", cfg.Runpod.DiskGB)
+	if cfg.Runpod.CloudType != "SECURE" {
+		t.Fatalf("default cloudType = %q, want SECURE", cfg.Runpod.CloudType)
+	}
+	if cfg.Runpod.DiskGB != 20 {
+		t.Fatalf("default diskGB = %d, want 20", cfg.Runpod.DiskGB)
 	}
 
 	cfg = Config{WorkRoot: "/custom/crabbox"}
@@ -151,23 +154,48 @@ func TestRunpodSSHEndpointPicksPublicPort22(t *testing.T) {
 		{IP: "203.0.113.5", PrivatePort: 22, PublicPort: 32100, IsIPPublic: true, Type: "tcp"},
 		{IP: "203.0.113.5", PrivatePort: 22, PublicPort: 32101, IsIPPublic: true, Type: "tcp"},
 	}}}
-	host, port := pod.SSHEndpoint()
-	if host != "203.0.113.5" || port != 32100 {
-		t.Fatalf("host=%q port=%d, want 203.0.113.5:32100", host, port)
+	endpoint := pod.SSHEndpoint()
+	if endpoint.Host != "203.0.113.5" || endpoint.Port != 32100 || endpoint.Kind != "public-tcp" || !endpoint.Public {
+		t.Fatalf("endpoint=%#v, want public 203.0.113.5:32100", endpoint)
 	}
 
 	pod = runpodPod{Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
 		{IP: "10.0.0.1", PrivatePort: 22, PublicPort: 32100, IsIPPublic: false, Type: "tcp"},
-	}}}
-	host, port = pod.SSHEndpoint()
-	if host != "" || port != 0 {
-		t.Fatalf("expected no public ssh endpoint, got %q:%d", host, port)
+	}}, Machine: runpodMachine{PodHostID: "pod-host-id"}}
+	endpoint = pod.SSHEndpoint()
+	if endpoint.Host != "" || endpoint.Port != 0 {
+		t.Fatalf("private mapping should not yield SSH endpoint, got %#v", endpoint)
 	}
 
 	pod = runpodPod{Runtime: nil}
-	host, port = pod.SSHEndpoint()
-	if host != "" || port != 0 {
-		t.Fatalf("nil runtime should yield empty endpoint, got %q:%d", host, port)
+	endpoint = pod.SSHEndpoint()
+	if endpoint.Host != "" || endpoint.Port != 0 {
+		t.Fatalf("nil runtime without host id should yield empty endpoint, got %#v", endpoint)
+	}
+}
+
+func TestRunpodDeployPayloadUsesGPUAvailabilityPriority(t *testing.T) {
+	payload := runpodDeployPayload(runpodDeployInput{
+		Name:              "crabbox-blue-12345678",
+		ImageName:         "runpod/pytorch:custom",
+		InstanceID:        "NVIDIA L4, NVIDIA RTX A4000",
+		CloudType:         "SECURE",
+		ContainerDiskInGb: 20,
+		Ports:             "22/tcp",
+	})
+	if payload["computeType"] != "GPU" || payload["gpuTypePriority"] != "availability" {
+		t.Fatalf("payload=%#v", payload)
+	}
+	gpuIDs, ok := payload["gpuTypeIds"].([]string)
+	if !ok || len(gpuIDs) != 2 || gpuIDs[0] != "NVIDIA L4" || gpuIDs[1] != "NVIDIA RTX A4000" {
+		t.Fatalf("gpuTypeIds=%#v", payload["gpuTypeIds"])
+	}
+	ports, ok := payload["ports"].([]string)
+	if !ok || len(ports) != 1 || ports[0] != "22/tcp" {
+		t.Fatalf("ports=%#v", payload["ports"])
+	}
+	if payload["supportPublicIp"] != true {
+		t.Fatalf("supportPublicIp=%#v", payload["supportPublicIp"])
 	}
 }
 
@@ -205,25 +233,16 @@ func TestRunpodLeaseIdentityHandlesNamedAndManualPods(t *testing.T) {
 }
 
 func TestRunpodDoctorChecksAuthAndListPods(t *testing.T) {
-	var queries []string
+	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test-key" {
 			t.Errorf("auth = %q, want Bearer test-key", r.Header.Get("Authorization"))
 		}
-		if r.Header.Get("Content-Type") != "application/json" {
+		if r.Header.Get("Content-Type") != "" {
 			t.Errorf("content-type = %q", r.Header.Get("Content-Type"))
 		}
-		body, _ := io.ReadAll(r.Body)
-		var payload struct {
-			Query string `json:"query"`
-		}
-		_ = json.Unmarshal(body, &payload)
-		queries = append(queries, payload.Query)
-		if strings.Contains(payload.Query, "myself") && !strings.Contains(payload.Query, "pods") {
-			_, _ = io.WriteString(w, `{"data":{"myself":{"id":"user_x","email":"a@b","clientBalance":0,"signedTermsOfService":true}}}`)
-			return
-		}
-		_, _ = io.WriteString(w, `{"data":{"myself":{"pods":[]}}}`)
+		paths = append(paths, r.URL.Path)
+		_, _ = io.WriteString(w, `[]`)
 	}))
 	defer server.Close()
 
@@ -241,11 +260,8 @@ func TestRunpodDoctorChecksAuthAndListPods(t *testing.T) {
 	if result.Provider != providerName {
 		t.Fatalf("provider=%q", result.Provider)
 	}
-	if len(queries) != 2 {
-		t.Fatalf("queries=%v, want 2 (whoami + list)", queries)
-	}
-	if !strings.Contains(queries[0], "myself") {
-		t.Fatalf("first query = %q, want whoami", queries[0])
+	if len(paths) != 2 || paths[0] != "/pods" || paths[1] != "/pods" {
+		t.Fatalf("paths=%v, want two /pods reads", paths)
 	}
 }
 
@@ -277,7 +293,7 @@ func (f *fakeRunpodAPI) Whoami(_ context.Context) (runpodMyself, error) {
 	f.whoamiCalls++
 	return runpodMyself{ID: "user_x", Email: "a@b"}, nil
 }
-func (f *fakeRunpodAPI) DeployCpuPod(_ context.Context, input runpodDeployInput) (runpodPod, error) {
+func (f *fakeRunpodAPI) DeployPod(_ context.Context, input runpodDeployInput) (runpodPod, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.deployCalls = append(f.deployCalls, input)
@@ -346,9 +362,26 @@ func TestRunpodWaitForPodSSHReturnsWhenPublicPortReady(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	host, port := pod.SSHEndpoint()
-	if host != "203.0.113.9" || port != 41200 {
-		t.Fatalf("host=%q port=%d", host, port)
+	endpoint := pod.SSHEndpoint()
+	if endpoint.Host != "203.0.113.9" || endpoint.Port != 41200 {
+		t.Fatalf("endpoint=%#v", endpoint)
+	}
+}
+
+func TestRunpodWaitForSSHRejectsProxyOnlyPods(t *testing.T) {
+	fake := &fakeRunpodAPI{getPod: func(id string) (runpodPod, error) {
+		return runpodPod{ID: id, Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING", Machine: runpodMachine{PodHostID: "pod_abc-1234"}}, nil
+	}}
+	backend := &runpodLeaseBackend{
+		cfg:                 Config{Runpod: RunpodConfig{APIKey: "k"}},
+		rt:                  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		client:              fake,
+		pollInitialOverride: 10 * time.Millisecond,
+		pollTimeoutOverride: 2 * time.Second,
+	}
+	_, err := backend.waitForPodSSH(context.Background(), fake, "pod_a")
+	if err == nil || !strings.Contains(err.Error(), "ssh endpoint not exposed") {
+		t.Fatalf("err=%v, want timeout without public TCP endpoint", err)
 	}
 }
 
@@ -364,17 +397,19 @@ func TestRunpodReleaseLeaseTerminatesPod(t *testing.T) {
 	}
 }
 
-func TestRunpodClientSendsBearerAndGraphQLBody(t *testing.T) {
+func TestRunpodClientSendsBearerAndRESTRequest(t *testing.T) {
 	var (
 		gotAuth        string
 		gotContentType string
 		gotMethod      string
+		gotPath        string
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		gotContentType = r.Header.Get("Content-Type")
 		gotMethod = r.Method
-		_, _ = io.WriteString(w, `{"data":{"myself":{"id":"user_x","email":"a@b","clientBalance":0,"signedTermsOfService":true}}}`)
+		gotPath = r.URL.Path
+		_, _ = io.WriteString(w, `[]`)
 	}))
 	defer server.Close()
 	cfg := Config{}
@@ -387,13 +422,68 @@ func TestRunpodClientSendsBearerAndGraphQLBody(t *testing.T) {
 	if _, err := client.Whoami(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if gotMethod != http.MethodPost {
+	if gotMethod != http.MethodGet {
 		t.Fatalf("method=%q", gotMethod)
+	}
+	if gotPath != "/pods" {
+		t.Fatalf("path=%q", gotPath)
 	}
 	if gotAuth != "Bearer test-key" {
 		t.Fatalf("auth=%q", gotAuth)
 	}
-	if gotContentType != "application/json" {
+	if gotContentType != "" {
 		t.Fatalf("content-type=%q", gotContentType)
+	}
+}
+
+func TestRunpodClientRetriesGPUCapacityFallbacks(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/pods" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var payload struct {
+			GPUTypeIDs []string `json:"gpuTypeIds"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.GPUTypeIDs) != 1 {
+			t.Fatalf("gpuTypeIds=%#v, want one id per fallback attempt", payload.GPUTypeIDs)
+		}
+		seen = append(seen, payload.GPUTypeIDs[0])
+		if payload.GPUTypeIDs[0] == "NVIDIA L4" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"create pod: There are no instances currently available","status":500}`)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"id":"pod_ok","name":"crabbox-blue-12345678","status":"RUNNING"}`)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Runpod.APIKey = "test-key"
+	cfg.Runpod.APIURL = server.URL
+	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pod, err := client.DeployPod(context.Background(), runpodDeployInput{
+		Name:              "crabbox-blue-12345678",
+		ImageName:         "runpod/pytorch:custom",
+		InstanceID:        "NVIDIA L4,NVIDIA RTX 4000 Ada Generation",
+		CloudType:         "SECURE",
+		ContainerDiskInGb: 20,
+		Ports:             "22/tcp",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pod.ID != "pod_ok" {
+		t.Fatalf("pod=%#v", pod)
+	}
+	if len(seen) != 2 || seen[0] != "NVIDIA L4" || seen[1] != "NVIDIA RTX 4000 Ada Generation" {
+		t.Fatalf("seen=%v", seen)
 	}
 }

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -1,0 +1,352 @@
+package runpod
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// runpodAPI is the minimal RunPod GraphQL surface the provider needs. The
+// provider keeps the surface intentionally small: deploy a CPU pod, look it
+// up, list pods, and terminate it. The pod's SSH coordinates come back via
+// the pod query's runtime.ports[] structure once the pod is in RUNNING state.
+type runpodAPI interface {
+	Whoami(ctx context.Context) (runpodMyself, error)
+	DeployCpuPod(ctx context.Context, input runpodDeployInput) (runpodPod, error)
+	GetPod(ctx context.Context, podID string) (runpodPod, error)
+	ListPods(ctx context.Context) ([]runpodPod, error)
+	TerminatePod(ctx context.Context, podID string) error
+}
+
+type runpodClient struct {
+	apiKey     string
+	apiURL     string
+	httpClient *http.Client
+}
+
+const runpodMaxGraphQLResponseBytes = 16 << 20
+
+type runpodAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *runpodAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+type runpodMyself struct {
+	ID                   string `json:"id"`
+	Email                string `json:"email"`
+	ClientBalance        any    `json:"clientBalance"`
+	SignedTermsOfService bool   `json:"signedTermsOfService"`
+}
+
+type runpodMachine struct {
+	PodHostID string `json:"podHostId"`
+}
+
+type runpodRuntimePort struct {
+	IP          string `json:"ip"`
+	PrivatePort int    `json:"privatePort"`
+	PublicPort  int    `json:"publicPort"`
+	IsIPPublic  bool   `json:"isIpPublic"`
+	Type        string `json:"type"`
+}
+
+type runpodRuntime struct {
+	Ports []runpodRuntimePort `json:"ports"`
+}
+
+type runpodPod struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	ImageName     string         `json:"imageName"`
+	DesiredStatus string         `json:"desiredStatus"`
+	MachineID     string         `json:"machineId"`
+	Machine       runpodMachine  `json:"machine"`
+	Runtime       *runpodRuntime `json:"runtime"`
+	CostPerHr     any            `json:"costPerHr"`
+}
+
+// SSHEndpoint returns the public TCP host:port mapping for the pod's port 22,
+// or empty values if the pod has not exposed an SSH endpoint yet.
+func (p runpodPod) SSHEndpoint() (host string, port int) {
+	if p.Runtime == nil {
+		return "", 0
+	}
+	for _, prt := range p.Runtime.Ports {
+		if prt.PrivatePort == 22 && prt.IsIPPublic && prt.IP != "" && prt.PublicPort != 0 && strings.EqualFold(prt.Type, "tcp") {
+			return prt.IP, prt.PublicPort
+		}
+	}
+	return "", 0
+}
+
+type runpodDeployInput struct {
+	Name              string
+	ImageName         string
+	InstanceID        string
+	CloudType         string
+	TemplateID        string
+	ContainerDiskInGb int
+	Ports             string
+	StartSSH          bool
+}
+
+func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
+	apiKey := strings.TrimSpace(cfg.Runpod.APIKey)
+	if apiKey == "" {
+		return nil, exit(2, "provider=%s requires RUNPOD_API_KEY", providerName)
+	}
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Runpod.APIURL, "https://api.runpod.io/graphql")), "/")
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: httpClient}, nil
+}
+
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type graphqlError struct {
+	Message    string         `json:"message"`
+	Path       []any          `json:"path,omitempty"`
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
+type graphqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []graphqlError  `json:"errors,omitempty"`
+}
+
+func (c *runpodClient) do(ctx context.Context, query string, vars map[string]any, out any) error {
+	body, err := json.Marshal(graphqlRequest{Query: query, Variables: vars})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, runpodMaxGraphQLResponseBytes+1))
+	if readErr != nil {
+		return readErr
+	}
+	if len(data) > runpodMaxGraphQLResponseBytes {
+		return fmt.Errorf("runpod response exceeds %d bytes", runpodMaxGraphQLResponseBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+	}
+	var envelope graphqlResponse
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("decode runpod response: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.Join(msgs, "; ")}
+	}
+	if out != nil {
+		if err := json.Unmarshal(envelope.Data, out); err != nil {
+			return fmt.Errorf("decode runpod data: %w", err)
+		}
+	}
+	return nil
+}
+
+const myselfQuery = `query crabboxRunpodMyself {
+  myself {
+    id
+    email
+    clientBalance
+    signedTermsOfService
+  }
+}`
+
+func (c *runpodClient) Whoami(ctx context.Context) (runpodMyself, error) {
+	var out struct {
+		Myself runpodMyself `json:"myself"`
+	}
+	if err := c.do(ctx, myselfQuery, nil, &out); err != nil {
+		return runpodMyself{}, err
+	}
+	if strings.TrimSpace(out.Myself.ID) == "" {
+		return runpodMyself{}, fmt.Errorf("runpod myself query returned empty id")
+	}
+	return out.Myself, nil
+}
+
+// deployCpuPodMutation deploys a CPU pod. Verified against the runpod-python
+// SDK's pod_mutations.generate_pod_deployment_mutation source: the upstream
+// SDK accepts `instanceId`, `cloudType`, `startSsh`, `templateId`,
+// `containerDiskInGb`, and `ports`. SSH is requested via startSsh + exposing
+// port 22/tcp; the pod query later reports the public mapping in
+// runtime.ports[].publicPort.
+const deployCpuPodMutation = `mutation crabboxRunpodDeployCpuPod($input: deployCpuPodInput!) {
+  deployCpuPod(input: $input) {
+    id
+    imageName
+    machineId
+    desiredStatus
+    machine {
+      podHostId
+    }
+  }
+}`
+
+func (c *runpodClient) DeployCpuPod(ctx context.Context, input runpodDeployInput) (runpodPod, error) {
+	payload := map[string]any{
+		"name":              input.Name,
+		"imageName":         input.ImageName,
+		"instanceId":        input.InstanceID,
+		"cloudType":         input.CloudType,
+		"startSsh":          input.StartSSH,
+		"containerDiskInGb": input.ContainerDiskInGb,
+		"ports":             input.Ports,
+	}
+	if strings.TrimSpace(input.TemplateID) != "" {
+		payload["templateId"] = input.TemplateID
+	}
+	var out struct {
+		DeployCpuPod runpodPod `json:"deployCpuPod"`
+	}
+	if err := c.do(ctx, deployCpuPodMutation, map[string]any{"input": payload}, &out); err != nil {
+		return runpodPod{}, err
+	}
+	if strings.TrimSpace(out.DeployCpuPod.ID) == "" {
+		return runpodPod{}, fmt.Errorf("deployCpuPod returned empty pod id")
+	}
+	return out.DeployCpuPod, nil
+}
+
+// podQuery fetches a single pod by ID with the runtime.ports[] field needed to
+// recover the public SSH endpoint. The runtime field is null until the pod
+// reaches RUNNING.
+const podQuery = `query crabboxRunpodPod($input: PodFilter!) {
+  pod(input: $input) {
+    id
+    name
+    imageName
+    desiredStatus
+    machineId
+    costPerHr
+    machine {
+      podHostId
+    }
+    runtime {
+      ports {
+        ip
+        privatePort
+        publicPort
+        isIpPublic
+        type
+      }
+    }
+  }
+}`
+
+func (c *runpodClient) GetPod(ctx context.Context, podID string) (runpodPod, error) {
+	if strings.TrimSpace(podID) == "" {
+		return runpodPod{}, fmt.Errorf("getPod: podId is required")
+	}
+	var out struct {
+		Pod runpodPod `json:"pod"`
+	}
+	if err := c.do(ctx, podQuery, map[string]any{"input": map[string]any{"podId": podID}}, &out); err != nil {
+		return runpodPod{}, err
+	}
+	if strings.TrimSpace(out.Pod.ID) == "" {
+		return runpodPod{}, fmt.Errorf("pod %s not found", podID)
+	}
+	return out.Pod, nil
+}
+
+const listPodsQuery = `query crabboxRunpodPods {
+  myself {
+    pods {
+      id
+      name
+      imageName
+      desiredStatus
+      machineId
+      costPerHr
+      machine {
+        podHostId
+      }
+      runtime {
+        ports {
+          ip
+          privatePort
+          publicPort
+          isIpPublic
+          type
+        }
+      }
+    }
+  }
+}`
+
+func (c *runpodClient) ListPods(ctx context.Context) ([]runpodPod, error) {
+	var out struct {
+		Myself struct {
+			Pods []runpodPod `json:"pods"`
+		} `json:"myself"`
+	}
+	if err := c.do(ctx, listPodsQuery, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Myself.Pods, nil
+}
+
+const terminatePodMutation = `mutation crabboxRunpodTerminate($input: PodTerminateInput!) {
+  podTerminate(input: $input)
+}`
+
+func (c *runpodClient) TerminatePod(ctx context.Context, podID string) error {
+	if strings.TrimSpace(podID) == "" {
+		return fmt.Errorf("terminatePod: podId is required")
+	}
+	if err := c.do(ctx, terminatePodMutation, map[string]any{"input": map[string]any{"podId": podID}}, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -4,20 +4,22 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
-// runpodAPI is the minimal RunPod GraphQL surface the provider needs. The
-// provider keeps the surface intentionally small: deploy a CPU pod, look it
-// up, list pods, and terminate it. The pod's SSH coordinates come back via
-// the pod query's runtime.ports[] structure once the pod is in RUNNING state.
+// runpodAPI is the minimal RunPod REST surface the provider needs. The
+// provider keeps the surface intentionally small: deploy a pod, look it up,
+// list pods, and terminate it. The pod's full SSH coordinates come back as
+// publicIp + portMappings["22"] once the pod reaches RUNNING.
 type runpodAPI interface {
 	Whoami(ctx context.Context) (runpodMyself, error)
-	DeployCpuPod(ctx context.Context, input runpodDeployInput) (runpodPod, error)
+	DeployPod(ctx context.Context, input runpodDeployInput) (runpodPod, error)
 	GetPod(ctx context.Context, podID string) (runpodPod, error)
 	ListPods(ctx context.Context) ([]runpodPod, error)
 	TerminatePod(ctx context.Context, podID string) error
@@ -29,7 +31,7 @@ type runpodClient struct {
 	httpClient *http.Client
 }
 
-const runpodMaxGraphQLResponseBytes = 16 << 20
+const runpodMaxResponseBytes = 16 << 20
 
 type runpodAPIError struct {
 	StatusCode int
@@ -71,25 +73,33 @@ type runpodPod struct {
 	ID            string         `json:"id"`
 	Name          string         `json:"name"`
 	ImageName     string         `json:"imageName"`
+	Image         string         `json:"image"`
 	DesiredStatus string         `json:"desiredStatus"`
+	Status        string         `json:"status"`
 	MachineID     string         `json:"machineId"`
 	Machine       runpodMachine  `json:"machine"`
 	Runtime       *runpodRuntime `json:"runtime"`
+	PublicIP      string         `json:"publicIp"`
+	PortMappings  map[string]int `json:"portMappings"`
 	CostPerHr     any            `json:"costPerHr"`
 }
 
-// SSHEndpoint returns the public TCP host:port mapping for the pod's port 22,
-// or empty values if the pod has not exposed an SSH endpoint yet.
-func (p runpodPod) SSHEndpoint() (host string, port int) {
+// SSHEndpoint returns the best SSH endpoint available for the pod.
+// Crabbox requires a public TCP port because RunPod's basic SSH proxy does not
+// support the SCP/SFTP behavior rsync needs.
+func (p runpodPod) SSHEndpoint() runpodSSHEndpoint {
+	if port := p.PortMappings["22"]; p.PublicIP != "" && port != 0 {
+		return runpodSSHEndpoint{Host: p.PublicIP, Port: port, Kind: "public-tcp", Public: true}
+	}
 	if p.Runtime == nil {
-		return "", 0
+		return runpodSSHEndpoint{}
 	}
 	for _, prt := range p.Runtime.Ports {
 		if prt.PrivatePort == 22 && prt.IsIPPublic && prt.IP != "" && prt.PublicPort != 0 && strings.EqualFold(prt.Type, "tcp") {
-			return prt.IP, prt.PublicPort
+			return runpodSSHEndpoint{Host: prt.IP, Port: prt.PublicPort, Kind: "public-tcp", Public: true}
 		}
 	}
-	return "", 0
+	return runpodSSHEndpoint{}
 }
 
 type runpodDeployInput struct {
@@ -108,7 +118,7 @@ func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
 	if apiKey == "" {
 		return nil, exit(2, "provider=%s requires RUNPOD_API_KEY", providerName)
 	}
-	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Runpod.APIURL, "https://api.runpod.io/graphql")), "/")
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Runpod.APIURL, "https://rest.runpod.io/v1")), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
@@ -123,223 +133,246 @@ func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
 	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: httpClient}, nil
 }
 
-type graphqlRequest struct {
-	Query     string         `json:"query"`
-	Variables map[string]any `json:"variables,omitempty"`
-}
-
-type graphqlError struct {
-	Message    string         `json:"message"`
-	Path       []any          `json:"path,omitempty"`
-	Extensions map[string]any `json:"extensions,omitempty"`
-}
-
-type graphqlResponse struct {
-	Data   json.RawMessage `json:"data"`
-	Errors []graphqlError  `json:"errors,omitempty"`
-}
-
-func (c *runpodClient) do(ctx context.Context, query string, vars map[string]any, out any) error {
-	body, err := json.Marshal(graphqlRequest{Query: query, Variables: vars})
-	if err != nil {
-		return err
+func (c *runpodClient) do(ctx context.Context, method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, method, c.apiURL+path, reader)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	data, readErr := io.ReadAll(io.LimitReader(resp.Body, runpodMaxGraphQLResponseBytes+1))
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, runpodMaxResponseBytes+1))
 	if readErr != nil {
 		return readErr
 	}
-	if len(data) > runpodMaxGraphQLResponseBytes {
-		return fmt.Errorf("runpod response exceeds %d bytes", runpodMaxGraphQLResponseBytes)
+	if len(data) > runpodMaxResponseBytes {
+		return fmt.Errorf("runpod response exceeds %d bytes", runpodMaxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
 	}
-	var envelope graphqlResponse
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return fmt.Errorf("decode runpod response: %w", err)
-	}
-	if len(envelope.Errors) > 0 {
-		msgs := make([]string, 0, len(envelope.Errors))
-		for _, e := range envelope.Errors {
-			msgs = append(msgs, e.Message)
-		}
-		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.Join(msgs, "; ")}
-	}
-	if out != nil {
-		if err := json.Unmarshal(envelope.Data, out); err != nil {
+	if out != nil && len(strings.TrimSpace(string(data))) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
 			return fmt.Errorf("decode runpod data: %w", err)
 		}
 	}
 	return nil
 }
 
-const myselfQuery = `query crabboxRunpodMyself {
-  myself {
-    id
-    email
-    clientBalance
-    signedTermsOfService
-  }
-}`
-
-func (c *runpodClient) Whoami(ctx context.Context) (runpodMyself, error) {
-	var out struct {
-		Myself runpodMyself `json:"myself"`
+func normalizeRunpodPod(pod runpodPod) runpodPod {
+	if pod.ImageName == "" {
+		pod.ImageName = pod.Image
 	}
-	if err := c.do(ctx, myselfQuery, nil, &out); err != nil {
-		return runpodMyself{}, err
+	if pod.DesiredStatus == "" {
+		pod.DesiredStatus = pod.Status
 	}
-	if strings.TrimSpace(out.Myself.ID) == "" {
-		return runpodMyself{}, fmt.Errorf("runpod myself query returned empty id")
+	if pod.PortMappings == nil {
+		pod.PortMappings = map[string]int{}
 	}
-	return out.Myself, nil
+	return pod
 }
 
-// deployCpuPodMutation deploys a CPU pod. Verified against the runpod-python
-// SDK's pod_mutations.generate_pod_deployment_mutation source: the upstream
-// SDK accepts `instanceId`, `cloudType`, `startSsh`, `templateId`,
-// `containerDiskInGb`, and `ports`. SSH is requested via startSsh + exposing
-// port 22/tcp; the pod query later reports the public mapping in
-// runtime.ports[].publicPort.
-const deployCpuPodMutation = `mutation crabboxRunpodDeployCpuPod($input: deployCpuPodInput!) {
-  deployCpuPod(input: $input) {
-    id
-    imageName
-    machineId
-    desiredStatus
-    machine {
-      podHostId
-    }
-  }
-}`
+func (c *runpodClient) Whoami(ctx context.Context) (runpodMyself, error) {
+	var pods []runpodPod
+	if err := c.do(ctx, http.MethodGet, "/pods", nil, &pods); err != nil {
+		return runpodMyself{}, err
+	}
+	return runpodMyself{ID: "authenticated"}, nil
+}
 
-func (c *runpodClient) DeployCpuPod(ctx context.Context, input runpodDeployInput) (runpodPod, error) {
+func cpuFlavorID(instanceID string) string {
+	if idx := strings.Index(instanceID, "-"); idx > 0 {
+		return instanceID[:idx]
+	}
+	return instanceID
+}
+
+func runpodInstanceIDs(instanceID string) []string {
+	parts := strings.FieldsFunc(instanceID, func(r rune) bool {
+		return r == ',' || r == '\n'
+	})
+	ids := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if id := strings.TrimSpace(part); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return []string{strings.TrimSpace(instanceID)}
+	}
+	return ids
+}
+
+func runpodDeployPayload(input runpodDeployInput) map[string]any {
 	payload := map[string]any{
 		"name":              input.Name,
 		"imageName":         input.ImageName,
-		"instanceId":        input.InstanceID,
-		"cloudType":         input.CloudType,
-		"startSsh":          input.StartSSH,
+		"cloudType":         blank(input.CloudType, "SECURE"),
 		"containerDiskInGb": input.ContainerDiskInGb,
-		"ports":             input.Ports,
+		"ports":             []string{input.Ports},
+		"supportPublicIp":   true,
 	}
-	if strings.TrimSpace(input.TemplateID) != "" {
+	if input.TemplateID != "" {
 		payload["templateId"] = input.TemplateID
 	}
-	var out struct {
-		DeployCpuPod runpodPod `json:"deployCpuPod"`
+	instanceIDs := runpodInstanceIDs(input.InstanceID)
+	if strings.HasPrefix(strings.ToLower(instanceIDs[0]), "cpu") {
+		payload["computeType"] = "CPU"
+		payload["cpuFlavorIds"] = []string{cpuFlavorID(instanceIDs[0])}
+		payload["cpuFlavorPriority"] = "availability"
+		return payload
 	}
-	if err := c.do(ctx, deployCpuPodMutation, map[string]any{"input": payload}, &out); err != nil {
-		return runpodPod{}, err
-	}
-	if strings.TrimSpace(out.DeployCpuPod.ID) == "" {
-		return runpodPod{}, fmt.Errorf("deployCpuPod returned empty pod id")
-	}
-	return out.DeployCpuPod, nil
+	payload["computeType"] = "GPU"
+	payload["gpuTypeIds"] = instanceIDs
+	payload["gpuTypePriority"] = "availability"
+	payload["gpuCount"] = 1
+	return payload
 }
 
-// podQuery fetches a single pod by ID with the runtime.ports[] field needed to
-// recover the public SSH endpoint. The runtime field is null until the pod
-// reaches RUNNING.
-const podQuery = `query crabboxRunpodPod($input: PodFilter!) {
-  pod(input: $input) {
-    id
-    name
-    imageName
-    desiredStatus
-    machineId
-    costPerHr
-    machine {
-      podHostId
-    }
-    runtime {
-      ports {
-        ip
-        privatePort
-        publicPort
-        isIpPublic
-        type
-      }
-    }
-  }
-}`
+func (c *runpodClient) DeployPod(ctx context.Context, input runpodDeployInput) (runpodPod, error) {
+	instanceIDs := runpodInstanceIDs(input.InstanceID)
+	if len(instanceIDs) > 1 && !strings.HasPrefix(strings.ToLower(instanceIDs[0]), "cpu") {
+		var capacityErr error
+		for _, instanceID := range instanceIDs {
+			attempt := input
+			attempt.InstanceID = instanceID
+			pod, err := c.deployPod(ctx, attempt)
+			if err == nil {
+				return pod, nil
+			}
+			if isRunpodCapacityError(err) {
+				capacityErr = err
+				continue
+			}
+			return runpodPod{}, err
+		}
+		if capacityErr != nil {
+			return runpodPod{}, capacityErr
+		}
+	}
+	return c.deployPod(ctx, input)
+}
+
+func (c *runpodClient) deployPod(ctx context.Context, input runpodDeployInput) (runpodPod, error) {
+	var pod runpodPod
+	if err := c.do(ctx, http.MethodPost, "/pods", runpodDeployPayload(input), &pod); err != nil {
+		return runpodPod{}, err
+	}
+	pod = normalizeRunpodPod(pod)
+	if strings.TrimSpace(pod.ID) == "" {
+		return runpodPod{}, fmt.Errorf("create pod returned empty id")
+	}
+	return pod, nil
+}
+
+func isRunpodCapacityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *runpodAPIError
+	if ok := errors.As(err, &apiErr); !ok {
+		return false
+	}
+	return apiErr.StatusCode == http.StatusInternalServerError && strings.Contains(strings.ToLower(apiErr.Body), "no instances currently available")
+}
 
 func (c *runpodClient) GetPod(ctx context.Context, podID string) (runpodPod, error) {
 	if strings.TrimSpace(podID) == "" {
 		return runpodPod{}, fmt.Errorf("getPod: podId is required")
 	}
-	var out struct {
-		Pod runpodPod `json:"pod"`
-	}
-	if err := c.do(ctx, podQuery, map[string]any{"input": map[string]any{"podId": podID}}, &out); err != nil {
+	var pod runpodPod
+	if err := c.do(ctx, http.MethodGet, "/pods/"+url.PathEscape(podID), nil, &pod); err != nil {
 		return runpodPod{}, err
 	}
-	if strings.TrimSpace(out.Pod.ID) == "" {
+	pod = normalizeRunpodPod(pod)
+	if strings.TrimSpace(pod.ID) == "" {
 		return runpodPod{}, fmt.Errorf("pod %s not found", podID)
 	}
-	return out.Pod, nil
+	return pod, nil
 }
-
-const listPodsQuery = `query crabboxRunpodPods {
-  myself {
-    pods {
-      id
-      name
-      imageName
-      desiredStatus
-      machineId
-      costPerHr
-      machine {
-        podHostId
-      }
-      runtime {
-        ports {
-          ip
-          privatePort
-          publicPort
-          isIpPublic
-          type
-        }
-      }
-    }
-  }
-}`
 
 func (c *runpodClient) ListPods(ctx context.Context) ([]runpodPod, error) {
-	var out struct {
-		Myself struct {
-			Pods []runpodPod `json:"pods"`
-		} `json:"myself"`
-	}
-	if err := c.do(ctx, listPodsQuery, nil, &out); err != nil {
+	var pods []runpodPod
+	if err := c.do(ctx, http.MethodGet, "/pods", nil, &pods); err != nil {
 		return nil, err
 	}
-	return out.Myself.Pods, nil
+	for i := range pods {
+		pods[i] = normalizeRunpodPod(pods[i])
+	}
+	return pods, nil
 }
-
-const terminatePodMutation = `mutation crabboxRunpodTerminate($input: PodTerminateInput!) {
-  podTerminate(input: $input)
-}`
 
 func (c *runpodClient) TerminatePod(ctx context.Context, podID string) error {
 	if strings.TrimSpace(podID) == "" {
 		return fmt.Errorf("terminatePod: podId is required")
 	}
-	if err := c.do(ctx, terminatePodMutation, map[string]any{"input": map[string]any{"podId": podID}}, nil); err != nil {
-		return err
+	return c.do(ctx, http.MethodDelete, "/pods/"+url.PathEscape(podID), nil, nil)
+}
+
+func decodePortMappings(raw map[string]any) map[string]int {
+	ports := make(map[string]int, len(raw))
+	for key, value := range raw {
+		switch v := value.(type) {
+		case float64:
+			ports[key] = int(v)
+		case int:
+			ports[key] = v
+		case string:
+			if parsed, err := strconv.Atoi(v); err == nil {
+				ports[key] = parsed
+			}
+		}
 	}
+	return ports
+}
+
+func (p *runpodPod) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		ID            string         `json:"id"`
+		Name          string         `json:"name"`
+		ImageName     string         `json:"imageName"`
+		Image         string         `json:"image"`
+		DesiredStatus string         `json:"desiredStatus"`
+		Status        string         `json:"status"`
+		MachineID     string         `json:"machineId"`
+		Machine       runpodMachine  `json:"machine"`
+		Runtime       *runpodRuntime `json:"runtime"`
+		PublicIP      string         `json:"publicIp"`
+		PortMappings  map[string]any `json:"portMappings"`
+		CostPerHr     any            `json:"costPerHr"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return fmt.Errorf("decode runpod response: %w", err)
+	}
+	*p = runpodPod{
+		ID:            aux.ID,
+		Name:          aux.Name,
+		ImageName:     aux.ImageName,
+		Image:         aux.Image,
+		DesiredStatus: aux.DesiredStatus,
+		Status:        aux.Status,
+		MachineID:     aux.MachineID,
+		Machine:       aux.Machine,
+		Runtime:       aux.Runtime,
+		PublicIP:      aux.PublicIP,
+		CostPerHr:     aux.CostPerHr,
+	}
+	p.PortMappings = decodePortMappings(aux.PortMappings)
 	return nil
 }
 

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -1,0 +1,119 @@
+package runpod
+
+import (
+	"context"
+	"flag"
+	"io"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type RunpodConfig = core.RunpodConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+type TailscaleConfig = core.TailscaleConfig
+
+const (
+	providerName  = "runpod"
+	targetLinux   = core.TargetLinux
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func leaseProviderName(leaseID, slug string) string {
+	return core.LeaseProviderName(leaseID, slug)
+}
+
+func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
+	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, provider)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
+	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
+}
+
+func sshTargetFromConfig(cfg Config, host string) SSHTarget {
+	return core.SSHTargetFromConfig(cfg, host)
+}
+
+func isDefaultWorkRoot(value string) bool {
+	return core.IsDefaultWorkRoot(value)
+}
+
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+}
+
+func bootstrapWaitTimeout(cfg Config) time.Duration {
+	return core.BootstrapWaitTimeout(cfg)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+// isRunpodProviderName reports whether the configured provider string refers to
+// the runpod provider, accepting the canonical name and the documented aliases
+// in a case- and whitespace-tolerant way.
+func isRunpodProviderName(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case providerName, "run-pod", "runpodio":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -98,6 +98,10 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }
 
+func runSSHQuiet(ctx context.Context, target SSHTarget, remote string) error {
+	return core.RunSSHQuiet(ctx, target, remote)
+}
+
 func bootstrapWaitTimeout(cfg Config) time.Duration {
 	return core.BootstrapWaitTimeout(cfg)
 }

--- a/internal/providers/runpod/flags.go
+++ b/internal/providers/runpod/flags.go
@@ -1,0 +1,74 @@
+package runpod
+
+import "flag"
+
+type runpodFlagValues struct {
+	APIURL     *string
+	CloudType  *string
+	InstanceID *string
+	Image      *string
+	TemplateID *string
+	DiskGB     *int
+	User       *string
+	WorkRoot   *string
+}
+
+// RegisterRunpodProviderFlags exposes runpod-specific flags. The API key is
+// intentionally not surfaced as a flag because secrets must not be passed as
+// command-line arguments; it is sourced from RUNPOD_API_KEY /
+// CRABBOX_RUNPOD_API_KEY.
+func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return runpodFlagValues{
+		APIURL:     fs.String("runpod-url", defaults.Runpod.APIURL, "RunPod GraphQL API URL"),
+		CloudType:  fs.String("runpod-cloud-type", defaults.Runpod.CloudType, "RunPod cloud type: ALL, SECURE, or COMMUNITY"),
+		InstanceID: fs.String("runpod-instance-id", defaults.Runpod.InstanceID, "RunPod CPU instance flavor ID, e.g. cpu3c-2-4"),
+		Image:      fs.String("runpod-image", defaults.Runpod.Image, "Docker image to deploy on the pod"),
+		TemplateID: fs.String("runpod-template-id", defaults.Runpod.TemplateID, "Optional RunPod template ID"),
+		DiskGB:     fs.Int("runpod-disk-gb", defaults.Runpod.DiskGB, "Container disk size in GB"),
+		User:       fs.String("runpod-user", defaults.Runpod.User, "SSH user for runpod pods"),
+		WorkRoot:   fs.String("runpod-work-root", defaults.Runpod.WorkRoot, "remote Crabbox work root on runpod pods"),
+	}
+}
+
+func ApplyRunpodProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if isRunpodProviderName(cfg.Provider) {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s; use --runpod-instance-id", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s; use --runpod-image", providerName)
+		}
+	}
+	v, ok := values.(runpodFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "runpod-url") {
+		cfg.Runpod.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "runpod-cloud-type") {
+		cfg.Runpod.CloudType = *v.CloudType
+	}
+	if flagWasSet(fs, "runpod-instance-id") {
+		cfg.Runpod.InstanceID = *v.InstanceID
+	}
+	if flagWasSet(fs, "runpod-image") {
+		cfg.Runpod.Image = *v.Image
+	}
+	if flagWasSet(fs, "runpod-template-id") {
+		cfg.Runpod.TemplateID = *v.TemplateID
+	}
+	if flagWasSet(fs, "runpod-disk-gb") {
+		cfg.Runpod.DiskGB = *v.DiskGB
+	}
+	if flagWasSet(fs, "runpod-user") {
+		cfg.Runpod.User = *v.User
+	}
+	if flagWasSet(fs, "runpod-work-root") {
+		cfg.Runpod.WorkRoot = *v.WorkRoot
+	}
+	if isRunpodProviderName(cfg.Provider) {
+		applyRunpodDefaults(cfg)
+	}
+	return nil
+}

--- a/internal/providers/runpod/flags.go
+++ b/internal/providers/runpod/flags.go
@@ -19,9 +19,9 @@ type runpodFlagValues struct {
 // CRABBOX_RUNPOD_API_KEY.
 func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	return runpodFlagValues{
-		APIURL:     fs.String("runpod-url", defaults.Runpod.APIURL, "RunPod GraphQL API URL"),
-		CloudType:  fs.String("runpod-cloud-type", defaults.Runpod.CloudType, "RunPod cloud type: ALL, SECURE, or COMMUNITY"),
-		InstanceID: fs.String("runpod-instance-id", defaults.Runpod.InstanceID, "RunPod CPU instance flavor ID, e.g. cpu3c-2-4"),
+		APIURL:     fs.String("runpod-url", defaults.Runpod.APIURL, "RunPod REST API URL"),
+		CloudType:  fs.String("runpod-cloud-type", defaults.Runpod.CloudType, "RunPod cloud type: SECURE or COMMUNITY"),
+		InstanceID: fs.String("runpod-instance-id", defaults.Runpod.InstanceID, "RunPod GPU type ID or CPU flavor ID"),
 		Image:      fs.String("runpod-image", defaults.Runpod.Image, "Docker image to deploy on the pod"),
 		TemplateID: fs.String("runpod-template-id", defaults.Runpod.TemplateID, "Optional RunPod template ID"),
 		DiskGB:     fs.Int("runpod-disk-gb", defaults.Runpod.DiskGB, "Container disk size in GB"),

--- a/internal/providers/runpod/provider.go
+++ b/internal/providers/runpod/provider.go
@@ -1,0 +1,59 @@
+package runpod
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"run-pod", "runpodio"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterRunpodProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyRunpodProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, exit(2, "provider=%s managed provisioning supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, exit(2, "--tailscale is not supported for provider=%s; runpod pods expose public SSH only", providerName)
+	}
+	return NewRunpodLeaseBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "runpod doctor backend unavailable")
+	}
+	return doctor, nil
+}


### PR DESCRIPTION
## Summary

Adds `provider: runpod` as an SSH-lease provider. Crabbox creates a CPU pod through the RunPod GraphQL API (`deployCpuPod`), polls `pod.runtime.ports[]` for the public TCP mapping to port 22, and hands callers a normal SSH lease. After that, sync, run, ssh, status, and stop reuse Crabbox's existing SSH transports.

## How it works

- `Acquire` -> `deployCpuPod(input: { startSsh: true, ports: "22/tcp", instanceId, image, containerDiskInGb, cloudType })`, then waits for `pod.runtime.ports[]` to publish `privatePort:22, isIpPublic:true` and a non-zero `publicPort`.
- `Resolve` / `List` use `pod(input: {podId})` and `myself { pods { ... } }`. List filters to `crabbox-` prefix unless `--all` is set.
- `ReleaseLease` calls `podTerminate(input: {podId})`.
- `Doctor` runs `myself` (auth) plus `myself.pods` (inventory) without ever invoking a mutation.

## Setup

```sh
export RUNPOD_API_KEY=...   # upload an ED25519 public key under RunPod settings once
crabbox doctor --provider runpod
crabbox run --provider runpod -- pnpm test
```

`CRABBOX_RUNPOD_API_KEY` overrides `RUNPOD_API_KEY`. Token is never accepted as a flag.

## Why this pattern

RunPod returns public SSH coordinates on pod create, so the SSH-lease shape mirrors `exe-dev` and lets Crabbox reuse its existing SSH sync/run/status/ssh/stop paths instead of growing a parallel verb tree.

## Tested

- Unit: `go test -race ./internal/providers/runpod/...` (16 tests, all pass), `go vet`, `gofmt` clean.
- Registry: `go test -race ./internal/providers/all/...` passes with `runpod` in the doctor-implementing list.
- Live: `RUNPOD_API_KEY=... crabbox doctor --provider runpod` returns `auth=ready control_plane=ready inventory=ready` against the real GraphQL endpoint. Live `crabbox run` exercises the `deployCpuPod` mutation and is correctly rejected with "Your account balance is too low to rent a pod" - the schema/mutation/input casing are validated but a funded RunPod account is required to actually boot a pod.

## Follow-ups

- Add GPU flavor support (`deployOnDemand` + `gpuTypeId`) once there is a Crabbox use case for paid GPU SKUs.
- Wire a `crabbox doctor --doctor-probe-ssh` check that opens the public port reported by `runtime.ports[]`.
- Plumb a coordinator-side broker path so teams can share a single funded RunPod account without distributing the API key.