### PR TITLE
feat: add Upstash Box provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `provider: upstash-box` for delegated Upstash Box sandbox runs through the Box REST API, including archive sync, `run`, `warmup`, `list`, `status`, `stop`, config/env overrides, and provider docs.
+
 ### Fixed
 
 ## 0.17.1 - 2026-05-22

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Supported providers:
   execution.
 - [Modal](docs/providers/modal.md) (`provider: modal`): delegated Modal
   Sandbox execution through the local Python client.
+- [Upstash Box](docs/providers/upstash-box.md) (`provider: upstash-box`):
+  delegated Upstash Box execution through the Box REST API.
 - [Tensorlake](docs/providers/tensorlake.md) (`provider: tensorlake`):
   delegated Tensorlake Firecracker sandbox execution through the Tensorlake CLI.
 - [Cloudflare](docs/providers/cloudflare.md)
@@ -152,8 +154,10 @@ For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For th
   `provider: islo` for delegated Islo sandbox execution through the Islo Go SDK,
   `provider: e2b` for delegated E2B sandbox execution through E2B sandbox APIs,
   `provider: modal` for Modal Sandbox execution through the local Python client,
+  `provider: upstash-box` for delegated Upstash Box execution through the Box
+  REST API,
   or `provider: tensorlake` for Tensorlake Firecracker sandbox execution through
-  the Tensorlake CLI. See [Daytona](docs/providers/daytona.md), [Islo](docs/providers/islo.md), [E2B](docs/providers/e2b.md), [Modal](docs/providers/modal.md), and [Tensorlake](docs/providers/tensorlake.md).
+  the Tensorlake CLI. See [Daytona](docs/providers/daytona.md), [Islo](docs/providers/islo.md), [E2B](docs/providers/e2b.md), [Modal](docs/providers/modal.md), [Upstash Box](docs/providers/upstash-box.md), and [Tensorlake](docs/providers/tensorlake.md).
 - **Cloudflare.** Set `provider: cloudflare` for delegated execution through a Worker runner and custom container image. See [Cloudflare](docs/providers/cloudflare.md).
 - **Trusted AWS images.** Operators can create AMIs from active brokered AWS leases and promote a known-good image as the coordinator default. See [Image bake runbook](docs/features/image-bake-runbook.md) and [Prebaked images](docs/features/prebaked-images.md).
 - **Cost guardrails.** Per-lease and monthly spend caps. Live pricing from EC2 Spot history or Hetzner server-type prices, with static fallbacks. `crabbox usage` summarizes spend by user, org, provider, and type. See [Cost and usage](docs/features/cost-usage.md).
@@ -348,6 +352,16 @@ modal:
   app: crabbox
   image: python:3.13-slim
   workdir: /workspace/crabbox
