### PR TITLE
chore: cross-tool MCP scoping + portfolio health hardening

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,16 @@
+[mcp_servers.context7]
+type = "http"
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.fetch]
+type = "stdio"
+command = "uvx"
+args = ["mcp-server-fetch"]
+
+[mcp_servers.github]
+type = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "${GITHUB_PERSONAL_ACCESS_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,14 +1,11 @@
 [mcp_servers.context7]
-type = "http"
 url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.fetch]
-type = "stdio"
 command = "uvx"
 args = ["mcp-server-fetch"]
 
 [mcp_servers.github]
-type = "stdio"
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-github"]
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules/
 .wrangler/
 *.test
 coverage.out
+*.backup-*
+.env
+.dev.vars

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/mcp.json",
+  "mcpServers": {
+    "context7": {"type": "http", "url": "https://mcp.context7.com/mcp"},
+    "fetch": {"type": "stdio", "command": "uvx", "args": ["mcp-server-fetch"]},
+    "github": {
+      "type": "stdio", "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.18.0",
   "description": "OpenClaw plugin for running Crabbox remote testbox workflows",
   "license": "MIT",
+  "private": true,
   "type": "module",
   "main": "index.js",
   "openclaw": {


### PR DESCRIPTION
## Summary
- Adds .mcp.json with portable env-var stanzas (context7, fetch, github)
- Adds .codex/config.toml with matching Codex overlay
- Adds .codex/AGENTS.md symlink -> ../AGENTS.md
- Patches .gitignore (*.backup-*, .env, .dev.vars)
- Adds "private": true to package.json

Part of cross-tool MCP scoping rollout (see SECURITY_TOKEN_ROTATION_2026-05-25 + MCP_PORTFOLIO_DASHBOARD docs in home-agent-config).

Note: Submitted from fork (LDMB123/crabbox) due to read-only org perms. Merge when convenient.

Generated with [Claude Code](https://claude.com/claude-code)