### PR TITLE
feat: add crew bridge plane for delegated and cross-provider peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.1 - Unreleased
+## Unreleased
 
 ### Added
 
@@ -8,6 +8,18 @@
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
+- Added `--crew <name>` for `crabbox warmup`/`run` plus `crabbox list --crew
+  <name>` so related leases share a reserved `crew` provider label and can be
+  selected together. On Tailscale-capable providers (Hetzner, Azure, GCP
+  managed Linux) the CLI advertises one extra ACL tag
+  `tag:cbx-crew-<owner>-<crew>` when the box joins the tailnet, and cloud-init
+  installs a 30s systemd timer that rewrites `/etc/hosts.cbx` and a managed
+  `/etc/hosts` block from `tailscale status --json` so peers are reachable as
+  `<slug>.box`. `crabbox doctor --crew <name>` verifies the one-time concrete
+  crew grants or ACL row when `TS_API_KEY` is exported and skips with a hint otherwise;
+  non-Tailscale providers honor the label as metadata and `doctor --crew`
+  reports the missing plane. See `docs/features/crew.md` for the one-time
+  policy snippet.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@
   non-Tailscale providers honor the label as metadata and `doctor --crew`
   reports the missing plane. See `docs/features/crew.md` for the one-time
   policy snippet.
+- Added the crew **bridge plane** — `crabbox crew peers --crew <name>`
+  returns a unified peer listing across every provider in the crew with a
+  per-peer `transport` hint (`tailnet`, `url`, `ssh`, `pending`, `none`) and
+  a canonical endpoint. Managed-Linux peers report their tailnet IPv4;
+  SSH-lease peers report `ssh://host:port`; delegated providers with a URL
+  adapter (Islo / E2B / Railway today; Modal / Cloudflare / Tensorlake
+  surface as `unsupported` until their providers expose a per-sandbox
+  HTTPS ingress) report per-port public HTTPS URLs minted through the
+  provider's native ingress (idempotent via `--share-port` / `--share-ttl`).
+  Providers without an adapter, plus Blacksmith, are surfaced as
+  `transport=none` with an honest note so doctor does not pretend the peer
+  is reachable. The companion `crabbox doctor --crew <name>` prints the
+  per-transport reachability matrix alongside its existing Tailscale ACL
+  check and is explicit about the asymmetry — `tailnet -> url` works,
+  `url -> tailnet` does not, and SSH pairs need operator-side bridging.
 
 ### Changed
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -41,5 +41,6 @@ Command docs live here, one file per top-level command. Keep `docs/cli.md` as th
 - [inspect](inspect.md)
 - [stop](stop.md)
 - [cleanup](cleanup.md)
+- [crew](crew.md)
 - [azure](azure.md)
 - [config](config.md)

--- a/docs/commands/crew.md
+++ b/docs/commands/crew.md
@@ -1,0 +1,110 @@
+# crew
+
+`crabbox crew` is the cross-provider peer-discovery surface. A single
+invocation lists every member of the named crew with a transport hint
+(`tailnet` / `url` / `ssh` / `pending` / `none`) and a canonical endpoint, so
+callers can dial peers without knowing which provider each lease lives on.
+See `docs/features/crew.md` for the full design.
+
+```sh
+crabbox crew peers --crew alpha
+crabbox crew peers --crew alpha --json
+crabbox crew peers --crew alpha --provider islo --share-port 8080
+crabbox crew peers --crew alpha --share-port 8080 --share-ttl 1h --json
+crabbox doctor --crew alpha
+```
+
+## `crew peers`
+
+List every peer in the named crew, regardless of provider. When
+`--provider` is omitted the command fans out across every provider in
+the crew; passing it preserves the original single-provider semantics.
+
+| Flag             | Default | Description                                            |
+| ---------------- | ------- | ------------------------------------------------------ |
+| `--crew <name>`  | —       | Required. The crew label to resolve.                   |
+| `--provider`     | (all)   | Restrict to a single provider; defaults to every provider represented in the crew. |
+| `--json`         | `false` | Emit machine-readable JSON instead of text.            |
+| `--share-port`   | `0`     | If non-zero, publish a public URL for that port on each URL-transport peer. The call is idempotent: an existing share is reused. |
+| `--share-ttl`    | `24h`   | TTL for shares created with `--share-port`. Islo clamps into the legal 60s..7d range. |
+
+Without `--share-port`, the command lists existing endpoints — calls are
+cheap and side-effect-free, suitable for use in scripts and CI doctor probes.
+
+JSON output:
+
+```json
+{
+  "members": [
+    { "slug": "web",  "provider": "hetzner",    "transport": "tailnet", "endpoint": "100.64.1.3",                  "labels": {"role": "web"} },
+    { "slug": "api",  "provider": "islo",       "transport": "url",     "endpoint": "https://abc.share.islo.dev",  "labels": {"role": "api"} },
+    { "slug": "db",   "provider": "runpod",     "transport": "ssh",     "endpoint": "ssh://1.2.3.4:22",            "labels": {"role": "db"} },
+    { "slug": "what", "provider": "blacksmith", "transport": "none",    "endpoint": "",                            "labels": {"role": "isolated"}, "note": "blacksmith owns connectivity" }
+  ]
+}
+```
+
+Transport semantics:
+
+| Transport | Producers                                                                | Endpoint shape              |
+| --------- | ------------------------------------------------------------------------ | --------------------------- |
+| `tailnet` | AWS / Azure / GCP / Hetzner / Proxmox / Static SSH (managed Linux)       | tailnet IPv4 (or FQDN)      |
+| `url`     | Islo / E2B / Railway today; Modal / Cloudflare / Tensorlake surface as `unsupported` until their providers expose a per-sandbox HTTPS ingress | per-sandbox public HTTPS URL |
+| `ssh`     | exe.dev / RunPod / Daytona / Sprites / Namespace / Semaphore             | `ssh://<host>:<port>`        |
+| `pending` | tailnet- or SSH-capable provider whose lease record has no endpoint yet  | empty                        |
+| `none`    | Blacksmith (owns connectivity), or any provider without a bridge adapter | empty (`note` explains why)  |
+
+## Provider support
+
+| Provider                                              | Transport class | Notes                                                                                                                              |
+| ----------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Hetzner / AWS / Azure / GCP / Proxmox / Static SSH    | `tailnet`       | Endpoint = tailnet IPv4 from the local claim sidecar (`tailscaleIPv4` field). Empty endpoint surfaces as `pending`.                |
+| exe.dev / RunPod / Daytona / Sprites / Namespace / Semaphore | `ssh`           | Endpoint = `ssh://<host>:<port>` from the local claim sidecar. Empty host surfaces as `pending`.                                   |
+| Islo                                                  | `url`           | Uses the islo `POST /sandboxes/{name}/shares` API. Existing shares are reused so calls are idempotent.                             |
+| E2B                                                   | `url`           | Synthesises the canonical `https://<port>-<sandboxID>.<domain>` preview URL directly from the existing E2B sandbox + config.       |
+| Railway                                               | `url`           | Surfaces the deployment URL already populated by Railway on `LatestDeployment`. One URL per service (no per-port routing).         |
+| Modal                                                 | `url`           | Sandbox lease record does not carry a tunnel URL today; the adapter returns an explicit `BridgeState=unsupported` signal.          |
+| Cloudflare                                            | `url`           | Worker URL is auth-gated; the adapter returns `BridgeState=unsupported` so callers see the gap.                                    |
+| Tensorlake                                            | `url`           | Serverless invocation model — no per-sandbox HTTPS endpoint; adapter returns `BridgeState=unsupported`.                            |
+| Blacksmith                                            | `none`          | Owns its own connectivity; surfaced with note "blacksmith owns connectivity".                                                       |
+
+Peers on `unsupported` URL adapters still appear in the output with
+`BridgeState=unsupported` (JSON) / `bridge=unsupported` (text) so callers
+see the gap rather than mistaking it for "no shares published yet".
+
+## `doctor --crew`
+
+`crabbox doctor --crew <name>` runs the Tailscale ACL row check (when the
+crew uses tailnet-capable providers) and, in the same invocation, prints
+the cross-provider reachability matrix:
+
+```
+crew "alpha": 4 members
+  transport breakdown: none=1 ssh=1 tailnet=1 url=1
+  reachability:
+    tailnet -> tailnet : OK
+    tailnet -> url     : OK (via outbound HTTPS)
+    tailnet -> ssh     : WARN (requires operator-side bridge — see SSH-mesh DRAFT PR)
+    tailnet -> none    : NO (destination has no published endpoint)
+    url     -> tailnet : NO (no public endpoint on tailnet members)
+    url     -> url     : OK
+    url     -> ssh     : WARN (requires operator-side bridge)
+    url     -> none    : NO (destination has no published endpoint)
+    ssh     -> tailnet : WARN (requires operator-side bridge)
+    ssh     -> url     : OK (via outbound HTTPS)
+    ssh     -> ssh     : WARN (requires operator-side bridge — peers do not share a mesh)
+    ssh     -> none    : NO (destination has no published endpoint)
+    none    -> *       : NO (source provider owns its own connectivity)
+```
+
+The matrix is intentionally asymmetric: `tailnet -> url` works (the tailnet
+peer makes an outbound HTTPS request) while `url -> tailnet` does not (the
+delegated peer has no route into the tailnet). SSH pairs are flagged WARN
+because Crabbox does not run an SSH mesh today — operator-side bridging is
+required.
+
+## Scope reminder
+
+The bridge plane is **HTTP-only** for URL-transport peers. Non-HTTP
+protocols (raw TCP/UDP, SSH on a custom port, Postgres, Redis, …) are not
+exposed by per-port HTTPS shares; use a tailnet-capable provider for those.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -9,6 +9,7 @@ crabbox doctor
 crabbox doctor --provider aws
 crabbox doctor --profile live-qa --id blue-lobster
 crabbox doctor --provider hetzner --target linux
+crabbox doctor --provider hetzner --crew alpha
 crabbox doctor --provider ssh --target windows --windows-mode normal --static-host win-dev.local
 crabbox doctor --json
 ```
@@ -44,6 +45,13 @@ what was checked. GCP uses an aggregated Compute Engine inventory query across
 zones, while the other built-in providers use their cheapest non-mutating list
 or readiness API. Blacksmith Testbox reports runtime as provider-hydrated
 because GitHub Actions hydration is owned by Testbox.
+
+Use `--crew <name>` to verify the Tailscale policy row for a crew before
+warming peers with `--tailscale`. The check confirms the concrete
+`tag:cbx-crew-<owner>-<crew>` tag is declared in `tagOwners` and allowed to
+reach itself through either `grants` or legacy `acls`. It reads the policy only
+when `TS_API_KEY` is exported; without that env var it skips with a hint. Plain
+`crabbox doctor` does not call the Tailscale ACL API.
 
 When `--profile <name> --id <lease>` selects a profile with `doctor.enabled:
 true`, doctor runs that profile's remote prerequisite contract instead of the
@@ -100,6 +108,7 @@ the exit code.
 ```text
 --provider hetzner|aws|azure|gcp|proxmox|ssh   provider to validate
 --profile <name>             configured profile for remote prereq checks
+--crew <name>                verify Tailscale ACL setup for this crew
 --json                       print JSON
 --doctor-probe-ssh           probe static SSH reachability
 --target linux|macos|windows target OS for ssh provider checks

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -16,11 +16,17 @@ crabbox list --provider islo
 crabbox list --provider e2b
 crabbox list --provider cloudflare --refresh
 crabbox list --json
+crabbox list --crew alpha
 ```
 
 `--refresh` asks providers with local claims, such as Cloudflare, to check live
 runner state before printing the list. Without it, Cloudflare list stays
 credential-free and reports local claims only.
+
+`--crew <name>` keeps only leases tagged with the requested crew. Crew names are
+normalized the same way as slugs (lowercased, non-alphanumeric runs collapsed to
+single dashes), so `--crew "Alpha Crew"` matches a lease created with `--crew
+alpha-crew`. See `docs/features/crew.md`.
 
 `crabbox pool list` remains as a compatibility alias.
 
@@ -54,6 +60,7 @@ Flags:
 --static-port <port>
 --static-work-root <path>
 --json
+--crew <name>
 --exe-dev-control-host <host>
 --sprites-api-url <url>
 --e2b-api-url <url>

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -17,6 +17,7 @@ crabbox run --env-from-profile ~/.project-live.profile --allow-env API_TOKEN --s
 crabbox run --id blue-lobster --full-resync -- pnpm check:changed
 crabbox run --label "update flow smoke" -- pnpm test:changed
 crabbox run --slug update-flow-smoke -- pnpm test:changed
+crabbox run --crew alpha --slug web -- pnpm test:integration
 crabbox run --id blue-lobster --env-from-profile ~/.project-live.profile --allow-env OPENAI_API_KEY --env-helper live -- ./.crabbox/env/live pnpm test:live
 crabbox run --fresh-pr acme/app#123 --script ./scripts/e2e-smoke.sh
 crabbox run --id cbx_abcdef123456 --junit junit.xml -- go test ./...
@@ -197,6 +198,14 @@ timing JSON, and coordinator run record when available.
 Use `--slug <slug>` only when creating a fresh lease. Crabbox normalizes the
 requested slug and may add a suffix when an active lease already uses it.
 
+Use `--crew <name>` to tag a new lease into a named crew. Crew is a reserved
+provider label that groups peers, and `crabbox list --crew <name>` selects
+them as a set. With `--tailscale` on a Tailscale-capable provider the CLI
+also advertises a `tag:cbx-crew-<owner>-<name>` ACL tag and cloud-init keeps
+`/etc/hosts.cbx` plus a managed `/etc/hosts` block in sync every 30 seconds so
+peers reach each other as `<slug>.cbx`. See
+[`docs/features/crew.md`](../features/crew.md).
+
 Use `--capture-stdout <path>` when stdout is binary or terminal-hostile. Crabbox
 writes the remote stdout bytes directly to the local file, leaves stderr on the
 terminal, and skips stdout run-log/event capture. This is useful for Windows
@@ -307,6 +316,7 @@ Flags:
 --azure-os-disk managed|ephemeral|auto
 --market spot|on-demand
 --slug <slug>
+--crew <name>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -9,6 +9,7 @@ crabbox warmup --provider azure --class beast
 crabbox warmup --browser
 crabbox warmup --tailscale
 crabbox warmup --slug update-flow-smoke
+crabbox warmup --crew alpha --slug db
 crabbox warmup --desktop --browser
 crabbox warmup --provider aws --target windows --desktop
 crabbox warmup --provider azure --target windows
@@ -29,6 +30,15 @@ crabbox warmup --provider ssh --target windows --windows-mode normal --static-ho
 The command returns a stable `cbx_...` lease ID and a friendly slug. Reuse either for subsequent `run`, `status`, `ssh`, `inspect`, and `stop` commands; scripts should keep using the canonical ID.
 Use `--slug <slug>` to request a human-chosen slug for a new lease. Crabbox
 normalizes it and may add a suffix when an active lease already uses it.
+
+Use `--crew <name>` to tag a new lease into a named crew. The crew name is
+stored on the lease as a reserved provider label, and `crabbox list --crew
+<name>` filters by it. When combined with `--tailscale` on a Tailscale-capable
+provider, the CLI also advertises a `tag:cbx-crew-<owner>-<name>` ACL tag and
+cloud-init refreshes `/etc/hosts.cbx` plus a managed `/etc/hosts` block every
+30 seconds so peers are reachable as `<slug>.cbx`. See
+[`docs/features/crew.md`](../features/crew.md) for the one-time policy snippet
+and the `doctor --crew` coverage.
 
 With `--provider blacksmith-testbox`, the canonical ID is the Blacksmith `tbx_...` ID returned by `blacksmith testbox warmup`; Crabbox still assigns and stores a local slug for reuse.
 
@@ -127,6 +137,7 @@ Flags:
 --azure-os-disk managed|ephemeral|auto
 --market spot|on-demand
 --slug <slug>
+--crew <name>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/features/crew.md
+++ b/docs/features/crew.md
@@ -1,0 +1,225 @@
+# Crew
+
+Read when:
+
+- you want to lease several boxes that act as one logical group;
+- you want `crabbox list` to show only the leases that belong to a group;
+- you want peers in a group to reach each other by name on the tailnet.
+
+A **crew** is a named set of Crabbox leases that should discover each other.
+The name is stored on each lease as a reserved provider label (`crew=<name>`) at
+provision time.
+There is no separate top-level crew object: a crew exists for as long as at
+least one active lease carries the label, and disappears when the last member
+is released. The primitive stays emergent and observable through the
+provider-label index the coordinator and direct backends already use.
+
+## Selector
+
+A reserved label key `crew` on every lease record.
+
+```sh
+crabbox warmup --crew alpha --slug db
+crabbox warmup --crew alpha --slug web
+crabbox warmup --crew alpha --slug worker
+```
+
+Each command tags its new lease with `crew=alpha` alongside the existing
+`slug`, `provider`, `class`, and `state` labels. The label is sanitized the
+same way as other provider labels and is bounded to 41 characters before
+sanitization so the same name fits inside hostname-derived identifiers
+(`<slug>.cbx` peer entries).
+
+```sh
+crabbox list --crew alpha
+crabbox list --crew alpha --json
+```
+
+The crew label is opt-in. Leases created without `--crew` carry no crew label
+and are unaffected.
+
+## Peer discovery on the tailnet
+
+When `--crew` is combined with `--tailscale` on a Tailscale-capable provider
+(Hetzner, Azure, GCP managed Linux), the CLI advertises one extra ACL tag
+when the box joins the tailnet:
+
+```
+tag:cbx-crew-<owner>-<crew>
+```
+
+The `<owner>` segment is derived from the operator's git email (local-part,
+truncated for tag length). The mint happens entirely in user (CLI) context —
+the broker never sees a Tailscale credential.
+
+Each crew member writes `/etc/hosts.cbx` from its own `tailscale status
+--json` output, filtered by the crew tag. The same systemd timer also
+maintains a Crabbox-owned block in `/etc/hosts`, so normal system resolution
+can find peers as `<slug>.cbx`:
+
+```sh
+curl http://db.cbx:5432/
+ssh worker.cbx
+```
+
+`<slug>` is the suffix of the `crabbox-<slug>` hostname template every
+Tailscale-capable provider already uses, so it doubles as the role name when
+slugs are role-shaped (`db`, `web`, `worker`).
+
+For providers without `FeatureTailscale` (E2B, Modal, Cloudflare, Railway,
+Islo, Tensorlake, Blacksmith, exe.dev, SSH, Proxmox, Sprites, Daytona,
+namespace-devbox), the crew label still sticks for `list --crew`, but the
+networking plane is unavailable. `crabbox doctor --crew <name>` flags this with
+`skip crew provider=<name> does not support the Tailscale plane`.
+
+## Example: two-lease web server demo
+
+End-to-end smoke that proves a crew is wired up. Each terminal runs from the
+same operator shell so `crabbox` shares the local claim store.
+
+Terminal 1 — start the server:
+
+```sh
+crabbox warmup --crew demo --slug web --provider hetzner
+crabbox ssh demo-web -- 'python3 -m http.server 8080'
+```
+
+Terminal 2 — hit it from a peer:
+
+```sh
+crabbox warmup --crew demo --slug client --provider hetzner
+crabbox ssh demo-client -- 'curl --max-time 5 http://web.cbx:8080'
+# expect HTTP 200 with the python directory listing
+```
+
+Cleanup:
+
+```sh
+crabbox release --crew demo
+```
+
+The `.cbx` peer name resolves through the managed `/etc/hosts` block that the
+crew-hosts systemd timer maintains on every Tailscale-capable peer.
+
+## Auto-bootstrap of the tailnet policy
+
+When `TS_API_KEY` is exported in the operator shell, the CLI self-bootstraps
+the `tag:cbx-crew-<owner>-<crew>` rows on the first `run` or `warmup` for a
+new crew: it reads the live policy with an ETag, merges the missing
+`tagOwners` and self-peering grant, and PUTs the result back with `If-Match`
+so a concurrent edit fails fast. Subsequent leases hit a cached row and
+no-op. `crabbox doctor --crew <name>` reports `auto-managed` in that mode.
+
+If you cannot expose `TS_API_KEY` to the CLI (e.g. shared tailnet,
+locked-down policy editing), fall back to the manual snippet below.
+
+## One-time tailnet setup (only if `TS_API_KEY` is not available)
+
+The crew plane needs a `tag:cbx-crew-<owner>-<crew>` entry in your tailnet
+policy file (Tailscale admin console -> Access Controls) plus one access row
+that opens peer-to-peer traffic for that tag. Tailscale's policy schema
+requires every advertised tag to be declared in `tagOwners` by its concrete
+name (no wildcards), so add one entry per `<crew>` you intend to ship:
+
+```hujson
+{
+  "tagOwners": {
+    "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"],
+  },
+  "grants": [
+    { "src": ["tag:cbx-crew-yossi-e-alpha"],
+      "dst": ["tag:cbx-crew-yossi-e-alpha"],
+      "ip": ["*"] },
+  ],
+}
+```
+
+Tailnets still using legacy ACLs can express the same rule as:
+
+```hujson
+{
+  "tagOwners": {
+    "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"],
+  },
+  "acls": [
+    { "action": "accept",
+      "src": ["tag:cbx-crew-yossi-e-alpha"],
+      "dst": ["tag:cbx-crew-yossi-e-alpha:*"] },
+  ],
+}
+```
+
+`<owner>` is the first seven characters of the operator's git email
+local-part — `yossi.eliaz@incredibuild.com` becomes `yossi-e`. `<crew>` is
+the normalized name you pass to `--crew`. The doctor check verifies the
+concrete tag declaration and matching peer-to-peer grants or ACL row for the
+crew you ask it to inspect.
+
+The plane stays operator-owned: the broker is a leaf and never holds
+Tailscale policy-edit credentials. When `TS_API_KEY` is set in the operator
+shell, the CLI uses it to (a) self-bootstrap the row on the first lease in
+each new crew and (b) verify it on `crabbox doctor --crew <name>`. Without
+that env var the auto-bootstrap is skipped silently and the doctor check
+falls back to a hint pointing at the manual snippet above. Plain `crabbox
+doctor` does not call the Tailscale ACL API unless a crew is explicitly
+selected.
+
+```sh
+export TS_API_KEY=tskey-api-XXXXXXXXXX
+export TS_TAILNET=example.com   # optional; defaults to '-' (the API key's tailnet)
+crabbox doctor --provider hetzner --crew alpha
+```
+
+## Self-hosted control plane (Headscale, others)
+
+Crew's network plane uses the Tailscale client (installed by cloud-init); it
+does not depend on who runs the control server. To point a crew at
+[Headscale](https://github.com/juanfont/headscale) or another self-hosted
+control plane, set both the client and admin endpoints before running
+`crabbox`:
+
+```sh
+export TS_CONTROL_URL=https://headscale.example.com   # client login server
+export TS_API_URL=https://headscale.example.com       # admin API base (used by crabbox)
+export TS_API_KEY=<your control-server admin token>
+crabbox warmup --crew alpha --provider hetzner --tailscale
+```
+
+`TS_CONTROL_URL` is forwarded into cloud-init and passed to `tailscale up`
+as `--login-server`, so the lease registers against the self-hosted control
+plane. `CRABBOX_TS_API_URL` is honored first if both are set, which lets you
+keep `TS_API_URL` pointed elsewhere for other tooling.
+
+Auto-bootstrap of the `tag:cbx-crew-*` policy row targets the Tailscale-shaped
+`/api/v2/tailnet/-/acl` route. Headscale's policy endpoint
+(`/api/v1/policy`) is not byte-compatible with that shape — it wraps the
+policy as a quoted string field and does not return an ETag — so the CLI
+detects the missing route (HTTP 404 or no `ETag` header on the response) and
+falls back gracefully. `crabbox doctor --crew <name>` reports a `skip` with
+the manual snippet pointer when this happens. For Headscale, apply the
+policy block from the section above via:
+
+```sh
+headscale policy set --file ./policy.hujson
+```
+
+The client-side plane (advertise-tags, `/etc/hosts.cbx` synthesis from
+`tailscale status --json`) works identically against either control plane.
+
+## Why a label, not a new object
+
+Crabbox's labels already drive cleanup, the portal lease list, broker
+filters, and machine identity. Putting the crew name in the same place makes
+the primitive observable, queryable, and removable through the same paths.
+The maintainer's recent PR #118 rewrite of exe.dev — from a custom transport
+into a normal SSH lease provider — set the rule the design follows: bend new
+features into existing abstractions; do not grow parallel verb trees.
+
+## Provider posture
+
+| Provider                                                            | `--crew` tagged | Peer DNS (`<slug>.cbx`)              | Tailscale ACL doctor check |
+| ------------------------------------------------------------------- | --------------- | ------------------------------------ | -------------------------- |
+| Hetzner / Azure / GCP managed Linux                                 | yes             | yes (`/etc/hosts` managed block)     | yes, with `doctor --crew`  |
+| AWS Linux / AWS Windows / AWS Mac                                   | yes             | follow-up                            | n/a (no `FeatureTailscale`)|
+| Proxmox / SSH / Daytona / Sprites / exe.dev / namespace-devbox      | yes             | n/a (non-managed tailnet)            | skip with `doctor --crew`  |
+| E2B / Modal / Cloudflare / Railway / Islo / Tensorlake / Blacksmith | yes             | n/a                                  | skip with `doctor --crew`  |

--- a/docs/features/crew.md
+++ b/docs/features/crew.md
@@ -206,6 +206,129 @@ headscale policy set --file ./policy.hujson
 The client-side plane (advertise-tags, `/etc/hosts.cbx` synthesis from
 `tailscale status --json`) works identically against either control plane.
 
+For delegated providers (E2B, Modal, Cloudflare, Railway, Islo, Tensorlake,
+Blacksmith), the label is honored as metadata but the Tailscale plane is not
+applicable. The **bridge plane** (see next section) gives delegated providers
+HTTP-only peer discovery on top of the provider's own ingress primitive.
+
+## Bridge plane (cross-provider peer discovery)
+
+`crabbox crew peers --crew <name>` is the single command that lists every
+member of a crew with a transport hint, regardless of how that member is
+hosted. It folds three planes into one view:
+
+- **Tailscale plane** for managed Linux providers (AWS / Azure / GCP /
+  Hetzner / Proxmox / Static SSH). Endpoint is the peer's tailnet IPv4
+  (or FQDN when only that is recorded). Reachability is direct on the
+  tailnet.
+- **URL plane** for delegated providers (Islo / E2B / Railway today;
+  Modal / Cloudflare / Tensorlake surface as `unsupported` until their
+  providers expose a per-sandbox HTTPS ingress). Endpoint is a
+  per-sandbox public HTTPS URL. The plane is deliberately HTTP-only — it
+  is not a general-purpose VPN.
+- **SSH plane** for SSH-lease providers (exe.dev / RunPod / Daytona /
+  Sprites / Namespace / Semaphore). Endpoint is `ssh://<host>:<port>`.
+
+Two more states cover the gaps honestly:
+
+- `pending` — the provider class is known but the lease record has not
+  yet captured an endpoint (tailnet not joined, share not minted, SSH
+  host not yet known).
+- `none` — the provider owns its own connectivity (Blacksmith) or
+  Crabbox has no bridge adapter for it. The peer is listed with a note
+  explaining the gap so the doctor command can report it without
+  pretending the peer is reachable.
+
+For URL-transport peers the bridge calls the provider's native ingress
+API (islo `share`, E2B preview, Modal web endpoint, …) through the
+`core.BridgeProvider` interface (`PublishPeer` / `ListPeerTargets`). For
+tailnet and SSH peers the unified view does not invoke a bridge adapter
+at all — it reads the endpoint straight off the local claim sidecar.
+
+### How it works on islo
+
+Islo exposes `POST /sandboxes/{name}/shares` to create a public HTTPS URL
+that routes to a chosen sandbox port. Crabbox's bridge calls that endpoint
+when the user asks for peer URLs, caches the results inside the islo
+share registry (so calls are idempotent), and surfaces them as
+`BridgePeerTarget` rows.
+
+```sh
+crabbox warmup --provider islo --crew bridge-demo --slug bridge-demo-web
+crabbox warmup --provider islo --crew bridge-demo --slug bridge-demo-client
+
+# Publish a public URL for port 8080 on every member of the crew.
+crabbox crew peers --crew bridge-demo --share-port 8080 --json
+```
+
+The JSON output contains one `BridgePeer` per lease, each with a list of
+`Targets` (`{port, url, shareID, expiresAt}`). A client that wants to dial
+the web peer from inside another sandbox uses the URL directly:
+
+```sh
+curl --silent --show-error https://abc123.share.islo.dev/
+```
+
+Without `--share-port`, the command lists *existing* shares rather than
+minting new ones, so the call is cheap and side-effect-free. That is also
+what the doctor probe runs (HEAD against the first target with a 3s budget
+per peer).
+
+### Honest scope
+
+- HTTP/HTTPS only. The bridge plane is built on islo `share`, which is an
+  HTTPS endpoint; raw TCP (Postgres, Redis, SSH) is out of scope.
+- One target per share. Each sandbox port needs its own share; the bridge
+  plane is per-port discovery, not a wildcard tunnel.
+- TTL: islo shares default to 24h, max 7d (the bridge clamps any user
+  override into that range). Renewal is the application's responsibility.
+- No name resolution. The bridge does not write `<slug>.cbx` aliases — peer
+  URLs are random subdomains under `share.islo.dev`. Applications consume
+  the JSON output and dial by URL; they do not assume a stable hostname.
+- Delegated provider only. The Tailscale plane is still the right answer
+  for managed Linux providers; the bridge plane is purpose-built for
+  backends that cannot join a tailnet.
+
+### Per-provider posture
+
+| Provider                                                | Transport       | Notes                                                                                                       |
+| ------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------- |
+| AWS / Azure / GCP / Hetzner / Proxmox / Static SSH      | `tailnet`       | Endpoint = tailnet IPv4 from the lease record. Empty endpoint surfaces as `pending`.                        |
+| exe.dev / RunPod / Daytona / Sprites / Namespace / Semaphore | `ssh`           | Endpoint = `ssh://<host>:<port>` from the lease record. Empty host surfaces as `pending`.                   |
+| Islo                                                    | `url`           | Implemented via the islo `share` API (per-port public HTTPS URL, idempotent).                               |
+| E2B                                                     | `url`           | URLs synthesised from the native `https://<port>-<sandboxID>.<domain>` preview convention.                  |
+| Railway                                                 | `url`           | Surfaces the existing deployment URL on `railwayDeployment.URL` (one URL per service, no per-port routing). |
+| Modal                                                   | `url` (unsupported) | Sandbox lease record carries no tunnel URL; the adapter returns an explicit `BridgeState=unsupported`.       |
+| Cloudflare                                              | `url` (unsupported) | Worker URL is auth-gated; the adapter returns `BridgeState=unsupported`.                                     |
+| Tensorlake                                              | `url` (unsupported) | Serverless invocation model — no per-sandbox HTTPS endpoint; the adapter returns `BridgeState=unsupported`.  |
+| Blacksmith                                              | `none`          | Owns its own connectivity; surfaced with the documented note.                                                 |
+
+### Doctor reachability matrix
+
+`crabbox doctor --crew <name>` runs the existing Tailscale ACL check for
+the named crew and, in the same invocation, prints the per-transport
+reachability matrix derived from the unified peer list:
+
+```
+crew "alpha": 4 members
+  transport breakdown: none=1 ssh=1 tailnet=1 url=1
+  reachability:
+    tailnet -> tailnet : OK
+    tailnet -> url     : OK (via outbound HTTPS)
+    tailnet -> ssh     : WARN (requires operator-side bridge — see SSH-mesh DRAFT PR)
+    url     -> tailnet : NO (no public endpoint on tailnet members)
+    url     -> url     : OK
+    url     -> ssh     : WARN (requires operator-side bridge)
+    ssh     -> tailnet : WARN (requires operator-side bridge)
+    ssh     -> url     : OK (via outbound HTTPS)
+    ssh     -> ssh     : WARN (requires operator-side bridge — peers do not share a mesh)
+```
+
+The matrix is asymmetric on purpose. A tailnet peer can dial a URL peer
+over outbound HTTPS, but a URL peer cannot dial a tailnet peer — the
+tailnet member has no public endpoint. SSH pairs are flagged WARN
+because Crabbox does not currently mesh SSH leases.
+
 ## Why a label, not a new object
 
 Crabbox's labels already drive cleanup, the portal lease list, broker

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -176,6 +176,7 @@ Commands:
   inspect     Print lease/provider details; add --json for scripts
   stop        Release a lease or delete a direct-provider machine
   cleanup     Sweep expired direct-provider machines or local provider state