+```
+
+Optional Upstash Box sandbox:
+
+```yaml
+provider: upstash-box
+upstashBox:
+  runtime: node
+  size: small
+  workdir: /workspace/home/crabbox
 ```
 
 Optional Tensorlake sandbox:

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -28,6 +28,7 @@ static SSH provider for existing machines.
 | [Islo](islo.md) | delegated run | Linux | Islo-owned sandbox execution |
 | [E2B](e2b.md) | delegated run | Linux | E2B-owned sandbox execution |
 | [Modal](modal.md) | delegated run | Linux | Modal Sandbox execution through the local Python client |
+| [Upstash Box](upstash-box.md) | delegated run | Linux | Upstash Box execution through the Box REST API |
 | [Tensorlake](tensorlake.md) | delegated run | Linux | Tensorlake Firecracker sandbox execution via the `tensorlake` CLI |
 | [Cloudflare](cloudflare.md) | delegated run | Linux | Cloudflare execution through a Worker and container runner |
 | [Railway](railway.md) | delegated run | Linux | redeploy and stream logs for an existing Railway service via the GraphQL API |
@@ -75,6 +76,8 @@ Proxmox and delegated providers do not use the Crabbox coordinator:
 - Islo uses the Islo API and SDK auth.
 - E2B uses E2B's sandbox REST and envd APIs.
 - Modal uses the local Modal Python client and Modal Sandbox APIs.
+- Upstash Box uses the [Upstash Box](https://upstash.com/blog/upstash-box)
+  REST API for sandbox lifecycle, archive upload, and command streaming.
 - Sprites uses the authenticated `sprite` CLI plus Sprites API.
 - Tensorlake uses the `tensorlake` CLI (`tensorlake sbx ...`) for sandbox lifecycle and command exec.
 - Cloudflare uses a deployed Worker runner backed by a Cloudflare
@@ -116,6 +119,7 @@ Sprites API and reaches SSH through `sprite proxy`; exe.dev provisions through
 | Islo | yes | yes | no | no | no | yes |
 | E2B | yes | yes | no | no | archive via E2B envd | no |
 | Modal | yes | yes | no | no | archive via Modal Sandbox exec | no |
+| Upstash Box | yes | yes | no | no | archive via Box file upload | no |
 | Tensorlake | yes | yes | no | no | archive via `tensorlake sbx cp` | no |
 | Cloudflare | yes | yes | no | no | archive via Worker runner | no |
 | Railway | yes | no | no | no | no | no |

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -1,0 +1,129 @@
+# Upstash Box Provider
+
+Read when:
+
+- choosing `provider: upstash-box`;
+- configuring Upstash Box runtime, size, region endpoint, or workdir;
+- changing `internal/providers/upstashbox`.
+
+Upstash Box is a delegated run provider. Crabbox calls the Upstash Box REST API
+for Box lifecycle, file upload, status/list, delete, and command streaming.
+Upstash owns sandbox state and process transport; Crabbox owns local config,
+repo claims, archive sync, slugs, timing summaries, and normalized list/status
+rendering.
+
+## When To Use
+
+Use Upstash Box when commands should run in Upstash-managed ephemeral Linux
+sandboxes and you do not need a Crabbox SSH target. Use AWS, Hetzner, Static
+SSH, Namespace Devbox, Semaphore, Sprites, or Daytona when you need `crabbox
+ssh`, VNC, code-server, or Actions hydration.
+
+## Prerequisites
+
+- Create an Upstash Box API key.
+- Export it as `UPSTASH_BOX_API_KEY` or `CRABBOX_UPSTASH_BOX_API_KEY`. Do not
+  pass API keys as command-line flags.
+
+## Commands
+
+```sh
+crabbox warmup --provider upstash-box --upstash-box-runtime node --upstash-box-size small
+crabbox run --provider upstash-box -- pnpm test
+crabbox run --provider upstash-box --id blue-lobster --shell 'pnpm install && pnpm test'
+crabbox status --provider upstash-box --id blue-lobster
+crabbox stop --provider upstash-box blue-lobster
+```
+
+## Auth
+
+```sh
+export UPSTASH_BOX_API_KEY=...
+```
+
+`CRABBOX_UPSTASH_BOX_BASE_URL` or `upstashBox.baseUrl` can override the default
+`https://us-east-1.box.upstash.com`.
+
+## Config
+
+```yaml
+provider: upstash-box
+target: linux
+upstashBox:
+  baseUrl: https://us-east-1.box.upstash.com
+  runtime: node
+  size: small
+  workdir: /workspace/home/crabbox
+  keepAlive: false
+```
+
+Provider flags:
+
+```text
+--upstash-box-base-url
+--upstash-box-runtime
+--upstash-box-size
+--upstash-box-workdir
+--upstash-box-keep-alive
+```
+
+Environment overrides:
+
+```text
+CRABBOX_UPSTASH_BOX_API_KEY / UPSTASH_BOX_API_KEY
+CRABBOX_UPSTASH_BOX_BASE_URL / UPSTASH_BOX_BASE_URL
+CRABBOX_UPSTASH_BOX_RUNTIME
+CRABBOX_UPSTASH_BOX_SIZE
+CRABBOX_UPSTASH_BOX_WORKDIR
+CRABBOX_UPSTASH_BOX_KEEP_ALIVE
+```
+
+## Lifecycle
+
+1. `warmup` / `run` without `--id` creates a Box named
+   `crabbox-<slug>-<lease-hex>` with the configured runtime and size.
+2. Crabbox stores a local claim with a normal `cbx_...` lease ID and friendly
+   slug.
+3. By default `run` archive-syncs the working tree: Git manifest → local
+   `tar -czf` → Upstash Box file upload to `/tmp/crabbox-upstash-box-sync-*.tgz`
+   → in-Box `tar -xzf` into `upstashBox.workdir`.
+4. The user command runs through the Box exec-stream endpoint in an `sh -c`
+   wrapper that changes into `upstashBox.workdir`, streaming output back through
+   Crabbox.
+5. Non-kept one-shot Boxes are deleted after the run. `--keep` and
+   `--keep-on-failure` retain the Box until `crabbox stop`.
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: yes, archive sync through Box file upload and exec.
+- Provider sync: no separate Upstash sync command.
+- Desktop/browser/code: no Crabbox VNC/code surface.
+- Actions hydration: no.
+- Coordinator: no.
+
+## Gotchas
+
+- IDs can be Crabbox slugs, `cbx_...` lease IDs, or Upstash Box IDs when the Box
+  uses Crabbox naming.
+- `--class` and `--type` are rejected; use `--upstash-box-size` and
+  `--upstash-box-runtime`.
+- `upstashBox.workdir` must be an absolute, dedicated directory. Broad roots
+  such as `/`, `/tmp`, `/workspace`, and `/workspace/home` are rejected before
+  sync or command execution.
+- `--checksum` is rejected because Upstash Box does not expose Crabbox's
+  SSH/rsync target. Large-sync guardrails still apply, and `--force-sync-large`
+  is honored for intentional large archive syncs.
+- Use `--sync-only` to pre-upload the archive into a kept Box before a later
+  command.
+- `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr captures,
+  `--capture-on-fail`, and `--download` are rejected because Upstash owns
+  command transport and Crabbox has no SSH target for those paths.
+- Forwarded environment values are written to a temporary shell profile in
+  `/tmp`, sourced for the command, and removed best-effort.
+- `upstashBox.keepAlive` maps to the provider's Box create option. Crabbox
+  `--keep` still controls whether a one-shot run deletes the Box afterward.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	Islo                     IsloConfig
 	Tensorlake               TensorlakeConfig
 	Modal                    ModalConfig
+	UpstashBox               UpstashBoxConfig
 	Cloudflare               CloudflareConfig
 	Semaphore                SemaphoreConfig
 	Sprites                  SpritesConfig
@@ -258,6 +259,15 @@ type ModalConfig struct {
 	Image   string
 	Workdir string
 	Python  string
+}
+
+type UpstashBoxConfig struct {
+	APIKey    string
+	BaseURL   string
+	Runtime   string
+	Size      string
+	Workdir   string
+	KeepAlive bool
 }
 
 type CloudflareConfig struct {
@@ -669,6 +679,12 @@ func baseConfig() Config {
 			Workdir: "/workspace/crabbox",
 			Python:  "python3",
 		},
+		UpstashBox: UpstashBoxConfig{
+			BaseURL: "https://us-east-1.box.upstash.com",
+			Runtime: "node",
+			Size:    "small",
+			Workdir: "/workspace/home/crabbox",
+		},
 		Cloudflare: CloudflareConfig{
 			Workdir: "/workspace/crabbox",
 		},
@@ -745,6 +761,7 @@ type fileConfig struct {
 	Islo             *fileIsloConfig                    `yaml:"islo,omitempty"`
 	Tensorlake       *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
 	Modal            *fileModalConfig                   `yaml:"modal,omitempty"`
+	UpstashBox       *fileUpstashBoxConfig              `yaml:"upstashBox,omitempty"`
 	Cloudflare       *fileCloudflareConfig              `yaml:"cloudflare,omitempty"`
 	Semaphore        *fileSemaphoreConfig               `yaml:"semaphore,omitempty"`
 	Sprites          *fileSpritesConfig                 `yaml:"sprites,omitempty"`
@@ -1035,6 +1052,14 @@ type fileModalConfig struct {
 	Image   string `yaml:"image,omitempty"`
 	Workdir string `yaml:"workdir,omitempty"`
 	Python  string `yaml:"python,omitempty"`
+}
+
+type fileUpstashBoxConfig struct {
+	BaseURL   string `yaml:"baseUrl,omitempty"`
+	Runtime   string `yaml:"runtime,omitempty"`
+	Size      string `yaml:"size,omitempty"`
+	Workdir   string `yaml:"workdir,omitempty"`
+	KeepAlive *bool  `yaml:"keepAlive,omitempty"`
 }
 
 type fileCloudflareConfig struct {
@@ -1983,6 +2008,23 @@ func applyFileConfig(cfg *Config, file fileConfig) {
 			cfg.Modal.Python = file.Modal.Python
 		}
 	}
+	if file.UpstashBox != nil {
+		if file.UpstashBox.BaseURL != "" {
+			cfg.UpstashBox.BaseURL = file.UpstashBox.BaseURL
+		}
+		if file.UpstashBox.Runtime != "" {
+			cfg.UpstashBox.Runtime = file.UpstashBox.Runtime
+		}
+		if file.UpstashBox.Size != "" {
+			cfg.UpstashBox.Size = file.UpstashBox.Size
+		}
+		if file.UpstashBox.Workdir != "" {
+			cfg.UpstashBox.Workdir = file.UpstashBox.Workdir
+		}
+		if file.UpstashBox.KeepAlive != nil {
+			cfg.UpstashBox.KeepAlive = *file.UpstashBox.KeepAlive
+		}
+	}
 	applyCloudflareFileConfig(cfg, file.Cloudflare)
 	if file.Semaphore != nil {
 		if file.Semaphore.Host != "" {
@@ -2634,6 +2676,14 @@ func applyEnv(cfg *Config) {
 	cfg.Modal.Image = getenv("CRABBOX_MODAL_IMAGE", cfg.Modal.Image)
 	cfg.Modal.Workdir = getenv("CRABBOX_MODAL_WORKDIR", cfg.Modal.Workdir)
 	cfg.Modal.Python = getenv("CRABBOX_MODAL_PYTHON", cfg.Modal.Python)
+	cfg.UpstashBox.APIKey = getenv("CRABBOX_UPSTASH_BOX_API_KEY", getenv("UPSTASH_BOX_API_KEY", cfg.UpstashBox.APIKey))
+	cfg.UpstashBox.BaseURL = getenv("CRABBOX_UPSTASH_BOX_BASE_URL", getenv("UPSTASH_BOX_BASE_URL", cfg.UpstashBox.BaseURL))
+	cfg.UpstashBox.Runtime = getenv("CRABBOX_UPSTASH_BOX_RUNTIME", cfg.UpstashBox.Runtime)
+	cfg.UpstashBox.Size = getenv("CRABBOX_UPSTASH_BOX_SIZE", cfg.UpstashBox.Size)
+	cfg.UpstashBox.Workdir = getenv("CRABBOX_UPSTASH_BOX_WORKDIR", cfg.UpstashBox.Workdir)
+	if value, ok := getenvBool("CRABBOX_UPSTASH_BOX_KEEP_ALIVE"); ok {
+		cfg.UpstashBox.KeepAlive = value
+	}
 	cfg.Cloudflare.APIURL = getenv("CRABBOX_CLOUDFLARE_RUNNER_URL", cfg.Cloudflare.APIURL)
 	cfg.Cloudflare.Token = getenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", cfg.Cloudflare.Token)
 	cfg.Cloudflare.Workdir = getenv("CRABBOX_CLOUDFLARE_WORKDIR", cfg.Cloudflare.Workdir)
@@ -2785,6 +2835,9 @@ func serverTypeForConfig(cfg Config) string {
 	}
 	if cfg.Provider == "modal" {
 		return blank(cfg.Modal.Image, "python:3.13-slim")
+	}
+	if cfg.Provider == "upstash-box" || cfg.Provider == "upstash" {
+		return blank(cfg.UpstashBox.Size, "small")
 	}
 	if cfg.Provider == "daytona" {
 		return "snapshot"

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -120,6 +120,14 @@ func configShowView(cfg Config) map[string]any {
 			"auth":    tokenState(cfg.Cloudflare.Token),
 			"workdir": cfg.Cloudflare.Workdir,
 		},
+		"upstashBox": map[string]any{
+			"baseUrl":   cfg.UpstashBox.BaseURL,
+			"auth":      tokenState(cfg.UpstashBox.APIKey),
+			"runtime":   cfg.UpstashBox.Runtime,
+			"size":      cfg.UpstashBox.Size,
+			"workdir":   cfg.UpstashBox.Workdir,
+			"keepAlive": cfg.UpstashBox.KeepAlive,
+		},
 		"static": map[string]any{
 			"id":       cfg.Static.ID,
 			"name":     cfg.Static.Name,
@@ -213,6 +221,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "blacksmith org=%s workflow=%s job=%s ref=%s idle_timeout=%s debug=%t\n", blank(cfg.Blacksmith.Org, "-"), blank(cfg.Blacksmith.Workflow, "-"), blank(cfg.Blacksmith.Job, "-"), blank(cfg.Blacksmith.Ref, "-"), cfg.Blacksmith.IdleTimeout, cfg.Blacksmith.Debug)
 	fmt.Fprintf(w, "namespace image=%s size=%s repository=%s site=%s volume_size_gb=%d auto_stop_idle_timeout=%s work_root=%s delete_on_release=%t\n", cfg.Namespace.Image, blank(cfg.Namespace.Size, "-"), blank(cfg.Namespace.Repository, "-"), blank(cfg.Namespace.Site, "-"), cfg.Namespace.VolumeSizeGB, cfg.Namespace.AutoStopIdleTimeout, cfg.Namespace.WorkRoot, cfg.Namespace.DeleteOnRelease)
 	fmt.Fprintf(w, "e2b api_url=%s domain=%s template=%s workdir=%s user=%s\n", cfg.E2B.APIURL, cfg.E2B.Domain, cfg.E2B.Template, cfg.E2B.Workdir, blank(cfg.E2B.User, "-"))
+	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(cfg.Cloudflare.APIURL, "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
 	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(w, "results junit=%s\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"))

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -22,4 +22,5 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"
 	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"
+	_ "github.com/openclaw/crabbox/internal/providers/upstashbox"
 )

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -28,6 +28,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"sprites",
 		"ssh",
 		"tensorlake",
+		"upstash-box",
 	}
 	for _, name := range providers {
 		t.Run(name, func(t *testing.T) {

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -1,0 +1,549 @@
+package upstashbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	started := b.now()
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, box, slug, err := b.createBox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s box=%s name=%s\n", leaseID, slug, providerName, box.ID, box.Name)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: upstash-box warmup keeps the box until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, err := cleanWorkdir(workdir(b.cfg))
+	if err != nil {
+		return RunResult{}, err
+	}
+	folder, err := workspaceFolder(workdir)
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return RunResult{}, err
+	}
+	leaseID, boxID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		var box boxData
+		leaseID, box, slug, err = b.createBox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+		if err != nil {
+			return RunResult{}, err
+		}
+		boxID = box.ID
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s box=%s name=%s\n", leaseID, slug, providerName, box.ID, box.Name)
+		acquired = true
+	} else {
+		leaseID, boxID, slug, err = b.resolveBoxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
+		defer func() {
+			if !shouldStop {
+				return
+			}
+			if err := client.DeleteBoxes(context.Background(), []string{boxID}); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: upstash-box delete failed for %s: %v\n", boxID, err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, boxID, req, workdir, folder)
+		if err != nil {
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, client, boxID, folder, false); err != nil {
+		return RunResult{}, err
+	}
+	if req.SyncOnly {
+		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		if req.TimingJSON {
+			err := writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+				Label:         strings.TrimSpace(req.Label),
+			})
+			return result, err
+		}
+		return result, nil
+	}
+
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	if req.EnvSummary {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	if len(req.Env) > 0 {
+		envPath := workspacePath(".crabbox-env-" + leaseID + ".sh")
+		if err := client.WriteFile(ctx, boxID, envPath, shellEnvProfile(req.Env)); err != nil {
+			return RunResult{}, err
+		}
+		defer func() {
+			_, _ = client.Exec(context.Background(), boxID, "rm -f "+shellQuote(envPath), "")
+		}()
+		command = ". " + shellQuote(envPath) + " && " + command
+	}
+	commandStarted := b.now()
+	exitCode, commandErr := client.ExecStream(ctx, boxID, command, folder, b.rt.Stdout)
+	commandDuration := b.now().Sub(commandStarted)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+		Provider:      providerName,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   strings.Join(req.Command, " "),
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "upstash-box run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "upstash-box run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      exitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}); err != nil {
+			return result, err
+		}
+	}
+	if commandErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("upstash-box run failed: %v", commandErr)}
+	}
+	if exitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("upstash-box run exited %d", exitCode)}
+	}
+	return result, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	boxes, err := client.ListBoxes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(boxes))
+	for _, box := range boxes {
+		if isCrabboxBox(box) {
+			servers = append(servers, boxToServer(b.cfg, box))
+		}
+	}
+	return servers, nil
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deadline := b.now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = b.now().Add(5 * time.Minute)
+	}
+	for {
+		box, err := client.GetBox(ctx, boxID)
+		if err != nil {
+			return StatusView{}, err
+		}
+		server := boxToServer(b.cfg, box)
+		view := StatusView{
+			ID:         leaseID,
+			Slug:       blank(slug, server.Labels["slug"]),
+			Provider:   providerName,
+			TargetOS:   targetLinux,
+			State:      box.Status,
+			ServerID:   box.ID,
+			ServerType: server.ServerType.Name,
+			Network:    networkPublic,
+			Ready:      statusReady(box.Status),
+			Labels:     server.Labels,
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for upstash-box %s to become ready", boxID)
+		}
+		select {
+		case <-ctx.Done():
+			return StatusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, boxID, _, err := b.resolveBoxID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteBoxes(ctx, []string{boxID}); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s box=%s\n", leaseID, boxID)
+	return nil
+}
+
+func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, boxData, string, error) {
+	leaseID := newLeaseID()
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return "", boxData{}, "", err
+	}
+	name := upstashBoxName(leaseID, slug)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s runtime=%s size=%s keep_alive=%t\n", providerName, leaseID, slug, name, runtimeName(b.cfg), sizeName(b.cfg), b.cfg.UpstashBox.KeepAlive)
+	box, err := client.CreateBox(ctx, createRequest{
+		Name:      name,
+		Runtime:   runtimeName(b.cfg),
+		Size:      sizeName(b.cfg),
+		KeepAlive: b.cfg.UpstashBox.KeepAlive,
+	})
+	if err != nil {
+		return "", boxData{}, "", err
+	}
+	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		_ = client.DeleteBoxes(context.Background(), []string{box.ID})
+		return "", boxData{}, "", err
+	}
+	return leaseID, box, slug, nil
+}
+
+func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot string, reclaim bool) (string, string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or Upstash Box id", providerName)
+	}
+	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+		return "", "", "", err
+	} else if ok && claim.Provider == providerName {
+		if repoRoot != "" {
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+				return "", "", "", err
+			}
+		}
+		box, err := resolveBoxByLease(ctx, client, claim.LeaseID)
+		if err != nil {
+			return "", "", "", err
+		}
+		return claim.LeaseID, box.ID, claim.Slug, nil
+	}
+	if strings.HasPrefix(id, "cbx_") {
+		box, err := resolveBoxByLease(ctx, client, id)
+		if err != nil {
+			return "", "", "", err
+		}
+		return id, box.ID, boxSlug(id, box), nil
+	}
+	if box, err := client.GetBox(ctx, id); err == nil && isCrabboxBox(box) {
+		leaseID := boxLeaseID(box)
+		return leaseID, box.ID, boxSlug(leaseID, box), nil
+	} else if err != nil && !isNotFound(err) {
+		return "", "", "", err
+	}
+	box, err := resolveBoxBySlug(ctx, client, id)
+	if err != nil {
+		return "", "", "", err
+	}
+	leaseID := boxLeaseID(box)
+	return leaseID, box.ID, boxSlug(leaseID, box), nil
+}
+
+func resolveBoxByLease(ctx context.Context, client api, leaseID string) (boxData, error) {
+	boxes, err := client.ListBoxes(ctx)
+	if err != nil {
+		return boxData{}, err
+	}
+	for _, box := range boxes {
+		if isCrabboxBox(box) && boxLeaseID(box) == leaseID {
+			return box, nil
+		}
+	}
+	return boxData{}, exit(4, "upstash-box lease %q was not found", leaseID)
+}
+
+func resolveBoxBySlug(ctx context.Context, client api, slug string) (boxData, error) {
+	boxes, err := client.ListBoxes(ctx)
+	if err != nil {
+		return boxData{}, err
+	}
+	for _, box := range boxes {
+		if isCrabboxBox(box) && boxSlug(boxLeaseID(box), box) == slug {
+			return box, nil
+		}
+	}
+	return boxData{}, exit(4, "upstash-box %q was not found", slug)
+}
+
+func (b *backend) now() time.Time {
+	return now(b.rt)
+}
+
+func boxToServer(cfg Config, box boxData) Server {
+	leaseID := boxLeaseID(box)
+	labels := directLeaseLabels(cfg, leaseID, boxSlug(leaseID, box), providerName, "", box.KeepAlive, time.Now().UTC())
+	labels["box_id"] = box.ID
+	labels["box_name"] = box.Name
+	labels["runtime"] = blank(box.Runtime, runtimeName(cfg))
+	labels["size"] = blank(box.Size, sizeName(cfg))
+	labels["state"] = box.Status
+	server := Server{
+		Provider: providerName,
+		CloudID:  box.ID,
+		Name:     blank(box.Name, box.ID),
+		Status:   box.Status,
+		Labels:   labels,
+	}
+	server.ServerType.Name = blank(box.Size, sizeName(cfg))
+	server.PublicNet.IPv4.IP = boxBaseHost(cfg)
+	return server
+}
+
+func boxBaseHost(cfg Config) string {
+	raw := blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com")
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return raw
+	}
+	return parsed.Host
+}
+
+var boxNamePattern = regexp.MustCompile(`^crabbox-(.+)-([0-9a-f]{12})$`)
+
+func isCrabboxBox(box boxData) bool {
+	return boxNamePattern.MatchString(strings.TrimSpace(box.Name))
+}
+
+func boxLeaseID(box boxData) string {
+	if match := boxNamePattern.FindStringSubmatch(strings.TrimSpace(box.Name)); len(match) == 3 {
+		return "cbx_" + match[2]
+	}
+	return "upstash_" + box.ID
+}
+
+func boxSlug(leaseID string, box boxData) string {
+	if match := boxNamePattern.FindStringSubmatch(strings.TrimSpace(box.Name)); len(match) == 3 {
+		return match[1]
+	}
+	return newLeaseSlug(leaseID)
+}
+
+func statusReady(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "running", "ready", "idle", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "404") || strings.Contains(msg, "not found")
+}
+
+func runtimeName(cfg Config) string {
+	return blank(strings.TrimSpace(cfg.UpstashBox.Runtime), "node")
+}
+
+func upstashBoxName(leaseID, slug string) string {
+	slug = strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
+	if slug == "" {
+		slug = newLeaseSlug(leaseID)
+	}
+	return "crabbox-" + slug + "-" + strings.TrimPrefix(leaseID, "cbx_")
+}
+
+func sizeName(cfg Config) string {
+	return blank(strings.TrimSpace(cfg.UpstashBox.Size), "small")
+}
+
+func workdir(cfg Config) string {
+	return blank(strings.TrimSpace(cfg.UpstashBox.Workdir), "/workspace/home/crabbox")
+}
+
+func cleanWorkdir(workdir string) (string, error) {
+	trimmed := strings.TrimSpace(workdir)
+	if trimmed == "" {
+		return "", exit(2, "upstash-box workdir is empty")
+	}
+	clean := path.Clean(trimmed)
+	if !strings.HasPrefix(clean, "/") {
+		return "", exit(2, "upstash-box workdir %q must resolve to an absolute path", workdir)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace", "/workspace/home":
+		return "", exit(2, "upstash-box workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
+}
+
+func buildCommand(command []string, shellMode bool) (string, error) {
+	if len(command) == 0 {
+		return "", errors.New("missing command")
+	}
+	var script string
+	if shellMode {
+		script = strings.Join(command, " ")
+	} else if shouldUseShell(command) || leadingEnvAssignment(command) {
+		script = shellScriptFromArgv(command)
+	} else {
+		script = "exec " + strings.Join(shellWords(command), " ")
+	}
+	return script, nil
+}
+
+const workspaceRoot = "/workspace/home"
+
+func workspaceFolder(workdir string) (string, error) {
+	clean, err := cleanWorkdir(workdir)
+	if err != nil {
+		return "", err
+	}
+	prefix := workspaceRoot + "/"
+	if !strings.HasPrefix(clean, prefix) {
+		return "", exit(2, "upstash-box workdir %q must be under %s", clean, workspaceRoot)
+	}
+	return strings.TrimPrefix(clean, prefix), nil
+}
+
+func workspacePath(name string) string {
+	return path.Join(workspaceRoot, name)
+}
+
+func shellEnvProfile(env map[string]string) string {
+	var b strings.Builder
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if !validEnvName(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	b.WriteString("set -a\n")
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(env[key]))
+		b.WriteByte('\n')
+	}
+	b.WriteString("set +a\n")
+	return b.String()
+}
+
+func validEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -1,0 +1,435 @@
+package upstashbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %s", p.Name(), providerName)
+	}
+	for _, alias := range []string{"upstash", "box", "upstashbox"} {
+		got, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if got.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", alias, got.Name())
+		}
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%v want delegated-run", spec.Kind)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%v want never", spec.Coordinator)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want linux", spec.Targets)
+	}
+	if !hasFeature(spec.Features, core.FeatureArchiveSync) {
+		t.Fatalf("features=%#v want archive sync", spec.Features)
+	}
+}
+
+func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
+	var createBody map[string]any
+	var deleteBody map[string]any
+	var writeBody map[string]any
+	uploadSeen := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Box-Api-Key"); got != "box_key" {
+			t.Fatalf("X-Box-Api-Key=%q", got)
+		}
+		switch r.URL.Path {
+		case "/v2/box":
+			switch r.Method {
+			case http.MethodPost:
+				if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": "box_1", "name": "crabbox-blue-123456789abc", "status": "running"})
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "box_1", "name": "crabbox-blue-123456789abc", "status": "running"}})
+			case http.MethodDelete:
+				if err := json.NewDecoder(r.Body).Decode(&deleteBody); err != nil {
+					t.Fatal(err)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+		case "/v2/box/box_1/exec":
+			var body struct {
+				Command []string `json:"command"`
+				Folder  string   `json:"folder"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(body.Command, []string{"sh", "-c", "echo hi"}) || body.Folder != "crabbox" {
+				t.Fatalf("exec body=%#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"exit_code": 0, "output": "hi\n"})
+		case "/v2/box/box_1/exec-stream":
+			_, _ = io.Copy(io.Discard, r.Body)
+			_, _ = io.WriteString(w, "hello\nevent: exit\ndata: {\"exit_code\":7}\n\n")
+		case "/v2/box/box_1/files/upload":
+			reader, err := r.MultipartReader()
+			if err != nil {
+				t.Fatal(err)
+			}
+			fields := readMultipart(t, reader)
+			if fields["paths"] != "/tmp/archive.tgz" || fields["files"] != "archive" {
+				t.Fatalf("multipart=%v", fields)
+			}
+			uploadSeen = true
+			w.WriteHeader(http.StatusNoContent)
+		case "/v2/box/box_1/files/write":
+			if err := json.NewDecoder(r.Body).Decode(&writeBody); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &client{apiKey: "box_key", base: srv.URL, http: srv.Client()}
+	box, err := client.CreateBox(context.Background(), createRequest{Name: "crabbox-blue-123456789abc", Runtime: "node", Size: "small", KeepAlive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if box.ID != "box_1" || createBody["runtime"] != "node" || createBody["size"] != "small" || createBody["keep_alive"] != true {
+		t.Fatalf("create box=%#v body=%v", box, createBody)
+	}
+	if _, err := client.ListBoxes(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := client.Exec(context.Background(), "box_1", "echo hi", "crabbox"); err != nil || result.Output != "hi\n" {
+		t.Fatalf("exec result=%#v err=%v", result, err)
+	}
+	var stdout bytes.Buffer
+	code, err := client.ExecStream(context.Background(), "box_1", "echo hi", "crabbox", &stdout)
+	if err != nil || code != 7 || stdout.String() != "hello\n" {
+		t.Fatalf("stream code=%d stdout=%q err=%v", code, stdout.String(), err)
+	}
+	archive := filepath.Join(t.TempDir(), "archive.tgz")
+	if err := os.WriteFile(archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.UploadFile(context.Background(), "box_1", archive, "/tmp/archive.tgz"); err != nil {
+		t.Fatal(err)
+	}
+	if !uploadSeen {
+		t.Fatal("upload not seen")
+	}
+	if err := client.WriteFile(context.Background(), "box_1", "/tmp/env.sh", "export A=1\n"); err != nil {
+		t.Fatal(err)
+	}
+	if writeBody["path"] != "/tmp/env.sh" || writeBody["content"] != "export A=1\n" {
+		t.Fatalf("write body=%v", writeBody)
+	}
+	if err := client.DeleteBoxes(context.Background(), []string{"box_1"}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(deleteBody["ids"], []any{"box_1"}) {
+		t.Fatalf("delete body=%v", deleteBody)
+	}
+}
+
+func TestCleanWorkdirAndCommand(t *testing.T) {
+	if got, err := cleanWorkdir(" /workspace/home/crabbox/ "); err != nil || got != "/workspace/home/crabbox" {
+		t.Fatalf("workdir=%q err=%v", got, err)
+	}
+	for _, value := range []string{"", "repo", "/", "/workspace", "/tmp"} {
+		if _, err := cleanWorkdir(value); err == nil {
+			t.Fatalf("cleanWorkdir(%q) succeeded", value)
+		}
+	}
+	command, err := buildCommand([]string{"go", "test", "./..."}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "exec 'go' 'test' './...'" {
+		t.Fatalf("command=%q", command)
+	}
+	env := shellEnvProfile(map[string]string{"B": "two", "A": "one two", "BAD; id >&2 #": "boom"})
+	if env != "set -a\nA='one two'\nB='two'\nset +a\n" {
+		t.Fatalf("env profile=%q", env)
+	}
+}
+
+func TestWarmupRejectsActionsRunner(t *testing.T) {
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
+		t.Fatalf("err=%v, want actions-runner rejection", err)
+	}
+}
+
+func TestParseExecStreamUsesFinalExitEvent(t *testing.T) {
+	body := strings.Join([]string{
+		"event: exit\n",
+		"data: {\"exit_code\":0}\n\n",
+		"still command output\n",
+		"event: exit\n",
+		"data: {\"exit_code\":7}\n\n",
+	}, "")
+	var stdout bytes.Buffer
+	code, err := parseExecStream(strings.NewReader(body), &stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 7 {
+		t.Fatalf("code=%d want 7", code)
+	}
+	if stdout.String() != "event: exit\ndata: {\"exit_code\":0}\n\nstill command output\n" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestParseExecStreamRequiresExitEvent(t *testing.T) {
+	var stdout bytes.Buffer
+	code, err := parseExecStream(strings.NewReader("partial output"), &stdout)
+	if err == nil || !strings.Contains(err.Error(), "without exit event") {
+		t.Fatalf("code=%d err=%v, want missing exit event", code, err)
+	}
+	if stdout.String() != "partial output" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestRunCreatesExecsAndDeletesOneShotBox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+		Command: []string{"echo", "hello"},
+		NoSync:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 || result.Provider != providerName {
+		t.Fatalf("result=%#v", result)
+	}
+	if fake.createReq.Runtime != "node" || fake.createReq.Size != "small" {
+		t.Fatalf("create req=%#v", fake.createReq)
+	}
+	if !reflect.DeepEqual(fake.verbs, []string{"create", "exec", "stream", "delete"}) {
+		t.Fatalf("verbs=%v", fake.verbs)
+	}
+	if !strings.Contains(fake.execCommands[0], "mkdir -p 'crabbox'") || strings.Contains(fake.execCommands[0], "rm -rf") {
+		t.Fatalf("prepare command=%q", fake.execCommands[0])
+	}
+	if fake.streamFolders[0] != "crabbox" || !strings.Contains(fake.streamCommands[0], "echo") {
+		t.Fatalf("stream command=%q", fake.streamCommands[0])
+	}
+}
+
+func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
+	fake := &fakeAPI{execResults: []execResult{{ExitCode: 0}, {ExitCode: 9, Error: "extract failed"}, {ExitCode: 0}}}
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "box_1", RunRequest{
+		Repo: Repo{Name: "repo", Root: newGitRepo(t)},
+	}, "/workspace/home/crabbox", "crabbox")
+	if err == nil {
+		t.Fatal("expected extract failure")
+	}
+	if !reflect.DeepEqual(fake.verbs, []string{"exec", "upload", "exec", "exec"}) {
+		t.Fatalf("verbs=%v", fake.verbs)
+	}
+	if !strings.Contains(fake.execCommands[2], "rm -f '.crabbox-upstash-box-sync-") {
+		t.Fatalf("cleanup command=%q", fake.execCommands[2])
+	}
+}
+
+func TestStatusMapsBoxName(t *testing.T) {
+	fake := &fakeAPI{box: boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Runtime: "python", Size: "medium", Status: "running"}}
+	withFakeAPI(t, fake)
+	cfg := testConfig()
+	cfg.UpstashBox.BaseURL = "https://eu-west-1.box.upstash.com"
+	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "box_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "cbx_123456789abc" || view.Slug != "blue" || view.ServerID != "box_1" || !view.Ready {
+		t.Fatalf("view=%#v", view)
+	}
+	if view.Labels["runtime"] != "python" || view.Labels["size"] != "medium" {
+		t.Fatalf("labels=%v", view.Labels)
+	}
+	server := boxToServer(cfg, fake.box)
+	if server.PublicNet.IPv4.IP != "eu-west-1.box.upstash.com" {
+		t.Fatalf("host=%q", server.PublicNet.IPv4.IP)
+	}
+}
+
+func hasFeature(features core.FeatureSet, want core.Feature) bool {
+	for _, feature := range features {
+		if feature == want {
+			return true
+		}
+	}
+	return false
+}
+
+func testConfig() Config {
+	return Config{
+		Provider: providerName,
+		UpstashBox: UpstashBoxConfig{
+			APIKey:  "box_key",
+			BaseURL: "https://us-east-1.box.upstash.com",
+			Runtime: "node",
+			Size:    "small",
+			Workdir: "/workspace/home/crabbox",
+		},
+	}
+}
+
+func testRuntime() Runtime {
+	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+}
+
+func withFakeAPI(t *testing.T, fake *fakeAPI) {
+	t.Helper()
+	original := newAPI
+	newAPI = func(Config, Runtime) (api, error) { return fake, nil }
+	t.Cleanup(func() { newAPI = original })
+}
+
+type fakeAPI struct {
+	verbs          []string
+	createReq      createRequest
+	box            boxData
+	execCommands   []string
+	execFolders    []string
+	streamCommands []string
+	streamFolders  []string
+	execResults    []execResult
+	deletedIDs     []string
+}
+
+func (f *fakeAPI) CreateBox(_ context.Context, createRequest createRequest) (boxData, error) {
+	f.verbs = append(f.verbs, "create")
+	f.createReq = createRequest
+	f.box = boxData{ID: "box_1", Name: createRequest.Name, Runtime: createRequest.Runtime, Size: createRequest.Size, Status: "running", KeepAlive: createRequest.KeepAlive}
+	return f.box, nil
+}
+
+func (f *fakeAPI) GetBox(context.Context, string) (boxData, error) {
+	if f.box.ID == "" {
+		f.box = boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Status: "running"}
+	}
+	return f.box, nil
+}
+
+func (f *fakeAPI) ListBoxes(context.Context) ([]boxData, error) {
+	if f.box.ID == "" {
+		f.box = boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Status: "running"}
+	}
+	return []boxData{f.box}, nil
+}
+
+func (f *fakeAPI) DeleteBoxes(_ context.Context, ids []string) error {
+	f.verbs = append(f.verbs, "delete")
+	f.deletedIDs = append(f.deletedIDs, ids...)
+	return nil
+}
+
+func (f *fakeAPI) Exec(_ context.Context, _ string, command, folder string) (execResult, error) {
+	f.verbs = append(f.verbs, "exec")
+	f.execCommands = append(f.execCommands, command)
+	f.execFolders = append(f.execFolders, folder)
+	if len(f.execResults) == 0 {
+		return execResult{ExitCode: 0}, nil
+	}
+	result := f.execResults[0]
+	f.execResults = f.execResults[1:]
+	return result, nil
+}
+
+func (f *fakeAPI) ExecStream(_ context.Context, _ string, command, folder string, stdout io.Writer) (int, error) {
+	f.verbs = append(f.verbs, "stream")
+	f.streamCommands = append(f.streamCommands, command)
+	f.streamFolders = append(f.streamFolders, folder)
+	_, _ = io.WriteString(stdout, "ok\n")
+	return 0, nil
+}
+
+func (f *fakeAPI) UploadFile(context.Context, string, string, string) error {
+	f.verbs = append(f.verbs, "upload")
+	return nil
+}
+
+func (f *fakeAPI) WriteFile(context.Context, string, string, string) error {
+	f.verbs = append(f.verbs, "write")
+	return nil
+}
+
+func readMultipart(t *testing.T, reader *multipart.Reader) map[string]string {
+	t.Helper()
+	fields := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			return fields
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if part.FormName() == "files" {
+			fields[part.FormName()] = string(data)
+			continue
+		}
+		fields[part.FormName()] = string(data)
+	}
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.email", "alice@example.com")
+	runGit(t, root, "config", "user.name", "Alice")
+	if err := os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "hello.txt")
+	runGit(t, root, "commit", "-m", "initial")
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -1,0 +1,415 @@
+package upstashbox
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type api interface {
+	CreateBox(context.Context, createRequest) (boxData, error)
+	GetBox(context.Context, string) (boxData, error)
+	ListBoxes(context.Context) ([]boxData, error)
+	DeleteBoxes(context.Context, []string) error
+	Exec(context.Context, string, string, string) (execResult, error)
+	ExecStream(context.Context, string, string, string, io.Writer) (int, error)
+	UploadFile(context.Context, string, string, string) error
+	WriteFile(context.Context, string, string, string) error
+}
+
+type client struct {
+	apiKey string
+	base   string
+	http   *http.Client
+}
+
+type createRequest struct {
+	Name      string
+	Runtime   string
+	Size      string
+	KeepAlive bool
+	Env       map[string]string
+}
+
+type boxData struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Runtime   string `json:"runtime"`
+	Size      string `json:"size"`
+	Status    string `json:"status"`
+	KeepAlive bool   `json:"keep_alive"`
+	CreatedAt int64  `json:"created_at"`
+	UpdatedAt int64  `json:"updated_at"`
+}
+
+type execResult struct {
+	ExitCode int    `json:"exit_code"`
+	Output   string `json:"output"`
+	Error    string `json:"error"`
+}
+
+var newAPI = func(cfg Config, rt Runtime) (api, error) {
+	apiKey := strings.TrimSpace(cfg.UpstashBox.APIKey)
+	if apiKey == "" {
+		return nil, exit(2, "provider=%s requires UPSTASH_BOX_API_KEY", providerName)
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	base := strings.TrimRight(blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com"), "/")
+	return &client{apiKey: apiKey, base: base, http: httpClient}, nil
+}
+
+func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, error) {
+	body := map[string]any{}
+	if req.Name != "" {
+		body["name"] = req.Name
+	}
+	if req.Runtime != "" {
+		body["runtime"] = req.Runtime
+	}
+	if req.Size != "" {
+		body["size"] = req.Size
+	}
+	if req.KeepAlive {
+		body["keep_alive"] = true
+	}
+	if len(req.Env) > 0 {
+		body["env_vars"] = req.Env
+	}
+	var box boxData
+	if err := c.doJSON(ctx, http.MethodPost, "/v2/box", nil, body, &box); err != nil {
+		return boxData{}, err
+	}
+	deadline := time.Now().Add(5 * time.Minute)
+	for {
+		status := strings.ToLower(strings.TrimSpace(box.Status))
+		if createStatusReady(status) {
+			return box, nil
+		}
+		if status == "error" || status == "failed" {
+			return boxData{}, exit(5, "upstash-box creation failed for %s", box.ID)
+		}
+		if time.Now().After(deadline) {
+			return boxData{}, exit(5, "upstash-box creation timed out for %s status=%s", box.ID, blank(box.Status, "unknown"))
+		}
+		select {
+		case <-ctx.Done():
+			return boxData{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+		next, err := c.GetBox(ctx, box.ID)
+		if err == nil {
+			box = next
+		}
+	}
+}
+
+func createStatusReady(status string) bool {
+	switch status {
+	case "idle", "running", "ready", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *client) GetBox(ctx context.Context, id string) (boxData, error) {
+	var box boxData
+	if err := c.doJSON(ctx, http.MethodGet, "/v2/box/"+url.PathEscape(id), nil, nil, &box); err != nil {
+		return boxData{}, err
+	}
+	return box, nil
+}
+
+func (c *client) ListBoxes(ctx context.Context) ([]boxData, error) {
+	var boxes []boxData
+	if err := c.doJSON(ctx, http.MethodGet, "/v2/box", nil, nil, &boxes); err != nil {
+		return nil, err
+	}
+	return boxes, nil
+}
+
+func (c *client) DeleteBoxes(ctx context.Context, ids []string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/v2/box", nil, map[string]any{"ids": ids}, nil)
+}
+
+func (c *client) Exec(ctx context.Context, boxID, command, folder string) (execResult, error) {
+	var result execResult
+	body := map[string]any{"command": []string{"sh", "-c", command}}
+	if strings.TrimSpace(folder) != "" {
+		body["folder"] = strings.TrimSpace(folder)
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/v2/box/"+url.PathEscape(boxID)+"/exec", nil, body, &result); err != nil {
+		return execResult{}, err
+	}
+	return result, nil
+}
+
+func (c *client) ExecStream(ctx context.Context, boxID, command, folder string, stdout io.Writer) (int, error) {
+	body := map[string]any{"command": []string{"sh", "-c", command}}
+	if strings.TrimSpace(folder) != "" {
+		body["folder"] = strings.TrimSpace(folder)
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v2/box/"+url.PathEscape(boxID)+"/exec-stream", bytes.NewReader(data))
+	if err != nil {
+		return 0, err
+	}
+	c.addHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, apiError(resp)
+	}
+	return parseExecStream(resp.Body, stdout)
+}
+
+func (c *client) UploadFile(ctx context.Context, boxID, localPath, remotePath string) error {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	reader, pipeWriter := io.Pipe()
+	writer := multipart.NewWriter(pipeWriter)
+	go func() {
+		var writeErr error
+		defer func() {
+			if closeErr := file.Close(); writeErr == nil {
+				writeErr = closeErr
+			}
+			if closeErr := writer.Close(); writeErr == nil {
+				writeErr = closeErr
+			}
+			_ = pipeWriter.CloseWithError(writeErr)
+		}()
+		if writeErr = writer.WriteField("paths", remotePath); writeErr != nil {
+			return
+		}
+		var part io.Writer
+		part, writeErr = writer.CreateFormFile("files", filepath.Base(remotePath))
+		if writeErr != nil {
+			return
+		}
+		_, writeErr = io.Copy(part, file)
+	}()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v2/box/"+url.PathEscape(boxID)+"/files/upload", reader)
+	if err != nil {
+		_ = reader.Close()
+		return err
+	}
+	c.addHeaders(req)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(resp)
+	}
+	return nil
+}
+
+func (c *client) WriteFile(ctx context.Context, boxID, remotePath, content string) error {
+	body := map[string]any{"path": remotePath, "content": content}
+	return c.doJSON(ctx, http.MethodPost, "/v2/box/"+url.PathEscape(boxID)+"/files/write", nil, body, nil)
+}
+
+func (c *client) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
+	var input io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		input = bytes.NewReader(data)
+	}
+	u := c.base + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, input)
+	if err != nil {
+		return err
+	}
+	c.addHeaders(req)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(resp)
+	}
+	if out == nil {
+		return nil
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode upstash-box response: %w", err)
+	}
+	return nil
+}
+
+func (c *client) addHeaders(req *http.Request) {
+	req.Header.Set("X-Box-Api-Key", c.apiKey)
+}
+
+func apiError(resp *http.Response) error {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	msg := strings.TrimSpace(string(data))
+	if msg == "" {
+		msg = resp.Status
+	}
+	return fmt.Errorf("upstash-box API %s: %s", resp.Status, msg)
+}
+
+func parseExecStream(r io.Reader, stdout io.Writer) (int, error) {
+	reader := bufio.NewReader(r)
+	var buffer strings.Builder
+	for {
+		chunk := make([]byte, 8192)
+		n, readErr := reader.Read(chunk)
+		if n > 0 {
+			buffer.Write(chunk[:n])
+			flushExecOutputCandidates(&buffer, stdout)
+		}
+		if readErr == io.EOF {
+			return finishExecStream(&buffer, stdout)
+		}
+		if readErr != nil {
+			return 0, readErr
+		}
+	}
+}
+
+const (
+	execExitMarker  = "event: exit\n"
+	execErrorMarker = "event: error\n"
+)
+
+func flushExecOutputCandidates(buffer *strings.Builder, stdout io.Writer) {
+	text := buffer.String()
+	idx := lastExecEventIndex(text)
+	if idx >= 0 {
+		if idx > 0 {
+			writeStreamOutput(stdout, text[:idx])
+			rest := text[idx:]
+			buffer.Reset()
+			buffer.WriteString(rest)
+		}
+		return
+	}
+	keep := 64
+	if len(text) > keep {
+		emit := text[:len(text)-keep]
+		writeStreamOutput(stdout, emit)
+		rest := text[len(text)-keep:]
+		buffer.Reset()
+		buffer.WriteString(rest)
+	}
+}
+
+func finishExecStream(buffer *strings.Builder, stdout io.Writer) (int, error) {
+	text := buffer.String()
+	buffer.Reset()
+	exitIdx := strings.LastIndex(text, execExitMarker)
+	errorIdx := strings.LastIndex(text, execErrorMarker)
+	if exitIdx >= 0 && exitIdx >= errorIdx {
+		if exitIdx > 0 {
+			writeStreamOutput(stdout, text[:exitIdx])
+		}
+		data := parseSSEData(text[exitIdx+len(execExitMarker):])
+		if data == "" {
+			return 1, fmt.Errorf("upstash-box exec stream missing exit data")
+		}
+		var parsed struct {
+			ExitCode int `json:"exit_code"`
+		}
+		if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+			return 1, fmt.Errorf("upstash-box exec stream invalid exit data: %w", err)
+		}
+		return parsed.ExitCode, nil
+	}
+	if errorIdx >= 0 {
+		if errorIdx > 0 {
+			writeStreamOutput(stdout, text[:errorIdx])
+		}
+		msg := parseSSEData(text[errorIdx+len(execErrorMarker):])
+		if msg == "" {
+			msg = "stream error"
+		}
+		return 1, fmt.Errorf("upstash-box exec stream: %s", msg)
+	}
+	if text != "" {
+		writeStreamOutput(stdout, text)
+	}
+	return 1, fmt.Errorf("upstash-box exec stream ended without exit event")
+}
+
+func lastExecEventIndex(text string) int {
+	exitIdx := strings.LastIndex(text, execExitMarker)
+	errorIdx := strings.LastIndex(text, execErrorMarker)
+	if errorIdx > exitIdx {
+		return errorIdx
+	}
+	return exitIdx
+}
+
+func writeStreamOutput(stdout io.Writer, text string) {
+	if stdout == nil || text == "" {
+		return
+	}
+	_, _ = io.WriteString(stdout, text)
+}
+
+func parseSSEData(text string) string {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "data:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	return ""
+}
+
+func commandExitError(prefix string, result execResult) error {
+	msg := strings.TrimSpace(result.Error)
+	if msg == "" {
+		msg = strings.TrimSpace(result.Output)
+	}
+	if msg == "" {
+		msg = "exit " + strconv.Itoa(result.ExitCode)
+	}
+	return exit(result.ExitCode, "%s: %s", prefix, msg)
+}

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -1,0 +1,133 @@
+package upstashbox
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type UpstashBoxConfig = core.UpstashBoxConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type SyncManifest = core.SyncManifest
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+
+const (
+	providerName = "upstash-box"
+	targetLinux  = core.TargetLinux
+
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellWords(words []string) []string {
+	return core.ShellWords(words)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes []string) (SyncManifest, error) {
+	return core.BuildSyncManifest(root, excludes)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+func now(rt Runtime) time.Time {
+	if rt.Clock != nil {
+		return rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/upstashbox/flags.go
+++ b/internal/providers/upstashbox/flags.go
@@ -1,0 +1,74 @@
+package upstashbox
+
+import (
+	"flag"
+	"strings"
+)
+
+type flagValues struct {
+	BaseURL   *string
+	Runtime   *string
+	Size      *string
+	Workdir   *string
+	KeepAlive *bool
+}
+
+func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return flagValues{
+		BaseURL:   fs.String("upstash-box-base-url", defaults.UpstashBox.BaseURL, "Upstash Box API base URL"),
+		Runtime:   fs.String("upstash-box-runtime", defaults.UpstashBox.Runtime, "Upstash Box runtime: node, python, golang, ruby, or rust"),
+		Size:      fs.String("upstash-box-size", defaults.UpstashBox.Size, "Upstash Box size: small, medium, or large"),
+		Workdir:   fs.String("upstash-box-workdir", defaults.UpstashBox.Workdir, "absolute working directory inside the Upstash Box"),
+		KeepAlive: fs.Bool("upstash-box-keep-alive", defaults.UpstashBox.KeepAlive, "create Upstash boxes with keepAlive enabled"),
+	}
+}
+
+func ApplyUpstashBoxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == providerName || cfg.Provider == "upstash" || cfg.Provider == "box" || cfg.Provider == "upstashbox" {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s; use --upstash-box-size", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s; use --upstash-box-runtime", providerName)
+		}
+	}
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "upstash-box-base-url") {
+		cfg.UpstashBox.BaseURL = *v.BaseURL
+	}
+	if flagWasSet(fs, "upstash-box-runtime") {
+		cfg.UpstashBox.Runtime = *v.Runtime
+	}
+	if flagWasSet(fs, "upstash-box-size") {
+		cfg.UpstashBox.Size = *v.Size
+	}
+	if flagWasSet(fs, "upstash-box-workdir") {
+		cfg.UpstashBox.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "upstash-box-keep-alive") {
+		cfg.UpstashBox.KeepAlive = *v.KeepAlive
+	}
+	return validateConfig(*cfg)
+}
+
+func validateConfig(cfg Config) error {
+	if runtime := strings.TrimSpace(cfg.UpstashBox.Runtime); runtime != "" {
+		switch runtime {
+		case "node", "python", "golang", "ruby", "rust", "node-alpine", "python-alpine", "golang-alpine", "ruby-alpine", "rust-alpine":
+		default:
+			return exit(2, "invalid upstash-box runtime %q", runtime)
+		}
+	}
+	if size := strings.TrimSpace(cfg.UpstashBox.Size); size != "" {
+		switch size {
+		case "small", "medium", "large":
+		default:
+			return exit(2, "invalid upstash-box size %q", size)
+		}
+	}
+	_, err := cleanWorkdir(workdir(cfg))
+	return err
+}

