### PR TITLE
feat: add broker ready pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `provider: apple-container` for local Apple silicon macOS Linux leases, including SSH sync/run lifecycle and provider-backed cache volumes. Thanks @zozo123.
 - Added a repo-local Blacksmith Testbox workflow and Crabbox config so delegated Testbox validation has workflow/job defaults.
 - Added `crabbox prewarm` to lease and hydrate reusable test-ready boxes from configured GitHub Actions, with provider-owned handling for delegated runners such as Blacksmith Testbox.
+- Added broker ready pools for hydrated reusable leases, including `prewarm --pool`, `run --pool`, `pool ready/register/borrow/return/ensure`, and the broker ready-pool API.
 - Added `crabbox doctor --all --prepare-check` to report provider matrix readiness, resolved test machine types, and hydration workflow/job setup without creating leases.
 - Added `crabbox webvnc daemon list` to show alive and stale local WebVNC helper daemons after agent runs.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,7 @@ Commands are grouped here for orientation. Each links to its detailed page under
 ```text
 crabbox warmup [lease flags]                 lease a box and wait until ready
 crabbox run -- <command...>                  sync, run a remote command, stream output
+crabbox run --pool <key> -- <command...>     borrow a hydrated ready-pool lease
 crabbox status --id <id>                     show lease state (--wait to block)
 crabbox inspect --id <id>                     print lease/provider details
 crabbox list                                  list machines (alias: crabbox pool list)
@@ -47,13 +48,14 @@ crabbox share --id <id> [--user|--org]        grant access to a lease
 crabbox unshare --id <id> [--user|--org|--all]
 crabbox stop <id-or-slug>                     end a lease (alias: crabbox release)
 crabbox cleanup [--dry-run]                   sweep expired direct-provider machines
+crabbox pool ready [key]                      list hydrated broker ready-pool leases
 ```
 
 See [warmup](commands/warmup.md), [run](commands/run.md),
 [status](commands/status.md), [inspect](commands/inspect.md),
 [list](commands/list.md), [share](commands/share.md),
 [unshare](commands/unshare.md), [stop](commands/stop.md),
-[cleanup](commands/cleanup.md).
+[cleanup](commands/cleanup.md), [pool](commands/pool.md).
 
 ### Run helpers and jobs
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -47,6 +47,7 @@ same order as the CLI help.
 - [inspect](inspect.md)
 - [stop](stop.md)
 - [cleanup](cleanup.md)
+- [pool](pool.md)
 - [pond](pond.md)
 - [azure](azure.md)
 - [config](config.md)

--- a/docs/commands/pool.md
+++ b/docs/commands/pool.md
@@ -1,0 +1,43 @@
+# pool
+
+`crabbox pool` contains machine-pool helpers. `pool list` keeps the older
+machine inventory alias. Ready-pool subcommands manage hydrated broker leases
+that can be borrowed by `crabbox run --pool`.
+
+```sh
+crabbox pool ready
+crabbox pool ready example/app/main/aws/linux/c6i.2xlarge
+crabbox pool register example/app/main/aws/linux/c6i.2xlarge --id cbx_...
+crabbox pool borrow example/app/main/aws/linux/c6i.2xlarge
+crabbox pool return example/app/main/aws/linux/c6i.2xlarge --id cbx_... --result ready --borrow-token <token>
+crabbox pool ensure example/app/main/aws/linux/c6i.2xlarge --min-ready 1 --create -- --provider aws --type c6i.2xlarge
+```
+
+## Ready Pools
+
+Ready pools are broker records for already hydrated leases. The CLI registers a
+lease after `prewarm` or `actions hydrate` has prepared it. Borrow marks one
+ready entry busy. Return either makes it ready again or drains and releases it.
+Manual returns for busy leases must pass the token printed by `pool borrow`.
+
+## Subcommands
+
+```text
+pool list                 list provider machine inventory
+pool ready [key]          list ready-pool entries
+pool register <key>       register a hydrated lease
+pool borrow <key>         borrow one ready lease
+pool return <key>         return, drain, or release a borrowed lease
+pool ensure <key>         check or create minimum ready capacity
+```
+
+`pool ensure --create` forwards arguments after `--` to `prewarm`, then adds
+`--pool <key>` so the created lease registers back into the requested pool.
+Forwarded `--repo` and `--ref` overrides are rejected; set the desired
+repository/ref in config before ensuring the pool.
+
+## See Also
+
+- [run](run.md)
+- [prewarm](prewarm.md)
+- [Broker ready pools](../spec/broker.md)

--- a/docs/commands/prewarm.md
+++ b/docs/commands/prewarm.md
@@ -8,6 +8,7 @@ Blacksmith Testbox, hydration stays provider-owned.
 ```sh
 crabbox prewarm
 crabbox prewarm --provider azure --probe-command 'node -v && pnpm -v'
+crabbox prewarm --pool example/app/main/aws/linux/c6i.2xlarge
 crabbox prewarm --dry-run
 ```
 
@@ -36,6 +37,7 @@ the upload quickly when nothing changed.
   `hydration=provider-owned`.
 - Optionally runs `--probe-command` without source sync to prove the hydrated
   runtime is usable.
+- Optionally registers the hydrated lease in a broker ready pool with `--pool`.
 - `--timing-json` includes `hydrateMs` and `probeMs`.
 
 ## Flags
@@ -54,6 +56,7 @@ same way they do on `warmup`.
 --wait-timeout <duration>    hydration wait timeout
 --keep-alive-minutes <n>     GitHub-runner keep-alive window
 --probe-command <command>    shell probe to run after hydration
+--pool <key>                 register the hydrated lease in a broker ready pool
 --dry-run                    print planned commands
 --timing-json                print machine-readable timing
 ```
@@ -63,3 +66,4 @@ same way they do on `warmup`.
 - [warmup](warmup.md)
 - [actions](actions.md)
 - [job](job.md)
+- [Broker ready pools](../spec/broker.md)

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -26,6 +26,7 @@ crabbox run --id cbx_abcdef123456 --junit junit.xml -- go test ./...
 crabbox run --provider ssh --target macos --static-host mac-studio.local -- xcodebuild test
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local -- dotnet test
 crabbox run --profile live-qa --preset qa-live --scenario login-regression --emit-proof /tmp/proof.md --stop-after success
+crabbox run --pool example/app/main/aws/linux/c6i.2xlarge -- pnpm test
 ```
 
 The trailing command after `--` is sent to the box verbatim as argv. Use
@@ -38,6 +39,16 @@ If `--id` is omitted, Crabbox creates a fresh, non-kept lease and releases it
 when the command exits. With `--id` it reuses an existing lease; `--id` accepts
 either the stable `cbx_...` ID or the active friendly slug (see
 [identifiers](../features/identifiers.md)).
+
+With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
+uses the pool-recorded SSH endpoint, runs the command, and returns the lease.
+The default `--pool-return auto` returns successful runs to the pool and drains
+failed runs so a bad machine is not reused. Use
+`--pool-return ready|drain|release` to override that policy for one run. See
+[Broker ready pools](../spec/broker.md).
+Pooled runs reject `--full-resync`/`--fresh-sync`. With `--no-sync`, pooled
+borrows require an exact commit match. Pooled runs also reject `--keep` and
+`--keep-on-failure`; use `--pool-return ready|drain|release` for lifecycle.
 
 On coordinator-backed one-shot runs, if SSH becomes unavailable after a
 successful sync but before the command starts, Crabbox stops that stale lease,

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -1,0 +1,150 @@
+# Broker ready pools
+
+Broker ready pools keep hydrated leases available before a test run asks for
+one. The goal is that the first command pays only borrow, SSH, optional sync,
+and command time; image boot and repository setup happen ahead of demand.
+
+## Goals
+
+- Keep at least one ready lease per configured pool.
+- Use the same pool contract for AWS, Azure, GCP, and other brokered SSH
+  providers.
+- Hydrate from the repository's configured GitHub Actions workflow so the box
+  matches CI setup.
+- Prefer provider images for the base operating system and toolchain, then use
+  Actions hydration for the latest repository state.
+- Return successful leases to the pool and drain failed or unhealthy leases.
+
+## Pool identity
+
+A pool key names one interchangeable lease class:
+
+```text
+<repo>/<ref>/<provider>/<target>/<type>
+```
+
+Examples:
+
+```text
+example/app/main/aws/linux/c6i.2xlarge
+example/app/main/azure/linux/standard-d2ads-v6
+```
+
+The key is operator-chosen and normalized by the broker. Entries also record
+repo, ref, commit, fingerprint, image, provider, target, server type, SSH
+endpoint, work root, owner, org, state, and expiry.
+
+## States
+
+```text
+ready      hydrated, active, borrowable
+busy       leased to one run
+draining   no longer borrowable; release or expiry cleanup owns it
+stale      broker entry exists but the backing lease is gone or expired
+```
+
+Only `ready` entries can be borrowed. Borrow marks exactly one entry `busy`.
+Return marks it `ready`, `draining`, or releases the backing lease.
+
+## Control plane
+
+Ready-pool APIs live beside normal lease APIs:
+
+```text
+GET  /v1/ready-pools
+GET  /v1/ready-pools/:key
+POST /v1/ready-pools/:key/register
+POST /v1/ready-pools/:key/borrow
+POST /v1/ready-pools/:key/return
+```
+
+The broker stores pool entries in the Fleet Durable Object. The CLI owns SSH
+keys, source sync, and Actions hydration, so it registers a lease only after it
+has proved the remote endpoint and setup. The broker is the arbiter for
+exclusive borrow/return and uses the recorded SSH endpoint so provider-specific
+port fallback does not repeat on every hot run.
+
+## CLI flow
+
+Prewarm and register:
+
+```sh
+crabbox prewarm --pool example/app/main/azure/linux/standard-d2ads-v6 \
+  --provider azure \
+  --type Standard_D2ads_v6 \
+  --market on-demand \
+  --probe-command 'node -v && pnpm -v'
+```
+
+Borrow for a run:
+
+```sh
+crabbox run --pool example/app/main/azure/linux/standard-d2ads-v6 -- pnpm test
+```
+
+Manual operations:
+
+```sh
+crabbox pool ready
+crabbox pool register example/app/main/aws/linux/c6i.2xlarge --id cbx_...
+crabbox pool borrow example/app/main/aws/linux/c6i.2xlarge
+crabbox pool return example/app/main/aws/linux/c6i.2xlarge --id cbx_... --result ready --borrow-token <token>
+crabbox pool ensure example/app/main/aws/linux/c6i.2xlarge --min-ready 1 --create -- \
+  --provider aws --type c6i.2xlarge
+```
+
+## Capacity algorithm
+
+Each pool has `minReady`, default `1`. A reconciler should run:
+
+```text
+targetReady = max(minReady, ceil(recentPeakConcurrentBorrows * 1.25))
+targetReady = clamp(targetReady, minReady, maxReady)
+```
+
+Use a short lookback for bursts, such as 30 minutes, and a longer decay window,
+such as 4 hours, before reducing `targetReady`. If ready entries are below
+target, create leases from the promoted provider image, hydrate them with the
+configured workflow for the current ref, probe them, and register them. If
+entries exceed target and are idle past the pool idle window, mark them
+draining and release the oldest first.
+`crabbox pool ensure --create` forwards provider sizing flags to `prewarm`, but
+repo/ref overrides must come from config so creation and readiness counting use
+the same borrow criteria.
+
+## Images and hydration
+
+Images are the base layer: operating system, runner user, SSH, language
+toolchains, package managers, Docker, and heavy system packages. Actions
+hydration is the repo layer: checkout, dependency install, generated caches,
+and project-specific setup from the same workflow that CI uses.
+
+When the repository's main ref moves, new pool entries should hydrate the new
+commit. Existing ready entries with older commits can serve only requests that
+do not require the newer commit; otherwise they become stale and drain after
+their current borrow or idle window.
+
+## Return rules
+
+`crabbox run --pool` defaults to `--pool-return auto`:
+
+- command success: return `ready`
+- command failure, SSH failure, failed sync, failed hydration marker read, or
+  failed preflight: return `drain`
+- explicit `--pool-return ready`: force reuse
+- explicit `--pool-return drain`: release backing lease after the run
+- explicit `--pool-return release`: release backing lease immediately
+
+Successful returns keep the lease active and borrowable. Drained returns are no
+longer borrowable and release the cloud machine to avoid poisoning the pool.
+Pooled runs reject full resync because that can replace the hydrated workspace.
+Pooled `--no-sync` runs require an exact commit match and do not borrow
+ref-only entries.
+
+## Provider contract
+
+Providers do not need pool-specific runtime logic. They must provide normal
+brokered SSH leases with stable lease records, expiry, SSH endpoint metadata,
+and release semantics. Provider-specific image selection remains in the normal
+lease request fields, so AWS, Azure, and GCP use the same register, borrow, and
+return path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -184,6 +184,7 @@ Commands:
   inspect     Print lease/provider details; add --json for scripts
   stop        Release a lease or delete a direct-provider machine
   cleanup     Sweep expired direct-provider machines or local provider state
