### PR TITLE
feat: add Azure ephemeral full-caching preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added Azure `--azure-os-disk ephemeral-preview` / `azure.osDisk: ephemeral-preview` for opt-in ephemeral OS disk full caching through Azure Compute API `2025-04-01`. Thanks @jwmoss.
 - Added configurable capacity-admin owner caps for coordinators that need elevated active lease limits for trusted operators.
 
 ### Changed

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -112,8 +112,8 @@ resolves to a disk snapshot where the provider supports one.
 - Azure cannot create a managed image from an active VM, so the Azure native
   path uses a managed OS-disk snapshot. That snapshot requires a managed OS disk
   (the default); creation refuses leases started with
-  `--azure-os-disk ephemeral`, where Azure reports success but does not capture
-  live disk state.
+  `--azure-os-disk ephemeral` or `--azure-os-disk ephemeral-preview`, where
+  Azure reports success but does not capture live disk state.
 
 Before a native snapshot, Crabbox cleans the source: on Linux it runs
 `cloud-init clean --logs` (so a forked box regenerates SSH host keys) and

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -371,7 +371,9 @@ failed rather than falling back to a different size.
 Azure one-shot leases use managed `StandardSSD_LRS` OS disks by default so they
 can become native checkpoint sources. Use `--azure-os-disk ephemeral` only for
 stateless leases that do not need native Azure checkpoint/fork support;
-`--azure-os-disk auto` is accepted for compatibility and resolves to managed.
+`--azure-os-disk ephemeral-preview` opts into Azure's public-preview
+full-caching ephemeral OS disk mode. `--azure-os-disk auto` is accepted for
+compatibility and resolves to managed.
 
 ## Flags
 

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -159,7 +159,9 @@ sync/run/actions contract. Azure Windows does not provision browser/code.
 Azure leases use managed `StandardSSD_LRS` OS disks by default so native
 disk-snapshot checkpoints can be created and forked. Use
 `--azure-os-disk ephemeral` only for stateless leases that don't need native