+  crew        Bridge plane peer discovery for delegated providers
   azure       Azure provider setup and login
   config      Show or update user config
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -885,12 +886,22 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
 		return `    echo "tailscale requested but no auth key was injected" >&2
     exit 1`
 	}
-	return `    retry sh -c 'curl -fsSL https://tailscale.com/install.sh | sh'
+	// TS_CONTROL_URL on the operator shell forwards to the box so the
+	// embedded `tailscale up` registers against a self-hosted control plane
+	// (Headscale, etc.) via --login-server. Unset means the default Tailscale
+	// control plane, which keeps the existing behavior identical.
+	controlURL := strings.TrimSpace(os.Getenv("TS_CONTROL_URL"))
+	loginServerExport := ""
+	if controlURL != "" {
+		loginServerExport = "TS_LOGIN_SERVER=" + shellQuote(controlURL) + "\n    "
+	}
+	loginServerFlag := `${TS_LOGIN_SERVER:+--login-server="$TS_LOGIN_SERVER"}`
+	tailscaleUpScript := `    retry sh -c 'curl -fsSL https://tailscale.com/install.sh | sh'
     systemctl enable --now tailscaled || service tailscaled start || true
     install -d -m 0750 -o ` + sshUserOwner + ` -g ` + sshUserGroup + ` /var/lib/crabbox
     set +x
-    TS_AUTHKEY=` + shellQuote(authKey) + `
-    tailscale up ` + strings.Join(tailscaleUpArgs, " ") + `
+    ` + loginServerExport + `TS_AUTHKEY=` + shellQuote(authKey) + `
+    tailscale up ` + strings.Join(tailscaleUpArgs, " ") + " " + loginServerFlag + `
     unset TS_AUTHKEY
     set -x
     ts_ip=""