+  pool        Manage ready-pool leases and list machine inventory aliases
   pond        Bridge plane peer discovery for delegated providers
   azure       Azure provider setup and login
   config      Show or update user config
@@ -219,6 +220,7 @@ Common Flows:
   crabbox results run_123
   crabbox cache stats --id blue-lobster
   crabbox cache volumes
+  crabbox pool ready
   crabbox usage --scope org
   crabbox admin leases --state active
   crabbox admin lease-audit --state expired --provider aws

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -471,9 +471,29 @@ type configSetBrokerKongCmd struct {
 }
 
 type poolKongCmd struct {
-	List poolListKongCmd `cmd:"" passthrough:"" help:"Alias for list."`
+	List     poolListKongCmd     `cmd:"" passthrough:"" help:"List machine inventory."`
+	Ready    poolReadyKongCmd    `cmd:"" passthrough:"" help:"List ready-pool leases."`
+	Register poolRegisterKongCmd `cmd:"" passthrough:"" help:"Register a hydrated lease in a ready pool."`
+	Borrow   poolBorrowKongCmd   `cmd:"" passthrough:"" help:"Borrow a ready-pool lease."`
+	Return   poolReturnKongCmd   `cmd:"" passthrough:"" help:"Return or drain a ready-pool lease."`
+	Ensure   poolEnsureKongCmd   `cmd:"" passthrough:"" help:"Ensure ready-pool capacity."`
 }
 type poolListKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolReadyKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolRegisterKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolBorrowKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolReturnKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolEnsureKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 
