### PR TITLE
feat: improve local container Docker test support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - Added `crabbox run --emit-proof` support for Blacksmith Testbox delegated runs, including bounded local stdout/stderr, timing, and metadata artifacts for successful proof runs.
+- Added local-container Docker socket pass-through with host-visible work roots so `provider: docker` leases can run Docker-based test suites through the host daemon.
+
+### Fixed
+
+- Fixed local Actions hydration for repo-local composite actions, cache no-ops, simple input conditions, safe `hashFiles`, secret-expression rejection, and Node 24.x setup on minimal Debian images.
 
 ## 0.17.0 - 2026-05-21
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -296,12 +296,17 @@ localContainer:
   cpus: 0
   memory: ""
   network: bridge
+  dockerSocket: false
 ```
 
 `provider: docker`, `provider: container`, and `provider: local-docker` are
 aliases for `local-container`. The backend uses Docker-compatible CLI commands,
 so Docker Desktop, OrbStack, Colima, and similar local runtimes work when their
-Docker context is active.
+Docker context is active. Set `dockerSocket: true` only when commands inside the
+lease must use the host Docker daemon. Crabbox mounts the active local Unix
+Docker socket and rejects remote Docker contexts. With the socket enabled and no
+explicit work root, Crabbox chooses a host-visible cache work root so nested
+Docker bind mounts can see the synced checkout.
 
 Use `--desktop --browser` to bootstrap Xvfb, XFCE, x11vnc, noVNC/websockify,
 desktop input tools, screenshot tools, ffmpeg, and a packaged browser inside

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -64,6 +64,7 @@ localContainer:
   cpus: 0
   memory: ""
   network: bridge
+  dockerSocket: false
 ```
 
 Provider flags:
@@ -76,6 +77,7 @@ Provider flags:
 --local-container-cpus <n>
 --local-container-memory <size>
 --local-container-network <network>
+--local-container-docker-socket
 ```
 
 Environment overrides:
@@ -88,7 +90,17 @@ CRABBOX_LOCAL_CONTAINER_WORK_ROOT
 CRABBOX_LOCAL_CONTAINER_CPUS
 CRABBOX_LOCAL_CONTAINER_MEMORY
 CRABBOX_LOCAL_CONTAINER_NETWORK
+CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET
 ```
+
+Set `localContainer.dockerSocket: true` or
+`CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1` when commands inside the lease need
+Docker. Crabbox mounts the active local Unix Docker socket into the container as
+`/var/run/docker.sock`, so `docker` commands run against the active local
+Docker-compatible daemon. Remote Docker contexts are rejected. When the socket is
+enabled and no work root is explicitly configured, Crabbox uses a host-visible
+cache work root and mounts it at the same absolute path inside the lease, so
+nested Docker bind mounts can see the synced checkout.
 
 ## Behavior
 
@@ -115,6 +127,8 @@ CRABBOX_LOCAL_CONTAINER_NETWORK
   are local-only. `webvnc` starts noVNC/websockify on the target and tunnels it
   over SSH; it does not use the authenticated Crabbox portal.
 - No code-server, Tailscale bootstrap, or native checkpoint support yet.
+- Docker socket pass-through is opt-in and gives the lease access to the host
+  Docker daemon.
 - `warmup --actions-runner` is not supported; use normal `crabbox run` for
   local container smoke tests or a remote SSH provider for GitHub runner
   registration.

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/url"
@@ -105,6 +107,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	applyResolvedServerConfig(&cfg, server)
 	if err := claimLeaseForRepoConfig(leaseID, slug, cfg, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
 		return err
 	}
@@ -597,6 +600,29 @@ type localHydrateStep struct {
 	With             map[string]string `yaml:"with"`
 }
 
+type localCompositeAction struct {
+	Name    string                          `yaml:"name"`
+	Inputs  map[string]localCompositeInput  `yaml:"inputs"`
+	Outputs map[string]localCompositeOutput `yaml:"outputs"`
+	Runs    localCompositeRuns              `yaml:"runs"`
+}
+
+type localCompositeInput struct {
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required"`
+	Default     string `yaml:"default"`
+}
+
+type localCompositeOutput struct {
+	Description string `yaml:"description"`
+	Value       string `yaml:"value"`
+}
+
+type localCompositeRuns struct {
+	Using string             `yaml:"using"`
+	Steps []localHydrateStep `yaml:"steps"`
+}
+
 func readLocalHydrateWorkflow(path string) (localHydrateWorkflow, error) {
 	var workflow localHydrateWorkflow
 	data, err := os.ReadFile(path)
@@ -670,10 +696,10 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 		"RUNNER_TOOL_CACHE":     runnerToolCache,
 		"CRABBOX_LOCAL_ACTIONS": "1",
 	}
