### PR TITLE
feat: add delegated run session output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added a portable `--os`/`os` lease selector with Ubuntu 26.04 as the preferred Linux image where provider catalogs support it, while preserving explicit provider image overrides.
 - Added Azure `capacity.regions` fallback with region-scoped managed network names and Azure capacity hints, matching the AWS capacity-routing model.
 - Added a repo-local Crabbox hydrate workflow and documented Azure as the preferred Windows/WSL2 provider when Azure quota or credits are available.
+- Added `crabbox run --lease-output <file>` for reusable delegated-run session JSON, starting with Blacksmith Testbox. Thanks @RomneyDa.
 
 ### Fixed
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -37,7 +37,11 @@ crabbox run --profile live-qa --preset qa-live --scenario login-regression --emi
 
 If `--id` is omitted, Crabbox creates a fresh non-kept lease and releases it when the command exits. On coordinator-backed one-shot runs, if SSH becomes unavailable after a successful sync but before the command starts, Crabbox stops that stale lease, creates one replacement lease, and retries sync once. It does not replace explicit `--id`, kept, `--keep-on-failure`, `--no-sync`, `--sync-only`, or custom-slug runs. `--id` accepts the stable `cbx_...` ID or the active friendly slug.
 
-With `--provider blacksmith-testbox`, `--id` accepts a Blacksmith `tbx_...` ID or a local Crabbox slug. Crabbox forwards the command to `blacksmith testbox run`, delegates sync to Blacksmith, and prints `sync=delegated` in the final timing summary.
+With `--provider blacksmith-testbox`, `--id` accepts a Blacksmith `tbx_...` ID
+or a local Crabbox slug. Crabbox forwards the command to
+`blacksmith testbox run`, delegates sync to Blacksmith, and prints
+`sync=delegated` in the final timing summary. Add `--lease-output <file>` with
+`--keep` to write a small JSON handle for follow-up `--id` runs and cleanup.
 
 With `--provider namespace-devbox`, `--id` accepts a Crabbox `cbx_...` ID,
 local slug, or existing Devbox name. Namespace owns create, SSH config, and list
@@ -355,6 +359,7 @@ Flags:
 --label <text>
 --reclaim
 --timing-json
+--lease-output <file>
 --blacksmith-org <org>
 --blacksmith-workflow <file|name|id>
 --blacksmith-job <job>

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -40,6 +40,15 @@ crabbox status --provider blacksmith-testbox --id tbx_123
 crabbox stop --provider blacksmith-testbox tbx_123
 ```
 
+Reusable session handoff:
+
+```sh
+crabbox run --provider blacksmith-testbox --keep --lease-output /tmp/session.json -- npm test
+lease_id="$(node -e 'console.log(require("/tmp/session.json").leaseId)')"
+crabbox run --provider blacksmith-testbox --id "$lease_id" -- npm run smoke
+crabbox stop --provider blacksmith-testbox "$lease_id"
+```
+
 Warm a fresh Testbox:
 
 ```sh
@@ -111,6 +120,9 @@ One-shot runs clean up the local claim/key and stop the Testbox after command
 completion unless `--keep` is set. Add `--keep-on-failure` when debugging live
 failures; successful runs still stop normally, while failed one-shot Testboxes
 remain available until idle timeout or explicit `crabbox stop`.
+Use `--lease-output <file>` with `crabbox run` to write a small JSON session
+handle for automation. The handle includes `leaseId`, reuse/keep state,
+detected Actions context, and a non-secret cleanup command.
 Failed runs save a local failure bundle with stdout/stderr, timing, and
 redacted env/config metadata even though remote file capture is delegated to
 Blacksmith. These implicit stream logs are capped so a verbose successful run

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -153,6 +153,7 @@ const (
 	FeatureRestore     Feature = "workspace-restore"
 	FeatureSnapshot    Feature = "provider-snapshot"
 	FeatureRunProof    Feature = "run-proof"
+	FeatureRunSession  Feature = "run-session"
 )
 
 type FeatureSet []Feature
