### PR TITLE
fix: support native Windows Crabbox hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a portable `--os`/`os` lease selector with Ubuntu 26.04 as the preferred Linux image where provider catalogs support it, while preserving explicit provider image overrides.
 - Added `--desktop-env gnome` for a GNOME-apps desktop profile on labwc/WayVNC.
 - Added GNOME Panel taskbars to the `--desktop-env gnome` profile, with GNOME launches kept visible through Xwayland.
+- Added native Windows support for GitHub-runner Actions hydration so workflows can prepare Windows leases before Crabbox attaches to the hydrated workspace.
 
 ### Fixed
 
@@ -14,6 +15,9 @@
 - Fixed failed-run summaries so application output mentioning provider auth no longer looks like a provider/auth blocker, shell `&&` command chains explain short-circuit behavior, observed phases identify the likely failed phase, and opt-in automatic JUnit discovery can add structured test failures.
 - Fixed Daytona provider sandbox inventory to use Daytona's cursor-based listing API.
 - Removed OpenClaw-specific hosted broker defaults and documentation from the generic Crabbox broker login flow.
+- Fixed native Windows `--fresh-pr` runs so PR checkout, local patch application, and post-bootstrap SSH port changes work over PowerShell.
+- Fixed native Windows Actions env handoff so `crabbox run` can consume bash-style hydrate env files and reuse hydrated Node/pnpm paths.
+- Fixed AWS coordinator EC2 polling to tolerate transient `InvalidInstanceID.NotFound` after instance creation and to report parsed AWS XML errors.
 
 ## 0.20.0 - 2026-05-26
 

--- a/docs/commands/actions.md
+++ b/docs/commands/actions.md
@@ -7,7 +7,7 @@ Default hydration runs the local hydrate workflow over SSH on the leased box. It
 GitHub runner hydration remains available as a fallback:
 
 - `actions hydrate --github-runner` registers the runner, dispatches the configured workflow with the canonical lease label, waits for the workflow to write the hydrated workspace marker, and then returns.
-- `actions register` gets a repository runner registration token through `gh api`, installs the official `actions/runner` package on an existing box, and starts it with systemd.
+- `actions register` gets a repository runner registration token through `gh api`, installs the official `actions/runner` package on an existing box, and starts it with systemd on Linux/WSL2 or a detached PowerShell runner on native Windows.
 - `actions dispatch` calls `gh workflow run` for the configured workflow.
 
 Blacksmith Testbox IDs (`tbx_...`) and `--provider blacksmith-testbox` are skipped because Blacksmith owns Testbox workflow hydration. Run commands against those boxes with `crabbox run --provider blacksmith-testbox --id <tbx_id> -- ...`.
@@ -16,9 +16,13 @@ For `actions hydrate`, Crabbox inspects the selected workflow's `workflow_dispat
 
 Runner names and extra labels use the friendly slug when available, but workflow inputs and state-file paths keep using the canonical `cbx_...` ID.
 
-Local hydration and runner registration support Linux and Windows WSL2 targets.
-Static macOS and native Windows hosts can run commands through `provider=ssh`,
-but Actions hydration still needs a POSIX shell target.
+Local hydration supports Linux and Windows WSL2 targets. GitHub runner hydration
+also supports native Windows targets with `--github-runner`, so the repository's
+real workflow can install Node, pnpm, browser tooling, services, or other
+project-owned setup before `crabbox run` attaches to the hydrated workspace.
+Static macOS hosts can run commands through `provider=ssh`, but Actions
+hydration still needs Linux, Windows WSL2, or native Windows with
+`--github-runner`.
 
 On success, `actions hydrate` prints a concise total duration line. Add `--timing-json` to emit a final JSON timing record with provider, lease ID, slug, total duration, exit code, and the GitHub Actions run URL when the GitHub fallback marker reports a run ID.
 

--- a/docs/features/actions-hydration.md
+++ b/docs/features/actions-hydration.md
@@ -43,7 +43,8 @@ The flow:
 The GitHub fallback flow is the old remote-runner path: `actions hydrate
 --github-runner` registers the machine as an ephemeral self-hosted runner,
 dispatches the workflow, waits for the marker, then later `run` attaches to that
-workspace.
+workspace. Use this path for native Windows targets and for workflows that need
+full GitHub Actions semantics.
 
 The important boundary: project setup lives in the repository workflow. Crabbox
 owns workflow translation for the local default, runner registration and

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -108,6 +108,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 		return err
 	}
 	applyResolvedServerConfig(&cfg, server)
+	target = targetWithConfigDefaults(target, cfg)
 	if err := claimLeaseForRepoConfig(leaseID, slug, cfg, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
 		return err
 	}
@@ -266,6 +267,8 @@ func (a App) actionsRegister(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	applyResolvedServerConfig(&cfg, server)
+	target = targetWithConfigDefaults(target, cfg)
 	if err := claimLeaseForRepoConfig(leaseID, slug, cfg, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
 		return err
 	}
@@ -317,8 +320,8 @@ func (a App) actionsDispatch(ctx context.Context, args []string) error {
 }
 
 func (a App) registerGitHubActionsRunner(ctx context.Context, cfg Config, target SSHTarget, leaseID, slug string, ghRepo GitHubRepo, nameOverride string, extraLabels []string) error {
-	if !supportsActionsRunnerTarget(target) {
-		return exit(2, "actions runner registration currently supports Linux and Windows WSL2 targets only")
+	if !supportsGitHubActionsRunnerTarget(target) {
+		return exit(2, "actions runner registration currently supports Linux and Windows targets only")
 	}
 	token, err := githubActionsRegistrationToken(ctx, ghRepo)
 	if err != nil {
@@ -329,8 +332,8 @@ func (a App) registerGitHubActionsRunner(ctx context.Context, cfg Config, target
 		name = leaseProviderName(leaseID, slug)
 	}
 	labels := githubActionsRunnerLabels(cfg, leaseID, slug, extraLabels)
-	script := githubActionsRunnerInstallScript(cfg.Actions.RunnerVersion, cfg.Actions.Ephemeral)
-	remote := fmt.Sprintf("RUNNER_REPO=%s RUNNER_NAME=%s RUNNER_LABELS=%s RUNNER_TOKEN=%s bash -s", shellQuote(ghRepo.Slug()), shellQuote(name), shellQuote(strings.Join(labels, ",")), shellQuote(token))
+	script := githubActionsRunnerInstallScriptForTarget(cfg.Actions.RunnerVersion, cfg.Actions.Ephemeral, target)
+	remote := githubActionsRunnerInstallRemoteCommand(target, ghRepo.Slug(), name, strings.Join(labels, ","), token)
 	if err := runSSHInputQuiet(ctx, target, remote, script); err != nil {
 		return exit(7, "register GitHub Actions runner on %s: %v", target.Host, err)
 	}
@@ -339,7 +342,25 @@ func (a App) registerGitHubActionsRunner(ctx context.Context, cfg Config, target
 }
 
 func supportsActionsRunnerTarget(target SSHTarget) bool {
+	return supportsGitHubActionsRunnerTarget(target)
+}
+
+func supportsLocalActionsHydrateTarget(target SSHTarget) bool {
 	return target.TargetOS == "" || target.TargetOS == targetLinux || isWindowsWSL2Target(target)
+}
+
+func supportsGitHubActionsRunnerTarget(target SSHTarget) bool {
+	return target.TargetOS == "" || target.TargetOS == targetLinux || target.TargetOS == targetWindows || isWindowsWSL2Target(target)
+}
+
+func targetWithConfigDefaults(target SSHTarget, cfg Config) SSHTarget {
+	if target.TargetOS == "" {
+		target.TargetOS = cfg.TargetOS
+	}
+	if target.WindowsMode == "" {
+		target.WindowsMode = cfg.WindowsMode
+	}
+	return target
 }
 
 func (a App) resolveLeaseTargetForActions(ctx context.Context, cfg Config, id string) (Server, SSHTarget, string, string, error) {
@@ -381,7 +402,7 @@ func exitCodeForError(err error, fallback int) int {
 }
 
 func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool) (actionsHydrationState, error) {
-	if !supportsActionsRunnerTarget(target) {
+	if !supportsLocalActionsHydrateTarget(target) {
 		return actionsHydrationState{}, exit(2, "local Actions hydration currently supports Linux and Windows WSL2 targets only")
 	}
 	if err := validateWorkflowInputFields(fields); err != nil {
@@ -2068,11 +2089,11 @@ func waitForActionsHydration(ctx context.Context, target SSHTarget, leaseID, exp
 }
 
 func readActionsHydrationState(ctx context.Context, target SSHTarget, leaseID string) (actionsHydrationState, error) {
-	out, err := runSSHOutput(ctx, target, remoteReadActionsHydrationState(leaseID))
+	out, err := runSSHOutput(ctx, target, remoteReadActionsHydrationStateForTarget(target, leaseID))
 	if err != nil {
 		return actionsHydrationState{}, err
 	}
-	return parseActionsHydrationState(out), nil
+	return normalizeActionsHydrationStateForTarget(target, parseActionsHydrationState(out)), nil
 }
 
 func waitForLocalActionsHydration(ctx context.Context, target SSHTarget, leaseID, expectedJob, pid string, timeout time.Duration, stderr io.Writer) (actionsHydrationState, error) {
@@ -2123,14 +2144,14 @@ func ensureLocalActionsRunEnv(ctx context.Context, target SSHTarget, leaseID str
 }
 
 func clearActionsHydrationState(ctx context.Context, target SSHTarget, leaseID string) error {
-	if err := runSSHQuiet(ctx, target, remoteClearActionsHydrationState(leaseID)); err != nil {
+	if err := runSSHQuiet(ctx, target, remoteClearActionsHydrationStateForTarget(target, leaseID)); err != nil {
 		return exit(7, "clear GitHub Actions hydration marker on %s: %v", target.Host, err)
 	}
 	return nil
 }
 
 func writeActionsHydrationStop(ctx context.Context, target SSHTarget, leaseID string) error {
-	if err := runSSHQuiet(ctx, target, remoteWriteActionsHydrationStop(leaseID)); err != nil {
+	if err := runSSHQuiet(ctx, target, remoteWriteActionsHydrationStopForTarget(target, leaseID)); err != nil {
 		return exit(7, "write GitHub Actions hydration stop marker on %s: %v", target.Host, err)
 	}
 	return nil
@@ -2161,8 +2182,39 @@ func parseActionsHydrationState(value string) actionsHydrationState {
 	return state
 }
 
+func normalizeActionsHydrationStateForTarget(target SSHTarget, state actionsHydrationState) actionsHydrationState {
+	if !isWindowsNativeTarget(target) {
+		return state
+	}
+	state.Workspace = windowsNativePathFromMSYSPath(state.Workspace)
+	state.EnvFile = windowsNativePathFromMSYSPath(state.EnvFile)
+	state.ServicesFile = windowsNativePathFromMSYSPath(state.ServicesFile)
+	return state
+}
+
+func windowsNativePathFromMSYSPath(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 3 && value[0] == '/' && value[2] == '/' {
+		drive := value[1]
+		if (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z') {
+			return strings.ToUpper(string(drive)) + `:\` + strings.ReplaceAll(value[3:], "/", `\`)
+		}
+	}
+	return value
+}
+
 func remoteReadActionsHydrationState(leaseID string) string {
 	return "cat \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " 2>/dev/null || true"
+}
+
+func remoteReadActionsHydrationStateForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$path = Join-Path $HOME ` + psQuote(windowsPathJoin(strings.Split(actionsHydrationStatePath(leaseID), "/")...)) + `
+if (Test-Path -LiteralPath $path) { Get-Content -Raw -LiteralPath $path }
+exit 0
+`)
+	}
+	return remoteReadActionsHydrationState(leaseID)
 }
 
 func remoteInstallLocalActionsHydrateScript(leaseID string) string {
@@ -2214,6 +2266,39 @@ func remoteClearActionsHydrationState(leaseID string) string {
 	return "rm -f \"$HOME\"/" + shellQuote(actionsHydrationStatePath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationEnvPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationServicesPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalScriptPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalLogPath(leaseID)) + " \"$HOME\"/" + shellQuote(actionsHydrationLocalExitPath(leaseID))
 }
 
+func remoteClearActionsHydrationStateForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		paths := []string{
+			actionsHydrationStatePath(leaseID),
+			actionsHydrationEnvPath(leaseID),
+			actionsHydrationServicesPath(leaseID),
+			actionsHydrationStopPath(leaseID),
+			actionsHydrationLocalScriptPath(leaseID),
+			actionsHydrationLocalLogPath(leaseID),
+			actionsHydrationLocalExitPath(leaseID),
+		}
+		var b strings.Builder
+		b.WriteString(`$ErrorActionPreference = "SilentlyContinue"` + "\n")
+		foreach := "$paths = @("
+		for i, value := range paths {
+			if i > 0 {
+				foreach += ", "
+			}
+			foreach += psQuote(windowsPathJoin(strings.Split(value, "/")...))
+		}
+		foreach += ")\n"
+		b.WriteString(foreach)
+		b.WriteString(`foreach ($rel in $paths) {
+  $path = Join-Path $HOME $rel
+  Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+}
+exit 0
+`)
+		return powershellCommand(b.String())
+	}
+	return remoteClearActionsHydrationState(leaseID)
+}
+
 func actionsHydrationStatePath(leaseID string) string {
 	return actionsHydrationDir() + "/" + leaseID + ".env"
 }
@@ -2255,6 +2340,18 @@ func actionsRunURL(repo GitHubRepo, runID string) string {
 
 func remoteWriteActionsHydrationStop(leaseID string) string {
 	return "mkdir -p \"$HOME\"/" + shellQuote(actionsHydrationDir()) + " && touch \"$HOME\"/" + shellQuote(actionsHydrationStopPath(leaseID))
+}
+
+func remoteWriteActionsHydrationStopForTarget(target SSHTarget, leaseID string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$ErrorActionPreference = "Stop"
+$dir = Join-Path $HOME ` + psQuote(windowsPathJoin(strings.Split(actionsHydrationDir(), "/")...)) + `
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+New-Item -ItemType File -Force -Path (Join-Path $HOME ` + psQuote(windowsPathJoin(strings.Split(actionsHydrationStopPath(leaseID), "/")...)) + `) | Out-Null
+exit 0
+`)
+	}
+	return remoteWriteActionsHydrationStop(leaseID)
 }
 
 func githubActionsRunnerInstallScript(version string, ephemeral bool) string {
@@ -2332,6 +2429,105 @@ SERVICE
 sudo systemctl daemon-reload
 sudo systemctl enable --now crabbox-actions-runner.service
 `, shellQuote(version), ephemeralArg)
+}
+
+func githubActionsRunnerInstallScriptForTarget(version string, ephemeral bool, target SSHTarget) string {
+	if isWindowsNativeTarget(target) {
+		return githubActionsRunnerInstallPowerShellScript(version, ephemeral)
+	}
+	return githubActionsRunnerInstallScript(version, ephemeral)
+}
+
+func githubActionsRunnerInstallRemoteCommand(target SSHTarget, repo, name, labels, token string) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$ErrorActionPreference = "Stop"
+$env:RUNNER_REPO = ` + psQuote(repo) + `
+$env:RUNNER_NAME = ` + psQuote(name) + `
+$env:RUNNER_LABELS = ` + psQuote(labels) + `
+$env:RUNNER_TOKEN = ` + psQuote(token) + `
+$script = [Console]::In.ReadToEnd()
+$path = Join-Path $env:TEMP ("crabbox-actions-runner-" + [Guid]::NewGuid().ToString("N") + ".ps1")
+[System.IO.File]::WriteAllText($path, $script, [System.Text.UTF8Encoding]::new($false))
+try {
+  & powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $path
+  exit $LASTEXITCODE
+} finally {
+  Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+}
+`)
+	}
+	return fmt.Sprintf("RUNNER_REPO=%s RUNNER_NAME=%s RUNNER_LABELS=%s RUNNER_TOKEN=%s bash -s", shellQuote(repo), shellQuote(name), shellQuote(labels), shellQuote(token))
+}
+
+func githubActionsRunnerInstallPowerShellScript(version string, ephemeral bool) string {
+	if version == "" {
+		version = "latest"
+	}
+	ephemeralArg := ""
+	if ephemeral {
+		ephemeralArg = `, "--ephemeral"`
+	}
+	return fmt.Sprintf(`$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+if ([string]::IsNullOrWhiteSpace($env:RUNNER_REPO) -or [string]::IsNullOrWhiteSpace($env:RUNNER_NAME) -or [string]::IsNullOrWhiteSpace($env:RUNNER_TOKEN)) {
+  throw "missing runner env"
+}
+$version = %s
+$arch = $env:PROCESSOR_ARCHITECTURE
+switch -Regex ($arch) {
+  "^(AMD64|x86_64)$" { $runnerArch = "x64"; break }
+  "^ARM64$" { $runnerArch = "arm64"; break }
+  default { throw "unsupported runner arch: $arch" }
+}
+if ($version -eq "latest") {
+  $release = Invoke-RestMethod -Uri "https://api.github.com/repos/actions/runner/releases/latest" -UseBasicParsing
+  $version = ($release.tag_name -replace "^v", "")
+}
+$runnerDir = Join-Path $HOME "actions-runner"
+New-Item -ItemType Directory -Force -Path $runnerDir | Out-Null
+Set-Location -LiteralPath $runnerDir
+$versionMarker = ".crabbox-runner-version-$version-$runnerArch"
+if (-not (Test-Path -LiteralPath ".\config.cmd") -or -not (Test-Path -LiteralPath $versionMarker)) {
+  Get-ChildItem -Force -LiteralPath $runnerDir | Remove-Item -Recurse -Force
+  $zip = Join-Path $runnerDir "actions-runner.zip"
+  Invoke-WebRequest -Uri "https://github.com/actions/runner/releases/download/v$version/actions-runner-win-$runnerArch-$version.zip" -OutFile $zip -UseBasicParsing
+  Expand-Archive -LiteralPath $zip -DestinationPath $runnerDir -Force
+  Remove-Item -LiteralPath $zip -Force
+  New-Item -ItemType File -Path $versionMarker -Force | Out-Null
+}
+if (Test-Path -LiteralPath ".\.runner") {
+  & .\config.cmd remove --unattended --token $env:RUNNER_TOKEN
+  if ($LASTEXITCODE -ne 0) { Write-Warning "previous runner removal failed; continuing with replace"; $global:LASTEXITCODE = 0 }
+}
+$configArgs = @("--unattended", "--replace"%s, "--url", "https://github.com/$env:RUNNER_REPO", "--token", $env:RUNNER_TOKEN, "--name", $env:RUNNER_NAME, "--labels", $env:RUNNER_LABELS)
+& .\config.cmd @configArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$runScript = Join-Path $runnerDir "run-crabbox.ps1"
+Set-Content -Encoding UTF8 -LiteralPath $runScript -Value @'
+$ErrorActionPreference = "Stop"
+Set-Location -LiteralPath $PSScriptRoot
+& .\run.cmd
+exit $LASTEXITCODE
+'@
+$log = Join-Path $runnerDir "crabbox-runner.log"
+$err = Join-Path $runnerDir "crabbox-runner.err.log"
+$taskName = ("crabbox-actions-runner-" + ($env:RUNNER_NAME -replace "[^A-Za-z0-9_.-]", "-"))
+$passwordPath = "C:\ProgramData\crabbox\windows.password"
+if (Test-Path -LiteralPath $passwordPath) {
+  Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+  $argument = '-NoLogo -NoProfile -ExecutionPolicy Bypass -File "' + $runScript + '"'
+  $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $argument
+  $trigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddMinutes(5))
+  $password = (Get-Content -Raw -LiteralPath $passwordPath).Trim()
+  Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -User (whoami) -Password $password -RunLevel Highest -Force | Out-Null
+  Start-ScheduledTask -TaskName $taskName
+  Write-Output ("started runner task=" + $taskName)
+} else {
+  $process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $runScript) -WorkingDirectory $runnerDir -RedirectStandardOutput $log -RedirectStandardError $err -WindowStyle Hidden -PassThru
+  Write-Output ("started runner pid=" + $process.Id)
+}
+`, psQuote(version), ephemeralArg)
 }
 
 func githubActionsRegistrationToken(ctx context.Context, repo GitHubRepo) (string, error) {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -158,21 +158,44 @@ func TestGitHubActionsRunnerInstallScriptUsesOfficialRunner(t *testing.T) {
 	}
 }
 
-func TestSupportsActionsRunnerTargetAllowsLinuxAndWSL2(t *testing.T) {
+func TestGitHubActionsRunnerInstallPowerShellScriptUsesOfficialWindowsRunner(t *testing.T) {
+	got := githubActionsRunnerInstallScriptForTarget("latest", true, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
+	for _, want := range []string{
+		"https://api.github.com/repos/actions/runner/releases/latest",
+		"actions-runner-win-$runnerArch-$version.zip",
+		".\\config.cmd",
+		"--ephemeral",
+		"New-ScheduledTaskAction",
+		"Start-ScheduledTask",
+		"C:\\ProgramData\\crabbox\\windows.password",
+		"Start-Process",
+		"run-crabbox.ps1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("windows install script missing %q", want)
+		}
+	}
+}
+
+func TestActionsHydrateTargetSupport(t *testing.T) {
 	tests := map[string]struct {
-		target SSHTarget
-		want   bool
+		target     SSHTarget
+		wantLocal  bool
+		wantGitHub bool
 	}{
-		"default":        {target: SSHTarget{}, want: true},
-		"linux":          {target: SSHTarget{TargetOS: targetLinux}, want: true},
-		"windows wsl2":   {target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, want: true},
-		"windows native": {target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, want: false},
-		"macos":          {target: SSHTarget{TargetOS: targetMacOS}, want: false},
+		"default":        {target: SSHTarget{}, wantLocal: true, wantGitHub: true},
+		"linux":          {target: SSHTarget{TargetOS: targetLinux}, wantLocal: true, wantGitHub: true},
+		"windows wsl2":   {target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, wantLocal: true, wantGitHub: true},
+		"windows native": {target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, wantLocal: false, wantGitHub: true},
+		"macos":          {target: SSHTarget{TargetOS: targetMacOS}, wantLocal: false, wantGitHub: false},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := supportsActionsRunnerTarget(tt.target); got != tt.want {
-				t.Fatalf("supportsActionsRunnerTarget(%#v)=%t want %t", tt.target, got, tt.want)
+			if got := supportsLocalActionsHydrateTarget(tt.target); got != tt.wantLocal {
+				t.Fatalf("supportsLocalActionsHydrateTarget(%#v)=%t want %t", tt.target, got, tt.wantLocal)
+			}
+			if got := supportsGitHubActionsRunnerTarget(tt.target); got != tt.wantGitHub {
+				t.Fatalf("supportsGitHubActionsRunnerTarget(%#v)=%t want %t", tt.target, got, tt.wantGitHub)
 			}
 		})
 	}
@@ -213,8 +236,8 @@ func TestValidateActionsRunnerCapabilityAllowsWSL2(t *testing.T) {
 	if err := validateActionsRunnerCapability(backend, Config{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}); err != nil {
 		t.Fatalf("wsl2 actions runner rejected: %v", err)
 	}
-	if err := validateActionsRunnerCapability(backend, Config{TargetOS: targetWindows, WindowsMode: windowsModeNormal}); err == nil {
-		t.Fatal("native windows actions runner accepted")
+	if err := validateActionsRunnerCapability(backend, Config{TargetOS: targetWindows, WindowsMode: windowsModeNormal}); err != nil {
+		t.Fatalf("native windows actions runner rejected: %v", err)
 	}
 }
 
@@ -954,6 +977,17 @@ func TestParseActionsHydrationState(t *testing.T) {
 	}
 }
 
+func TestNormalizeActionsHydrationStateForNativeWindows(t *testing.T) {
+	got := normalizeActionsHydrationStateForTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, actionsHydrationState{
+		Workspace:    "/c/Users/runner/actions-runner/_work/openclaw/openclaw",
+		EnvFile:      "/c/Users/runner/.crabbox/actions/cbx-123.env.sh",
+		ServicesFile: "/c/Users/runner/.crabbox/actions/cbx-123.services",
+	})
+	if got.Workspace != `C:\Users\runner\actions-runner\_work\openclaw\openclaw` || got.EnvFile != `C:\Users\runner\.crabbox\actions\cbx-123.env.sh` || got.ServicesFile != `C:\Users\runner\.crabbox\actions\cbx-123.services` {
+		t.Fatalf("unexpected normalized state: %#v", got)
+	}
+}
+
 func TestActionsHydrationStatePathMatchesWorkflowInput(t *testing.T) {
 	got := actionsHydrationStatePath("cbx_123")
 	if got != ".crabbox/actions/cbx_123.env" {
@@ -986,6 +1020,22 @@ func TestRemoteWriteActionsHydrationStopMatchesWorkflowInput(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stop command %q missing %q", got, want)
+		}
+	}
+}
+
+func TestWindowsActionsHydrationMarkerCommandsUsePowerShellHome(t *testing.T) {
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	for name, command := range map[string]string{
+		"read":  remoteReadActionsHydrationStateForTarget(target, "cbx_123"),
+		"clear": remoteClearActionsHydrationStateForTarget(target, "cbx_123"),
+		"stop":  remoteWriteActionsHydrationStopForTarget(target, "cbx_123"),
+	} {
+		decoded := decodePowerShellCommand(t, command)
+		for _, want := range []string{`$HOME`, `.crabbox\actions`, `cbx_123`} {
+			if !strings.Contains(decoded, want) {
+				t.Fatalf("%s command missing %q in:\n%s", name, want, decoded)
+			}
 		}
 	}
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -554,8 +554,8 @@ func validateActionsRunnerCapability(backend Backend, cfg Config) error {
 	if backend.Spec().Name == "local-container" {
 		return exit(2, "--actions-runner is not supported for provider=local-container; use normal crabbox run or a remote SSH provider")
 	}
-	if !supportsActionsRunnerTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}) {
-		return exit(2, "--actions-runner requires target=linux or target=windows with windows-mode=wsl2")
+	if !supportsGitHubActionsRunnerTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}) {
+		return exit(2, "--actions-runner requires target=linux or target=windows")
 	}
 	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -618,7 +618,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		if hydrateTarget.WindowsMode == "" {
 			hydrateTarget.WindowsMode = cfg.WindowsMode
 		}
-		hydrateSupported := supportsActionsRunnerTarget(hydrateTarget)
+		hydrateSupported := supportsLocalActionsHydrateTarget(hydrateTarget) || supportsGitHubActionsRunnerTarget(hydrateTarget)
 		printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
 		preflightPrinted = true
 	}
@@ -646,7 +646,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		if hydrateTarget.WindowsMode == "" {
 			hydrateTarget.WindowsMode = cfg.WindowsMode
 		}
-		if autoHydrateActions && supportsActionsRunnerTarget(hydrateTarget) {
+		if autoHydrateActions && supportsLocalActionsHydrateTarget(hydrateTarget) {
 			rawJSRuntimePreflightDone = true
 			return nil
 		}
@@ -678,7 +678,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		if hydrateTarget.WindowsMode == "" {
 			hydrateTarget.WindowsMode = cfg.WindowsMode
 		}
-		if !supportsActionsRunnerTarget(hydrateTarget) {
+		if !supportsLocalActionsHydrateTarget(hydrateTarget) {
 			return nil
 		}
 		fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
@@ -806,11 +806,29 @@ retrySync:
 		recorder.Event("sync.started", "sync", "")
 		timings.syncSteps.sshReady = time.Since(stepStart)
 		if !freshPR.Empty() {
-			if isWindowsNativeTarget(target) {
-				return recordFailure(exit(2, "--fresh-pr is not supported for native Windows targets"))
-			}
 			stepStart = time.Now()
-			if out, err := runSSHCombinedOutput(ctx, target, remoteFreshPRCheckoutCommand(workdir, freshPR)); err != nil {
+			checkoutCommand := remoteFreshPRCheckoutCommandForTarget(workdir, freshPR, target)
+			out, err := runSSHCombinedOutput(ctx, target, checkoutCommand)
+			if err != nil && isWindowsNativeTarget(target) {
+				fmt.Fprintf(a.Stderr, "warning: fresh-pr checkout SSH failed on native Windows; refreshing SSH port and retrying once: %v\n", err)
+				target.Port = cfg.SSHPort
+				target.FallbackPorts = cfg.SSHFallbackPorts
+				target = bootstrapNetworkTarget(cfg, server, target)
+				if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute); waitErr != nil {
+					return recordFailure(waitErr)
+				}
+				if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
+					return recordFailure(resolveErr)
+				} else {
+					target = resolved.Target
+					if resolved.FallbackReason != "" {
+						fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
+					}
+				}
+				checkoutCommand = remoteFreshPRCheckoutCommandForTarget(workdir, freshPR, target)
+				out, err = runSSHCombinedOutput(ctx, target, checkoutCommand)
+			}
+			if err != nil {
 				return recordFailure(exit(6, "fresh-pr checkout failed: %v: %s", err, strings.TrimSpace(out)))
 			}
 			timings.syncSteps.gitSeed = time.Since(stepStart)

--- a/internal/cli/run_fresh_pr.go
+++ b/internal/cli/run_fresh_pr.go
@@ -119,6 +119,34 @@ func remoteFreshPRCheckoutCommand(workdir string, spec FreshPRSpec) string {
 	return "bash -lc " + shellQuote(script)
 }
 
+func remoteFreshPRCheckoutCommandForTarget(workdir string, spec FreshPRSpec, target SSHTarget) string {
+	if isWindowsNativeTarget(target) {
+		return windowsRemoteFreshPRCheckoutCommand(workdir, spec)
+	}
+	return remoteFreshPRCheckoutCommand(workdir, spec)
+}
+
+func windowsRemoteFreshPRCheckoutCommand(workdir string, spec FreshPRSpec) string {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", spec.Owner, spec.Repo)
+	branch := fmt.Sprintf("crabbox-pr-%d", spec.Number)
+	ref := fmt.Sprintf("pull/%d/head:%s", spec.Number, branch)
+	return powershellCommand(`$ErrorActionPreference = "Stop"
+$workdir = ` + psQuote(workdir) + `
+$parent = Split-Path -Parent $workdir
+if (Test-Path -LiteralPath $workdir) {
+  Remove-Item -LiteralPath $workdir -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $parent | Out-Null
+git clone --quiet --filter=blob:none ` + psQuote(repoURL) + ` $workdir
+if ($LASTEXITCODE -ne 0) { throw "git clone failed with exit $LASTEXITCODE" }
+Set-Location -LiteralPath $workdir
+git fetch --quiet origin ` + psQuote(ref) + `
+if ($LASTEXITCODE -ne 0) { throw "git fetch failed with exit $LASTEXITCODE" }
+git checkout --quiet ` + psQuote(branch) + `
+if ($LASTEXITCODE -ne 0) { throw "git checkout failed with exit $LASTEXITCODE" }
+`)
+}
+
 func localGitBinaryDiff(root string) ([]byte, error) {
 	cmd := exec.Command("git", "diff", "--binary", "HEAD")
 	cmd.Dir = root
@@ -130,6 +158,17 @@ func remoteApplyLocalPatchCommand(workdir string) string {
 	return "bash -lc " + shellQuote(script)
 }
 
+func remoteApplyLocalPatchCommandForTarget(workdir string, target SSHTarget) string {
+	if isWindowsNativeTarget(target) {
+		return powershellCommand(`$ErrorActionPreference = "Stop"
+Set-Location -LiteralPath ` + psQuote(workdir) + `
+git apply --whitespace=nowarn -
+if ($LASTEXITCODE -ne 0) { throw "git apply failed with exit $LASTEXITCODE" }
+`)
+	}
+	return remoteApplyLocalPatchCommand(workdir)
+}
+
 func applyLocalPatchToFreshPR(ctx context.Context, target SSHTarget, workdir string, repo Repo) (bool, error) {
 	diff, err := localGitBinaryDiff(repo.Root)
 	if err != nil {
@@ -138,7 +177,7 @@ func applyLocalPatchToFreshPR(ctx context.Context, target SSHTarget, workdir str
 	if len(diff) == 0 {
 		return false, nil
 	}
-	if err := runSSHInput(ctx, target, remoteApplyLocalPatchCommand(workdir), bytes.NewReader(diff), io.Discard, io.Discard); err != nil {
+	if err := runSSHInput(ctx, target, remoteApplyLocalPatchCommandForTarget(workdir, target), bytes.NewReader(diff), io.Discard, io.Discard); err != nil {
 		return false, exit(7, "apply local patch: %v", err)
 	}
 	return true, nil

--- a/internal/cli/run_fresh_pr_test.go
+++ b/internal/cli/run_fresh_pr_test.go
@@ -60,3 +60,39 @@ func TestRemoteFreshPRCheckoutCommand(t *testing.T) {
 		}
 	}
 }
+
+func TestWindowsRemoteFreshPRCheckoutCommand(t *testing.T) {
+	got := remoteFreshPRCheckoutCommandForTarget(`C:\crabbox\cbx\fresh-pr-example-org-my-app-66278`, FreshPRSpec{
+		Owner:  "example-org",
+		Repo:   "my-app",
+		Number: 66278,
+	}, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
+	decoded := decodePowerShellCommand(t, got)
+	for _, want := range []string{
+		"Remove-Item -LiteralPath $workdir -Recurse -Force",
+		"git clone --quiet --filter=blob:none",
+		"https://github.com/example-org/my-app.git",
+		"git fetch --quiet origin",
+		"pull/66278/head:crabbox-pr-66278",
+		"git checkout --quiet",
+		"crabbox-pr-66278",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("checkout command missing %q in %q", want, decoded)
+		}
+	}
+}
+
+func TestWindowsRemoteApplyLocalPatchCommand(t *testing.T) {
+	got := remoteApplyLocalPatchCommandForTarget(`C:\crabbox\cbx\fresh-pr-example-org-my-app-66278`, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
+	decoded := decodePowerShellCommand(t, got)
+	for _, want := range []string{
+		`Set-Location -LiteralPath 'C:\crabbox\cbx\fresh-pr-example-org-my-app-66278'`,
+		"git apply --whitespace=nowarn -",
+		"git apply failed with exit $LASTEXITCODE",
+	} {
+		if !strings.Contains(decoded, want) {
+			t.Fatalf("apply-patch command missing %q in %q", want, decoded)
+		}
+	}
+}

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -225,6 +225,9 @@ func hydrateCommandSuggestion(cfg Config, target SSHTarget, leaseID string, supp
 	if cfg.Actions.Job != "" {
 		args = append(args, "--job", cfg.Actions.Job)
 	}
+	if !supportsLocalActionsHydrateTarget(SSHTarget{TargetOS: targetOS, WindowsMode: windowsMode}) && supportsGitHubActionsRunnerTarget(SSHTarget{TargetOS: targetOS, WindowsMode: windowsMode}) {
+		args = append(args, "--github-runner")
+	}
 	command := strings.Join(readableShellWords(args), " ")
 	if !supported {
 		command += " (unsupported for this provider/target)"

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -46,7 +46,7 @@ func TestWindowsRemoteRunScriptCommandUsesPowerShellFile(t *testing.T) {
 	decoded := decodePowerShellCommand(t, got)
 	for _, want := range []string{
 		`Set-Location -LiteralPath 'C:\crabbox\repo'`,
-		`Get-Content -Encoding UTF8 -LiteralPath '.crabbox\env\run.env'`,
+		`Import-CrabboxEnvFile '.crabbox\env\run.env'`,
 		`$env:API_TOKEN = 'secret'`,
 		`$__crabboxScript = '.crabbox\scripts\abc-script.ps1'`,
 		`$__crabboxArgs = @('arg one')`,

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1181,6 +1181,26 @@ func TestRemotePreflightRawWorkspaceHydrateWarning(t *testing.T) {
 	}
 }
 
+func TestRemotePreflightNativeWindowsHydrateSuggestionUsesGitHubRunner(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+	lines := remotePreflightWorkspaceLines(cfg, SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, "cbx_123", `C:\crabbox\cbx_123\repo`, false, "", true)
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"hydrate_supported=true",
+		"--target windows",
+		"--windows-mode normal",
+		"--github-runner",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("preflight text missing %q in %q", want, got)
+		}
+	}
+}
+
 func TestRemotePreflightRawWorkspaceSkipsHydrateSuggestionWithoutWorkflow(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"
@@ -1216,7 +1236,7 @@ func TestWindowsRemoteCapabilityPreflightCommandUsesCommandEnvironment(t *testin
 	decoded := decodePowerShellCommand(t, got)
 	for _, want := range []string{
 		`Set-Location -LiteralPath 'C:\crabbox\repo'`,
-		`Get-Content -Encoding UTF8 -LiteralPath '.crabbox\env\run.env'`,
+		`Import-CrabboxEnvFile '.crabbox\env\run.env'`,
 		`$env:CI = '1'`,
 		`Test-Value "user" { whoami }`,
 		`Test-Value "cwd" { (Get-Location).Path }`,

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -136,8 +136,13 @@ func TestWindowsNativeRemoteCommandSourcesMultipleEnvFiles(t *testing.T) {
 	}, []string{"pwsh", "-NoProfile", "-Command", "echo ok"})
 	decoded := decodePowerShellCommand(t, got)
 	for _, want := range []string{
-		`Get-Content -Encoding UTF8 -LiteralPath '.crabbox\actions.env'`,
-		`Get-Content -Encoding UTF8 -LiteralPath '.crabbox\env\run.env'`,
+		`Import-CrabboxEnvFile '.crabbox\actions.env'`,
+		`Import-CrabboxEnvFile '.crabbox\env\run.env'`,
+		`$Path -match '^/([A-Za-z])/(.*)$'`,
+		`$Path = ($matches[1].ToUpperInvariant() + ':\' + $matches[2].Replace('/', '\'))`,
+		`(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$`,
+		`Add-CrabboxPath $env:PNPM_HOME`,
+		`Get-ChildItem -LiteralPath $nodeRoot -Recurse -Filter node.exe`,
 		`$env:CI = '1'`,
 	} {
 		if !strings.Contains(decoded, want) {

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -204,12 +204,47 @@ func windowsRemoteShellCommandWithEnvFiles(workdir string, env map[string]string
 func writeWindowsRemotePrefix(b *bytes.Buffer, workdir string, env map[string]string, envFiles []string) {
 	b.WriteString(`$ErrorActionPreference = "Stop"` + "\n")
 	b.WriteString(`Set-Location -LiteralPath ` + psQuote(workdir) + "\n")
+	if len(envFiles) > 0 {
+		b.WriteString(`function Import-CrabboxEnvFile($Path) {
+  if ($Path -match '^/([A-Za-z])/(.*)$') {
+    $Path = ($matches[1].ToUpperInvariant() + ':\' + $matches[2].Replace('/', '\'))
+  }
+  if (-not (Test-Path -LiteralPath $Path)) { return }
+  Get-Content -Encoding UTF8 -LiteralPath $Path | ForEach-Object {
+    if ($_ -match '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+      $name = $matches[1]
+      $value = $matches[2].Trim()
+      if (($value.StartsWith("'") -and $value.EndsWith("'")) -or ($value.StartsWith('"') -and $value.EndsWith('"'))) {
+        $value = $value.Substring(1, $value.Length - 2)
+      }
+      $value = $value.Replace('\ ', ' ')
+      [Environment]::SetEnvironmentVariable($name, $value, 'Process')
+    }
+  }
+}
+function Add-CrabboxPath($Path) {
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  if (Test-Path -LiteralPath $Path) { $env:Path = "$Path;$env:Path" }
+}
+`)
+	}
 	for _, envFile := range envFiles {
 		envFile = strings.TrimSpace(envFile)
 		if envFile == "" {
 			continue
 		}
-		b.WriteString(`if (Test-Path -LiteralPath ` + psQuote(envFile) + `) { Get-Content -Encoding UTF8 -LiteralPath ` + psQuote(envFile) + ` | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process') } } }` + "\n")
+		b.WriteString(`Import-CrabboxEnvFile ` + psQuote(envFile) + "\n")
+	}
+	if len(envFiles) > 0 {
+		b.WriteString(`Add-CrabboxPath $env:PNPM_HOME
+if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TOOL_CACHE)) {
+  $nodeRoot = Join-Path $env:RUNNER_TOOL_CACHE 'node'
+  if (Test-Path -LiteralPath $nodeRoot) {
+    $node = Get-ChildItem -LiteralPath $nodeRoot -Recurse -Filter node.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($node) { Add-CrabboxPath $node.DirectoryName }
+  }
+}
+`)
 	}
 	for key, value := range env {
 		b.WriteString(`$env:` + key + ` = ` + psQuote(value) + "\n")

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -461,9 +461,17 @@ export class EC2SpotClient {
   async waitForServerIP(instanceID: string): Promise<ProviderMachine> {
     const deadline = Date.now() + 600_000;
     while (Date.now() < deadline) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- polling waits between EC2 reads.
-      const server = await this.getServer(instanceID);
-      if (server.host) {
+      let server: ProviderMachine | undefined;
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- polling waits between EC2 reads.
+        server = await this.getServer(instanceID);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isAWSInstanceNotFoundError(message)) {
+          throw error;
+        }
+      }
+      if (server?.host) {
         return server;
       }
       // oxlint-disable-next-line eslint/no-await-in-loop -- this delay is the polling interval.
@@ -1393,7 +1401,7 @@ export class EC2SpotClient {
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(`aws ${action}: http ${response.status}: ${trimBody(text)}`);
+      throw new Error(this.awsQueryErrorMessage(action, response.status, text));
     }
     const parsed = this.parser.parse(text) as unknown;
     const parsedRecord = record(parsed);
@@ -1413,12 +1421,37 @@ export class EC2SpotClient {
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(`aws ${action}: http ${response.status}: ${trimBody(text)}`);
+      throw new Error(this.awsQueryErrorMessage(action, response.status, text));
     }
     const parsed = this.parser.parse(text) as unknown;
     const parsedRecord = record(parsed);
     const root = parsedRecord[`${action}Response`] ?? parsedRecord["Response"] ?? parsedRecord;
     return record(root);
+  }
+
+  private awsQueryErrorMessage(action: string, status: number, text: string): string {
+    let detail = "";
+    try {
+      const parsed = this.parser.parse(text) as unknown;
+      const parsedRecord = record(parsed);
+      const root = record(
+        parsedRecord["ErrorResponse"] ?? parsedRecord["Response"] ?? parsedRecord,
+      );
+      const error = record(
+        items(
+          root["Error"] ??
+            root["error"] ??
+            record(root["Errors"])["Error"] ??
+            record(root["Errors"])["error"],
+        )[0],
+      );
+      const code = asString(error["Code"] ?? error["code"]);
+      const message = asString(error["Message"] ?? error["message"]);
+      detail = code && message ? `${code}: ${message}` : code || message;
+    } catch {
+      detail = "";
+    }
+    return `aws ${action}: http ${status}: ${detail || trimBody(text).replace(/\s+/g, " ")}`;
   }
 
   private async quotaPreflightAttempt(

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -91,6 +91,76 @@ describe("aws provider", () => {
     ]);
   });
 
+  it("reports parsed AWS XML query errors instead of the XML declaration", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(
+          `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Errors>
+    <Error>
+      <Code>AuthFailure</Code>
+      <Message>AWS was not able to validate the provided access credentials</Message>
+    </Error>
+  </Errors>
+  <RequestID>req-1</RequestID>
+</Response>`,
+          { status: 400 },
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "us-east-1",
+    );
+
+    await expect(client.listCrabboxServers()).rejects.toThrow(
+      "aws DescribeInstances: http 400: AuthFailure: AWS was not able to validate the provided access credentials",
+    );
+  });
+
+  it("waits through transient EC2 instance visibility after RunInstances", async () => {
+    vi.useFakeTimers();
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "us-east-1",
+    ) as EC2SpotClient & {
+      getServer: (instanceID: string) => Promise<{
+        id: string;
+        name: string;
+        provider: "aws";
+        cloudID: string;
+        host: string;
+        status: string;
+        serverType: string;
+      }>;
+    };
+    let calls = 0;
+    client.getServer = async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error(
+          "aws DescribeInstances: http 400: InvalidInstanceID.NotFound: The instance ID 'i-1' does not exist",
+        );
+      }
+      return {
+        id: "i-1",
+        name: "blue-lobster",
+        provider: "aws",
+        cloudID: "i-1",
+        host: "203.0.113.10",
+        status: "running",
+        serverType: "m7i.large",
+      };
+    };
+
+    const resultPromise = client.waitForServerIP("i-1");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(resultPromise).resolves.toMatchObject({ host: "203.0.113.10" });
+    expect(calls).toBe(2);
+  });
+
   it("turns low AWS vCPU quota into a doctor readiness warning", () => {
     const check = awsCapacityReadinessCheckForQuota(
       {


### PR DESCRIPTION
Summary
- support native Windows `--fresh-pr` checkout and local patch apply with PowerShell-safe git commands
- let native Windows use GitHub Actions runner hydration, including scheduled-task runner launch, marker commands, env handoff, and MSYS path normalization
- retry fresh-pr checkout after native Windows SSH port resolution and make AWS coordinator errors/retries clearer

Verification
- `go test ./...`
- `cd worker && npm test -- --run test/aws.test.ts && npm run check && npm run format:check && npm run lint && npm run build`
- `cd worker && npm run deploy` -> `crabbox-coordinator` version `2e6746fc-a357-447c-a92d-b523f7852891`
- `autoreview --mode local` -> clean, no accepted/actionable findings
- live AWS native Windows: warmed lease `cbx_a7fb1b6848ad` / slug `coral-hermit`, SSH ready on `crabbox@44.201.64.172:2222`
- live Actions runner proof: `actions register --target windows --windows-mode normal --id coral-hermit --repo openclaw/openclaw --name crabbox-coral-hermit-scheduled-smoke --labels crabbox-windows-scheduled-smoke`; GitHub runner `253` came online and idle, then was deleted
- live hydrate proof: OpenClaw run https://github.com/openclaw/openclaw/actions/runs/26486007981 reached the native Windows GitHub runner and completed checkout/setup-node, then failed in OpenClaw's pnpm/corepack workflow step before the hydration marker; lease was released

Follow-up
- fix OpenClaw's Windows hydrate workflow pnpm/corepack setup, then rerun the PR 85597 Windows proof
