### PR TITLE
refactor(worker): route provider behavior through capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Crabbox is a generic remote software testing and execution tool. New code, docs,
 
 ## Architecture Boundaries
 
-Keep core provider-neutral. Core may pass generic context such as request source CIDRs, active leases, lease state, and provision hooks; provider-specific reconciliation, firewall/security-group semantics, labels, snapshots, hosts, regions, and rollout compatibility live behind provider adapters. Do not add `provider == aws/gcp/...` logic in core unless it is unavoidable routing glue and no provider hook fits.
+Keep core provider-neutral. Core may pass generic request/lease context and call provider capabilities for defaults, access, provision, images, release, cleanup, and diagnostics. Provider-specific reconciliation, firewall/security-group semantics, labels, snapshots, hosts, regions, rollout compatibility, and resource naming live behind provider adapters. No `provider == aws/gcp/...` logic in core unless it is unavoidable routing/config glue and no provider hook fits.
 
 ## Build, Test, and Development Commands
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -10,13 +10,15 @@ Core can pass generic context into providers:
 - active lease records
 - normalized lease config
 - provider-neutral lease metadata
-- provisioning and cleanup lifecycle hooks
+- provider capability hooks for defaults, access, provisioning, native images, release, cleanup, and diagnostics
 
 Providers must own provider-specific policy:
 
 - firewall and security-group reconciliation
-- host, region, zone, subnet, and image selection
+- host, region, zone, subnet, and default image selection
+- native image creation, lookup, promotion, deletion, and provider image metadata
 - labels, tags, and orphan-detection details
+- resource names and provider API identifiers
 - rollout compatibility for provider-owned state
 - provider API retry and partial-failure behavior
 
@@ -25,3 +27,13 @@ For example, core should not know that AWS SSH access is a shared security group
 ## Design Rule
 
 When a fix needs a provider-specific branch in core, first add or reuse a provider hook. A small provider-neutral hook is usually cleaner than spreading `provider == ...` branches through lease, heartbeat, run, status, or cleanup paths. Provider-specific fields may remain in public config for compatibility, but persisted coordinator state should prefer provider-neutral metadata when the concept applies across providers.
+
+The healthy shape is:
+
+- core validates generic request shape, authorizes the caller, enforces cost limits, persists lease records, and schedules cleanup
+- provider adapters resolve provider defaults before readiness checks need them
+- provider adapters finalize provider-owned lease metadata after provisioning
+- provider adapters own release cleanup, including auxiliary keys or API resources
+- image and checkpoint routes dispatch by capability instead of encoding AWS, Azure, or GCP behavior inline
+
+Provider names may still appear in central config schemas, API routing, admin feature gates, and provider registries. That is routing. Once code decides how a cloud resource is named, selected, reconciled, promoted, deleted, or retried, it belongs in the provider adapter.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -957,27 +957,15 @@ export class FleetDurableObject implements DurableObject {
         { status: 403 },
       );
     }