@@ -383,6 +384,7 @@ type RunResult struct {
 	Command       time.Duration
 	Total         time.Duration
 	SyncDelegated bool
+	Session       *RunSessionHandle
 	Provider      string
 	LeaseID       string
 	Slug          string
@@ -390,6 +392,17 @@ type RunResult struct {
 	LogExcerpt    string
 	ActionsURL    string
 	Artifacts     []RunArtifact
+}
+
+type RunSessionHandle struct {
+	Provider       string `json:"provider"`
+	LeaseID        string `json:"leaseId"`
+	Slug           string `json:"slug,omitempty"`
+	Reused         bool   `json:"reused"`
+	Kept           bool   `json:"kept"`
+	ActionsURL     string `json:"actionsUrl,omitempty"`
+	RunID          string `json:"runId,omitempty"`
+	CleanupCommand string `json:"cleanupCommand"`
 }
 
 type LeaseTarget struct {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -179,6 +179,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	emitProof := fs.String("emit-proof", "", "write a generated proof block after a successful run")
 	proofTemplate := fs.String("proof-template", "", "proof template name from the selected profile")
 	stopAfter := fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never")
+	leaseOutput := fs.String("lease-output", "", "write a small JSON lease handle for orchestrators")
 	var downloads stringListFlag
 	var allowEnvFlags stringListFlag
 	var envProfileFlags stringListFlag
@@ -264,7 +265,21 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if err := preflightRunLocalOutputs(*captureStdout, *captureStderr, downloads); err != nil {
 		return err
 	}
+	if strings.TrimSpace(*leaseOutput) != "" {
+		if err := preflightLocalOutputPath("lease output", strings.TrimSpace(*leaseOutput), false); err != nil {
+			return err
+		}
+	}
 	if strings.TrimSpace(*emitProof) != "" {
+		if strings.TrimSpace(*leaseOutput) != "" {
+			samePath, err := sameLocalOutputPath(strings.TrimSpace(*leaseOutput), strings.TrimSpace(*emitProof))
+			if err != nil {
+				return err
+			}
+			if samePath {
+				return exit(2, "lease output and emit proof paths must be different")
+			}
+		}
 		if err := preflightProofOutputPath(strings.TrimSpace(*emitProof), *captureStdout, *captureStderr, downloads); err != nil {
 			return err
 		}
@@ -359,6 +374,11 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	if strings.TrimSpace(*leaseOutput) != "" && !backend.Spec().Features.Has(FeatureRunSession) {
+		// TODO: Let other reusable delegated providers populate RunResult.Session
+		// and advertise FeatureRunSession once their lifecycle contract is covered.
+		return exit(2, "--lease-output is not supported for provider=%s yet", backend.Spec().Name)
+	}
 	options := leaseOptionsFromConfig(cfg)
 	scriptRequested := *scriptPath != "" || *scriptStdin
 	runReq := RunRequest{
@@ -409,6 +429,12 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		result, runErr := delegated.Run(ctx, runReq)
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
+		}
+		if err := writeRunLeaseOutput(strings.TrimSpace(*leaseOutput), result.Session); err != nil {
+			if runErr == nil {
+				return err
+			}
+			fmt.Fprintf(a.Stderr, "warning: lease output failed: %v\n", err)
 		}
 		if runErr == nil && strings.TrimSpace(*emitProof) != "" {
 			proof, err := writeDelegatedRunProof(strings.TrimSpace(*emitProof), strings.TrimSpace(*proofTemplate), cfg, result, runReq)
@@ -1342,6 +1368,16 @@ afterSync:
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
 	return nil
+}
+
+func writeRunLeaseOutput(path string, session *RunSessionHandle) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if session == nil {
+		return exit(2, "--lease-output was requested but provider did not return a session handle")
+	}
+	return writeJSONFile(path, session)
 }
 
 type countingWriteCloser struct {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -329,6 +329,7 @@ func TestRunCommandRejectsUnsupportedDelegatedCaptureOptions(t *testing.T) {
 		{name: "daytona download", provider: "daytona", args: []string{"--download", "/tmp/proof=proof.bin"}, want: "daytona delegates run execution; --download is not supported"},
 		{name: "islo download", provider: "islo", args: []string{"--download", "/tmp/proof=proof.bin"}, want: "islo delegates run execution; --download is not supported"},
 		{name: "e2b download", provider: "e2b", args: []string{"--download", "/tmp/proof=proof.bin"}, want: "e2b delegates run execution; --download is not supported"},
+		{name: "e2b lease output", provider: "e2b", args: []string{"--lease-output", "session.json"}, want: "--lease-output is not supported for provider=e2b yet"},
 		{name: "e2b stop after", provider: "e2b", args: []string{"--stop-after", "never"}, want: "e2b delegates run execution; --stop-after is not supported"},
 		{name: "daytona script", provider: "daytona", args: []string{"--script", "testdata/missing.sh"}, want: "daytona delegates run execution; --script is not supported"},
 		{name: "e2b fresh pr", provider: "e2b", args: []string{"--fresh-pr", "example-org/my-app#1"}, want: "e2b delegates sync; --fresh-pr is not supported"},
@@ -1044,6 +1045,8 @@ func TestRunCommandPreflightsLocalOutputOptions(t *testing.T) {
 		{name: "malformed download", args: []string{"--download", "out.bin", "--", "true"}, want: "--download expects remote=local"},
 		{name: "missing capture directory", args: []string{"--capture-stdout", filepath.Join(t.TempDir(), "missing", "stdout.bin"), "--", "true"}, want: "capture stdout:"},
 		{name: "missing stderr capture directory", args: []string{"--capture-stderr", filepath.Join(t.TempDir(), "missing", "stderr.bin"), "--", "true"}, want: "capture stderr:"},
+		{name: "missing lease output directory", args: []string{"--lease-output", filepath.Join(t.TempDir(), "missing", "session.json"), "--", "true"}, want: "lease output:"},
+		{name: "same lease output and proof path", args: []string{"--lease-output", "session.json", "--emit-proof", "session.json", "--", "true"}, want: "lease output and emit proof paths must be different"},
 		{name: "same capture path", args: []string{"--capture-stdout", "run.log", "--capture-stderr", "run.log", "--", "true"}, want: "paths must be different"},
 	}
 	for _, tt := range tests {
@@ -1058,6 +1061,34 @@ func TestRunCommandPreflightsLocalOutputOptions(t *testing.T) {
 				t.Fatalf("message=%q want %q", exitErr.Message, tt.want)
 			}
 		})
+	}
+}
+
+func TestWriteRunLeaseOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	session := &RunSessionHandle{
+		Provider:       "blacksmith-testbox",
+		LeaseID:        "tbx_abc123",
+		Slug:           "blue-lobster",
+		Kept:           true,
+		CleanupCommand: "crabbox stop --provider blacksmith-testbox tbx_abc123",
+	}
+	if err := writeRunLeaseOutput(path, session); err != nil {
+		t.Fatal(err)
+	}
+	var got RunSessionHandle
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Provider != session.Provider || got.LeaseID != session.LeaseID || !got.Kept || got.CleanupCommand != session.CleanupCommand {
+		t.Fatalf("session=%#v", got)
+	}
+	if err := writeRunLeaseOutput(filepath.Join(t.TempDir(), "unsupported.json"), nil); err == nil || !strings.Contains(err.Error(), "provider did not return a session handle") {
+		t.Fatalf("unsupported err=%v", err)
 	}
 }
 

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -201,6 +201,16 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	result.Command = commandDuration
 	result.Total = total
 	result.SyncDelegated = true
