### PR TITLE
fix: enable broker cost cap defaults

### DIFF
--- a/worker/test/wrangler-config.test.ts
+++ b/worker/test/wrangler-config.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const wranglerConfig = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+
+const requiredCostGuardrails = [
+  "CRABBOX_MAX_ACTIVE_LEASES",
+  "CRABBOX_MAX_ACTIVE_LEASES_PER_OWNER",
+  "CRABBOX_MAX_ACTIVE_LEASES_PER_ORG",
+  "CRABBOX_MAX_MONTHLY_USD",
+  "CRABBOX_MAX_MONTHLY_USD_PER_OWNER",
+  "CRABBOX_MAX_MONTHLY_USD_PER_ORG",
+];
+
+describe("wrangler config", () => {
+  it("keeps deployed and preview coordinator cost guardrails enabled", () => {
+    for (const name of requiredCostGuardrails) {
+      const values = configValues(name);
+      expect(values, `${name} should be set in production and preview vars`).toHaveLength(2);
+      expect(
+        values.every((value) => value > 0),
+        `${name} should be nonzero`,
+      ).toBe(true);
+    }
+  });
+});
+
+function configValues(name: string): number[] {
+  const pattern = new RegExp(`"${name}"\\s*:\\s*"(\\d+)"`, "g");
+  return [...wranglerConfig.matchAll(pattern)].map((match) => Number(match[1]));
+}

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -23,6 +23,12 @@
     "CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE": "1",
     "CRABBOX_CAPACITY_HINTS": "1",
     "CRABBOX_CAPACITY_LARGE_CLASSES": "beast",
+    "CRABBOX_MAX_ACTIVE_LEASES": "4",
+    "CRABBOX_MAX_ACTIVE_LEASES_PER_OWNER": "2",
+    "CRABBOX_MAX_ACTIVE_LEASES_PER_ORG": "4",
+    "CRABBOX_MAX_MONTHLY_USD": "2500",
+    "CRABBOX_MAX_MONTHLY_USD_PER_OWNER": "1000",
+    "CRABBOX_MAX_MONTHLY_USD_PER_ORG": "2500",
   },
   "durable_objects": {
     "bindings": [
@@ -40,6 +46,12 @@
       "CRABBOX_CAPACITY_REGIONS": "eu-west-1,eu-west-2,eu-central-1,us-east-1,us-west-2",
       "CRABBOX_CAPACITY_HINTS": "1",
       "CRABBOX_CAPACITY_LARGE_CLASSES": "beast",
+      "CRABBOX_MAX_ACTIVE_LEASES": "4",
+      "CRABBOX_MAX_ACTIVE_LEASES_PER_OWNER": "2",
+      "CRABBOX_MAX_ACTIVE_LEASES_PER_ORG": "4",
+      "CRABBOX_MAX_MONTHLY_USD": "2500",
+      "CRABBOX_MAX_MONTHLY_USD_PER_OWNER": "1000",
+      "CRABBOX_MAX_MONTHLY_USD_PER_ORG": "2500",
     },
     "durable_objects": {
       "bindings": [


### PR DESCRIPTION
Summary:
- add explicit coordinator active-lease and monthly USD caps to the checked-in Worker deploy config
- add a Worker config regression test so production and preview vars cannot silently lose those caps

Verification:
- npm ci --prefix worker
- npm test --prefix worker -- wrangler-config
- npm run format:check --prefix worker
- npm run lint --prefix worker
- npm run check --prefix worker
- npm run build --prefix worker
- npm test --prefix worker
- git diff --check

Deployment note:
- this branch changes the deploy config, but production still needs a Worker deploy with Cloudflare auth before crabbox usage reports nonzero limits
- current local shell has no Cloudflare or Azure auth, so I did not deploy
