### PR TITLE
feat: add apple-container local development provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `provider: apple-container` for local Apple silicon macOS Linux leases, including SSH sync/run lifecycle and provider-backed cache volumes. Thanks @zozo123.
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Targets: **L**inux, **M**acOS, **W**indows.
 | [Proxmox](docs/providers/proxmox.md) | `proxmox` | L | direct | Clone Linux QEMU templates on a private Proxmox VE cluster. |
 | [Static SSH](docs/providers/ssh.md) | `ssh` (`static`, `static-ssh`) | L / M / W | direct | Existing machines; no provisioning. |
 | [Local Container](docs/providers/local-container.md) | `local-container` (`docker`, `container`, `local-docker`) | L | direct | Local Docker-compatible runtime (Docker Desktop, OrbStack, Colima). |
+| [Apple Container](docs/providers/apple-container.md) | `apple-container` (`apple`, `applecontainer`) | L | direct | Apple's native `container` runtime on Apple silicon macOS. |
 | [exe.dev](docs/providers/exe-dev.md) | `exe-dev` (`exe`, `exedev`) | L | direct | exe.dev VMs exposed as public SSH leases. |
 | [Namespace Devbox](docs/providers/namespace-devbox.md) | `namespace-devbox` (`namespace`, `namespace-devboxes`) | L | direct | Namespace.so Devboxes over SSH. |
 | [Semaphore](docs/providers/semaphore.md) | `semaphore` (`sem`) | L | direct | A Semaphore CI job leased as a testbox. |

--- a/docs/features/cache-volumes.md
+++ b/docs/features/cache-volumes.md
@@ -84,7 +84,9 @@ Providers advertise cache volume support with the `cache-volume` feature.
 Blacksmith Testbox implements the feature by forwarding each resolved volume as
 a `blacksmith testbox warmup --sticky-disk key:path` argument. Local Container
 implements it with Docker named volumes mounted at the configured paths; the
-Docker volume name is derived from the cache key.
+Docker volume name is derived from the cache key. Apple Container implements it
+with host cache directories under the local user cache directory mounted with
+Apple's `--volume` flag.
 
 Providers that do not advertise `cache-volume` ignore non-required configured
 volumes. Required volumes fail early when the selected provider cannot honor

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -31,6 +31,8 @@ SSH-lease providers further differ by how they reach the cloud:
   provisioning, no cleanup.
 - **Local container** — `local-container` starts a labeled Linux container
   through a Docker-compatible local runtime (Docker Desktop, OrbStack, Colima).
+  `apple-container` is the equivalent for Apple's native `container` runtime on
+  Apple silicon macOS.
 - **Delegated sandbox** — managed sandbox/proof runners that execute remotely
   without an SSH lease (e.g. `e2b`, `modal`, `islo`, `cloudflare`,
   `azure-dynamic-sessions`).
@@ -57,6 +59,7 @@ Each page below maps to an adapter under `internal/providers/<dir>`. The
 | [Parallels](parallels.md) | `parallels` | — | Linux, macOS, Windows | no (direct) |
 | [Static SSH](ssh.md) | `ssh` | `static`, `static-ssh` | Linux, macOS, Windows | no (static) |
 | [Local Container](local-container.md) | `local-container` | `docker`, `container`, `local-docker` | Linux | no (local) |
+| [Apple Container](apple-container.md) | `apple-container` | `apple`, `applecontainer` | Linux | no (local) |
 | [exe.dev](exe-dev.md) | `exe-dev` | `exe`, `exedev` | Linux | no (direct) |
 | [Namespace Devbox](namespace-devbox.md) | `namespace-devbox` | `namespace`, `namespace-devboxes` | Linux | no (direct) |
 | [Semaphore](semaphore.md) | `semaphore` | `sem` | Linux | no (direct) |

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -61,6 +61,14 @@ crabbox ssh --provider apple --id apple-smoke
 crabbox stop --provider apple apple-smoke
 ```
 
+Cache-volume smoke:
+
+```sh
+crabbox run --provider apple-container \
+  --cache-volume pnpm-store=my-app-apple-container-pnpm:/var/cache/crabbox/pnpm \
+  -- pnpm test
+```
+
 ## Configuration
 
 ```yaml
@@ -121,7 +129,7 @@ variable consumed by the bootstrap script.
    local user cache directory and mounted into the container with
    `container run --volume <host-cache>:<path>`.
 5. Crabbox reads the container IP from `container inspect`
-   (`networks[0].address`, stripped of its CIDR suffix), waits for SSH
+   (`networks[0].address` or `networks[0].ipv4Address`, stripped of its CIDR suffix), waits for SSH
    readiness, syncs tracked and non-ignored files into `appleContainer.workRoot`,
    then drives the command over the normal SSH executor.
 6. `status`, `list`, and `stop` inspect or remove labeled containers via
@@ -148,6 +156,9 @@ variable consumed by the bootstrap script.
   packages on first start. Use a prebuilt image with SSH/Git/rsync packages when
   startup time matters, or when the container has no network egress to install
   them.
+- If Apple's default container DNS setup does not inherit a working resolver,
+  pass an explicit nameserver through `--apple-container-extra-run-args '--dns 8.8.8.8'`
+  or configure the equivalent `appleContainer.extraRunArgs` value.
 
 ## Runtime expectations
 
@@ -156,7 +167,7 @@ The backend relies on the documented Apple `container` CLI surface:
 - `container system start` / `container system status`;
 - `container run -d --name --label --env --cpus --memory --volume <image> <args>`;
 - `container ls --all --format json`;
-- `container inspect <id>` (network address from `networks[].address`);
+- `container inspect <id>` (network address from `networks[].address` or `networks[].ipv4Address`);
 - `container delete --force <id>`.
 
 A few details of the JSON shape (the exact label location and whether

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -1,0 +1,168 @@
+# Apple Container Provider
+
+Read this when you:
+
+- choose `provider: apple-container` (aliases `apple`, `applecontainer`);
+- run Crabbox against Apple's [`container`](https://github.com/apple/container)
+  runtime on Apple silicon macOS;
+- change `internal/providers/applecontainer`.
+
+Apple Container is an SSH-lease provider that runs leases as Linux containers on
+the local Mac using Apple's native `container` CLI. Crabbox starts a labeled
+container through `container run`, reads the container's routable IP address from
+`container inspect`, syncs the current checkout into the container over SSH, runs
+the command with the normal SSH executor, and removes the container on `stop`.
+Everything stays on the Mac running the CLI — there is no coordinator
+involvement.
+
+This provider is a provider-owned adapter: it does not reuse the Docker-specific
+code in [Local Container](local-container.md), because Apple's runtime is not
+assumed to be Docker-compatible. In particular, Apple containers receive their
+own routable IP on the host bridge, so Crabbox connects straight to the
+container IP on the standard SSH port instead of publishing a loopback host
+port.
+
+## When to use it
+
+Reach for Apple Container when you want:
+
+- a zero-cloud Linux smoke path on Apple silicon macOS using Apple's first-party
+  container runtime;
+- to avoid installing a Docker-compatible runtime when `container` is already
+  present.
+
+Use [Local Container](local-container.md) when you run Docker Desktop,
+OrbStack, Colima, or another Docker-compatible runtime, or when you need
+desktop/browser smoke. Use a remote provider — [AWS](aws.md), [Azure](azure.md),
+[Google Cloud](gcp.md), [Hetzner](hetzner.md), or [static SSH](ssh.md) — when you
+need stronger host separation, larger capacity, or shared team infrastructure.
+
+## Prerequisites
+
+- macOS 26 (or newer) on Apple silicon. Apple's `container` runtime is supported
+  on macOS 26; older releases are not supported. The provider is gated to
+  `darwin/arm64`; `doctor` reports a clear error on other platforms.
+- Install Apple's `container` CLI from <https://github.com/apple/container> and
+  start the background service once:
+
+  ```sh
+  container system start
+  ```
+
+## Quick start
+
+```sh
+container system status
+crabbox run --provider apple-container -- pnpm test
+
+crabbox warmup --provider apple --slug apple-smoke
+crabbox run --provider apple --id apple-smoke -- pnpm test:changed
+crabbox ssh --provider apple --id apple-smoke
+crabbox stop --provider apple apple-smoke
+```
+
+## Configuration
+
+```yaml
+provider: apple-container
+target: linux
+appleContainer:
+  cliPath: container        # path to Apple's container CLI
+  image: ubuntu:26.04       # base image; defaults to the Crabbox OS image (--os)
+  user: crabbox             # SSH user created inside the container
+  workRoot: /work/crabbox   # remote Crabbox work root
+  cpus: 0                   # CPU limit; 0 leaves the runtime default
+  memory: ""                # memory limit, e.g. 8g
+  extraRunArgs: []          # extra args appended to `container run`
+```
+
+Defaults applied when unset: `cliPath=container`, `image=` the Crabbox OS image
+default (follows `--os`; currently `ubuntu:26.04`), `user=crabbox`,
+`workRoot=/work/crabbox`, SSH port `22`.
+
+Provider flags:
+
+```text
+--apple-container-cli <path-or-name>
+--apple-container-image <image>
+--apple-container-user <user>
+--apple-container-work-root <path>
+--apple-container-cpus <n>
+--apple-container-memory <size>
+--apple-container-extra-run-args "<space separated args>"
+```
+
+Environment overrides:
+
+```text
+CRABBOX_APPLE_CONTAINER_CLI
+CRABBOX_APPLE_CONTAINER_IMAGE
+CRABBOX_APPLE_CONTAINER_USER
+CRABBOX_APPLE_CONTAINER_WORK_ROOT
+CRABBOX_APPLE_CONTAINER_CPUS
+CRABBOX_APPLE_CONTAINER_MEMORY
+CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS
+```
+
+No secrets are passed as CLI arguments. The only key material handed to the
+container is the per-lease SSH public key, supplied through an environment
+variable consumed by the bootstrap script.
+
+## Lease behavior
+
+1. `warmup` or a fresh `run` creates a per-lease SSH key.
+2. The provider runs `container run -d` with Crabbox labels and the public-key
+   auth environment the bootstrap script needs. Apple containers are reachable
+   on their own IP, so no host port is published.
+3. On Debian/Ubuntu-compatible images, the container installs
+   `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when missing, creates the
+   SSH user, writes the authorized key, and starts `sshd`.
+4. Crabbox reads the container IP from `container inspect`
+   (`networks[0].address`, stripped of its CIDR suffix), waits for SSH
+   readiness, syncs tracked and non-ignored files into `appleContainer.workRoot`,
+   then drives the command over the normal SSH executor.
+5. `status`, `list`, and `stop` inspect or remove labeled containers via
+   `container ls --all --format json`, `container inspect`, and
+   `container delete --force`.
+6. `cleanup --provider apple-container` removes stopped containers and running
+   non-`keep` containers whose local claim is stale past the idle timeout plus a
+   safety grace period, and prunes orphaned claims.
+
+## Limits and caveats
+
+- macOS on Apple silicon only; the provider is gated to `darwin/arm64`.
+- Linux target only; `--tailscale` and non-Linux targets are rejected.
+- `--actions-runner` is not supported: the container runs `sshd` as PID 1 with no
+  init system, so the GitHub Actions runner installer (which needs `systemctl`)
+  cannot run. Use a remote SSH provider for `--actions-runner` workflows.
+- No coordinator support; lifecycle is local to the Mac running the CLI.
+- No desktop, browser, VNC, code-server, Tailscale bootstrap, or checkpoint
+  support. Use [Local Container](local-container.md) for local desktop/browser
+  smoke.
+- The default image (the Crabbox OS image, currently `ubuntu:26.04`) bootstraps
+  packages on first start. Use a prebuilt image with SSH/Git/rsync packages when
+  startup time matters, or when the container has no network egress to install
+  them.
+
+## Runtime expectations
+
+The backend relies on the documented Apple `container` CLI surface:
+
+- `container system start` / `container system status`;
+- `container run -d --name --label --env --cpus --memory <image> <args>`;
+- `container ls --all --format json`;
+- `container inspect <id>` (network address from `networks[].address`);
+- `container delete --force <id>`.
+
+A few details of the JSON shape (the exact label location and whether
+`container run` echoes an id on stdout) are not fully pinned down by the public
+docs; the adapter chooses the most CLI-consistent behavior and notes those
+assumptions in code comments. Full create/SSH/sync/run/status/delete coverage
+requires a real Apple silicon Mac with `container` installed.
+
+## Related
+
+- [Provider reference](README.md)
+- [Local Container](local-container.md)
+- [Static SSH](ssh.md)
+- [Sync](../features/sync.md)

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -117,14 +117,17 @@ variable consumed by the bootstrap script.
 3. On Debian/Ubuntu-compatible images, the container installs
    `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when missing, creates the
    SSH user, writes the authorized key, and starts `sshd`.
-4. Crabbox reads the container IP from `container inspect`
+4. Configured `cache.volumes` are created as host cache directories under the
+   local user cache directory and mounted into the container with
+   `container run --volume <host-cache>:<path>`.
+5. Crabbox reads the container IP from `container inspect`
    (`networks[0].address`, stripped of its CIDR suffix), waits for SSH
    readiness, syncs tracked and non-ignored files into `appleContainer.workRoot`,
    then drives the command over the normal SSH executor.
-5. `status`, `list`, and `stop` inspect or remove labeled containers via
+6. `status`, `list`, and `stop` inspect or remove labeled containers via
    `container ls --all --format json`, `container inspect`, and
    `container delete --force`.
-6. `cleanup --provider apple-container` removes stopped containers and running
+7. `cleanup --provider apple-container` removes stopped containers and running
    non-`keep` containers whose local claim is stale past the idle timeout plus a
    safety grace period, and prunes orphaned claims.
 
@@ -139,6 +142,8 @@ variable consumed by the bootstrap script.
 - No desktop, browser, VNC, code-server, Tailscale bootstrap, or checkpoint
   support. Use [Local Container](local-container.md) for local desktop/browser
   smoke.
+- `cache.volumes` are supported for rebuildable dependency caches. They are
+  local to the Mac user account and are not shared with other machines.
 - The default image (the Crabbox OS image, currently `ubuntu:26.04`) bootstraps
   packages on first start. Use a prebuilt image with SSH/Git/rsync packages when
   startup time matters, or when the container has no network egress to install
@@ -149,7 +154,7 @@ variable consumed by the bootstrap script.
 The backend relies on the documented Apple `container` CLI surface:
 
 - `container system start` / `container system status`;
-- `container run -d --name --label --env --cpus --memory <image> <args>`;
+- `container run -d --name --label --env --cpus --memory --volume <image> <args>`;
 - `container ls --all --format json`;
 - `container inspect <id>` (network address from `networks[].address`);
 - `container delete --force <id>`.

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -249,6 +249,14 @@ func TestValidateActionsRunnerCapabilityRejectsLocalContainer(t *testing.T) {
 	}
 }
 
