### PR TITLE
fix(local-container): harden docker socket leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### Fixed
 
+- Fixed local-container Docker socket pass-through on Docker Desktop, OrbStack, Colima, and similar local VM runtimes by mounting the daemon-visible socket path instead of the client context socket path.
+- Fixed local-container Docker socket sync on local VM runtimes that reject rsync mtime updates on host-mounted work roots.
+- Fixed local-container Docker socket bootstrap to prefer Docker's current Debian/Ubuntu CLI package before falling back to distro `docker.io`.
+- Fixed `crabbox cleanup --provider docker` support for stale local-container leases.
+- Fixed `provider: docker` stop/release cleanup so host-visible per-lease work directories created for Docker socket pass-through are removed with the lease.
 - Fixed local Actions hydration for repo-local composite actions, cache no-ops, simple input conditions, safe `hashFiles`, secret-expression rejection, and Node 24.x setup on minimal Debian images.
 
 ## 0.17.0 - 2026-05-21

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -99,8 +99,10 @@ Docker. Crabbox mounts the active local Unix Docker socket into the container as
 `/var/run/docker.sock`, so `docker` commands run against the active local
 Docker-compatible daemon. Remote Docker contexts are rejected. When the socket is
 enabled and no work root is explicitly configured, Crabbox uses a host-visible
-cache work root and mounts it at the same absolute path inside the lease, so
-nested Docker bind mounts can see the synced checkout.
+cache work root. On POSIX clients it mounts that root at the same absolute path
+inside the lease so nested Docker bind mounts can see the synced checkout. On
+Windows npipe clients, the host cache root is mounted at the Linux guest work
+root instead because Windows paths are not valid Linux container work paths.
 
 ## Behavior
 
@@ -117,6 +119,9 @@ nested Docker bind mounts can see the synced checkout.
 6. Crabbox waits for SSH readiness, syncs tracked and nonignored files into
    `localContainer.workRoot`, and uses the normal SSH executor.
 7. `status`, `list`, and `stop` inspect or remove labeled containers.
+8. `cleanup --provider docker` removes stopped containers and running
+   non-`keep` containers whose local claim or lease labels are stale past the
+   idle timeout plus a safety grace period.
 
 ## Limits
 
@@ -128,14 +133,17 @@ nested Docker bind mounts can see the synced checkout.
   over SSH; it does not use the authenticated Crabbox portal.
 - No code-server, Tailscale bootstrap, or native checkpoint support yet.
 - Docker socket pass-through is opt-in and gives the lease access to the host
-  Docker daemon.
+  Docker daemon. On Docker Desktop, OrbStack, Colima, and similar local VM
+  runtimes, Crabbox mounts the daemon-visible `/var/run/docker.sock` rather than
+  the client context socket path. Socket mode syncs without preserving mtimes so
+  host-mounted local VM filesystems do not fail on metadata updates.
 - `warmup --actions-runner` is not supported; use normal `crabbox run` for
   local container smoke tests or a remote SSH provider for GitHub runner
   registration.
 - The Docker daemon is a powerful local capability. Do not treat this as the
   same host isolation boundary as a remote VM or microVM.
-- The current checkout is synced into the container by default. Crabbox does not
-  bind-mount the repo or mount the Docker socket.
+- The current checkout is synced into the container by default rather than
+  bind-mounted. Crabbox mounts the Docker socket only when explicitly enabled.
 - The default `debian:bookworm` image bootstraps packages on first start. Use a
   prebuilt image with SSH/Git/rsync/desktop/browser packages when startup time
   matters.

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -489,7 +489,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		}
 	}
 	fmt.Fprintf(a.Stderr, "syncing %s -> %s:%s for local actions hydrate\n", repo.Root, target.Host, workdir)
-	if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+	if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketConfig(cfg), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 		return exit(6, "rsync failed: %v", err)
 	}
 	fingerprint := ""

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -674,7 +674,7 @@ func (testLocalContainerProvider) Spec() ProviderSpec {
 		Name:        "local-container",
 		Kind:        ProviderKindSSHLease,
 		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureDesktop, FeatureBrowser},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser},
 		Coordinator: CoordinatorNever,
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -829,7 +829,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			timings.syncSteps.prune = time.Since(stepStart)
 		}
 		stepStart = time.Now()
-		if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+		if err := rsync(ctx, target, repo.Root, workdir, excludes, a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketSync(cfg, server), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 			return recordFailure(exit(6, "rsync failed: %v", err))
 		}
 		timings.syncSteps.rsync = time.Since(stepStart)
