### PR TITLE
feat(images): support fast snapshot restore promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `provider: runpod` for RunPod public TCP SSH leases through the RunPod REST API, including Crabbox sync/run, `crabbox ssh`, `crabbox doctor`, and provider docs. Thanks @zozo123.
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
+- Added explicit AWS Fast Snapshot Restore promotion support for hot developer-image AMIs via `crabbox image promote --fast-snapshot-restore --fsr-az <az>` and the AWS developer-image mint wrapper.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
 
 ### Changed

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -100,6 +100,8 @@ Flags:
 --type <instance-type>   instance type the AMI boots on, for example mac1.metal
 --server-type <type>     alias for --type
 --architecture <arch>    AWS AMI architecture, for example x86_64_mac or arm64_mac
+--fast-snapshot-restore  enable AWS Fast Snapshot Restore for backing snapshots
+--fsr-az <az>            availability zone for Fast Snapshot Restore; repeatable
 --json                   print JSON
 ```
 
@@ -109,6 +111,22 @@ their source lease. For external macOS AMIs, Crabbox reads the AMI architecture
 from AWS and also accepts `--type` or `--architecture` when you want to pin the
 promotion metadata explicitly. Add `--json` to print the promoted image record
 for automation.
+
+Add `--fast-snapshot-restore` plus one or more `--fsr-az` values when the
+promoted image backs hot lanes that need immediate EBS snapshot reads:
+
+```sh
+crabbox image promote \
+  --target windows \
+  --region us-west-2 \
+  --fast-snapshot-restore \
+  --fsr-az us-west-2a \
+  --fsr-az us-west-2b \
+  ami-1234567890abcdef0
+```
+
+Fast Snapshot Restore is provider-billed per snapshot and availability zone.
+Use it for known hot zones, not every candidate bake.
 
 Future brokered AWS leases use the promoted image when the request does not set
 an explicit `awsAMI` or `CRABBOX_AWS_AMI` override. Promotion stores coordinator

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -206,6 +206,20 @@ scripts/mint-aws-devtools-image.sh \
   --run
 ```
 
+For hot maintainer lanes that need lower first-boot variance, enable Fast
+Snapshot Restore only in the availability zones you will actually launch from:
+
+```bash
+scripts/mint-aws-devtools-image.sh \
+  --target windows \
+  --region us-west-2 \
+  --type m7i.large \
+  --fast-snapshot-restore \
+  --fsr-az us-west-2a \
+  --fsr-az us-west-2b \
+  --run
+```
+
 The Linux prep script installs common CLI/build tooling, GitHub CLI, Node 24,
 corepack/pnpm, Chrome or Chromium for browser lanes, desktop/VNC helpers, Docker
 Engine, Compose, buildx, and a small default Docker image set. The Windows prep
@@ -252,8 +266,11 @@ EBS snapshots hydrate lazily by default, so new regions or availability zones
 can still pay first-read penalties. For hot production lanes, keep capacity in
 the same region as the promoted AMI, track the wrapper timing logs, and enable
 AWS Fast Snapshot Restore on the backing snapshots in the availability zones
-where the image must boot immediately. Treat snapshot warmup as a separate
-provider-cost decision; do not enable it casually for every candidate image.
+where the image must boot immediately. Use `crabbox image promote
+--fast-snapshot-restore --fsr-az <az>` directly or pass
+`--fast-snapshot-restore --fsr-az <az>` to the AWS developer-image wrapper.
+Treat snapshot warmup as a separate provider-cost decision; do not enable it
+casually for every candidate image.
 
 ## macOS Images
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -242,8 +242,10 @@ The AWS provider imports the local SSH public key as an EC2 key pair when needed
 Grant the Worker AWS principal EC2 launch/list/tag/terminate permissions for
 instances, key pairs, and managed security groups, plus `CreateImage`,
 `DeregisterImage`, `RegisterImage`, `DescribeSnapshots`, `DeleteSnapshot`,