-Azure checkpoint/fork support; `--azure-os-disk auto` resolves to managed.
+Azure checkpoint/fork support. Use `--azure-os-disk ephemeral-preview` for
+Azure's public-preview full-caching ephemeral OS disk mode; `--azure-os-disk
+auto` resolves to managed.
 
 `--azure-backend dynamic-sessions` keeps `--provider azure` as the family
 selector while routing to the `azure-dynamic-sessions` delegated backend.
@@ -221,7 +223,7 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 --reclaim                          overwrite an existing local claim for this lease
 --timing-json                      print a final JSON timing record on stderr
 --azure-backend vm|dynamic-sessions
---azure-os-disk managed|ephemeral|auto
+--azure-os-disk managed|ephemeral|ephemeral-preview|auto
 ```
 
 Provider-specific flags (for example `--azure-backend`, `--e2b-template`,

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -36,6 +36,7 @@ dynamic-sessions`; see the [providers overview](providers.md).
 crabbox warmup --provider azure --class beast
 crabbox warmup --provider azure --arch arm64 --class fast
 crabbox warmup --provider azure --class beast --azure-os-disk ephemeral
+crabbox warmup --provider azure --class beast --azure-os-disk ephemeral-preview
 crabbox run --provider azure --class standard -- pnpm test
 crabbox warmup --provider azure --target windows --class standard
 crabbox warmup --provider azure --target windows --desktop --class standard
@@ -101,8 +102,14 @@ Azure leases use managed `StandardSSD_LRS` OS disks by default (config
 by hand. Use `azure.osDisk: ephemeral` or `--azure-os-disk ephemeral` only for
 stateless leases that should use a local OS disk; provisioning fails if the
 selected SKU has no ephemeral OS support, and native Azure checkpoint/fork is
-unavailable. `azure.osDisk: auto` is accepted for compatibility and resolves to
-managed.
+unavailable.
+
+`azure.osDisk: ephemeral-preview` opts into Azure's public-preview
+full-caching mode for ephemeral OS disks. Crabbox sends Compute API
+`2025-04-01` with `diffDiskSettings.enableFullCaching: true`; for known
+Crabbox Azure fallback lists it skips 2-core, 4-core, and no-local-disk SKUs
+that the preview cannot support. `azure.osDisk: auto` is accepted for
+compatibility and resolves to managed.
 
 ## Quick Start With `az login`
 

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -86,8 +86,8 @@ for new Azure leases. Crabbox refuses native checkpoint creation from Azure
 ephemeral-OS-disk leases (Azure reports success but does not capture live disk
 state). Azure disk-snapshot forks boot from a specialized OS disk and may inherit
 the source machine identity — treat them as exact clones. Use
-`--azure-os-disk ephemeral` only for stateless leases that do not need native
-checkpoints.
+`--azure-os-disk ephemeral` or `--azure-os-disk ephemeral-preview` only for
+stateless leases that do not need native checkpoints.
 
 **Parallels notes.** A forkable Parallels snapshot must be taken from a
 powered-off VM (linked clones require it). `checkpoint create` stops a running VM

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -262,7 +262,7 @@ azure:
   backend: vm           # vm | dynamic-sessions
   location: eastus
   resourceGroup: crabbox-leases
-  osDisk: managed       # managed | ephemeral | auto
+  osDisk: managed       # managed | ephemeral | ephemeral-preview | auto
   vnet: crabbox-vnet
   subnet: crabbox-subnet
   nsg: crabbox-nsg
@@ -270,8 +270,10 @@ azure:
 
 Azure uses managed `StandardSSD_LRS` OS disks by default so leases can support
 native disk-snapshot checkpoints. `ephemeral` opts into local OS disks for
-stateless leases and disables native Azure checkpoint/fork support. `auto` is
-accepted for compatibility and resolves to managed.
+stateless leases and disables native Azure checkpoint/fork support.
+`ephemeral-preview` opts into Azure's public-preview full-caching ephemeral OS
+disk mode and skips known unsupported Crabbox Azure SKUs. `auto` is accepted for
+compatibility and resolves to managed.
 
 ### Azure Dynamic Sessions
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -36,6 +36,7 @@ Azure supports both execution modes:
 crabbox warmup --provider azure --class beast
 crabbox warmup --provider azure --arch arm64 --class fast
 crabbox warmup --provider azure --class beast --azure-os-disk ephemeral
+crabbox warmup --provider azure --class beast --azure-os-disk ephemeral-preview
 crabbox run --provider azure --class standard -- pnpm test
 crabbox run --provider azure --azure-backend dynamic-sessions -- pnpm test
 crabbox warmup --provider azure --target windows --class standard
@@ -50,7 +51,9 @@ crabbox cleanup --provider azure
 `--type` is exact (for example `--type Standard_D32ads_v6`). Use `--class` when
 you want SKU fallback. Azure leases use managed OS disks by default, so native
 checkpoint/fork works without extra flags. Pass `--azure-os-disk ephemeral` only
-for stateless leases that do not need native checkpoint/fork.
+for stateless leases that do not need native checkpoint/fork. Pass
+`--azure-os-disk ephemeral-preview` to opt into Azure's public-preview
+full-caching mode for ephemeral OS disks.
 
 ## Backend selection
 
@@ -99,13 +102,17 @@ ARM64 is not supported for native Windows, WSL2, or macOS targets.
 VM public IP, `private` uses the NIC private IP from the vnet. Use `private` when
 connecting through a VPN to the Azure virtual network.
 
-`azure.osDisk` accepts `managed`, `ephemeral`, or `auto`:
+`azure.osDisk` accepts `managed`, `ephemeral`, `ephemeral-preview`, or `auto`:
 
 - `managed` (default) provisions a managed `StandardSSD_LRS` OS disk so Azure
   native disk-snapshot checkpoints work.
 - `ephemeral` opts into a local OS disk. It requires a SKU with ephemeral OS disk
   support, fails during provisioning when the selected SKU cannot support it, and
   disables native Azure checkpoint/fork.
+- `ephemeral-preview` enables Azure ephemeral OS disk full caching with Compute
+  API `2025-04-01`. It is public preview, has the same checkpoint/fork limits as
+  `ephemeral`, and skips known unsupported 2-core, 4-core, and no-local-disk
+  Azure SKUs from Crabbox fallback lists.
 - `auto` is accepted for compatibility and resolves to `managed`.
 
 ### Environment variables
@@ -121,7 +128,7 @@ CRABBOX_AZURE_BACKEND            # vm | dynamic-sessions
 CRABBOX_AZURE_LOCATION
 CRABBOX_AZURE_RESOURCE_GROUP
 CRABBOX_AZURE_IMAGE
-CRABBOX_AZURE_OS_DISK            # managed | ephemeral | auto
+CRABBOX_AZURE_OS_DISK            # managed | ephemeral | ephemeral-preview | auto
 CRABBOX_AZURE_VNET
 CRABBOX_AZURE_SUBNET
 CRABBOX_AZURE_NSG

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -1,16 +1,23 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
@@ -19,21 +26,23 @@ import (
 )
 
 const (
-	azureAddressSpace           = "10.42.0.0/16"
-	azureSubnetCIDR             = "10.42.0.0/24"
-	azureProviderTag            = "crabbox"
-	AzureOSDiskAuto             = "auto"
-	AzureOSDiskEphemeral        = "ephemeral"
-	AzureOSDiskManaged          = "managed"
-	defaultAzureLinuxImage      = "Canonical:ubuntu-26_04-lts:server:latest"
-	defaultAzureLinuxARM64Image = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
-	azureNobleLinuxImage        = "Canonical:ubuntu-24_04-lts:server:latest"
-	azureNobleLinuxARM64Image   = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
-	legacyAzureJammyImage       = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
-	legacyAzureNobleGen2Image   = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
-	defaultAzureWindowsImage    = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
-	azureDeleteRetryDelay       = 15 * time.Second
-	azureDeleteRetryAttempts    = 13
+	azureAddressSpace             = "10.42.0.0/16"
+	azureSubnetCIDR               = "10.42.0.0/24"
+	azureProviderTag              = "crabbox"
+	AzureOSDiskAuto               = "auto"
+	AzureOSDiskEphemeral          = "ephemeral"
+	AzureOSDiskEphemeralPreview   = "ephemeral-preview"
+	AzureOSDiskManaged            = "managed"
+	azureComputePreviewAPIVersion = "2025-04-01"
+	defaultAzureLinuxImage        = "Canonical:ubuntu-26_04-lts:server:latest"
+	defaultAzureLinuxARM64Image   = "Canonical:ubuntu-26_04-lts:server-arm64:latest"
+	azureNobleLinuxImage          = "Canonical:ubuntu-24_04-lts:server:latest"
+	azureNobleLinuxARM64Image     = "Canonical:ubuntu-24_04-lts:server-arm64:latest"
+	legacyAzureJammyImage         = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+	legacyAzureNobleGen2Image     = "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest"
+	defaultAzureWindowsImage      = "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest"
+	azureDeleteRetryDelay         = 15 * time.Second
+	azureDeleteRetryAttempts      = 13
 )
 
 type AzureClient struct {
@@ -188,7 +197,12 @@ func azureVMSizeCandidatesForClass(class string) []string {
 }
 
 func azureVMSizeCandidatesForConfig(cfg Config) []string {
-	return azureVMSizeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), cfg.Class)
+	candidates := azureVMSizeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), cfg.Class)
+	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
+	if err != nil || !azureOSDiskUsesFullCaching(mode) {
+		return candidates
+	}
+	return azureEphemeralFullCachingCandidates(cfg, candidates)
 }
 
 func azureVMSizeCandidatesForTargetModeArchitectureClass(target, windowsMode, architecture, class string) []string {
@@ -258,6 +272,30 @@ func azureWindowsVMSizeCandidatesForClass(class string) []string {
 	}
 }
 
+func azureEphemeralFullCachingCandidates(cfg Config, candidates []string) []string {
+	filtered := filterAzureEphemeralFullCachingCandidates(candidates)
+	if len(filtered) > 0 {
+		return filtered
+	}
+	if cfg.TargetOS == targetWindows {
+		return filterAzureEphemeralFullCachingCandidates(appendUniqueStrings(
+			azureWindowsVMSizeCandidatesForClass("large"),
+			azureWindowsVMSizeCandidatesForClass("beast")...,
+		))
+	}
+	return candidates
+}
+
+func filterAzureEphemeralFullCachingCandidates(candidates []string) []string {
+	var filtered []string
+	for _, candidate := range candidates {
+		if azureSupportsEphemeralFullCaching(candidate) {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
 func azureSupportsEphemeralOS(vmSize string) bool {
 	normalized := strings.ToLower(vmSize)
 	if strings.HasPrefix(normalized, "standard_f") && strings.HasSuffix(normalized, "s_v2") {
@@ -273,6 +311,36 @@ func azureSupportsEphemeralOS(vmSize string) bool {
 	return false
 }
 
+func azureSupportsEphemeralFullCaching(vmSize string) bool {
+	if !azureSupportsEphemeralOS(vmSize) {
+		return false
+	}
+	cores, ok := azureVMSizeVCPUCount(vmSize)
+	if !ok {
+		return false
+	}
+	return cores > 4
+}
+
+func azureVMSizeVCPUCount(vmSize string) (int, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(vmSize))
+	if !strings.HasPrefix(normalized, "standard_") {
+		return 0, false
+	}
+	for i := len("standard_"); i < len(normalized); i++ {
+		if normalized[i] < '0' || normalized[i] > '9' {
+			continue
+		}
+		j := i + 1
+		for j < len(normalized) && normalized[j] >= '0' && normalized[j] <= '9' {
+			j++
+		}
+		cores, err := strconv.Atoi(normalized[i:j])
+		return cores, err == nil
+	}
+	return 0, false
+}
+
 func NormalizeAzureOSDiskMode(value string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "":
@@ -281,26 +349,47 @@ func NormalizeAzureOSDiskMode(value string) (string, error) {
 		return AzureOSDiskManaged, nil
 	case AzureOSDiskEphemeral:
 		return AzureOSDiskEphemeral, nil
+	case AzureOSDiskEphemeralPreview:
+		return AzureOSDiskEphemeralPreview, nil
 	case AzureOSDiskManaged:
 		return AzureOSDiskManaged, nil
 	default:
-		return "", exit(2, "azure.osDisk must be auto, managed, or ephemeral")
+		return "", exit(2, "azure.osDisk must be auto, managed, ephemeral, or ephemeral-preview")
 	}
 }
 
+func azureOSDiskIsEphemeral(mode string) bool {
+	return mode == AzureOSDiskEphemeral || mode == AzureOSDiskEphemeralPreview
+}
+
+func azureOSDiskUsesFullCaching(mode string) bool {
+	return mode == AzureOSDiskEphemeralPreview
+}
+
 func (c *AzureClient) useEphemeralOSDisk(ctx context.Context, cfg Config) (bool, error) {
-	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
+	mode, err := c.validatedAzureOSDiskMode(ctx, cfg)
 	if err != nil {
 		return false, err
 	}
-	if mode != AzureOSDiskEphemeral {
-		return false, nil
+	return azureOSDiskIsEphemeral(mode), nil
+}
+
+func (c *AzureClient) validatedAzureOSDiskMode(ctx context.Context, cfg Config) (string, error) {
+	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
+	if err != nil {
+		return "", err
+	}
+	if !azureOSDiskIsEphemeral(mode) {
+		return mode, nil
 	}
 	supported := c.supportsEphemeralOS(ctx, cfg.ServerType)
 	if !supported {
-		return false, exit(2, "azure.osDisk=ephemeral requires an Azure VM size with ephemeral OS disk support; %s is not supported", cfg.ServerType)
+		return "", exit(2, "azure.osDisk=%s requires an Azure VM size with ephemeral OS disk support; %s is not supported", mode, cfg.ServerType)
 	}
-	return supported, nil
+	if azureOSDiskUsesFullCaching(mode) && !azureSupportsEphemeralFullCaching(cfg.ServerType) {
+		return "", exit(2, "azure.osDisk=ephemeral-preview requires a full-caching preview Azure VM size; %s is not supported because preview full caching requires more than 4 vCPUs and local storage larger than 2x the OS disk plus 1 GiB", cfg.ServerType)
+	}
+	return mode, nil
 }
 
 func (c *AzureClient) supportsEphemeralOS(ctx context.Context, vmSize string) bool {
@@ -617,9 +706,6 @@ func (c *AzureClient) CreateServerWithFallback(ctx context.Context, cfg Config, 
 }
 
 func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
-	if err := c.EnsureSharedInfra(ctx); err != nil {
-		return Server{}, cfg, err
-	}
 	var candidates []string
 	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		candidates = []string{cfg.ServerType}
@@ -630,11 +716,21 @@ func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cf
 		}
 	}
 	var errs []error
+	sharedInfraReady := false
 	for i, vmSize := range candidates {
 		next := cfg
 		next.ServerType = vmSize
 		if i > 0 && logf != nil {
 			logf("fallback provisioning type=%s after quota/capacity rejection\n", vmSize)
+		}
+		if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
+			return Server{}, next, err
+		}
+		if !sharedInfraReady {
+			if err := c.EnsureSharedInfra(ctx); err != nil {
+				return Server{}, next, err
+			}
+			sharedInfraReady = true
 		}
 		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep)
 		if err == nil {
@@ -652,6 +748,15 @@ func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cf
 			next.Capacity.Market = "on-demand"
 			if logf != nil {
 				logf("fallback provisioning type=%s market=on-demand after spot rejection\n", vmSize)
+			}
+			if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
+				return Server{}, next, err
+			}
+			if !sharedInfraReady {
+				if err := c.EnsureSharedInfra(ctx); err != nil {
+					return Server{}, next, err
+				}
+				sharedInfraReady = true
 			}
 			server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep)
 			if err == nil {
@@ -776,14 +881,19 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 		Name:         to.Ptr(diskName),
 		CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
 	}
-	useEphemeralOSDisk, err := c.useEphemeralOSDisk(ctx, cfg)
+	osDiskMode, err := c.validatedAzureOSDiskMode(ctx, cfg)
 	if err != nil {
 		return Server{}, err
 	}
-	if useEphemeralOSDisk {
+	if azureOSDiskIsEphemeral(osDiskMode) {
 		osDisk.Caching = to.Ptr(armcompute.CachingTypesReadOnly)
 		osDisk.DiffDiskSettings = &armcompute.DiffDiskSettings{
 			Option: to.Ptr(armcompute.DiffDiskOptionsLocal),
+		}
+		if azureOSDiskUsesFullCaching(osDiskMode) {
+			osDisk.ManagedDisk = &armcompute.ManagedDiskParameters{
+				StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardSSDLRS),
+			}
 		}
 	} else {
 		osDisk.Caching = to.Ptr(armcompute.CachingTypesReadWrite)
@@ -814,30 +924,238 @@ func (c *AzureClient) createServerSteps(ctx context.Context, cfg Config, publicK
 	if strings.EqualFold(cfg.Capacity.Market, "spot") {
 		applyAzureSpotCapacity(vmProperties)
 	}
-	vmPoller, err := c.vmc.BeginCreateOrUpdate(ctx, c.ResourceGroup, name, armcompute.VirtualMachine{
+	vm := armcompute.VirtualMachine{
 		Location:   to.Ptr(c.Location),
 		Tags:       tags,
 		Properties: vmProperties,
-	}, nil)
-	if err != nil {
-		return Server{}, fmt.Errorf("begin vm: %w", err)
 	}
-	vmResp, err := vmPoller.PollUntilDone(ctx, nil)
-	if err != nil {
-		return Server{}, fmt.Errorf("vm: %w", err)
+	var createdVM armcompute.VirtualMachine
+	if azureOSDiskUsesFullCaching(osDiskMode) {
+		createdVM, err = c.createVMWithEphemeralFullCaching(ctx, name, vm)
+		if err != nil {
+			return Server{}, err
+		}
+	} else {
+		vmPoller, err := c.vmc.BeginCreateOrUpdate(ctx, c.ResourceGroup, name, vm, nil)
+		if err != nil {
+			return Server{}, fmt.Errorf("begin vm: %w", err)
+		}
+		vmResp, err := vmPoller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return Server{}, fmt.Errorf("vm: %w", err)
+		}
+		createdVM = vmResp.VirtualMachine
 	}
 	if cfg.TargetOS == targetWindows {
 		if err := c.installWindowsBootstrapExtension(ctx, name, tags); err != nil {
 			return Server{}, err
 		}
 	}
-	return azureVMToServer(vmResp.VirtualMachine, "", ""), nil
+	return azureVMToServer(createdVM, "", ""), nil
 }
 
 func applyAzureSpotCapacity(vmProperties *armcompute.VirtualMachineProperties) {
 	vmProperties.Priority = to.Ptr(armcompute.VirtualMachinePriorityTypesSpot)
 	vmProperties.EvictionPolicy = to.Ptr(armcompute.VirtualMachineEvictionPolicyTypesDelete)
 	vmProperties.BillingProfile = &armcompute.BillingProfile{MaxPrice: to.Ptr(float64(-1))}
+}
+
+func (c *AzureClient) createVMWithEphemeralFullCaching(ctx context.Context, name string, vm armcompute.VirtualMachine) (armcompute.VirtualMachine, error) {
+	payload, err := azureEphemeralFullCachingVMPayload(vm)
+	if err != nil {
+		return armcompute.VirtualMachine{}, err
+	}
+	path := azureResourcePath(
+		"subscriptions", c.SubscriptionID,
+		"resourceGroups", c.ResourceGroup,
+		"providers", "Microsoft.Compute",
+		"virtualMachines", name,
+	)
+	respBody, headers, status, err := c.azureARM(ctx, http.MethodPut, path, azureComputePreviewAPIVersion, payload)
+	if err != nil {
+		return armcompute.VirtualMachine{}, fmt.Errorf("begin vm: %w", err)
+	}
+	if pollURL := azurePollURL(headers); pollURL != "" {
+		if err := c.pollAzureARMOperation(ctx, pollURL); err != nil {
+			return armcompute.VirtualMachine{}, fmt.Errorf("vm: %w", err)
+		}
+	}
+	if len(respBody) == 0 || status == http.StatusAccepted {
+		respBody, _, _, err = c.azureARM(ctx, http.MethodGet, path, azureComputePreviewAPIVersion, nil)
+		if err != nil {
+			return armcompute.VirtualMachine{}, fmt.Errorf("get vm: %w", err)
+		}
+	}
+	var created armcompute.VirtualMachine
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return armcompute.VirtualMachine{}, fmt.Errorf("decode vm: %w", err)
+	}
+	return created, nil
+}
+
+func azureEphemeralFullCachingVMPayload(vm armcompute.VirtualMachine) ([]byte, error) {
+	data, err := json.Marshal(vm)
+	if err != nil {
+		return nil, fmt.Errorf("encode vm: %w", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decode vm payload: %w", err)
+	}
+	properties, ok := payload["properties"].(map[string]any)
+	if !ok {
+		return nil, errors.New("azure vm payload missing properties")
+	}
+	storageProfile, ok := properties["storageProfile"].(map[string]any)
+	if !ok {
+		return nil, errors.New("azure vm payload missing storageProfile")
+	}
+	osDisk, ok := storageProfile["osDisk"].(map[string]any)
+	if !ok {
+		return nil, errors.New("azure vm payload missing osDisk")
+	}
+	diffDiskSettings, ok := osDisk["diffDiskSettings"].(map[string]any)
+	if !ok {
+		diffDiskSettings = map[string]any{}
+		osDisk["diffDiskSettings"] = diffDiskSettings
+	}
+	diffDiskSettings["option"] = "Local"
+	diffDiskSettings["enableFullCaching"] = true
+	osDisk["caching"] = "ReadOnly"
+	osDisk["managedDisk"] = map[string]any{"storageAccountType": "StandardSSD_LRS"}
+	return json.Marshal(payload)
+}
+
+func (c *AzureClient) azureARM(ctx context.Context, method, path, apiVersion string, body []byte) ([]byte, http.Header, int, error) {
+	token, err := c.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	endpoint := "https://management.azure.com" + path
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	q := u.Query()
+	q.Set("api-version", apiVersion)
+	u.RawQuery = q.Encode()
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), reader)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if readErr != nil {
+		return nil, resp.Header, resp.StatusCode, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, resp.Header, resp.StatusCode, fmt.Errorf("azure %s %s: http %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, resp.Header, resp.StatusCode, nil
+}
+
+func (c *AzureClient) pollAzureARMOperation(ctx context.Context, pollURL string) error {
+	for {
+		status, retryAfter, err := c.azureARMOperationStatus(ctx, pollURL)
+		if err != nil {
+			return err
+		}
+		switch strings.ToLower(status) {
+		case "succeeded":
+			return nil
+		case "failed", "canceled", "cancelled":
+			return fmt.Errorf("operation %s", status)
+		}
+		delay := azureDeleteRetryDelay
+		if retryAfter > 0 {
+			delay = retryAfter
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *AzureClient) azureARMOperationStatus(ctx context.Context, pollURL string) (string, time.Duration, error) {
+	token, err := c.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://management.azure.com/.default"},
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pollURL, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if readErr != nil {
+		return "", 0, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, fmt.Errorf("azure poll %s: http %d: %s", pollURL, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var operation struct {
+		Status string `json:"status"`
+		Error  any    `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &operation); err != nil {
+		return "", 0, fmt.Errorf("decode operation: %w", err)
+	}
+	if operation.Status == "" {
+		return "succeeded", 0, nil
+	}
+	if strings.EqualFold(operation.Status, "failed") && operation.Error != nil {
+		data, _ := json.Marshal(operation.Error)
+		return operation.Status, 0, fmt.Errorf("operation failed: %s", data)
+	}
+	return operation.Status, retryAfterDuration(resp.Header.Get("Retry-After")), nil
+}
+
+func azurePollURL(headers http.Header) string {
+	if value := strings.TrimSpace(headers.Get("Azure-AsyncOperation")); value != "" {
+		return value
+	}
+	return strings.TrimSpace(headers.Get("Location"))
+}
+
+func retryAfterDuration(value string) time.Duration {
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func azureResourcePath(parts ...string) string {
+	escaped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		escaped = append(escaped, url.PathEscape(part))
+	}
+	return "/" + strings.Join(escaped, "/")
 }
 
 func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string) (*armcompute.OSProfile, error) {

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -199,6 +199,9 @@ func azureVMSizeCandidatesForClass(class string) []string {
 func azureVMSizeCandidatesForConfig(cfg Config) []string {
 	candidates := azureVMSizeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), cfg.Class)
 	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
+	if cfg.AzureSnapshot != "" {
+		mode = AzureOSDiskManaged
+	}
 	if err != nil || !azureOSDiskUsesFullCaching(mode) {
 		return candidates
 	}

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -715,8 +715,10 @@ func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cf
 		if i > 0 && logf != nil {
 			logf("fallback provisioning type=%s after quota/capacity rejection\n", vmSize)
 		}
-		if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
-			return Server{}, next, err
+		if next.AzureSnapshot == "" {
+			if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
+				return Server{}, next, err
+			}
 		}
 		if !sharedInfraReady {
 			if err := c.EnsureSharedInfra(ctx); err != nil {
@@ -741,8 +743,10 @@ func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cf
 			if logf != nil {
 				logf("fallback provisioning type=%s market=on-demand after spot rejection\n", vmSize)
 			}
-			if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
-				return Server{}, next, err
+			if next.AzureSnapshot == "" {
+				if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
+					return Server{}, next, err
+				}
 			}
 			if !sharedInfraReady {
 				if err := c.EnsureSharedInfra(ctx); err != nil {
@@ -778,6 +782,9 @@ func azureProvisioningCandidatesForConfig(cfg Config) []string {
 }
 
 func azureCanPrependNonExplicitServerType(cfg Config) bool {
+	if cfg.AzureSnapshot != "" {
+		return true
+	}
 	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
 	if err != nil {
 		return true

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -706,15 +706,7 @@ func (c *AzureClient) CreateServerWithFallback(ctx context.Context, cfg Config, 
 }
 
 func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
-	var candidates []string
-	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
-		candidates = []string{cfg.ServerType}
-	} else {
-		candidates = azureVMSizeCandidatesForConfig(cfg)
-		if cfg.ServerType != "" && cfg.ServerType != candidates[0] {
-			candidates = append([]string{cfg.ServerType}, candidates...)
-		}
-	}
+	candidates := azureProvisioningCandidatesForConfig(cfg)
 	var errs []error
 	sharedInfraReady := false
 	for i, vmSize := range candidates {
@@ -769,6 +761,31 @@ func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cf
 		}
 	}
 	return Server{}, cfg, joinErrors(errs)
+}
+
+func azureProvisioningCandidatesForConfig(cfg Config) []string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return []string{cfg.ServerType}
+	}
+	candidates := azureVMSizeCandidatesForConfig(cfg)
+	if cfg.ServerType == "" || len(candidates) == 0 || cfg.ServerType == candidates[0] {
+		return candidates
+	}
+	if !azureCanPrependNonExplicitServerType(cfg) {
+		return candidates
+	}
+	return append([]string{cfg.ServerType}, candidates...)
+}
+
+func azureCanPrependNonExplicitServerType(cfg Config) bool {
+	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
+	if err != nil {
+		return true
+	}
+	if azureOSDiskUsesFullCaching(mode) {
+		return azureSupportsEphemeralFullCaching(cfg.ServerType)
+	}
+	return true
 }
 
 func azureRegionCandidates(cfg Config, preferredLocation string) []string {

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -163,6 +164,29 @@ func TestAzureVMSizeCandidatesForConfigHonorsARM64(t *testing.T) {
 	}
 }
 