+	result.Session = &core.RunSessionHandle{
+		Provider:       blacksmithTestboxProvider,
+		LeaseID:        leaseID,
+		Slug:           slug,
+		Reused:         !acquired,
+		Kept:           !shouldStop,
+		ActionsURL:     result.ActionsURL,
+		RunID:          blacksmithActionsRunID(result.ActionsURL),
+		CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", blacksmithTestboxProvider, leaseID),
+	}
 	if code != 0 {
 		local, bytes, bundleErr := core.CaptureLocalFailureBundle(leaseID, core.FailureCaptureMetadata{
 			Provider:   blacksmithTestboxProvider,
@@ -221,6 +231,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			fmt.Fprintf(b.rt.Stderr, "failure-bundle local=%s bytes=%d secret_risk=caller-redacts-before-sharing\n", local, bytes)
 		}
 		core.HandleDelegatedRunFailure(b.rt.Stderr, req, blacksmithTestboxProvider, leaseID, slug, blacksmithIdleTimeout(b.cfg), b.cfg.TTL, acquired, &shouldStop)
+		result.Session.Kept = !shouldStop
 		return result, ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
 	}
 	return result, nil
@@ -324,6 +335,16 @@ func (b *blacksmithBackend) blacksmithProofResult(req RunRequest, leaseID, slug 
 
 func firstBlacksmithActionsURL(text string) string {
 	return githubActionsRunURLPattern.FindString(text)
+}
+
+func blacksmithActionsRunID(actionsURL string) string {
+	_, after, ok := strings.Cut(actionsURL, "/actions/runs/")
+	if !ok {
+		return ""
+	}
+	runID, _, _ := strings.Cut(after, "/")
+	runID, _, _ = strings.Cut(runID, "?")
+	return runID
 }
 
 func persistBlacksmithRunArtifacts(repoRoot, leaseID string, exitCode int, commandDuration, total time.Duration, report timingReport, stdoutData, stderrData []byte, result RunResult) ([]core.RunArtifact, error) {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -435,6 +435,87 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	}
 }
 
+func TestBlacksmithKeptRunWritesLeaseOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
+			return LocalCommandResult{Stdout: "ready tbx_kept123\n"}, nil
+		}
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			if req.Stdout != nil {
+				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/987654321\n"))
+			}
+			return LocalCommandResult{}, nil
+		}
+		return LocalCommandResult{}, nil
+	}}
+
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := newTestBlacksmithBackend(cfg, runner)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: "/repo"},
+		Command: []string{"npm", "test"},
+		Keep:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("blacksmith calls=%d, want list/warmup/run without stop: %#v", len(runner.calls), runner.calls)
+	}
+	if result.Session == nil {
+		t.Fatal("missing session handle")
+	}
+	got := result.Session
+	if got.Provider != blacksmithTestboxProvider || got.LeaseID != "tbx_kept123" || got.Slug == "" || got.Reused || !got.Kept {
+		t.Fatalf("lease output=%#v", got)
+	}
+	if got.ActionsURL != "https://github.com/example-org/my-app/actions/runs/987654321" || got.RunID != "987654321" {
+		t.Fatalf("actions fields=%#v", got)
+	}
+	if got.CleanupCommand != "crabbox stop --provider blacksmith-testbox tbx_kept123" {
+		t.Fatalf("cleanup command=%q", got.CleanupCommand)
+	}
+}
+
+func TestBlacksmithReusedRunWritesLeaseOutput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			return LocalCommandResult{}, nil
+		}
+		return LocalCommandResult{}, nil
+	}}
+
+	cfg := baseConfig()
+	backend := newTestBlacksmithBackend(cfg, runner)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: "/repo"},
+		ID:      "tbx_reuse123",
+		Command: []string{"npm", "run", "smoke"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("blacksmith calls=%d, want run only: %#v", len(runner.calls), runner.calls)
+	}
+	if result.Session == nil {
+		t.Fatal("missing session handle")
+	}
+	got := result.Session
+	if got.Provider != blacksmithTestboxProvider || got.LeaseID != "tbx_reuse123" || !got.Reused || !got.Kept {
+		t.Fatalf("lease output=%#v", got)
+	}
+}
+
 func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -583,7 +664,7 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 		cfg:  cfg,
 		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), RunRequest{
 		Repo:          Repo{Root: "/repo"},
 		Command:       []string{"false"},
 		KeepOnFailure: true,
@@ -594,6 +675,9 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	}
 	if len(runner.calls) != 3 {
 		t.Fatalf("blacksmith calls=%d want list/warmup/run without stop: %#v", len(runner.calls), runner.calls)
+	}
+	if result.Session == nil || !result.Session.Kept {
+		t.Fatalf("session=%#v, want kept after keep-on-failure", result.Session)
 	}
 	got := stderr.String()
 	if !strings.Contains(got, "failure-bundle local=") || !strings.Contains(got, "keep-on-failure: kept lease=tbx_keepfail") {

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -21,7 +21,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Name:        "blacksmith-testbox",
 		Kind:        core.ProviderKindDelegatedRun,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureRunProof},
+		Features:    core.FeatureSet{core.FeatureRunProof, core.FeatureRunSession},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
This is to allow more robust automations that use `--keep` without parsing log files/terminal output

## Summary
- Add `crabbox run --lease-output <file>` as a generic delegated-run session output path.
- Add a core `RunSessionHandle`/`FeatureRunSession` contract and core JSON writer, with Blacksmith Testbox as the first producer.
- Document the reusable Blacksmith session lifecycle and add regression coverage for kept/reused Testboxes, unsupported providers, core JSON writing, and invalid output paths.

## Why this is needed
Blacksmith Testbox reuse already existed in a manual form: `crabbox run --keep --provider blacksmith-testbox ...` could leave a Testbox alive, and a later `crabbox run --id tbx_... --provider blacksmith-testbox ...` could reuse it.

The missing piece was a stable way for automation to get that `tbx_...` session handle. Callers had to scrape human terminal output, infer whether the Testbox was kept, construct cleanup themselves, and separately correlate any Actions run URL. That is brittle for release validators, auditors, or other orchestration scripts that need to pass one hydrated remote proof context through multiple steps.

## Design
The implementation keeps output writing in core instead of Blacksmith-specific file code:

- `RunResult.Session` carries a `RunSessionHandle`.
- `FeatureRunSession` lets providers explicitly advertise that they return this handle.
- `run.go` owns `--lease-output` validation and JSON writing.
- Blacksmith populates the handle today.
- A TODO marks the extension point for other reusable delegated providers to populate `RunResult.Session` and advertise `FeatureRunSession` once their lifecycle contract is covered.

