### PR TITLE
feat(aws): surface quota pressure in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added AWS doctor capacity readiness checks that surface Spot and On-Demand vCPU quota pressure before warmup. Thanks @jwmoss.
 - Added an experimental Linux `--desktop-env wayland` profile using Sway, WayVNC, Wayland browser launch env, and `grim` screenshots while keeping XFCE as the default desktop.
 
 ### Fixed

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -18,6 +18,7 @@ crabbox doctor --json
 ```text
 config       config files load and parse, required keys are present
 auth         broker token is set, signed token is valid, identity resolves
+provider     provider API, broker secret readiness, and capacity preflights
 network      coordinator URL reachable, DNS works, SSH transport probes work
 ssh          SSH key path readable, key permissions sane, ssh-keygen on PATH
 tools        provider-applicable local tools are present and executable
@@ -32,18 +33,27 @@ When `CRABBOX_SSH_KEY` is explicitly set, doctor validates the private key
 and the matching `.pub` file. When unset, it skips that check because
 per-lease keys do not need a global key.
 
-When a coordinator is configured, doctor also asks the broker for secret
-readiness for managed brokered providers such as AWS, Azure, GCP, and Hetzner. It
-reports missing Worker secret names such as `AZURE_TENANT_ID` without exposing
-secret values. Static, Proxmox, and delegated providers skip this broker-secret check.
-Delegated providers can still run their own direct readiness checks; for example,
-Cloudflare validates the configured runner URL and bearer token against the
-authenticated runner readiness API. Direct provider checks print stable fields
-such as `timeout=10s`, `api=list`, and `mutation=false` so scripts can tell
-what was checked. GCP uses an aggregated Compute Engine inventory query across
-zones, while the other built-in providers use their cheapest non-mutating list
-or readiness API. Blacksmith Testbox reports runtime as provider-hydrated
-because GitHub Actions hydration is owned by Testbox.
+Provider readiness checks validate the selected provider without creating a
+lease. When a coordinator is configured, doctor asks the broker for secret
+readiness for managed brokered providers such as AWS, Azure, GCP, and Hetzner.
+It reports missing Worker secret names such as `AZURE_TENANT_ID` without
+exposing secret values. Static, Proxmox, and delegated providers skip this
+broker-secret check. For AWS, broker readiness also includes non-mutating EC2
+vCPU quota checks when the broker has AWS secrets. Low quotas print advisory
+`warning capacity` lines with the quota code, applied limit, default type,
+required vCPUs, and a lower recommended class/type. If Service Quotas cannot be
+inspected, the capacity check is skipped with `capacity=unknown`.
+
+Delegated providers can still run their own direct readiness checks; for
+example, Cloudflare validates the configured runner URL and bearer token against
+the authenticated runner readiness API. Direct provider checks print stable
+fields such as `timeout=10s`, `api=list`, and `mutation=false` so scripts can
+tell what was checked. Direct AWS also checks EC2 vCPU quotas through Service
+Quotas and reports advisory capacity warnings before a lease is created. GCP
+uses an aggregated Compute Engine inventory query across zones, while the other
+built-in providers use their cheapest non-mutating list or readiness API.
+Blacksmith Testbox reports runtime as provider-hydrated because GitHub Actions
+hydration is owned by Testbox.
 
 When `--profile <name> --id <lease>` selects a profile with `doctor.enabled:
 true`, doctor runs that profile's remote prerequisite contract instead of the
@@ -88,12 +98,15 @@ hint:
 failed  provider provider=gcp class=auth hint=check_gcp_project_credentials_and_compute_instances_list ...
 ```
 
+AWS quota warnings are advisory. Doctor still exits `0` unless another check
+fails.
+
 `--json` prints the same checks as structured JSON with `ok`, `provider`, and
 `checks` fields. Each check includes `status`, `check`, `message`, and parsed
 `details` when available.
 
-Exit code is `0` on full success, `1` on any failure. Skips never change
-the exit code.
+Exit code is `0` when there are no failures, `1` on any failure. Skips and
+warnings never change the exit code.
 
 ## Flags
 

--- a/docs/features/capacity-fallback.md
+++ b/docs/features/capacity-fallback.md
@@ -134,6 +134,8 @@ them sequentially.
 
 Hints apply only on the brokered (Worker) path. Direct AWS mode still falls
 back through the class chain but does not run quota or placement preflight.
+`crabbox doctor --provider aws` can run the EC2 vCPU quota preflight before the
+first warmup in both direct and brokered setups.
 
 ## Region And Availability Zone Routing
 

--- a/docs/features/doctor.md
+++ b/docs/features/doctor.md
@@ -17,11 +17,12 @@ readiness.
 
 ## Categories
 
-Doctor groups checks under five categories:
+Doctor groups checks under six categories:
 
 ```text
 config       config files load and parse, required keys are present
 auth         broker token is set, signed token is valid, identity resolves
+provider     provider API, broker secret readiness, and capacity preflights
 network      coordinator URL reachable, DNS works, SSH transport probes work
 ssh          SSH key path readable, key type acceptable, ssh-keygen on PATH
 tools        provider-applicable local tools are present and executable
@@ -53,10 +54,20 @@ diffable across runs.
   `git config user.email`.
 - `whoami` succeeds against the configured coordinator with the stored
   token.
+
+When auth is missing, doctor prints `crabbox login` as the next step.
+
+## What `provider` Checks
+
 - Provider readiness succeeds for managed brokered providers that need Worker
   secrets. Missing names are reported without exposing values, for example
   `AZURE_TENANT_ID` or `AZURE_SUBSCRIPTION_ID`. Delegated and static providers
-  skip this check.
+  skip this check. AWS broker readiness also performs non-mutating EC2 vCPU
+  quota checks through Service Quotas when broker secrets are available. Low
+  quotas emit advisory `warning capacity` lines with the quota code, applied
+  limit, default type, required vCPUs, and recommended class/type. If Service
+  Quotas cannot be inspected, the capacity check is skipped with
+  `capacity=unknown` instead of warning about unproven pressure.
 - Direct provider readiness succeeds for delegated providers that expose a cheap
   non-mutating check. Cloudflare validates its runner URL and bearer token
   directly instead of treating a healthy coordinator as proof of runner
@@ -64,10 +75,9 @@ diffable across runs.
   providers now expose provider-owned direct doctor checks; providers with list
   APIs use non-mutating inventory checks when running in direct mode. Direct
   checks include stable `timeout`, `api`, and `mutation` fields; for example
-  GCP reports an aggregated Compute Engine list query, and Blacksmith Testbox
-  reports provider-owned runtime hydration.
-
-When auth is missing, doctor prints `crabbox login` as the next step.
+  AWS reports EC2 inventory plus advisory vCPU quota checks, GCP reports an
+  aggregated Compute Engine list query, and Blacksmith Testbox reports
+  provider-owned runtime hydration.
 
 ## What `network` Checks
 
@@ -111,7 +121,8 @@ Doctor avoids mutating provider state on purpose. It does not:
 - start a real lease or provision a server;
 - create, delete, or mutate cloud or Proxmox resources;
 - call delegated provider APIs except for explicit, cheap readiness or inventory
-  probes such as Cloudflare runner auth checks or provider list commands;
+  probes such as Cloudflare runner auth checks, Service Quotas reads, or
+  provider list commands;
 - run `git ls-files` against the repo (that belongs in `crabbox sync-plan`);
 - estimate costs;
 - modify config or rotate keys.
@@ -134,6 +145,9 @@ auth:
   ok    broker: https://crabbox.openclaw.ai
   ok    owner: alex@example.com
   ok    org:   openclaw
+provider:
+  ok    provider provider=aws coordinator_secrets=ready
+  warning capacity provider=aws capacity=quota_pressure market=spot recommended_class=standard
 network:
   ok    coordinator dns
   ok    coordinator https
@@ -160,8 +174,14 @@ network:
   skip  coordinator unconfigured (direct provider mode)
 ```
 