@@ -1885,6 +1885,14 @@ func applyResolvedServerConfig(cfg *Config, server Server) {
 	if root := server.Labels["work_root"]; root != "" {
 		cfg.WorkRoot = root
 	}
+	if cfg.Provider == "local-container" || server.Provider == "local-container" {
+		if root := server.Labels["work_root"]; root != "" {
+			cfg.LocalContainer.WorkRoot = root
+		}
+		if labelBool(server.Labels["docker_socket"]) {
+			cfg.LocalContainer.DockerSocket = true
+		}
+	}
 }
 
 func readyNetworkDisplay(cfg Config, server Server, target SSHTarget) NetworkMode {
@@ -2325,6 +2333,17 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 
 func DeleteServer(ctx context.Context, cfg Config, server Server) error {
 	return deleteServer(ctx, cfg, server)
+}
+
+func localContainerDockerSocketSync(cfg Config, server Server) bool {
+	if cfg.Provider != "local-container" && server.Provider != "local-container" {
+		return false
+	}
+	return cfg.LocalContainer.DockerSocket || labelBool(server.Labels["docker_socket"])
+}
+
+func localContainerDockerSocketConfig(cfg Config) bool {
+	return cfg.Provider == "local-container" && cfg.LocalContainer.DockerSocket
 }
 
 func serverProviderKey(server Server) string {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2031,3 +2031,46 @@ func TestRecordRunFailureCapturesShadowedReturnErrors(t *testing.T) {
 		t.Fatalf("nil failure should not clear recorded error, got %v", recorded)
 	}
 }
+
+func TestLocalContainerDockerSocketSyncUsesResolvedLabels(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "local-container"
+	server := Server{
+		Provider: "local-container",
+		Labels:   map[string]string{"docker_socket": "1"},
+	}
+	if !localContainerDockerSocketSync(cfg, server) {
+		t.Fatal("socket-enabled resolved lease should sync without preserving mtimes")
+	}
+	server.Labels["docker_socket"] = "0"
+	cfg.LocalContainer.DockerSocket = true
+	if !localContainerDockerSocketSync(cfg, server) {
+		t.Fatal("socket-enabled config should sync without preserving mtimes")
+	}
+	cfg.Provider = "aws"
+	server.Provider = "aws"
+	if localContainerDockerSocketSync(cfg, server) {
+		t.Fatal("non-local-container provider should preserve normal rsync defaults")
+	}
+}
+
+func TestApplyResolvedServerConfigRestoresLocalContainerSocketConfig(t *testing.T) {
+	cfg := defaultConfig()
+	server := Server{
+		Provider: "local-container",
+		Labels: map[string]string{
+			"docker_socket": "1",
+			"work_root":     "/tmp/crabbox-local-container-work",
+		},
+	}
+	applyResolvedServerConfig(&cfg, server)
+	if cfg.Provider != "local-container" || !cfg.LocalContainer.DockerSocket {
+		t.Fatalf("local-container socket labels not restored: provider=%s local=%#v", cfg.Provider, cfg.LocalContainer)
+	}
+	if cfg.WorkRoot != server.Labels["work_root"] || cfg.LocalContainer.WorkRoot != server.Labels["work_root"] {
+		t.Fatalf("work roots not restored: workRoot=%q local=%q", cfg.WorkRoot, cfg.LocalContainer.WorkRoot)
+	}
+	if !localContainerDockerSocketConfig(cfg) {
+		t.Fatal("restored socket config should use no-times sync")
+	}
+}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -547,11 +547,20 @@ type rsyncOptions struct {
 	FullResync        bool
 	UseFilesFrom      bool
 	FilesFrom         []byte
+	NoTimes           bool
 	Timeout           time.Duration
 	HeartbeatInterval time.Duration
 }
 
+func normalizeRsyncOptions(opts rsyncOptions) rsyncOptions {
+	if opts.NoTimes {
+		opts.Checksum = true
+	}
+	return opts
+}
+
 func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []string, stdout, stderr io.Writer, opts rsyncOptions) error {
+	opts = normalizeRsyncOptions(opts)
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
@@ -560,6 +569,9 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	args := []string{
 		"-az",
 		"-e", strings.Join(shellWords(append([]string{"ssh"}, sshBaseArgs(target)...)), " "),
+	}
+	if opts.NoTimes {
+		args = append(args, "--no-times", "--omit-dir-times")
 	}
 	if opts.Delete && !opts.UseFilesFrom {
 		args = append(args, "--delete")

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -694,6 +694,18 @@ func TestRsyncLocalPathPassesThroughNonWindowsPath(t *testing.T) {
 	}
 }
 
+func TestNormalizeRsyncOptionsNoTimesForcesChecksum(t *testing.T) {
+	t.Parallel()
+	got := normalizeRsyncOptions(rsyncOptions{NoTimes: true})
+	if !got.Checksum {
+		t.Fatal("NoTimes rsync must force checksum comparison")
+	}
+	got = normalizeRsyncOptions(rsyncOptions{})
+	if got.Checksum {
+		t.Fatal("normal rsync should keep checksum disabled by default")
+	}
+}
+
 func TestWindowsToWSLPath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -16,8 +17,10 @@ import (
 )
 
 const (
-	providerName = "local-container"
-	sshPort      = "2222"
+	providerName        = "local-container"
+	sshPort             = "2222"
+	workRootMarkerName  = ".crabbox-local-container-work-root"
+	dockerSocketInGuest = "/var/run/docker.sock"
 )
 
 type backend struct {
@@ -107,7 +110,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		return core.LeaseTarget{}, err
 	}
-	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, providerName, b.claimScope(ctx), req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		if !req.Keep {
 			_ = b.removeContainer(context.Background(), containerID)
 		}
@@ -132,7 +135,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, providerName, b.claimScope(ctx), req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 			return core.LeaseTarget{}, err
 		}
 	}
@@ -168,22 +171,115 @@ func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.Doct
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	lease := req.Lease
 	id := strings.TrimSpace(req.Lease.Server.CloudID)
 	if id == "" {
-		container, _, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
+		container, leaseID, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
 		if err != nil {
 			return err
 		}
 		id = container.ID
+		if lease.LeaseID == "" {
+			lease.LeaseID = leaseID
+		}
+		lease.Server = b.serverFromContainer(container, b.configForRun())
 	}
 	if id == "" {
 		return core.Exit(2, "provider=%s release requires a container id", providerName)
 	}
+	hostLeaseRoot := hostLeaseWorkRoot(lease)
 	if err := b.removeContainer(ctx, id); err != nil {
 		return err
 	}
