### PR TITLE
feat: add AWS FSR status route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a thin macOS developer-tools image mint wrapper that keeps paid host allocation explicit while wiring the reusable prep script, promotion, checkpoint proof, and lifecycle evidence defaults.
 - Added AWS Linux and Windows developer-image prep scripts plus a guarded mint wrapper for baking Docker, Node 24, pnpm, GitHub CLI, and common developer tooling into fast-booting Crabbox AMIs.
 - Added explicit AWS Fast Snapshot Restore promotion support for hot developer-image AMIs via `crabbox image promote --fast-snapshot-restore --fsr-az <az>` and the AWS developer-image mint wrapper.
+- Added `crabbox image fsr-status` and the coordinator Fast Snapshot Restore status route for checking live AWS snapshot/AZ state after promotion.
 - Added a light/dark mode toggle to the Crabbox documentation site that defaults to the system color scheme, persists the choice in local storage, and applies before first paint to avoid a flash.
 
 ### Changed

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -10,6 +10,7 @@ crabbox image create --id cbx_... --name crabbox-runner-20260501-1246 --wait
 crabbox image promote ami-...
 crabbox image promote ami-... --target macos --region us-east-1 --type mac1.metal
 crabbox image promote ami-... --json
+crabbox image fsr-status ami-... --region us-west-2 --fsr-az us-west-2a
 crabbox image delete ami-... --region eu-west-1
 crabbox image delete my-azure-image --provider azure --region westeurope
 crabbox image delete my-gcp-image --provider gcp --region europe-west1-b --project example-project
@@ -127,6 +128,19 @@ crabbox image promote \
 
 Fast Snapshot Restore is provider-billed per snapshot and availability zone.
 Use it for known hot zones, not every candidate bake.