-Exit code is `0` on full success, `1` on any failure. Skips do not change
-the exit code.
+Warnings swap `ok` for `warning` and are advisory:
+
+```text
+warning capacity provider=aws capacity=quota_pressure market=spot quota_code=L-34B43A08 limit_vcpus=32 default_type=c7a.48xlarge default_needed_vcpus=192 recommended_class=standard recommended_type=c7a.8xlarge
+```
+
+Exit code is `0` when there are no failures, `1` on any failure. Skips and
+warnings do not change the exit code.
 
 Use `--json` for automation. The JSON view contains the overall `ok` boolean,
 selected `provider`, and a `checks` array with each check's status, category,

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -114,6 +114,10 @@ provider labels and `crabbox cleanup`.
 
 - Spot capacity and quota errors are normal. Prefer classes over exact `--type`
   when you want fallback.
+- Run `crabbox doctor --provider aws` before first warmup in a new or unfunded
+  account. Doctor checks EC2 vCPU Service Quotas for the effective class/type
+  and reports a smaller recommended class/type when `beast` would exceed the
+  account cap.
 - Brokered leases include `capacityHints` unless disabled with
   `capacity.hints: false` or `CRABBOX_CAPACITY_HINTS=0`.
 - During capacity pressure, prefer `standard` or `fast` plus multiple

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,6 +101,7 @@ Symptoms:
 Checks:
 
 ```sh
+bin/crabbox doctor --provider aws
 bin/crabbox list --json
 bin/crabbox usage --scope all
 CRABBOX_CAPACITY_REGIONS=eu-west-1,eu-west-2,eu-central-1,us-east-1,us-west-2 \
@@ -116,6 +117,7 @@ Fixes:
 - set `CRABBOX_CAPACITY_AVAILABILITY_ZONES` only when you intentionally want a specific zone in those regions;
 - set `CRABBOX_CAPACITY_STRATEGY=most-available`;
 - keep capacity hints enabled, or set `CRABBOX_CAPACITY_LARGE_CLASSES` when your installation wants warnings for classes beyond `beast`;
+- if `doctor` prints `warning capacity`, use its recommended class/type or request the printed AWS quota code;
 - raise the AWS `Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances` quota for C/M/R/T/Z families, or the matching Spot quota when using Spot;
 - raise Hetzner dedicated-core quota when dedicated classes are required;
 - temporarily use AWS fallback capacity.
@@ -125,7 +127,8 @@ uses AWS Service Quotas when available and reports the quota code, applied vCPU
 limit, requested type, and required vCPUs before trying the next candidate.
 Brokered responses also include `capacityHints` so callers can surface the
 selected region/market and next operator action instead of parsing provider
-errors.
+errors. `crabbox doctor --provider aws` can surface the same quota pressure
+before the first warmup.
 
 If AWS reports `InvalidInstanceID.NotFound` during coordinator-backed lease
 creation, the backing instance record was stale by the time Crabbox tried to use

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.302.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/daytonaio/daytona/libs/api-client-go v0.177.0
 	github.com/daytonaio/daytona/libs/sdk-go v0.177.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.7 h1:LRcX5C4jwSmkbmkamPVLU3/VALAo0Fuy77a2TgMKYx0=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.7/go.mod h1:52QJsp2N27Em8o5H/cgkBwjTY4I/TYpTBHMlqhuCHMQ=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -13,12 +13,15 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 const (
 	awsUbuntuOwner           = "099720109477"
 	awsSSHIngressDescription = "Crabbox SSH"
+	awsSpotQuotaCode         = "L-34B43A08"
+	awsOnDemandQuotaCode     = "L-1216C47A"
 )
 
 var awsSnapshotDeleteBackoff = []time.Duration{
@@ -31,9 +34,10 @@ var awsSnapshotDeleteBackoff = []time.Duration{
 }
 
 type AWSClient struct {
-	ec2    *ec2.Client
-	sts    *sts.Client
-	region string
+	ec2           *ec2.Client
+	serviceQuotas *servicequotas.Client
+	sts           *sts.Client
+	region        string
 }
 
 func newAWSClient(ctx context.Context, cfg Config) (*AWSClient, error) {
@@ -48,11 +52,48 @@ func newAWSClientForRegion(ctx context.Context, cfg Config, region string) (*AWS
 	if err != nil {
 		return nil, err
 	}
-	return &AWSClient{ec2: ec2.NewFromConfig(awsCfg), sts: sts.NewFromConfig(awsCfg), region: region}, nil
+	return &AWSClient{
+		ec2:           ec2.NewFromConfig(awsCfg),
+		serviceQuotas: servicequotas.NewFromConfig(awsCfg),
+		sts:           sts.NewFromConfig(awsCfg),
+		region:        region,
+	}, nil
 }
 
 func NewAWSClient(ctx context.Context, cfg Config) (*AWSClient, error) {
 	return newAWSClient(ctx, cfg)
+}
+
+func (c *AWSClient) CapacityDoctorChecks(ctx context.Context, cfg Config) []DoctorCheck {
+	if cfg.TargetOS == targetMacOS || c.serviceQuotas == nil {
+		return nil
+	}
+	if cfg.Provider == "" {
+		cfg.Provider = "aws"
+	}
+	if cfg.ServerType == "" {
+		cfg.ServerType = serverTypeForConfig(cfg)
+	}
+	checks := make([]DoctorCheck, 0, 2)
+	for _, market := range awsCapacityDoctorMarkets(cfg) {
+		limit, known, err := c.appliedEC2ServiceQuota(ctx, awsQuotaCodeForMarket(market))
+		checks = append(checks, awsCapacityDoctorCheckForQuota(cfg, market, limit, known, err))
+	}
+	return checks
+}
+
+func (c *AWSClient) appliedEC2ServiceQuota(ctx context.Context, quotaCode string) (float64, bool, error) {
+	out, err := c.serviceQuotas.GetServiceQuota(ctx, &servicequotas.GetServiceQuotaInput{
+		ServiceCode: aws.String("ec2"),
+		QuotaCode:   aws.String(quotaCode),
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if out.Quota == nil || out.Quota.Value == nil {
+		return 0, false, nil
+	}
+	return *out.Quota.Value, true, nil
 }
 
 func (c *AWSClient) SpotPlacementScores(ctx context.Context, cfg Config) ([]types.SpotPlacementScore, error) {
@@ -986,6 +1027,162 @@ func awsLaunchCandidates(cfg Config) []string {
 		}
 	}
 	return appendUniqueStrings([]string{cfg.ServerType}, append(awsInstanceTypeCandidatesForConfig(cfg), fallback)...)
+}
+
+func awsCapacityDoctorMarkets(cfg Config) []string {
+	market := strings.TrimSpace(cfg.Capacity.Market)
+	if market == "" {
+		market = "spot"
+	}
+	markets := []string{market}
+	if market == "spot" && strings.HasPrefix(cfg.Capacity.Fallback, "on-demand") {
+		markets = append(markets, "on-demand")
+	}
+	return appendUniqueStrings(markets)
+}
+
+func awsQuotaCodeForMarket(market string) string {
+	if market == "on-demand" {
+		return awsOnDemandQuotaCode
+	}
+	return awsSpotQuotaCode
+}
+
+func awsCapacityDoctorCheckForQuota(cfg Config, market string, quotaValue float64, quotaKnown bool, quotaErr error) DoctorCheck {
+	serverType := strings.TrimSpace(cfg.ServerType)
+	if serverType == "" {
+		serverType = serverTypeForConfig(cfg)
+	}
+	quotaCode := awsQuotaCodeForMarket(market)
+	needed := awsInstanceTypeVCPUs(serverType)
+	base := map[string]string{
+		"provider":             "aws",
+		"market":               market,
+		"quota_code":           quotaCode,
+		"default_class":        cfg.Class,
+		"default_type":         serverType,
+		"default_needed_vcpus": strconv.Itoa(needed),
+	}
+	if quotaErr != nil {
+		base["hint"] = "allow_servicequotas_getservicequota"
+		base["error"] = quotaErr.Error()
+		return DoctorCheck{
+			Status:  "skip",
+			Check:   "capacity",
+			Message: awsDoctorMessage("provider=aws capacity=unknown", base),
+			Details: base,
+		}
+	}
+	if !quotaKnown {
+		base["hint"] = "servicequotas_unavailable"
+		return DoctorCheck{
+			Status:  "skip",
+			Check:   "capacity",
+			Message: awsDoctorMessage("provider=aws capacity=unknown", base),
+			Details: base,
+		}
+	}
+	limit := int(quotaValue)
+	base["limit_vcpus"] = strconv.Itoa(limit)
+	if needed == 0 {
+		base["hint"] = "unknown_instance_vcpus"
+		return DoctorCheck{
+			Status:  "skip",
+			Check:   "capacity",
+			Message: awsDoctorMessage("provider=aws capacity=unknown", base),
+			Details: base,
+		}
+	}
+	if quotaValue < float64(needed) {
+		recommendedClass, recommendedType := awsRecommendedClassForQuota(cfg, limit)
+		if recommendedClass != "" {
+			base["recommended_class"] = recommendedClass
+			base["recommended_type"] = recommendedType
+		}
+		base["hint"] = "lower_class_or_request_quota"
+		return DoctorCheck{
+			Status:  "warning",
+			Check:   "capacity",
+			Message: awsDoctorMessage("provider=aws capacity=quota_pressure", base),
+			Details: base,
+		}
+	}
+	base["hint"] = "quota_satisfies_default_class"
+	return DoctorCheck{
+		Status:  "ok",
+		Check:   "capacity",
+		Message: awsDoctorMessage("provider=aws capacity=ready", base),
+		Details: base,
+	}
+}
+
+func awsDoctorMessage(prefix string, details map[string]string) string {
+	keys := make([]string, 0, len(details))
+	for key := range details {
+		if key == "provider" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(prefix)
+	for _, key := range keys {
+		if details[key] == "" {
+			continue
+		}
+		b.WriteByte(' ')
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(strings.ReplaceAll(details[key], " ", "_"))
+	}
+	return b.String()
+}
+
+func awsRecommendedClassForQuota(cfg Config, limitVCPUs int) (string, string) {
+	if limitVCPUs <= 0 {
+		return "", ""
+	}
+	classes := []string{"beast", "large", "fast", "standard"}
+	for _, class := range classes {
+		candidates := awsInstanceTypeCandidatesForTargetModeClass(cfg.TargetOS, cfg.WindowsMode, class)
+		if len(candidates) == 0 {
+			continue
+		}
+		if awsInstanceTypeVCPUs(candidates[0]) <= limitVCPUs {
+			return class, candidates[0]
+		}
+	}
+	for _, serverType := range awsInstanceTypeCandidatesForTargetModeClass(cfg.TargetOS, cfg.WindowsMode, "standard") {
+		if awsInstanceTypeVCPUs(serverType) <= limitVCPUs {
+			return "standard", serverType
+		}
+	}
+	return "", ""
+}
+
+func awsInstanceTypeVCPUs(serverType string) int {
+	_, size, ok := strings.Cut(strings.TrimSpace(serverType), ".")
+	if !ok || size == "" {
+		return 0
+	}
+	if strings.HasSuffix(size, "xlarge") {
+		multiplier := strings.TrimSuffix(size, "xlarge")
+		if multiplier == "" {
+			return 4
+		}
+		parsed, err := strconv.Atoi(multiplier)
+		if err != nil {
+			return 0
+		}
+		return parsed * 4
+	}
+	switch size {
+	case "nano", "micro", "small", "medium", "large":
+		return 2
+	default:
+		return 0
+	}
 }
 
 func awsInstanceTypeSupportsNestedVirtualization(instanceType string) bool {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -42,6 +42,69 @@ func TestApplyAWSRunInstanceTargetOptionsLeavesNativeWindowsDefault(t *testing.T
 	}
 }
 
+func TestAWSCapacityDoctorCheckWarnsWhenQuotaBelowDefaultClass(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Class = "beast"
+	cfg.ServerType = serverTypeForConfig(cfg)
+
+	check := awsCapacityDoctorCheckForQuota(cfg, "spot", 32, true, nil)
+
+	if check.Status != "warning" {
+		t.Fatalf("status=%q, want warning", check.Status)
+	}
+	if check.Details["quota_code"] != awsSpotQuotaCode {
+		t.Fatalf("quota_code=%q", check.Details["quota_code"])
+	}
+	if check.Details["default_needed_vcpus"] != "192" {
+		t.Fatalf("default_needed_vcpus=%q", check.Details["default_needed_vcpus"])
+	}
+	if check.Details["recommended_class"] != "standard" || check.Details["recommended_type"] != "c7a.8xlarge" {
+		t.Fatalf("recommendation=(%q,%q), want standard/c7a.8xlarge", check.Details["recommended_class"], check.Details["recommended_type"])
+	}
+	if !strings.Contains(check.Message, "capacity=quota_pressure") {
+		t.Fatalf("message=%q, want quota pressure", check.Message)
+	}
+}
+
+func TestAWSCapacityDoctorCheckPassesWhenQuotaCoversDefaultClass(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Class = "beast"
+	cfg.ServerType = serverTypeForConfig(cfg)
+
+	check := awsCapacityDoctorCheckForQuota(cfg, "spot", 256, true, nil)
+
+	if check.Status != "ok" {
+		t.Fatalf("status=%q, want ok", check.Status)
+	}
+	if check.Details["hint"] != "quota_satisfies_default_class" {
+		t.Fatalf("hint=%q", check.Details["hint"])
+	}
+}
+
+func TestAWSCapacityDoctorCheckSkipsWhenQuotaUnknown(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Class = "beast"
+	cfg.ServerType = serverTypeForConfig(cfg)
+
+	check := awsCapacityDoctorCheckForQuota(cfg, "spot", 0, false, nil)
+
+	if check.Status != "skip" {
+		t.Fatalf("status=%q, want skip", check.Status)
+	}
+	if check.Details["hint"] != "servicequotas_unavailable" {
+		t.Fatalf("hint=%q", check.Details["hint"])
+	}
+	if !strings.Contains(check.Message, "capacity=unknown") {
+		t.Fatalf("message=%q, want unknown capacity", check.Message)
+	}
+}
+
 func TestAWSInstanceToServerPreservesHostID(t *testing.T) {
 	server := awsInstanceToServer(types.Instance{
 		InstanceId:   aws.String("i-1234567890abcdef0"),

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -161,10 +161,11 @@ type CoordinatorWhoami struct {
 }
 
 type CoordinatorProviderReadiness struct {
-	Provider   string   `json:"provider"`
-	Configured bool     `json:"configured"`
-	Missing    []string `json:"missing,omitempty"`
-	Message    string   `json:"message,omitempty"`
+	Provider   string        `json:"provider"`
+	Configured bool          `json:"configured"`
+	Missing    []string      `json:"missing,omitempty"`
+	Message    string        `json:"message,omitempty"`
+	Checks     []DoctorCheck `json:"checks,omitempty"`
 }
 
 type CoordinatorImage struct {
@@ -857,10 +858,26 @@ func (c *CoordinatorClient) Whoami(ctx context.Context) (CoordinatorWhoami, erro
 	return res, err
 }
 
-func (c *CoordinatorClient) ProviderReadiness(ctx context.Context, provider string) (CoordinatorProviderReadiness, error) {
+func (c *CoordinatorClient) ProviderReadiness(ctx context.Context, cfg Config) (CoordinatorProviderReadiness, error) {
 	var res CoordinatorProviderReadiness
-	path := "/v1/providers/" + url.PathEscape(provider) + "/readiness"
-	err := c.do(ctx, http.MethodGet, path, nil, &res)
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return res, err
+	}
+	values := url.Values{}
+	values.Set("target", cfg.TargetOS)
+	values.Set("windowsMode", cfg.WindowsMode)
+	values.Set("class", cfg.Class)
+	values.Set("serverType", cfg.ServerType)
+	values.Set("serverTypeExplicit", strconv.FormatBool(cfg.ServerTypeExplicit))
+	values.Set("market", cfg.Capacity.Market)
+	values.Set("fallback", cfg.Capacity.Fallback)
+	values.Set("region", cfg.AWSRegion)
+	path := "/v1/providers/" + url.PathEscape(provider.Name()) + "/readiness"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	err = c.do(ctx, http.MethodGet, path, nil, &res)
 	return res, err
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -66,6 +66,39 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		}
 		fmt.Fprintf(a.Stdout, "%-7s %-8s %s\n", status, check, message)
 	}
+	recordProviderDoctorCheck := func(provider string, check DoctorCheck) {
+		status := strings.TrimSpace(check.Status)
+		if status == "" {
+			status = "ok"
+		}
+		name := strings.TrimSpace(check.Check)
+		if name == "" {
+			name = "provider"
+		}
+		message := strings.TrimSpace(check.Message)
+		details := make(map[string]string, len(check.Details)+2)
+		if message != "" {
+			for key, value := range parseDoctorDetails(message) {
+				details[key] = value
+			}
+		}
+		for key, value := range check.Details {
+			details[key] = value
+		}
+		if provider != "" && details["provider"] == "" {
+			details["provider"] = provider
+		}
+		if name == "provider" {
+			details["timeout"] = doctorProviderTimeout.String()
+			if message != "" && !strings.Contains(message, "provider=") {
+				message = fmt.Sprintf("provider=%s timeout=%s %s", provider, doctorProviderTimeout, message)
+			}
+		}
+		record(status, name, message, details)
+		if doctorStatusFails(status) {
+			ok = false
+		}
+	}
 	finish := func() error {
 		if *jsonOut {
 			if err := json.NewEncoder(a.Stdout).Encode(doctorJSONOutput{OK: ok, Provider: cfg.Provider, Checks: checks}); err != nil {
@@ -155,7 +188,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 					record("ok", "broker", fmt.Sprintf("auth=%s owner=%s org=%s default_type=%s", whoami.Auth, whoami.Owner, whoami.Org, cfg.ServerType), map[string]string{"auth": whoami.Auth, "owner": whoami.Owner, "org": whoami.Org, "default_type": cfg.ServerType})
 				}
 				if coordinatorProviderReadinessSupported(cfg.Provider) {
-					readiness, err := coord.ProviderReadiness(ctx, cfg.Provider)
+					readiness, err := coord.ProviderReadiness(ctx, cfg)
 					if err == nil {
 						if readiness.Configured {
 							record("ok", "provider", fmt.Sprintf("provider=%s coordinator_secrets=ready", readiness.Provider), map[string]string{"provider": readiness.Provider, "coordinator_secrets": "ready"})
@@ -163,6 +196,9 @@ func (a App) doctor(ctx context.Context, args []string) error {
 							hint := doctorErrorHint(readiness.Provider, "config")
 							record("failed", "provider", fmt.Sprintf("provider=%s missing=%s class=config hint=%s", readiness.Provider, strings.Join(readiness.Missing, ","), hint), map[string]string{"provider": readiness.Provider, "missing": strings.Join(readiness.Missing, ","), "class": "config", "hint": hint})
 							ok = false
+						}
+						for _, check := range readiness.Checks {
+							recordProviderDoctorCheck(readiness.Provider, check)
 						}
 					} else if !isCoordinatorNotFoundError(err) {
 						class := doctorErrorClass(err)
@@ -229,11 +265,24 @@ func (a App) doctor(ctx context.Context, args []string) error {
 				record("failed", "provider", fmt.Sprintf("provider=%s class=%s hint=%s %v", doctor.Spec().Name, class, hint, err), map[string]string{"provider": doctor.Spec().Name, "class": class, "hint": hint, "error": err.Error(), "timeout": doctorProviderTimeout.String()})
 				ok = false
 			} else {
-				message := fmt.Sprintf("provider=%s timeout=%s %s", result.Provider, doctorProviderTimeout, result.Message)
-				details := parseDoctorDetails(result.Message)
-				details["provider"] = result.Provider
-				details["timeout"] = doctorProviderTimeout.String()
-				record("ok", "provider", message, details)
+				if len(result.Checks) > 0 {
+					for _, check := range result.Checks {
+						recordProviderDoctorCheck(result.Provider, check)
+					}
+				} else {
+					status := strings.TrimSpace(result.Status)
+					if status == "" {
+						status = "ok"
+					}
+					message := fmt.Sprintf("provider=%s timeout=%s %s", result.Provider, doctorProviderTimeout, result.Message)
+					details := parseDoctorDetails(result.Message)
+					details["provider"] = result.Provider
+					details["timeout"] = doctorProviderTimeout.String()
+					record(status, "provider", message, details)
+					if doctorStatusFails(status) {
+						ok = false
+					}
+				}
 			}
 		}
 		return finish()
@@ -288,6 +337,15 @@ func parseDoctorDetails(message string) map[string]string {
 		details[key] = value
 	}
 	return details
+}
+
+func doctorStatusFails(status string) bool {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "failed", "missing":
+		return true
+	default:
+		return false
+	}
 }
 
 func doctorErrorClass(err error) string {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -90,9 +90,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 		}
 		if name == "provider" {
 			details["timeout"] = doctorProviderTimeout.String()
-			if message != "" && !strings.Contains(message, "provider=") {
-				message = fmt.Sprintf("provider=%s timeout=%s %s", provider, doctorProviderTimeout, message)
-			}
+			message = doctorProviderMessage(provider, message)
 		}
 		record(status, name, message, details)
 		if doctorStatusFails(status) {
@@ -337,6 +335,46 @@ func parseDoctorDetails(message string) map[string]string {
 		details[key] = value
 	}
 	return details
+}
+
+func doctorProviderMessage(provider, message string) string {
+	fields := strings.Fields(message)
+	if len(fields) == 0 {
+		return ""
+	}
+	hasProvider := false
+	hasTimeout := false
+	for _, field := range fields {
+		key, _, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "provider":
+			hasProvider = true
+		case "timeout":
+			hasTimeout = true
+		}
+	}
+	if !hasProvider && provider != "" {
+		fields = append([]string{fmt.Sprintf("provider=%s", provider)}, fields...)
+		hasProvider = true
+	}
+	if !hasTimeout {
+		timeoutField := fmt.Sprintf("timeout=%s", doctorProviderTimeout)
+		insert := 0
+		if hasProvider {
+			for i, field := range fields {
+				key, _, ok := strings.Cut(field, "=")
+				if ok && key == "provider" {
+					insert = i + 1
+					break
+				}
+			}
+		}
+		fields = append(fields[:insert], append([]string{timeoutField}, fields[insert:]...)...)
+	}
+	return strings.Join(fields, " ")
 }
 
 func doctorStatusFails(status string) bool {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os/exec"
 	"path/filepath"
 	"slices"
@@ -160,6 +161,71 @@ func TestDoctorJSONCoordinatorOutput(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("provider readiness missing from JSON: %#v", view.Checks)
+	}
+}
+
+func TestDoctorJSONCoordinatorOutputIncludesCapacityWarnings(t *testing.T) {
+	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+
+	var readinessQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			_ = json.NewEncoder(w).Encode(CoordinatorWhoami{Auth: "token", Owner: "alice@example.test", Org: "example-org"})
+		case "/v1/providers/aws/readiness":
+			readinessQuery = r.URL.Query()
+			_ = json.NewEncoder(w).Encode(CoordinatorProviderReadiness{
+				Provider:   "aws",
+				Configured: true,
+				Checks: []DoctorCheck{{
+					Status:  "warning",
+					Check:   "capacity",
+					Message: "provider=aws capacity=quota_pressure market=spot recommended_class=standard",
+					Details: map[string]string{"provider": "aws", "market": "spot", "recommended_class": "standard"},
+				}},
+			})
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "aws", "--json"})
+	if err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if readinessQuery.Get("class") != "beast" || readinessQuery.Get("serverType") != "c7a.48xlarge" {
+		t.Fatalf("readiness query=%s, want default AWS class/type", readinessQuery.Encode())
+	}
+	var view doctorJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
+	}
+	if !view.OK {
+		t.Fatalf("capacity warning should not fail doctor: %#v", view)
+	}
+	found := false
+	for _, check := range view.Checks {
+		if check.Check == "capacity" && check.Status == "warning" && check.Details["recommended_class"] == "standard" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("capacity warning missing from JSON: %#v", view.Checks)
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -113,6 +113,38 @@ func TestDoctorRunsDirectProviderCheckForCoordinatorNeverProvider(t *testing.T) 
 	}
 }
 
+func TestDoctorDirectProviderCheckIncludesTimeoutWhenMessageHasProvider(t *testing.T) {
+	for _, tool := range doctorLocalTools(testCloudflareProvider{}.Spec()) {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	testCloudflareDoctorResult = &DoctorResult{
+		Provider: "cloudflare",
+		Checks: []DoctorCheck{{
+			Status:  "ok",
+			Check:   "provider",
+			Message: "provider=cloudflare direct_check=ready",
+			Details: map[string]string{"provider": "cloudflare"},
+		}},
+	}
+	defer func() { testCloudflareDoctorResult = nil }()
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "cloudflare"})
+	if err != nil {
+		t.Fatalf("doctor error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "ok      provider provider=cloudflare timeout=10s direct_check=ready") {
+		t.Fatalf("doctor provider check did not include timeout: %q", stdout.String())
+	}
+}
+
 func TestDoctorJSONCoordinatorOutput(t *testing.T) {
 	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
 		if _, err := exec.LookPath(tool); err != nil {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -162,6 +162,15 @@ type DoctorRequest struct {
 type DoctorResult struct {
 	Provider string
 	Message  string
+	Status   string
+	Checks   []DoctorCheck
+}
+
+type DoctorCheck struct {
+	Status  string            `json:"status"`
+	Check   string            `json:"check"`
+	Message string            `json:"message,omitempty"`
+	Details map[string]string `json:"details,omitempty"`
 }
 
 func InventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -582,6 +582,8 @@ func (p testModalProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 
 type testCloudflareProvider struct{}
 
+var testCloudflareDoctorResult *DoctorResult
+
 func (testCloudflareProvider) Name() string { return "cloudflare" }
 func (testCloudflareProvider) Aliases() []string {
 	return []string{"cf"}
@@ -774,6 +776,9 @@ type testDoctorDelegatedBackend struct {
 }
 
 func (b testDoctorDelegatedBackend) Doctor(context.Context, DoctorRequest) (DoctorResult, error) {
+	if testCloudflareDoctorResult != nil {
+		return *testCloudflareDoctorResult, nil
+	}
 	return DoctorResult{Provider: b.spec.Name, Message: "direct_check=ready"}, nil
 }
 

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -127,12 +127,27 @@ func (b *awsLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseVie
 }
 
 func (b *awsLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	client, err := newAWSClient(ctx, b.Cfg)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
 	result := core.InventoryDoctorResult("aws", len(servers))
 	result.Message += fmt.Sprintf(" region=%s default_type=%s", b.Cfg.AWSRegion, b.Cfg.ServerType)
+	result.Checks = append(result.Checks, core.DoctorCheck{
+		Status:  "ok",
+		Check:   "provider",
+		Message: result.Message,
+		Details: map[string]string{
+			"provider":     "aws",
+			"region":       b.Cfg.AWSRegion,
+			"default_type": b.Cfg.ServerType,
+		},
+	})
+	result.Checks = append(result.Checks, client.CapacityDoctorChecks(ctx, b.Cfg)...)
 	return result, nil
 }
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -99,6 +99,13 @@ export interface AWSServiceQuota {
   unit?: string;
 }
 
+export interface AWSCapacityReadinessCheck {
+  status: "ok" | "skip" | "warning";
+  check: "capacity";
+  message: string;
+  details: Record<string, string>;
+}
+
 export interface AWSIdentity {
   account: string;
   arn: string;
@@ -208,6 +215,19 @@ export class EC2SpotClient {
     this.aws = new AwsClient(clientOptions);
     this.serviceQuotas = new AwsClient({ ...clientOptions, service: "servicequotas" });
     this.stsClient = new AwsClient({ ...clientOptions, service: "sts" });
+  }
+
+  async capacityReadinessChecks(config: LeaseConfig): Promise<AWSCapacityReadinessCheck[]> {
+    if (config.target === "macos") {
+      return [];
+    }
+    return await Promise.all(
+      awsCapacityReadinessMarkets(config).map(async (market) => {
+        const code = awsQuotaCodeForMarket(market);
+        const quota = await this.appliedServiceQuota(code);
+        return awsCapacityReadinessCheckForQuota(config, market, this.region, quota);
+      }),
+    );
   }
 
   async identity(): Promise<AWSIdentity> {
@@ -1914,6 +1934,116 @@ export function awsQuotaPreflightAttempt(
     category: "quota",
     message: `quota ${quotaCode} in ${region} is ${quotaValue} vCPUs; ${serverType} needs ${needed} vCPUs`,
   };
+}
+
+type AWSCapacityReadinessConfig = Pick<
+  LeaseConfig,
+  "target" | "windowsMode" | "class" | "serverType" | "capacityMarket" | "capacityFallback"
+>;
+
+export function awsCapacityReadinessCheckForQuota(
+  config: AWSCapacityReadinessConfig,
+  market: string,
+  region: string,
+  quotaValue: number | undefined,
+): AWSCapacityReadinessCheck {
+  const quotaCode = awsQuotaCodeForMarket(market);
+  const needed = awsInstanceTypeVCPUs(config.serverType);
+  const details: Record<string, string> = {
+    provider: "aws",
+    market,
+    region,
+    quota_code: quotaCode,
+    default_class: config.class,
+    default_type: config.serverType,
+    default_needed_vcpus: String(needed ?? 0),
+  };
+  if (quotaValue === undefined) {
+    details["hint"] = "servicequotas_unavailable_or_forbidden";
+    return {
+      status: "skip",
+      check: "capacity",
+      message: awsCapacityReadinessMessage("provider=aws capacity=unknown", details),
+      details,
+    };
+  }
+  details["limit_vcpus"] = String(Math.trunc(quotaValue));
+  if (!needed) {
+    details["hint"] = "unknown_instance_vcpus";
+    return {
+      status: "skip",
+      check: "capacity",
+      message: awsCapacityReadinessMessage("provider=aws capacity=unknown", details),
+      details,
+    };
+  }
+  if (quotaValue < needed) {
+    const recommendation = awsRecommendedClassForQuota(config, Math.trunc(quotaValue));
+    if (recommendation) {
+      details["recommended_class"] = recommendation.machineClass;
+      details["recommended_type"] = recommendation.serverType;
+    }
+    details["hint"] = "lower_class_or_request_quota";
+    return {
+      status: "warning",
+      check: "capacity",
+      message: awsCapacityReadinessMessage("provider=aws capacity=quota_pressure", details),
+      details,
+    };
+  }
+  details["hint"] = "quota_satisfies_default_class";
+  return {
+    status: "ok",
+    check: "capacity",
+    message: awsCapacityReadinessMessage("provider=aws capacity=ready", details),
+    details,
+  };
+}
+
+function awsCapacityReadinessMarkets(config: AWSCapacityReadinessConfig): string[] {
+  const markets = [config.capacityMarket || "spot"];
+  if (config.capacityMarket === "spot" && config.capacityFallback.startsWith("on-demand")) {
+    markets.push("on-demand");
+  }
+  return uniqueStrings(markets);
+}
+
+function awsCapacityReadinessMessage(prefix: string, details: Record<string, string>): string {
+  const suffix = Object.entries(details)
+    .filter(([key, value]) => key !== "provider" && value)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value.replaceAll(" ", "_")}`)
+    .join(" ");
+  return suffix ? `${prefix} ${suffix}` : prefix;
+}
+
+function awsRecommendedClassForQuota(
+  config: Pick<LeaseConfig, "target" | "windowsMode">,
+  limitVCPUs: number,
+): { machineClass: string; serverType: string } | undefined {
+  if (limitVCPUs <= 0) {
+    return undefined;
+  }
+  for (const machineClass of ["beast", "large", "fast", "standard"]) {
+    const [serverType] = awsInstanceTypeCandidatesForTargetClass(
+      config.target,
+      machineClass,
+      config.windowsMode,
+    );
+    if (serverType && (awsInstanceTypeVCPUs(serverType) ?? 0) <= limitVCPUs) {
+      return { machineClass, serverType };
+    }
+  }
+  for (const serverType of awsInstanceTypeCandidatesForTargetClass(
+    config.target,
+    "standard",
+    config.windowsMode,
+  )) {
+    if ((awsInstanceTypeVCPUs(serverType) ?? 0) <= limitVCPUs) {
+      return { machineClass: "standard", serverType };
+    }
+  }
+  return undefined;
 }
 
 function uniqueStrings(values: string[]): string[] {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -70,6 +70,7 @@ import type {
   TestFailure,
   TestResultSummary,
   TailscaleMetadata,
+  WindowsMode,
 } from "./types";
 import { costLimits, enforceCostLimits, leaseCost, requestOrg, usageSummary } from "./usage";
 
@@ -386,7 +387,7 @@ export class FleetDurableObject implements DurableObject {
         parts[2] &&
         parts[3] === "readiness"
       ) {
-        return this.providerReadiness(parts[2]);
+        return await this.providerReadiness(request, parts[2]);
       }
       if (method === "GET" && parts.join("/") === "v1/control") {
         return await this.controlSocket(request);
@@ -1359,14 +1360,22 @@ export class FleetDurableObject implements DurableObject {
     });
   }
 