-	core.RemoveLeaseClaim(req.Lease.LeaseID)
-	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
+	var cleanupErr error
+	if hostLeaseRoot != "" {
+		cleanupErr = os.RemoveAll(hostLeaseRoot)
+	}
+	core.RemoveLeaseClaim(lease.LeaseID)
+	core.RemoveStoredTestboxKey(lease.LeaseID)
+	if cleanupErr != nil {
+		return core.Exit(2, "remove local-container host work root %s: %v", hostLeaseRoot, cleanupErr)
+	}
+	return nil
+}
+
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return err
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return err
+	}
+	claimScope := b.claimScope(ctx)
+	claimsByLease := map[string]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider == providerName {
+			claimsByLease[claim.LeaseID] = claim
+		}
+	}
+	liveLeases := map[string]struct{}{}
+	now := time.Now().UTC()
+	removed := 0
+	for _, container := range containers {
+		server := b.serverFromContainer(container, b.configForRun())
+		leaseID := strings.TrimSpace(server.Labels["lease"])
+		if leaseID != "" {
+			liveLeases[leaseID] = struct{}{}
+		}
+		claim, hasClaim := claimsByLease[leaseID]
+		shouldDelete, reason := shouldCleanupLocalContainer(server, claim, hasClaim, now)
+		if !shouldDelete {
+			fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+		if err := b.removeContainer(ctx, container.ID); err != nil {
+			return err
+		}
+		var cleanupErr error
+		hostLeaseRoot := hostLeaseWorkRootFromLabels(leaseID, server.Labels)
+		if hostLeaseRoot != "" {
+			cleanupErr = os.RemoveAll(hostLeaseRoot)
+		}
+		if leaseID != "" {
+			core.RemoveLeaseClaim(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
+		}
+		if cleanupErr != nil {
+			return core.Exit(2, "remove local-container host work root %s: %v", hostLeaseRoot, cleanupErr)
+		}
+		removed++
+	}
+	claimsRemoved := 0
+	for leaseID, claim := range claimsByLease {
+		if leaseID == "" {
+			continue
+		}
+		if _, ok := liveLeases[leaseID]; ok {
+			continue
+		}
+		if !localContainerClaimMatchesScope(claim, claimScope, now) {
+			continue
+		}
+		reason := "missing container"
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", leaseID, blank(claim.Slug, "-"), reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", leaseID, blank(claim.Slug, "-"), reason)
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
+		claimsRemoved++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(containers))
+	}
 	return nil
 }
 
@@ -192,7 +288,13 @@ func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, 
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	original := server.Labels
+	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	for _, key := range []string{"container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"} {
+		if value := strings.TrimSpace(original[key]); value != "" {
+			server.Labels[key] = value
+		}
+	}
 	return server, nil
 }
 
