### PR TITLE
fix: propagate gnome xwayland desktop env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added a portable `--os`/`os` lease selector with Ubuntu 26.04 as the preferred Linux image where provider catalogs support it, while preserving explicit provider image overrides.
 - Added `--desktop-env gnome` for a GNOME-apps desktop profile on labwc/WayVNC.
-- Added GNOME Panel taskbars to the `--desktop-env gnome` profile.
+- Added GNOME Panel taskbars to the `--desktop-env gnome` profile, with GNOME launches kept visible through Xwayland.
 
 ### Fixed
 

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -196,7 +196,8 @@ families, or provider image names.
 operator takeover. Linux defaults to Xvfb, slim XFCE, and x11vnc; use
 `--desktop-env wayland` for the experimental labwc/WayVNC profile on Ubuntu
 26.04-compatible images, or `--desktop-env gnome` for a GNOME-apps profile with
-GNOME Panel taskbars on labwc/WayVNC. It does not imply a browser. Use
+GNOME Panel taskbars on labwc/WayVNC. GNOME-profile app launches use Xwayland
+so the panel can list open windows. It does not imply a browser. Use
 `--desktop --browser` when a headed browser should run in the visible display.
 
 `--code` provisions `code-server` for Linux leases and enables

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -892,7 +892,7 @@ func cloudInitOptionalWriteFiles(cfg Config) string {
 func cloudInitWaylandDesktopWriteFiles(desktopEnv string) string {
 	displayEnv := ""
 	if desktopEnv == desktopEnvGnome {
-		displayEnv = "      DISPLAY=:0\n"
+		displayEnv = "      DISPLAY=:0\n      GDK_BACKEND=x11\n      MOZ_ENABLE_WAYLAND=0\n"
 	}
 	return `  - path: /usr/local/bin/crabbox-start-wayland-desktop
     permissions: '0755'
@@ -995,7 +995,7 @@ func cloudInitOptionalBootstrap(cfg Config) string {
     gnome-terminal -- bash -l >/tmp/crabbox-gnome-terminal.log 2>&1 &
     nautilus --new-window "$HOME" >/tmp/crabbox-nautilus.log 2>&1 &
 `
-			desktopEnvExtra = "    DISPLAY=:0\n"
+			desktopEnvExtra = "    DISPLAY=:0\n    GDK_BACKEND=x11\n    MOZ_ENABLE_WAYLAND=0\n"
 		}
 		parts = append(parts, `    retry apt-get install -y --no-install-recommends `+packages+`
     install -d -m 0750 -o crabbox -g crabbox /var/lib/crabbox

--- a/internal/cli/capabilities.go
+++ b/internal/cli/capabilities.go
@@ -236,7 +236,7 @@ func probeDesktopEnv(ctx context.Context, target SSHTarget) (map[string]string, 
 
 func probeDesktopEnvCommand() string {
 	return `if [ -f ` + shellQuote(desktopEnvPath) + ` ]; then . ` + shellQuote(desktopEnvPath) + `; fi
-for key in CRABBOX_DESKTOP_ENV DISPLAY XAUTHORITY XDG_RUNTIME_DIR WAYLAND_DISPLAY; do
+for key in CRABBOX_DESKTOP_ENV DISPLAY XAUTHORITY XDG_RUNTIME_DIR WAYLAND_DISPLAY GDK_BACKEND MOZ_ENABLE_WAYLAND; do
   eval "value=\${$key:-}"
   [ -n "$value" ] && printf '%s=%s\n' "$key" "$value"
 done`

--- a/internal/cli/coordinator_capabilities_test.go
+++ b/internal/cli/coordinator_capabilities_test.go
@@ -118,6 +118,8 @@ func TestProbeDesktopEnvCommandIncludesXAuthority(t *testing.T) {
 		"XAUTHORITY",
 		"XDG_RUNTIME_DIR",
 		"WAYLAND_DISPLAY",
+		"GDK_BACKEND",
+		"MOZ_ENABLE_WAYLAND",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("desktop env probe missing %q:\n%s", want, got)

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -11,7 +11,7 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 	got := desktopLaunchRemoteCommand(
 		SSHTarget{TargetOS: targetLinux},
 		"/work/crabbox/cbx_1/repo",
-		map[string]string{"DISPLAY": ":99", "BROWSER": "/usr/bin/chromium"},
+		map[string]string{"DISPLAY": ":99", "BROWSER": "/usr/bin/chromium", "GDK_BACKEND": "x11", "MOZ_ENABLE_WAYLAND": "0"},
 		[]string{"/usr/bin/chromium", "https://example.com"},
 		true,
 	)
@@ -20,6 +20,8 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 		"cd '/work/crabbox/cbx_1/repo'",
 		"DISPLAY=':99'",
 		"BROWSER='/usr/bin/chromium'",
+		"GDK_BACKEND='x11'",
+		"MOZ_ENABLE_WAYLAND='0'",
 		"setsid '/usr/bin/chromium' 'https://example.com'",
 		"crabbox-desktop-launch.log",
 		"wmctrl -r :ACTIVE: -b remove,fullscreen",

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1157,6 +1157,8 @@ WAYLAND_DISPLAY=$display
 EOF
 if [ "$desktop_env" = "gnome" ]; then
   printf 'DISPLAY=:0\n' >>/var/lib/crabbox/desktop.env
+  printf 'GDK_BACKEND=x11\n' >>/var/lib/crabbox/desktop.env
+  printf 'MOZ_ENABLE_WAYLAND=0\n' >>/var/lib/crabbox/desktop.env
 fi
 chown "$user" /var/lib/crabbox/desktop.env
 chmod 0644 /var/lib/crabbox/desktop.env

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -615,7 +615,10 @@ function optionalWriteFiles(config: LeaseConfig): string {
   }
   if (config.desktopEnv !== "xfce") {
     const desktopEnv = config.desktopEnv;
-    const displayEnv = desktopEnv === "gnome" ? "      DISPLAY=:0\n" : "";
+    const displayEnv =
+      desktopEnv === "gnome"
+        ? "      DISPLAY=:0\n      GDK_BACKEND=x11\n      MOZ_ENABLE_WAYLAND=0\n"
+        : "";
     return `  - path: /usr/local/bin/crabbox-start-wayland-desktop
     permissions: '0755'
     content: |
@@ -1006,7 +1009,9 @@ function optionalBootstrap(config: LeaseConfig): string {
     const packages = gnome
       ? "labwc wayvnc gnome-panel wlr-randr grim slurp wtype wl-clipboard dbus-user-session xwayland xdg-desktop-portal-wlr xdg-desktop-portal-gtk gnome-terminal nautilus gsettings-desktop-schemas adwaita-icon-theme fonts-dejavu-core fonts-liberation iproute2 openssl procps"
       : "labwc wayvnc foot grim slurp wtype wl-clipboard wlr-randr dbus-user-session xwayland xdg-desktop-portal-wlr fonts-dejavu-core fonts-liberation iproute2 openssl procps";
-    const desktopEnvExtra = gnome ? "    DISPLAY=:0\n" : "";
+    const desktopEnvExtra = gnome
+      ? "    DISPLAY=:0\n    GDK_BACKEND=x11\n    MOZ_ENABLE_WAYLAND=0\n"
+      : "";
     const autostart = gnome
       ? `    wlr-randr --output HEADLESS-1 --custom-mode 1920x1080 >/tmp/crabbox-wlr-randr.log 2>&1 || true
     for _ in $(seq 1 20); do


### PR DESCRIPTION
## Summary
- persist GNOME Xwayland launch overrides in desktop.env
- forward GDK_BACKEND and MOZ_ENABLE_WAYLAND through desktop capability probing
- document that GNOME-profile app launches use Xwayland so GNOME Panel can list windows

## Verification
- autoreview --mode local --engine codex --no-web-search
- go test ./internal/cli ./internal/providers/localcontainer
- npm run format:check --prefix worker && npm run lint --prefix worker && npm run check --prefix worker && npm test --prefix worker -- bootstrap.test.ts
- go test ./... && go vet ./... && go build -trimpath -o bin/crabbox ./cmd/crabbox
- npm run lint --prefix worker && npm run check --prefix worker && npm test --prefix worker && npm run build --prefix worker
