### PR TITLE
fix(cli): accept --id on stop and auto-route static_ leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed brokered AWS provisioning to compact stale Crabbox SSH ingress after EC2 reports the security group rule limit, then retry the current source rule before failing.
 - Fixed coordinator lease cleanup so expired AWS leases whose EC2 instance is already gone still clean provider keys before closing.
+- Fixed `crabbox stop` to accept `--id <lease>` like every other lease command, and updated the stop hint that `crabbox run` prints so it can be pasted back verbatim. Thanks @edihasaj.
+- Fixed lease commands (`run`, `status`, `stop`, `ssh`, `inspect`, `screenshot`, `vnc`, `webvnc`, `actions`, `artifacts`, `checkpoint`, `egress`) to auto-route `--id static_<slug>` ids to `--provider ssh` and restore the original static host from the local lease claim, so static SSH leases no longer require repeating routing flags after `crabbox warmup`.
 
 ## 0.21.0 - 2026-05-27
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -77,7 +77,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) error {
 		}
 		return nil
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *leaseIDFlag})
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,7 @@ func (a App) actionsRegister(ctx context.Context, args []string) error {
 	if *leaseIDFlag == "" {
 		return exit(2, "actions register requires --id")
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *leaseIDFlag})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -138,7 +138,7 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 		*contactSheet = false
 	}
 	needsDesktop := artifactCollectNeedsDesktop(*screenshot, *video, *doctor, *webvncStatus)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: needsDesktop})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: needsDesktop})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -144,7 +144,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		return exit(2, "checkpoint strategy must be auto, disk-snapshot, or image")
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (a App) checkpointList(ctx context.Context, args []string) error {
 	}
 	setIDFromFirstArg(fs, id)
 	if strings.TrimSpace(*id) != "" || flagWasSet(fs, "provider") || flagWasSet(fs, "parallels-template") {
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 		if err != nil {
 			return err
 		}
@@ -568,7 +568,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		if fs.NArg() != 0 {
 			return exit(2, "usage: crabbox checkpoint restore --provider parallels --id <vm-or-lease> --snapshot <name-or-id>")
 		}
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 		if err != nil {
 			return err
 		}
@@ -616,7 +616,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 	if record.Kind != checkpointKindArchive {
 		if isNativeCheckpointKind(record.Kind) {
 			if record.Kind == checkpointKindParallels {
-				cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+				cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 				if err != nil {
 					return err
 				}
@@ -644,7 +644,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		}
 		return exit(2, "checkpoint %s has kind=%s; restore requires %s", record.ID, record.Kind, checkpointKindArchive)
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}
@@ -897,7 +897,7 @@ func (a App) checkpointDelete(ctx context.Context, args []string) error {
 		if *localOnly {
 			return exit(2, "--local-only applies only to recorded checkpoints")
 		}
-		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+		cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *sourceID})
 		if err != nil {
 			return err
 		}

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -14,6 +14,12 @@ type leaseClaim struct {
 	Slug               string `json:"slug,omitempty"`
 	Provider           string `json:"provider,omitempty"`
 	ProviderScope      string `json:"providerScope,omitempty"`
+	StaticHost         string `json:"staticHost,omitempty"`
+	StaticUser         string `json:"staticUser,omitempty"`
+	StaticPort         string `json:"staticPort,omitempty"`
+	StaticWorkRoot     string `json:"staticWorkRoot,omitempty"`
+	TargetOS           string `json:"targetOS,omitempty"`
+	WindowsMode        string `json:"windowsMode,omitempty"`
 	RepoRoot           string `json:"repoRoot"`
 	ClaimedAt          string `json:"claimedAt"`
 	LastUsedAt         string `json:"lastUsedAt"`
@@ -26,7 +32,19 @@ func claimLeaseForRepo(leaseID, slug, repoRoot string, idleTimeout time.Duration
 
 func claimLeaseForRepoConfig(leaseID, slug string, cfg Config, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	provider := canonicalClaimProvider(cfg.Provider)
-	return claimLeaseForRepoProviderScope(leaseID, slug, provider, providerClaimScope(provider, cfg), repoRoot, idleTimeout, reclaim)
+	staticDetails := staticClaimDetails{}
+	if isStaticProvider(provider) {
+		staticDetails = staticClaimDetails{
+			Present:     true,
+			Host:        strings.TrimSpace(cfg.Static.Host),
+			User:        strings.TrimSpace(cfg.Static.User),
+			Port:        strings.TrimSpace(cfg.Static.Port),
+			WorkRoot:    strings.TrimSpace(cfg.Static.WorkRoot),
+			TargetOS:    strings.TrimSpace(cfg.TargetOS),
+			WindowsMode: strings.TrimSpace(cfg.WindowsMode),
+		}
+	}
+	return claimLeaseForRepoProviderScopeDetails(leaseID, slug, provider, providerClaimScope(provider, cfg), staticDetails, repoRoot, idleTimeout, reclaim)
 }
 
 func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
@@ -34,6 +52,20 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 }
 
 func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return claimLeaseForRepoProviderScopeDetails(leaseID, slug, provider, providerScope, staticClaimDetails{}, repoRoot, idleTimeout, reclaim)
+}
+
+type staticClaimDetails struct {
+	Present     bool
+	Host        string
+	User        string
+	Port        string
+	WorkRoot    string
+	TargetOS    string
+	WindowsMode string
+}
+
+func claimLeaseForRepoProviderScopeDetails(leaseID, slug, provider, providerScope string, staticDetails staticClaimDetails, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	if leaseID == "" || repoRoot == "" {
 		return nil
 	}
@@ -59,6 +91,21 @@ func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repo
 	}
 	if providerScope != "" {
 		existing.ProviderScope = providerScope
+	}
+	if staticDetails.Present {
+		existing.StaticHost = staticDetails.Host
+		existing.StaticUser = staticDetails.User
+		existing.StaticPort = staticDetails.Port
+		existing.StaticWorkRoot = staticDetails.WorkRoot
+		existing.TargetOS = staticDetails.TargetOS
+		existing.WindowsMode = staticDetails.WindowsMode
+	} else if provider != "" && !isStaticProvider(provider) {
+		existing.StaticHost = ""
+		existing.StaticUser = ""
+		existing.StaticPort = ""
+		existing.StaticWorkRoot = ""
+		existing.TargetOS = ""
+		existing.WindowsMode = ""
 	}
 	existing.RepoRoot = repoRoot
 	existing.LastUsedAt = now

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -30,6 +30,11 @@ func TestClaimLeaseForRepoConfigScopesProviderClaims(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := filepath.Join(t.TempDir(), "repo")
 	cfg := Config{Provider: "ssh"}
+	cfg.Static.Host = "mac-mini.local"
+	cfg.Static.User = "agent"
+	cfg.Static.Port = "2222"
+	cfg.Static.WorkRoot = "/work/crabbox"
+	cfg.TargetOS = targetMacOS
 	if err := claimLeaseForRepoConfig("cbx_static", "mac-mini", cfg, repo, 10*time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
@@ -39,6 +44,26 @@ func TestClaimLeaseForRepoConfigScopesProviderClaims(t *testing.T) {
 	}
 	if claim.Provider != staticProvider {
 		t.Fatalf("provider=%q want %q", claim.Provider, staticProvider)
+	}
+	if claim.StaticHost != "mac-mini.local" {
+		t.Fatalf("staticHost=%q want mac-mini.local", claim.StaticHost)
+	}
+	if claim.StaticUser != "agent" || claim.StaticPort != "2222" || claim.StaticWorkRoot != "/work/crabbox" || claim.TargetOS != targetMacOS {
+		t.Fatalf("static claim details not stored: %#v", claim)
+	}
+
+	cfg.Static.User = ""
+	cfg.Static.Port = ""
+	cfg.Static.WorkRoot = ""
+	if err := claimLeaseForRepoConfig("cbx_static", "mac-mini", cfg, repo, 10*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err = readLeaseClaim("cbx_static")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.StaticUser != "" || claim.StaticPort != "" || claim.StaticWorkRoot != "" {
+		t.Fatalf("static claim details should be cleared on update: %#v", claim)
 	}
 
 	cfg.Provider = "aws"

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -170,7 +170,7 @@ func (a App) desktopCommandTarget(ctx context.Context, name string, args []strin
 		return SSHTarget{}, Config{}, "", err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return SSHTarget{}, Config{}, "", err
 	}

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -184,7 +184,7 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err := validateEgressListen(*listen); err != nil {
 		return err
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (a App) egressStop(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	cfg, cfgErr := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, cfgErr := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if cfgErr == nil {
 		if _, target, leaseID, resolveErr := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false); resolveErr == nil {
 			_ = runSSHQuiet(ctx, target, "pkill -f '[c]rabbox-egress-client egress client' >/dev/null 2>&1 || true")

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -19,7 +19,7 @@ func (a App) inspect(ctx context.Context, args []string) error {
 		return err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -60,6 +60,9 @@ func applyLeaseCreateFlagsForLease(cfg *Config, fs *flag.FlagSet, values leaseCr
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
 		return err
 	}
+	if err := autoRouteStaticLease(cfg, fs, existingLeaseID); err != nil {
+		return err
+	}
 	if flagWasSet(fs, "os") {
 		osImage, err := normalizeOSImage(*values.OSImage)
 		if err != nil {
@@ -112,6 +115,11 @@ func validateLeaseDurations(cfg Config) error {
 
 type leaseTargetConfigOptions struct {
 	Desktop bool
+	// LeaseID is the resolved lease id/slug from the command's --id flag (or
+	// equivalent positional). When set, `static_<host>` ids auto-route to the
+	// ssh provider so callers don't have to re-pass --provider / --static-host
+	// that warmup already implied.
+	LeaseID string
 }
 
 func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags targetFlagValues, networkFlags networkModeFlagValues, opts leaseTargetConfigOptions) (Config, error) {
@@ -124,6 +132,9 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 		cfg.Desktop = true
 	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
+		return Config{}, err
+	}
+	if err := autoRouteStaticLease(&cfg, fs, opts.LeaseID); err != nil {
 		return Config{}, err
 	}
 	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -654,7 +654,7 @@ func TestPopulateRunTimingMetadata(t *testing.T) {
 	if report.RunID != "run_123" || report.MachineType != "cpx31" || report.RepoPath != "/repo/app" || report.Workdir != "/work/cbx_123/app" {
 		t.Fatalf("metadata not populated: %#v", report)
 	}
-	if report.StopCommand == "" || !strings.Contains(report.StopCommand, "crabbox stop --provider aws cbx_123") {
+	if report.StopCommand == "" || !strings.Contains(report.StopCommand, "crabbox stop --provider aws --id cbx_123") {
 		t.Fatalf("stop command=%q", report.StopCommand)
 	}
 	if len(report.Artifacts) != 1 || report.Artifacts[0].Path != "/tmp/proof.md" {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1507,7 +1507,9 @@ func runStopCommand(cfg Config, id string) string {
 		args = append(args, "--static-work-root", cfg.Static.WorkRoot)
 	}
 	args = appendProviderStopRoutingArgs(args, cfg)
-	args = append(args, id)
+	if strings.TrimSpace(id) != "" {
+		args = append(args, "--id", id)
+	}
 	return strings.Join(readableShellWords(args), " ")
 }
 
@@ -2428,13 +2430,16 @@ func (a App) stop(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("stop", a.Stderr)
 	provider := fs.String("provider", defaults.Provider, providerHelpAll())
+	id := fs.String("id", "", "lease id or slug")
 	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	if fs.NArg() != 1 {
-		return exit(2, "usage: crabbox stop <lease-or-server-id>")
+	idFlagSet := flagWasSet(fs, "id")
+	setIDFromFirstArg(fs, id)
+	if strings.TrimSpace(*id) == "" || fs.NArg() > 1 || (idFlagSet && fs.NArg() > 0) {
+		return exit(2, "usage: crabbox stop --id <lease-or-server-id>")
 	}
 	cfg, err := loadConfig()
 	if err != nil {
@@ -2447,22 +2452,25 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
+	if err := autoRouteStaticLease(&cfg, fs, *id); err != nil {
+		return err
+	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
-		return delegated.Stop(ctx, StopRequest{Options: leaseOptionsFromConfig(cfg), ID: fs.Arg(0)})
+		return delegated.Stop(ctx, StopRequest{Options: leaseOptionsFromConfig(cfg), ID: *id})
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
 		return exit(2, "provider=%s does not support stop", backend.Spec().Name)
 	}
-	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: fs.Arg(0), ReleaseOnly: true})
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, ReleaseOnly: true})
 	if err != nil {
 		if backendCoordinator(backend) != nil {
 			fmt.Fprintf(a.Stderr, "warning: could not inspect lease before release: %v\n", err)
-			lease = LeaseTarget{LeaseID: fs.Arg(0)}
+			lease = LeaseTarget{LeaseID: *id}
 		} else {
 			return err
 		}

--- a/internal/cli/screenshot.go
+++ b/internal/cli/screenshot.go
@@ -24,7 +24,7 @@ func (a App) screenshot(ctx context.Context, args []string) error {
 		return err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/ssh_cmd.go
+++ b/internal/cli/ssh_cmd.go
@@ -19,7 +19,7 @@ func (a App) ssh(ctx context.Context, args []string) error {
 		return err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression coverage for the two `crabbox stop` and static-lease UX gaps
+// fixed in the same change: stop should accept --id like every other lease
+// command, and ids that carry the synthesised `static_<slug>` prefix should
+// route to provider=ssh without re-passing --provider / --static-host.
+
+func TestAutoRouteStaticLeaseRestoresHostFromStaticClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "mac-studio.local"
+	claimed.Static.User = "builder"
+	claimed.Static.Port = "2202"
+	claimed.Static.WorkRoot = "/Users/builder/project"
+	claimed.TargetOS = targetMacOS
+	if err := claimLeaseForRepoConfig("static_mac-studio-local", "mac-studio-local", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := autoRouteStaticLease(&cfg, fs, "static_mac-studio-local"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != staticProvider {
+		t.Fatalf("provider=%q, want %q", cfg.Provider, staticProvider)
+	}
+	if cfg.Static.Host != "mac-studio.local" {
+		t.Fatalf("static.host=%q, want mac-studio.local", cfg.Static.Host)
+	}
+	if cfg.Static.User != "builder" || cfg.Static.Port != "2202" || cfg.Static.WorkRoot != "/Users/builder/project" || cfg.TargetOS != targetMacOS {
+		t.Fatalf("static route details not restored: %#v", cfg.Static)
+	}
+}
+
+func TestAutoRouteStaticLeaseDoesNotGuessHostWithoutClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := autoRouteStaticLease(&cfg, fs, "static_192-168-1-10"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != staticProvider {
+		t.Fatalf("provider=%q, want %q", cfg.Provider, staticProvider)
+	}
+	if cfg.Static.Host != "" {
+		t.Fatalf("static.host=%q, want empty without claim/config", cfg.Static.Host)
+	}
+}
+
+func TestAutoRouteStaticLeaseClaimOverridesConfiguredStaticHost(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "claimed.example.com"
+	if err := claimLeaseForRepoConfig("static_claimed-example-com", "claimed-example-com", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := baseConfig()
+	defaults.Static.Host = "default.example.com"
+	fs := newFlagSet("test", io.Discard)
+	registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := autoRouteStaticLease(&cfg, fs, "static_claimed-example-com"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Static.Host != "claimed.example.com" {
+		t.Fatalf("static.host=%q, want claimed.example.com", cfg.Static.Host)
+	}
+}
+
+func TestAutoRouteStaticLeaseRespectsExplicitStaticTargetFlags(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "claimed.example.com"
+	claimed.Static.User = "claimed"
+	claimed.Static.Port = "2222"
+	claimed.Static.WorkRoot = "/claimed"
+	claimed.TargetOS = targetMacOS
+	if err := claimLeaseForRepoConfig("static_claimed-example-com", "claimed-example-com", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	target := registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, []string{
+		"--static-host", "flag.example.com",
+		"--static-user", "flag-user",
+		"--static-port", "2022",
+		"--static-work-root", "/flag",
+		"--target", "linux",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyTargetFlagOverrides(&cfg, fs, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := autoRouteStaticLease(&cfg, fs, "static_claimed-example-com"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Static.Host != "flag.example.com" || cfg.Static.User != "flag-user" || cfg.Static.Port != "2022" || cfg.Static.WorkRoot != "/flag" || cfg.TargetOS != targetLinux {
+		t.Fatalf("explicit static target flags not preserved: cfg=%#v static=%#v", cfg, cfg.Static)
+	}
+}
+
+func TestAutoRouteStaticLeaseRespectsExplicitProviderFlag(t *testing.T) {
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	provider := fs.String("provider", defaults.Provider, "")
+	registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, []string{"--provider", "hetzner"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	cfg.Provider = *provider
+	if err := autoRouteStaticLease(&cfg, fs, "static_my-box"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "hetzner" {
+		t.Fatalf("provider=%q, want hetzner (user override)", cfg.Provider)
+	}
+	if cfg.Static.Host != "" {
+		t.Fatalf("static.host=%q, want empty (non-ssh provider)", cfg.Static.Host)
+	}
+}
+
+func TestAutoRouteStaticLeaseRespectsExplicitStaticHost(t *testing.T) {
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	target := registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, []string{"--static-host", "other-box"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyTargetFlagOverrides(&cfg, fs, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := autoRouteStaticLease(&cfg, fs, "static_my-box"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != staticProvider {
+		t.Fatalf("provider=%q, want %q", cfg.Provider, staticProvider)
+	}
+	if cfg.Static.Host != "other-box" {
+		t.Fatalf("static.host=%q, want other-box (user override)", cfg.Static.Host)
+	}
+}
+
+func TestAutoRouteStaticLeaseIgnoresNonStaticIDs(t *testing.T) {
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	registerTargetFlags(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := autoRouteStaticLease(&cfg, fs, "cbx_abc123"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != defaults.Provider {
+		t.Fatalf("provider=%q, want %q (unchanged)", cfg.Provider, defaults.Provider)
+	}
+	if cfg.Static.Host != "" {
+		t.Fatalf("static.host=%q, want empty (unchanged)", cfg.Static.Host)
+	}
+}
+
+// Issue 1 end-to-end: applyLeaseCreateFlagsForLease (the path `crabbox run`
+// uses) must auto-route static_<slug> ids so users don't have to repeat
+// --provider ssh --static-host on every command after warmup.
+func TestApplyLeaseCreateFlagsForLeaseAutoRoutesStaticID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimed := baseConfig()
+	claimed.Provider = staticProvider
+	claimed.Static.Host = "dev.example.com"
+	if err := claimLeaseForRepoConfig("static_dev-example-com", "dev-example-com", claimed, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := baseConfig()
+	fs := newFlagSet("test", io.Discard)
+	values := registerLeaseCreateFlags(fs, defaults)
+	// run.go owns its own --id flag outside the lease-create flag set; the
+	// existing lease id is then handed to applyLeaseCreateFlagsForLease as a
+	// plain string. Mirror that here.
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlagsForLease(&cfg, fs, values, "static_dev-example-com"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != staticProvider {
+		t.Fatalf("provider=%q, want %q", cfg.Provider, staticProvider)
+	}
+	if cfg.Static.Host != "dev.example.com" {
+		t.Fatalf("static.host=%q, want dev.example.com", cfg.Static.Host)
+	}
+}
+
+// Issue 2: runStopCommand must emit `--id <lease>` so the emitted command can
+// be pasted back into `crabbox stop` (which now accepts --id like every other
+// lease command).
+func TestRunStopCommandEmitsIDFlag(t *testing.T) {
+	got := runStopCommand(Config{Provider: "aws", TargetOS: targetLinux}, "cbx_123")
+	want := "--id cbx_123"
+	if !strings.Contains(got, want) {
+		t.Fatalf("stop command missing %q:\n%s", want, got)
+	}
+	if strings.Contains(got, " cbx_123") && !strings.Contains(got, "--id cbx_123") {
+		t.Fatalf("stop command should not emit lease id as trailing positional:\n%s", got)
+	}
+}
+
+func TestStopAcceptsIDFlag(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{"--provider", "e2b", "--id", "box_123"})
+	if err != nil {
+		t.Fatalf("stop --id: %v", err)
+	}
+}
+
+func TestStopRejectsIDFlagWithExtraPositional(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{"--provider", "e2b", "--id", "box_123", "box_456"})
+	if err == nil || !strings.Contains(err.Error(), "usage: crabbox stop --id") {
+		t.Fatalf("expected usage error for --id plus positional, got %v", err)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -23,7 +23,7 @@ func (a App) status(ctx context.Context, args []string) error {
 		return err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"path"
 	"strings"
 )
@@ -193,6 +194,64 @@ func isStaticProvider(provider string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// staticLeaseIDPrefix is the prefix `staticLease` stamps on lease IDs it
+// synthesises from a static SSH host.
+const staticLeaseIDPrefix = "static_"
+
+// autoRouteStaticLease infers `--provider ssh` from a `static_<slug>` lease ID
+// and restores the original static host from the local claim when the caller
+// did not already pass --static-host.
+func autoRouteStaticLease(cfg *Config, fs *flag.FlagSet, id string) error {
+	suffix, ok := strings.CutPrefix(strings.TrimSpace(id), staticLeaseIDPrefix)
+	if !ok || suffix == "" {
+		return nil
+	}
+	if !flagWasSet(fs, "provider") {
+		cfg.Provider = staticProvider
+	}
+	if !isStaticProvider(cfg.Provider) {
+		return nil
+	}
+	claim, ok, err := staticLeaseClaim(id)
+	if err != nil {
+		return err
+	}
+	if ok {
+		restoreStaticClaimTarget(cfg, fs, claim)
+	}
+	normalizeTargetConfig(cfg)
+	return validateTargetConfig(*cfg)
+}
+
+func staticLeaseClaim(id string) (leaseClaim, bool, error) {
+	claim, ok, err := resolveLeaseClaim(id)
+	if err != nil || !ok || !isStaticProvider(claim.Provider) {
+		return leaseClaim{}, false, err
+	}
+	return claim, true, nil
+}
+
+func restoreStaticClaimTarget(cfg *Config, fs *flag.FlagSet, claim leaseClaim) {
+	if !flagWasSet(fs, "static-host") && strings.TrimSpace(claim.StaticHost) != "" {
+		cfg.Static.Host = strings.TrimSpace(claim.StaticHost)
+	}
+	if !flagWasSet(fs, "static-user") && strings.TrimSpace(claim.StaticUser) != "" {
+		cfg.Static.User = strings.TrimSpace(claim.StaticUser)
+	}
+	if !flagWasSet(fs, "static-port") && strings.TrimSpace(claim.StaticPort) != "" {
+		cfg.Static.Port = strings.TrimSpace(claim.StaticPort)
+	}
+	if !flagWasSet(fs, "static-work-root") && strings.TrimSpace(claim.StaticWorkRoot) != "" {
+		cfg.Static.WorkRoot = strings.TrimSpace(claim.StaticWorkRoot)
+	}
+	if !flagWasSet(fs, "target") && strings.TrimSpace(claim.TargetOS) != "" {
+		cfg.TargetOS = strings.TrimSpace(claim.TargetOS)
+	}
+	if !flagWasSet(fs, "windows-mode") && strings.TrimSpace(claim.WindowsMode) != "" {
+		cfg.WindowsMode = strings.TrimSpace(claim.WindowsMode)
 	}
 }
 

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -24,7 +24,7 @@ func (a App) vnc(ctx context.Context, args []string) error {
 		return err
 	}
 	setIDFromFirstArg(fs, id)
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -81,7 +81,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if *daemon || *background {
 		return a.webVNCDaemonStart(ctx, stripLegacyWebVNCDaemonFlags(args))
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox webvnc daemon start --id <lease-id-or-slug>")
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}
@@ -418,7 +418,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox webvnc status --id <lease-id-or-slug>")
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}
@@ -533,7 +533,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox webvnc reset --id <lease-id-or-slug>")
 	}
-	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{Desktop: true})
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Add `--id <lease>` to `crabbox stop` (positional still accepted) and update the `stop_command` that `crabbox run` prints so it can be pasted back verbatim.
- Add `autoRouteStaticLease`, applied by both `loadLeaseTargetConfig` (status, ssh, inspect, screenshot, vnc, webvnc, actions, artifacts, checkpoint, egress) and `applyLeaseCreateFlagsForLease` (run), so a lease id with the synthesised `static_<host>` prefix routes to `--provider ssh` with `--static-host <host>` derived from the suffix when the user did not set either flag explicitly. Explicit `--provider` or `--static-host` always wins.

## Why

Two cliffs after `crabbox warmup --provider ssh --target macos --static-host my-box`:

1. The emitted `stop_command` ended in a trailing positional lease id, but every other lease subcommand (run, status, inspect, ssh, etc.) takes `--id`. `crabbox stop --id ...` rejected the flag, so the only crabbox-emitted command users could not paste back verbatim was the one printed by every successful run.
2. `crabbox status --id static_my-box` (or `run`, `stop`, `ssh`, ...) silently fell back to the default coordinator provider and failed with provider auth errors until the user re-typed `--provider ssh --static-host my-box --static-user ... --static-work-root ...` on every invocation.

After: a static SSH lease can be driven by id alone, and the stop hint is pasteable.

## Reproduction

\`\`\`sh
crabbox warmup --provider ssh --target macos --static-host my-box --static-user alice --static-work-root /Users/alice/crabbox
# Before: requires --provider ssh + --static-* on every follow-up.
# After:  --id alone is enough.
crabbox status --id static_my-box --static-work-root /Users/alice/crabbox --static-user alice
crabbox run    --id static_my-box --static-work-root /Users/alice/crabbox --static-user alice --shell -- 'uname -a'
crabbox stop   --id static_my-box --static-work-root /Users/alice/crabbox --static-user alice
\`\`\`

(`--static-work-root` and `--static-user` still need to be passed where they differ from defaults; only `--provider` and `--static-host` are auto-resolved from the id prefix.)

## Verification

- \`gofmt -w \$(git ls-files '*.go')\`
- \`go vet ./...\`
- \`go test -race -count=1 ./...\` — all packages green
- New regression tests in \`internal/cli/static_route_test.go\` cover: prefix routing, explicit `--provider` override, explicit `--static-host` override, non-static ids ignored, `applyLeaseCreateFlagsForLease` end-to-end, and that `runStopCommand` emits `--id <lease>`.
- Updated \`TestPopulateRunTimingMetadata\` to expect the new `--id` form in the stop hint.
- Live proof against a static SSH macOS lease:
  - \`crabbox status --id static_<host>\` returned \`state=leased ready=true\` without \`--provider\`.
  - \`crabbox run --id static_<host> --shell -- 'echo hi from \$(hostname)'\` synced 196 files and ran the command (exit 0).
  - \`crabbox stop --id static_<host>\` released the lease.

## Compatibility

- `crabbox stop <lease-id>` (positional) still works; `--id` is additive.
- Auto-route is a no-op for ids without the `static_` prefix and for callers that set `--provider` or `--static-host` explicitly, so behaviour for cbx_*, tbx_*, etc. is unchanged.

## Out of scope

- Slug-only lookup (e.g. `--id my-box` without the `static_` prefix) still requires either a coordinator or the full static flag set; a local slug→host store would be a separate change.