### PR TITLE
fix: retry stale coordinator lease before command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed coordinator-backed AWS SSH ingress so active lease source CIDRs are preserved through provider-owned access reconciliation instead of core AWS special cases. Thanks @obviyus.
+- Fixed coordinator-backed one-shot runs to replace a lease once when SSH drops after sync but before the command starts, stopping the stale lease and retrying sync on the replacement.
 - Fixed Linux desktop theme setup so WebVNC sessions install and prefer native Arc-Dark/other dark XFCE themes instead of custom-painting panel and window chrome.
 - Fixed Linux WebVNC desktop sessions so they follow the portal light/dark toggle and system theme changes after the remote desktop has already connected.
 - Fixed run failure summaries and timing JSON to classify likely blocked stages, redact known HTML auth challenge bodies from failure excerpts, and reject unsupported Blacksmith environment forwarding before warmup.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -35,7 +35,7 @@ crabbox run --provider ssh --target windows --windows-mode wsl2 --static-host wi
 crabbox run --profile live-qa --preset qa-live --scenario login-regression --emit-proof /tmp/proof.md --stop-after success
 ```
 
-If `--id` is omitted, Crabbox creates a fresh non-kept lease and releases it when the command exits. `--id` accepts the stable `cbx_...` ID or the active friendly slug.
+If `--id` is omitted, Crabbox creates a fresh non-kept lease and releases it when the command exits. On coordinator-backed one-shot runs, if SSH becomes unavailable after a successful sync but before the command starts, Crabbox stops that stale lease, creates one replacement lease, and retries sync once. It does not replace explicit `--id`, kept, `--keep-on-failure`, `--no-sync`, `--sync-only`, or custom-slug runs. `--id` accepts the stable `cbx_...` ID or the active friendly slug.
 
 With `--provider blacksmith-testbox`, `--id` accepts a Blacksmith `tbx_...` ID or a local Crabbox slug. Crabbox forwards the command to `blacksmith testbox run`, delegates sync to Blacksmith, and prints `sync=delegated` in the final timing summary.
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -541,6 +541,19 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			return recordFailure(err)
 		}
 	}
+	var stopHeartbeat func()
+	stopRunHeartbeat := func() {
+		if stopHeartbeat == nil {
+			return
+		}
+		stopHeartbeat()
+		stopHeartbeat = nil
+	}
+	defer stopRunHeartbeat()
+	startRunHeartbeat := func(updateIdleTimeout *time.Duration) {
+		stopRunHeartbeat()
+		stopHeartbeat = startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.IdleTimeout, updateIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
+	}
 	if useCoordinator && leaseID != "" {
 		var heartbeatIdleTimeout *time.Duration
 		if *leaseIDFlag != "" && flagWasSet(fs, "idle-timeout") {
@@ -551,8 +564,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 				return recordFailure(err)
 			}
 		}
-		stopHeartbeat := startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.IdleTimeout, heartbeatIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
-		defer stopHeartbeat()
+		startRunHeartbeat(heartbeatIdleTimeout)
 	}
 
 	if cfg.Sync.BaseRef == "" {
@@ -681,6 +693,78 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		fmt.Fprintf(a.Stderr, "using local Actions workspace %s\n", workdir)
 		return nil
 	}
+	beforeCommandLeaseReplacementAttempted := false
+	replaceLeaseAfterBeforeCommandSSHFailure := func(waitErr error) (bool, error) {
+		if beforeCommandLeaseReplacementAttempted ||
+			!shouldReplaceLeaseAfterBeforeCommandSSHFailure(waitErr, acquired, useCoordinator, *leaseIDFlag != "", *keep, *keepOnFailure, *noSync, *syncOnly, *stopAfter, requestedSlug) {
+			return false, nil
+		}
+		beforeCommandLeaseReplacementAttempted = true
+		oldLease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
+		oldLeaseID := leaseID
+		oldSlug := serverSlug(server)
+		fmt.Fprintf(a.Stderr, "warning: SSH became unavailable after sync on lease=%s slug=%s; replacing lease once and retrying sync\n", oldLeaseID, blank(oldSlug, "-"))
+		recorder.Event("lease.replace.started", "leasing", fmt.Sprintf("old_lease=%s old_slug=%s reason=ssh_before_command", oldLeaseID, blank(oldSlug, "-")))
+
+		stopRunHeartbeat()
+		recorder.resetTelemetryForLeaseReplacement()
+		releaseApp := a
+		if *timingJSON {
+			releaseApp.Stderr = io.Discard
+		}
+		if err := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, oldLease); err != nil {
+			recorder.Event("lease.replace.failed", "leasing", err.Error())
+			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, err)
+		}
+		acquired = false
+
+		newLease, err := sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim})
+		if err != nil {
+			recorder.Event("lease.replace.failed", "leasing", err.Error())
+			return true, err
+		}
+
+		server, target, leaseID = newLease.Server, newLease.SSH, newLease.LeaseID
+		acquired = true
+		coord = newLease.Coordinator
+		useCoordinator = coord != nil
+		applyResolvedServerConfig(&cfg, server)
+		if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
+			return true, err
+		}
+		if err := validateRunArtifactGlobTarget(target, expansion.ArtifactGlobs); err != nil {
+			return true, err
+		}
+		if expansion.Profile.Doctor.Enabled && isWindowsNativeTarget(target) {
+			return true, exit(2, "profile doctor is not supported for native Windows targets")
+		}
+		if useCoordinator {
+			recorder.AttachLease(leaseID, serverSlug(server), cfg)
+			startRunHeartbeat(nil)
+		}
+		if err := claimLeaseForRepoConfig(leaseID, serverSlug(server), cfg, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+			return true, err
+		}
+		workdir = remoteJoin(cfg, leaseID, repo.Name)
+		if !freshPR.Empty() {
+			workdir = remoteJoin(cfg, leaseID, freshPR.WorkdirName())
+		}
+		actionsEnvFile = ""
+		profileEnvFile = ""
+		actionsURL = ""
+		hydratedByActions = false
+		contextPrinted = false
+		preflightPrinted = false
+		rawJSRuntimePreflightDone = false
+		exitNodeEgressChecked = false
+		timings.sync = 0
+		timings.syncSteps = syncStepTimings{}
+		timings.syncSkipped = false
+		fmt.Fprintf(a.Stderr, "retrying sync on replacement lease=%s slug=%s\n", leaseID, blank(serverSlug(server), "-"))
+		recorder.Event("lease.replace.finished", "leasing", fmt.Sprintf("lease=%s slug=%s", leaseID, blank(serverSlug(server), "-")))
+		return true, nil
+	}
+retrySync:
 	if !*noSync {
 		syncStart := time.Now()
 		if freshPR.Empty() {
@@ -899,6 +983,13 @@ afterSync:
 	recorder.Event("bootstrap.waiting", "bootstrap", "waiting for SSH before command")
 	target = bootstrapNetworkTarget(cfg, server, target)
 	if err := waitForSSHReady(ctx, &target, a.Stderr, "before command", 2*time.Minute); err != nil {
+		replaced, replaceErr := replaceLeaseAfterBeforeCommandSSHFailure(err)
+		if replaceErr != nil {
+			return recordFailure(replaceErr)
+		}
+		if replaced {
+			goto retrySync
+		}
 		return recordFailure(err)
 	}
 	a.refreshTailscaleMetadata(ctx, cfg, coord, useCoordinator, &server, target, leaseID)
@@ -1993,6 +2084,19 @@ func isBootstrapWaitError(err error) bool {
 
 func IsBootstrapWaitError(err error) bool {
 	return isBootstrapWaitError(err)
+}
+
+func shouldReplaceLeaseAfterBeforeCommandSSHFailure(err error, acquired, useCoordinator, explicitLeaseID, keep, keepOnFailure, noSync, syncOnly bool, stopAfter, requestedSlug string) bool {
+	if !isBootstrapWaitError(err) ||
+		!acquired ||
+		!useCoordinator ||
+		explicitLeaseID ||
+		noSync ||
+		syncOnly ||
+		strings.TrimSpace(requestedSlug) != "" {
+		return false
+	}
+	return shouldReleaseRunLease(acquired, keep, keepOnFailure, stopAfter, err)
 }
 
 func releaseCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leaseID string) error {

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -266,6 +266,17 @@ func (r *runRecorder) stopTelemetrySampler() {
 	}
 }
 
+func (r *runRecorder) resetTelemetryForLeaseReplacement() {
+	if r == nil {
+		return
+	}
+	r.stopTelemetrySampler()
+	r.telemetryMu.Lock()
+	r.telemetryStart = nil
+	r.telemetrySamples = nil
+	r.telemetryMu.Unlock()
+}
+
 func (r *runRecorder) waitForOutputEvents(timeout time.Duration) {
 	if r == nil || r.output == nil {
 		return

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -234,6 +234,32 @@ func TestRunRecorderFinishUsesExtendedTimeout(t *testing.T) {
 	}
 }
 
+func TestRunRecorderResetTelemetryForLeaseReplacement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(done)
+	}()
+	rec := &runRecorder{
+		telemetryStart:   &LeaseTelemetry{CapturedAt: "2026-05-02T00:00:00Z"},
+		telemetrySamples: []*LeaseTelemetry{{CapturedAt: "2026-05-02T00:00:01Z"}},
+		telemetryCancel:  cancel,
+		telemetryDone:    done,
+	}
+
+	rec.resetTelemetryForLeaseReplacement()
+
+	if rec.telemetryStart != nil || rec.telemetryCancel != nil || rec.telemetryDone != nil || len(rec.telemetrySamples) != 0 {
+		t.Fatalf("telemetry not reset: %#v", rec)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("telemetry sampler was not stopped")
+	}
+}
+
 type blockingRoundTripper struct {
 	started chan struct{}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -195,6 +195,46 @@ func TestFormatRunSummaryNoSync(t *testing.T) {
 	}
 }
 
+func TestShouldReplaceLeaseAfterBeforeCommandSSHFailure(t *testing.T) {
+	waitErr := exit(5, "timed out waiting for SSH on 203.0.113.10 during before command")
+	otherErr := exit(6, "rsync failed")
+	tests := []struct {
+		name            string
+		err             error
+		acquired        bool
+		useCoordinator  bool
+		explicitLeaseID bool
+		keep            bool
+		keepOnFailure   bool
+		noSync          bool
+		syncOnly        bool
+		stopAfter       string
+		requestedSlug   string
+		want            bool
+	}{
+		{name: "fresh coordinator one shot", err: waitErr, acquired: true, useCoordinator: true, want: true},
+		{name: "wrong error", err: otherErr, acquired: true, useCoordinator: true},
+		{name: "direct backend", err: waitErr, acquired: true},
+		{name: "existing lease", err: waitErr, acquired: true, useCoordinator: true, explicitLeaseID: true},
+		{name: "kept lease", err: waitErr, acquired: true, useCoordinator: true, keep: true},
+		{name: "keep on failure", err: waitErr, acquired: true, useCoordinator: true, keepOnFailure: true},
+		{name: "no sync", err: waitErr, acquired: true, useCoordinator: true, noSync: true},
+		{name: "sync only", err: waitErr, acquired: true, useCoordinator: true, syncOnly: true},
+		{name: "custom slug", err: waitErr, acquired: true, useCoordinator: true, requestedSlug: "qa-smoke"},
+		{name: "stop after failure", err: waitErr, acquired: true, useCoordinator: true, stopAfter: "failure", want: true},
+		{name: "stop after success", err: waitErr, acquired: true, useCoordinator: true, stopAfter: "success"},
+		{name: "stop after never", err: waitErr, acquired: true, useCoordinator: true, stopAfter: "never"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldReplaceLeaseAfterBeforeCommandSSHFailure(tt.err, tt.acquired, tt.useCoordinator, tt.explicitLeaseID, tt.keep, tt.keepOnFailure, tt.noSync, tt.syncOnly, tt.stopAfter, tt.requestedSlug)
+			if got != tt.want {
+				t.Fatalf("shouldReplaceLeaseAfterBeforeCommandSSHFailure()=%t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTimingJSONShape(t *testing.T) {
 	var buf bytes.Buffer
 	err := writeTimingJSON(&buf, timingReportFromRun("aws", "cbx_123", "blue-crab", runTimings{


### PR DESCRIPTION
## Summary
- Replace a coordinator-backed one-shot lease once when SSH drops after sync but before the command starts.
- Release the stale lease before acquiring the replacement so coordinator active-lease and budget limits are respected.
- Reset coordinator heartbeat, run telemetry, workspace state, and sync timing before retrying sync on the replacement lease.
- Document the bounded retry behavior and add changelog coverage.

## Verification
- `go test ./internal/cli`
- `go test ./...`
- `npm run docs:check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` (clean)