--- a/internal/providers/upstashbox/provider.go
+++ b/internal/providers/upstashbox/provider.go
@@ -1,0 +1,53 @@
+package upstashbox
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"upstash", "box", "upstashbox"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterUpstashBoxProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyUpstashBoxProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "upstash-box doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -1,0 +1,128 @@
+package upstashbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, req RunRequest, workdir, folder string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+	manifestStarted := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStarted)
+	preflightStarted := b.now()
+	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStarted)
+	prepareStarted := b.now()
+	if err := b.prepareWorkspace(ctx, client, boxID, folder, b.cfg.Sync.Delete); err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStarted)
+	archiveStarted := b.now()
+	archive, err := createSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := b.now().Sub(archiveStarted)
+	uploadStarted := b.now()
+	remoteArchive := workspacePath(".crabbox-upstash-box-sync-" + randomSuffix() + ".tgz")
+	if err := client.UploadFile(ctx, boxID, archive.Name(), remoteArchive); err != nil {
+		return nil, 0, fmt.Errorf("upstash-box upload archive: %w", err)
+	}
+	remoteArchiveName := path.Base(remoteArchive)
+	extract := strings.Join([]string{
+		"tar -xzf " + shellQuote(remoteArchiveName) + " -C " + shellQuote(folder),
+		"rm -f " + shellQuote(remoteArchiveName),
+	}, " && ")
+	if err := b.execShell(ctx, client, boxID, extract, io.Discard); err != nil {
+		_, _ = client.Exec(context.Background(), boxID, "rm -f "+shellQuote(remoteArchiveName), "")
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStarted)
+	total := b.now().Sub(start)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "upstash_box_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func (b *backend) prepareWorkspace(ctx context.Context, client api, boxID, folder string, delete bool) error {
+	folder = strings.Trim(strings.TrimSpace(folder), "/")
+	if folder == "" || strings.Contains(folder, "..") {
+		return exit(2, "upstash-box workspace folder %q is invalid", folder)
+	}
+	command := "mkdir -p " + shellQuote(folder)
+	if delete {
+		command = "rm -rf " + shellQuote(folder) + " && " + command
+	}
+	return b.execShell(ctx, client, boxID, command, io.Discard)
+}
+
+func (b *backend) execShell(ctx context.Context, client api, boxID, command string, stdout io.Writer) error {
+	result, err := client.Exec(ctx, boxID, command, "")
+	if err != nil {
+		return fmt.Errorf("upstash-box exec %q: %w", command, err)
+	}
+	if stdout != nil && result.Output != "" {
+		_, _ = io.WriteString(stdout, result.Output)
+	}
+	if result.ExitCode != 0 {
+		return commandExitError("upstash-box exec "+command, result)
+	}
+	return nil
+}
+
+func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
+	var input bytes.Buffer
+	input.Write(manifest.NUL())
+	archive, err := os.CreateTemp("", "crabbox-upstash-box-sync-*.tgz")
+	if err != nil {
+		return nil, fmt.Errorf("create sync archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
+	cmd.Stdin = &input
+	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
+	cmd.Stdout = archive
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	keep = true
+	return archive, nil
+}
+
+func randomSuffix() string {
+	return strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
+}


### PR DESCRIPTION
## Summary

- add `provider: upstash-box` as a delegated Upstash Box runner
- add Upstash Box config/env/flags, archive sync, run/warmup/list/status/stop, and provider docs
- document the provider in the README, provider index, and changelog

## Verification

- `go test ./...`
- autoreview clean: no accepted/actionable findings reported
- live Upstash Box smoke with stored API key:
  - `crabbox doctor --provider upstash-box`
  - `crabbox run --provider upstash-box --no-sync -- echo upstash-box-live-ok`
  - `crabbox run --provider upstash-box -- sh -c 'test -f README.md && echo upstash-box-sync-ok'`
  - post-run doctor showed `leases=0`

## Config / Secrets

- reads `UPSTASH_BOX_API_KEY` or `CRABBOX_UPSTASH_BOX_API_KEY`
- no API key flags; no secrets stored in repo
