### PR TITLE
feat(islo): implement Crabbox run session handles

### DIFF
--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -165,11 +165,10 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=islo sandbox=%s\n", leaseID, slug, name)
 		acquired = true
 	} else {
-		leaseID, name, err = resolveIsloLeaseID(req.ID, req.Repo.Root, req.Reclaim)
+		leaseID, name, slug, err = resolveIsloLeaseID(req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
-		slug = newLeaseSlug(leaseID)
 	}
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
@@ -281,7 +280,7 @@ func (b *isloBackend) Status(ctx context.Context, req StatusRequest) (statusView
 	if err != nil {
 		return statusView{}, err
 	}
-	leaseID, name, err := resolveIsloLeaseID(req.ID, "", false)
+	leaseID, name, _, err := resolveIsloLeaseID(req.ID, "", false)
 	if err != nil {
 		return statusView{}, err
 	}
@@ -314,7 +313,7 @@ func (b *isloBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, name, err := resolveIsloLeaseID(req.ID, "", false)
+	leaseID, name, _, err := resolveIsloLeaseID(req.ID, "", false)
 	if err != nil {
 		return err
 	}
@@ -404,31 +403,32 @@ func isloExecCommand(command []string, shellMode bool) ([]string, error) {
 	return command, nil
 }
 
-func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, error) {
+func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, string, error) {
 	if id == "" {
-		return "", "", exit(2, "provider=islo requires a Crabbox-created sandbox name, lease id, or slug")
+		return "", "", "", exit(2, "provider=islo requires a Crabbox-created sandbox name, lease id, or slug")
 	}
 	if strings.HasPrefix(id, isloLeasePrefix) {
 		name := strings.TrimPrefix(id, isloLeasePrefix)
 		if !isCrabboxIsloSandboxName(name) {
-			return "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
+			return "", "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
 		}
-		return id, name, nil
+		return id, name, newLeaseSlug(id), nil
 	}
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
-		return "", "", err
+		return "", "", "", err
 	} else if ok && claim.Provider == isloProvider {
 		if repoRoot != "" {
 			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, isloProvider, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", err
+				return "", "", "", err
 			}
 		}
-		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, isloLeasePrefix), nil
+		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, isloLeasePrefix), blank(claim.Slug, newLeaseSlug(claim.LeaseID)), nil
 	}
 	if !isCrabboxIsloSandboxName(id) {
-		return "", "", exit(4, "islo sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<crabbox-sandbox-name>", id, isloLeasePrefix)
+		return "", "", "", exit(4, "islo sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<crabbox-sandbox-name>", id, isloLeasePrefix)
 	}
-	return isloLeasePrefix + id, id, nil
+	leaseID := isloLeasePrefix + id
+	return leaseID, id, newLeaseSlug(leaseID), nil
 }
 
 func isloSandboxToServer(sandbox *gosdk.SandboxResponse) Server {

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -407,16 +407,9 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 	if id == "" {
 		return "", "", "", exit(2, "provider=islo requires a Crabbox-created sandbox name, lease id, or slug")
 	}
-	if strings.HasPrefix(id, isloLeasePrefix) {
-		name := strings.TrimPrefix(id, isloLeasePrefix)
-		if !isCrabboxIsloSandboxName(name) {
-			return "", "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
-		}
-		return id, name, newLeaseSlug(id), nil
-	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := resolveIsloClaim(id); err != nil {
 		return "", "", "", err
-	} else if ok && claim.Provider == isloProvider {
+	} else if ok {
 		if repoRoot != "" {
 			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, isloProvider, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
 				return "", "", "", err
@@ -424,11 +417,33 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 		}
 		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, isloLeasePrefix), blank(claim.Slug, newLeaseSlug(claim.LeaseID)), nil
 	}
+	if strings.HasPrefix(id, isloLeasePrefix) {
+		name := strings.TrimPrefix(id, isloLeasePrefix)
+		if !isCrabboxIsloSandboxName(name) {
+			return "", "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
+		}
+		return id, name, newLeaseSlug(id), nil
+	}
 	if !isCrabboxIsloSandboxName(id) {
 		return "", "", "", exit(4, "islo sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<crabbox-sandbox-name>", id, isloLeasePrefix)
 	}
 	leaseID := isloLeasePrefix + id
 	return leaseID, id, newLeaseSlug(leaseID), nil
+}
+
+func resolveIsloClaim(id string) (core.LeaseClaim, bool, error) {
+	claim, ok, err := resolveLeaseClaim(id)
+	if err != nil || (ok && claim.Provider == isloProvider) {
+		return claim, ok, err
+	}
+	if strings.HasPrefix(id, isloLeasePrefix) || !isCrabboxIsloSandboxName(id) {
+		return core.LeaseClaim{}, false, nil
+	}
+	claim, ok, err = resolveLeaseClaim(isloLeasePrefix + id)
+	if err != nil || (ok && claim.Provider == isloProvider) {
+		return claim, ok, err
+	}
+	return core.LeaseClaim{}, false, nil
 }
 
 func isloSandboxToServer(sandbox *gosdk.SandboxResponse) Server {

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -183,26 +183,7 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			removeLeaseClaim(leaseID)
 		}()
 	}
