### PR TITLE
docs: scope README Release badge to push events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Scoped the README Release badge to `?event=push` so it reflects tag-push release runs instead of cancelled `workflow_dispatch` runs. Fixes https://github.com/openclaw/crabbox/issues/189.
+- Scoped the README Release badge to `?event=push` so it reflects tag-push release runs instead of cancelled `workflow_dispatch` runs. Fixes https://github.com/openclaw/crabbox/issues/189. Thanks @zozo123.
 
 ## 0.23.0 - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.23.1 - Unreleased
 
+### Fixed
+
+- Scoped the README Release badge to `?event=push` so it reflects tag-push release runs instead of cancelled `workflow_dispatch` runs. Fixes https://github.com/openclaw/crabbox/issues/189.
+
 ## 0.23.0 - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Crabbox banner](docs/assets/readme-banner.jpg)
 
 [![CI](https://github.com/openclaw/crabbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openclaw/crabbox/actions/workflows/ci.yml)
-[![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)
+[![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)
 [![Latest release](https://img.shields.io/github/v/release/openclaw/crabbox?sort=semver)](https://github.com/openclaw/crabbox/releases/latest)
 
 **Warm a box, sync the diff, run the suite.**


### PR DESCRIPTION
## Summary

The README Release badge rendered red ("release - failing") even though the release flow works. The badge SVG URL had no event filter, so GitHub resolved it against the most-recent workflow run — a cancelled `workflow_dispatch` run on `main` — instead of the successful tag-push release runs. The CI badge on the line above is already scoped with `?branch=main`.

This scopes the Release badge to `?event=push` so it reflects tag-push release status. Only the badge SVG URL changes; the link target and the release workflow are untouched.

## Verification

```
$ rg -n "actions/workflows/release.yml/badge.svg" README.md
6:[![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)

# before (unscoped) — what main renders today
$ curl -L -s 'https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg' \
    | sed -n 's/.*<title>\([^<]*\)<\/title>.*/\1/p'
release - failing

# after (?event=push) — the URL this PR uses
$ curl -L -s 'https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=push' \
    | sed -n 's/.*<title>\([^<]*\)<\/title>.*/\1/p'
release - passing

$ go build -trimpath -o bin/crabbox ./cmd/crabbox   # OK
$ git diff --check                                   # clean
```

Closes https://github.com/openclaw/crabbox/issues/189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