+func TestAzureVMSizeCandidatesForConfigFiltersEphemeralPreview(t *testing.T) {
+	t.Parallel()
+	arm := baseConfig()
+	arm.Provider = "azure"
+	arm.TargetOS = targetLinux
+	arm.Architecture = ArchitectureARM64
+	arm.architectureExplicit = true
+	arm.Class = "standard"
+	arm.AzureOSDisk = AzureOSDiskEphemeralPreview
+	if got := azureVMSizeCandidatesForConfig(arm); !reflect.DeepEqual(got, []string{"Standard_D32pds_v6", "Standard_D16pds_v6"}) {
+		t.Fatalf("arm preview candidates=%v", got)
+	}
+	windows := baseConfig()
+	windows.Provider = "azure"
+	windows.TargetOS = targetWindows
+	windows.WindowsMode = windowsModeNormal
+	windows.Class = "standard"
+	windows.AzureOSDisk = AzureOSDiskEphemeralPreview
+	if got := azureVMSizeCandidatesForConfig(windows); !reflect.DeepEqual(got, []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5"}) {
+		t.Fatalf("windows preview candidates=%v", got)
+	}
+}
+
 func TestAzureWindowsVMSizeCandidatesForClass(t *testing.T) {
 	t.Parallel()
 	got := azureWindowsVMSizeCandidatesForClass("beast")
@@ -253,14 +277,37 @@ func TestAzureSupportsEphemeralOS(t *testing.T) {
 	}
 }
 