+
+Check the live AWS Fast Snapshot Restore state after promotion:
+
+```sh
+crabbox image fsr-status \
+  --region us-west-2 \
+  --fsr-az us-west-2a \
+  ami-1234567890abcdef0
+```
+
+`fsr-status` describes the AMI backing snapshots in AWS and returns the current
+state for each matching snapshot/AZ pair. Omit `--fsr-az` to return all Fast
+Snapshot Restore records AWS reports for the image snapshots.
 
 Future brokered AWS leases use the promoted image when the request does not set
 an explicit `awsAMI` or `CRABBOX_AWS_AMI` override. Promotion stores coordinator

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -307,14 +307,18 @@ type cacheWarmKongCmd struct {
 }
 
 type imageKongCmd struct {
-	Create  imageCreateKongCmd  `cmd:"" passthrough:"" help:"Create a provider image from a brokered lease."`
-	Promote imagePromoteKongCmd `cmd:"" passthrough:"" help:"Promote an AMI for brokered AWS runners."`
-	Delete  imageDeleteKongCmd  `cmd:"" passthrough:"" help:"Delete a provider image."`
+	Create    imageCreateKongCmd    `cmd:"" passthrough:"" help:"Create a provider image from a brokered lease."`
+	Promote   imagePromoteKongCmd   `cmd:"" passthrough:"" help:"Promote an AMI for brokered AWS runners."`
+	FSRStatus imageFSRStatusKongCmd `cmd:"" name:"fsr-status" passthrough:"" help:"Show AWS Fast Snapshot Restore status for an image."`
+	Delete    imageDeleteKongCmd    `cmd:"" passthrough:"" help:"Delete a provider image."`
 }
 type imageCreateKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type imagePromoteKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type imageFSRStatusKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type imageDeleteKongCmd struct {
@@ -558,6 +562,9 @@ func (c *imageCreateKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *imagePromoteKongCmd) Run(ctx context.Context, app App) error {
 	return app.imagePromote(ctx, c.Args)
+}
+func (c *imageFSRStatusKongCmd) Run(ctx context.Context, app App) error {
+	return app.imageFSRStatus(ctx, c.Args)
 }
 func (c *imageDeleteKongCmd) Run(ctx context.Context, app App) error {
 	return app.imageDelete(ctx, c.Args)

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -177,6 +177,7 @@ type CoordinatorImage struct {
 	Project              string                           `json:"project,omitempty"`
 	ResourceID           string                           `json:"resourceID,omitempty"`
 	SnapshotIDs          []string                         `json:"snapshotIds,omitempty"`
+	Snapshots            []string                         `json:"snapshots,omitempty"`
 	Direct               bool                             `json:"direct,omitempty"`
 	Target               string                           `json:"target,omitempty"`
 	WindowsMode          string                           `json:"windowsMode,omitempty"`
@@ -1203,6 +1204,18 @@ func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, re
 		Image CoordinatorImage `json:"image"`
 	}
 	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote", refs...), map[string]any{}, &res)
+	return res.Image, err
+}
+
+func (c *CoordinatorClient) FastSnapshotRestoreStatus(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorImage, error) {
+	var res struct {
+		Image                CoordinatorImage                 `json:"image"`
+		FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores"`
+	}
+	err := c.do(ctx, http.MethodGet, imagePath(imageID, "fast-snapshot-restore", refs...), nil, &res)
+	if len(res.Image.FastSnapshotRestores) == 0 && len(res.FastSnapshotRestores) > 0 {
+		res.Image.FastSnapshotRestores = res.FastSnapshotRestores
+	}
 	return res.Image, err
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1179,6 +1179,20 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 				t.Fatalf("promote fsrAz=%#v", got)
 			}
 			_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","name":"openclaw-crabbox-test","state":"available","region":"eu-west-1","promotedAt":"2026-05-01T12:46:00Z"}}`))
+		case "/v1/images/ami-12345678/fast-snapshot-restore":
+			if r.Method != http.MethodGet {
+				t.Fatalf("method=%s", r.Method)
+			}
+			if got := r.URL.Query().Get("provider"); got != "aws" {
+				t.Fatalf("fsr provider=%q", got)
+			}
+			if got := r.URL.Query().Get("region"); got != "us-east-1" {
+				t.Fatalf("fsr region=%q", got)
+			}
+			if got := r.URL.Query()["fsrAz"]; !reflect.DeepEqual(got, []string{"us-east-1a"}) {
+				t.Fatalf("fsr fsrAz=%#v", got)
+			}
+			_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","name":"openclaw-crabbox-test","state":"available","region":"us-east-1","fastSnapshotRestores":[{"snapshotID":"snap-root","availabilityZone":"us-east-1a","state":"enabled"}]}}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -1198,6 +1212,9 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 	}
 	if promoted, err := client.PromoteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", Target: "macos", ServerType: "mac1.metal", Architecture: "x86_64_mac", FastSnapshotRestore: true, FastSnapshotRestoreAZs: []string{"us-east-1a", "us-east-1b"}}); err != nil || promoted.PromotedAt == "" {
 		t.Fatalf("promoted=%#v err=%v", promoted, err)
+	}
+	if status, err := client.FastSnapshotRestoreStatus(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "us-east-1", FastSnapshotRestoreAZs: []string{"us-east-1a"}}); err != nil || len(status.FastSnapshotRestores) != 1 || status.FastSnapshotRestores[0].State != "enabled" {
+		t.Fatalf("fsr status=%#v err=%v", status, err)
 	}
 	if err := client.DeleteImage(context.Background(), "ami-12345678", CoordinatorImageRef{Provider: "aws", Region: "eu-west-1", Kind: "aws-ami"}); err != nil {
 		t.Fatalf("delete image: %v", err)

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -87,6 +87,49 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	return nil
 }
 
+func (a App) imageFSRStatus(ctx context.Context, args []string) error {
+	fs := newFlagSet("image fsr-status", a.Stderr)
+	provider := fs.String("provider", "aws", "image provider: aws")
+	region := fs.String("region", "", "AWS region containing the AMI or snapshot")
+	var fastSnapshotRestoreAZs stringListFlag
+	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore status; repeatable")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox image fsr-status <ami-id|snapshot-id> [--region <aws-region>] [--fsr-az <az>]")
+	}
+	normalizedProvider := normalizeProviderName(*provider)
+	if normalizedProvider != "aws" {
+		return exit(2, "unsupported image provider %q; Fast Snapshot Restore is AWS-only", *provider)
+	}
+	coord, err := configuredAdminCoordinator()
+	if err != nil {
+		return err
+	}
+	image, err := coord.FastSnapshotRestoreStatus(ctx, fs.Arg(0), CoordinatorImageRef{
+		Provider:               normalizedProvider,
+		Region:                 *region,
+		FastSnapshotRestoreAZs: fastSnapshotRestoreAZs,
+	})
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(image)
+	}
+	fmt.Fprintf(a.Stdout, "image=%s state=%s region=%s fsr=%d\n", image.ID, blank(image.State, "-"), blank(image.Region, "-"), len(image.FastSnapshotRestores))
+	if len(image.FastSnapshotRestores) == 0 {
+		fmt.Fprintln(a.Stdout, "fsr none")
+		return nil
+	}
+	for _, status := range image.FastSnapshotRestores {
+		fmt.Fprintf(a.Stdout, "fsr snapshot=%s az=%s state=%s reason=%s\n", status.SnapshotID, status.AvailabilityZone, blank(status.State, "-"), blank(status.StateTransitionReason, "-"))
+	}
+	return nil
+}
+
 func (a App) imageDelete(ctx context.Context, args []string) error {
 	fs := newFlagSet("image delete", a.Stderr)
 	provider := fs.String("provider", "aws", "image provider: aws, azure, or gcp")

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -610,6 +610,44 @@ export class EC2SpotClient {
         );
   }
 
