### PR TITLE
feat: crew SSH-mesh (DRAFT, stacked on #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `crabbox crew connect <name>` and `--expose <port>` on `crabbox run`/`warmup` for an operator-orchestrated SSH-mesh plane. `connect` opens local `ssh -L` tunnels from the operator's machine to every crew member's declared expose port and writes `~/.crabbox/crew/<name>/{hosts,env}` so the operator can dial peers as `127.0.0.1:<local-port>`. `crabbox doctor --crew <name>` adds a `crew-mesh` sub-check that counts members and exposed ports. Works on every SSH-accessible provider; no Tailscale, no Headscale, no relay required. See `docs/features/crew-ssh-mesh.md`.
 - Added `provider: runpod` for RunPod public TCP SSH leases through the RunPod REST API, including Crabbox sync/run, `crabbox ssh`, `crabbox doctor`, and provider docs. Thanks @zozo123.
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.16.1 - Unreleased
+## Unreleased
 
 ### Added
 
@@ -8,6 +8,18 @@
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
+- Added `--crew <name>` for `crabbox warmup`/`run` plus `crabbox list --crew
+  <name>` so related leases share a reserved `crew` provider label and can be
+  selected together. On Tailscale-capable providers (Hetzner, Azure, GCP
+  managed Linux) the CLI advertises one extra ACL tag
+  `tag:cbx-crew-<owner>-<crew>` when the box joins the tailnet, and cloud-init
+  installs a 30s systemd timer that rewrites `/etc/hosts.cbx` and a managed
+  `/etc/hosts` block from `tailscale status --json` so peers are reachable as
+  `<slug>.box`. `crabbox doctor --crew <name>` verifies the one-time concrete
+  crew grants or ACL row when `TS_API_KEY` is exported and skips with a hint otherwise;
+  non-Tailscale providers honor the label as metadata and `doctor --crew`
+  reports the missing plane. See `docs/features/crew.md` for the one-time
+  policy snippet.
 
 ### Changed
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -9,6 +9,7 @@ crabbox doctor
 crabbox doctor --provider aws
 crabbox doctor --profile live-qa --id blue-lobster
 crabbox doctor --provider hetzner --target linux
+crabbox doctor --provider hetzner --crew alpha
 crabbox doctor --provider ssh --target windows --windows-mode normal --static-host win-dev.local
 crabbox doctor --json
 ```
@@ -44,6 +45,13 @@ what was checked. GCP uses an aggregated Compute Engine inventory query across
 zones, while the other built-in providers use their cheapest non-mutating list
 or readiness API. Blacksmith Testbox reports runtime as provider-hydrated
 because GitHub Actions hydration is owned by Testbox.
+
+Use `--crew <name>` to verify the Tailscale policy row for a crew before
+warming peers with `--tailscale`. The check confirms the concrete
+`tag:cbx-crew-<owner>-<crew>` tag is declared in `tagOwners` and allowed to
+reach itself through either `grants` or legacy `acls`. It reads the policy only
+when `TS_API_KEY` is exported; without that env var it skips with a hint. Plain
+`crabbox doctor` does not call the Tailscale ACL API.
 
 When `--profile <name> --id <lease>` selects a profile with `doctor.enabled:
 true`, doctor runs that profile's remote prerequisite contract instead of the
@@ -100,6 +108,7 @@ the exit code.
 ```text
 --provider hetzner|aws|azure|gcp|proxmox|ssh   provider to validate
 --profile <name>             configured profile for remote prereq checks
+--crew <name>                verify Tailscale ACL setup for this crew
 --json                       print JSON
 --doctor-probe-ssh           probe static SSH reachability
 --target linux|macos|windows target OS for ssh provider checks

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -16,11 +16,17 @@ crabbox list --provider islo
 crabbox list --provider e2b
 crabbox list --provider cloudflare --refresh
 crabbox list --json
+crabbox list --crew alpha
 ```
 
 `--refresh` asks providers with local claims, such as Cloudflare, to check live
 runner state before printing the list. Without it, Cloudflare list stays
 credential-free and reports local claims only.
+
+`--crew <name>` keeps only leases tagged with the requested crew. Crew names are
+normalized the same way as slugs (lowercased, non-alphanumeric runs collapsed to
+single dashes), so `--crew "Alpha Crew"` matches a lease created with `--crew
+alpha-crew`. See `docs/features/crew.md`.
 
 `crabbox pool list` remains as a compatibility alias.
 
@@ -54,6 +60,7 @@ Flags:
 --static-port <port>
 --static-work-root <path>
 --json
+--crew <name>
 --exe-dev-control-host <host>
 --sprites-api-url <url>
 --e2b-api-url <url>

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -206,6 +206,13 @@ also advertises a `tag:cbx-crew-<owner>-<name>` ACL tag and cloud-init keeps
 peers reach each other as `<slug>.cbx`. See
 [`docs/features/crew.md`](../features/crew.md).
 
+Use `--expose <port>` (repeatable; accepts comma-separated lists) to declare a
+TCP port this lease wants reachable through the operator-side SSH-mesh plane.
+Crabbox writes the normalized port list into a reserved provider label so
+`crabbox crew connect <name>` can later open local `ssh -L` tunnels from the
+operator's machine to each declared port. See
+[`docs/features/crew-ssh-mesh.md`](../features/crew-ssh-mesh.md).
+
 Use `--capture-stdout <path>` when stdout is binary or terminal-hostile. Crabbox
 writes the remote stdout bytes directly to the local file, leaves stderr on the
 terminal, and skips stdout run-log/event capture. This is useful for Windows
@@ -317,6 +324,7 @@ Flags:
 --market spot|on-demand
 --slug <slug>
 --crew <name>
+--expose <port>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -17,6 +17,7 @@ crabbox run --env-from-profile ~/.project-live.profile --allow-env API_TOKEN --s
 crabbox run --id blue-lobster --full-resync -- pnpm check:changed
 crabbox run --label "update flow smoke" -- pnpm test:changed
 crabbox run --slug update-flow-smoke -- pnpm test:changed
+crabbox run --crew alpha --slug web -- pnpm test:integration
 crabbox run --id blue-lobster --env-from-profile ~/.project-live.profile --allow-env OPENAI_API_KEY --env-helper live -- ./.crabbox/env/live pnpm test:live
 crabbox run --fresh-pr acme/app#123 --script ./scripts/e2e-smoke.sh
 crabbox run --id cbx_abcdef123456 --junit junit.xml -- go test ./...
@@ -197,6 +198,14 @@ timing JSON, and coordinator run record when available.
 Use `--slug <slug>` only when creating a fresh lease. Crabbox normalizes the
 requested slug and may add a suffix when an active lease already uses it.
 
+Use `--crew <name>` to tag a new lease into a named crew. Crew is a reserved
+provider label that groups peers, and `crabbox list --crew <name>` selects
+them as a set. With `--tailscale` on a Tailscale-capable provider the CLI
+also advertises a `tag:cbx-crew-<owner>-<name>` ACL tag and cloud-init keeps
+`/etc/hosts.cbx` plus a managed `/etc/hosts` block in sync every 30 seconds so
+peers reach each other as `<slug>.cbx`. See
+[`docs/features/crew.md`](../features/crew.md).
+
 Use `--capture-stdout <path>` when stdout is binary or terminal-hostile. Crabbox
 writes the remote stdout bytes directly to the local file, leaves stderr on the
 terminal, and skips stdout run-log/event capture. This is useful for Windows
@@ -307,6 +316,7 @@ Flags:
 --azure-os-disk managed|ephemeral|auto
 --market spot|on-demand
 --slug <slug>
+--crew <name>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -31,6 +31,13 @@ The command returns a stable `cbx_...` lease ID and a friendly slug. Reuse eithe
 Use `--slug <slug>` to request a human-chosen slug for a new lease. Crabbox
 normalizes it and may add a suffix when an active lease already uses it.
 
+Use `--expose <port>` (repeatable; accepts comma-separated lists) to declare
+a TCP port this lease wants reachable through the operator-side SSH-mesh
+plane. Crabbox writes the normalized port list into a reserved provider label
+so `crabbox crew connect <name>` can later open local `ssh -L` tunnels from
+the operator's machine to each declared port. See
+[`docs/features/crew-ssh-mesh.md`](../features/crew-ssh-mesh.md).
+
 Use `--crew <name>` to tag a new lease into a named crew. The crew name is
 stored on the lease as a reserved provider label, and `crabbox list --crew
 <name>` filters by it. When combined with `--tailscale` on a Tailscale-capable
@@ -138,6 +145,7 @@ Flags:
 --market spot|on-demand
 --slug <slug>
 --crew <name>
+--expose <port>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -9,6 +9,7 @@ crabbox warmup --provider azure --class beast
 crabbox warmup --browser
 crabbox warmup --tailscale
 crabbox warmup --slug update-flow-smoke
+crabbox warmup --crew alpha --slug db
 crabbox warmup --desktop --browser
 crabbox warmup --provider aws --target windows --desktop
 crabbox warmup --provider azure --target windows
@@ -29,6 +30,15 @@ crabbox warmup --provider ssh --target windows --windows-mode normal --static-ho
 The command returns a stable `cbx_...` lease ID and a friendly slug. Reuse either for subsequent `run`, `status`, `ssh`, `inspect`, and `stop` commands; scripts should keep using the canonical ID.
 Use `--slug <slug>` to request a human-chosen slug for a new lease. Crabbox
 normalizes it and may add a suffix when an active lease already uses it.
+
+Use `--crew <name>` to tag a new lease into a named crew. The crew name is
+stored on the lease as a reserved provider label, and `crabbox list --crew
+<name>` filters by it. When combined with `--tailscale` on a Tailscale-capable
+provider, the CLI also advertises a `tag:cbx-crew-<owner>-<name>` ACL tag and
+cloud-init refreshes `/etc/hosts.cbx` plus a managed `/etc/hosts` block every
+30 seconds so peers are reachable as `<slug>.cbx`. See
+[`docs/features/crew.md`](../features/crew.md) for the one-time policy snippet
+and the `doctor --crew` coverage.
 
 With `--provider blacksmith-testbox`, the canonical ID is the Blacksmith `tbx_...` ID returned by `blacksmith testbox warmup`; Crabbox still assigns and stores a local slug for reuse.
 
@@ -127,6 +137,7 @@ Flags:
 --azure-os-disk managed|ephemeral|auto
 --market spot|on-demand
 --slug <slug>
+--crew <name>
 --ttl <duration>
 --idle-timeout <duration>
 --desktop

--- a/docs/features/crew-ssh-mesh.md
+++ b/docs/features/crew-ssh-mesh.md
@@ -1,0 +1,103 @@
+# Crew SSH-mesh
+
+Read when:
+
+- you want the operator's shell to dial crew peers by name without relying on
+  Tailscale, Headscale, a SaaS relay, or any provider-specific network;
+- the provider only gives you SSH access to each lease (AWS, Proxmox,
+  exe.dev, RunPod, Sprites, Namespace, Semaphore, Daytona, plain SSH);
+- a Tailscale plane is not available, not desired, or not allowed.
+
+The SSH-mesh plane is operator-mediated: `crabbox crew connect <name>` opens
+local `ssh -L` tunnels from the operator's machine to every crew member that
+declared `--expose <port>` on its `crabbox run` / `warmup` call. The operator
+(and any tool the operator launches in the same shell) can then reach peers
+at `127.0.0.1:<port>`. No daemon ships to the lease, no relay, no SaaS —
+just the same SSH credentials the SSH-lease providers already configure.
+
+## How it composes with the Tailscale plane
+
+The Tailscale plane (`docs/features/crew.md`) gives lease-to-lease peer
+discovery and lets two boxes inside a tailnet reach each other as
+`<slug>.cbx`. The SSH-mesh plane gives the operator-side dial path that
+every SSH-accessible provider supports out of the box. The two planes are
+complementary:
+
+| Plane       | Reach (operator -> peer) | Reach (peer -> peer)             | Providers                           |
+| ----------- | ------------------------ | -------------------------------- | ----------------------------------- |
+| Tailscale   | via tailnet              | yes, `<slug>.cbx`                | Hetzner, Azure, GCP managed Linux   |
+| SSH-mesh    | yes, `127.0.0.1:<port>`  | not in v1 (operator-side only)   | every SSH-lease provider            |
+
+`crabbox doctor --crew <name>` reports both planes alongside each other.
+
+## Declaring exposed ports
+
+Add one `--expose <port>` per TCP port the lease wants reachable through
+the SSH-mesh:
+
+```sh
+crabbox warmup --crew alpha --slug web    --expose 8080
+crabbox warmup --crew alpha --slug client --expose 8080 --expose 9090
+```
+
+The flag is repeatable and accepts comma-separated lists
+(`--expose 8080,9090`). Crabbox writes the normalized port list into a
+reserved provider label (`crabbox_exposed_ports=8080-9090`) so
+`crew connect` can discover the ports without growing a new store.
+
+## Opening the mesh
+
+```sh
+crabbox crew connect alpha
+```
+
+Crabbox reads the active crew members, allocates one loopback port per
+declared exposed port, and opens an `ssh -L 127.0.0.1:<local>:127.0.0.1:<remote>`
+tunnel per (peer, port). The same connection options the rest of the CLI
+uses (ControlMaster + ControlPersist for connection reuse) apply, so the
+fan-out is cheap even with several peers.
+
+Crabbox writes two files under `~/.crabbox/crew/<name>/`:
+
+- `hosts` — operator-readable mapping from `<peer>.cbx (remote :<port>)`
+  to its assigned `127.0.0.1:<local>` address.
+- `env` — `export CRABBOX_CREW_<PEER>_<PORT>=127.0.0.1:<local>` for each
+  forward, so the operator can `eval $(crabbox crew connect <name> --export)`
+  and dial peers by variable.
+
+```sh
+eval $(crabbox crew connect alpha --export)
+curl "$CRABBOX_CREW_WEB_8080/health"
+```
+
+The default invocation holds the tunnels open in the foreground; press
+Ctrl-C to tear them down. Use `--json` to print the forward table without
+holding the connections.
+
+## What this is NOT
+
+- **Lease-to-lease peer dial** (true P2P mesh). That requires an
+  operator-side hub plus reverse tunnels and is a future PR.
+- **UDP forwarding.** `ssh -L` is TCP-only.
+- **Auto-plane selection.** v1 expects the operator to pick the SSH-mesh
+  plane explicitly via `crew connect`; the Tailscale plane keeps its own
+  auto-managed path.
+
+## Doctor
+
+`crabbox doctor --crew <name>` adds a `crew-mesh` sub-check that reports:
+
+- how many active members the crew has,
+- how many declared `--expose` ports,
+- the total port count.
+
+It is a `skip` when no member has declared a port (the plane has nothing
+to forward), and `ok` once at least one port is in scope.
+
+## Why the operator owns this
+
+Putting the mesh in the operator's shell keeps the broker out of the
+network path. The SSH credentials needed to open `-L` forwards are the
+ones the operator already holds for `crabbox ssh`, so no new secret
+flows through Crabbox. The plane stays usable on providers that have no
+Tailscale support and on locked-down networks that block tailnet traffic.

--- a/docs/features/crew.md
+++ b/docs/features/crew.md
@@ -1,0 +1,189 @@
+# Crew
+
+Read when:
+
+- you want to lease several boxes that act as one logical group;
+- you want `crabbox list` to show only the leases that belong to a group;
+- you want peers in a group to reach each other by name on the tailnet.
+
+A **crew** is a named set of Crabbox leases that should discover each other.
+The name is stored on each lease as a reserved provider label (`crew=<name>`) at
+provision time.
+There is no separate top-level crew object: a crew exists for as long as at
+least one active lease carries the label, and disappears when the last member
+is released. The primitive stays emergent and observable through the
+provider-label index the coordinator and direct backends already use.
+
+## Selector
+
+A reserved label key `crew` on every lease record.
+
+```sh
+crabbox warmup --crew alpha --slug db
+crabbox warmup --crew alpha --slug web
+crabbox warmup --crew alpha --slug worker
+```
+
+Each command tags its new lease with `crew=alpha` alongside the existing
+`slug`, `provider`, `class`, and `state` labels. The label is sanitized the
+same way as other provider labels and is bounded to 41 characters before
+sanitization so the same name fits inside hostname-derived identifiers
+(`<slug>.cbx` peer entries).
+
+```sh
+crabbox list --crew alpha
+crabbox list --crew alpha --json
+```
+
+The crew label is opt-in. Leases created without `--crew` carry no crew label
+and are unaffected.
+
+## Peer discovery on the tailnet
+
+When `--crew` is combined with `--tailscale` on a Tailscale-capable provider
+(Hetzner, Azure, GCP managed Linux), the CLI advertises one extra ACL tag
+when the box joins the tailnet:
+
+```
+tag:cbx-crew-<owner>-<crew>
+```
+
+The `<owner>` segment is derived from the operator's git email (local-part,
+truncated for tag length). The mint happens entirely in user (CLI) context —
+the broker never sees a Tailscale credential.
+
+Each crew member writes `/etc/hosts.cbx` from its own `tailscale status
+--json` output, filtered by the crew tag. The same systemd timer also
+maintains a Crabbox-owned block in `/etc/hosts`, so normal system resolution
+can find peers as `<slug>.cbx`:
+
+```sh
+curl http://db.cbx:5432/
+ssh worker.cbx
+```
+
+`<slug>` is the suffix of the `crabbox-<slug>` hostname template every
+Tailscale-capable provider already uses, so it doubles as the role name when
+slugs are role-shaped (`db`, `web`, `worker`).
+
+For providers without `FeatureTailscale` (E2B, Modal, Cloudflare, Railway,
+Islo, Tensorlake, Blacksmith, exe.dev, SSH, Proxmox, Sprites, Daytona,
+namespace-devbox), the crew label still sticks for `list --crew`, but the
+networking plane is unavailable. `crabbox doctor --crew <name>` flags this with
+`skip crew provider=<name> does not support the Tailscale plane`.
+
+## Example: two-lease web server demo
+
+End-to-end smoke that proves a crew is wired up. Each terminal runs from the
+same operator shell so `crabbox` shares the local claim store.
+
+Terminal 1 — start the server:
+
+```sh
+crabbox warmup --crew demo --slug web --provider hetzner
+crabbox ssh demo-web -- 'python3 -m http.server 8080'
+```
+
+Terminal 2 — hit it from a peer:
+
+```sh
+crabbox warmup --crew demo --slug client --provider hetzner
+crabbox ssh demo-client -- 'curl --max-time 5 http://web.cbx:8080'
+# expect HTTP 200 with the python directory listing
+```
+
+Cleanup:
+
+```sh
+crabbox release --crew demo
+```
+
+The `.cbx` peer name resolves through the managed `/etc/hosts` block that the
+crew-hosts systemd timer maintains on every Tailscale-capable peer.
+
+## Auto-bootstrap of the tailnet policy
+
+When `TS_API_KEY` is exported in the operator shell, the CLI self-bootstraps
+the `tag:cbx-crew-<owner>-<crew>` rows on the first `run` or `warmup` for a
+new crew: it reads the live policy with an ETag, merges the missing
+`tagOwners` and self-peering grant, and PUTs the result back with `If-Match`
+so a concurrent edit fails fast. Subsequent leases hit a cached row and
+no-op. `crabbox doctor --crew <name>` reports `auto-managed` in that mode.
+
+If you cannot expose `TS_API_KEY` to the CLI (e.g. shared tailnet,
+locked-down policy editing), fall back to the manual snippet below.
+
+## One-time tailnet setup (only if `TS_API_KEY` is not available)
+
+The crew plane needs a `tag:cbx-crew-<owner>-<crew>` entry in your tailnet
+policy file (Tailscale admin console -> Access Controls) plus one access row
+that opens peer-to-peer traffic for that tag. Tailscale's policy schema
+requires every advertised tag to be declared in `tagOwners` by its concrete
+name (no wildcards), so add one entry per `<crew>` you intend to ship:
+
+```hujson
+{
+  "tagOwners": {
+    "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"],
+  },
+  "grants": [
+    { "src": ["tag:cbx-crew-yossi-e-alpha"],
+      "dst": ["tag:cbx-crew-yossi-e-alpha"],
+      "ip": ["*"] },
+  ],
+}
+```
+
+Tailnets still using legacy ACLs can express the same rule as:
+
+```hujson
+{
+  "tagOwners": {
+    "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"],
+  },
+  "acls": [
+    { "action": "accept",
+      "src": ["tag:cbx-crew-yossi-e-alpha"],
+      "dst": ["tag:cbx-crew-yossi-e-alpha:*"] },
+  ],
+}
+```
+
+`<owner>` is the first seven characters of the operator's git email
+local-part — `yossi.eliaz@incredibuild.com` becomes `yossi-e`. `<crew>` is
+the normalized name you pass to `--crew`. The doctor check verifies the
+concrete tag declaration and matching peer-to-peer grants or ACL row for the
+crew you ask it to inspect.
+
+The plane stays operator-owned: the broker is a leaf and never holds
+Tailscale policy-edit credentials. When `TS_API_KEY` is set in the operator
+shell, the CLI uses it to (a) self-bootstrap the row on the first lease in
+each new crew and (b) verify it on `crabbox doctor --crew <name>`. Without
+that env var the auto-bootstrap is skipped silently and the doctor check
+falls back to a hint pointing at the manual snippet above. Plain `crabbox
+doctor` does not call the Tailscale ACL API unless a crew is explicitly
+selected.
+
+```sh
+export TS_API_KEY=tskey-api-XXXXXXXXXX
+export TS_TAILNET=example.com   # optional; defaults to '-' (the API key's tailnet)
+crabbox doctor --provider hetzner --crew alpha
+```
+
+## Why a label, not a new object
+
+Crabbox's labels already drive cleanup, the portal lease list, broker
+filters, and machine identity. Putting the crew name in the same place makes
+the primitive observable, queryable, and removable through the same paths.
+The maintainer's recent PR #118 rewrite of exe.dev — from a custom transport
+into a normal SSH lease provider — set the rule the design follows: bend new
+features into existing abstractions; do not grow parallel verb trees.
+
+## Provider posture
+
+| Provider                                                            | `--crew` tagged | Peer DNS (`<slug>.cbx`)              | Tailscale ACL doctor check |
+| ------------------------------------------------------------------- | --------------- | ------------------------------------ | -------------------------- |
+| Hetzner / Azure / GCP managed Linux                                 | yes             | yes (`/etc/hosts` managed block)     | yes, with `doctor --crew`  |
+| AWS Linux / AWS Windows / AWS Mac                                   | yes             | follow-up                            | n/a (no `FeatureTailscale`)|
+| Proxmox / SSH / Daytona / Sprites / exe.dev / namespace-devbox      | yes             | n/a (non-managed tailnet)            | skip with `doctor --crew`  |
+| E2B / Modal / Cloudflare / Railway / Islo / Tensorlake / Blacksmith | yes             | n/a                                  | skip with `doctor --crew`  |

--- a/docs/features/crew.md
+++ b/docs/features/crew.md
@@ -72,6 +72,11 @@ namespace-devbox), the crew label still sticks for `list --crew`, but the
 networking plane is unavailable. `crabbox doctor --crew <name>` flags this with
 `skip crew provider=<name> does not support the Tailscale plane`.
 
+For SSH-accessible providers without a Tailscale plane, the operator-side
+SSH-mesh plane gives an equivalent dial path: see
+[`docs/features/crew-ssh-mesh.md`](crew-ssh-mesh.md) for `--expose <port>` on
+`run`/`warmup` and `crabbox crew connect <name>`.
+
 ## Example: two-lease web server demo
 
 End-to-end smoke that proves a crew is wired up. Each terminal runs from the

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -885,7 +885,7 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
 		return `    echo "tailscale requested but no auth key was injected" >&2
     exit 1`
 	}
-	return `    retry sh -c 'curl -fsSL https://tailscale.com/install.sh | sh'
+	tailscaleUpScript := `    retry sh -c 'curl -fsSL https://tailscale.com/install.sh | sh'
     systemctl enable --now tailscaled || service tailscaled start || true
     install -d -m 0750 -o ` + sshUserOwner + ` -g ` + sshUserGroup + ` /var/lib/crabbox
     set +x
@@ -911,4 +911,100 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
     fi
     chown ` + sshUserChown + ` /var/lib/crabbox/tailscale-* || true
     chmod 0640 /var/lib/crabbox/tailscale-* || true`
