### PR TITLE
[codex] classify run failures and env forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Linux desktop theme setup so WebVNC sessions also apply dark window-manager chrome and panel styling instead of only darkening GTK apps and browser content.
+- Fixed run failure summaries and timing JSON to classify likely blocked stages, redact known HTML auth challenge bodies from failure excerpts, and reject unsupported Blacksmith environment forwarding before warmup.
 - Fixed desktop browser launches so Linux WebVNC browser sessions inherit the dark desktop theme, advertise dark color-scheme preference to web apps, and repair older managed browser wrappers before launch.
 
 ## 0.18.0 - 2026-05-23

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -237,10 +237,11 @@ capture, and downloads before command execution.
 Use `--timing-json` to emit a final JSON timing record with provider, lease ID,
 slug, run ID, machine type, repo path, remote workdir, sync phases, command
 phases, command duration, total duration, exit code, stop command, artifacts,
-and Actions run URL when available. Commands can emit phase markers on stdout
-or stderr as `CRABBOX_PHASE:<name>`; Crabbox records those as `commandPhases`
-without removing the marker line from output. In `blacksmith-testbox` mode,
-sync is reported as delegated in the same schema.
+and Actions run URL when available. Failed runs also include `blockedStage` and
+`retryLikely` when Crabbox can classify the likely blocker. Commands can emit
+phase markers on stdout or stderr as `CRABBOX_PHASE:<name>`; Crabbox records
+those as `commandPhases` without removing the marker line from output. In
+`blacksmith-testbox` mode, sync is reported as delegated in the same schema.
 
 Before the first rsync into a Git checkout, Crabbox tries to seed the remote worktree from the local `origin` remote so the first sync is a dirty-tree overlay instead of a full source upload. Project-specific excludes can live in `.crabboxignore` or `sync.exclude` in `crabbox.yaml` / `.crabbox.yaml`; env forwarding and base ref belong in config.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -85,8 +85,11 @@ machine without adding file bytes to coordinator logs.
 Test results are stored as structured summaries when `--junit` or
 `results.junit` is configured.
 