+  async fastSnapshotRestoreStatus(
+    snapshotIDs: string[],
+    availabilityZones: string[] = [],
+  ): Promise<ProviderFastSnapshotRestore[]> {
+    const snapshots = uniqueStrings(snapshotIDs);
+    const zones = uniqueStrings(availabilityZones);
+    if (snapshots.length === 0) {
+      return [];
+    }
+    const params: Record<string, string> = {
+      "Filter.1.Name": "snapshot-id",
+    };
+    snapshots.forEach((snapshotID, index) => {
+      params[`Filter.1.Value.${index + 1}`] = snapshotID;
+    });
+    if (zones.length > 0) {
+      params["Filter.2.Name"] = "availability-zone";
+      zones.forEach((zone, index) => {
+        params[`Filter.2.Value.${index + 1}`] = zone;
+      });
+    }
+    const statuses: ProviderFastSnapshotRestore[] = [];
+    let nextToken = "";
+    for (let page = 0; page < 100; page++) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- EC2 pagination depends on the previous token.
+      const root = await this.ec2("DescribeFastSnapshotRestores", {
+        ...params,
+        ...(nextToken ? { NextToken: nextToken } : {}),
+      });
+      statuses.push(...fastSnapshotRestoreItems(root, "fastSnapshotRestoreSet"));
+      nextToken = asString(root["nextToken"]);
+      if (!nextToken) {
+        return statuses;
+      }
+    }
+    throw new Error("aws fast snapshot restore status pagination exceeded 100 pages");
+  }
+
   async listMacHosts(serverType = "", state = ""): Promise<AWSMacHost[]> {
     const params: Record<string, string> = {};
     let filter = 1;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3696,7 +3696,10 @@ export class FleetDurableObject implements DurableObject {
     const project = url.searchParams.get("project") ?? undefined;
     const kind = url.searchParams.get("kind") ?? undefined;
     const known = provider === "aws" ? await this.createdAWSImage(decodedImageID) : undefined;
-    const knownRegion = known?.region ?? "";
+    const promotedAWSImage =
+      provider === "aws" ? await this.promotedAWSImageByID(decodedImageID) : undefined;
+    const awsMetadata = known ?? promotedAWSImage;
+    const knownRegion = awsMetadata?.region ?? "";
     const providerRegion = region || knownRegion;
     if (method === "GET" && action === undefined) {
       let image: ProviderImage;
@@ -3714,12 +3717,55 @@ export class FleetDurableObject implements DurableObject {
         }
         throw error;
       }
-      return json({ image: provider === "aws" ? mergeAWSImageMetadata(image, known) : image });
+      return json({
+        image: provider === "aws" ? mergeAWSImageMetadata(image, awsMetadata) : image,
+      });
+    }
+    if (method === "GET" && (action === "fast-snapshot-restore" || action === "fsr-status")) {
+      if (provider !== "aws") {
+        return json(
+          { error: "unsupported_provider", message: "Fast Snapshot Restore is AWS-only" },
+          { status: 400 },
+        );
+      }
+      const rawRegion = region ?? knownRegion;
+      const imageRegion = rawRegion ? sanitizeAWSRegion(rawRegion) : "";
+      if (rawRegion && !imageRegion) {
+        return json(
+          { error: "invalid_region", message: "region must be an AWS region name" },
+          { status: 400 },
+        );
+      }
+      const image = mergeAWSImageMetadata(
+        await this.provider("aws", imageRegion).getImage(decodedImageID),
+        awsMetadata,
+      );
+      const snapshots = image.snapshots ?? [];
+      if (snapshots.length === 0) {
+        return json(
+          {
+            error: "image_snapshots_missing",
+            message: `image ${decodedImageID} has no EBS snapshots to describe for Fast Snapshot Restore`,
+          },
+          { status: 409 },
+        );
+      }
+      const availabilityZones = fastSnapshotRestoreStatusAZs(url, image.region ?? imageRegion);
+      const fastSnapshotRestores = await this.provider(
+        "aws",
+        image.region ?? imageRegion,
+      ).fastSnapshotRestoreStatus?.(snapshots, availabilityZones);
+      const imageWithStatus = {
+        ...image,
+        fastSnapshotRestores: fastSnapshotRestores ?? [],
+      };
+      return json({
+        image: imageWithStatus,
+        fastSnapshotRestores: imageWithStatus.fastSnapshotRestores,
+      });
     }
     if (method === "DELETE" && action === undefined) {
-      const promoted =
-        provider === "aws" ? await this.promotedAWSImageByID(decodedImageID) : undefined;
-      if (promoted?.id === decodedImageID) {
+      if (promotedAWSImage?.id === decodedImageID) {
         return json(
           {
             error: "image_promoted",
@@ -4626,6 +4672,16 @@ function fastSnapshotRestoreAZs(
     ...splitCommaList(url.searchParams.get("fsrAzs") ?? ""),
     ...splitCommaList(env.CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS ?? ""),
     ...splitCommaList(env.CRABBOX_CAPACITY_AVAILABILITY_ZONES ?? ""),
+  ];
+  return [...new Set(zones.map((zone) => zone.trim()).filter((zone) => validAWSAZ(zone, region)))];
+}
+
+function fastSnapshotRestoreStatusAZs(url: URL, region: string): string[] {
+  const zones = [
+    ...url.searchParams.getAll("fsrAz"),
+    ...url.searchParams.getAll("az"),
+    ...splitCommaList(url.searchParams.get("fsrAzs") ?? ""),
+    ...splitCommaList(url.searchParams.get("azs") ?? ""),
   ];
   return [...new Set(zones.map((zone) => zone.trim()).filter((zone) => validAWSAZ(zone, region)))];
 }
@@ -6200,6 +6256,10 @@ interface CloudProvider {
     snapshotIDs: string[],
     availabilityZones: string[],
   ): Promise<ProviderFastSnapshotRestore[]>;
+  fastSnapshotRestoreStatus?(
+    snapshotIDs: string[],
+    availabilityZones?: string[],
+  ): Promise<ProviderFastSnapshotRestore[]>;
   deleteSSHKey(name: string): Promise<void>;
   hourlyPriceUSD(
     serverType: string,
@@ -6508,6 +6568,13 @@ class AWSProvider implements CloudProvider {
     availabilityZones: string[],
   ): Promise<ProviderFastSnapshotRestore[]> {
     return this.client.enableFastSnapshotRestore(snapshotIDs, availabilityZones);
+  }
+
+  fastSnapshotRestoreStatus(
+    snapshotIDs: string[],
+    availabilityZones?: string[],
+  ): Promise<ProviderFastSnapshotRestore[]> {
+    return this.client.fastSnapshotRestoreStatus(snapshotIDs, availabilityZones);
   }
 
   deleteImage(imageID: string): Promise<void> {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1369,6 +1369,69 @@ describe("aws provider", () => {
       "DeleteSnapshot",
     ]);
   });
+
+  it("describes Fast Snapshot Restore status for selected snapshots and zones", async () => {
+    const actions: string[] = [];
+    const queries: URLSearchParams[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const body = await request.clone().text();
+        const params = new URLSearchParams(body);
+        const action = params.get("Action") ?? "";
+        actions.push(action);
+        queries.push(params);
+        if (action === "DescribeFastSnapshotRestores") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeFastSnapshotRestoresResponse>
+  <fastSnapshotRestoreSet>
+    <item>
+      <snapshotId>snap-root</snapshotId>
+      <availabilityZone>us-west-2a</availabilityZone>
+      <state>enabled</state>
+    </item>
+    <item>
+      <snapshotId>snap-tools</snapshotId>
+      <availabilityZone>us-west-2a</availabilityZone>
+      <state>enabling</state>
+      <stateTransitionReason>Client.UserInitiated</stateTransitionReason>
+    </item>
+  </fastSnapshotRestoreSet>
+</DescribeFastSnapshotRestoresResponse>`);
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "us-west-2",
+    );
+    const statuses = await client.fastSnapshotRestoreStatus(
+      ["snap-root", "snap-tools", "snap-root"],
+      ["us-west-2a", "us-west-2a"],
+    );
+
+    expect(actions).toEqual(["DescribeFastSnapshotRestores"]);
+    expect(queries[0].get("Filter.1.Name")).toBe("snapshot-id");
+    expect(queries[0].get("Filter.1.Value.1")).toBe("snap-root");
+    expect(queries[0].get("Filter.1.Value.2")).toBe("snap-tools");
+    expect(queries[0].get("Filter.2.Name")).toBe("availability-zone");
+    expect(queries[0].get("Filter.2.Value.1")).toBe("us-west-2a");
+    expect(statuses).toEqual([
+      { snapshotID: "snap-root", availabilityZone: "us-west-2a", state: "enabled" },
+      {
+        snapshotID: "snap-tools",
+        availabilityZone: "us-west-2a",
+        state: "enabling",
+        stateTransitionReason: "Client.UserInitiated",
+      },
+    ]);
+  });
 });
 
 function ec2ConfiguredSecurityGroupResponse(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -19,6 +19,8 @@ import type {
   Env,
   ExternalRunnerRecord,
   LeaseRecord,
+  ProviderFastSnapshotRestore,
+  ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
   RunRecord,
@@ -4073,6 +4075,77 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("returns current AWS Fast Snapshot Restore status for promoted images", async () => {
+    const storage = new MemoryStorage();
+    const statusCalls: Array<{ snapshots: string[]; zones: string[] | undefined }> = [];
+    storage.seed("image:aws:promoted:windows:x86_64:us-west-2", {
+      id: "ami-devtools",
+      name: "devtools-windows",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "us-west-2",
+      target: "windows",
+      architecture: "x86_64",
+      snapshots: ["snap-root"],
+      promotedAt: "2026-05-21T00:00:00Z",
+    });
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        onGetImage(imageID) {
+          return {
+            id: imageID,
+            name: "devtools-windows",
+            state: "available",
+            provider: "aws",
+            kind: "aws-ami",
+            region: "us-west-2",
+            resourceID: imageID,
+            architecture: "x86_64",
+            snapshots: ["snap-root", "snap-tools"],
+          };
+        },
+        onFastSnapshotRestoreStatus(snapshotIDs, availabilityZones) {
+          statusCalls.push({ snapshots: snapshotIDs, zones: availabilityZones });
+          return [
+            {
+              snapshotID: "snap-root",
+              availabilityZone: "us-west-2a",
+              state: "enabled",
+            },
+          ];
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request(
+        "GET",
+        "/v1/images/ami-devtools/fast-snapshot-restore?region=us-west-2&fsrAz=us-west-2a",
+        {
+          headers: { "x-crabbox-admin": "true" },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(statusCalls).toEqual([
+      { snapshots: ["snap-root", "snap-tools"], zones: ["us-west-2a"] },
+    ]);
+    await expect(response.json()).resolves.toMatchObject({
+      image: {
+        id: "ami-devtools",
+        target: "windows",
+        fastSnapshotRestores: [
+          { snapshotID: "snap-root", availabilityZone: "us-west-2a", state: "enabled" },
+        ],
+      },
+      fastSnapshotRestores: [
+        { snapshotID: "snap-root", availabilityZone: "us-west-2a", state: "enabled" },
+      ],
+    });
+  });
+
   it("requires Fast Snapshot Restore availability zones when no defaults are configured", async () => {
     const fleet = testFleet(new MemoryStorage(), {
       aws: fakeProvider(),
@@ -5821,6 +5894,10 @@ function fakeProvider(
     onGetImage?: (imageID: string, kind?: string) => Promise<ProviderImage> | ProviderImage;
     onDeleteImage?: (imageID: string, kind?: string) => void;
     onEnableFastSnapshotRestore?: (snapshotIDs: string[], availabilityZones: string[]) => void;
+    onFastSnapshotRestoreStatus?: (
+      snapshotIDs: string[],
+      availabilityZones: string[] | undefined,
+    ) => ProviderFastSnapshotRestore[];
     onRefreshSSHIngress?: (config: LeaseConfig) => void;
   } = {},
   onDelete?: (id: string) => Promise<void>,
@@ -5963,6 +6040,12 @@ function fakeProvider(
           state: "enabling",
         })),
       );
+    },
+    async fastSnapshotRestoreStatus(snapshotIDs: string[], availabilityZones?: string[]) {
+      if (result.onFastSnapshotRestoreStatus) {
+        return result.onFastSnapshotRestoreStatus(snapshotIDs, availabilityZones);
+      }
+      return [];
     },
     async deleteSSHKey() {},
     async hourlyPriceUSD() {


### PR DESCRIPTION
Summary:
- add a coordinator image route for live AWS Fast Snapshot Restore status
- add `crabbox image fsr-status` for AMIs and snapshots with optional AZ filtering
- document the status check and add an Unreleased changelog entry

Verification:
- go test ./internal/cli -run 'TestCoordinatorImageCreateAndPromote'
- go test ./...
- npm test --prefix worker -- aws.test.ts fleet.test.ts
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm run build --prefix worker
- go build -trimpath -o bin/crabbox ./cmd/crabbox
- ./bin/crabbox image fsr-status --help