@@ -911,4 +922,100 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
     fi
     chown ` + sshUserChown + ` /var/lib/crabbox/tailscale-* || true
     chmod 0640 /var/lib/crabbox/tailscale-* || true`
+	if crew := normalizeCrewName(cfg.Crew); crew != "" {
+		tailscaleUpScript += "\n" + cloudInitCrewHostsBootstrap(cfg.Crew)
+	}
+	return tailscaleUpScript
+}
+
+// cloudInitCrewHostsBootstrap installs /usr/local/bin/crabbox-crew-hosts and a
+// systemd timer that rewrites /etc/hosts.cbx plus a managed /etc/hosts block
+// every 30s with one entry per crew peer reachable on the local tailnet. Peers
+// are discovered purely from the box-local `tailscale status --json` output
+// filtered by the crew ACL tag, so the broker never sees a Tailscale
+// credential. Each peer renders as `<tailnet-ipv4> <slug>.cbx` where `<slug>`
+// is the suffix of the `crabbox-<slug>` hostname template every
+// Tailscale-capable provider already uses.
+func cloudInitCrewHostsBootstrap(crew string) string {
+	tag := crewTailscaleTag(localCoordinatorOwner(), crew)
+	if tag == "" {
+		return ""
+	}
+	hostsFile := shellQuote(crewHostsFile)
+	tagLiteral := shellQuote(tag)
+	systemHostsFile := shellQuote("/etc/hosts")
+	return `    install -m 0644 /dev/null ` + hostsFile + ` || true
+    cat >/usr/local/bin/crabbox-crew-hosts <<'CREWHOSTS'
+#!/bin/sh
+set -eu
+TAG="$1"
+OUT="$2"
+SYSTEM_HOSTS="${3:-/etc/hosts}"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP" "$TMP".raw "$TMP".hosts' EXIT
+if ! tailscale status --json >"$TMP".raw 2>/dev/null; then
+  exit 0
+fi
+jq -r --arg tag "$TAG" '
+  [(.Peer // {}) | to_entries[] | .value]
+  | map(select((.Tags // []) | index($tag)))
+  | map({ ip: ((.TailscaleIPs // [])[0] // ""), host: ((.HostName // "") | sub("^crabbox-"; "")) })
+  | map(select(.ip != "" and .host != ""))
+  | unique_by(.ip)
+  | .[]
+  | "\(.ip) \(.host).cbx"
+' "$TMP".raw > "$TMP"
+printf '# managed by crabbox-crew-hosts; do not edit\n' >"$OUT".new
+cat "$TMP" >>"$OUT".new
+mv "$OUT".new "$OUT"
+chmod 0644 "$OUT"
+BEGIN="# crabbox crew hosts begin"
+END="# crabbox crew hosts end"
+if [ -f "$SYSTEM_HOSTS" ]; then
+  awk -v begin="$BEGIN" -v end="$END" '
+    $0 == begin { skip = 1; next }
+    $0 == end { skip = 0; next }
+    !skip { print }
+  ' "$SYSTEM_HOSTS" >"$TMP".hosts
+else
+  : >"$TMP".hosts
+fi
+{
+  cat "$TMP".hosts
+  printf '%s\n' "$BEGIN"
+  cat "$TMP"
+  printf '%s\n' "$END"
+} >"$SYSTEM_HOSTS".new
+mv "$SYSTEM_HOSTS".new "$SYSTEM_HOSTS"
+chmod 0644 "$SYSTEM_HOSTS"
+CREWHOSTS
+    chmod 0755 /usr/local/bin/crabbox-crew-hosts
+    cat >/etc/systemd/system/crabbox-crew-hosts.service <<'CREWUNIT'
+[Unit]
+Description=Refresh Crabbox crew peer hostnames
+After=tailscaled.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/crabbox-crew-hosts ` + tag + ` ` + crewHostsFile + ` /etc/hosts
+CREWUNIT
+    cat >/etc/systemd/system/crabbox-crew-hosts.timer <<'CREWTIMER'
+[Unit]
+Description=Refresh Crabbox crew hostnames every ` + crewHostsRefreshPeriod + `
+
+[Timer]
+OnBootSec=10s
+OnUnitActiveSec=` + crewHostsRefreshPeriod + `
+AccuracySec=2s
+Unit=crabbox-crew-hosts.service
+
+[Install]
+WantedBy=timers.target
+CREWTIMER
+    systemctl daemon-reload
+    systemctl enable --now crabbox-crew-hosts.timer
+    /usr/local/bin/crabbox-crew-hosts ` + tagLiteral + ` ` + hostsFile + ` ` + systemHostsFile + ` || true
+    test -f ` + hostsFile + `
+`
 }

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -194,6 +194,38 @@ func TestCloudInitTailscaleProfile(t *testing.T) {
 	}
 }
 
+// TestCloudInitTailscaleHonorsControlURL exercises the self-hosted control
+// plane path: when TS_CONTROL_URL is set in the operator shell, cloud-init
+// must forward it into the box so `tailscale up` registers against the
+// custom login server (e.g. Headscale) via --login-server. Unset means the
+// default Tailscale control plane and no new flag is introduced.
+func TestCloudInitTailscaleHonorsControlURL(t *testing.T) {
+	t.Setenv("TS_CONTROL_URL", "https://headscale.example.com")
+	cfg := baseConfig()
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = "tskey-secret"
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	for _, want := range []string{
+		"TS_LOGIN_SERVER='https://headscale.example.com'",
+		`${TS_LOGIN_SERVER:+--login-server="$TS_LOGIN_SERVER"}`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("cloudInit(TS_CONTROL_URL) missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	t.Setenv("TS_CONTROL_URL", "")
+	got = cloudInit(cfg, "ssh-ed25519 test")
+	if strings.Contains(got, "TS_LOGIN_SERVER=") {
+		t.Fatalf("cloudInit must not export TS_LOGIN_SERVER when TS_CONTROL_URL is unset:\n%s", got)
+	}
+	// The conditional shell expansion is still present so the box honors a
+	// downstream override, but no operator-supplied value should leak.
+	if !strings.Contains(got, `${TS_LOGIN_SERVER:+--login-server="$TS_LOGIN_SERVER"}`) {
+		t.Fatal("cloudInit must keep the conditional --login-server expansion even when unset")
+	}
+}
+
 func TestCloudInitTailscaleDefaultsAndMissingAuthKey(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Tailscale.Enabled = true

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -14,6 +14,7 @@ type leaseClaim struct {
 	Slug               string `json:"slug,omitempty"`
 	Provider           string `json:"provider,omitempty"`
 	ProviderScope      string `json:"providerScope,omitempty"`
+	Crew               string `json:"crew,omitempty"`
 	RepoRoot           string `json:"repoRoot"`
 	ClaimedAt          string `json:"claimedAt"`
 	LastUsedAt         string `json:"lastUsedAt"`
@@ -30,10 +31,18 @@ func claimLeaseForRepoConfig(leaseID, slug string, cfg Config, repoRoot string, 
 }
 
 func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return claimLeaseForRepoProviderScope(leaseID, slug, provider, "", repoRoot, idleTimeout, reclaim)
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", "", repoRoot, idleTimeout, reclaim)
 }
 
 func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, providerScope, "", repoRoot, idleTimeout, reclaim)
+}
+
+func claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", crew, repoRoot, idleTimeout, reclaim)
+}
+
+func claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, providerScope, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	if leaseID == "" || repoRoot == "" {
 		return nil
 	}
@@ -59,6 +68,9 @@ func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repo
 	}
 	if providerScope != "" {
 		existing.ProviderScope = providerScope
+	}
+	if crew = normalizeCrewName(crew); crew != "" {
+		existing.Crew = crew
 	}
 	existing.RepoRoot = repoRoot
 	existing.LastUsedAt = now

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -10,15 +10,46 @@ import (
 )
 
 type leaseClaim struct {
-	LeaseID            string `json:"leaseID"`
-	Slug               string `json:"slug,omitempty"`
-	Provider           string `json:"provider,omitempty"`
-	ProviderScope      string `json:"providerScope,omitempty"`
+	LeaseID       string `json:"leaseID"`
+	Slug          string `json:"slug,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	ProviderScope string `json:"providerScope,omitempty"`
+	// Crew, when non-empty, records the crew label that grouped the lease at
+	// claim time. Direct providers surface `crew=<name>` through the
+	// provider-label index so `crabbox list --crew <name>` works; delegated
+	// providers (islo, e2b, modal, ...) do not own a label store, so the local
+	// claim sidecar is the source of truth for those backends and for the
+	// crew bridge plane (see internal/cli/crew_bridge.go).
 	Crew               string `json:"crew,omitempty"`
 	RepoRoot           string `json:"repoRoot"`
 	ClaimedAt          string `json:"claimedAt"`
 	LastUsedAt         string `json:"lastUsedAt"`
 	IdleTimeoutSeconds int    `json:"idleTimeoutSeconds,omitempty"`
+	// TailscaleIPv4 / TailscaleFQDN, when populated, are the canonical
+	// tailnet address for the lease. Managed-Linux providers (AWS / Azure /
+	// GCP / Hetzner / Proxmox / Static SSH) write these here so the unified
+	// `crew peers` view can report transport=tailnet with a real endpoint
+	// without re-querying the provider. When empty, the resolver reports
+	// transport=pending with a note rather than pretending the peer is
+	// reachable.
+	TailscaleIPv4 string `json:"tailscaleIPv4,omitempty"`
+	TailscaleFQDN string `json:"tailscaleFQDN,omitempty"`
+	// SSHHost / SSHPort, when populated, are the public SSH address for
+	// SSH-lease providers (exe.dev, RunPod, Daytona, Sprites, Namespace,
+	// Semaphore). The unified `crew peers` view reports them as
+	// `ssh://<host>:<port>`; when empty, transport=pending.
+	SSHHost string `json:"sshHost,omitempty"`
+	SSHPort int    `json:"sshPort,omitempty"`
+	// BridgeURL, when populated, is the canonical public HTTPS endpoint for
+	// delegated providers that mint per-sandbox URLs (Islo, E2B, Modal,
+	// Cloudflare, Railway, Tensorlake). When empty, the per-provider bridge
+	// adapter is queried at `crew peers` time.
+	BridgeURL string `json:"bridgeURL,omitempty"`
+	// Labels carries optional free-form labels surfaced to the unified
+	// `crew peers` view (for example `role=web`). The claim sidecar is the
+	// source of truth for delegated providers; direct providers can mirror
+	// a subset here so the view stays uniform.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 func claimLeaseForRepo(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
@@ -42,6 +73,10 @@ func claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot s
 	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", crew, repoRoot, idleTimeout, reclaim)
 }
 
+// claimLeaseForRepoProviderScopeCrew is the crew-aware variant. It is used by
+// delegated providers (islo and the next ones to come online for the bridge
+// plane) so the crew name is durable in the local claim sidecar even when the
+// provider does not own a label store of its own.
 func claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, providerScope, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	if leaseID == "" || repoRoot == "" {
 		return nil

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -26,6 +26,31 @@ func TestClaimLeaseForRepoWritesAndUpdatesClaim(t *testing.T) {
 	}
 }
 
+func TestClaimLeaseForRepoProviderStoresCrew(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := claimLeaseForRepoProviderWithCrew("isb_crabbox-test", "web", "islo", "Alpha Crew", repo, 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := readLeaseClaim("isb_crabbox-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("crew=%q want alpha-crew", claim.Crew)
+	}
+	if err := claimLeaseForRepoProvider("isb_crabbox-test", "web", "islo", repo, 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err = readLeaseClaim("isb_crabbox-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("crew should be preserved when omitted, got %q", claim.Crew)
+	}
+}
+
 func TestClaimLeaseForRepoConfigScopesProviderClaims(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := filepath.Join(t.TempDir(), "repo")

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -54,6 +54,7 @@ type crabboxKongCLI struct {
 	Config     configKongCmd     `cmd:"" help:"Show or update user config."`
 	Pool       poolKongCmd       `cmd:"" help:"Alias commands for machine pools."`
 	Machine    machineKongCmd    `cmd:"" help:"Alias commands for direct-provider machines."`
+	Crew       crewKongCmd       `cmd:"" help:"Crew bridge plane: peer discovery for delegated providers."`
 }
 
 type kongExit struct {
@@ -116,7 +117,7 @@ func normalizeKongHelpArgs(args []string) []string {
 
 func isKongCommandGroup(command string) bool {
 	switch command {
-	case "actions", "admin", "artifacts", "azure", "cache", "capsule", "checkpoint", "config", "desktop", "image", "job", "machine", "media", "pool":
+	case "actions", "admin", "artifacts", "azure", "cache", "capsule", "checkpoint", "config", "crew", "desktop", "image", "job", "machine", "media", "pool":
 		return true
 	default:
 		return false
@@ -459,6 +460,13 @@ type machineCleanupKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 
+type crewKongCmd struct {
+	Peers crewPeersKongCmd `cmd:"" passthrough:"" help:"List peer endpoints for a crew on a delegated provider."`
+}
+type crewPeersKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+
 type versionKongCmd struct{}
 
 func (c *initKongCmd) Run(ctx context.Context, app App) error     { return app.initProject(ctx, c.Args) }
@@ -660,6 +668,10 @@ func (c *poolListKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *machineCleanupKongCmd) Run(ctx context.Context, app App) error {
 	return app.cleanup(ctx, c.Args)
+}
+
+func (c *crewPeersKongCmd) Run(ctx context.Context, app App) error {
+	return app.crewPeers(ctx, stripKongCommandPath(c.Args, "crew", "peers"))
 }
 
 func (c *versionKongCmd) Run(app App) error {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Code                bool
 	Network             NetworkMode
 	Class               string
+	Crew                string
 	ServerType          string
 	ServerTypeExplicit  bool
 	Coordinator         string

--- a/internal/cli/crew.go
+++ b/internal/cli/crew.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"strings"
+)
+
+// crewLabelKey is the reserved provider-label key used to group leases into a
+// crew. The key is part of the provider label index that every direct and
+// brokered backend already writes, so `list --crew <name>` can select peers
+// without growing a new verb tree.
+//
+// The label is emergent: there is no top-level crew object. A crew exists for
+// as long as at least one active lease carries this label.
+const crewLabelKey = "crew"
+
+// crewTailscaleTagPrefix is the ACL tag namespace used for crew peers. Every
+// member of crew `<name>` owned by `<owner>` is advertised as
+// `tag:cbx-crew-<owner>-<name>` so one concrete ACL row gates that crew.
+const crewTailscaleTagPrefix = "tag:cbx-crew-"
+
+// crewHostsFile is written on every Tailscale-capable Linux peer. A timer
+// refreshes it and a managed /etc/hosts block every 30s from the box-local
+// `tailscale status --json` output, so peers stay reachable as `<slug>.cbx`
+// without the broker ever seeing a Tailscale credential.
+const crewHostsFile = "/etc/hosts.cbx"
+
+// crewHostsRefreshPeriod is the refresh cadence baked into the systemd timer
+// that rewrites crew host entries. Kept low so a new peer is discoverable
+// within a single user-visible interaction window.
+const crewHostsRefreshPeriod = "30s"
+
+// maxRequestedCrewNameLength bounds the user-visible portion of the label.
+// Provider label values are already capped at 63 characters by
+// sanitizeProviderLabelValue; we use a stricter limit here so the same name
+// also fits inside future hostname-derived identifiers (e.g. `<crew>.<peer>`)
+// without truncation.
+const maxRequestedCrewNameLength = 41
+
+// maxCrewTailscaleTagOwnerLength bounds the owner segment of the crew ACL
+// tag. Tailscale tags are limited to 63 characters; with the `tag:cbx-crew-`
+// prefix (14 chars) and the crew name suffix (up to 41 chars plus a `-`
+// separator) we reserve seven characters for the owner. The owner is
+// derived from the operator's git email local-part and truncated rather than
+// rejected so the same email shape works for personal and shared tailnets.
+const maxCrewTailscaleTagOwnerLength = 7
+
+// normalizeCrewName lowercases the requested name and replaces every character
+// outside `[a-z0-9-]` with `-`, collapsing runs and trimming leading/trailing
+// dashes. The shape matches normalizeLeaseSlug; crew names participate in the
+// same DNS-ish identifier space so peer hostnames stay regular.
+func normalizeCrewName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var out strings.Builder
+	lastDash := false
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			out.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+// requestedCrewName validates a user-supplied `--crew <name>` flag value.
+// Empty input is allowed: callers treat that as "no crew assignment".
+func requestedCrewName(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", nil
+	}
+	name := normalizeCrewName(value)
+	if name == "" {
+		return "", exit(2, "--crew must contain at least one letter or digit")
+	}
+	if len(name) > maxRequestedCrewNameLength {
+		return "", exit(2, "--crew must be %d characters or fewer after normalization", maxRequestedCrewNameLength)
+	}
+	return name, nil
+}
+
+// serverCrew returns the crew label value attached to a server, normalized for
+// comparison. Servers without a crew label return the empty string.
+func serverCrew(server Server) string {
+	if server.Labels == nil {
+		return ""
+	}
+	return normalizeCrewName(server.Labels[crewLabelKey])
+}
+
+// filterServersByCrew returns the subset of servers whose crew label matches
+// the requested name. The filter is a no-op when crew is empty so callers can
+// pass `--crew` through unconditionally.
+func filterServersByCrew(servers []Server, crew string) []Server {
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return servers
+	}
+	out := make([]Server, 0, len(servers))
+	for _, server := range servers {
+		if serverCrew(server) == crew {
+			out = append(out, server)
+		}
+	}
+	return out
+}
+
+// crewTagOwner derives the tag-safe owner segment from an operator identity
+// (typically `localCoordinatorOwner()` — a git email). Anything outside
+// `[a-z0-9-]` collapses to `-`; the result is trimmed and bounded so the full
+// tag stays within Tailscale's 63-character ceiling. Returns "" when the
+// input does not yield any valid characters; callers fall back to the
+// hard-coded "user" segment in that case so the tag prefix stays stable.
+func crewTagOwner(identity string) string {
+	identity = strings.ToLower(strings.TrimSpace(identity))
+	if at := strings.IndexByte(identity, '@'); at > 0 {
+		identity = identity[:at]
+	}
+	owner := normalizeCrewName(identity)
+	if owner == "" {
+		return ""
+	}
+	if len(owner) > maxCrewTailscaleTagOwnerLength {
+		owner = strings.Trim(owner[:maxCrewTailscaleTagOwnerLength], "-")
+	}
+	return owner
+}
+
+// crewTailscaleTag renders the ACL tag advertised by every crew peer. Returns
+// "" when either argument is empty so callers can compose the value
+// unconditionally and skip emission when the lease is not actually a crew
+// member.
+func crewTailscaleTag(owner, crew string) string {
+	owner = crewTagOwner(owner)
+	if owner == "" {
+		owner = "user"
+	}
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return ""
+	}
+	return crewTailscaleTagPrefix + owner + "-" + crew
+}
+
+// appendCrewTailscaleTag mutates cfg.Tailscale.Tags to include the crew tag
+// when both `--crew` and Tailscale are in play. The mint happens entirely in
+// user (CLI) context: the same auth key the operator already supplies is
+// re-used with one extra advertised tag, so the broker never sees a
+// Tailscale credential. No-op when the provider lacks FeatureTailscale or
+// when Tailscale is not enabled on this lease.
+func appendCrewTailscaleTag(cfg *Config, providerSupportsTailscale bool) {
+	if cfg == nil || !cfg.Tailscale.Enabled || !providerSupportsTailscale {
+		return
+	}
+	tag := crewTailscaleTag(localCoordinatorOwner(), cfg.Crew)
+	if tag == "" {
+		return
+	}
+	cfg.Tailscale.Tags = appendUniqueStrings(cfg.Tailscale.Tags, tag)
+}
+
+// providerCapableOfTailscale reports whether the named provider advertises
+// FeatureTailscale. Unknown providers return false, mirroring the
+// conservative posture other capability checks already take.
+func providerCapableOfTailscale(provider string) bool {
+	p, err := ProviderFor(provider)
+	if err != nil {
+		return false
+	}
+	return featureSetHas(p.Spec().Features, FeatureTailscale)
+}

--- a/internal/cli/crew_acl.go
+++ b/internal/cli/crew_acl.go
@@ -1,0 +1,323 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// crewACLEnsureTimeout bounds each request made by crewACLEnsure so the auth-
+// key mint path stays responsive even when Tailscale is slow. The total time
+// budget is roughly twice this (one GET + at most one PUT).
+const crewACLEnsureTimeout = 6 * time.Second
+
+// Tailnet API base URL resolution. CRABBOX_TS_API_URL wins over TS_API_URL so
+// operators can point the CLI at a self-hosted control plane (e.g. Headscale)
+// without leaking that override into other Tailscale tooling running in the
+// same shell. The default is the Tailscale-hosted REST API.
+const (
+	tailnetAPIURLEnvVar        = "TS_API_URL"
+	crabboxTailnetAPIURLEnvVar = "CRABBOX_TS_API_URL"
+	defaultTailnetAPIURL       = "https://api.tailscale.com"
+)
+
+// resolveTailnetAPIURL returns the base URL of the tailnet REST API the CLI
+// should talk to for crew ACL bootstrap. Trailing slashes are stripped so the
+// callers can append paths without thinking about it.
+func resolveTailnetAPIURL() string {
+	for _, v := range []string{os.Getenv(crabboxTailnetAPIURLEnvVar), os.Getenv(tailnetAPIURLEnvVar)} {
+		if v = strings.TrimRight(strings.TrimSpace(v), "/"); v != "" {
+			return v
+		}
+	}
+	return defaultTailnetAPIURL
+}
+
+// ErrCrewACLAutoBootstrapUnavailable is returned when the configured tailnet
+// control plane (e.g. Headscale) does not expose a Tailscale-compatible
+// policy REST API. Callers fall back to the manual snippet in
+// docs/features/crew.md instead of failing the lease creation.
+var ErrCrewACLAutoBootstrapUnavailable = errors.New("crew acl: auto-bootstrap unavailable on this control plane")
+
+// crewACLMaxAttempts caps the GET → merge → PUT loop. The first 412 from PUT
+// almost always reflects a benign concurrent edit (another operator running
+// the same bootstrap path), so re-reading the policy and retrying once is
+// safe. Two attempts is the smallest value that lets us tolerate a single
+// race; persistent 412s are surfaced as a clear error.
+const crewACLMaxAttempts = 2
+
+// errCrewACLPreconditionFailed is returned by PutPolicy when the server
+// rejected the write with HTTP 412 (ETag mismatch). It is wrapped so callers
+// can detect the race via errors.Is and decide whether to retry.
+var errCrewACLPreconditionFailed = errors.New("crew acl: tailnet policy changed during update (ETag mismatch)")
+
+// crewTailnetACLClient is satisfied by anything that can read and update the
+// tailnet policy file. The real implementation hits the Tailscale API; tests
+// inject a stub so unit tests never reach the network.
+type crewTailnetACLClient interface {
+	GetPolicy(ctx context.Context, tailnet string) (body string, etag string, err error)
+	PutPolicy(ctx context.Context, tailnet string, body string, etag string) error
+}
+
+// crewTailnetACLClientFactory is overridden in tests. It returns nil when no
+// API key is available so callers can fall through to the manual-setup path.
+var crewTailnetACLClientFactory = newCrewTailnetACLClient
+
+// crewACLEnsure makes sure the concrete crew tag is declared in tagOwners and
+// covered by a self-peering grant on the operator's tailnet. It is a no-op
+// when the rows are already present. When changes are needed the function
+// reads the current policy with an ETag, parses it as JSON, merges in the
+// missing entries, and PUTs the result back with If-Match so concurrent
+// edits fail-fast.
+//
+// The function is intentionally strict: if the live policy uses HuJSON
+// constructs (line comments, trailing commas) that the standard JSON parser
+// cannot decode, it returns a clear error so the caller falls back to the
+// existing manual snippet instead of risking a destructive overwrite.
+func crewACLEnsure(ctx context.Context, client crewTailnetACLClient, tailnet, owner, crew string) error {
+	if client == nil {
+		return fmt.Errorf("crew acl client unavailable")
+	}
+	tag := crewTailscaleTag(owner, crew)
+	if tag == "" {
+		return fmt.Errorf("crew acl: empty tag (owner=%q crew=%q)", owner, crew)
+	}
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	var lastPutErr error
+	for attempt := 1; attempt <= crewACLMaxAttempts; attempt++ {
+		getCtx, cancelGet := context.WithTimeout(ctx, crewACLEnsureTimeout)
+		body, etag, err := client.GetPolicy(getCtx, tailnet)
+		cancelGet()
+		if err != nil {
+			return fmt.Errorf("crew acl: read policy: %w", err)
+		}
+		if crewACLRowPresent(body, tag) {
+			return nil
+		}
+		merged, err := crewACLMergePolicy(body, tag)
+		if err != nil {
+			return err
+		}
+		putCtx, cancelPut := context.WithTimeout(ctx, crewACLEnsureTimeout)
+		err = client.PutPolicy(putCtx, tailnet, merged, etag)
+		cancelPut()
+		if err == nil {
+			return nil
+		}
+		// A 412 means another writer raced us; re-read the policy with a
+		// fresh ETag and retry. Once the retry budget is exhausted, surface
+		// the race with a distinct error so operators know rerunning is
+		// safe (vs. a hard auth failure). Any non-412 error is fatal — the
+		// caller falls back to the manual snippet.
+		if errors.Is(err, errCrewACLPreconditionFailed) {
+			lastPutErr = err
+			if attempt < crewACLMaxAttempts {
+				continue
+			}
+			return fmt.Errorf("crew acl: ETag race persisted after %d attempts: %w", crewACLMaxAttempts, lastPutErr)
+		}
+		return fmt.Errorf("crew acl: update policy: %w", err)
+	}
+	// Defensive: the loop body always returns or continues; reaching here
+	// would indicate a bug in the loop bounds.
+	return fmt.Errorf("crew acl: ETag race persisted after %d attempts: %w", crewACLMaxAttempts, lastPutErr)
+}
+
+// crewACLMergePolicy parses the policy as JSON, ensures both the tagOwners
+// entry and a self-peering grant for the tag, and returns the re-serialized
+// document. Returns a clear error when the policy is not valid JSON (e.g.
+// contains HuJSON comments) so the caller falls back to manual setup.
+func crewACLMergePolicy(body, tag string) (string, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return "", fmt.Errorf("crew acl: empty policy body")
+	}
+	var policy map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &policy); err != nil {
+		return "", fmt.Errorf("crew acl: cannot merge non-JSON policy (add the tag:cbx-crew-... rows manually): %w", err)
+	}
+	if policy == nil {
+		policy = map[string]json.RawMessage{}
+	}
+
+	// Merge tagOwners.
+	tagOwners := map[string]json.RawMessage{}
+	if raw, ok := policy["tagOwners"]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &tagOwners); err != nil {
+			return "", fmt.Errorf("crew acl: cannot parse tagOwners: %w", err)
+		}
+	}
+	if _, ok := tagOwners[tag]; !ok {
+		owners, err := json.Marshal([]string{"autogroup:admin"})
+		if err != nil {
+			return "", err
+		}
+		tagOwners[tag] = owners
+	}
+	updatedOwners, err := json.Marshal(tagOwners)
+	if err != nil {
+		return "", err
+	}
+	policy["tagOwners"] = updatedOwners
+
+	// Prefer grants when the policy already uses that shape, otherwise
+	// append a legacy acls row. We never down-convert grants→acls.
+	if raw, ok := policy["grants"]; ok && len(raw) > 0 {
+		var grants []map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &grants); err != nil {
+			return "", fmt.Errorf("crew acl: cannot parse grants: %w", err)
+		}
+		grants = append(grants, crewGrantEntry(tag))
+		updatedGrants, err := json.Marshal(grants)
+		if err != nil {
+			return "", err
+		}
+		policy["grants"] = updatedGrants
+	} else {
+		var acls []map[string]json.RawMessage
+		if raw, ok := policy["acls"]; ok && len(raw) > 0 {
+			if err := json.Unmarshal(raw, &acls); err != nil {
+				return "", fmt.Errorf("crew acl: cannot parse acls: %w", err)
+			}
+		}
+		acls = append(acls, crewACLEntry(tag))
+		updatedACLs, err := json.Marshal(acls)
+		if err != nil {
+			return "", err
+		}
+		policy["acls"] = updatedACLs
+	}
+
+	out, err := json.MarshalIndent(policy, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func crewGrantEntry(tag string) map[string]json.RawMessage {
+	src, _ := json.Marshal([]string{tag})
+	dst, _ := json.Marshal([]string{tag})
+	ip, _ := json.Marshal([]string{"*"})
+	return map[string]json.RawMessage{
+		"src": src,
+		"dst": dst,
+		"ip":  ip,
+	}
+}
+
+func crewACLEntry(tag string) map[string]json.RawMessage {
+	action, _ := json.Marshal("accept")
+	src, _ := json.Marshal([]string{tag})
+	dst, _ := json.Marshal([]string{tag + ":*"})
+	return map[string]json.RawMessage{
+		"action": action,
+		"src":    src,
+		"dst":    dst,
+	}
+}
+
+// liveCrewTailnetACLClient is the production implementation. It targets the
+// documented "Get tailnet policy file" and "Set tailnet policy file"
+// endpoints and threads ETag through so concurrent edits fail-fast.
+type liveCrewTailnetACLClient struct {
+	apiKey string
+	http   *http.Client
+}
+
+func newCrewTailnetACLClient(apiKey string) crewTailnetACLClient {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil
+	}
+	return &liveCrewTailnetACLClient{apiKey: apiKey, http: &http.Client{Timeout: crewACLEnsureTimeout}}
+}
+
+func (c *liveCrewTailnetACLClient) GetPolicy(ctx context.Context, tailnet string) (string, string, error) {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := resolveTailnetAPIURL() + "/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if readErr != nil {
+		return "", "", readErr
+	}
+	// 404/501 mean the configured control plane (e.g. Headscale) does not
+	// expose Tailscale's `/api/v2/tailnet/.../acl` route. Surface a distinct
+	// sentinel so callers fall back to the manual snippet rather than
+	// erroring the lease creation path.
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusNotImplemented {
+		return "", "", fmt.Errorf("%w: GET %s returned %d", ErrCrewACLAutoBootstrapUnavailable, url, resp.StatusCode)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", tailscaleAPIError(resp.StatusCode, body)
+	}
+	// Missing ETag on a 2xx response means concurrent-edit safety via
+	// If-Match isn't possible — we never PUT without a CAS token, so treat
+	// this as "auto-bootstrap unavailable" and let the manual path handle it.
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		return "", "", fmt.Errorf("%w: GET %s returned no ETag header", ErrCrewACLAutoBootstrapUnavailable, url)
+	}
+	return string(body), etag, nil
+}
+
+func (c *liveCrewTailnetACLClient) PutPolicy(ctx context.Context, tailnet, body, etag string) error {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := resolveTailnetAPIURL() + "/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if etag != "" {
+		req.Header.Set("If-Match", etag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return errCrewACLPreconditionFailed
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return tailscaleAPIError(resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+func tailscaleAPIError(status int, body []byte) error {
+	var envelope struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Message != "" {
+		return fmt.Errorf("tailscale api %d: %s", status, envelope.Message)
+	}
+	return fmt.Errorf("tailscale api %d", status)
+}

--- a/internal/cli/crew_acl_test.go
+++ b/internal/cli/crew_acl_test.go
@@ -1,0 +1,450 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// stubCrewTailnetACLClient lets unit tests exercise crewACLEnsure without
+// touching the network. Each method records call counts and the last input
+// body so assertions can be made against the merge logic.
+type stubCrewTailnetACLClient struct {
+	policy   string
+	etag     string
+	getErr   error
+	putErr   error
+	gets     int32
+	puts     int32
+	lastBody string
+	lastEtag string
+}
+
+func (s *stubCrewTailnetACLClient) GetPolicy(_ context.Context, _ string) (string, string, error) {
+	atomic.AddInt32(&s.gets, 1)
+	return s.policy, s.etag, s.getErr
+}
+
+func (s *stubCrewTailnetACLClient) PutPolicy(_ context.Context, _, body, etag string) error {
+	atomic.AddInt32(&s.puts, 1)
+	s.lastBody = body
+	s.lastEtag = etag
+	return s.putErr
+}
+
+func TestCrewACLEnsureNoopWhenRowPresent(t *testing.T) {
+	tag := crewTailscaleTag("user", "alpha")
+	stub := &stubCrewTailnetACLClient{
+		policy: crewPolicyFixture(tag),
+		etag:   `"v1"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 1 {
+		t.Fatalf("expected 1 GET, got %d", stub.gets)
+	}
+	if atomic.LoadInt32(&stub.puts) != 0 {
+		t.Fatalf("expected no PUT when row present, got %d", stub.puts)
+	}
+}
+
+func TestCrewACLEnsureUpsertsMissingRowAndPropagatesETag(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]},"acls":[{"action":"accept","src":["*"],"dst":["*:*"]}]}`,
+		etag:   `"v7"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&stub.puts) != 1 {
+		t.Fatalf("expected 1 PUT, got %d", stub.puts)
+	}
+	if stub.lastEtag != `"v7"` {
+		t.Fatalf("expected If-Match etag to be propagated, got %q", stub.lastEtag)
+	}
+	wantTag := crewTailscaleTag("user", "alpha")
+	if !strings.Contains(stub.lastBody, wantTag) {
+		t.Fatalf("expected new policy body to mention %q, got:\n%s", wantTag, stub.lastBody)
+	}
+	// The merged body must still parse as JSON and carry the expected entries.
+	var policy map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stub.lastBody), &policy); err != nil {
+		t.Fatalf("merged policy is not valid JSON: %v\n%s", err, stub.lastBody)
+	}
+	if !crewACLRowPresent(stub.lastBody, wantTag) {
+		t.Fatalf("merged policy should pass crewACLRowPresent, got:\n%s", stub.lastBody)
+	}
+}
+
+func TestCrewACLEnsurePrefersGrantsWhenPolicyUsesGrants(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]},"grants":[{"src":["tag:crabbox"],"dst":["tag:crabbox"],"ip":["*"]}]}`,
+		etag:   `"v1"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if !strings.Contains(stub.lastBody, `"grants"`) {
+		t.Fatalf("expected grants stanza preserved, got:\n%s", stub.lastBody)
+	}
+	if strings.Contains(stub.lastBody, `"acls"`) {
+		t.Fatalf("must not down-convert grants policy to acls, got:\n%s", stub.lastBody)
+	}
+}
+
+func TestCrewACLEnsureETagMismatchReturnsClearError(t *testing.T) {
+	// A persistent 412 from the server must surface a clear, actionable
+	// error after the retry budget is exhausted. The stub returns the
+	// sentinel so crewACLEnsure goes through the full retry loop.
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`,
+		etag:   `"v1"`,
+		putErr: errCrewACLPreconditionFailed,
+	}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error on ETag mismatch")
+	}
+	if !strings.Contains(err.Error(), "ETag race persisted") {
+		t.Fatalf("expected ETag race persisted error after retry, got %v", err)
+	}
+	if !errors.Is(err, errCrewACLPreconditionFailed) {
+		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}
+
+func TestCrewACLEnsureRefusesMalformedPolicy(t *testing.T) {
+	// HuJSON line comments make the body non-JSON. We must refuse rather
+	// than overwrite the operator's policy.
+	stub := &stubCrewTailnetACLClient{
+		policy: `// my tailnet policy
+{
+  "tagOwners": { "tag:crabbox": ["autogroup:admin"] }
+}`,
+		etag: `"v1"`,
+	}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error on non-JSON policy")
+	}
+	if !strings.Contains(err.Error(), "non-JSON") {
+		t.Fatalf("expected non-JSON error, got %v", err)
+	}
+	if atomic.LoadInt32(&stub.puts) != 0 {
+		t.Fatalf("must not PUT when merge fails, got %d puts", stub.puts)
+	}
+}
+
+func TestCrewACLEnsurePropagatesGetError(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{getErr: fmt.Errorf("tailscale api 401: invalid api key")}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error when GET fails")
+	}
+	if !strings.Contains(err.Error(), "read policy") {
+		t.Fatalf("expected read policy error, got %v", err)
+	}
+}
+
+// TestCrewACLEnsureLiveClientETagFlow uses an httptest server to validate the
+// production HTTP client's ETag handling end-to-end. It covers (a) ETag is
+// echoed from GET to PUT's If-Match header and (b) a 412 from the server is
+// surfaced as a clear error.
+func TestCrewACLEnsureLiveClientETagFlow(t *testing.T) {
+	t.Run("happy path threads ETag", func(t *testing.T) {
+		var lastIfMatch string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("ETag", `"v42"`)
+				_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+			case http.MethodPost:
+				lastIfMatch = r.Header.Get("If-Match")
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		}))
+		defer srv.Close()
+		client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+		if err := crewACLEnsure(context.Background(), client, "-", "user", "alpha"); err != nil {
+			t.Fatalf("crewACLEnsure: %v", err)
+		}
+		if lastIfMatch != `"v42"` {
+			t.Fatalf("expected If-Match propagated, got %q", lastIfMatch)
+		}
+	})
+
+	t.Run("server 412 surfaces clear error after retry", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("ETag", `"v1"`)
+				_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+			case http.MethodPost:
+				w.WriteHeader(http.StatusPreconditionFailed)
+			}
+		}))
+		defer srv.Close()
+		client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+		err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+		if err == nil {
+			t.Fatal("expected error on 412")
+		}
+		if !strings.Contains(err.Error(), "ETag race persisted") {
+			t.Fatalf("expected ETag race persisted error, got %v", err)
+		}
+	})
+}
+
+// newCrewTailnetTestClient returns a client wired against an httptest server.
+// It mirrors the live client's request shape but rewrites the base URL so the
+// test stays hermetic.
+func newCrewTailnetTestClient(t *testing.T, baseURL, apiKey string) crewTailnetACLClient {
+	t.Helper()
+	return &testCrewTailnetClient{base: baseURL, apiKey: apiKey, http: http.DefaultClient}
+}
+
+type testCrewTailnetClient struct {
+	base   string
+	apiKey string
+	http   *http.Client
+}
+
+func (c *testCrewTailnetClient) GetPolicy(ctx context.Context, _ string) (string, string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/api/v2/tailnet/-/acl", nil)
+	req.SetBasicAuth(c.apiKey, "")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", "", fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return string(body), resp.Header.Get("ETag"), nil
+}
+
+func (c *testCrewTailnetClient) PutPolicy(ctx context.Context, _, body, etag string) error {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v2/tailnet/-/acl", strings.NewReader(body))
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Content-Type", "application/json")
+	if etag != "" {
+		req.Header.Set("If-Match", etag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return errCrewACLPreconditionFailed
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// TestCrewACLEnsureRetriesOnce412ThenSucceeds wires an httptest server that
+// rejects the first PUT with 412 and accepts the second. crewACLEnsure must
+// observe the ETag race, re-read the policy, and complete in two attempts
+// without bubbling the transient failure to the caller.
+func TestCrewACLEnsureRetriesOnce412ThenSucceeds(t *testing.T) {
+	var gets, puts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			atomic.AddInt32(&gets, 1)
+			w.Header().Set("ETag", `"v1"`)
+			_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+		case http.MethodPost:
+			n := atomic.AddInt32(&puts, 1)
+			if n == 1 {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+	if err := crewACLEnsure(context.Background(), client, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&gets) != 2 {
+		t.Fatalf("expected 2 GETs (initial + retry), got %d", gets)
+	}
+	if atomic.LoadInt32(&puts) != 2 {
+		t.Fatalf("expected 2 PUTs (first 412, second 200), got %d", puts)
+	}
+}
+
+// TestCrewACLEnsureSurfacesAfterPersistent412 ensures the retry budget is
+// bounded: a server that always returns 412 must not be hammered indefinitely.
+// The function should fail after exactly crewACLMaxAttempts PUTs with a
+// clear, actionable error.
+func TestCrewACLEnsureSurfacesAfterPersistent412(t *testing.T) {
+	var puts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("ETag", `"v1"`)
+			_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+		case http.MethodPost:
+			atomic.AddInt32(&puts, 1)
+			w.WriteHeader(http.StatusPreconditionFailed)
+		}
+	}))
+	defer srv.Close()
+	client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+	err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error after persistent 412")
+	}
+	if !strings.Contains(err.Error(), "ETag race persisted") {
+		t.Fatalf("expected ETag race persisted error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&puts); got != int32(crewACLMaxAttempts) {
+		t.Fatalf("expected exactly %d PUTs, got %d", crewACLMaxAttempts, got)
+	}
+}
+
+func TestMaybeBootstrapCrewACLNoopWithoutAPIKey(t *testing.T) {
+	t.Setenv("TS_API_KEY", "")
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("expected silent noop without TS_API_KEY, got %v", err)
+	}
+}
+
+func TestMaybeBootstrapCrewACLCallsFactoryWhenKeyPresent(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	tag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	stub := &stubCrewTailnetACLClient{policy: crewPolicyFixture(tag), etag: `"v1"`}
+	prev := crewTailnetACLClientFactory
+	defer func() { crewTailnetACLClientFactory = prev }()
+	crewTailnetACLClientFactory = func(_ string) crewTailnetACLClient { return stub }
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("maybeBootstrapCrewACL: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 1 {
+		t.Fatalf("expected 1 GET when key is set, got %d", stub.gets)
+	}
+}
+
+func TestResolveTailnetAPIURLDefaults(t *testing.T) {
+	t.Setenv("TS_API_URL", "")
+	t.Setenv("CRABBOX_TS_API_URL", "")
+	if got := resolveTailnetAPIURL(); got != defaultTailnetAPIURL {
+		t.Fatalf("resolveTailnetAPIURL default mismatch: got %q want %q", got, defaultTailnetAPIURL)
+	}
+}
+
+func TestResolveTailnetAPIURLOverrideViaTSAPIURL(t *testing.T) {
+	t.Setenv("CRABBOX_TS_API_URL", "")
+	t.Setenv("TS_API_URL", "https://headscale.example.com/")
+	if got := resolveTailnetAPIURL(); got != "https://headscale.example.com" {
+		t.Fatalf("resolveTailnetAPIURL TS_API_URL override mismatch: got %q", got)
+	}
+}
+
+func TestResolveTailnetAPIURLCrabboxOverrideWins(t *testing.T) {
+	t.Setenv("TS_API_URL", "https://headscale.example.com")
+	t.Setenv("CRABBOX_TS_API_URL", "https://primary.example.com")
+	if got := resolveTailnetAPIURL(); got != "https://primary.example.com" {
+		t.Fatalf("resolveTailnetAPIURL CRABBOX_TS_API_URL precedence mismatch: got %q", got)
+	}
+}
+
+// TestCrewACLEnsureReturnsUnavailableOn404 wires the live client at an httptest
+// server that always replies 404 (the shape of a Headscale control plane,
+// which exposes /api/v1/policy instead of Tailscale's /api/v2/tailnet/.../acl
+// route). The live client must surface ErrCrewACLAutoBootstrapUnavailable so
+// the lease creation path falls back to the manual snippet without erroring.
+func TestCrewACLEnsureReturnsUnavailableOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("CRABBOX_TS_API_URL", srv.URL)
+	t.Setenv("TS_API_URL", "")
+	client := newCrewTailnetACLClient("stub-key")
+	if client == nil {
+		t.Fatal("expected live client when api key is non-empty")
+	}
+	err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+	if !errors.Is(err, ErrCrewACLAutoBootstrapUnavailable) {
+		t.Fatalf("expected ErrCrewACLAutoBootstrapUnavailable on 404, got %v", err)
+	}
+}
+
+// TestCrewACLEnsureReturnsUnavailableWhenMissingETag asserts that a 2xx
+// response without an ETag header (the way Headscale's policy GET responds)
+// is treated as auto-bootstrap unavailable — we cannot safely PUT without
+// concurrent-edit protection.
+func TestCrewACLEnsureReturnsUnavailableWhenMissingETag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"tagOwners":{},"acls":[]}`)
+	}))
+	defer srv.Close()
+	t.Setenv("CRABBOX_TS_API_URL", srv.URL)
+	t.Setenv("TS_API_URL", "")
+	client := newCrewTailnetACLClient("stub-key")
+	if client == nil {
+		t.Fatal("expected live client when api key is non-empty")
+	}
+	err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+	if !errors.Is(err, ErrCrewACLAutoBootstrapUnavailable) {
+		t.Fatalf("expected ErrCrewACLAutoBootstrapUnavailable when ETag missing, got %v", err)
+	}
+}
+
+// TestMaybeBootstrapCrewACLSilentlySkipsWhenControlPlaneUnavailable covers the
+// integration path: when crewACLEnsure surfaces ErrCrewACLAutoBootstrapUnavailable
+// (e.g. against Headscale), the lease creation must not fail. Doctor surfaces
+// the same condition with a manual-snippet pointer.
+func TestMaybeBootstrapCrewACLSilentlySkipsWhenControlPlaneUnavailable(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	prev := crewTailnetACLClientFactory
+	defer func() { crewTailnetACLClientFactory = prev }()
+	crewTailnetACLClientFactory = func(_ string) crewTailnetACLClient {
+		return &stubCrewTailnetACLClient{getErr: fmt.Errorf("%w: GET / returned 404", ErrCrewACLAutoBootstrapUnavailable)}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("expected silent skip on unavailable control plane, got %v", err)
+	}
+}
+
+func TestMaybeBootstrapCrewACLSkipsNonTailscaleProvider(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	stub := &stubCrewTailnetACLClient{}
+	prev := crewTailnetACLClientFactory
+	defer func() { crewTailnetACLClientFactory = prev }()
+	crewTailnetACLClientFactory = func(_ string) crewTailnetACLClient { return stub }
+	cfg := Config{Provider: "e2b", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("maybeBootstrapCrewACL: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 0 {
+		t.Fatalf("expected no API call for non-Tailscale provider, got %d gets", stub.gets)
+	}
+}

--- a/internal/cli/crew_bridge.go
+++ b/internal/cli/crew_bridge.go
@@ -1,0 +1,499 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// BridgePeer is the cross-provider shape returned by `crabbox crew peers`.
+// One row per crew member, regardless of which plane carries that member:
+//
+//   - Managed-Linux providers (AWS / Azure / GCP / Hetzner / Proxmox / SSH)
+//     surface with Transport="tailnet" and Endpoint=tailnet IPv4.
+//   - SSH-lease providers (exe.dev / RunPod / Daytona / Sprites / Namespace /
+//     Semaphore) surface with Transport="ssh" and Endpoint=ssh://host:port.
+//   - Delegated-with-URL providers (Islo, E2B, Modal, Cloudflare, Railway,
+//     Tensorlake) surface with Transport="url" and a per-port public URL.
+//   - Blacksmith and any provider without a Crabbox bridge adapter surface
+//     with Transport="none" and an honest Note so doctor reports the gap
+//     instead of pretending the peer is reachable.
+//
+// BridgeState is retained for backward compatibility with PR #136's first
+// shape: it carries "unsupported" / "unsupported-provider" for URL-transport
+// peers whose per-provider adapter explicitly cannot bridge.
+type BridgePeer struct {
+	Slug        string             `json:"slug"`
+	LeaseID     string             `json:"leaseID"`
+	Provider    string             `json:"provider"`
+	Crew        string             `json:"crew"`
+	Transport   string             `json:"transport"`
+	Endpoint    string             `json:"endpoint"`
+	Labels      map[string]string  `json:"labels,omitempty"`
+	Note        string             `json:"note,omitempty"`
+	Targets     []BridgePeerTarget `json:"targets,omitempty"`
+	BridgeState string             `json:"bridgeState,omitempty"`
+}
+
+// Transport classes used by the unified `crew peers` view and by the doctor
+// reachability matrix. The five values cover every shape the resolver can
+// emit; see bridgePeerFromClaim for the per-provider mapping.
+const (
+	TransportTailnet = "tailnet"
+	TransportURL     = "url"
+	TransportSSH     = "ssh"
+	TransportNone    = "none"
+	TransportPending = "pending"
+)
+
+// BridgePeerTarget is a single externally reachable HTTPS endpoint published
+// for a sandbox port. Different providers will populate it from different
+// native primitives (islo shares, modal web endpoints, e2b previews, …); the
+// shape stays uniform so client tooling can dial peers without knowing the
+// provider.
+type BridgePeerTarget struct {
+	Port      int       `json:"port"`
+	URL       string    `json:"url"`
+	ShareID   string    `json:"shareID,omitempty"`
+	ExpiresAt time.Time `json:"expiresAt,omitempty"`
+}
+
+// BridgeProvider is the interface delegated-provider backends implement to
+// surface peer endpoints to the crew bridge plane. A backend that does not
+// implement BridgeProvider is treated as "metadata-only" — the crew label is
+// still honored, peers are listed without targets, and `crew peers` reports
+// the gap honestly instead of pretending to bridge.
+//
+// Implementations are responsible for:
+//
+//   - PublishPeer: idempotently turning a (sandbox, port) pair into a public
+//     URL. Implementations may cache existing shares and return them rather
+//     than minting new ones.
+//   - ListPeerTargets: returning whatever public URLs are currently live for
+//     a sandbox, without side effects.
+//
+// The PublishPeer flow is opt-in: it is only invoked when the user passes
+// `--share-port` to `crabbox crew peers`. ListPeerTargets is always cheap and
+// safe — it is what powers the doctor probe.
+type BridgeProvider interface {
+	PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (BridgePeerTarget, error)
+	ListPeerTargets(ctx context.Context, leaseID string) ([]BridgePeerTarget, error)
+}
+
+// crewPeersFlags holds the parsed flags for `crabbox crew peers`. It is
+// extracted so the command can be unit tested without touching the global
+// flag set.
+type crewPeersFlags struct {
+	Crew      string
+	Provider  string
+	JSON      bool
+	SharePort int
+	ShareTTL  time.Duration
+}
+
+func (a App) crew(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		a.crewHelp()
+		return exit(2, "missing crew subcommand")
+	}
+	switch args[0] {
+	case "peers":
+		return a.crewPeers(ctx, args[1:])
+	case "-h", "--help", "help":
+		a.crewHelp()
+		return nil
+	default:
+		a.crewHelp()
+		return exit(2, "unknown crew subcommand %q", args[0])
+	}
+}
+
+func (a App) crewHelp() {
+	fmt.Fprintln(a.Stdout, `Crew bridge plane — list peer endpoints for delegated providers.
+
+Usage:
+  crabbox crew peers --crew <name> [flags]
+
+Flags:
+  --crew <name>          Required. Crew label to resolve.
+  --provider <name>      Restrict to a single provider (default: all delegated
+                         providers in the crew).
+  --json                 Emit machine-readable JSON instead of text.
+  --share-port <port>    Publish a per-peer public URL for this port (idempotent).
+  --share-ttl <duration> TTL for shares created with --share-port (default 24h).
+
+Examples:
+  crabbox crew peers --crew alpha
+  crabbox crew peers --crew alpha --provider islo
+  crabbox crew peers --crew alpha --json
+  crabbox crew peers --crew alpha --share-port 8080 --json
+
+The bridge plane is HTTP-only by design: peers are reachable via the per-
+provider native ingress (islo shares, e2b sandbox previews, railway deploy
+URLs, …). Non-HTTP protocols are out of scope — use the Tailscale plane for
+arbitrary TCP/UDP. Providers that do not expose a per-sandbox HTTPS ingress
+(modal, cloudflare, tensorlake) are honestly reported as unsupported instead
+of pretending to bridge.`)
+}
+
+func (a App) crewPeers(ctx context.Context, args []string) error {
+	fs := newFlagSet("crew peers", a.Stderr)
+	flags := crewPeersFlags{ShareTTL: 24 * time.Hour}
+	fs.StringVar(&flags.Crew, "crew", "", "crew label to resolve (required)")
+	fs.StringVar(&flags.Provider, "provider", "", "restrict to a single provider (default: all delegated providers in the crew)")
+	fs.BoolVar(&flags.JSON, "json", false, "emit machine-readable JSON")
+	fs.IntVar(&flags.SharePort, "share-port", 0, "if set, publish a public URL for this port on each peer")
+	fs.DurationVar(&flags.ShareTTL, "share-ttl", 24*time.Hour, "TTL for shares created with --share-port")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	crewName, err := requestedCrewName(flags.Crew)
+	if err != nil {
+		return err
+	}
+	if crewName == "" {
+		return exit(2, "--crew is required")
+	}
+	if flags.SharePort != 0 && (flags.SharePort < 1 || flags.SharePort > 65535) {
+		return exit(2, "--share-port must be between 1 and 65535")
+	}
+	// Empty --provider means "every provider represented in the crew"; the
+	// resolver fans out per provider and concatenates the result. Non-empty
+	// preserves the original single-provider semantics so existing scripts
+	// (and the islo live-demo in PR #136) keep working unchanged.
+	provider := strings.TrimSpace(flags.Provider)
+	peers, err := resolveCrewPeers(ctx, runtimeForApp(a), crewName, provider, flags)
+	if err != nil {
+		return err
+	}
+	if flags.JSON {
+		return json.NewEncoder(a.Stdout).Encode(crewPeersJSON{Members: peers})
+	}
+	renderBridgePeers(a.Stdout, peers)
+	return nil
+}
+
+// crewPeersJSON wraps the peer list so the JSON output matches the
+// documented `{ "members": [...] }` shape. Callers that need a raw slice
+// can decode either form — the wrapper carries no other fields.
+type crewPeersJSON struct {
+	Members []BridgePeer `json:"members"`
+}
+
+// resolveCrewPeers builds the BridgePeer list for a crew. The resolver is
+// split out so unit tests can swap in fakes for the provider backend and the
+// claim store without going through the full kong/flag stack.
+//
+// When provider is non-empty the resolver behaves as in the original PR #136
+// design: a single backend is configured and every matching claim is fanned
+// out against it. When provider is empty the resolver groups matching claims
+// by provider, configures each backend exactly once, and concatenates the
+// results — this is the path that gives `crabbox crew peers --crew <name>`
+// honest cross-provider output without making the caller enumerate providers
+// by hand.
+func resolveCrewPeers(ctx context.Context, rt Runtime, crew, provider string, flags crewPeersFlags) ([]BridgePeer, error) {
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	matches := filterClaimsForCrew(claims, crew, provider)
+	if len(matches) == 0 {
+		return []BridgePeer{}, nil
+	}
+	// Bucket claims by provider so each backend is configured at most once,
+	// even when the same provider has several leases in the crew.
+	byProvider := make(map[string][]leaseClaim)
+	order := make([]string, 0, 4)
+	for _, claim := range matches {
+		key := strings.TrimSpace(claim.Provider)
+		if _, ok := byProvider[key]; !ok {
+			order = append(order, key)
+		}
+		byProvider[key] = append(byProvider[key], claim)
+	}
+	sort.Strings(order)
+	peers := make([]BridgePeer, 0, len(matches))
+	for _, p := range order {
+		providerPeers, err := resolveCrewPeersForProvider(ctx, rt, p, byProvider[p], flags)
+		if err != nil {
+			return nil, err
+		}
+		peers = append(peers, providerPeers...)
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].Slug == peers[j].Slug {
+			return peers[i].LeaseID < peers[j].LeaseID
+		}
+		return peers[i].Slug < peers[j].Slug
+	})
+	return peers, nil
+}
+
+// resolveCrewPeersForProvider configures one provider backend and fans the
+// per-provider claim list through it. The caller is responsible for stitching
+// the per-provider slices together into the final, slug-sorted view returned
+// to the user.
+//
+// The transport class is determined per-provider:
+//
+//   - tailnet — managed Linux providers (AWS / Azure / GCP / Hetzner /
+//     Proxmox / Static SSH). The resolver does not invoke a bridge backend
+//     at all for these; the endpoint is read straight off the claim sidecar
+//     (TailscaleIPv4 / TailscaleFQDN), and missing endpoints surface as
+//     transport=pending with an honest note.
+//   - ssh — SSH-lease providers (exe.dev / RunPod / Daytona / Sprites /
+//     Namespace / Semaphore). Endpoint is built from SSHHost+SSHPort; an
+//     unset host surfaces as transport=pending.
+//   - url — delegated-with-URL providers. The per-provider BridgeProvider is
+//     invoked for live target discovery, preserving the original PR #136
+//     behavior (publish/list/honest-unsupported).
+//   - none — Blacksmith and providers with no Crabbox bridge adapter.
+//     Surfaced with a documented note so doctor stays honest.
+func resolveCrewPeersForProvider(ctx context.Context, rt Runtime, provider string, claims []leaseClaim, flags crewPeersFlags) ([]BridgePeer, error) {
+	class := providerTransportClass(provider)
+	peers := make([]BridgePeer, 0, len(claims))
+	var bridge BridgeProvider
+	bridgeLoaded := false
+	for _, claim := range claims {
+		peer := bridgePeerFromClaim(claim, class)
+		if peer.Transport == TransportURL {
+			if !bridgeLoaded {
+				b, err := loadBridgeProvider(provider, rt)
+				if err != nil {
+					return nil, err
+				}
+				bridge = b
+				bridgeLoaded = true
+			}
+			// We invoke the bridge backend when the caller asked us to mint
+			// a share (--share-port) or when no canonical endpoint is yet
+			// recorded on the claim. Skipping the lookup when an endpoint
+			// is already known keeps `crew peers` cheap for read-only
+			// listings on already-published shares.
+			needBridge := flags.SharePort > 0 || peer.Endpoint == ""
+			if bridge == nil && needBridge {
+				peer.BridgeState = "unsupported-provider"
+				peer.Transport = TransportNone
+				peer.Note = fmt.Sprintf("no bridge adapter for provider %s", peer.Provider)
+				peers = append(peers, peer)
+				continue
+			}
+			if needBridge {
+				if flags.SharePort > 0 {
+					target, perr := bridge.PublishPeer(ctx, claim.LeaseID, flags.SharePort, flags.ShareTTL)
+					if perr != nil {
+						if errors.Is(perr, ErrBridgeNotImplemented) {
+							peer.BridgeState = "unsupported"
+							peer.Note = fmt.Sprintf("bridge adapter for provider %s reports unsupported", peer.Provider)
+							peers = append(peers, peer)
+							continue
+						}
+						return nil, fmt.Errorf("publish peer %s port=%d: %w", claim.LeaseID, flags.SharePort, perr)
+					}
+					peer.Targets = append(peer.Targets, target)
+					if peer.Endpoint == "" {
+						peer.Endpoint = target.URL
+					}
+				} else {
+					targets, lerr := bridge.ListPeerTargets(ctx, claim.LeaseID)
+					if lerr != nil {
+						if errors.Is(lerr, ErrBridgeNotImplemented) {
+							peer.BridgeState = "unsupported"
+							peer.Note = fmt.Sprintf("bridge adapter for provider %s reports unsupported", peer.Provider)
+							peers = append(peers, peer)
+							continue
+						}
+						return nil, fmt.Errorf("list peer targets %s: %w", claim.LeaseID, lerr)
+					}
+					peer.Targets = targets
+					if peer.Endpoint == "" && len(targets) > 0 {
+						peer.Endpoint = targets[0].URL
+					}
+				}
+			}
+		}
+		peers = append(peers, peer)
+	}
+	return peers, nil
+}
+
+// bridgePeerFromClaim turns a single lease claim into the unified peer row.
+// The transport class is provided by the caller (it has already classified
+// the provider once for the fan-out path); the rest of the row is filled in
+// from the claim sidecar without any provider API calls.
+func bridgePeerFromClaim(claim leaseClaim, class string) BridgePeer {
+	peer := BridgePeer{
+		Slug:     claim.Slug,
+		LeaseID:  claim.LeaseID,
+		Provider: claim.Provider,
+		Crew:     claim.Crew,
+		Labels:   cloneStringMap(claim.Labels),
+	}
+	switch class {
+	case TransportTailnet:
+		endpoint := firstNonEmpty(claim.TailscaleIPv4, claim.TailscaleFQDN)
+		if endpoint == "" {
+			peer.Transport = TransportPending
+			peer.Note = "tailnet endpoint not yet recorded for this lease"
+			return peer
+		}
+		peer.Transport = TransportTailnet
+		peer.Endpoint = endpoint
+	case TransportSSH:
+		if claim.SSHHost == "" {
+			peer.Transport = TransportPending
+			peer.Note = "ssh endpoint not yet recorded for this lease"
+			return peer
+		}
+		port := claim.SSHPort
+		if port == 0 {
+			port = 22
+		}
+		peer.Transport = TransportSSH
+		peer.Endpoint = fmt.Sprintf("ssh://%s:%d", claim.SSHHost, port)
+	case TransportURL:
+		peer.Transport = TransportURL
+		peer.Endpoint = claim.BridgeURL
+	case TransportNone:
+		peer.Transport = TransportNone
+		if isBlacksmithProvider(claim.Provider) {
+			peer.Note = "blacksmith owns connectivity"
+		} else {
+			peer.Note = fmt.Sprintf("no bridge adapter for provider %s", claim.Provider)
+		}
+	default:
+		peer.Transport = TransportNone
+		peer.Note = fmt.Sprintf("no bridge adapter for provider %s", claim.Provider)
+	}
+	return peer
+}
+
+// providerTransportClass maps a provider name to its transport class. The
+// mapping is authoritative here (rather than derived from provider feature
+// flags) so the classification is stable when a future provider's Go-side
+// adapter lags behind the lease-record format.
+func providerTransportClass(provider string) string {
+	switch normalizeProviderName(provider) {
+	case "aws", "azure", "gcp", "hetzner", "proxmox", "ssh":
+		return TransportTailnet
+	case "exe-dev", "exedev", "runpod", "daytona", "sprites", "namespace", "namespace-devbox", "semaphore":
+		return TransportSSH
+	case "islo", "e2b", "modal", "cloudflare", "railway", "tensorlake":
+		return TransportURL
+	case "blacksmith", "blacksmith-testbox":
+		return TransportNone
+	default:
+		return TransportNone
+	}
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// filterClaimsForCrew returns the subset of claims that belong to the named
+// crew and (when provider is non-empty) the named provider. Empty crew
+// returns no matches — crews are never implicit.
+func filterClaimsForCrew(claims []leaseClaim, crew, provider string) []leaseClaim {
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return nil
+	}
+	provider = strings.TrimSpace(provider)
+	out := make([]leaseClaim, 0, len(claims))
+	for _, claim := range claims {
+		if normalizeCrewName(claim.Crew) != crew {
+			continue
+		}
+		if provider != "" && claim.Provider != provider {
+			continue
+		}
+		out = append(out, claim)
+	}
+	return out
+}
+
+// loadBridgeProviderFunc is the factory used by resolveCrewPeers; it is a
+// package var so unit tests can inject a fake bridge without going through
+// provider registration. Production code lets it default to the real lookup.
+var loadBridgeProviderFunc = realLoadBridgeProvider
+
+func loadBridgeProvider(provider string, rt Runtime) (BridgeProvider, error) {
+	return loadBridgeProviderFunc(provider, rt)
+}
+
+func realLoadBridgeProvider(provider string, rt Runtime) (BridgeProvider, error) {
+	if strings.TrimSpace(provider) == "" {
+		return nil, nil
+	}
+	// loadConfig (not baseConfig) is used so provider credentials picked up
+	// from the user config file and from environment variables (ISLO_API_KEY,
+	// E2B_API_KEY, …) flow through to the bridge backend. Without this the
+	// bridge plane would refuse to call provider APIs even when the rest of
+	// the CLI is happy.
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Provider = provider
+	resolved, err := ProviderFor(provider)
+	if err != nil {
+		return nil, exit(2, "unknown provider %q for crew bridge", provider)
+	}
+	backend, err := resolved.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	bridge, ok := backend.(BridgeProvider)
+	if !ok {
+		// Backends without bridge support still expose metadata; surface a
+		// stable error so callers (and the JSON consumer) can detect that
+		// peer URLs are not available for this provider.
+		return nil, nil
+	}
+	return bridge, nil
+}
+
+// ErrBridgeNotImplemented is returned by helpers that need an explicit signal
+// that the requested provider does not implement BridgeProvider yet.
+var ErrBridgeNotImplemented = errors.New("crew bridge plane not implemented for this provider")
+
+func renderBridgePeers(w interface{ Write([]byte) (int, error) }, peers []BridgePeer) {
+	if len(peers) == 0 {
+		fmt.Fprintln(w, "no peers found")
+		return
+	}
+	for _, peer := range peers {
+		fmt.Fprintf(w, "%s\tlease=%s\tprovider=%s\tcrew=%s\ttransport=%s", peer.Slug, peer.LeaseID, peer.Provider, peer.Crew, peer.Transport)
+		if peer.Endpoint != "" {
+			fmt.Fprintf(w, "\tendpoint=%s", peer.Endpoint)
+		}
+		if peer.BridgeState != "" {
+			fmt.Fprintf(w, "\tbridge=%s", peer.BridgeState)
+		}
+		if peer.Note != "" {
+			fmt.Fprintf(w, "\tnote=%q", peer.Note)
+		}
+		for _, target := range peer.Targets {
+			fmt.Fprintf(w, "\n  bridge target port=%d url=%s", target.Port, target.URL)
+			if target.ShareID != "" {
+				fmt.Fprintf(w, " share=%s", target.ShareID)
+			}
+			if !target.ExpiresAt.IsZero() {
+				fmt.Fprintf(w, " expires=%s", target.ExpiresAt.Format(time.RFC3339))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+}

--- a/internal/cli/crew_bridge_doctor.go
+++ b/internal/cli/crew_bridge_doctor.go
@@ -1,0 +1,326 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// BridgePeerProbeResult records the result of a single HTTPS reachability
+// probe against one BridgePeerTarget. The result is intentionally simple —
+// the doctor surface is a smoke check, not a uptime monitor.
+type BridgePeerProbeResult struct {
+	Slug       string `json:"slug"`
+	URL        string `json:"url"`
+	Port       int    `json:"port"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	State      string `json:"state"`
+	Detail     string `json:"detail,omitempty"`
+}
+
+// ProbeBridgePeers issues a HEAD request against each peer's first published
+// target with a strict per-probe timeout. The total wall-clock budget is
+// `perProbeTimeout * len(peers)` in the worst case; callers should cap it via
+// the parent context if they care.
+//
+// The state is one of:
+//
+//   - "reachable" — HEAD returned a status code (any code).
+//   - "unreachable" — HEAD failed (network error, TLS error, dial timeout).
+//   - "no-targets" — peer has no published bridge targets.
+//   - "unsupported" — provider explicitly does not implement the bridge
+//     plane (e.g. modal/cloudflare/tensorlake). The peer is still listed so
+//     `crabbox crew peers` callers see the gap.
+//   - "unsupported-provider" — provider has no BridgeProvider implementation
+//     at all. Same semantic as "unsupported" but produced by the framework
+//     fallback rather than an explicit per-provider adapter.
+//
+// A peer that returned a 4xx/5xx is still recorded as "reachable" because the
+// bridge plane only asserts that the public URL exists and routes; the user
+// app served on the port may legitimately answer 404 to a HEAD request.
+func ProbeBridgePeers(ctx context.Context, client *http.Client, peers []BridgePeer, perProbeTimeout time.Duration) []BridgePeerProbeResult {
+	if client == nil {
+		client = &http.Client{Timeout: perProbeTimeout}
+	}
+	if perProbeTimeout <= 0 {
+		perProbeTimeout = 3 * time.Second
+	}
+	results := make([]BridgePeerProbeResult, 0, len(peers))
+	for _, peer := range peers {
+		if len(peer.Targets) == 0 {
+			state := peer.BridgeState
+			if state == "" {
+				state = "no-targets"
+			}
+			results = append(results, BridgePeerProbeResult{
+				Slug:  peer.Slug,
+				State: state,
+			})
+			continue
+		}
+		target := peer.Targets[0]
+		probeCtx, cancel := context.WithTimeout(ctx, perProbeTimeout)
+		req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, target.URL, nil)
+		if err != nil {
+			cancel()
+			results = append(results, BridgePeerProbeResult{
+				Slug:   peer.Slug,
+				URL:    target.URL,
+				Port:   target.Port,
+				State:  "unreachable",
+				Detail: err.Error(),
+			})
+			continue
+		}
+		resp, err := client.Do(req)
+		cancel()
+		if err != nil {
+			results = append(results, BridgePeerProbeResult{
+				Slug:   peer.Slug,
+				URL:    target.URL,
+				Port:   target.Port,
+				State:  "unreachable",
+				Detail: shortenProbeError(err.Error()),
+			})
+			continue
+		}
+		_ = resp.Body.Close()
+		results = append(results, BridgePeerProbeResult{
+			Slug:       peer.Slug,
+			URL:        target.URL,
+			Port:       target.Port,
+			StatusCode: resp.StatusCode,
+			State:      "reachable",
+		})
+	}
+	return results
+}
+
+// shortenProbeError trims the verbose context/url prefix that net/http likes
+// to put on dial errors so the doctor row stays inside a single terminal
+// line. The full error is still available in the error chain if the caller
+// asks for it.
+func shortenProbeError(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.LastIndex(s, ": "); idx >= 0 && idx < len(s)-2 {
+		return s[idx+2:]
+	}
+	return s
+}
+
+// Reachability cell states used by the crew doctor matrix. The mapping in
+// reachabilityCell captures the asymmetric reality of the four planes — a
+// peer reachable only by URL cannot be dialed from a peer that lives only
+// on the tailnet (the tailnet member has no public endpoint to push toward).
+const (
+	reachOK   = "ok"
+	reachWarn = "warn"
+	reachNo   = "no"
+)
+
+// ReachabilityCell records a single source→destination cell of the crew
+// reachability matrix. Note carries the honest caveat for non-trivial cells
+// (operator-side bridges, asymmetric reach, …).
+type ReachabilityCell struct {
+	From  string `json:"from"`
+	To    string `json:"to"`
+	State string `json:"state"`
+	Note  string `json:"note,omitempty"`
+}
+
+// CrewReachabilityMatrix is the per-crew reachability matrix surfaced by
+// `crabbox doctor --crew <name>`. Members lists every distinct transport
+// observed in the crew (so callers can interpret the per-row meaning), and
+// Cells is the dense matrix indexed by (from, to) transport pair.
+type CrewReachabilityMatrix struct {
+	Crew       string             `json:"crew"`
+	Members    []BridgePeer       `json:"members"`
+	Breakdown  map[string]int     `json:"breakdown"`
+	Transports []string           `json:"transports"`
+	Cells      []ReachabilityCell `json:"cells"`
+}
+
+// crewReachableTransports is the canonical ordering for matrix rows/cols.
+// `pending` is folded into `tailnet` in the breakdown (class is known; only
+// the live endpoint is missing); `none` is reported as a separate row so
+// doctor can be honest about the gap.
+var crewReachableTransports = []string{
+	TransportTailnet,
+	TransportURL,
+	TransportSSH,
+	TransportNone,
+}
+
+// reachabilityCell returns the ok/warn/no cell for a (from, to) transport
+// pair plus the honest note attached to it. The mapping is asymmetric on
+// purpose — see docs/features/crew.md for the rationale.
+func reachabilityCell(from, to string) ReachabilityCell {
+	cell := ReachabilityCell{From: from, To: to, State: reachNo}
+	switch from {
+	case TransportTailnet:
+		switch to {
+		case TransportTailnet:
+			cell.State = reachOK
+		case TransportURL:
+			cell.State = reachOK
+			cell.Note = "via outbound HTTPS"
+		case TransportSSH:
+			cell.State = reachWarn
+			cell.Note = "requires operator-side bridge — see SSH-mesh DRAFT PR"
+		case TransportNone:
+			cell.Note = "destination has no published endpoint"
+		}
+	case TransportURL:
+		switch to {
+		case TransportTailnet:
+			cell.Note = "no public endpoint on tailnet members"
+		case TransportURL:
+			cell.State = reachOK
+		case TransportSSH:
+			cell.State = reachWarn
+			cell.Note = "requires operator-side bridge"
+		case TransportNone:
+			cell.Note = "destination has no published endpoint"
+		}
+	case TransportSSH:
+		switch to {
+		case TransportTailnet:
+			cell.State = reachWarn
+			cell.Note = "requires operator-side bridge"
+		case TransportURL:
+			cell.State = reachOK
+			cell.Note = "via outbound HTTPS"
+		case TransportSSH:
+			cell.State = reachWarn
+			cell.Note = "requires operator-side bridge — peers do not share a mesh"
+		case TransportNone:
+			cell.Note = "destination has no published endpoint"
+		}
+	case TransportNone:
+		cell.Note = "source provider owns its own connectivity"
+	}
+	return cell
+}
+
+// buildCrewReachabilityMatrix folds a peer list into the doctor matrix. It
+// only emits rows/cols for transports actually present in the crew, so a
+// crew with no SSH-lease members will not get an "ssh →" row.
+func buildCrewReachabilityMatrix(crew string, peers []BridgePeer) CrewReachabilityMatrix {
+	breakdown := map[string]int{}
+	for _, peer := range peers {
+		key := peer.Transport
+		if key == TransportPending {
+			// Roll "pending" up into "tailnet" for the breakdown so users see
+			// a single class count; the per-peer state is still visible in
+			// the members list.
+			key = TransportTailnet
+		}
+		breakdown[key]++
+	}
+	transports := observedTransports(breakdown)
+	cells := make([]ReachabilityCell, 0, len(transports)*len(transports))
+	for _, from := range transports {
+		for _, to := range transports {
+			cells = append(cells, reachabilityCell(from, to))
+		}
+	}
+	return CrewReachabilityMatrix{
+		Crew:       crew,
+		Members:    peers,
+		Breakdown:  breakdown,
+		Transports: transports,
+		Cells:      cells,
+	}
+}
+
+func observedTransports(breakdown map[string]int) []string {
+	seen := map[string]bool{}
+	for transport, count := range breakdown {
+		if count > 0 {
+			seen[transport] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	// Use the canonical ordering rather than alphabetical so the matrix reads
+	// "tailnet, url, ssh, none" — the natural order from least-trust to
+	// most-isolated source.
+	for _, t := range crewReachableTransports {
+		if seen[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// renderCrewReachabilityMatrix prints the doctor matrix in the same shape
+// shown in the user-facing docs. Cell glyphs are pure ASCII so the output
+// stays readable on terminals without unicode font support.
+func renderCrewReachabilityMatrix(w io.Writer, matrix CrewReachabilityMatrix) {
+	fmt.Fprintf(w, "crew %q: %d members\n", matrix.Crew, len(matrix.Members))
+	parts := make([]string, 0, len(matrix.Breakdown))
+	for _, transport := range crewReachableTransports {
+		if matrix.Breakdown[transport] > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", transport, matrix.Breakdown[transport]))
+		}
+	}
+	sort.Strings(parts)
+	fmt.Fprintf(w, "  transport breakdown: %s\n", strings.Join(parts, " "))
+	if len(matrix.Cells) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "  reachability:")
+	for _, cell := range matrix.Cells {
+		glyph := reachabilityGlyph(cell.State)
+		line := fmt.Sprintf("    %-7s -> %-7s : %s", cell.From, cell.To, glyph)
+		if cell.Note != "" {
+			line += " (" + cell.Note + ")"
+		}
+		fmt.Fprintln(w, line)
+	}
+}
+
+func reachabilityGlyph(state string) string {
+	switch state {
+	case reachOK:
+		return "OK"
+	case reachWarn:
+		return "WARN"
+	case reachNo:
+		return "NO"
+	default:
+		return state
+	}
+}
+
+// doctorCrewReachabilitySummary builds the cross-provider reachability
+// matrix from the local claim sidecar and returns the text rendering. The
+// result is plugged into the existing doctor finish() helper without
+// adding new top-level commands — doctor stays the single entry point.
+func doctorCrewReachabilitySummary(crew string) (CrewReachabilityMatrix, string, error) {
+	if crew == "" {
+		return CrewReachabilityMatrix{}, "", nil
+	}
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return CrewReachabilityMatrix{}, "", err
+	}
+	matches := filterClaimsForCrew(claims, crew, "")
+	peers := make([]BridgePeer, 0, len(matches))
+	for _, claim := range matches {
+		peers = append(peers, bridgePeerFromClaim(claim, providerTransportClass(claim.Provider)))
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		if peers[i].Slug == peers[j].Slug {
+			return peers[i].LeaseID < peers[j].LeaseID
+		}
+		return peers[i].Slug < peers[j].Slug
+	})
+	matrix := buildCrewReachabilityMatrix(crew, peers)
+	var buf strings.Builder
+	renderCrewReachabilityMatrix(&buf, matrix)
+	return matrix, buf.String(), nil
+}

--- a/internal/cli/crew_bridge_test.go
+++ b/internal/cli/crew_bridge_test.go
@@ -1,0 +1,572 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFilterClaimsForCrew(t *testing.T) {
+	claims := []leaseClaim{
+		{LeaseID: "isb_1", Slug: "web", Provider: "islo", Crew: "alpha"},
+		{LeaseID: "isb_2", Slug: "client", Provider: "islo", Crew: "Alpha"},
+		{LeaseID: "cbx_3", Slug: "db", Provider: "hetzner", Crew: "alpha"},
+		{LeaseID: "isb_4", Slug: "other", Provider: "islo", Crew: "bravo"},
+		{LeaseID: "isb_5", Slug: "noCrew", Provider: "islo"},
+	}
+	out := filterClaimsForCrew(claims, "alpha", "islo")
+	if len(out) != 2 {
+		t.Fatalf("expected 2 islo+alpha claims, got %d: %#v", len(out), out)
+	}
+	if out[0].LeaseID != "isb_1" || out[1].LeaseID != "isb_2" {
+		t.Fatalf("unexpected order: %#v", out)
+	}
+	if all := filterClaimsForCrew(claims, "alpha", ""); len(all) != 3 {
+		t.Fatalf("expected 3 alpha claims across providers, got %d", len(all))
+	}
+	if empty := filterClaimsForCrew(claims, "", "islo"); len(empty) != 0 {
+		t.Fatalf("expected 0 claims for empty crew, got %d", len(empty))
+	}
+	if none := filterClaimsForCrew(claims, "charlie", "islo"); len(none) != 0 {
+		t.Fatalf("expected 0 matches for crew=charlie, got %d", len(none))
+	}
+}
+
+type fakeBridgeProvider struct {
+	listed    map[string][]BridgePeerTarget
+	published map[string]BridgePeerTarget
+	listErr   error
+	pubErr    error
+	calls     int
+}
+
+func (f *fakeBridgeProvider) PublishPeer(_ context.Context, leaseID string, port int, _ time.Duration) (BridgePeerTarget, error) {
+	f.calls++
+	if f.pubErr != nil {
+		return BridgePeerTarget{}, f.pubErr
+	}
+	t := f.published[leaseID]
+	t.Port = port
+	return t, nil
+}
+
+func (f *fakeBridgeProvider) ListPeerTargets(_ context.Context, leaseID string) ([]BridgePeerTarget, error) {
+	f.calls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listed[leaseID], nil
+}
+
+func withTempClaims(t *testing.T, claims []leaseClaim) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	for _, claim := range claims {
+		if err := claimLeaseForRepoProviderScopeCrew(claim.LeaseID, claim.Slug, claim.Provider, claim.ProviderScope, claim.Crew, claim.RepoRoot, 30*time.Minute, false); err != nil {
+			t.Fatalf("seed claim %s: %v", claim.LeaseID, err)
+		}
+	}
+}
+
+func TestResolveCrewPeersListsTargets(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_web", Slug: "bridge-web", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+		{LeaseID: "isb_client", Slug: "bridge-client", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+		{LeaseID: "isb_other", Slug: "noise", Provider: "islo", Crew: "other", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{
+		listed: map[string][]BridgePeerTarget{
+			"isb_web": {{Port: 8080, URL: "https://web.share.islo.dev", ShareID: "shr_web"}},
+		},
+	}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(provider string, _ Runtime) (BridgeProvider, error) {
+		if provider != "islo" {
+			t.Fatalf("unexpected provider %q", provider)
+		}
+		return fake, nil
+	}
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "islo", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d: %#v", len(peers), peers)
+	}
+	if peers[0].Slug != "bridge-client" || peers[1].Slug != "bridge-web" {
+		t.Fatalf("peers not sorted by slug: %#v", peers)
+	}
+	if len(peers[1].Targets) != 1 || peers[1].Targets[0].URL == "" {
+		t.Fatalf("expected web peer to have 1 target with URL, got %#v", peers[1].Targets)
+	}
+	if len(peers[0].Targets) != 0 {
+		t.Fatalf("client peer should have no targets in this fake, got %#v", peers[0].Targets)
+	}
+	if peers[0].Crew != "demo" || peers[1].Crew != "demo" {
+		t.Fatalf("peers should carry crew=demo, got %#v", peers)
+	}
+}
+
+func TestResolveCrewPeersPublishesShare(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_w", Slug: "w", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{
+		published: map[string]BridgePeerTarget{
+			"isb_w": {URL: "https://abc.share.islo.dev", ShareID: "shr_w"},
+		},
+	}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return fake, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "islo", crewPeersFlags{SharePort: 8080, ShareTTL: time.Hour})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 1 || len(peers[0].Targets) != 1 {
+		t.Fatalf("expected 1 peer with 1 target, got %#v", peers)
+	}
+	if peers[0].Targets[0].Port != 8080 || peers[0].Targets[0].URL == "" {
+		t.Fatalf("publish should have set port=8080 and URL: %#v", peers[0].Targets[0])
+	}
+	if fake.calls != 1 {
+		t.Fatalf("expected 1 fake call, got %d", fake.calls)
+	}
+}
+
+func TestResolveCrewPeersUnknownProvider(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_w", Slug: "w", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+	})
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) {
+		return nil, nil // backend exists but does not implement BridgeProvider
+	}
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "islo", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 1 || len(peers[0].Targets) != 0 {
+		t.Fatalf("expected 1 peer with no targets, got %#v", peers)
+	}
+	if peers[0].BridgeState != "unsupported-provider" {
+		t.Fatalf("expected BridgeState=unsupported-provider for backend without BridgeProvider, got %q", peers[0].BridgeState)
+	}
+}
+
+func TestResolveCrewPeersExplicitlyUnsupportedAdapter(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "cbx_modal", Slug: "fn", Provider: "modal", Crew: "demo", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{listErr: ErrBridgeNotImplemented}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return fake, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "modal", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 1 || peers[0].BridgeState != "unsupported" {
+		t.Fatalf("expected ErrBridgeNotImplemented to surface as BridgeState=unsupported, got %#v", peers)
+	}
+	if len(peers[0].Targets) != 0 {
+		t.Fatalf("expected no targets when adapter reports unsupported, got %#v", peers[0].Targets)
+	}
+}
+
+func TestResolveCrewPeersExplicitlyUnsupportedPublish(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "cbx_cf", Slug: "edge", Provider: "cloudflare", Crew: "demo", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{pubErr: ErrBridgeNotImplemented}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return fake, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "cloudflare", crewPeersFlags{SharePort: 8080, ShareTTL: time.Hour})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 1 || peers[0].BridgeState != "unsupported" {
+		t.Fatalf("expected publish unsupported to surface as BridgeState=unsupported, got %#v", peers)
+	}
+}
+
+func TestResolveCrewPeersMultiProviderFanOut(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_islo1", Slug: "islo-a", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+		{LeaseID: "cbx_e2b1", Slug: "e2b-a", Provider: "e2b", Crew: "demo", RepoRoot: "/r"},
+		{LeaseID: "cbx_modal1", Slug: "modal-a", Provider: "modal", Crew: "demo", RepoRoot: "/r"},
+		{LeaseID: "isb_other", Slug: "noise", Provider: "islo", Crew: "other", RepoRoot: "/r"},
+	})
+	// Each provider key maps to a distinct adapter so we can assert that
+	// resolveCrewPeers picks the right backend per provider rather than
+	// applying one backend uniformly.
+	adapters := map[string]*fakeBridgeProvider{
+		"islo":  {listed: map[string][]BridgePeerTarget{"isb_islo1": {{Port: 80, URL: "https://islo-a.share.islo.dev"}}}},
+		"e2b":   {listed: map[string][]BridgePeerTarget{"cbx_e2b1": {{Port: 8080, URL: "https://8080-sbx.e2b.app"}}}},
+		"modal": {listErr: ErrBridgeNotImplemented},
+	}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(provider string, _ Runtime) (BridgeProvider, error) {
+		if adapter, ok := adapters[provider]; ok {
+			return adapter, nil
+		}
+		t.Fatalf("unexpected provider in fan-out: %q", provider)
+		return nil, nil
+	}
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	// Empty provider triggers the fan-out path.
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 3 {
+		t.Fatalf("expected 3 peers across providers, got %d: %#v", len(peers), peers)
+	}
+	byProvider := map[string]BridgePeer{}
+	for _, p := range peers {
+		byProvider[p.Provider] = p
+	}
+	if got := byProvider["islo"].Targets; len(got) != 1 || got[0].URL == "" {
+		t.Fatalf("islo peer should have its target, got %#v", got)
+	}
+	if got := byProvider["e2b"].Targets; len(got) != 1 || got[0].URL == "" {
+		t.Fatalf("e2b peer should have its target, got %#v", got)
+	}
+	if state := byProvider["modal"].BridgeState; state != "unsupported" {
+		t.Fatalf("modal peer should report unsupported, got %q", state)
+	}
+}
+
+func TestResolveCrewPeersListError(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_w", Slug: "w", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{listErr: errors.New("api down")}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return fake, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+	if _, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "islo", crewPeersFlags{}); err == nil {
+		t.Fatalf("expected ListPeerTargets error to surface")
+	}
+}
+
+func TestCrewPeersCommandRendersJSON(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "isb_w", Slug: "web", Provider: "islo", Crew: "demo", RepoRoot: "/r"},
+	})
+	fake := &fakeBridgeProvider{
+		listed: map[string][]BridgePeerTarget{
+			"isb_w": {{Port: 8080, URL: "https://x.share.islo.dev"}},
+		},
+	}
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return fake, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	var out, errBuf strings.Builder
+	app := App{Stdout: &out, Stderr: &errBuf}
+	if err := app.crewPeers(context.Background(), []string{"--crew", "demo", "--json"}); err != nil {
+		t.Fatalf("crewPeers: %v", err)
+	}
+	var payload crewPeersJSON
+	if err := json.Unmarshal([]byte(out.String()), &payload); err != nil {
+		t.Fatalf("decode json: %v (raw=%q)", err, out.String())
+	}
+	peers := payload.Members
+	if len(peers) != 1 || peers[0].Targets[0].URL == "" {
+		t.Fatalf("unexpected peers JSON: %#v", peers)
+	}
+	if peers[0].Transport != TransportURL {
+		t.Fatalf("expected transport=url for islo peer, got %q", peers[0].Transport)
+	}
+}
+
+func TestCrewPeersCommandRequiresCrew(t *testing.T) {
+	var out, errBuf strings.Builder
+	app := App{Stdout: &out, Stderr: &errBuf}
+	if err := app.crewPeers(context.Background(), nil); err == nil {
+		t.Fatalf("expected error when --crew is missing")
+	}
+}
+
+func TestCrewPeersCommandRejectsBadPort(t *testing.T) {
+	var out, errBuf strings.Builder
+	app := App{Stdout: &out, Stderr: &errBuf}
+	if err := app.crewPeers(context.Background(), []string{"--crew", "demo", "--share-port", "70000"}); err == nil {
+		t.Fatalf("expected error for out-of-range port")
+	}
+}
+
+func TestProbeBridgePeersReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	peers := []BridgePeer{{
+		Slug:    "web",
+		Targets: []BridgePeerTarget{{Port: 80, URL: srv.URL}},
+	}, {
+		Slug: "missing",
+	}}
+	results := ProbeBridgePeers(context.Background(), srv.Client(), peers, 2*time.Second)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 probe results, got %d", len(results))
+	}
+	if results[0].State != "reachable" || results[0].StatusCode != 200 {
+		t.Fatalf("first probe should be reachable+200: %#v", results[0])
+	}
+	if results[1].State != "no-targets" {
+		t.Fatalf("second probe should be no-targets: %#v", results[1])
+	}
+}
+
+func TestProbeBridgePeersUnreachable(t *testing.T) {
+	peers := []BridgePeer{{
+		Slug:    "broken",
+		Targets: []BridgePeerTarget{{Port: 80, URL: "https://127.0.0.1:1/" + strings.Repeat("x", 4)}},
+	}}
+	results := ProbeBridgePeers(context.Background(), &http.Client{Timeout: 500 * time.Millisecond}, peers, 500*time.Millisecond)
+	if results[0].State != "unreachable" {
+		t.Fatalf("expected unreachable, got %#v", results[0])
+	}
+}
+
+// TestCrewPeersIncludesManagedLinuxWithTailnetTransport asserts that a
+// managed-Linux peer with a recorded Tailscale IPv4 is surfaced into the
+// unified crew listing with transport=tailnet and the tailnet IP as the
+// endpoint — even when no delegated-provider bridge backend is configured
+// (the resolver should never consult a URL adapter for hetzner peers).
+func TestCrewPeersIncludesManagedLinuxWithTailnetTransport(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "cbx_web", Slug: "web", Provider: "hetzner", Crew: "demo", RepoRoot: "/r"},
+	})
+	mutateClaim(t, "cbx_web", func(c *leaseClaim) { c.TailscaleIPv4 = "100.64.1.3" })
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(provider string, _ Runtime) (BridgeProvider, error) {
+		t.Fatalf("bridge provider lookup must not be invoked for tailnet peers; got provider=%q", provider)
+		return nil, nil
+	}
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(peers))
+	}
+	if peers[0].Transport != TransportTailnet {
+		t.Fatalf("transport=%q want tailnet", peers[0].Transport)
+	}
+	if peers[0].Endpoint != "100.64.1.3" {
+		t.Fatalf("endpoint=%q want 100.64.1.3", peers[0].Endpoint)
+	}
+}
+
+// TestCrewPeersIncludesSSHLeaseWithSSHTransport asserts that SSH-lease
+// providers (RunPod here) surface their endpoint as `ssh://host:port` so
+// downstream tooling can dial it without provider-specific knowledge.
+func TestCrewPeersIncludesSSHLeaseWithSSHTransport(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "rp_db", Slug: "db", Provider: "runpod", Crew: "demo", RepoRoot: "/r"},
+	})
+	mutateClaim(t, "rp_db", func(c *leaseClaim) {
+		c.SSHHost = "1.2.3.4"
+		c.SSHPort = 2200
+	})
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) {
+		t.Fatalf("bridge provider lookup must not be invoked for ssh peers")
+		return nil, nil
+	}
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if peers[0].Transport != TransportSSH {
+		t.Fatalf("transport=%q want ssh", peers[0].Transport)
+	}
+	if peers[0].Endpoint != "ssh://1.2.3.4:2200" {
+		t.Fatalf("endpoint=%q want ssh://1.2.3.4:2200", peers[0].Endpoint)
+	}
+}
+
+// TestCrewPeersHandlesPendingTailscaleIP covers the case where the lease
+// is tagged for a tailnet-capable provider but the IP has not been
+// recorded yet (race between provision and tailnet join). The peer should
+// be reported as transport=pending with an honest note rather than being
+// dropped or pretending the endpoint exists.
+func TestCrewPeersHandlesPendingTailscaleIP(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "cbx_pend", Slug: "pend", Provider: "aws", Crew: "demo", RepoRoot: "/r"},
+	})
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return nil, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if peers[0].Transport != TransportPending {
+		t.Fatalf("transport=%q want pending", peers[0].Transport)
+	}
+	if peers[0].Endpoint != "" {
+		t.Fatalf("pending peer must not report a fake endpoint; got %q", peers[0].Endpoint)
+	}
+	if peers[0].Note == "" {
+		t.Fatalf("pending peer should carry an honest note")
+	}
+}
+
+// TestCrewPeersHandlesBlacksmithAsNone asserts that Blacksmith — the
+// provider that owns its own connectivity outside Crabbox's planes — is
+// surfaced as transport=none with the exact note documented in the public
+// API so client tooling can detect it.
+func TestCrewPeersHandlesBlacksmithAsNone(t *testing.T) {
+	withTempClaims(t, []leaseClaim{
+		{LeaseID: "bs_what", Slug: "what", Provider: "blacksmith", Crew: "demo", RepoRoot: "/r"},
+	})
+	prev := loadBridgeProviderFunc
+	loadBridgeProviderFunc = func(string, Runtime) (BridgeProvider, error) { return nil, nil }
+	t.Cleanup(func() { loadBridgeProviderFunc = prev })
+
+	peers, err := resolveCrewPeers(context.Background(), Runtime{}, "demo", "", crewPeersFlags{})
+	if err != nil {
+		t.Fatalf("resolveCrewPeers: %v", err)
+	}
+	if peers[0].Transport != TransportNone {
+		t.Fatalf("transport=%q want none", peers[0].Transport)
+	}
+	if peers[0].Note != "blacksmith owns connectivity" {
+		t.Fatalf("note=%q want \"blacksmith owns connectivity\"", peers[0].Note)
+	}
+	if peers[0].Endpoint != "" {
+		t.Fatalf("blacksmith peer must not report an endpoint; got %q", peers[0].Endpoint)
+	}
+}
+
+// TestDoctorCrewReachabilityMatrixAsymmetric pins the asymmetry that
+// `crabbox doctor --crew` reports between the transport planes. The
+// matrix must not pretend `url -> tailnet` is reachable, and it must
+// flag `* -> ssh` and `ssh -> *` as warnings (operator-side bridge
+// required) rather than ok.
+func TestDoctorCrewReachabilityMatrixAsymmetric(t *testing.T) {
+	peers := []BridgePeer{
+		{Slug: "web", Provider: "hetzner", Transport: TransportTailnet, Endpoint: "100.64.1.3"},
+		{Slug: "api", Provider: "islo", Transport: TransportURL, Endpoint: "https://api.share.islo.dev"},
+		{Slug: "db", Provider: "runpod", Transport: TransportSSH, Endpoint: "ssh://1.2.3.4:22"},
+		{Slug: "what", Provider: "blacksmith", Transport: TransportNone, Note: "blacksmith owns connectivity"},
+	}
+	matrix := buildCrewReachabilityMatrix("alpha", peers)
+	if got, want := len(matrix.Transports), 4; got != want {
+		t.Fatalf("transports=%d want %d (%v)", got, want, matrix.Transports)
+	}
+	cellState := func(from, to string) string {
+		for _, cell := range matrix.Cells {
+			if cell.From == from && cell.To == to {
+				return cell.State
+			}
+		}
+		t.Fatalf("cell %s -> %s missing", from, to)
+		return ""
+	}
+	if got := cellState(TransportURL, TransportTailnet); got != reachNo {
+		t.Fatalf("url -> tailnet should be NO (no public endpoint on tailnet), got %q", got)
+	}
+	if got := cellState(TransportTailnet, TransportURL); got != reachOK {
+		t.Fatalf("tailnet -> url should be OK (outbound HTTPS), got %q", got)
+	}
+	if got := cellState(TransportTailnet, TransportSSH); got != reachWarn {
+		t.Fatalf("tailnet -> ssh should be WARN (operator-side bridge), got %q", got)
+	}
+	if got := cellState(TransportSSH, TransportSSH); got != reachWarn {
+		t.Fatalf("ssh -> ssh should be WARN (no shared mesh), got %q", got)
+	}
+	if got := cellState(TransportSSH, TransportURL); got != reachOK {
+		t.Fatalf("ssh -> url should be OK (outbound HTTPS), got %q", got)
+	}
+	if got := cellState(TransportNone, TransportTailnet); got != reachNo {
+		t.Fatalf("none -> tailnet should be NO (provider owns its own connectivity), got %q", got)
+	}
+	for _, want := range []string{TransportTailnet, TransportURL, TransportSSH, TransportNone} {
+		found := false
+		for _, got := range matrix.Transports {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("matrix transports missing %q (have %v)", want, matrix.Transports)
+		}
+	}
+	if matrix.Breakdown[TransportTailnet] != 1 || matrix.Breakdown[TransportURL] != 1 || matrix.Breakdown[TransportSSH] != 1 || matrix.Breakdown[TransportNone] != 1 {
+		t.Fatalf("unexpected breakdown: %#v", matrix.Breakdown)
+	}
+}
+
+// TestRenderCrewReachabilityMatrixIncludesAsymmetricNotes checks the
+// human renderer surfaces the per-cell notes verbatim so reviewers can
+// audit the claims without parsing JSON.
+func TestRenderCrewReachabilityMatrixIncludesAsymmetricNotes(t *testing.T) {
+	peers := []BridgePeer{
+		{Slug: "web", Provider: "hetzner", Transport: TransportTailnet, Endpoint: "100.64.1.3"},
+		{Slug: "api", Provider: "islo", Transport: TransportURL, Endpoint: "https://x"},
+	}
+	matrix := buildCrewReachabilityMatrix("alpha", peers)
+	var buf strings.Builder
+	renderCrewReachabilityMatrix(&buf, matrix)
+	out := buf.String()
+	if !strings.Contains(out, "tailnet -> url") {
+		t.Fatalf("renderer should label rows by transport pair, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no public endpoint on tailnet members") {
+		t.Fatalf("renderer should surface the url -> tailnet asymmetry note, got:\n%s", out)
+	}
+}
+
+// mutateClaim is a helper for tests that need to overlay endpoint
+// metadata onto a seeded lease claim. It re-reads the claim sidecar
+// produced by withTempClaims, applies the mutation, and writes it back
+// through the same path the production claim writer uses so JSON-shape
+// changes stay covered by the on-disk format.
+func mutateClaim(t *testing.T, leaseID string, fn func(*leaseClaim)) {
+	t.Helper()
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatalf("readLeaseClaim %s: %v", leaseID, err)
+	}
+	if claim.LeaseID == "" {
+		t.Fatalf("no claim seeded for lease %s", leaseID)
+	}
+	fn(&claim)
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		t.Fatalf("leaseClaimPath %s: %v", leaseID, err)
+	}
+	data, err := json.MarshalIndent(claim, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal claim %s: %v", leaseID, err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write claim %s: %v", leaseID, err)
+	}
+}