+	if crew := normalizeCrewName(cfg.Crew); crew != "" {
+		tailscaleUpScript += "\n" + cloudInitCrewHostsBootstrap(cfg.Crew)
+	}
+	return tailscaleUpScript
+}
+
+// cloudInitCrewHostsBootstrap installs /usr/local/bin/crabbox-crew-hosts and a
+// systemd timer that rewrites /etc/hosts.cbx plus a managed /etc/hosts block
+// every 30s with one entry per crew peer reachable on the local tailnet. Peers
+// are discovered purely from the box-local `tailscale status --json` output
+// filtered by the crew ACL tag, so the broker never sees a Tailscale
+// credential. Each peer renders as `<tailnet-ipv4> <slug>.cbx` where `<slug>`
+// is the suffix of the `crabbox-<slug>` hostname template every
+// Tailscale-capable provider already uses.
+func cloudInitCrewHostsBootstrap(crew string) string {
+	tag := crewTailscaleTag(localCoordinatorOwner(), crew)
+	if tag == "" {
+		return ""
+	}
+	hostsFile := shellQuote(crewHostsFile)
+	tagLiteral := shellQuote(tag)
+	systemHostsFile := shellQuote("/etc/hosts")
+	return `    install -m 0644 /dev/null ` + hostsFile + ` || true
+    cat >/usr/local/bin/crabbox-crew-hosts <<'CREWHOSTS'
+#!/bin/sh
+set -eu
+TAG="$1"
+OUT="$2"
+SYSTEM_HOSTS="${3:-/etc/hosts}"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP" "$TMP".raw "$TMP".hosts' EXIT
+if ! tailscale status --json >"$TMP".raw 2>/dev/null; then
+  exit 0
+fi
+jq -r --arg tag "$TAG" '
+  [(.Peer // {}) | to_entries[] | .value]
+  | map(select((.Tags // []) | index($tag)))
+  | map({ ip: ((.TailscaleIPs // [])[0] // ""), host: ((.HostName // "") | sub("^crabbox-"; "")) })
+  | map(select(.ip != "" and .host != ""))
+  | unique_by(.ip)
+  | .[]
+  | "\(.ip) \(.host).cbx"
+' "$TMP".raw > "$TMP"
+printf '# managed by crabbox-crew-hosts; do not edit\n' >"$OUT".new
+cat "$TMP" >>"$OUT".new
+mv "$OUT".new "$OUT"
+chmod 0644 "$OUT"
+BEGIN="# crabbox crew hosts begin"
+END="# crabbox crew hosts end"
+if [ -f "$SYSTEM_HOSTS" ]; then
+  awk -v begin="$BEGIN" -v end="$END" '
+    $0 == begin { skip = 1; next }
+    $0 == end { skip = 0; next }
+    !skip { print }
+  ' "$SYSTEM_HOSTS" >"$TMP".hosts
+else
+  : >"$TMP".hosts
+fi
+{
+  cat "$TMP".hosts
+  printf '%s\n' "$BEGIN"
+  cat "$TMP"
+  printf '%s\n' "$END"
+} >"$SYSTEM_HOSTS".new
+mv "$SYSTEM_HOSTS".new "$SYSTEM_HOSTS"
+chmod 0644 "$SYSTEM_HOSTS"
+CREWHOSTS
+    chmod 0755 /usr/local/bin/crabbox-crew-hosts
+    cat >/etc/systemd/system/crabbox-crew-hosts.service <<'CREWUNIT'
+[Unit]
+Description=Refresh Crabbox crew peer hostnames
+After=tailscaled.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/crabbox-crew-hosts ` + tag + ` ` + crewHostsFile + ` /etc/hosts
+CREWUNIT
+    cat >/etc/systemd/system/crabbox-crew-hosts.timer <<'CREWTIMER'
+[Unit]
+Description=Refresh Crabbox crew hostnames every ` + crewHostsRefreshPeriod + `
+
+[Timer]
+OnBootSec=10s
+OnUnitActiveSec=` + crewHostsRefreshPeriod + `
+AccuracySec=2s
+Unit=crabbox-crew-hosts.service
+
+[Install]
+WantedBy=timers.target
+CREWTIMER
+    systemctl daemon-reload
+    systemctl enable --now crabbox-crew-hosts.timer
+    /usr/local/bin/crabbox-crew-hosts ` + tagLiteral + ` ` + hostsFile + ` ` + systemHostsFile + ` || true
+    test -f ` + hostsFile + `
+`
 }

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -14,6 +14,7 @@ type leaseClaim struct {
 	Slug               string `json:"slug,omitempty"`
 	Provider           string `json:"provider,omitempty"`
 	ProviderScope      string `json:"providerScope,omitempty"`
+	Crew               string `json:"crew,omitempty"`
 	RepoRoot           string `json:"repoRoot"`
 	ClaimedAt          string `json:"claimedAt"`
 	LastUsedAt         string `json:"lastUsedAt"`
@@ -30,10 +31,18 @@ func claimLeaseForRepoConfig(leaseID, slug string, cfg Config, repoRoot string, 
 }
 
 func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return claimLeaseForRepoProviderScope(leaseID, slug, provider, "", repoRoot, idleTimeout, reclaim)
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", "", repoRoot, idleTimeout, reclaim)
 }
 
 func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, providerScope, "", repoRoot, idleTimeout, reclaim)
+}
+
+func claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, "", crew, repoRoot, idleTimeout, reclaim)
+}
+
+func claimLeaseForRepoProviderScopeCrew(leaseID, slug, provider, providerScope, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	if leaseID == "" || repoRoot == "" {
 		return nil
 	}
@@ -59,6 +68,9 @@ func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repo
 	}
 	if providerScope != "" {
 		existing.ProviderScope = providerScope
+	}
+	if crew = normalizeCrewName(crew); crew != "" {
+		existing.Crew = crew
 	}
 	existing.RepoRoot = repoRoot
 	existing.LastUsedAt = now

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -26,6 +26,31 @@ func TestClaimLeaseForRepoWritesAndUpdatesClaim(t *testing.T) {
 	}
 }
 