@@ -724,6 +744,21 @@ func (c *azureLoginKongCmd) Run(ctx context.Context, app App) error {
 
 func (c *poolListKongCmd) Run(ctx context.Context, app App) error {
 	return app.list(ctx, c.Args)
+}
+func (c *poolReadyKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolList(ctx, stripKongCommandPath(c.Args, "pool", "ready"))
+}
+func (c *poolRegisterKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolRegister(ctx, stripKongCommandPath(c.Args, "pool", "register"))
+}
+func (c *poolBorrowKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolBorrow(ctx, stripKongCommandPath(c.Args, "pool", "borrow"))
+}
+func (c *poolReturnKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolReturn(ctx, stripKongCommandPath(c.Args, "pool", "return"))
+}
+func (c *poolEnsureKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolEnsure(ctx, stripKongCommandPath(c.Args, "pool", "ensure"))
 }
 func (c *machineCleanupKongCmd) Run(ctx context.Context, app App) error {
 	return app.cleanup(ctx, c.Args)

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -402,6 +402,43 @@ type CoordinatorExternalRunnerSyncResponse struct {
 	Stale   []CoordinatorExternalRunner `json:"stale"`
 }
 
+type CoordinatorReadyPoolEntry struct {
+	Key          string `json:"key"`
+	LeaseID      string `json:"leaseID"`
+	State        string `json:"state"`
+	Owner        string `json:"owner"`
+	Org          string `json:"org"`
+	Repo         string `json:"repo,omitempty"`
+	Ref          string `json:"ref,omitempty"`
+	Commit       string `json:"commit,omitempty"`
+	Fingerprint  string `json:"fingerprint,omitempty"`
+	Image        string `json:"image,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	TargetOS     string `json:"target,omitempty"`
+	WindowsMode  string `json:"windowsMode,omitempty"`
+	Class        string `json:"class,omitempty"`
+	ServerType   string `json:"serverType,omitempty"`
+	SSHHost      string `json:"sshHost,omitempty"`
+	SSHUser      string `json:"sshUser,omitempty"`
+	SSHPort      string `json:"sshPort,omitempty"`
+	WorkRoot     string `json:"workRoot,omitempty"`
+	BorrowedBy   string `json:"borrowedBy,omitempty"`
+	BorrowedAt   string `json:"borrowedAt,omitempty"`
+	BorrowToken  string `json:"borrowToken,omitempty"`
+	LastReadyAt  string `json:"lastReadyAt,omitempty"`
+	LastUsedAt   string `json:"lastUsedAt,omitempty"`
+	LastResult   string `json:"lastResult,omitempty"`
+	FailureCount int    `json:"failureCount,omitempty"`
+	CreatedAt    string `json:"createdAt"`
+	UpdatedAt    string `json:"updatedAt"`
+	ExpiresAt    string `json:"expiresAt"`
+}
+
+type CoordinatorReadyPoolResponse struct {
+	Entry CoordinatorReadyPoolEntry `json:"entry"`
+	Lease CoordinatorLease          `json:"lease"`
+}
+
 type CoordinatorRunEventResponse struct {
 	Event CoordinatorRunEvent `json:"event"`
 }
@@ -843,6 +880,50 @@ func (c *CoordinatorClient) Leases(ctx context.Context, state string, limit int)
 	}
 	err := c.do(ctx, http.MethodGet, path, nil, &res)
 	return res.Leases, err
+}
+
+func (c *CoordinatorClient) ReadyPools(ctx context.Context) ([]CoordinatorReadyPoolEntry, error) {
+	var res struct {
+		Pools []CoordinatorReadyPoolEntry `json:"pools"`
+	}
+	err := c.do(ctx, http.MethodGet, "/v1/ready-pools", nil, &res)
+	return res.Pools, err
+}
+
+func (c *CoordinatorClient) ReadyPool(ctx context.Context, key string) ([]CoordinatorReadyPoolEntry, error) {
+	var res struct {
+		Pool []CoordinatorReadyPoolEntry `json:"pool"`
+	}
+	err := c.do(ctx, http.MethodGet, "/v1/ready-pools/"+url.PathEscape(key), nil, &res)
+	return res.Pool, err
+}
+
+func (c *CoordinatorClient) RegisterReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/register", input, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) BorrowReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/borrow", input, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) ReturnReadyPoolLease(ctx context.Context, key, leaseID, result, reason, borrowToken string) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	body := map[string]any{"leaseID": leaseID}
+	if result != "" {
+		body["result"] = result
+	}
+	if reason != "" {
+		body["reason"] = reason
+	}
+	if borrowToken != "" {
+		body["borrowToken"] = borrowToken
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/return", body, &res)
+	return res, err
 }
 
 func (c *CoordinatorClient) Usage(ctx context.Context, scope, owner, org, month string) (CoordinatorUsageResponse, error) {

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -24,6 +24,7 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 	waitTimeout := fs.Duration("wait-timeout", 20*time.Minute, "time to wait for Actions hydration")
 	keepAliveMinutes := fs.Int("keep-alive-minutes", 90, "minutes for workflow to keep a GitHub runner job alive")
 	probeCommand := fs.String("probe-command", "", "optional shell command to prove the hydrated box is test-ready")
+	poolKey := fs.String("pool", "", "register the hydrated lease in a broker ready pool")
 	dryRun := fs.Bool("dry-run", false, "print the planned Crabbox commands without running them")
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	timingJSON := fs.Bool("timing-json", false, "print final timing as JSON")
@@ -61,6 +62,10 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
+	}
+	readyPoolKey := strings.TrimSpace(*poolKey)
+	if readyPoolKey != "" && backendCoordinator(backend) == nil {
+		return exit(2, "--pool requires a coordinator-backed SSH lease provider")
 	}
 	leaseArgs := prewarmWarmupArgs(args)
 	if backend.Spec().Kind == ProviderKindDelegatedRun && isBlacksmithProvider(cfg.Provider) {
@@ -114,6 +119,12 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 		}
 		probeMs = time.Since(probeStarted).Milliseconds()
 	}
+	if readyPoolKey != "" {
+		if err := a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *githubRunner); err != nil {
+			a.releasePrewarmLeaseAfterPoolFailure(ctx, backend, cfg, leaseID, err)
+			return err
+		}
+	}
 	total := time.Since(started)
 	fmt.Fprintf(a.Stdout, "prewarm complete id=%s provider=%s hydration=%s warmup=%dms hydrate=%dms probe=%dms total=%s\n", leaseID, cfg.Provider, hydration, warmupMs, hydrateMs, probeMs, total.Round(time.Millisecond))
 	if *timingJSON {
@@ -166,7 +177,7 @@ func prewarmWarmupArgs(args []string) []string {
 	out := make([]string, 0, len(args)+1)
 	valueFlags := map[string]struct{}{
 		"repo": {}, "workflow": {}, "job": {}, "ref": {},
-		"wait-timeout": {}, "keep-alive-minutes": {}, "probe-command": {},
+		"wait-timeout": {}, "keep-alive-minutes": {}, "probe-command": {}, "pool": {},
 	}
 	boolFlags := map[string]struct{}{
 		"no-hydrate": {}, "github-runner": {}, "dry-run": {}, "timing-json": {},
@@ -194,6 +205,91 @@ func prewarmWarmupArgs(args []string) []string {
 	}
 	out = append(out, "--keep=true")
 	return out
+}
+
+func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, leaseID, poolKey string, githubRunner bool) error {
+	repo, _ := findRepo()
+	input := map[string]any{"leaseID": leaseID}
+	if repoValue := firstNonBlank(cfg.Actions.Repo, bestEffortGitHubRepoSlug(repo, cfg)); repoValue != "" {
+		input["repo"] = repoValue
+	}
+	if refValue := firstNonBlank(cfg.Actions.Ref, repo.BaseRef); refValue != "" {
+		input["ref"] = refValue
+	}
+	if commit := prewarmReadyPoolCommit(cfg, repo, githubRunner); commit != "" {
+		input["commit"] = commit
+	}
+	addStringInput(input, "sshHost", readyPoolClaimSSHHost(leaseID))
+	addStringInput(input, "sshPort", readyPoolClaimSSHPort(leaseID))
+	addStringInput(input, "workRoot", readyPoolClaimWorkRoot(leaseID))
+	coord, err := readyPoolCoordinatorFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	res, err := coord.RegisterReadyPoolLease(ctx, poolKey, input)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(a.Stdout, "pool registered key=%s lease=%s state=%s\n", res.Entry.Key, res.Entry.LeaseID, res.Entry.State)
+	return nil
+}
+
+func (a App) releasePrewarmLeaseAfterPoolFailure(ctx context.Context, backend Backend, cfg Config, leaseID string, cause error) {
+	sshBackend, ok := backend.(SSHLeaseBackend)
+	if !ok {
+		return
+	}
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{
+		Repo:    Repo{},
+		Options: leaseOptionsFromConfig(cfg),
+		ID:      leaseID,
+	})
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release skipped: %v\n", leaseID, cause, err)
+		return
+	}
+	if err := a.releaseBackendLeaseBestEffort(ctx, sshBackend, lease); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release failed: %v\n", leaseID, cause, err)
+	}
+}
+
+func prewarmReadyPoolCommit(cfg Config, repo Repo, githubRunner bool) string {
+	ref := strings.TrimSpace(cfg.Actions.Ref)
+	if ref == "" {
+		if githubRunner {
+			return ""
+		}
+		return strings.TrimSpace(repo.Head)
+	}
+	if isGitCommitSHA(ref) {
+		if githubRunner || ref == strings.TrimSpace(repo.Head) {
+			return ref
+		}
+		return ""
+	}
+	if githubRunner {
+		return ""
+	}
+	if repo.Root == "" {
+		return ""
+	}
+	branch := strings.TrimSpace(gitOutput(repo.Root, "rev-parse", "--abbrev-ref", "HEAD"))
+	if branch != "" && (ref == branch || ref == "refs/heads/"+branch) {
+		return strings.TrimSpace(repo.Head)
+	}
+	return ""
+}
+
+func isGitCommitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, ch := range value {
+		if !((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 func prewarmBlacksmithHydrationArgs(fs *flag.FlagSet, args []string, workflow, job, ref string) []string {

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -92,6 +93,111 @@ cache:
 	if !strings.Contains(got, "crabbox run --blacksmith-workflow testbox.yml --blacksmith-job check --provider blacksmith-testbox") ||
 		!strings.Contains(got, "--no-sync --no-hydrate --shell -- 'node -v'") {
 		t.Fatalf("blacksmith prewarm should still run explicit probe:\n%s", got)
+	}
+}
+
+func TestPrewarmPoolRequiresCoordinatorBeforeWarmup(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	if err := os.WriteFile(filepath.Join(dir, ".crabbox.yaml"), []byte(`provider: azure
+target: linux
+class: standard
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.Run(context.Background(), []string{"prewarm", "--dry-run", "--provider", "azure", "--pool", "example"})
+	if err == nil {
+		t.Fatalf("prewarm --pool without coordinator succeeded; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), "--pool requires a coordinator-backed SSH lease provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "crabbox warmup") {
+		t.Fatalf("prewarm --pool planned warmup before broker validation:\n%s", stdout.String())
+	}
+}
+
+func TestPrewarmReadyPoolCommitUsesOnlyKnownHydratedSHA(t *testing.T) {
+	repo := Repo{Root: t.TempDir(), Head: strings.Repeat("a", 40), BaseRef: "main"}
+	cfg := Config{}
+	if got := prewarmReadyPoolCommit(cfg, repo, false); got != repo.Head {
+		t.Fatalf("empty actions ref should use local head: %q", got)
+	}
+	if got := prewarmReadyPoolCommit(cfg, repo, true); got != "" {
+		t.Fatalf("github-runner default ref should omit commit, got %q", got)
+	}
+
+	cfg.Actions.Ref = strings.Repeat("b", 40)
+	if got := prewarmReadyPoolCommit(cfg, repo, true); got != cfg.Actions.Ref {
+		t.Fatalf("sha actions ref should be registered as commit: %q", got)
+	}
+	if got := prewarmReadyPoolCommit(cfg, repo, false); got != "" {
+		t.Fatalf("local hydration should not register non-head sha as commit: %q", got)
+	}
+
+	cfg.Actions.Ref = "main"
+	if got := prewarmReadyPoolCommit(cfg, repo, true); got != "" {
+		t.Fatalf("github-runner branch ref should omit commit, got %q", got)
+	}
+	if got := prewarmReadyPoolCommit(cfg, repo, false); got != "" {
+		t.Fatalf("non-checked-out actions ref should omit commit, got %q", got)
+	}
+}
+
+func TestReadyPoolRunBorrowCommitOmitsBranchRef(t *testing.T) {
+	repo := Repo{Head: strings.Repeat("a", 40)}
+	cfg := Config{}
+	if got := readyPoolRunBorrowCommit(cfg, repo); got != repo.Head {
+		t.Fatalf("empty actions ref should borrow exact local head: %q", got)
+	}
+	if !readyPoolRunAllowsMissingCommit(cfg, repo) {
+		t.Fatalf("empty actions ref should allow ref-only hydrated entries")
+	}
+
+	cfg.Actions.Ref = "main"
+	if got := readyPoolRunBorrowCommit(cfg, repo); got != "" {
+		t.Fatalf("branch actions ref should borrow by ref only, got %q", got)
+	}
+
+	cfg.Actions.Ref = strings.Repeat("b", 40)
+	if got := readyPoolRunBorrowCommit(cfg, repo); got != repo.Head {
+		t.Fatalf("sha actions ref should keep local commit filter: %q", got)
+	}
+	if readyPoolRunAllowsMissingCommit(cfg, repo) {
+		t.Fatalf("sha actions ref should require exact commit")
+	}
+
+	dir := t.TempDir()
+	runPrewarmGit(t, dir, "init", "-b", "main")
+	runPrewarmGit(t, dir, "config", "user.email", "test@example.com")
+	runPrewarmGit(t, dir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("ready\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runPrewarmGit(t, dir, "add", "README.md")
+	runPrewarmGit(t, dir, "commit", "-m", "initial")
+	head := gitOutput(dir, "rev-parse", "HEAD")
+	cfg.Actions.Ref = "main"
+	if got := readyPoolRunBorrowCommit(cfg, Repo{Root: dir, Head: head}); got != head {
+		t.Fatalf("checked-out actions branch should borrow exact head: %q", got)
+	}
+	if !readyPoolRunAllowsMissingCommit(cfg, Repo{Root: dir, Head: head}) {
+		t.Fatalf("checked-out actions branch should allow GitHub-runner ref-only entries")
+	}
+}
+
+func runPrewarmGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }
 

--- a/internal/cli/ready_pool.go
+++ b/internal/cli/ready_pool.go
@@ -1,0 +1,525 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (a App) readyPoolList(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool ready", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	args, key := extractFirstPositionalArg(args, nil)
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	coord, err := readyPoolCoordinator()
+	if err != nil {
+		return err
+	}
+	var entries []CoordinatorReadyPoolEntry
+	if key == "" {
+		entries, err = coord.ReadyPools(ctx)
+	} else {
+		entries, err = coord.ReadyPool(ctx, key)
+	}
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(entries)
+	}
+	renderReadyPoolEntries(a.Stdout, entries)
+	return nil
+}
+
+func (a App) readyPoolRegister(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool register", a.Stderr)
+	id := fs.String("id", "", "lease id")
+	repoFlag := fs.String("repo", "", "repository owner/name")
+	ref := fs.String("ref", "", "source ref")
+	commit := fs.String("commit", "", "source commit")
+	fingerprint := fs.String("fingerprint", "", "repo setup fingerprint")
+	image := fs.String("image", "", "base image id or name")
+	sshHost := fs.String("ssh-host", "", "proven SSH host")
+	sshUser := fs.String("ssh-user", "", "proven SSH user")
+	sshPort := fs.String("ssh-port", "", "proven SSH port")
+	workRoot := fs.String("work-root", "", "remote work root")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	args, key := extractFirstPositionalArg(args, poolRegisterValueFlags())
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if key == "" || *id == "" {
+		return exit(2, "usage: crabbox pool register <key> --id <lease-id>")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	repo, _ := findRepo()
+	input := map[string]any{"leaseID": strings.TrimSpace(*id)}
+	if repoValue := firstNonBlank(*repoFlag, cfg.Actions.Repo, bestEffortGitHubRepoSlug(repo, cfg)); repoValue != "" {
+		input["repo"] = repoValue
+	}
+	refValue := firstNonBlank(*ref, cfg.Actions.Ref, repo.BaseRef)
+	if refValue != "" {
+		input["ref"] = refValue
+	}
+	if commitValue := readyPoolRegisterCommit(cfg, repo, refValue, *commit); commitValue != "" {
+		input["commit"] = commitValue
+	}
+	addStringInput(input, "fingerprint", *fingerprint)
+	addStringInput(input, "image", *image)
+	addStringInput(input, "sshHost", firstNonBlank(*sshHost, readyPoolClaimSSHHost(*id)))
+	addStringInput(input, "sshUser", *sshUser)
+	addStringInput(input, "sshPort", firstNonBlank(*sshPort, readyPoolClaimSSHPort(*id)))
+	addStringInput(input, "workRoot", firstNonBlank(*workRoot, readyPoolClaimWorkRoot(*id)))
+	coord, err := readyPoolCoordinatorFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	res, err := coord.RegisterReadyPoolLease(ctx, key, input)
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(res)
+	}
+	fmt.Fprintf(a.Stdout, "registered pool=%s lease=%s state=%s repo=%s ref=%s commit=%s\n", res.Entry.Key, res.Entry.LeaseID, res.Entry.State, blank(res.Entry.Repo, "-"), blank(res.Entry.Ref, "-"), shortCommit(res.Entry.Commit))
+	return nil
+}
+
+func (a App) readyPoolBorrow(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool borrow", a.Stderr)
+	repo := fs.String("repo", "", "repository owner/name")
+	ref := fs.String("ref", "", "source ref")
+	commit := fs.String("commit", "", "source commit")
+	fingerprint := fs.String("fingerprint", "", "repo setup fingerprint")
+	provider := fs.String("provider", "", "provider filter")
+	target := fs.String("target", "", "target OS filter")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	args, key := extractFirstPositionalArg(args, poolBorrowValueFlags())
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if key == "" {
+		return exit(2, "usage: crabbox pool borrow <key>")
+	}
+	coord, err := readyPoolCoordinator()
+	if err != nil {
+		return err
+	}
+	res, err := coord.BorrowReadyPoolLease(ctx, key, readyPoolBorrowInput(*repo, *ref, *commit, *fingerprint, *provider, *target))
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(res)
+	}
+	fmt.Fprintf(a.Stdout, "borrowed pool=%s lease=%s state=%s token=%s ssh=%s@%s:%s\n", res.Entry.Key, res.Entry.LeaseID, res.Entry.State, res.Entry.BorrowToken, blank(res.Entry.SSHUser, res.Lease.SSHUser), blank(res.Entry.SSHHost, res.Lease.Host), blank(res.Entry.SSHPort, res.Lease.SSHPort))
+	return nil
+}
+
+func (a App) readyPoolReturn(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool return", a.Stderr)
+	id := fs.String("id", "", "lease id")
+	result := fs.String("result", "ready", "return result: ready, drain, or release")
+	reason := fs.String("reason", "", "short reason")
+	borrowToken := fs.String("borrow-token", "", "borrow token from pool borrow")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	args, key := extractFirstPositionalArg(args, map[string]bool{"id": true, "result": true, "reason": true, "borrow-token": true})
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if key == "" || *id == "" {
+		return exit(2, "usage: crabbox pool return <key> --id <lease-id>")
+	}
+	if err := validateReadyPoolReturnResult(*result); err != nil {
+		return err
+	}
+	coord, err := readyPoolCoordinator()
+	if err != nil {
+		return err
+	}
+	res, err := coord.ReturnReadyPoolLease(ctx, key, *id, *result, *reason, *borrowToken)
+	if err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(res)
+	}
+	fmt.Fprintf(a.Stdout, "returned pool=%s lease=%s state=%s result=%s\n", res.Entry.Key, res.Entry.LeaseID, res.Entry.State, *result)
+	return nil
+}
+
+func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool ensure", a.Stderr)
+	minReady := fs.Int("min-ready", 1, "minimum ready leases")
+	create := fs.Bool("create", false, "create one missing ready lease with prewarm")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	args, key := extractFirstPositionalArg(args, map[string]bool{"min-ready": true})
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if key == "" {
+		return exit(2, "usage: crabbox pool ensure <key> [--create] [prewarm flags...]")
+	}
+	if err := validateReadyPoolEnsurePrewarmArgs(fs.Args()); err != nil {
+		return err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	coord, err := readyPoolCoordinatorFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	repo, err := findRepo()
+	if err != nil {
+		return err
+	}
+	repoSlug := cfg.Actions.Repo
+	if repoSlug == "" {
+		repoSlug = bestEffortGitHubRepoSlug(repo, cfg)
+	}
+	borrowInput := readyPoolRunBorrowInput(cfg, repo, repoSlug)
+	entries, err := coord.ReadyPool(ctx, key)
+	if err != nil {
+		return err
+	}
+	ready := countReadyPoolEntries(entries, borrowInput)
+	if ready >= *minReady {
+		if *jsonOut {
+			if err := json.NewEncoder(a.Stdout).Encode(map[string]any{"key": key, "ready": ready, "minReady": *minReady, "entries": entries}); err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(a.Stdout, "pool=%s ready=%d min_ready=%d\n", key, ready, *minReady)
+		}
+		return nil
+	}
+	if !*create {
+		if *jsonOut {
+			if err := json.NewEncoder(a.Stdout).Encode(map[string]any{"key": key, "ready": ready, "minReady": *minReady, "entries": entries}); err != nil {
+				return err
+			}
+		}
+		return exit(5, "pool=%s ready=%d min_ready=%d create=false", key, ready, *minReady)
+	}
+	prewarmArgs := append([]string{}, fs.Args()...)
+	prewarmArgs = append(prewarmArgs, "--pool", key)
+	prewarmApp := a
+	if *jsonOut {
+		prewarmApp.Stdout = a.Stderr
+	}
+	for next := ready; next < *minReady; next++ {
+		if err := prewarmApp.prewarm(ctx, prewarmArgs); err != nil {
+			return err
+		}
+	}
+	entries, err = coord.ReadyPool(ctx, key)
+	if err != nil {
+		return err
+	}
+	ready = countReadyPoolEntries(entries, borrowInput)
+	if ready < *minReady {
+		if *jsonOut {
+			if err := json.NewEncoder(a.Stdout).Encode(map[string]any{"key": key, "ready": ready, "minReady": *minReady, "entries": entries}); err != nil {
+				return err
+			}
+		}
+		return exit(5, "pool=%s ready=%d min_ready=%d create=true", key, ready, *minReady)
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(map[string]any{"key": key, "ready": ready, "minReady": *minReady, "entries": entries})
+	}
+	fmt.Fprintf(a.Stdout, "pool=%s ready=%d min_ready=%d\n", key, ready, *minReady)
+	return nil
+}
+
+func readyPoolCoordinator() (*CoordinatorClient, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return nil, err
+	}
+	return readyPoolCoordinatorFromConfig(cfg)
+}
+
+func validateReadyPoolEnsurePrewarmArgs(args []string) error {
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		if arg == "--" {
+			continue
+		}
+		switch {
+		case arg == "--repo" || arg == "--ref" || strings.HasPrefix(arg, "--repo=") || strings.HasPrefix(arg, "--ref="):
+			return exit(2, "pool ensure --create does not support forwarded --repo or --ref overrides")
+		}
+	}
+	return nil
+}
+
+func readyPoolCoordinatorFromConfig(cfg Config) (*CoordinatorClient, error) {
+	coord, ok, err := newCoordinatorClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, exit(2, "ready pools require broker.url or CRABBOX_COORDINATOR")
+	}
+	return coord, nil
+}
+
+func readyPoolBorrowInput(repo, ref, commit, fingerprint, provider, target string) map[string]any {
+	input := map[string]any{}
+	addStringInput(input, "repo", repo)
+	addStringInput(input, "ref", ref)
+	addStringInput(input, "commit", commit)
+	addStringInput(input, "fingerprint", fingerprint)
+	addStringInput(input, "provider", provider)
+	addStringInput(input, "target", target)
+	return input
+}
+
+func readyPoolRegisterCommit(cfg Config, repo Repo, ref, explicitCommit string) string {
+	if explicitCommit = strings.TrimSpace(explicitCommit); explicitCommit != "" {
+		return explicitCommit
+	}
+	cfg.Actions.Ref = strings.TrimSpace(ref)
+	return prewarmReadyPoolCommit(cfg, repo, false)
+}
+
+func readyPoolRunBorrowInput(cfg Config, repo Repo, repoSlug string) map[string]any {
+	input := readyPoolBorrowInput(repoSlug, firstNonBlank(cfg.Actions.Ref, repo.BaseRef), readyPoolRunBorrowCommit(cfg, repo), "", "", "")
+	if readyPoolRunAllowsMissingCommit(cfg, repo) {
+		input["allowMissingCommit"] = true
+	}
+	return input
+}
+
+func readyPoolRunBorrowInputForRun(cfg Config, repo Repo, repoSlug string, noSync bool) (map[string]any, error) {
+	input := readyPoolRunBorrowInput(cfg, repo, repoSlug)
+	if !noSync {
+		return input, nil
+	}
+	if readyPoolInputString(input, "commit") == "" {
+		return nil, exit(2, "--pool --no-sync requires an exact commit match; omit --no-sync or use a checked-out branch/SHA ref")
+	}
+	delete(input, "allowMissingCommit")
+	return input, nil
+}
+
+func readyPoolRunBorrowCommit(cfg Config, repo Repo) string {
+	ref := strings.TrimSpace(cfg.Actions.Ref)
+	if ref == "" || isGitCommitSHA(ref) {
+		return strings.TrimSpace(repo.Head)
+	}
+	if repo.Root == "" {
+		return ""
+	}
+	branch := strings.TrimSpace(gitOutput(repo.Root, "rev-parse", "--abbrev-ref", "HEAD"))
+	if branch != "" && (ref == branch || ref == "refs/heads/"+branch) {
+		return strings.TrimSpace(repo.Head)
+	}
+	return ""
+}
+
+func readyPoolRunAllowsMissingCommit(cfg Config, repo Repo) bool {
+	ref := strings.TrimSpace(cfg.Actions.Ref)
+	if ref == "" {
+		return true
+	}
+	if isGitCommitSHA(ref) {
+		return false
+	}
+	return true
+}
+
+func addStringInput(input map[string]any, key, value string) {
+	if value = strings.TrimSpace(value); value != "" {
+		input[key] = value
+	}
+}
+
+func bestEffortGitHubRepoSlug(repo Repo, cfg Config) string {
+	ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo)
+	if err != nil {
+		return ""
+	}
+	return ghRepo.Slug()
+}
+
+func readyPoolClaimSSHHost(leaseID string) string {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return ""
+	}
+	return claim.SSHHost
+}
+
+func readyPoolClaimSSHPort(leaseID string) string {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil || claim.SSHPort <= 0 {
+		return ""
+	}
+	return strconv.Itoa(claim.SSHPort)
+}
+
+func readyPoolClaimWorkRoot(leaseID string) string {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return ""
+	}
+	return claim.Labels["work_root"]
+}
+
+func poolRegisterValueFlags() map[string]bool {
+	return map[string]bool{
+		"id": true, "repo": true, "ref": true, "commit": true, "fingerprint": true,
+		"image": true, "ssh-host": true, "ssh-user": true, "ssh-port": true, "work-root": true,
+	}
+}
+
+func poolBorrowValueFlags() map[string]bool {
+	return map[string]bool{
+		"repo": true, "ref": true, "commit": true, "fingerprint": true,
+		"provider": true, "target": true,
+	}
+}
+
+func validateReadyPoolReturnResult(result string) error {
+	switch strings.TrimSpace(result) {
+	case "ready", "drain", "release":
+		return nil
+	default:
+		return exit(2, "--result must be ready, drain, or release")
+	}
+}
+
+func validateReadyPoolRunReturnPolicy(policy string) error {
+	switch strings.TrimSpace(policy) {
+	case "", "auto", "ready", "drain", "release":
+		return nil
+	default:
+		return exit(2, "--pool-return must be auto, ready, drain, or release")
+	}
+}
+
+func readyPoolRunReturnResult(policy string, runFailure error) string {
+	switch strings.TrimSpace(policy) {
+	case "ready", "drain", "release":
+		return strings.TrimSpace(policy)
+	case "", "auto":
+		if runFailure == nil {
+			return "ready"
+		}
+		return "drain"
+	default:
+		return "drain"
+	}
+}
+
+func readyPoolReturnNeedsHydrationStop(result string) bool {
+	return result == "drain" || result == "release"
+}
+
+func readyPoolRunReturnReason(runFailure error) string {
+	if runFailure == nil {
+		return "run succeeded"
+	}
+	return "run failed"
+}
+
+func applyReadyPoolEndpoint(target SSHTarget, entry CoordinatorReadyPoolEntry) SSHTarget {
+	if entry.SSHHost != "" {
+		target.Host = entry.SSHHost
+	}
+	if entry.SSHUser != "" {
+		target.User = entry.SSHUser
+	}
+	if entry.SSHPort != "" {
+		target.Port = entry.SSHPort
+		target.FallbackPorts = nil
+	}
+	return target
+}
+
+func countReadyPoolEntries(entries []CoordinatorReadyPoolEntry, borrowInput map[string]any) int {
+	ready := 0
+	now := time.Now()
+	for _, entry := range entries {
+		expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(entry.ExpiresAt))
+		if entry.State == "ready" && err == nil && expiresAt.After(now) && readyPoolEntryMatchesBorrowInput(entry, borrowInput) {
+			ready++
+		}
+	}
+	return ready
+}
+
+func readyPoolEntryMatchesBorrowInput(entry CoordinatorReadyPoolEntry, input map[string]any) bool {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "repo", value: entry.Repo},
+		{name: "ref", value: entry.Ref},
+		{name: "fingerprint", value: entry.Fingerprint},
+		{name: "provider", value: entry.Provider},
+		{name: "target", value: entry.TargetOS},
+	} {
+		if !readyPoolStringMatches(field.value, readyPoolInputString(input, field.name)) {
+			return false
+		}
+	}
+	commit := readyPoolInputString(input, "commit")
+	if commit == "" {
+		return true
+	}
+	if entry.Commit == commit {
+		return true
+	}
+	allowMissingCommit, _ := input["allowMissingCommit"].(bool)
+	return allowMissingCommit && entry.Commit == ""
+}
+
+func readyPoolStringMatches(got, want string) bool {
+	want = strings.TrimSpace(want)
+	return want == "" || strings.TrimSpace(got) == want
+}
+
+func readyPoolInputString(input map[string]any, key string) string {
+	value, _ := input[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func renderReadyPoolEntries(out io.Writer, entries []CoordinatorReadyPoolEntry) {
+	for _, entry := range entries {
+		fmt.Fprintf(out, "%-22s %-16s %-12s %-18s provider=%s type=%s repo=%s ref=%s commit=%s ssh=%s@%s:%s\n",
+			entry.Key,
+			entry.LeaseID,
+			entry.State,
+			blank(entry.UpdatedAt, "-"),
+			blank(entry.Provider, "-"),
+			blank(entry.ServerType, "-"),
+			blank(entry.Repo, "-"),
+			blank(entry.Ref, "-"),
+			shortCommit(entry.Commit),
+			blank(entry.SSHUser, "-"),
+			blank(entry.SSHHost, "-"),
+			blank(entry.SSHPort, "-"),
+		)
+	}
+}
+
+func shortCommit(commit string) string {
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return blank(commit, "-")
+}

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadyPoolReturnNeedsHydrationStop(t *testing.T) {
+	for _, tc := range []struct {
+		result string
+		want   bool
+	}{
+		{result: "ready", want: false},
+		{result: "drain", want: true},
+		{result: "release", want: true},
+		{result: "", want: false},
+	} {
+		if got := readyPoolReturnNeedsHydrationStop(tc.result); got != tc.want {
+			t.Fatalf("readyPoolReturnNeedsHydrationStop(%q)=%v, want %v", tc.result, got, tc.want)
+		}
+	}
+}
+
+func TestCountReadyPoolEntriesUsesBorrowCriteria(t *testing.T) {
+	future := time.Now().Add(time.Hour).Format(time.RFC3339Nano)
+	entries := []CoordinatorReadyPoolEntry{
+		{State: "ready", ExpiresAt: future, Repo: "openclaw/openclaw", Ref: "main", Commit: "aaa"},
+		{State: "ready", ExpiresAt: future, Repo: "openclaw/openclaw", Ref: "main", Commit: "bbb"},
+		{State: "ready", ExpiresAt: future, Repo: "openclaw/openclaw", Ref: "main"},
+		{State: "busy", ExpiresAt: future, Repo: "openclaw/openclaw", Ref: "main", Commit: "aaa"},
+		{State: "ready", ExpiresAt: future, Repo: "openclaw/openclaw", Ref: "release", Commit: "aaa"},
+	}
+
+	strict := map[string]any{"repo": "openclaw/openclaw", "ref": "main", "commit": "aaa"}
+	if got := countReadyPoolEntries(entries, strict); got != 1 {
+		t.Fatalf("strict ready count=%d, want 1", got)
+	}
+
+	branch := map[string]any{"repo": "openclaw/openclaw", "ref": "main", "commit": "aaa", "allowMissingCommit": true}
+	if got := countReadyPoolEntries(entries, branch); got != 2 {
+		t.Fatalf("branch ready count=%d, want 2", got)
+	}
+}
+
+func TestReadyPoolRunBorrowInputForRunRequiresExactNoSyncCommit(t *testing.T) {
+	repo := Repo{Head: "aaa", BaseRef: "main"}
+	input, err := readyPoolRunBorrowInputForRun(Config{}, repo, "openclaw/openclaw", true)
+	if err != nil {
+		t.Fatalf("no-sync exact head input failed: %v", err)
+	}
+	if _, ok := input["allowMissingCommit"]; ok {
+		t.Fatalf("no-sync exact head input allowed missing commit: %#v", input)
+	}
+
+	_, err = readyPoolRunBorrowInputForRun(Config{Actions: ActionsConfig{Ref: "feature"}}, Repo{BaseRef: "main"}, "openclaw/openclaw", true)
+	if err == nil {
+		t.Fatal("no-sync ref-only input succeeded")
+	}
+}
+
+func TestValidateReadyPoolEnsurePrewarmArgsRejectsCriteriaOverrides(t *testing.T) {
+	if err := validateReadyPoolEnsurePrewarmArgs([]string{"--provider", "aws", "--type", "c6i.2xlarge"}); err != nil {
+		t.Fatalf("provider args rejected: %v", err)
+	}
+	for _, args := range [][]string{
+		{"--ref", "release"},
+		{"--ref=release"},
+		{"--repo", "owner/repo"},
+		{"--repo=owner/repo"},
+	} {
+		if err := validateReadyPoolEnsurePrewarmArgs(args); err == nil {
+			t.Fatalf("criteria override %v was accepted", args)
+		}
+	}
+}
+
+func TestReadyPoolRegisterCommitOmitsMismatchedImplicitCommit(t *testing.T) {
+	head := strings.Repeat("a", 40)
+	other := strings.Repeat("b", 40)
+	repo := Repo{Head: head}
+	if got := readyPoolRegisterCommit(Config{}, repo, "", ""); got != head {
+		t.Fatalf("default register commit=%q, want head", got)
+	}
+	if got := readyPoolRegisterCommit(Config{}, repo, other, ""); got != "" {
+		t.Fatalf("mismatched ref sha registered commit %q", got)
+	}
+	if got := readyPoolRegisterCommit(Config{}, repo, other, other); got != other {
+		t.Fatalf("explicit commit=%q, want other", got)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -182,6 +182,8 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	proofTemplate := fs.String("proof-template", "", "proof template name from the selected profile")
 	stopAfter := fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never")
 	leaseOutput := fs.String("lease-output", "", "write a small JSON lease handle for orchestrators")
+	readyPool := fs.String("pool", "", "borrow a broker ready-pool lease")
+	readyPoolReturn := fs.String("pool-return", "auto", "ready-pool return policy: auto, ready, drain, release")
 	var downloads stringListFlag
 	var allowEnvFlags stringListFlag
 	var envProfileFlags stringListFlag
@@ -221,7 +223,22 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if requestedSlug != "" && strings.TrimSpace(*leaseIDFlag) != "" {
 		return exit(2, "--slug only applies when creating a new lease; omit --id or use the existing slug")
 	}
+	if strings.TrimSpace(*readyPool) != "" && strings.TrimSpace(*leaseIDFlag) != "" {
+		return exit(2, "--pool borrows the lease id; omit --id")
+	}
+	if strings.TrimSpace(*readyPool) != "" && strings.TrimSpace(*stopAfter) != "" {
+		return exit(2, "--pool uses --pool-return for cleanup policy; omit --stop-after")
+	}
+	if strings.TrimSpace(*readyPool) != "" && (*keep || *keepOnFailure) {
+		return exit(2, "--pool uses --pool-return for lifecycle; omit --keep and --keep-on-failure")
+	}
+	if err := validateReadyPoolRunReturnPolicy(*readyPoolReturn); err != nil {
+		return err
+	}
 	fullResyncRequested := *fullResync || *freshSync
+	if strings.TrimSpace(*readyPool) != "" && fullResyncRequested {
+		return exit(2, "--pool cannot be combined with --full-resync or --fresh-sync")
+	}
 
 	cfg, err := loadConfig()
 	if err != nil {
@@ -376,6 +393,40 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	var server Server
+	var target SSHTarget
+	var leaseID string
+	var borrowedPool *CoordinatorReadyPoolResponse
+	var runFailure error
+	defer func() {
+		if borrowedPool == nil {
+			return
+		}
+		failure := runFailure
+		if failure == nil {
+			failure = err
+		}
+		result := readyPoolRunReturnResult(*readyPoolReturn, failure)
+		coord, coordErr := readyPoolCoordinatorFromConfig(cfg)
+		if coordErr != nil {
+			fmt.Fprintf(a.Stderr, "warning: ready-pool return skipped for %s: %v\n", borrowedPool.Entry.LeaseID, coordErr)
+			if failure == nil {
+				err = coordErr
+			}
+			return
+		}
+		if readyPoolReturnNeedsHydrationStop(result) {
+			a.writeActionsHydrationStopBestEffort(context.Background(), target, borrowedPool.Entry.LeaseID)
+		}
+		if _, returnErr := coord.ReturnReadyPoolLease(context.Background(), borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, readyPoolRunReturnReason(failure), borrowedPool.Entry.BorrowToken); returnErr != nil {
+			fmt.Fprintf(a.Stderr, "warning: ready-pool return failed for %s: %v\n", borrowedPool.Entry.LeaseID, returnErr)
+			if failure == nil {
+				err = returnErr
+			}
+			return
+		}
+		fmt.Fprintf(a.Stderr, "returned pool=%s lease=%s result=%s\n", borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result)
+	}()
 	if strings.TrimSpace(*leaseOutput) != "" && !backend.Spec().Features.Has(FeatureRunSession) {
 		// TODO: Let other reusable delegated providers populate RunResult.Session
 		// and advertise FeatureRunSession once their lifecycle contract is covered.
@@ -419,6 +470,9 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		StopAfter:        strings.TrimSpace(*stopAfter),
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
+		if strings.TrimSpace(*readyPool) != "" {
+			return exit(2, "--pool requires a brokered SSH lease provider")
+		}
 		if expansion.Profile.Doctor.Enabled {
 			return exit(2, "%s delegates run execution; profile doctor is not supported", backend.Spec().Name)
 		}
@@ -451,6 +505,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	if !ok {
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
+	coord := backendCoordinator(backend)
 	var script *RunScriptSpec
 	if scriptRequested {
 		script, err = loadRunScript(*scriptPath, *scriptStdin, a.Stdin)
@@ -459,15 +514,30 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		}
 		runReq.Script = script
 	}
+	if strings.TrimSpace(*readyPool) != "" {
+		if coord == nil {
+			return exit(2, "--pool requires a coordinator-backed SSH lease provider")
+		}
+		repoSlug := cfg.Actions.Repo
+		if repoSlug == "" {
+			repoSlug = bestEffortGitHubRepoSlug(repo, cfg)
+		}
+		borrowInput, err := readyPoolRunBorrowInputForRun(cfg, repo, repoSlug, *noSync)
+		if err != nil {
+			return err
+		}
+		res, err := coord.BorrowReadyPoolLease(ctx, strings.TrimSpace(*readyPool), borrowInput)
+		if err != nil {
+			return err
+		}
+		borrowedPool = &res
+		*leaseIDFlag = res.Entry.LeaseID
+		fmt.Fprintf(a.Stderr, "borrowed pool=%s lease=%s\n", res.Entry.Key, res.Entry.LeaseID)
+	}
 
-	var server Server
-	var target SSHTarget
-	var leaseID string
 	acquired := false
-	coord := backendCoordinator(backend)
 	useCoordinator := coord != nil
 	recorder := &runRecorder{}
-	var runFailure error
 	failureClassificationPrinted := false
 	recordFailure := func(failure error) error {
 		if failure != nil && !failureClassificationPrinted {
@@ -492,6 +562,9 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		lease, err = sshBackend.Resolve(ctx, ResolveRequest{Repo: repo, Options: options, ID: *leaseIDFlag, Reclaim: *reclaim})
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+			if borrowedPool != nil {
+				target = applyReadyPoolEndpoint(target, borrowedPool.Entry)
+			}
 			if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
 				err = resolveErr
 			} else {
@@ -524,6 +597,9 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		return recordFailure(err)
 	}
 	applyResolvedServerConfig(&cfg, server)
+	if borrowedPool != nil && strings.TrimSpace(borrowedPool.Entry.WorkRoot) != "" {
+		cfg.WorkRoot = strings.TrimSpace(borrowedPool.Entry.WorkRoot)
+	}
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return recordFailure(err)
 	}
@@ -562,7 +638,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			fmt.Fprintf(a.Stderr, "lease cleanup stopped=true policy=%s lease=%s slug=%s\n", blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"))
 		}
 	}()
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim || borrowedPool != nil); err != nil {
 		return recordFailure(err)
 	}
 	if !useCoordinator && leaseID != "" {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -60,6 +60,10 @@ import type {
   ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
+  ReadyPoolBorrowRequest,
+  ReadyPoolEntry,
+  ReadyPoolRegisterRequest,
+  ReadyPoolReturnRequest,
   PromotedImageRecord,
   RunCreateRequest,
   RunEventRecord,
@@ -98,6 +102,7 @@ const textDecoder = new TextDecoder();
 const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
+const readyPoolPrefix = "ready-pool:";
 
 interface WebVNCTicketRecord {
   ticket: string;
@@ -364,6 +369,7 @@ export class FleetDurableObject implements DurableObject {
   private readonly egressClients = new Map<string, WebSocket>();
   private readonly egressSessions = new Map<string, EgressSessionStatus>();
   private readonly controlSockets = new Map<string, WebSocket>();
+  private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly state: DurableObjectState,
@@ -401,6 +407,9 @@ export class FleetDurableObject implements DurableObject {
       }
       if (method === "GET" && parts.join("/") === "v1/pool") {
         return await this.pool(request);
+      }
+      if (parts[0] === "v1" && parts[1] === "ready-pools") {
+        return await this.readyPoolRoute(request, parts[2], parts[3]);
       }
       if (method === "GET" && parts.join("/") === "v1/usage") {
         return await this.usage(request);
@@ -3030,6 +3039,339 @@ export class FleetDurableObject implements DurableObject {
     return json({ machines });
   }
 
+  private async readyPoolRoute(
+    request: Request,
+    rawKey?: string,
+    action?: string,
+  ): Promise<Response> {
+    const method = request.method.toUpperCase();
+    if (method === "GET" && !rawKey) {
+      return json({ pools: await this.allReadyPoolStatus(request) });
+    }
+    const decodedKey = decodeReadyPoolRouteKey(rawKey ?? "");
+    const key = decodedKey === undefined ? "" : normalizeReadyPoolKey(decodedKey);
+    if (!key) {
+      return json({ error: "invalid_pool_key" }, { status: 400 });
+    }
+    if (method === "GET" && !action) {
+      return json({ pool: await this.readyPoolStatus(key, request) });
+    }
+    if (method === "POST" && action === "register") {
+      return await this.registerReadyPoolLease(request, key);
+    }
+    if (method === "POST" && action === "borrow") {
+      return await this.borrowReadyPoolLease(request, key);
+    }
+    if (method === "POST" && action === "return") {
+      return await this.returnReadyPoolLease(request, key);
+    }
+    return notFound();
+  }
+
+  private async readyPoolStatus(key: string, request: Request): Promise<ReadyPoolEntry[]> {
+    const entries = (await this.visibleReadyPoolEntries(request)).filter(
+      (entry) => entry.key === key,
+    );
+    await this.markStaleReadyPoolEntries(
+      entries,
+      new Map((await this.leaseRecords()).map((lease) => [lease.id, lease])),
+      Date.now(),
+    );
+    return (await this.visibleReadyPoolEntries(request)).filter((entry) => entry.key === key);
+  }
+
+  private async allReadyPoolStatus(request: Request): Promise<ReadyPoolEntry[]> {
+    const entries = await this.visibleReadyPoolEntries(request);
+    await this.markStaleReadyPoolEntries(
+      entries,
+      new Map((await this.leaseRecords()).map((lease) => [lease.id, lease])),
+      Date.now(),
+    );
+    return await this.visibleReadyPoolEntries(request);
+  }
+
+  private async visibleReadyPoolEntries(request: Request): Promise<ReadyPoolEntry[]> {
+    const entries = await this.readyPoolEntries();
+    const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
+    return entries
+      .filter((entry) =>
+        this.readyPoolEntryVisibleToRequest(entry, request, leases.get(entry.leaseID)),
+      )
+      .map((entry) => redactReadyPoolEntry(entry))
+      .toSorted((a, b) => a.key.localeCompare(b.key) || a.leaseID.localeCompare(b.leaseID));
+  }
+
+  private async registerReadyPoolLease(request: Request, key: string): Promise<Response> {
+    const input = await readJson<ReadyPoolRegisterRequest>(request);
+    const leaseID = input.leaseID ?? "";
+    if (!validLeaseID(leaseID)) {
+      return json({ error: "invalid_lease_id" }, { status: 400 });
+    }
+    const lease = await this.resolveLease(leaseID, request, isAdminRequest(request));
+    if (!lease) {
+      return notFound();
+    }
+    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
+    }
+    if (lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
+      return json({ error: "lease_not_active" }, { status: 409 });
+    }
+    return await this.withReadyPoolBorrowLock(async () => {
+      const existingPoolEntries = (await this.readyPoolEntries()).filter(
+        (entry) => entry.leaseID === leaseID,
+      );
+      if (existingPoolEntries.some((entry) => entry.state === "busy")) {
+        return json(
+          {
+            error: "lease_pool_busy",
+            message: "lease is currently borrowed from a ready pool",
+          },
+          { status: 409 },
+        );
+      }
+      const now = new Date().toISOString();
+      const entry: ReadyPoolEntry = {
+        key,
+        leaseID,
+        state: "ready",
+        owner: lease.owner,
+        org: lease.org,
+        provider: lease.provider,
+        target: lease.target,
+        class: lease.class,
+        serverType: lease.serverType,
+        lastReadyAt: now,
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: lease.expiresAt,
+      };
+      addReadyPoolEntryString(entry, "repo", input.repo);
+      addReadyPoolEntryString(entry, "ref", input.ref);
+      addReadyPoolEntryString(entry, "commit", input.commit);
+      addReadyPoolEntryString(entry, "fingerprint", input.fingerprint);
+      addReadyPoolEntryString(entry, "image", input.image);
+      addReadyPoolEntryString(entry, "sshHost", readyPoolLeaseSSHHost(lease, input.sshHost));
+      addReadyPoolEntryString(entry, "sshUser", readyPoolLeaseSSHUser(lease, input.sshUser));
+      addReadyPoolEntryString(entry, "sshPort", readyPoolLeaseSSHPort(lease, input.sshPort));
+      addReadyPoolEntryString(entry, "workRoot", readyPoolLeaseWorkRoot(lease, input.workRoot));
+      if (lease.windowsMode) {
+        entry.windowsMode = lease.windowsMode;
+      }
+      await Promise.all(
+        existingPoolEntries
+          .filter((existing) => existing.key !== key)
+          .map((existing) => this.deleteReadyPoolEntry(existing)),
+      );
+      await this.putReadyPoolEntry(entry);
+      return json({ entry, lease });
+    });
+  }
+
+  private async borrowReadyPoolLease(request: Request, key: string): Promise<Response> {
+    const input = await readJson<ReadyPoolBorrowRequest>(request);
+    return await this.withReadyPoolBorrowLock(async () => {
+      const entries = (await this.readyPoolStatus(key, request)).filter((entry) =>
+        readyPoolEntryMatches(entry, input),
+      );
+      const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
+      const nowMs = Date.now();
+      const candidates: Array<{ entry: ReadyPoolEntry; lease: LeaseRecord }> = [];
+      let blockedByManageAccess = false;
+      for (const entry of entries) {
+        const lease = leases.get(entry.leaseID);
+        if (
+          lease &&
+          entry.state === "ready" &&
+          lease.state === "active" &&
+          Date.parse(lease.expiresAt) > nowMs
+        ) {
+          if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+            blockedByManageAccess = true;
+            continue;
+          }
+          candidates.push({ entry, lease });
+        }
+      }
+      const ready = candidates.toSorted(
+        (a, b) =>
+          Date.parse(a.entry.lastReadyAt ?? a.entry.createdAt) -
+          Date.parse(b.entry.lastReadyAt ?? b.entry.createdAt),
+      );
+      if (ready.length === 0) {
+        await this.markStaleReadyPoolEntries(entries, leases, nowMs);
+        if (blockedByManageAccess) {
+          return json(
+            { error: "forbidden", message: "lease manage access required" },
+            { status: 403 },
+          );
+        }
+        return json(
+          { error: "no_ready_lease", message: "no matching ready lease in pool" },
+          { status: 409 },
+        );
+      }
+      const first = ready[0];
+      if (!first) {
+        await this.markStaleReadyPoolEntries(entries, leases, nowMs);
+        if (blockedByManageAccess) {
+          return json(
+            { error: "forbidden", message: "lease manage access required" },
+            { status: 403 },
+          );
+        }
+        return json(
+          { error: "no_ready_lease", message: "no matching ready lease in pool" },
+          { status: 409 },
+        );
+      }
+      const { entry, lease } = first;
+      const now = new Date().toISOString();
+      const borrowed: ReadyPoolEntry = {
+        ...entry,
+        state: "busy",
+        borrowedBy: requestOwner(request),
+        borrowedAt: now,
+        borrowToken: crypto.randomUUID(),
+        lastUsedAt: now,
+        updatedAt: now,
+        expiresAt: lease.expiresAt,
+      };
+      await this.putReadyPoolEntry(borrowed);
+      return json({ entry: borrowed, lease });
+    });
+  }
+
+  private async returnReadyPoolLease(request: Request, key: string): Promise<Response> {
+    const input = await readJson<ReadyPoolReturnRequest>(request);
+    const leaseID = input.leaseID ?? "";
+    if (!validLeaseID(leaseID)) {
+      return json({ error: "invalid_lease_id" }, { status: 400 });
+    }
+    return await this.withReadyPoolBorrowLock(async () => {
+      const current = await this.getReadyPoolEntry(key, leaseID);
+      if (!current) {
+        return notFound();
+      }
+      const lease = await this.getLease(leaseID);
+      if (!this.readyPoolEntryVisibleToRequest(current, request, lease)) {
+        return notFound();
+      }
+      const canManage =
+        isAdminRequest(request) ||
+        Boolean(lease && this.leaseManageableByRequest(lease, request, false));
+      if (current.state !== "busy" && !canManage) {
+        return json(
+          { error: "not_borrowed", message: "pool entry is not borrowed" },
+          { status: 409 },
+        );
+      }
+      if (current.borrowedBy && current.borrowedBy !== requestOwner(request) && !canManage) {
+        return json(
+          { error: "forbidden", message: "lease is borrowed by another user" },
+          { status: 403 },
+        );
+      }
+      if (
+        current.state === "busy" &&
+        current.borrowToken &&
+        nonSecretString(input.borrowToken) !== current.borrowToken
+      ) {
+        return json(
+          { error: "borrow_token_mismatch", message: "borrow token does not match current borrow" },
+          { status: 409 },
+        );
+      }
+      const result = String(input.result ?? "ready");
+      if (result !== "ready" && result !== "drain" && result !== "release") {
+        return json(
+          { error: "invalid_result", message: "result must be ready, drain, or release" },
+          { status: 400 },
+        );
+      }
+      if (result === "release" || result === "drain") {
+        if (!canManage) {
+          return json(
+            { error: "forbidden", message: "lease manage access required" },
+            { status: 403 },
+          );
+        }
+        const drained = this.nextReturnedReadyPoolEntry(current, lease, "draining", input.reason);
+        await this.putReadyPoolEntry(drained);
+        if (lease && lease.state === "active") {
+          return json({
+            entry: drained,
+            lease: await this.releaseResolvedLease(lease, { deleteServer: true, keep: false }),
+          });
+        }
+        return json({ entry: drained, lease });
+      }
+      if (!lease || lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
+        const stale = this.nextReturnedReadyPoolEntry(current, lease, "stale", input.reason);
+        await this.putReadyPoolEntry(stale);
+        return json({ entry: stale, lease });
+      }
+      const returned = this.nextReturnedReadyPoolEntry(current, lease, "ready", input.reason);
+      await this.putReadyPoolEntry(returned);
+      return json({ entry: returned, lease });
+    });
+  }
+
+  private nextReturnedReadyPoolEntry(
+    current: ReadyPoolEntry,
+    lease: LeaseRecord | undefined,
+    state: ReadyPoolEntry["state"],
+    reason?: string,
+  ): ReadyPoolEntry {
+    const now = new Date().toISOString();
+    const failures = state === "ready" ? 0 : (current.failureCount ?? 0) + 1;
+    const {
+      borrowedAt: _borrowedAt,
+      borrowedBy: _borrowedBy,
+      borrowToken: _borrowToken,
+      ...base
+    } = current;
+    void _borrowedAt;
+    void _borrowedBy;
+    void _borrowToken;
+    const returned: ReadyPoolEntry = {
+      ...base,
+      state,
+      lastResult: nonSecretString(reason) || state,
+      failureCount: failures,
+      updatedAt: now,
+      expiresAt: lease?.expiresAt ?? current.expiresAt,
+    };
+    if (state === "ready") {
+      returned.lastReadyAt = now;
+    } else if (current.lastReadyAt) {
+      returned.lastReadyAt = current.lastReadyAt;
+    }
+    return returned;
+  }
+
+  private async markStaleReadyPoolEntries(
+    entries: ReadyPoolEntry[],
+    leases: Map<string, LeaseRecord>,
+    nowMs: number,
+  ): Promise<void> {
+    await Promise.all(
+      entries
+        .filter((entry) => {
+          const lease = leases.get(entry.leaseID);
+          return !lease || lease.state !== "active" || Date.parse(lease.expiresAt) <= nowMs;
+        })
+        .map((entry) =>
+          this.putReadyPoolEntry({
+            ...entry,
+            state: "stale",
+            updatedAt: new Date().toISOString(),
+            lastResult: "lease expired or missing",
+          }),
+        ),
+    );
+  }
+
   private async listLeases(request: Request): Promise<Response> {
     const leases = isAdminRequest(request)
       ? this.filterLeases(await this.leaseRecords(), request)
@@ -4272,6 +4614,41 @@ export class FleetDurableObject implements DurableObject {
     return active;
   }
 
+  private async readyPoolEntries(): Promise<ReadyPoolEntry[]> {
+    const entries = await this.state.storage.list<ReadyPoolEntry>({ prefix: readyPoolPrefix });
+    return [...entries.values()];
+  }
+
+  private async getReadyPoolEntry(
+    key: string,
+    leaseID: string,
+  ): Promise<ReadyPoolEntry | undefined> {
+    return this.state.storage.get<ReadyPoolEntry>(readyPoolKey(key, leaseID));
+  }
+
+  private async putReadyPoolEntry(entry: ReadyPoolEntry): Promise<void> {
+    await this.state.storage.put(readyPoolKey(entry.key, entry.leaseID), entry);
+  }
+
+  private async deleteReadyPoolEntry(entry: ReadyPoolEntry): Promise<void> {
+    await this.state.storage.delete(readyPoolKey(entry.key, entry.leaseID));
+  }
+
+  private async withReadyPoolBorrowLock<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.readyPoolBorrowQueue.catch(() => {});
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.readyPoolBorrowQueue = previous.then(() => next);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
   private async runRecords(): Promise<RunRecord[]> {
     const runs = await this.state.storage.list<RunRecord>({ prefix: "run:" });
     return [...runs.values()];
@@ -4310,6 +4687,17 @@ export class FleetDurableObject implements DurableObject {
 
   private leaseVisibleToRequest(lease: LeaseRecord, request: Request, admin: boolean): boolean {
     return this.leaseAccessRole(lease, request, admin) !== undefined;
+  }
+
+  private readyPoolEntryVisibleToRequest(
+    entry: ReadyPoolEntry,
+    request: Request,
+    lease: LeaseRecord | undefined,
+  ): boolean {
+    if (isAdminRequest(request)) {
+      return true;
+    }
+    return Boolean(lease && this.leaseVisibleToRequest(lease, request, false));
   }
 
   private leaseManageableByRequest(lease: LeaseRecord, request: Request, admin: boolean): boolean {
@@ -4579,6 +4967,90 @@ function providerAccessPrefix(): string {
 
 function providerAccessKey(leaseID: string): string {
   return `${providerAccessPrefix()}${leaseID}`;
+}
+
+function normalizeReadyPoolKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function decodeReadyPoolRouteKey(value: string): string | undefined {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readyPoolEntryMatches(entry: ReadyPoolEntry, input: ReadyPoolBorrowRequest): boolean {
+  return (
+    readyPoolFieldMatches(entry.repo, input.repo) &&
+    readyPoolFieldMatches(entry.ref, input.ref) &&
+    readyPoolFieldMatches(entry.commit, input.commit, input.allowMissingCommit === true) &&
+    readyPoolFieldMatches(entry.fingerprint, input.fingerprint) &&
+    readyPoolFieldMatches(entry.provider, input.provider) &&
+    readyPoolFieldMatches(entry.target, input.target)
+  );
+}
+
+function addReadyPoolEntryString(
+  entry: ReadyPoolEntry,
+  key: keyof ReadyPoolEntry,
+  value: unknown,
+): void {
+  const text = nonSecretString(value);
+  if (text) {
+    (entry as unknown as Record<string, unknown>)[key] = text;
+  }
+}
+
+function readyPoolLeaseSSHHost(lease: LeaseRecord, requested: unknown): string {
+  const host = nonSecretString(requested);
+  const allowed = new Set(
+    [lease.host, lease.tailscale?.fqdn, lease.tailscale?.ipv4].filter((value): value is string =>
+      Boolean(value),
+    ),
+  );
+  return host && allowed.has(host) ? host : lease.host;
+}
+
+function readyPoolLeaseSSHUser(lease: LeaseRecord, requested: unknown): string {
+  const user = nonSecretString(requested);
+  return safeReadyPoolSSHUser(user) ? user : lease.sshUser;
+}
+
+function safeReadyPoolSSHUser(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_.-]{0,63}$/.test(value);
+}
+
+function readyPoolLeaseSSHPort(lease: LeaseRecord, requested: unknown): string {
+  const port = nonSecretString(requested);
+  const allowed = new Set([lease.sshPort, ...(lease.sshFallbackPorts ?? [])]);
+  return port && allowed.has(port) ? port : lease.sshPort;
+}
+
+function readyPoolLeaseWorkRoot(lease: LeaseRecord, requested: unknown): string {
+  return nonSecretString(requested) || lease.workRoot;
+}
+
+function readyPoolFieldMatches(
+  stored: string | undefined,
+  requested: string | undefined,
+  allowMissing = false,
+): boolean {
+  const want = nonSecretString(requested);
+  if (!want) {
+    return true;
+  }
+  const got = nonSecretString(stored);
+  return got === want || (allowMissing && got === "");
+}
+
+function readyPoolKey(key: string, leaseID: string): string {
+  return `${readyPoolPrefix}${key}:${leaseID}`;
 }
 
 function runKey(runID: string): string {
@@ -7566,4 +8038,10 @@ function isRetryableAWSRegionProvisioningError(message: string): boolean {
     message.includes("quota ") ||
     message.includes("capacity")
   );
+}
+
+function redactReadyPoolEntry(entry: ReadyPoolEntry): ReadyPoolEntry {
+  const { borrowToken: _borrowToken, ...redacted } = entry;
+  void _borrowToken;
+  return redacted;
 }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -245,6 +245,70 @@ export interface LeaseRecord {
   endedAt?: string;
 }
 
+export type ReadyPoolEntryState = "ready" | "busy" | "draining" | "stale";
+
+export interface ReadyPoolEntry {
+  key: string;
+  leaseID: string;
+  state: ReadyPoolEntryState;
+  owner: string;
+  org: string;
+  repo?: string;
+  ref?: string;
+  commit?: string;
+  fingerprint?: string;
+  image?: string;
+  provider?: Provider;
+  target?: TargetOS;
+  windowsMode?: WindowsMode;
+  class?: string;
+  serverType?: string;
+  sshHost?: string;
+  sshUser?: string;
+  sshPort?: string;
+  workRoot?: string;
+  borrowedBy?: string;
+  borrowedAt?: string;
+  borrowToken?: string;
+  lastReadyAt?: string;
+  lastUsedAt?: string;
+  lastResult?: string;
+  failureCount?: number;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+}
+
+export interface ReadyPoolRegisterRequest {
+  leaseID?: string;
+  repo?: string;
+  ref?: string;
+  commit?: string;
+  fingerprint?: string;
+  image?: string;
+  sshHost?: string;
+  sshUser?: string;
+  sshPort?: string;
+  workRoot?: string;
+}
+
+export interface ReadyPoolBorrowRequest {
+  repo?: string;
+  ref?: string;
+  commit?: string;
+  allowMissingCommit?: boolean;
+  fingerprint?: string;
+  provider?: Provider;
+  target?: TargetOS;
+}
+
+export interface ReadyPoolReturnRequest {
+  leaseID?: string;
+  result?: "ready" | "drain" | "release";
+  reason?: string;
+  borrowToken?: string;
+}
+
 export interface LeaseNetworkState {
   sshSourceCIDRs?: string[];
   sshSourceCIDRsComplete?: boolean;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -731,6 +731,299 @@ describe("fleet lease identity and idle", () => {
     expect(found.lease.slug).toBe("blue-lobster");
   });
 
+  it("registers, borrows, and returns ready-pool leases", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "peter@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "azure",
+        host: "192.0.2.22",
+        sshPort: "2222",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        provider: "azure",
+        host: "192.0.2.23",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const register = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/register", {
+        headers,
+        body: {
+          leaseID: "cbx_000000000001",
+          repo: "example/app",
+          ref: "main",
+          commit: "abc123",
+          sshUser: "ubuntu",
+          sshPort: "22",
+          workRoot: "/workspace/app",
+        },
+      }),
+    );
+    expect(register.status).toBe(200);
+    const registerBody = (await register.json()) as {
+      entry: { sshUser: string; workRoot: string };
+    };
+    expect(registerBody.entry.sshUser).toBe("ubuntu");
+    expect(registerBody.entry.workRoot).toBe("/workspace/app");
+
+    const slashRegister = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example%2Fapp%2Fmain/register", {
+        headers,
+        body: { leaseID: "cbx_000000000002" },
+      }),
+    );
+    expect(slashRegister.status).toBe(200);
+    const slashBody = (await slashRegister.json()) as { entry: { key: string } };
+    expect(slashBody.entry.key).toBe("example/app/main");
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        provider: "azure",
+        host: "192.0.2.23",
+        expiresAt: "2026-05-01T00:00:00.000Z",
+      }),
+    );
+    const allPools = await fleet.fetch(request("GET", "/v1/ready-pools", { headers }));
+    expect(allPools.status).toBe(200);
+    const allPoolsBody = (await allPools.json()) as {
+      pools: Array<{ key: string; state: string }>;
+    };
+    expect(allPoolsBody.pools.find((entry) => entry.key === "example/app/main")?.state).toBe(
+      "stale",
+    );
+
+    const borrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/borrow", {
+        headers,
+        body: { repo: "example/app", ref: "main" },
+      }),
+    );
+    expect(borrow.status).toBe(200);
+    const borrowed = (await borrow.json()) as {
+      entry: { state: string; sshPort: string; borrowToken: string };
+    };
+    expect(borrowed.entry.state).toBe("busy");
+    expect(borrowed.entry.sshPort).toBe("22");
+    expect(borrowed.entry.borrowToken).toBeTruthy();
+
+    const busyStatus = await fleet.fetch(request("GET", "/v1/ready-pools/example", { headers }));
+    expect(busyStatus.status).toBe(200);
+    const busyStatusBody = (await busyStatus.json()) as {
+      pool: Array<{ state: string; borrowToken?: string }>;
+    };
+    expect(busyStatusBody.pool.find((entry) => entry.state === "busy")?.borrowToken).toBe(
+      undefined,
+    );
+
+    const empty = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/borrow", {
+        headers,
+        body: { repo: "example/app", ref: "main" },
+      }),
+    );
+    expect(empty.status).toBe(409);
+
+    const returned = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/return", {
+        headers,
+        body: {
+          leaseID: "cbx_000000000001",
+          result: "ready",
+          borrowToken: borrowed.entry.borrowToken,
+        },
+      }),
+    );
+    expect(returned.status).toBe(200);
+    const returnedBody = (await returned.json()) as {
+      entry: { state: string; borrowedBy?: string };
+    };
+    expect(returnedBody.entry.state).toBe("ready");
+    expect(returnedBody.entry.borrowedBy).toBeUndefined();
+
+    const destructiveReadyReturn = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/return", {
+        headers: { "x-crabbox-owner": "friend@example.com", "x-crabbox-org": "openclaw" },
+        body: { leaseID: "cbx_000000000001", result: "drain" },
+      }),
+    );
+    expect(destructiveReadyReturn.status).toBe(404);
+
+    const sparseRegister = await fleet.fetch(
+      request("POST", "/v1/ready-pools/sparse/register", {
+        headers,
+        body: {
+          leaseID: "cbx_000000000001",
+          repo: "example/app",
+          ref: "main",
+          sshUser: "-oProxyCommand=bad",
+        },
+      }),
+    );
+    expect(sparseRegister.status).toBe(200);
+    const sparseBody = (await sparseRegister.json()) as { entry: { sshUser: string } };
+    expect(sparseBody.entry.sshUser).toBe("crabbox");
+
+    const staleCommitBorrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/sparse/borrow", {
+        headers,
+        body: { repo: "example/app", ref: "main", commit: "abc123" },
+      }),
+    );
+    expect(staleCommitBorrow.status).toBe(409);
+
+    const movePool = await fleet.fetch(
+      request("POST", "/v1/ready-pools/other/register", {
+        headers,
+        body: {
+          leaseID: "cbx_000000000001",
+          repo: "example/app",
+          ref: "main",
+          commit: "abc123",
+        },
+      }),
+    );
+    expect(movePool.status).toBe(200);
+
+    const oldPoolBorrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/borrow", {
+        headers,
+        body: { repo: "example/app", ref: "main" },
+      }),
+    );
+    expect(oldPoolBorrow.status).toBe(409);
+
+    const newPoolBorrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/other/borrow", {
+        headers,
+        body: { repo: "example/app", ref: "main" },
+      }),
+    );
+    expect(newPoolBorrow.status).toBe(200);
+    const newPoolBorrowBody = (await newPoolBorrow.json()) as {
+      entry: { borrowToken: string };
+    };
+
+    const busyMove = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/register", {
+        headers,
+        body: { leaseID: "cbx_000000000001" },
+      }),
+    );
+    expect(busyMove.status).toBe(409);
+
+    const staleReturn = await fleet.fetch(
+      request("POST", "/v1/ready-pools/other/return", {
+        headers,
+        body: { leaseID: "cbx_000000000001", result: "ready", borrowToken: "old-token" },
+      }),
+    );
+    expect(staleReturn.status).toBe(409);
+
+    const cleanReturn = await fleet.fetch(
+      request("POST", "/v1/ready-pools/other/return", {
+        headers,
+        body: {
+          leaseID: "cbx_000000000001",
+          result: "ready",
+          borrowToken: newPoolBorrowBody.entry.borrowToken,
+        },
+      }),
+    );
+    expect(cleanReturn.status).toBe(200);
+  });
+
+  it("requires manage access to borrow and drain ready-pool leases", async () => {
+    const storage = new MemoryStorage();
+    let deleted = "";
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async (id) => {
+        deleted = id;
+      }),
+    });
+    const ownerHeaders = {
+      "x-crabbox-owner": "peter@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    const friendHeaders = {
+      "x-crabbox-owner": "friend@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        share: { users: { "friend@example.com": "use" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const register = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/register", {
+        headers: ownerHeaders,
+        body: { leaseID: "cbx_000000000001" },
+      }),
+    );
+    expect(register.status).toBe(200);
+
+    const borrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/borrow", {
+        headers: friendHeaders,
+        body: {},
+      }),
+    );
+    expect(borrow.status).toBe(403);
+
+    const ownerBorrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/borrow", {
+        headers: ownerHeaders,
+        body: {},
+      }),
+    );
+    expect(ownerBorrow.status).toBe(200);
+    const ownerBorrowBody = (await ownerBorrow.json()) as { entry: { borrowToken: string } };
+
+    const friendDrain = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/return", {
+        headers: friendHeaders,
+        body: { leaseID: "cbx_000000000001", result: "drain" },
+      }),
+    );
+    expect(friendDrain.status).toBe(403);
+
+    const drain = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/return", {
+        headers: ownerHeaders,
+        body: {
+          leaseID: "cbx_000000000001",
+          result: "drain",
+          borrowToken: ownerBorrowBody.entry.borrowToken,
+        },
+      }),
+    );
+    expect(drain.status).toBe(200);
+    const drained = (await drain.json()) as {
+      entry: { state: string };
+      lease: { state: string };
+    };
+    expect(drained.entry.state).toBe("draining");
+    expect(drained.lease.state).toBe("released");
+    expect(deleted).toBe("123");
+  });
+
   it("shares leases with explicit users or the owning org", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -1590,6 +1883,8 @@ describe("fleet lease identity and idle", () => {
   it("scopes non-admin usage to the current owner", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
+    const createdAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     storage.seed(
       "lease:cbx_000000000001",
       testLease({
@@ -1598,6 +1893,8 @@ describe("fleet lease identity and idle", () => {
         org: "openclaw",
         estimatedHourlyUSD: 1,
         maxEstimatedUSD: 1,
+        createdAt,
+        expiresAt,
       }),
     );
     storage.seed(
@@ -1608,6 +1905,8 @@ describe("fleet lease identity and idle", () => {
         org: "openclaw",
         estimatedHourlyUSD: 1,
         maxEstimatedUSD: 1,
+        createdAt,
+        expiresAt,
       }),
     );
     const usage = await fleet.fetch(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1910,7 +1910,7 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     const usage = await fleet.fetch(
-      request("GET", "/v1/usage?scope=all&owner=peter@example.com&month=2026-05", {
+      request("GET", `/v1/usage?scope=all&owner=peter@example.com&month=${createdAt.slice(0, 7)}`, {
         headers: {
           "x-crabbox-owner": "friend@example.com",
           "x-crabbox-org": "openclaw",


### PR DESCRIPTION
## Summary
- Add broker ready-pool APIs for registering, borrowing, returning, listing, and staleness-refreshing hydrated leases.
- Add CLI support for `crabbox pool ready/register/borrow/return/ensure`, `prewarm --pool`, and `run --pool` with borrow tokens and safe return policies.
- Document the broker pool design, capacity algorithm, command surface, and pooled run constraints.

## Verification
- `go test ./...`
- `go vet ./...`
- `npm run lint --prefix worker && npm test --prefix worker`
- `scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean
