### PR TITLE
refactor: move checkpoint fork config into providers

### DIFF
--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -491,6 +491,21 @@ func nativeCoordinatorImageRef(record checkpointRecord) CoordinatorImageRef {
 	}
 }
 
+func nativeCheckpointForkRecord(record checkpointRecord) NativeCheckpointForkRecord {
+	return NativeCheckpointForkRecord{
+		Kind:        record.Kind,
+		ImageID:     record.Native.ImageID,
+		Resource:    record.Native.Resource,
+		Region:      record.Native.Region,
+		Project:     record.Native.Project,
+		Direct:      record.Native.Direct,
+		HostID:      record.HostID,
+		TargetOS:    record.TargetOS,
+		WindowsMode: record.WindowsMode,
+		ServerType:  record.ServerType,
+	}
+}
+
 func coordinatorStatusCode(err error) int {
 	var httpErr CoordinatorHTTPError
 	if errors.As(err, &httpErr) {
@@ -507,76 +522,33 @@ func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record check
 	} else if cfg.CoordAdminToken != "" {
 		cfg.CoordToken = cfg.CoordAdminToken
 	}
-	switch record.Kind {
-	case checkpointKindAWSAMI:
-		cfg.AWSAMI = record.Native.ImageID
-		if record.Native.Region != "" {
-			cfg.AWSRegion = record.Native.Region
-		}
-	case checkpointKindAWSEBS:
-		cfg.AWSSnapshot = record.Native.ImageID
-		if record.Native.Region != "" {
-			cfg.AWSRegion = record.Native.Region
-		}
-	case checkpointKindAzure:
-		cfg.AzureImage = firstNonBlank(record.Native.Resource, record.Native.ImageID)
-		if record.Native.Region != "" {
-			cfg.AzureLocation = record.Native.Region
-		}
-	case checkpointKindAzureOS:
-		cfg.AzureSnapshot = firstNonBlank(record.Native.Resource, record.Native.ImageID)
-		if record.Native.Region != "" {
-			cfg.AzureLocation = record.Native.Region
-		}
-	case checkpointKindGCP:
-		cfg.GCPMachineImage = firstNonBlank(record.Native.Resource, record.Native.ImageID)
-		if record.Native.Region != "" {
-			cfg.GCPZone = record.Native.Region
-		}
-		if record.Native.Project != "" {
-			cfg.GCPProject = record.Native.Project
-			cfg.gcpProjectExplicit = true
-		}
-	case checkpointKindGCPDisk:
-		cfg.GCPSnapshot = firstNonBlank(record.Native.Resource, record.Native.ImageID)
-		if record.Native.Region != "" {
-			cfg.GCPZone = record.Native.Region
-		}
-		if record.Native.Project != "" {
-			cfg.GCPProject = record.Native.Project
-			cfg.gcpProjectExplicit = true
-		}
-	case checkpointKindParallels:
-		cfg.Provider = "parallels"
-		cfg.Coordinator = ""
-		cfg.CoordToken = ""
-		cfg.Parallels.SourceID = record.Native.Resource
-		cfg.Parallels.SourceSnapshotID = record.Native.ImageID
-		applyParallelsHostRefConfig(cfg, record.Native.Region)
-	}
 	if record.TargetOS != "" {
 		cfg.TargetOS = record.TargetOS
 	}
 	if record.WindowsMode != "" {
 		cfg.WindowsMode = record.WindowsMode
 	}
-	if cfg.Provider == "aws" && cfg.TargetOS == targetMacOS {
-		if record.Native.Direct && record.HostID != "" {
-			cfg.HostID = record.HostID
-			cfg.AWSMacHostID = record.HostID
-		}
-		if !flagWasSet(fs, "market") {
-			cfg.Capacity.Market = "on-demand"
-		}
-		normalizeTargetConfig(cfg)
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return err
 	}
-	if cfg.Provider == "azure" && flagWasSet(fs, "azure-os-disk") {
-		mode, err := NormalizeAzureOSDiskMode(fs.Lookup("azure-os-disk").Value.String())
-		if err != nil {
-			return err
-		}
-		cfg.AzureOSDisk = mode
-		cfg.AzureOSDiskExplicit = true
+	forkProvider, ok := provider.(NativeCheckpointForkProvider)
+	if !ok {
+		return exit(2, "provider=%s does not support native checkpoint fork config", cfg.Provider)
+	}
+	azureOSDisk := ""
+	azureOSDiskExplicit := flagWasSet(fs, "azure-os-disk")
+	if azureOSDiskExplicit {
+		azureOSDisk = fs.Lookup("azure-os-disk").Value.String()
+	}
+	if err := forkProvider.ApplyNativeCheckpointForkConfig(NativeCheckpointForkRequest{
+		Config:              cfg,
+		Record:              nativeCheckpointForkRecord(record),
+		MarketExplicit:      flagWasSet(fs, "market"),
+		AzureOSDisk:         azureOSDisk,
+		AzureOSDiskExplicit: azureOSDiskExplicit,
+	}); err != nil {
+		return err
 	}
 	if !flagWasSet(fs, "type") {
 		if record.ServerType != "" && !flagWasSet(fs, "class") {

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -1477,6 +1477,31 @@ func TestApplyNativeCheckpointForkConfigHonorsAzureOSDiskFlagAfterProviderRewrit
 	}
 }
 
+func TestApplyNativeCheckpointForkConfigHonorsEmptyAzureOSDiskFlag(t *testing.T) {
+	fs := newFlagSet("checkpoint fork", io.Discard)
+	_ = fs.String("type", "", "provider type")
+	_ = fs.String("azure-os-disk", AzureOSDiskManaged, "Azure OS disk mode")
+	if err := parseFlags(fs, []string{"--azure-os-disk="}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	cfg.Provider = "hetzner"
+	cfg.AzureOSDisk = AzureOSDiskEphemeral
+	cfg.AzureOSDiskExplicit = true
+	record := checkpointRecord{Kind: checkpointKindAzureOS, TargetOS: targetLinux}
+	record.Native.ImageID = "checkpoint-azure"
+
+	if err := applyNativeCheckpointForkConfig(&cfg, fs, record); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "azure" {
+		t.Fatalf("Provider=%q", cfg.Provider)
+	}
+	if cfg.AzureOSDisk != AzureOSDiskManaged || !cfg.AzureOSDiskExplicit {
+		t.Fatalf("AzureOSDisk=%q explicit=%t", cfg.AzureOSDisk, cfg.AzureOSDiskExplicit)
+	}
+}
+
 func TestParseInterspersedFlagsAllowsCheckpointBeforeFlags(t *testing.T) {
 	fs := newFlagSet("checkpoint restore", io.Discard)
 	id := fs.String("id", "", "lease id")

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -80,6 +80,31 @@ type NativeCheckpointProvider interface {
 	NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool)
 }
 
+type NativeCheckpointForkRecord struct {
+	Kind        string
+	ImageID     string
+	Resource    string
+	Region      string
+	Project     string
+	Direct      bool
+	HostID      string
+	TargetOS    string
+	WindowsMode string
+	ServerType  string
+}
+
+type NativeCheckpointForkRequest struct {
+	Config              *Config
+	Record              NativeCheckpointForkRecord
+	MarketExplicit      bool
+	AzureOSDisk         string
+	AzureOSDiskExplicit bool
+}
+
+type NativeCheckpointForkProvider interface {
+	ApplyNativeCheckpointForkConfig(req NativeCheckpointForkRequest) error
+}
+
 type JSONListBackend interface {
 	Backend
 	ListJSON(ctx context.Context, req ListRequest) (any, error)

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -11,6 +11,10 @@ func BaseConfig() Config {
 	return baseConfig()
 }
 
+func NormalizeTargetConfig(cfg *Config) {
+	normalizeTargetConfig(cfg)
+}
+
 func ExpandUserPath(path string) string {
 	return expandUserPath(path)
 }
@@ -113,6 +117,15 @@ func ServerSlug(server Server) string {
 
 func ServerProviderKey(server Server) string {
 	return serverProviderKey(server)
+}
+
+func SetGCPProjectExplicit(cfg *Config, project string) {
+	cfg.GCPProject = project
+	cfg.gcpProjectExplicit = true
+}
+
+func ApplyParallelsHostRefConfig(cfg *Config, hostRef string) {
+	applyParallelsHostRefConfig(cfg, hostRef)
 }
 
 func IsCanonicalLeaseID(value string) bool {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -61,6 +61,28 @@ func (testAzureProvider) NativeCheckpointCapability(req NativeCheckpointRequest)
 	}
 	return NativeCheckpointCapability{Kind: checkpointKindAzureOS}, true
 }
+func (testAzureProvider) ApplyNativeCheckpointForkConfig(req NativeCheckpointForkRequest) error {
+	switch req.Record.Kind {
+	case checkpointKindAzure:
+		req.Config.AzureImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	case checkpointKindAzureOS:
+		req.Config.AzureSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	default:
+		return exit(2, "provider=azure does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		req.Config.AzureLocation = req.Record.Region
+	}
+	if req.AzureOSDiskExplicit {
+		mode, err := NormalizeAzureOSDiskMode(req.AzureOSDisk)
+		if err != nil {
+			return err
+		}
+		req.Config.AzureOSDisk = mode
+		req.Config.AzureOSDiskExplicit = true
+	}
+	return nil
+}
 
 type testHetznerProvider struct{}
 
@@ -114,6 +136,24 @@ func (testGCPProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (
 	}
 	return NativeCheckpointCapability{Kind: checkpointKindGCPDisk}, true
 }
+func (testGCPProvider) ApplyNativeCheckpointForkConfig(req NativeCheckpointForkRequest) error {
+	switch req.Record.Kind {
+	case checkpointKindGCP:
+		req.Config.GCPMachineImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	case checkpointKindGCPDisk:
+		req.Config.GCPSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	default:
+		return exit(2, "provider=gcp does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		req.Config.GCPZone = req.Record.Region
+	}
+	if req.Record.Project != "" {
+		req.Config.GCPProject = req.Record.Project
+		req.Config.gcpProjectExplicit = true
+	}
+	return nil
+}
 
 type testAWSProvider struct{}
 
@@ -165,6 +205,30 @@ func (testAWSProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (
 	}
 	return NativeCheckpointCapability{Kind: checkpointKindAWSEBS}, true
 }
+func (testAWSProvider) ApplyNativeCheckpointForkConfig(req NativeCheckpointForkRequest) error {
+	switch req.Record.Kind {
+	case checkpointKindAWSAMI:
+		req.Config.AWSAMI = req.Record.ImageID
+	case checkpointKindAWSEBS:
+		req.Config.AWSSnapshot = req.Record.ImageID
+	default:
+		return exit(2, "provider=aws does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		req.Config.AWSRegion = req.Record.Region
+	}
+	if req.Config.TargetOS == targetMacOS {
+		if req.Record.Direct && req.Record.HostID != "" {
+			req.Config.HostID = req.Record.HostID
+			req.Config.AWSMacHostID = req.Record.HostID
+		}
+		if !req.MarketExplicit {
+			req.Config.Capacity.Market = "on-demand"
+		}
+		normalizeTargetConfig(req.Config)
+	}
+	return nil
+}
 
 type testParallelsProvider struct{}
 
@@ -196,6 +260,18 @@ func (testParallelsProvider) NativeCheckpointCapability(req NativeCheckpointRequ
 		return NativeCheckpointCapability{}, false
 	}
 	return NativeCheckpointCapability{Kind: checkpointKindParallels, Direct: true}, true
+}
+func (testParallelsProvider) ApplyNativeCheckpointForkConfig(req NativeCheckpointForkRequest) error {
+	if req.Record.Kind != checkpointKindParallels {
+		return exit(2, "provider=parallels does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	req.Config.Provider = "parallels"
+	req.Config.Coordinator = ""
+	req.Config.CoordToken = ""
+	req.Config.Parallels.SourceID = req.Record.Resource
+	req.Config.Parallels.SourceSnapshotID = req.Record.ImageID
+	applyParallelsHostRefConfig(req.Config, req.Record.Region)
+	return nil
 }
 
 type testProxmoxProvider struct{}

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -82,3 +82,29 @@ func isWindowsNativeTarget(req core.NativeCheckpointRequest) bool {
 	return firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) == core.TargetWindows &&
 		firstNonBlank(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal
 }
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	cfg := req.Config
+	switch req.Record.Kind {
+	case core.CheckpointKindAWSAMI:
+		cfg.AWSAMI = req.Record.ImageID
+	case core.CheckpointKindAWSEBS:
+		cfg.AWSSnapshot = req.Record.ImageID
+	default:
+		return core.Exit(2, "provider=aws does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		cfg.AWSRegion = req.Record.Region
+	}
+	if cfg.TargetOS == core.TargetMacOS {
+		if req.Record.Direct && req.Record.HostID != "" {
+			cfg.HostID = req.Record.HostID
+			cfg.AWSMacHostID = req.Record.HostID
+		}
+		if !req.MarketExplicit {
+			cfg.Capacity.Market = "on-demand"
+		}
+		core.NormalizeTargetConfig(cfg)
+	}
+	return nil
+}

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -95,3 +95,27 @@ func firstNonBlank(values ...string) string {
 	}
 	return ""
 }
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	cfg := req.Config
+	switch req.Record.Kind {
+	case core.CheckpointKindAzure:
+		cfg.AzureImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	case core.CheckpointKindAzureOS:
+		cfg.AzureSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	default:
+		return core.Exit(2, "provider=azure does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		cfg.AzureLocation = req.Record.Region
+	}
+	if req.AzureOSDiskExplicit {
+		mode, err := core.NormalizeAzureOSDiskMode(req.AzureOSDisk)
+		if err != nil {
+			return err
+		}
+		cfg.AzureOSDisk = mode
+		cfg.AzureOSDiskExplicit = true
+	}
+	return nil
+}

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -68,3 +68,22 @@ func firstNonBlank(values ...string) string {
 	}
 	return ""
 }
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	cfg := req.Config
+	switch req.Record.Kind {
+	case core.CheckpointKindGCP:
+		cfg.GCPMachineImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	case core.CheckpointKindGCPDisk:
+		cfg.GCPSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+	default:
+		return core.Exit(2, "provider=gcp does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	if req.Record.Region != "" {
+		cfg.GCPZone = req.Record.Region
+	}
+	if req.Record.Project != "" {
+		core.SetGCPProjectExplicit(cfg, req.Record.Project)
+	}
+	return nil
+}

--- a/internal/providers/parallels/provider.go
+++ b/internal/providers/parallels/provider.go
@@ -164,3 +164,17 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	}
 	return core.NativeCheckpointCapability{Kind: core.CheckpointKindParallels, Direct: true}, true
 }
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	if req.Record.Kind != core.CheckpointKindParallels {
+		return core.Exit(2, "provider=parallels does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	cfg := req.Config
+	cfg.Provider = "parallels"
+	cfg.Coordinator = ""
+	cfg.CoordToken = ""
+	cfg.Parallels.SourceID = req.Record.Resource
+	cfg.Parallels.SourceSnapshotID = req.Record.ImageID
+	core.ApplyParallelsHostRefConfig(cfg, req.Record.Region)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Move provider-native checkpoint fork config into provider hooks for AWS, Azure, GCP, and Parallels.
- Keep generic fork flow in core: provider selection, target/windows-mode carryover, coordinator token handoff, and server type defaults.
- Add regression coverage for the explicit empty `--azure-os-disk=` override after provider rewrite.

## Verification
- `go test ./...`
- `go vet ./...`
- autoreview: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean after fixing the accepted Azure empty-flag finding
- live AWS Crabbox proof: provider `aws`, lease `cbx_0b0774fb48d4`, run `run_d62f9bac632c`, command `sudo apt-get update && sudo apt-get install -y golang-go && go version && go test ./...`, exit 0, lease stopped
