### PR TITLE
[codex] docs: use reliable release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/openclaw/crabbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openclaw/crabbox/actions/workflows/ci.yml)
 [![Release](https://github.com/openclaw/crabbox/actions/workflows/release.yml/badge.svg?event=push)](https://github.com/openclaw/crabbox/actions/workflows/release.yml)
-[![Latest release](https://img.shields.io/github/v/release/openclaw/crabbox?sort=semver)](https://github.com/openclaw/crabbox/releases/latest)
+[![Latest release](https://badgen.net/github/release/openclaw/crabbox/stable)](https://github.com/openclaw/crabbox/releases/latest)
 
 **Warm a box, sync the diff, run the suite.**
 


### PR DESCRIPTION
## Summary
- Replace the README latest-release badge from Shields GitHub-release endpoint with Badgen.
- Keep the badge linked to the GitHub latest release page.

## Root cause
Shields can render its own GitHub token-pool failure as a gray README badge, even when Crabbox releases are healthy.

## Validation
- `curl -sS -L https://badgen.net/github/release/openclaw/crabbox/stable` returns an SVG for `release: v0.24.0`.
- `git diff --check`
- `scripts/check-docs.sh`