### PR TITLE
refactor: route CLI provider behavior through capabilities

### DIFF
--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1287,7 +1287,7 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 			return kind
 		}
 		if !isAutoCheckpointStrategy(strategy) {
-			if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+			if kind, ok := directNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
 				return kind
 			}
 		}
@@ -1296,14 +1296,14 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
 			return kind
 		}
-		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+		if kind, ok := directNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
 			return kind
 		}
 		if kind, ok := parallelsNativeCheckpointKind(cfg, server, normalizedStrategy); ok {
 			return kind
 		}
 		if isAutoCheckpointStrategy(strategy) {
-			if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
+			if kind, ok := directNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
 				return kind
 			}
 		}
@@ -1312,7 +1312,7 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 		if kind, ok := nativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
 			return kind
 		}
-		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
+		if kind, ok := directNativeCheckpointKind(cfg, server, target, checkpointStrategyImage); ok {
 			return kind
 		}
 		return "unsupported"
@@ -1323,7 +1323,7 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 		if kind, ok := parallelsNativeCheckpointKind(cfg, server, checkpointStrategyDiskSnapshot); ok {
 			return kind
 		}
-		if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, checkpointStrategyDiskSnapshot); ok {
+		if kind, ok := directNativeCheckpointKind(cfg, server, target, checkpointStrategyDiskSnapshot); ok {
 			return kind
 		}
 		return "unsupported"

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -68,11 +68,12 @@ func (coordinatorCheckpointDriver) Create(ctx context.Context, req checkpointNat
 		return CoordinatorImage{}, exit(2, "native checkpoints require a configured coordinator")
 	}
 	strategy := normalizeCheckpointStrategy(req.Strategy)
-	if _, ok := nativeCheckpointKind(req.Cfg, req.Server, req.Target, strategy); !ok {
+	capability, ok := providerNativeCheckpointCapability(req.Cfg, req.Server, req.Target, strategy)
+	if !ok || capability.Direct || capability.Kind == "" {
 		return CoordinatorImage{}, exit(2, "native checkpoints support brokered AWS Linux/macOS leases and brokered Azure/GCP Linux leases only")
 	}
-	if req.Server.Provider == "azure" && strategy == checkpointStrategyImage {
-		return CoordinatorImage{}, exit(2, "Azure managed images require a stopped/generalized source VM; use --strategy disk-snapshot for active Azure leases")
+	if capability.CreateUnsupported != "" {
+		return CoordinatorImage{}, exit(2, "%s", capability.CreateUnsupported)
 	}
 	name := req.Name
 	if name == "" {
@@ -165,10 +166,10 @@ func parallelsRunningState(state string) bool {
 }
 
 func nativeCheckpointCreateDriver(cfg Config, server Server, target SSHTarget, strategy string) (checkpointNativeCreateDriver, bool) {
-	if _, ok := parallelsNativeCheckpointKind(cfg, server, strategy); ok {
+	if _, ok := directParallelsNativeCheckpointKind(cfg, server, target, strategy); ok {
 		return directParallelsCheckpointDriver{}, true
 	}
-	if kind, ok := directAWSNativeCheckpointKind(cfg, server, target, strategy); ok && kind == checkpointKindAWSAMI {
+	if kind, ok := directNativeCheckpointKind(cfg, server, target, strategy); ok && kind == checkpointKindAWSAMI {
 		return directAWSAMICheckpointDriver{}, true
 	}
 	if _, ok := nativeCheckpointKind(cfg, server, target, strategy); ok {
@@ -275,72 +276,55 @@ func remotePrepareNativeImageCommand() string {
 }
 
 func nativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
-	if cfg.Coordinator == "" || server.CloudID == "" || isWindowsNativeTarget(target) {
+	capability, ok := providerNativeCheckpointCapability(cfg, server, target, strategy)
+	if !ok || capability.Direct {
 		return "", false
 	}
-	targetOS := firstNonBlank(target.TargetOS, cfg.TargetOS)
-	strategy = normalizeCheckpointStrategy(strategy)
-	switch server.Provider {
-	case "aws":
-		if targetOS != targetLinux && targetOS != targetMacOS {
-			return "", false
-		}
-		if targetOS == targetMacOS {
-			return checkpointKindAWSAMI, true
-		}
-		if strategy == checkpointStrategyImage {
-			return checkpointKindAWSAMI, true
-		}
-		return checkpointKindAWSEBS, true
-	case "azure":
-		if targetOS != targetLinux {
-			return "", false
-		}
-		if strategy == checkpointStrategyImage {
-			return checkpointKindAzure, true
-		}
-		return checkpointKindAzureOS, true
-	case "gcp":
-		if targetOS != targetLinux {
-			return "", false
-		}
-		if strategy == checkpointStrategyImage {
-			return checkpointKindGCP, true
-		}
-		return checkpointKindGCPDisk, true
-	default:
+	if capability.Kind == "" {
 		return "", false
 	}
+	return capability.Kind, true
 }
 
 func parallelsNativeCheckpointKind(cfg Config, server Server, strategy string) (string, bool) {
-	if cfg.Provider == "parallels" || server.Provider == "parallels" {
-		if server.CloudID == "" {
-			return "", false
-		}
-		if normalizeCheckpointStrategy(strategy) == checkpointStrategyImage {
-			return "", false
-		}
-		return checkpointKindParallels, true
-	}
-	return "", false
+	return directParallelsNativeCheckpointKind(cfg, server, SSHTarget{}, strategy)
 }
 
-func directAWSNativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
-	if cfg.Coordinator != "" || server.Provider != "aws" || server.CloudID == "" || isWindowsNativeTarget(target) {
+func directParallelsNativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
+	capability, ok := providerNativeCheckpointCapability(cfg, server, target, strategy)
+	if !ok || !capability.Direct || capability.Kind != checkpointKindParallels {
 		return "", false
 	}
-	targetOS := firstNonBlank(target.TargetOS, cfg.TargetOS)
-	if targetOS != targetLinux && targetOS != targetMacOS {
+	return capability.Kind, true
+}
+
+func directNativeCheckpointKind(cfg Config, server Server, target SSHTarget, strategy string) (string, bool) {
+	capability, ok := providerNativeCheckpointCapability(cfg, server, target, strategy)
+	if !ok || !capability.Direct {
 		return "", false
 	}
-	if targetOS == targetMacOS {
-		return checkpointKindAWSAMI, true
-	}
-	if normalizeCheckpointStrategy(strategy) != checkpointStrategyImage {
+	if capability.Kind == "" {
 		return "", false
 	}
-	return checkpointKindAWSAMI, true
+	return capability.Kind, true
+}
+
+func providerNativeCheckpointCapability(cfg Config, server Server, target SSHTarget, strategy string) (NativeCheckpointCapability, bool) {
+	providerName := firstNonBlank(server.Provider, cfg.Provider)
+	provider, err := ProviderFor(providerName)
+	if err != nil {
+		return NativeCheckpointCapability{}, false
+	}
+	capabilityProvider, ok := provider.(NativeCheckpointProvider)
+	if !ok {
+		return NativeCheckpointCapability{}, false
+	}
+	return capabilityProvider.NativeCheckpointCapability(NativeCheckpointRequest{
+		Config:   cfg,
+		Server:   server,
+		Target:   target,
+		Strategy: normalizeCheckpointStrategy(strategy),
+	})
 }
 
 func (record checkpointRecord) nativeProvider() string {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -59,6 +59,27 @@ type CleanupBackend interface {
 	Cleanup(ctx context.Context, req CleanupRequest) error
 }
 
+type ReleaseLeaseReporter interface {
+	ReleaseLeaseMessage(lease LeaseTarget) string
+}
+
+type NativeCheckpointCapability struct {
+	Kind              string
+	Direct            bool
+	CreateUnsupported string
+}
+
+type NativeCheckpointRequest struct {
+	Config   Config
+	Server   Server
+	Target   SSHTarget
+	Strategy string
+}
+
+type NativeCheckpointProvider interface {
+	NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool)
+}
+
 type JSONListBackend interface {
 	Backend
 	ListJSON(ctx context.Context, req ListRequest) (any, error)

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -111,10 +111,34 @@ func ServerSlug(server Server) string {
 	return serverSlug(server)
 }
 
+func ServerProviderKey(server Server) string {
+	return serverProviderKey(server)
+}
+
 func IsCanonicalLeaseID(value string) bool {
 	return isCanonicalLeaseID(value)
 }
 
 func PowershellCommand(script string) string {
 	return powershellCommand(script)
+}
+
+func ValidCrabboxProviderKey(value string) bool {
+	return validCrabboxProviderKey(value)
+}
+
+const (
+	CheckpointKindAWSAMI           = checkpointKindAWSAMI
+	CheckpointKindAWSEBS           = checkpointKindAWSEBS
+	CheckpointKindAzure            = checkpointKindAzure
+	CheckpointKindAzureOS          = checkpointKindAzureOS
+	CheckpointKindGCP              = checkpointKindGCP
+	CheckpointKindGCPDisk          = checkpointKindGCPDisk
+	CheckpointKindParallels        = checkpointKindParallels
+	CheckpointStrategyImage        = checkpointStrategyImage
+	CheckpointStrategyDiskSnapshot = checkpointStrategyDiskSnapshot
+)
+
+func NormalizeCheckpointStrategy(value string) string {
+	return normalizeCheckpointStrategy(value)
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -22,6 +22,7 @@ func init() {
 	RegisterProvider(testCloudflareProvider{})
 	RegisterProvider(testSpritesProvider{})
 	RegisterProvider(testLocalContainerProvider{})
+	RegisterProvider(testParallelsProvider{})
 }
 
 type testAzureProvider struct{}
@@ -47,6 +48,18 @@ func (testAzureProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 }
 func (p testAzureProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
+}
+func (testAzureProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
+	if req.Config.Coordinator == "" || req.Server.CloudID == "" || firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != targetLinux {
+		return NativeCheckpointCapability{}, false
+	}
+	if normalizeCheckpointStrategy(req.Strategy) == checkpointStrategyImage {
+		return NativeCheckpointCapability{
+			Kind:              checkpointKindAzure,
+			CreateUnsupported: "Azure managed images require a stopped/generalized source VM; use --strategy disk-snapshot for active Azure leases",
+		}, true
+	}
+	return NativeCheckpointCapability{Kind: checkpointKindAzureOS}, true
 }
 
 type testHetznerProvider struct{}
@@ -92,6 +105,15 @@ func (testGCPProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 func (p testGCPProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
+func (testGCPProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
+	if req.Config.Coordinator == "" || req.Server.CloudID == "" || firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != targetLinux {
+		return NativeCheckpointCapability{}, false
+	}
+	if normalizeCheckpointStrategy(req.Strategy) == checkpointStrategyImage {
+		return NativeCheckpointCapability{Kind: checkpointKindGCP}, true
+	}
+	return NativeCheckpointCapability{Kind: checkpointKindGCPDisk}, true
+}
 
 type testAWSProvider struct{}
 
@@ -122,6 +144,58 @@ func (p testAWSProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 		return testAWSBackendOverride, nil
 	}
 	return testSSHBackend{spec: p.Spec()}, nil
+}
+func (testAWSProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" || isWindowsNativeTarget(req.Target) {
+		return NativeCheckpointCapability{}, false
+	}
+	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
+	if targetOS != targetLinux && targetOS != targetMacOS {
+		return NativeCheckpointCapability{}, false
+	}
+	strategy := normalizeCheckpointStrategy(req.Strategy)
+	if req.Config.Coordinator == "" {
+		if targetOS != targetMacOS && strategy != checkpointStrategyImage {
+			return NativeCheckpointCapability{}, false
+		}
+		return NativeCheckpointCapability{Kind: checkpointKindAWSAMI, Direct: true}, true
+	}
+	if targetOS == targetMacOS || strategy == checkpointStrategyImage {
+		return NativeCheckpointCapability{Kind: checkpointKindAWSAMI}, true
+	}
+	return NativeCheckpointCapability{Kind: checkpointKindAWSEBS}, true
+}
+
+type testParallelsProvider struct{}
+
+func (testParallelsProvider) Name() string      { return "parallels" }
+func (testParallelsProvider) Aliases() []string { return nil }
+func (testParallelsProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name: "parallels",
+		Kind: ProviderKindSSHLease,
+		Targets: []TargetSpec{
+			{OS: targetLinux},
+			{OS: targetMacOS},
+			{OS: targetWindows, WindowsMode: windowsModeNormal},
+			{OS: targetWindows, WindowsMode: windowsModeWSL2},
+		},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureCheckpoint, FeatureFork, FeatureRestore, FeatureSnapshot},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testParallelsProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (testParallelsProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p testParallelsProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+func (testParallelsProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" || normalizeCheckpointStrategy(req.Strategy) == checkpointStrategyImage {
+		return NativeCheckpointCapability{}, false
+	}
+	return NativeCheckpointCapability{Kind: checkpointKindParallels, Direct: true}, true
 }
 
 type testProxmoxProvider struct{}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2385,12 +2385,8 @@ func (a App) stop(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.Stderr, "released lease=%s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 		return nil
 	}
-	if isStaticProvider(cfg.Provider) || lease.Server.Provider == staticProvider {
-		fmt.Fprintf(a.Stderr, "released static lease=%s host=%s\n", lease.LeaseID, lease.SSH.Host)
-		return nil
-	}
-	if cfg.Provider == "namespace-devbox" || cfg.Provider == "namespace" || lease.Server.Provider == "namespace-devbox" {
-		fmt.Fprintf(a.Stderr, "released namespace devbox lease=%s name=%s\n", lease.LeaseID, lease.Server.Name)
+	if reporter, ok := backend.(ReleaseLeaseReporter); ok {
+		fmt.Fprintln(a.Stderr, reporter.ReleaseLeaseMessage(lease))
 		return nil
 	}
 	fmt.Fprintf(a.Stderr, "deleted lease=%s server=%s name=%s\n", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
@@ -2416,50 +2412,6 @@ func leaseDisplayID(lease CoordinatorLease) string {
 		return lease.CloudID
 	}
 	return fmt.Sprint(lease.ServerID)
-}
-
-func deleteServer(ctx context.Context, cfg Config, server Server) error {
-	if isStaticProvider(cfg.Provider) || server.Provider == staticProvider {
-		return nil
-	}
-	if cfg.Provider == "aws" || server.Provider == "aws" || strings.HasPrefix(server.CloudID, "i-") {
-		client, err := newAWSClient(ctx, cfg)
-		if err != nil {
-			return err
-		}
-		if err := client.DeleteServer(ctx, server.CloudID); err != nil {
-			return err
-		}
-		if keyName := serverProviderKey(server); validCrabboxProviderKey(keyName) {
-			return client.DeleteSSHKey(ctx, keyName)
-		}
-		return nil
-	}
-	if cfg.Provider == "azure" || server.Provider == "azure" {
-		return deleteAzureServer(ctx, cfg, server)
-	}
-	if cfg.Provider == "proxmox" || server.Provider == "proxmox" {
-		client, err := NewProxmoxClient(cfg)
-		if err != nil {
-			return err
-		}
-		return client.DeleteServer(ctx, server.CloudID)
-	}
-	client, err := newHetznerClient()
-	if err != nil {
-		return err
-	}
-	if err := client.DeleteServer(ctx, server.ID); err != nil {
-		return err
-	}
-	if keyName := serverProviderKey(server); validCrabboxProviderKey(keyName) {
-		return client.DeleteSSHKey(ctx, keyName)
-	}
-	return nil
-}
-
-func DeleteServer(ctx context.Context, cfg Config, server Server) error {
-	return deleteServer(ctx, cfg, server)
 }
 
 func localContainerDockerSocketSync(cfg Config, server Server) bool {

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -30,7 +30,7 @@ type awsLeaseBackend struct{ shared.DirectSSHBackend }
 
 func NewAWSLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = "aws"
-	return &awsLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt}}
+	return &awsLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer}}
 }
 
 func (b *awsLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
@@ -144,6 +144,10 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	return nil
 }
 
+func (b *awsLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
 func (b *awsLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	return b.DirectSSHBackend.Touch(ctx, req.Lease.Server, req.State), nil
 }
@@ -227,6 +231,16 @@ func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
 func deleteServer(ctx context.Context, cfg Config, server Server) error {
-	return core.DeleteServer(ctx, cfg, server)
+	client, err := newAWSClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+		return err
+	}
+	if keyName := core.ServerProviderKey(server); core.ValidCrabboxProviderKey(keyName) {
+		return client.DeleteSSHKey(ctx, keyName)
+	}
+	return nil
 }
 func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -47,3 +47,38 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	}
 	return doctor, nil
 }
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" || isWindowsNativeTarget(req) {
+		return core.NativeCheckpointCapability{}, false
+	}
+	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
+	if targetOS != core.TargetLinux && targetOS != core.TargetMacOS {
+		return core.NativeCheckpointCapability{}, false
+	}
+	strategy := core.NormalizeCheckpointStrategy(req.Strategy)
+	if req.Config.Coordinator == "" {
+		if targetOS != core.TargetMacOS && strategy != core.CheckpointStrategyImage {
+			return core.NativeCheckpointCapability{}, false
+		}
+		return core.NativeCheckpointCapability{Kind: core.CheckpointKindAWSAMI, Direct: true}, true
+	}
+	if targetOS == core.TargetMacOS || strategy == core.CheckpointStrategyImage {
+		return core.NativeCheckpointCapability{Kind: core.CheckpointKindAWSAMI}, true
+	}
+	return core.NativeCheckpointCapability{Kind: core.CheckpointKindAWSEBS}, true
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isWindowsNativeTarget(req core.NativeCheckpointRequest) bool {
+	return firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) == core.TargetWindows &&
+		firstNonBlank(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal
+}

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -30,7 +30,7 @@ type azureLeaseBackend struct{ shared.DirectSSHBackend }
 
 func NewAzureLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = "azure"
-	return &azureLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt}}
+	return &azureLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer}}
 }
 
 func (b *azureLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
@@ -160,6 +160,10 @@ func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	return nil
 }
 
+func (b *azureLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
 func (b *azureLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	return b.DirectSSHBackend.Touch(ctx, req.Lease.Server, req.State), nil
 }
@@ -199,7 +203,15 @@ func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSH
 	return core.BootstrapManagedWindowsDesktop(ctx, cfg, target, publicKey, stderr)
 }
 func deleteServer(ctx context.Context, cfg Config, server Server) error {
-	return core.DeleteServer(ctx, cfg, server)
+	client, err := newAzureClient(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	name := server.CloudID
+	if name == "" {
+		name = server.Name
+	}
+	return client.DeleteServer(ctx, name)
 }
 func blank(value, fallback string) string { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -70,3 +70,28 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	}
 	return doctor, nil
 }
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if req.Config.Coordinator == "" || req.Server.CloudID == "" {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
+		return core.NativeCheckpointCapability{
+			Kind:              core.CheckpointKindAzure,
+			CreateUnsupported: "Azure managed images require a stopped/generalized source VM; use --strategy disk-snapshot for active Azure leases",
+		}, true
+	}
+	return core.NativeCheckpointCapability{Kind: core.CheckpointKindAzureOS}, true
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -190,6 +190,10 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	return nil
 }
 
+func (b *gcpLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
 func (b *gcpLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -46,3 +46,25 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	}
 	return doctor, nil
 }
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if req.Config.Coordinator == "" || req.Server.CloudID == "" {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
+		return core.NativeCheckpointCapability{Kind: core.CheckpointKindGCP}, true
+	}
+	return core.NativeCheckpointCapability{Kind: core.CheckpointKindGCPDisk}, true
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -30,7 +30,7 @@ type hetznerLeaseBackend struct{ shared.DirectSSHBackend }
 
 func NewHetznerLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = "hetzner"
-	return &hetznerLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt}}
+	return &hetznerLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer}}
 }
 
 func (b *hetznerLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
@@ -150,6 +150,10 @@ func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 	return nil
 }
 