-    if (config.provider === "aws" && !config.awsAMI && !config.awsSnapshot) {
-      if (config.target === "macos") {
-        config.awsPromotedAMIs = await this.promotedAWSImagesForFallback(config);
-      } else {
-        const promoted = await this.promotedAWSImage(config);
-        config.awsAMI = promoted?.id ?? "";
-        if (promoted?.region) {
-          config.awsRegion = promoted.region;
-        }
-      }
-    }
-    if (config.provider === "azure" && !config.azureLocation) {
-      config.azureLocation = azureLocationFor(this.env, "");
-    }
-    if (config.provider === "gcp" && !config.gcpProject) {
-      config.gcpProject =
-        this.env.CRABBOX_GCP_PROJECT?.trim() || this.env.GCP_PROJECT_ID?.trim() || "";
-    }
+    config =
+      (await this.provider(
+        config.provider,
+        providerRegionForConfig(config),
+        providerProjectForConfig(config),
+      ).prepareLeaseConfig?.(config)) ?? config;
     const readiness = this.providerConfigurationReadiness(
       config.provider,
-      config.provider === "gcp" ? config.gcpProject : undefined,
+      providerProjectForConfig(config),
     );
     if (!readiness.configured) {
       return json(
@@ -1006,8 +994,8 @@ export class FleetDurableObject implements DurableObject {
     }
     const provider = this.provider(
       config.provider,
-      config.provider === "gcp" ? config.gcpZone : config.awsRegion,
-      config.provider === "gcp" ? config.gcpProject : undefined,
+      providerRegionForConfig(config),
+      providerProjectForConfig(config),
     );
     const providerHourlyUSD = await provider
       .hourlyPriceUSD(config.serverType, config)
@@ -1116,15 +1104,17 @@ export class FleetDurableObject implements DurableObject {
     if (market) {
       record.market = market;
     }
-    if (config.provider === "aws" && server.region) {
-      config.awsRegion = server.region;
-    }
     if (attempts && attempts.length > 0) {
       record.provisioningAttempts = attempts;
     }
     record.serverID = server.id;
     record.serverName = server.name;
     record.host = server.host;
+    const finalized = await provider.finalizeLeaseCreate?.(config, record, server, attempts ?? []);
+    if (finalized) {
+      config = finalized.config;
+      record = finalized.lease;
+    }
     const finalProviderHourlyUSD = await provider
       .hourlyPriceUSD(serverType, config)
       .catch(() => undefined);
@@ -1137,20 +1127,6 @@ export class FleetDurableObject implements DurableObject {
     );
     record.estimatedHourlyUSD = finalCost.hourlyUSD;
     record.maxEstimatedUSD = finalCost.maxUSD;
-    if (config.provider === "aws") {
-      record.region = server.region ?? config.awsRegion;
-      const hints = capacityHints(this.env, config, record, attempts ?? []);
-      if (hints.length > 0) {
-        record.capacityHints = hints;
-      }
-    }
-    if (config.provider === "azure") {
-      record.region = config.azureLocation;
-    }
-    if (config.provider === "gcp") {
-      record.region = server.region ?? config.gcpZone;
-      record.providerProject = config.gcpProject;
-    }
     await this.putLease(record);
     if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
       await this.deleteProviderAccess(record.id);
@@ -3733,18 +3709,17 @@ export class FleetDurableObject implements DurableObject {
     if (!lease) {
       return notFound();
     }
-    if (!lease.cloudID || !providerSupportsNativeImages(lease.provider)) {
+    const provider = this.provider(lease.provider, lease.region, lease.providerProject);
+    if (!lease.cloudID || !provider.supportsNativeImages()) {
       return json(
         {
           error: "unsupported_provider",
-          message: "native images are supported for AWS, Azure, and GCP leases",
+          message: provider.nativeImagesUnsupportedMessage(),
         },
         { status: 400 },
       );
     }
-    const strategy = checkpointStrategy(
-      input.strategy ?? (lease.provider === "aws" ? "image" : "disk-snapshot"),
-    );
+    const strategy = checkpointStrategy(input.strategy ?? provider.defaultImageStrategy(lease));
     if (!strategy) {
       return json(
         {
@@ -3754,31 +3729,18 @@ export class FleetDurableObject implements DurableObject {
         { status: 400 },
       );
     }
-    if (lease.provider === "azure" && strategy === "image") {
+    const unsupportedStrategy = provider.validateLeaseImageStrategy(lease, strategy);
+    if (unsupportedStrategy) {
       return json(
         {
           error: "unsupported_strategy",
-          message:
-            "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases",
+          message: unsupportedStrategy,
         },
         { status: 400 },
       );
     }
-    const image = await this.provider(
-      lease.provider,
-      lease.region,
-      lease.providerProject,
-    ).createImage(
-      lease.cloudID,
-      providerImageResourceName(lease.provider, name, leaseID),
-      input.noReboot ?? true,
-      strategy,
-    );
-    const enriched = lease.provider === "aws" ? enrichAWSImage(image, lease) : image;
-    if (lease.provider === "aws") {
-      await this.state.storage.put(createdAWSImageKey(enriched.id), enriched);
-    }
-    return json({ image: enriched }, { status: 201 });
+    const image = await provider.createLeaseImage(lease, name, input.noReboot ?? true, strategy);
+    return json({ image }, { status: 201 });
   }
 
   private async imageRoute(request: Request, imageID: string, action?: string): Promise<Response> {
@@ -3798,19 +3760,16 @@ export class FleetDurableObject implements DurableObject {
     const region = url.searchParams.get("region") ?? undefined;
     const project = url.searchParams.get("project") ?? undefined;
     const kind = url.searchParams.get("kind") ?? undefined;
-    const known = provider === "aws" ? await this.createdAWSImage(decodedImageID) : undefined;
-    const promotedAWSImage =
-      provider === "aws" ? await this.promotedAWSImageByID(decodedImageID) : undefined;
-    const awsMetadata = known ?? promotedAWSImage;
-    const knownRegion = awsMetadata?.region ?? "";
+    const imageProvider = this.provider(provider, region, project);
+    const metadata = await imageProvider.storedImageMetadata(decodedImageID);
+    const knownRegion = metadata?.region ?? "";
     const providerRegion = region || knownRegion;
+    const providerForRegion =
+      providerRegion === region ? imageProvider : this.provider(provider, providerRegion, project);
     if (method === "GET" && action === undefined) {
       let image: ProviderImage;
       try {
-        image = await this.provider(provider, providerRegion, project).getImage(
-          decodedImageID,
-          kind,
-        );
+        image = await providerForRegion.getImage(decodedImageID, kind);
       } catch (error) {
         if (isProviderImageNotFound(error)) {
           return json(
@@ -3821,247 +3780,42 @@ export class FleetDurableObject implements DurableObject {
         throw error;
       }
       return json({
-        image: provider === "aws" ? mergeAWSImageMetadata(image, awsMetadata) : image,
+        image: providerForRegion.decorateImage(image, metadata),
       });
     }
     if (method === "GET" && (action === "fast-snapshot-restore" || action === "fsr-status")) {
-      if (provider !== "aws") {
+      if (!providerForRegion.fastSnapshotRestoreForImage) {
         return json(
           { error: "unsupported_provider", message: "Fast Snapshot Restore is AWS-only" },
           { status: 400 },
         );
       }
-      const rawRegion = region ?? knownRegion;
-      const imageRegion = rawRegion ? sanitizeAWSRegion(rawRegion) : "";
-      if (rawRegion && !imageRegion) {
-        return json(
-          { error: "invalid_region", message: "region must be an AWS region name" },
-          { status: 400 },
-        );
-      }
-      const image = mergeAWSImageMetadata(
-        await this.provider("aws", imageRegion).getImage(decodedImageID),
-        awsMetadata,
+      const result = await providerForRegion.fastSnapshotRestoreForImage(
+        decodedImageID,
+        metadata,
+        url,
       );
-      const snapshots = image.snapshots ?? [];
-      if (snapshots.length === 0) {
-        return json(
-          {
-            error: "image_snapshots_missing",
-            message: `image ${decodedImageID} has no EBS snapshots to describe for Fast Snapshot Restore`,
-          },
-          { status: 409 },
-        );
-      }
-      const availabilityZones = fastSnapshotRestoreStatusAZs(url, image.region ?? imageRegion);
-      const fastSnapshotRestores = await this.provider(
-        "aws",
-        image.region ?? imageRegion,
-      ).fastSnapshotRestoreStatus?.(snapshots, availabilityZones);
-      const imageWithStatus = {
-        ...image,
-        fastSnapshotRestores: fastSnapshotRestores ?? [],
-      };
-      return json({
-        image: imageWithStatus,
-        fastSnapshotRestores: imageWithStatus.fastSnapshotRestores,
-      });
+      return result instanceof Response ? result : json(result);
     }
     if (method === "DELETE" && action === undefined) {
-      if (promotedAWSImage?.id === decodedImageID) {
-        return json(
-          {
-            error: "image_promoted",
-            message: `image ${decodedImageID} is the promoted AWS image; promote another image before deleting it`,
-          },
-          { status: 409 },
-        );
+      const deleteBlocked = await providerForRegion.validateDeleteImage(decodedImageID, metadata);
+      if (deleteBlocked) {
+        return json(deleteBlocked.body, { status: deleteBlocked.status });
       }
-      await this.provider(provider, providerRegion, project).deleteImage(decodedImageID, kind);
+      await providerForRegion.deleteImage(decodedImageID, kind);
       return json({ imageID: decodedImageID, deleted: true });
     }
     if (method === "POST" && action === "promote") {
-      if (provider !== "aws") {
+      if (!providerForRegion.promoteImage) {
         return json(
           { error: "unsupported_provider", message: "image promotion is currently AWS-only" },
           { status: 400 },
         );
       }
-      const input: {
-        target?: string;
-        region?: string;
-        serverType?: string;
-        architecture?: string;
-        fastSnapshotRestore?: unknown;
-        fastSnapshotRestoreAvailabilityZones?: string[];
-      } = await readJson<{
-        target?: string;
-        region?: string;
-        serverType?: string;
-        architecture?: string;
-        fastSnapshotRestore?: unknown;
-        fastSnapshotRestoreAvailabilityZones?: string[];
-      }>(request).catch(() => ({}));
-      const target = normalizeAWSImageTarget(
-        input.target ?? url.searchParams.get("target") ?? known?.target ?? "linux",
-      );
-      if (!target) {
-        return json(
-          { error: "invalid_target", message: "target must be linux, macos, or windows" },
-          { status: 400 },
-        );
-      }
-      const rawRegion = input.region ?? region ?? knownRegion;
-      const imageRegion = sanitizeAWSRegion(rawRegion);
-      if (rawRegion && !imageRegion) {
-        return json(
-          { error: "invalid_region", message: "region must be an AWS region name" },
-          { status: 400 },
-        );
-      }
-      const metadata: Partial<ProviderImage> = { ...known, target, region: imageRegion };
-      const serverType =
-        input.serverType ?? url.searchParams.get("serverType") ?? known?.serverType;
-      if (serverType) {
-        metadata.serverType = serverType;
-      }
-      const architecture =
-        input.architecture ?? url.searchParams.get("architecture") ?? known?.architecture;
-      if (architecture) {
-        metadata.architecture = architecture;
-      }
-      const fastSnapshotRestore = boolFromUnknown(
-        input.fastSnapshotRestore ?? url.searchParams.get("fastSnapshotRestore"),
-      );
-      const fastSnapshotRestoreAvailabilityZones = fastSnapshotRestore
-        ? fastSnapshotRestoreAZs(
-            input.fastSnapshotRestoreAvailabilityZones,
-            url,
-            imageRegion,
-            this.env,
-          )
-        : [];
-      if (fastSnapshotRestore && fastSnapshotRestoreAvailabilityZones.length === 0) {
-        return json(
-          {
-            error: "invalid_fast_snapshot_restore_zones",
-            message:
-              "Fast Snapshot Restore promotion requires at least one availability zone via fsrAz, fastSnapshotRestoreAvailabilityZones, CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS, or CRABBOX_CAPACITY_AVAILABILITY_ZONES",
-          },
-          { status: 400 },
-        );
-      }
-      const image = mergeAWSImageMetadata(
-        await this.provider("aws", imageRegion).getImage(decodedImageID),
-        metadata,
-      );
-      if (image.state !== "available") {
-        return json(
-          { error: "image_not_available", message: `image ${decodedImageID} is ${image.state}` },
-          { status: 409 },
-        );
-      }
-      if (target === "macos" && !image.serverType) {
-        return json(
-          {
-            error: "invalid_server_type",
-            message: "macOS AWS image promotion requires serverType",
-          },
-          { status: 400 },
-        );
-      }
-      if (fastSnapshotRestoreAvailabilityZones.length > 0 && (image.snapshots ?? []).length === 0) {
-        return json(
-          {
-            error: "image_snapshots_missing",
-            message: `image ${decodedImageID} has no EBS snapshots to enable for Fast Snapshot Restore`,
-          },
-          { status: 409 },
-        );
-      }
-      const fastSnapshotRestores =
-        fastSnapshotRestoreAvailabilityZones.length > 0
-          ? await this.provider("aws", imageRegion).enableFastSnapshotRestore?.(
-              image.snapshots ?? [],
-              fastSnapshotRestoreAvailabilityZones,
-            )
-          : undefined;
-      const promoted: PromotedImageRecord = {
-        ...image,
-        ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
-        target,
-        region: image.region ?? imageRegion,
-        architecture:
-          image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
-        promotedAt: new Date().toISOString(),
-      };
-      await this.state.storage.put(promotedAWSImageKey(promoted), promoted);
-      if (target === "linux") {
-        await this.state.storage.put(legacyPromotedAWSImageKey(), promoted);
-      }
-      return json({ image: promoted });
+      const result = await providerForRegion.promoteImage(decodedImageID, metadata, request, url);
+      return result instanceof Response ? result : json(result);
     }
     return json({ error: "not_found" }, { status: 404 });
-  }
-
-  private async createdAWSImage(imageID: string): Promise<ProviderImage | undefined> {
-    return this.state.storage.get<ProviderImage>(createdAWSImageKey(imageID));
-  }
-
-  private async promotedAWSImage(config: {
-    target: TargetOS;
-    serverType: string;
-    awsRegion: string;
-  }): Promise<PromotedImageRecord | undefined> {
-    const scoped = await this.state.storage.get<PromotedImageRecord>(
-      promotedAWSImageKey({
-        target: config.target,
-        architecture: awsImageArchitectureForTarget(config.target, config.serverType),
-        serverType: config.serverType,
-        region: config.awsRegion,
-      }),
-    );
-    if (scoped) {
-      return scoped;
-    }
-    if (config.target === "macos") {
-      return this.state.storage.get<PromotedImageRecord>(
-        legacyScopedPromotedAWSImageKey({
-          target: config.target,
-          architecture: awsImageArchitectureForTarget(config.target, config.serverType),
-          region: config.awsRegion,
-        }),
-      );
-    }
-    if (config.target !== "linux") {
-      return scoped;
-    }
-    return this.state.storage.get<PromotedImageRecord>(legacyPromotedAWSImageKey());
-  }
-
-  private async promotedAWSImagesForFallback(config: LeaseConfig): Promise<Record<string, string>> {
-    const out: Record<string, string> = {};
-    for (const region of awsRegionCandidates(config, this.env, config.awsRegion)) {
-      for (const serverType of awsLaunchCandidates(config)) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- storage reads preserve deterministic fallback key construction.
-        const promoted = await this.promotedAWSImage({
-          target: config.target,
-          serverType,
-          awsRegion: region,
-        });
-        if (promoted?.id) {
-          out[awsPromotedAMIConfigKey(region, serverType)] = promoted.id;
-        }
-      }
-    }
-    return out;
-  }
-
-  private async promotedAWSImageByID(imageID: string): Promise<PromotedImageRecord | undefined> {
-    const promoted = await this.state.storage.list<PromotedImageRecord>({
-      prefix: promotedAWSImagePrefix(),
-    });
-    return [...promoted.values()].find((image) => image.id === imageID);
   }
 
   private async expireLeases(): Promise<void> {
@@ -4514,7 +4268,11 @@ export class FleetDurableObject implements DurableObject {
       return testProvider;
     }
     if (provider === "aws") {
-      return new AWSProvider(this.env, region || this.env.CRABBOX_AWS_REGION || "eu-west-1");
+      return new AWSProvider(
+        this.env,
+        region || this.env.CRABBOX_AWS_REGION || "eu-west-1",
+        this.state.storage,
+      );
     }
     if (provider === "azure") {
       return new AzureProvider(this.env);
@@ -4526,25 +4284,7 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private async deleteLeaseServer(lease: LeaseRecord): Promise<void> {
-    if (lease.provider === "aws") {
-      await this.provider("aws", lease.region).deleteServer(lease.cloudID);
-      if (validCrabboxProviderKey(lease.providerKey)) {
-        await this.provider("aws", lease.region).deleteSSHKey(lease.providerKey);
-      }
-      return;
-    }
-    if (lease.provider === "azure") {
-      await this.provider("azure").deleteServer(lease.cloudID);
-      return;
-    }
-    if (lease.provider === "gcp") {
-      await this.provider("gcp", lease.region, lease.providerProject).deleteServer(lease.cloudID);
-      return;
-    }
-    await this.provider("hetzner").deleteServer(String(lease.serverID));
-    if (validCrabboxProviderKey(lease.providerKey)) {
-      await this.provider("hetzner").deleteSSHKey(lease.providerKey);
-    }
+    await this.provider(lease.provider, lease.region, lease.providerProject).releaseLease(lease);
   }
 
   private async releaseResolvedLease(
@@ -5018,10 +4758,6 @@ function validImageName(value: string): boolean {
   return /^[A-Za-z0-9()[\]./_ -]{3,128}$/.test(value);
 }
 
-function providerSupportsNativeImages(provider: Provider): boolean {
-  return provider === "aws" || provider === "azure" || provider === "gcp";
-}
-
 function hasNativeLeaseSource(config: LeaseConfig): boolean {
   return Boolean(
     config.awsSnapshot || config.azureSnapshot || config.gcpMachineImage || config.gcpSnapshot,
@@ -5068,6 +4804,16 @@ function providerFromQuery(value: string | null): Provider | undefined {
   return undefined;
 }
 
+function providerRegionForConfig(config: LeaseConfig): string | undefined {
+  if (config.provider === "gcp") return config.gcpZone;
+  if (config.provider === "azure") return config.azureLocation;
+  return config.awsRegion;
+}
+
+function providerProjectForConfig(config: LeaseConfig): string | undefined {
+  return config.provider === "gcp" ? config.gcpProject : undefined;
+}
+
 function providerImageResourceName(provider: Provider, name: string, leaseID: string): string {
   if (provider === "aws") {
     return name;
@@ -5094,6 +4840,18 @@ function providerImageResourceName(provider: Provider, name: string, leaseID: st
 
 function unsupportedProviderImageLifecycle(provider: Provider) {
   return () => Promise.reject(new Error(`${provider} images are not supported`));
+}
+
+function noStoredImageMetadata(): Promise<ProviderImage | undefined> {
+  return Promise.resolve(undefined);
+}
+
+function passthroughProviderImage(image: ProviderImage): ProviderImage {
+  return image;
+}
+
+function allowProviderImageDelete(): Promise<undefined> {
+  return Promise.resolve(undefined);
 }
 
 function validCrabboxProviderKey(value: string | undefined): value is string {
@@ -6478,6 +6236,9 @@ function parseProviderLabelTime(value: string | undefined): number {
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
   getServer?(id: string): Promise<ProviderMachine>;
+  prepareLeaseConfig?(
+    config: ReturnType<typeof leaseConfig>,
+  ): Promise<ReturnType<typeof leaseConfig>>;
   prepareLeaseCreate?(
     config: ReturnType<typeof leaseConfig>,
     lease: LeaseRecord,
@@ -6499,15 +6260,48 @@ interface CloudProvider {
     market?: string;
     attempts?: ProvisioningAttempt[];
   }>;
+  finalizeLeaseCreate?(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+    server: ProviderMachine,
+    attempts: ProvisioningAttempt[],
+  ): Promise<ProviderLeaseCreateFinalization>;
+  releaseLease(lease: LeaseRecord): Promise<void>;
   deleteServer(id: string): Promise<void>;
-  createImage(
-    instanceID: string,
+  supportsNativeImages(): boolean;
+  nativeImagesUnsupportedMessage(): string;
+  defaultImageStrategy(lease: LeaseRecord): "image" | "disk-snapshot";
+  validateLeaseImageStrategy(
+    lease: LeaseRecord,
+    strategy: "image" | "disk-snapshot",
+  ): string | undefined;
+  createLeaseImage(
+    lease: LeaseRecord,
     name: string,
     noReboot: boolean,
     strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage>;
   getImage(imageID: string, kind?: string): Promise<ProviderImage>;
   deleteImage(imageID: string, kind?: string): Promise<void>;
+  storedImageMetadata(imageID: string): Promise<ProviderImage | undefined>;
+  decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>): ProviderImage;
+  validateDeleteImage(
+    imageID: string,
+    metadata?: Partial<ProviderImage>,
+  ): Promise<{ status: number; body: Record<string, unknown> } | undefined>;
+  promoteImage?(
+    imageID: string,
+    metadata: ProviderImage | undefined,
+    request: Request,
+    url: URL,
+  ): Promise<Response | { image: ProviderImage }>;
+  fastSnapshotRestoreForImage?(
+    imageID: string,
+    metadata: ProviderImage | undefined,
+    url: URL,
+  ): Promise<
+    Response | { image: ProviderImage; fastSnapshotRestores: ProviderFastSnapshotRestore[] }
+  >;
   enableFastSnapshotRestore?(
     snapshotIDs: string[],
     availabilityZones: string[],
@@ -6523,6 +6317,12 @@ interface CloudProvider {
   ): Promise<number | undefined>;
 }
 
+interface ProviderStateStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+}
+
 interface ProviderAccessContext {
   requestSourceCIDRs: string[];
   activeLeases: LeaseRecord[];
@@ -6534,16 +6334,24 @@ interface ProviderLeaseCreatePreparation {
   provisioning?: ProviderProvisioningContext;
 }
 
+interface ProviderLeaseCreateFinalization {
+  config: ReturnType<typeof leaseConfig>;
+  lease: LeaseRecord;
+}
+
 interface ProviderProvisioningContext {
   sshIngressReconcile?: "authoritative" | "additive";
   publishAccessBeforeProvisioning?: boolean;
 }
 
 class HetznerProvider implements CloudProvider {
-  private readonly client: HetznerClient;
+  private clientValue?: HetznerClient;
 
-  constructor(env: Env) {
-    this.client = new HetznerClient(env);
+  constructor(private readonly env: Env) {}
+
+  private get client(): HetznerClient {
+    this.clientValue ??= new HetznerClient(this.env);
+    return this.clientValue;
   }
 
   async listCrabboxServers(): Promise<ProviderMachine[]> {
@@ -6575,9 +6383,35 @@ class HetznerProvider implements CloudProvider {
     await this.client.deleteServer(Number(id));
   }
 
-  createImage = unsupportedProviderImageLifecycle("hetzner");
+  async releaseLease(lease: LeaseRecord): Promise<void> {
+    await this.deleteServer(String(lease.serverID));
+    if (validCrabboxProviderKey(lease.providerKey)) {
+      await this.deleteSSHKey(lease.providerKey);
+    }
+  }
+
+  supportsNativeImages(): boolean {
+    return false;
+  }
+
+  nativeImagesUnsupportedMessage(): string {
+    return "native images are supported for AWS, Azure, and GCP leases";
+  }
+
+  defaultImageStrategy(): "image" | "disk-snapshot" {
+    return "disk-snapshot";
+  }
+
+  validateLeaseImageStrategy(): string | undefined {
+    return undefined;
+  }
+
+  createLeaseImage = unsupportedProviderImageLifecycle("hetzner");
   getImage = unsupportedProviderImageLifecycle("hetzner");
   deleteImage = unsupportedProviderImageLifecycle("hetzner");
+  storedImageMetadata = noStoredImageMetadata;
+  decorateImage = passthroughProviderImage;
+  validateDeleteImage = allowProviderImageDelete;
 
   async deleteSSHKey(name: string): Promise<void> {
     await this.client.deleteSSHKey(name);
@@ -6592,14 +6426,25 @@ class HetznerProvider implements CloudProvider {
 }
 
 class AzureProvider implements CloudProvider {
-  private readonly client: AzureClient;
+  private clientValue?: AzureClient;
 
-  constructor(env: Env) {
-    this.client = new AzureClient(env);
+  constructor(private readonly env: Env) {}
+
+  private get client(): AzureClient {
+    this.clientValue ??= new AzureClient(this.env);
+    return this.clientValue;
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  async prepareLeaseConfig(
+    config: ReturnType<typeof leaseConfig>,
+  ): Promise<ReturnType<typeof leaseConfig>> {
+    return config.azureLocation
+      ? config
+      : { ...config, azureLocation: azureLocationFor(this.env, "") };
   }
 
   createServerWithFallback(
@@ -6620,20 +6465,48 @@ class AzureProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
-  createImage(
-    instanceID: string,
+  async finalizeLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+  ): Promise<ProviderLeaseCreateFinalization> {
+    return { config, lease: { ...lease, region: config.azureLocation } };
+  }
+
+  async releaseLease(lease: LeaseRecord): Promise<void> {
+    await this.deleteServer(lease.cloudID);
+  }
+
+  supportsNativeImages(): boolean {
+    return true;
+  }
+
+  nativeImagesUnsupportedMessage(): string {
+    return "native images are supported for AWS, Azure, and GCP leases";
+  }
+
+  defaultImageStrategy(): "image" | "disk-snapshot" {
+    return "disk-snapshot";
+  }
+
+  validateLeaseImageStrategy(
+    _lease: LeaseRecord,
+    strategy: "image" | "disk-snapshot",
+  ): string | undefined {
+    return strategy === "image"
+      ? "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases"
+      : undefined;
+  }
+
+  createLeaseImage(
+    lease: LeaseRecord,
     name: string,
     _noReboot: boolean,
-    strategy: "image" | "disk-snapshot",
+    _strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage> {
-    if (strategy === "image") {
-      return Promise.reject(
-        new Error(
-          "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases",
-        ),
-      );
-    }
-    return this.client.createDiskSnapshot(instanceID, name);
+    return this.client.createDiskSnapshot(
+      lease.cloudID,
+      providerImageResourceName(lease.provider, name, lease.id),
+    );
   }
 
   getImage(imageID: string, kind?: string): Promise<ProviderImage> {
@@ -6643,6 +6516,10 @@ class AzureProvider implements CloudProvider {
   deleteImage(imageID: string, kind?: string): Promise<void> {
     return this.client.deleteImage(imageID, kind);
   }
+
+  storedImageMetadata = noStoredImageMetadata;
+  decorateImage = passthroughProviderImage;
+  validateDeleteImage = allowProviderImageDelete;
 
   async deleteSSHKey(): Promise<void> {
     // Azure stores the SSH public key inline on the VM; nothing to clean up.
@@ -6654,14 +6531,33 @@ class AzureProvider implements CloudProvider {
 }
 
 class GCPProvider implements CloudProvider {
-  private readonly client: GCPClient;
+  private clientValue?: GCPClient;
 
-  constructor(env: Env, zone?: string, project?: string) {
-    this.client = new GCPClient(env, zone, project);
+  constructor(
+    private readonly env: Env,
+    private readonly zone?: string,
+    private readonly project?: string,
+  ) {}
+
+  private get client(): GCPClient {
+    this.clientValue ??= new GCPClient(this.env, this.zone, this.project);
+    return this.clientValue;
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
     return this.client.listCrabboxServers();
+  }
+
+  async prepareLeaseConfig(
+    config: ReturnType<typeof leaseConfig>,
+  ): Promise<ReturnType<typeof leaseConfig>> {
+    if (config.gcpProject) {
+      return config;
+    }
+    return {
+      ...config,
+      gcpProject: this.env.CRABBOX_GCP_PROJECT?.trim() || this.env.GCP_PROJECT_ID?.trim() || "",
+    };
   }
 
   createServerWithFallback(
@@ -6682,15 +6578,56 @@ class GCPProvider implements CloudProvider {
     return this.client.deleteServer(id);
   }
 
-  createImage(
-    instanceID: string,
+  async finalizeLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+    server: ProviderMachine,
+  ): Promise<ProviderLeaseCreateFinalization> {
+    return {
+      config,
+      lease: {
+        ...lease,
+        region: server.region ?? config.gcpZone,
+        providerProject: config.gcpProject,
+      },
+    };
+  }
+
+  async releaseLease(lease: LeaseRecord): Promise<void> {
+    await this.deleteServer(lease.cloudID);
+  }
+
+  supportsNativeImages(): boolean {
+    return true;
+  }
+
+  nativeImagesUnsupportedMessage(): string {
+    return "native images are supported for AWS, Azure, and GCP leases";
+  }
+
+  defaultImageStrategy(): "image" | "disk-snapshot" {
+    return "disk-snapshot";
+  }
+
+  validateLeaseImageStrategy(): string | undefined {
+    return undefined;
+  }
+
+  createLeaseImage(
+    lease: LeaseRecord,
     name: string,
     _noReboot: boolean,
     strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage> {
     return strategy === "image"
-      ? this.client.createImage(instanceID, name)
-      : this.client.createDiskSnapshot(instanceID, name);
+      ? this.client.createImage(
+          lease.cloudID,
+          providerImageResourceName(lease.provider, name, lease.id),
+        )
+      : this.client.createDiskSnapshot(
+          lease.cloudID,
+          providerImageResourceName(lease.provider, name, lease.id),
+        );
   }
 
   getImage(imageID: string, kind?: string): Promise<ProviderImage> {
@@ -6700,6 +6637,10 @@ class GCPProvider implements CloudProvider {
   deleteImage(imageID: string, kind?: string): Promise<void> {
     return this.client.deleteImage(imageID, kind);
   }
+
+  storedImageMetadata = noStoredImageMetadata;
+  decorateImage = passthroughProviderImage;
+  validateDeleteImage = allowProviderImageDelete;
 
   deleteSSHKey(): Promise<void> {
     return this.client.deleteSSHKey();
@@ -6711,15 +6652,20 @@ class GCPProvider implements CloudProvider {
 }
 
 class AWSProvider implements CloudProvider {
-  private readonly client: EC2SpotClient;
+  private clientValue?: EC2SpotClient;
   private readonly region: string;
 
   constructor(
     private readonly env: Env,
     region: string,
+    private readonly storage: ProviderStateStorage,
   ) {
     this.region = region;
-    this.client = new EC2SpotClient(env, region);
+  }
+
+  private get client(): EC2SpotClient {
+    this.clientValue ??= new EC2SpotClient(this.env, this.region);
+    return this.clientValue;
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
@@ -6728,6 +6674,23 @@ class AWSProvider implements CloudProvider {
 
   getServer(id: string): Promise<ProviderMachine> {
     return this.client.getServer(id);
+  }
+
+  async prepareLeaseConfig(
+    config: ReturnType<typeof leaseConfig>,
+  ): Promise<ReturnType<typeof leaseConfig>> {
+    if (config.awsAMI || config.awsSnapshot) {
+      return config;
+    }
+    if (config.target === "macos") {
+      return { ...config, awsPromotedAMIs: await this.promotedImagesForFallback(config) };
+    }
+    const promoted = await this.promotedImage(config);
+    return {
+      ...config,
+      awsAMI: promoted?.id ?? "",
+      ...(promoted?.region ? { awsRegion: promoted.region } : {}),
+    };
   }
 
   async prepareLeaseCreate(
@@ -6894,15 +6857,57 @@ class AWSProvider implements CloudProvider {
     await this.client.deleteServer(id);
   }
 
-  createImage(
-    instanceID: string,
+  async finalizeLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+    server: ProviderMachine,
+    attempts: ProvisioningAttempt[],
+  ): Promise<ProviderLeaseCreateFinalization> {
+    const nextConfig = server.region ? { ...config, awsRegion: server.region } : config;
+    const nextLease: LeaseRecord = { ...lease, region: server.region ?? nextConfig.awsRegion };
+    const hints = capacityHints(this.env, nextConfig, nextLease, attempts);
+    if (hints.length > 0) {
+      nextLease.capacityHints = hints;
+    }
+    return { config: nextConfig, lease: nextLease };
+  }
+
+  async releaseLease(lease: LeaseRecord): Promise<void> {
+    await this.deleteServer(lease.cloudID);
+    if (validCrabboxProviderKey(lease.providerKey)) {
+      await this.deleteSSHKey(lease.providerKey);
+    }
+  }
+
+  supportsNativeImages(): boolean {
+    return true;
+  }
+
+  nativeImagesUnsupportedMessage(): string {
+    return "native images are supported for AWS, Azure, and GCP leases";
+  }
+
+  defaultImageStrategy(): "image" | "disk-snapshot" {
+    return "image";
+  }
+
+  validateLeaseImageStrategy(): string | undefined {
+    return undefined;
+  }
+
+  async createLeaseImage(
+    lease: LeaseRecord,
     name: string,
     noReboot: boolean,
     strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage> {
-    return strategy === "image"
-      ? this.client.createImage(instanceID, name, noReboot)
-      : this.client.createDiskSnapshot(instanceID, name);
+    const image =
+      strategy === "image"
+        ? await this.client.createImage(lease.cloudID, name, noReboot)
+        : await this.client.createDiskSnapshot(lease.cloudID, name);
+    const enriched = enrichAWSImage(image, lease);
+    await this.storage.put(createdAWSImageKey(enriched.id), enriched);
+    return enriched;
   }
 
   getImage(imageID: string): Promise<ProviderImage> {
@@ -6927,6 +6932,191 @@ class AWSProvider implements CloudProvider {
     return this.client.deleteImage(imageID);
   }
 
+  async storedImageMetadata(imageID: string): Promise<ProviderImage | undefined> {
+    return (
+      (await this.promotedImageByID(imageID)) ??
+      (await this.storage.get<ProviderImage>(createdAWSImageKey(imageID)))
+    );
+  }
+
+  decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>): ProviderImage {
+    return mergeAWSImageMetadata(image, metadata);
+  }
+
+  async validateDeleteImage(
+    imageID: string,
+    metadata?: Partial<ProviderImage>,
+  ): Promise<{ status: number; body: Record<string, unknown> } | undefined> {
+    if (metadata?.id === imageID && "promotedAt" in metadata) {
+      return {
+        status: 409,
+        body: {
+          error: "image_promoted",
+          message: `image ${imageID} is the promoted AWS image; promote another image before deleting it`,
+        },
+      };
+    }
+    return undefined;
+  }
+
+  async fastSnapshotRestoreForImage(
+    imageID: string,
+    metadata: ProviderImage | undefined,
+    url: URL,
+  ): Promise<
+    Response | { image: ProviderImage; fastSnapshotRestores: ProviderFastSnapshotRestore[] }
+  > {
+    const rawRegion = url.searchParams.get("region") ?? metadata?.region ?? "";
+    const imageRegion = rawRegion ? sanitizeAWSRegion(rawRegion) : "";
+    if (rawRegion && !imageRegion) {
+      return json(
+        { error: "invalid_region", message: "region must be an AWS region name" },
+        { status: 400 },
+      );
+    }
+    const region = imageRegion || this.region;
+    const provider =
+      region === this.region ? this : new AWSProvider(this.env, region, this.storage);
+    const image = mergeAWSImageMetadata(await provider.getImage(imageID), metadata);
+    const snapshots = image.snapshots ?? [];
+    if (snapshots.length === 0) {
+      return json(
+        {
+          error: "image_snapshots_missing",
+          message: `image ${imageID} has no EBS snapshots to describe for Fast Snapshot Restore`,
+        },
+        { status: 409 },
+      );
+    }
+    const availabilityZones = fastSnapshotRestoreStatusAZs(url, image.region ?? imageRegion);
+    const fastSnapshotRestores = await provider.fastSnapshotRestoreStatus(
+      snapshots,
+      availabilityZones,
+    );
+    const imageWithStatus = { ...image, fastSnapshotRestores };
+    return {
+      image: imageWithStatus,
+      fastSnapshotRestores: imageWithStatus.fastSnapshotRestores ?? [],
+    };
+  }
+
+  async promoteImage(
+    imageID: string,
+    known: ProviderImage | undefined,
+    request: Request,
+    url: URL,
+  ): Promise<Response | { image: ProviderImage }> {
+    const input: {
+      target?: string;
+      region?: string;
+      serverType?: string;
+      architecture?: string;
+      fastSnapshotRestore?: unknown;
+      fastSnapshotRestoreAvailabilityZones?: string[];
+    } = await readJson<{
+      target?: string;
+      region?: string;
+      serverType?: string;
+      architecture?: string;
+      fastSnapshotRestore?: unknown;
+      fastSnapshotRestoreAvailabilityZones?: string[];
+    }>(request).catch(() => ({}));
+    const target = normalizeAWSImageTarget(
+      input.target ?? url.searchParams.get("target") ?? known?.target ?? "linux",
+    );
+    if (!target) {
+      return json(
+        { error: "invalid_target", message: "target must be linux, macos, or windows" },
+        { status: 400 },
+      );
+    }
+    const rawRegion = input.region ?? url.searchParams.get("region") ?? known?.region ?? "";
+    const imageRegion = sanitizeAWSRegion(rawRegion);
+    if (rawRegion && !imageRegion) {
+      return json(
+        { error: "invalid_region", message: "region must be an AWS region name" },
+        { status: 400 },
+      );
+    }
+    const metadata: Partial<ProviderImage> = { ...known, target, region: imageRegion };
+    const serverType = input.serverType ?? url.searchParams.get("serverType") ?? known?.serverType;
+    if (serverType) {
+      metadata.serverType = serverType;
+    }
+    const architecture =
+      input.architecture ?? url.searchParams.get("architecture") ?? known?.architecture;
+    if (architecture) {
+      metadata.architecture = architecture;
+    }
+    const fastSnapshotRestore = boolFromUnknown(
+      input.fastSnapshotRestore ?? url.searchParams.get("fastSnapshotRestore"),
+    );
+    const fastSnapshotRestoreAvailabilityZones = fastSnapshotRestore
+      ? fastSnapshotRestoreAZs(
+          input.fastSnapshotRestoreAvailabilityZones,
+          url,
+          imageRegion,
+          this.env,
+        )
+      : [];
+    if (fastSnapshotRestore && fastSnapshotRestoreAvailabilityZones.length === 0) {
+      return json(
+        {
+          error: "invalid_fast_snapshot_restore_zones",
+          message:
+            "Fast Snapshot Restore promotion requires at least one availability zone via fsrAz, fastSnapshotRestoreAvailabilityZones, CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS, or CRABBOX_CAPACITY_AVAILABILITY_ZONES",
+        },
+        { status: 400 },
+      );
+    }
+    const region = imageRegion || this.region;
+    const provider =
+      region === this.region ? this : new AWSProvider(this.env, region, this.storage);
+    const image = mergeAWSImageMetadata(await provider.getImage(imageID), metadata);
+    if (image.state !== "available") {
+      return json(
+        { error: "image_not_available", message: `image ${imageID} is ${image.state}` },
+        { status: 409 },
+      );
+    }
+    if (target === "macos" && !image.serverType) {
+      return json(
+        { error: "invalid_server_type", message: "macOS AWS image promotion requires serverType" },
+        { status: 400 },
+      );
+    }
+    if (fastSnapshotRestoreAvailabilityZones.length > 0 && (image.snapshots ?? []).length === 0) {
+      return json(
+        {
+          error: "image_snapshots_missing",
+          message: `image ${imageID} has no EBS snapshots to enable for Fast Snapshot Restore`,
+        },
+        { status: 409 },
+      );
+    }
+    const fastSnapshotRestores =
+      fastSnapshotRestoreAvailabilityZones.length > 0
+        ? await provider.enableFastSnapshotRestore(
+            image.snapshots ?? [],
+            fastSnapshotRestoreAvailabilityZones,
+          )
+        : undefined;
+    const promoted: PromotedImageRecord = {
+      ...image,
+      ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
+      target,
+      region: image.region ?? imageRegion,
+      architecture:
+        image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
+      promotedAt: new Date().toISOString(),
+    };
+    await this.storage.put(promotedAWSImageKey(promoted), promoted);
+    if (target === "linux") {
+      await this.storage.put(legacyPromotedAWSImageKey(), promoted);
+    }
+    return { image: promoted };
+  }
+
   async deleteSSHKey(name: string): Promise<void> {
     await this.client.deleteSSHKey(name);
   }
@@ -6938,6 +7128,62 @@ class AWSProvider implements CloudProvider {
     const region = config.awsRegion || this.region;
     const client = region === this.region ? this.client : new EC2SpotClient(this.env, region);
     return client.hourlySpotPriceUSD(serverType);
+  }
+
+  private async promotedImage(config: {
+    target: TargetOS;
+    serverType: string;
+    awsRegion: string;
+  }): Promise<PromotedImageRecord | undefined> {
+    const scoped = await this.storage.get<PromotedImageRecord>(
+      promotedAWSImageKey({
+        target: config.target,
+        architecture: awsImageArchitectureForTarget(config.target, config.serverType),
+        serverType: config.serverType,
+        region: config.awsRegion,
+      }),
+    );
+    if (scoped) {
+      return scoped;
+    }
+    if (config.target === "macos") {
+      return this.storage.get<PromotedImageRecord>(
+        legacyScopedPromotedAWSImageKey({
+          target: config.target,
+          architecture: awsImageArchitectureForTarget(config.target, config.serverType),
+          region: config.awsRegion,
+        }),
+      );
+    }
+    if (config.target !== "linux") {
+      return scoped;
+    }
+    return this.storage.get<PromotedImageRecord>(legacyPromotedAWSImageKey());
+  }
+
+  private async promotedImagesForFallback(config: LeaseConfig): Promise<Record<string, string>> {
+    const out: Record<string, string> = {};
+    for (const region of awsRegionCandidates(config, this.env, config.awsRegion)) {
+      for (const serverType of awsLaunchCandidates(config)) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- storage reads preserve deterministic fallback key construction.
+        const promoted = await this.promotedImage({
+          target: config.target,
+          serverType,
+          awsRegion: region,
+        });
+        if (promoted?.id) {
+          out[awsPromotedAMIConfigKey(region, serverType)] = promoted.id;
+        }
+      }
+    }
+    return out;
+  }
+
+  private async promotedImageByID(imageID: string): Promise<PromotedImageRecord | undefined> {
+    const promoted = await this.storage.list<PromotedImageRecord>({
+      prefix: promotedAWSImagePrefix(),
+    });
+    return [...promoted.values()].find((image) => image.id === imageID);
   }
 }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4498,7 +4498,7 @@ describe("fleet lease identity and idle", () => {
     );
     storage.seed("image:aws:promoted", {
       id: "ami-000000000001",
-      name: "openclaw-crabbox-test",
+      name: "crabbox-image-test",
       state: "available",
       region: "us-east-2",
       promotedAt: "2026-05-01T12:46:00Z",
@@ -4740,6 +4740,29 @@ describe("fleet lease identity and idle", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "unsupported_strategy" });
   });
 
+  it("rejects unsupported native image providers before constructing provider clients", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    storage.seed(
+      "lease:cbx_000000000004",
+      testLease({
+        id: "cbx_000000000004",
+        provider: "hetzner",
+        cloudID: "123",
+      }),
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/images", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { leaseID: "cbx_000000000004", name: "After Install" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "unsupported_provider" });
+  });
+
   it("rejects invalid native image strategies", async () => {
     let created = false;
     const storage = new MemoryStorage();
@@ -4907,6 +4930,42 @@ describe("fleet lease identity and idle", () => {
       name: "openclaw-crabbox-test",
       state: "available",
       region: "eu-west-1",
+      promotedAt: "2026-05-01T12:46:00Z",
+    });
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        onDeleteImage(imageID) {
+          deleted = imageID;
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("DELETE", "/v1/images/ami-000000000001", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(deleted).toBe("");
+    await expect(response.json()).resolves.toMatchObject({ error: "image_promoted" });
+  });
+
+  it("rejects deleting a promoted AWS image even when a created-image record also exists", async () => {
+    let deleted = "";
+    const storage = new MemoryStorage();
+    const image = {
+      id: "ami-000000000001",
+      name: "openclaw-crabbox-test",
+      state: "available",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "eu-west-1",
+    };
+    storage.seed("image:aws:created:ami-000000000001", image);
+    storage.seed("image:aws:promoted", {
+      ...image,
       promotedAt: "2026-05-01T12:46:00Z",
     });
     const fleet = testFleet(storage, {
@@ -6184,6 +6243,13 @@ function testFleet(
   providers = {},
   env: Partial<Env> = {},
 ): FleetDurableObject {
+  for (const provider of Object.values(providers)) {
+    (
+      provider as {
+        attachStorage?: (storage: MemoryStorage) => void;
+      }
+    ).attachStorage?.(storage);
+  }
   return new FleetDurableObject(
     { storage } as unknown as DurableObjectState,
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
@@ -6237,11 +6303,19 @@ function fakeProvider(
       sshIngressReconcile?: "authoritative" | "additive";
       publishAccessBeforeProvisioning?: boolean;
     }) => void;
+    onPrepareLeaseConfig?: (
+      config: LeaseConfig,
+      storage: MemoryStorage | undefined,
+    ) => Promise<LeaseConfig> | LeaseConfig;
   } = {},
   onDelete?: (id: string) => Promise<void>,
   onGet?: (id: string) => Promise<ProviderMachine> | ProviderMachine,
 ) {
+  let storage: MemoryStorage | undefined;
   return {
+    attachStorage(nextStorage: MemoryStorage) {
+      storage = nextStorage;
+    },
     async listCrabboxServers() {
       return result.servers ?? [];
     },
@@ -6267,6 +6341,32 @@ function fakeProvider(
       context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
     ) {
       return result.onPrepareLeaseCreate?.(config, lease, context);
+    },
+    async prepareLeaseConfig(config: LeaseConfig) {
+      const prepared = await result.onPrepareLeaseConfig?.(config, storage);
+      if (prepared) {
+        return prepared;
+      }
+      if ((result.provider ?? config.provider) !== "aws" || config.awsAMI || config.awsSnapshot) {
+        return config;
+      }
+      if (config.target === "macos") {
+        const awsPromotedAMIs: Record<string, string> = {};
+        const promoted = await storage?.list<ProviderImage>({ prefix: "image:aws:promoted" });
+        for (const image of promoted?.values() ?? []) {
+          if (image.target !== "macos" || !image.region || !image.serverType) {
+            continue;
+          }
+          awsPromotedAMIs[awsPromotedAMIConfigKey(image.region, image.serverType)] = image.id;
+        }
+        return { ...config, awsPromotedAMIs };
+      }
+      const promoted = await storage?.get<ProviderImage>("image:aws:promoted");
+      return {
+        ...config,
+        awsAMI: promoted?.id ?? "",
+        ...(promoted?.region ? { awsRegion: promoted.region } : {}),
+      };
     },
     async refreshLeaseAccess(
       lease: LeaseRecord,
@@ -6313,6 +6413,89 @@ function fakeProvider(
     },
     async deleteServer(id: string) {
       await onDelete?.(id);
+    },
+    async releaseLease(lease: LeaseRecord) {
+      await onDelete?.(
+        (lease.provider ?? result.provider) === "hetzner" ? String(lease.serverID) : lease.cloudID,
+      );
+    },
+    async finalizeLeaseCreate(
+      config: LeaseConfig,
+      lease: LeaseRecord,
+      server: ProviderMachine,
+      attempts: ProvisioningAttempt[],
+    ) {
+      const provider = result.provider ?? lease.provider;
+      const nextLease = { ...lease };
+      if (provider === "aws") {
+        nextLease.region = server.region ?? config.awsRegion;
+        const codes = new Set(attempts.map((attempt) => attempt.category));
+        if (codes.has("capacity") || codes.has("quota") || result.market === "on-demand") {
+          const regionsTried = [
+            ...new Set(
+              [...attempts.map((attempt) => attempt.region), server.region].filter(Boolean),
+            ),
+          ];
+          nextLease.capacityHints = [
+            {
+              code: "aws_capacity_routed",
+              message: "AWS capacity fallback selected a working launch path",
+              regionsTried,
+            },
+            { code: "aws_quota_pressure", message: "AWS quota or capacity pressure was observed" },
+            { code: "aws_on_demand_fallback", message: "AWS on-demand fallback was used" },
+            { code: "capacity_large_class", message: "Large class capacity can be constrained" },
+          ];
+        }
+      }
+      if (provider === "azure") {
+        nextLease.region = config.azureLocation;
+      }
+      if (provider === "gcp") {
+        nextLease.region = server.region ?? config.gcpZone;
+        nextLease.providerProject = config.gcpProject;
+      }
+      return { config, lease: nextLease };
+    },
+    supportsNativeImages() {
+      return (result.provider ?? "aws") !== "hetzner";
+    },
+    nativeImagesUnsupportedMessage() {
+      return "native images are supported for AWS, Azure, and GCP leases";
+    },
+    defaultImageStrategy() {
+      return (result.provider ?? "aws") === "aws" ? "image" : "disk-snapshot";
+    },
+    validateLeaseImageStrategy(_lease: LeaseRecord, strategy: "image" | "disk-snapshot") {
+      return (result.provider ?? "aws") === "azure" && strategy === "image"
+        ? "Azure managed images require a stopped/generalized source VM; use disk-snapshot checkpoints for active Azure leases"
+        : undefined;
+    },
+    async createLeaseImage(
+      lease: LeaseRecord,
+      name: string,
+      noReboot = true,
+      strategy: "image" | "disk-snapshot" = "disk-snapshot",
+    ) {
+      const image = await this.createImage(
+        lease.cloudID,
+        fakeProviderImageResourceName(lease.provider, name, lease.id),
+        noReboot,
+        strategy,
+      );
+      const enriched =
+        lease.provider === "aws"
+          ? fakeMergeAWSImageMetadata(image, {
+              target: lease.target,
+              windowsMode: lease.windowsMode,
+              serverType: lease.serverType,
+              region: image.region ?? lease.region,
+            })
+          : image;
+      if (lease.provider === "aws") {
+        await storage?.put(`image:aws:created:${enriched.id}`, enriched);
+      }
+      return enriched;
     },
     async createImage(
       instanceID: string,
@@ -6389,6 +6572,121 @@ function fakeProvider(
     async deleteImage(imageID: string, kind?: string) {
       result.onDeleteImage?.(imageID, kind);
     },
+    async storedImageMetadata(imageID: string) {
+      const promoted = await storage?.list<ProviderImage>({ prefix: "image:aws:promoted" });
+      return (
+        [...(promoted?.values() ?? [])].find((image) => image.id === imageID) ??
+        (await storage?.get<ProviderImage>(`image:aws:created:${imageID}`))
+      );
+    },
+    decorateImage(image: ProviderImage, metadata?: Partial<ProviderImage>) {
+      return (result.provider ?? "aws") === "aws"
+        ? fakeMergeAWSImageMetadata(image, metadata)
+        : image;
+    },
+    async validateDeleteImage(imageID: string, metadata?: Partial<ProviderImage>) {
+      if (metadata?.id === imageID && "promotedAt" in metadata) {
+        return {
+          status: 409,
+          body: {
+            error: "image_promoted",
+            message: `image ${imageID} is the promoted AWS image; promote another image before deleting it`,
+          },
+        };
+      }
+      return undefined;
+    },
+    async fastSnapshotRestoreForImage(
+      imageID: string,
+      metadata: ProviderImage | undefined,
+      url: URL,
+    ) {
+      const image = fakeMergeAWSImageMetadata(await this.getImage(imageID), metadata);
+      const snapshots = image.snapshots ?? [];
+      if (snapshots.length === 0) {
+        return jsonResponse(
+          {
+            error: "image_snapshots_missing",
+            message: `image ${imageID} has no EBS snapshots to describe for Fast Snapshot Restore`,
+          },
+          409,
+        );
+      }
+      const zones = fakeFastSnapshotRestoreStatusAZs(url, image.region ?? "");
+      const fastSnapshotRestores = await this.fastSnapshotRestoreStatus(snapshots, zones);
+      return { image: { ...image, fastSnapshotRestores }, fastSnapshotRestores };
+    },
+    async promoteImage(imageID: string, known: ProviderImage | undefined, req: Request, url: URL) {
+      const input = (await req
+        .clone()
+        .json()
+        .catch(() => ({}))) as {
+        target?: string;
+        region?: string;
+        serverType?: string;
+        architecture?: string;
+        fastSnapshotRestore?: unknown;
+        fastSnapshotRestoreAvailabilityZones?: string[];
+      };
+      const target = fakeNormalizeAWSImageTarget(
+        input.target ?? url.searchParams.get("target") ?? known?.target ?? "linux",
+      );
+      if (!target) {
+        return jsonResponse(
+          { error: "invalid_target", message: "target must be linux, macos, or windows" },
+          400,
+        );
+      }
+      const region = input.region ?? url.searchParams.get("region") ?? known?.region ?? "";
+      const metadata: Partial<ProviderImage> = { ...known, target, region };
+      const serverType =
+        input.serverType ?? url.searchParams.get("serverType") ?? known?.serverType;
+      if (serverType) {
+        metadata.serverType = serverType;
+      }
+      const architecture =
+        input.architecture ?? url.searchParams.get("architecture") ?? known?.architecture;
+      if (architecture) {
+        metadata.architecture = architecture;
+      }
+      const fastSnapshotRestore = fakeBoolFromUnknown(
+        input.fastSnapshotRestore ?? url.searchParams.get("fastSnapshotRestore"),
+      );
+      const zones = fastSnapshotRestore
+        ? fakeFastSnapshotRestoreAZs(input.fastSnapshotRestoreAvailabilityZones, url, region)
+        : [];
+      if (fastSnapshotRestore && zones.length === 0) {
+        return jsonResponse({ error: "invalid_fast_snapshot_restore_zones" }, 400);
+      }
+      const image = fakeMergeAWSImageMetadata(await this.getImage(imageID), metadata);
+      if (image.state !== "available") {
+        return jsonResponse({ error: "image_not_available" }, 409);
+      }
+      if (target === "macos" && !image.serverType) {
+        return jsonResponse({ error: "invalid_server_type" }, 400);
+      }
+      if (zones.length > 0 && (image.snapshots ?? []).length === 0) {
+        return jsonResponse({ error: "image_snapshots_missing" }, 409);
+      }
+      const fastSnapshotRestores =
+        zones.length > 0
+          ? await this.enableFastSnapshotRestore(image.snapshots ?? [], zones)
+          : undefined;
+      const promoted = {
+        ...image,
+        ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
+        target,
+        region: image.region ?? region,
+        architecture:
+          image.architecture ?? fakeAWSImageArchitectureForTarget(target, image.serverType ?? ""),
+        promotedAt: "2026-05-25T00:00:00.000Z",
+      };
+      await storage?.put(fakePromotedAWSImageKey(promoted), promoted);
+      if (target === "linux") {
+        await storage?.put("image:aws:promoted", promoted);
+      }
+      return { image: promoted };
+    },
     async enableFastSnapshotRestore(snapshotIDs: string[], availabilityZones: string[]) {
       result.onEnableFastSnapshotRestore?.(snapshotIDs, availabilityZones);
       return snapshotIDs.flatMap((snapshotID) =>
@@ -6410,6 +6708,134 @@ function fakeProvider(
       return 0.1;
     },
   };
+}
+
+function fakeProviderImageResourceName(provider: string, name: string, leaseID: string): string {
+  if (provider === "aws") {
+    return name;
+  }
+  const allowed = provider === "gcp" ? /[^a-z0-9-]/g : /[^a-z0-9_.-]/g;
+  const normalized = name.trim().toLowerCase().replaceAll(allowed, "-");
+  const trimmed =
+    provider === "gcp"
+      ? normalized
+          .replaceAll(/^[^a-z]+/g, "")
+          .replaceAll(/-+/g, "-")
+          .replaceAll(/-+$/g, "")
+      : normalized
+          .replaceAll(/^[^a-z]+/g, "")
+          .replaceAll(/-+/g, "-")
+          .replaceAll(/[-.]+$/g, "");
+  const fallback = leaseID.toLowerCase().replaceAll(/[^a-z0-9-]/g, "-");
+  const maxLength = provider === "gcp" ? 63 : 80;
+  const truncated = (trimmed || `checkpoint-${fallback}`).slice(0, maxLength);
+  return provider === "gcp"
+    ? truncated.replaceAll(/-+$/g, "")
+    : truncated.replaceAll(/[-.]+$/g, "");
+}
+
+function fakeMergeAWSImageMetadata(
+  image: ProviderImage,
+  metadata?: Partial<ProviderImage>,
+): ProviderImage {
+  const target =
+    fakeNormalizeAWSImageTarget(metadata?.target ?? image.target ?? "linux") ?? "linux";
+  const serverType = metadata?.serverType ?? image.serverType ?? "";
+  const result: ProviderImage = {
+    ...metadata,
+    ...image,
+    target,
+    architecture:
+      metadata?.architecture ??
+      image.architecture ??
+      fakeAWSImageArchitectureForTarget(target, serverType),
+  };
+  const windowsMode = metadata?.windowsMode ?? image.windowsMode;
+  if (windowsMode !== undefined) {
+    result.windowsMode = windowsMode;
+  }
+  if (serverType) {
+    result.serverType = serverType;
+  }
+  if (image.region) {
+    result.region = image.region;
+  } else if (metadata?.region) {
+    result.region = metadata.region;
+  }
+  return result;
+}
+
+function fakeNormalizeAWSImageTarget(
+  value: string | undefined,
+): "linux" | "macos" | "windows" | undefined {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "":
+    case "linux":
+    case "ubuntu":
+      return "linux";
+    case "mac":
+    case "macos":
+    case "darwin":
+    case "osx":
+      return "macos";
+    case "win":
+    case "windows":
+      return "windows";
+    default:
+      return undefined;
+  }
+}
+
+function fakeAWSImageArchitectureForTarget(
+  target: "linux" | "macos" | "windows",
+  serverType: string,
+): string {
+  if (target === "macos") {
+    return serverType.startsWith("mac1.") ? "x86_64_mac" : "arm64_mac";
+  }
+  return "x86_64";
+}
+
+function fakePromotedAWSImageKey(
+  image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType">,
+): string {
+  const target = image.target ?? "linux";
+  const architecture = image.architecture ?? fakeAWSImageArchitectureForTarget(target, "");
+  const region = image.region ?? "";
+  if (target === "macos") {
+    return `image:aws:promoted:${target}:${architecture}:${(image.serverType ?? "").trim().toLowerCase()}:${region}`;
+  }
+  return `image:aws:promoted:${target}:${architecture}:${region}`;
+}
+
+function fakeBoolFromUnknown(value: unknown): boolean {
+  if (value === true) return true;
+  if (value === false || value === undefined || value === null) return false;
+  return ["1", "true", "yes", "on"].includes(String(value).trim().toLowerCase());
+}
+
+function fakeFastSnapshotRestoreAZs(
+  inputZones: string[] | undefined,
+  url: URL,
+  region: string,
+): string[] {
+  return [
+    ...new Set(
+      [...(inputZones ?? []), ...url.searchParams.getAll("fsrAz")]
+        .map((zone) => zone.trim())
+        .filter((zone) => !region || zone.startsWith(region)),
+    ),
+  ];
+}
+
+function fakeFastSnapshotRestoreStatusAZs(url: URL, region: string): string[] {
+  return [
+    ...new Set(
+      [...url.searchParams.getAll("fsrAz"), ...url.searchParams.getAll("az")]
+        .map((zone) => zone.trim())
+        .filter((zone) => !region || zone.startsWith(region)),
+    ),
+  ];
 }
 
 function testMachine(overrides: Partial<ProviderMachine>): ProviderMachine {


### PR DESCRIPTION
## Summary

- route provider-owned lease defaults, post-provision metadata, release cleanup, native images, AWS image promotion, and FSR handling through provider capabilities
- keep fleet core focused on orchestration, authorization, cost limits, persistence, and provider capability dispatch
- make provider clients lazy where capability checks should not require provider credentials
- document the provider boundary in AGENTS and vision docs
- add regression coverage for promoted AWS image deletion, unsupported native-image providers, provider release/default/finalization behavior, and existing AWS SSH access reconciliation paths

## Verification

- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `npm run docs:check`
- `npm run check`
- `go test ./...`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- live AWS Crabbox proof: provider=`aws`, lease=`cbx_61381b273f3e`, run=`run_e026ec0eb84d`, `npm ci --prefix worker && npm run check --prefix worker && npm test --prefix worker -- fleet.test.ts aws.test.ts`, exit=0, leaseStopped=true

## Audit Notes

Remaining provider-name branches are routing/config/admin gates rather than resource policy. The next cleanup candidates are direct CLI image/checkpoint switches in `internal/cli/checkpoint_native.go` and direct stop/delete fallback routing in `internal/cli/run.go`; those should move behind CLI provider backend capabilities if they grow further.
