### PR TITLE
fix(worker): gzip AWS Linux user data

### DIFF
--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,7 +1,7 @@
 import { AwsClient } from "aws4fetch";
 import { XMLParser } from "fast-xml-parser";
 
-import { awsUserData } from "./bootstrap";
+import { awsRunInstancesUserData } from "./bootstrap";
 import {
   awsPromotedAMIConfigKey,
   awsInstanceTypeCandidatesForTargetClass,
@@ -1046,7 +1046,7 @@ export class EC2SpotClient {
         KeyName: config.providerKey,
         MaxCount: "1",
         MinCount: "1",
-        UserData: btoa(awsUserData(config)),
+        UserData: await awsRunInstancesUserData(config),
         "BlockDeviceMapping.1.DeviceName": "/dev/sda1",
         "BlockDeviceMapping.1.Ebs.DeleteOnTermination": "true",
         "BlockDeviceMapping.1.Ebs.Encrypted": "true",

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -19,6 +19,27 @@ export function awsUserData(config: LeaseConfig): string {
   return cloudInit(config);
 }
 
+export async function awsRunInstancesUserData(config: LeaseConfig): Promise<string> {
+  const userData = awsUserData(config);
+  const bytes =
+    config.target === "linux" ? await gzip(userData) : new TextEncoder().encode(userData);
+  return base64Encode(bytes);
+}
+
+async function gzip(value: string): Promise<Uint8Array> {
+  const stream = new Blob([value]).stream().pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
+  }
+  return btoa(chunks.join(""));
+}
+
 export function cloudInit(config: LeaseConfig): string {
   const portLines = sshPorts(config)
     .map((port) => `      Port ${port}`)

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -939,6 +939,87 @@ describe("aws provider", () => {
     expect(isRetryableAWSProvisioningError(imageMiss)).toBe(true);
   });
 
+  it("sends compressed Linux cloud-init user data to RunInstances", async () => {
+    let userData = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (new URL(request.url).hostname.startsWith("servicequotas.")) {
+          return new Response(JSON.stringify({ Quota: { Value: 999 } }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+        if (securityGroupResponse) {
+          return securityGroupResponse;
+        }
+        if (action === "DescribeKeyPairs") {
+          return ec2XMLResponse("<DescribeKeyPairsResponse />");
+        }
+        if (action === "DescribeImages") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeImagesResponse>
+  <imagesSet>
+    <item>
+      <imageId>ami-linux</imageId>
+      <name>ubuntu</name>
+      <imageState>available</imageState>
+      <creationDate>2026-05-01T00:00:00.000Z</creationDate>
+    </item>
+  </imagesSet>
+</DescribeImagesResponse>`);
+        }
+        if (action === "RunInstances") {
+          userData = params.get("UserData") ?? "";
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+<RunInstancesResponse>
+  <instancesSet>
+    <item>
+      <instanceId>i-linux</instanceId>
+      <instanceType>c7a.8xlarge</instanceType>
+      <ipAddress>203.0.113.44</ipAddress>
+      <instanceState><name>pending</name></instanceState>
+    </item>
+  </instancesSet>
+</RunInstancesResponse>`);
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
+      } as never,
+      "us-east-1",
+    );
+    await client.createServerWithFallback(
+      leaseConfig({
+        provider: "aws",
+        target: "linux",
+        class: "standard",
+        desktop: true,
+        browser: true,
+        sshPublicKey: `ssh-rsa ${"a".repeat(724)}`,
+      }),
+      "cbx_abcdef123456",
+      "violet-prawn",
+      "alice@example.com",
+    );
+
+    expect(atob(userData).length).toBeLessThan(16 * 1024);
+    expect(await gunzipBase64(userData)).toContain("crabbox-configure-desktop-theme");
+  });
+
   it("resolves macOS AMIs per fallback instance type", async () => {
     const imageQueries: string[] = [];
     const hostTypes: string[] = [];
@@ -1869,4 +1950,10 @@ function ec2ConfiguredSecurityGroupResponse(
 
 function ec2XMLResponse(body: string, status = 200): Response {
   return new Response(body, { status, headers: { "content-type": "application/xml" } });
+}
+
+async function gunzipBase64(value: string): Promise<string> {
+  const bytes = Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return await new Response(stream).text();
 }

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  awsRunInstancesUserData,
   awsUserData,
   azureWindowsBootstrapPowerShell,
   cloudInit,
@@ -48,6 +49,12 @@ const config: LeaseConfig = {
   keep: false,
   sshPublicKey: "ssh-ed25519 test",
 };
+
+async function gunzipBase64(value: string): Promise<string> {
+  const bytes = Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return await new Response(stream).text();
+}
 
 describe("cloud-init bootstrap", () => {
   it("uses retrying package installation in runcmd", () => {
@@ -234,6 +241,21 @@ describe("cloud-init bootstrap", () => {
     expect(sshIndex).toBeLessThan(browserIndex);
     expect(bootstrappedIndex).toBeGreaterThan(desktopIndex);
     expect(bootstrappedIndex).toBeGreaterThan(browserIndex);
+  });
+
+  it("compresses AWS Linux user data below the EC2 launch limit", async () => {
+    const longKey = `ssh-rsa ${"a".repeat(724)}`;
+    const raw = awsUserData({ ...config, desktop: true, browser: true, sshPublicKey: longKey });
+    const encoded = await awsRunInstancesUserData({
+      ...config,
+      desktop: true,
+      browser: true,
+      sshPublicKey: longKey,
+    });
+    const compressedBytes = atob(encoded).length;
+    expect(new TextEncoder().encode(raw).length).toBeGreaterThan(16 * 1024);
+    expect(compressedBytes).toBeLessThan(16 * 1024);
+    expect(await gunzipBase64(encoded)).toBe(raw);
   });
 
   it("adds browser setup only when requested", () => {


### PR DESCRIPTION
Summary
- gzip AWS Linux cloud-init before sending it to EC2 RunInstances
- keep non-Linux AWS user data as plain base64
- add regression coverage for oversized desktop/browser cloud-init and the RunInstances payload

Verification
- npm test --prefix worker -- bootstrap.test.ts aws.test.ts
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm test --prefix worker
- npm run build --prefix worker
- git diff --check

Live AWS proof
- Raw desktop/browser user-data DryRun reproduced: Encoded User data is limited to 25600 bytes
- Gzipped desktop/browser user-data DryRun returned: DryRunOperation
- Real t3.nano launch with gzipped user-data succeeded, then was immediately terminated: i-027213dd1508af798
- Active instances with the test tag after cleanup: []
