### PR TITLE
fix: tighten local Actions and Parallels fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed `crabbox cleanup --provider docker` support for stale local-container leases.
 - Fixed `provider: docker` stop/release cleanup so host-visible per-lease work directories created for Docker socket pass-through are removed with the lease.
 - Fixed local Actions hydration for repo-local composite actions, cache no-ops, simple input conditions, safe `hashFiles`, secret-expression rejection, and Node 24.x setup on minimal Debian images.
+- Fixed Parallels linked-clone provisioning to require an explicit source snapshot so `prlctl` cannot create a template-side linked-clone snapshot implicitly.
 
 ## 0.17.0 - 2026-05-21
 

--- a/docs/providers/parallels.md
+++ b/docs/providers/parallels.md
@@ -8,9 +8,9 @@ Read when:
 - changing `internal/providers/parallels` or Parallels checkpoint behavior.
 
 Parallels is a direct SSH lease provider. Crabbox asks `prlctl` to create a
-linked clone from a configured source VM and optional snapshot, starts the clone,
-discovers the guest IP, injects the per-lease SSH key with Parallels Tools, then
-uses the normal Crabbox SSH sync/run/checkpoint path.
+linked clone from a configured source VM and explicit snapshot, starts the
+clone, discovers the guest IP, injects the per-lease SSH key with Parallels
+Tools, then uses the normal Crabbox SSH sync/run/checkpoint path.
 
 The provider is local-first. Set `parallels.host` when the Parallels Desktop
 install lives on another Mac reachable over SSH.
@@ -59,9 +59,13 @@ Each template should already include:
   shell/PowerShell);
 - a known-good Parallels snapshot for fast linked clones.
 
-Linked clones require a power-off snapshot. Parallels also refuses to clone from
-a busy source VM, so keep template VMs shut down when they are used as local
-fleet bases.
+Linked clones require an explicit power-off snapshot. Crabbox rejects linked
+clone requests without `parallels.sourceSnapshot`/`sourceSnapshotId`, because
+otherwise `prlctl` creates a source-side "Snapshot for linked clone" on the
+template VM. Use `cloneMode: full` or `cloneMode: unlink` only when you
+intentionally want to clone the current source VM state without a snapshot.
+Parallels also refuses to clone from a busy source VM, so keep template VMs shut
+down when they are used as local fleet bases.
 
 For macOS templates, use a user with SSH login permission and a writable
 `parallels.workRoot`, for example `/Users/<user>/crabbox`. For Windows native

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -721,7 +721,9 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 	}
 	b.WriteString("mkdir -p \"$RUNNER_TEMP\" \"$RUNNER_TOOL_CACHE\"\n")
 	for key, value := range inputs {
-		fmt.Fprintf(&b, "export INPUT_%s=%s\n", actionInputEnvName(key), shellQuote(value))
+		envName := "INPUT_" + actionInputEnvName(key)
+		env[envName] = value
+		fmt.Fprintf(&b, "export %s=%s\n", envName, shellQuote(value))
 	}
 	b.WriteString(localActionsRuntimeShell())
 	ctx := localHydrateScriptContext{
@@ -812,6 +814,11 @@ func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx l
 			if err := appendLocalHydrateRunStep(b, shellName, wd, run); err != nil {
 				return err
 			}
+			if step.ID != "" {
+				if outputs := inferLocalRunStepOutputs(run, stepEnv); len(outputs) > 0 {
+					ctx.StepOutputs[step.ID] = outputs
+				}
+			}
 		}
 		for _, key := range sortedKeys(step.Env) {
 			fmt.Fprintf(b, "__crabbox_restore_step_env %s\n", shellQuote(key))
@@ -893,6 +900,9 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 			}
 			return ""
 		}
+		if localActionsDirectSecretPattern.MatchString(expr) {
+			return ""
+		}
 		if output, ok := localActionsStepOutput(expr, stepOutputs); ok {
 			return output
 		}
@@ -909,6 +919,7 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 }
 
 var localActionsExpressionPattern = regexp.MustCompile(`\$\{\{\s*([^}]+?)\s*\}\}`)