This keeps the PR small while avoiding a Blacksmith-only output implementation that would need to be undone later.

## What this enables
A tool can now:

1. Start one hydrated Blacksmith Testbox and keep it alive.
2. Read the exact `leaseId` from JSON instead of parsing console output.
3. Run follow-up checks against the same remote workspace with `--id`.
4. Hand the same session/proof context to another process, including any detected Actions URL/run ID.
5. Finalize the session using the included non-secret cleanup command.

This does not change default one-shot behavior. If `--lease-output` is not passed, ordinary `crabbox run --provider blacksmith-testbox ...` still warms, runs one command, and stops the Testbox unless `--keep` or failure-retention policy applies.

## Example usage
```sh
crabbox run --provider blacksmith-testbox --keep --lease-output /tmp/session.json -- npm test
lease_id="$(node -e 'console.log(require("/tmp/session.json").leaseId)')"
crabbox run --provider blacksmith-testbox --id "$lease_id" -- npm run smoke
crabbox stop --provider blacksmith-testbox "$lease_id"
```

Example JSON:

```json
{
  "provider": "blacksmith-testbox",
  "leaseId": "tbx_abc123",
  "slug": "blue-lobster",
  "reused": false,
  "kept": true,
  "actionsUrl": "https://github.com/example-org/my-app/actions/runs/123456789",
  "runId": "123456789",
  "cleanupCommand": "crabbox stop --provider blacksmith-testbox tbx_abc123"
}
```

## Verification
- `go test ./internal/providers/blacksmith`
- `go test ./internal/cli -run 'TestRunCommandPreflightsLocalOutputOptions|TestRunCommandRejectsUnsupportedDelegatedCaptureOptions|TestWriteRunLeaseOutput|TestProviderFlagsApplyDaytonaAndIsloWithoutCoreEdits'`
- `go test ./...`