-	fmt.Fprintf(b.rt.Stderr, "provider=islo lease=%s sandbox=%s\n", leaseID, name)
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		var err error
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, name, req)
-		if err != nil {
-			return RunResult{}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, name, workspace); err != nil {
-		return RunResult{}, err
-	}
-	commandStart := b.now()
-	exitCode, runErr := b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env)
-	commandDuration := b.now().Sub(commandStart)
 	result := RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
 		SyncDelegated: true,
 		Session: &core.RunSessionHandle{
 			Provider:       isloProvider,
@@ -213,6 +194,30 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", isloProvider, leaseID),
 		},
 	}
+	finishResult := func() RunResult {
+		result.Total = b.now().Sub(started)
+		result.Session.Kept = !shouldStop
+		return result
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=islo lease=%s sandbox=%s\n", leaseID, name)
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		var err error
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, name, req)
+		if err != nil {
+			return finishResult(), err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, client, name, workspace); err != nil {
+		return finishResult(), err
+	}
+	commandStart := b.now()
+	exitCode, runErr := b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env)
+	commandDuration := b.now().Sub(commandStart)
+	result.ExitCode = exitCode
+	result.Command = commandDuration
+	result.Total = b.now().Sub(started)
 	if req.NoSync {
 		fmt.Fprintf(b.rt.Stderr, "islo run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	} else {
@@ -440,8 +445,11 @@ func resolveIsloClaim(id string) (core.LeaseClaim, bool, error) {
 		return core.LeaseClaim{}, false, nil
 	}
 	claim, ok, err = resolveLeaseClaim(isloLeasePrefix + id)
-	if err != nil || (ok && claim.Provider == isloProvider) {
+	if err != nil {
 		return claim, ok, err
+	}
+	if ok && claim.Provider == isloProvider && claim.LeaseID == isloLeasePrefix+id {
+		return claim, true, nil
 	}
 	return core.LeaseClaim{}, false, nil
 }

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -205,6 +205,14 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 		Command:       commandDuration,
 		Total:         b.now().Sub(started),
 		SyncDelegated: true,
+		Session: &core.RunSessionHandle{
+			Provider:       isloProvider,
+			LeaseID:        leaseID,
+			Slug:           slug,
+			Reused:         !acquired,
+			Kept:           !shouldStop,
+			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", isloProvider, leaseID),
+		},
 	}
 	if req.NoSync {
 		fmt.Fprintf(b.rt.Stderr, "islo run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
@@ -229,10 +237,12 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 	}
 	if runErr != nil {
 		handleDelegatedRunFailure(b.rt.Stderr, req, isloProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		result.Session.Kept = !shouldStop
 		return result, ExitError{Code: 1, Message: fmt.Sprintf("islo run failed: %v", runErr)}
 	}
 	if exitCode != 0 {
 		handleDelegatedRunFailure(b.rt.Stderr, req, isloProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		result.Session.Kept = !shouldStop
 		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("islo run exited %d", exitCode)}
 	}
 	return result, nil

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -191,7 +191,7 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			Slug:           slug,
 			Reused:         !acquired,
 			Kept:           !shouldStop,
-			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", isloProvider, leaseID),
+			CleanupCommand: isloCleanupCommand(leaseID),
 		},
 	}
 	finishResult := func() RunResult {
@@ -434,6 +434,10 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 	}
 	leaseID := isloLeasePrefix + id
 	return leaseID, id, newLeaseSlug(leaseID), nil
+}
+
+func isloCleanupCommand(leaseID string) string {
+	return fmt.Sprintf("crabbox stop --provider %s %s", isloProvider, shellQuote(leaseID))
 }
 
 func resolveIsloClaim(id string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -412,6 +412,18 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 	if id == "" {
 		return "", "", "", exit(2, "provider=islo requires a Crabbox-created sandbox name, lease id, or slug")
 	}
+	if strings.HasPrefix(id, isloLeasePrefix) {
+		name := strings.TrimPrefix(id, isloLeasePrefix)
+		if !isCrabboxIsloSandboxName(name) {
+			return "", "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
+		}
+		if claim, ok, err := resolveExactIsloLeaseClaim(id); err != nil {
+			return "", "", "", err
+		} else if ok {
+			return claim.LeaseID, name, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), nil
+		}
+		return id, name, newLeaseSlug(id), nil
+	}
 	if claim, ok, err := resolveIsloClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok {
@@ -422,18 +434,22 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 		}
 		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, isloLeasePrefix), blank(claim.Slug, newLeaseSlug(claim.LeaseID)), nil
 	}