-	if err := mergeInterpolatedEnv(env, workflow.Env, inputs, workdir); err != nil {
+	if err := mergeInterpolatedEnv(env, workflow.Env, inputs, workdir, repo.Root, nil); err != nil {
 		return "", err
 	}
-	if err := mergeInterpolatedEnv(env, job.Env, inputs, workdir); err != nil {
+	if err := mergeInterpolatedEnv(env, job.Env, inputs, workdir, repo.Root, nil); err != nil {
 		return "", err
 	}
 
@@ -687,7 +713,7 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 	b.WriteString("  *) export RUNNER_ARCH=\"$(uname -m)\" ;;\n")
 	b.WriteString("esac\n")
 	for _, key := range sortedKeys(env) {
-		value, err := interpolateLocalActionsValue(env[key], inputs, env, workdir)
+		value, err := interpolateLocalActionsValue(env[key], inputs, env, workdir, repo.Root, nil)
 		if err != nil {
 			return "", err
 		}
@@ -698,10 +724,40 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 		fmt.Fprintf(&b, "export INPUT_%s=%s\n", actionInputEnvName(key), shellQuote(value))
 	}
 	b.WriteString(localActionsRuntimeShell())
-	for i, step := range job.Steps {
-		skip, err := shouldSkipLocalHydrateStep(step.If)
+	ctx := localHydrateScriptContext{
+		RepoRoot:         repo.Root,
+		Workdir:          workdir,
+		Inputs:           inputs,
+		Env:              env,
+		WorkflowDefaults: workflow.Defaults,
+		JobDefaults:      job.Defaults,
+		StepOutputs:      map[string]map[string]string{},
+	}
+	if err := appendLocalHydrateSteps(&b, job.Steps, ctx); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+type localHydrateScriptContext struct {
+	RepoRoot         string
+	Workdir          string
+	Inputs           map[string]string
+	Env              map[string]string
+	WorkflowDefaults localHydrateDefaults
+	JobDefaults      localHydrateDefaults
+	StepOutputs      map[string]map[string]string
+	Depth            int
+}
+
+func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx localHydrateScriptContext) error {
+	if ctx.Depth > 8 {
+		return exit(2, "local Actions hydration composite action nesting is too deep")
+	}
+	for i, step := range steps {
+		skip, err := shouldSkipLocalHydrateStep(step.If, ctx.Inputs, ctx.Env, ctx.StepOutputs)
 		if err != nil {
-			return "", err
+			return err
 		}
 		if skip {
 			continue
@@ -710,56 +766,59 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 		if label == "" {
 			label = firstNonBlank(step.Uses, fmt.Sprintf("step %d", i+1))
 		}
-		fmt.Fprintf(&b, "echo %s\n", shellQuote("local actions: "+label))
-		stepEnv := copyStringMap(env)
-		if err := mergeInterpolatedEnv(stepEnv, step.Env, inputs, workdir); err != nil {
-			return "", err
+		fmt.Fprintf(b, "echo %s\n", shellQuote("local actions: "+label))
+		stepEnv := copyStringMap(ctx.Env)
+		if err := mergeInterpolatedEnv(stepEnv, step.Env, ctx.Inputs, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs); err != nil {
+			return err
 		}
 		for _, key := range sortedKeys(step.Env) {
 			if !validShellEnvName(key) {
-				return "", exit(2, "local Actions hydration does not support env name %q", key)
+				return exit(2, "local Actions hydration does not support env name %q", key)
 			}
-			value, err := interpolateLocalActionsValue(stepEnv[key], inputs, stepEnv, workdir)
+			value, err := interpolateLocalActionsValue(stepEnv[key], ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 			if err != nil {
-				return "", err
+				return err
 			}
-			fmt.Fprintf(&b, "__crabbox_save_step_env %s\n", shellQuote(key))
-			fmt.Fprintf(&b, "export %s=%s\n", key, shellQuote(value))
+			fmt.Fprintf(b, "__crabbox_save_step_env %s\n", shellQuote(key))
+			fmt.Fprintf(b, "export %s=%s\n", key, shellQuote(value))
 		}
 		b.WriteString("__crabbox_prepare_step_files\n")
 		if step.Uses != "" {
-			usesScript, err := localHydrateUsesScript(step, inputs, stepEnv, workdir)
+			usesScript, outputs, err := localHydrateUsesScript(step, ctx, stepEnv)
 			if err != nil {
-				return "", err
+				return err
 			}
 			b.WriteString(usesScript)
+			if step.ID != "" && len(outputs) > 0 {
+				ctx.StepOutputs[step.ID] = outputs
+			}
 		}
 		if step.Run != "" {
-			shellName := firstNonBlank(step.Shell, job.Defaults.Run.Shell, workflow.Defaults.Run.Shell, "bash")
-			wd := firstNonBlank(step.WorkingDirectory, job.Defaults.Run.WorkingDirectory, workflow.Defaults.Run.WorkingDirectory)
-			wd, err = interpolateLocalActionsValue(wd, inputs, stepEnv, workdir)
+			shellName := firstNonBlank(step.Shell, ctx.JobDefaults.Run.Shell, ctx.WorkflowDefaults.Run.Shell, "bash")
+			wd := firstNonBlank(step.WorkingDirectory, ctx.JobDefaults.Run.WorkingDirectory, ctx.WorkflowDefaults.Run.WorkingDirectory)
+			wd, err = interpolateLocalActionsValue(wd, ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 			if err != nil {
-				return "", err
+				return err
 			}
 			if wd == "" {
-				wd = workdir
+				wd = ctx.Workdir
 			} else if !strings.HasPrefix(wd, "/") {
-				wd = path.Join(workdir, wd)
+				wd = path.Join(ctx.Workdir, wd)
 			}
-			run, err := interpolateLocalActionsValue(step.Run, inputs, stepEnv, workdir)
+			run, err := interpolateLocalActionsValue(step.Run, ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 			if err != nil {
-				return "", err
+				return err
 			}
-			if err := appendLocalHydrateRunStep(&b, shellName, wd, run); err != nil {
-				return "", err
+			if err := appendLocalHydrateRunStep(b, shellName, wd, run); err != nil {
+				return err
 			}
 		}
 		for _, key := range sortedKeys(step.Env) {
-			fmt.Fprintf(&b, "__crabbox_restore_step_env %s\n", shellQuote(key))
+			fmt.Fprintf(b, "__crabbox_restore_step_env %s\n", shellQuote(key))
 		}
 		b.WriteString("__crabbox_apply_step_files\n")
 	}
-	return b.String(), nil
+	return nil
 }
 
 func fieldsMap(fields []string) (map[string]string, error) {
@@ -785,9 +844,9 @@ func repoSlugForActions(cfg Config, repo Repo) string {
 	return repo.Name + "/" + repo.Name
 }
 
-func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs map[string]string, workdir string) error {
+func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) error {
 	for key, value := range src {
-		interpolated, err := interpolateLocalActionsValue(value, inputs, dst, workdir)
+		interpolated, err := interpolateLocalActionsValue(value, inputs, dst, workdir, repoRoot, stepOutputs)
 		if err != nil {
 			return err
 		}
@@ -796,7 +855,7 @@ func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs m
 	return nil
 }
 
-func interpolateLocalActionsValue(value string, inputs, env map[string]string, workdir string) (string, error) {
+func interpolateLocalActionsValue(value string, inputs, env map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) (string, error) {
 	replacements := map[string]string{
 		"github.workspace":  workdir,
 		"github.ref":        env["GITHUB_REF"],
@@ -805,6 +864,9 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 		"github.run_id":     env["GITHUB_RUN_ID"],
 		"runner.temp":       env["RUNNER_TEMP"],
 		"runner.tool_cache": env["RUNNER_TOOL_CACHE"],
+	}
+	if actionPath := env["GITHUB_ACTION_PATH"]; actionPath != "" {
+		replacements["github.action_path"] = actionPath
 	}
 	var unsupported string
 	out := localActionsExpressionPattern.ReplaceAllStringFunc(value, func(match string) string {
@@ -815,6 +877,9 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 		expr := strings.TrimSpace(parts[1])
 		if replacement, ok := replacements[expr]; ok {
 			return replacement
+		}
+		if hash, ok := localActionsHashFiles(expr, repoRoot); ok {
+			return hash
 		}
 		if key, ok := strings.CutPrefix(expr, "inputs."); ok {
 			if input, ok := inputs[key]; ok {
@@ -828,6 +893,9 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 			}
 			return ""
 		}
+		if output, ok := localActionsStepOutput(expr, stepOutputs); ok {
+			return output
+		}
 		unsupported = expr
 		return match
 	})
@@ -840,9 +908,9 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 	return out, nil
 }
 
-var localActionsExpressionPattern = regexp.MustCompile(`\$\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}`)
+var localActionsExpressionPattern = regexp.MustCompile(`\$\{\{\s*([^}]+?)\s*\}\}`)
 
-func shouldSkipLocalHydrateStep(expr string) (bool, error) {
+func shouldSkipLocalHydrateStep(expr string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (bool, error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		return false, nil
@@ -855,50 +923,61 @@ func shouldSkipLocalHydrateStep(expr string) (bool, error) {
 	case "false", "cancelled()", "failure()":
 		return true, nil
 	default:
+		result, ok := evalLocalActionsIf(expr, inputs, env, stepOutputs)
+		if ok {
+			return !result, nil
+		}
 		return false, exit(2, "local Actions hydration does not support if expression %q", expr)
 	}
 }
 
-func localHydrateUsesScript(step localHydrateStep, inputs, env map[string]string, workdir string) (string, error) {
+func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext, env map[string]string) (string, map[string]string, error) {
 	uses := strings.ToLower(strings.TrimSpace(step.Uses))
 	switch {
 	case strings.HasPrefix(uses, "actions/checkout@"):
-		if err := validateLocalCheckoutStep(step, inputs, env, workdir); err != nil {
-			return "", err
+		if err := validateLocalCheckoutStep(step, ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot); err != nil {
+			return "", nil, err
 		}
-		return "# actions/checkout handled by Crabbox sync/git seed\n", nil
+		return "# actions/checkout handled by Crabbox sync/git seed\n", nil, nil
 	case strings.HasPrefix(uses, "actions/setup-node@"):
-		if err := validateLocalActionWithKeys("actions/setup-node", step.With, "node-version", "node-version-file"); err != nil {
-			return "", err
+		if err := validateLocalActionWithKeys("actions/setup-node", step.With, "node-version", "node-version-file", "check-latest"); err != nil {
+			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"node-version", "node-version-file"}, "", inputs, env, workdir)
+		version, err := localHydrateWithInput(step, []string{"node-version", "node-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
+		version = normalizeLocalNodeVersionSpec(version)
 		if strings.TrimSpace(step.With["node-version"]) != "" && !supportedLocalNodeVersionSpec(version) {
-			return "", exit(2, "local Actions hydration does not support actions/setup-node version %q; rerun with --github-runner when the workflow needs full GitHub Actions semantics", version)
+			return "", nil, exit(2, "local Actions hydration does not support actions/setup-node version %q; rerun with --github-runner when the workflow needs full GitHub Actions semantics", version)
 		}
-		return "__crabbox_setup_node " + shellQuote(version) + "\n", nil
+		return "__crabbox_setup_node " + shellQuote(version) + "\n", nil, nil
 	case strings.HasPrefix(uses, "actions/setup-go@"):
 		if err := validateLocalActionWithKeys("actions/setup-go", step.With, "go-version", "go-version-file"); err != nil {
-			return "", err
+			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"go-version", "go-version-file"}, "", inputs, env, workdir)
+		version, err := localHydrateWithInput(step, []string{"go-version", "go-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
-		return "__crabbox_setup_go " + shellQuote(version) + "\n", nil
+		return "__crabbox_setup_go " + shellQuote(version) + "\n", nil, nil
 	case strings.HasPrefix(uses, "actions/setup-python@"):
 		if err := validateLocalActionWithKeys("actions/setup-python", step.With, "python-version", "python-version-file"); err != nil {
-			return "", err
+			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"python-version", "python-version-file"}, "", inputs, env, workdir)
+		version, err := localHydrateWithInput(step, []string{"python-version", "python-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
-		return "__crabbox_setup_python " + shellQuote(version) + "\n", nil
+		return "__crabbox_setup_python " + shellQuote(version) + "\n", nil, nil
+	case strings.HasPrefix(uses, "actions/cache/restore@"):
+		return "printf 'cache-hit=false\\ncache-matched-key=\\n' >> \"$GITHUB_OUTPUT\"\n", map[string]string{"cache-hit": "false", "cache-matched-key": ""}, nil
+	case strings.HasPrefix(uses, "actions/cache/save@"):
+		return "# actions/cache/save skipped by local Actions hydration\n", nil, nil
+	case isLocalCompositeActionUse(step.Uses):
+		return localCompositeActionScript(step, ctx, env)
 	default:
-		return "", exit(2, "local Actions hydration does not support uses step %q", step.Uses)
+		return "", nil, exit(2, "local Actions hydration does not support uses step %q", step.Uses)
 	}
 }
 
@@ -919,7 +998,7 @@ func validateLocalActionWithKeys(action string, with map[string]string, allowed 
 	return nil
 }
 
-func localHydrateWithInput(step localHydrateStep, names []string, fallback string, inputs, env map[string]string, workdir string) (string, error) {
+func localHydrateWithInput(step localHydrateStep, names []string, fallback string, inputs, env map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) (string, error) {
 	value := fallback
 	for _, name := range names {
 		if raw := strings.TrimSpace(step.With[name]); raw != "" {
@@ -927,16 +1006,16 @@ func localHydrateWithInput(step localHydrateStep, names []string, fallback strin
 			break
 		}
 	}
-	return interpolateLocalActionsValue(value, inputs, env, workdir)
+	return interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, stepOutputs)
 }
 
-func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]string, workdir string) error {
+func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]string, workdir, repoRoot string) error {
 	for key, value := range step.With {
 		switch strings.ToLower(strings.TrimSpace(key)) {
 		case "ref", "fetch-depth", "persist-credentials", "set-safe-directory":
 			continue
 		case "path":
-			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir)
+			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, nil)
 			if err != nil {
 				return err
 			}
@@ -944,7 +1023,7 @@ func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]str
 				continue
 			}
 		case "submodules", "lfs":
-			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir)
+			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, nil)
 			if err != nil {
 				return err
 			}
@@ -955,6 +1034,151 @@ func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]str
 		return exit(2, "local Actions hydration does not support actions/checkout option %q; rerun with --github-runner when the workflow needs full GitHub Actions semantics", key)
 	}
 	return nil
+}
+
+func isLocalCompositeActionUse(uses string) bool {
+	uses = strings.TrimSpace(uses)
+	return strings.HasPrefix(uses, "./") || uses == "." || strings.HasPrefix(uses, "../")
+}
+
+func localCompositeActionScript(step localHydrateStep, ctx localHydrateScriptContext, env map[string]string) (string, map[string]string, error) {
+	actionPath, err := localCompositeActionPath(ctx.RepoRoot, step.Uses)
+	if err != nil {
+		return "", nil, err
+	}
+	action, err := readLocalCompositeAction(actionPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(action.Runs.Using), "composite") {
+		return "", nil, exit(2, "local Actions hydration only supports repo-local composite actions; %s uses %q", step.Uses, action.Runs.Using)
+	}
+	inputs := map[string]string{}
+	for _, name := range sortedCompositeInputKeys(action.Inputs) {
+		inputs[name] = action.Inputs[name].Default
+	}
+	for _, name := range sortedKeys(step.With) {
+		value, err := interpolateLocalActionsValue(step.With[name], ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		if err != nil {
+			return "", nil, err
+		}
+		inputs[name] = value
+	}
+	for name, spec := range action.Inputs {
+		if spec.Required && strings.TrimSpace(inputs[name]) == "" {
+			return "", nil, exit(2, "local composite action %s requires input %s", step.Uses, name)
+		}
+	}
+	actionTargetPath, err := localCompositeActionTargetPath(ctx.Workdir, step.Uses)
+	if err != nil {
+		return "", nil, err
+	}
+	next := ctx
+	next.Inputs = inputs
+	next.Env = copyStringMap(env)
+	next.Env["GITHUB_ACTION_PATH"] = actionTargetPath
+	next.StepOutputs = map[string]map[string]string{}
+	next.Depth++
+	var b strings.Builder
+	fmt.Fprintf(&b, "__crabbox_save_step_env %s\n", shellQuote("GITHUB_ACTION_PATH"))
+	fmt.Fprintf(&b, "export GITHUB_ACTION_PATH=%s\n", shellQuote(actionTargetPath))
+	for _, name := range sortedKeys(inputs) {
+		envName := "INPUT_" + actionInputEnvName(name)
+		fmt.Fprintf(&b, "__crabbox_save_step_env %s\n", shellQuote(envName))
+		fmt.Fprintf(&b, "export %s=%s\n", envName, shellQuote(inputs[name]))
+	}
+	if err := appendLocalHydrateSteps(&b, action.Runs.Steps, next); err != nil {
+		return "", nil, err
+	}
+	for _, name := range sortedKeys(inputs) {
+		fmt.Fprintf(&b, "__crabbox_restore_step_env %s\n", shellQuote("INPUT_"+actionInputEnvName(name)))
+	}
+	fmt.Fprintf(&b, "__crabbox_restore_step_env %s\n", shellQuote("GITHUB_ACTION_PATH"))
+	outputs, err := localCompositeActionOutputs(action.Outputs, next, actionTargetPath)
+	if err != nil {
+		return "", nil, err
+	}
+	return b.String(), outputs, nil
+}
+
+func localCompositeActionPath(repoRoot, uses string) (string, error) {
+	if repoRoot == "" {
+		return "", exit(2, "local Actions hydration cannot resolve repo-local action %q without a repository root", uses)
+	}
+	uses = strings.TrimSpace(uses)
+	if at := strings.IndexByte(uses, '@'); at >= 0 {
+		return "", exit(2, "local Actions hydration does not support versioned repo-local action %q", uses)
+	}
+	clean := filepath.Clean(uses)
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", exit(2, "local Actions hydration repo-local action must stay inside the repository: %q", uses)
+	}
+	return filepath.Join(repoRoot, clean), nil
+}
+
+func localCompositeActionTargetPath(workdir, uses string) (string, error) {
+	uses = strings.TrimSpace(uses)
+	if at := strings.IndexByte(uses, '@'); at >= 0 {
+		return "", exit(2, "local Actions hydration does not support versioned repo-local action %q", uses)
+	}
+	clean := filepath.Clean(uses)
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", exit(2, "local Actions hydration repo-local action must stay inside the repository: %q", uses)
+	}
+	return path.Join(workdir, filepath.ToSlash(clean)), nil
+}
+
+func readLocalCompositeAction(dir string) (localCompositeAction, error) {
+	var lastErr error
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var action localCompositeAction
+		if err := yaml.Unmarshal(data, &action); err != nil {
+			return action, err
+		}
+		return action, nil
+	}
+	return localCompositeAction{}, exit(2, "local composite action %s is not readable: %v", dir, lastErr)
+}
+
+func sortedCompositeInputKeys(values map[string]localCompositeInput) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func localCompositeActionOutputs(specs map[string]localCompositeOutput, ctx localHydrateScriptContext, actionTargetPath string) (map[string]string, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	env := copyStringMap(ctx.Env)
+	env["GITHUB_ACTION_PATH"] = actionTargetPath
+	out := map[string]string{}
+	for _, name := range sortedCompositeOutputKeys(specs) {
+		value, err := interpolateLocalActionsValue(specs[name].Value, ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
+func sortedCompositeOutputKeys(values map[string]localCompositeOutput) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func validateWorkflowInputFields(fields []string) error {
@@ -1031,6 +1255,187 @@ func supportedLocalNodeVersionSpec(value string) bool {
 		}
 	}
 	return true
+}
+
+func normalizeLocalNodeVersionSpec(value string) string {
+	value = strings.TrimSpace(strings.TrimPrefix(value, "v"))
+	value = strings.TrimSuffix(value, ".x")
+	value = strings.TrimSuffix(value, ".X")
+	return value
+}
+
+func localActionsHashFiles(expr, repoRoot string) (string, bool) {
+	if !strings.HasPrefix(expr, "hashFiles(") || !strings.HasSuffix(expr, ")") {
+		return "", false
+	}
+	if repoRoot == "" {
+		return "", true
+	}
+	arg := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expr, "hashFiles("), ")"))
+	arg = strings.Trim(arg, `'"`)
+	if !validLocalActionsHashPattern(arg) {
+		return "", true
+	}
+	matches, err := localActionsHashMatches(repoRoot, arg)
+	if err != nil || len(matches) == 0 {
+		return "", true
+	}
+	sort.Strings(matches)
+	h := sha256.New()
+	wrote := false
+	for _, match := range matches {
+		rel, err := filepath.Rel(repoRoot, match)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			continue
+		}
+		info, err := os.Lstat(match)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		data, err := os.ReadFile(match)
+		if err != nil {
+			continue
+		}
+		_, _ = h.Write([]byte(filepath.ToSlash(strings.TrimPrefix(match, repoRoot+string(filepath.Separator)))))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write(data)
+		_, _ = h.Write([]byte{0})
+		wrote = true
+	}
+	if !wrote {
+		return "", true
+	}
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+func validLocalActionsHashPattern(pattern string) bool {
+	if pattern == "" || filepath.IsAbs(pattern) {
+		return false
+	}
+	for _, part := range strings.Split(filepath.ToSlash(pattern), "/") {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func localActionsHashMatches(repoRoot, pattern string) ([]string, error) {
+	pattern = filepath.ToSlash(pattern)
+	var matches []string
+	err := filepath.WalkDir(repoRoot, func(filePath string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(repoRoot, filePath)
+		if err != nil {
+			return err
+		}
+		if localActionsPathMatch(pattern, filepath.ToSlash(rel)) {
+			matches = append(matches, filePath)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+func localActionsPathMatch(pattern, name string) bool {
+	return localActionsPathMatchParts(strings.Split(pattern, "/"), strings.Split(name, "/"))
+}
+
+func localActionsPathMatchParts(pattern, name []string) bool {
+	if len(pattern) == 0 {
+		return len(name) == 0
+	}
+	if pattern[0] == "**" {
+		if localActionsPathMatchParts(pattern[1:], name) {
+			return true
+		}
+		return len(name) > 0 && localActionsPathMatchParts(pattern, name[1:])
+	}
+	if len(name) == 0 {
+		return false
+	}
+	matched, err := path.Match(pattern[0], name[0])
+	if err != nil || !matched {
+		return false
+	}
+	return localActionsPathMatchParts(pattern[1:], name[1:])
+}
+
+func localActionsStepOutput(expr string, stepOutputs map[string]map[string]string) (string, bool) {
+	if !strings.HasPrefix(expr, "steps.") {
+		return "", false
+	}
+	parts := strings.Split(expr, ".")
+	if len(parts) == 4 && parts[2] == "outputs" && parts[1] != "" && parts[3] != "" {
+		if outputs := stepOutputs[parts[1]]; outputs != nil {
+			value, ok := outputs[parts[3]]
+			return value, ok
+		}
+	}
+	return "", false
+}
+
+func evalLocalActionsIf(expr string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (bool, bool) {
+	parts := strings.Split(expr, "&&")
+	if len(parts) == 0 {
+		return false, false
+	}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		var op string
+		if strings.Contains(part, "==") {
+			op = "=="
+		} else if strings.Contains(part, "!=") {
+			op = "!="
+		} else {
+			return false, false
+		}
+		left, right, ok := strings.Cut(part, op)
+		if !ok {
+			return false, false
+		}
+		leftValue, ok := localActionsIfValue(strings.TrimSpace(left), inputs, env, stepOutputs)
+		if !ok {
+			return false, false
+		}
+		rightValue, ok := localActionsIfValue(strings.TrimSpace(right), inputs, env, stepOutputs)
+		if !ok {
+			return false, false
+		}
+		matched := leftValue == rightValue
+		if op == "!=" {
+			matched = !matched
+		}
+		if !matched {
+			return false, true
+		}
+	}
+	return true, true
+}
+
+func localActionsIfValue(value string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 {
+		if value[0] == '\'' && value[len(value)-1] == '\'' || value[0] == '"' && value[len(value)-1] == '"' {
+			return value[1 : len(value)-1], true
+		}
+	}
+	if key, ok := strings.CutPrefix(value, "inputs."); ok {
+		return inputs[key], true
+	}
+	if _, ok := strings.CutPrefix(value, "env."); ok {
+		return "", false
+	}
+	if output, ok := localActionsStepOutput(value, stepOutputs); ok {
+		return output, true
+	}
+	return "", false
 }
 
 func appendLocalHydrateRunStep(b *strings.Builder, shellName, workdir, script string) error {
@@ -1175,6 +1580,25 @@ __crabbox_arch() {
     *) uname -m ;;
   esac
 }
+__crabbox_sudo() {
+  if [ "$(id -u)" = "0" ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+__crabbox_ensure_xz() {
+  if command -v xz >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v apt-get >/dev/null 2>&1; then
+    __crabbox_sudo apt-get update >/tmp/crabbox-actions-apt-update.log 2>&1 || true
+    __crabbox_sudo apt-get install -y --no-install-recommends xz-utils
+  fi
+  command -v xz >/dev/null 2>&1
+}
 __crabbox_setup_node() {
   local requested="${1:-}"
   if [ -n "$requested" ] && [ -f "$GITHUB_WORKSPACE/$requested" ]; then
@@ -1229,6 +1653,7 @@ __crabbox_setup_node() {
 	    tmp="$RUNNER_TEMP/node-${version}.tar.xz"
 	    mkdir -p "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP"
 	    curl -fsSL -o "$tmp" "https://nodejs.org/dist/${version}/node-${version}-linux-${arch}.tar.xz"
+	    __crabbox_ensure_xz || { echo "xz is required to extract Node archives; install xz-utils or use a fuller local-container image" >&2; return 2; }
 	    tar -xJf "$tmp" -C "$RUNNER_TOOL_CACHE"
 	  fi
 	  rm -f "$RUNNER_TOOL_CACHE/node"

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -338,6 +338,167 @@ func TestLocalActionsHydrateScriptTranslatesCoreSteps(t *testing.T) {
 	}
 }
 
+func TestLocalActionsHydrateScriptTracksCacheRestoreOutputs(t *testing.T) {
+	job := localHydrateJob{Steps: []localHydrateStep{
+		{ID: "deps", Uses: "actions/cache/restore@v5"},
+		{Name: "Install on miss", If: "steps.deps.outputs.cache-hit == 'false'", Run: "echo install"},
+		{Name: "Skip on hit", If: "steps.deps.outputs.cache-hit != 'false'", Run: "exit 99"},
+		{Name: "Report", Run: "echo ${{ steps.deps.outputs.cache-hit }}"},
+	}}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"printf 'cache-hit=false\\ncache-matched-key=\\n' >> \"$GITHUB_OUTPUT\"",
+		"echo install",
+		"echo false",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("local hydrate script missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "exit 99") || strings.Contains(got, "${{ steps.deps.outputs.cache-hit }}") {
+		t.Fatalf("cache output condition or interpolation failed:\n%s", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptExpandsLocalCompositeActions(t *testing.T) {
+	root := t.TempDir()
+	actionDir := filepath.Join(root, ".github", "actions", "setup-node-env")
+	if err := os.MkdirAll(actionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lockfileVersion: '9.0'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	action := []byte(`name: Setup Node
+inputs:
+  node-version:
+    default: "24.x"
+  install-bun:
+    default: "true"
+outputs:
+  cache-hit:
+    value: ${{ steps.pnpm-cache-restore.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Cache restore
+      id: pnpm-cache-restore
+      if: inputs.install-bun == 'false'
+      uses: actions/cache/restore@v5
+      with:
+        key: ${{ hashFiles('pnpm-lock.yaml') }}
+    - name: Skipped Bun
+      if: inputs.install-bun == 'true'
+      run: exit 99
+      shell: bash
+    - name: Install
+      env:
+        NODE_VERSION: ${{ inputs.node-version }}
+        ACTION_SCRIPT: ${{ github.action_path }}/setup.sh
+      run: |
+        echo "$GITHUB_ACTION_PATH"
+        echo "$ACTION_SCRIPT"
+        echo "$NODE_VERSION"
+        printf 'NEXT=1\n' >> "$GITHUB_ENV"
+      shell: bash
+`)
+	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), action, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	job := localHydrateJob{Steps: []localHydrateStep{
+		{ID: "setup", Uses: "./.github/actions/setup-node-env", With: map[string]string{"install-bun": "false"}},
+		{If: "steps.setup.outputs.cache-hit == 'false'", Run: "echo outer install"},
+	}}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"export INPUT_NODE_VERSION='24.x'",
+		"__crabbox_setup_node '24'",
+		"printf 'cache-hit=false\\ncache-matched-key=\\n' >> \"$GITHUB_OUTPUT\"",
+		"export GITHUB_ACTION_PATH='/work/cbx_123/repo/.github/actions/setup-node-env'",
+		"export ACTION_SCRIPT='/work/cbx_123/repo/.github/actions/setup-node-env/setup.sh'",
+		"echo \"$GITHUB_ACTION_PATH\"",
+		"echo \"$NODE_VERSION\"",
+		"echo outer install",
+		"printf 'NEXT=1\\n' >> \"$GITHUB_ENV\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("local composite script missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "exit 99") || strings.Contains(got, "${{") {
+		t.Fatalf("local composite script kept skipped or unresolved content:\n%s", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptRejectsUnknownStepOutputs(t *testing.T) {
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+		Steps: []localHydrateStep{
+			{ID: "build", Run: "printf 'artifact=app\\n' >> \"$GITHUB_OUTPUT\""},
+			{Run: "echo ${{ steps.build.outputs.artifact }}"},
+		},
+	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil {
+		t.Fatal("runtime step output expression accepted")
+	}
+	if !strings.Contains(err.Error(), "steps.build.outputs.artifact") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLocalActionsHashFilesMatchesRecursiveGlobs(t *testing.T) {
+	root := t.TempDir()
+	for _, file := range []string{"pnpm-lock.yaml", filepath.Join("packages", "app", "pnpm-lock.yaml")} {
+		path := filepath.Join(root, file)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(file+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hash, ok := localActionsHashFiles("hashFiles('**/pnpm-lock.yaml')", root)
+	if !ok || hash == "" {
+		t.Fatalf("recursive hashFiles did not match: ok=%v hash=%q", ok, hash)
+	}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+		Steps: []localHydrateStep{{Run: "echo ${{ hashFiles('**/pnpm-lock.yaml') }}"}},
+	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "echo "+hash) {
+		t.Fatalf("recursive hash not interpolated:\n%s", got)
+	}
+}
+
+func TestLocalActionsHashFilesSkipsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "outside-lock.yaml")
+	if err := os.WriteFile(target, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "pnpm-lock.yaml")); err != nil {
+		t.Fatal(err)
+	}
+	hash, ok := localActionsHashFiles("hashFiles('pnpm-lock.yaml')", root)
+	if !ok {
+		t.Fatal("hashFiles expression was not handled")
+	}
+	if hash != "" {
+		t.Fatalf("symlink was hashed: %q", hash)
+	}
+}
+
 func TestLocalActionsHydrateScriptUsesFullGitHubRef(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Actions.Ref = "refs/tags/v1.2.3"
@@ -406,6 +567,20 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedSetupNodeOptions(t *testing.
 	}
 	if !strings.Contains(err.Error(), "--github-runner") {
 		t.Fatalf("unsupported setup-node option error should suggest GitHub fallback: %v", err)
+	}
+}
+
+func TestLocalActionsHydrateScriptAllowsSetupNodeCheckLatest(t *testing.T) {
+	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "22", "check-latest": "true"}}}}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatalf("setup-node check-latest should be allowed: %v", err)
+	}
+	if !strings.Contains(got, "__crabbox_setup_node '22'") {
+		t.Fatalf("setup-node script missing version:\n%s", got)
+	}
+	if !strings.Contains(got, "xz-utils") {
+		t.Fatalf("setup-node script should ensure xz-utils:\n%s", got)
 	}
 }
 
@@ -518,9 +693,30 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedIf(t *testing.T) {
 	}
 }
 
+func TestLocalActionsHydrateScriptRejectsEnvIf(t *testing.T) {
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+		Steps: []localHydrateStep{
+			{Run: "printf 'RUN_TESTS=true\\n' >> \"$GITHUB_ENV\""},
+			{If: "env.RUN_TESTS == 'true'", Run: "echo nope"},
+		},
+	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil {
+		t.Fatal("env if expression accepted")
+	}
+}
+
+func TestLocalActionsHydrateScriptRejectsSecretsExpressions(t *testing.T) {
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN }}' '${{ secrets.MISSING_TOKEN }}'"}},
+	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil {
+		t.Fatal("secret expression accepted")
+	}
+}
+
 func TestLocalActionsHydrateScriptRejectsUnsupportedExpression(t *testing.T) {
 	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
-		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN }}'"}},
+		Steps: []localHydrateStep{{Run: "echo '${{ matrix.node }}'"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil {
 		t.Fatal("unsupported expression accepted")

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -342,13 +342,14 @@ type SpritesConfig struct {
 }
 
 type LocalContainerConfig struct {
-	Runtime  string
-	Image    string
-	User     string
-	WorkRoot string
-	CPUs     int
-	Memory   string
-	Network  string
+	Runtime      string
+	Image        string
+	User         string
+	WorkRoot     string
+	CPUs         int
+	Memory       string
+	Network      string
+	DockerSocket bool
 }
 
 type StaticConfig struct {
@@ -1072,13 +1073,14 @@ type fileSpritesConfig struct {
 }
 
 type fileLocalContainerConfig struct {
-	Runtime  string `yaml:"runtime,omitempty"`
-	Image    string `yaml:"image,omitempty"`
-	User     string `yaml:"user,omitempty"`
-	WorkRoot string `yaml:"workRoot,omitempty"`
-	CPUs     int    `yaml:"cpus,omitempty"`
-	Memory   string `yaml:"memory,omitempty"`
-	Network  string `yaml:"network,omitempty"`
+	Runtime      string `yaml:"runtime,omitempty"`
+	Image        string `yaml:"image,omitempty"`
+	User         string `yaml:"user,omitempty"`
+	WorkRoot     string `yaml:"workRoot,omitempty"`
+	CPUs         int    `yaml:"cpus,omitempty"`
+	Memory       string `yaml:"memory,omitempty"`
+	Network      string `yaml:"network,omitempty"`
+	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -2032,6 +2034,9 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 		if file.LocalContainer.Network != "" {
 			cfg.LocalContainer.Network = file.LocalContainer.Network
 		}
+		if file.LocalContainer.DockerSocket != nil {
+			cfg.LocalContainer.DockerSocket = *file.LocalContainer.DockerSocket
+		}
 	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
@@ -2648,6 +2653,9 @@ func applyEnv(cfg *Config) {
 	cfg.LocalContainer.CPUs = getenvInt("CRABBOX_LOCAL_CONTAINER_CPUS", cfg.LocalContainer.CPUs)
 	cfg.LocalContainer.Memory = getenv("CRABBOX_LOCAL_CONTAINER_MEMORY", cfg.LocalContainer.Memory)
 	cfg.LocalContainer.Network = getenv("CRABBOX_LOCAL_CONTAINER_NETWORK", cfg.LocalContainer.Network)
+	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET"); ok {
+		cfg.LocalContainer.DockerSocket = value
+	}
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -125,6 +125,7 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_LOCAL_CONTAINER_CPUS",
 		"CRABBOX_LOCAL_CONTAINER_MEMORY",
 		"CRABBOX_LOCAL_CONTAINER_NETWORK",
+		"CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET",
 		"CRABBOX_NAMESPACE_IMAGE",
 		"CRABBOX_NAMESPACE_SIZE",
 		"CRABBOX_NAMESPACE_REPOSITORY",
@@ -881,6 +882,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_LOCAL_CONTAINER_CPUS", "6")
 	t.Setenv("CRABBOX_LOCAL_CONTAINER_MEMORY", "12g")
 	t.Setenv("CRABBOX_LOCAL_CONTAINER_NETWORK", "bridge")
+	t.Setenv("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET", "true")
 	t.Setenv("CRABBOX_NAMESPACE_IMAGE", "namespace-env-image")
 	t.Setenv("CRABBOX_NAMESPACE_SIZE", "XL")
 	t.Setenv("CRABBOX_NAMESPACE_REPOSITORY", "github.com/openclaw/env")
@@ -997,7 +999,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	if cfg.Sprites.Token != "sprites-token-env" || cfg.Sprites.APIURL != "https://api.sprites-env.example" || cfg.Sprites.WorkRoot != "/home/sprite/env" {
 		t.Fatalf("unexpected sprites env: %#v", cfg.Sprites)
 	}
-	if cfg.LocalContainer.Runtime != "docker" || cfg.LocalContainer.Image != "ubuntu:env" || cfg.LocalContainer.User != "runner-env" || cfg.LocalContainer.WorkRoot != "/workspace/env" || cfg.LocalContainer.CPUs != 6 || cfg.LocalContainer.Memory != "12g" || cfg.LocalContainer.Network != "bridge" {
+	if cfg.LocalContainer.Runtime != "docker" || cfg.LocalContainer.Image != "ubuntu:env" || cfg.LocalContainer.User != "runner-env" || cfg.LocalContainer.WorkRoot != "/workspace/env" || cfg.LocalContainer.CPUs != 6 || cfg.LocalContainer.Memory != "12g" || cfg.LocalContainer.Network != "bridge" || !cfg.LocalContainer.DockerSocket {
 		t.Fatalf("unexpected local-container env: %#v", cfg.LocalContainer)
 	}
 	if cfg.Blacksmith.IdleTimeout != 2*time.Hour || !cfg.Blacksmith.Debug {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -225,6 +225,7 @@ func TestProviderFlagsApplyLocalContainerWithoutCoreEdits(t *testing.T) {
 		"--local-container-cpus", "4",
 		"--local-container-memory", "8g",
 		"--local-container-network", "bridge",
+		"--local-container-docker-socket",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +234,7 @@ func TestProviderFlagsApplyLocalContainerWithoutCoreEdits(t *testing.T) {
 	if err := applyProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Provider != "local-container" || cfg.LocalContainer.Runtime != "docker" || cfg.LocalContainer.Image != "ubuntu:24.04" || cfg.LocalContainer.User != "runner" || cfg.SSHUser != "runner" || cfg.WorkRoot != "/workspace/crabbox" || cfg.LocalContainer.CPUs != 4 || cfg.LocalContainer.Memory != "8g" || cfg.LocalContainer.Network != "bridge" {
+	if cfg.Provider != "local-container" || cfg.LocalContainer.Runtime != "docker" || cfg.LocalContainer.Image != "ubuntu:24.04" || cfg.LocalContainer.User != "runner" || cfg.SSHUser != "runner" || cfg.WorkRoot != "/workspace/crabbox" || cfg.LocalContainer.CPUs != 4 || cfg.LocalContainer.Memory != "8g" || cfg.LocalContainer.Network != "bridge" || !cfg.LocalContainer.DockerSocket {
 		t.Fatalf("local-container flags not applied: provider=%s cfg=%#v", cfg.Provider, cfg.LocalContainer)
 	}
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -680,24 +680,26 @@ func (testLocalContainerProvider) Spec() ProviderSpec {
 }
 
 type testLocalContainerFlagValues struct {
-	Runtime  *string
-	Image    *string
-	User     *string
-	WorkRoot *string
-	CPUs     *int
-	Memory   *string
-	Network  *string
+	Runtime      *string
+	Image        *string
+	User         *string
+	WorkRoot     *string
+	CPUs         *int
+	Memory       *string
+	Network      *string
+	DockerSocket *bool
 }
 
 func (testLocalContainerProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
 	return testLocalContainerFlagValues{
-		Runtime:  fs.String("local-container-runtime", defaults.LocalContainer.Runtime, "Docker-compatible CLI"),
-		Image:    fs.String("local-container-image", defaults.LocalContainer.Image, "container image"),
-		User:     fs.String("local-container-user", defaults.LocalContainer.User, "container SSH user"),
-		WorkRoot: fs.String("local-container-work-root", defaults.LocalContainer.WorkRoot, "container work root"),
-		CPUs:     fs.Int("local-container-cpus", defaults.LocalContainer.CPUs, "container CPUs"),
-		Memory:   fs.String("local-container-memory", defaults.LocalContainer.Memory, "container memory"),
-		Network:  fs.String("local-container-network", defaults.LocalContainer.Network, "container network"),
+		Runtime:      fs.String("local-container-runtime", defaults.LocalContainer.Runtime, "Docker-compatible CLI"),
+		Image:        fs.String("local-container-image", defaults.LocalContainer.Image, "container image"),
+		User:         fs.String("local-container-user", defaults.LocalContainer.User, "container SSH user"),
+		WorkRoot:     fs.String("local-container-work-root", defaults.LocalContainer.WorkRoot, "container work root"),
+		CPUs:         fs.Int("local-container-cpus", defaults.LocalContainer.CPUs, "container CPUs"),
+		Memory:       fs.String("local-container-memory", defaults.LocalContainer.Memory, "container memory"),
+		Network:      fs.String("local-container-network", defaults.LocalContainer.Network, "container network"),
+		DockerSocket: fs.Bool("local-container-docker-socket", defaults.LocalContainer.DockerSocket, "container Docker socket"),
 	}
 }
 func (testLocalContainerProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
@@ -727,6 +729,9 @@ func (testLocalContainerProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, valu
 	}
 	if flagWasSet(fs, "local-container-network") {
 		cfg.LocalContainer.Network = *v.Network
+	}
+	if flagWasSet(fs, "local-container-docker-socket") {
+		cfg.LocalContainer.DockerSocket = *v.DockerSocket
 	}
 	if cfg.Provider == "docker" || cfg.Provider == "container" || cfg.Provider == "local-docker" {
 		cfg.Provider = "local-container"

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -160,7 +162,8 @@ func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.Doct
 	if req.ProbeSSH {
 		probe = "requires_running_lease"
 	}
-	msg := fmt.Sprintf("cli=ready control_plane=local inventory=ready api=list mutation=false leases=%d runtime=%s context=%s ssh_probe=%s image=%s", len(containers), runtime, blank(contextName, "-"), probe, b.configForRun().LocalContainer.Image)
+	cfg := b.configForRun()
+	msg := fmt.Sprintf("cli=ready control_plane=local inventory=ready api=list mutation=false leases=%d runtime=%s context=%s ssh_probe=%s image=%s docker_socket=%v", len(containers), runtime, blank(contextName, "-"), probe, cfg.LocalContainer.Image, cfg.LocalContainer.DockerSocket)
 	return core.DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
@@ -217,6 +220,9 @@ func applyDefaults(cfg *core.Config) {
 	if cfg.LocalContainer.User == "" {
 		cfg.LocalContainer.User = "crabbox"
 	}
+	if cfg.LocalContainer.DockerSocket && isDefaultWorkRoot(cfg.LocalContainer.WorkRoot) && isDefaultWorkRoot(cfg.WorkRoot) {
+		cfg.LocalContainer.WorkRoot = defaultDockerSocketWorkRoot()
+	}
 	if cfg.LocalContainer.WorkRoot == "" {
 		if !isDefaultWorkRoot(cfg.WorkRoot) {
 			cfg.LocalContainer.WorkRoot = cfg.WorkRoot
@@ -240,6 +246,7 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	labels["ssh_user"] = cfg.LocalContainer.User
 	labels["ssh_port"] = sshPort
 	labels["work_root"] = cfg.LocalContainer.WorkRoot
+	labels["docker_socket"] = boolEnv(cfg.LocalContainer.DockerSocket)
 	args := []string{
 		"run", "-d",
 		"--name", name,
@@ -253,6 +260,7 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		"-e", "CRABBOX_SSH_PORT=" + sshPort,
 		"-e", "CRABBOX_DESKTOP=" + boolEnv(cfg.Desktop),
 		"-e", "CRABBOX_BROWSER=" + boolEnv(cfg.Browser),
+		"-e", "CRABBOX_DOCKER_SOCKET=" + boolEnv(cfg.LocalContainer.DockerSocket),
 	}
 	for key, value := range labels {
 		args = append(args, "--label", key+"="+value)
@@ -262,6 +270,24 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	}
 	if memory := strings.TrimSpace(cfg.LocalContainer.Memory); memory != "" {
 		args = append(args, "--memory", memory)
+	}
+	if cfg.LocalContainer.DockerSocket {
+		if err := os.MkdirAll(cfg.LocalContainer.WorkRoot, 0o755); err != nil {
+			return "", core.Exit(2, "create local-container host work root %s: %v", cfg.LocalContainer.WorkRoot, err)
+		}
+		leaseWorkRoot := filepath.Join(cfg.LocalContainer.WorkRoot, leaseID)
+		if err := os.MkdirAll(leaseWorkRoot, 0o777); err != nil {
+			return "", core.Exit(2, "create local-container host lease work root %s: %v", leaseWorkRoot, err)
+		}
+		if err := os.Chmod(leaseWorkRoot, 0o777); err != nil {
+			return "", core.Exit(2, "make local-container host lease work root writable %s: %v", leaseWorkRoot, err)
+		}
+		args = append(args, "-v", cfg.LocalContainer.WorkRoot+":"+cfg.LocalContainer.WorkRoot)
+		socketPath, err := b.dockerSocketMountPath(ctx)
+		if err != nil {
+			return "", err
+		}
+		args = append(args, "-v", socketPath+":/var/run/docker.sock")
 	}
 	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "-lc", bootstrapScript)
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
@@ -273,6 +299,70 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		return "", core.Exit(2, "%s run did not return a container id", cfg.LocalContainer.Runtime)
 	}
 	return id, nil
+}
+
+func (b *backend) dockerSocketMountPath(ctx context.Context) (string, error) {
+	if host := strings.TrimSpace(os.Getenv("DOCKER_HOST")); host != "" {
+		return dockerSocketMountPathFromHost(host)
+	}
+	if result, err := b.docker(ctx, []string{"context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"}, nil, nil); err == nil {
+		host := strings.TrimSpace(result.Stdout)
+		if host != "" && host != "<no value>" {
+			var decoded string
+			if err := json.Unmarshal([]byte(host), &decoded); err == nil {
+				host = decoded
+			}
+			return dockerSocketMountPathFromHost(host)
+		}
+	}
+	return validateDockerSocketMountPath("/var/run/docker.sock")
+}
+
+func dockerSocketMountPathFromHost(host string) (string, error) {
+	path, ok := localDockerSocketPath(host)
+	if !ok {
+		return "", core.Exit(2, "local-container docker socket requested but active Docker host %q is not a local Unix socket", host)
+	}
+	return validateDockerSocketMountPath(path)
+}
+
+func localDockerSocketPath(host string) (string, bool) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", false
+	}
+	if strings.HasPrefix(host, "/") {
+		return host, true
+	}
+	if strings.HasPrefix(host, "unix://") {
+		u, err := url.Parse(host)
+		if err == nil && u.Path != "" {
+			return u.Path, true
+		}
+		path := strings.TrimPrefix(host, "unix://")
+		if strings.HasPrefix(path, "/") {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func validateDockerSocketMountPath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", core.Exit(2, "local-container docker socket requested but %s is not available: %v", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return "", core.Exit(2, "local-container docker socket requested but %s is not a socket", path)
+	}
+	return path, nil
+}
+
+func defaultDockerSocketWorkRoot() string {
+	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
+		return filepath.Join(cache, "crabbox", "local-container-work")
+	}
+	return filepath.Join(os.TempDir(), "crabbox-local-container-work")
 }
 
 func (b *backend) prepareLease(ctx context.Context, cfg core.Config, container inspectContainer, leaseID, slug string, wait bool) (core.LeaseTarget, error) {
@@ -570,6 +660,14 @@ if [ "${CRABBOX_BROWSER:-0}" = "1" ] && command -v apt-get >/dev/null 2>&1; then
     apt-get install -y --no-install-recommends firefox || true
   fi
 fi
+if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y --no-install-recommends docker.io
+fi
+if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1; then
+  echo "docker socket requested but docker CLI is not installed; use a Debian/Ubuntu-compatible image or preinstall docker" >&2
+  exit 127
+fi
 if ! command -v /usr/sbin/sshd >/dev/null 2>&1; then
   echo "missing /usr/sbin/sshd; use a Debian/Ubuntu-compatible image or a prebuilt Crabbox runner image" >&2
   exit 127
@@ -584,11 +682,28 @@ home_dir="$(getent passwd "$user" | cut -d: -f6)"
 if [ -z "$home_dir" ]; then
   home_dir="/home/$user"
 fi
+if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && [ -S /var/run/docker.sock ]; then
+  socket_gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
+  if [ -n "$socket_gid" ]; then
+    socket_group="$(getent group "$socket_gid" | cut -d: -f1 || true)"
+    if [ -z "$socket_group" ]; then
+      socket_group="crabbox-docker"
+      groupadd -g "$socket_gid" "$socket_group" 2>/dev/null || socket_group=""
+    fi
+    if [ -n "$socket_group" ]; then
+      usermod -aG "$socket_group" "$user" || true
+    fi
+  fi
+fi
 mkdir -p /run/sshd "$work_root" "$home_dir/.ssh"
 printf '%s\n' "$CRABBOX_AUTHORIZED_KEY" > "$home_dir/.ssh/authorized_keys"
 chmod 700 "$home_dir/.ssh"
 chmod 600 "$home_dir/.ssh/authorized_keys"
-chown -R "$user" "$home_dir/.ssh" "$work_root"
+if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ]; then
+  chown -R "$user" "$home_dir/.ssh"
+else
+  chown -R "$user" "$home_dir/.ssh" "$work_root"
+fi
 if command -v sudo >/dev/null 2>&1; then
   printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$user" > /etc/sudoers.d/crabbox
   chmod 440 /etc/sudoers.d/crabbox

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -3,6 +3,7 @@ package localcontainer
 import (
 	"context"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,17 @@ func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (
 
 func commandKey(args []string) string {
 	return strings.Join(args, "\x00")
+}
+
+func recordedArgsForCommand(t *testing.T, runner *recordingRunner, command string) string {
+	t.Helper()
+	for i := len(runner.calls) - 1; i >= 0; i-- {
+		if len(runner.calls[i].Args) > 0 && runner.calls[i].Args[0] == command {
+			return strings.Join(runner.calls[i].Args, "\n")
+		}
+	}
+	t.Fatalf("%s command was not recorded: %#v", command, runner.calls)
+	return ""
 }
 
 func testBackend(runner *recordingRunner) *backend {
@@ -97,6 +109,7 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 		"-e\nCRABBOX_WORK_ROOT=/workspace/crabbox",
 		"-e\nCRABBOX_DESKTOP=0",
 		"-e\nCRABBOX_BROWSER=0",
+		"-e\nCRABBOX_DOCKER_SOCKET=0",
 		"--cpus\n4",
 		"--memory\n8g",
 		"--label\nprovider=local-container",
@@ -112,13 +125,126 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 			t.Fatalf("docker run args missing %q:\n%s", want, args)
 		}
 	}
+	if strings.Contains(args, "-v\n/var/run/docker.sock:/var/run/docker.sock") {
+		t.Fatalf("docker socket should be opt-in:\n%s", args)
+	}
+}
+
+func TestCreateContainerCanMountDockerSocket(t *testing.T) {
+	if _, err := os.Stat("/var/run/docker.sock"); err != nil {
+		t.Skipf("docker socket not available: %v", err)
+	}
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.LocalContainer.DockerSocket = true
+	cfg.LocalContainer.WorkRoot = t.TempDir()
+	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
+
+	_, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "run")
+	for _, want := range []string{
+		"--label\ndocker_socket=1",
+		"-e\nCRABBOX_DOCKER_SOCKET=1",
+		"-v\n" + cfg.LocalContainer.WorkRoot + ":" + cfg.LocalContainer.WorkRoot,
+		"-v\n/var/run/docker.sock:/var/run/docker.sock",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("docker socket run args missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestCreateContainerMountsDockerHostUnixSocket(t *testing.T) {
+	socketDir, err := os.MkdirTemp("/tmp", "cbx-sock-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(socketDir)
+	socketPath := filepath.Join(socketDir, "docker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	t.Setenv("DOCKER_HOST", "unix://"+socketPath)
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.LocalContainer.DockerSocket = true
+	cfg.LocalContainer.WorkRoot = t.TempDir()
+	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
+
+	_, err = b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "run")
+	if !strings.Contains(args, "-v\n"+socketPath+":/var/run/docker.sock") {
+		t.Fatalf("docker host socket was not mounted:\n%s", args)
+	}
+	leaseRoot := filepath.Join(cfg.LocalContainer.WorkRoot, "cbx_123")
+	info, err := os.Stat(leaseRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o777 {
+		t.Fatalf("lease work root mode=%#o want 0777", info.Mode().Perm())
+	}
+}
+
+func TestDockerSocketMountRejectsRemoteDockerHost(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://127.0.0.1:2375")
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	if _, err := b.dockerSocketMountPath(context.Background()); err == nil {
+		t.Fatal("remote docker host accepted")
+	}
+}
+
+func TestConfigForRunUsesHostVisibleWorkRootWithDockerSocket(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.LocalContainer.DockerSocket = true
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	got := b.configForRun()
+	if got.LocalContainer.WorkRoot == "/work/crabbox" || got.WorkRoot == "/work/crabbox" {
+		t.Fatalf("docker socket work root should be host-visible: %#v", got.LocalContainer)
+	}
+	if !strings.Contains(got.LocalContainer.WorkRoot, "crabbox") || got.WorkRoot != got.LocalContainer.WorkRoot {
+		t.Fatalf("unexpected docker socket work root: workRoot=%q local=%q", got.WorkRoot, got.LocalContainer.WorkRoot)
+	}
 }
 
 func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 	for _, want := range []string{
 		`home_dir="$(getent passwd "$user" | cut -d: -f6)"`,
 		`"$home_dir/.ssh/authorized_keys"`,
+		`if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ]; then`,
+		`chown -R "$user" "$home_dir/.ssh"`,
 		`chown -R "$user" "$home_dir/.ssh" "$work_root"`,
+	} {
+		if !strings.Contains(bootstrapScript, want) {
+			t.Fatalf("bootstrap script missing %q", want)
+		}
+	}
+}
+
+func TestBootstrapScriptSupportsDockerSocketCLI(t *testing.T) {
+	for _, want := range []string{
+		`[ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker`,
+		`apt-get install -y --no-install-recommends docker.io`,
+		`docker socket requested but docker CLI is not installed`,
+		`stat -c '%g' /var/run/docker.sock`,
+		`usermod -aG "$socket_group" "$user"`,
 	} {
 		if !strings.Contains(bootstrapScript, want) {
 			t.Fatalf("bootstrap script missing %q", want)

--- a/internal/providers/localcontainer/flags.go
+++ b/internal/providers/localcontainer/flags.go
@@ -7,13 +7,14 @@ import (
 )
 
 type flagValues struct {
-	Runtime  *string
-	Image    *string
-	User     *string
-	WorkRoot *string
-	CPUs     *int
-	Memory   *string
-	Network  *string
+	Runtime      *string
+	Image        *string
+	User         *string
+	WorkRoot     *string
+	CPUs         *int
+	Memory       *string
+	Network      *string
+	DockerSocket *bool
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -25,6 +26,8 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 		CPUs:     fs.Int("local-container-cpus", defaults.LocalContainer.CPUs, "CPU limit for local-container leases; 0 leaves runtime default"),
 		Memory:   fs.String("local-container-memory", defaults.LocalContainer.Memory, "memory limit for local-container leases, for example 8g"),
 		Network:  fs.String("local-container-network", defaults.LocalContainer.Network, "container network for local-container leases"),
+		DockerSocket: fs.Bool("local-container-docker-socket", defaults.LocalContainer.DockerSocket,
+			"mount /var/run/docker.sock into local-container leases so docker commands use the host daemon"),
 	}
 }
 
@@ -55,6 +58,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.FlagWasSet(fs, "local-container-network") {
 		cfg.LocalContainer.Network = *v.Network
+	}
+	if core.FlagWasSet(fs, "local-container-docker-socket") {
+		cfg.LocalContainer.DockerSocket = *v.DockerSocket
 	}
 	if cfg.Provider == providerName || cfg.Provider == "docker" || cfg.Provider == "container" || cfg.Provider == "local-docker" {
 		applyDefaults(cfg)


### PR DESCRIPTION
## Summary
- add local-container Docker socket pass-through with active local Unix socket detection and host-visible work roots
- expand local Actions hydration for repo-local composite actions, cache restore/save no-ops, simple input/step-output conditions, safe hashFiles, and Node 24.x setup
- document Docker provider socket behavior and add regression coverage

## Verification
- go test ./internal/cli -run 'TestLocalActions'
- go test ./internal/providers/localcontainer
- go test ./...
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'go test ./...'
- bin/crabbox warmup --provider docker --local-container-docker-socket --slug crabbox-socket-pr-smoke --keep --timing-json
- bin/crabbox run --provider docker --id crabbox-socket-pr-smoke -- docker version --format '{{.Server.Version}} {{.Server.Os}}/{{.Server.Arch}}'
- bin/crabbox stop --provider docker crabbox-socket-pr-smoke
