### PR TITLE
fix: stop native Windows hydrate runners

### DIFF
--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1040,6 +1040,20 @@ func TestWindowsActionsHydrationMarkerCommandsUsePowerShellHome(t *testing.T) {
 	}
 }
 
+func TestActionsHydrationStopIsWrittenForNativeWindowsTargets(t *testing.T) {
+	target := SSHTarget{Host: "203.0.113.10", TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	if !shouldWriteActionsHydrationStop("cbx_123", target) {
+		t.Fatal("native Windows hydrated runners must receive the stop marker")
+	}
+	if shouldWriteActionsHydrationStop("", target) {
+		t.Fatal("empty lease id should not write a stop marker")
+	}
+	target.Host = ""
+	if shouldWriteActionsHydrationStop("cbx_123", target) {
+		t.Fatal("missing SSH target should not write a stop marker")
+	}
+}
+
 func TestLocalActionsRemoteCommandsQuoteLeasePaths(t *testing.T) {
 	leaseID := "lease id;touch nope"
 	for name, tc := range map[string]struct {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2445,10 +2445,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 }
 
 func (a App) writeActionsHydrationStopBestEffort(ctx context.Context, target SSHTarget, leaseID string) {
-	if leaseID == "" || target.Host == "" {
-		return
-	}
-	if isWindowsNativeTarget(target) {
+	if !shouldWriteActionsHydrationStop(leaseID, target) {
 		return
 	}
 	stopCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -2456,6 +2453,10 @@ func (a App) writeActionsHydrationStopBestEffort(ctx context.Context, target SSH
 	if err := writeActionsHydrationStop(stopCtx, target, leaseID); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: could not stop GitHub Actions hydration for %s: %v\n", leaseID, err)
 	}
+}
+
+func shouldWriteActionsHydrationStop(leaseID string, target SSHTarget) bool {
+	return leaseID != "" && target.Host != ""
 }
 
 func leaseDisplayID(lease CoordinatorLease) string {


### PR DESCRIPTION
Summary
- Remove the stale native-Windows guard from the Actions hydrate stop-marker path.
- Keep the existing safety checks: only write when the lease id and SSH target are known.
- Add regression coverage so native Windows hydrated runners are treated as stop-marker capable.

Verification
- go test ./internal/cli -run 'Test(ActionsHydrationStopIsWrittenForNativeWindowsTargets|WindowsActionsHydrationMarkerCommandsUsePowerShellHome|RemoteWriteActionsHydrationStopMatchesWorkflowInput|RemoteClearActionsHydrationStateRemovesReadyAndStop)$'
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main