-and `servicequotas:GetServiceQuota`. The image permissions are required for
-`crabbox image`, native AWS checkpoints, and macOS image bake validation.
+`DescribeFastSnapshotRestores`, `EnableFastSnapshotRestores`, and
+`servicequotas:GetServiceQuota`. The image permissions are required for
+`crabbox image`, native AWS checkpoints, macOS image bake validation, and
+explicit Fast Snapshot Restore promotion for hot AMIs.
 Service Quotas access is best-effort: when it is available, Crabbox can skip
 known quota-impossible instance types before calling `RunInstances`; when it
 is missing, EC2 launch errors are still classified after the failed call.

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -148,6 +148,7 @@ const awsProviderPolicyJSON = `{
         "ec2:DescribeInstances",
         "ec2:DescribeKeyPairs",
         "ec2:DescribeSecurityGroups",
+        "ec2:DescribeFastSnapshotRestores",
         "ec2:DescribeSnapshots",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
@@ -170,6 +171,7 @@ const awsProviderPolicyJSON = `{
         "ec2:DeregisterImage",
         "ec2:CreateSnapshot",
         "ec2:DeleteSnapshot",
+        "ec2:EnableFastSnapshotRestores",
         "ec2:CreateTags"
       ],
       "Resource": "*"

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -123,6 +123,7 @@ func TestAdminAWSPolicyPrintsProviderPermissions(t *testing.T) {
 		`"ec2:CreateImage"`,
 		`"ec2:RegisterImage"`,
 		`"ec2:DeleteSnapshot"`,
+		`"ec2:EnableFastSnapshotRestores"`,
 		`"servicequotas:GetServiceQuota"`,
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -167,22 +167,30 @@ type CoordinatorProviderReadiness struct {
 }
 
 type CoordinatorImage struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	State        string   `json:"state"`
-	Provider     string   `json:"provider,omitempty"`
-	Kind         string   `json:"kind,omitempty"`
-	Region       string   `json:"region,omitempty"`
-	AccountID    string   `json:"accountId,omitempty"`
-	Project      string   `json:"project,omitempty"`
-	ResourceID   string   `json:"resourceID,omitempty"`
-	SnapshotIDs  []string `json:"snapshotIds,omitempty"`
-	Direct       bool     `json:"direct,omitempty"`
-	Target       string   `json:"target,omitempty"`
-	WindowsMode  string   `json:"windowsMode,omitempty"`
-	ServerType   string   `json:"serverType,omitempty"`
-	Architecture string   `json:"architecture,omitempty"`
-	PromotedAt   string   `json:"promotedAt,omitempty"`
+	ID                   string                           `json:"id"`
+	Name                 string                           `json:"name"`
+	State                string                           `json:"state"`
+	Provider             string                           `json:"provider,omitempty"`
+	Kind                 string                           `json:"kind,omitempty"`
+	Region               string                           `json:"region,omitempty"`
+	AccountID            string                           `json:"accountId,omitempty"`
+	Project              string                           `json:"project,omitempty"`
+	ResourceID           string                           `json:"resourceID,omitempty"`
+	SnapshotIDs          []string                         `json:"snapshotIds,omitempty"`
+	Direct               bool                             `json:"direct,omitempty"`
+	Target               string                           `json:"target,omitempty"`
+	WindowsMode          string                           `json:"windowsMode,omitempty"`
+	ServerType           string                           `json:"serverType,omitempty"`
+	Architecture         string                           `json:"architecture,omitempty"`
+	PromotedAt           string                           `json:"promotedAt,omitempty"`
+	FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores,omitempty"`
+}
+
+type CoordinatorFastSnapshotRestore struct {
+	SnapshotID            string `json:"snapshotID"`
+	AvailabilityZone      string `json:"availabilityZone"`
+	State                 string `json:"state,omitempty"`
+	StateTransitionReason string `json:"stateTransitionReason,omitempty"`
 }
 
 type CoordinatorMacHost struct {
@@ -236,13 +244,15 @@ type CoordinatorAWSPolicyTarget struct {
 }
 
 type CoordinatorImageRef struct {
-	Provider     string
-	Region       string
-	Project      string
-	Kind         string
-	Target       string
-	ServerType   string
-	Architecture string
+	Provider               string
+	Region                 string
+	Project                string
+	Kind                   string
+	Target                 string
+	ServerType             string
+	Architecture           string
+	FastSnapshotRestore    bool
+	FastSnapshotRestoreAZs []string
 }
 
 type CoordinatorGitHubLoginStart struct {
@@ -1228,6 +1238,14 @@ func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {
 		}
 		if strings.TrimSpace(ref.Architecture) != "" {
 			values.Set("architecture", strings.TrimSpace(ref.Architecture))
+		}
+		if ref.FastSnapshotRestore {
+			values.Set("fastSnapshotRestore", "true")
+		}
+		for _, zone := range ref.FastSnapshotRestoreAZs {
+			if strings.TrimSpace(zone) != "" {
+				values.Add("fsrAz", strings.TrimSpace(zone))
+			}
 		}
 	}
 	if encoded := values.Encode(); encoded != "" {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1172,6 +1172,12 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 			if got := r.URL.Query().Get("architecture"); got != "x86_64_mac" {
 				t.Fatalf("promote architecture=%q", got)
 			}
+			if got := r.URL.Query().Get("fastSnapshotRestore"); got != "true" {
+				t.Fatalf("promote fastSnapshotRestore=%q", got)
+			}
+			if got := r.URL.Query()["fsrAz"]; !reflect.DeepEqual(got, []string{"us-east-1a", "us-east-1b"}) {
+				t.Fatalf("promote fsrAz=%#v", got)
+			}
 			_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","name":"openclaw-crabbox-test","state":"available","region":"eu-west-1","promotedAt":"2026-05-01T12:46:00Z"}}`))
 		default:
 			http.NotFound(w, r)
@@ -1190,7 +1196,7 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 	if image, err := client.Image(context.Background(), "ami-12345678"); err != nil || image.State != "available" {
 		t.Fatalf("image=%#v err=%v", image, err)
 	}
-	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", Target: "macos", ServerType: "mac1.metal", Architecture: "x86_64_mac"}); err != nil || promoted.PromotedAt == "" {
+	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", Target: "macos", ServerType: "mac1.metal", Architecture: "x86_64_mac", FastSnapshotRestore: true, FastSnapshotRestoreAZs: []string{"us-east-1a", "us-east-1b"}}); err != nil || promoted.PromotedAt == "" {
 		t.Fatalf("promoted=%#v err=%v", promoted, err)
 	}
 	if err := client.DeleteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "eu-west-1", Kind: "aws-ami"}); err != nil {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -51,12 +51,15 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	serverType := fs.String("type", "", "AWS instance type the AMI boots on, for example mac1.metal")
 	serverTypeAlias := fs.String("server-type", "", "alias for --type")
 	architecture := fs.String("architecture", "", "AWS AMI architecture, for example x86_64_mac or arm64_mac")
+	fastSnapshotRestore := fs.Bool("fast-snapshot-restore", false, "enable AWS Fast Snapshot Restore for the promoted AMI snapshots")
+	var fastSnapshotRestoreAZs stringListFlag
+	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore; repeatable")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox image promote <ami-id> [--target linux|macos|windows] [--region <aws-region>] [--type <instance-type>] [--architecture <arch>]")
+		return exit(2, "usage: crabbox image promote <ami-id> [--target linux|macos|windows] [--region <aws-region>] [--type <instance-type>] [--architecture <arch>] [--fast-snapshot-restore --fsr-az <az>]")
 	}
 	if *serverType == "" {
 		*serverType = *serverTypeAlias
@@ -66,11 +69,13 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		return err
 	}
 	image, err := coord.PromoteImage(ctx, fs.Arg(0), CoordinatorImageRef{
-		Provider:     "aws",
-		Region:       *region,
-		Target:       *target,
-		ServerType:   *serverType,
-		Architecture: *architecture,
+		Provider:               "aws",
+		Region:                 *region,
+		Target:                 *target,
+		ServerType:             *serverType,
+		Architecture:           *architecture,
+		FastSnapshotRestore:    *fastSnapshotRestore,
+		FastSnapshotRestoreAZs: fastSnapshotRestoreAZs,
 	})
 	if err != nil {
 		return err

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -17,6 +17,8 @@ reboot_settle_seconds="${CRABBOX_IMAGE_REBOOT_SETTLE_SECONDS:-30}"
 reboot_ready_settle_seconds="${CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS:-180}"
 windows_warmup_wait_timeout="${CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT:-15m}"
 windows_warmup_settle_seconds="${CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS:-90}"
+fast_snapshot_restore="${CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE:-0}"
+fast_snapshot_restore_azs="${CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE_AZS:-}"
 run="${CRABBOX_IMAGE_RUN:-0}"
 promote="${CRABBOX_IMAGE_PROMOTE:-1}"
 keep_lease="${CRABBOX_IMAGE_KEEP_LEASE:-0}"
@@ -42,6 +44,9 @@ Flags:
   --name NAME           image name
   --run                 allow paid lease/image work
   --no-promote          smoke candidate only
+  --fast-snapshot-restore
+                       enable AWS Fast Snapshot Restore when promoting
+  --fsr-az AZ           availability zone for Fast Snapshot Restore; repeatable
   --keep-lease          keep proof leases alive
   --desktop             request desktop bootstrap
   --no-desktop          do not request desktop bootstrap
@@ -62,6 +67,8 @@ Useful env:
   CRABBOX_IMAGE_REBOOT_READY_SETTLE_SECONDS
   CRABBOX_IMAGE_WINDOWS_WARMUP_WAIT_TIMEOUT
   CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS
+  CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE
+  CRABBOX_IMAGE_FAST_SNAPSHOT_RESTORE_AZS
 USAGE
 }
 