+func TestClaimLeaseForRepoProviderStoresCrew(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := claimLeaseForRepoProviderWithCrew("isb_crabbox-test", "web", "islo", "Alpha Crew", repo, 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := readLeaseClaim("isb_crabbox-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("crew=%q want alpha-crew", claim.Crew)
+	}
+	if err := claimLeaseForRepoProvider("isb_crabbox-test", "web", "islo", repo, 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err = readLeaseClaim("isb_crabbox-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("crew should be preserved when omitted, got %q", claim.Crew)
+	}
+}
+
 func TestClaimLeaseForRepoConfigScopesProviderClaims(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := filepath.Join(t.TempDir(), "repo")

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -52,6 +52,7 @@ type crabboxKongCLI struct {
 	Cleanup    cleanupKongCmd    `cmd:"" passthrough:"" help:"Sweep expired direct-provider machines or local provider state."`
 	Azure      azureKongCmd      `cmd:"" help:"Azure provider setup and login."`
 	Config     configKongCmd     `cmd:"" help:"Show or update user config."`
+	Crew       crewKongCmd       `cmd:"" help:"Operator-side SSH-mesh against a crew."`
 	Pool       poolKongCmd       `cmd:"" help:"Alias commands for machine pools."`
 	Machine    machineKongCmd    `cmd:"" help:"Alias commands for direct-provider machines."`
 }
@@ -445,6 +446,14 @@ type configSetBrokerKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 
+type crewKongCmd struct {
+	Connect crewConnectKongCmd `cmd:"" passthrough:"" help:"Open SSH -L forwards to every crew member that declared --expose ports."`
+}
+
+type crewConnectKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+
 type poolKongCmd struct {
 	List poolListKongCmd `cmd:"" passthrough:"" help:"Alias for list."`
 }
@@ -493,6 +502,9 @@ func (c *inspectKongCmd) Run(ctx context.Context, app App) error { return app.in
 func (c *stopKongCmd) Run(ctx context.Context, app App) error    { return app.stop(ctx, c.Args) }
 func (c *releaseKongCmd) Run(ctx context.Context, app App) error { return app.stop(ctx, c.Args) }
 func (c *cleanupKongCmd) Run(ctx context.Context, app App) error { return app.cleanup(ctx, c.Args) }
+func (c *crewConnectKongCmd) Run(ctx context.Context, app App) error {
+	return app.crewConnect(ctx, c.Args)
+}
 
 func (c *desktopLaunchKongCmd) Run(ctx context.Context, app App) error {
 	return app.desktopLaunch(ctx, c.Args)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Network             NetworkMode
 	Class               string
 	Crew                string
+	ExposedPorts        []string
 	ServerType          string
 	ServerTypeExplicit  bool
 	Coordinator         string

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Code                bool
 	Network             NetworkMode
 	Class               string
+	Crew                string
 	ServerType          string
 	ServerTypeExplicit  bool
 	Coordinator         string

--- a/internal/cli/crew.go
+++ b/internal/cli/crew.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"strings"
+)
+
+// crewLabelKey is the reserved provider-label key used to group leases into a
+// crew. The key is part of the provider label index that every direct and
+// brokered backend already writes, so `list --crew <name>` can select peers
+// without growing a new verb tree.
+//
+// The label is emergent: there is no top-level crew object. A crew exists for
+// as long as at least one active lease carries this label.
+const crewLabelKey = "crew"
+
+// crewTailscaleTagPrefix is the ACL tag namespace used for crew peers. Every
+// member of crew `<name>` owned by `<owner>` is advertised as
+// `tag:cbx-crew-<owner>-<name>` so one concrete ACL row gates that crew.
+const crewTailscaleTagPrefix = "tag:cbx-crew-"
+
+// crewHostsFile is written on every Tailscale-capable Linux peer. A timer
+// refreshes it and a managed /etc/hosts block every 30s from the box-local
+// `tailscale status --json` output, so peers stay reachable as `<slug>.cbx`
+// without the broker ever seeing a Tailscale credential.
+const crewHostsFile = "/etc/hosts.cbx"
+
+// crewHostsRefreshPeriod is the refresh cadence baked into the systemd timer
+// that rewrites crew host entries. Kept low so a new peer is discoverable
+// within a single user-visible interaction window.
+const crewHostsRefreshPeriod = "30s"
+
+// maxRequestedCrewNameLength bounds the user-visible portion of the label.
+// Provider label values are already capped at 63 characters by
+// sanitizeProviderLabelValue; we use a stricter limit here so the same name
+// also fits inside future hostname-derived identifiers (e.g. `<crew>.<peer>`)
+// without truncation.
+const maxRequestedCrewNameLength = 41
+
+// maxCrewTailscaleTagOwnerLength bounds the owner segment of the crew ACL
+// tag. Tailscale tags are limited to 63 characters; with the `tag:cbx-crew-`
+// prefix (14 chars) and the crew name suffix (up to 41 chars plus a `-`
+// separator) we reserve seven characters for the owner. The owner is
+// derived from the operator's git email local-part and truncated rather than
+// rejected so the same email shape works for personal and shared tailnets.
+const maxCrewTailscaleTagOwnerLength = 7
+
+// normalizeCrewName lowercases the requested name and replaces every character
+// outside `[a-z0-9-]` with `-`, collapsing runs and trimming leading/trailing
+// dashes. The shape matches normalizeLeaseSlug; crew names participate in the
+// same DNS-ish identifier space so peer hostnames stay regular.
+func normalizeCrewName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var out strings.Builder
+	lastDash := false
+	for _, r := range value {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			out.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			out.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+// requestedCrewName validates a user-supplied `--crew <name>` flag value.
+// Empty input is allowed: callers treat that as "no crew assignment".
+func requestedCrewName(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", nil
+	}
+	name := normalizeCrewName(value)
+	if name == "" {
+		return "", exit(2, "--crew must contain at least one letter or digit")
+	}
+	if len(name) > maxRequestedCrewNameLength {
+		return "", exit(2, "--crew must be %d characters or fewer after normalization", maxRequestedCrewNameLength)
+	}
+	return name, nil
+}
+
+// serverCrew returns the crew label value attached to a server, normalized for
+// comparison. Servers without a crew label return the empty string.
+func serverCrew(server Server) string {
+	if server.Labels == nil {
+		return ""
+	}
+	return normalizeCrewName(server.Labels[crewLabelKey])
+}
+
+// filterServersByCrew returns the subset of servers whose crew label matches
+// the requested name. The filter is a no-op when crew is empty so callers can
+// pass `--crew` through unconditionally.
+func filterServersByCrew(servers []Server, crew string) []Server {
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return servers
+	}
+	out := make([]Server, 0, len(servers))
+	for _, server := range servers {
+		if serverCrew(server) == crew {
+			out = append(out, server)
+		}
+	}
+	return out
+}
+
+// crewTagOwner derives the tag-safe owner segment from an operator identity
+// (typically `localCoordinatorOwner()` — a git email). Anything outside
+// `[a-z0-9-]` collapses to `-`; the result is trimmed and bounded so the full
+// tag stays within Tailscale's 63-character ceiling. Returns "" when the
+// input does not yield any valid characters; callers fall back to the
+// hard-coded "user" segment in that case so the tag prefix stays stable.
+func crewTagOwner(identity string) string {
+	identity = strings.ToLower(strings.TrimSpace(identity))
+	if at := strings.IndexByte(identity, '@'); at > 0 {
+		identity = identity[:at]
+	}
+	owner := normalizeCrewName(identity)
+	if owner == "" {
+		return ""
+	}
+	if len(owner) > maxCrewTailscaleTagOwnerLength {
+		owner = strings.Trim(owner[:maxCrewTailscaleTagOwnerLength], "-")
+	}
+	return owner
+}
+
+// crewTailscaleTag renders the ACL tag advertised by every crew peer. Returns
+// "" when either argument is empty so callers can compose the value
+// unconditionally and skip emission when the lease is not actually a crew
+// member.
+func crewTailscaleTag(owner, crew string) string {
+	owner = crewTagOwner(owner)
+	if owner == "" {
+		owner = "user"
+	}
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return ""
+	}
+	return crewTailscaleTagPrefix + owner + "-" + crew
+}
+
+// appendCrewTailscaleTag mutates cfg.Tailscale.Tags to include the crew tag
+// when both `--crew` and Tailscale are in play. The mint happens entirely in
+// user (CLI) context: the same auth key the operator already supplies is
+// re-used with one extra advertised tag, so the broker never sees a
+// Tailscale credential. No-op when the provider lacks FeatureTailscale or
+// when Tailscale is not enabled on this lease.
+func appendCrewTailscaleTag(cfg *Config, providerSupportsTailscale bool) {
+	if cfg == nil || !cfg.Tailscale.Enabled || !providerSupportsTailscale {
+		return
+	}
+	tag := crewTailscaleTag(localCoordinatorOwner(), cfg.Crew)
+	if tag == "" {
+		return
+	}
+	cfg.Tailscale.Tags = appendUniqueStrings(cfg.Tailscale.Tags, tag)
+}
+
+// providerCapableOfTailscale reports whether the named provider advertises
+// FeatureTailscale. Unknown providers return false, mirroring the
+// conservative posture other capability checks already take.
+func providerCapableOfTailscale(provider string) bool {
+	p, err := ProviderFor(provider)
+	if err != nil {
+		return false
+	}
+	return featureSetHas(p.Spec().Features, FeatureTailscale)
+}

--- a/internal/cli/crew_acl.go
+++ b/internal/cli/crew_acl.go
@@ -1,0 +1,280 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// crewACLEnsureTimeout bounds each request made by crewACLEnsure so the auth-
+// key mint path stays responsive even when Tailscale is slow. The total time
+// budget is roughly twice this (one GET + at most one PUT).
+const crewACLEnsureTimeout = 6 * time.Second
+
+// crewACLMaxAttempts caps the GET → merge → PUT loop. The first 412 from PUT
+// almost always reflects a benign concurrent edit (another operator running
+// the same bootstrap path), so re-reading the policy and retrying once is
+// safe. Two attempts is the smallest value that lets us tolerate a single
+// race; persistent 412s are surfaced as a clear error.
+const crewACLMaxAttempts = 2
+
+// errCrewACLPreconditionFailed is returned by PutPolicy when the server
+// rejected the write with HTTP 412 (ETag mismatch). It is wrapped so callers
+// can detect the race via errors.Is and decide whether to retry.
+var errCrewACLPreconditionFailed = errors.New("crew acl: tailnet policy changed during update (ETag mismatch)")
+
+// crewTailnetACLClient is satisfied by anything that can read and update the
+// tailnet policy file. The real implementation hits the Tailscale API; tests
+// inject a stub so unit tests never reach the network.
+type crewTailnetACLClient interface {
+	GetPolicy(ctx context.Context, tailnet string) (body string, etag string, err error)
+	PutPolicy(ctx context.Context, tailnet string, body string, etag string) error
+}
+
+// crewTailnetACLClientFactory is overridden in tests. It returns nil when no
+// API key is available so callers can fall through to the manual-setup path.
+var crewTailnetACLClientFactory = newCrewTailnetACLClient
+
+// crewACLEnsure makes sure the concrete crew tag is declared in tagOwners and
+// covered by a self-peering grant on the operator's tailnet. It is a no-op
+// when the rows are already present. When changes are needed the function
+// reads the current policy with an ETag, parses it as JSON, merges in the
+// missing entries, and PUTs the result back with If-Match so concurrent
+// edits fail-fast.
+//
+// The function is intentionally strict: if the live policy uses HuJSON
+// constructs (line comments, trailing commas) that the standard JSON parser
+// cannot decode, it returns a clear error so the caller falls back to the
+// existing manual snippet instead of risking a destructive overwrite.
+func crewACLEnsure(ctx context.Context, client crewTailnetACLClient, tailnet, owner, crew string) error {
+	if client == nil {
+		return fmt.Errorf("crew acl client unavailable")
+	}
+	tag := crewTailscaleTag(owner, crew)
+	if tag == "" {
+		return fmt.Errorf("crew acl: empty tag (owner=%q crew=%q)", owner, crew)
+	}
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	var lastPutErr error
+	for attempt := 1; attempt <= crewACLMaxAttempts; attempt++ {
+		getCtx, cancelGet := context.WithTimeout(ctx, crewACLEnsureTimeout)
+		body, etag, err := client.GetPolicy(getCtx, tailnet)
+		cancelGet()
+		if err != nil {
+			return fmt.Errorf("crew acl: read policy: %w", err)
+		}
+		if crewACLRowPresent(body, tag) {
+			return nil
+		}
+		merged, err := crewACLMergePolicy(body, tag)
+		if err != nil {
+			return err
+		}
+		putCtx, cancelPut := context.WithTimeout(ctx, crewACLEnsureTimeout)
+		err = client.PutPolicy(putCtx, tailnet, merged, etag)
+		cancelPut()
+		if err == nil {
+			return nil
+		}
+		// A 412 means another writer raced us; re-read the policy with a
+		// fresh ETag and retry. Once the retry budget is exhausted, surface
+		// the race with a distinct error so operators know rerunning is
+		// safe (vs. a hard auth failure). Any non-412 error is fatal — the
+		// caller falls back to the manual snippet.
+		if errors.Is(err, errCrewACLPreconditionFailed) {
+			lastPutErr = err
+			if attempt < crewACLMaxAttempts {
+				continue
+			}
+			return fmt.Errorf("crew acl: ETag race persisted after %d attempts: %w", crewACLMaxAttempts, lastPutErr)
+		}
+		return fmt.Errorf("crew acl: update policy: %w", err)
+	}
+	// Defensive: the loop body always returns or continues; reaching here
+	// would indicate a bug in the loop bounds.
+	return fmt.Errorf("crew acl: ETag race persisted after %d attempts: %w", crewACLMaxAttempts, lastPutErr)
+}
+
+// crewACLMergePolicy parses the policy as JSON, ensures both the tagOwners
+// entry and a self-peering grant for the tag, and returns the re-serialized
+// document. Returns a clear error when the policy is not valid JSON (e.g.
+// contains HuJSON comments) so the caller falls back to manual setup.
+func crewACLMergePolicy(body, tag string) (string, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return "", fmt.Errorf("crew acl: empty policy body")
+	}
+	var policy map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &policy); err != nil {
+		return "", fmt.Errorf("crew acl: cannot merge non-JSON policy (add the tag:cbx-crew-... rows manually): %w", err)
+	}
+	if policy == nil {
+		policy = map[string]json.RawMessage{}
+	}
+
+	// Merge tagOwners.
+	tagOwners := map[string]json.RawMessage{}
+	if raw, ok := policy["tagOwners"]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &tagOwners); err != nil {
+			return "", fmt.Errorf("crew acl: cannot parse tagOwners: %w", err)
+		}
+	}
+	if _, ok := tagOwners[tag]; !ok {
+		owners, err := json.Marshal([]string{"autogroup:admin"})
+		if err != nil {
+			return "", err
+		}
+		tagOwners[tag] = owners
+	}
+	updatedOwners, err := json.Marshal(tagOwners)
+	if err != nil {
+		return "", err
+	}
+	policy["tagOwners"] = updatedOwners
+
+	// Prefer grants when the policy already uses that shape, otherwise
+	// append a legacy acls row. We never down-convert grants→acls.
+	if raw, ok := policy["grants"]; ok && len(raw) > 0 {
+		var grants []map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &grants); err != nil {
+			return "", fmt.Errorf("crew acl: cannot parse grants: %w", err)
+		}
+		grants = append(grants, crewGrantEntry(tag))
+		updatedGrants, err := json.Marshal(grants)
+		if err != nil {
+			return "", err
+		}
+		policy["grants"] = updatedGrants
+	} else {
+		var acls []map[string]json.RawMessage
+		if raw, ok := policy["acls"]; ok && len(raw) > 0 {
+			if err := json.Unmarshal(raw, &acls); err != nil {
+				return "", fmt.Errorf("crew acl: cannot parse acls: %w", err)
+			}
+		}
+		acls = append(acls, crewACLEntry(tag))
+		updatedACLs, err := json.Marshal(acls)
+		if err != nil {
+			return "", err
+		}
+		policy["acls"] = updatedACLs
+	}
+
+	out, err := json.MarshalIndent(policy, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func crewGrantEntry(tag string) map[string]json.RawMessage {
+	src, _ := json.Marshal([]string{tag})
+	dst, _ := json.Marshal([]string{tag})
+	ip, _ := json.Marshal([]string{"*"})
+	return map[string]json.RawMessage{
+		"src": src,
+		"dst": dst,
+		"ip":  ip,
+	}
+}
+
+func crewACLEntry(tag string) map[string]json.RawMessage {
+	action, _ := json.Marshal("accept")
+	src, _ := json.Marshal([]string{tag})
+	dst, _ := json.Marshal([]string{tag + ":*"})
+	return map[string]json.RawMessage{
+		"action": action,
+		"src":    src,
+		"dst":    dst,
+	}
+}
+
+// liveCrewTailnetACLClient is the production implementation. It targets the
+// documented "Get tailnet policy file" and "Set tailnet policy file"
+// endpoints and threads ETag through so concurrent edits fail-fast.
+type liveCrewTailnetACLClient struct {
+	apiKey string
+	http   *http.Client
+}
+
+func newCrewTailnetACLClient(apiKey string) crewTailnetACLClient {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil
+	}
+	return &liveCrewTailnetACLClient{apiKey: apiKey, http: &http.Client{Timeout: crewACLEnsureTimeout}}
+}
+
+func (c *liveCrewTailnetACLClient) GetPolicy(ctx context.Context, tailnet string) (string, string, error) {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := "https://api.tailscale.com/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if readErr != nil {
+		return "", "", readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", tailscaleAPIError(resp.StatusCode, body)
+	}
+	return string(body), resp.Header.Get("ETag"), nil
+}
+
+func (c *liveCrewTailnetACLClient) PutPolicy(ctx context.Context, tailnet, body, etag string) error {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := "https://api.tailscale.com/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if etag != "" {
+		req.Header.Set("If-Match", etag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return errCrewACLPreconditionFailed
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return tailscaleAPIError(resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+func tailscaleAPIError(status int, body []byte) error {
+	var envelope struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Message != "" {
+		return fmt.Errorf("tailscale api %d: %s", status, envelope.Message)
+	}
+	return fmt.Errorf("tailscale api %d", status)
+}

--- a/internal/cli/crew_acl_test.go
+++ b/internal/cli/crew_acl_test.go
@@ -1,0 +1,364 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// stubCrewTailnetACLClient lets unit tests exercise crewACLEnsure without
+// touching the network. Each method records call counts and the last input
+// body so assertions can be made against the merge logic.
+type stubCrewTailnetACLClient struct {
+	policy   string
+	etag     string
+	getErr   error
+	putErr   error
+	gets     int32
+	puts     int32
+	lastBody string
+	lastEtag string
+}
+
+func (s *stubCrewTailnetACLClient) GetPolicy(_ context.Context, _ string) (string, string, error) {
+	atomic.AddInt32(&s.gets, 1)
+	return s.policy, s.etag, s.getErr
+}
+
+func (s *stubCrewTailnetACLClient) PutPolicy(_ context.Context, _, body, etag string) error {
+	atomic.AddInt32(&s.puts, 1)
+	s.lastBody = body
+	s.lastEtag = etag
+	return s.putErr
+}
+
+func TestCrewACLEnsureNoopWhenRowPresent(t *testing.T) {
+	tag := crewTailscaleTag("user", "alpha")
+	stub := &stubCrewTailnetACLClient{
+		policy: crewPolicyFixture(tag),
+		etag:   `"v1"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 1 {
+		t.Fatalf("expected 1 GET, got %d", stub.gets)
+	}
+	if atomic.LoadInt32(&stub.puts) != 0 {
+		t.Fatalf("expected no PUT when row present, got %d", stub.puts)
+	}
+}
+
+func TestCrewACLEnsureUpsertsMissingRowAndPropagatesETag(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]},"acls":[{"action":"accept","src":["*"],"dst":["*:*"]}]}`,
+		etag:   `"v7"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&stub.puts) != 1 {
+		t.Fatalf("expected 1 PUT, got %d", stub.puts)
+	}
+	if stub.lastEtag != `"v7"` {
+		t.Fatalf("expected If-Match etag to be propagated, got %q", stub.lastEtag)
+	}
+	wantTag := crewTailscaleTag("user", "alpha")
+	if !strings.Contains(stub.lastBody, wantTag) {
+		t.Fatalf("expected new policy body to mention %q, got:\n%s", wantTag, stub.lastBody)
+	}
+	// The merged body must still parse as JSON and carry the expected entries.
+	var policy map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stub.lastBody), &policy); err != nil {
+		t.Fatalf("merged policy is not valid JSON: %v\n%s", err, stub.lastBody)
+	}
+	if !crewACLRowPresent(stub.lastBody, wantTag) {
+		t.Fatalf("merged policy should pass crewACLRowPresent, got:\n%s", stub.lastBody)
+	}
+}
+
+func TestCrewACLEnsurePrefersGrantsWhenPolicyUsesGrants(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]},"grants":[{"src":["tag:crabbox"],"dst":["tag:crabbox"],"ip":["*"]}]}`,
+		etag:   `"v1"`,
+	}
+	if err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if !strings.Contains(stub.lastBody, `"grants"`) {
+		t.Fatalf("expected grants stanza preserved, got:\n%s", stub.lastBody)
+	}
+	if strings.Contains(stub.lastBody, `"acls"`) {
+		t.Fatalf("must not down-convert grants policy to acls, got:\n%s", stub.lastBody)
+	}
+}
+
+func TestCrewACLEnsureETagMismatchReturnsClearError(t *testing.T) {
+	// A persistent 412 from the server must surface a clear, actionable
+	// error after the retry budget is exhausted. The stub returns the
+	// sentinel so crewACLEnsure goes through the full retry loop.
+	stub := &stubCrewTailnetACLClient{
+		policy: `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`,
+		etag:   `"v1"`,
+		putErr: errCrewACLPreconditionFailed,
+	}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error on ETag mismatch")
+	}
+	if !strings.Contains(err.Error(), "ETag race persisted") {
+		t.Fatalf("expected ETag race persisted error after retry, got %v", err)
+	}
+	if !errors.Is(err, errCrewACLPreconditionFailed) {
+		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}
+
+func TestCrewACLEnsureRefusesMalformedPolicy(t *testing.T) {
+	// HuJSON line comments make the body non-JSON. We must refuse rather
+	// than overwrite the operator's policy.
+	stub := &stubCrewTailnetACLClient{
+		policy: `// my tailnet policy
+{
+  "tagOwners": { "tag:crabbox": ["autogroup:admin"] }
+}`,
+		etag: `"v1"`,
+	}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error on non-JSON policy")
+	}
+	if !strings.Contains(err.Error(), "non-JSON") {
+		t.Fatalf("expected non-JSON error, got %v", err)
+	}
+	if atomic.LoadInt32(&stub.puts) != 0 {
+		t.Fatalf("must not PUT when merge fails, got %d puts", stub.puts)
+	}
+}
+
+func TestCrewACLEnsurePropagatesGetError(t *testing.T) {
+	stub := &stubCrewTailnetACLClient{getErr: fmt.Errorf("tailscale api 401: invalid api key")}
+	err := crewACLEnsure(context.Background(), stub, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error when GET fails")
+	}
+	if !strings.Contains(err.Error(), "read policy") {
+		t.Fatalf("expected read policy error, got %v", err)
+	}
+}
+
+// TestCrewACLEnsureLiveClientETagFlow uses an httptest server to validate the
+// production HTTP client's ETag handling end-to-end. It covers (a) ETag is
+// echoed from GET to PUT's If-Match header and (b) a 412 from the server is
+// surfaced as a clear error.
+func TestCrewACLEnsureLiveClientETagFlow(t *testing.T) {
+	t.Run("happy path threads ETag", func(t *testing.T) {
+		var lastIfMatch string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("ETag", `"v42"`)
+				_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+			case http.MethodPost:
+				lastIfMatch = r.Header.Get("If-Match")
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		}))
+		defer srv.Close()
+		client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+		if err := crewACLEnsure(context.Background(), client, "-", "user", "alpha"); err != nil {
+			t.Fatalf("crewACLEnsure: %v", err)
+		}
+		if lastIfMatch != `"v42"` {
+			t.Fatalf("expected If-Match propagated, got %q", lastIfMatch)
+		}
+	})
+
+	t.Run("server 412 surfaces clear error after retry", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				w.Header().Set("ETag", `"v1"`)
+				_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+			case http.MethodPost:
+				w.WriteHeader(http.StatusPreconditionFailed)
+			}
+		}))
+		defer srv.Close()
+		client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+		err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+		if err == nil {
+			t.Fatal("expected error on 412")
+		}
+		if !strings.Contains(err.Error(), "ETag race persisted") {
+			t.Fatalf("expected ETag race persisted error, got %v", err)
+		}
+	})
+}
+
+// newCrewTailnetTestClient returns a client wired against an httptest server.
+// It mirrors the live client's request shape but rewrites the base URL so the
+// test stays hermetic.
+func newCrewTailnetTestClient(t *testing.T, baseURL, apiKey string) crewTailnetACLClient {
+	t.Helper()
+	return &testCrewTailnetClient{base: baseURL, apiKey: apiKey, http: http.DefaultClient}
+}
+
+type testCrewTailnetClient struct {
+	base   string
+	apiKey string
+	http   *http.Client
+}
+
+func (c *testCrewTailnetClient) GetPolicy(ctx context.Context, _ string) (string, string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/api/v2/tailnet/-/acl", nil)
+	req.SetBasicAuth(c.apiKey, "")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", "", fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return string(body), resp.Header.Get("ETag"), nil
+}
+
+func (c *testCrewTailnetClient) PutPolicy(ctx context.Context, _, body, etag string) error {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v2/tailnet/-/acl", strings.NewReader(body))
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Content-Type", "application/json")
+	if etag != "" {
+		req.Header.Set("If-Match", etag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return errCrewACLPreconditionFailed
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// TestCrewACLEnsureRetriesOnce412ThenSucceeds wires an httptest server that
+// rejects the first PUT with 412 and accepts the second. crewACLEnsure must
+// observe the ETag race, re-read the policy, and complete in two attempts
+// without bubbling the transient failure to the caller.
+func TestCrewACLEnsureRetriesOnce412ThenSucceeds(t *testing.T) {
+	var gets, puts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			atomic.AddInt32(&gets, 1)
+			w.Header().Set("ETag", `"v1"`)
+			_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+		case http.MethodPost:
+			n := atomic.AddInt32(&puts, 1)
+			if n == 1 {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+	client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+	if err := crewACLEnsure(context.Background(), client, "-", "user", "alpha"); err != nil {
+		t.Fatalf("crewACLEnsure: %v", err)
+	}
+	if atomic.LoadInt32(&gets) != 2 {
+		t.Fatalf("expected 2 GETs (initial + retry), got %d", gets)
+	}
+	if atomic.LoadInt32(&puts) != 2 {
+		t.Fatalf("expected 2 PUTs (first 412, second 200), got %d", puts)
+	}
+}
+
+// TestCrewACLEnsureSurfacesAfterPersistent412 ensures the retry budget is
+// bounded: a server that always returns 412 must not be hammered indefinitely.
+// The function should fail after exactly crewACLMaxAttempts PUTs with a
+// clear, actionable error.
+func TestCrewACLEnsureSurfacesAfterPersistent412(t *testing.T) {
+	var puts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("ETag", `"v1"`)
+			_, _ = io.WriteString(w, `{"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`)
+		case http.MethodPost:
+			atomic.AddInt32(&puts, 1)
+			w.WriteHeader(http.StatusPreconditionFailed)
+		}
+	}))
+	defer srv.Close()
+	client := newCrewTailnetTestClient(t, srv.URL, "stub-key")
+	err := crewACLEnsure(context.Background(), client, "-", "user", "alpha")
+	if err == nil {
+		t.Fatal("expected error after persistent 412")
+	}
+	if !strings.Contains(err.Error(), "ETag race persisted") {
+		t.Fatalf("expected ETag race persisted error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&puts); got != int32(crewACLMaxAttempts) {
+		t.Fatalf("expected exactly %d PUTs, got %d", crewACLMaxAttempts, got)
+	}
+}
+
+func TestMaybeBootstrapCrewACLNoopWithoutAPIKey(t *testing.T) {
+	t.Setenv("TS_API_KEY", "")
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("expected silent noop without TS_API_KEY, got %v", err)
+	}
+}
+
+func TestMaybeBootstrapCrewACLCallsFactoryWhenKeyPresent(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	tag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	stub := &stubCrewTailnetACLClient{policy: crewPolicyFixture(tag), etag: `"v1"`}
+	prev := crewTailnetACLClientFactory
+	defer func() { crewTailnetACLClientFactory = prev }()
+	crewTailnetACLClientFactory = func(_ string) crewTailnetACLClient { return stub }
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("maybeBootstrapCrewACL: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 1 {
+		t.Fatalf("expected 1 GET when key is set, got %d", stub.gets)
+	}
+}
+
+func TestMaybeBootstrapCrewACLSkipsNonTailscaleProvider(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	stub := &stubCrewTailnetACLClient{}
+	prev := crewTailnetACLClientFactory
+	defer func() { crewTailnetACLClientFactory = prev }()
+	crewTailnetACLClientFactory = func(_ string) crewTailnetACLClient { return stub }
+	cfg := Config{Provider: "e2b", Crew: "alpha"}
+	cfg.Tailscale.Enabled = true
+	if err := maybeBootstrapCrewACL(context.Background(), cfg); err != nil {
+		t.Fatalf("maybeBootstrapCrewACL: %v", err)
+	}
+	if atomic.LoadInt32(&stub.gets) != 0 {
+		t.Fatalf("expected no API call for non-Tailscale provider, got %d gets", stub.gets)
+	}
+}