-  private providerReadiness(provider: string): Response {
+  private async providerReadiness(request: Request, provider: string): Promise<Response> {
     if (!isManagedProvider(provider)) {
       return json(
         { error: "invalid_provider", message: `unsupported provider: ${provider}` },
         { status: 400 },
       );
     }
-    return json(this.providerConfigurationReadiness(provider));
+    const url = new URL(request.url);
+    const readiness = this.providerConfigurationReadiness(
+      provider,
+      url.searchParams.get("gcpProject") ?? undefined,
+    );
+    if (provider === "aws" && readiness.configured && !this.testProviders.aws) {
+      readiness.checks = await this.awsProviderCapacityChecks(url.searchParams);
+    }
+    return json(readiness);
   }
 
   private providerConfigurationReadiness(
@@ -1382,6 +1391,42 @@ export class FleetDurableObject implements DurableObject {
       };
     }
     return providerReadiness(provider, this.env, gcpProject);
+  }
+
+  private async awsProviderCapacityChecks(
+    params: URLSearchParams,
+  ): Promise<ProviderReadinessCheck[]> {
+    const capacity: NonNullable<LeaseRequest["capacity"]> = {};
+    const market = normalizeReadinessMarket(params.get("market"));
+    if (market) {
+      capacity.market = market;
+    }
+    const fallback = params.get("fallback");
+    if (fallback) {
+      capacity.fallback = fallback;
+    }
+    const leaseRequest: LeaseRequest = {
+      provider: "aws",
+      target: normalizeReadinessTarget(params.get("target")),
+      windowsMode: normalizeReadinessWindowsMode(params.get("windowsMode")),
+      serverTypeExplicit: params.get("serverTypeExplicit") === "true",
+      capacity,
+      sshPublicKey: readinessDummySSHPublicKey,
+    };
+    const className = params.get("class");
+    if (className) {
+      leaseRequest.class = className;
+    }
+    const serverType = params.get("serverType") || params.get("type");
+    if (serverType) {
+      leaseRequest.serverType = serverType;
+    }
+    const region = params.get("region");
+    if (region) {
+      leaseRequest.awsRegion = region;
+    }
+    const config = leaseConfig(leaseRequest);
+    return await new EC2SpotClient(this.env, config.awsRegion).capacityReadinessChecks(config);
   }
 
   private async portalRoute(request: Request, parts: string[]): Promise<Response> {
@@ -4547,6 +4592,14 @@ interface ProviderReadiness {
   configured: boolean;
   missing: string[];
   message: string;
+  checks?: ProviderReadinessCheck[];
+}
+
+interface ProviderReadinessCheck {
+  status: string;
+  check: string;
+  message?: string;
+  details?: Record<string, string>;
 }
 
 function providerReadiness(provider: Provider, env: Env, gcpProject?: string): ProviderReadiness {
@@ -4579,6 +4632,24 @@ function providerReadiness(provider: Provider, env: Env, gcpProject?: string): P
         ? `${provider} coordinator secrets are configured`
         : `${provider} coordinator secrets missing: ${missing.join(", ")}`,
   };
+}
+
+const readinessDummySSHPublicKey =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEcrabboxDoctorReadinessPlaceholder crabbox-doctor";
+
+function normalizeReadinessTarget(value: string | null): TargetOS {
+  return value === "windows" || value === "macos" ? value : "linux";
+}
+
+function normalizeReadinessWindowsMode(value: string | null): WindowsMode {
+  return value === "wsl2" ? "wsl2" : "normal";
+}
+
+function normalizeReadinessMarket(value: string | null): "spot" | "on-demand" | undefined {
+  if (value === "spot" || value === "on-demand") {
+    return value;
+  }
+  return undefined;
 }
 
 function providerRequiredSecrets(provider: Provider): Array<keyof Env> {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -5,6 +5,7 @@ import {
   addRunInstancesTagSpecifications,
   applyAWSRunInstanceTargetOptions,
   awsAvailabilityZoneForRegion,
+  awsCapacityReadinessCheckForQuota,
   awsInstanceTypeVCPUs,
   awsHostIDsFromSet,
   awsLaunchCandidates,
@@ -88,6 +89,66 @@ describe("aws provider", () => {
       { cidr: "203.0.113.10/32", family: "ipv4", port: "2222" },
       { cidr: "2001:db8::1/128", family: "ipv6", port: "2222" },
     ]);
+  });
+
+  it("turns low AWS vCPU quota into a doctor readiness warning", () => {
+    const check = awsCapacityReadinessCheckForQuota(
+      {
+        target: "linux",
+        windowsMode: "normal",
+        class: "beast",
+        serverType: "c7a.48xlarge",
+        capacityMarket: "spot",
+        capacityFallback: "on-demand-after-120s",
+      },
+      "spot",
+      "eu-west-1",
+      32,
+    );
+
+    expect(check).toMatchObject({
+      status: "warning",
+      check: "capacity",
+      details: {
+        provider: "aws",
+        market: "spot",
+        quota_code: "L-34B43A08",
+        default_needed_vcpus: "192",
+        recommended_class: "standard",
+        recommended_type: "c7a.8xlarge",
+        hint: "lower_class_or_request_quota",
+      },
+    });
+    expect(check.message).toContain("capacity=quota_pressure");
+  });
+
+  it("skips AWS vCPU quota readiness when quota cannot be inspected", () => {
+    const check = awsCapacityReadinessCheckForQuota(
+      {
+        target: "linux",
+        windowsMode: "normal",
+        class: "beast",
+        serverType: "c7a.48xlarge",
+        capacityMarket: "spot",
+        capacityFallback: "on-demand-after-120s",
+      },
+      "spot",
+      "eu-west-1",
+      undefined,
+    );
+
+    expect(check).toMatchObject({
+      status: "skip",
+      check: "capacity",
+      details: {
+        provider: "aws",
+        market: "spot",
+        quota_code: "L-34B43A08",
+        default_needed_vcpus: "192",
+        hint: "servicequotas_unavailable_or_forbidden",
+      },
+    });
+    expect(check.message).toContain("capacity=unknown");
   });
 
   it("selects stale Crabbox SSH ingress rules before adding the current source CIDR", () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -5865,6 +5865,56 @@ describe("fleet identity", () => {
     });
   });
 