-	if strings.HasPrefix(id, isloLeasePrefix) {
-		name := strings.TrimPrefix(id, isloLeasePrefix)
-		if !isCrabboxIsloSandboxName(name) {
-			return "", "", "", exit(4, "islo lease %q is not a Crabbox-owned sandbox", id)
-		}
-		return id, name, newLeaseSlug(id), nil
-	}
 	if !isCrabboxIsloSandboxName(id) {
 		return "", "", "", exit(4, "islo sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<crabbox-sandbox-name>", id, isloLeasePrefix)
 	}
 	leaseID := isloLeasePrefix + id
 	return leaseID, id, newLeaseSlug(leaseID), nil
+}
+
+func resolveExactIsloLeaseClaim(leaseID string) (core.LeaseClaim, bool, error) {
+	claim, ok, err := resolveLeaseClaim(leaseID)
+	if err != nil {
+		return claim, ok, err
+	}
+	if ok && claim.Provider == isloProvider && claim.LeaseID == leaseID {
+		return claim, true, nil
+	}
+	return core.LeaseClaim{}, false, nil
 }
 
 func isloCleanupCommand(leaseID string) string {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -132,12 +132,14 @@ func TestResolveIsloLeaseIDPreservesClaimSlug(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotLeaseID, name, slug, err := resolveIsloLeaseID("web", root, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotLeaseID != leaseID || name != "crabbox-repo-abcdef" || slug != "web" {
-		t.Fatalf("lease=%q name=%q slug=%q", gotLeaseID, name, slug)
+	for _, id := range []string{"web", leaseID, "crabbox-repo-abcdef"} {
+		gotLeaseID, name, slug, err := resolveIsloLeaseID(id, root, false)
+		if err != nil {
+			t.Fatalf("id=%q err=%v", id, err)
+		}
+		if gotLeaseID != leaseID || name != "crabbox-repo-abcdef" || slug != "web" {
+			t.Fatalf("id=%q lease=%q name=%q slug=%q", id, gotLeaseID, name, slug)
+		}
 	}
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -112,15 +112,32 @@ func TestIsloStatusReady(t *testing.T) {
 }
 
 func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
-	if _, _, err := resolveIsloLeaseID("production", "", false); err == nil {
+	if _, _, _, err := resolveIsloLeaseID("production", "", false); err == nil {
 		t.Fatal("expected raw non-Crabbox sandbox to be rejected")
 	}
-	leaseID, name, err := resolveIsloLeaseID("crabbox-repo-abcdef", "", false)
+	leaseID, name, slug, err := resolveIsloLeaseID("crabbox-repo-abcdef", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" {
-		t.Fatalf("lease=%q name=%q", leaseID, name)
+	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" || slug == "" {
+		t.Fatalf("lease=%q name=%q slug=%q", leaseID, name, slug)
+	}
+}
+
+func TestResolveIsloLeaseIDPreservesClaimSlug(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, root, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+
+	gotLeaseID, name, slug, err := resolveIsloLeaseID("web", root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLeaseID != leaseID || name != "crabbox-repo-abcdef" || slug != "web" {
+		t.Fatalf("lease=%q name=%q slug=%q", gotLeaseID, name, slug)
 	}
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -157,6 +157,45 @@ func TestIsloRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
 	}
 }
 
+func TestIsloRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	root := t.TempDir()
+	if err := os.WriteFile(root+"/go.mod", []byte("module example.test/repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: root, Name: "repo"},
+		Keep:    true,
+		Command: []string{"true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Session == nil {
+		t.Fatal("missing session handle")
+	}
+	got := result.Session
+	if got.Provider != isloProvider || got.LeaseID != "isb_crabbox-repo-abcdef" || got.Slug == "" || got.Reused || !got.Kept {
+		t.Fatalf("session=%#v", got)
+	}
+	if got.CleanupCommand != "crabbox stop --provider islo isb_crabbox-repo-abcdef" {
+		t.Fatalf("cleanup command=%q", got.CleanupCommand)
+	}
+}
+
 func TestIsloCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
 	client := &fakeIsloSyncClient{}
 	backend := &isloBackend{
@@ -530,6 +569,16 @@ func (f *fakeIsloSyncClient) commandContains(value string) bool {
 		}
 	}
 	return false
+}
+
+func swapNewIsloClient(client isloAPI) func() {
+	previous := newIsloClient
+	newIsloClient = func(Config, Runtime) (isloAPI, error) {
+		return client, nil
+	}
+	return func() {
+		newIsloClient = previous
+	}
 }
 
 func tarGzipContains(t *testing.T, data []byte, name string) bool {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -143,6 +143,22 @@ func TestResolveIsloLeaseIDPreservesClaimSlug(t *testing.T) {
 	}
 }
 
+func TestResolveIsloLeaseIDIgnoresSyntheticSlugCollision(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	if err := claimLeaseForRepoProvider("isb_crabbox-other-abcdef", "isb-crabbox-repo-abcdef", isloProvider, root, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+
+	leaseID, name, slug, err := resolveIsloLeaseID("crabbox-repo-abcdef", root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" || slug == "isb-crabbox-repo-abcdef" {
+		t.Fatalf("lease=%q name=%q slug=%q", leaseID, name, slug)
+	}
+}
+
 func TestIsloWorkspacePathDefaultsUnderWorkspace(t *testing.T) {
 	if got, err := isloWorkspacePath(Config{}); err != nil || got != "/workspace/crabbox" {
 		t.Fatalf("workspace=%q err=%v", got, err)
@@ -212,6 +228,36 @@ func TestIsloRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	}
 	if got.CleanupCommand != "crabbox stop --provider islo isb_crabbox-repo-abcdef" {
 		t.Fatalf("cleanup command=%q", got.CleanupCommand)
+	}
+}
+
+func TestIsloRunReturnsSessionHandleWhenPrepareFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeIsloSyncClient{
+		createName: "crabbox-repo-abcdef",
+		execErr:    errors.New("prepare failed"),
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+		Keep:    true,
+		NoSync:  true,
+		Command: []string{"true"},
+	})
+	if err == nil {
+		t.Fatal("expected prepare error")
+	}
+	if result.Session == nil {
+		t.Fatal("missing session handle")
+	}
+	if result.Session.LeaseID != "isb_crabbox-repo-abcdef" || !result.Session.Kept {
+		t.Fatalf("session=%#v", result.Session)
 	}
 }
 
@@ -527,6 +573,7 @@ type fakeIsloSyncClient struct {
 	uploadPath        string
 	uploaded          bytes.Buffer
 	uploadErr         error
+	execErr           error
 	closeUploadReader bool
 	createRequest     *gosdk.SandboxCreate
 	createName        string
@@ -570,6 +617,9 @@ func (f *fakeIsloSyncClient) UploadArchive(_ context.Context, _ string, targetPa
 func (f *fakeIsloSyncClient) ExecStream(_ context.Context, _ string, req *gosdk.ExecRequest, _, _ io.Writer) (int, error) {
 	f.execRequests = append(f.execRequests, req)
 	f.prepareCommands = append(f.prepareCommands, strings.Join(req.GetCommand(), " "))
+	if f.execErr != nil {
+		return 1, f.execErr
+	}
 	return 0, nil
 }
 

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -159,6 +159,13 @@ func TestResolveIsloLeaseIDIgnoresSyntheticSlugCollision(t *testing.T) {
 	}
 }
 
+func TestIsloCleanupCommandQuotesLeaseID(t *testing.T) {
+	got := isloCleanupCommand("isb_crabbox-repo-a;touch")
+	if got != "crabbox stop --provider islo 'isb_crabbox-repo-a;touch'" {
+		t.Fatalf("cleanup command=%q", got)
+	}
+}
+
 func TestIsloWorkspacePathDefaultsUnderWorkspace(t *testing.T) {
 	if got, err := isloWorkspacePath(Config{}); err != nil || got != "/workspace/crabbox" {
 		t.Fatalf("workspace=%q err=%v", got, err)
@@ -226,7 +233,7 @@ func TestIsloRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	if got.Provider != isloProvider || got.LeaseID != "isb_crabbox-repo-abcdef" || got.Slug == "" || got.Reused || !got.Kept {
 		t.Fatalf("session=%#v", got)
 	}
-	if got.CleanupCommand != "crabbox stop --provider islo isb_crabbox-repo-abcdef" {
+	if got.CleanupCommand != "crabbox stop --provider islo 'isb_crabbox-repo-abcdef'" {
 		t.Fatalf("cleanup command=%q", got.CleanupCommand)
 	}
 }

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -157,6 +157,13 @@ func TestResolveIsloLeaseIDIgnoresSyntheticSlugCollision(t *testing.T) {
 	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" || slug == "isb-crabbox-repo-abcdef" {
 		t.Fatalf("lease=%q name=%q slug=%q", leaseID, name, slug)
 	}
+	leaseID, name, slug, err = resolveIsloLeaseID("isb_crabbox-repo-abcdef", root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" || slug == "isb-crabbox-repo-abcdef" {
+		t.Fatalf("explicit lease=%q name=%q slug=%q", leaseID, name, slug)
+	}
 }
 
 func TestIsloCleanupCommandQuotesLeaseID(t *testing.T) {

--- a/internal/providers/islo/provider.go
+++ b/internal/providers/islo/provider.go
@@ -22,7 +22,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      "islo",
 		Kind:        core.ProviderKindDelegatedRun,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureURLBridge},
+		Features:    core.FeatureSet{core.FeatureURLBridge, core.FeatureRunSession},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary
- Implement the existing Crabbox `RunSessionHandle` / `FeatureRunSession` contract for the Islo delegated provider.
- Populate `RunResult.Session` so `crabbox run --provider islo --keep --lease-output session.json -- ...` gives orchestrators a stable lease handle.
- Add a regression test for kept Islo session handles and cleanup command metadata.

## Dependencies
- Supports the provider-generic Harbor adapter PR https://github.com/harbor-framework/harbor/pull/1745.
- Required by the stacked Harbor run-session acquisition PR: https://github.com/harbor-framework/harbor/pull/1746.

## Provider model
- This PR does not make Harbor Islo-only. It makes Islo the first delegated provider, after Blacksmith, to implement the generic Crabbox session-handle contract.
- Other Crabbox providers can adopt the same `FeatureRunSession` + `RunResult.Session` shape in follow-up PRs.

## Test plan
- `go test ./internal/providers/islo`