+var localActionsDirectSecretPattern = regexp.MustCompile(`^secrets\.[A-Za-z_][A-Za-z0-9_]*$`)
 
 func shouldSkipLocalHydrateStep(expr string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (bool, error) {
 	expr = strings.TrimSpace(expr)
@@ -1084,6 +1095,7 @@ func localCompositeActionScript(step localHydrateStep, ctx localHydrateScriptCon
 	fmt.Fprintf(&b, "export GITHUB_ACTION_PATH=%s\n", shellQuote(actionTargetPath))
 	for _, name := range sortedKeys(inputs) {
 		envName := "INPUT_" + actionInputEnvName(name)
+		next.Env[envName] = inputs[name]
 		fmt.Fprintf(&b, "__crabbox_save_step_env %s\n", shellQuote(envName))
 		fmt.Fprintf(&b, "export %s=%s\n", envName, shellQuote(inputs[name]))
 	}
@@ -1379,6 +1391,84 @@ func localActionsStepOutput(expr string, stepOutputs map[string]map[string]strin
 		}
 	}
 	return "", false
+}
+
+var localRunStepOutputEchoPattern = regexp.MustCompile(`^echo\s+(?:"([^"]*)"|'([^']*)')\s*>>\s*"?\$GITHUB_OUTPUT"?\s*$`)
+var localShellVariablePattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+func inferLocalRunStepOutputs(script string, env map[string]string) map[string]string {
+	outputs := map[string]string{}
+	for _, line := range strings.Split(script, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		match := localRunStepOutputEchoPattern.FindStringSubmatch(line)
+		if len(match) != 3 {
+			return nil
+		}
+		content := firstNonBlank(match[1], match[2])
+		singleQuoted := match[2] != ""
+		key, value, ok := strings.Cut(content, "=")
+		if !ok || !validLocalActionsOutputName(key) {
+			continue
+		}
+		if singleQuoted {
+			outputs[key] = value
+			continue
+		}
+		expanded, ok := expandLocalShellVariables(value, env)
+		if !ok {
+			return nil
+		}
+		outputs[key] = expanded
+	}
+	if len(outputs) == 0 {
+		return nil
+	}
+	return outputs
+}
+
+func validLocalActionsOutputName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_', r == '-':
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func expandLocalShellVariables(value string, env map[string]string) (string, bool) {
+	if strings.Contains(value, `\$`) {
+		return "", false
+	}
+	ok := true
+	out := localShellVariablePattern.ReplaceAllStringFunc(value, func(match string) string {
+		parts := localShellVariablePattern.FindStringSubmatch(match)
+		for _, key := range parts[1:] {
+			if key != "" {
+				value, exists := env[key]
+				if !exists {
+					ok = false
+					return match
+				}
+				return value
+			}
+		}
+		return ""
+	})
+	if !ok || strings.Contains(out, "$") || strings.Contains(out, "`") {
+		return "", false
+	}
+	return out, true
 }
 
 func evalLocalActionsIf(expr string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (bool, bool) {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -440,6 +440,168 @@ runs:
 	}
 }
 
+func TestLocalActionsHydrateScriptTracksCompositeRunStepOutputs(t *testing.T) {
+	root := t.TempDir()
+	actionDir := filepath.Join(root, ".github", "actions", "pnpm-cache")
+	if err := os.MkdirAll(actionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	action := []byte(`name: pnpm cache
+inputs:
+  use-actions-cache:
+    default: "true"
+outputs:
+  cache-enabled:
+    value: ${{ steps.config.outputs.enabled }}
+  primary-key:
+    value: ${{ steps.config.outputs.primary-key }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve cache keys
+      id: config
+      shell: bash
+      env:
+        CACHE_KEY_SUFFIX: node24-pnpm11
+      run: |
+        echo "enabled=$INPUT_USE_ACTIONS_CACHE" >> "$GITHUB_OUTPUT"
+        echo "primary-key=${RUNNER_OS}-pnpm-store-${CACHE_KEY_SUFFIX}" >> "$GITHUB_OUTPUT"
+`)
+	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), action, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	job := localHydrateJob{Steps: []localHydrateStep{
+		{ID: "cache", Uses: "./.github/actions/pnpm-cache"},
+		{If: "steps.cache.outputs.cache-enabled == 'true'", Run: "echo cache is enabled"},
+		{Run: "echo ${{ steps.cache.outputs.primary-key }}"},
+	}}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`echo "enabled=$INPUT_USE_ACTIONS_CACHE" >> "$GITHUB_OUTPUT"`,
+		"echo cache is enabled",
+		"echo Linux-pnpm-store-node24-pnpm11",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("local composite run output script missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "${{") {
+		t.Fatalf("local composite run output script kept unresolved content:\n%s", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptRejectsDynamicCompositeRunStepOutputs(t *testing.T) {
+	root := t.TempDir()
+	actionDir := filepath.Join(root, ".github", "actions", "dynamic-output")
+	if err := os.MkdirAll(actionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	action := []byte(`name: dynamic output
+outputs:
+  value:
+    value: ${{ steps.config.outputs.value }}
+runs:
+  using: composite
+  steps:
+    - id: config
+      shell: bash
+      run: |
+        value=computed-at-runtime
+        echo "value=$value" >> "$GITHUB_OUTPUT"
+`)
+	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), action, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	job := localHydrateJob{Steps: []localHydrateStep{
+		{ID: "dynamic", Uses: "./.github/actions/dynamic-output"},
+		{Run: "echo ${{ steps.dynamic.outputs.value }}"},
+	}}
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
+		t.Fatalf("dynamic composite output should require GitHub fallback: %v", err)
+	}
+}
+
+func TestLocalActionsHydrateScriptRejectsConditionalCompositeRunStepOutputs(t *testing.T) {
+	root := t.TempDir()
+	actionDir := filepath.Join(root, ".github", "actions", "conditional-output")
+	if err := os.MkdirAll(actionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	action := []byte(`name: conditional output
+outputs:
+  enabled:
+    value: ${{ steps.config.outputs.enabled }}
+runs:
+  using: composite
+  steps:
+    - id: config
+      shell: bash
+      run: |
+        if [ "$INPUT_ENABLED" = true ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        fi
+`)
+	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), action, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	job := localHydrateJob{Steps: []localHydrateStep{
+		{ID: "conditional", Uses: "./.github/actions/conditional-output"},
+		{If: "steps.conditional.outputs.enabled == 'true'", Run: "echo enabled"},
+	}}
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
+		t.Fatalf("conditional composite output should require GitHub fallback: %v", err)
+	}
+}
+
+func TestInferLocalRunStepOutputsPreservesSingleQuotedPayload(t *testing.T) {
+	got := inferLocalRunStepOutputs(`echo 'value=$FOO' >> "$GITHUB_OUTPUT"`, map[string]string{"FOO": "expanded"})
+	if got["value"] != "$FOO" {
+		t.Fatalf("single-quoted output expanded unexpectedly: %#v", got)
+	}
+}
+
+func TestInferLocalRunStepOutputsRejectsParameterExpansion(t *testing.T) {
+	got := inferLocalRunStepOutputs(`echo "value=${FOO:-fallback}" >> "$GITHUB_OUTPUT"`, map[string]string{"FOO": "expanded"})
+	if len(got) != 0 {
+		t.Fatalf("parameter expansion inferred unexpectedly: %#v", got)
+	}
+}
+
+func TestInferLocalRunStepOutputsRejectsEscapedDollar(t *testing.T) {
+	got := inferLocalRunStepOutputs(`echo "value=\$FOO" >> "$GITHUB_OUTPUT"`, map[string]string{"FOO": "expanded"})
+	if len(got) != 0 {
+		t.Fatalf("escaped dollar inferred unexpectedly: %#v", got)
+	}
+}
+
+func TestInferLocalRunStepOutputsRejectsUnmodeledOverwrite(t *testing.T) {
+	got := inferLocalRunStepOutputs(`echo "enabled=false" >> "$GITHUB_OUTPUT"
+echo "enabled=$RUNTIME_VALUE" >> "$GITHUB_OUTPUT"`, nil)
+	if len(got) != 0 {
+		t.Fatalf("unmodeled overwrite inferred unexpectedly: %#v", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptAllowsEmptySecrets(t *testing.T) {
+	job := localHydrateJob{Env: map[string]string{
+		"OPENAI_API_KEY": "${{ secrets.OPENAI_API_KEY }}",
+	}, Steps: []localHydrateStep{
+		{Run: "test -z \"$OPENAI_API_KEY\""},
+	}}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "export OPENAI_API_KEY=''") || strings.Contains(got, "${{") {
+		t.Fatalf("local hydrate script did not empty secret expression:\n%s", got)
+	}
+}
+
 func TestLocalActionsHydrateScriptRejectsUnknownStepOutputs(t *testing.T) {
 	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{
@@ -705,12 +867,24 @@ func TestLocalActionsHydrateScriptRejectsEnvIf(t *testing.T) {
 	}
 }
 
-func TestLocalActionsHydrateScriptRejectsSecretsExpressions(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+func TestLocalActionsHydrateScriptEmptiesSecretsExpressions(t *testing.T) {
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN }}' '${{ secrets.MISSING_TOKEN }}'"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
-	if err == nil {
-		t.Fatal("secret expression accepted")
+	if err != nil {
+		t.Fatalf("secret expression should render empty locally: %v", err)
+	}
+	if strings.Contains(got, "${{") || !strings.Contains(got, "echo '' ''") {
+		t.Fatalf("local hydrate script did not empty secret expressions:\n%s", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptRejectsComplexSecretsExpressions(t *testing.T) {
+	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN != '' }}'"}},
+	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
+		t.Fatalf("complex secret expression should require GitHub fallback: %v", err)
 	}
 }
 

--- a/internal/cli/parallels.go
+++ b/internal/cli/parallels.go
@@ -191,6 +191,9 @@ func (c *ParallelsClient) Clone(ctx context.Context, source, snapshotID, leaseID
 	}
 	switch strings.ToLower(strings.TrimSpace(c.Cfg.Parallels.CloneMode)) {
 	case "", "linked":
+		if strings.TrimSpace(snapshotID) == "" {
+			return Server{}, exit(2, "Parallels linked clones require --parallels-source-snapshot or --parallels-source-snapshot-id; otherwise prlctl creates a source-side linked-clone snapshot")
+		}
 		if snapshotID != "" {
 			snapshot, ok, err := c.snapshotByID(ctx, source, snapshotID)
 			if err != nil {

--- a/internal/cli/parallels_test.go
+++ b/internal/cli/parallels_test.go
@@ -147,6 +147,20 @@ func TestParallelsCloneRejectsSnapshotIDForFullAndUnlink(t *testing.T) {
 	}
 }
 
+func TestParallelsLinkedCloneRequiresExplicitSnapshot(t *testing.T) {
+	runner := &parallelsFakeRunner{}
+	client := NewParallelsClient(Config{
+		Parallels: ParallelsConfig{CloneMode: "linked"},
+	}, runner)
+	_, err := client.Clone(context.Background(), "source-vm", "", "cbx_abcdef123456", "fork", true)
+	if err == nil || !strings.Contains(err.Error(), "require --parallels-source-snapshot") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.requests) != 0 {
+		t.Fatalf("clone should fail before prlctl: %#v", runner.requests)
+	}
+}
+
 func TestApplyParallelsTemplateConfig(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "parallels"


### PR DESCRIPTION
## Summary
- keep local Actions hydration conservative for repo-local composite run-step outputs
- render direct `secrets.NAME` expressions as empty for local fallback while rejecting complex secret expressions
- require explicit Parallels source snapshots for linked clones and document the safety behavior

## Verification
- `go test ./internal/cli -run 'Test(LocalActions|Parallels|InferLocalRunStepOutputs)'`
- `autoreview --mode local --no-web-search`: clean