+func (b *hetznerLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
 func (b *hetznerLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	return b.DirectSSHBackend.Touch(ctx, req.Lease.Server, req.State), nil
 }
@@ -188,7 +192,17 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 }
 func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 func deleteServer(ctx context.Context, cfg Config, server Server) error {
-	return core.DeleteServer(ctx, cfg, server)
+	client, err := newHetznerClient()
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteServer(ctx, server.ID); err != nil {
+		return err
+	}
+	if keyName := core.ServerProviderKey(server); core.ValidCrabboxProviderKey(keyName) {
+		return client.DeleteSSHKey(ctx, keyName)
+	}
+	return nil
 }
 func parseServerID(s string) (int64, bool) { return core.ParseServerID(s) }
 func blank(value, fallback string) string  { return core.Blank(value, fallback) }

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -136,6 +136,10 @@ func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLea
 	return nil
 }
 
+func (b *namespaceLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("released namespace devbox lease=%s name=%s", lease.LeaseID, lease.Server.Name)
+}
+
 func (b *namespaceLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {

--- a/internal/providers/parallels/provider.go
+++ b/internal/providers/parallels/provider.go
@@ -154,3 +154,13 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	}
 	return doctor, nil
 }
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
+		return core.NativeCheckpointCapability{}, false
+	}
+	return core.NativeCheckpointCapability{Kind: core.CheckpointKindParallels, Direct: true}, true
+}

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -12,6 +12,7 @@ type DirectSSHBackend struct {
 	SpecValue core.ProviderSpec
 	Cfg       core.Config
 	RT        core.Runtime
+	Delete    func(context.Context, core.Config, core.Server) error
 }
 
 func (b *DirectSSHBackend) Spec() core.ProviderSpec { return b.SpecValue }
