### PR TITLE
feat: add Blacksmith delegated proof artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.17.1 - Unreleased
 
+### Added
+
+- Added `crabbox run --emit-proof` support for Blacksmith Testbox delegated runs, including bounded local stdout/stderr, timing, and metadata artifacts for successful proof runs.
+
 ## 0.17.0 - 2026-05-21
 
 ### Added

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -173,6 +173,8 @@ Rules:
   - `FeatureRestore` - backend can restore a workspace to a previous checkpoint.
   - `FeatureSnapshot` - backend can return a provider-native snapshot handle
     that Crabbox can reference in checkpoint metadata.
+  - `FeatureRunProof` - delegated backend can return bounded stream/timing
+    metadata for core `crabbox run --emit-proof` rendering.
 - `Coordinator` is `CoordinatorSupported` only when the Cloudflare Worker can
   provision your runners. Direct-only providers, including all delegated run
   backends and Static SSH, set `CoordinatorNever`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,11 +73,13 @@ a local `.crabbox/captures/*.tar.gz` bundle by default. SSH-backed runs include
 the uploaded script, redacted env/config summaries, timing JSON, command
 stdout/stderr, common test/report/log paths, and a generic gateway log tail when
 present. Blacksmith delegated runs include stdout/stderr plus timing and
-redacted env/config metadata. Implicit stdout/stderr files inside automatic
-failure bundles are capped; use `--capture-stdout` / `--capture-stderr` when a
-full local stream file is required. `--capture-on-fail` remains accepted for
-older scripts. Crabbox does not redact captured files, so treat them as
-secret-bearing until reviewed.
+redacted env/config metadata. Successful Blacksmith runs also support
+`--emit-proof`; when requested, Crabbox writes bounded stdout/stderr, timing,
+metadata, and the generated proof block as local run artifacts. Implicit
+stdout/stderr files inside automatic failure bundles are capped; use
+`--capture-stdout` / `--capture-stderr` when a full local stream file is
+required. `--capture-on-fail` remains accepted for older scripts. Crabbox does
+not redact captured files, so treat them as secret-bearing until reviewed.
 `run --download remote=local` copies successful-run artifacts back to the local
 machine without adding file bytes to coordinator logs.
 Test results are stored as structured summaries when `--junit` or

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -350,6 +350,7 @@ cli.FeatureCheckpoint
 cli.FeatureFork
 cli.FeatureRestore
 cli.FeatureSnapshot
+cli.FeatureRunProof
 ```
 
 Actions runner hydration is intentionally not a provider feature. It is a core
@@ -369,6 +370,8 @@ Checkpoint-related features are reserved for versioned workspaces:
 - `FeatureRestore`: provider can restore an existing workspace to a checkpoint.
 - `FeatureSnapshot`: provider can expose a native snapshot id for Crabbox
   metadata.
+- `FeatureRunProof`: delegated provider can return bounded stream/timing
+  metadata for core `crabbox run --emit-proof` rendering.
 
 Do not set these flags for plain SSH access alone. Generic Git/archive/log
 checkpoints are core-owned and should work even when the provider advertises no

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -112,6 +112,19 @@ redacted env/config metadata even though remote file capture is delegated to
 Blacksmith. These implicit stream logs are capped so a verbose successful run
 does not fill local temp storage.
 
+`--emit-proof <path>` is supported for successful Blacksmith runs. Crabbox
+renders the same proof block used by SSH-backed runs from the delegated
+stdout/stderr transcript, command timing, Testbox ID, and any GitHub Actions run
+URL found in the stream. When proof is requested, Crabbox also keeps bounded
+local transcript artifacts under `.crabbox/runs/<testbox-id>/`:
+
+```text
+blacksmith.stdout.log
+blacksmith.stderr.log
+timing.json
+metadata.json
+```
+
 Crabbox terminates a local Blacksmith CLI invocation that remains in the sync
 phase for five minutes without post-sync output. Set
 `CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS=0` to disable the guard, or set a larger
@@ -130,6 +143,7 @@ visibility-only detail page for the row.
 - Crabbox sync: no.
 - Provider sync: yes, Blacksmith-owned.
 - Desktop/browser/code: no Crabbox VNC/code surface.
+- Proof: yes, from delegated stream/timing metadata.
 - Actions hydration: Blacksmith-owned workflow setup, not Crabbox SSH hydration.
 - Coordinator: no.
 
@@ -137,9 +151,9 @@ visibility-only detail page for the row.
 
 - `--sync-only`, `--checksum`, and `--force-sync-large` do not apply because
   Blacksmith owns sync.
-- `--script`, `--script-stdin`, `--fresh-pr`, local captures, and
-  `--download` are rejected because Blacksmith owns command transport and
-  artifact handling.
+- `--script`, `--script-stdin`, `--fresh-pr`, local captures, `--download`, and
+  `--artifact-glob` are rejected because Blacksmith owns command transport and
+  remote artifact handling. Use `--emit-proof` for PR-ready transcript proof.
 - `list` and `status` are core-rendered from parsed Blacksmith CLI output.
 - `blacksmith.workflow` is required only when Crabbox needs to create a Testbox.
   Reusing an existing ID or slug does not need workflow config.

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -450,6 +450,18 @@ func TestRenderRunProofUsesSafeMarkdownFence(t *testing.T) {
 	}
 }
 
+func TestSelectProofLogExcerptStripsTerminalControl(t *testing.T) {
+	got := selectProofLogExcerpt("\x1b[2KWaiting for testbox... queued\r\x1b[2KTestbox ready!\nblacksmith-proof-live-ok\n")
+	for _, want := range []string{"Waiting for testbox... queued", "Testbox ready!", "blacksmith-proof-live-ok"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("excerpt missing %q:\n%s", want, got)
+		}
+	}
+	if strings.ContainsAny(got, "\x1b\r") {
+		t.Fatalf("excerpt contains terminal control bytes: %q", got)
+	}
+}
+
 func TestRenderRunProofRejectsUnresolvedTemplateVariables(t *testing.T) {
 	_, err := renderRunProof(proofRenderInput{
 		Template: ProofTemplateConfig{
@@ -968,6 +980,40 @@ profiles:
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "proof template") {
 		t.Fatalf("error=%v, want proof template config error", err)
+	}
+}
+
+func TestRunCommandDelegatedProviderEmitsProof(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".crabbox.yaml"), []byte(`provider: blacksmith-testbox
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	proofPath := filepath.Join(dir, "proof.md")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "blacksmith-testbox",
+		"--emit-proof", proofPath,
+		"--",
+		"pnpm", "test",
+	})
+	if err != nil {
+		t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	proofData, err := os.ReadFile(proofPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof := string(proofData)
+	for _, want := range []string{"## Real behavior proof", "blacksmith-testbox", "delegated test output", "suite pass"} {
+		if !strings.Contains(proof, want) {
+			t.Fatalf("proof missing %q:\n%s", want, proof)
+		}
+	}
+	if !strings.Contains(stderr.String(), "artifact kind=proof") {
+		t.Fatalf("stderr missing proof artifact line:\n%s", stderr.String())
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -106,6 +106,7 @@ const (
 	FeatureFork        Feature = "workspace-fork"
 	FeatureRestore     Feature = "workspace-restore"
 	FeatureSnapshot    Feature = "provider-snapshot"
+	FeatureRunProof    Feature = "run-proof"
 )
 
 type FeatureSet []Feature
@@ -258,39 +259,40 @@ type ListRequest struct {
 }
 
 type RunRequest struct {
-	Repo            Repo
-	ID              string
-	Options         LeaseOptions
-	Keep            bool
-	Reclaim         bool
-	NoSync          bool
-	SyncOnly        bool
-	DebugSync       bool
-	ShellMode       bool
-	ChecksumSync    bool
-	ForceSyncLarge  bool
-	FullResync      bool
-	EnvHelper       string
-	CaptureStdout   string
-	CaptureStderr   string
-	CaptureOnFail   bool
-	KeepOnFailure   bool
-	Preflight       bool
-	Downloads       []string
-	Env             map[string]string
-	EnvSummary      bool
-	ScriptRequested bool
-	Script          *RunScriptSpec
-	FreshPR         FreshPRSpec
-	ApplyLocalPatch bool
-	Command         []string
-	Label           string
-	RequestedSlug   string
-	TimingJSON      bool
-	ArtifactGlobs   []string
-	EmitProof       string
-	ProofTemplate   string
-	StopAfter       string
+	Repo             Repo
+	ID               string
+	Options          LeaseOptions
+	Keep             bool
+	Reclaim          bool
+	NoSync           bool
+	SyncOnly         bool
+	DebugSync        bool
+	ShellMode        bool
+	ChecksumSync     bool
+	ForceSyncLarge   bool
+	FullResync       bool
+	EnvHelper        string
+	CaptureStdout    string
+	CaptureStderr    string
+	CaptureOnFail    bool
+	KeepOnFailure    bool
+	Preflight        bool
+	Downloads        []string
+	Env              map[string]string
+	EnvSummary       bool
+	ScriptRequested  bool
+	Script           *RunScriptSpec
+	FreshPR          FreshPRSpec
+	ApplyLocalPatch  bool
+	Command          []string
+	Label            string
+	RequestedSlug    string
+	TimingJSON       bool
+	ArtifactGlobs    []string
+	EmitProof        string
+	ProofTemplate    string
+	ProfileVariables map[string]string
+	StopAfter        string
 }
 
 type WarmupRequest struct {
@@ -325,6 +327,13 @@ type RunResult struct {
 	Command       time.Duration
 	Total         time.Duration
 	SyncDelegated bool
+	Provider      string
+	LeaseID       string
+	Slug          string
+	CommandText   string
+	LogExcerpt    string
+	ActionsURL    string
+	Artifacts     []RunArtifact
 }
 
 type LeaseTarget struct {
@@ -536,7 +545,7 @@ func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error 
 	if len(req.ArtifactGlobs) > 0 {
 		return exit(2, "%s delegates run execution; --artifact-glob is not supported", provider)
 	}
-	if req.EmitProof != "" {
+	if req.EmitProof != "" && !featureSetHas(spec.Features, FeatureRunProof) {
 		return exit(2, "%s delegates run execution; --emit-proof is not supported", provider)
 	}
 	if req.StopAfter != "" {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -431,6 +431,16 @@ func TestRejectDelegatedSyncOptionsAllowsArchiveSyncControls(t *testing.T) {
 	}
 }
 
+func TestRejectDelegatedSyncOptionsAllowsProofFeature(t *testing.T) {
+	spec := ProviderSpec{Name: "blacksmith-testbox", Kind: ProviderKindDelegatedRun, Features: FeatureSet{FeatureRunProof}}
+	if err := RejectDelegatedSyncOptionsForSpec(spec, RunRequest{EmitProof: "/tmp/proof.md"}); err != nil {
+		t.Fatalf("delegated proof provider should allow --emit-proof: %v", err)
+	}
+	if err := RejectDelegatedSyncOptionsForSpec(ProviderSpec{Name: "islo"}, RunRequest{EmitProof: "/tmp/proof.md"}); err == nil {
+		t.Fatal("plain delegated provider should reject --emit-proof")
+	}
+}
+
 func TestProviderFlagsApplyDaytonaAndIsloWithoutCoreEdits(t *testing.T) {
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -282,7 +282,7 @@ func (testBlacksmithProvider) Spec() ProviderSpec {
 		Name:        "blacksmith-testbox",
 		Kind:        ProviderKindDelegatedRun,
 		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    nil,
+		Features:    FeatureSet{FeatureRunProof},
 		Coordinator: CoordinatorNever,
 	}
 }
@@ -746,7 +746,13 @@ func (b testDelegatedBackend) Warmup(context.Context, WarmupRequest) error {
 	return nil
 }
 func (b testDelegatedBackend) Run(context.Context, RunRequest) (RunResult, error) {
-	return RunResult{}, nil
+	return RunResult{
+		Provider:    b.spec.Name,
+		LeaseID:     "tbx_test",
+		Slug:        "testbox",
+		CommandText: "pnpm test",
+		LogExcerpt:  "delegated test output\nsuite pass",
+	}, nil
 }
 func (b testDelegatedBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
 	return nil, nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -353,38 +353,39 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	options := leaseOptionsFromConfig(cfg)
 	scriptRequested := *scriptPath != "" || *scriptStdin
 	runReq := RunRequest{
-		Repo:            repo,
-		ID:              *leaseIDFlag,
-		Options:         options,
-		Keep:            *keep,
-		KeepOnFailure:   *keepOnFailure,
-		Reclaim:         *reclaim,
-		NoSync:          *noSync,
-		SyncOnly:        *syncOnly,
-		DebugSync:       *debugSync,
-		ShellMode:       *shellMode,
-		ChecksumSync:    *checksumSync,
-		ForceSyncLarge:  *forceSyncLarge,
-		FullResync:      fullResyncRequested,
-		EnvHelper:       envHelperName,
-		CaptureStdout:   *captureStdout,
-		CaptureStderr:   *captureStderr,
-		CaptureOnFail:   *captureOnFail,
-		Preflight:       *preflight,
-		Downloads:       downloads,
-		Env:             envSelection.Effective,
-		EnvSummary:      envSelection.SummaryRequested,
-		ScriptRequested: scriptRequested,
-		FreshPR:         freshPR,
-		ApplyLocalPatch: *applyLocalPatch,
-		Command:         command,
-		Label:           runLabelValue,
-		RequestedSlug:   requestedSlug,
-		TimingJSON:      *timingJSON,
-		ArtifactGlobs:   expansion.ArtifactGlobs,
-		EmitProof:       strings.TrimSpace(*emitProof),
-		ProofTemplate:   strings.TrimSpace(*proofTemplate),
-		StopAfter:       strings.TrimSpace(*stopAfter),
+		Repo:             repo,
+		ID:               *leaseIDFlag,
+		Options:          options,
+		Keep:             *keep,
+		KeepOnFailure:    *keepOnFailure,
+		Reclaim:          *reclaim,
+		NoSync:           *noSync,
+		SyncOnly:         *syncOnly,
+		DebugSync:        *debugSync,
+		ShellMode:        *shellMode,
+		ChecksumSync:     *checksumSync,
+		ForceSyncLarge:   *forceSyncLarge,
+		FullResync:       fullResyncRequested,
+		EnvHelper:        envHelperName,
+		CaptureStdout:    *captureStdout,
+		CaptureStderr:    *captureStderr,
+		CaptureOnFail:    *captureOnFail,
+		Preflight:        *preflight,
+		Downloads:        downloads,
+		Env:              envSelection.Effective,
+		EnvSummary:       envSelection.SummaryRequested,
+		ScriptRequested:  scriptRequested,
+		FreshPR:          freshPR,
+		ApplyLocalPatch:  *applyLocalPatch,
+		Command:          command,
+		Label:            runLabelValue,
+		RequestedSlug:    requestedSlug,
+		TimingJSON:       *timingJSON,
+		ArtifactGlobs:    expansion.ArtifactGlobs,
+		EmitProof:        strings.TrimSpace(*emitProof),
+		ProofTemplate:    strings.TrimSpace(*proofTemplate),
+		ProfileVariables: expansion.Variables,
+		StopAfter:        strings.TrimSpace(*stopAfter),
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
 		if expansion.Profile.Doctor.Enabled {
@@ -399,6 +400,13 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		result, runErr := delegated.Run(ctx, runReq)
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+		}
+		if runErr == nil && strings.TrimSpace(*emitProof) != "" {
+			proof, err := writeDelegatedRunProof(strings.TrimSpace(*emitProof), strings.TrimSpace(*proofTemplate), cfg, result, runReq)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 		}
 		return runErr
 	}
@@ -1225,6 +1233,35 @@ func populateRunTimingMetadata(report *timingReport, cfg Config, repo Repo, serv
 	report.StopCommand = runStopCommand(cfg, firstNonBlank(serverSlug(server), leaseID))
 	report.IdleTimeout = cfg.IdleTimeout.String()
 	report.Artifacts = artifacts
+}
+
+func writeDelegatedRunProof(path, templateName string, cfg Config, result RunResult, req RunRequest) (runArtifact, error) {
+	template := cfg.ProofTemplates[strings.TrimSpace(templateName)]
+	provider := firstNonBlank(result.Provider, cfg.Provider)
+	leaseID := result.LeaseID
+	slug := result.Slug
+	command := strings.TrimSpace(result.CommandText)
+	if command == "" {
+		command = runCommandDisplay(req.Command, req.ShellMode)
+	}
+	logExcerpt := strings.TrimSpace(result.LogExcerpt)
+	if logExcerpt == "" {
+		logExcerpt = "(no console output captured)"
+	}
+	return writeRunProof(path, templateName, proofRenderInput{
+		Template:    template,
+		Provider:    provider,
+		LeaseID:     leaseID,
+		Slug:        slug,
+		Command:     command,
+		LogExcerpt:  logExcerpt,
+		ActionsURL:  result.ActionsURL,
+		Artifacts:   result.Artifacts,
+		Variables:   req.ProfileVariables,
+		CommandMs:   result.Command.Milliseconds(),
+		ExitCode:    result.ExitCode,
+		GeneratedAt: time.Now(),
+	})
 }
 
 func runCommandDisplay(command []string, shellMode bool) string {

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -12,12 +12,14 @@ import (
 	"time"
 )
 
-type runArtifact struct {
+type RunArtifact struct {
 	Kind     string `json:"kind"`
 	Path     string `json:"path"`
 	Template string `json:"template,omitempty"`
 	Bytes    int    `json:"bytes,omitempty"`
 }
+
+type runArtifact = RunArtifact
 
 type runArtifactResult struct {
 	Files []runArtifact `json:"files,omitempty"`
@@ -57,6 +59,10 @@ func localRunArtifactPath(repoRoot, runID, leaseID, name string) string {
 		root = "."
 	}
 	return filepath.Join(root, ".crabbox", "runs", safeCaptureName(firstNonBlank(runID, leaseID, "run")), name)
+}
+
+func LocalRunArtifactPath(repoRoot, runID, leaseID, name string) string {
+	return localRunArtifactPath(repoRoot, runID, leaseID, name)
 }
 
 func validateRunArtifactGlobs(globs []string) error {
@@ -331,6 +337,7 @@ func markdownFence(info, content string) (string, string) {
 }
 
 func selectProofLogExcerpt(log string) string {
+	log = strings.ReplaceAll(stripANSI(log), "\r", "\n")
 	lines := strings.Split(strings.TrimSpace(log), "\n")
 	out := make([]string, 0, 12)
 	for i := len(lines) - 1; i >= 0 && len(out) < 12; i-- {
@@ -350,6 +357,10 @@ func selectProofLogExcerpt(log string) string {
 		excerpt = excerpt[len(excerpt)-4000:]
 	}
 	return excerpt
+}
+
+func SelectProofLogExcerpt(log string) string {
+	return selectProofLogExcerpt(log)
 }
 
 func remoteProfileDoctorCommand(profile string, doctor DoctorProfileConfig, workdir string) string {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -2,10 +2,13 @@ package blacksmith
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -91,7 +94,7 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 }
 
 func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectDelegatedSyncOptions(blacksmithTestboxProvider, req); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 		return RunResult{}, err
 	}
 	started := b.rt.Clock.Now()
@@ -147,9 +150,20 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		return RunResult{}, err
 	}
 	defer stderrCleanup()
+	stdoutProof := newBlacksmithProofTailBuffer()
+	stderrProof := newBlacksmithProofTailBuffer()
 	commandStart := b.rt.Clock.Now()
 	phaseTracker := core.NewCommandPhaseTracker(commandStart)
-	code := b.runTestbox(ctx, leaseID, req.Command, req.DebugSync, req.ShellMode, phaseTracker, stdoutCapture, stderrCapture)
+	code := b.runTestbox(
+		ctx,
+		leaseID,
+		req.Command,
+		req.DebugSync,
+		req.ShellMode,
+		phaseTracker,
+		mergeWriters(stdoutCapture, stdoutProof),
+		mergeWriters(stderrCapture, stderrProof),
+	)
 	if closeErr := stdoutCapture.Close(); closeErr != nil && code == 0 {
 		return RunResult{}, core.Exit(2, "blacksmith failure bundle stdout close: %v", closeErr)
 	}
@@ -168,7 +182,16 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			return RunResult{}, err
 		}
 	}
-	result := RunResult{ExitCode: code, Command: commandDuration, Total: total, SyncDelegated: true}
+	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
+	proof, proofErr := b.blacksmithProofResult(req, leaseID, slug, code, commandDuration, total, report, stdoutProof.Bytes(), stderrProof.Bytes(), actionsURL)
+	if proofErr != nil && code == 0 {
+		return RunResult{}, proofErr
+	}
+	result := proof
+	result.ExitCode = code
+	result.Command = commandDuration
+	result.Total = total
+	result.SyncDelegated = true
 	if code != 0 {
 		local, bytes, bundleErr := core.CaptureLocalFailureBundle(leaseID, core.FailureCaptureMetadata{
 			Provider:   blacksmithTestboxProvider,
@@ -192,6 +215,145 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		return result, ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
 	}
 	return result, nil
+}
+
+var githubActionsRunURLPattern = regexp.MustCompile(`https://github\.com/[^\s"'<>]+/actions/runs/[0-9]+[^\s"'<>]*`)
+
+const blacksmithProofStreamCaptureBytes = 1024 * 1024
+
+type blacksmithProofTailBuffer struct {
+	mu         sync.Mutex
+	data       []byte
+	scanTail   string
+	actionsURL string
+	truncated  bool
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func newBlacksmithProofTailBuffer() *blacksmithProofTailBuffer {
+	return &blacksmithProofTailBuffer{data: make([]byte, 0, 32*1024)}
+}
+
+func (b *blacksmithProofTailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.actionsURL == "" {
+		probe := b.scanTail + string(p)
+		if match := firstBlacksmithActionsURL(probe); match != "" {
+			b.actionsURL = match
+		}
+		if len(probe) > 2048 {
+			b.scanTail = probe[len(probe)-2048:]
+		} else {
+			b.scanTail = probe
+		}
+	}
+	if len(p) >= blacksmithProofStreamCaptureBytes {
+		b.data = append(b.data[:0], p[len(p)-blacksmithProofStreamCaptureBytes:]...)
+		b.truncated = true
+		return len(p), nil
+	}
+	overflow := len(b.data) + len(p) - blacksmithProofStreamCaptureBytes
+	if overflow > 0 {
+		copy(b.data, b.data[overflow:])
+		b.data = b.data[:len(b.data)-overflow]
+		b.truncated = true
+	}
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+
+func (b *blacksmithProofTailBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	data := append([]byte(nil), b.data...)
+	if !b.truncated {
+		return data
+	}
+	prefix := fmt.Appendf(nil, "[crabbox: proof stream kept last %d bytes]\n", blacksmithProofStreamCaptureBytes)
+	return append(prefix, data...)
+}
+
+func (b *blacksmithProofTailBuffer) ActionsURL() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.actionsURL
+}
+
+func (b *blacksmithBackend) blacksmithProofResult(req RunRequest, leaseID, slug string, exitCode int, commandDuration, total time.Duration, report timingReport, stdoutData, stderrData []byte, actionsURL string) (RunResult, error) {
+	combined := strings.TrimSpace(string(stdoutData) + "\n" + string(stderrData))
+	result := RunResult{
+		Provider:    blacksmithTestboxProvider,
+		LeaseID:     leaseID,
+		Slug:        slug,
+		CommandText: blacksmithCommandString(req.Command, req.ShellMode),
+		LogExcerpt:  core.SelectProofLogExcerpt(combined),
+		ActionsURL:  firstNonBlank(actionsURL, firstBlacksmithActionsURL(combined)),
+	}
+	if strings.TrimSpace(req.EmitProof) == "" {
+		return result, nil
+	}
+	artifacts, err := persistBlacksmithRunArtifacts(req.Repo.Root, leaseID, exitCode, commandDuration, total, report, stdoutData, stderrData, result)
+	if err != nil {
+		return RunResult{}, err
+	}
+	result.Artifacts = artifacts
+	return result, nil
+}
+
+func firstBlacksmithActionsURL(text string) string {
+	return githubActionsRunURLPattern.FindString(text)
+}
+
+func persistBlacksmithRunArtifacts(repoRoot, leaseID string, exitCode int, commandDuration, total time.Duration, report timingReport, stdoutData, stderrData []byte, result RunResult) ([]core.RunArtifact, error) {
+	metadata := map[string]any{
+		"provider":      blacksmithTestboxProvider,
+		"leaseId":       leaseID,
+		"slug":          result.Slug,
+		"command":       result.CommandText,
+		"exitCode":      exitCode,
+		"commandMs":     commandDuration.Milliseconds(),
+		"totalMs":       total.Milliseconds(),
+		"actionsRunUrl": result.ActionsURL,
+	}
+	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	timingJSON, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	files := []struct {
+		kind string
+		name string
+		data []byte
+	}{
+		{kind: "stdout", name: "blacksmith.stdout.log", data: stdoutData},
+		{kind: "stderr", name: "blacksmith.stderr.log", data: stderrData},
+		{kind: "timing", name: "timing.json", data: append(timingJSON, '\n')},
+		{kind: "metadata", name: "metadata.json", data: append(metadataJSON, '\n')},
+	}
+	artifacts := make([]core.RunArtifact, 0, len(files))
+	for _, file := range files {
+		path := core.LocalRunArtifactPath(repoRoot, "", leaseID, file.name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, core.Exit(2, "blacksmith proof artifact create %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, file.data, 0o600); err != nil {
+			return nil, core.Exit(2, "blacksmith proof artifact write %s: %v", path, err)
+		}
+		artifacts = append(artifacts, core.RunArtifact{Kind: file.kind, Path: path, Bytes: len(file.data)})
+	}
+	return artifacts, nil
 }
 
 func (b *blacksmithBackend) List(ctx context.Context, req ListRequest) ([]Server, error) {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -355,6 +355,71 @@ func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	}
 }
 
+func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
+			return LocalCommandResult{Stdout: "ready tbx_proof123\n"}, nil
+		}
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			if req.Stdout != nil {
+				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/123456789\n"))
+				_, _ = req.Stdout.Write([]byte(strings.Repeat("verbose setup line\n", blacksmithProofStreamCaptureBytes/19+8)))
+				_, _ = req.Stdout.Write([]byte("scenario pass delegated-proof\n"))
+			}
+			if req.Stderr != nil {
+				_, _ = req.Stderr.Write([]byte("stderr detail\n"))
+			}
+			return LocalCommandResult{}, nil
+		}
+		return LocalCommandResult{}, nil
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := newTestBlacksmithBackend(cfg, runner)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:      Repo{Root: repo},
+		Command:   []string{"pnpm", "test"},
+		EmitProof: filepath.Join(repo, "proof.md"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.LeaseID != "tbx_proof123" || result.ActionsURL != "https://github.com/example-org/my-app/actions/runs/123456789" {
+		t.Fatalf("result=%#v", result)
+	}
+	if !strings.Contains(result.LogExcerpt, "scenario pass delegated-proof") || !strings.Contains(result.LogExcerpt, "stderr detail") {
+		t.Fatalf("log excerpt=%q", result.LogExcerpt)
+	}
+	if len(result.Artifacts) != 4 {
+		t.Fatalf("artifacts=%#v", result.Artifacts)
+	}
+	for _, artifact := range result.Artifacts {
+		data, err := os.ReadFile(artifact.Path)
+		if err != nil {
+			t.Fatalf("read artifact %#v: %v", artifact, err)
+		}
+		if artifact.Bytes != len(data) {
+			t.Fatalf("artifact bytes mismatch for %#v got=%d", artifact, len(data))
+		}
+	}
+	stdoutPath := core.LocalRunArtifactPath(repo, "", "tbx_proof123", "blacksmith.stdout.log")
+	stdoutData, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stdoutData), "scenario pass delegated-proof") {
+		t.Fatalf("stdout artifact missing run output:\n%s", stdoutData)
+	}
+	if strings.Contains(string(stdoutData), "https://github.com/example-org/my-app/actions/runs/123456789") {
+		t.Fatalf("stdout artifact should be tail-limited, got early URL:\n%s", stdoutData)
+	}
+}
+
 func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -21,7 +21,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Name:        "blacksmith-testbox",
 		Kind:        core.ProviderKindDelegatedRun,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    nil,
+		Features:    core.FeatureSet{core.FeatureRunProof},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary

- allow delegated providers with `FeatureRunProof` to render `crabbox run --emit-proof`
- add Blacksmith Testbox proof metadata from tail-bounded stdout/stderr, timing JSON, metadata JSON, and Actions run URL capture
- document Blacksmith proof behavior and the provider feature flag

## Verification

- `go test ./...`
- `go vet ./...`
- `npm run docs:check`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `codex review --uncommitted`: no actionable correctness issues
- live Blacksmith Testbox proof against `openclaw/openclaw`: `tbx_01ks7ejtdvsa880y9kqryw3hn8`, Actions run https://github.com/openclaw/openclaw/actions/runs/26278540304, proof `/tmp/crabbox-blacksmith-proof-final.md`

Live proof emitted local artifacts under `/Users/steipete/Projects/clawdbot2/.crabbox/runs/tbx_01ks7ejtdvsa880y9kqryw3hn8/`:

- `blacksmith.stdout.log`
- `blacksmith.stderr.log`
- `timing.json`
- `metadata.json`