@@ -99,6 +106,19 @@ while [[ "$#" -gt 0 ]]; do
     --no-promote)
       promote=0
       shift
+      ;;
+    --fast-snapshot-restore)
+      fast_snapshot_restore=1
+      shift
+      ;;
+    --fsr-az)
+      [[ "$#" -ge 2 ]] || { printf '%s requires a value\n' "$1" >&2; exit 2; }
+      if [[ -n "$fast_snapshot_restore_azs" ]]; then
+        fast_snapshot_restore_azs+=",$2"
+      else
+        fast_snapshot_restore_azs="$2"
+      fi
+      shift 2
       ;;
     --keep-lease)
       keep_lease=1
@@ -558,6 +578,7 @@ AWS devtools image mint
   type:   ${server_type:-auto}
   prep:   $prep_script
   proof:  desktop=$desktop browser=$browser promote=$promote
+  fsr:    enabled=$fast_snapshot_restore azs=${fast_snapshot_restore_azs:-auto}
   paid:   run=$run keep_lease=$keep_lease
 EOF
 
@@ -592,8 +613,17 @@ if [[ "$promote" != "1" ]]; then
   exit 0
 fi
 
-promote_args=(image promote "$ami_id" --target "$target" --json)
+promote_args=(image promote --target "$target" --json)
 [[ -n "$region" ]] && promote_args+=(--region "$region")