--- a/internal/cli/crew_mesh.go
+++ b/internal/cli/crew_mesh.go
@@ -1,0 +1,564 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// crewExposedPortsLabelKey is the reserved provider-label key that carries the
+// comma-separated list of TCP ports a lease wants reachable over the SSH-mesh
+// plane. The key lives next to crewLabelKey in the existing provider label
+// index so `crabbox crew connect` can discover ports without growing a new
+// store.
+const crewExposedPortsLabelKey = "crabbox_exposed_ports"
+
+// crewMaxExposedPort is the inclusive ceiling on TCP port numbers accepted by
+// --expose. Anything above this is malformed input and rejected at flag-parse
+// time so we never write garbage into provider labels.
+const crewMaxExposedPort = 65535
+
+// crewMaxExposedPortsPerLease bounds the per-lease --expose list so the
+// resulting comma-separated label fits inside the 63-character provider label
+// ceiling enforced by sanitizeProviderLabelValue (six characters per port plus
+// a separator leaves headroom for up to ten ports).
+const crewMaxExposedPortsPerLease = 10
+
+// crewMeshLocalPortStart is the first port the operator-side allocator hands
+// out for local -L forwards. Picked above the IANA registered range so it
+// rarely collides with developer-local services.
+const crewMeshLocalPortStart = 51820
+
+// crewMeshLocalPortEnd bounds the operator-side allocator. The window is
+// generous (a few thousand ports) so a single operator can connect to many
+// large crews simultaneously without exhausting it.
+const crewMeshLocalPortEnd = 52819
+
+// crewMeshHostsRoot is the per-user state directory under HOME where
+// `crew connect` writes the rendered hosts and env files. The structure
+// mirrors the existing ~/.crabbox layout other commands already use.
+const crewMeshHostsRoot = ".crabbox/crew"
+
+// crewMeshHostsFileName is the rendered file mapping <peer>.cbx to the local
+// loopback port the operator can use to reach that peer's exposed port.
+const crewMeshHostsFileName = "hosts"
+
+// crewMeshEnvFileName is the rendered shell-export snippet so an operator can
+// `eval $(crabbox crew connect <name> --export)` and use peer names directly.
+const crewMeshEnvFileName = "env"
+
+// crewMeshRunner abstracts os/exec.CommandContext so the connect orchestration
+// is testable without spawning real ssh processes. The production runner
+// returns a real *exec.Cmd; tests inject a recorder that captures arguments.
+type crewMeshRunner interface {
+	Command(ctx context.Context, name string, args ...string) crewMeshHandle
+}
+
+// crewMeshHandle is the minimal surface area the connect loop needs from a
+// spawned process: start it, wait for it to exit, and tear it down on context
+// cancellation. The real implementation wraps *exec.Cmd; tests substitute a
+// stub that records the invocation and exits when signaled.
+type crewMeshHandle interface {
+	Start() error
+	Wait() error
+	Process() processSignaler
+	String() string
+}
+
+// processSignaler is the subset of *os.Process that the connect loop touches
+// when the operator presses Ctrl-C and the orchestrator tears down each
+// underlying ssh process in turn.
+type processSignaler interface {
+	Signal(os.Signal) error
+	Kill() error
+}
+
+// crewMeshExecRunner is the production crewMeshRunner. It wraps
+// exec.CommandContext directly so behaviour under ctx cancellation matches
+// every other Crabbox SSH invocation.
+type crewMeshExecRunner struct{}
+
+func (crewMeshExecRunner) Command(ctx context.Context, name string, args ...string) crewMeshHandle {
+	return &crewMeshExecHandle{cmd: exec.CommandContext(ctx, name, args...)}
+}
+
+type crewMeshExecHandle struct {
+	cmd *exec.Cmd
+}
+
+func (h *crewMeshExecHandle) Start() error   { return h.cmd.Start() }
+func (h *crewMeshExecHandle) Wait() error    { return h.cmd.Wait() }
+func (h *crewMeshExecHandle) String() string { return h.cmd.String() }
+func (h *crewMeshExecHandle) Process() processSignaler {
+	if h.cmd.Process == nil {
+		return nil
+	}
+	return h.cmd.Process
+}
+
+// crewMeshDefaultRunner is overridden in tests via the package-level pointer
+// so the production crewMeshExecRunner never appears in unit tests. Reads are
+// guarded by the tests running serially per package.
+var crewMeshDefaultRunner crewMeshRunner = crewMeshExecRunner{}
+
+// requestedExposedPorts validates and normalizes the values from a repeated
+// `--expose` flag. Each entry must be a positive TCP port; comma-separated
+// values are expanded; duplicates are dropped. The result is sorted so the
+// rendered provider label is deterministic across re-runs with the same flag
+// order.
+func requestedExposedPorts(values []string) ([]string, error) {
+	seen := map[int]bool{}
+	out := []int{}
+	for _, raw := range values {
+		if strings.TrimSpace(raw) == "" {
+			return nil, exit(2, "--expose value must not be empty")
+		}
+		parts := splitCommaList(raw)
+		if len(parts) == 0 {
+			return nil, exit(2, "--expose value must not be empty")
+		}
+		for _, part := range parts {
+			port, err := strconv.Atoi(strings.TrimSpace(part))
+			if err != nil || port <= 0 || port > crewMaxExposedPort {
+				return nil, exit(2, "--expose %q must be a TCP port in 1..%d", part, crewMaxExposedPort)
+			}
+			if seen[port] {
+				continue
+			}
+			seen[port] = true
+			out = append(out, port)
+		}
+	}
+	if len(out) > crewMaxExposedPortsPerLease {
+		return nil, exit(2, "--expose accepts at most %d distinct ports per lease", crewMaxExposedPortsPerLease)
+	}
+	sort.Ints(out)
+	rendered := make([]string, len(out))
+	for i, port := range out {
+		rendered[i] = strconv.Itoa(port)
+	}
+	return rendered, nil
+}
+
+// crewExposedPortsLabelSeparator joins port numbers inside the provider
+// label. We use `-` rather than `,` because sanitizeProviderLabelValue
+// rewrites any character outside [A-Za-z0-9_.-] to `_`, which would corrupt a
+// comma-separated list at storage time.
+const crewExposedPortsLabelSeparator = "-"
+
+// renderExposedPortsLabel turns a normalized port list into the
+// label-safe form written into the provider label. Returns "" for an empty
+// list so callers can use the helper unconditionally and skip emission when
+// no ports are exposed.
+func renderExposedPortsLabel(ports []string) string {
+	if len(ports) == 0 {
+		return ""
+	}
+	return strings.Join(ports, crewExposedPortsLabelSeparator)
+}
+
+// parseExposedPortsLabel inverts renderExposedPortsLabel. Unparseable tokens
+// are skipped silently so a half-corrupted label never aborts the connect
+// flow; the upstream writer is authoritative and any garbage there is an
+// upstream bug we surface in tests rather than at runtime.
+func parseExposedPortsLabel(value string) []int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	out := []int{}
+	for _, part := range strings.Split(value, crewExposedPortsLabelSeparator) {
+		port, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || port <= 0 || port > crewMaxExposedPort {
+			continue
+		}
+		out = append(out, port)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// crewMember is the projection of a Server crew connect consumes. The
+// connect orchestration only needs the name shown in rendered hosts, the
+// SSHTarget used to launch ssh, and the declared exposed ports.
+type crewMember struct {
+	Name  string
+	SSH   SSHTarget
+	Ports []int
+	Lease string
+}
+
+// crewMeshForward is one (peer, port) pair plus the loopback port the
+// operator-side allocator assigned to it. The doctor sub-check counts these
+// to report the SSH-mesh plane status without re-running the orchestration.
+type crewMeshForward struct {
+	Peer       string
+	RemotePort int
+	LocalPort  int
+	LeaseID    string
+}
+
+// crewMeshSummary captures the operator-visible result of preparing a
+// connect: the forwards, the path of the rendered hosts file, and the env
+// export lines so the same object can be returned from tests or rendered to
+// stdout in production.
+type crewMeshSummary struct {
+	HostsPath string
+	EnvPath   string
+	Exports   []string
+	Forwards  []crewMeshForward
+}
+
+// crewConnectOptions bundles the dependencies the orchestration needs.
+// Production wires App.Stdout/Stderr + the real runner; tests substitute a
+// recorder so the suite never spawns processes or touches HOME.
+type crewConnectOptions struct {
+	Stdout    io.Writer
+	Stderr    io.Writer
+	HomeDir   string
+	Runner    crewMeshRunner
+	PortAlloc func(used map[int]bool) (int, error)
+}
+
+// (a App) crewConnect is the Kong-dispatched entry point. It reads crew
+// members, computes the forward table, writes hosts + env, prints the
+// operator-visible exports, then holds the connections open until the
+// context is cancelled (Ctrl-C). Errors during teardown are best-effort:
+// the operator already knows the connect is over by the time we get there.
+func (a App) crewConnect(ctx context.Context, args []string) error {
+	defaults := defaultConfig()
+	fs := newFlagSet("crew connect", a.Stderr)
+	provider := fs.String("provider", defaults.Provider, providerHelpAll())
+	jsonOut := fs.Bool("json", false, "print the forward table as JSON and exit")
+	exportOnly := fs.Bool("export", false, "print shell exports for the rendered hosts and exit")
+	providerFlags := registerProviderFlags(fs, defaults)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return exit(2, "usage: crabbox crew connect <name>")
+	}
+	crew, err := requestedCrewName(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	if crew == "" {
+		return exit(2, "usage: crabbox crew connect <name>")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	cfg.Provider = *provider
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
+		return err
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return err
+	}
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok {
+		return exit(2, "provider=%s does not expose SSH leases; crew connect requires an SSH-mesh-capable provider", backend.Spec().Name)
+	}
+	servers, err := sshBackend.List(ctx, ListRequest{Options: leaseOptionsFromConfig(cfg)})
+	if err != nil {
+		return err
+	}
+	members, err := collectCrewMembers(ctx, sshBackend, cfg, servers, crew)
+	if err != nil {
+		return err
+	}
+	opts := crewConnectOptions{Stdout: a.Stdout, Stderr: a.Stderr, HomeDir: os.Getenv("HOME"), Runner: crewMeshDefaultRunner}
+	summary, err := prepareCrewMeshSummary(crew, members, opts)
+	if err != nil {
+		return err
+	}
+	if len(summary.Forwards) == 0 {
+		fmt.Fprintf(a.Stderr, "crew %q has no members declaring --expose; nothing to forward\n", crew)
+		return nil
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(summary)
+	}
+	if *exportOnly {
+		for _, line := range summary.Exports {
+			fmt.Fprintln(a.Stdout, line)
+		}
+		return nil
+	}
+	fmt.Fprintf(a.Stdout, "crew %q SSH-mesh ready (%d forwards)\n", crew, len(summary.Forwards))
+	for _, line := range summary.Exports {
+		fmt.Fprintln(a.Stdout, line)
+	}
+	fmt.Fprintf(a.Stdout, "wrote %s\nwrote %s\n", summary.HostsPath, summary.EnvPath)
+	return runCrewMeshForwards(ctx, opts, members, summary)
+}
+
+// collectCrewMembers narrows a backend's list output to the crew of interest
+// and resolves each member's SSHTarget. Servers without an exposed-ports
+// label are kept in the projection (Ports is empty) so the no-op case is
+// observable to callers and to doctor.
+func collectCrewMembers(ctx context.Context, backend SSHLeaseBackend, cfg Config, servers []Server, crew string) ([]crewMember, error) {
+	servers = filterServersByCrew(servers, crew)
+	out := make([]crewMember, 0, len(servers))
+	for _, server := range servers {
+		lease, err := backend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: serverSlug(server)})
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s: %w", server.Name, err)
+		}
+		name := strings.TrimSpace(serverSlug(server))
+		if name == "" {
+			name = lease.LeaseID
+		}
+		out = append(out, crewMember{
+			Name:  name,
+			SSH:   lease.SSH,
+			Ports: parseExposedPortsLabel(server.Labels[crewExposedPortsLabelKey]),
+			Lease: lease.LeaseID,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// prepareCrewMeshSummary builds the forward table and renders hosts + env
+// files under HOME. It does not spawn processes; orchestration is split out
+// so the rendering is unit-testable in isolation from any ssh exec.
+func prepareCrewMeshSummary(crew string, members []crewMember, opts crewConnectOptions) (crewMeshSummary, error) {
+	used := map[int]bool{}
+	alloc := opts.PortAlloc
+	if alloc == nil {
+		alloc = allocateLocalForwardPort
+	}
+	forwards := []crewMeshForward{}
+	for _, member := range members {
+		for _, port := range member.Ports {
+			localPort, err := alloc(used)
+			if err != nil {
+				return crewMeshSummary{}, err
+			}
+			used[localPort] = true
+			forwards = append(forwards, crewMeshForward{
+				Peer:       member.Name,
+				RemotePort: port,
+				LocalPort:  localPort,
+				LeaseID:    member.Lease,
+			})
+		}
+	}
+	if len(forwards) == 0 {
+		return crewMeshSummary{}, nil
+	}
+	hostsPath, envPath, err := crewMeshHostsAndEnvPaths(opts.HomeDir, crew)
+	if err != nil {
+		return crewMeshSummary{}, err
+	}
+	hostsBody := renderCrewMeshHostsFile(forwards)
+	envBody, exports := renderCrewMeshEnvFile(forwards)
+	if err := writeCrewMeshStateFile(hostsPath, hostsBody); err != nil {
+		return crewMeshSummary{}, err
+	}
+	if err := writeCrewMeshStateFile(envPath, envBody); err != nil {
+		return crewMeshSummary{}, err
+	}
+	return crewMeshSummary{HostsPath: hostsPath, EnvPath: envPath, Exports: exports, Forwards: forwards}, nil
+}
+
+// allocateLocalForwardPort walks the operator-side window looking for a free
+// loopback port not already in the in-flight allocation set. It probes the
+// kernel with a listen(0) bind so we never collide with an unrelated service
+// the operator is already running on the same address.
+func allocateLocalForwardPort(used map[int]bool) (int, error) {
+	for port := crewMeshLocalPortStart; port <= crewMeshLocalPortEnd; port++ {
+		if used[port] {
+			continue
+		}
+		addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			continue
+		}
+		_ = listener.Close()
+		return port, nil
+	}
+	return 0, exit(7, "no free loopback ports between %d and %d for SSH-mesh forwards", crewMeshLocalPortStart, crewMeshLocalPortEnd)
+}
+
+// crewMeshHostsAndEnvPaths returns the absolute paths to the per-crew state
+// files under HOME. The parent directory is created with 0700 so the layout
+// matches the rest of ~/.crabbox.
+func crewMeshHostsAndEnvPaths(home, crew string) (string, string, error) {
+	if home == "" {
+		return "", "", exit(2, "HOME is unset; cannot write crew SSH-mesh state files")
+	}
+	dir := filepath.Join(home, crewMeshHostsRoot, crew)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", err
+	}
+	return filepath.Join(dir, crewMeshHostsFileName), filepath.Join(dir, crewMeshEnvFileName), nil
+}
+
+// renderCrewMeshHostsFile renders the operator-visible hosts table that maps
+// `<peer>.cbx` (with `<peer>:<port>.cbx` for multi-port peers) to its assigned
+// loopback port. The format mirrors /etc/hosts so an operator can paste the
+// content into their resolver if they choose.
+func renderCrewMeshHostsFile(forwards []crewMeshForward) string {
+	var b strings.Builder
+	b.WriteString("# crabbox crew SSH-mesh — operator-side forwards\n")
+	b.WriteString("# Format: <local-port> <peer>.cbx\n")
+	for _, fwd := range forwards {
+		fmt.Fprintf(&b, "127.0.0.1:%d  %s.cbx (remote :%d)\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+	}
+	return b.String()
+}
+
+// renderCrewMeshEnvFile renders the shell-export snippet and the list of
+// individual export lines used by `crew connect --export`. The snippet is
+// stable across re-runs with the same forward set so `eval $(crabbox crew
+// connect --export)` is safe to re-run.
+func renderCrewMeshEnvFile(forwards []crewMeshForward) (string, []string) {
+	exports := make([]string, 0, len(forwards))
+	var b strings.Builder
+	b.WriteString("# crabbox crew SSH-mesh — eval $(crabbox crew connect <name> --export)\n")
+	for _, fwd := range forwards {
+		line := fmt.Sprintf("export CRABBOX_CREW_%s_%d=127.0.0.1:%d", strings.ToUpper(envSafeName(fwd.Peer)), fwd.RemotePort, fwd.LocalPort)
+		exports = append(exports, line)
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), exports
+}
+
+// envSafeName collapses anything outside [A-Z0-9_] in a peer name so the
+// resulting variable name is a valid shell identifier. Empty inputs fold to
+// "_" so the helper never panics on edge cases the caller has already
+// validated upstream.
+func envSafeName(name string) string {
+	name = strings.ToUpper(strings.TrimSpace(name))
+	if name == "" {
+		return "_"
+	}
+	var b strings.Builder
+	for _, r := range name {
+		ok := (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+// writeCrewMeshStateFile persists rendered content with 0600 permissions so
+// the hosts and env files sit alongside other Crabbox per-user secrets in
+// terms of disk-level posture.
+func writeCrewMeshStateFile(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o600)
+}
+
+// crewMeshSSHArgsForForward builds the `ssh -L ...` argument vector for one
+// forward. It re-uses sshBaseArgs so ControlMaster + key + port options stay
+// identical to the rest of the CLI's SSH plumbing — no new transport, no new
+// surface area.
+func crewMeshSSHArgsForForward(target SSHTarget, fwd crewMeshForward) []string {
+	args := append([]string{}, sshBaseArgs(target)...)
+	forward := fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", fwd.LocalPort, fwd.RemotePort)
+	args = append(args,
+		"-N",
+		"-L", forward,
+		target.User+"@"+target.Host,
+	)
+	return args
+}
+
+// runCrewMeshForwards spawns one ssh -L per forward in the summary, waits for
+// ctx cancellation or any process exit, and tears the rest down. The
+// orchestration is deliberately simple: ControlMaster + ControlPersist (from
+// sshBaseArgs) reuses a single underlying TCP connection per peer so the
+// fan-out is cheap.
+func runCrewMeshForwards(ctx context.Context, opts crewConnectOptions, members []crewMember, summary crewMeshSummary) error {
+	runner := opts.Runner
+	if runner == nil {
+		runner = crewMeshDefaultRunner
+	}
+	peerTarget := map[string]SSHTarget{}
+	for _, member := range members {
+		peerTarget[member.Name] = member.SSH
+	}
+	type runningForward struct {
+		fwd    crewMeshForward
+		handle crewMeshHandle
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	running := []runningForward{}
+	for _, fwd := range summary.Forwards {
+		target, ok := peerTarget[fwd.Peer]
+		if !ok {
+			cancel()
+			return exit(7, "no SSH target resolved for crew peer %q", fwd.Peer)
+		}
+		args := crewMeshSSHArgsForForward(target, fwd)
+		handle := runner.Command(ctx, "ssh", args...)
+		if err := handle.Start(); err != nil {
+			cancel()
+			return fmt.Errorf("start ssh -L %d:%d for %s: %w", fwd.LocalPort, fwd.RemotePort, fwd.Peer, err)
+		}
+		running = append(running, runningForward{fwd: fwd, handle: handle})
+		fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+	}
+	var wg sync.WaitGroup
+	var firstErr error
+	var firstErrOnce sync.Once
+	for _, rf := range running {
+		wg.Add(1)
+		go func(rf runningForward) {
+			defer wg.Done()
+			err := rf.handle.Wait()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				firstErrOnce.Do(func() { firstErr = err })
+			}
+			cancel()
+		}(rf)
+	}
+	<-ctx.Done()
+	for _, rf := range running {
+		if proc := rf.handle.Process(); proc != nil {
+			_ = proc.Signal(os.Interrupt)
+		}
+	}
+	wg.Wait()
+	if firstErr != nil && ctx.Err() == nil {
+		return firstErr
+	}
+	return nil
+}
+
+// crewMeshDoctorCounts inspects a slice of servers (already filtered by
+// crew) and returns the per-plane summary doctor surfaces. The function is
+// intentionally pure: no network, no SSH, no provider calls. doctor invokes
+// it from doctorCrewMeshSummary so the test suite exercises every branch
+// without spawning subprocesses.
+func crewMeshDoctorCounts(servers []Server) (memberCount, exposedCount, totalPorts int) {
+	for _, server := range servers {
+		memberCount++
+		ports := parseExposedPortsLabel(server.Labels[crewExposedPortsLabelKey])
+		if len(ports) > 0 {
+			exposedCount++
+			totalPorts += len(ports)
+		}
+	}
+	return memberCount, exposedCount, totalPorts
+}

--- a/internal/cli/crew_mesh_test.go
+++ b/internal/cli/crew_mesh_test.go
@@ -1,0 +1,448 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// crewMeshRecordingHandle is the test double for crewMeshHandle. It records
+// the argv at Start() and blocks Wait() on the signal channel so the orchestration
+// loop can be terminated deterministically without real ssh processes.
+type crewMeshRecordingHandle struct {
+	name    string
+	args    []string
+	started bool
+	signal  chan struct{}
+	mu      sync.Mutex
+}
+
+func (h *crewMeshRecordingHandle) Start() error {
+	h.mu.Lock()
+	h.started = true
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *crewMeshRecordingHandle) Wait() error {
+	<-h.signal
+	return nil
+}
+
+func (h *crewMeshRecordingHandle) String() string {
+	return h.name + " " + strings.Join(h.args, " ")
+}
+
+func (h *crewMeshRecordingHandle) Process() processSignaler { return testProcessSignaler{h.signal} }
+
+// testProcessSignaler closes the underlying channel on the first signal so
+// the handle's Wait() returns.
+type testProcessSignaler struct {
+	signal chan struct{}
+}
+
+func (p testProcessSignaler) Signal(_ os.Signal) error {
+	select {
+	case <-p.signal:
+	default:
+		close(p.signal)
+	}
+	return nil
+}
+
+func (p testProcessSignaler) Kill() error {
+	return p.Signal(nil)
+}
+
+// crewMeshRecordingRunner mirrors the exedev backend's pattern: it captures
+// every (name, args) invocation it sees so tests can assert on the full SSH
+// argument vector without spawning processes.
+type crewMeshRecordingRunner struct {
+	mu      sync.Mutex
+	calls   [][]string
+	handles []*crewMeshRecordingHandle
+}
+
+func (r *crewMeshRecordingRunner) Command(_ context.Context, name string, args ...string) crewMeshHandle {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string{name}, args...))
+	h := &crewMeshRecordingHandle{name: name, args: append([]string{}, args...), signal: make(chan struct{})}
+	r.handles = append(r.handles, h)
+	return h
+}
+
+func TestRequestedExposedPortsAcceptsValidPorts(t *testing.T) {
+	got, err := requestedExposedPorts([]string{"8080", "9090", "9090", "80,443"})
+	if err != nil {
+		t.Fatalf("requestedExposedPorts: %v", err)
+	}
+	want := []string{"80", "443", "8080", "9090"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ports=%v want %v", got, want)
+	}
+}
+
+func TestRequestedExposedPortsRejectsBadInput(t *testing.T) {
+	cases := []string{"abc", "0", "70000", "-1", ""}
+	for _, in := range cases {
+		if _, err := requestedExposedPorts([]string{in}); err == nil {
+			t.Fatalf("expected error for input %q", in)
+		}
+	}
+}
+
+func TestRequestedExposedPortsCaps(t *testing.T) {
+	values := []string{}
+	for port := 8000; port < 8000+crewMaxExposedPortsPerLease+1; port++ {
+		values = append(values, intString(port))
+	}
+	if _, err := requestedExposedPorts(values); err == nil {
+		t.Fatalf("expected error when more than %d ports requested", crewMaxExposedPortsPerLease)
+	}
+}
+
+func intString(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	for value > 0 {
+		digits = append([]byte{byte('0' + value%10)}, digits...)
+		value /= 10
+	}
+	if negative {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}
+
+func TestApplyLeaseCreateFlagsSetsExposedPorts(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--expose", "8080", "--expose", "9090"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyLeaseCreateFlags: %v", err)
+	}
+	want := []string{"8080", "9090"}
+	if !reflect.DeepEqual(cfg.ExposedPorts, want) {
+		t.Fatalf("cfg.ExposedPorts=%v want %v", cfg.ExposedPorts, want)
+	}
+}
+
+func TestDirectLeaseLabelsRecordExposedPorts(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:        "standard",
+		Profile:      "default",
+		ProviderKey:  "crabbox-cbx-abcdef123456",
+		ServerType:   "cpx62",
+		Crew:         "alpha",
+		ExposedPorts: []string{"8080", "9090"},
+		TTL:          15 * time.Minute,
+		IdleTimeout:  4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if labels[crewExposedPortsLabelKey] != "8080-9090" {
+		t.Fatalf("crabbox_exposed_ports label=%q want 8080-9090; full=%#v", labels[crewExposedPortsLabelKey], labels)
+	}
+}
+
+func TestDirectLeaseLabelsOmitExposedPortsWhenEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:       "standard",
+		Profile:     "default",
+		ProviderKey: "crabbox-cbx-abcdef123456",
+		ServerType:  "cpx62",
+		TTL:         15 * time.Minute,
+		IdleTimeout: 4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if _, ok := labels[crewExposedPortsLabelKey]; ok {
+		t.Fatalf("expected no exposed-ports label when none requested; got %#v", labels)
+	}
+}
+
+func TestParseExposedPortsLabelTolerantOfGarbage(t *testing.T) {
+	got := parseExposedPortsLabel("8080-xyz-9090-bad-80")
+	want := []int{80, 8080, 9090}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ports=%v want %v", got, want)
+	}
+	if got := parseExposedPortsLabel("  "); len(got) != 0 {
+		t.Fatalf("empty label should produce no ports; got %v", got)
+	}
+	if got := parseExposedPortsLabel("99999999"); len(got) != 0 {
+		t.Fatalf("out-of-range token should be dropped; got %v", got)
+	}
+}
+
+func TestCrewMeshDoctorCounts(t *testing.T) {
+	servers := []Server{
+		{Name: "web", Labels: map[string]string{crewLabelKey: "alpha", crewExposedPortsLabelKey: "8080-9090"}},
+		{Name: "client", Labels: map[string]string{crewLabelKey: "alpha"}},
+		{Name: "worker", Labels: map[string]string{crewLabelKey: "alpha", crewExposedPortsLabelKey: "3000"}},
+	}
+	members, exposed, ports := crewMeshDoctorCounts(servers)
+	if members != 3 || exposed != 2 || ports != 3 {
+		t.Fatalf("counts=(%d,%d,%d) want (3,2,3)", members, exposed, ports)
+	}
+}
+
+func TestCrewMeshDoctorCountsEmpty(t *testing.T) {
+	members, exposed, ports := crewMeshDoctorCounts(nil)
+	if members != 0 || exposed != 0 || ports != 0 {
+		t.Fatalf("counts=(%d,%d,%d) want (0,0,0)", members, exposed, ports)
+	}
+}
+
+func TestPrepareCrewMeshSummaryRendersHostsAndEnv(t *testing.T) {
+	tmp := t.TempDir()
+	members := []crewMember{
+		{Name: "web", SSH: SSHTarget{User: "ubuntu", Host: "1.2.3.4", Port: "22"}, Ports: []int{8080}, Lease: "cbx_aaa"},
+		{Name: "worker", SSH: SSHTarget{User: "ubuntu", Host: "5.6.7.8", Port: "22"}, Ports: []int{3000, 4000}, Lease: "cbx_bbb"},
+	}
+	allocPort := 60000
+	opts := crewConnectOptions{
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+		HomeDir: tmp,
+		PortAlloc: func(used map[int]bool) (int, error) {
+			for {
+				allocPort++
+				if !used[allocPort] {
+					return allocPort, nil
+				}
+			}
+		},
+	}
+	summary, err := prepareCrewMeshSummary("alpha", members, opts)
+	if err != nil {
+		t.Fatalf("prepareCrewMeshSummary: %v", err)
+	}
+	if len(summary.Forwards) != 3 {
+		t.Fatalf("forwards=%d want 3", len(summary.Forwards))
+	}
+	if summary.Forwards[0].Peer != "web" || summary.Forwards[0].RemotePort != 8080 {
+		t.Fatalf("first forward unexpected: %#v", summary.Forwards[0])
+	}
+	for i := 1; i < len(summary.Forwards); i++ {
+		if summary.Forwards[i].LocalPort == summary.Forwards[i-1].LocalPort {
+			t.Fatalf("duplicate local port %d in forwards %#v", summary.Forwards[i].LocalPort, summary.Forwards)
+		}
+	}
+	hostsBody, err := os.ReadFile(summary.HostsPath)
+	if err != nil {
+		t.Fatalf("read hosts: %v", err)
+	}
+	if !strings.Contains(string(hostsBody), "web.cbx") || !strings.Contains(string(hostsBody), "worker.cbx") {
+		t.Fatalf("hosts file missing peer entries: %s", hostsBody)
+	}
+	envBody, err := os.ReadFile(summary.EnvPath)
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	if !strings.Contains(string(envBody), "CRABBOX_CREW_WEB_8080") {
+		t.Fatalf("env file missing CRABBOX_CREW_WEB_8080: %s", envBody)
+	}
+	wantHostsPath := filepath.Join(tmp, crewMeshHostsRoot, "alpha", crewMeshHostsFileName)
+	if summary.HostsPath != wantHostsPath {
+		t.Fatalf("HostsPath=%q want %q", summary.HostsPath, wantHostsPath)
+	}
+}
+
+func TestPrepareCrewMeshSummaryEmpty(t *testing.T) {
+	opts := crewConnectOptions{Stdout: io.Discard, Stderr: io.Discard, HomeDir: t.TempDir()}
+	summary, err := prepareCrewMeshSummary("alpha", nil, opts)
+	if err != nil {
+		t.Fatalf("prepareCrewMeshSummary empty: %v", err)
+	}
+	if len(summary.Forwards) != 0 {
+		t.Fatalf("expected zero forwards from empty input; got %d", len(summary.Forwards))
+	}
+}
+
+func TestPrepareCrewMeshSummarySkipsMembersWithoutPorts(t *testing.T) {
+	tmp := t.TempDir()
+	members := []crewMember{
+		{Name: "no-ports", SSH: SSHTarget{User: "ubuntu", Host: "1.2.3.4", Port: "22"}},
+		{Name: "web", SSH: SSHTarget{User: "ubuntu", Host: "5.6.7.8", Port: "22"}, Ports: []int{8080}},
+	}
+	allocPort := 60500
+	opts := crewConnectOptions{
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+		HomeDir: tmp,
+		PortAlloc: func(used map[int]bool) (int, error) {
+			for {
+				allocPort++
+				if !used[allocPort] {
+					return allocPort, nil
+				}
+			}
+		},
+	}
+	summary, err := prepareCrewMeshSummary("alpha", members, opts)
+	if err != nil {
+		t.Fatalf("prepareCrewMeshSummary: %v", err)
+	}
+	if len(summary.Forwards) != 1 || summary.Forwards[0].Peer != "web" {
+		t.Fatalf("expected only one forward for web; got %#v", summary.Forwards)
+	}
+}
+
+func TestCrewMeshSSHArgsBuildsLocalForward(t *testing.T) {
+	target := SSHTarget{User: "ubuntu", Host: "lease.example", Port: "22", Key: "/tmp/test-key"}
+	fwd := crewMeshForward{Peer: "web", RemotePort: 8080, LocalPort: 51900, LeaseID: "cbx_x"}
+	args := crewMeshSSHArgsForForward(target, fwd)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-L 127.0.0.1:51900:127.0.0.1:8080") {
+		t.Fatalf("args missing -L spec: %v", args)
+	}
+	if !strings.Contains(joined, "ubuntu@lease.example") {
+		t.Fatalf("args missing user@host: %v", args)
+	}
+	if !strings.Contains(joined, "-N") {
+		t.Fatalf("args missing -N (no remote command): %v", args)
+	}
+	if !strings.Contains(joined, "ControlMaster=auto") && !strings.Contains(joined, "ControlMaster=no") {
+		t.Fatalf("args missing ControlMaster option: %v", args)
+	}
+}
+
+func TestRunCrewMeshForwardsLaunchesPerForwardAndTearsDown(t *testing.T) {
+	runner := &crewMeshRecordingRunner{}
+	members := []crewMember{
+		{Name: "web", SSH: SSHTarget{User: "ubuntu", Host: "lease-web.example", Port: "22"}, Ports: []int{8080}},
+		{Name: "worker", SSH: SSHTarget{User: "ubuntu", Host: "lease-worker.example", Port: "22"}, Ports: []int{3000, 4000}},
+	}
+	forwards := []crewMeshForward{
+		{Peer: "web", RemotePort: 8080, LocalPort: 60000},
+		{Peer: "worker", RemotePort: 3000, LocalPort: 60001},
+		{Peer: "worker", RemotePort: 4000, LocalPort: 60002},
+	}
+	summary := crewMeshSummary{Forwards: forwards}
+	opts := crewConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: runner}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- runCrewMeshForwards(ctx, opts, members, summary) }()
+	deadline := time.After(2 * time.Second)
+	for {
+		runner.mu.Lock()
+		count := len(runner.handles)
+		runner.mu.Unlock()
+		if count >= 3 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("only %d handles started after 2s", count)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runCrewMeshForwards did not return after context cancel")
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runCrewMeshForwards: %v", err)
+		}
+	}
+	if got := len(runner.calls); got != 3 {
+		t.Fatalf("expected 3 ssh invocations, got %d (%v)", got, runner.calls)
+	}
+	// Verify each ssh invocation carries the right -L spec.
+	wantSpecs := []string{
+		"127.0.0.1:60000:127.0.0.1:8080",
+		"127.0.0.1:60001:127.0.0.1:3000",
+		"127.0.0.1:60002:127.0.0.1:4000",
+	}
+	gotSpecs := []string{}
+	for _, call := range runner.calls {
+		if call[0] != "ssh" {
+			t.Fatalf("expected ssh invocation, got %v", call)
+		}
+		for i, arg := range call {
+			if arg == "-L" && i+1 < len(call) {
+				gotSpecs = append(gotSpecs, call[i+1])
+			}
+		}
+	}
+	sort.Strings(wantSpecs)
+	sort.Strings(gotSpecs)
+	if !reflect.DeepEqual(wantSpecs, gotSpecs) {
+		t.Fatalf("forward specs=%v want %v", gotSpecs, wantSpecs)
+	}
+}
+
+func TestEnvSafeName(t *testing.T) {
+	cases := map[string]string{
+		"web":         "WEB",
+		"client-foo":  "CLIENT_FOO",
+		"a.b/c":       "A_B_C",
+		"  ":          "_",
+		"123-name":    "123_NAME",
+		"crew/peer-1": "CREW_PEER_1",
+	}
+	for in, want := range cases {
+		if got := envSafeName(in); got != want {
+			t.Fatalf("envSafeName(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderCrewMeshHostsFileIncludesAllPeers(t *testing.T) {
+	body := renderCrewMeshHostsFile([]crewMeshForward{
+		{Peer: "web", RemotePort: 8080, LocalPort: 51820},
+		{Peer: "worker", RemotePort: 3000, LocalPort: 51821},
+	})
+	if !strings.Contains(body, "127.0.0.1:51820") || !strings.Contains(body, "127.0.0.1:51821") {
+		t.Fatalf("hosts body missing local ports: %s", body)
+	}
+	if !strings.Contains(body, "web.cbx") || !strings.Contains(body, "worker.cbx") {
+		t.Fatalf("hosts body missing peer names: %s", body)
+	}
+}
+
+func TestRenderCrewMeshEnvFileEmitsStableExports(t *testing.T) {
+	body, exports := renderCrewMeshEnvFile([]crewMeshForward{
+		{Peer: "web", RemotePort: 8080, LocalPort: 51820},
+		{Peer: "worker", RemotePort: 3000, LocalPort: 51821},
+	})
+	if len(exports) != 2 {
+		t.Fatalf("exports=%d want 2", len(exports))
+	}
+	if !strings.Contains(exports[0], "export CRABBOX_CREW_WEB_8080=127.0.0.1:51820") {
+		t.Fatalf("unexpected first export: %q", exports[0])
+	}
+	if !strings.Contains(body, "CRABBOX_CREW_WORKER_3000=127.0.0.1:51821") {
+		t.Fatalf("env body missing worker export: %s", body)
+	}
+}

--- a/internal/cli/crew_test.go
+++ b/internal/cli/crew_test.go
@@ -1,0 +1,514 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeCrewName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"alpha", "alpha"},
+		{"  Alpha  ", "alpha"},
+		{"alpha-bravo", "alpha-bravo"},
+		{"Alpha_Bravo Charlie", "alpha-bravo-charlie"},
+		{"---alpha---", "alpha"},
+		{"alpha//bravo??", "alpha-bravo"},
+		{"crew!!", "crew"},
+		{"123-abc", "123-abc"},
+	}
+	for _, tc := range cases {
+		if got := normalizeCrewName(tc.in); got != tc.want {
+			t.Fatalf("normalizeCrewName(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRequestedCrewNameValidates(t *testing.T) {
+	got, err := requestedCrewName(" Alpha Crew ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "alpha-crew" {
+		t.Fatalf("crew=%q want alpha-crew", got)
+	}
+	if got, err := requestedCrewName(""); err != nil || got != "" {
+		t.Fatalf("empty input got=%q err=%v", got, err)
+	}
+	if _, err := requestedCrewName("!!"); err == nil {
+		t.Fatalf("expected error for crew with no alnum")
+	}
+	tooLong := strings.Repeat("a", maxRequestedCrewNameLength+1)
+	if _, err := requestedCrewName(tooLong); err == nil {
+		t.Fatalf("expected error for crew %d chars", maxRequestedCrewNameLength+1)
+	}
+}
+
+func TestDirectLeaseLabelsRecordCrew(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:       "standard",
+		Profile:     "default",
+		ProviderKey: "crabbox-cbx-abcdef123456",
+		ServerType:  "cpx62",
+		Crew:        "alpha",
+		TTL:         15 * time.Minute,
+		IdleTimeout: 4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if labels["crew"] != "alpha" {
+		t.Fatalf("crew label=%q want alpha; full=%#v", labels["crew"], labels)
+	}
+}
+
+func TestDirectLeaseLabelsOmitCrewWhenEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Class:       "standard",
+		Profile:     "default",
+		ProviderKey: "crabbox-cbx-abcdef123456",
+		ServerType:  "cpx62",
+		TTL:         15 * time.Minute,
+		IdleTimeout: 4 * time.Minute,
+	}
+	labels := directLeaseLabels(cfg, "cbx_abcdef123456", "blue-lobster", "hetzner", "", true, now)
+	if _, ok := labels["crew"]; ok {
+		t.Fatalf("crew label should be omitted when cfg.Crew is empty; got %#v", labels)
+	}
+}
+
+func TestFilterServersByCrew(t *testing.T) {
+	servers := []Server{
+		{Name: "a", Labels: map[string]string{"crew": "alpha"}},
+		{Name: "b", Labels: map[string]string{"crew": "bravo"}},
+		{Name: "c", Labels: map[string]string{}},
+		{Name: "d", Labels: map[string]string{"crew": "Alpha"}},
+	}
+	got := filterServersByCrew(servers, "alpha")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 servers for crew=alpha, got %d (%#v)", len(got), got)
+	}
+	if got[0].Name != "a" || got[1].Name != "d" {
+		t.Fatalf("filtered set unexpected: %#v", got)
+	}
+	if same := filterServersByCrew(servers, ""); len(same) != len(servers) {
+		t.Fatalf("empty filter should be a no-op, got %d", len(same))
+	}
+	if none := filterServersByCrew(servers, "charlie"); len(none) != 0 {
+		t.Fatalf("expected zero matches for crew=charlie, got %d", len(none))
+	}
+}
+
+func TestApplyLeaseCreateFlagsSetsCrew(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "Alpha Crew"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyLeaseCreateFlags: %v", err)
+	}
+	if cfg.Crew != "alpha-crew" {
+		t.Fatalf("cfg.Crew=%q want alpha-crew", cfg.Crew)
+	}
+	opts := leaseOptionsFromConfig(cfg)
+	if opts.Crew != "alpha-crew" {
+		t.Fatalf("leaseOptionsFromConfig.Crew=%q want alpha-crew", opts.Crew)
+	}
+}
+
+func TestApplyLeaseCreateFlagsRejectsBadCrew(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "!!"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err == nil {
+		t.Fatalf("expected error for invalid --crew")
+	}
+}
+
+func TestFilterJSONListViewByCrew(t *testing.T) {
+	view := []any{
+		map[string]any{"id": "a", "labels": map[string]any{"crew": "alpha"}},
+		map[string]any{"id": "b", "labels": map[string]any{"crew": "bravo"}},
+		map[string]any{"id": "c", "labels": map[string]any{}},
+		map[string]any{"id": "d", "labels": map[string]any{"crew": "Alpha"}},
+		"not-a-map",
+	}
+	filtered := filterJSONListViewByCrew(view, "alpha")
+	out, ok := filtered.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", filtered)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entries, got %d (%#v)", len(out), out)
+	}
+	if same := filterJSONListViewByCrew(view, ""); !sameAny(same, view) {
+		t.Fatalf("empty filter should be identity")
+	}
+	if other := filterJSONListViewByCrew("not-a-list", "alpha"); other != "not-a-list" {
+		t.Fatalf("non-slice view should pass through unchanged, got %#v", other)
+	}
+	unsupported := []any{
+		map[string]any{"id": "native-a", "state": "ready"},
+		map[string]any{"id": "native-b", "state": "leased"},
+	}
+	if same := filterJSONListViewByCrew(unsupported, "alpha"); fmt.Sprintf("%#v", same) != fmt.Sprintf("%#v", unsupported) {
+		t.Fatalf("unlabeled JSON list should pass through unchanged, got %#v", same)
+	}
+}
+
+func sameAny(a, b any) bool {
+	as, aok := a.([]any)
+	bs, bok := b.([]any)
+	if !aok || !bok || len(as) != len(bs) {
+		return false
+	}
+	for i := range as {
+		if _, ok := as[i].(map[string]any); ok {
+			continue
+		}
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCrewTagOwnerTruncatesAndNormalizes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"yossi.eliaz@incredibuild.com", "yossi-e"},
+		{"  Alpha.Bravo@example.com  ", "alpha-b"},
+		{"a@b", "a"},
+		{"!!", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := crewTagOwner(tc.in); got != tc.want {
+			t.Fatalf("crewTagOwner(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCrewTailscaleTagShape(t *testing.T) {
+	if got := crewTailscaleTag("yossi.eliaz@incredibuild.com", "Alpha Crew"); got != "tag:cbx-crew-yossi-e-alpha-crew" {
+		t.Fatalf("crewTailscaleTag=%q want tag:cbx-crew-yossi-e-alpha-crew", got)
+	}
+	if got := crewTailscaleTag("", "alpha"); got != "tag:cbx-crew-user-alpha" {
+		t.Fatalf("crewTailscaleTag empty owner=%q want tag:cbx-crew-user-alpha", got)
+	}
+	if got := crewTailscaleTag("yossi", ""); got != "" {
+		t.Fatalf("crewTailscaleTag empty crew=%q want empty", got)
+	}
+}
+
+func TestAppendCrewTailscaleTag(t *testing.T) {
+	cfg := Config{
+		Crew: "alpha",
+		Tailscale: TailscaleConfig{
+			Enabled: true,
+			Tags:    []string{"tag:crabbox"},
+		},
+	}
+	appendCrewTailscaleTag(&cfg, true)
+	found := false
+	for _, tag := range cfg.Tailscale.Tags {
+		if strings.HasPrefix(tag, "tag:cbx-crew-") && strings.HasSuffix(tag, "-alpha") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected crew tag appended, got %#v", cfg.Tailscale.Tags)
+	}
+	// Idempotent: a second call must not duplicate the entry.
+	before := len(cfg.Tailscale.Tags)
+	appendCrewTailscaleTag(&cfg, true)
+	if len(cfg.Tailscale.Tags) != before {
+		t.Fatalf("appendCrewTailscaleTag duplicated entry; got %#v", cfg.Tailscale.Tags)
+	}
+	// No-op when Tailscale is not enabled.
+	cfg2 := Config{Crew: "alpha", Tailscale: TailscaleConfig{Tags: []string{"tag:crabbox"}}}
+	appendCrewTailscaleTag(&cfg2, true)
+	if len(cfg2.Tailscale.Tags) != 1 {
+		t.Fatalf("expected no-op when Tailscale disabled, got %#v", cfg2.Tailscale.Tags)
+	}
+	// No-op when the provider does not advertise FeatureTailscale.
+	cfg3 := Config{Crew: "alpha", Tailscale: TailscaleConfig{Enabled: true, Tags: []string{"tag:crabbox"}}}
+	appendCrewTailscaleTag(&cfg3, false)
+	if len(cfg3.Tailscale.Tags) != 1 {
+		t.Fatalf("expected no-op when provider lacks FeatureTailscale, got %#v", cfg3.Tailscale.Tags)
+	}
+}
+
+func TestApplyLeaseCreateFlagsAddsCrewTailscaleTag(t *testing.T) {
+	defaults := Config{
+		Provider:    "hetzner",
+		Profile:     "default",
+		Class:       "standard",
+		TargetOS:    targetLinux,
+		TTL:         time.Hour,
+		IdleTimeout: 15 * time.Minute,
+		Network:     NetworkAuto,
+		Capacity:    CapacityConfig{Market: "spot"},
+		Tailscale: TailscaleConfig{
+			HostnameTemplate: "crabbox-{slug}",
+			Tags:             []string{"tag:crabbox"},
+		},
+	}
+	fs := flag.NewFlagSet("warmup", flag.ContinueOnError)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := fs.Parse([]string{"--crew", "alpha", "--tailscale"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyLeaseCreateFlags: %v", err)
+	}
+	if !cfg.Tailscale.Enabled {
+		t.Fatalf("expected Tailscale enabled by --tailscale")
+	}
+	hasCrewTag := false
+	for _, tag := range cfg.Tailscale.Tags {
+		if strings.HasPrefix(tag, "tag:cbx-crew-") && strings.HasSuffix(tag, "-alpha") {
+			hasCrewTag = true
+		}
+	}
+	if !hasCrewTag {
+		t.Fatalf("expected crew Tailscale tag on cfg, got %#v", cfg.Tailscale.Tags)
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapEmittedWhenCrewAndTailscale(t *testing.T) {
+	cfg := baseConfig()
+	cfg.SSHUser = "runner"
+	cfg.Crew = "alpha"
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = "tskey-secret"
+	cfg.Tailscale.Tags = []string{"tag:crabbox", "tag:cbx-crew-user-alpha"}
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	for _, want := range []string{
+		"/etc/hosts.cbx",
+		"/usr/local/bin/crabbox-crew-hosts",
+		"/etc/systemd/system/crabbox-crew-hosts.service",
+		"/etc/systemd/system/crabbox-crew-hosts.timer",
+		"/etc/hosts",
+		"# crabbox crew hosts begin",
+		"# crabbox crew hosts end",
+		"OnUnitActiveSec=30s",
+		"ExecStart=/usr/local/bin/crabbox-crew-hosts",
+		"tag:cbx-crew-",
+		"tailscale status --json",
+		"systemctl enable --now crabbox-crew-hosts.timer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("cloudInit(crew) missing %q", want)
+		}
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapAbsentWithoutCrew(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.AuthKey = "tskey-secret"
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	if strings.Contains(got, "crabbox-crew-hosts") {
+		t.Fatalf("cloudInit without --crew must not install crew hosts service")
+	}
+}
+
+func TestCloudInitCrewHostsBootstrapAbsentWithoutTailscale(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Crew = "alpha"
+	got := cloudInit(cfg, "ssh-ed25519 test")
+	if strings.Contains(got, "crabbox-crew-hosts") {
+		t.Fatalf("cloudInit without --tailscale must not install crew hosts service even when --crew is set")
+	}
+}
+
+// stubDoctorTailscaleACLClient lets unit tests exercise doctorCrewSummary
+// without touching the real Tailscale API.
+type stubDoctorTailscaleACLClient struct {
+	policy string
+	err    error
+}
+
+func (s stubDoctorTailscaleACLClient) PolicyHuJSON(_ context.Context, _ string) (string, error) {
+	return s.policy, s.err
+}
+
+func TestDoctorCrewSummaryNoopsWithoutCrew(t *testing.T) {
+	cfg := Config{Provider: "hetzner"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "" || message != "" || details != nil {
+		t.Fatalf("expected no crew check without cfg.Crew, got status=%q msg=%q details=%#v", status, message, details)
+	}
+}
+
+func TestDoctorCrewSummarySkipsNonTailscaleProviderWithCrew(t *testing.T) {
+	cfg := Config{Provider: "e2b", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "skip" {
+		t.Fatalf("expected skip, got %q", status)
+	}
+	want := `crew "alpha": provider e2b does not support the Tailscale plane; crew networking unavailable`
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["reason"] != "provider_not_tailscale_capable" {
+		t.Fatalf("expected reason metadata, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummarySkipsWhenAPIKeyMissing(t *testing.T) {
+	t.Setenv("TS_API_KEY", "")
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, _, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "skip" {
+		t.Fatalf("expected skip when TS_API_KEY is missing, got %q", status)
+	}
+	if details["reason"] != "ts_api_key_missing" {
+		t.Fatalf("expected ts_api_key_missing reason, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryOKWhenACLPresent(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	tag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	policy := crewPolicyFixture(tag)
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{policy: policy}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "ok" {
+		t.Fatalf("expected ok, got %q (msg=%q details=%#v)", status, message, details)
+	}
+	wantTag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	want := fmt.Sprintf(`crew "alpha": Tailscale plane auto-managed (%s)`, wantTag)
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["mode"] != "auto-managed" {
+		t.Fatalf("expected mode=auto-managed when TS_API_KEY is set, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryFailsWhenACLMissing(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	policy := crewPolicyFixture("tag:cbx-crew-user-bravo")
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{policy: policy}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, details := doctorCrewSummary(context.Background(), cfg)
+	if status != "failed" {
+		t.Fatalf("expected failed, got %q", status)
+	}
+	wantTag := crewTailscaleTag(localCoordinatorOwner(), "alpha")
+	want := fmt.Sprintf(`crew "alpha": tailnet policy row missing for %s. Run with $TS_API_KEY exported to auto-install, or apply the snippet from docs/features/crew.md`, wantTag)
+	if message != want {
+		t.Fatalf("verdict text drifted\n want: %q\n got:  %q", want, message)
+	}
+	if details["remedy"] == "" {
+		t.Fatalf("expected remedy in details, got %#v", details)
+	}
+}
+
+func TestDoctorCrewSummaryFailsWhenAPIClientErrors(t *testing.T) {
+	t.Setenv("TS_API_KEY", "tskey-api-stub")
+	prev := doctorTailscaleACLClientFactory
+	defer func() { doctorTailscaleACLClientFactory = prev }()
+	doctorTailscaleACLClientFactory = func(_ string) doctorTailscaleACLClient {
+		return stubDoctorTailscaleACLClient{err: fmt.Errorf("tailscale api 401: invalid api key")}
+	}
+	cfg := Config{Provider: "hetzner", Crew: "alpha"}
+	status, message, _ := doctorCrewSummary(context.Background(), cfg)
+	if status != "failed" {
+		t.Fatalf("expected failed, got %q", status)
+	}
+	if !strings.Contains(message, "policy lookup failed") {
+		t.Fatalf("expected policy lookup failure message, got %q", message)
+	}
+}
+
+func TestCrewACLRowPresentChecksConcreteTag(t *testing.T) {
+	tag := "tag:cbx-crew-yossi-e-alpha"
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"both present", crewPolicyFixture(tag), true},
+		{"grants present", crewGrantPolicyFixture(tag), true},
+		{"commented sample before grants", `{
+  // "tagOwners": { "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"] },
+  "tagOwners": { "tag:cbx-crew-yossi-e-alpha": ["autogroup:admin"] },
+  "grants": [{ "src": ["tag:cbx-crew-yossi-e-alpha"], "dst": ["tag:cbx-crew-yossi-e-alpha"], "ip": ["*"] }]
+}`, true},
+		{"different crew", crewPolicyFixture("tag:cbx-crew-yossi-e-bravo"), false},
+		{"missing tagOwners", `{"acls":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:cbx-crew-yossi-e-alpha:*"]}]}`, false},
+		{"missing dst", `{"tagOwners":{"tag:cbx-crew-yossi-e-alpha":["autogroup:admin"]},"acls":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:crabbox:*"]}]}`, false},
+		{"grant src only", `{"tagOwners":{"tag:cbx-crew-yossi-e-alpha":["autogroup:admin"]},"grants":[{"src":["tag:cbx-crew-yossi-e-alpha"],"dst":["tag:crabbox"],"ip":["*"]}]}`, false},
+		{"missing tag mention", `{"acls":[{"src":["*"]}],"tagOwners":{"tag:crabbox":["autogroup:admin"]}}`, false},
+		{"empty body", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := crewACLRowPresent(tc.body, tag); got != tc.want {
+				t.Fatalf("crewACLRowPresent(%q)=%v want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func crewPolicyFixture(tag string) string {
+	return fmt.Sprintf(`{
+  "tagOwners": { %q: ["autogroup:admin"] },
+  "acls": [{ "action": "accept", "src": [%q], "dst": [%q] }]
+}`, tag, tag, tag+":*")
+}
+
+func crewGrantPolicyFixture(tag string) string {
+	return fmt.Sprintf(`{
+  "tagOwners": { %q: ["autogroup:admin"] },
+  "grants": [{ "src": [%q], "dst": [%q], "ip": ["*"] }]
+}`, tag, tag, tag)
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -33,6 +33,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	profile := fs.String("profile", defaults.Profile, "configured profile for remote prerequisite checks")
 	id := fs.String("id", "", "remote lease id to inspect")
+	crew := fs.String("crew", defaults.Crew, "verify Tailscale ACL setup for this crew")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	probeSSH := fs.Bool("doctor-probe-ssh", false, "probe static SSH reachability during doctor")
 	targetFlags := registerTargetFlags(fs, defaults)
@@ -48,6 +49,13 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	cfg.Profile = strings.TrimSpace(*profile)
 	if err := applySelectedProfileConfig(&cfg); err != nil {
 		return err
+	}
+	if flagWasSet(fs, "crew") {
+		crewName, err := requestedCrewName(*crew)
+		if err != nil {
+			return err
+		}
+		cfg.Crew = crewName
 	}
 	ok := true
 	var checks []doctorJSONCheck
@@ -67,6 +75,12 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stdout, "%-7s %-8s %s\n", status, check, message)
 	}
 	finish := func() error {
+		if status, message, details := doctorCrewSummary(ctx, cfg); status != "" {
+			if status == "failed" {
+				ok = false
+			}
+			record(status, "crew", message, details)
+		}
 		if *jsonOut {
 			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
 				return err

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -81,6 +81,12 @@ func (a App) doctor(ctx context.Context, args []string) error {
 			}
 			record(status, "crew", message, details)
 		}
+		if status, message, details := a.doctorCrewMeshSummary(ctx, cfg); status != "" {
+			if status == "failed" {
+				ok = false
+			}
+			record(status, "crew-mesh", message, details)
+		}
 		if *jsonOut {
 			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
 				return err

--- a/internal/cli/doctor_crew.go
+++ b/internal/cli/doctor_crew.go
@@ -15,6 +15,54 @@ import (
 // doctor command stays responsive even when the user's tailnet is degraded.
 const doctorCrewTimeout = 4 * time.Second
 
+// doctorCrewMeshTimeout bounds the provider List call the SSH-mesh sub-check
+// makes when verifying how many crew members have declared --expose ports.
+// Kept short so doctor stays responsive even when a provider inventory is
+// slow.
+const doctorCrewMeshTimeout = 8 * time.Second
+
+// doctorCrewMeshSummary reports the operator-side SSH-mesh plane readiness
+// for the selected crew. It runs alongside the Tailscale plane sub-check
+// (doctorCrewSummary) — the two planes are complementary, so doctor surfaces
+// both. Returns ("","",nil) when no crew is selected or no SSH-lease backend
+// is available, mirroring the discipline of every other doctor sub-check.
+func (a App) doctorCrewMeshSummary(ctx context.Context, cfg Config) (string, string, map[string]string) {
+	crew := normalizeCrewName(cfg.Crew)
+	if crew == "" {
+		return "", "", nil
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return "skip", fmt.Sprintf("crew %q: SSH-mesh plane unavailable: %v", crew, err), map[string]string{"crew": crew, "plane": "ssh-mesh", "reason": "backend_unavailable"}
+	}
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok {
+		return "skip", fmt.Sprintf("crew %q: provider %s does not expose SSH leases; SSH-mesh plane unavailable", crew, backend.Spec().Name), map[string]string{"crew": crew, "plane": "ssh-mesh", "provider": backend.Spec().Name, "reason": "provider_not_ssh_capable"}
+	}
+	listCtx, cancel := context.WithTimeout(ctx, doctorCrewMeshTimeout)
+	defer cancel()
+	servers, err := sshBackend.List(listCtx, ListRequest{Options: leaseOptionsFromConfig(cfg)})
+	if err != nil {
+		return "skip", fmt.Sprintf("crew %q: SSH-mesh inventory failed: %v", crew, err), map[string]string{"crew": crew, "plane": "ssh-mesh", "reason": "list_failed", "error": err.Error()}
+	}
+	members := filterServersByCrew(servers, crew)
+	memberCount, exposedCount, totalPorts := crewMeshDoctorCounts(members)
+	details := map[string]string{
+		"crew":            crew,
+		"plane":           "ssh-mesh",
+		"members":         fmt.Sprintf("%d", memberCount),
+		"members_exposed": fmt.Sprintf("%d", exposedCount),
+		"exposed_ports":   fmt.Sprintf("%d", totalPorts),
+	}
+	if memberCount == 0 {
+		return "skip", fmt.Sprintf("crew %q: no active members; SSH-mesh has nothing to forward", crew), details
+	}
+	if exposedCount == 0 {
+		return "skip", fmt.Sprintf("crew %q: %d members but none declared --expose; SSH-mesh has nothing to forward", crew, memberCount), details
+	}
+	return "ok", fmt.Sprintf("crew %q: SSH-mesh ready (%d/%d members exposing %d ports)", crew, exposedCount, memberCount, totalPorts), details
+}
+
 // doctorTailscaleACLClient is satisfied by anything that can return the raw
 // policy document for the user's tailnet. The real implementation hits the
 // Tailscale API; tests inject a stub so unit tests never reach the network.

--- a/internal/cli/doctor_crew.go
+++ b/internal/cli/doctor_crew.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// doctorCrewTimeout bounds the live Tailscale API call. Kept short so the
+// doctor command stays responsive even when the user's tailnet is degraded.
+const doctorCrewTimeout = 4 * time.Second
+
+// doctorTailscaleACLClient is satisfied by anything that can return the raw
+// policy document for the user's tailnet. The real implementation hits the
+// Tailscale API; tests inject a stub so unit tests never reach the network.
+type doctorTailscaleACLClient interface {
+	PolicyHuJSON(ctx context.Context, tailnet string) (string, error)
+}
+
+// doctorTailscaleACLClientFactory is overridden in tests. It returns nil when
+// the live client is not available so the check can degrade gracefully.
+var doctorTailscaleACLClientFactory = newDoctorTailscaleACLClient
+
+// doctorCrewSummary is the doctor entry point invoked from finish(). It
+// always returns either ("","",nil) — meaning "no crew check applies" — or a
+// triplet ready to feed into the existing record(...) helper. The check is
+// intentionally bounded to a few seconds so doctor stays fast even on
+// degraded tailnets.
+func doctorCrewSummary(ctx context.Context, cfg Config) (string, string, map[string]string) {
+	crew := normalizeCrewName(cfg.Crew)
+	if crew == "" {
+		return "", "", nil
+	}
+	tag := crewTailscaleTag(localCoordinatorOwner(), crew)
+	if tag == "" {
+		return "", "", nil
+	}
+	if !providerCapableOfTailscale(cfg.Provider) {
+		return "skip", fmt.Sprintf("crew %q: provider %s does not support the Tailscale plane; crew networking unavailable", crew, cfg.Provider), map[string]string{"provider": cfg.Provider, "crew": crew, "tag": tag, "plane": "tailscale", "reason": "provider_not_tailscale_capable"}
+	}
+	apiKey := strings.TrimSpace(os.Getenv("TS_API_KEY"))
+	if apiKey == "" {
+		return "skip", "TS_API_KEY missing; skipped ACL verification", map[string]string{"crew": crew, "tag": tag, "reason": "ts_api_key_missing"}
+	}
+	tailnet := strings.TrimSpace(os.Getenv("TS_TAILNET"))
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	client := doctorTailscaleACLClientFactory(apiKey)
+	if client == nil {
+		return "skip", "tailscale api client unavailable", map[string]string{"crew": crew, "tag": tag, "reason": "client_unavailable"}
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, doctorCrewTimeout)
+	defer cancel()
+	body, err := client.PolicyHuJSON(checkCtx, tailnet)
+	if err != nil {
+		return "failed", fmt.Sprintf("tailscale policy lookup failed: %v", err), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "error": err.Error()}
+	}
+	if crewACLRowPresent(body, tag) {
+		return "ok", fmt.Sprintf("crew %q: Tailscale plane auto-managed (%s)", crew, tag), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "mode": "auto-managed"}
+	}
+	return "failed", fmt.Sprintf("crew %q: tailnet policy row missing for %s. Run with $TS_API_KEY exported to auto-install, or apply the snippet from docs/features/crew.md", crew, tag), map[string]string{"crew": crew, "tag": tag, "tailnet": tailnet, "remedy": "see_docs_features_crew_md"}
+}
+
+// crewACLRowPresent checks for the concrete tag declaration and access row
+// needed by a crew. The Tailscale policy file is HuJSON and not trivially
+// JSON-parseable without an extra dependency, so keep the scan textual but
+// exact enough: the tag must appear under tagOwners and either a legacy ACL row
+// (`tag` -> `tag:*`) or a grants row (`tag` -> `tag`) must be present.
+func crewACLRowPresent(policy, tag string) bool {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return false
+	}
+	quotedTag := `"` + tag + `"`
+	quotedDst := `"` + tag + `:*"`
+	if !policySectionContains(policy, "tagOwners", quotedTag) {
+		return false
+	}
+	if policySectionContains(policy, "acls", quotedTag) &&
+		policySectionContains(policy, "acls", quotedDst) {
+		return true
+	}
+	if grants, ok := policySection(policy, "grants"); ok {
+		return strings.Count(grants, quotedTag) >= 2 && strings.Contains(grants, `"ip"`)
+	}
+	return false
+}
+
+func policySectionContains(policy, section, token string) bool {
+	body, ok := policySection(policy, section)
+	return ok && strings.Contains(body, token)
+}
+
+func policySection(policy, section string) (string, bool) {
+	start := activePolicySectionStart(policy, section)
+	if start < 0 {
+		return "", false
+	}
+	rest := policy[start+len(section)+2:]
+	colon := strings.IndexByte(rest, ':')
+	if colon < 0 {
+		return "", false
+	}
+	rest = rest[colon+1:]
+	trimmed := strings.TrimLeft(rest, " \t\r\n")
+	if trimmed == "" {
+		return "", false
+	}
+	open := trimmed[0]
+	close := byte(0)
+	switch open {
+	case '{':
+		close = '}'
+	case '[':
+		close = ']'
+	default:
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(trimmed); i++ {
+		ch := trimmed[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		if ch == '"' {
+			inString = true
+			continue
+		}
+		switch ch {
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return trimmed[:i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+func activePolicySectionStart(policy, section string) int {
+	offset := 0
+	prefix := `"` + section + `"`
+	for _, line := range strings.SplitAfter(policy, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, prefix) {
+			return offset + strings.Index(line, prefix)
+		}
+		offset += len(line)
+	}
+	return -1
+}
+
+// liveDoctorTailscaleACLClient is the production implementation. It targets
+// the documented "Get tailnet policy file" endpoint and returns the response
+// body verbatim so the substring scan above sees the user's HuJSON exactly
+// as they wrote it.
+type liveDoctorTailscaleACLClient struct {
+	apiKey string
+	http   *http.Client
+}
+
+func newDoctorTailscaleACLClient(apiKey string) doctorTailscaleACLClient {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil
+	}
+	return &liveDoctorTailscaleACLClient{apiKey: apiKey, http: &http.Client{Timeout: doctorCrewTimeout}}
+}
+
+func (c *liveDoctorTailscaleACLClient) PolicyHuJSON(ctx context.Context, tailnet string) (string, error) {
+	if tailnet == "" {
+		tailnet = "-"
+	}
+	url := "https://api.tailscale.com/api/v2/tailnet/" + tailnet + "/acl"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(c.apiKey, "")
+	req.Header.Set("Accept", "application/hujson")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if readErr != nil {
+		return "", readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Return body as error detail when the response is a JSON error
+		// envelope so the caller surfaces actionable text.
+		var envelope struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &envelope) == nil && envelope.Message != "" {
+			return "", fmt.Errorf("tailscale api %d: %s", resp.StatusCode, envelope.Message)
+		}
+		return "", fmt.Errorf("tailscale api %d", resp.StatusCode)
+	}
+	return string(body), nil
+}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -17,6 +17,7 @@ type leaseCreateFlagValues struct {
 	Market        *string
 	Slug          *string
 	Crew          *string
+	Expose        *stringListFlag
 	TTL           *time.Duration
 	Idle          *time.Duration
 	Desktop       *bool
@@ -28,6 +29,8 @@ type leaseCreateFlagValues struct {
 }
 
 func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlagValues {
+	expose := stringListFlag{}
+	fs.Var(&expose, "expose", "declare a TCP port this lease wants reachable over the SSH-mesh plane; repeatable")
 	return leaseCreateFlagValues{
 		Provider:      fs.String("provider", defaults.Provider, providerHelpAll()),
 		Profile:       fs.String("profile", defaults.Profile, "profile"),
@@ -36,6 +39,7 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 		Market:        fs.String("market", defaults.Capacity.Market, "capacity market: spot or on-demand"),
 		Slug:          fs.String("slug", "", "request a friendly slug for a new lease"),
 		Crew:          fs.String("crew", defaults.Crew, "tag this lease with a crew name so peers can be selected with --crew"),
+		Expose:        &expose,
 		TTL:           fs.Duration("ttl", defaults.TTL, "maximum lease lifetime"),
 		Idle:          fs.Duration("idle-timeout", defaults.IdleTimeout, "idle timeout"),
 		Desktop:       fs.Bool("desktop", defaults.Desktop, "provision or require a visible desktop/VNC session"),
@@ -61,6 +65,13 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 			return err
 		}
 		cfg.Crew = crew
+	}
+	if values.Expose != nil && len(*values.Expose) > 0 {
+		ports, err := requestedExposedPorts(*values.Expose)
+		if err != nil {
+			return err
+		}
+		cfg.ExposedPorts = ports
 	}
 	applyCapabilityFlags(cfg, *values.Desktop, *values.Browser, *values.Code)
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -14,6 +16,7 @@ type leaseCreateFlagValues struct {
 	ServerType    *string
 	Market        *string
 	Slug          *string
+	Crew          *string
 	TTL           *time.Duration
 	Idle          *time.Duration
 	Desktop       *bool
@@ -32,6 +35,7 @@ func registerLeaseCreateFlags(fs *flag.FlagSet, defaults Config) leaseCreateFlag
 		ServerType:    fs.String("type", getenv("CRABBOX_SERVER_TYPE", ""), "provider server/instance type"),
 		Market:        fs.String("market", defaults.Capacity.Market, "capacity market: spot or on-demand"),
 		Slug:          fs.String("slug", "", "request a friendly slug for a new lease"),
+		Crew:          fs.String("crew", defaults.Crew, "tag this lease with a crew name so peers can be selected with --crew"),
 		TTL:           fs.Duration("ttl", defaults.TTL, "maximum lease lifetime"),
 		Idle:          fs.Duration("idle-timeout", defaults.IdleTimeout, "idle timeout"),
 		Desktop:       fs.Bool("desktop", defaults.Desktop, "provision or require a visible desktop/VNC session"),
@@ -51,6 +55,13 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	cfg.Provider = *values.Provider
 	cfg.Profile = *values.Profile
 	cfg.Class = *values.Class
+	if flagWasSet(fs, "crew") {
+		crew, err := requestedCrewName(*values.Crew)
+		if err != nil {
+			return err
+		}
+		cfg.Crew = crew
+	}
 	applyCapabilityFlags(cfg, *values.Desktop, *values.Browser, *values.Code)
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
 		return err
@@ -81,7 +92,39 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	if err := validateRequestedCapabilities(*cfg); err != nil {
 		return err
 	}
+	if cfg.Crew != "" {
+		appendCrewTailscaleTag(cfg, providerCapableOfTailscale(cfg.Provider))
+		if err := maybeBootstrapCrewACL(context.Background(), *cfg); err != nil {
+			return err
+		}
+	}
 	return validateLeaseDurations(*cfg)
+}
+
+// maybeBootstrapCrewACL self-bootstraps the crew tag's tagOwners + grants
+// rows on the operator tailnet when TS_API_KEY is exported. When the key is
+// absent, when the provider lacks Tailscale, or when the row is already
+// present, this is a silent no-op so doctor still owns the manual-snippet
+// fallback path. Failures from the live API are surfaced so the lease is
+// not created against a tailnet that cannot actually carry crew traffic.
+func maybeBootstrapCrewACL(ctx context.Context, cfg Config) error {
+	if cfg.Crew == "" || !cfg.Tailscale.Enabled {
+		return nil
+	}
+	if !providerCapableOfTailscale(cfg.Provider) {
+		return nil
+	}
+	apiKey := strings.TrimSpace(os.Getenv("TS_API_KEY"))
+	if apiKey == "" {
+		return nil
+	}
+	client := crewTailnetACLClientFactory(apiKey)
+	if client == nil {
+		return nil
+	}
+	tailnet := strings.TrimSpace(os.Getenv("TS_TAILNET"))
+	owner := localCoordinatorOwner()
+	return crewACLEnsure(ctx, client, tailnet, owner, cfg.Crew)
 }
 
 func validateLeaseDurations(cfg Config) error {

--- a/internal/cli/pool.go
+++ b/internal/cli/pool.go
@@ -20,6 +20,7 @@ func (a App) list(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
 	jsonOut := fs.Bool("json", false, "print JSON")
 	refresh := fs.Bool("refresh", false, "refresh provider-backed state where supported")
+	crewFilter := fs.String("crew", "", "only list leases tagged with this crew")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -36,6 +37,10 @@ func (a App) list(ctx context.Context, args []string) error {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
+	crewName, err := requestedCrewName(*crewFilter)
+	if err != nil {
+		return err
+	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
@@ -47,6 +52,9 @@ func (a App) list(ctx context.Context, args []string) error {
 				return err
 			}
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+			if crewName != "" {
+				view = filterJSONListViewByCrew(view, crewName)
+			}
 			return json.NewEncoder(a.Stdout).Encode(view)
 		}
 	}
@@ -63,11 +71,68 @@ func (a App) list(ctx context.Context, args []string) error {
 		return err
 	}
 	a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+	if crewName != "" {
+		servers = filterServersByCrew(servers, crewName)
+	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(servers)
 	}
 	renderServerList(a.Stdout, servers)
 	return nil
+}
+
+// filterJSONListViewByCrew filters a list-view payload (whatever shape the
+// backend produces) by inspecting label-bearing entries. Backends that emit
+// shapes without labels are returned unchanged so JSON list output stays
+// authoritative for those providers.
+func filterJSONListViewByCrew(view any, crew string) any {
+	crew = normalizeCrewName(crew)
+	if crew == "" {
+		return view
+	}
+	entries, ok := view.([]any)
+	if !ok {
+		return view
+	}
+	hasLabels := false
+	for _, entry := range entries {
+		if extractLabelMap(entry) != nil {
+			hasLabels = true
+			break
+		}
+	}
+	if !hasLabels {
+		return view
+	}
+	kept := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		labels := extractLabelMap(entry)
+		if labels == nil {
+			continue
+		}
+		if normalizeCrewName(labels[crewLabelKey]) == crew {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
+}
+
+func extractLabelMap(entry any) map[string]string {
+	mapEntry, ok := entry.(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := mapEntry["labels"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if str, ok := value.(string); ok {
+			labels[key] = str
+		}
+	}
+	return labels
 }
 
 func (a App) syncExternalRunnersBestEffort(ctx context.Context, cfg Config, backend Backend) {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -207,6 +207,7 @@ type LeaseOptions struct {
 	TargetOS      string
 	WindowsMode   string
 	Class         string
+	Crew          string
 	ServerType    string
 	IdleTimeout   time.Duration
 	TTL           time.Duration
@@ -463,6 +464,7 @@ func leaseOptionsFromConfig(cfg Config) LeaseOptions {
 		TargetOS:      cfg.TargetOS,
 		WindowsMode:   cfg.WindowsMode,
 		Class:         cfg.Class,
+		Crew:          normalizeCrewName(cfg.Crew),
 		ServerType:    cfg.ServerType,
 		IdleTimeout:   cfg.IdleTimeout,
 		TTL:           cfg.TTL,

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -28,6 +28,10 @@ func ClaimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repo
 	return claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot, idleTimeout, reclaim)
 }
 
+func ClaimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot, idleTimeout, reclaim)
+}
+
 func ResolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
 	return resolveLeaseClaim(identifier)
 }

--- a/internal/cli/provider_labels.go
+++ b/internal/cli/provider_labels.go
@@ -32,6 +32,9 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	if market != "" {
 		labels["market"] = market
 	}
+	if crew := normalizeCrewName(cfg.Crew); crew != "" {
+		labels[crewLabelKey] = crew
+	}
 	if cfg.TargetOS == targetWindows {
 		labels["windows_mode"] = cfg.WindowsMode
 	}

--- a/internal/cli/provider_labels.go
+++ b/internal/cli/provider_labels.go
@@ -35,6 +35,9 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	if crew := normalizeCrewName(cfg.Crew); crew != "" {
 		labels[crewLabelKey] = crew
 	}
+	if rendered := renderExposedPortsLabel(cfg.ExposedPorts); rendered != "" {
+		labels[crewExposedPortsLabelKey] = rendered
+	}
 	if cfg.TargetOS == targetWindows {
 		labels["windows_mode"] = cfg.WindowsMode
 	}

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -354,7 +354,7 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 		_ = client.DeleteSandbox(context.Background(), sandbox.GetName())
 		return "", "", "", err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, isloProvider, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseForRepoProviderWithCrew(leaseID, slug, isloProvider, b.cfg.Crew, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		_ = client.DeleteSandbox(context.Background(), sandbox.GetName())
 		return "", "", "", err
 	}
@@ -424,13 +424,15 @@ func isloSandboxToServer(sandbox *gosdk.SandboxResponse) Server {
 	if sandbox == nil {
 		return Server{Provider: isloProvider, Labels: map[string]string{"provider": isloProvider}}
 	}
+	leaseID := isloLeasePrefix + sandbox.GetName()
 	labels := map[string]string{
 		"provider": isloProvider,
-		"lease":    isloLeasePrefix + sandbox.GetName(),
-		"slug":     newLeaseSlug(isloLeasePrefix + sandbox.GetName()),
+		"lease":    leaseID,
+		"slug":     newLeaseSlug(leaseID),
 		"target":   targetLinux,
 		"state":    sandbox.GetStatus(),
 	}
+	applyIsloClaimLabels(labels, leaseID)
 	return Server{
 		Provider: isloProvider,
 		CloudID:  sandbox.GetID(),
@@ -449,9 +451,16 @@ func isloStatusView(leaseID string, sandbox *gosdk.SandboxResponse) statusView {
 		status = sandbox.GetStatus()
 		image = sandbox.GetImage()
 	}
+	labels := map[string]string{
+		"provider": isloProvider,
+		"lease":    leaseID,
+		"slug":     newLeaseSlug(leaseID),
+		"state":    status,
+	}
+	applyIsloClaimLabels(labels, leaseID)
 	return statusView{
 		ID:         leaseID,
-		Slug:       newLeaseSlug(leaseID),
+		Slug:       labels["slug"],
 		Provider:   isloProvider,
 		TargetOS:   targetLinux,
 		State:      status,
@@ -459,11 +468,20 @@ func isloStatusView(leaseID string, sandbox *gosdk.SandboxResponse) statusView {
 		ServerType: image,
 		Network:    NetworkPublic,
 		Ready:      isloStatusReady(status),
-		Labels: map[string]string{
-			"provider": isloProvider,
-			"lease":    leaseID,
-			"state":    status,
-		},
+		Labels:     labels,
+	}
+}
+
+func applyIsloClaimLabels(labels map[string]string, leaseID string) {
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil || !ok {
+		return
+	}
+	if claim.Slug != "" {
+		labels["slug"] = normalizeLeaseSlug(claim.Slug)
+	}
+	if claim.Crew != "" {
+		labels["crew"] = claim.Crew
 	}
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -187,6 +187,36 @@ func TestIsloCreateSandboxPassesRelativeWorkdirToProvider(t *testing.T) {
 	}
 }
 
+func TestIsloCreateSandboxStoresCrewClaimForList(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}
+	backend := &isloBackend{
+		cfg: Config{
+			Crew: "Alpha Crew",
+			Islo: IsloConfig{Workdir: "team/repo"},
+		},
+		rt: Runtime{Stderr: io.Discard},
+	}
+	leaseID, _, slug, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil || !ok {
+		t.Fatalf("resolve claim ok=%t err=%v", ok, err)
+	}
+	if claim.Crew != "alpha-crew" {
+		t.Fatalf("claim crew=%q want alpha-crew", claim.Crew)
+	}
+	server := isloSandboxToServer(&gosdk.SandboxResponse{Name: client.createName, Status: "running"})
+	if server.Labels["crew"] != "alpha-crew" {
+		t.Fatalf("server crew label=%q labels=%#v", server.Labels["crew"], server.Labels)
+	}
+	if server.Labels["slug"] != normalizeLeaseSlug(slug) {
+		t.Fatalf("server slug=%q want %q", server.Labels["slug"], normalizeLeaseSlug(slug))
+	}
+}
+
 func TestIsloSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/providers/islo/core.go
+++ b/internal/providers/islo/core.go
@@ -62,6 +62,10 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
 }
 
+func claimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderWithCrew(leaseID, slug, provider, crew, repoRoot, idleTimeout, reclaim)
+}
+
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -76,6 +76,7 @@ export interface LeaseConfig {
   idleTimeoutSeconds: number;
   keep: boolean;
   sshPublicKey: string;
+  crew: string;
 }
 
 export type AzureOSDiskMode = "managed" | "ephemeral";
@@ -199,7 +200,19 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     idleTimeoutSeconds,
     keep: input.keep ?? false,
     sshPublicKey,
+    crew: normalizeCrewName(input.crew ?? ""),
   };
+}
+
+// normalizeCrewName mirrors the Go-side helper in internal/cli/crew.go. The
+// `crew` label is a reserved provider-label key that groups N leases so peers
+// can be selected by `crabbox list --crew <name>`.
+export function normalizeCrewName(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
 }
 
 export function awsPromotedAMIConfigKey(region: string, serverType: string): string {

--- a/worker/src/provider-labels.ts
+++ b/worker/src/provider-labels.ts
@@ -35,6 +35,9 @@ export function leaseProviderLabels(
   if (config.target === "windows") {
     labels["windows_mode"] = config.windowsMode;
   }
+  if (config.crew) {
+    labels["crew"] = config.crew;
+  }
   if (config.desktop) {
     labels["desktop"] = "true";
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -150,6 +150,7 @@ export interface LeaseRequest {
   idleTimeoutSeconds?: number;
   keep?: boolean;
   sshPublicKey?: string;
+  crew?: string;
 }
 
 export type Provider = "hetzner" | "aws" | "azure" | "gcp";

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -237,6 +237,13 @@ describe("lease config", () => {
     expect(config.code).toBe(true);
   });
 
+  it("normalizes the optional crew label and defaults it to empty", () => {
+    const empty = leaseConfig({ sshPublicKey: "ssh-ed25519 test" });
+    expect(empty.crew).toBe("");
+    const tagged = leaseConfig({ sshPublicKey: "ssh-ed25519 test", crew: " Alpha Crew " });
+    expect(tagged.crew).toBe("alpha-crew");
+  });
+
   it("preserves Tailscale lease capability requests", () => {
     const config = leaseConfig({
       sshPublicKey: "ssh-ed25519 test",

--- a/worker/test/provider-labels.test.ts
+++ b/worker/test/provider-labels.test.ts
@@ -117,4 +117,106 @@ describe("provider labels", () => {
     expect(labels.tailscale_exit_node_allow_lan_access).toBe("true");
     expect(Object.values(labels).join(" ")).not.toContain("tskey-secret");
   });
+
+  it("includes the crew label when the lease is tagged", () => {
+    const config: LeaseConfig = {
+      provider: "aws",
+      target: "linux",
+      windowsMode: "normal",
+      desktop: false,
+      browser: false,
+      tailscale: false,
+      tailscaleTags: ["tag:crabbox"],
+      tailscaleHostname: "",
+      tailscaleAuthKey: "",
+      tailscaleExitNode: "",
+      tailscaleExitNodeAllowLanAccess: false,
+      profile: "default",
+      class: "beast",
+      serverType: "c7a.48xlarge",
+      image: "ami",
+      location: "eu-west-1",
+      sshUser: "crabbox",
+      sshPort: "2222",
+      sshFallbackPorts: ["22"],
+      awsRegion: "eu-west-1",
+      awsRootGB: 400,
+      awsAMI: "",
+      awsSGID: "",
+      awsSubnetID: "",
+      awsProfile: "",
+      capacityMarket: "spot",
+      capacityStrategy: "most-available",
+      capacityFallback: "on-demand-after-120s",
+      capacityRegions: [],
+      capacityAvailabilityZones: [],
+      providerKey: "crabbox-cbx-123",
+      workRoot: "/work/crabbox",
+      ttlSeconds: 600,
+      idleTimeoutSeconds: 7200,
+      keep: false,
+      sshPublicKey: "ssh-ed25519 test",
+      crew: "alpha",
+    } as LeaseConfig;
+    const labels = leaseProviderLabels(
+      config,
+      "cbx_123",
+      "blue-lobster",
+      "peter@example.com",
+      "aws",
+      new Date("2026-05-01T12:00:00Z"),
+    );
+    expect(labels.crew).toBe("alpha");
+  });
+
+  it("omits the crew label when the lease has no crew", () => {
+    const config: LeaseConfig = {
+      provider: "aws",
+      target: "linux",
+      windowsMode: "normal",
+      desktop: false,
+      browser: false,
+      tailscale: false,
+      tailscaleTags: ["tag:crabbox"],
+      tailscaleHostname: "",
+      tailscaleAuthKey: "",
+      tailscaleExitNode: "",
+      tailscaleExitNodeAllowLanAccess: false,
+      profile: "default",
+      class: "beast",
+      serverType: "c7a.48xlarge",
+      image: "ami",
+      location: "eu-west-1",
+      sshUser: "crabbox",
+      sshPort: "2222",
+      sshFallbackPorts: ["22"],
+      awsRegion: "eu-west-1",
+      awsRootGB: 400,
+      awsAMI: "",
+      awsSGID: "",
+      awsSubnetID: "",
+      awsProfile: "",
+      capacityMarket: "spot",
+      capacityStrategy: "most-available",
+      capacityFallback: "on-demand-after-120s",
+      capacityRegions: [],
+      capacityAvailabilityZones: [],
+      providerKey: "crabbox-cbx-123",
+      workRoot: "/work/crabbox",
+      ttlSeconds: 600,
+      idleTimeoutSeconds: 7200,
+      keep: false,
+      sshPublicKey: "ssh-ed25519 test",
+      crew: "",
+    } as LeaseConfig;
+    const labels = leaseProviderLabels(
+      config,
+      "cbx_123",
+      "blue-lobster",
+      "peter@example.com",
+      "aws",
+      new Date("2026-05-01T12:00:00Z"),
+    );
+    expect(labels.crew).toBeUndefined();
+  });
 });


### PR DESCRIPTION
> **Stacked on [#openclaw/crabbox#129](https://github.com/openclaw/crabbox/pull/129)** — merge that first. The diff here will collapse to just the SSH-mesh additions once #129 lands.

## TL;DR
Operator-orchestrated SSH-mesh: `crabbox crew connect <name>` opens local SSH `-L` tunnels from the operator's machine to each crew member's `--expose`'d port. Peers reachable by name at `127.0.0.1:<port>` for the operator's shell. Works on every SSH-accessible provider. No Tailscale, no Headscale, no relay, no SaaS — just SSH.

## How it works
- `--expose <port>` on `run`/`warmup`: declares the lease wants this port reachable. Repeatable; multi-valued. Written into a reserved provider label.
- `crabbox crew connect <name>`: reads crew members, opens `ssh -L` per (member, port), writes `~/.crabbox/crew/<name>/{hosts,env}`, holds connections open with SSH ControlMaster reuse. `--export` prints shell exports; `--json` dumps the forward table.
- `crabbox doctor --crew <name>`: reports the SSH-mesh plane alongside the Tailscale plane (`crew-mesh` sub-check).

## What this is NOT
- Lease-to-lease peer dial (true P2P) — future PR with operator-side hub + reverse tunnels.
- UDP — SSH `-L` is TCP-only.
- Auto-plane selection — manual for v1.

## Tested
- Unit tests with mocked SSH exec runner: `--expose` parsing, label rendering, hosts/env file rendering, doctor counts, `ssh -L` arg construction, and full launch + teardown over a recording runner. `go test -race ./internal/cli/...` clean.
- Live validation: **skipped** — no funded SSH-lease provider available in this dev environment (RunPod balance $0; no live exedev credentials). Mocked-exec test exercises the orchestration end-to-end.

## Open questions
- Naming: `--expose <port>` vs `--mesh-port <port>` vs `--reachable <port>`?
- Should `crew connect` daemonize or stay foreground (current: foreground)?
- Conflict with the in-flight delegated-providers bridge plane PR (#136)?

## Related
- **#129** — crew foundation (this PR stacks on it; merge that first).
- **#136** — crew bridge plane for delegated providers (parallel solution for non-SSH delegated providers).
- #132 — wandb (independent).
- #133 — runpod (merged; one of the SSH-capable providers this PR targets).