+func TestAzureSupportsEphemeralFullCaching(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"Standard_D2ads_v6":  false,
+		"Standard_D4ads_v6":  false,
+		"Standard_D8ads_v6":  true,
+		"Standard_D32ads_v6": true,
+		"Standard_F32s_v2":   true,
+		"Standard_D32pds_v6": true,
+		"Standard_D32ps_v6":  false,
+		"Standard_D96pds_v6": true,
+		"Standard_D96ps_v6":  false,
+		"Standard_D32as_v6":  false,
+		"custom-size":        false,
+	}
+	for size, want := range cases {
+		if got := azureSupportsEphemeralFullCaching(size); got != want {
+			t.Fatalf("size=%q got %v want %v", size, got, want)
+		}
+	}
+}
+
 func TestNormalizeAzureOSDiskMode(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"":          AzureOSDiskManaged,
-		"auto":      AzureOSDiskManaged,
-		"MANAGED":   AzureOSDiskManaged,
-		"ephemeral": AzureOSDiskEphemeral,
-		" managed ": AzureOSDiskManaged,
+		"":                  AzureOSDiskManaged,
+		"auto":              AzureOSDiskManaged,
+		"MANAGED":           AzureOSDiskManaged,
+		"ephemeral":         AzureOSDiskEphemeral,
+		"ephemeral-preview": AzureOSDiskEphemeralPreview,
+		" managed ":         AzureOSDiskManaged,
 	}
 	for input, want := range cases {
 		got, err := NormalizeAzureOSDiskMode(input)
@@ -302,6 +349,21 @@ func TestAzureUseEphemeralOSDiskModes(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "ephemeral preview allows supported full caching sku",
+			cfg:  Config{AzureOSDisk: AzureOSDiskEphemeralPreview, ServerType: "Standard_D8ads_v6"},
+			want: true,
+		},
+		{
+			name:    "ephemeral preview rejects two core sku",
+			cfg:     Config{AzureOSDisk: AzureOSDiskEphemeralPreview, ServerType: "Standard_D2ads_v6"},
+			wantErr: true,
+		},
+		{
+			name:    "ephemeral preview rejects arm sku without local disk",
+			cfg:     Config{AzureOSDisk: AzureOSDiskEphemeralPreview, ServerType: "Standard_D32ps_v6"},
+			wantErr: true,
+		},
+		{
 			name:    "ephemeral rejects unsupported sku",
 			cfg:     Config{AzureOSDisk: AzureOSDiskEphemeral, ServerType: "Standard_D2as_v6"},
 			wantErr: true,
@@ -325,6 +387,71 @@ func TestAzureUseEphemeralOSDiskModes(t *testing.T) {
 				t.Fatalf("useEphemeralOSDisk=%t want %t", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestAzureCreateServerWithFallbackRejectsEphemeralPreviewBeforeSharedInfra(t *testing.T) {
+	t.Parallel()
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetLinux
+	cfg.AzureLocation = "eastus"
+	cfg.AzureOSDisk = AzureOSDiskEphemeralPreview
+	cfg.ServerType = "Standard_D32ps_v6"
+	cfg.ServerTypeExplicit = true
+	client := &AzureClient{Location: "eastus"}
+	_, resolved, err := client.createServerWithFallbackInLocation(t.Context(), cfg, "ssh-ed25519 test", "cbx_123456789abc", "bad-preview", false, nil)
+	if err == nil {
+		t.Fatal("expected unsupported ephemeral-preview SKU to fail")
+	}
+	if !strings.Contains(err.Error(), "azure.osDisk=ephemeral-preview requires") {
+		t.Fatalf("error=%v, want ephemeral-preview validation", err)
+	}
+	if resolved.ServerType != "Standard_D32ps_v6" {
+		t.Fatalf("resolved server type=%q", resolved.ServerType)
+	}
+}
+
+func TestAzureEphemeralFullCachingVMPayload(t *testing.T) {
+	t.Parallel()
+	vm := armcompute.VirtualMachine{
+		Location: to.Ptr("eastus"),
+		Properties: &armcompute.VirtualMachineProperties{
+			StorageProfile: &armcompute.StorageProfile{
+				OSDisk: &armcompute.OSDisk{
+					CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
+					Caching:      to.Ptr(armcompute.CachingTypesReadOnly),
+					DiffDiskSettings: &armcompute.DiffDiskSettings{
+						Option: to.Ptr(armcompute.DiffDiskOptionsLocal),
+					},
+				},
+			},
+		},
+	}
+	data, err := azureEphemeralFullCachingVMPayload(vm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatal(err)
+	}
+	properties := payload["properties"].(map[string]any)
+	storageProfile := properties["storageProfile"].(map[string]any)
+	osDisk := storageProfile["osDisk"].(map[string]any)
+	diffDiskSettings := osDisk["diffDiskSettings"].(map[string]any)
+	if diffDiskSettings["enableFullCaching"] != true {
+		t.Fatalf("enableFullCaching=%v", diffDiskSettings["enableFullCaching"])
+	}
+	if diffDiskSettings["option"] != "Local" {
+		t.Fatalf("option=%v", diffDiskSettings["option"])
+	}
+	if osDisk["caching"] != "ReadOnly" {
+		t.Fatalf("caching=%v", osDisk["caching"])
+	}
+	managedDisk := osDisk["managedDisk"].(map[string]any)
+	if managedDisk["storageAccountType"] != "StandardSSD_LRS" {
+		t.Fatalf("managedDisk=%v", managedDisk)
 	}
 }
 

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -215,6 +215,13 @@ func TestAzureProvisioningCandidatesSkipsStaleEphemeralPreviewDefault(t *testing
 	if !reflect.DeepEqual(got, []string{"Standard_D2ads_v6"}) {
 		t.Fatalf("explicit candidate=%v, want exact unsupported type preserved", got)
 	}
+
+	cfg.ServerTypeExplicit = false
+	cfg.AzureSnapshot = "snapshot-id"
+	got = azureProvisioningCandidatesForConfig(cfg)
+	if got[0] != "Standard_D2ads_v6" {
+		t.Fatalf("snapshot-backed first candidate=%q, want stale managed-disk type preserved; all=%v", got[0], got)
+	}
 }
 
 func TestAzureWindowsVMSizeCandidatesForClass(t *testing.T) {

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -187,6 +187,36 @@ func TestAzureVMSizeCandidatesForConfigFiltersEphemeralPreview(t *testing.T) {
 	}
 }
 
+func TestAzureProvisioningCandidatesSkipsStaleEphemeralPreviewDefault(t *testing.T) {
+	t.Parallel()
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Class = "standard"
+	cfg.AzureOSDisk = AzureOSDiskEphemeralPreview
+	cfg.ServerType = "Standard_D2ads_v6"
+	cfg.ServerTypeExplicit = false
+	got := azureProvisioningCandidatesForConfig(cfg)
+	if len(got) == 0 {
+		t.Fatal("no candidates")
+	}
+	if got[0] != "Standard_D8ads_v6" {
+		t.Fatalf("first candidate=%q, want Standard_D8ads_v6; all=%v", got[0], got)
+	}
+	for _, candidate := range got {
+		if candidate == "Standard_D2ads_v6" {
+			t.Fatalf("stale unsupported default was prepended: %v", got)
+		}
+	}
+
+	cfg.ServerTypeExplicit = true
+	got = azureProvisioningCandidatesForConfig(cfg)
+	if !reflect.DeepEqual(got, []string{"Standard_D2ads_v6"}) {
+		t.Fatalf("explicit candidate=%v, want exact unsupported type preserved", got)
+	}
+}
+
 func TestAzureWindowsVMSizeCandidatesForClass(t *testing.T) {
 	t.Parallel()
 	got := azureWindowsVMSizeCandidatesForClass("beast")

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -38,7 +38,7 @@ func (Provider) Spec() core.ProviderSpec {
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
 		Backend: fs.String("azure-backend", defaults.AzureBackend, "Azure backend: vm or dynamic-sessions"),
-		OSDisk:  fs.String("azure-os-disk", defaults.AzureOSDisk, "Azure OS disk mode: managed, ephemeral, or auto"),
+		OSDisk:  fs.String("azure-os-disk", defaults.AzureOSDisk, "Azure OS disk mode: managed, ephemeral, ephemeral-preview, or auto"),
 	}
 }
 

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -1,8 +1,16 @@
 import { azureWindowsBootstrapPowerShell, cloudInit } from "./bootstrap";
-import { azureVMSizeCandidatesForTargetClass, sshPorts, type LeaseConfig } from "./config";
+import {
+  azureSupportsEphemeralFullCaching,
+  azureSupportsEphemeralOS,
+  azureVMSizeCandidatesForTargetClass,
+  sshPorts,
+  type LeaseConfig,
+} from "./config";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
 import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
+
+export { azureSupportsEphemeralFullCaching, azureSupportsEphemeralOS } from "./config";
 
 const ADDRESS_SPACE = "10.42.0.0/16";
 const SUBNET_CIDR = "10.42.0.0/24";
@@ -12,6 +20,7 @@ const API_VERSIONS = {
   compute: "2024-07-01",
   disks: "2024-03-02",
 };
+const COMPUTE_FULL_CACHING_PREVIEW_API_VERSION = "2025-04-01";
 const DELETE_RETRY_ATTEMPTS = 13;
 const DELETE_RETRY_DELAY_MS = 15_000;
 const MIN_LRO_POLL_INTERVAL_MS = 15_000;
@@ -43,7 +52,7 @@ interface AzureVM {
       osDisk?: {
         managedDisk?: { id?: string };
         osType?: string;
-        diffDiskSettings?: { option?: string; placement?: string };
+        diffDiskSettings?: { option?: string; placement?: string; enableFullCaching?: boolean };
       };
     };
   };
@@ -243,7 +252,6 @@ export class AzureClient {
     market: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    const infra = await this.ensureSharedInfra(location, config);
     const candidates =
       config.serverTypeExplicit && config.serverType
         ? [config.serverType]
@@ -254,21 +262,24 @@ export class AzureClient {
               config.class,
               config.windowsMode,
               config.architecture,
+              config.azureOSDisk,
             ),
           );
     const failures: string[] = [];
     const attempts: ProvisioningAttempt[] = [];
+    let infra: AzureSharedInfraNames | undefined;
     for (const vmSize of candidates) {
+      const nextConfig = { ...config, serverType: vmSize };
+      // Validate preview-only OS disk requirements before allocating network resources.
+      // oxlint-disable-next-line eslint/no-await-in-loop -- SKU fallback must stay sequential.
+      await this.validateOSDiskMode(nextConfig, location);
       try {
+        if (!infra) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- shared infra is created once, after config validation.
+          infra = await this.ensureSharedInfra(location, config);
+        }
         // oxlint-disable-next-line eslint/no-await-in-loop -- SKU fallback must stay sequential.
-        const server = await this.createVM(
-          { ...config, serverType: vmSize },
-          location,
-          leaseID,
-          slug,
-          owner,
-          infra,
-        );
+        const server = await this.createVM(nextConfig, location, leaseID, slug, owner, infra);
         return attempts.length > 0
           ? { server, serverType: vmSize, market: config.capacityMarket, attempts }
           : { server, serverType: vmSize, market: config.capacityMarket };
@@ -287,10 +298,20 @@ export class AzureClient {
     }
     if (config.capacityMarket === "spot" && config.capacityFallback.startsWith("on-demand")) {
       for (const vmSize of candidates) {
+        const nextConfig: LeaseConfig = {
+          ...config,
+          capacityMarket: "on-demand",
+          serverType: vmSize,
+        };
+        // oxlint-disable-next-line eslint/no-await-in-loop -- market fallback must preserve ordered capacity preference.
+        await this.validateOSDiskMode(nextConfig, location);
         try {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- market fallback must preserve ordered capacity preference.
+          if (!infra) {
+            // oxlint-disable-next-line eslint/no-await-in-loop -- shared infra is created once, after config validation.
+            infra = await this.ensureSharedInfra(location, config);
+          }
           const server = await this.createVM(
-            { ...config, capacityMarket: "on-demand", serverType: vmSize },
+            nextConfig,
             location,
             leaseID,
             slug,
@@ -694,7 +715,12 @@ export class AzureClient {
       };
       if (await this.useEphemeralOSDisk(config, location)) {
         osDisk["caching"] = "ReadOnly";
-        osDisk["diffDiskSettings"] = { option: "Local" };
+        const diffDiskSettings: Record<string, unknown> = { option: "Local" };
+        if (azureOSDiskUsesFullCaching(config.azureOSDisk)) {
+          diffDiskSettings["enableFullCaching"] = true;
+          osDisk["managedDisk"] = { storageAccountType: "StandardSSD_LRS" };
+        }
+        osDisk["diffDiskSettings"] = diffDiskSettings;
       } else {
         osDisk["caching"] = "ReadWrite";
         osDisk["managedDisk"] = { storageAccountType: "StandardSSD_LRS" };
@@ -712,7 +738,7 @@ export class AzureClient {
     await this.arm(
       "PUT",
       vmPath(this.resourceGroup, name),
-      API_VERSIONS.compute,
+      azureComputeAPIVersionForOSDisk(config.azureOSDisk),
       {
         location,
         tags,
@@ -1078,12 +1104,21 @@ export class AzureClient {
   }
 
   private async useEphemeralOSDisk(config: LeaseConfig, location: string): Promise<boolean> {
+    return await this.validateOSDiskMode(config, location);
+  }
+
+  private async validateOSDiskMode(config: LeaseConfig, location: string): Promise<boolean> {
     const mode = config.azureOSDisk;
-    if (mode !== "ephemeral") return false;
+    if (!azureOSDiskIsEphemeral(mode)) return false;
     const supported = await this.supportsEphemeralOS(config.serverType, location);
     if (!supported) {
       throw new Error(
-        `azureOSDisk=ephemeral requires an Azure VM size with ephemeral OS disk support; ${config.serverType} is not supported`,
+        `azureOSDisk=${mode} requires an Azure VM size with ephemeral OS disk support; ${config.serverType} is not supported`,
+      );
+    }
+    if (azureOSDiskUsesFullCaching(mode) && !azureSupportsEphemeralFullCaching(config.serverType)) {
+      throw new Error(
+        `azureOSDisk=ephemeral-preview requires a full-caching preview Azure VM size; ${config.serverType} is not supported because preview full caching requires more than 4 vCPUs and local storage larger than 2x the OS disk plus 1 GiB`,
       );
     }
     return supported;
@@ -1374,21 +1409,18 @@ export function azureLROPollIntervalMS(retryAfter: string | null): number {
   return Math.max(seconds * 1000, MIN_LRO_POLL_INTERVAL_MS);
 }
 
-export function azureSupportsEphemeralOS(vmSize: string): boolean {
-  const normalized = vmSize.toLowerCase();
-  if (normalized.startsWith("standard_f") && normalized.endsWith("s_v2")) {
-    return true;
-  }
-  if (normalized.includes("pds_v6") || normalized.includes("plds_v6")) {
-    return true;
-  }
-  if (
-    (normalized.startsWith("standard_d") || normalized.startsWith("standard_e")) &&
-    (normalized.includes("ds_v5") || normalized.includes("ds_v6"))
-  ) {
-    return true;
-  }
-  return false;
+function azureOSDiskIsEphemeral(mode: string): boolean {
+  return mode === "ephemeral" || mode === "ephemeral-preview";
+}
+
+function azureOSDiskUsesFullCaching(mode: string): boolean {
+  return mode === "ephemeral-preview";
+}
+
+function azureComputeAPIVersionForOSDisk(mode: string): string {
+  return azureOSDiskUsesFullCaching(mode)
+    ? COMPUTE_FULL_CACHING_PREVIEW_API_VERSION
+    : API_VERSIONS.compute;
 }
 
 function azureSKUCapabilityTrue(

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -258,9 +258,11 @@ export class AzureClient {
     let infra: AzureSharedInfraNames | undefined;
     for (const vmSize of candidates) {
       const nextConfig = { ...config, serverType: vmSize };
-      // Validate preview-only OS disk requirements before allocating network resources.
-      // oxlint-disable-next-line eslint/no-await-in-loop -- SKU fallback must stay sequential.
-      await this.validateOSDiskMode(nextConfig, location);
+      if (!nextConfig.azureSnapshot) {
+        // Validate preview-only OS disk requirements before allocating network resources.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- SKU fallback must stay sequential.
+        await this.validateOSDiskMode(nextConfig, location);
+      }
       try {
         if (!infra) {
           // oxlint-disable-next-line eslint/no-await-in-loop -- shared infra is created once, after config validation.
@@ -291,8 +293,10 @@ export class AzureClient {
           capacityMarket: "on-demand",
           serverType: vmSize,
         };
-        // oxlint-disable-next-line eslint/no-await-in-loop -- market fallback must preserve ordered capacity preference.
-        await this.validateOSDiskMode(nextConfig, location);
+        if (!nextConfig.azureSnapshot) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- market fallback must preserve ordered capacity preference.
+          await this.validateOSDiskMode(nextConfig, location);
+        }
         try {
           if (!infra) {
             // oxlint-disable-next-line eslint/no-await-in-loop -- shared infra is created once, after config validation.
@@ -727,7 +731,7 @@ export class AzureClient {
     await this.arm(
       "PUT",
       vmPath(this.resourceGroup, name),
-      azureComputeAPIVersionForOSDisk(config.azureOSDisk),
+      azureComputeAPIVersionForOSDisk(config.azureSnapshot ? "managed" : config.azureOSDisk),
       {
         location,
         tags,
@@ -1410,17 +1414,18 @@ function azureProvisioningCandidatesForConfig(config: LeaseConfig): string[] {
   if (config.serverTypeExplicit && config.serverType) {
     return [config.serverType];
   }
+  const azureOSDisk = config.azureSnapshot ? "managed" : config.azureOSDisk;
   const candidates = azureVMSizeCandidatesForTargetClass(
     config.target,
     config.class,
     config.windowsMode,
     config.architecture,
-    config.azureOSDisk,
+    azureOSDisk,
   );
   if (!config.serverType || config.serverType === candidates[0]) {
     return candidates;
   }
-  if (azureOSDiskUsesFullCaching(config.azureOSDisk)) {
+  if (azureOSDiskUsesFullCaching(azureOSDisk)) {
     return azureSupportsEphemeralFullCaching(config.serverType)
       ? prependUnique(config.serverType, candidates)
       : candidates;

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -310,6 +310,7 @@ export class AzureClient {
             // oxlint-disable-next-line eslint/no-await-in-loop -- shared infra is created once, after config validation.
             infra = await this.ensureSharedInfra(location, config);
           }
+          // oxlint-disable-next-line eslint/no-await-in-loop -- market fallback must preserve ordered capacity preference.
           const server = await this.createVM(
             nextConfig,
             location,

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -252,19 +252,7 @@ export class AzureClient {
     market: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    const candidates =
-      config.serverTypeExplicit && config.serverType
-        ? [config.serverType]
-        : prependUnique(
-            config.serverType,
-            azureVMSizeCandidatesForTargetClass(
-              config.target,
-              config.class,
-              config.windowsMode,
-              config.architecture,
-              config.azureOSDisk,
-            ),
-          );
+    const candidates = azureProvisioningCandidatesForConfig(config);
     const failures: string[] = [];
     const attempts: ProvisioningAttempt[] = [];
     let infra: AzureSharedInfraNames | undefined;
@@ -1416,6 +1404,28 @@ function azureOSDiskIsEphemeral(mode: string): boolean {
 
 function azureOSDiskUsesFullCaching(mode: string): boolean {
   return mode === "ephemeral-preview";
+}
+
+function azureProvisioningCandidatesForConfig(config: LeaseConfig): string[] {
+  if (config.serverTypeExplicit && config.serverType) {
+    return [config.serverType];
+  }
+  const candidates = azureVMSizeCandidatesForTargetClass(
+    config.target,
+    config.class,
+    config.windowsMode,
+    config.architecture,
+    config.azureOSDisk,
+  );
+  if (!config.serverType || config.serverType === candidates[0]) {
+    return candidates;
+  }
+  if (azureOSDiskUsesFullCaching(config.azureOSDisk)) {
+    return azureSupportsEphemeralFullCaching(config.serverType)
+      ? prependUnique(config.serverType, candidates)
+      : candidates;
+  }
+  return prependUnique(config.serverType, candidates);
 }
 
 function azureComputeAPIVersionForOSDisk(mode: string): string {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -84,7 +84,7 @@ export interface LeaseConfig {
   exposedPorts: string[];
 }
 
-export type AzureOSDiskMode = "managed" | "ephemeral";
+export type AzureOSDiskMode = "managed" | "ephemeral" | "ephemeral-preview";
 export type Architecture = "amd64" | "arm64";
 
 export interface LeaseConfigDefaults {
@@ -156,9 +156,10 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     }
   }
   const machineClass = input.class ?? "beast";
+  const azureOSDisk = normalizeAzureOSDiskMode(input.azureOSDisk ?? defaults.azureOSDisk);
   const serverType =
     input.serverType ??
-    serverTypeForConfig(provider, target, windowsMode, machineClass, architecture);
+    serverTypeForConfig(provider, target, windowsMode, machineClass, architecture, azureOSDisk);
   if (input.serverType) {
     validateArchitectureServerType(
       provider,
@@ -222,7 +223,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
           : (linuxOSImage?.azureImage ?? "")
         : ""),
     azureSnapshot: input.azureSnapshot ?? "",
-    azureOSDisk: normalizeAzureOSDiskMode(input.azureOSDisk ?? defaults.azureOSDisk),
+    azureOSDisk,
     gcpProject: input.gcpProject ?? "",
     gcpZone: input.gcpZone ?? "",
     gcpImage: input.gcpImage ?? (osExplicit ? (linuxOSImage?.gcpImage ?? "") : ""),
@@ -379,8 +380,10 @@ export function normalizeAzureOSDiskMode(value: string | undefined): AzureOSDisk
       return "managed";
     case "ephemeral":
       return "ephemeral";
+    case "ephemeral-preview":
+      return "ephemeral-preview";
     default:
-      throw new Error("azureOSDisk must be auto, managed, or ephemeral");
+      throw new Error("azureOSDisk must be auto, managed, ephemeral, or ephemeral-preview");
   }
 }
 
@@ -554,6 +557,7 @@ export function serverTypeForConfig(
   windowsMode: WindowsMode,
   machineClass: string,
   architecture: Architecture = "amd64",
+  azureOSDisk: AzureOSDiskMode = "managed",
 ): string {
   if (provider === "aws") {
     return (
@@ -563,8 +567,13 @@ export function serverTypeForConfig(
   }
   if (provider === "azure") {
     return (
-      azureVMSizeCandidatesForTargetClass(target, machineClass, windowsMode, architecture)[0] ??
-      machineClass
+      azureVMSizeCandidatesForTargetClass(
+        target,
+        machineClass,
+        windowsMode,
+        architecture,
+        azureOSDisk,
+      )[0] ?? machineClass
     );
   }
   if (provider === "gcp") {
@@ -612,14 +621,20 @@ export function azureVMSizeCandidatesForTargetClass(
   machineClass: string,
   windowsMode: WindowsMode = "normal",
   architecture: Architecture = "amd64",
+  azureOSDisk: AzureOSDiskMode = "managed",
 ): string[] {
+  let candidates: string[];
   if (target === "linux") {
-    return azureVMSizeCandidatesForArchitectureClass(architecture, machineClass);
+    candidates = azureVMSizeCandidatesForArchitectureClass(architecture, machineClass);
+  } else if (target === "windows" && (windowsMode === "normal" || windowsMode === "wsl2")) {
+    candidates = azureWindowsVMSizeCandidatesForClass(machineClass);
+  } else {
+    candidates = [machineClass];
   }
-  if (target === "windows" && (windowsMode === "normal" || windowsMode === "wsl2")) {
-    return azureWindowsVMSizeCandidatesForClass(machineClass);
+  if (azureOSDisk === "ephemeral-preview") {
+    return azureEphemeralFullCachingCandidates(target, candidates);
   }
-  return [machineClass];
+  return candidates;
 }
 
 export function azureVMSizeCandidatesForClass(machineClass: string): string[] {
@@ -726,6 +741,52 @@ export function azureVMSizeIsARM64(vmSize: string): boolean {
     normalized.includes("pls_v6") ||
     normalized.includes("plds_v6")
   );
+}
+
+export function azureSupportsEphemeralOS(vmSize: string): boolean {
+  const normalized = vmSize.toLowerCase();
+  if (normalized.startsWith("standard_f") && normalized.endsWith("s_v2")) {
+    return true;
+  }
+  if (normalized.includes("pds_v6") || normalized.includes("plds_v6")) {
+    return true;
+  }
+  if (
+    (normalized.startsWith("standard_d") || normalized.startsWith("standard_e")) &&
+    (normalized.includes("ds_v5") || normalized.includes("ds_v6"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function azureSupportsEphemeralFullCaching(vmSize: string): boolean {
+  if (!azureSupportsEphemeralOS(vmSize)) return false;
+  const cores = azureVMSizeVCPUCount(vmSize);
+  return cores !== undefined && cores > 4;
+}
+
+function azureVMSizeVCPUCount(vmSize: string): number | undefined {
+  const match = vmSize
+    .trim()
+    .toLowerCase()
+    .match(/^standard_[a-z]+(\d+)/);
+  if (!match?.[1]) return undefined;
+  return Number.parseInt(match[1], 10);
+}
+
+function azureEphemeralFullCachingCandidates(target: TargetOS, candidates: string[]): string[] {
+  const filtered = candidates.filter(azureSupportsEphemeralFullCaching);
+  if (filtered.length > 0) return filtered;
+  if (target === "windows") {
+    return [
+      ...azureWindowsVMSizeCandidatesForClass("large"),
+      ...azureWindowsVMSizeCandidatesForClass("beast"),
+    ]
+      .filter((value, index, values) => values.indexOf(value) === index)
+      .filter(azureSupportsEphemeralFullCaching);
+  }
+  return candidates;
 }
 
 export function azureWindowsVMSizeCandidatesForClass(machineClass: string): string[] {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -157,9 +157,18 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   }
   const machineClass = input.class ?? "beast";
   const azureOSDisk = normalizeAzureOSDiskMode(input.azureOSDisk ?? defaults.azureOSDisk);
+  const azureSnapshot = input.azureSnapshot ?? "";
+  const serverTypeAzureOSDisk = azureSnapshot ? "managed" : azureOSDisk;
   const serverType =
     input.serverType ??
-    serverTypeForConfig(provider, target, windowsMode, machineClass, architecture, azureOSDisk);
+    serverTypeForConfig(
+      provider,
+      target,
+      windowsMode,
+      machineClass,
+      architecture,
+      serverTypeAzureOSDisk,
+    );
   if (input.serverType) {
     validateArchitectureServerType(
       provider,
@@ -222,7 +231,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
           ? (linuxOSImage?.azureArm64Image ?? "")
           : (linuxOSImage?.azureImage ?? "")
         : ""),
-    azureSnapshot: input.azureSnapshot ?? "",
+    azureSnapshot,
     azureOSDisk,
     gcpProject: input.gcpProject ?? "",
     gcpZone: input.gcpZone ?? "",

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -8,6 +8,7 @@ import {
   azureRegionCandidates,
   azureRegionalName,
   azureSpotFallbackTimeoutMs,
+  azureSupportsEphemeralFullCaching,
   azureSupportsEphemeralOS,
   azureTagsFromLabels,
   conciseAzureProvisioningMessage,
@@ -683,6 +684,155 @@ describe("azure provider", () => {
     expect(vmBody?.properties.storageProfile.osDisk.diffDiskSettings).toBeUndefined();
   });
 
+  it("uses full-caching ephemeral OS disks for azureOSDisk=ephemeral-preview", async () => {
+    const client = new AzureClient(baseEnv);
+    const bodies: unknown[] = [];
+    const vmAPIVersions: string[] = [];
+    const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (isAzureLoginURL(url.toString())) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
+        );
+      }
+      if (init?.body) bodies.push(JSON.parse(String(init.body)));
+      if (
+        url.pathname.includes("/virtualMachines/crabbox-blue-lobster") &&
+        init?.method === "PUT"
+      ) {
+        vmAPIVersions.push(url.searchParams.get("api-version") ?? "");
+      }
+      if (url.pathname.endsWith("/resourceGroups/crabbox-leases")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/virtualNetworks/crabbox-vnet")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/networkSecurityGroups/crabbox-nsg") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ tags: { managed_by: "crabbox" }, properties: { securityRules: [] } }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.pathname.endsWith("/providers/Microsoft.Compute/skus")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              value: [
+                {
+                  name: "Standard_D8ads_v6",
+                  resourceType: "virtualMachines",
+                  capabilities: [{ name: "EphemeralOSDiskSupported", value: "True" }],
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.pathname.includes("/publicIPAddresses/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ properties: { ipAddress: "192.0.2.10" } }), {
+            status: 200,
+          }),
+        );
+      }
+      if (url.pathname.includes("/virtualMachines/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "crabbox-blue-lobster",
+              tags: { crabbox: "true" },
+              properties: {
+                provisioningState: "Succeeded",
+                hardwareProfile: { vmSize: "Standard_D8ads_v6" },
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+    client.fetcher = fakeFetch;
+
+    await client.createServerWithFallback(
+      testLeaseConfig({ azureOSDisk: "ephemeral-preview", serverType: "Standard_D8ads_v6" }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "owner",
+    );
+
+    expect(vmAPIVersions).toContain("2025-04-01");
+    const vmBody = bodies.find(
+      (body): body is { properties: { storageProfile: { osDisk: Record<string, unknown> } } } =>
+        typeof body === "object" &&
+        body !== null &&
+        "properties" in body &&
+        JSON.stringify(body).includes("storageProfile") &&
+        JSON.stringify(body).includes("osDisk"),
+    );
+    expect(vmBody?.properties.storageProfile.osDisk).toMatchObject({
+      caching: "ReadOnly",
+      managedDisk: { storageAccountType: "StandardSSD_LRS" },
+      diffDiskSettings: { option: "Local", enableFullCaching: true },
+    });
+  });
+
+  it("rejects unsupported azureOSDisk=ephemeral-preview SKUs before allocating network resources", async () => {
+    const client = new AzureClient(baseEnv);
+    const calls: string[] = [];
+    const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      calls.push(`${init?.method ?? "GET"} ${url.pathname}`);
+      if (isAzureLoginURL(url.toString())) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/providers/Microsoft.Compute/skus")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              value: [
+                {
+                  name: "Standard_D4ads_v6",
+                  resourceType: "virtualMachines",
+                  capabilities: [{ name: "EphemeralOSDiskSupported", value: "True" }],
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+    client.fetcher = fakeFetch;
+
+    await expect(
+      client.createServerWithFallback(
+        testLeaseConfig({ azureOSDisk: "ephemeral-preview", serverType: "Standard_D4ads_v6" }),
+        "cbx_123456789abc",
+        "bad-preview",
+        "owner",
+      ),
+    ).rejects.toThrow(/azureOSDisk=ephemeral-preview requires/);
+    expect(calls.some((call) => call.includes("/providers/Microsoft.Compute/skus"))).toBe(true);
+    expect(calls.some((call) => call.includes("/resourceGroups/crabbox-leases"))).toBe(false);
+    expect(calls.some((call) => call.includes("/virtualNetworks/"))).toBe(false);
+    expect(calls.some((call) => call.includes("/networkSecurityGroups/"))).toBe(false);
+    expect(calls.some((call) => call.includes("/publicIPAddresses/"))).toBe(false);
+    expect(calls.some((call) => call.includes("/networkInterfaces/"))).toBe(false);
+    expect(calls.some((call) => call.includes("/virtualMachines/"))).toBe(false);
+  });
+
   it("rejects azureOSDisk=ephemeral when the selected SKU cannot support it", async () => {
     const client = new AzureClient(baseEnv);
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -1186,6 +1336,16 @@ describe("azure provider", () => {
     expect(azureSupportsEphemeralOS("Standard_F2s_v2")).toBe(true);
     expect(azureSupportsEphemeralOS("Standard_D48ads_v6")).toBe(true);
     expect(azureSupportsEphemeralOS("Standard_F48s_v2")).toBe(true);
+  });
+
+  it("uses a conservative ephemeral full-caching fallback", () => {
+    expect(azureSupportsEphemeralFullCaching("Standard_D2ads_v6")).toBe(false);
+    expect(azureSupportsEphemeralFullCaching("Standard_D4ads_v6")).toBe(false);
+    expect(azureSupportsEphemeralFullCaching("Standard_D8ads_v6")).toBe(true);
+    expect(azureSupportsEphemeralFullCaching("Standard_D32ads_v6")).toBe(true);
+    expect(azureSupportsEphemeralFullCaching("Standard_D32pds_v6")).toBe(true);
+    expect(azureSupportsEphemeralFullCaching("Standard_D32ps_v6")).toBe(false);
+    expect(azureSupportsEphemeralFullCaching("Standard_D32as_v6")).toBe(false);
   });
 
   it("filters listCrabboxServers by crabbox=true tag", async () => {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -989,15 +989,24 @@ describe("azure provider", () => {
   it("installs an SSH key extension when forking Linux VMs from OS disk snapshots", async () => {
     const client = new AzureClient(baseEnv);
     const bodies: unknown[] = [];
+    const vmAPIVersions: string[] = [];
     const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : input.toString();
-      const pathname = new URL(url).pathname;
+      const parsedURL = new URL(url);
+      const pathname = parsedURL.pathname;
       if (isAzureLoginURL(url)) {
         return Promise.resolve(
           new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
         );
       }
       if (init?.body) bodies.push(JSON.parse(String(init.body)));
+      if (
+        pathname.includes("/virtualMachines/crabbox-blue-lobster") &&
+        !pathname.includes("/extensions/") &&
+        init?.method === "PUT"
+      ) {
+        vmAPIVersions.push(parsedURL.searchParams.get("api-version") ?? "");
+      }
       if (pathname.endsWith("/resourceGroups/crabbox-leases")) {
         return Promise.resolve(
           new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
@@ -1049,7 +1058,10 @@ describe("azure provider", () => {
       testLeaseConfig({
         azureSnapshot:
           "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+        azureOSDisk: "ephemeral-preview",
         capacityMarket: "on-demand",
+        serverType: "Standard_D2ads_v6",
+        serverTypeExplicit: false,
         sshPublicKey: "ssh-ed25519 snapshot-key",
       }),
       "cbx_123456789abc",
@@ -1072,6 +1084,7 @@ describe("azure provider", () => {
         type: "CustomScript",
       },
     });
+    expect(vmAPIVersions).toEqual(["2024-07-01"]);
     expect(JSON.stringify(extensionBody)).toContain("ssh-ed25519 snapshot-key");
   });
 

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -785,6 +785,102 @@ describe("azure provider", () => {
     });
   });
 
+  it("skips stale non-explicit defaults for azureOSDisk=ephemeral-preview fallback", async () => {
+    const client = new AzureClient(baseEnv);
+    const vmSizes: string[] = [];
+    const fakeFetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (isAzureLoginURL(url.toString())) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "tkn", expires_in: 3600 }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/resourceGroups/crabbox-leases")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/virtualNetworks/crabbox-vnet")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tags: { managed_by: "crabbox" } }), { status: 200 }),
+        );
+      }
+      if (url.pathname.endsWith("/networkSecurityGroups/crabbox-nsg") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ tags: { managed_by: "crabbox" }, properties: { securityRules: [] } }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.pathname.endsWith("/providers/Microsoft.Compute/skus")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              value: [
+                {
+                  name: "Standard_D8ads_v6",
+                  resourceType: "virtualMachines",
+                  capabilities: [{ name: "EphemeralOSDiskSupported", value: "True" }],
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.pathname.includes("/publicIPAddresses/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ properties: { ipAddress: "192.0.2.10" } }), {
+            status: 200,
+          }),
+        );
+      }
+      if (
+        url.pathname.includes("/virtualMachines/") &&
+        !url.pathname.includes("/extensions/") &&
+        init?.method === "PUT" &&
+        init.body
+      ) {
+        const body = JSON.parse(String(init.body)) as {
+          properties?: { hardwareProfile?: { vmSize?: string } };
+        };
+        vmSizes.push(body.properties?.hardwareProfile?.vmSize ?? "");
+      }
+      if (url.pathname.includes("/virtualMachines/") && init?.method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              name: "crabbox-blue-lobster",
+              tags: { crabbox: "true" },
+              properties: {
+                provisioningState: "Succeeded",
+                hardwareProfile: { vmSize: "Standard_D8ads_v6" },
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+    client.fetcher = fakeFetch;
+
+    await client.createServerWithFallback(
+      testLeaseConfig({
+        target: "windows",
+        azureOSDisk: "ephemeral-preview",
+        serverType: "Standard_D2ads_v6",
+        serverTypeExplicit: false,
+      }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "owner",
+    );
+
+    expect(vmSizes).toEqual(["Standard_D8ads_v6"]);
+  });
+
   it("rejects unsupported azureOSDisk=ephemeral-preview SKUs before allocating network resources", async () => {
     const client = new AzureClient(baseEnv);
     const calls: string[] = [];

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -364,6 +364,25 @@ describe("lease config", () => {
     expect(config.azureImage).toBe("Canonical:ubuntu-26_04-lts:server-arm64:latest");
   });
 
+  it("filters Azure defaults for ephemeral-preview full caching", () => {
+    const arm = leaseConfig({
+      provider: "azure",
+      architecture: "arm64",
+      class: "standard",
+      azureOSDisk: "ephemeral-preview",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(arm.serverType).toBe("Standard_D32pds_v6");
+    const windows = leaseConfig({
+      provider: "azure",
+      target: "windows",
+      class: "standard",
+      azureOSDisk: "ephemeral-preview",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(windows.serverType).toBe("Standard_D8ads_v6");
+  });
+
   it("uses AWS ARM defaults when requested", () => {
     const config = leaseConfig({
       provider: "aws",
@@ -470,6 +489,13 @@ describe("lease config", () => {
     expect(
       leaseConfig({
         provider: "azure",
+        azureOSDisk: "ephemeral-preview",
+        sshPublicKey: "ssh-ed25519 test",
+      }).azureOSDisk,
+    ).toBe("ephemeral-preview");
+    expect(
+      leaseConfig({
+        provider: "azure",
         azureOSDisk: "auto",
         sshPublicKey: "ssh-ed25519 test",
       }).azureOSDisk,
@@ -480,7 +506,7 @@ describe("lease config", () => {
         azureOSDisk: "premium",
         sshPublicKey: "ssh-ed25519 test",
       }),
-    ).toThrow("azureOSDisk must be auto, managed, or ephemeral");
+    ).toThrow("azureOSDisk must be auto, managed, ephemeral, or ephemeral-preview");
   });
 
   it("uses Worker Azure OS disk defaults when the request omits one", () => {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -381,6 +381,16 @@ describe("lease config", () => {
       sshPublicKey: "ssh-ed25519 test",
     });
     expect(windows.serverType).toBe("Standard_D8ads_v6");
+    const snapshot = leaseConfig({
+      provider: "azure",
+      target: "windows",
+      class: "standard",
+      azureSnapshot:
+        "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/snapshots/checkpoint-azure",
+      azureOSDisk: "ephemeral-preview",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(snapshot.serverType).toBe("Standard_D2ads_v6");
   });
 
   it("uses AWS ARM defaults when requested", () => {

--- a/worker/test/wrangler-config.test.ts
+++ b/worker/test/wrangler-config.test.ts
@@ -18,11 +18,8 @@ describe("wrangler config", () => {
   it("keeps deployed and preview coordinator cost guardrails enabled", () => {
     for (const name of requiredCostGuardrails) {
       const values = configValues(name);
-      expect(values, `${name} should be set in production and preview vars`).toHaveLength(2);
-      expect(
-        values.every((value) => value > 0),
-        `${name} should be nonzero`,
-      ).toBe(true);
+      expect(values).toHaveLength(2);
+      expect(values.every((value) => value > 0)).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add `--azure-os-disk ephemeral-preview` / `azure.osDisk: ephemeral-preview` for Azure ephemeral OS disk full caching
- set `diffDiskSettings.enableFullCaching: true` with Compute API `2025-04-01` on direct CLI and Worker VM create paths
- filter Crabbox Azure fallback candidates for preview-compatible x64 and ARM64 local-disk SKUs, including Windows promotion from too-small classes to D8/D16
- reject unsupported explicit preview SKUs before shared Azure network allocation and keep native checkpoint paths refusing ephemeral OS disk leases

## Live findings
- Azure announced [public preview: Ephemeral OS Disk with full caching for VM/VMSS](https://techcommunity.microsoft.com/blog/azurecompute/public-preview-ephemeral-os-disk-with-full-caching-for-vmvmss/4500191); this PR wires that preview capability into Crabbox with explicit SKU validation
- Go SDK `armcompute/v6` and checked `v7.3.0` do not expose `enableFullCaching`, so only the preview VM create path uses a narrow raw ARM PUT
- direct Linux x64 `Standard_D8ads_v6` and brokered Linux x64 `Standard_D8ads_v6` both returned `diffDiskSettings.enableFullCaching: true` from Azure after create
- Azure Resource SKUs audit across the hardcoded Crabbox VM sizes matched the fallback filter; unsupported preview SKUs are now rejected before resource group/VNet/NIC/PIP allocation
- Linux ARM64 `pds_v6` SKUs advertise ephemeral OS disk support and NVMe placement in East US; live ARM64 create is blocked in this tenant by Dpdsv6 and spot vCPU quotas
- Windows x64 `Standard_D8ads_v6` DiskSpd, 4K random write, 512 MiB, 15s, QD32 x 4: `ephemeral` = 138.58 MiB/s, 35475.34 IOPS, 3.416 ms avg latency; `ephemeral-preview` = 139.09 MiB/s, 35607.92 IOPS, 3.551 ms avg latency

## Verification
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go test ./internal/cli -run 'Azure|CoordinatorCreateLease.*Azure|ApplyNativeCheckpointForkConfigHonorsAzureOSDisk'`
- `go test ./internal/providers/azure`
- `go vet ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker -- test/azure.test.ts test/config.test.ts`
- `npm run build --prefix worker`
- `git diff --check`
- `CRABBOX_CONFIG=/dev/null CRABBOX_AZURE_LOCATION=eastus bin/crabbox run --provider azure --target windows --type Standard_D8ads_v6 --azure-os-disk ephemeral --market on-demand --no-sync --preflight --stop-after always --slug diskspd-ephemeral --shell '<DiskSpd workload>'`
- `CRABBOX_CONFIG=/dev/null CRABBOX_AZURE_LOCATION=eastus bin/crabbox run --provider azure --target windows --type Standard_D8ads_v6 --azure-os-disk ephemeral-preview --market on-demand --no-sync --preflight --stop-after always --slug diskspd-preview --shell '<DiskSpd workload>'`
- `az resource list -g crabbox-leases --query "[?contains(name,'diskspd') || contains(name,'ephem-preview')].{type:type,name:name}" -o table` returned no leftover resources