+if [[ "$fast_snapshot_restore" == "1" ]]; then
+  promote_args+=(--fast-snapshot-restore)
+  IFS=',' read -r -a fsr_az_values <<<"$fast_snapshot_restore_azs"
+  for fsr_az in "${fsr_az_values[@]}"; do
+    [[ -n "$fsr_az" ]] || continue
+    promote_args+=(--fsr-az "$fsr_az")
+  done
+fi
+promote_args+=("$ami_id")
 run_cmd "$CRABBOX_BIN" "${promote_args[@]}"
 
 if [[ "$keep_lease" != "1" ]]; then

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -125,7 +125,20 @@ test("AWS devtools mint wrapper defaults to dry plan", async () => {
 test("AWS devtools mint wrapper runs linux source candidate and promoted proof", async () => {
   const fake = await setupFakeCrabbox();
   const result = await runScript(
-    ["--target", "linux", "--region", "us-west-2", "--type", "m7i.large", "--run", "--prep-script", fake.linuxPrep],
+    [
+      "--target",
+      "linux",
+      "--region",
+      "us-west-2",
+      "--type",
+      "m7i.large",
+      "--run",
+      "--fast-snapshot-restore",
+      "--fsr-az",
+      "us-west-2a",
+      "--prep-script",
+      fake.linuxPrep,
+    ],
     {
       CRABBOX_BIN: fake.fake,
       CRABBOX_FAKE_LOG: fake.log,
@@ -146,7 +159,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.match(log, /run --provider aws --target linux --id cbx_source --no-sync --script/);
   assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
   assert.match(log, /image create --id cbx_source --name crabbox-linux-devtools-/);
-  assert.match(log, /image promote ami-devtools --target linux --json --region us-west-2/);
+  assert.match(log, /image promote --target linux --json --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/);
 });
 
 test("AWS devtools mint wrapper maps windows flags", async () => {

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -11,7 +11,13 @@ import {
 } from "./config";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
-import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
+import type {
+  Env,
+  ProviderFastSnapshotRestore,
+  ProviderImage,
+  ProviderMachine,
+  ProvisioningAttempt,
+} from "./types";
 
 const awsUbuntuOwner = "099720109477";
 const ec2Version = "2016-11-15";
@@ -558,6 +564,50 @@ export class EC2SpotClient {
       // oxlint-disable-next-line eslint/no-await-in-loop -- EBS snapshot deletes are independent cleanup calls.
       await this.deleteSnapshotWithRetry(snapshotID);
     }
+  }
+
+  async enableFastSnapshotRestore(
+    snapshotIDs: string[],
+    availabilityZones: string[],
+  ): Promise<ProviderFastSnapshotRestore[]> {
+    const snapshots = uniqueStrings(snapshotIDs);
+    const zones = uniqueStrings(availabilityZones);
+    if (snapshots.length === 0 || zones.length === 0) {
+      return [];
+    }
+    const params: Record<string, string> = {};
+    snapshots.forEach((snapshotID, index) => {
+      params[`SourceSnapshotId.${index + 1}`] = snapshotID;
+    });
+    zones.forEach((zone, index) => {
+      params[`AvailabilityZone.${index + 1}`] = zone;
+    });
+    const root = await this.ec2("EnableFastSnapshotRestores", params);
+    const successes = fastSnapshotRestoreItems(root, "enableFastSnapshotRestoreSuccessSet");
+    const errors = fastSnapshotRestoreItems(root, "enableFastSnapshotRestoreErrorSet");
+    if (errors.length > 0) {
+      const message = errors
+        .map((error) =>
+          [
+            error.snapshotID,
+            error.availabilityZone,
+            error.stateTransitionReason || error.state || "failed",
+          ]
+            .filter(Boolean)
+            .join(":"),
+        )
+        .join(", ");
+      throw new Error(`aws fast snapshot restore failed: ${message}`);
+    }
+    return successes.length > 0
+      ? successes
+      : snapshots.flatMap((snapshotID) =>
+          zones.map((availabilityZone) => ({
+            snapshotID,
+            availabilityZone,
+            state: "enabling",
+          })),
+        );
   }
 
   async listMacHosts(serverType = "", state = ""): Promise<AWSMacHost[]> {
@@ -1563,6 +1613,24 @@ function imageSnapshotIDs(image: Record<string, unknown>): string[] {
     .map((mapping) => asString(record(record(mapping)["ebs"])["snapshotId"]))
     .filter((snapshotID) => snapshotID !== "");
   return [...new Set(snapshots)];
+}
+
+function fastSnapshotRestoreItems(
+  root: Record<string, unknown>,
+  field: string,
+): ProviderFastSnapshotRestore[] {
+  return items(record(root[field])["item"]).map((entry) => {
+    const item = record(entry);
+    const error = record(item["error"]);
+    const state = asString(item["state"] ?? error["code"]);
+    const stateTransitionReason = asString(item["stateTransitionReason"] ?? error["message"]);
+    return {
+      snapshotID: asString(item["snapshotId"] ?? item["sourceSnapshotId"]),
+      availabilityZone: asString(item["availabilityZone"]),
+      ...(state ? { state } : {}),
+      ...(stateTransitionReason ? { stateTransitionReason } : {}),
+    };
+  });
 }
 
 function tagValue(resource: Record<string, unknown>, key: string): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -54,6 +54,7 @@ import type {
   LeaseShareRole,
   LeaseTelemetry,
   Provider,
+  ProviderFastSnapshotRestore,
   ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
@@ -3742,11 +3743,15 @@ export class FleetDurableObject implements DurableObject {
         region?: string;
         serverType?: string;
         architecture?: string;
+        fastSnapshotRestore?: unknown;
+        fastSnapshotRestoreAvailabilityZones?: string[];
       } = await readJson<{
         target?: string;
         region?: string;
         serverType?: string;
         architecture?: string;
+        fastSnapshotRestore?: unknown;
+        fastSnapshotRestoreAvailabilityZones?: string[];
       }>(request).catch(() => ({}));
       const target = normalizeAWSImageTarget(
         input.target ?? url.searchParams.get("target") ?? known?.target ?? "linux",
@@ -3776,6 +3781,27 @@ export class FleetDurableObject implements DurableObject {
       if (architecture) {
         metadata.architecture = architecture;
       }
+      const fastSnapshotRestore = boolFromUnknown(
+        input.fastSnapshotRestore ?? url.searchParams.get("fastSnapshotRestore"),
+      );
+      const fastSnapshotRestoreAvailabilityZones = fastSnapshotRestore
+        ? fastSnapshotRestoreAZs(
+            input.fastSnapshotRestoreAvailabilityZones,
+            url,
+            imageRegion,
+            this.env,
+          )
+        : [];
+      if (fastSnapshotRestore && fastSnapshotRestoreAvailabilityZones.length === 0) {
+        return json(
+          {
+            error: "invalid_fast_snapshot_restore_zones",
+            message:
+              "Fast Snapshot Restore promotion requires at least one availability zone via fsrAz, fastSnapshotRestoreAvailabilityZones, CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS, or CRABBOX_CAPACITY_AVAILABILITY_ZONES",
+          },
+          { status: 400 },
+        );
+      }
       const image = mergeAWSImageMetadata(
         await this.provider("aws", imageRegion).getImage(decodedImageID),
         metadata,
@@ -3795,8 +3821,25 @@ export class FleetDurableObject implements DurableObject {
           { status: 400 },
         );
       }
+      if (fastSnapshotRestoreAvailabilityZones.length > 0 && (image.snapshots ?? []).length === 0) {
+        return json(
+          {
+            error: "image_snapshots_missing",
+            message: `image ${decodedImageID} has no EBS snapshots to enable for Fast Snapshot Restore`,
+          },
+          { status: 409 },
+        );
+      }
+      const fastSnapshotRestores =
+        fastSnapshotRestoreAvailabilityZones.length > 0
+          ? await this.provider("aws", imageRegion).enableFastSnapshotRestore?.(
+              image.snapshots ?? [],
+              fastSnapshotRestoreAvailabilityZones,
+            )
+          : undefined;
       const promoted: PromotedImageRecord = {
         ...image,
+        ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
         target,
         region: image.region ?? imageRegion,
         architecture:
@@ -4562,6 +4605,43 @@ function awsImageArchitectureForTarget(target: TargetOS, serverType: string): st
 function sanitizeAWSRegion(value: string): string {
   const region = value.trim().toLowerCase();
   return /^[a-z]{2}-[a-z-]+-[0-9]$/.test(region) ? region : "";
+}
+
+function boolFromUnknown(value: unknown): boolean {
+  if (value === true) return true;
+  if (value === false || value === undefined || value === null) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(normalized);
+}
+
+function fastSnapshotRestoreAZs(
+  inputZones: string[] | undefined,
+  url: URL,
+  region: string,
+  env: Pick<Env, "CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS" | "CRABBOX_CAPACITY_AVAILABILITY_ZONES">,
+): string[] {
+  const zones = [
+    ...(inputZones ?? []),
+    ...url.searchParams.getAll("fsrAz"),
+    ...splitCommaList(url.searchParams.get("fsrAzs") ?? ""),
+    ...splitCommaList(env.CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS ?? ""),
+    ...splitCommaList(env.CRABBOX_CAPACITY_AVAILABILITY_ZONES ?? ""),
+  ];
+  return [...new Set(zones.map((zone) => zone.trim()).filter((zone) => validAWSAZ(zone, region)))];
+}
+
+function splitCommaList(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function validAWSAZ(zone: string, region: string): boolean {
+  if (!/^[a-z]{2}-[a-z-]+-[0-9][a-z]$/.test(zone)) {
+    return false;
+  }
+  return region === "" || zone.startsWith(region);
 }
 
 function sanitizeMacHostQuotaError(message: string): string {
@@ -6116,6 +6196,10 @@ interface CloudProvider {
   ): Promise<ProviderImage>;
   getImage(imageID: string, kind?: string): Promise<ProviderImage>;
   deleteImage(imageID: string, kind?: string): Promise<void>;
+  enableFastSnapshotRestore?(
+    snapshotIDs: string[],
+    availabilityZones: string[],
+  ): Promise<ProviderFastSnapshotRestore[]>;
   deleteSSHKey(name: string): Promise<void>;
   hourlyPriceUSD(
     serverType: string,
@@ -6417,6 +6501,13 @@ class AWSProvider implements CloudProvider {
 
   getImage(imageID: string): Promise<ProviderImage> {
     return this.client.getImage(imageID);
+  }
+
+  enableFastSnapshotRestore(
+    snapshotIDs: string[],
+    availabilityZones: string[],
+  ): Promise<ProviderFastSnapshotRestore[]> {
+    return this.client.enableFastSnapshotRestore(snapshotIDs, availabilityZones);
   }
 
   deleteImage(imageID: string): Promise<void> {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -11,6 +11,7 @@ export interface Env {
   CRABBOX_AWS_INSTANCE_PROFILE?: string;
   CRABBOX_AWS_ROOT_GB?: string;
   CRABBOX_AWS_SSH_CIDRS?: string;
+  CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS?: string;
   CRABBOX_HOST_ID?: string;
   CRABBOX_AWS_MAC_HOST_ID?: string;
   CRABBOX_AWS_ORPHAN_SWEEP_ENABLED?: string;
@@ -284,6 +285,14 @@ export interface ProviderImage {
   project?: string;
   resourceID?: string;
   snapshots?: string[];
+  fastSnapshotRestores?: ProviderFastSnapshotRestore[];
+}
+
+export interface ProviderFastSnapshotRestore {
+  snapshotID: string;
+  availabilityZone: string;
+  state?: string;
+  stateTransitionReason?: string;
 }
 
 export interface PromotedImageRecord extends ProviderImage {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -189,6 +189,63 @@ describe("aws provider", () => {
     expect(calls).not.toContain("DescribeVpcs:::");
   });
 
+  it("enables Fast Snapshot Restore for AMI snapshots in selected zones", async () => {
+    const calls: Array<Record<string, string>> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = Object.fromEntries(new URLSearchParams(await request.clone().text()));
+        calls.push(params);
+        if (params.Action === "EnableFastSnapshotRestores") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<EnableFastSnapshotRestoresResponse>
+  <enableFastSnapshotRestoreSuccessSet>
+    <item>
+      <snapshotId>snap-root</snapshotId>
+      <availabilityZone>us-west-2a</availabilityZone>
+      <state>enabling</state>
+    </item>
+    <item>
+      <snapshotId>snap-root</snapshotId>
+      <availabilityZone>us-west-2b</availabilityZone>
+      <state>enabled</state>
+    </item>
+  </enableFastSnapshotRestoreSuccessSet>
+</EnableFastSnapshotRestoresResponse>`);
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${params.Action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      } as never,
+      "us-west-2",
+    );
+
+    const records = await client.enableFastSnapshotRestore(
+      ["snap-root", "snap-root"],
+      ["us-west-2a", "us-west-2b"],
+    );
+
+    expect(calls[0]).toMatchObject({
+      Action: "EnableFastSnapshotRestores",
+      "SourceSnapshotId.1": "snap-root",
+      "AvailabilityZone.1": "us-west-2a",
+      "AvailabilityZone.2": "us-west-2b",
+    });
+    expect(calls[0]).not.toHaveProperty("SourceSnapshotId.2");
+    expect(records).toEqual([
+      { snapshotID: "snap-root", availabilityZone: "us-west-2a", state: "enabling" },
+      { snapshotID: "snap-root", availabilityZone: "us-west-2b", state: "enabled" },
+    ]);
+  });
+
   it("does not tag Spot request resources for On-Demand launches", () => {
     const spotParams: Record<string, string> = {};
     addRunInstancesTagSpecifications(spotParams, { crabbox: "true", Name: "crabbox-cbx" }, "spot");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4021,6 +4021,76 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("enables Fast Snapshot Restore when promoting an AWS image", async () => {
+    const storage = new MemoryStorage();
+    const fsrCalls: Array<{ snapshots: string[]; zones: string[] }> = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        onGetImage(imageID) {
+          return {
+            id: imageID,
+            name: "devtools-windows",
+            state: "available",
+            provider: "aws",
+            kind: "aws-ami",
+            region: "us-west-2",
+            resourceID: imageID,
+            architecture: "x86_64",
+            snapshots: ["snap-root", "snap-tools"],
+          };
+        },
+        onEnableFastSnapshotRestore(snapshotIDs, availabilityZones) {
+          fsrCalls.push({ snapshots: snapshotIDs, zones: availabilityZones });
+        },
+      }),
+    });
+
+    const promoted = await fleet.fetch(
+      request("POST", "/v1/images/ami-devtools/promote?target=windows&region=us-west-2", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          fastSnapshotRestore: true,
+          fastSnapshotRestoreAvailabilityZones: ["us-west-2a", "us-west-2b"],
+        },
+      }),
+    );
+
+    expect(promoted.status).toBe(200);
+    expect(fsrCalls).toEqual([
+      { snapshots: ["snap-root", "snap-tools"], zones: ["us-west-2a", "us-west-2b"] },
+    ]);
+    expect(storage.value("image:aws:promoted:windows:x86_64:us-west-2")).toEqual(
+      expect.objectContaining({
+        id: "ami-devtools",
+        target: "windows",
+        fastSnapshotRestores: [
+          { snapshotID: "snap-root", availabilityZone: "us-west-2a", state: "enabling" },
+          { snapshotID: "snap-root", availabilityZone: "us-west-2b", state: "enabling" },
+          { snapshotID: "snap-tools", availabilityZone: "us-west-2a", state: "enabling" },
+          { snapshotID: "snap-tools", availabilityZone: "us-west-2b", state: "enabling" },
+        ],
+      }),
+    );
+  });
+
+  it("requires Fast Snapshot Restore availability zones when no defaults are configured", async () => {
+    const fleet = testFleet(new MemoryStorage(), {
+      aws: fakeProvider(),
+    });
+
+    const promoted = await fleet.fetch(
+      request("POST", "/v1/images/ami-devtools/promote?target=linux&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { fastSnapshotRestore: true },
+      }),
+    );
+
+    expect(promoted.status).toBe(400);
+    await expect(promoted.json()).resolves.toMatchObject({
+      error: "invalid_fast_snapshot_restore_zones",
+    });
+  });
+
   it("uses promoted AWS image region when creating leases", async () => {
     const storage = new MemoryStorage();
     let createdConfig: LeaseConfig | undefined;
@@ -5750,6 +5820,7 @@ function fakeProvider(
     ) => void;
     onGetImage?: (imageID: string, kind?: string) => Promise<ProviderImage> | ProviderImage;
     onDeleteImage?: (imageID: string, kind?: string) => void;
+    onEnableFastSnapshotRestore?: (snapshotIDs: string[], availabilityZones: string[]) => void;
     onRefreshSSHIngress?: (config: LeaseConfig) => void;
   } = {},
   onDelete?: (id: string) => Promise<void>,
@@ -5882,6 +5953,16 @@ function fakeProvider(
     },
     async deleteImage(imageID: string, kind?: string) {
       result.onDeleteImage?.(imageID, kind);
+    },
+    async enableFastSnapshotRestore(snapshotIDs: string[], availabilityZones: string[]) {
+      result.onEnableFastSnapshotRestore?.(snapshotIDs, availabilityZones);
+      return snapshotIDs.flatMap((snapshotID) =>
+        availabilityZones.map((availabilityZone) => ({
+          snapshotID,
+          availabilityZone,
+          state: "enabling",
+        })),
+      );
     },
     async deleteSSHKey() {},
     async hourlyPriceUSD() {


### PR DESCRIPTION
## Summary

- add explicit AWS Fast Snapshot Restore support to `crabbox image promote` and promoted-image coordinator metadata
- wire the AWS developer-image mint wrapper through `--fast-snapshot-restore --fsr-az <az>` and fix its promote flag ordering so real CLI promotion works
- update AWS IAM policy/docs/runbook/changelog for hot developer-image AMIs

## Verification

- `shellcheck scripts/mint-aws-devtools-image.sh`
- `node --test scripts/mint-aws-devtools-image.test.js`
- `go test ./internal/cli`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm test --prefix worker -- aws.test.ts fleet.test.ts`
- GitHub checks: Go, Worker, Docs, Release Check, CodeQL, Socket, and Analyze jobs all passing on `f141596b7531c6fb567ec9d848ec928a15f69bda`

## Notes

- Fast Snapshot Restore remains explicit because AWS bills it per snapshot and availability zone.
- After merge/deploy, promote the hot Linux/Windows developer AMIs again with selected `--fsr-az` values and verify promoted warmup timings.