+  it("reports AWS capacity quota readiness before a lease is requested", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const awsRequest = input instanceof Request ? input : new Request(input, init);
+        expect(new URL(awsRequest.url).hostname).toBe("servicequotas.eu-west-1.amazonaws.com");
+        expect(awsRequest.headers.get("x-amz-target")).toBe(
+          "ServiceQuotasV20190624.GetServiceQuota",
+        );
+        return new Response(JSON.stringify({ Quota: { Value: 32 } }), {
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+    const fleet = testFleet(
+      undefined,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "test",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    const response = await fleet.fetch(
+      request(
+        "GET",
+        "/v1/providers/aws/readiness?target=linux&class=beast&serverType=c7a.48xlarge&market=spot&fallback=on-demand-after-120s&region=eu-west-1",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      checks?: Array<{ status: string; details: Record<string, string> }>;
+    };
+    expect(body.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "warning",
+          details: expect.objectContaining({
+            market: "spot",
+            default_needed_vcpus: "192",
+            recommended_class: "standard",
+            recommended_type: "c7a.8xlarge",
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("fails brokered Azure leases with provider_not_configured before constructing Azure", async () => {
     const fleet = testFleet();
     const response = await fleet.fetch(


### PR DESCRIPTION
## Summary

- extend existing AWS provider doctor readiness with non-mutating EC2 Spot and On-Demand vCPU Service Quotas checks
- surface confirmed quota pressure as advisory capacity warnings with the quota code, applied limit, default vCPU requirement, and recommended class/type; unreadable Service Quotas are skipped as `capacity=unknown`
- preserve the `timeout=10s` text field for direct provider doctor checks that already include a `provider=...` field
- return brokered AWS readiness capacity checks from the Worker and document `crabbox doctor --provider aws` as the pre-warmup check for new or unfunded AWS accounts

## Verification

- `go test ./...`
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `bin/crabbox doctor --provider aws --json` exited 0 and reported advisory Spot and On-Demand quota pressure with recommended class/type fallbacks

Redacted excerpt from the latest doctor run:

```json
{
  "ok": true,
  "provider": "aws",
  "checks": [
    {
      "status": "ok",
      "check": "provider",
      "provider": "aws",
      "message": "provider=aws coordinator_secrets=ready",
      "details": {
        "coordinator_secrets": "ready",
        "provider": "aws"
      }
    },
    {
      "status": "warning",
      "check": "capacity",
      "provider": "aws",
      "message": "provider=aws capacity=quota_pressure default_class=beast default_needed_vcpus=192 default_type=c7a.48xlarge hint=lower_class_or_request_quota limit_vcpus=32 market=spot quota_code=L-34B43A08 recommended_class=standard recommended_type=c7a.8xlarge region=eu-west-1",
      "details": {
        "capacity": "quota_pressure",
        "default_class": "beast",
        "default_needed_vcpus": "192",
        "default_type": "c7a.48xlarge",
        "hint": "lower_class_or_request_quota",
        "limit_vcpus": "32",
        "market": "spot",
        "provider": "aws",
        "quota_code": "L-34B43A08",
        "recommended_class": "standard",
        "recommended_type": "c7a.8xlarge",
        "region": "eu-west-1"
      }
    },
    {
      "status": "warning",
      "check": "capacity",
      "provider": "aws",
      "message": "provider=aws capacity=quota_pressure default_class=beast default_needed_vcpus=192 default_type=c7a.48xlarge hint=lower_class_or_request_quota limit_vcpus=16 market=on-demand quota_code=L-1216C47A recommended_class=standard recommended_type=c7a.4xlarge region=eu-west-1",
      "details": {
        "capacity": "quota_pressure",
        "default_class": "beast",
        "default_needed_vcpus": "192",
        "default_type": "c7a.48xlarge",
        "hint": "lower_class_or_request_quota",
        "limit_vcpus": "16",
        "market": "on-demand",
        "provider": "aws",
        "quota_code": "L-1216C47A",
        "recommended_class": "standard",
        "recommended_type": "c7a.4xlarge",
        "region": "eu-west-1"
      }
    }
  ]
}
```

`exit=0`

- `git diff --check`

## Notes

- Brokered AWS already preflights quota during provisioning; this PR surfaces the same signal earlier in doctor without creating provider resources.
- `warmup` does not run doctor automatically.
- No new user secret is required; AWS Service Quotas reads use the existing provider credentials/policy surface.