@@ -25,7 +26,10 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", s.DisplayID(), s.Name)
 		if !req.DryRun {
-			if err := core.DeleteServer(ctx, b.Cfg, s); err != nil {
+			if b.Delete == nil {
+				return core.Exit(2, "provider=%s cleanup backend has no delete capability", b.SpecValue.Name)
+			}
+			if err := b.Delete(ctx, b.Cfg, s); err != nil {
 				return err
 			}
 		}

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -97,6 +97,10 @@ func (b *staticLeaseBackend) ReleaseLease(_ context.Context, req ReleaseLeaseReq
 	return nil
 }
 
+func (b *staticLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("released static lease=%s host=%s", lease.LeaseID, lease.SSH.Host)
+}
+
 func (b *staticLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {


### PR DESCRIPTION
## Summary
- Move CLI release/cleanup output and direct-provider deletion behind provider-owned backend hooks.
- Move native checkpoint kind selection behind provider capability hooks for AWS, Azure, GCP, and Parallels.
- Preserve legacy per-lease provider key cleanup by exporting the existing server provider-key helper.

## Verification
- `go test ./...`
- `go vet ./...`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `npm run docs:check`
- `npm run check`
- autoreview: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean after fixing accepted findings
- live AWS Crabbox proof: provider `aws`, lease `cbx_b8568c591705`, run `run_aca623059a1b`, command `sudo apt-get update && sudo apt-get install -y golang-go && go version && go test ./...`, exit 0, lease stopped

## Notes
- First live attempt `run_514f0f450918` / `cbx_f8775d489927` failed with `go: command not found`; lease stopped. Rerun installed Go and passed.