@@ -221,7 +323,11 @@ func applyDefaults(cfg *core.Config) {
 		cfg.LocalContainer.User = "crabbox"
 	}
 	if cfg.LocalContainer.DockerSocket && isDefaultWorkRoot(cfg.LocalContainer.WorkRoot) && isDefaultWorkRoot(cfg.WorkRoot) {
-		cfg.LocalContainer.WorkRoot = defaultDockerSocketWorkRoot()
+		if runtime.GOOS == "windows" {
+			cfg.LocalContainer.WorkRoot = "/work/crabbox"
+		} else {
+			cfg.LocalContainer.WorkRoot = defaultDockerSocketWorkRoot()
+		}
 	}
 	if cfg.LocalContainer.WorkRoot == "" {
 		if !isDefaultWorkRoot(cfg.WorkRoot) {
@@ -245,8 +351,14 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	labels["image"] = cfg.LocalContainer.Image
 	labels["ssh_user"] = cfg.LocalContainer.User
 	labels["ssh_port"] = sshPort
-	labels["work_root"] = cfg.LocalContainer.WorkRoot
 	labels["docker_socket"] = boolEnv(cfg.LocalContainer.DockerSocket)
+	containerWorkRoot := cfg.LocalContainer.WorkRoot
+	hostWorkRoot := ""
+	if cfg.LocalContainer.DockerSocket {
+		hostWorkRoot, containerWorkRoot = dockerSocketWorkRoots(cfg)
+		labels["host_work_root"] = hostWorkRoot
+	}
+	labels["work_root"] = containerWorkRoot
 	args := []string{
 		"run", "-d",
 		"--name", name,
@@ -256,7 +368,7 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		"-p", "127.0.0.1::" + sshPort,
 		"-e", "CRABBOX_AUTHORIZED_KEY=" + publicKey,
 		"-e", "CRABBOX_SSH_USER=" + cfg.LocalContainer.User,
-		"-e", "CRABBOX_WORK_ROOT=" + cfg.LocalContainer.WorkRoot,
+		"-e", "CRABBOX_WORK_ROOT=" + containerWorkRoot,
 		"-e", "CRABBOX_SSH_PORT=" + sshPort,
 		"-e", "CRABBOX_DESKTOP=" + boolEnv(cfg.Desktop),
 		"-e", "CRABBOX_BROWSER=" + boolEnv(cfg.Browser),
@@ -272,22 +384,25 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		args = append(args, "--memory", memory)
 	}
 	if cfg.LocalContainer.DockerSocket {
-		if err := os.MkdirAll(cfg.LocalContainer.WorkRoot, 0o755); err != nil {
-			return "", core.Exit(2, "create local-container host work root %s: %v", cfg.LocalContainer.WorkRoot, err)
+		if err := os.MkdirAll(hostWorkRoot, 0o755); err != nil {
+			return "", core.Exit(2, "create local-container host work root %s: %v", hostWorkRoot, err)
 		}
-		leaseWorkRoot := filepath.Join(cfg.LocalContainer.WorkRoot, leaseID)
+		if err := markLocalContainerWorkRoot(hostWorkRoot); err != nil {
+			return "", core.Exit(2, "mark local-container host work root %s: %v", hostWorkRoot, err)
+		}
+		leaseWorkRoot := filepath.Join(hostWorkRoot, leaseID)
 		if err := os.MkdirAll(leaseWorkRoot, 0o777); err != nil {
 			return "", core.Exit(2, "create local-container host lease work root %s: %v", leaseWorkRoot, err)
 		}
 		if err := os.Chmod(leaseWorkRoot, 0o777); err != nil {
 			return "", core.Exit(2, "make local-container host lease work root writable %s: %v", leaseWorkRoot, err)
 		}
-		args = append(args, "-v", cfg.LocalContainer.WorkRoot+":"+cfg.LocalContainer.WorkRoot)
+		args = append(args, "-v", hostWorkRoot+":"+containerWorkRoot)
 		socketPath, err := b.dockerSocketMountPath(ctx)
 		if err != nil {
 			return "", err
 		}
-		args = append(args, "-v", socketPath+":/var/run/docker.sock")
+		args = append(args, "-v", socketPath+":"+dockerSocketInGuest)
 	}
 	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "-lc", bootstrapScript)
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
@@ -315,15 +430,58 @@ func (b *backend) dockerSocketMountPath(ctx context.Context) (string, error) {
 			return dockerSocketMountPathFromHost(host)
 		}
 	}
-	return validateDockerSocketMountPath("/var/run/docker.sock")
+	if runtime.GOOS != "linux" {
+		return dockerSocketInGuest, nil
+	}
+	return validateDockerSocketMountPath(dockerSocketInGuest)
 }
 
 func dockerSocketMountPathFromHost(host string) (string, error) {
+	return dockerSocketMountPathFromHostForGOOS(host, runtime.GOOS)
+}
+
+func dockerSocketMountPathFromHostForGOOS(host, goos string) (string, error) {
+	if goos == "windows" && windowsDockerPipeHost(host) {
+		return dockerSocketInGuest, nil
+	}
 	path, ok := localDockerSocketPath(host)
 	if !ok {
 		return "", core.Exit(2, "local-container docker socket requested but active Docker host %q is not a local Unix socket", host)
 	}
+	if goos != "linux" {
+		return dockerSocketInGuest, nil
+	}
 	return validateDockerSocketMountPath(path)
+}
+
+func dockerSocketWorkRoots(cfg core.Config) (string, string) {
+	return dockerSocketWorkRootsForGOOS(cfg.LocalContainer.WorkRoot, runtime.GOOS)
+}
+
+func dockerSocketWorkRootsForGOOS(workRoot, goos string) (string, string) {
+	workRoot = strings.TrimSpace(workRoot)
+	if workRoot == "" {
+		workRoot = "/work/crabbox"
+	}
+	if goos == "windows" {
+		if windowsHostPath(workRoot) {
+			return workRoot, "/work/crabbox"
+		}
+		return defaultDockerSocketWorkRoot(), workRoot
+	}
+	return workRoot, workRoot
+}
+
+func windowsHostPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if len(path) >= 3 && ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) && path[1] == ':' && (path[2] == '\\' || path[2] == '/') {
+		return true
+	}
+	return strings.HasPrefix(path, `\\`)
+}
+
+func windowsDockerPipeHost(host string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(host)), "npipe:")
 }
 
 func localDockerSocketPath(host string) (string, bool) {
@@ -363,6 +521,10 @@ func defaultDockerSocketWorkRoot() string {
 		return filepath.Join(cache, "crabbox", "local-container-work")
 	}
 	return filepath.Join(os.TempDir(), "crabbox-local-container-work")
+}
+
+func markLocalContainerWorkRoot(root string) error {
+	return os.WriteFile(filepath.Join(root, workRootMarkerName), []byte("crabbox local-container work root\n"), 0o644)
 }
 
 func (b *backend) prepareLease(ctx context.Context, cfg core.Config, container inspectContainer, leaseID, slug string, wait bool) (core.LeaseTarget, error) {
@@ -490,8 +652,76 @@ func (b *backend) runtimeInfo(ctx context.Context) (string, string) {
 	if err != nil {
 		return "unknown", ""
 	}
-	contextName, _ := b.docker(ctx, []string{"context", "show"}, nil, nil)
-	return strings.TrimSpace(version.Stdout), strings.TrimSpace(contextName.Stdout)
+	return strings.TrimSpace(version.Stdout), b.runtimeContext(ctx)
+}
+
+func (b *backend) runtimeContext(ctx context.Context) string {
+	contextName, err := b.docker(ctx, []string{"context", "show"}, nil, nil)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(contextName.Stdout)
+}
+
+func (b *backend) claimScope(ctx context.Context) string {
+	return localContainerClaimScope(b.configForRun().LocalContainer.Runtime, b.runtimeContext(ctx), b.runtimeHost(ctx))
+}
+
+func localContainerClaimScope(runtimeName, contextName string, hostValues ...string) string {
+	runtimeName = strings.TrimSpace(runtimeName)
+	contextName = strings.TrimSpace(contextName)
+	host := ""
+	if len(hostValues) > 0 {
+		host = strings.TrimSpace(hostValues[0])
+	}
+	if runtimeName == "" || contextName == "" {
+		return ""
+	}
+	scope := "runtime:" + runtimeName + "/context:" + contextName
+	if host != "" {
+		scope += "/host:" + host
+	}
+	return scope
+}
+
+func (b *backend) runtimeHost(ctx context.Context) string {
+	if host := strings.TrimSpace(os.Getenv("DOCKER_HOST")); host != "" {
+		return host
+	}
+	result, err := b.docker(ctx, []string{"context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"}, nil, nil)
+	if err != nil {
+		return ""
+	}
+	host := strings.TrimSpace(result.Stdout)
+	if host == "" || host == "<no value>" {
+		return ""
+	}
+	var decoded string
+	if err := json.Unmarshal([]byte(host), &decoded); err == nil {
+		host = decoded
+	}
+	return strings.TrimSpace(host)
+}
+
+func localContainerClaimMatchesScope(claim core.LeaseClaim, currentScope string, now time.Time) bool {
+	currentScope = strings.TrimSpace(currentScope)
+	claimScope := strings.TrimSpace(claim.ProviderScope)
+	if currentScope != "" && claimScope == currentScope {
+		return true
+	}
+	return claimScope == "" && localContainerClaimExpired(claim, now)
+}
+
+func localContainerClaimExpired(claim core.LeaseClaim, now time.Time) bool {
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil || lastUsed.IsZero() {
+		return false
+	}
+	idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	if idle <= 0 {
+		return false
+	}
+	return now.After(lastUsed.Add(idle).Add(12 * time.Hour))
 }
 
 func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
@@ -588,6 +818,104 @@ func firstNonBlank(values ...string) string {
 	return ""
 }
 
+func hostLeaseWorkRoot(lease core.LeaseTarget) string {
+	return hostLeaseWorkRootFromLabels(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]), lease.Server.Labels)
+}
+
+func hostLeaseWorkRootFromLabels(leaseID string, labels map[string]string) string {
+	if labels["docker_socket"] != "1" {
+		return ""
+	}
+	root := strings.TrimSpace(firstNonBlank(labels["host_work_root"], labels["work_root"]))
+	leaseID = strings.TrimSpace(leaseID)
+	if root == "" || leaseID == "" || !filepath.IsAbs(root) {
+		return ""
+	}
+	if !safeLocalContainerLeaseID(leaseID) {
+		return ""
+	}
+	root = filepath.Clean(root)
+	if !trustedLocalContainerWorkRoot(root) {
+		return ""
+	}
+	leaseRoot := filepath.Join(root, leaseID)
+	rel, err := filepath.Rel(root, leaseRoot)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return ""
+	}
+	return leaseRoot
+}
+
+func safeLocalContainerLeaseID(leaseID string) bool {
+	if !strings.HasPrefix(leaseID, "cbx_") || len(leaseID) <= len("cbx_") {
+		return false
+	}
+	for _, r := range strings.TrimPrefix(leaseID, "cbx_") {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func trustedLocalContainerWorkRoot(root string) bool {
+	info, err := os.Stat(filepath.Join(root, workRootMarkerName))
+	if err == nil && !info.IsDir() {
+		return true
+	}
+	return filepath.Clean(root) == filepath.Clean(defaultDockerSocketWorkRoot())
+}
+
+func shouldCleanupLocalContainer(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	labels := server.Labels
+	if labels == nil {
+		return false, "missing labels"
+	}
+	if strings.EqualFold(labels["keep"], "true") {
+		return false, "keep=true"
+	}
+	if !strings.EqualFold(server.Status, "running") && server.Status != "ready" {
+		return true, "container state=" + blank(server.Status, "unknown")
+	}
+	if hasClaim {
+		lastUsed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
+		if err != nil || lastUsed.IsZero() {
+			return false, "claim active"
+		}
+		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+		if idle <= 0 {
+			return false, "claim active"
+		}
+		expires := lastUsed.Add(idle)
+		if now.After(expires.Add(12 * time.Hour)) {
+			return true, "claim expired"
+		}
+		return false, "claim active"
+	}
+	if expires, ok := localContainerLabelTime(labels["expires_at"]); ok {
+		if now.After(expires.Add(12 * time.Hour)) {
+			return true, "expired"
+		}
+		return false, "not expired"
+	}
+	return false, "missing claim"
+}
+
+func localContainerLabelTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	if unix, err := strconv.ParseInt(value, 10, 64); err == nil && unix > 0 {
+		return time.Unix(unix, 0).UTC(), true
+	}
+	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+		return parsed.UTC(), true
+	}
+	return time.Time{}, false
+}
+
 func boolEnv(value bool) string {
 	if value {
 		return "1"
@@ -662,7 +990,31 @@ if [ "${CRABBOX_BROWSER:-0}" = "1" ] && command -v apt-get >/dev/null 2>&1; then
 fi
 if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
   apt-get update
-  apt-get install -y --no-install-recommends docker.io
+  install_docker_cli=0
+  if [ -r /etc/os-release ]; then
+    . /etc/os-release
+    case "${ID:-}" in
+      debian|ubuntu)
+        install -m 0755 -d /etc/apt/keyrings
+        if curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc; then
+          chmod a+r /etc/apt/keyrings/docker.asc
+          codename="${VERSION_CODENAME:-}"
+          if [ -n "$codename" ]; then
+            arch="$(dpkg --print-architecture)"
+            printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/%s %s stable\n' "$arch" "$ID" "$codename" > /etc/apt/sources.list.d/docker.list
+            if apt-get update && apt-get install -y --no-install-recommends docker-ce-cli; then
+              install_docker_cli=1
+            else
+              rm -f /etc/apt/sources.list.d/docker.list
+            fi
+          fi
+        fi
+        ;;
+    esac
+  fi
+  if [ "$install_docker_cli" != "1" ]; then
+    apt-get install -y --no-install-recommends docker.io
+  fi
 fi
 if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1; then
   echo "docker socket requested but docker CLI is not installed; use a Debian/Ubuntu-compatible image or preinstall docker" >&2

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -6,8 +6,11 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -73,6 +76,9 @@ func TestProviderAliases(t *testing.T) {
 	spec := Provider{}.Spec()
 	if !spec.Features.Has(core.FeatureDesktop) || !spec.Features.Has(core.FeatureBrowser) {
 		t.Fatalf("local-container features=%v, want desktop and browser", spec.Features)
+	}
+	if !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("local-container features=%v, want cleanup", spec.Features)
 	}
 }
 
