### PR TITLE
fix(aws): close missing-instance lease cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed brokered AWS provisioning to compact stale Crabbox SSH ingress after EC2 reports the security group rule limit, then retry the current source rule before failing.
+- Fixed coordinator lease cleanup so expired AWS leases whose EC2 instance is already gone still clean provider keys before closing.
 
 ## 0.21.0 - 2026-05-27
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -6988,7 +6988,17 @@ class AWSProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
-    await this.deleteServer(lease.cloudID);
+    try {
+      await this.deleteServer(lease.cloudID);
+    } catch (error) {
+      const message = errorMessage(error);
+      if (!isCloudNotFoundError(message)) {
+        throw error;
+      }
+      console.warn(
+        `AWS lease cleanup found missing instance lease=${lease.id} cloud=${lease.cloudID}: ${message}`,
+      );
+    }
     if (validCrabboxProviderKey(lease.providerKey)) {
       await this.deleteSSHKey(lease.providerKey);
     }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -174,6 +174,38 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBeUndefined();
   });
 
+  it("keeps provider cleanup failures active even when the cloud instance is already gone", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async () => {
+        throw new Error("aws instance not found: i-000000000001");
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-000000000001",
+        region: "eu-west-1",
+        cleanupAttempts: 2,
+        cleanupError: "previous failure",
+        cleanupFailedAt: "2026-05-01T00:00:10.000Z",
+        cleanupRetryAt: "2026-05-01T00:05:10.000Z",
+        expiresAt: "2026-05-01T00:00:01.000Z",
+      }),
+    );
+
+    await fleet.alarm();
+
+    const lease = storage.value<LeaseRecord>("lease:cbx_000000000001");
+    expect(lease?.state).toBe("active");
+    expect(lease?.cleanupAttempts).toBe(3);
+    expect(lease?.cleanupError).toContain("aws instance not found");
+    expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(Date.now());
+    expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
+  });
+
   it("schedules the real expiry before stale cleanup retry metadata", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);


### PR DESCRIPTION
## Summary
- treat missing AWS EC2 instances as an idempotent terminate step during lease cleanup
- still clean generated Crabbox provider SSH keys before closing the lease
- add a regression around fleet cleanup retry ownership

## Verification
- npm test -- --run test/fleet.test.ts -t "provider cleanup failures|expires leases"
- npm run format:check
- npm run check
- npm run lint
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode local