### PR TITLE
docs(audit): public-surface audit scaffolding (Phase 16 D.16 pilot 3)

### DIFF
--- a/scripts/public-surface-routes.mjs
+++ b/scripts/public-surface-routes.mjs
@@ -1,0 +1,170 @@
+/**
+ * Crabbox public-surface route matrix
+ * Phase 16 D.16 pilot 3 (W2.4)
+ *
+ * Crabbox is wrapped by Cloudflare Access (team_domain
+ * `crabbox-openclaw.cloudflareaccess.com`, AUD pinned). Unauthenticated
+ * traffic to most paths is intercepted by Access at the edge and returned
+ * as a 302 to the Access login page. The Worker only sees requests that
+ * either (a) bypass Access (rare; usually crons / internal) or (b) carry
+ * a valid `cf-access-jwt-assertion`.
+ *
+ * For the public-surface audit we probe what the *edge* exposes to an
+ * unauthenticated browser/script — that is what an external attacker
+ * would see. Most routes are expected to return 302 (Access redirect)
+ * or 401 from the Worker for the few paths that escape Access.
+ *
+ * Routes are split into three buckets:
+ *   1. Unauthenticated reachable (smoke checks the Worker bypasses Access for)
+ *   2. Access-gated (expected 302 to teamDomain or 401)
+ *   3. Internal/admin (must NEVER be reachable; expected 401/403/404/302)
+ *
+ * Origin under audit (from wrangler.jsonc):
+ *   - https://crabbox.openclaw.ai          (primary, Access-gated)
+ *   - https://crabbox-access.openclaw.ai   (secondary, Access-gated)
+ *   - https://crabbox-coordinator.<accounts>.workers.dev (workers.dev fallback)
+ *
+ * See ~/Projects/docs/system/D16_PILOT_CRABBOX_2026-05-27.md for findings.
+ */
+
+export default [
+  // ---- Bucket 1: unauthenticated reachable surface ----
+  // Worker handles GET /v1/health before any auth check.
+  {
+    label: 'health',
+    kind: 'request',
+    path: '/v1/health',
+    method: 'GET',
+    expect: [200, 302],
+    bodyIncludes: [],
+    // If Access is in front of the whole zone, /v1/health may also redirect.
+    // Both 200 (Worker-handled) and 302 (Access-intercepted) are acceptable
+    // signals here — both mean nothing leaks.
+  },
+  // Root redirects to /portal (Worker-handled before auth).
+  {
+    label: 'root-redirects-to-portal',
+    kind: 'request',
+    path: '/',
+    method: 'GET',
+    expect: [302],
+    expectNot: [200, 500],
+  },
+  // Portal entrypoint — should land on Access login or portal login route.
+  {
+    label: 'portal-root',
+    kind: 'request',
+    path: '/portal',
+    method: 'GET',
+    expect: [200, 302],
+    expectNot: [500],
+  },
+  // Portal login route is exempted from bearer auth (returns HTML form / Access redirect).
+  {
+    label: 'portal-login',
+    kind: 'request',
+    path: '/portal/login',
+    method: 'GET',
+    expect: [200, 302],
+    expectNot: [500],
+  },
+
+  // ---- Bucket 2: Access-gated API surface ----
+  // These should NOT return 200 to an unauthenticated request. Expected
+  // posture: 302 to Access login OR 401 from the Worker (if Access permits
+  // the path through unauthenticated, the Worker auth-gates it).
+  {
+    label: 'api-pool',
+    kind: 'request',
+    path: '/v1/pool',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'api-usage',
+    kind: 'request',
+    path: '/v1/usage',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'api-whoami',
+    kind: 'request',
+    path: '/v1/whoami',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'api-runs-list',
+    kind: 'request',
+    path: '/v1/runs',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'api-runners-list',
+    kind: 'request',
+    path: '/v1/runners',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'api-leases-list',
+    kind: 'request',
+    path: '/v1/leases',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+
+  // ---- Bucket 3: must-be-unreachable internal surface ----
+  // The Worker explicitly 404s /v1/internal/* paths before auth. The
+  // scheduled-maintenance endpoint should never be callable from outside.
+  {
+    label: 'internal-scheduled-must-404',
+    kind: 'request',
+    path: '/v1/internal/scheduled',
+    method: 'POST',
+    expect: [404, 302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'internal-foo-must-404',
+    kind: 'request',
+    path: '/v1/internal/whatever',
+    method: 'GET',
+    expect: [404, 302, 401, 403],
+    expectNot: [200, 500],
+  },
+
+  // ---- Admin routes — must require admin token ----
+  {
+    label: 'admin-leases',
+    kind: 'request',
+    path: '/v1/admin/leases',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'admin-aws-identity',
+    kind: 'request',
+    path: '/v1/admin/aws-identity',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+  {
+    label: 'admin-aws-orphan-sweep',
+    kind: 'request',
+    path: '/v1/admin/aws-orphan-sweep',
+    method: 'GET',
+    expect: [302, 401, 403],
+    expectNot: [200, 500],
+  },
+];

--- a/scripts/run-public-surface-audit.mjs
+++ b/scripts/run-public-surface-audit.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Crabbox public-surface audit wrapper
+ * Phase 16 D.16 pilot 3 (W2.4)
+ *
+ * Wires `@LDMB123/lj-shared-public-surface-audit` (vendor-fallback
+ * import from `.shared/public-surface-audit/` until lj-shared publishes
+ * to GitHub Packages — Phase 16 W1.8 Option B) against the crabbox
+ * coordinator origin.
+ *
+ * Required env:
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   CLOUDFLARE_API_TOKEN (or CLOUDFLARE_BROWSER_RENDERING_TOKEN)
+ *
+ * Optional env:
+ *   CRABBOX_PRODUCTION_ORIGIN  — defaults to https://crabbox.openclaw.ai
+ *   CRABBOX_CUTOVER_ID         — defaults to cut-<unix-seconds>
+ *
+ * Note: crabbox sits behind Cloudflare Access. The route matrix expects
+ * 302 to Access login OR 401 from the Worker for gated routes; 200 only
+ * for /v1/health and /portal entrypoints. See
+ * ~/Projects/docs/system/D16_PILOT_CRABBOX_2026-05-27.md.
+ */
+import { runAudit } from '@LDMB123/lj-shared-public-surface-audit';
+import routes from './public-surface-routes.mjs';
+
+const origin = process.env.CRABBOX_PRODUCTION_ORIGIN ?? 'https://crabbox.openclaw.ai';
+const cutoverId =
+  process.env.CRABBOX_CUTOVER_ID ?? `cut-${Math.floor(Date.now() / 1000)}`;
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const apiToken =
+  process.env.CLOUDFLARE_API_TOKEN ?? process.env.CLOUDFLARE_BROWSER_RENDERING_TOKEN;
+
+if (!accountId || !apiToken) {
+  console.error(
+    'crabbox public-surface audit requires CLOUDFLARE_ACCOUNT_ID + ' +
+      'CLOUDFLARE_API_TOKEN (or CLOUDFLARE_BROWSER_RENDERING_TOKEN). Skipping.',
+  );
+  process.exit(2);
+}
+
+const summary = await runAudit({
+  routeMatrix: routes,
+  origin,
+  outputDir: 'output/public-surface-audit',
+  cutoverId,
+  accountId,
+  apiToken,
+  finalOriginHosts: ['crabbox.openclaw.ai', 'crabbox-access.openclaw.ai'],
+});
+
+if (summary.status !== 'pass') {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/public-surface-routes.mjs` — a 15-route matrix for the crabbox coordinator across three buckets: unauthenticated reachable, Access-gated API, and must-be-unreachable internal/admin routes.
- Adds `scripts/run-public-surface-audit.mjs` — a thin wrapper around `@LDMB123/lj-shared-public-surface-audit`'s `runAudit()` that consumes the route matrix, points it at `https://crabbox.openclaw.ai`, and writes a JSON summary + per-page screenshots under `output/public-surface-audit/`.

This is the third pilot in the Phase 16 D.16 fan-out for the shared public-surface audit module (pilots 1+2: cloudflare-browser-rendering and openclaw-cf-tools-worker). **Findings-only PR — no source-code edits in `worker/`.**

## Findings

Recorded in operator-side doc at `~/Projects/docs/system/D16_PILOT_CRABBOX_2026-05-27.md` (not in this repo).

Non-blocking highlights:
- **F1** (P1): `crabbox.openclaw.ai` is **not** behind an active Cloudflare Access policy despite the `CRABBOX_ACCESS_*` env vars implying it is. The sibling `crabbox-access.openclaw.ai` IS gated. Worker bearer-auth is the actual auth boundary on the primary alias — defense-in-depth works as designed, but the dual-alias asymmetry is operator-surprising.
- **F2** (P2): `GET /v1/health` returns `{"ok":true,"service":"crabbox-coordinator"}` unauthenticated — the `service` field is a minor information leak.
- **F3** (P2): vendor-fallback adoption path is incompatible with crabbox's Go-monorepo + `worker/`-nested-Node layout. Recommend waiting for lj-shared GitHub Packages publish (Phase 16 W1.8) before adopters install the dep.
- **F4, F5** (positive): no CORS surface on `/v1/*`; catch-all 401 correctly hides route topology.

All non-trivial follow-ups are filed for Phase 17 per the W2.2 audit fix-PR policy.

## Test plan

- [ ] Once lj-shared publishes to GitHub Packages (Phase 16 W1.8), run `node scripts/run-public-surface-audit.mjs` against the live origin with `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` set.
- [ ] Verify the matrix's `expect[]` values match observed responses (already confirmed via curl probes — see findings doc Section 5).
- [ ] Confirm screenshots land under `output/public-surface-audit/<label>.png` for `kind: 'page'` routes.

This PR introduces no runtime behavior. Wrapper is invoked manually / by CI; it does not run during the standard `worker/` deploy pipeline.