### PR TITLE
Align Crabbox package metadata with v0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "OpenClaw plugin for running Crabbox remote testbox workflows",
   "license": "MIT",
   "type": "module",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@cloudflare/containers": "^0.3.4",
         "@novnc/novnc": "^1.7.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Align root package metadata with Crabbox v0.17.0.
- Align worker package metadata and lockfile metadata with v0.17.0.
- Makes OpenClaw plugin runtime inspection report the current 0.17.0 plugin version.

## Verification
- npm run check --prefix worker
- npm test
- git diff --check