+func TestValidateActionsRunnerCapabilityRejectsAppleContainer(t *testing.T) {
+	backend := testSSHBackend{spec: ProviderSpec{Name: "apple-container"}}
+	err := validateActionsRunnerCapability(backend, Config{Provider: "apple-container", TargetOS: targetLinux})
+	if err == nil || !strings.Contains(err.Error(), "provider=apple-container") {
+		t.Fatalf("apple-container actions runner error=%v", err)
+	}
+}
+
 func TestLocalActionsWorkflowPathRequiresRepoWorkflowFile(t *testing.T) {
 	root := t.TempDir()
 	workflow := filepath.Join(root, ".github", "workflows", "hydrate.yml")

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -119,6 +119,8 @@ type Config struct {
 	Sprites                     SpritesConfig
 	LocalContainer              LocalContainerConfig
 	localContainerImageExplicit bool
+	AppleContainer              AppleContainerConfig
+	appleContainerImageExplicit bool
 	Tailscale                   TailscaleConfig
 	Static                      StaticConfig
 	Results                     ResultsConfig
@@ -416,6 +418,16 @@ type LocalContainerConfig struct {
 	Memory       string
 	Network      string
 	DockerSocket bool
+}
+
+type AppleContainerConfig struct {
+	CLIPath      string
+	Image        string
+	User         string
+	WorkRoot     string
+	CPUs         int
+	Memory       string
+	ExtraRunArgs []string
 }
 
 type StaticConfig struct {
@@ -784,6 +796,9 @@ func applyOSImageProviderDefaults(cfg *Config, force bool) {
 	if force || cfg.LocalContainer.Image == "" || (!cfg.localContainerImageExplicit && (cfg.LocalContainer.Image == base.LocalContainer.Image || wasOSDefault)) {
 		cfg.LocalContainer.Image = containerImage
 	}
+	if force || cfg.AppleContainer.Image == "" || (!cfg.appleContainerImageExplicit && (cfg.AppleContainer.Image == base.AppleContainer.Image || wasOSDefault)) {
+		cfg.AppleContainer.Image = containerImage
+	}
 	cfg.osImageProviderDefaults = cfg.OSImage
 }
 
@@ -793,6 +808,10 @@ func MarkIsloImageExplicit(cfg *Config) {
 
 func MarkLocalContainerImageExplicit(cfg *Config) {
 	cfg.localContainerImageExplicit = true
+}
+
+func MarkAppleContainerImageExplicit(cfg *Config) {
+	cfg.appleContainerImageExplicit = true
 }
 
 func baseConfig() Config {
@@ -960,6 +979,12 @@ func baseConfig() Config {
 			User:    "crabbox",
 			Network: "bridge",
 		},
+		AppleContainer: AppleContainerConfig{
+			CLIPath:  "container",
+			Image:    containerImage,
+			User:     "crabbox",
+			WorkRoot: "/work/crabbox",
+		},
 		Tailscale: TailscaleConfig{
 			Tags:             []string{"tag:crabbox"},
 			HostnameTemplate: "crabbox-{slug}",
@@ -1024,6 +1049,7 @@ type fileConfig struct {
 	Semaphore            *fileSemaphoreConfig               `yaml:"semaphore,omitempty"`
 	Sprites              *fileSpritesConfig                 `yaml:"sprites,omitempty"`
 	LocalContainer       *fileLocalContainerConfig          `yaml:"localContainer,omitempty"`
+	AppleContainer       *fileAppleContainerConfig          `yaml:"appleContainer,omitempty"`
 	Tailscale            *fileTailscaleConfig               `yaml:"tailscale,omitempty"`
 	Static               *fileStaticConfig                  `yaml:"static,omitempty"`
 	Results              *fileResultsConfig                 `yaml:"results,omitempty"`
@@ -1385,6 +1411,16 @@ type fileLocalContainerConfig struct {
 	Memory       string `yaml:"memory,omitempty"`
 	Network      string `yaml:"network,omitempty"`
 	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
+}
+
+type fileAppleContainerConfig struct {
+	CLIPath      string   `yaml:"cliPath,omitempty"`
+	Image        string   `yaml:"image,omitempty"`
+	User         string   `yaml:"user,omitempty"`
+	WorkRoot     string   `yaml:"workRoot,omitempty"`
+	CPUs         int      `yaml:"cpus,omitempty"`
+	Memory       string   `yaml:"memory,omitempty"`
+	ExtraRunArgs []string `yaml:"extraRunArgs,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -2431,6 +2467,30 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.LocalContainer.DockerSocket = *file.LocalContainer.DockerSocket
 		}
 	}
+	if file.AppleContainer != nil {
+		if file.AppleContainer.CLIPath != "" {
+			cfg.AppleContainer.CLIPath = file.AppleContainer.CLIPath
+		}
+		if file.AppleContainer.Image != "" {
+			cfg.AppleContainer.Image = file.AppleContainer.Image
+			cfg.appleContainerImageExplicit = true
+		}
+		if file.AppleContainer.User != "" {
+			cfg.AppleContainer.User = file.AppleContainer.User
+		}
+		if file.AppleContainer.WorkRoot != "" {
+			cfg.AppleContainer.WorkRoot = file.AppleContainer.WorkRoot
+		}
+		if file.AppleContainer.CPUs > 0 {
+			cfg.AppleContainer.CPUs = file.AppleContainer.CPUs
+		}
+		if file.AppleContainer.Memory != "" {
+			cfg.AppleContainer.Memory = file.AppleContainer.Memory
+		}
+		if len(file.AppleContainer.ExtraRunArgs) > 0 {
+			cfg.AppleContainer.ExtraRunArgs = append([]string(nil), file.AppleContainer.ExtraRunArgs...)
+		}
+	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
 			cfg.Tailscale.Enabled = *file.Tailscale.Enabled
@@ -3115,6 +3175,18 @@ func applyEnv(cfg *Config) error {
 	cfg.LocalContainer.Network = getenv("CRABBOX_LOCAL_CONTAINER_NETWORK", cfg.LocalContainer.Network)
 	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET"); ok {
 		cfg.LocalContainer.DockerSocket = value
+	}
+	cfg.AppleContainer.CLIPath = getenv("CRABBOX_APPLE_CONTAINER_CLI", cfg.AppleContainer.CLIPath)
+	if image := os.Getenv("CRABBOX_APPLE_CONTAINER_IMAGE"); image != "" {
+		cfg.AppleContainer.Image = image
+		cfg.appleContainerImageExplicit = true
+	}
+	cfg.AppleContainer.User = getenv("CRABBOX_APPLE_CONTAINER_USER", cfg.AppleContainer.User)
+	cfg.AppleContainer.WorkRoot = getenv("CRABBOX_APPLE_CONTAINER_WORK_ROOT", cfg.AppleContainer.WorkRoot)
+	cfg.AppleContainer.CPUs = getenvInt("CRABBOX_APPLE_CONTAINER_CPUS", cfg.AppleContainer.CPUs)
+	cfg.AppleContainer.Memory = getenv("CRABBOX_APPLE_CONTAINER_MEMORY", cfg.AppleContainer.Memory)
+	if extra := strings.Fields(os.Getenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS")); len(extra) > 0 {
+		cfg.AppleContainer.ExtraRunArgs = extra
 	}
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -143,6 +143,14 @@ func configShowView(cfg Config) map[string]any {
 			"cliPath": cfg.AsciiBox.CLIPath,
 			"workdir": cfg.AsciiBox.Workdir,
 		},
+		"appleContainer": map[string]any{
+			"cliPath":  cfg.AppleContainer.CLIPath,
+			"image":    cfg.AppleContainer.Image,
+			"user":     cfg.AppleContainer.User,
+			"workRoot": cfg.AppleContainer.WorkRoot,
+			"cpus":     cfg.AppleContainer.CPUs,
+			"memory":   cfg.AppleContainer.Memory,
+		},
 		"static": map[string]any{
 			"id":       cfg.Static.ID,
 			"name":     cfg.Static.Name,
@@ -240,6 +248,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "e2b api_url=%s domain=%s template=%s workdir=%s user=%s\n", cfg.E2B.APIURL, cfg.E2B.Domain, cfg.E2B.Template, cfg.E2B.Workdir, blank(cfg.E2B.User, "-"))
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
+	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(cfg.Cloudflare.APIURL, "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
 	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(w, "results junit=%s auto=%t\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"), cfg.Results.Auto)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -112,6 +112,13 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_ASCII_BOX_CLI",
 		"BOX_CLI",
 		"CRABBOX_ASCII_BOX_WORKDIR",
+		"CRABBOX_APPLE_CONTAINER_CLI",
+		"CRABBOX_APPLE_CONTAINER_IMAGE",
+		"CRABBOX_APPLE_CONTAINER_USER",
+		"CRABBOX_APPLE_CONTAINER_WORK_ROOT",
+		"CRABBOX_APPLE_CONTAINER_CPUS",
+		"CRABBOX_APPLE_CONTAINER_MEMORY",
+		"CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS",
 		"CRABBOX_WANDB_API_KEY",
 		"WANDB_API_KEY",
 		"CRABBOX_WANDB_DEFAULT_IMAGE",
@@ -203,6 +210,41 @@ func TestAsciiBoxConfigDefaultsFileAndEnv(t *testing.T) {
 	applyEnv(&cfg)
 	if cfg.AsciiBox.APIKey != "override-key" || cfg.AsciiBox.BaseURL != "https://override.example.test" || cfg.AsciiBox.CLIPath != "/opt/box" || cfg.AsciiBox.Workdir != "/home/user/env-project" {
 		t.Fatalf("env asciiBox config not applied: %#v", cfg.AsciiBox)
+	}
+}
+
+func TestAppleContainerConfigDefaultsFileAndEnv(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if cfg.AppleContainer.CLIPath != "container" || cfg.AppleContainer.User != "crabbox" {
+		t.Fatalf("apple container defaults not applied: %#v", cfg.AppleContainer)
+	}
+	applyFileConfig(&cfg, fileConfig{
+		Provider: "apple-container",
+		AppleContainer: &fileAppleContainerConfig{
+			CLIPath:      "/opt/bin/container",
+			Image:        "example-org/my-app:test",
+			User:         "runner",
+			WorkRoot:     "/work/example",
+			CPUs:         4,
+			Memory:       "8g",
+			ExtraRunArgs: []string{"--mount", "type=virtiofs,source=/tmp,target=/tmp"},
+		},
+	})
+	if cfg.Provider != "apple-container" || cfg.AppleContainer.CLIPath != "/opt/bin/container" || cfg.AppleContainer.Image != "example-org/my-app:test" || cfg.AppleContainer.User != "runner" || cfg.AppleContainer.WorkRoot != "/work/example" || cfg.AppleContainer.CPUs != 4 || cfg.AppleContainer.Memory != "8g" || len(cfg.AppleContainer.ExtraRunArgs) != 2 {
+		t.Fatalf("file appleContainer config not applied: %#v", cfg.AppleContainer)
+	}
+
+	t.Setenv("CRABBOX_APPLE_CONTAINER_CLI", "/usr/local/bin/container")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_IMAGE", "example-org/other:live")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_USER", "env-user")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_WORK_ROOT", "/work/env")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_CPUS", "6")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_MEMORY", "12g")
+	t.Setenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS", "--dns 1.1.1.1")
+	applyEnv(&cfg)
+	if cfg.AppleContainer.CLIPath != "/usr/local/bin/container" || cfg.AppleContainer.Image != "example-org/other:live" || cfg.AppleContainer.User != "env-user" || cfg.AppleContainer.WorkRoot != "/work/env" || cfg.AppleContainer.CPUs != 6 || cfg.AppleContainer.Memory != "12g" || len(cfg.AppleContainer.ExtraRunArgs) != 2 {
+		t.Fatalf("env appleContainer config not applied: %#v", cfg.AppleContainer)
 	}
 }
 
@@ -1249,6 +1291,48 @@ os: ubuntu:24.04
 	}
 	if cfg.TargetOS != targetLinux || cfg.Image != "ubuntu-24.04" || cfg.AzureImage != "Canonical:ubuntu-24_04-lts:server:latest" {
 		t.Fatalf("portable os defaults not applied through target alias: target=%q image=%q azure=%q", cfg.TargetOS, cfg.Image, cfg.AzureImage)
+	}
+}
+
+func TestAppleContainerImageFollowsOSImageDefault(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	cfgPath := filepath.Join(home, "crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	if err := os.WriteFile(cfgPath, []byte("target: linux\nos: ubuntu:24.04\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// apple-container must track the OS image default the same way local-container does.
+	if cfg.AppleContainer.Image == "" || cfg.AppleContainer.Image != cfg.LocalContainer.Image {
+		t.Fatalf("apple-container image should follow the os default like local-container: apple=%q local=%q", cfg.AppleContainer.Image, cfg.LocalContainer.Image)
+	}
+	if cfg.AppleContainer.Image == baseConfig().AppleContainer.Image {
+		t.Fatalf("--os did not update apple-container image: still base %q", cfg.AppleContainer.Image)
+	}
+}
+
+func TestAppleContainerExplicitImageSurvivesOSDefault(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	cfgPath := filepath.Join(home, "crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	if err := os.WriteFile(cfgPath, []byte("target: linux\nos: ubuntu:24.04\nappleContainer:\n  image: my-org/custom:tag\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AppleContainer.Image != "my-org/custom:tag" {
+		t.Fatalf("explicit apple-container image was overwritten by --os: %q", cfg.AppleContainer.Image)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -690,8 +690,8 @@ func validateActionsRunnerCapability(backend Backend, cfg Config) error {
 	if _, ok := backend.(SSHLeaseBackend); !ok {
 		return exit(2, "--actions-runner requires an SSH lease provider")
 	}
-	if backend.Spec().Name == "local-container" {
-		return exit(2, "--actions-runner is not supported for provider=local-container; use normal crabbox run or a remote SSH provider")
+	if name := backend.Spec().Name; name == "local-container" || name == "apple-container" {
+		return exit(2, "--actions-runner is not supported for provider=%s; use normal crabbox run or a remote SSH provider", name)
 	}
 	if !supportsGitHubActionsRunnerTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}) {
 		return exit(2, "--actions-runner requires target=linux or target=windows")

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -1,6 +1,7 @@
 package all
 
 import (
+	_ "github.com/openclaw/crabbox/internal/providers/applecontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/asciibox"
 	_ "github.com/openclaw/crabbox/internal/providers/aws"
 	_ "github.com/openclaw/crabbox/internal/providers/azure"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -6,8 +6,29 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func TestAppleContainerRegistersWithoutAliasCollision(t *testing.T) {
+	for _, alias := range []string{"apple-container", "apple", "applecontainer"} {
+		provider, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if provider.Name() != "apple-container" {
+			t.Fatalf("ProviderFor(%q).Name=%q want apple-container", alias, provider.Name())
+		}
+	}
+	// The bare "container" alias must keep pointing at local-container.
+	got, err := core.ProviderFor("container")
+	if err != nil {
+		t.Fatalf("ProviderFor(container): %v", err)
+	}
+	if got.Name() != "local-container" {
+		t.Fatalf("'container' alias now resolves to %q; apple-container must not steal it", got.Name())
+	}
+}
+
 func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 	providers := []string{
+		"apple-container",
 		"aws",
 		"azure",
 		"azure-dynamic-sessions",

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -132,6 +132,13 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		return core.LeaseTarget{}, err
 	}
+	c, err = b.waitForNetworkAddress(ctx, containerID, c, core.BootstrapWaitTimeout(cfg))
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
 	lease, err := b.prepareLease(ctx, cfg, c, leaseID, slug, true)
 	if err != nil {
 		if !req.Keep {
@@ -505,6 +512,50 @@ func (b *backend) inspectContainer(ctx context.Context, id string) (inspectConta
 		return inspectContainer{}, exit(4, "container not found: %s", id)
 	}
 	return containers[0], nil
+}
+
+func (b *backend) waitForNetworkAddress(ctx context.Context, id string, c inspectContainer, timeout time.Duration) (inspectContainer, error) {
+	if c.ip() != "" {
+		return c, nil
+	}
+	if appleContainerTerminalStatus(c.status()) {
+		return inspectContainer{}, exit(5, "apple-container %s stopped before a network address was assigned", id)
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return inspectContainer{}, ctx.Err()
+		case <-deadline.C:
+			return inspectContainer{}, exit(5, "apple-container %s has no network address yet", id)
+		case <-tick.C:
+			next, err := b.inspectContainer(ctx, id)
+			if err != nil {
+				return inspectContainer{}, err
+			}
+			if next.ip() != "" {
+				return next, nil
+			}
+			if appleContainerTerminalStatus(next.status()) {
+				return inspectContainer{}, exit(5, "apple-container %s stopped before a network address was assigned", id)
+			}
+		}
+	}
+}
+
+func appleContainerTerminalStatus(status string) bool {
+	switch status {
+	case "stopped", "exited", "dead":
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *backend) resolveContainer(ctx context.Context, identifier string) (inspectContainer, string, string, error) {

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -2,9 +2,11 @@ package applecontainer
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -143,6 +145,12 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		return core.LeaseTarget{}, err
 	}
+	if err := core.UpdateLeaseClaimCacheVolumes(leaseID, core.CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, c.id())
 	return lease, nil
@@ -150,6 +158,9 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
+	if err := requireMacOS(); err != nil {
+		return core.LeaseTarget{}, err
+	}
 	c, leaseID, slug, err := b.resolveContainer(ctx, req.ID)
 	if err != nil {
 		return core.LeaseTarget{}, err
@@ -171,6 +182,9 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 
 func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
+	if err := requireMacOS(); err != nil {
+		return nil, err
+	}
 	containers, err := b.listContainers(ctx)
 	if err != nil {
 		return nil, err
@@ -210,6 +224,9 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	if err := requireMacOS(); err != nil {
+		return err
+	}
 	lease := req.Lease
 	id := strings.TrimSpace(req.Lease.Server.CloudID)
 	if id == "" {
@@ -239,6 +256,9 @@ func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
+	if err := requireMacOS(); err != nil {
+		return err
+	}
 	containers, err := b.listContainers(ctx)
 	if err != nil {
 		return err
@@ -326,6 +346,10 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	labels["ssh_user"] = cfg.AppleContainer.User
 	labels["ssh_port"] = sshPort
 	labels["work_root"] = cfg.AppleContainer.WorkRoot
+	cacheVolumeMounts, err := appleContainerCacheVolumeMounts(cfg.Cache.Volumes)
+	if err != nil {
+		return "", err
+	}
 
 	// `container run [<options>] <image> [<arguments>...]`. We detach (-d) and
 	// pass the same Crabbox bootstrap contract used by local-container via
@@ -345,6 +369,9 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		"-e", "CRABBOX_WORK_ROOT=" + cfg.AppleContainer.WorkRoot,
 		"-e", "CRABBOX_SSH_PORT=" + sshPort,
 	}
+	for i, volume := range cfg.Cache.Volumes {
+		args = append(args, "-e", fmt.Sprintf("CRABBOX_CACHE_VOLUME_PATH_%d=%s", i, strings.TrimSpace(volume.Path)))
+	}
 	// Labels keep ownership/lease metadata queryable from `container inspect`.
 	for key, value := range labels {
 		args = append(args, "--label", key+"="+value)
@@ -354,6 +381,9 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	}
 	if memory := strings.TrimSpace(cfg.AppleContainer.Memory); memory != "" {
 		args = append(args, "--memory", memory)
+	}
+	for _, mount := range cacheVolumeMounts {
+		args = append(args, "--volume", mount)
 	}
 	args = append(args, cfg.AppleContainer.ExtraRunArgs...)
 	args = append(args, cfg.AppleContainer.Image, "/bin/sh", "-lc", bootstrapScript)
@@ -369,6 +399,78 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 		id = name
 	}
 	return id, nil
+}
+
+func appleContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, error) {
+	if len(volumes) == 0 {
+		return nil, nil
+	}
+	root, err := appleContainerCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	mounts := make([]string, 0, len(volumes))
+	for _, volume := range volumes {
+		key := strings.TrimSpace(volume.Key)
+		path := strings.TrimSpace(volume.Path)
+		if key == "" {
+			return nil, exit(2, "cache volume key is required")
+		}
+		if strings.Contains(key, ":") {
+			return nil, exit(2, "cache volume key %q must not contain ':'", key)
+		}
+		if path == "" {
+			return nil, exit(2, "cache volume path is required")
+		}
+		if !strings.HasPrefix(path, "/") {
+			return nil, exit(2, "cache volume path %q must be absolute", path)
+		}
+		hostPath := filepath.Join(root, appleContainerCacheVolumeName(key))
+		if err := os.MkdirAll(hostPath, 0o777); err != nil {
+			return nil, exit(2, "create apple-container cache volume %s: %v", hostPath, err)
+		}
+		if err := os.Chmod(hostPath, 0o777); err != nil {
+			return nil, exit(2, "make apple-container cache volume writable %s: %v", hostPath, err)
+		}
+		mounts = append(mounts, hostPath+":"+path)
+	}
+	return mounts, nil
+}
+
+func appleContainerCacheRoot() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", exit(2, "user cache directory is unavailable")
+	}
+	return filepath.Join(dir, "crabbox", "apple-container-cache"), nil
+}
+
+func appleContainerCacheVolumeName(key string) string {
+	key = strings.TrimSpace(key)
+	sum := sha256.Sum256([]byte(key))
+	var safe strings.Builder
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+			safe.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			safe.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			safe.WriteRune(r)
+		case r == '.' || r == '_' || r == '-':
+			safe.WriteRune(r)
+		default:
+			safe.WriteByte('-')
+		}
+		if safe.Len() >= 80 {
+			break
+		}
+	}
+	name := strings.Trim(safe.String(), ".-_")
+	if name == "" {
+		name = "volume"
+	}
+	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
 }
 
 func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
@@ -644,6 +746,11 @@ printf '%s\n' "$CRABBOX_AUTHORIZED_KEY" > "$home_dir/.ssh/authorized_keys"
 chmod 700 "$home_dir/.ssh"
 chmod 600 "$home_dir/.ssh/authorized_keys"
 chown -R "$user" "$home_dir/.ssh" "$work_root"
+env | sed -n 's/^CRABBOX_CACHE_VOLUME_PATH_[0-9][0-9]*=//p' | while IFS= read -r cache_path; do
+  [ -n "$cache_path" ] || continue
+  mkdir -p "$cache_path"
+  chown -R "$user" "$cache_path" 2>/dev/null || true
+done
 if command -v sudo >/dev/null 2>&1; then
   printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$user" > /etc/sudoers.d/crabbox
   chmod 440 /etc/sudoers.d/crabbox

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -1,0 +1,653 @@
+package applecontainer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type backend struct {
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
+}
+
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
+	applyDefaults(&cfg)
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func isAppleContainerProvider(name string) bool {
+	switch name {
+	case providerName, "apple", "applecontainer":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyDefaults(cfg *core.Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = core.TargetLinux
+	}
+	if cfg.TargetOS == core.TargetLinux {
+		cfg.WindowsMode = ""
+	}
+	cfg.SSHFallbackPorts = []string{}
+	if cfg.AppleContainer.CLIPath == "" {
+		cfg.AppleContainer.CLIPath = "container"
+	}
+	if cfg.AppleContainer.Image == "" {
+		cfg.AppleContainer.Image = "debian:bookworm"
+	}
+	if cfg.AppleContainer.User == "" {
+		cfg.AppleContainer.User = "crabbox"
+	}
+	if cfg.AppleContainer.WorkRoot == "" {
+		if !isDefaultWorkRoot(cfg.WorkRoot) {
+			cfg.AppleContainer.WorkRoot = cfg.WorkRoot
+		} else {
+			cfg.AppleContainer.WorkRoot = "/work/crabbox"
+		}
+	}
+	cfg.SSHUser = cfg.AppleContainer.User
+	cfg.SSHPort = sshPort
+	cfg.WorkRoot = cfg.AppleContainer.WorkRoot
+	cfg.ServerType = cfg.AppleContainer.Image
+}
+
+func isDefaultWorkRoot(value string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || value == "/work/crabbox"
+}
+
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
+
+func (b *backend) configForRun() core.Config {
+	cfg := b.cfg
+	applyDefaults(&cfg)
+	return cfg
+}
+
+// container runs the Apple container CLI with the configured binary path.
+func (b *backend) container(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
+	cfg := b.configForRun()
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
+		Name:   cfg.AppleContainer.CLIPath,
+		Args:   args,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	cfg := b.configForRun()
+	if err := requireMacOS(); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(containers))
+	for _, c := range containers {
+		servers = append(servers, b.serverFromContainer(c, cfg))
+	}
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	cleanupKey := true
+	defer func() {
+		if cleanupKey {
+			core.RemoveStoredTestboxKey(leaseID)
+		}
+	}()
+	cfg.SSHKey = keyPath
+	name := core.LeaseProviderName(leaseID, slug)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s keep=%v\n", providerName, leaseID, slug, cfg.AppleContainer.Image, req.Keep)
+	containerID, err := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	c, err := b.inspectContainer(ctx, containerID)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
+	lease, err := b.prepareLease(ctx, cfg, c, leaseID, slug, true)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, "", cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			_ = b.removeContainer(context.Background(), containerID)
+		}
+		return core.LeaseTarget{}, err
+	}
+	cleanupKey = false
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, c.id())
+	return lease, nil
+}
+
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	cfg := b.configForRun()
+	c, leaseID, slug, err := b.resolveContainer(ctx, req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: b.serverFromContainer(c, cfg), LeaseID: leaseID}, nil
+	}
+	lease, err := b.prepareLease(ctx, cfg, c, leaseID, slug, false)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" {
+		if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, "", cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
+	cfg := b.configForRun()
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	views := make([]core.LeaseView, 0, len(containers))
+	for _, c := range containers {
+		views = append(views, b.serverFromContainer(c, cfg))
+	}
+	return views, nil
+}
+
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	cfg := b.configForRun()
+	if err := requireMacOS(); err != nil {
+		return core.DoctorResult{}, err
+	}
+	// `container system status` reports whether the background API service is
+	// running. We use it as the readiness probe before listing.
+	statusResult, statusErr := b.container(ctx, []string{"system", "status"}, nil, nil)
+	if statusErr != nil {
+		return core.DoctorResult{}, exit(2, "%s system status failed (is the container CLI installed and started with `container system start`?): %s", providerName, commandDetail(statusResult, statusErr))
+	}
+	// The lease path shells out to `container run` with detached mode, `--user`,
+	// and `--label`. Probe that surface here so doctor fails fast on a CLI whose
+	// service/list API exists but whose `run` subcommand is absent or
+	// incompatible, instead of reporting ready and then failing on every
+	// warmup/run.
+	if err := b.checkRunSurface(ctx); err != nil {
+		return core.DoctorResult{}, err
+	}
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	msg := fmt.Sprintf("cli=ready run=ready control_plane=local system=ready inventory=ready mutation=false leases=%d image=%s", len(containers), cfg.AppleContainer.Image)
+	return core.DoctorResult{Provider: providerName, Message: msg}, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	lease := req.Lease
+	id := strings.TrimSpace(req.Lease.Server.CloudID)
+	if id == "" {
+		c, leaseID, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
+		if err != nil {
+			return err
+		}
+		id = c.id()
+		if lease.LeaseID == "" {
+			lease.LeaseID = leaseID
+		}
+	}
+	if id == "" {
+		return exit(2, "provider=%s release requires a container id", providerName)
+	}
+	if err := b.removeContainer(ctx, id); err != nil {
+		return err
+	}
+	core.RemoveLeaseClaim(lease.LeaseID)
+	core.RemoveStoredTestboxKey(lease.LeaseID)
+	return nil
+}
+
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("released lease=%s container=%s", lease.LeaseID, blank(lease.Server.CloudID, lease.Server.Labels["container_id"]))
+}
+
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	cfg := b.configForRun()
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return err
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return err
+	}
+	claimsByLease := map[string]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider == providerName {
+			claimsByLease[claim.LeaseID] = claim
+		}
+	}
+	liveLeases := map[string]struct{}{}
+	now := time.Now().UTC()
+	removed := 0
+	for _, c := range containers {
+		server := b.serverFromContainer(c, cfg)
+		leaseID := strings.TrimSpace(server.Labels["lease"])
+		if leaseID != "" {
+			liveLeases[leaseID] = struct{}{}
+		}
+		claim, hasClaim := claimsByLease[leaseID]
+		shouldDelete, reason := shouldCleanup(server, claim, hasClaim, now)
+		if !shouldDelete {
+			fmt.Fprintf(b.rt.Stderr, "skip container id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+		if err := b.removeContainer(ctx, c.id()); err != nil {
+			return err
+		}
+		if leaseID != "" {
+			core.RemoveLeaseClaim(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
+		}
+		removed++
+	}
+	claimsRemoved := 0
+	for leaseID := range claimsByLease {
+		if leaseID == "" {
+			continue
+		}
+		if _, ok := liveLeases[leaseID]; ok {
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing container\n", leaseID)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s reason=missing container\n", leaseID)
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
+		claimsRemoved++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(containers))
+	}
+	return nil
+}
+
+func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	original := server.Labels
+	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	for _, key := range []string{"container_id", "image", "ssh_user", "ssh_port", "work_root"} {
+		if value := strings.TrimSpace(original[key]); value != "" {
+			server.Labels[key] = value
+		}
+	}
+	return server, nil
+}
+
+func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, error) {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	labels["image"] = cfg.AppleContainer.Image
+	labels["ssh_user"] = cfg.AppleContainer.User
+	labels["ssh_port"] = sshPort
+	labels["work_root"] = cfg.AppleContainer.WorkRoot
+
+	// `container run [<options>] <image> [<arguments>...]`. We detach (-d) and
+	// pass the same Crabbox bootstrap contract used by local-container via
+	// environment variables; command exec and file sync happen over standard
+	// Crabbox SSH afterwards. Apple's runtime assigns a routable IP, so no
+	// host port publishing is required.
+	// Force the bootstrap to run as root: it installs packages, creates the SSH
+	// user, writes /etc/sudoers.d, and starts sshd. An image with a non-root
+	// default USER would otherwise exit before sshd starts and leave `crabbox
+	// run` waiting on port 22 until timeout.
+	args := []string{
+		"run", "-d",
+		"--name", name,
+		"--user", "root",
+		"-e", "CRABBOX_AUTHORIZED_KEY=" + publicKey,
+		"-e", "CRABBOX_SSH_USER=" + cfg.AppleContainer.User,
+		"-e", "CRABBOX_WORK_ROOT=" + cfg.AppleContainer.WorkRoot,
+		"-e", "CRABBOX_SSH_PORT=" + sshPort,
+	}
+	// Labels keep ownership/lease metadata queryable from `container inspect`.
+	for key, value := range labels {
+		args = append(args, "--label", key+"="+value)
+	}
+	if cfg.AppleContainer.CPUs > 0 {
+		args = append(args, "--cpus", strconv.Itoa(cfg.AppleContainer.CPUs))
+	}
+	if memory := strings.TrimSpace(cfg.AppleContainer.Memory); memory != "" {
+		args = append(args, "--memory", memory)
+	}
+	args = append(args, cfg.AppleContainer.ExtraRunArgs...)
+	args = append(args, cfg.AppleContainer.Image, "/bin/sh", "-lc", bootstrapScript)
+
+	result, err := b.container(ctx, args, nil, b.rt.Stderr)
+	if err != nil {
+		return "", commandError("container run", result, err)
+	}
+	id := strings.TrimSpace(result.Stdout)
+	if id == "" {
+		// `container run --name X` uses the supplied name as the id; fall back
+		// to it when the CLI does not echo an id on stdout.
+		id = name
+	}
+	return id, nil
+}
+
+func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
+	result, err := b.container(ctx, []string{"ls", "--all", "--format", "json"}, nil, nil)
+	if err != nil {
+		return nil, commandError("container ls", result, err)
+	}
+	all, err := decodeInspect([]byte(result.Stdout))
+	if err != nil {
+		return nil, exit(2, "parse container ls: %v", err)
+	}
+	out := make([]inspectContainer, 0, len(all))
+	for _, c := range all {
+		labels := c.labels()
+		if labels["crabbox"] == "true" && labels["provider"] == providerName {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (b *backend) inspectContainer(ctx context.Context, id string) (inspectContainer, error) {
+	result, err := b.container(ctx, []string{"inspect", id}, nil, nil)
+	if err != nil {
+		return inspectContainer{}, commandError("container inspect", result, err)
+	}
+	containers, err := decodeInspect([]byte(result.Stdout))
+	if err != nil {
+		return inspectContainer{}, exit(2, "parse container inspect for %s: %v", id, err)
+	}
+	if len(containers) == 0 {
+		return inspectContainer{}, exit(4, "container not found: %s", id)
+	}
+	return containers[0], nil
+}
+
+func (b *backend) resolveContainer(ctx context.Context, identifier string) (inspectContainer, string, string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return inspectContainer{}, "", "", exit(2, "provider=%s requires --id <lease-id-or-slug-or-container>", providerName)
+	}
+	var wantLease, wantSlug string
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
+		return inspectContainer{}, "", "", err
+	} else if ok {
+		wantLease = claim.LeaseID
+		wantSlug = claim.Slug
+	}
+	containers, err := b.listContainers(ctx)
+	if err != nil {
+		return inspectContainer{}, "", "", err
+	}
+	normalized := core.NormalizeLeaseSlug(identifier)
+	for _, c := range containers {
+		labels := c.labels()
+		leaseID := labels["lease"]
+		slug := labels["slug"]
+		if wantLease != "" && leaseID == wantLease {
+			return c, leaseID, slug, nil
+		}
+		if wantSlug != "" && core.NormalizeLeaseSlug(slug) == core.NormalizeLeaseSlug(wantSlug) {
+			return c, leaseID, slug, nil
+		}
+		if wantLease != "" || wantSlug != "" {
+			continue
+		}
+		if c.id() == identifier || leaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(slug) == normalized) {
+			return c, leaseID, slug, nil
+		}
+	}
+	return inspectContainer{}, "", "", exit(4, "apple-container lease not found: %s", identifier)
+}
+
+func (b *backend) removeContainer(ctx context.Context, id string) error {
+	// `container delete --force <id>` removes a running or stopped container.
+	result, err := b.container(ctx, []string{"delete", "--force", id}, nil, b.rt.Stderr)
+	if err != nil {
+		return commandError("container delete", result, err)
+	}
+	return nil
+}
+
+func (b *backend) prepareLease(ctx context.Context, cfg core.Config, c inspectContainer, leaseID, slug string, wait bool) (core.LeaseTarget, error) {
+	server := b.serverFromContainer(c, cfg)
+	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
+		cfg.AppleContainer.User = user
+		cfg.SSHUser = user
+	}
+	if root := strings.TrimSpace(server.Labels["work_root"]); root != "" {
+		cfg.AppleContainer.WorkRoot = root
+		cfg.WorkRoot = root
+	}
+	host := c.ip()
+	if host == "" {
+		return core.LeaseTarget{}, exit(5, "apple-container %s has no network address yet", c.id())
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			cfg.SSHKey = keyPath
+		}
+	}
+	target := core.SSHTargetFromConfig(cfg, host)
+	target.Port = sshPort
+	target.ReadyCheck = readyCheck(cfg)
+	if wait {
+		if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "apple container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		server.Status = "ready"
+		server.Labels["state"] = "ready"
+	}
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.Server {
+	labels := map[string]string{}
+	for key, value := range c.labels() {
+		labels[key] = value
+	}
+	labels["container_id"] = c.id()
+	if labels["provider"] == "" {
+		labels["provider"] = providerName
+	}
+	if labels["server_type"] == "" {
+		labels["server_type"] = firstNonBlank(c.image(), cfg.AppleContainer.Image)
+	}
+	if labels["state"] == "" {
+		labels["state"] = c.status()
+	}
+	labels["ssh_port"] = sshPort
+	status := c.status()
+	if c.running() && labels["state"] == "ready" {
+		status = "ready"
+	}
+	server := core.Server{
+		CloudID:  c.id(),
+		Provider: providerName,
+		Name:     c.id(),
+		Status:   status,
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = c.ip()
+	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.AppleContainer.Image)
+	return server
+}
+
+// checkRunSurface verifies the `container run` subcommand exists and advertises
+// the options the lease path depends on (`--user`, `--label`). It uses
+// `run --help`, which has no side effects, so doctor can detect an incompatible
+// CLI before any lease is attempted.
+func (b *backend) checkRunSurface(ctx context.Context) error {
+	result, err := b.container(ctx, []string{"run", "--help"}, nil, nil)
+	if err != nil {
+		return exit(2, "%s `container run` subcommand unavailable (incompatible container CLI?): %s", providerName, commandDetail(result, err))
+	}
+	help := result.Stdout + result.Stderr
+	for _, opt := range []string{"--user", "--label"} {
+		if !strings.Contains(help, opt) {
+			return exit(2, "%s `container run` is missing the required %s option; upgrade Apple's container CLI", providerName, opt)
+		}
+	}
+	return nil
+}
+
+func requireMacOS() error {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		return exit(2, "provider=%s requires macOS on Apple silicon; current host is %s/%s", providerName, runtime.GOOS, runtime.GOARCH)
+	}
+	return nil
+}
+
+func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	labels := server.Labels
+	if labels == nil {
+		return false, "missing labels"
+	}
+	if strings.EqualFold(labels["keep"], "true") {
+		return false, "keep=true"
+	}
+	if !strings.EqualFold(server.Status, "running") && server.Status != "ready" {
+		return true, "container state=" + blank(server.Status, "unknown")
+	}
+	if hasClaim {
+		lastUsed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
+		if err != nil || lastUsed.IsZero() {
+			return false, "claim active"
+		}
+		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+		if idle <= 0 {
+			return false, "claim active"
+		}
+		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+			return true, "claim expired"
+		}
+		return false, "claim active"
+	}
+	return false, "missing claim"
+}
+
+func readyCheck(cfg core.Config) string {
+	checks := []string{
+		"git --version >/tmp/crabbox-ready.log 2>&1",
+		"rsync --version >>/tmp/crabbox-ready.log 2>&1",
+		"python3 --version >>/tmp/crabbox-ready.log 2>&1",
+		"test -d " + shellQuote(cfg.AppleContainer.WorkRoot),
+	}
+	return strings.Join(checks, " && ")
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func commandError(action string, result core.LocalCommandResult, err error) error {
+	code := result.ExitCode
+	if code == 0 {
+		code = 1
+	}
+	return exit(code, "%s failed: %s", action, commandDetail(result, err))
+}
+
+func commandDetail(result core.LocalCommandResult, err error) string {
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		return fmt.Sprintf("%v: %s", err, detail)
+	}
+	return fmt.Sprintf("%v", err)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// bootstrapScript provisions sshd, the Crabbox SSH user and work root inside a
+// Debian/Ubuntu-compatible image. It mirrors the local-container contract but
+// is intentionally provider-owned so Apple-specific assumptions stay isolated.
+const bootstrapScript = `
+set -eu
+export DEBIAN_FRONTEND=noninteractive
+need_install=0
+for tool in /usr/sbin/sshd git rsync curl sudo python3; do
+  command -v "$tool" >/dev/null 2>&1 || need_install=1
+done
+if [ "$need_install" = "1" ] && command -v apt-get >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y --no-install-recommends openssh-server ca-certificates git rsync curl sudo python3
+fi
+if ! command -v /usr/sbin/sshd >/dev/null 2>&1; then
+  echo "missing /usr/sbin/sshd; use a Debian/Ubuntu-compatible image or a prebuilt Crabbox runner image" >&2
+  exit 127
+fi
+user="${CRABBOX_SSH_USER:-crabbox}"
+work_root="${CRABBOX_WORK_ROOT:-/work/crabbox}"
+ssh_port="${CRABBOX_SSH_PORT:-22}"
+if ! id "$user" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash "$user"
+fi
+home_dir="$(getent passwd "$user" | cut -d: -f6)"
+if [ -z "$home_dir" ]; then
+  home_dir="/home/$user"
+fi
+mkdir -p /run/sshd "$work_root" "$home_dir/.ssh"
+printf '%s\n' "$CRABBOX_AUTHORIZED_KEY" > "$home_dir/.ssh/authorized_keys"
+chmod 700 "$home_dir/.ssh"
+chmod 600 "$home_dir/.ssh/authorized_keys"
+chown -R "$user" "$home_dir/.ssh" "$work_root"
+if command -v sudo >/dev/null 2>&1; then
+  printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$user" > /etc/sudoers.d/crabbox
+  chmod 440 /etc/sudoers.d/crabbox
+fi
+sed -i 's/^#\?Port .*/Port '"$ssh_port"'/' /etc/ssh/sshd_config 2>/dev/null || true
+exec /usr/sbin/sshd -D -e
+`

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -15,12 +16,18 @@ import (
 type recordingRunner struct {
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
+	sequences map[string][]core.LocalCommandResult
 	errors    map[string]error
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	key := commandKey(req.Args)
+	if seq := r.sequences[key]; len(seq) > 0 {
+		result := seq[0]
+		r.sequences[key] = seq[1:]
+		return result, nil
+	}
 	if err, ok := r.errors[key]; ok {
 		return r.responses[key], err
 	}
@@ -343,6 +350,44 @@ func TestPrepareLeaseRequiresNetworkAddress(t *testing.T) {
 	}
 }
 
+func TestWaitForNetworkAddressPollsInspect(t *testing.T) {
+	runner := &recordingRunner{
+		sequences: map[string][]core.LocalCommandResult{
+			commandKey([]string{"inspect", "crabbox-wait"}): {
+				{Stdout: `[{"status":"running","configuration":{"id":"crabbox-wait","labels":{"crabbox":"true","provider":"apple-container"}}}]`},
+				{Stdout: sampleInspectJSON("crabbox-wait", "wait", "cbx_wait")},
+			},
+		},
+	}
+	b := testBackend(runner)
+	start := inspectContainer{
+		Status:        "running",
+		Configuration: inspectConfiguration{ID: "crabbox-wait", Labels: map[string]string{"crabbox": "true", "provider": providerName}},
+	}
+	c, err := b.waitForNetworkAddress(context.Background(), "crabbox-wait", start, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.ip(); got != "192.168.64.7" {
+		t.Fatalf("ip=%q want 192.168.64.7", got)
+	}
+	args := recordedArgsForCommand(t, runner, "inspect")
+	if !strings.Contains(args, "inspect\ncrabbox-wait") {
+		t.Fatalf("inspect args=%q", args)
+	}
+}
+
+func TestWaitForNetworkAddressStopsOnExitedContainer(t *testing.T) {
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	start := inspectContainer{
+		Status:        "stopped",
+		Configuration: inspectConfiguration{ID: "crabbox-exited", Labels: map[string]string{"crabbox": "true", "provider": providerName}},
+	}
+	if _, err := b.waitForNetworkAddress(context.Background(), "crabbox-exited", start, time.Minute); err == nil || !strings.Contains(err.Error(), "stopped before a network address") {
+		t.Fatalf("error=%v, want stopped before network address", err)
+	}
+}
+
 func TestRemoveContainerUsesDeleteForce(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -470,6 +515,10 @@ func TestInspectIPStripsCIDR(t *testing.T) {
 	bare := inspectContainer{Networks: []inspectNetwork{{Address: "10.0.0.5"}}}
 	if got := bare.ip(); got != "10.0.0.5" {
 		t.Fatalf("ip=%q want 10.0.0.5", got)
+	}
+	current := inspectContainer{Networks: []inspectNetwork{{IPv4Address: "192.168.64.4/24"}}}
+	if got := current.ip(); got != "192.168.64.4" {
+		t.Fatalf("ip=%q want 192.168.64.4", got)
 	}
 }
 

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -1,0 +1,407 @@
+package applecontainer
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls     []core.LocalCommandRequest
+	responses map[string]core.LocalCommandResult
+	errors    map[string]error
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	key := commandKey(req.Args)
+	if err, ok := r.errors[key]; ok {
+		return r.responses[key], err
+	}
+	if result, ok := r.responses[key]; ok {
+		return result, nil
+	}
+	if len(req.Args) > 0 {
+		if result, ok := r.responses[req.Args[0]]; ok {
+			return result, nil
+		}
+	}
+	return core.LocalCommandResult{}, nil
+}
+
+func commandKey(args []string) string {
+	return strings.Join(args, "\x00")
+}
+
+func recordedArgsForCommand(t *testing.T, runner *recordingRunner, command string) string {
+	t.Helper()
+	for i := len(runner.calls) - 1; i >= 0; i-- {
+		if len(runner.calls[i].Args) > 0 && runner.calls[i].Args[0] == command {
+			return strings.Join(runner.calls[i].Args, "\n")
+		}
+	}
+	t.Fatalf("%s command was not recorded: %#v", command, runner.calls)
+	return ""
+}
+
+func testBackend(runner *recordingRunner) *backend {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{
+		CLIPath:  "container",
+		Image:    "debian:bookworm",
+		User:     "runner",
+		WorkRoot: "/work/crabbox",
+		CPUs:     4,
+		Memory:   "8g",
+	}
+	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+}
+
+func sampleInspectJSON(id, slug, lease string) string {
+	return `[{
+		"status":"running",
+		"configuration":{
+			"id":"` + id + `",
+			"image":{"reference":"debian:bookworm"},
+			"hostname":"` + id + `",
+			"labels":{"crabbox":"true","provider":"apple-container","lease":"` + lease + `","slug":"` + slug + `","state":"ready","ssh_user":"runner","work_root":"/work/crabbox","image":"debian:bookworm"}
+		},
+		"networks":[{"address":"192.168.64.7/24","gateway":"192.168.64.1","hostname":"` + id + `.test.","network":"default"}]
+	}]`
+}
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %s", p.Name(), providerName)
+	}
+	for _, alias := range []string{"apple-container", "apple", "applecontainer"} {
+		got, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if got.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", alias, got.Name())
+		}
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindSSHLease {
+		t.Fatalf("kind=%v want ssh-lease", spec.Kind)
+	}
+	if spec.Family != "container" {
+		t.Fatalf("family=%q want container", spec.Family)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want linux", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("features=%#v want ssh, crabbox sync, cleanup", spec.Features)
+	}
+}
+
+func TestAliasDoesNotCollideWithLocalContainer(t *testing.T) {
+	// The bare "container" alias belongs to local-container; apple-container
+	// must not steal it. Cross-provider registry collisions are asserted in
+	// internal/providers/all; here we guard the provider's own alias set.
+	for _, alias := range (Provider{}).Aliases() {
+		if alias == "container" {
+			t.Fatalf("apple-container must not declare the 'container' alias")
+		}
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer = core.AppleContainerConfig{}
+	applyDefaults(&cfg)
+	if cfg.AppleContainer.CLIPath != "container" || cfg.AppleContainer.Image != "debian:bookworm" || cfg.AppleContainer.User != "crabbox" || cfg.AppleContainer.WorkRoot != "/work/crabbox" {
+		t.Fatalf("defaults not applied: %#v", cfg.AppleContainer)
+	}
+	if cfg.SSHUser != "crabbox" || cfg.SSHPort != sshPort || cfg.WorkRoot != "/work/crabbox" {
+		t.Fatalf("derived ssh fields wrong: user=%s port=%s work=%s", cfg.SSHUser, cfg.SSHPort, cfg.WorkRoot)
+	}
+}
+
+func TestConfigForRunHonorsGlobalWorkRoot(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.WorkRoot = "/tmp/cbx"
+	cfg.AppleContainer.WorkRoot = ""
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	got := b.configForRun()
+	if got.WorkRoot != "/tmp/cbx" || got.AppleContainer.WorkRoot != "/tmp/cbx" {
+		t.Fatalf("work root=%q apple=%q want /tmp/cbx", got.WorkRoot, got.AppleContainer.WorkRoot)
+	}
+}
+
+func TestCreateContainerBuildsRunArgs(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.AppleContainer.ExtraRunArgs = []string{"--dns", "1.1.1.1"}
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "crabbox-blue\n"}
+
+	id, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "crabbox-blue" {
+		t.Fatalf("id=%q", id)
+	}
+	call := runner.calls[0]
+	if call.Name != "container" {
+		t.Fatalf("binary=%q want container", call.Name)
+	}
+	args := strings.Join(call.Args, "\n")
+	for _, want := range []string{
+		"run\n-d",
+		"--name\ncrabbox-blue",
+		"--user\nroot",
+		"-e\nCRABBOX_AUTHORIZED_KEY=ssh-ed25519 AAAA test",
+		"-e\nCRABBOX_SSH_USER=runner",
+		"-e\nCRABBOX_WORK_ROOT=/work/crabbox",
+		"-e\nCRABBOX_SSH_PORT=22",
+		"--label\nprovider=apple-container",
+		"--label\nlease=cbx_123",
+		"--label\nslug=blue-lobster",
+		"--label\nssh_user=runner",
+		"--cpus\n4",
+		"--memory\n8g",
+		"--dns\n1.1.1.1",
+		"debian:bookworm",
+		"/bin/sh",
+		"-lc",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("run args missing %q:\n%s", want, args)
+		}
+	}
+	// No host port publishing: Apple containers are reachable directly.
+	if strings.Contains(args, "-p\n") {
+		t.Fatalf("apple-container should not publish host ports:\n%s", args)
+	}
+}
+
+func TestCreateContainerNoSecretsAsCLIArgs(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "crabbox-blue\n"}
+	if _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue", "PUBKEY", true); err != nil {
+		t.Fatal(err)
+	}
+	// The only key material passed is the public key (safe) via env. Ensure no
+	// private-looking material leaks into args.
+	args := strings.Join(runner.calls[0].Args, "\n")
+	if strings.Contains(strings.ToUpper(args), "PRIVATE") {
+		t.Fatalf("unexpected secret-like content in args:\n%s", args)
+	}
+}
+
+func TestListContainersFiltersByLabel(t *testing.T) {
+	lsJSON := `[
+		` + strings.TrimPrefix(strings.TrimSuffix(sampleInspectJSON("crabbox-blue", "blue-lobster", "cbx_123"), "]"), "[") + `,
+		{"status":"running","configuration":{"id":"someone-elses","image":{"reference":"alpine"},"labels":{"app":"web"}},"networks":[{"address":"192.168.64.9/24"}]}
+	]`
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: lsJSON},
+		},
+	}
+	b := testBackend(runner)
+	views, err := b.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("views=%d want 1 (crabbox-owned only)", len(views))
+	}
+	v := views[0]
+	if v.Provider != providerName || v.CloudID != "crabbox-blue" || v.Labels["ssh_port"] != "22" || v.PublicNet.IPv4.IP != "192.168.64.7" {
+		t.Fatalf("unexpected view: %#v", v)
+	}
+}
+
+func TestResolveAndSSHTarget(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: sampleInspectJSON("crabbox-blue", "blue-lobster", "cbx_123")},
+		},
+	}
+	b := testBackend(runner)
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "blue-lobster"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_123" {
+		t.Fatalf("lease id=%q", lease.LeaseID)
+	}
+	if lease.SSH.Host != "192.168.64.7" || lease.SSH.Port != "22" || lease.SSH.User != "runner" || lease.SSH.TargetOS != core.TargetLinux {
+		t.Fatalf("unexpected ssh target: %#v", lease.SSH)
+	}
+	if !strings.Contains(lease.SSH.ReadyCheck, "rsync --version") || !strings.Contains(lease.SSH.ReadyCheck, "test -d '/work/crabbox'") {
+		t.Fatalf("ready check missing expectations: %q", lease.SSH.ReadyCheck)
+	}
+}
+
+func TestPrepareLeaseRequiresNetworkAddress(t *testing.T) {
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	cfg := b.configForRun()
+	c := inspectContainer{
+		Status:        "running",
+		Configuration: inspectConfiguration{ID: "crabbox-noip", Labels: map[string]string{"crabbox": "true", "provider": providerName, "ssh_user": "runner", "work_root": "/work/crabbox"}},
+	}
+	if _, err := b.prepareLease(context.Background(), cfg, c, "cbx_x", "x", false); err == nil {
+		t.Fatal("prepareLease accepted a container without a network address")
+	}
+}
+
+func TestRemoveContainerUsesDeleteForce(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"delete", "--force", "crabbox-blue"}): {},
+		},
+	}
+	b := testBackend(runner)
+	if err := b.removeContainer(context.Background(), "crabbox-blue"); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "delete")
+	if !strings.Contains(args, "delete\n--force\ncrabbox-blue") {
+		t.Fatalf("delete args=%q", args)
+	}
+}
+
+func TestDoctorReportsMissingCLI(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("doctor CLI probe only exercised on macOS/Apple silicon")
+	}
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"system", "status"}): {Stderr: "command not found"},
+		},
+		errors: map[string]error{
+			commandKey([]string{"system", "status"}): errFake("exit status 127"),
+		},
+	}
+	b := testBackend(runner)
+	if _, err := b.Doctor(context.Background(), core.DoctorRequest{}); err == nil {
+		t.Fatal("doctor passed despite failing system status")
+	}
+}
+
+func TestDoctorReadyWhenSystemRunning(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("doctor only reports ready on macOS/Apple silicon")
+	}
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"system", "status"}):                {Stdout: "running\n"},
+			commandKey([]string{"run", "--help"}):                   {Stdout: "OPTIONS:\n  -u, --user <user>\n  --label <label>\n"},
+			commandKey([]string{"ls", "--all", "--format", "json"}): {Stdout: "[]"},
+		},
+	}
+	b := testBackend(runner)
+	res, err := b.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Provider != providerName || !strings.Contains(res.Message, "system=ready") || !strings.Contains(res.Message, "run=ready") {
+		t.Fatalf("doctor result=%#v", res)
+	}
+}
+
+func TestDoctorRejectsIncompatibleRunCLI(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("doctor run-surface probe only exercised on macOS/Apple silicon")
+	}
+	// `system status` succeeds but the `run` subcommand is missing/incompatible.
+	t.Run("run subcommand missing", func(t *testing.T) {
+		runner := &recordingRunner{
+			responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"system", "status"}): {Stdout: "running\n"},
+			},
+			errors: map[string]error{
+				commandKey([]string{"run", "--help"}): errFake("unknown subcommand \"run\""),
+			},
+		}
+		if _, err := testBackend(runner).Doctor(context.Background(), core.DoctorRequest{}); err == nil {
+			t.Fatal("doctor passed despite missing run subcommand")
+		}
+	})
+	// `run --help` works but does not advertise the options the lease path needs.
+	t.Run("run missing required options", func(t *testing.T) {
+		runner := &recordingRunner{
+			responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"system", "status"}): {Stdout: "running\n"},
+				commandKey([]string{"run", "--help"}):    {Stdout: "OPTIONS:\n  --memory <size>\n"},
+			},
+		}
+		if _, err := testBackend(runner).Doctor(context.Background(), core.DoctorRequest{}); err == nil {
+			t.Fatal("doctor passed despite run lacking --user/--label")
+		}
+	})
+}
+
+func TestRequireMacOSGate(t *testing.T) {
+	err := requireMacOS()
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		if err != nil {
+			t.Fatalf("requireMacOS errored on darwin/arm64: %v", err)
+		}
+		return
+	}
+	// Every other host, including darwin/amd64, must be rejected.
+	if err == nil {
+		t.Fatal("requireMacOS should reject hosts that are not darwin/arm64")
+	}
+	if !strings.Contains(err.Error(), "Apple silicon") {
+		t.Fatalf("unexpected gate error: %v", err)
+	}
+}
+
+func TestConfigureRejectsTailscaleAndNonLinux(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Tailscale.Enabled = true
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted tailscale")
+	}
+	cfg = core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted non-linux target")
+	}
+}
+
+func TestInspectIPStripsCIDR(t *testing.T) {
+	c := inspectContainer{Networks: []inspectNetwork{{Address: "192.168.64.42/24"}}}
+	if got := c.ip(); got != "192.168.64.42" {
+		t.Fatalf("ip=%q want 192.168.64.42", got)
+	}
+	bare := inspectContainer{Networks: []inspectNetwork{{Address: "10.0.0.5"}}}
+	if got := bare.ip(); got != "10.0.0.5" {
+		t.Fatalf("ip=%q want 10.0.0.5", got)
+	}
+}
+
+func TestDecodeInspectToleratesStringImage(t *testing.T) {
+	containers, err := decodeInspect([]byte(`[{"status":"running","configuration":{"id":"x","image":"alpine:3"},"networks":[]}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(containers) != 1 || containers[0].image() != "alpine:3" {
+		t.Fatalf("decoded=%#v", containers)
+	}
+}
+
+type errFake string
+
+func (e errFake) Error() string { return string(e) }

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -3,7 +3,9 @@ package applecontainer
 import (
 	"context"
 	"io"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -99,8 +101,8 @@ func TestProviderSpecAndAliases(t *testing.T) {
 	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
 		t.Fatalf("targets=%#v want linux", spec.Targets)
 	}
-	if !spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) {
-		t.Fatalf("features=%#v want ssh, crabbox sync, cleanup", spec.Features)
+	if !spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) || !spec.Features.Has(core.FeatureCacheVolume) {
+		t.Fatalf("features=%#v want ssh, crabbox sync, cleanup, cache-volume", spec.Features)
 	}
 }
 
@@ -204,6 +206,56 @@ func TestCreateContainerNoSecretsAsCLIArgs(t *testing.T) {
 	}
 }
 
+func TestCreateContainerMountsCacheVolumes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.Cache.Volumes = []core.CacheVolumeConfig{
+		{Key: "my-app/linux node24 lock", Path: "/var/cache/crabbox/pnpm"},
+		{Key: "npm-cache", Path: "/var/cache/crabbox/npm"},
+	}
+	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "crabbox-blue\n"}
+
+	if _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "run")
+	root, err := appleContainerCacheRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, volume := range cfg.Cache.Volumes {
+		want := "--volume\n" + filepath.Join(root, appleContainerCacheVolumeName(volume.Key)) + ":" + volume.Path
+		if !strings.Contains(args, want) {
+			t.Fatalf("cache volume mount missing %q:\n%s", want, args)
+		}
+	}
+	for i, volume := range cfg.Cache.Volumes {
+		want := "-e\nCRABBOX_CACHE_VOLUME_PATH_" + strconv.Itoa(i) + "=" + volume.Path
+		if !strings.Contains(args, want) {
+			t.Fatalf("cache volume path env missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestAppleContainerCacheVolumeNameIsStableAndFilesystemSafe(t *testing.T) {
+	got := appleContainerCacheVolumeName("My App/linux node24 lock")
+	again := appleContainerCacheVolumeName("My App/linux node24 lock")
+	if got != again {
+		t.Fatalf("cache volume name unstable: %q then %q", got, again)
+	}
+	if !strings.HasPrefix(got, "crabbox-cache-my-app-linux-node24-lock-") {
+		t.Fatalf("cache volume name=%q, want sanitized prefix", got)
+	}
+	if strings.ContainsAny(got, " /:") {
+		t.Fatalf("cache volume name contains unsafe characters: %q", got)
+	}
+}
+
 func TestListContainersFiltersByLabel(t *testing.T) {
 	lsJSON := `[
 		` + strings.TrimPrefix(strings.TrimSuffix(sampleInspectJSON("crabbox-blue", "blue-lobster", "cbx_123"), "]"), "[") + `,
@@ -215,14 +267,14 @@ func TestListContainersFiltersByLabel(t *testing.T) {
 		},
 	}
 	b := testBackend(runner)
-	views, err := b.List(context.Background(), core.ListRequest{})
+	containers, err := b.listContainers(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(views) != 1 {
-		t.Fatalf("views=%d want 1 (crabbox-owned only)", len(views))
+	if len(containers) != 1 {
+		t.Fatalf("containers=%d want 1 (crabbox-owned only)", len(containers))
 	}
-	v := views[0]
+	v := b.serverFromContainer(containers[0], b.configForRun())
 	if v.Provider != providerName || v.CloudID != "crabbox-blue" || v.Labels["ssh_port"] != "22" || v.PublicNet.IPv4.IP != "192.168.64.7" {
 		t.Fatalf("unexpected view: %#v", v)
 	}
@@ -235,7 +287,11 @@ func TestResolveAndSSHTarget(t *testing.T) {
 		},
 	}
 	b := testBackend(runner)
-	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "blue-lobster"})
+	c, leaseID, slug, err := b.resolveContainer(context.Background(), "blue-lobster")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.prepareLease(context.Background(), b.configForRun(), c, leaseID, slug, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,6 +303,31 @@ func TestResolveAndSSHTarget(t *testing.T) {
 	}
 	if !strings.Contains(lease.SSH.ReadyCheck, "rsync --version") || !strings.Contains(lease.SSH.ReadyCheck, "test -d '/work/crabbox'") {
 		t.Fatalf("ready check missing expectations: %q", lease.SSH.ReadyCheck)
+	}
+}
+
+func TestRuntimeMethodsRejectUnsupportedHostBeforeContainerCLI(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("unsupported-host gate only applies off macOS/Apple silicon")
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	if _, err := b.List(context.Background(), core.ListRequest{}); err == nil || !strings.Contains(err.Error(), "Apple silicon") {
+		t.Fatalf("List error=%v, want Apple silicon gate", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("unsupported host should not invoke container CLI: %#v", runner.calls)
+	}
+}
+
+func TestBootstrapScriptToleratesCacheVolumeChownFailures(t *testing.T) {
+	for _, want := range []string{
+		`CRABBOX_CACHE_VOLUME_PATH_`,
+		`chown -R "$user" "$cache_path" 2>/dev/null || true`,
+	} {
+		if !strings.Contains(bootstrapScript, want) {
+			t.Fatalf("bootstrap script missing %q", want)
+		}
 	}
 }
 

--- a/internal/providers/applecontainer/client.go
+++ b/internal/providers/applecontainer/client.go
@@ -8,8 +8,9 @@ import (
 
 // inspectContainer mirrors the JSON returned by `container inspect <id>` and
 // `container ls --format json`. Apple's runtime documents the network shape
-// (a `networks` array carrying `address` in CIDR form) and a `configuration`
-// object that holds the container id/image. The label location is not fully
+// (a `networks` array carrying an IPv4 address in CIDR form) and a
+// `configuration` object that holds the container id/image. The label location
+// is not fully
 // documented; we look for labels in the most CLI-consistent places
 // (`configuration.labels` and a top-level `labels`) and tolerate either.
 //
@@ -57,10 +58,12 @@ func (i *inspectImage) UnmarshalJSON(data []byte) error {
 }
 
 type inspectNetwork struct {
-	Address  string `json:"address"`
-	Gateway  string `json:"gateway,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Network  string `json:"network,omitempty"`
+	Address     string `json:"address"`
+	IPv4Address string `json:"ipv4Address,omitempty"`
+	Gateway     string `json:"gateway,omitempty"`
+	IPv4Gateway string `json:"ipv4Gateway,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Network     string `json:"network,omitempty"`
 }
 
 func decodeInspect(data []byte) ([]inspectContainer, error) {
@@ -109,7 +112,7 @@ func (c inspectContainer) status() string {
 // ip returns the container's first network address without its CIDR suffix.
 func (c inspectContainer) ip() string {
 	for _, n := range c.Networks {
-		addr := strings.TrimSpace(n.Address)
+		addr := firstNonBlank(n.Address, n.IPv4Address)
 		if addr == "" {
 			continue
 		}

--- a/internal/providers/applecontainer/client.go
+++ b/internal/providers/applecontainer/client.go
@@ -1,0 +1,133 @@
+package applecontainer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// inspectContainer mirrors the JSON returned by `container inspect <id>` and
+// `container ls --format json`. Apple's runtime documents the network shape
+// (a `networks` array carrying `address` in CIDR form) and a `configuration`
+// object that holds the container id/image. The label location is not fully
+// documented; we look for labels in the most CLI-consistent places
+// (`configuration.labels` and a top-level `labels`) and tolerate either.
+//
+// Reference: https://github.com/apple/container/blob/main/docs/how-to.md
+type inspectContainer struct {
+	Status        string               `json:"status"`
+	Configuration inspectConfiguration `json:"configuration"`
+	Networks      []inspectNetwork     `json:"networks"`
+	Labels        map[string]string    `json:"labels,omitempty"`
+}
+
+type inspectConfiguration struct {
+	ID       string            `json:"id"`
+	Image    inspectImage      `json:"image"`
+	Hostname string            `json:"hostname,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+// inspectImage tolerates both an object ({"reference":"..."}) and a bare
+// string image form, since the documented surface does not pin this down.
+type inspectImage struct {
+	Reference string `json:"reference,omitempty"`
+}
+
+func (i *inspectImage) UnmarshalJSON(data []byte) error {
+	data = []byte(strings.TrimSpace(string(data)))
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		i.Reference = s
+		return nil
+	}
+	type alias inspectImage
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*i = inspectImage(a)
+	return nil
+}
+
+type inspectNetwork struct {
+	Address  string `json:"address"`
+	Gateway  string `json:"gateway,omitempty"`
+	Hostname string `json:"hostname,omitempty"`
+	Network  string `json:"network,omitempty"`
+}
+
+func decodeInspect(data []byte) ([]inspectContainer, error) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil, nil
+	}
+	var containers []inspectContainer
+	if err := json.Unmarshal([]byte(trimmed), &containers); err != nil {
+		// `container inspect <id>` may return a single object in some
+		// versions; fall back to a single-element decode.
+		var single inspectContainer
+		if singleErr := json.Unmarshal([]byte(trimmed), &single); singleErr != nil {
+			return nil, fmt.Errorf("decode container inspect: %w", err)
+		}
+		return []inspectContainer{single}, nil
+	}
+	return containers, nil
+}
+
+func (c inspectContainer) id() string {
+	return strings.TrimSpace(c.Configuration.ID)
+}
+
+func (c inspectContainer) labels() map[string]string {
+	out := map[string]string{}
+	for k, v := range c.Configuration.Labels {
+		out[k] = v
+	}
+	for k, v := range c.Labels {
+		if _, ok := out[k]; !ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func (c inspectContainer) image() string {
+	return strings.TrimSpace(c.Configuration.Image.Reference)
+}
+
+func (c inspectContainer) status() string {
+	return strings.ToLower(strings.TrimSpace(c.Status))
+}
+
+// ip returns the container's first network address without its CIDR suffix.
+func (c inspectContainer) ip() string {
+	for _, n := range c.Networks {
+		addr := strings.TrimSpace(n.Address)
+		if addr == "" {
+			continue
+		}
+		if idx := strings.IndexByte(addr, '/'); idx >= 0 {
+			addr = addr[:idx]
+		}
+		if addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
+func (c inspectContainer) running() bool {
+	switch c.status() {
+	case "running", "ready":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/applecontainer/core.go
+++ b/internal/providers/applecontainer/core.go
@@ -1,0 +1,37 @@
+package applecontainer
+
+import (
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Type aliases keep the provider body terse while leaning on the shared core
+// package, mirroring the asciibox/localcontainer providers.
+type Config = core.Config
+type AppleContainerConfig = core.AppleContainerConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type CommandRunner = core.CommandRunner
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type Backend = core.Backend
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+
+const (
+	providerName = "apple-container"
+	targetLinux  = core.TargetLinux
+	// sshPort is the in-guest SSH port. Apple's container runtime gives each
+	// container a routable IP on the host vmnet bridge, so unlike Docker we
+	// connect straight to the container IP on the standard SSH port rather
+	// than to a published host port.
+	sshPort            = "22"
+	workRootMarkerName = ".crabbox-apple-container-work-root"
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}

--- a/internal/providers/applecontainer/flags.go
+++ b/internal/providers/applecontainer/flags.go
@@ -1,0 +1,73 @@
+package applecontainer
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	CLIPath  *string
+	Image    *string
+	User     *string
+	WorkRoot *string
+	CPUs     *int
+	Memory   *string
+	ExtraRun *string
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		CLIPath:  fs.String("apple-container-cli", defaults.AppleContainer.CLIPath, "path to Apple's container CLI"),
+		Image:    fs.String("apple-container-image", defaults.AppleContainer.Image, "container image for apple-container leases"),
+		User:     fs.String("apple-container-user", defaults.AppleContainer.User, "SSH user created inside apple-container leases"),
+		WorkRoot: fs.String("apple-container-work-root", defaults.AppleContainer.WorkRoot, "remote Crabbox work root inside apple-container leases"),
+		CPUs:     fs.Int("apple-container-cpus", defaults.AppleContainer.CPUs, "CPU limit for apple-container leases; 0 leaves runtime default"),
+		Memory:   fs.String("apple-container-memory", defaults.AppleContainer.Memory, "memory limit for apple-container leases, for example 8g"),
+		ExtraRun: fs.String("apple-container-extra-run-args", strings.Join(defaults.AppleContainer.ExtraRunArgs, " "), "extra arguments appended to container run, space separated"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "apple-container-cli") {
+		cfg.AppleContainer.CLIPath = *v.CLIPath
+	}
+	if core.FlagWasSet(fs, "apple-container-image") {
+		cfg.AppleContainer.Image = *v.Image
+		core.MarkAppleContainerImageExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "apple-container-user") {
+		cfg.AppleContainer.User = *v.User
+		cfg.SSHUser = *v.User
+	}
+	if core.FlagWasSet(fs, "apple-container-work-root") {
+		cfg.AppleContainer.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if core.FlagWasSet(fs, "apple-container-cpus") {
+		cfg.AppleContainer.CPUs = *v.CPUs
+	}
+	if core.FlagWasSet(fs, "apple-container-memory") {
+		cfg.AppleContainer.Memory = *v.Memory
+	}
+	if core.FlagWasSet(fs, "apple-container-extra-run-args") {
+		cfg.AppleContainer.ExtraRunArgs = splitExtraArgs(*v.ExtraRun)
+	}
+	if isAppleContainerProvider(cfg.Provider) {
+		applyDefaults(cfg)
+	}
+	return nil
+}
+
+func splitExtraArgs(value string) []string {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}

--- a/internal/providers/applecontainer/provider.go
+++ b/internal/providers/applecontainer/provider.go
@@ -1,0 +1,60 @@
+package applecontainer
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"apple", "applecontainer"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "container",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; use a remote SSH provider when tailnet reachability is required", providerName)
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}

--- a/internal/providers/applecontainer/provider.go
+++ b/internal/providers/applecontainer/provider.go
@@ -24,7 +24,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      "container",
 		Kind:        core.ProviderKindSSHLease,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary

- add `provider: apple-container` as a built-in local-development provider for Apple's native `container` runtime (https://github.com/apple/container) on Apple-silicon macOS
- provider-owned adapter under `internal/providers/applecontainer` that shells out to the `container` CLI for lifecycle (`run`/`ls`/`inspect`/`delete`) and runs command exec + file sync over standard Crabbox SSH, reusing the core SSH helpers exactly as `local-container`/`ascii-box` do
- config/env/flags, provider docs, registration, and table-driven regression coverage

## Design Notes

Apple's runtime is **not** assumed Docker-compatible, so this does not reuse the `local-container` Docker code. Each Apple container gets its own routable IP on the host bridge, so the SSH target is the container IP on port 22 (CIDR-stripped from the inspect `networks` address) rather than a published loopback host port. Apple-specific lifecycle stays behind the adapter; core stays provider-neutral. The bare `container` alias is left to `local-container`; this provider uses `apple-container` (`apple`, `applecontainer`). macOS/Apple-silicon gated (`darwin/arm64`); rejects non-Linux targets and `--tailscale`; the `container run` forces `--user root` so the bootstrap can install/start sshd regardless of the image's default user; no secrets passed as CLI args.

## Config / Secrets

- CLI path env: `CRABBOX_APPLE_CONTAINER_CLI`; config block `appleContainer.*`; aliases `apple`, `applecontainer`
- default image follows the Crabbox OS image (`--os`, currently `ubuntu:26.04`)

## Review feedback addressed (ClawSweeper)

- Rebased onto latest `main` — conflict-free.
- [P3] Removed release-owned `CHANGELOG.md` entry (now identical to `main`).
- [P3] Fixed documented default image (`debian:bookworm` → the `--os`-derived default).
- [P2] macOS gate now requires `darwin/arm64` (rejects amd64 Macs); `Doctor` reuses `requireMacOS()`.
- [P2] `container run --user root` so a non-root image USER can't stall the SSH wait (+ regression assertion).
- [P3] Documented the macOS 26 runtime requirement.
- [P1] **Full SSH/sync/run E2E now proven** — see below.

## Verification

```text
gofmt -l ...            # clean
go build -trimpath -o bin/crabbox ./cmd/crabbox   # OK
go vet ./...            # OK
go test ./internal/cli ./internal/providers/applecontainer ./internal/providers/all   # ok
```
CI: Go · Docs · Plugin · Worker · Release Check all green.

## Live / E2E (full path proven on Apple silicon)

Host: `Darwin arm64`, Apple `container` CLI v0.3.0. Because Apple's sandbox containers on this host have no outbound network egress, the bootstrap can't `apt-get` into the stock image — so this uses the documented prebuilt-image path. The image was built once and loaded into the runtime (reproducible):

```text
docker buildx build --platform linux/arm64 -o type=oci,dest=sshd.tar .   # ubuntu:24.04 + openssh-server,git,rsync,curl,sudo,python3
container images load -i sshd.tar    # -> crabbox-sshd:latest
```

Full `crabbox run` (create → SSH → sync → remote command → cleanup):

```text
$ crabbox run --provider apple-container --apple-container-image crabbox-sshd:latest -- \
    sh -lc 'echo ===REMOTE_OK===; whoami; uname -sm; python3 --version; cat README.txt'
provisioning provider=apple-container lease=<redacted> slug=jade-crayfish image=crabbox-sshd:latest keep=false
provisioned lease=<redacted> container=crabbox-jade-crayfish-<id> state=ready
syncing /private/tmp/e2e-demo -> 192.168.64.15:/work/crabbox/<lease>/e2e-demo
  ssh=crabbox@192.168.64.15:22 ip=192.168.64.15
sync candidate: 1 files, 39 B
sync complete in 342ms
running on 192.168.64.15 sh -lc 'echo ===REMOTE_OK===; whoami; uname -sm; python3 --version; cat README.txt'
===REMOTE_OK===
crabbox
Linux aarch64
Python 3.12.3
hello crabbox e2e 2026-05-31T11:00:55Z
command complete in 41ms total=397ms
run summary sync=342ms command=41ms total=397ms sync_skipped=false exit=0
releasing <redacted> server=crabbox-jade-crayfish-<id>
lease cleanup stopped=true policy=auto
```

This exercises the complete path the P1 finding asked for: the container reaches SSH (`state=ready`), Crabbox **syncs** the working tree, **executes a remote command** over SSH (whoami `crabbox`, `Linux aarch64`, reads the synced file), and **cleans up** (`stopped=true`, `container ls` clean afterward). `doctor` and the lifecycle (create/inspect/delete) were also verified live earlier.

Closes https://github.com/openclaw/crabbox/issues/187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