--- a/internal/cli/crew_test.go
+++ b/internal/cli/crew_test.go
@@ -1,0 +1,546 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeCrewName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"alpha", "alpha"},
+		{"  Alpha  ", "alpha"},
+		{"alpha-bravo", "alpha-bravo"},
+		{"Alpha_Bravo Charlie", "alpha-bravo-charlie"},
+		{"---alpha---", "alpha"},
+		{"alpha//bravo??", "alpha-bravo"},
+		{"crew!!", "crew"},
+		{"123-abc", "123-abc"},
+	}
+	for _, tc := range cases {
+		if got := normalizeCrewName(tc.in); got != tc.want {
+			t.Fatalf("normalizeCrewName(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRequestedCrewNameValidates(t *testing.T) {
+	got, err := requestedCrewName(" Alpha Crew ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "alpha-crew" {
+		t.Fatalf("crew=%q want alpha-crew", got)
+	}
+	if got, err := requestedCrewName(""); err != nil || got != "" {
+		t.Fatalf("empty input got=%q err=%v", got, err)
+	}
+	if _, err := requestedCrewName("!!"); err == nil {
+		t.Fatalf("expected error for crew with no alnum")
+	}
+	tooLong := strings.Repeat("a", maxRequestedCrewNameLength+1)
+	if _, err := requestedCrewName(tooLong); err == nil {
+		t.Fatalf("expected error for crew %d chars", maxRequestedCrewNameLength+1)
+	}
+}
+
+func TestDirectLeaseLabelsRecordCrew(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:       "standard",
+		Profile:     "default",
+		ProviderKey: "crabbox-cbx-abcdef123456",
+		ServerType:  "cpx62",
+		Crew:        "alpha",
+		TTL:         15 * time.Minute,
+		IdleTimeout: 4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if labels["crew"] != "alpha" {
+		t.Fatalf("crew label=%q want alpha; full=%#v", labels["crew"], labels)
+	}
+}
+
+func TestDirectLeaseLabelsOmitCrewWhenEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:       "standard",
+		Profile:     "default",
+		ProviderKey: "crabbox-cbx-abcdef123456",
+		ServerType:  "cpx62",
+		TTL:         15 * time.Minute,
+		IdleTimeout: 4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if _, ok := labels["crew"]; ok {
+		t.Fatalf("crew label should be omitted when cfg.Crew is empty; got %#v", labels)
+	}
+}
+
+func TestFilterServersByCrew(t *testing.T) {
+	servers := []Server{
+		{Name: "a", Labels: map[string]string{"crew": "alpha"}},
+		{Name: "b", Labels: map[string]string{"crew": "bravo"}},
+		{Name: "c", Labels: map[string]string{}},
+		{Name: "d", Labels: map[string]string{"crew": "Alpha"}},
+	}
+	got := filterServersByCrew(servers, "alpha")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 servers for crew=alpha, got %d (%#v)", len(got), got)
+	}
+	if got[0].Name != "a" || got[1].Name != "d" {
+		t.Fatalf("filtered set unexpected: %#v", got)
+	}
+	if same := filterServersByCrew(servers, ""); len(same) != len(servers) {
+		t.Fatalf("empty filter should be a no-op, got %d", len(same))
+	}
+	if none := filterServersByCrew(servers, "charlie"); len(none) != 0 {
+		t.Fatalf("expected zero matches for crew=charlie, got %d", len(none))
+	}
+}
+
+func TestApplyLeaseCreateFlagsSetsCrew(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "Alpha Crew"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyLeaseCreateFlags: %v", err)
+	}
+	if cfg.Crew != "alpha-crew" {
+		t.Fatalf("cfg.Crew=%q want alpha-crew", cfg.Crew)
+	}
+	opts := leaseOptionsFromConfig(cfg)
+	if opts.Crew != "alpha-crew" {
+		t.Fatalf("leaseOptionsFromConfig.Crew=%q want alpha-crew", opts.Crew)
+	}
+}
+
+func TestApplyLeaseCreateFlagsRejectsBadCrew(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "!!"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err == nil {
+		t.Fatalf("expected error for invalid --crew")
+	}
+}
+
+func TestFilterJSONListViewByCrew(t *testing.T) {
+	view := []any{
+		map[string]any{"id": "a", "labels": map[string]any{"crew": "alpha"}},
+		map[string]any{"id": "b", "labels": map[string]any{"crew": "bravo"}},
+		map[string]any{"id": "c", "labels": map[string]any{}},
+		map[string]any{"id": "d", "labels": map[string]any{"crew": "Alpha"}},
+		"not-a-map",
+	}
+	filtered := filterJSONListViewByCrew(view, "alpha")
+	out, ok := filtered.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", filtered)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entries, got %d (%#v)", len(out), out)
+	}
+	if same := filterJSONListViewByCrew(view, ""); !sameAny(same, view) {
+		t.Fatalf("empty filter should be identity")
+	}
+	if other := filterJSONListViewByCrew("not-a-list", "alpha"); other != "not-a-list" {
+		t.Fatalf("non-slice view should pass through unchanged, got %#v", other)
+	}
+	unsupported := []any{
+		map[string]any{"id": "native-a", "state": "ready"},
+		map[string]any{"id": "native-b", "state": "leased"},
+	}
+	if same := filterJSONListViewByCrew(unsupported, "alpha"); fmt.Sprintf("%#v", same) != fmt.Sprintf("%#v", unsupported) {
+		t.Fatalf("unlabeled JSON list should pass through unchanged, got %#v", same)
+	}
+}
+
+func sameAny(a, b any) bool {
+	as, aok := a.([]any)
+	bs, bok := b.([]any)
+	if !aok || !bok || len(as) != len(bs) {
+		return false
+	}
+	for i := range as {
+		if _, ok := as[i].(map[string]any); ok {
+			continue
+		}
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCrewTagOwnerTruncatesAndNormalizes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"yossi.eliaz@incredibuild.com", "yossi-e"},
+		{"  Alpha.Bravo@example.com  ", "alpha-b"},
+		{"a@b", "a"},
+		{"!!", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := crewTagOwner(tc.in); got != tc.want {
+			t.Fatalf("crewTagOwner(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCrewTailscaleTagShape(t *testing.T) {
+	if got := crewTailscaleTag("yossi.eliaz@incredibuild.com", "Alpha Crew"); got != "tag:cbx-crew-yossi-e-alpha-crew" {
+		t.Fatalf("crewTailscaleTag=%q want tag:cbx-crew-yossi-e-alpha-crew", got)
+	}
+	if got := crewTailscaleTag("", "alpha"); got != "tag:cbx-crew-user-alpha" {
+		t.Fatalf("crewTailscaleTag empty owner=%q want tag:cbx-crew-user-alpha", got)
+	}
+	if got := crewTailscaleTag("yossi", ""); got != "" {
+		t.Fatalf("crewTailscaleTag empty crew=%q want empty", got)
+	}
+}
+
+func TestAppendCrewTailscaleTag(t *testing.T) {
+	cfg := Config{
+		Crew: "alpha",
+		Tailscale: TailscaleConfig{
+			Enabled: true,
+			Tags:    []string{"tag:crabbox"},
+		},
+	}
+	appendCrewTailscaleTag(&cfg, true)
+	found := false
+	for _, tag := range cfg.Tailscale.Tags {
+		if strings.HasPrefix(tag, "tag:cbx-crew-") && strings.HasSuffix(tag, "-alpha") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected crew tag appended, got %#v", cfg.Tailscale.Tags)
+	}
+	// Idempotent: a second call must not duplicate the entry.
+	before := len(cfg.Tailscale.Tags)
+	appendCrewTailscaleTag(&cfg, true)
+	if len(cfg.Tailscale.Tags) != before {
+		t.Fatalf("appendCrewTailscaleTag duplicated entry; got %#v", cfg.Tailscale.Tags)
+	}
+	// No-op when Tailscale is not enabled.
+	cfg2 := Config{Crew: "alpha", Tailscale: TailscaleConfig{Tags: []string{"tag:crabbox"}}}
+	appendCrewTailscaleTag(&cfg2, true)
+	if len(cfg2.Tailscale.Tags) != 1 {
+		t.Fatalf("expected no-op when Tailscale disabled, got %#v", cfg2.Tailscale.Tags)
+	}
+	// No-op when the provider does not advertise FeatureTailscale.
+	cfg3 := Config{Crew: "alpha", Tailscale: TailscaleConfig{Enabled: true, Tags: []string{"tag:crabbox"}}}
+	appendCrewTailscaleTag(&cfg3, false)
+	if len(cfg3.Tailscale.Tags) != 1 {
+		t.Fatalf("expected no-op when provider lacks FeatureTailscale, got %#v", cfg3.Tailscale.Tags)
+	}
+}
+
+func TestApplyLeaseCreateFlagsAddsCrewTailscaleTag(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+		Tailscale: TailscaleConfig{
+			HostnameTemplate: "crabbox-{slug}",
+			Tags:             []string{"tag:crabbox"},
+		},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "alpha", "--tailscale"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyLeaseCreateFlags: %v", err)
+	}
+	if !cfg.Tailscale.Enabled {
+		t.Fatalf("expected Tailscale enabled by --tailscale")
+	}
+	hasCrewTag := false
+	for _, tag := range cfg.Tailscale.Tags {
+		if strings.HasPrefix(tag, "tag:cbx-crew-") && strings.HasSuffix(tag, "-alpha") {
+			hasCrewTag = true
+		}
+	}
+	if !hasCrewTag {
+		t.Fatalf("expected crew Tailscale tag on cfg, got %#v", cfg.Tailscale.Tags)
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapEmittedWhenCrewAndTailscale(t *testing.T) {
+	cfg := baseConfig()
+	cfg.SSHUser = "runner"
+	cfg.Crew = "alpha"
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = "tskey-secret"
+	cfg.Tailscale.Tags = []string{"tag:crabbox", "tag:cbx-crew-user-alpha"}
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	for _, want := range []string{
+		"/etc/hosts.cbx",
+		"/usr/local/bin/crabbox-crew-hosts",
+		"/etc/systemd/system/crabbox-crew-hosts.service",
+		"/etc/systemd/system/crabbox-crew-hosts.timer",
+		"/etc/hosts",
+		"# crabbox crew hosts begin",
+		"# crabbox crew hosts end",
+		"OnUnitActiveSec=30s",
+		"ExecStart=/usr/local/bin/crabbox-crew-hosts",
+		"tag:cbx-crew-",
+		"tailscale status --json",
+		"systemctl enable --now crabbox-crew-hosts.timer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("cloudInit(crew) missing %q", want)
+		}
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapAbsentWithoutCrew(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = "tskey-secret"
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	if strings.Contains(got, "crabbox-crew-hosts") {
+		t.Fatalf("cloudInit without --crew must not install crew hosts service")
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapAbsentWithoutTailscale(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Crew = "alpha"
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	if strings.Contains(got, "crabbox-crew-hosts") {
+		t.Fatalf("cloudInit without --tailscale must not install crew hosts service even when --crew is set")
+	}
+}
+
+// stubDoctorTailscaleACLClient lets unit tests exercise doctorCrewSummary
+// without touching the real Tailscale API.
+type stubDoctorTailscaleACLClient struct {
+	policy string
+	err    error
+}
+
+func (s stubDoctorTailscaleACLClient) PolicyHuJSON(_ context.Context, _ string) (string, error) {
+	return s.policy, s.err
+}
+
+func TestDoctorCrewSummaryNoopsWithoutCrew(t *testing.T) {
+	cfg := Config{Provider: "hetzner"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "" || message != "" || details != nil {
+		t.Fatalf("expected no crew check without cfg.Crew, got status=%q msg=%q details=%#v", status, message, details)
+	}
+}
+
+func TestDoctorCrewSummarySkipsNonTailscaleProviderWithCrew(t *testing.T) {
+	cfg := Config{Provider: "e2b", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "skip" {
+		t.Fatalf("expected skip, got %q", status)
+	}
+	want := `crew "alpha": provider e2b does not support the Tailscale plane; crew networking unavailable`
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["reason"] != "provider_not_tailscale_capable" {
+		t.Fatalf("expected reason metadata, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummarySkipsWhenAPIKeyMissing(t *testing.T) {
+	t.Setenv("TS_API_KEY", "")
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, _, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "skip" {
+		t.Fatalf("expected skip when TS_API_KEY is missing, got %q", status)
+	}
+	if details["reason"] != "ts_api_key_missing" {
+		t.Fatalf("expected ts_api_key_missing reason, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryOKWhenACLPresent(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	tag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	policy := crewPolicyFixture(tag)
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{policy: policy}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "ok" {
+		t.Fatalf("expected ok, got %q (msg=%q details=%#v)", status, message, details)
+	}
+	wantTag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	want := fmt.Sprintf(`crew "alpha": Tailscale plane auto-managed (%s)`, wantTag)
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["mode"] != "auto-managed" {
+		t.Fatalf("expected mode=auto-managed when TS_API_KEY is set, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryFailsWhenACLMissing(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	policy := crewPolicyFixture("tag:cbx-crew-user-bravo")
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{policy: policy}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "failed" {
+		t.Fatalf("expected failed, got %q", status)
+	}
+	wantTag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	want := fmt.Sprintf(`crew "alpha": tailnet policy row missing for %s. Run with $TS_API_KEY exported to auto-install, or apply the snippet from docs/features/crew.md`, wantTag)
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["remedy"] == "" {
+		t.Fatalf("expected remedy in details, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryFailsWhenAPIClientErrors(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{err: fmt.Errorf("tailscale api 401: invalid api key")}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, _ := doctorCrewSummary(context.Background(), cfg)
+	if status != "failed" {
+		t.Fatalf("expected failed, got %q", status)
+	}
+	if !strings.Contains(message, "policy lookup failed") {
+		t.Fatalf("expected policy lookup failure message, got %q", message)
+	}
+}
+
+// TestDoctorCrewSummarySkipsWhenControlPlaneIncompatible covers self-hosted
+// control planes (e.g. Headscale) whose policy endpoint is not byte-compatible
+// with Tailscale's /api/v2/tailnet/.../acl shape. Doctor must skip with a
+// helpful pointer at the manual snippet rather than reporting a failure.
+func TestDoctorCrewSummarySkipsWhenControlPlaneIncompatible(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	t.Setenv("CRABBOX_TS_API_URL", "https://headscale.example.com")
+	t.Setenv("TS_API_URL", "")
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{err: fmt.Errorf("%w: GET https://headscale.example.com/api/v2/tailnet/-/acl returned 404", ErrCrewACLAutoBootstrapUnavailable)}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "skip" {
+		t.Fatalf("expected skip on incompatible control plane, got %q (msg=%q)", status, message)
+	}
+	if !strings.Contains(message, "https://headscale.example.com") {
+		t.Fatalf("expected control plane URL in message, got %q", message)
+	}
+	if !strings.Contains(message, "docs/features/crew.md") {
+		t.Fatalf("expected manual snippet pointer, got %q", message)
+	}
+	if details["reason"] != "control_plane_incompatible" {
+		t.Fatalf("expected control_plane_incompatible reason, got %#v", details)
+	}
+	if details["api_url"] != "https://headscale.example.com" {
+		t.Fatalf("expected api_url metadata, got %#v", details)
+	}
+}
+
+func TestCrewACLRowPresentChecksConcreteTag(t *testing.T) {
+	tag := "tag:cbx-crew-yossi-e-alpha"
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"both present", crewPolicyFixture(tag), true},
+		{"grants present", crewGrantPolicyFixture(tag), true},
+		{"commented sample before grants", `{
+  // "tagOwners": { "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"] },
+  "tagOwners": { "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"] },
+  "grants": [{ "src": ["tag:cbx-crew-yossi-e-alpha"], "dst": ["tag:cbx-crew-yossi-e-alpha"], "ip": ["*"] }]
+}`, true},
+		{"different crew", crewPolicyFixture("tag:cbx-crew-yossi-e-bravo"), false},
+		{"missing tagOwners", `{"acls":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:cbx-crew-yossi-e-alpha:*"]}]}`, false},
+		{"missing dst", `{"tagOwners":{"tag:cbx-crew-yossi-e-alpha":["autogroup:admin"]},"acls":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:crabbox:*"]}]}`, false},
+		{"grant src only", `{"tagOwners":{"tag:cbx-crew-yossi-e-alpha":["autogroup:admin"]},"grants":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:crabbox"],"ip":["*"]}]}`, false},
+		{"missing tag mention", `{"acls":[{"src":["*"]}],"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`, false},
+		{"empty body", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := crewACLRowPresent(tc.body, tag); got != tc.want {
+				t.Fatalf("crewACLRowPresent(%q)=%v want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func crewPolicyFixture(tag string) string {
+	return fmt.Sprintf(`{
+  "tagOwners": { %q: ["autogroup:admin"] },
+  "acls": [{ "action": "accept", "src": [%q], "dst": [%q] }]
+}`, tag, tag, tag+":*")
+}
+
+func crewGrantPolicyFixture(tag string) string {
+	return fmt.Sprintf(`{
+  "tagOwners": { %q: ["autogroup:admin"] },
+  "grants": [{ "src": [%q], "dst": [%q], "ip": ["*"] }]
+}`, tag, tag, tag)
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -33,6 +33,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	profile := fs.String("profile", defaults.Profile, "configured profile for remote prerequisite checks")
 	id := fs.String("id", "", "remote lease id to inspect")
+	crew := fs.String("crew", defaults.Crew, "verify Tailscale ACL setup for this crew")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	probeSSH := fs.Bool("doctor-probe-ssh", false, "probe static SSH reachability during doctor")
 	targetFlags := registerTargetFlags(fs, defaults)
@@ -48,6 +49,13 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	cfg.Profile = strings.TrimSpace(*profile)
 	if err := applySelectedProfileConfig(&cfg); err != nil {
 		return err
+	}
+	if flagWasSet(fs, "crew") {
+		crewName, err := requestedCrewName(*crew)
+		if err != nil {
+			return err
+		}
+		cfg.Crew = crewName
 	}
 	ok := true
 	var checks []doctorJSONCheck
@@ -67,6 +75,12 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stdout, "%-7s %-8s %s\n", status, check, message)
 	}
 	finish := func() error {
+		if status, message, details := doctorCrewSummary(ctx, cfg); status != "" {
+			if status == "failed" {
+				ok = false
+			}
+			record(status, "crew", message, details)
+		}
 		if *jsonOut {
 			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
 				return err

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -81,6 +81,26 @@ func (a App) doctor(ctx context.Context, args []string) error {
 			}
 			record(status, "crew", message, details)
 		}
+		// Cross-provider reachability matrix: a separate doctor row that
+		// folds the unified `crew peers` view into a per-transport-pair
+		// reachability grid. The grid is the load-bearing output users get
+		// when they pass `--crew`, so the matrix text is also written to
+		// stdout in non-JSON mode so it shows up alongside the per-check
+		// status lines.
+		if crew := normalizeCrewName(cfg.Crew); crew != "" {
+			matrix, rendered, err := doctorCrewReachabilitySummary(crew)
+			if err != nil {
+				return err
+			}
+			details := map[string]string{"crew": crew, "members": fmt.Sprintf("%d", len(matrix.Members))}
+			for transport, count := range matrix.Breakdown {
+				details["transport_"+transport] = fmt.Sprintf("%d", count)
+			}
+			record("ok", "crew-matrix", fmt.Sprintf("crew %q: %d members; matrix=%d cells", crew, len(matrix.Members), len(matrix.Cells)), details)
+			if !*jsonOut {
+				fmt.Fprint(a.Stdout, rendered)
+			}
+		}
 		if *jsonOut {
 			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
 				return err

--- a/internal/cli/doctor_crew.go
+++ b/internal/cli/doctor_crew.go
@@ -1,0 +1,235 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// doctorCrewTimeout bounds the live Tailscale API call. Kept short so the
+// doctor command stays responsive even when the user's tailnet is degraded.
+const doctorCrewTimeout = 4 * time.Second
+
+// doctorTailscaleACLClient is satisfied by anything that can return the raw
+// policy document for the user's tailnet. The real implementation hits the
+// Tailscale API; tests inject a stub so unit tests never reach the network.
+type doctorTailscaleACLClient interface {
+	PolicyHuJSON(ctx context.Context, tailnet string) (string, error)
+}
+
+// doctorTailscaleACLClientFactory is overridden in tests. It returns nil when
+// the live client is not available so the check can degrade gracefully.
+var doctorTailscaleACLClientFactory = newDoctorTailscaleACLClient
+
+// doctorCrewSummary is the doctor entry point invoked from finish(). It
+// always returns either ("","",nil) — meaning "no crew check applies" — or a
+// triplet ready to feed into the existing record(...) helper. The check is
+// intentionally bounded to a few seconds so doctor stays fast even on
+// degraded tailnets.
+func doctorCrewSummary(ctx context.Context, cfg Config) (string, string, map[string]string) {
+	crew := normalizeCrewName(cfg.Crew)
+	if crew == "" {
+		return "", "", nil
+	}
+	tag := crewTailscaleTag(localCoordinatorOwner(), crew)
+	if tag == "" {
+		return "", "", nil
+	}
+	if !providerCapableOfTailscale(cfg.Provider) {
+		return "skip", fmt.Sprintf("crew %q: provider %s does not support the Tailscale plane; crew networking unavailable", crew, cfg.Provider), map[string]string{"provider": cfg.Provider, "crew": crew, "tag": tag, "plane": "tailscale", "reason": "provider_not_tailscale_capable"}
+	}
+	apiKey := strings.TrimSpace(os.Getenv("TS_API_KEY"))
+	if apiKey == "" {
+		return "skip", "TS_API_KEY missing; skipped ACL verification", map[string]string{"crew": crew, "tag": tag, "reason": "ts_api_key_missing"}
+	}
+	tailnet := strings.TrimSpace(os.Getenv("TS_TAILNET"))
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	client := doctorTailscaleACLClientFactory(apiKey)
+	if client == nil {
+		return "skip", "tailscale api client unavailable", map[string]string{"crew": crew, "tag": tag, "reason": "client_unavailable"}
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, doctorCrewTimeout)
+	defer cancel()
+	body, err := client.PolicyHuJSON(checkCtx, tailnet)
+	if err != nil {
+		// Self-hosted control planes (e.g. Headscale) do not expose the
+		// Tailscale `/api/v2/tailnet/.../acl` route. Skip with a helpful
+		// message pointing operators at the manual snippet rather than
+		// failing — the network plane still works against the client-side
+		// Tailscale binary regardless of which control plane runs it.
+		if errors.Is(err, ErrCrewACLAutoBootstrapUnavailable) {
+			return "skip", fmt.Sprintf("crew %q: control plane at %s does not expose a Tailscale-compatible policy API; apply the snippet from docs/features/crew.md (e.g. Headscale: `headscale policy set --file ./policy.hujson`)", crew, resolveTailnetAPIURL()), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "api_url": resolveTailnetAPIURL(), "reason": "control_plane_incompatible"}
+		}
+		return "failed", fmt.Sprintf("tailscale policy lookup failed: %v", err), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "error": err.Error()}
+	}
+	if crewACLRowPresent(body, tag) {
+		return "ok", fmt.Sprintf("crew %q: Tailscale plane auto-managed (%s)", crew, tag), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "mode": "auto-managed"}
+	}
+	return "failed", fmt.Sprintf("crew %q: tailnet policy row missing for %s. Run with $TS_API_KEY exported to auto-install, or apply the snippet from docs/features/crew.md", crew, tag), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "remedy": "see_docs_features_crew_md"}
+}
+
+// crewACLRowPresent checks for the concrete tag declaration and access row
+// needed by a crew. The Tailscale policy file is HuJSON and not trivially
+// JSON-parseable without an extra dependency, so keep the scan textual but
+// exact enough: the tag must appear under tagOwners and either a legacy ACL row
+// (`tag` -> `tag:*`) or a grants row (`tag` -> `tag`) must be present.
+func crewACLRowPresent(policy, tag string) bool {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return false
+	}
+	quotedTag := `"` + tag + `"`
+	quotedDst := `"` + tag + `:*"`
+	if !policySectionContains(policy, "tagOwners", quotedTag) {
+		return false
+	}
+	if policySectionContains(policy, "acls", quotedTag) &&
+		policySectionContains(policy, "acls", quotedDst) {
+		return true
+	}
+	if grants, ok := policySection(policy, "grants"); ok {
+		return strings.Count(grants, quotedTag) >= 2 && strings.Contains(grants, `"ip"`)
+	}
+	return false
+}
+
+func policySectionContains(policy, section, token string) bool {
+	body, ok := policySection(policy, section)
+	return ok && strings.Contains(body, token)
+}
+
+func policySection(policy, section string) (string, bool) {
+	start := activePolicySectionStart(policy, section)
+	if start < 0 {
+		return "", false
+	}
+	rest := policy[start+len(section)+2:]
+	colon := strings.IndexByte(rest, ':')
+	if colon < 0 {
+		return "", false
+	}
+	rest = rest[colon+1:]
+	trimmed := strings.TrimLeft(rest, " \t\r\n")
+	if trimmed == "" {
+		return "", false
+	}
+	open := trimmed[0]
+	close := byte(0)
+	switch open {
+	case '{':
+		close = '}'
+	case '[':
+		close = ']'
+	default:
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(trimmed); i++ {
+		ch := trimmed[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		if ch == '"' {
+			inString = true
+			continue
+		}
+		switch ch {
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return trimmed[:i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+func activePolicySectionStart(policy, section string) int {
+	offset := 0
+	prefix := `"` + section + `"`
+	for _, line := range strings.SplitAfter(policy, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, prefix) {
+			return offset + strings.Index(line, prefix)
+		}
+		offset += len(line)
+	}
+	return -1
+}
+
+// liveDoctorTailscaleACLClient is the production implementation. It targets
+// the documented "Get tailnet policy file" endpoint and returns the response
+// body verbatim so the substring scan above sees the user's HuJSON exactly
+// as they wrote it.
+type liveDoctorTailscaleACLClient struct {
+	apiKey string
+	http   *http.Client
+}
+
+func newDoctorTailscaleACLClient(apiKey string) doctorTailscaleACLClient {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil
+	}
+	return &liveDoctorTailscaleACLClient{apiKey: apiKey, http: &http.Client{Timeout: doctorCrewTimeout}}
+}
+
+func (c *liveDoctorTailscaleACLClient) PolicyHuJSON(ctx context.Context, tailnet string) (string, error) {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := resolveTailnetAPIURL() + "/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Accept", "application/hujson")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if readErr != nil {
+		return "", readErr
+	}
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusNotImplemented {
+		return "", fmt.Errorf("%w: GET %s returned %d", ErrCrewACLAutoBootstrapUnavailable, url, resp.StatusCode)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Return body as error detail when the response is a JSON error
+		// envelope so the caller surfaces actionable text.
+		var envelope struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &envelope) == nil && envelope.Message != "" {
+			return "", fmt.Errorf("tailscale api %d: %s", resp.StatusCode, envelope.Message)
+		}
+		return "", fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return string(body), nil
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -14,6 +17,7 @@ type leaseCreateFlagValues struct {
 	ServerType    *string
 	Market        *string
 	Slug          *string
+	Crew          *string
 	TTL           *time.Duration
 	Idle          *time.Duration
 	Desktop       *bool
@@ -32,6 +36,7 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 		ServerType:    fs.String("type", getenv("CRABBOX_SERVER_TYPE", ""), "provider server/instance type"),
 		Market:        fs.String("market", defaults.Capacity.Market, "capacity market: spot or on-demand"),
 		Slug:          fs.String("slug", "", "request a friendly slug for a new lease"),
+		Crew:          fs.String("crew", defaults.Crew, "tag this lease with a crew name so peers can be selected with --crew"),
 		TTL:           fs.Duration("ttl", defaults.TTL, "maximum lease lifetime"),
 		Idle:          fs.Duration("idle-timeout", defaults.IdleTimeout, "idle timeout"),
 		Desktop:       fs.Bool("desktop", defaults.Desktop, "provision or require a visible desktop/VNC session"),
@@ -51,6 +56,13 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	cfg.Provider = *values.Provider
 	cfg.Profile = *values.Profile
 	cfg.Class = *values.Class
+	if flagWasSet(fs, "crew") {
+		crew, err := requestedCrewName(*values.Crew)
+		if err != nil {
+			return err
+		}
+		cfg.Crew = crew
+	}
 	applyCapabilityFlags(cfg, *values.Desktop, *values.Browser, *values.Code)
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
 		return err
@@ -81,7 +93,46 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	if err := validateRequestedCapabilities(*cfg); err != nil {
 		return err
 	}
+	if cfg.Crew != "" {
+		appendCrewTailscaleTag(cfg, providerCapableOfTailscale(cfg.Provider))
+		if err := maybeBootstrapCrewACL(context.Background(), *cfg); err != nil {
+			return err
+		}
+	}
 	return validateLeaseDurations(*cfg)
+}
+
+// maybeBootstrapCrewACL self-bootstraps the crew tag's tagOwners + grants
+// rows on the operator tailnet when TS_API_KEY is exported. When the key is
+// absent, when the provider lacks Tailscale, or when the row is already
+// present, this is a silent no-op so doctor still owns the manual-snippet
+// fallback path. Failures from the live API are surfaced so the lease is
+// not created against a tailnet that cannot actually carry crew traffic.
+func maybeBootstrapCrewACL(ctx context.Context, cfg Config) error {
+	if cfg.Crew == "" || !cfg.Tailscale.Enabled {
+		return nil
+	}
+	if !providerCapableOfTailscale(cfg.Provider) {
+		return nil
+	}
+	apiKey := strings.TrimSpace(os.Getenv("TS_API_KEY"))
+	if apiKey == "" {
+		return nil
+	}
+	client := crewTailnetACLClientFactory(apiKey)
+	if client == nil {
+		return nil
+	}
+	tailnet := strings.TrimSpace(os.Getenv("TS_TAILNET"))
+	owner := localCoordinatorOwner()
+	err := crewACLEnsure(ctx, client, tailnet, owner, cfg.Crew)
+	// A self-hosted control plane (e.g. Headscale) without a Tailscale-shaped
+	// policy API must not block lease creation. Doctor surfaces the same
+	// condition to the operator with the manual-snippet pointer.
+	if errors.Is(err, ErrCrewACLAutoBootstrapUnavailable) {
+		return nil
+	}
+	return err
 }
 
 func validateLeaseDurations(cfg Config) error {

--- a/internal/cli/pool.go
+++ b/internal/cli/pool.go
@@ -20,6 +20,7 @@ func (a App) list(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	jsonOut := fs.Bool("json", false, "print JSON")
 	refresh := fs.Bool("refresh", false, "refresh provider-backed state where supported")
+	crewFilter := fs.String("crew", "", "only list leases tagged with this crew")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -36,6 +37,10 @@ func (a App) list(ctx context.Context, args []string) error {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
+	crewName, err := requestedCrewName(*crewFilter)
+	if err != nil {
+		return err
+	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
@@ -47,6 +52,9 @@ func (a App) list(ctx context.Context, args []string) error {
 				return err
 			}
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+			if crewName != "" {
+				view = filterJSONListViewByCrew(view, crewName)
+			}
 			return json.NewEncoder(a.Stdout).Encode(view)
 		}
 	}
@@ -63,11 +71,68 @@ func (a App) list(ctx context.Context, args []string) error {
 		return err
 	}
 	a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+	if crewName != "" {
+		servers = filterServersByCrew(servers, crewName)
+	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(servers)
 	}
 	renderServerList(a.Stdout, servers)
 	return nil
+}
+
+// filterJSONListViewByCrew filters a list-view payload (whatever shape the
+// backend produces) by inspecting label-bearing entries. Backends that emit
+// shapes without labels are returned unchanged so JSON list output stays
+// authoritative for those providers.
+func filterJSONListViewByCrew(view any, crew string) any {
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return view
+	}
+	entries, ok := view.([]any)
+	if !ok {
+		return view
+	}
+	hasLabels := false
+	for _, entry := range entries {
+		if extractLabelMap(entry) != nil {
+			hasLabels = true
+			break
+		}
+	}
+	if !hasLabels {
+		return view
+	}
+	kept := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		labels := extractLabelMap(entry)
+		if labels == nil {
+			continue
+		}
+		if normalizeCrewName(labels[crewLabelKey]) == crew {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
+}
+
+func extractLabelMap(entry any) map[string]string {
+	mapEntry, ok := entry.(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := mapEntry["labels"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if str, ok := value.(string); ok {
+			labels[key] = str
+		}
+	}
+	return labels
 }
 
 func (a App) syncExternalRunnersBestEffort(ctx context.Context, cfg Config, backend Backend) {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -207,6 +207,7 @@ type LeaseOptions struct {
 	TargetOS      string
 	WindowsMode   string
 	Class         string
+	Crew          string
 	ServerType    string
 	IdleTimeout   time.Duration
 	TTL           time.Duration
@@ -463,6 +464,7 @@ func leaseOptionsFromConfig(cfg Config) LeaseOptions {
 		TargetOS:      cfg.TargetOS,
 		WindowsMode:   cfg.WindowsMode,
 		Class:         cfg.Class,
+		Crew:          normalizeCrewName(cfg.Crew),
 		ServerType:    cfg.ServerType,
 		IdleTimeout:   cfg.IdleTimeout,
 		TTL:           cfg.TTL,

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -32,6 +32,13 @@ func ClaimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot s
 	return claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot, idleTimeout, reclaim)
 }
 
+// ClaimLeaseForRepoProviderCrew is the crew-aware variant exposed for
+// delegated providers that need to persist the crew label in the local claim
+// sidecar (delegated providers do not own a provider-side label store).
+func ClaimLeaseForRepoProviderCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", crew, repoRoot, idleTimeout, reclaim)
+}
+
 func ResolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
 	return resolveLeaseClaim(identifier)
 }

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -28,6 +28,10 @@ func ClaimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repo
 	return claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot, idleTimeout, reclaim)
 }
 
+func ClaimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot, idleTimeout, reclaim)
+}
+
 func ResolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
 	return resolveLeaseClaim(identifier)
 }

--- a/internal/cli/provider_labels.go
+++ b/internal/cli/provider_labels.go
@@ -32,6 +32,9 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	if market != "" {
 		labels["market"] = market
 	}
+	if crew := normalizeCrewName(cfg.Crew); crew != "" {
+		labels[crewLabelKey] = crew
+	}
 	if cfg.TargetOS == targetWindows {
 		labels["windows_mode"] = cfg.WindowsMode
 	}

--- a/internal/providers/cloudflare/bridge.go
+++ b/internal/providers/cloudflare/bridge.go
@@ -1,0 +1,31 @@
+package cloudflare
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Cloudflare Container sandboxes are reached through a single Worker URL
+// gated by a bearer token. There is no per-sandbox HTTPS preview that an
+// unrelated peer could dial without that token — the runner is the only
+// authorised caller. The bridge plane is HTTP-only and intentionally
+// requires public per-sandbox ingress, so cloudflare is explicitly
+// unsupported rather than silently broken.
+//
+// The adapter still satisfies core.BridgeProvider so the resolver tags the
+// peer as `BridgeState="unsupported"`, which surfaces the gap to callers via
+// `crabbox crew peers` instead of pretending the peer has no targets yet.
+
+// PublishPeer reports that Cloudflare does not participate in the bridge plane.
+func (b *cloudflareBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_, _, _, _ = ctx, leaseID, port, ttl
+	return core.BridgePeerTarget{}, core.ErrBridgeNotImplemented
+}
+
+// ListPeerTargets reports that Cloudflare does not participate in the bridge plane.
+func (b *cloudflareBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	_, _ = ctx, leaseID
+	return nil, core.ErrBridgeNotImplemented
+}

--- a/internal/providers/cloudflare/bridge_test.go
+++ b/internal/providers/cloudflare/bridge_test.go
@@ -1,0 +1,23 @@
+package cloudflare
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCloudflareBridgeIsExplicitlyUnsupported(t *testing.T) {
+	backend := &cloudflareBackend{}
+	if _, err := backend.PublishPeer(context.Background(), "cbx_x", 8080, time.Hour); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected PublishPeer to return ErrBridgeNotImplemented, got %v", err)
+	}
+	if _, err := backend.ListPeerTargets(context.Background(), "cbx_x"); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected ListPeerTargets to return ErrBridgeNotImplemented, got %v", err)
+	}
+}
+
+// Static check: ensure cloudflareBackend satisfies core.BridgeProvider.
+var _ core.BridgeProvider = (*cloudflareBackend)(nil)

--- a/internal/providers/e2b/bridge.go
+++ b/internal/providers/e2b/bridge.go
@@ -1,0 +1,97 @@
+package e2b
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// E2B's bridge plane is built around the native per-sandbox preview URL
+// convention `https://<port>-<sandboxID>.<domain>`. The domain is read from
+// the provider config (set by `--e2b-domain` or E2B_DOMAIN, defaulting to
+// `e2b.app`) — exactly the same source the rest of the e2b backend already
+// uses for `envdURL`, so no new fields are introduced on the lease record.
+//
+// Listing peer targets without a port hint is impossible against E2B's API
+// (there is no public "list active previews" endpoint), so ListPeerTargets is
+// intentionally an empty success: the caller learns that the peer exists but
+// has no published-by-name preview yet. PublishPeer, on the other hand, is a
+// deterministic URL builder: ask for port N, get the canonical URL back. The
+// E2B preview is always live as long as the sandbox is running, so the URL is
+// usable immediately — no idempotent "create share" round-trip needed.
+
+// PublishPeer implements core.BridgeProvider for E2B. It deterministically
+// synthesizes the preview URL for the requested port; no API call is made,
+// matching the way E2B itself documents per-port ingress.
+func (b *e2bBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_ = ctx
+	_ = ttl
+	if port <= 0 || port > 65535 {
+		return core.BridgePeerTarget{}, exit(2, "e2b bridge: port %d out of range", port)
+	}
+	sandboxID, domain, err := b.bridgeSandboxCoords(leaseID)
+	if err != nil {
+		return core.BridgePeerTarget{}, err
+	}
+	return core.BridgePeerTarget{
+		Port: port,
+		URL:  e2bPreviewURL(domain, sandboxID, port),
+	}, nil
+}
+
+// ListPeerTargets implements core.BridgeProvider for E2B. Because E2B does
+// not expose a "list active previews" endpoint, the side-effect-free view is
+// empty — callers learn the peer exists but no targets are surfaced until
+// `--share-port` is passed.
+func (b *e2bBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	_ = ctx
+	if _, _, err := b.bridgeSandboxCoords(leaseID); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// bridgeSandboxCoords returns the (sandboxID, domain) pair the URL builder
+// needs, validating that the lease id is a Crabbox-managed E2B lease before
+// returning anything. The domain falls back to the same default used by the
+// rest of the backend so the bridge plane stays consistent with `envdURL`.
+func (b *e2bBackend) bridgeSandboxCoords(leaseID string) (string, string, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return "", "", exit(2, "e2b bridge: missing lease id")
+	}
+	if !strings.HasPrefix(leaseID, "cbx_") && !strings.HasPrefix(leaseID, "e2b_") {
+		return "", "", exit(2, "e2b bridge: lease %q is not an E2B-claimed Crabbox lease", leaseID)
+	}
+	client, err := newE2BClient(b.cfg, b.rt)
+	if err != nil {
+		return "", "", err
+	}
+	sandbox, err := resolveE2BSandboxByLease(context.Background(), client, leaseID)
+	if err != nil {
+		return "", "", err
+	}
+	if sandbox.SandboxID == "" {
+		return "", "", exit(4, "e2b bridge: no sandbox bound to lease %q", leaseID)
+	}
+	domain := strings.TrimSpace(sandbox.Domain)
+	if domain == "" {
+		domain = strings.TrimSpace(blank(b.cfg.E2B.Domain, "e2b.app"))
+	}
+	return sandbox.SandboxID, domain, nil
+}
+
+// e2bPreviewURL builds the canonical per-port preview URL. Kept package-local
+// (and exported only via PublishPeer) so the URL convention has a single
+// source of truth — if E2B ever rotates the scheme, only this builder
+// changes.
+func e2bPreviewURL(domain, sandboxID string, port int) string {
+	domain = strings.TrimSpace(domain)
+	if domain == "" {
+		domain = "e2b.app"
+	}
+	return "https://" + strconv.Itoa(port) + "-" + sandboxID + "." + domain
+}

--- a/internal/providers/e2b/bridge_test.go
+++ b/internal/providers/e2b/bridge_test.go
@@ -1,0 +1,134 @@
+package e2b
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeBridgeAPI struct {
+	fakeE2BSyncClient
+	listed  []e2bSandbox
+	listErr error
+}
+
+func (f *fakeBridgeAPI) ListSandboxes(_ context.Context, _ map[string]string) ([]e2bSandbox, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listed, nil
+}
+
+func newBridgeBackend(t *testing.T, fake *fakeBridgeAPI) *e2bBackend {
+	t.Helper()
+	prev := newE2BClient
+	newE2BClient = func(Config, Runtime) (e2bAPI, error) { return fake, nil }
+	t.Cleanup(func() { newE2BClient = prev })
+	return &e2bBackend{
+		cfg: Config{Provider: e2bProvider, E2B: E2BConfig{APIKey: "key", Domain: "e2b.app"}},
+		rt:  Runtime{},
+	}
+}
+
+func TestE2BPublishPeerReturnsCanonicalURL(t *testing.T) {
+	fake := &fakeBridgeAPI{
+		listed: []e2bSandbox{{
+			SandboxID: "sbx-abc123",
+			Domain:    "e2b.app",
+			Metadata: map[string]string{
+				"crabbox":  "true",
+				"provider": e2bProvider,
+				"lease":    "cbx_lease",
+				"slug":     "web",
+			},
+		}},
+	}
+	backend := newBridgeBackend(t, fake)
+	target, err := backend.PublishPeer(context.Background(), "cbx_lease", 8080, time.Hour)
+	if err != nil {
+		t.Fatalf("PublishPeer: %v", err)
+	}
+	if target.Port != 8080 {
+		t.Fatalf("expected port 8080, got %d", target.Port)
+	}
+	want := "https://8080-sbx-abc123.e2b.app"
+	if target.URL != want {
+		t.Fatalf("expected URL %q, got %q", want, target.URL)
+	}
+}
+
+func TestE2BPublishPeerFallsBackToConfigDomain(t *testing.T) {
+	fake := &fakeBridgeAPI{
+		listed: []e2bSandbox{{
+			SandboxID: "sbx-z",
+			Domain:    "",
+			Metadata: map[string]string{
+				"crabbox":  "true",
+				"provider": e2bProvider,
+				"lease":    "cbx_l",
+			},
+		}},
+	}
+	backend := newBridgeBackend(t, fake)
+	target, err := backend.PublishPeer(context.Background(), "cbx_l", 443, time.Hour)
+	if err != nil {
+		t.Fatalf("PublishPeer: %v", err)
+	}
+	if !strings.HasSuffix(target.URL, ".e2b.app") {
+		t.Fatalf("expected fallback domain e2b.app, got %q", target.URL)
+	}
+}
+
+func TestE2BPublishPeerRejectsBadInput(t *testing.T) {
+	fake := &fakeBridgeAPI{}
+	backend := newBridgeBackend(t, fake)
+	if _, err := backend.PublishPeer(context.Background(), "", 8080, time.Hour); err == nil {
+		t.Fatalf("expected rejection of empty lease id")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "isb_islo", 8080, time.Hour); err == nil {
+		t.Fatalf("expected rejection of non-e2b lease prefix")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "cbx_x", 0, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 0")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "cbx_x", 70000, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 70000")
+	}
+}
+
+func TestE2BPublishPeerSurfacesAPIError(t *testing.T) {
+	fake := &fakeBridgeAPI{listErr: errors.New("e2b down")}
+	backend := newBridgeBackend(t, fake)
+	if _, err := backend.PublishPeer(context.Background(), "cbx_lease", 8080, time.Hour); err == nil {
+		t.Fatalf("expected list error to surface")
+	}
+}
+
+func TestE2BListPeerTargetsIsEmpty(t *testing.T) {
+	fake := &fakeBridgeAPI{
+		listed: []e2bSandbox{{
+			SandboxID: "sbx-y",
+			Domain:    "e2b.app",
+			Metadata: map[string]string{
+				"crabbox":  "true",
+				"provider": e2bProvider,
+				"lease":    "cbx_lease",
+			},
+		}},
+	}
+	backend := newBridgeBackend(t, fake)
+	targets, err := backend.ListPeerTargets(context.Background(), "cbx_lease")
+	if err != nil {
+		t.Fatalf("ListPeerTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected empty targets (no list API on E2B), got %d", len(targets))
+	}
+}
+
+// Static check: ensure e2bBackend satisfies core.BridgeProvider.
+var _ core.BridgeProvider = (*e2bBackend)(nil)

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -354,7 +354,7 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 		_ = client.DeleteSandbox(context.Background(), sandbox.GetName())
 		return "", "", "", err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, isloProvider, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseForRepoProviderWithCrew(leaseID, slug, isloProvider, b.cfg.Crew, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		_ = client.DeleteSandbox(context.Background(), sandbox.GetName())
 		return "", "", "", err
 	}
@@ -424,13 +424,15 @@ func isloSandboxToServer(sandbox *gosdk.SandboxResponse) Server {
 	if sandbox == nil {
 		return Server{Provider: isloProvider, Labels: map[string]string{"provider": isloProvider}}
 	}
+	leaseID := isloLeasePrefix + sandbox.GetName()
 	labels := map[string]string{
 		"provider": isloProvider,
-		"lease":    isloLeasePrefix + sandbox.GetName(),
-		"slug":     newLeaseSlug(isloLeasePrefix + sandbox.GetName()),
+		"lease":    leaseID,
+		"slug":     newLeaseSlug(leaseID),
 		"target":   targetLinux,
 		"state":    sandbox.GetStatus(),
 	}
+	applyIsloClaimLabels(labels, leaseID)
 	return Server{
 		Provider: isloProvider,
 		CloudID:  sandbox.GetID(),
@@ -449,9 +451,16 @@ func isloStatusView(leaseID string, sandbox *gosdk.SandboxResponse) statusView {
 		status = sandbox.GetStatus()
 		image = sandbox.GetImage()
 	}
+	labels := map[string]string{
+		"provider": isloProvider,
+		"lease":    leaseID,
+		"slug":     newLeaseSlug(leaseID),
+		"state":    status,
+	}
+	applyIsloClaimLabels(labels, leaseID)
 	return statusView{
 		ID:         leaseID,
-		Slug:       newLeaseSlug(leaseID),
+		Slug:       labels["slug"],
 		Provider:   isloProvider,
 		TargetOS:   targetLinux,
 		State:      status,
@@ -459,11 +468,20 @@ func isloStatusView(leaseID string, sandbox *gosdk.SandboxResponse) statusView {
 		ServerType: image,
 		Network:    NetworkPublic,
 		Ready:      isloStatusReady(status),
-		Labels: map[string]string{
-			"provider": isloProvider,
-			"lease":    leaseID,
-			"state":    status,
-		},
+		Labels:     labels,
+	}
+}
+
+func applyIsloClaimLabels(labels map[string]string, leaseID string) {
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil || !ok {
+		return
+	}
+	if claim.Slug != "" {
+		labels["slug"] = normalizeLeaseSlug(claim.Slug)
+	}
+	if claim.Crew != "" {
+		labels["crew"] = claim.Crew
 	}
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	gosdk "github.com/islo-labs/go-sdk"
 )
@@ -512,6 +513,14 @@ func (f *fakeIsloSyncClient) ExecStream(_ context.Context, _ string, req *gosdk.
 	f.execRequests = append(f.execRequests, req)
 	f.prepareCommands = append(f.prepareCommands, strings.Join(req.GetCommand(), " "))
 	return 0, nil
+}
+
+func (f *fakeIsloSyncClient) CreateShare(context.Context, string, int, time.Duration) (IsloShare, error) {
+	return IsloShare{}, nil
+}
+
+func (f *fakeIsloSyncClient) ListShares(context.Context, string) ([]IsloShare, error) {
+	return nil, nil
 }
 
 func (f *fakeIsloSyncClient) commandContains(value string) bool {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -187,6 +187,36 @@ func TestIsloCreateSandboxPassesRelativeWorkdirToProvider(t *testing.T) {
 	}
 }
 
+func TestIsloCreateSandboxStoresCrewClaimForList(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}
+	backend := &isloBackend{
+		cfg: Config{
+			Crew: "Alpha Crew",
+			Islo: IsloConfig{Workdir: "team/repo"},
+		},
+		rt: Runtime{Stderr: io.Discard},
+	}
+	leaseID, _, slug, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil || !ok {
+		t.Fatalf("resolve claim ok=%t err=%v", ok, err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("claim crew=%q want alpha-crew", claim.Crew)
+	}
+	server := isloSandboxToServer(&gosdk.SandboxResponse{Name: client.createName, Status: "running"})
+	if server.Labels["crew"] != "alpha-crew" {
+		t.Fatalf("server crew label=%q labels=%#v", server.Labels["crew"], server.Labels)
+	}
+	if server.Labels["slug"] != normalizeLeaseSlug(slug) {
+		t.Fatalf("server slug=%q want %q", server.Labels["slug"], normalizeLeaseSlug(slug))
+	}
+}
+
 func TestIsloSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/providers/islo/bridge.go
+++ b/internal/providers/islo/bridge.go
@@ -1,0 +1,97 @@
+package islo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// PublishPeer implements core.BridgeProvider. It is idempotent — if a share
+// for the requested port already exists, the existing share is returned
+// rather than minting another one. This matters because every call to the
+// islo create-share endpoint counts as a published URL on the user's tenant.
+func (b *isloBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	if port <= 0 || port > 65535 {
+		return core.BridgePeerTarget{}, exit(2, "islo bridge: port %d out of range", port)
+	}
+	name, err := isloSandboxNameFromLeaseID(leaseID)
+	if err != nil {
+		return core.BridgePeerTarget{}, err
+	}
+	client, err := newIsloClient(b.cfg, b.rt)
+	if err != nil {
+		return core.BridgePeerTarget{}, err
+	}
+	existing, err := client.ListShares(ctx, name)
+	if err == nil {
+		for _, share := range existing {
+			if share.Port == port && share.URL != "" {
+				return bridgeTargetFromShare(share), nil
+			}
+		}
+	}
+	share, err := client.CreateShare(ctx, name, port, ttl)
+	if err != nil {
+		return core.BridgePeerTarget{}, err
+	}
+	return bridgeTargetFromShare(share), nil
+}
+
+// ListPeerTargets implements core.BridgeProvider. It is side-effect free —
+// the doctor probe and the no-flag `crew peers` view both call it.
+func (b *isloBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	name, err := isloSandboxNameFromLeaseID(leaseID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := newIsloClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	shares, err := client.ListShares(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.BridgePeerTarget, 0, len(shares))
+	for _, share := range shares {
+		if share.URL == "" {
+			continue
+		}
+		out = append(out, bridgeTargetFromShare(share))
+	}
+	return out, nil
+}
+
+func bridgeTargetFromShare(share IsloShare) core.BridgePeerTarget {
+	return core.BridgePeerTarget{
+		Port:      share.Port,
+		URL:       share.URL,
+		ShareID:   share.ShareID,
+		ExpiresAt: share.ExpiresAt,
+	}
+}
+
+// isloSandboxNameFromLeaseID accepts either the `isb_<sandbox>` lease id used
+// by the rest of the islo backend or a bare sandbox name and returns the
+// canonical sandbox name. Anything else is rejected up front so the bridge
+// plane does not silently make share-API calls against an unrelated tenant
+// resource.
+func isloSandboxNameFromLeaseID(leaseID string) (string, error) {
+	leaseID = strings.TrimSpace(leaseID)
+	if leaseID == "" {
+		return "", exit(2, "islo bridge: missing lease id")
+	}
+	if strings.HasPrefix(leaseID, isloLeasePrefix) {
+		name := strings.TrimPrefix(leaseID, isloLeasePrefix)
+		if !isCrabboxIsloSandboxName(name) {
+			return "", exit(2, "islo bridge: lease %q is not a Crabbox-owned sandbox", leaseID)
+		}
+		return name, nil
+	}
+	if isCrabboxIsloSandboxName(leaseID) {
+		return leaseID, nil
+	}
+	return "", exit(2, "islo bridge: lease %q is not a Crabbox-owned islo sandbox", leaseID)
+}

--- a/internal/providers/islo/bridge_test.go
+++ b/internal/providers/islo/bridge_test.go
@@ -1,0 +1,124 @@
+package islo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeBridgeClient struct {
+	fakeIsloSyncClient
+	created     []IsloShare
+	preexisting []IsloShare
+	listErr     error
+}
+
+func (f *fakeBridgeClient) CreateShare(_ context.Context, _ string, port int, ttl time.Duration) (IsloShare, error) {
+	share := IsloShare{
+		ShareID:   "shr_new",
+		URL:       "https://new.share.islo.dev",
+		Port:      port,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	f.created = append(f.created, share)
+	return share, nil
+}
+
+func (f *fakeBridgeClient) ListShares(context.Context, string) ([]IsloShare, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.preexisting, nil
+}
+
+func newBridgeBackend(t *testing.T, fake *fakeBridgeClient) *isloBackend {
+	t.Helper()
+	prev := newIsloClient
+	newIsloClient = func(Config, Runtime) (isloAPI, error) { return fake, nil }
+	t.Cleanup(func() { newIsloClient = prev })
+	return &isloBackend{
+		cfg: Config{Provider: isloProvider, Islo: IsloConfig{APIKey: "key"}},
+		rt:  Runtime{},
+	}
+}
+
+func TestPublishPeerReusesExistingShare(t *testing.T) {
+	fake := &fakeBridgeClient{
+		preexisting: []IsloShare{{ShareID: "shr_existing", URL: "https://existing.share.islo.dev", Port: 8080}},
+	}
+	backend := newBridgeBackend(t, fake)
+	target, err := backend.PublishPeer(context.Background(), "isb_crabbox-x-abc123", 8080, time.Hour)
+	if err != nil {
+		t.Fatalf("PublishPeer: %v", err)
+	}
+	if target.ShareID != "shr_existing" || target.URL == "" {
+		t.Fatalf("expected reuse of existing share, got %#v", target)
+	}
+	if len(fake.created) != 0 {
+		t.Fatalf("expected no new share, got %d created", len(fake.created))
+	}
+}
+
+func TestPublishPeerCreatesWhenAbsent(t *testing.T) {
+	fake := &fakeBridgeClient{}
+	backend := newBridgeBackend(t, fake)
+	target, err := backend.PublishPeer(context.Background(), "isb_crabbox-x-abc123", 9090, time.Hour)
+	if err != nil {
+		t.Fatalf("PublishPeer: %v", err)
+	}
+	if target.ShareID != "shr_new" || target.Port != 9090 {
+		t.Fatalf("expected new share, got %#v", target)
+	}
+	if len(fake.created) != 1 {
+		t.Fatalf("expected 1 new share, got %d", len(fake.created))
+	}
+}
+
+func TestPublishPeerRejectsNonCrabboxLease(t *testing.T) {
+	fake := &fakeBridgeClient{}
+	backend := newBridgeBackend(t, fake)
+	if _, err := backend.PublishPeer(context.Background(), "isb_random-stranger", 8080, time.Hour); err == nil {
+		t.Fatalf("expected rejection of non-Crabbox sandbox")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "", 8080, time.Hour); err == nil {
+		t.Fatalf("expected rejection of empty lease id")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "isb_crabbox-x-abc123", 0, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 0")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "isb_crabbox-x-abc123", 70000, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 70000")
+	}
+}
+
+func TestListPeerTargetsFiltersBlankURLs(t *testing.T) {
+	fake := &fakeBridgeClient{
+		preexisting: []IsloShare{
+			{ShareID: "a", URL: "https://a.share.islo.dev", Port: 8080},
+			{ShareID: "b", URL: "", Port: 9090},
+			{ShareID: "c", URL: "https://c.share.islo.dev", Port: 5432},
+		},
+	}
+	backend := newBridgeBackend(t, fake)
+	targets, err := backend.ListPeerTargets(context.Background(), "isb_crabbox-x-abc123")
+	if err != nil {
+		t.Fatalf("ListPeerTargets: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets with URLs, got %d: %#v", len(targets), targets)
+	}
+}
+
+func TestListPeerTargetsSurfacesErrors(t *testing.T) {
+	fake := &fakeBridgeClient{listErr: errors.New("islo down")}
+	backend := newBridgeBackend(t, fake)
+	if _, err := backend.ListPeerTargets(context.Background(), "isb_crabbox-x-abc123"); err == nil {
+		t.Fatalf("expected listErr to surface")
+	}
+}
+
+// Static check: ensure isloBackend satisfies core.BridgeProvider.
+var _ core.BridgeProvider = (*isloBackend)(nil)

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -27,6 +27,19 @@ type isloAPI interface {
 	DeleteSandbox(context.Context, string) error
 	UploadArchive(context.Context, string, string, io.Reader) error
 	ExecStream(context.Context, string, *gosdk.ExecRequest, io.Writer, io.Writer) (int, error)
+	CreateShare(ctx context.Context, sandboxName string, port int, ttl time.Duration) (IsloShare, error)
+	ListShares(ctx context.Context, sandboxName string) ([]IsloShare, error)
+}
+
+// IsloShare describes a per-port public HTTPS share produced by the islo
+// `POST /sandboxes/{name}/shares` API. It is the islo-specific shape of the
+// generic BridgePeer entry surfaced by the crew bridge plane.
+type IsloShare struct {
+	ShareID   string    `json:"share_id"`
+	URL       string    `json:"url"`
+	Port      int       `json:"port"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 type isloSDKClient struct {
@@ -140,6 +153,121 @@ func multipartArchiveBody(archive io.Reader) (io.Reader, string) {
 	prefix.WriteString("Content-Type: application/gzip\r\n\r\n")
 	suffix := "\r\n--" + boundary + "--\r\n"
 	return io.MultiReader(strings.NewReader(prefix.String()), archive, strings.NewReader(suffix)), writer.FormDataContentType()
+}
+
+type isloCreateShareRequest struct {
+	Port       int  `json:"port"`
+	TTLSeconds *int `json:"ttl_seconds,omitempty"`
+}
+
+type isloShareResponse struct {
+	ShareID   string  `json:"share_id"`
+	URL       string  `json:"url"`
+	Port      int     `json:"port"`
+	CreatedAt string  `json:"created_at"`
+	ExpiresAt *string `json:"expires_at"`
+}
+
+func (c *isloSDKClient) CreateShare(ctx context.Context, name string, port int, ttl time.Duration) (IsloShare, error) {
+	reqBody := isloCreateShareRequest{Port: port}
+	if ttl > 0 {
+		seconds := int(ttl.Seconds())
+		// Islo accepts 60s..7d. Snap into range so the bridge plane uses the
+		// closest legal TTL rather than refusing the call — the user-facing
+		// flag already validates the original range.
+		if seconds < 60 {
+			seconds = 60
+		}
+		if seconds > 7*24*3600 {
+			seconds = 7 * 24 * 3600
+		}
+		reqBody.TTLSeconds = &seconds
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return IsloShare{}, fmt.Errorf("encode share request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/sandboxes/"+url.PathEscape(name)+"/shares", bytes.NewReader(body))
+	if err != nil {
+		return IsloShare{}, err
+	}
+	if err := c.authorize(ctx, httpReq); err != nil {
+		return IsloShare{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return IsloShare{}, fmt.Errorf("islo create share: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return IsloShare{}, fmt.Errorf("islo create share %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	var raw isloShareResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return IsloShare{}, fmt.Errorf("decode share response: %w", err)
+	}
+	return isloShareFromAPI(raw), nil
+}
+
+func (c *isloSDKClient) ListShares(ctx context.Context, name string) ([]IsloShare, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/sandboxes/"+url.PathEscape(name)+"/shares", nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.authorize(ctx, httpReq); err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("islo list shares: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode >= 400 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("islo list shares %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	var raw []isloShareResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode share list response: %w", err)
+	}
+	out := make([]IsloShare, 0, len(raw))
+	for _, item := range raw {
+		out = append(out, isloShareFromAPI(item))
+	}
+	return out, nil
+}
+
+func (c *isloSDKClient) authorize(ctx context.Context, req *http.Request) error {
+	token, err := c.auth.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("islo auth: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+func isloShareFromAPI(raw isloShareResponse) IsloShare {
+	share := IsloShare{
+		ShareID: raw.ShareID,
+		URL:     raw.URL,
+		Port:    raw.Port,
+	}
+	if t, err := time.Parse(time.RFC3339, raw.CreatedAt); err == nil {
+		share.CreatedAt = t
+	}
+	if raw.ExpiresAt != nil && *raw.ExpiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, *raw.ExpiresAt); err == nil {
+			share.ExpiresAt = t
+		}
+	}
+	return share
 }
 
 func (c *isloSDKClient) ExecStream(ctx context.Context, name string, req *gosdk.ExecRequest, stdout, stderr io.Writer) (int, error) {

--- a/internal/providers/islo/core.go
+++ b/internal/providers/islo/core.go
@@ -62,6 +62,10 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
 }
 
+func claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot, idleTimeout, reclaim)
+}
+
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }

--- a/internal/providers/modal/bridge.go
+++ b/internal/providers/modal/bridge.go
@@ -1,0 +1,33 @@
+package modal
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Modal sandboxes do not carry a per-sandbox HTTPS ingress URL on the lease
+// record today. Modal does expose tunnels via `Sandbox.tunnels()` in the
+// Python SDK, but the existing `modalSandbox` struct that the rest of this
+// backend works with does not populate them — extending the provider to
+// surface tunnels would be a runtime-behavior change, which is explicitly
+// out of scope for PR #136.
+//
+// So the modal adapter implements core.BridgeProvider only to return
+// core.ErrBridgeNotImplemented. The crew bridge resolver maps that error to
+// BridgeState="unsupported" on the peer, which is honest reporting: callers
+// see modal peers listed in the crew with a clear "no bridge plane for this
+// provider" signal instead of a silently empty Targets slice.
+
+// PublishPeer reports that Modal does not participate in the bridge plane.
+func (b *modalBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_, _, _, _ = ctx, leaseID, port, ttl
+	return core.BridgePeerTarget{}, core.ErrBridgeNotImplemented
+}
+
+// ListPeerTargets reports that Modal does not participate in the bridge plane.
+func (b *modalBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	_, _ = ctx, leaseID
+	return nil, core.ErrBridgeNotImplemented
+}

--- a/internal/providers/modal/bridge_test.go
+++ b/internal/providers/modal/bridge_test.go
@@ -1,0 +1,25 @@
+package modal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestModalBridgeIsExplicitlyUnsupported(t *testing.T) {
+	backend := &modalBackend{}
+	if _, err := backend.PublishPeer(context.Background(), "cbx_x", 8080, time.Hour); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected PublishPeer to return ErrBridgeNotImplemented, got %v", err)
+	}
+	if _, err := backend.ListPeerTargets(context.Background(), "cbx_x"); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected ListPeerTargets to return ErrBridgeNotImplemented, got %v", err)
+	}
+}
+
+// Static check: ensure modalBackend satisfies core.BridgeProvider so the
+// "unsupported" signal flows through the resolver instead of being silently
+// dropped by the framework's fallback path.
+var _ core.BridgeProvider = (*modalBackend)(nil)

--- a/internal/providers/railway/bridge.go
+++ b/internal/providers/railway/bridge.go
@@ -1,0 +1,80 @@
+package railway
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Railway exposes a single public HTTPS endpoint per service deployment via
+// `railwayDeployment.URL`. That URL is already populated by the existing
+// `LatestDeployment` query the rest of the backend uses for `Status` and
+// `Stop`, so the bridge adapter is a thin read on top of fields the provider
+// already surfaces — no new lease record state is introduced.
+//
+// Two consequences flow from Railway's "one URL per service" model:
+//
+//   - PublishPeer cannot honor an arbitrary port. The Railway service binds
+//     a single port internally; the external URL is fixed to whatever
+//     Railway routed in front of it. The adapter accepts the port flag for
+//     interface parity, surfaces it on the target for the JSON consumer, and
+//     uses the deployment URL verbatim. Callers asking for a port that is
+//     not the service port get an HTTPS URL that simply will not resolve at
+//     the layer-4 level — which is honest behaviour.
+//   - ListPeerTargets returns the deployment URL whenever one is live; an
+//     empty slice when the service has no deployment yet (a sleeping service
+//     is not a bridge target).
+
+// PublishPeer implements core.BridgeProvider for Railway by surfacing the
+// latest deployment URL for the lease's service id.
+func (b *railwayBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_ = ttl
+	if port <= 0 || port > 65535 {
+		return core.BridgePeerTarget{}, exit(2, "railway bridge: port %d out of range", port)
+	}
+	url, err := b.bridgeDeploymentURL(ctx, leaseID)
+	if err != nil {
+		return core.BridgePeerTarget{}, err
+	}
+	return core.BridgePeerTarget{Port: port, URL: url}, nil
+}
+
+// ListPeerTargets implements core.BridgeProvider for Railway. The slice is
+// empty when the service has no live deployment, which keeps the doctor probe
+// honest instead of pretending a sleeping service is bridge-reachable.
+func (b *railwayBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	url, err := b.bridgeDeploymentURL(ctx, leaseID)
+	if err != nil {
+		return nil, err
+	}
+	if url == "" {
+		return nil, nil
+	}
+	return []core.BridgePeerTarget{{URL: url}}, nil
+}
+
+// bridgeDeploymentURL resolves a Railway lease (the service id, by Railway's
+// convention) to its current deployment URL. Returns an empty string when the
+// service has no deployment yet — callers translate that to "no targets"
+// rather than a hard error.
+func (b *railwayBackend) bridgeDeploymentURL(ctx context.Context, leaseID string) (string, error) {
+	serviceID := strings.TrimSpace(leaseID)
+	if serviceID == "" {
+		return "", exit(2, "railway bridge: missing lease id")
+	}
+	projectID, environmentID, err := b.requireProjectEnv()
+	if err != nil {
+		return "", err
+	}
+	client, err := b.api()
+	if err != nil {
+		return "", err
+	}
+	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, serviceID)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(deployment.URL), nil
+}

--- a/internal/providers/railway/bridge_test.go
+++ b/internal/providers/railway/bridge_test.go
@@ -1,0 +1,87 @@
+package railway
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestRailwayPublishPeerReturnsDeploymentURL(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployment: railwayDeployment{URL: "https://web-cbx-up.railway.app", Status: railwayStatusSuccess},
+	}
+	backend := newRailwayBackendForTest(api)
+	target, err := backend.PublishPeer(context.Background(), "svc-1", 8080, time.Hour)
+	if err != nil {
+		t.Fatalf("PublishPeer: %v", err)
+	}
+	if target.URL != "https://web-cbx-up.railway.app" {
+		t.Fatalf("expected deployment URL, got %q", target.URL)
+	}
+	if target.Port != 8080 {
+		t.Fatalf("expected port 8080 echoed, got %d", target.Port)
+	}
+}
+
+func TestRailwayPublishPeerRejectsBadInput(t *testing.T) {
+	api := &fakeRailwayAPI{deployment: railwayDeployment{URL: "https://x.railway.app"}}
+	backend := newRailwayBackendForTest(api)
+	if _, err := backend.PublishPeer(context.Background(), "", 8080, time.Hour); err == nil {
+		t.Fatalf("expected rejection of empty lease id")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "svc-1", 0, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 0")
+	}
+	if _, err := backend.PublishPeer(context.Background(), "svc-1", 70000, time.Hour); err == nil {
+		t.Fatalf("expected rejection of port 70000")
+	}
+}
+
+func TestRailwayPublishPeerRequiresProjectEnv(t *testing.T) {
+	api := &fakeRailwayAPI{deployment: railwayDeployment{URL: "https://x.railway.app"}}
+	backend := newRailwayBackendForTest(api)
+	backend.cfg.Railway.ProjectID = ""
+	if _, err := backend.PublishPeer(context.Background(), "svc-1", 8080, time.Hour); err == nil {
+		t.Fatalf("expected error when project id is missing")
+	}
+}
+
+func TestRailwayPublishPeerSurfacesAPIError(t *testing.T) {
+	api := &fakeRailwayAPI{latestErr: errors.New("railway down")}
+	backend := newRailwayBackendForTest(api)
+	if _, err := backend.PublishPeer(context.Background(), "svc-1", 8080, time.Hour); err == nil {
+		t.Fatalf("expected API error to surface")
+	}
+}
+
+func TestRailwayListPeerTargetsLive(t *testing.T) {
+	api := &fakeRailwayAPI{
+		deployment: railwayDeployment{URL: "https://live.railway.app", Status: railwayStatusSuccess},
+	}
+	backend := newRailwayBackendForTest(api)
+	targets, err := backend.ListPeerTargets(context.Background(), "svc-1")
+	if err != nil {
+		t.Fatalf("ListPeerTargets: %v", err)
+	}
+	if len(targets) != 1 || targets[0].URL != "https://live.railway.app" {
+		t.Fatalf("expected one live target, got %#v", targets)
+	}
+}
+
+func TestRailwayListPeerTargetsEmptyWhenNoDeployment(t *testing.T) {
+	api := &fakeRailwayAPI{deployment: railwayDeployment{URL: ""}}
+	backend := newRailwayBackendForTest(api)
+	targets, err := backend.ListPeerTargets(context.Background(), "svc-1")
+	if err != nil {
+		t.Fatalf("ListPeerTargets: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected no targets for sleeping service, got %#v", targets)
+	}
+}
+
+// Static check: ensure railwayBackend satisfies core.BridgeProvider.
+var _ core.BridgeProvider = (*railwayBackend)(nil)

--- a/internal/providers/tensorlake/bridge.go
+++ b/internal/providers/tensorlake/bridge.go
@@ -1,0 +1,31 @@
+package tensorlake
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Tensorlake is a serverless function platform — runs are scheduled as
+// invocations of registered Tensorlake functions, not as long-lived sandboxes
+// with their own HTTPS ingress. There is no per-sandbox URL on the lease
+// record because there is no per-sandbox endpoint in the platform; ingress is
+// owned by Tensorlake's central API.
+//
+// As with modal and cloudflare, the adapter implements core.BridgeProvider
+// only to return core.ErrBridgeNotImplemented so the resolver flags the peer
+// with BridgeState="unsupported" instead of silently emitting an empty Targets
+// slice that callers could misread as "no shares yet".
+
+// PublishPeer reports that Tensorlake does not participate in the bridge plane.
+func (b *tensorlakeBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_, _, _, _ = ctx, leaseID, port, ttl
+	return core.BridgePeerTarget{}, core.ErrBridgeNotImplemented
+}
+
+// ListPeerTargets reports that Tensorlake does not participate in the bridge plane.
+func (b *tensorlakeBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	_, _ = ctx, leaseID
+	return nil, core.ErrBridgeNotImplemented
+}

--- a/internal/providers/tensorlake/bridge_test.go
+++ b/internal/providers/tensorlake/bridge_test.go
@@ -1,0 +1,23 @@
+package tensorlake
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestTensorlakeBridgeIsExplicitlyUnsupported(t *testing.T) {
+	backend := &tensorlakeBackend{}
+	if _, err := backend.PublishPeer(context.Background(), "cbx_x", 8080, time.Hour); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected PublishPeer to return ErrBridgeNotImplemented, got %v", err)
+	}
+	if _, err := backend.ListPeerTargets(context.Background(), "cbx_x"); !errors.Is(err, core.ErrBridgeNotImplemented) {
+		t.Fatalf("expected ListPeerTargets to return ErrBridgeNotImplemented, got %v", err)
+	}
+}
+
+// Static check: ensure tensorlakeBackend satisfies core.BridgeProvider.
+var _ core.BridgeProvider = (*tensorlakeBackend)(nil)

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -76,6 +76,7 @@ export interface LeaseConfig {
   idleTimeoutSeconds: number;
   keep: boolean;
   sshPublicKey: string;
+  crew: string;
 }
 
 export type AzureOSDiskMode = "managed" | "ephemeral";
@@ -199,7 +200,19 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     idleTimeoutSeconds,
     keep: input.keep ?? false,
     sshPublicKey,
+    crew: normalizeCrewName(input.crew ?? ""),
   };
+}
+
+// normalizeCrewName mirrors the Go-side helper in internal/cli/crew.go. The
+// `crew` label is a reserved provider-label key that groups N leases so peers
+// can be selected by `crabbox list --crew <name>`.
+export function normalizeCrewName(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
 }
 
 export function awsPromotedAMIConfigKey(region: string, serverType: string): string {

--- a/worker/src/provider-labels.ts
+++ b/worker/src/provider-labels.ts
@@ -35,6 +35,9 @@ export function leaseProviderLabels(
   if (config.target === "windows") {
     labels["windows_mode"] = config.windowsMode;
   }
+  if (config.crew) {
+    labels["crew"] = config.crew;
+  }
   if (config.desktop) {
     labels["desktop"] = "true";
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -150,6 +150,7 @@ export interface LeaseRequest {
   idleTimeoutSeconds?: number;
   keep?: boolean;
   sshPublicKey?: string;
+  crew?: string;
 }
 
 export type Provider = "hetzner" | "aws" | "azure" | "gcp";

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -237,6 +237,13 @@ describe("lease config", () => {
     expect(config.code).toBe(true);
   });
 
+  it("normalizes the optional crew label and defaults it to empty", () => {
+    const empty = leaseConfig({ sshPublicKey: "ssh-ed25519 test" });
+    expect(empty.crew).toBe("");
+    const tagged = leaseConfig({ sshPublicKey: "ssh-ed25519 test", crew: " Alpha Crew " });
+    expect(tagged.crew).toBe("alpha-crew");
+  });
+
   it("preserves Tailscale lease capability requests", () => {
     const config = leaseConfig({
       sshPublicKey: "ssh-ed25519 test",

--- a/worker/test/provider-labels.test.ts
+++ b/worker/test/provider-labels.test.ts
@@ -117,4 +117,106 @@ describe("provider labels", () => {
     expect(labels.tailscale_exit_node_allow_lan_access).toBe("true");
     expect(Object.values(labels).join(" ")).not.toContain("tskey-secret");
   });
+
+  it("includes the crew label when the lease is tagged", () => {
+    const config: LeaseConfig = {
+      provider: "aws",
+      target: "linux",
+      windowsMode: "normal",
+      desktop: false,
+      browser: false,
+      tailscale: false,
+      tailscaleTags: ["tag:crabbox"],
+      tailscaleHostname: "",
+      tailscaleAuthKey: "",
+      tailscaleExitNode: "",
+      tailscaleExitNodeAllowLanAccess: false,
+      profile: "default",
+      class: "beast",
+      serverType: "c7a.48xlarge",
+      image: "ami",
+      location: "eu-west-1",
+      sshUser: "crabbox",
+      sshPort: "2222",
+      sshFallbackPorts: ["22"],
+      awsRegion: "eu-west-1",
+      awsRootGB: 400,
+      awsAMI: "",
+      awsSGID: "",
+      awsSubnetID: "",
+      awsProfile: "",
+      capacityMarket: "spot",
+      capacityStrategy: "most-available",
+      capacityFallback: "on-demand-after-120s",
+      capacityRegions: [],
+      capacityAvailabilityZones: [],
+      providerKey: "crabbox-cbx-123",
+      workRoot: "/work/crabbox",
+      ttlSeconds: 600,
+      idleTimeoutSeconds: 7200,
+      keep: false,
+      sshPublicKey: "ssh-ed25519 test",
+      crew: "alpha",
+    } as LeaseConfig;
+    const labels = leaseProviderLabels(
+      config,
+      "cbx_123",
+      "blue-lobster",
+      "peter@example.com",
+      "aws",
+      new Date("2026-05-01T12:00:00Z"),
+    );
+    expect(labels.crew).toBe("alpha");
+  });
+
+  it("omits the crew label when the lease has no crew", () => {
+    const config: LeaseConfig = {
+      provider: "aws",
+      target: "linux",
+      windowsMode: "normal",
+      desktop: false,
+      browser: false,
+      tailscale: false,
+      tailscaleTags: ["tag:crabbox"],
+      tailscaleHostname: "",
+      tailscaleAuthKey: "",
+      tailscaleExitNode: "",
+      tailscaleExitNodeAllowLanAccess: false,
+      profile: "default",
+      class: "beast",
+      serverType: "c7a.48xlarge",
+      image: "ami",
+      location: "eu-west-1",
+      sshUser: "crabbox",
+      sshPort: "2222",
+      sshFallbackPorts: ["22"],
+      awsRegion: "eu-west-1",
+      awsRootGB: 400,
+      awsAMI: "",
+      awsSGID: "",
+      awsSubnetID: "",
+      awsProfile: "",
+      capacityMarket: "spot",
+      capacityStrategy: "most-available",
+      capacityFallback: "on-demand-after-120s",
+      capacityRegions: [],
+      capacityAvailabilityZones: [],
+      providerKey: "crabbox-cbx-123",
+      workRoot: "/work/crabbox",
+      ttlSeconds: 600,
+      idleTimeoutSeconds: 7200,
+      keep: false,
+      sshPublicKey: "ssh-ed25519 test",
+      crew: "",
+    } as LeaseConfig;
+    const labels = leaseProviderLabels(
+      config,
+      "cbx_123",
+      "blue-lobster",
+      "peter@example.com",
+      "aws",
+      new Date("2026-05-01T12:00:00Z"),
+    );
+    expect(labels.crew).toBeUndefined();
+  });
 });


### PR DESCRIPTION
> **Depends on #129** — merge that first. The diff here currently includes the crew foundation commit plus the bridge commit; once #129 lands and this branch is rebased, only the bridge commit will remain. Marked as DRAFT until #129 merges.

## TL;DR

PR #129 introduced crews and the Tailscale plane for managed-Linux providers. This PR makes `crabbox crew peers --crew <name>` return one row per crew member regardless of provider, with a `transport` hint and a canonical endpoint. The result: a single command lists tailnet peers, URL peers, SSH peers, and even providers that own their own connectivity, with a documented reachability matrix that is honest about the asymmetric pairs.

## Cross-provider unified peer view

`crabbox crew peers --crew <name> --json` returns the documented `{ "members": [...] }` shape:

```json
{
  "members": [
    { "slug": "web",  "provider": "hetzner",    "transport": "tailnet", "endpoint": "100.64.1.3",                  "labels": {"role": "web"} },
    { "slug": "api",  "provider": "islo",       "transport": "url",     "endpoint": "https://abc.share.islo.dev",  "labels": {"role": "api"} },
    { "slug": "db",   "provider": "runpod",     "transport": "ssh",     "endpoint": "ssh://1.2.3.4:22",            "labels": {"role": "db"} },
    { "slug": "what", "provider": "blacksmith", "transport": "none",    "endpoint": "",                            "labels": {"role": "isolated"}, "note": "blacksmith owns connectivity" }
  ]
}
```

| Transport | Producers                                                                | Endpoint                    |
| --------- | ------------------------------------------------------------------------ | --------------------------- |
| `tailnet` | AWS / Azure / GCP / Hetzner / Proxmox / Static SSH                       | tailnet IPv4 (or FQDN)      |
| `url`     | Islo / E2B / Railway (supported); Modal / Cloudflare / Tensorlake (`BridgeState=unsupported`) | per-sandbox HTTPS URL |
| `ssh`     | exe.dev / RunPod / Daytona / Sprites / Namespace / Semaphore             | `ssh://<host>:<port>`        |
| `pending` | tailnet- or SSH-capable provider whose lease record has no endpoint yet  | empty (note explains why)    |
| `none`    | Blacksmith; any provider without a bridge adapter                        | empty (note explains why)    |

The resolver does **not** invoke a provider API for tailnet or SSH peers — it reads the endpoint straight off the local claim sidecar (new optional fields `tailscaleIPv4`, `tailscaleFQDN`, `sshHost`, `sshPort`, `bridgeURL`, `labels`). When those fields are empty for a managed-Linux or SSH-lease provider, the peer surfaces as `transport=pending` with an honest note rather than pretending the endpoint exists.

For URL peers the per-provider `BridgeProvider` adapter from #136's original commit is still invoked when no canonical endpoint is recorded yet, preserving the islo live-demo behavior and the `BridgeState=unsupported` signal that Modal/Cloudflare/Tensorlake emit today.

## Doctor reachability matrix

`crabbox doctor --crew <name>` keeps the existing Tailscale ACL row check from #129 and, in the same invocation, prints the per-transport reachability matrix derived from the unified peer list:

```
crew "alpha": 4 members
  transport breakdown: none=1 ssh=1 tailnet=1 url=1
  reachability:
    tailnet -> tailnet : OK
    tailnet -> url     : OK (via outbound HTTPS)
    tailnet -> ssh     : WARN (requires operator-side bridge — see SSH-mesh DRAFT PR)
    tailnet -> none    : NO (destination has no published endpoint)
    url     -> tailnet : NO (no public endpoint on tailnet members)
    url     -> url     : OK
    url     -> ssh     : WARN (requires operator-side bridge)
    url     -> none    : NO (destination has no published endpoint)
    ssh     -> tailnet : WARN (requires operator-side bridge)
    ssh     -> url     : OK (via outbound HTTPS)
    ssh     -> ssh     : WARN (requires operator-side bridge — peers do not share a mesh)
    ssh     -> none    : NO (destination has no published endpoint)
    none    -> *       : NO (source provider owns its own connectivity)
```

The matrix is intentionally asymmetric: `tailnet -> url` works (outbound HTTPS), `url -> tailnet` does not (no public endpoint on tailnet peers), and SSH pairs are flagged WARN because Crabbox does not currently mesh SSH leases — operator-side bridging is required (see #137 for the SSH-mesh DRAFT).

## Provider coverage matrix

| Provider                                                | Transport       | Live in this PR | Notes                                                                                                       |
| ------------------------------------------------------- | --------------- | --------------- | ----------------------------------------------------------------------------------------------------------- |
| AWS / Azure / GCP / Hetzner / Proxmox / Static SSH      | `tailnet`       | yes             | Endpoint = tailnet IPv4 from the lease record; empty surfaces as `pending`.                                  |
| exe.dev / RunPod / Daytona / Sprites / Namespace / Semaphore | `ssh`           | yes             | Endpoint = `ssh://host:port`; empty surfaces as `pending`.                                                  |
| Islo                                                    | `url`           | yes             | Live-validated. islo `share` API, idempotent.                                                                |
| E2B                                                     | `url`           | yes             | Synthesised `https://<port>-<sandboxID>.<domain>`.                                                            |
| Railway                                                 | `url`           | yes             | Existing deployment URL on `LatestDeployment`. One URL per service.                                          |
| Modal / Cloudflare / Tensorlake                         | `url`           | unsupported     | Adapters return `BridgeState=unsupported` so the gap is visible instead of silent.                          |
| Blacksmith                                              | `none`          | yes             | `note: "blacksmith owns connectivity"`.                                                                       |

## Tested

- `go test -race ./...` — all packages green (39s for `internal/cli`).
- New tests in `internal/cli/crew_bridge_test.go`:
  - `TestCrewPeersIncludesManagedLinuxWithTailnetTransport`
  - `TestCrewPeersIncludesSSHLeaseWithSSHTransport`
  - `TestCrewPeersHandlesPendingTailscaleIP`
  - `TestCrewPeersHandlesBlacksmithAsNone`
  - `TestDoctorCrewReachabilityMatrixAsymmetric`
  - `TestRenderCrewReachabilityMatrixIncludesAsymmetricNotes`
- Pre-existing islo / E2B / Railway / Modal / Cloudflare / Tensorlake adapter tests, plus the existing fan-out test, all unchanged and passing.
- Smoke-tested the rendered output by seeding `XDG_STATE_HOME/crabbox/claims/*.json` for four providers (hetzner, islo, runpod, blacksmith) and confirming the JSON matches the documented shape and the doctor matrix matches the table above.

Live islo evidence from PR #136's first commit (still valid after this refactor): live-validated against two real islo.dev sandboxes. From the client sandbox, dialing the web peer's published share URL via `urllib.request.urlopen` returned **HTTP 200** with the expected Python http.server body. Both sandboxes cleaned up. No new live tests were run for this amend — the resolver path for managed-Linux and SSH-lease peers is exercised by the unit suite against mocked claim sidecars; the URL-transport path is unchanged from the previously live-validated islo run.

## Why not Tailscale-here for delegated providers

Delegated providers don't expose a VM Crabbox can install `tailscaled` on. The Tailscale plane stays the right answer for managed Linux providers; the bridge plane is the narrow HTTP-only primitive that delegated providers can actually provide.

## Honest scope

- URL-transport peers are HTTP/HTTPS only, one target per port, no DNS aliasing. Non-HTTP protocols (Postgres, raw TCP, SSH on a custom port) are not in scope for that plane.
- SSH-transport peers are not meshed today. `crabbox crew peers` reports the SSH endpoint honestly so callers can dial it directly; the matrix flags SSH pairs as WARN. See #137 for the operator-orchestrated SSH-mesh alternative.
- Providers without a per-sandbox HTTPS ingress (Modal, Cloudflare, Tensorlake) are honestly reported as `BridgeState=unsupported` instead of silently emitting empty peer rows.
- Tailnet endpoints are read from the local claim sidecar. The new `tailscaleIPv4` / `tailscaleFQDN` / `sshHost` / `sshPort` / `bridgeURL` / `labels` fields are optional and additive — existing claim sidecars without them surface as `pending` (with note) for managed-Linux and SSH-lease providers, which is the same as the previous behavior of "no peer row at all" but more visible.

## Follow-ups

- Wire managed-Linux and SSH-lease provisioners to populate the new claim-sidecar endpoint fields at lease creation so `transport=pending` shrinks to "never" for normal usage.
- Modal tunnel surfacing on the lease record (would flip Modal from `unsupported` to `supported` without touching this PR).
- A `crabbox doctor crew --bridge` flag that also runs `ProbeBridgePeers` against the URL-transport peers.
- Optional `<slug>.cbx` alias rewriting once peer URLs are stable enough for clients to assume DNS.
- See DRAFT **#137** for the operator-orchestrated SSH-mesh alternative.

## Note on base

This branch is rooted on `main` and lands the bridge plane on top of the crew foundation introduced by #129. Until #129 lands, the PR shows two commits: the rebased crew commit (identical to #129's tip) and the bridge commit. Once #129 merges, this PR can be rebased and only the bridge commit will remain.

## Related

- **#129** — crew foundation (this PR builds on it; merge that first).
- **#137** — DRAFT SSH-mesh alternative for SSH-only providers (also stacked on #129).
- #132 — wandb provider (independent; no crew interaction).
- #133 — runpod (merged; independent).