-`--timing-json` includes sync phases and command phases. Commands can add
-user-defined phases by printing marker lines to stdout or stderr:
+`--timing-json` includes sync phases and command phases. Failed runs add
+`blockedStage` and `retryLikely` when Crabbox can classify the likely blocker;
+the human run summary prints the same values as `blocked_stage` and
+`retry_likely`. Commands can add user-defined phases by printing marker lines
+to stdout or stderr:
 
 ```sh
 echo CRABBOX_PHASE:install

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -80,9 +80,10 @@ Blacksmith authentication stays in the Blacksmith CLI. Run
 
 `--env-from-profile`, `--allow-env`, and `CRABBOX_ENV_ALLOW` are useful for
 direct SSH-backed Crabbox runs, but Blacksmith delegated runs cannot inject
-CLI-side environment values into the remote Testbox command. Crabbox prints an
-explicit `env forwarding ... behavior=unsupported` summary when those knobs are
-present; put live secrets in the Blacksmith workflow instead.
+CLI-side environment values into the remote Testbox command. Crabbox fails
+before warmup with an explicit `env forwarding ... behavior=unsupported`
+summary when those knobs are present; put live secrets in the Blacksmith
+workflow instead.
 
 ## Lifecycle
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -431,7 +431,15 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	useCoordinator := coord != nil
 	recorder := &runRecorder{}
 	var runFailure error
+	failureClassificationPrinted := false
 	recordFailure := func(failure error) error {
+		if failure != nil && !failureClassificationPrinted {
+			classification := ClassifyRunFailure(1, failure.Error(), nil)
+			if classification.BlockedStage != "" && classification.BlockedStage != "unknown" {
+				fmt.Fprintf(a.Stderr, "failure classification%s\n", FormatFailureClassificationFields(classification))
+				failureClassificationPrinted = true
+			}
+		}
 		return recordRunFailure(&runFailure, failure)
 	}
 	recordCommand := runScriptRecordCommand(script, command)
@@ -1105,6 +1113,12 @@ afterSync:
 		}
 	}
 	total := time.Since(timings.started)
+	if code != 0 {
+		classification := ClassifyRunFailure(code, logBuffer.String(), timings.commandPhases)
+		timings.blockedStage = classification.BlockedStage
+		timings.retryLikely = classification.RetryLikely
+		failureClassificationPrinted = true
+	}
 	report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, code, actionsURL)
 	populateRunTimingMetadata(&report, cfg, repo, server, leaseID, recorder.runID, workdir, runArtifacts)
 	report.Label = runLabelValue
@@ -1369,6 +1383,8 @@ type runTimings struct {
 	syncSteps     syncStepTimings
 	commandPhases []timingPhase
 	syncSkipped   bool
+	blockedStage  string
+	retryLikely   string
 }
 
 type syncStepTimings struct {
@@ -1406,6 +1422,7 @@ func formatRunSummary(timings runTimings, total time.Duration, exitCode int) str
 	if breakdown := formatCommandPhaseTimings(timings.commandPhases); breakdown != "" {
 		summary += " command_phases=" + breakdown
 	}
+	summary += FormatFailureClassificationFields(FailureClassification{BlockedStage: timings.blockedStage, RetryLikely: timings.retryLikely})
 	return summary
 }
 

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -338,6 +338,9 @@ func markdownFence(info, content string) (string, string) {
 
 func selectProofLogExcerpt(log string) string {
 	log = strings.ReplaceAll(stripANSI(log), "\r", "\n")
+	if redacted, ok := RedactKnownFailureBody(log); ok {
+		return redacted
+	}
 	lines := strings.Split(strings.TrimSpace(log), "\n")
 	out := make([]string, 0, 12)
 	for i := len(lines) - 1; i >= 0 && len(out) < 12; i-- {

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+type FailureClassification struct {
+	BlockedStage string
+	RetryLikely  string
+}
+
+func ClassifyRunFailure(exitCode int, text string, phases []TimingPhase) FailureClassification {
+	if exitCode == 0 {
+		return FailureClassification{}
+	}
+	lower := strings.ToLower(stripANSI(text))
+	switch {
+	case strings.Contains(lower, "timed out waiting for ssh"):
+		return FailureClassification{BlockedStage: "ssh", RetryLikely: "true"}
+	case isKnownHTMLAuthBody(lower) ||
+		strings.Contains(lower, "cloudflare access") ||
+		strings.Contains(lower, "provider_auth") ||
+		strings.Contains(lower, "provider auth"):
+		return FailureClassification{BlockedStage: "provider_auth", RetryLikely: "false"}
+	case strings.Contains(lower, "exdev") ||
+		strings.Contains(lower, "enomem") ||
+		strings.Contains(lower, "package-import-method") ||
+		strings.Contains(lower, "child-concurrency") ||
+		strings.Contains(lower, "network-concurrency"):
+		return FailureClassification{BlockedStage: "install", RetryLikely: "unknown"}
+	case strings.Contains(lower, "model_call") ||
+		strings.Contains(lower, "model call") ||
+		strings.Contains(lower, "rate limit") ||
+		strings.Contains(lower, "context length") ||
+		strings.Contains(lower, "context window") ||
+		strings.Contains(lower, "tokens") && strings.Contains(lower, "maximum"):
+		return FailureClassification{BlockedStage: "model_call", RetryLikely: "unknown"}
+	}
+	if phaseName := finalTimingPhaseName(phases); strings.Contains(phaseName, "install") || strings.Contains(phaseName, "hydrate") || strings.Contains(phaseName, "setup") {
+		return FailureClassification{BlockedStage: "install", RetryLikely: "unknown"}
+	}
+	return FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}
+}
+
+func ApplyFailureClassification(report *TimingReport, classification FailureClassification) {
+	if report == nil {
+		return
+	}
+	report.BlockedStage = classification.BlockedStage
+	report.RetryLikely = classification.RetryLikely
+}
+
+func FormatFailureClassificationFields(classification FailureClassification) string {
+	if classification.BlockedStage == "" {
+		return ""
+	}
+	retry := classification.RetryLikely
+	if retry == "" {
+		retry = "unknown"
+	}
+	return fmt.Sprintf(" blocked_stage=%s retry_likely=%s", classification.BlockedStage, retry)
+}
+
+func RedactKnownFailureBody(text string) (string, bool) {
+	trimmed := strings.TrimSpace(stripANSI(text))
+	if trimmed == "" {
+		return "", false
+	}
+	lower := strings.ToLower(trimmed)
+	if !isKnownHTMLAuthBody(lower) {
+		return "", false
+	}
+	kind := "html"
+	if strings.Contains(lower, "cloudflare") {
+		kind = "cloudflare_html"
+	}
+	if strings.Contains(lower, "access") || strings.Contains(lower, "login") || strings.Contains(lower, "challenge") {
+		kind = "auth_" + kind
+	}
+	title := htmlTitle(trimmed)
+	if title != "" {
+		return fmt.Sprintf("[crabbox: redacted %s response bytes=%d title=%q]", kind, len(text), title), true
+	}
+	return fmt.Sprintf("[crabbox: redacted %s response bytes=%d]", kind, len(text)), true
+}
+
+func isKnownHTMLAuthBody(lower string) bool {
+	hasHTML := strings.Contains(lower, "<!doctype html") ||
+		strings.Contains(lower, "<html") ||
+		strings.Contains(lower, "<body") ||
+		strings.Contains(lower, "<head")
+	if !hasHTML {
+		return false
+	}
+	return strings.Contains(lower, "cloudflare access") ||
+		strings.Contains(lower, "cf-access") ||
+		strings.Contains(lower, "__cf_chl_")
+}
+
+func htmlTitle(text string) string {
+	lower := strings.ToLower(text)
+	start := strings.Index(lower, "<title")
+	if start < 0 {
+		return ""
+	}
+	closeStart := strings.Index(lower[start:], ">")
+	if closeStart < 0 {
+		return ""
+	}
+	titleStart := start + closeStart + 1
+	end := strings.Index(lower[titleStart:], "</title>")
+	if end < 0 {
+		return ""
+	}
+	title := strings.Join(strings.Fields(text[titleStart:titleStart+end]), " ")
+	if len(title) > 120 {
+		title = title[:117] + "..."
+	}
+	return title
+}
+
+func finalTimingPhaseName(phases []TimingPhase) string {
+	for i := len(phases) - 1; i >= 0; i-- {
+		name := strings.ToLower(strings.TrimSpace(phases[i].Name))
+		if name != "" {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClassifyRunFailureStages(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		want  string
+		retry string
+	}{
+		{name: "ssh", text: "timed out waiting for SSH on 127.0.0.1 during before command", want: "ssh", retry: "true"},
+		{name: "provider auth", text: "<!doctype html><html><title>Cloudflare Access</title><body>login</body></html>", want: "provider_auth", retry: "false"},
+		{name: "install", text: "pnpm install failed with ENOMEM", want: "install", retry: "unknown"},
+		{name: "model", text: "model call failed: context window maximum tokens exceeded", want: "model_call", retry: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyRunFailure(1, tt.text, nil)
+			if got.BlockedStage != tt.want || got.RetryLikely != tt.retry {
+				t.Fatalf("ClassifyRunFailure()=%#v, want stage=%q retry=%q", got, tt.want, tt.retry)
+			}
+		})
+	}
+}
+
+func TestClassifyRunFailureUsesFinalPhaseAfterErrorSignatures(t *testing.T) {
+	got := ClassifyRunFailure(1, "pnpm install completed\nunit tests failed", []TimingPhase{
+		{Name: "install"},
+		{Name: "test"},
+	})
+	if got.BlockedStage != "unknown" {
+		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
+	}
+	got = ClassifyRunFailure(1, "test failed", []TimingPhase{
+		{Name: "install"},
+		{Name: "test"},
+	})
+	if got.BlockedStage != "unknown" {
+		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
+	}
+	got = ClassifyRunFailure(1, "exit status 1", []TimingPhase{
+		{Name: "test"},
+		{Name: "install"},
+	})
+	if got.BlockedStage != "install" {
+		t.Fatalf("ClassifyRunFailure()=%#v, want install", got)
+	}
+}
+
+func TestClassifyRunFailureDoesNotTreatApplicationConnectionErrorsAsSSH(t *testing.T) {
+	got := ClassifyRunFailure(1, "dial tcp 127.0.0.1:5432: connection refused", nil)
+	if got.BlockedStage != "unknown" {
+		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
+	}
+}
+
+func TestClassifyRunFailureDoesNotTreatApplicationAuthFailuresAsProviderAuth(t *testing.T) {
+	got := ClassifyRunFailure(1, "expected 200, got 401 Unauthorized", nil)
+	if got.BlockedStage != "unknown" {
+		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
+	}
+}
+
+func TestFormatRunSummaryIncludesFailureClassification(t *testing.T) {
+	got := formatRunSummary(runTimings{
+		sync:         time.Second,
+		command:      2 * time.Second,
+		blockedStage: "install",
+		retryLikely:  "unknown",
+	}, 3*time.Second, 1)
+	for _, want := range []string{"blocked_stage=install", "retry_likely=unknown"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestTimingJSONIncludesFailureClassification(t *testing.T) {
+	report := timingReportFromRun("aws", "cbx_123", "slug", runTimings{
+		blockedStage: "ssh",
+		retryLikely:  "true",
+	}, time.Second, 1)
+	var buf bytes.Buffer
+	if err := writeTimingJSON(&buf, report); err != nil {
+		t.Fatal(err)
+	}
+	var got TimingReport
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.BlockedStage != "ssh" || got.RetryLikely != "true" {
+		t.Fatalf("classification not encoded: %#v", got)
+	}
+}
+
+func TestFailureTailRedactsHTMLAuthBody(t *testing.T) {
+	tail := newStreamTailBuffer(40)
+	_, _ = tail.Write([]byte("<!doctype html><html><head><title>Cloudflare Access</title></head><body>login</body></html>\n"))
+	var buf bytes.Buffer
+	printFailureTail(&buf, "stderr", tail, "")
+	out := buf.String()
+	if !strings.Contains(out, "stderr tail redacted:") || !strings.Contains(out, "redacted auth_cloudflare_html response") {
+		t.Fatalf("tail was not redacted: %q", out)
+	}
+	if strings.Contains(out, "<html>") || strings.Contains(out, "<body>") {
+		t.Fatalf("tail leaked HTML body: %q", out)
+	}
+}
+
+func TestFailureTailKeepsNonAuthHTMLBody(t *testing.T) {
+	tail := newStreamTailBuffer(40)
+	_, _ = tail.Write([]byte("<!doctype html><html><head><title>App Output</title></head><body>rendered page</body></html>\n"))
+	var buf bytes.Buffer
+	printFailureTail(&buf, "stdout", tail, "")
+	out := buf.String()
+	if strings.Contains(out, "tail redacted") || !strings.Contains(out, "<body>rendered page</body>") {
+		t.Fatalf("non-auth HTML tail was changed: %q", out)
+	}
+}
+
+func TestFailureTailKeepsApplicationAuthHTMLBody(t *testing.T) {
+	tail := newStreamTailBuffer(40)
+	_, _ = tail.Write([]byte("<!doctype html><html><head><title>App Login</title></head><body>401 Unauthorized access denied</body></html>\n"))
+	var buf bytes.Buffer
+	printFailureTail(&buf, "stdout", tail, "")
+	out := buf.String()
+	if strings.Contains(out, "tail redacted") || !strings.Contains(out, "401 Unauthorized") {
+		t.Fatalf("application auth HTML tail was changed: %q", out)
+	}
+}
+
+func TestSelectProofLogExcerptRedactsHTMLAuthBody(t *testing.T) {
+	got := SelectProofLogExcerpt("<!doctype html><html><head><title>Cloudflare Access</title></head><body>login</body></html>")
+	if !strings.Contains(got, "redacted auth_cloudflare_html response") {
+		t.Fatalf("proof excerpt was not redacted: %q", got)
+	}
+}

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -912,6 +912,10 @@ func printFailureTail(w io.Writer, label string, tail *streamTailBuffer, capture
 		fmt.Fprintf(w, "%s tail: empty\n", label)
 		return
 	}
+	if redacted, ok := RedactKnownFailureBody(strings.Join(lines, "\n")); ok {
+		fmt.Fprintf(w, "%s tail redacted: %s\n", label, redacted)
+		return
+	}
 	fmt.Fprintf(w, "%s tail last %d lines:\n", label, len(lines))
 	for _, line := range lines {
 		fmt.Fprintf(w, "%s\n", line)

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -26,6 +26,8 @@ type TimingReport struct {
 	Workdir       string        `json:"workdir,omitempty"`
 	StopCommand   string        `json:"stopCommand,omitempty"`
 	IdleTimeout   string        `json:"idleTimeout,omitempty"`
+	BlockedStage  string        `json:"blockedStage,omitempty"`
+	RetryLikely   string        `json:"retryLikely,omitempty"`
 	Artifacts     []runArtifact `json:"artifacts,omitempty"`
 	LeaseStopped  *bool         `json:"leaseStopped,omitempty"`
 	LeaseStopErr  string        `json:"leaseStopError,omitempty"`
@@ -81,6 +83,8 @@ func timingReportFromRun(provider, leaseID, slug string, timings runTimings, tot
 		CommandPhases: timings.commandPhases,
 		TotalMs:       total.Milliseconds(),
 		ExitCode:      exitCode,
+		BlockedStage:  timings.blockedStage,
+		RetryLikely:   timings.retryLikely,
 	}
 }
 

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -97,6 +97,11 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 		return RunResult{}, err
 	}
+	if blacksmithEnvForwardingRequested(req) {
+		core.PrintEnvForwardingSummary(b.rt.Stderr, blacksmithTestboxProvider, "unsupported", req.Options.EnvAllow, req.Env)
+		fmt.Fprintf(b.rt.Stderr, "env forwarding note=blacksmith-testbox delegates execution to the Blacksmith CLI; configure secrets in the Testbox workflow instead\n")
+		return RunResult{}, core.Exit(2, "env forwarding is unsupported for provider=%s; configure secrets in the provider workflow or use an SSH-backed provider", blacksmithTestboxProvider)
+	}
 	started := b.rt.Clock.Now()
 	leaseID := req.ID
 	slug := ""
@@ -174,8 +179,12 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	commandDuration := finished.Sub(commandStart)
 	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, finished)
 	total := finished.Sub(started)
-	fmt.Fprintf(b.rt.Stderr, "blacksmith run summary sync=delegated command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code)
 	report := delegatedTimingReport(blacksmithTestboxProvider, leaseID, slug, "blacksmith-testbox owns sync", commandDuration, commandPhases, total, code)
+	if code != 0 {
+		classification := core.ClassifyRunFailure(code, string(stdoutProof.Bytes())+"\n"+string(stderrProof.Bytes()), commandPhases)
+		core.ApplyFailureClassification(&report, classification)
+	}
+	fmt.Fprintf(b.rt.Stderr, "blacksmith run summary sync=delegated command=%s total=%s exit=%d%s\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code, core.FormatFailureClassificationFields(core.FailureClassification{BlockedStage: report.BlockedStage, RetryLikely: report.RetryLikely}))
 	report.Label = strings.TrimSpace(req.Label)
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
@@ -218,6 +227,32 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 }
 
 var githubActionsRunURLPattern = regexp.MustCompile(`https://github\.com/[^\s"'<>]+/actions/runs/[0-9]+[^\s"'<>]*`)