@@ -151,6 +157,7 @@ func TestCreateContainerCanMountDockerSocket(t *testing.T) {
 	args := recordedArgsForCommand(t, runner, "run")
 	for _, want := range []string{
 		"--label\ndocker_socket=1",
+		"--label\nhost_work_root=" + cfg.LocalContainer.WorkRoot,
 		"-e\nCRABBOX_DOCKER_SOCKET=1",
 		"-v\n" + cfg.LocalContainer.WorkRoot + ":" + cfg.LocalContainer.WorkRoot,
 		"-v\n/var/run/docker.sock:/var/run/docker.sock",
@@ -182,6 +189,11 @@ func TestCreateContainerMountsDockerHostUnixSocket(t *testing.T) {
 	cfg.LocalContainer.DockerSocket = true
 	cfg.LocalContainer.WorkRoot = t.TempDir()
 	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
+	rootInfo, err := os.Stat(cfg.LocalContainer.WorkRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootMode := rootInfo.Mode().Perm()
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
 	_, err = b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
@@ -189,8 +201,19 @@ func TestCreateContainerMountsDockerHostUnixSocket(t *testing.T) {
 		t.Fatal(err)
 	}
 	args := recordedArgsForCommand(t, runner, "run")
-	if !strings.Contains(args, "-v\n"+socketPath+":/var/run/docker.sock") {
+	wantSocketPath := socketPath
+	if runtime.GOOS != "linux" {
+		wantSocketPath = "/var/run/docker.sock"
+	}
+	if !strings.Contains(args, "-v\n"+wantSocketPath+":/var/run/docker.sock") {
 		t.Fatalf("docker host socket was not mounted:\n%s", args)
+	}
+	rootInfo, err = os.Stat(cfg.LocalContainer.WorkRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rootInfo.Mode().Perm() != rootMode {
+		t.Fatalf("host work root mode=%#o want preserved %#o", rootInfo.Mode().Perm(), rootMode)
 	}
 	leaseRoot := filepath.Join(cfg.LocalContainer.WorkRoot, "cbx_123")
 	info, err := os.Stat(leaseRoot)
@@ -210,12 +233,98 @@ func TestDockerSocketMountRejectsRemoteDockerHost(t *testing.T) {
 	}
 }
 
+func TestDockerSocketMountUsesDaemonSocketForNonLinuxClient(t *testing.T) {
+	path, err := dockerSocketMountPathFromHostForGOOS("unix:///var/run/docker.sock", "darwin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "/var/run/docker.sock" {
+		t.Fatalf("path=%q, want daemon-visible socket", path)
+	}
+}
+
+func TestDockerSocketMountUsesDaemonSocketForWindowsPipe(t *testing.T) {
+	path, err := dockerSocketMountPathFromHostForGOOS(`npipe:////./pipe/docker_engine`, "windows")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "/var/run/docker.sock" {
+		t.Fatalf("path=%q, want daemon-visible socket", path)
+	}
+}
+
+func TestDockerSocketWorkRootsUseLinuxGuestPathForWindows(t *testing.T) {
+	host, guest := dockerSocketWorkRootsForGOOS(`C:\crabbox\local-container-work`, "windows")
+	if host != `C:\crabbox\local-container-work` {
+		t.Fatalf("host root=%q", host)
+	}
+	if guest != "/work/crabbox" {
+		t.Fatalf("guest root=%q, want /work/crabbox", guest)
+	}
+
+	host, guest = dockerSocketWorkRootsForGOOS("/work/custom", "windows")
+	if !strings.Contains(host, "crabbox") || guest != "/work/custom" {
+		t.Fatalf("default Windows socket roots host=%q guest=%q", host, guest)
+	}
+}
+
+func TestPrepareLeaseUsesLabeledGuestWorkRootForReadyCheck(t *testing.T) {
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	cfg := b.configForRun()
+	cfg.LocalContainer.DockerSocket = true
+	cfg.LocalContainer.WorkRoot = `C:\crabbox\local-container-work`
+	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
+	container := inspectContainer{
+		ID:   "container1234567890",
+		Name: "/crabbox-windows-root",
+		Config: inspectConfig{
+			Image: "ubuntu:24.04",
+			Labels: map[string]string{
+				"crabbox":        "true",
+				"provider":       providerName,
+				"lease":          "cbx_windows",
+				"slug":           "windows-root",
+				"state":          "ready",
+				"server_type":    "ubuntu:24.04",
+				"ssh_user":       "runner",
+				"docker_socket":  "1",
+				"host_work_root": `C:\crabbox\local-container-work`,
+				"work_root":      "/work/crabbox",
+			},
+		},
+		State: inspectState{Status: "running", Running: true},
+		NetworkSettings: inspectNetworking{
+			Ports: map[string][]inspectPort{"2222/tcp": []inspectPort{{HostIP: "127.0.0.1", HostPort: "49153"}}},
+		},
+	}
+
+	lease, err := b.prepareLease(context.Background(), cfg, container, "cbx_windows", "windows-root", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.ReadyCheck == "" || !strings.Contains(lease.SSH.ReadyCheck, "test -d '/work/crabbox'") {
+		t.Fatalf("ready check did not use guest work root: %q", lease.SSH.ReadyCheck)
+	}
+	if strings.Contains(lease.SSH.ReadyCheck, `C:\crabbox`) {
+		t.Fatalf("ready check used host work root: %q", lease.SSH.ReadyCheck)
+	}
+	if lease.SSH.User != "runner" || lease.SSH.Port != "49153" {
+		t.Fatalf("unexpected lease target: %#v", lease.SSH)
+	}
+}
+
 func TestConfigForRunUsesHostVisibleWorkRootWithDockerSocket(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.LocalContainer.DockerSocket = true
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	got := b.configForRun()
+	if runtime.GOOS == "windows" {
+		if got.LocalContainer.WorkRoot != "/work/crabbox" || got.WorkRoot != "/work/crabbox" {
+			t.Fatalf("windows docker socket work root should stay Linux-visible: %#v", got.LocalContainer)
+		}
+		return
+	}
 	if got.LocalContainer.WorkRoot == "/work/crabbox" || got.WorkRoot == "/work/crabbox" {
 		t.Fatalf("docker socket work root should be host-visible: %#v", got.LocalContainer)
 	}
@@ -241,6 +350,10 @@ func TestBootstrapScriptUsesAccountHomeDirectory(t *testing.T) {
 func TestBootstrapScriptSupportsDockerSocketCLI(t *testing.T) {
 	for _, want := range []string{
 		`[ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker`,
+		`https://download.docker.com/linux/${ID}/gpg`,
+		`if apt-get update && apt-get install -y --no-install-recommends docker-ce-cli; then`,
+		`rm -f /etc/apt/sources.list.d/docker.list`,
+		`apt-get install -y --no-install-recommends docker-ce-cli`,
 		`apt-get install -y --no-install-recommends docker.io`,
 		`docker socket requested but docker CLI is not installed`,
 		`stat -c '%g' /var/run/docker.sock`,
@@ -316,6 +429,46 @@ func TestListAndResolveContainers(t *testing.T) {
 	}
 }
 
+func TestTouchPreservesLocalContainerLabels(t *testing.T) {
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	lease := core.LeaseTarget{
+		LeaseID: "cbx_touch",
+		Server: core.Server{
+			Labels: map[string]string{
+				"docker_socket":  "1",
+				"host_work_root": "/tmp/crabbox-local-container-work",
+				"work_root":      "/tmp/crabbox-local-container-work",
+				"ssh_user":       "runner",
+			},
+		},
+	}
+	server, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.Labels["work_root"] != lease.Server.Labels["work_root"] || server.Labels["host_work_root"] != lease.Server.Labels["host_work_root"] || server.Labels["docker_socket"] != "1" || server.Labels["ssh_user"] != "runner" {
+		t.Fatalf("provider labels not preserved: %#v", server.Labels)
+	}
+	if server.Labels["state"] != "running" {
+		t.Fatalf("state not touched: %#v", server.Labels)
+	}
+}
+
+func TestHostLeaseWorkRootRequiresTrustedLabels(t *testing.T) {
+	hostRoot := t.TempDir()
+	leaseID := "cbx_trusted"
+	if got := hostLeaseWorkRootFromLabels(leaseID, map[string]string{"docker_socket": "1", "work_root": hostRoot}); got != "" {
+		t.Fatalf("unmarked work root accepted: %q", got)
+	}
+	if got := hostLeaseWorkRootFromLabels("Users", map[string]string{"docker_socket": "1", "work_root": "/"}); got != "" {
+		t.Fatalf("spoofed lease root accepted: %q", got)
+	}
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	if got := hostLeaseWorkRootFromLabels(leaseID, map[string]string{"docker_socket": "1", "host_work_root": hostRoot, "work_root": "/work/crabbox"}); got != filepath.Join(hostRoot, leaseID) {
+		t.Fatalf("work root=%q want %q", got, filepath.Join(hostRoot, leaseID))
+	}
+}
+
 func TestFindContainerForClaimReturnsMatchedContainerIdentity(t *testing.T) {
 	inspectJSON := `[{
 		"Id":"newcontainer123456",
@@ -364,5 +517,331 @@ func TestReleaseLeaseRemovesStoredKey(t *testing.T) {
 	}
 	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("stored key still exists after release: %v", err)
+	}
+}
+
+func TestReleaseLeaseRemovesDockerSocketHostWorkRoot(t *testing.T) {
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	leaseRoot := filepath.Join(hostRoot, "cbx_release")
+	if err := os.MkdirAll(filepath.Join(leaseRoot, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"rm", "-f", "container123"}): {},
+		},
+	}
+	b := testBackend(runner)
+	lease := core.LeaseTarget{
+		LeaseID: "cbx_release",
+		Server: core.Server{
+			CloudID: "container123",
+			Labels: map[string]string{
+				"docker_socket": "1",
+				"work_root":     hostRoot,
+			},
+		},
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(leaseRoot); !os.IsNotExist(err) {
+		t.Fatalf("host lease root still exists after release: %v", err)
+	}
+	if _, err := os.Stat(hostRoot); err != nil {
+		t.Fatalf("host work root parent removed: %v", err)
+	}
+}
+
+func TestReleaseLeaseWithIDResolvesHostWorkRoot(t *testing.T) {
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	leaseRoot := filepath.Join(hostRoot, "cbx_release")
+	if err := os.MkdirAll(filepath.Join(leaseRoot, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := `[{
+		"Id":"container1234567890",
+		"Name":"/crabbox-release",
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_release","slug":"release-root","state":"ready","server_type":"ubuntu:24.04","ssh_user":"runner","work_root":"` + hostRoot + `","docker_socket":"1"}},
+		"State":{"Status":"running","Running":true},
+		"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}
+	}]`
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "container1234567890\n"},
+			commandKey([]string{"inspect", "container1234567890"}):  {Stdout: inspectJSON},
+			commandKey([]string{"rm", "-f", "container1234567890"}): {},
+		},
+	}
+	b := testBackend(runner)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_release"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(leaseRoot); !os.IsNotExist(err) {
+		t.Fatalf("host lease root still exists after release by id: %v", err)
+	}
+}
+
+func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	leaseRoot := filepath.Join(hostRoot, "cbx_cleanup")
+	if err := os.MkdirAll(filepath.Join(leaseRoot, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	created := time.Now().Add(-48 * time.Hour).Unix()
+	inspectJSON := `[{
+		"Id":"abcdef1234567890",
+		"Name":"/crabbox-cleanup",
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_cleanup","slug":"old-cleanup","state":"ready","server_type":"ubuntu:24.04","ssh_user":"runner","work_root":"` + hostRoot + `","docker_socket":"1","expires_at":"` + strconv.FormatInt(created, 10) + `"}},
+		"State":{"Status":"running","Running":true},
+		"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}
+	}]`
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "abcdef1234567890\n"},
+			commandKey([]string{"inspect", "abcdef1234567890"}):  {Stdout: inspectJSON},
+			commandKey([]string{"rm", "-f", "abcdef1234567890"}): {},
+		},
+	}
+	b := testBackend(runner)
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(leaseRoot); !os.IsNotExist(err) {
+		t.Fatalf("host lease root still exists after cleanup: %v", err)
+	}
+	args := recordedArgsForCommand(t, runner, "rm")
+	if !strings.Contains(args, "abcdef1234567890") {
+		t.Fatalf("cleanup did not remove container:\n%s", args)
+	}
+}
+
+func TestCleanupRemovesClaimAfterHostWorkRootFailure(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	claimDir := filepath.Join(stateHome, "crabbox", "claims")
+	if err := os.MkdirAll(claimDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	expired := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	claimData := []byte(`{"leaseID":"cbx_cleanup","slug":"old-cleanup","provider":"` + providerName + `","repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(expired) + `,"lastUsedAt":` + strconv.Quote(expired) + `,"idleTimeoutSeconds":60}`)
+	if err := os.WriteFile(filepath.Join(claimDir, "cbx_cleanup.json"), claimData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath("cbx_cleanup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hostRoot := t.TempDir()
+	markTestLocalContainerWorkRoot(t, hostRoot)
+	leaseRoot := filepath.Join(hostRoot, "cbx_cleanup")
+	if err := os.MkdirAll(filepath.Join(leaseRoot, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(hostRoot, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(hostRoot, 0o700)
+	})
+	created := time.Now().Add(-48 * time.Hour).Unix()
+	inspectJSON := `[{
+		"Id":"abcdef1234567890",
+		"Name":"/crabbox-cleanup",
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_cleanup","slug":"old-cleanup","state":"ready","server_type":"ubuntu:24.04","ssh_user":"runner","work_root":"` + hostRoot + `","docker_socket":"1","expires_at":"` + strconv.FormatInt(created, 10) + `"}},
+		"State":{"Status":"running","Running":true},
+		"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}
+	}]`
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "abcdef1234567890\n"},
+			commandKey([]string{"inspect", "abcdef1234567890"}):  {Stdout: inspectJSON},
+			commandKey([]string{"rm", "-f", "abcdef1234567890"}): {},
+		},
+	}
+	b := testBackend(runner)
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
+		t.Fatal("cleanup succeeded despite host work root removal failure")
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_cleanup"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("claim still exists after partial cleanup failure: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stored key still exists after partial cleanup failure: %v", err)
+	}
+}
+
+func TestCleanupRemovesClaimWithoutContainer(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	scope := localContainerClaimScope("docker", "default")
+	keyPath := writeLocalContainerClaimAndKey(t, "cbx_missing", "missing-container", scope)
+
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"context", "show"}): {Stdout: "default\n"},
+	}})
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_missing"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("claim still exists after cleanup: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stored key still exists after cleanup: %v", err)
+	}
+}
+
+func TestCleanupDryRunKeepsClaimWithoutContainer(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	scope := localContainerClaimScope("docker", "default")
+	keyPath := writeLocalContainerClaimAndKey(t, "cbx_missing", "missing-container", scope)
+
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"context", "show"}): {Stdout: "default\n"},
+	}})
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_missing"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "cbx_missing" {
+		t.Fatalf("claim removed during dry-run: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key removed during dry-run: %v", err)
+	}
+}
+
+func TestCleanupKeepsClaimFromDifferentRuntimeContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	keyPath := writeLocalContainerClaimAndKey(t, "cbx_other", "other-context", localContainerClaimScope("docker", "colima"))
+
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"context", "show"}): {Stdout: "desktop-linux\n"},
+	}})
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_other"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "cbx_other" {
+		t.Fatalf("claim from another context was removed: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key from another context was removed: %v", err)
+	}
+}
+
+func TestCleanupKeepsClaimFromDifferentDockerHostSameContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	keyPath := writeLocalContainerClaimAndKey(t, "cbx_other_host", "other-host", localContainerClaimScope("docker", "default", "unix:///tmp/docker-a.sock"))
+	t.Setenv("DOCKER_HOST", "unix:///tmp/docker-b.sock")
+
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"context", "show"}): {Stdout: "default\n"},
+	}})
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_other_host"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "cbx_other_host" {
+		t.Fatalf("claim from another Docker host was removed: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key from another Docker host was removed: %v", err)
+	}
+}
+
+func TestCleanupRemovesStaleLegacyUnscopedClaimWithoutContainer(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	lastUsed := time.Now().Add(-48 * time.Hour).UTC()
+	keyPath := writeLocalContainerClaimAndKeyAt(t, "cbx_legacy", "legacy-missing", "", lastUsed, time.Minute)
+
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"context", "show"}): {Stdout: "default\n"},
+	}})
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim("cbx_legacy"); err != nil {
+		t.Fatal(err)
+	} else if claim.LeaseID != "" {
+		t.Fatalf("stale legacy claim still exists after cleanup: %#v", claim)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("stale legacy stored key still exists after cleanup: %v", err)
+	}
+}
+
+func writeLocalContainerClaimAndKey(t *testing.T, leaseID, slug string, scopes ...string) string {
+	t.Helper()
+	scope := ""
+	if len(scopes) > 0 {
+		scope = scopes[0]
+	}
+	return writeLocalContainerClaimAndKeyAt(t, leaseID, slug, scope, time.Now().UTC(), time.Minute)
+}
+
+func writeLocalContainerClaimAndKeyAt(t *testing.T, leaseID, slug, scope string, lastUsed time.Time, idle time.Duration) string {
+	t.Helper()
+	if err := writeLocalContainerClaim(t, leaseID, slug, scope, lastUsed, idle); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return keyPath
+}
+
+func writeLocalContainerClaim(t *testing.T, leaseID, slug, scope string, lastUsed time.Time, idle time.Duration) error {
+	t.Helper()
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		t.Fatal("XDG_STATE_HOME must be set before writing test claims")
+	}
+	claimDir := filepath.Join(stateHome, "crabbox", "claims")
+	if err := os.MkdirAll(claimDir, 0o700); err != nil {
+		return err
+	}
+	scopeField := ""
+	if scope != "" {
+		scopeField = `,"providerScope":` + strconv.Quote(scope)
+	}
+	data := []byte(`{"leaseID":` + strconv.Quote(leaseID) + `,"slug":` + strconv.Quote(slug) + `,"provider":` + strconv.Quote(providerName) + scopeField + `,"repoRoot":` + strconv.Quote(t.TempDir()) + `,"claimedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"lastUsedAt":` + strconv.Quote(lastUsed.Format(time.RFC3339)) + `,"idleTimeoutSeconds":` + strconv.Itoa(int(idle.Seconds())) + `}`)
+	return os.WriteFile(filepath.Join(claimDir, leaseID+".json"), data, 0o600)
+}
+
+func markTestLocalContainerWorkRoot(t *testing.T, root string) {
+	t.Helper()
+	if err := markLocalContainerWorkRoot(root); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -23,7 +23,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Name:        providerName,
 		Kind:        core.ProviderKindSSHLease,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureDesktop, core.FeatureBrowser},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary

- add local-container cleanup support for stale Docker containers, orphaned local claims, and stored per-lease keys
- harden Docker socket leases by restoring socket labels on reuse, syncing without mtime preservation while keeping checksum comparison, and cleaning marked or legacy-default per-lease host work roots
- make Docker socket pass-through work across Docker Desktop, OrbStack, Colima, and local VM contexts, including Windows npipe clients, and prefer Docker's current Debian/Ubuntu CLI package during bootstrap

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check origin/main...HEAD`
- `node scripts/check-docs-links.mjs`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- live Docker socket smoke: created a kept `provider=docker` socket lease, reused it by ID without repeating the socket flag, forced a dirty sync, ran `docker version` inside the lease twice, then stopped the smoke lease
- autoreview: passed after fixes for Windows guest work roots, rsync no-mtime checksum mode, Docker context/host cleanup scoping, legacy unscoped claim cleanup, and legacy default work-root cleanup

## Notes

Follow-up hardening for https://github.com/openclaw/crabbox/pull/144 and https://github.com/openclaw/crabbox/issues/134.

Docker socket pass-through remains opt-in and gives the lease access to the host Docker daemon. Cleanup scopes missing-container claim pruning by the active local runtime/context/host, and only removes legacy unscoped missing claims once they are stale past the idle timeout grace period.
