### PR TITLE
fix: accept FSR status flags after image id

### DIFF
--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1221,6 +1221,44 @@ func TestCoordinatorImageCreateAndPromote(t *testing.T) {
 	}
 }
 
+func TestImageFSRStatusAcceptsFlagsAfterImageID(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var gotPath, gotRegion, gotAuth string
+	var gotAZs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRegion = r.URL.Query().Get("region")
+		gotAZs = r.URL.Query()["fsrAz"]
+		gotAuth = r.Header.Get("Authorization")
+		if r.Method != http.MethodGet {
+			t.Fatalf("method=%s", r.Method)
+		}
+		_, _ = w.Write([]byte(`{"image":{"id":"ami-12345678","state":"available","region":"us-west-2","fastSnapshotRestores":[{"snapshotID":"snap-root","availabilityZone":"us-west-2a","state":"enabled"}]}}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+	var out bytes.Buffer
+	app := App{Stdout: &out, Stderr: io.Discard}
+	err := app.imageFSRStatus(context.Background(), []string{"ami-12345678", "--region", "us-west-2", "--fsr-az", "us-west-2a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/v1/images/ami-12345678/fast-snapshot-restore" || gotRegion != "us-west-2" || !reflect.DeepEqual(gotAZs, []string{"us-west-2a"}) {
+		t.Fatalf("request path=%q region=%q azs=%#v", gotPath, gotRegion, gotAZs)
+	}
+	if gotAuth != "Bearer admin-token" {
+		t.Fatalf("auth=%q", gotAuth)
+	}
+	if !strings.Contains(out.String(), "fsr snapshot=snap-root az=us-west-2a state=enabled") {
+		t.Fatalf("output=%q", out.String())
+	}
+}
+
 func TestLeaseStatusRequiresSSHReadiness(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_123" {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -94,7 +94,7 @@ func (a App) imageFSRStatus(ctx context.Context, args []string) error {
 	var fastSnapshotRestoreAZs stringListFlag
 	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore status; repeatable")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {


### PR DESCRIPTION
Summary:
- allow `crabbox image fsr-status ami-... --region ... --fsr-az ...`
- add regression coverage for the natural positional-then-flags form

Verification:
- go test ./internal/cli -run 'TestImageFSRStatusAcceptsFlagsAfterImageID|TestCoordinatorImageCreateAndPromote'