+
+func blacksmithEnvForwardingRequested(req RunRequest) bool {
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		return true
+	}
+	for _, name := range req.Options.EnvAllow {
+		if !blacksmithDefaultEnvMetadataName(name) {
+			return true
+		}
+	}
+	for name := range req.Env {
+		if !blacksmithDefaultEnvMetadataName(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func blacksmithDefaultEnvMetadataName(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "", "CI", "NODE_OPTIONS":
+		return true
+	default:
+		return false
+	}
+}
 
 const blacksmithProofStreamCaptureBytes = 1024 * 1024
 

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -103,6 +103,132 @@ func TestBlacksmithWarmupArgsRequiresWorkflow(t *testing.T) {
 	}
 }
 
+func TestBlacksmithRunRejectsEnvForwardingBeforeWarmup(t *testing.T) {
+	var stderr bytes.Buffer
+	runner := &blacksmithFuncRunner{}
+	cfg := baseConfig()
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:       Repo{Root: "/repo"},
+		Command:    []string{"true"},
+		EnvSummary: true,
+		Options: core.LeaseOptions{
+			EnvAllow: []string{"API_TOKEN"},
+		},
+		Env: map[string]string{"API_TOKEN": "secret-token-value"},
+	})
+	var exitErr ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("Run error=%v, want exit 2", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was called before validation: %#v", runner.calls)
+	}
+	out := stderr.String()
+	for _, want := range []string{"provider=blacksmith-testbox", "behavior=unsupported", "configure secrets in the Testbox workflow"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stderr missing %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "secret-token-value") {
+		t.Fatalf("stderr leaked env value: %q", out)
+	}
+}
+
+func TestBlacksmithRunDoesNotRejectDefaultEnvMetadata(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	var stderr bytes.Buffer
+	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
+		return LocalCommandResult{ExitCode: 1}, errors.New("warmup failed")
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: "/repo"},
+		Command: []string{"true"},
+		Options: core.LeaseOptions{
+			EnvAllow: []string{"CI", "NODE_OPTIONS"},
+		},
+		Env: map[string]string{"NODE_OPTIONS": "--max-old-space-size=4096"},
+	})
+	if err == nil {
+		t.Fatal("expected warmup failure")
+	}
+	if len(runner.calls) == 0 {
+		t.Fatal("runner was not called")
+	}
+	if strings.Contains(stderr.String(), "behavior=unsupported") {
+		t.Fatalf("default env metadata was rejected: %q", stderr.String())
+	}
+}
+
+func TestBlacksmithRunRejectsExplicitDefaultEnvBeforeWarmup(t *testing.T) {
+	var stderr bytes.Buffer
+	runner := &blacksmithFuncRunner{}
+	cfg := baseConfig()
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:       Repo{Root: "/repo"},
+		Command:    []string{"true"},
+		EnvSummary: true,
+		Options: core.LeaseOptions{
+			EnvAllow: []string{"CI", "NODE_OPTIONS"},
+		},
+		Env: map[string]string{"NODE_OPTIONS": "--max-old-space-size=4096"},
+	})
+	var exitErr ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("Run error=%v, want exit 2", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was called before validation: %#v", runner.calls)
+	}
+}
+
+func TestBlacksmithRunRejectsConfiguredEnvForwardingBeforeWarmup(t *testing.T) {
+	var stderr bytes.Buffer
+	runner := &blacksmithFuncRunner{}
+	cfg := baseConfig()
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: "/repo"},
+		Command: []string{"true"},
+		Options: core.LeaseOptions{
+			EnvAllow: []string{"API_TOKEN"},
+		},
+		Env: map[string]string{"API_TOKEN": "secret-token-value"},
+	})
+	var exitErr ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("Run error=%v, want exit 2", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runner was called before validation: %#v", runner.calls)
+	}
+	if strings.Contains(stderr.String(), "secret-token-value") {
+		t.Fatalf("stderr leaked env value: %q", stderr.String())
+	}
+}
+
 func TestBlacksmithWarmupFailureRemovesPendingKey(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- add bounded run failure classification for install, SSH, provider auth, model-call, and unknown blockers in human summaries and timing JSON
- redact known Cloudflare Access/challenge HTML bodies from failure tails and proof excerpts without hiding ordinary app HTML
- reject unsupported Blacksmith env-forwarding requests before warmup while preserving default CI/NODE_OPTIONS metadata behavior
- document the new timing fields and Blacksmith env-forwarding failure mode

## Validation

- `go test ./internal/cli ./internal/providers/blacksmith`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test ./internal/cli ./internal/providers/blacksmith"`

Autoreview result: clean, no accepted/actionable findings reported.