### PR TITLE
chore(codex): introduce .codex/config.toml with wrapper-script pointer (Phase 12 B.9)

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,16 @@
+# Codex per-repo overlay for crabbox.
+#
+# Token-bearing MCP servers point at canonical wrappers in
+# ~/.codex/wrappers/ (Phase 12+13 item B.9) because Codex does not expand
+# ${VAR} references in config.toml. See ~/.codex/wrappers/README.md and
+# ~/Projects/openclaw-cf-tools-worker/RUNBOOK_WRAPPER_ROLLBACK.md.
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.fetch]
+command = "uvx"
+args = ["mcp-server-fetch"]
+
+[mcp_servers.github]
+command = "/Users/louisherman/.codex/wrappers/github-token.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "OpenClaw plugin for running Crabbox remote testbox workflows",
   "license": "MIT",
   "type": "module",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@cloudflare/containers": "^0.3.4",
         "@novnc/novnc": "^1.7.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Introduce `.codex/config.toml` directly in the **wrapper-script pointer** shape (`~/.codex/wrappers/github-token.sh`) — Crabbox had no `.codex/config.toml` on `main` yet (pending on sister branch `claude/portfolio-sweep-2026-05-25`), so we land the correct shape once instead of shipping the broken inline-`\${VAR:-}` form first.
- Codex (codex-rs) passes the env HashMap verbatim and does **not** expand `\${VAR}` references in TOML (memory: `feedback_codex_no_env_var_interpolation`, PR #174). The wrapper-script pattern is the supported substitute.
- Wrapper resolves via documented chain (env → `gh auth token` → 1Password), keeps the bearer off argv, and `exec`s the real MCP target.
- Also adds the `.codex/AGENTS.md` symlink for cross-tool AGENTS.md discovery from Codex (matches the established pattern across the portfolio).

## References
- `~/.codex/wrappers/README.md` — wrapper pattern, smoke tests, leak safety
- `~/Projects/openclaw-cf-tools-worker/RUNBOOK_WRAPPER_ROLLBACK.md` — rollback runbook
- Phase 12+13 W1 Track A → (r) (shard-2)

## Preflight
- Snapshot of pending sister-branch shape: `~/.claude/state/snapshots/2026-05-25/codex-configs/crabbox.toml.preflip`
- Smoke test: `~/.codex/wrappers/github-token.sh --print-token-only` returns non-empty (verified via `[[ -n ]]` — no token bytes echoed per global secrets rule).
- Codex guardian not running (PF.1) — flip exercised only through wrapper smoke; no live Codex session start in this PR window.

## Test plan
- [ ] CI green
- [ ] Smoke: `env -i HOME=\$HOME PATH=/opt/homebrew/bin:/usr/bin:/bin ~/.codex/wrappers/github-token.sh --print-token-only` returns non-empty on reviewer's machine.
- [ ] Rollback rehearsal (per RUNBOOK_WRAPPER_ROLLBACK.md) is to delete `.codex/config.toml` (file is net-new on main).

Co-authored by automation under Phase 12+13 W1 shard-2.