### PR TITLE
feat: add Multipass provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `provider: multipass` for local Ubuntu VM SSH leases through Canonical Multipass, including cloud-init bootstrap, Crabbox sync/run lifecycle, cleanup, and cache-volume support. Thanks @jwmoss.
+
 ### Changed
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,7 @@ Pick whichever matches your intent:
   [Google Cloud](providers/gcp.md), [Hetzner](providers/hetzner.md),
   [Proxmox](providers/proxmox.md), [Parallels](providers/parallels.md),
   [Local Container](providers/local-container.md),
+  [Multipass](providers/multipass.md),
   [Static SSH](providers/ssh.md), [Railway](providers/railway.md),
   [RunPod](providers/runpod.md),
   [Blacksmith Testbox](providers/blacksmith-testbox.md),

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -29,8 +29,8 @@ so brokered expiry is owned entirely by the coordinator's TTL alarm. See
 What cleanup does depends on the selected provider:
 
 - **Direct cloud/VM providers** (for example `hetzner`, `aws`, `azure`, `gcp`,
-  `proxmox`, `parallels`, `cloudflare`, `local-container`) enumerate the
-  machines they own and decide, per machine, whether to delete it.
+  `proxmox`, `parallels`, `cloudflare`, `local-container`, `multipass`)
+  enumerate the machines they own and decide, per machine, whether to delete it.
 - **`namespace-devbox`** removes only Crabbox-owned local Namespace SSH files;
   it does not delete remote Devboxes.
 - Providers that have nothing to sweep return an error rather than acting. For
@@ -102,8 +102,9 @@ namespace ssh cleanup no crabbox files found
 ## Flags
 
 ```text
---provider hetzner|aws|azure|gcp|proxmox|namespace-devbox|cloudflare  provider to sweep (default from config)
---dry-run                                                            print decisions without making provider calls
+--provider hetzner|aws|azure|gcp|proxmox|namespace-devbox|cloudflare|multipass
+                                                                       provider to sweep (default from config)
+--dry-run                                                              print decisions without making provider calls
 ```
 
 Provider and target flags (for example `--target`, `--windows-mode`,

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -373,6 +373,27 @@ Use `--desktop --browser` to bootstrap Xvfb, XFCE, x11vnc, noVNC/websockify,
 desktop input tools, screenshot tools, ffmpeg, and a packaged browser inside
 the container.
 
+### Multipass
+
+```yaml
+provider: multipass
+multipass:
+  cliPath: multipass
+  image: "26.04"
+  user: crabbox
+  workRoot: /work/crabbox
+  cpus: 4
+  memory: 8G
+  disk: 30G
+  launchTimeout: 20m
+```
+
+`provider: mp` and `provider: canonical-multipass` are aliases for `multipass`.
+The backend drives Canonical's `multipass` CLI on the local workstation, launches
+an Ubuntu VM with cloud-init, discovers the VM IP with `multipass info`, then
+uses the normal Crabbox SSH sync/run path. The Multipass image follows the
+portable `osImage` default unless `multipass.image` is set explicitly.
+
 ### Blacksmith Testbox
 
 ```yaml

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -66,6 +66,7 @@ ssh              Existing SSH host (no provisioning)      Linux, macOS, Windows
 parallels        Parallels Desktop linked clones          Linux, macOS, Windows
 proxmox          Proxmox VE QEMU VM clones                Linux
 local-container  Local Docker-compatible containers       Linux
+multipass        Canonical Multipass local Ubuntu VMs     Linux
 daytona          Daytona sandboxes (short-lived SSH)      Linux
 exe-dev          exe.dev managed VMs (public SSH)         Linux
 namespace-devbox Namespace Devboxes                       Linux
@@ -105,6 +106,7 @@ wandb                   Weights & Biases run sandboxes
 - [Parallels](../providers/parallels.md): local or remote Mac Parallels Desktop VM clones and small Mac fleets.
 - [Proxmox](../providers/proxmox.md): direct Proxmox VE Linux QEMU VM clones.
 - [Local Container](../providers/local-container.md): local Linux containers through Docker-compatible runtimes.
+- [Multipass](../providers/multipass.md): local Ubuntu VMs through Canonical Multipass.
 - [Daytona](../providers/daytona.md): Daytona SDK/toolbox sandbox leases.
 - [exe.dev](../providers/exe-dev.md): exe.dev VMs exposed as SSH leases.
 - [Namespace Devbox](../providers/namespace-devbox.md): Namespace Devbox SSH leases.
@@ -252,6 +254,10 @@ list, and cleanup.
   Docker-compatible runtime, publishes SSH on loopback, syncs over SSH, and
   removes it on `stop`. Cache volumes use Docker named volumes. It does not
   bind-mount the repo or the Docker socket by default. Reads `DOCKER_HOST`.
+- **multipass** (alias `mp`) — launches a local Ubuntu VM through Canonical
+  Multipass with cloud-init, resolves the VM IP through `multipass info`, syncs
+  over SSH, and deletes the VM with `multipass delete --purge`. Cache volumes
+  are host directories mounted into the VM.
 - **daytona** — creates a sandbox from `daytona.snapshot`, syncs and runs through
   Daytona's SDK/toolbox APIs, and mints short-lived SSH tokens only for explicit
   `crabbox ssh` access.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -196,6 +196,7 @@ internal/providers/hetzner              # Hetzner Cloud SSH lease backend (coord
 internal/providers/proxmox              # Proxmox VE SSH lease backend
 internal/providers/parallels            # Parallels macOS VM host SSH lease backend
 internal/providers/localcontainer       # local Docker container SSH backend
+internal/providers/multipass            # Canonical Multipass local Ubuntu VM SSH backend
 internal/providers/ssh                  # static / BYO SSH backend
 internal/providers/daytona              # Daytona SSH lease + delegated SDK backend
 internal/providers/namespace            # Namespace devbox SSH backend

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -29,10 +29,10 @@ SSH-lease providers further differ by how they reach the cloud:
   API itself and cleans up best-effort via provider labels.
 - **Static SSH** — `ssh` connects to a preexisting machine you supply; no
   provisioning, no cleanup.
-- **Local container** — `local-container` starts a labeled Linux container
-  through a Docker-compatible local runtime (Docker Desktop, OrbStack, Colima).
-  `apple-container` is the equivalent for Apple's native `container` runtime on
-  Apple silicon macOS.
+- **Local runtime** — `local-container` starts a labeled Linux container through
+  a Docker-compatible local runtime (Docker Desktop, OrbStack, Colima),
+  `apple-container` uses Apple's native `container` runtime on Apple silicon
+  macOS, and `multipass` launches local Ubuntu VMs through Canonical Multipass.
 - **Delegated sandbox** — managed sandbox/proof runners that execute remotely
   without an SSH lease (e.g. `e2b`, `modal`, `islo`, `cloudflare`,
   `azure-dynamic-sessions`).
@@ -60,6 +60,7 @@ Each page below maps to an adapter under `internal/providers/<dir>`. The
 | [Static SSH](ssh.md) | `ssh` | `static`, `static-ssh` | Linux, macOS, Windows | no (static) |
 | [Local Container](local-container.md) | `local-container` | `docker`, `container`, `local-docker` | Linux | no (local) |
 | [Apple Container](apple-container.md) | `apple-container` | `apple`, `applecontainer` | Linux | no (local) |
+| [Multipass](multipass.md) | `multipass` | `mp`, `canonical-multipass` | Linux | no (local) |
 | [exe.dev](exe-dev.md) | `exe-dev` | `exe`, `exedev` | Linux | no (direct) |
 | [Namespace Devbox](namespace-devbox.md) | `namespace-devbox` | `namespace`, `namespace-devboxes` | Linux | no (direct) |
 | [Semaphore](semaphore.md) | `semaphore` | `sem` | Linux | no (direct) |
@@ -99,7 +100,8 @@ reports.
 - Capability flags (`--desktop`, `--browser`, `--code`, VNC) are validated
   against each provider's declared feature set. Among the SSH-lease providers,
   desktop/browser/code surfaces are richest on `aws`, `azure`, `hetzner`,
-  `parallels`, `ssh`, and `local-container`; most direct sandbox/delegated
+  `parallels`, `ssh`, and `local-container`; `multipass` exposes local VM SSH
+  and sync only in its first implementation, and most direct sandbox/delegated
   providers expose `ssh` and Crabbox sync only.
 - Actions runner hydration requires a normal SSH lease on Linux. Use a
   Linux-capable SSH-lease provider for that path.
@@ -108,6 +110,7 @@ reports.
 crabbox warmup --provider aws --class beast
 crabbox run --provider hetzner -- pnpm test
 crabbox run --provider docker -- pnpm test
+crabbox run --provider multipass -- go test ./...
 crabbox run --provider blacksmith-testbox --id tbx_123 -- pnpm test
 crabbox run --provider namespace-devbox --id blue-lobster -- pnpm test
 ```
@@ -115,7 +118,7 @@ crabbox run --provider namespace-devbox --id blue-lobster -- pnpm test
 ## Implementation
 
 Provider implementation lives under `internal/providers/<name>`; registration is
-in `internal/providers/all/imports.go`. Command orchestration and the renderer
+in `internal/providers/all/all.go`. Command orchestration and the renderer
 surface stay in `internal/cli`.
 
 Related docs:

--- a/docs/providers/multipass.md
+++ b/docs/providers/multipass.md
@@ -16,7 +16,28 @@ The provider is local only. It never uses the coordinator or cloud credentials.
 
 **Targets:** Linux.
 
+**Hosts:** macOS, Linux, or Windows workstations with the Multipass CLI and
+daemon installed.
+
 **Capabilities:** SSH, Crabbox sync, cleanup, cache volumes.
+
+## Host Requirements
+
+Install Canonical Multipass before selecting this provider:
+
+```sh
+multipass version
+multipass list --format json
+```
+
+On macOS, install from Canonical's installer or with Homebrew:
+
+```sh
+brew install --cask multipass
+```
+
+The first Crabbox run may take longer while Multipass downloads the selected
+Ubuntu image and initializes the local VM backend.
 
 ## When To Use It
 
@@ -35,6 +56,12 @@ or [Hetzner](hetzner.md) when you need larger machines, non-Linux targets,
 desktop/browser/code surfaces, native snapshots, tailnet reachability, or shared
 team infrastructure.
 
+Multipass is not a Docker replacement in Crabbox. Docker-compatible providers
+run containers that share a host kernel; Multipass runs a full Ubuntu VM with
+its own kernel, systemd, cloud-init, SSH daemon, disk, and network identity.
+Choose Multipass when the test needs VM-like behavior. Choose Local Container
+when the test only needs a fast disposable Linux userland.
+
 ## Quick Start
 
 ```sh
@@ -44,6 +71,7 @@ multipass list --format json
 crabbox run --provider multipass -- go test ./...
 
 crabbox warmup --provider mp --slug multipass-smoke
+crabbox status --provider mp --id multipass-smoke
 crabbox run --provider mp --id multipass-smoke -- uname -a
 crabbox ssh --provider mp --id multipass-smoke
 crabbox stop --provider mp multipass-smoke
@@ -111,8 +139,11 @@ CRABBOX_MULTIPASS_LAUNCH_TIMEOUT
 1. `warmup` or a fresh `run` creates a per-lease SSH key.
 2. The provider writes a temporary cloud-init file using Crabbox's Linux
    bootstrap and launches an instance with `multipass launch --name ...`.
-3. Optional cache volumes are host directories under the Crabbox user cache and
-   are passed to Multipass with repeated `--mount host:guest` arguments.
+3. Optional cache volumes are host directories under the Crabbox user cache.
+   On macOS with the QEMU driver, Crabbox launches the VM, stops it, attaches
+   each cache with `multipass mount --type native`, then starts it again.
+   Other drivers use Multipass classic launch mounts with repeated
+   `--mount host:guest` arguments.
 4. Crabbox reads instance details with `multipass info --format json`, waits for
    SSH readiness on port `22`, syncs the checkout to `multipass.workRoot`, then
    runs the command over the normal SSH path.
@@ -140,6 +171,9 @@ instances are ignored by `list` unless their name starts with `crabbox-`, and
   VM smoke tests, or a remote SSH provider for GitHub runner registration.
 - Cache volumes are host directories, not provider-managed disks. Remove stale
   directories under the user cache when a cache key is obsolete.
+- On macOS with the default QEMU driver, Crabbox uses Multipass native mounts
+  for cache volumes. Other Multipass drivers use the standard classic mount
+  path.
 - Startup time depends on Multipass image availability, the host hypervisor, and
   first-boot package setup.
 
@@ -148,8 +182,12 @@ instances are ignored by `list` unless their name starts with `crabbox-`, and
 The backend relies on the standard Multipass CLI:
 
 - `multipass version`
+- `multipass get local.driver`
 - `multipass launch --name <name> --cloud-init <file> --cpus <n> --memory <size>
-  --disk <size> --timeout <seconds> --mount <host>:<guest> <image>`
+  --disk <size> --timeout <seconds> [--mount <host>:<guest>] <image>`
+- `multipass stop <name>`
+- `multipass mount --type native <host> <name>:<guest>`
+- `multipass start <name>`
 - `multipass list --format json`
 - `multipass info --format json <name>`
 - `multipass delete --purge <name>`

--- a/docs/providers/multipass.md
+++ b/docs/providers/multipass.md
@@ -1,0 +1,159 @@
+# Multipass Provider
+
+Read this when you:
+
+- choose `provider: multipass` (aliases `mp`, `canonical-multipass`);
+- want local Ubuntu VMs through Canonical Multipass instead of a local
+  container;
+- change `internal/providers/multipass`.
+
+Multipass is a local SSH-lease provider. Crabbox drives the configured
+`multipass` CLI on the same workstation, launches an Ubuntu VM with cloud-init,
+creates a per-lease SSH user/key, syncs the checkout over SSH, runs commands
+through the normal Crabbox SSH executor, and deletes the VM on `stop`.
+
+The provider is local only. It never uses the coordinator or cloud credentials.
+
+**Targets:** Linux.
+
+**Capabilities:** SSH, Crabbox sync, cleanup, cache volumes.
+
+## When To Use It
+
+Reach for Multipass when you want:
+
+- a local Ubuntu VM smoke path with stronger isolation than a container;
+- the same Crabbox `warmup`, `run`, `ssh`, `stop`, and `cleanup` workflow used
+  for remote SSH providers;
+- a quick way to test against Canonical Ubuntu cloud images on macOS, Windows,
+  or Linux hosts where Multipass is installed.
+
+Use [Local Container](local-container.md) when startup speed and container cache
+reuse matter more than VM isolation. Use [Parallels](parallels.md),
+[Proxmox](proxmox.md), [AWS](aws.md), [Azure](azure.md), [Google Cloud](gcp.md),
+or [Hetzner](hetzner.md) when you need larger machines, non-Linux targets,
+desktop/browser/code surfaces, native snapshots, tailnet reachability, or shared
+team infrastructure.
+
+## Quick Start
+
+```sh
+multipass version
+multipass list --format json
+
+crabbox run --provider multipass -- go test ./...
+
+crabbox warmup --provider mp --slug multipass-smoke
+crabbox run --provider mp --id multipass-smoke -- uname -a
+crabbox ssh --provider mp --id multipass-smoke
+crabbox stop --provider mp multipass-smoke
+```
+
+Cache volume smoke:
+
+```sh
+crabbox run --provider multipass \
+  --cache-volume gomod=my-app-linux-go:/var/cache/crabbox/go \
+  -- go test ./...
+```
+
+## Configuration
+
+```yaml
+provider: multipass
+multipass:
+  cliPath: multipass      # Multipass CLI to invoke
+  image: "26.04"          # Multipass image selector
+  user: crabbox           # SSH user created by cloud-init
+  workRoot: /work/crabbox # remote Crabbox work root
+  cpus: 4
+  memory: 8G
+  disk: 30G
+  launchTimeout: 20m
+```
+
+Defaults applied when unset: `cliPath=multipass`, `image=26.04`,
+`user=crabbox`, `workRoot=/work/crabbox`, `cpus=4`, `memory=8G`, `disk=30G`,
+`launchTimeout=20m`, SSH port `22`.
+
+The Multipass image follows Crabbox's portable `osImage` default unless
+`multipass.image`, `--multipass-image`, or `CRABBOX_MULTIPASS_IMAGE` is set.
+For example, `osImage: ubuntu:24.04` selects `multipass.image: "24.04"`.
+
+Provider flags:
+
+```text
+--multipass-cli <path-or-name>
+--multipass-image <image>
+--multipass-user <user>
+--multipass-work-root <path>
+--multipass-cpus <n>
+--multipass-memory <size>
+--multipass-disk <size>
+--multipass-launch-timeout <duration>
+```
+
+Environment overrides:
+
+```text
+CRABBOX_MULTIPASS_CLI
+CRABBOX_MULTIPASS_IMAGE
+CRABBOX_MULTIPASS_USER
+CRABBOX_MULTIPASS_WORK_ROOT
+CRABBOX_MULTIPASS_CPUS
+CRABBOX_MULTIPASS_MEMORY
+CRABBOX_MULTIPASS_DISK
+CRABBOX_MULTIPASS_LAUNCH_TIMEOUT
+```
+
+## Lease Behavior
+
+1. `warmup` or a fresh `run` creates a per-lease SSH key.
+2. The provider writes a temporary cloud-init file using Crabbox's Linux
+   bootstrap and launches an instance with `multipass launch --name ...`.
+3. Optional cache volumes are host directories under the Crabbox user cache and
+   are passed to Multipass with repeated `--mount host:guest` arguments.
+4. Crabbox reads instance details with `multipass info --format json`, waits for
+   SSH readiness on port `22`, syncs the checkout to `multipass.workRoot`, then
+   runs the command over the normal SSH path.
+5. The provider records a local Crabbox claim with the Multipass instance name.
+6. `list`, `status`, and `stop` resolve by lease ID, slug, or Multipass instance
+   name. `stop` deletes and purges the VM.
+7. `cleanup --provider multipass` deletes stopped Crabbox VMs and running
+   non-`keep` VMs whose local claim is stale past the idle timeout plus the
+   direct-provider grace window.
+
+Multipass does not expose provider labels. Crabbox therefore treats the instance
+name and local lease claim as the source of ownership. Unclaimed user-created
+instances are ignored by `list` unless their name starts with `crabbox-`, and
+`cleanup` skips unclaimed running instances.
+
+## Limits And Caveats
+
+- Linux target only; non-Linux targets are rejected.
+- No coordinator support; lifecycle is local to the machine running the CLI.
+- No Tailscale bootstrap. Use a remote SSH provider when tailnet reachability is
+  required.
+- No desktop, browser, VNC, WebVNC, code-server, or native checkpoint support in
+  this first implementation.
+- `warmup --actions-runner` is not supported. Use plain `crabbox run` for local
+  VM smoke tests, or a remote SSH provider for GitHub runner registration.
+- Cache volumes are host directories, not provider-managed disks. Remove stale
+  directories under the user cache when a cache key is obsolete.
+- Startup time depends on Multipass image availability, the host hypervisor, and
+  first-boot package setup.
+
+## Runtime Expectations
+
+The backend relies on the standard Multipass CLI:
+
+- `multipass version`
+- `multipass launch --name <name> --cloud-init <file> --cpus <n> --memory <size>
+  --disk <size> --timeout <seconds> --mount <host>:<guest> <image>`
+- `multipass list --format json`
+- `multipass info --format json <name>`
+- `multipass delete --purge <name>`
+
+See Canonical's [Multipass product page](https://canonical.com/multipass) and
+the Ubuntu [Multipass CLI reference](https://documentation.ubuntu.com/multipass/latest/reference/command-line-interface/)
+for installation and CLI behavior.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -74,6 +74,7 @@ SSH-lease providers:
 - Proxmox VE: `internal/providers/proxmox`, with CLI helpers in `internal/cli/proxmox.go`
 - Static/BYO SSH host: `internal/providers/ssh`, with target mapping in `internal/cli/static.go`
 - Local Docker container: `internal/providers/localcontainer`
+- Canonical Multipass local Ubuntu VM: `internal/providers/multipass`
 - Daytona, exe.dev, Namespace devbox, RunPod, Semaphore, Sprites, Railway:
   `internal/providers/daytona`, `internal/providers/exedev`, `internal/providers/namespace`,
   `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`,

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -257,6 +257,14 @@ func TestValidateActionsRunnerCapabilityRejectsAppleContainer(t *testing.T) {
 	}
 }
 
+func TestValidateActionsRunnerCapabilityRejectsMultipass(t *testing.T) {
+	backend := testSSHBackend{spec: ProviderSpec{Name: "multipass"}}
+	err := validateActionsRunnerCapability(backend, Config{Provider: "multipass", TargetOS: targetLinux})
+	if err == nil || !strings.Contains(err.Error(), "provider=multipass") {
+		t.Fatalf("multipass actions runner error=%v", err)
+	}
+}
+
 func TestLocalActionsWorkflowPathRequiresRepoWorkflowFile(t *testing.T) {
 	root := t.TempDir()
 	workflow := filepath.Join(root, ".github", "workflows", "hydrate.yml")

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -94,6 +94,10 @@ runcmd:
 `, cfg.SSHUser, publicKey, cfg.WorkRoot, portLines, readyChecks, writeFiles, bootstrap)
 }
 
+func CloudInitUserData(cfg Config, publicKey string) string {
+	return cloudInit(cfg, publicKey)
+}
+
 func windowsUserData(cfg Config, publicKey string) string {
 	_ = cfg
 	_ = publicKey

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -121,6 +121,8 @@ type Config struct {
 	localContainerImageExplicit bool
 	AppleContainer              AppleContainerConfig
 	appleContainerImageExplicit bool
+	Multipass                   MultipassConfig
+	multipassImageExplicit      bool
 	Tailscale                   TailscaleConfig
 	Static                      StaticConfig
 	Results                     ResultsConfig
@@ -428,6 +430,17 @@ type AppleContainerConfig struct {
 	CPUs         int
 	Memory       string
 	ExtraRunArgs []string
+}
+
+type MultipassConfig struct {
+	CLIPath       string
+	Image         string
+	User          string
+	WorkRoot      string
+	CPUs          int
+	Memory        string
+	Disk          string
+	LaunchTimeout time.Duration
 }
 
 type StaticConfig struct {
@@ -779,6 +792,10 @@ func applyOSImageProviderDefaults(cfg *Config, force bool) {
 	if err != nil {
 		return
 	}
+	multipassImage, err := osImageDefaultMultipassImage(cfg.OSImage)
+	if err != nil {
+		return
+	}
 	base := baseConfig()
 	wasOSDefault := cfg.osImageProviderDefaults != ""
 	if force || cfg.Image == "" || (!cfg.imageExplicit && (cfg.Image == base.Image || wasOSDefault)) {
@@ -799,6 +816,9 @@ func applyOSImageProviderDefaults(cfg *Config, force bool) {
 	if force || cfg.AppleContainer.Image == "" || (!cfg.appleContainerImageExplicit && (cfg.AppleContainer.Image == base.AppleContainer.Image || wasOSDefault)) {
 		cfg.AppleContainer.Image = containerImage
 	}
+	if force || cfg.Multipass.Image == "" || (!cfg.multipassImageExplicit && (cfg.Multipass.Image == base.Multipass.Image || wasOSDefault)) {
+		cfg.Multipass.Image = multipassImage
+	}
 	cfg.osImageProviderDefaults = cfg.OSImage
 }
 
@@ -814,6 +834,10 @@ func MarkAppleContainerImageExplicit(cfg *Config) {
 	cfg.appleContainerImageExplicit = true
 }
 
+func MarkMultipassImageExplicit(cfg *Config) {
+	cfg.multipassImageExplicit = true
+}
+
 func baseConfig() Config {
 	home, _ := os.UserHomeDir()
 	sshKey := ""
@@ -825,6 +849,7 @@ func baseConfig() Config {
 	provider := "hetzner"
 	osImage := defaultOSImage
 	hetznerImage, azureImage, gcpImage, isloImage, containerImage, _ := osImageDefaultProviderImages(osImage)
+	multipassImage, _ := osImageDefaultMultipassImage(osImage)
 	return Config{
 		Profile:            "default",
 		Provider:           provider,
@@ -985,6 +1010,16 @@ func baseConfig() Config {
 			User:     "crabbox",
 			WorkRoot: "/work/crabbox",
 		},
+		Multipass: MultipassConfig{
+			CLIPath:       "multipass",
+			Image:         multipassImage,
+			User:          "crabbox",
+			WorkRoot:      defaultPOSIXWorkRoot,
+			CPUs:          4,
+			Memory:        "8G",
+			Disk:          "30G",
+			LaunchTimeout: 20 * time.Minute,
+		},
 		Tailscale: TailscaleConfig{
 			Tags:             []string{"tag:crabbox"},
 			HostnameTemplate: "crabbox-{slug}",
@@ -1050,6 +1085,7 @@ type fileConfig struct {
 	Sprites              *fileSpritesConfig                 `yaml:"sprites,omitempty"`
 	LocalContainer       *fileLocalContainerConfig          `yaml:"localContainer,omitempty"`
 	AppleContainer       *fileAppleContainerConfig          `yaml:"appleContainer,omitempty"`
+	Multipass            *fileMultipassConfig               `yaml:"multipass,omitempty"`
 	Tailscale            *fileTailscaleConfig               `yaml:"tailscale,omitempty"`
 	Static               *fileStaticConfig                  `yaml:"static,omitempty"`
 	Results              *fileResultsConfig                 `yaml:"results,omitempty"`
@@ -1421,6 +1457,17 @@ type fileAppleContainerConfig struct {
 	CPUs         int      `yaml:"cpus,omitempty"`
 	Memory       string   `yaml:"memory,omitempty"`
 	ExtraRunArgs []string `yaml:"extraRunArgs,omitempty"`
+}
+
+type fileMultipassConfig struct {
+	CLIPath       string `yaml:"cliPath,omitempty"`
+	Image         string `yaml:"image,omitempty"`
+	User          string `yaml:"user,omitempty"`
+	WorkRoot      string `yaml:"workRoot,omitempty"`
+	CPUs          int    `yaml:"cpus,omitempty"`
+	Memory        string `yaml:"memory,omitempty"`
+	Disk          string `yaml:"disk,omitempty"`
+	LaunchTimeout string `yaml:"launchTimeout,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -2492,6 +2539,33 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.AppleContainer.ExtraRunArgs = append([]string(nil), file.AppleContainer.ExtraRunArgs...)
 		}
 	}
+	if file.Multipass != nil {
+		if file.Multipass.CLIPath != "" {
+			cfg.Multipass.CLIPath = file.Multipass.CLIPath
+		}
+		if file.Multipass.Image != "" {
+			cfg.Multipass.Image = file.Multipass.Image
+			cfg.multipassImageExplicit = true
+		}
+		if file.Multipass.User != "" {
+			cfg.Multipass.User = file.Multipass.User
+		}
+		if file.Multipass.WorkRoot != "" {
+			cfg.Multipass.WorkRoot = file.Multipass.WorkRoot
+		}
+		if file.Multipass.CPUs > 0 {
+			cfg.Multipass.CPUs = file.Multipass.CPUs
+		}
+		if file.Multipass.Memory != "" {
+			cfg.Multipass.Memory = file.Multipass.Memory
+		}
+		if file.Multipass.Disk != "" {
+			cfg.Multipass.Disk = file.Multipass.Disk
+		}
+		if file.Multipass.LaunchTimeout != "" {
+			applyLeaseDuration(&cfg.Multipass.LaunchTimeout, file.Multipass.LaunchTimeout)
+		}
+	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
 			cfg.Tailscale.Enabled = *file.Tailscale.Enabled
@@ -3189,6 +3263,19 @@ func applyEnv(cfg *Config) error {
 	if extra := strings.Fields(os.Getenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS")); len(extra) > 0 {
 		cfg.AppleContainer.ExtraRunArgs = extra
 	}
+	cfg.Multipass.CLIPath = getenv("CRABBOX_MULTIPASS_CLI", cfg.Multipass.CLIPath)
+	if image := os.Getenv("CRABBOX_MULTIPASS_IMAGE"); image != "" {
+		cfg.Multipass.Image = image
+		cfg.multipassImageExplicit = true
+	}
+	cfg.Multipass.User = getenv("CRABBOX_MULTIPASS_USER", cfg.Multipass.User)
+	cfg.Multipass.WorkRoot = getenv("CRABBOX_MULTIPASS_WORK_ROOT", cfg.Multipass.WorkRoot)
+	cfg.Multipass.CPUs = getenvInt("CRABBOX_MULTIPASS_CPUS", cfg.Multipass.CPUs)
+	cfg.Multipass.Memory = getenv("CRABBOX_MULTIPASS_MEMORY", cfg.Multipass.Memory)
+	cfg.Multipass.Disk = getenv("CRABBOX_MULTIPASS_DISK", cfg.Multipass.Disk)
+	if timeout := os.Getenv("CRABBOX_MULTIPASS_LAUNCH_TIMEOUT"); timeout != "" {
+		applyLeaseDuration(&cfg.Multipass.LaunchTimeout, timeout)
+	}
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}
@@ -3318,7 +3405,7 @@ func serverTypeForConfig(cfg Config) string {
 			return typer.ServerTypeForConfig(cfg)
 		}
 	}
-	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) || cfg.Provider == "islo" || cfg.Provider == "sprites" || cfg.Provider == "local-container" {
+	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) || cfg.Provider == "islo" || cfg.Provider == "sprites" || cfg.Provider == "local-container" || cfg.Provider == "multipass" {
 		return ""
 	}
 	if cfg.Provider == "namespace-devbox" || cfg.Provider == "namespace" {
@@ -3367,7 +3454,7 @@ func serverTypeForProviderClass(provider, class string) string {
 			return typer.ServerTypeForClass(class)
 		}
 	}
-	if isBlacksmithProvider(provider) || isStaticProvider(provider) || provider == "islo" || provider == "sprites" || provider == "local-container" {
+	if isBlacksmithProvider(provider) || isStaticProvider(provider) || provider == "islo" || provider == "sprites" || provider == "local-container" || provider == "multipass" {
 		return ""
 	}
 	if provider == "namespace-devbox" || provider == "namespace" {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -151,6 +151,16 @@ func configShowView(cfg Config) map[string]any {
 			"cpus":     cfg.AppleContainer.CPUs,
 			"memory":   cfg.AppleContainer.Memory,
 		},
+		"multipass": map[string]any{
+			"cliPath":       cfg.Multipass.CLIPath,
+			"image":         cfg.Multipass.Image,
+			"user":          cfg.Multipass.User,
+			"workRoot":      cfg.Multipass.WorkRoot,
+			"cpus":          cfg.Multipass.CPUs,
+			"memory":        cfg.Multipass.Memory,
+			"disk":          cfg.Multipass.Disk,
+			"launchTimeout": cfg.Multipass.LaunchTimeout.String(),
+		},
 		"static": map[string]any{
 			"id":       cfg.Static.ID,
 			"name":     cfg.Static.Name,
@@ -249,6 +259,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
+	fmt.Fprintf(w, "multipass cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s disk=%s launch_timeout=%s\n", cfg.Multipass.CLIPath, cfg.Multipass.Image, cfg.Multipass.User, cfg.Multipass.WorkRoot, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), cfg.Multipass.LaunchTimeout)
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(cfg.Cloudflare.APIURL, "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
 	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(w, "results junit=%s auto=%t\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"), cfg.Results.Auto)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -119,6 +119,14 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_APPLE_CONTAINER_CPUS",
 		"CRABBOX_APPLE_CONTAINER_MEMORY",
 		"CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS",
+		"CRABBOX_MULTIPASS_CLI",
+		"CRABBOX_MULTIPASS_IMAGE",
+		"CRABBOX_MULTIPASS_USER",
+		"CRABBOX_MULTIPASS_WORK_ROOT",
+		"CRABBOX_MULTIPASS_CPUS",
+		"CRABBOX_MULTIPASS_MEMORY",
+		"CRABBOX_MULTIPASS_DISK",
+		"CRABBOX_MULTIPASS_LAUNCH_TIMEOUT",
 		"CRABBOX_WANDB_API_KEY",
 		"WANDB_API_KEY",
 		"CRABBOX_WANDB_DEFAULT_IMAGE",
@@ -245,6 +253,43 @@ func TestAppleContainerConfigDefaultsFileAndEnv(t *testing.T) {
 	applyEnv(&cfg)
 	if cfg.AppleContainer.CLIPath != "/usr/local/bin/container" || cfg.AppleContainer.Image != "example-org/other:live" || cfg.AppleContainer.User != "env-user" || cfg.AppleContainer.WorkRoot != "/work/env" || cfg.AppleContainer.CPUs != 6 || cfg.AppleContainer.Memory != "12g" || len(cfg.AppleContainer.ExtraRunArgs) != 2 {
 		t.Fatalf("env appleContainer config not applied: %#v", cfg.AppleContainer)
+	}
+}
+
+func TestMultipassConfigDefaultsFileAndEnv(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if cfg.Multipass.CLIPath != "multipass" || cfg.Multipass.Image != "26.04" || cfg.Multipass.User != "crabbox" {
+		t.Fatalf("multipass defaults not applied: %#v", cfg.Multipass)
+	}
+	applyFileConfig(&cfg, fileConfig{
+		Provider: "multipass",
+		Multipass: &fileMultipassConfig{
+			CLIPath:       "/opt/bin/multipass",
+			Image:         "24.04",
+			User:          "runner",
+			WorkRoot:      "/work/example",
+			CPUs:          4,
+			Memory:        "8G",
+			Disk:          "40G",
+			LaunchTimeout: "7m",
+		},
+	})
+	if cfg.Provider != "multipass" || cfg.Multipass.CLIPath != "/opt/bin/multipass" || cfg.Multipass.Image != "24.04" || cfg.Multipass.User != "runner" || cfg.Multipass.WorkRoot != "/work/example" || cfg.Multipass.CPUs != 4 || cfg.Multipass.Memory != "8G" || cfg.Multipass.Disk != "40G" || cfg.Multipass.LaunchTimeout != 7*time.Minute {
+		t.Fatalf("file multipass config not applied: %#v", cfg.Multipass)
+	}
+
+	t.Setenv("CRABBOX_MULTIPASS_CLI", "/usr/local/bin/multipass")
+	t.Setenv("CRABBOX_MULTIPASS_IMAGE", "26.04")
+	t.Setenv("CRABBOX_MULTIPASS_USER", "env-user")
+	t.Setenv("CRABBOX_MULTIPASS_WORK_ROOT", "/work/env")
+	t.Setenv("CRABBOX_MULTIPASS_CPUS", "6")
+	t.Setenv("CRABBOX_MULTIPASS_MEMORY", "12G")
+	t.Setenv("CRABBOX_MULTIPASS_DISK", "80G")
+	t.Setenv("CRABBOX_MULTIPASS_LAUNCH_TIMEOUT", "11m")
+	applyEnv(&cfg)
+	if cfg.Multipass.CLIPath != "/usr/local/bin/multipass" || cfg.Multipass.Image != "26.04" || cfg.Multipass.User != "env-user" || cfg.Multipass.WorkRoot != "/work/env" || cfg.Multipass.CPUs != 6 || cfg.Multipass.Memory != "12G" || cfg.Multipass.Disk != "80G" || cfg.Multipass.LaunchTimeout != 11*time.Minute {
+		t.Fatalf("env multipass config not applied: %#v", cfg.Multipass)
 	}
 }
 
@@ -1333,6 +1378,44 @@ func TestAppleContainerExplicitImageSurvivesOSDefault(t *testing.T) {
 	}
 	if cfg.AppleContainer.Image != "my-org/custom:tag" {
 		t.Fatalf("explicit apple-container image was overwritten by --os: %q", cfg.AppleContainer.Image)
+	}
+}
+
+func TestMultipassImageFollowsOSImageDefault(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	cfgPath := filepath.Join(home, "crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	if err := os.WriteFile(cfgPath, []byte("target: linux\nos: ubuntu:24.04\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Multipass.Image != "24.04" {
+		t.Fatalf("multipass image should follow --os default: %q", cfg.Multipass.Image)
+	}
+}
+
+func TestMultipassExplicitImageSurvivesOSDefault(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	cfgPath := filepath.Join(home, "crabbox.yaml")
+	t.Setenv("CRABBOX_CONFIG", cfgPath)
+	if err := os.WriteFile(cfgPath, []byte("target: linux\nos: ubuntu:24.04\nmultipass:\n  image: daily:26.04\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Multipass.Image != "daily:26.04" {
+		t.Fatalf("explicit multipass image was overwritten by --os: %q", cfg.Multipass.Image)
 	}
 }
 

--- a/internal/cli/os_image.go
+++ b/internal/cli/os_image.go
@@ -131,3 +131,11 @@ func osImageDefaultProviderImagesForArchitecture(value string, architecture stri
 	}
 	return spec.HetznerImage, spec.AzureImage, spec.GCPImage, spec.DockerImage, spec.ContainerName, nil
 }
+
+func osImageDefaultMultipassImage(value string) (string, error) {
+	spec, err := osImageSpecFor(value)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(spec.Selector, "ubuntu:"), nil
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -690,7 +690,7 @@ func validateActionsRunnerCapability(backend Backend, cfg Config) error {
 	if _, ok := backend.(SSHLeaseBackend); !ok {
 		return exit(2, "--actions-runner requires an SSH lease provider")
 	}
-	if name := backend.Spec().Name; name == "local-container" || name == "apple-container" {
+	if name := backend.Spec().Name; name == "local-container" || name == "apple-container" || name == "multipass" {
 		return exit(2, "--actions-runner is not supported for provider=%s; use normal crabbox run or a remote SSH provider", name)
 	}
 	if !supportsGitHubActionsRunnerTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}) {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -105,6 +105,10 @@ func UpdateLeaseClaimCacheVolumes(leaseID string, specs []string) error {
 	return updateLeaseClaimCacheVolumes(leaseID, specs)
 }
 
+func UpdateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
+	return updateLeaseClaimEndpoint(leaseID, server, target)
+}
+
 func ListLeaseClaims() ([]LeaseClaim, error) {
 	return listLeaseClaims()
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -24,6 +24,7 @@ func init() {
 	RegisterProvider(testCloudflareProvider{})
 	RegisterProvider(testSpritesProvider{})
 	RegisterProvider(testLocalContainerProvider{})
+	RegisterProvider(testMultipassProvider{})
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 }
@@ -1003,6 +1004,89 @@ func (testLocalContainerProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, valu
 	return nil
 }
 func (p testLocalContainerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testMultipassProvider struct{}
+
+func (testMultipassProvider) Name() string { return "multipass" }
+func (testMultipassProvider) Aliases() []string {
+	return []string{"mp", "canonical-multipass"}
+}
+func (testMultipassProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "multipass",
+		Family:      "local-vm",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureCacheVolume},
+		Coordinator: CoordinatorNever,
+	}
+}
+
+type testMultipassFlagValues struct {
+	CLIPath       *string
+	Image         *string
+	User          *string
+	WorkRoot      *string
+	CPUs          *int
+	Memory        *string
+	Disk          *string
+	LaunchTimeout *string
+}
+
+func (testMultipassProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return testMultipassFlagValues{
+		CLIPath:       fs.String("multipass-cli", defaults.Multipass.CLIPath, "Multipass CLI"),
+		Image:         fs.String("multipass-image", defaults.Multipass.Image, "Multipass image"),
+		User:          fs.String("multipass-user", defaults.Multipass.User, "Multipass SSH user"),
+		WorkRoot:      fs.String("multipass-work-root", defaults.Multipass.WorkRoot, "Multipass work root"),
+		CPUs:          fs.Int("multipass-cpus", defaults.Multipass.CPUs, "Multipass CPUs"),
+		Memory:        fs.String("multipass-memory", defaults.Multipass.Memory, "Multipass memory"),
+		Disk:          fs.String("multipass-disk", defaults.Multipass.Disk, "Multipass disk"),
+		LaunchTimeout: fs.String("multipass-launch-timeout", defaults.Multipass.LaunchTimeout.String(), "Multipass launch timeout"),
+	}
+}
+func (testMultipassProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(testMultipassFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "multipass-cli") {
+		cfg.Multipass.CLIPath = *v.CLIPath
+	}
+	if flagWasSet(fs, "multipass-image") {
+		cfg.Multipass.Image = *v.Image
+		cfg.multipassImageExplicit = true
+	}
+	if flagWasSet(fs, "multipass-user") {
+		cfg.Multipass.User = *v.User
+		cfg.SSHUser = *v.User
+	}
+	if flagWasSet(fs, "multipass-work-root") {
+		cfg.Multipass.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if flagWasSet(fs, "multipass-cpus") {
+		cfg.Multipass.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "multipass-memory") {
+		cfg.Multipass.Memory = *v.Memory
+	}
+	if flagWasSet(fs, "multipass-disk") {
+		cfg.Multipass.Disk = *v.Disk
+	}
+	if flagWasSet(fs, "multipass-launch-timeout") {
+		if err := ApplyLeaseDuration(&cfg.Multipass.LaunchTimeout, *v.LaunchTimeout); err != nil {
+			return err
+		}
+	}
+	if cfg.Provider == "mp" || cfg.Provider == "canonical-multipass" {
+		cfg.Provider = "multipass"
+	}
+	return nil
+}
+func (p testMultipassProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/localcontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/modal"
+	_ "github.com/openclaw/crabbox/internal/providers/multipass"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
 	_ "github.com/openclaw/crabbox/internal/providers/parallels"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -42,6 +42,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"islo",
 		"local-container",
 		"modal",
+		"multipass",
 		"namespace-devbox",
 		"proxmox",
 		"railway",

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +21,8 @@ type backend struct {
 	cfg  Config
 	rt   Runtime
 }
+
+var multipassHostOS = runtime.GOOS
 
 type listResponse struct {
 	List []multipassInstance `json:"list"`
@@ -125,6 +128,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	name := leaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Multipass.Image, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), req.Keep)
 	if err := b.createInstance(ctx, cfg, name, leaseID, slug, publicKey); err != nil {
+		_ = b.removeInstance(context.Background(), name)
 		return LeaseTarget{}, err
 	}
 	info, err := b.inspectInstance(ctx, name)
@@ -375,18 +379,67 @@ func (b *backend) createInstance(ctx context.Context, cfg Config, name, leaseID,
 	if cfg.Multipass.LaunchTimeout > 0 {
 		args = append(args, "--timeout", strconv.Itoa(durationSecondsCeil(cfg.Multipass.LaunchTimeout)))
 	}
-	for _, mount := range mounts {
-		args = append(args, "--mount", mount)
+	useNativeMounts := len(mounts) > 0 && b.useNativeMounts(ctx)
+	if !useNativeMounts {
+		for _, mount := range mounts {
+			args = append(args, "--mount", mount.arg())
+		}
 	}
 	args = append(args, cfg.Multipass.Image)
 	result, err := b.multipass(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
 		return commandError("multipass launch", result, err)
 	}
+	if useNativeMounts {
+		if err := b.attachNativeMounts(ctx, name, mounts); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, error) {
+type multipassCacheMount struct {
+	hostPath  string
+	guestPath string
+}
+
+func (m multipassCacheMount) arg() string {
+	return m.hostPath + ":" + m.guestPath
+}
+
+func (b *backend) useNativeMounts(ctx context.Context) bool {
+	if multipassHostOS != "darwin" {
+		return false
+	}
+	result, err := b.multipass(ctx, []string{"get", "local.driver"}, nil, io.Discard)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(result.Stdout) == "qemu"
+}
+
+func (b *backend) attachNativeMounts(ctx context.Context, name string, mounts []multipassCacheMount) error {
+	if len(mounts) == 0 {
+		return nil
+	}
+	result, err := b.multipass(ctx, []string{"stop", name}, nil, b.rt.Stderr)
+	if err != nil {
+		return commandError("multipass stop", result, err)
+	}
+	for _, mount := range mounts {
+		result, err := b.multipass(ctx, []string{"mount", "--type", "native", mount.hostPath, name + ":" + mount.guestPath}, nil, b.rt.Stderr)
+		if err != nil {
+			return commandError("multipass mount", result, err)
+		}
+	}
+	result, err = b.multipass(ctx, []string{"start", name}, nil, b.rt.Stderr)
+	if err != nil {
+		return commandError("multipass start", result, err)
+	}
+	return nil
+}
+
+func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]multipassCacheMount, error) {
 	if len(volumes) == 0 {
 		return nil, nil
 	}
@@ -394,7 +447,7 @@ func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, err
 	if err != nil {
 		return nil, err
 	}
-	mounts := make([]string, 0, len(volumes))
+	mounts := make([]multipassCacheMount, 0, len(volumes))
 	for _, volume := range volumes {
 		key := strings.TrimSpace(volume.Key)
 		path := strings.TrimSpace(volume.Path)
@@ -417,7 +470,7 @@ func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, err
 		if err := os.Chmod(hostPath, 0o777); err != nil {
 			return nil, exit(2, "make multipass cache volume writable %s: %v", hostPath, err)
 		}
-		mounts = append(mounts, hostPath+":"+path)
+		mounts = append(mounts, multipassCacheMount{hostPath: hostPath, guestPath: path})
 	}
 	return mounts, nil
 }

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -1,0 +1,777 @@
+package multipass
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+type listResponse struct {
+	List []multipassInstance `json:"list"`
+}
+
+type infoResponse struct {
+	Errors []any                         `json:"errors"`
+	Info   map[string]multipassInfoEntry `json:"info"`
+}
+
+type multipassInstance struct {
+	Name    string   `json:"name"`
+	State   string   `json:"state"`
+	IPv4    []string `json:"ipv4"`
+	Release string   `json:"release"`
+}
+
+type multipassInfoEntry struct {
+	State        string   `json:"state"`
+	IPv4         []string `json:"ipv4"`
+	Release      string   `json:"release"`
+	ImageHash    string   `json:"image_hash"`
+	ImageRelease string   `json:"image_release"`
+}
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	applyDefaults(&cfg)
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func applyDefaults(cfg *Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetLinux
+	}
+	if cfg.TargetOS == targetLinux {
+		cfg.WindowsMode = ""
+	}
+	cfg.SSHFallbackPorts = []string{}
+	if cfg.Multipass.CLIPath == "" {
+		cfg.Multipass.CLIPath = "multipass"
+	}
+	if cfg.Multipass.Image == "" {
+		cfg.Multipass.Image = "26.04"
+	}
+	if cfg.Multipass.User == "" {
+		cfg.Multipass.User = "crabbox"
+	}
+	if cfg.Multipass.WorkRoot == "" {
+		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
+			cfg.Multipass.WorkRoot = cfg.WorkRoot
+		} else {
+			cfg.Multipass.WorkRoot = "/work/crabbox"
+		}
+	}
+	if cfg.Multipass.LaunchTimeout <= 0 {
+		cfg.Multipass.LaunchTimeout = 20 * time.Minute
+	}
+	cfg.SSHUser = cfg.Multipass.User
+	cfg.SSHPort = sshPort
+	cfg.WorkRoot = cfg.Multipass.WorkRoot
+	cfg.ServerType = cfg.Multipass.Image
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) configForRun() Config {
+	cfg := b.cfg
+	applyDefaults(&cfg)
+	return cfg
+}
+
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	cfg := b.configForRun()
+	leaseID := newLeaseID()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := make([]Server, 0, len(instances))
+	for _, inst := range instances {
+		servers = append(servers, b.serverFromInstance(inst, claims[inst.Name], cfg))
+	}
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cleanupKey := true
+	defer func() {
+		if cleanupKey {
+			removeStoredTestboxKey(leaseID)
+		}
+	}()
+	cfg.SSHKey = keyPath
+	name := leaseProviderName(leaseID, slug)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Multipass.Image, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), req.Keep)
+	if err := b.createInstance(ctx, cfg, name, leaseID, slug, publicKey); err != nil {
+		return LeaseTarget{}, err
+	}
+	info, err := b.inspectInstance(ctx, name)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeInstance(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	labels["instance"] = name
+	labels["image"] = cfg.Multipass.Image
+	labels["ssh_user"] = cfg.Multipass.User
+	labels["ssh_port"] = sshPort
+	labels["work_root"] = cfg.Multipass.WorkRoot
+	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
+	lease, err := b.prepareLease(ctx, cfg, info.toInstance(name), claim, true)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeInstance(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			_ = b.removeInstance(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		if !req.Keep {
+			_ = b.removeInstance(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := updateLeaseClaimCacheVolumes(leaseID, cacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
+		if !req.Keep {
+			_ = b.removeInstance(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	cleanupKey = false
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
+	return lease, nil
+}
+
+func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	cfg := b.configForRun()
+	inst, claim, err := b.resolveInstance(ctx, req.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.ReleaseOnly {
+		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+	}
+	if claim.LeaseID == "" {
+		return LeaseTarget{}, exit(4, "multipass instance %q has no Crabbox lease claim; use `crabbox stop --provider multipass %s` to delete it or warm a new lease", inst.Name, inst.Name)
+	}
+	lease, err := b.prepareLease(ctx, cfg, inst, claim, false)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" {
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	cfg := b.configForRun()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return nil, err
+	}
+	views := make([]LeaseView, 0, len(instances))
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if claim.LeaseID == "" && !strings.HasPrefix(inst.Name, "crabbox-") {
+			continue
+		}
+		views = append(views, b.serverFromInstance(inst, claim, cfg))
+	}
+	return views, nil
+}
+
+func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+	cfg := b.configForRun()
+	version, err := b.multipass(ctx, []string{"version"}, nil, nil)
+	if err != nil {
+		return DoctorResult{}, commandError("multipass version", version, err)
+	}
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	probe := "unchecked"
+	if req.ProbeSSH {
+		probe = "requires_running_lease"
+	}
+	msg := fmt.Sprintf("cli=ready daemon=ready control_plane=local inventory=ready api=list mutation=false leases=%d runtime=%s image=%s ssh_probe=%s", len(instances), firstLine(version.Stdout+version.Stderr), cfg.Multipass.Image, probe)
+	return DoctorResult{Provider: providerName, Message: msg}, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	lease := req.Lease
+	if lease.LeaseID == "" {
+		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
+	}
+	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	if name == "" && lease.LeaseID != "" {
+		inst, claim, err := b.resolveInstance(ctx, lease.LeaseID)
+		if err != nil {
+			return err
+		}
+		name = inst.Name
+		if lease.LeaseID == "" {
+			lease.LeaseID = claim.LeaseID
+		}
+	}
+	if name == "" {
+		return exit(2, "provider=%s release requires a Multipass instance name", providerName)
+	}
+	if err := b.removeInstance(ctx, name); err != nil {
+		return err
+	}
+	if lease.LeaseID != "" {
+		removeLeaseClaim(lease.LeaseID)
+		removeStoredTestboxKey(lease.LeaseID)
+	}
+	return nil
+}
+
+func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+}
+
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	cfg := b.configForRun()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return err
+	}
+	live := map[string]struct{}{}
+	now := time.Now().UTC()
+	removed := 0
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if claim.LeaseID != "" {
+			live[claim.LeaseID] = struct{}{}
+		}
+		server := b.serverFromInstance(inst, claim, cfg)
+		shouldDelete, reason := shouldCleanup(server, claim, claim.LeaseID != "", now)
+		if !shouldDelete {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=%s\n", inst.Name, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+		if err := b.removeInstance(ctx, inst.Name); err != nil {
+			return err
+		}
+		if claim.LeaseID != "" {
+			removeLeaseClaim(claim.LeaseID)
+			removeStoredTestboxKey(claim.LeaseID)
+		}
+		removed++
+	}
+	claimsRemoved := 0
+	for _, claim := range claims {
+		if claim.LeaseID == "" {
+			continue
+		}
+		if _, ok := live[claim.LeaseID]; ok {
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+		removeLeaseClaim(claim.LeaseID)
+		removeStoredTestboxKey(claim.LeaseID)
+		claimsRemoved++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(instances))
+	}
+	return nil
+}
+
+func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	original := server.Labels
+	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	for _, key := range []string{"image", "instance", "ssh_user", "ssh_port", "work_root"} {
+		if value := strings.TrimSpace(original[key]); value != "" {
+			server.Labels[key] = value
+		}
+	}
+	return server, nil
+}
+
+func (b *backend) createInstance(ctx context.Context, cfg Config, name, leaseID, slug, publicKey string) error {
+	mounts, err := multipassCacheVolumeMounts(cfg.Cache.Volumes)
+	if err != nil {
+		return err
+	}
+	userData := cloudInitUserData(cfg, publicKey)
+	tmp, err := os.CreateTemp("", "crabbox-multipass-*.cloud-init.yaml")
+	if err != nil {
+		return exit(2, "create multipass cloud-init file: %v", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.WriteString(userData); err != nil {
+		_ = tmp.Close()
+		return exit(2, "write multipass cloud-init file: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return exit(2, "close multipass cloud-init file: %v", err)
+	}
+	args := []string{"launch", "--name", name, "--cloud-init", tmpPath}
+	if cfg.Multipass.CPUs > 0 {
+		args = append(args, "--cpus", strconv.Itoa(cfg.Multipass.CPUs))
+	}
+	if memory := strings.TrimSpace(cfg.Multipass.Memory); memory != "" {
+		args = append(args, "--memory", memory)
+	}
+	if disk := strings.TrimSpace(cfg.Multipass.Disk); disk != "" {
+		args = append(args, "--disk", disk)
+	}
+	if cfg.Multipass.LaunchTimeout > 0 {
+		args = append(args, "--timeout", strconv.Itoa(durationSecondsCeil(cfg.Multipass.LaunchTimeout)))
+	}
+	for _, mount := range mounts {
+		args = append(args, "--mount", mount)
+	}
+	args = append(args, cfg.Multipass.Image)
+	result, err := b.multipass(ctx, args, nil, b.rt.Stderr)
+	if err != nil {
+		return commandError("multipass launch", result, err)
+	}
+	return nil
+}
+
+func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, error) {
+	if len(volumes) == 0 {
+		return nil, nil
+	}
+	root, err := multipassCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	mounts := make([]string, 0, len(volumes))
+	for _, volume := range volumes {
+		key := strings.TrimSpace(volume.Key)
+		path := strings.TrimSpace(volume.Path)
+		if key == "" {
+			return nil, exit(2, "cache volume key is required")
+		}
+		if strings.Contains(key, ":") {
+			return nil, exit(2, "cache volume key %q must not contain ':'", key)
+		}
+		if path == "" {
+			return nil, exit(2, "cache volume path is required")
+		}
+		if !strings.HasPrefix(path, "/") {
+			return nil, exit(2, "cache volume path %q must be absolute", path)
+		}
+		hostPath := filepath.Join(root, multipassCacheVolumeName(key))
+		if err := os.MkdirAll(hostPath, 0o777); err != nil {
+			return nil, exit(2, "create multipass cache volume %s: %v", hostPath, err)
+		}
+		if err := os.Chmod(hostPath, 0o777); err != nil {
+			return nil, exit(2, "make multipass cache volume writable %s: %v", hostPath, err)
+		}
+		mounts = append(mounts, hostPath+":"+path)
+	}
+	return mounts, nil
+}
+
+func multipassCacheRoot() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", exit(2, "user cache directory is unavailable")
+	}
+	return filepath.Join(dir, "crabbox", "multipass-cache"), nil
+}
+
+func multipassCacheVolumeName(key string) string {
+	key = strings.TrimSpace(key)
+	sum := sha256.Sum256([]byte(key))
+	var safe strings.Builder
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+			safe.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			safe.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			safe.WriteRune(r)
+		case r == '.' || r == '_' || r == '-':
+			safe.WriteRune(r)
+		default:
+			safe.WriteByte('-')
+		}
+		if safe.Len() >= 80 {
+			break
+		}
+	}
+	name := strings.Trim(safe.String(), ".-_")
+	if name == "" {
+		name = "volume"
+	}
+	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
+}
+
+func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error) {
+	result, err := b.multipass(ctx, []string{"list", "--format", "json"}, nil, nil)
+	if err != nil {
+		return nil, commandError("multipass list", result, err)
+	}
+	var out listResponse
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		return nil, exit(2, "parse multipass list: %v", err)
+	}
+	return out.List, nil
+}
+
+func (b *backend) inspectInstance(ctx context.Context, name string) (multipassInfoEntry, error) {
+	result, err := b.multipass(ctx, []string{"info", "--format", "json", name}, nil, nil)
+	if err != nil {
+		return multipassInfoEntry{}, commandError("multipass info", result, err)
+	}
+	var out infoResponse
+	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
+		return multipassInfoEntry{}, exit(2, "parse multipass info for %s: %v", name, err)
+	}
+	if len(out.Errors) > 0 {
+		return multipassInfoEntry{}, exit(4, "multipass info for %s returned %d error(s)", name, len(out.Errors))
+	}
+	info, ok := out.Info[name]
+	if !ok {
+		return multipassInfoEntry{}, exit(4, "multipass instance not found: %s", name)
+	}
+	return info, nil
+}
+
+func (b *backend) resolveInstance(ctx context.Context, identifier string) (multipassInstance, core.LeaseClaim, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return multipassInstance{}, core.LeaseClaim{}, exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
+	}
+	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+		return multipassInstance{}, core.LeaseClaim{}, err
+	} else if ok {
+		name := instanceNameFromClaim(claim)
+		if name == "" {
+			return multipassInstance{}, core.LeaseClaim{}, exit(4, "multipass lease %s has no instance name in its claim", claim.LeaseID)
+		}
+		info, err := b.inspectInstance(ctx, name)
+		if err != nil {
+			return multipassInstance{}, core.LeaseClaim{}, err
+		}
+		return info.toInstance(name), claim, nil
+	}
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return multipassInstance{}, core.LeaseClaim{}, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return multipassInstance{}, core.LeaseClaim{}, err
+	}
+	normalized := normalizeLeaseSlug(identifier)
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && normalizeLeaseSlug(claim.Slug) == normalized) {
+			if info, err := b.inspectInstance(ctx, inst.Name); err == nil {
+				inst = info.toInstance(inst.Name)
+			}
+			return inst, claim, nil
+		}
+	}
+	return multipassInstance{}, core.LeaseClaim{}, exit(4, "multipass lease not found: %s", identifier)
+}
+
+func (b *backend) prepareLease(ctx context.Context, cfg Config, inst multipassInstance, claim core.LeaseClaim, wait bool) (LeaseTarget, error) {
+	server := b.serverFromInstance(inst, claim, cfg)
+	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
+		cfg.Multipass.User = user
+		cfg.SSHUser = user
+	}
+	if root := strings.TrimSpace(server.Labels["work_root"]); root != "" {
+		cfg.Multipass.WorkRoot = root
+		cfg.WorkRoot = root
+	}
+	host := inst.ip()
+	if host == "" {
+		return LeaseTarget{}, exit(5, "multipass instance %s has no IPv4 address", inst.Name)
+	}
+	if claim.LeaseID != "" {
+		keyPath, err := testboxKeyPath(claim.LeaseID)
+		if err == nil {
+			if _, statErr := os.Stat(keyPath); statErr == nil {
+				cfg.SSHKey = keyPath
+			}
+		}
+	}
+	target := sshTargetFromConfig(cfg, host)
+	target.Port = sshPort
+	target.FallbackPorts = []string{}
+	target.ReadyCheck = "/usr/local/bin/crabbox-ready"
+	if wait {
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "multipass ssh", bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+		server.Status = "ready"
+		server.Labels["state"] = "ready"
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+}
+
+func (b *backend) removeInstance(ctx context.Context, name string) error {
+	result, err := b.multipass(ctx, []string{"delete", "--purge", name}, nil, b.rt.Stderr)
+	if err != nil {
+		return commandError("multipass delete", result, err)
+	}
+	return nil
+}
+
+func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseClaim, cfg Config) Server {
+	labels := map[string]string{}
+	for key, value := range claim.Labels {
+		labels[key] = value
+	}
+	if labels["crabbox"] == "" {
+		labels["crabbox"] = "true"
+	}
+	if labels["provider"] == "" {
+		labels["provider"] = providerName
+	}
+	if labels["instance"] == "" {
+		labels["instance"] = inst.Name
+	}
+	if labels["lease"] == "" {
+		labels["lease"] = claim.LeaseID
+	}
+	if labels["slug"] == "" {
+		labels["slug"] = claim.Slug
+	}
+	if labels["state"] == "" {
+		labels["state"] = multipassState(inst.State)
+	}
+	if labels["server_type"] == "" {
+		labels["server_type"] = firstNonBlank(inst.Release, cfg.Multipass.Image)
+	}
+	if labels["image"] == "" {
+		labels["image"] = cfg.Multipass.Image
+	}
+	if labels["ssh_user"] == "" {
+		labels["ssh_user"] = cfg.Multipass.User
+	}
+	if labels["ssh_port"] == "" {
+		labels["ssh_port"] = sshPort
+	}
+	if labels["work_root"] == "" {
+		labels["work_root"] = cfg.Multipass.WorkRoot
+	}
+	status := multipassState(inst.State)
+	if instanceRunning(inst.State) && labels["state"] == "ready" {
+		status = "ready"
+	}
+	server := Server{
+		CloudID:  inst.Name,
+		Provider: providerName,
+		Name:     inst.Name,
+		Status:   status,
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = inst.ip()
+	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.Multipass.Image)
+	return server
+}
+
+func providerClaims() (map[string]core.LeaseClaim, error) {
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider != providerName {
+			continue
+		}
+		name := instanceNameFromClaim(claim)
+		if name == "" {
+			continue
+		}
+		out[name] = claim
+	}
+	return out, nil
+}
+
+func instanceScope(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	return "instance:" + name
+}
+
+func instanceNameFromClaim(claim core.LeaseClaim) string {
+	if name := strings.TrimSpace(claim.Labels["instance"]); name != "" {
+		return name
+	}
+	return instanceNameFromScope(claim.ProviderScope)
+}
+
+func instanceNameFromScope(scope string) string {
+	return strings.TrimPrefix(strings.TrimSpace(scope), "instance:")
+}
+
+func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	if strings.EqualFold(server.Labels["keep"], "true") {
+		return false, "keep=true"
+	}
+	if !instanceRunning(server.Status) && server.Status != "ready" {
+		return true, "instance state=" + blank(server.Status, "unknown")
+	}
+	if hasClaim {
+		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+		if err != nil || lastUsed.IsZero() {
+			return false, "claim active"
+		}
+		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+		if idle <= 0 {
+			return false, "claim active"
+		}
+		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+			return true, "claim expired"
+		}
+		return false, "claim active"
+	}
+	return false, "missing claim"
+}
+
+func (b *backend) multipass(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+	cfg := b.configForRun()
+	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   cfg.Multipass.CLIPath,
+		Args:   args,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+}
+
+func (i multipassInstance) ip() string {
+	for _, ip := range i.IPv4 {
+		ip = strings.TrimSpace(ip)
+		if ip != "" && ip != "--" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func (i multipassInfoEntry) toInstance(name string) multipassInstance {
+	return multipassInstance{
+		Name:    name,
+		State:   i.State,
+		IPv4:    append([]string(nil), i.IPv4...),
+		Release: firstNonBlank(i.Release, i.ImageRelease),
+	}
+}
+
+func instanceRunning(state string) bool {
+	switch multipassState(state) {
+	case "running", "ready":
+		return true
+	default:
+		return false
+	}
+}
+
+func multipassState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func commandError(action string, result LocalCommandResult, err error) error {
+	code := result.ExitCode
+	if code == 0 {
+		code = 1
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		return exit(code, "%s failed: %v: %s", action, err, detail)
+	}
+	return exit(code, "%s failed: %v", action, err)
+}
+
+func durationSecondsCeil(duration time.Duration) int {
+	seconds := int(duration / time.Second)
+	if duration%time.Second != 0 {
+		seconds++
+	}
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
+}
+
+func firstLine(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	if idx := strings.IndexByte(value, '\n'); idx >= 0 {
+		value = value[:idx]
+	}
+	return strings.TrimSpace(value)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -124,10 +124,16 @@ func TestApplyDefaults(t *testing.T) {
 }
 
 func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
+	oldHostOS := multipassHostOS
+	multipassHostOS = "darwin"
+	t.Cleanup(func() { multipassHostOS = oldHostOS })
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
-	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"launch": {}}}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"get", "local.driver"}): {Stdout: "qemu\n"},
+		"launch": {},
+	}}
 	b := testBackend(runner)
 	cfg := b.configForRun()
 	cfg.Cache.Volumes = []core.CacheVolumeConfig{
@@ -137,14 +143,15 @@ func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
 	if err := b.createInstance(context.Background(), cfg, "crabbox-blue-1234abcd", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test"); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("calls=%d", len(runner.calls))
+	if len(runner.calls) == 0 {
+		t.Fatal("no commands recorded")
 	}
+	launchArgs := recordedArgsForCommand(t, runner, "launch")
 	call := runner.calls[0]
 	if call.Name != "multipass" {
 		t.Fatalf("binary=%q want multipass", call.Name)
 	}
-	args := strings.Join(call.Args, "\n")
+	args := launchArgs
 	root, err := multipassCacheRoot()
 	if err != nil {
 		t.Fatal(err)
@@ -155,11 +162,19 @@ func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
 		"--memory\n8G",
 		"--disk\n40G",
 		"--timeout\n600",
-		"--mount\n" + filepath.Join(root, multipassCacheVolumeName("my-app/linux node24 lock")) + ":/var/cache/crabbox/pnpm",
 		"24.04",
 	} {
 		if !strings.Contains(args, want) {
 			t.Fatalf("launch args missing %q:\n%s", want, args)
+		}
+	}
+	if strings.Contains(args, "--mount") {
+		t.Fatalf("darwin qemu launch should not include --mount:\n%s", args)
+	}
+	mountArgs := recordedArgsForCommand(t, runner, "mount")
+	for _, want := range []string{"mount\n--type\nnative", filepath.Join(root, multipassCacheVolumeName("my-app/linux node24 lock")), "crabbox-blue-1234abcd:/var/cache/crabbox/pnpm"} {
+		if !strings.Contains(mountArgs, want) {
+			t.Fatalf("native mount args missing %q:\n%s", want, mountArgs)
 		}
 	}
 	cloudInit := runner.cloudInit
@@ -171,6 +186,40 @@ func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
 	} {
 		if !strings.Contains(cloudInit, want) {
 			t.Fatalf("cloud-init missing %q:\n%s", want, cloudInit)
+		}
+	}
+}
+
+func TestCreateInstanceFallsBackToClassicMountsForDarwinVirtualBox(t *testing.T) {
+	oldHostOS := multipassHostOS
+	multipassHostOS = "darwin"
+	t.Cleanup(func() { multipassHostOS = oldHostOS })
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"get", "local.driver"}): {Stdout: "virtualbox\n"},
+		"launch": {},
+	}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.Cache.Volumes = []core.CacheVolumeConfig{{Key: "gomod", Path: "/var/cache/crabbox/go"}}
+
+	if err := b.createInstance(context.Background(), cfg, "crabbox-blue-1234abcd", "cbx_123", "blue-lobster", "PUB"); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "launch")
+	root, err := multipassCacheRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mountArg := filepath.Join(root, multipassCacheVolumeName("gomod")) + ":/var/cache/crabbox/go"
+	if !strings.Contains(args, "--mount\n"+mountArg) {
+		t.Fatalf("virtualbox launch args missing classic mount %q:\n%s", mountArg, args)
+	}
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && call.Args[0] == "mount" {
+			t.Fatalf("virtualbox should not use native mount command: %#v", call.Args)
 		}
 	}
 }
@@ -264,6 +313,29 @@ func TestRemoveInstanceUsesDeletePurge(t *testing.T) {
 	args := recordedArgsForCommand(t, runner, "delete")
 	if !strings.Contains(args, "delete\n--purge\ncrabbox-blue-1234abcd") {
 		t.Fatalf("delete args=%q", args)
+	}
+}
+
+func TestAcquireCleansUpLaunchFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"list", "--format", "json"}): {Stdout: `{"list":[]}`},
+			"launch": {Stderr: "launch failed"},
+		},
+		errors: map[string]error{"launch": errors.New("launch failed")},
+	}
+	b := testBackend(runner)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true})
+	if err == nil || !strings.Contains(err.Error(), "multipass launch failed") {
+		t.Fatalf("Acquire error=%v", err)
+	}
+	deleteArgs := recordedArgsForCommand(t, runner, "delete")
+	if !strings.Contains(deleteArgs, "delete\n--purge\ncrabbox-") {
+		t.Fatalf("delete not recorded after launch failure:\n%s", deleteArgs)
 	}
 }
 

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -1,0 +1,438 @@
+package multipass
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls     []core.LocalCommandRequest
+	cloudInit string
+	responses map[string]core.LocalCommandResult
+	errors    map[string]error
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	if len(req.Args) > 0 && req.Args[0] == "launch" {
+		r.cloudInit = readLaunchCloudInit(req.Args)
+	}
+	key := commandKey(req.Args)
+	if err, ok := r.errors[key]; ok {
+		return r.responses[key], err
+	}
+	if result, ok := r.responses[key]; ok {
+		return result, nil
+	}
+	if len(req.Args) > 0 {
+		if err, ok := r.errors[req.Args[0]]; ok {
+			return r.responses[req.Args[0]], err
+		}
+		if result, ok := r.responses[req.Args[0]]; ok {
+			return result, nil
+		}
+	}
+	return core.LocalCommandResult{}, nil
+}
+
+func commandKey(args []string) string {
+	return strings.Join(args, "\x00")
+}
+
+func recordedArgsForCommand(t *testing.T, runner *recordingRunner, command string) string {
+	t.Helper()
+	for i := len(runner.calls) - 1; i >= 0; i-- {
+		if len(runner.calls[i].Args) > 0 && runner.calls[i].Args[0] == command {
+			return strings.Join(runner.calls[i].Args, "\n")
+		}
+	}
+	t.Fatalf("%s command was not recorded: %#v", command, runner.calls)
+	return ""
+}
+
+func testBackend(runner *recordingRunner) *backend {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Multipass = core.MultipassConfig{
+		CLIPath:       "multipass",
+		Image:         "24.04",
+		User:          "runner",
+		WorkRoot:      "/workspace/crabbox",
+		CPUs:          4,
+		Memory:        "8G",
+		Disk:          "40G",
+		LaunchTimeout: 10 * time.Minute,
+	}
+	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+}
+
+func sampleListJSON() string {
+	return `{"list":[{"name":"crabbox-blue-1234abcd","state":"Running","ipv4":["192.168.64.7"],"release":"Ubuntu 24.04 LTS"},{"name":"primary","state":"Stopped","ipv4":[],"release":"Ubuntu 24.04 LTS"}]}`
+}
+
+func sampleInfoJSON(name string) string {
+	return `{"errors":[],"info":{"` + name + `":{"state":"Running","ipv4":["192.168.64.7"],"release":"Ubuntu 24.04.4 LTS","image_hash":"abc123","image_release":"24.04 LTS"}}}`
+}
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %s", p.Name(), providerName)
+	}
+	for _, alias := range []string{"multipass", "mp", "canonical-multipass"} {
+		got, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if got.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", alias, got.Name())
+		}
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Family != "local-vm" {
+		t.Fatalf("unexpected spec: %#v", spec)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Multipass = core.MultipassConfig{}
+	applyDefaults(&cfg)
+	if cfg.Multipass.CLIPath != "multipass" || cfg.Multipass.Image != "26.04" || cfg.Multipass.User != "crabbox" || cfg.Multipass.WorkRoot != "/work/crabbox" {
+		t.Fatalf("defaults not applied: %#v", cfg.Multipass)
+	}
+	if cfg.SSHUser != "crabbox" || cfg.SSHPort != sshPort || len(cfg.SSHFallbackPorts) != 0 || cfg.WorkRoot != "/work/crabbox" {
+		t.Fatalf("derived SSH fields wrong: user=%s port=%s fallback=%v work=%s", cfg.SSHUser, cfg.SSHPort, cfg.SSHFallbackPorts, cfg.WorkRoot)
+	}
+}
+
+func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"launch": {}}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.Cache.Volumes = []core.CacheVolumeConfig{
+		{Key: "my-app/linux node24 lock", Path: "/var/cache/crabbox/pnpm"},
+	}
+
+	if err := b.createInstance(context.Background(), cfg, "crabbox-blue-1234abcd", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls=%d", len(runner.calls))
+	}
+	call := runner.calls[0]
+	if call.Name != "multipass" {
+		t.Fatalf("binary=%q want multipass", call.Name)
+	}
+	args := strings.Join(call.Args, "\n")
+	root, err := multipassCacheRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"launch\n--name\ncrabbox-blue-1234abcd",
+		"--cpus\n4",
+		"--memory\n8G",
+		"--disk\n40G",
+		"--timeout\n600",
+		"--mount\n" + filepath.Join(root, multipassCacheVolumeName("my-app/linux node24 lock")) + ":/var/cache/crabbox/pnpm",
+		"24.04",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("launch args missing %q:\n%s", want, args)
+		}
+	}
+	cloudInit := runner.cloudInit
+	for _, want := range []string{
+		"name: runner",
+		"ssh-ed25519 AAAA test",
+		"test -w /workspace/crabbox",
+		"Port 22",
+	} {
+		if !strings.Contains(cloudInit, want) {
+			t.Fatalf("cloud-init missing %q:\n%s", want, cloudInit)
+		}
+	}
+}
+
+func readLaunchCloudInit(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--cloud-init" {
+			data, err := os.ReadFile(args[i+1])
+			if err != nil {
+				return ""
+			}
+			return string(data)
+		}
+	}
+	return ""
+}
+
+func TestListAndResolveInstancesWithClaim(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	claimServer := core.Server{
+		CloudID: "crabbox-blue-1234abcd",
+		Labels: map[string]string{
+			"crabbox":   "true",
+			"provider":  providerName,
+			"lease":     "cbx_123",
+			"slug":      "blue-lobster",
+			"instance":  "crabbox-blue-1234abcd",
+			"ssh_user":  "runner",
+			"ssh_port":  "22",
+			"work_root": "/workspace/crabbox",
+		},
+	}
+	claimTarget := core.SSHTarget{Host: "192.168.64.7", Port: "22"}
+	if err := claimLeaseForRepoProviderScopePond("cbx_123", "blue-lobster", providerName, instanceScope("crabbox-blue-1234abcd"), "", t.TempDir(), 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateLeaseClaimEndpoint("cbx_123", claimServer, claimTarget); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"list", "--format", "json"}):                          {Stdout: sampleListJSON()},
+		commandKey([]string{"info", "--format", "json", "crabbox-blue-1234abcd"}): {Stdout: sampleInfoJSON("crabbox-blue-1234abcd")},
+	}}
+	b := testBackend(runner)
+
+	views, err := b.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("views=%d want 1", len(views))
+	}
+	if views[0].Provider != providerName || views[0].CloudID != "crabbox-blue-1234abcd" || views[0].Labels["slug"] != "blue-lobster" || views[0].PublicNet.IPv4.IP != "192.168.64.7" {
+		t.Fatalf("unexpected view: %#v", views[0])
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "blue-lobster"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_123" || lease.SSH.Host != "192.168.64.7" || lease.SSH.Port != "22" || lease.SSH.User != "runner" || len(lease.SSH.FallbackPorts) != 0 || lease.SSH.ReadyCheck != "/usr/local/bin/crabbox-ready" {
+		t.Fatalf("unexpected lease: %#v", lease)
+	}
+}
+
+func TestDoctorReady(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"version"}):                  {Stdout: "multipass 1.16.0\nmultipassd 1.16.0\n"},
+		commandKey([]string{"list", "--format", "json"}): {Stdout: `{"list":[]}`},
+	}}
+	b := testBackend(runner)
+	res, err := b.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Provider != providerName || !strings.Contains(res.Message, "daemon=ready") || !strings.Contains(res.Message, "multipass 1.16.0") {
+		t.Fatalf("doctor result=%#v", res)
+	}
+}
+
+func TestRemoveInstanceUsesDeletePurge(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"delete", "--purge", "crabbox-blue-1234abcd"}): {},
+	}}
+	b := testBackend(runner)
+	if err := b.removeInstance(context.Background(), "crabbox-blue-1234abcd"); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "delete")
+	if !strings.Contains(args, "delete\n--purge\ncrabbox-blue-1234abcd") {
+		t.Fatalf("delete args=%q", args)
+	}
+}
+
+func TestDoctorReportsMissingCLI(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{"version": {Stderr: "command not found", ExitCode: 127}},
+		errors:    map[string]error{"version": errors.New("exec: multipass not found")},
+	}
+	b := testBackend(runner)
+	if _, err := b.Doctor(context.Background(), core.DoctorRequest{}); err == nil || !strings.Contains(err.Error(), "multipass version failed") {
+		t.Fatalf("doctor error=%v", err)
+	}
+}
+
+func TestDurationSecondsCeil(t *testing.T) {
+	for input, want := range map[time.Duration]int{
+		0:                       1,
+		1500 * time.Millisecond: 2,
+		2 * time.Second:         2,
+	} {
+		if got := durationSecondsCeil(input); got != want {
+			t.Fatalf("%s -> %d want %d", input, got, want)
+		}
+	}
+}
+
+func TestCacheVolumeNameIsStableAndFilesystemSafe(t *testing.T) {
+	got := multipassCacheVolumeName("My App/linux node24 lock")
+	again := multipassCacheVolumeName("My App/linux node24 lock")
+	if got != again {
+		t.Fatalf("cache volume name unstable: %q then %q", got, again)
+	}
+	if !strings.HasPrefix(got, "crabbox-cache-my-app-linux-node24-lock-") {
+		t.Fatalf("cache volume name=%q, want sanitized prefix", got)
+	}
+	if strings.ContainsAny(got, " /:") {
+		t.Fatalf("cache volume name contains unsafe characters: %q", got)
+	}
+}
+
+func TestConfigureRejectsTailscaleAndNonLinux(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Tailscale.Enabled = true
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted tailscale")
+	}
+	cfg = core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted non-linux target")
+	}
+}
+
+func TestLaunchTimeoutFlagParsesDuration(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := registerFlags(fs, core.BaseConfig())
+	if err := fs.Parse([]string{"--multipass-launch-timeout", "7m"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	if err := applyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Multipass.LaunchTimeout != 7*time.Minute {
+		t.Fatalf("launch timeout=%s", cfg.Multipass.LaunchTimeout)
+	}
+}
+
+func TestNoPrivateKeyMaterialInLaunchArgs(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"launch": {}}}
+	b := testBackend(runner)
+	if err := b.createInstance(context.Background(), b.configForRun(), "crabbox-blue-1234abcd", "cbx_123", "blue-lobster", "PUBLIC-KEY"); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "launch")
+	if strings.Contains(strings.ToUpper(args), "PRIVATE") {
+		t.Fatalf("unexpected secret-like content in args:\n%s", args)
+	}
+	if strings.Contains(args, "PUBLIC-KEY") {
+		t.Fatalf("public key should be in cloud-init file, not process args:\n%s", args)
+	}
+}
+
+func TestInstanceScopeRoundTrip(t *testing.T) {
+	name := "crabbox-blue-1234abcd"
+	if got := instanceNameFromScope(instanceScope(name)); got != name {
+		t.Fatalf("instance name=%q want %q", got, name)
+	}
+}
+
+func TestListJSONDecode(t *testing.T) {
+	var out listResponse
+	if err := json.Unmarshal([]byte(sampleListJSON()), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.List) != 2 || out.List[0].ip() != "192.168.64.7" {
+		t.Fatalf("decoded=%#v", out)
+	}
+}
+
+func TestInfoJSONDecode(t *testing.T) {
+	var out infoResponse
+	if err := json.Unmarshal([]byte(sampleInfoJSON("crabbox-blue-1234abcd")), &out); err != nil {
+		t.Fatal(err)
+	}
+	inst := out.Info["crabbox-blue-1234abcd"].toInstance("crabbox-blue-1234abcd")
+	if inst.Name != "crabbox-blue-1234abcd" || inst.Release != "Ubuntu 24.04.4 LTS" || inst.ip() != "192.168.64.7" {
+		t.Fatalf("decoded=%#v", inst)
+	}
+}
+
+func TestCacheVolumeMountValidation(t *testing.T) {
+	if _, err := multipassCacheVolumeMounts([]core.CacheVolumeConfig{{Key: "bad:key", Path: "/cache"}}); err == nil {
+		t.Fatal("accepted ':' in cache key")
+	}
+	if _, err := multipassCacheVolumeMounts([]core.CacheVolumeConfig{{Key: "ok", Path: "relative"}}); err == nil {
+		t.Fatal("accepted relative cache path")
+	}
+}
+
+func TestLaunchTimeoutArgumentRoundsUp(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"launch": {}}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.Multipass.LaunchTimeout = 1500 * time.Millisecond
+	if err := b.createInstance(context.Background(), cfg, "crabbox-blue-1234abcd", "cbx_123", "blue-lobster", "PUB"); err != nil {
+		t.Fatal(err)
+	}
+	args := recordedArgsForCommand(t, runner, "launch")
+	if !strings.Contains(args, "--timeout\n2") {
+		t.Fatalf("timeout arg not rounded up:\n%s", args)
+	}
+}
+
+func TestServerFromUnclaimedCrabboxNamedInstance(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromInstance(multipassInstance{Name: "crabbox-blue-1234abcd", State: "Running", IPv4: []string{"192.168.64.7"}, Release: "Ubuntu 24.04 LTS"}, core.LeaseClaim{}, b.configForRun())
+	if server.CloudID != "crabbox-blue-1234abcd" || server.Labels["provider"] != providerName || server.Labels["instance"] != "crabbox-blue-1234abcd" {
+		t.Fatalf("server=%#v", server)
+	}
+}
+
+func TestShouldCleanupRespectsKeepLabel(t *testing.T) {
+	server := Server{Status: "stopped", Labels: map[string]string{"keep": "true"}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now()); ok || reason != "keep=true" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupExpiredClaim(t *testing.T) {
+	server := Server{Status: "running", Labels: map[string]string{}}
+	claim := core.LeaseClaim{LeaseID: "cbx_123", LastUsedAt: time.Now().Add(-48 * time.Hour).Format(time.RFC3339), IdleTimeoutSeconds: int((30 * time.Minute).Seconds())}
+	if ok, reason := shouldCleanup(server, claim, true, time.Now()); !ok || reason != "claim expired" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
+	server := Server{Status: "running", Labels: map[string]string{}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestLaunchArgTimeoutValueIsNumeric(t *testing.T) {
+	if _, err := strconv.Atoi(strconv.Itoa(durationSecondsCeil(10 * time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -1,0 +1,127 @@
+package multipass
+
+import (
+	"context"
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type MultipassConfig = core.MultipassConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+
+const (
+	providerName = "multipass"
+	targetLinux  = core.TargetLinux
+	sshPort      = "22"
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func leaseProviderName(leaseID, slug string) string {
+	return core.LeaseProviderName(leaseID, slug)
+}
+
+func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
+	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
+	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
+}
+
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, provider)
+}
+
+func listLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaims()
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
+	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
+}
+
+func updateLeaseClaimCacheVolumes(leaseID string, specs []string) error {
+	return core.UpdateLeaseClaimCacheVolumes(leaseID, specs)
+}
+
+func cacheVolumeStickyDiskSpecs(volumes []core.CacheVolumeConfig) []string {
+	return core.CacheVolumeStickyDiskSpecs(volumes)
+}
+
+func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
+	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
+}
+
+func testboxKeyPath(leaseID string) (string, error) {
+	return core.TestboxKeyPath(leaseID)
+}
+
+func removeStoredTestboxKey(leaseID string) {
+	core.RemoveStoredTestboxKey(leaseID)
+}
+
+func sshTargetFromConfig(cfg Config, host string) SSHTarget {
+	return core.SSHTargetFromConfig(cfg, host)
+}
+
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+}
+
+func bootstrapWaitTimeout(cfg Config) time.Duration {
+	return core.BootstrapWaitTimeout(cfg)
+}
+
+func cloudInitUserData(cfg Config, publicKey string) string {
+	return core.CloudInitUserData(cfg, publicKey)
+}

--- a/internal/providers/multipass/flags.go
+++ b/internal/providers/multipass/flags.go
@@ -1,0 +1,81 @@
+package multipass
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	CLIPath       *string
+	Image         *string
+	User          *string
+	WorkRoot      *string
+	CPUs          *int
+	Memory        *string
+	Disk          *string
+	LaunchTimeout *string
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		CLIPath:       fs.String("multipass-cli", defaults.Multipass.CLIPath, "Multipass CLI path"),
+		Image:         fs.String("multipass-image", defaults.Multipass.Image, "Multipass Ubuntu image selector"),
+		User:          fs.String("multipass-user", defaults.Multipass.User, "SSH user created inside Multipass leases"),
+		WorkRoot:      fs.String("multipass-work-root", defaults.Multipass.WorkRoot, "remote Crabbox work root inside Multipass leases"),
+		CPUs:          fs.Int("multipass-cpus", defaults.Multipass.CPUs, "CPU count for Multipass leases; 0 leaves Multipass default"),
+		Memory:        fs.String("multipass-memory", defaults.Multipass.Memory, "memory size for Multipass leases, for example 8G"),
+		Disk:          fs.String("multipass-disk", defaults.Multipass.Disk, "disk size for Multipass leases, for example 30G"),
+		LaunchTimeout: fs.String("multipass-launch-timeout", defaults.Multipass.LaunchTimeout.String(), "Multipass launch timeout"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "multipass-cli") {
+		cfg.Multipass.CLIPath = *v.CLIPath
+	}
+	if flagWasSet(fs, "multipass-image") {
+		cfg.Multipass.Image = *v.Image
+		core.MarkMultipassImageExplicit(cfg)
+	}
+	if flagWasSet(fs, "multipass-user") {
+		cfg.Multipass.User = *v.User
+		cfg.SSHUser = *v.User
+	}
+	if flagWasSet(fs, "multipass-work-root") {
+		cfg.Multipass.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if flagWasSet(fs, "multipass-cpus") {
+		cfg.Multipass.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "multipass-memory") {
+		cfg.Multipass.Memory = *v.Memory
+	}
+	if flagWasSet(fs, "multipass-disk") {
+		cfg.Multipass.Disk = *v.Disk
+	}
+	if flagWasSet(fs, "multipass-launch-timeout") {
+		if err := core.ApplyLeaseDuration(&cfg.Multipass.LaunchTimeout, *v.LaunchTimeout); err != nil {
+			return err
+		}
+	}
+	if isMultipassProviderName(cfg.Provider) {
+		applyDefaults(cfg)
+	}
+	return nil
+}
+
+func isMultipassProviderName(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case providerName, "mp", "canonical-multipass":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/multipass/provider.go
+++ b/internal/providers/multipass/provider.go
@@ -1,0 +1,60 @@
+package multipass
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"mp", "canonical-multipass"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "local-vm",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; use a remote SSH provider when tailnet reachability is required", providerName)
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}


### PR DESCRIPTION
From https://x.com/_lopopolo/status/2061613371883954430 adding multipass as a provider for crabbox.

---

## Summary

Adds `provider=multipass` as a local Ubuntu VM SSH-lease provider backed by Canonical Multipass.

- launches local Ubuntu VMs with `multipass launch` and Crabbox cloud-init
- creates per-lease SSH keys/users and runs through the normal Crabbox SSH sync/run path
- supports `warmup`, `run`, `ssh`, `status`, `stop`, `cleanup`, portable `--os` image defaults, and cache volumes
- keeps lifecycle local-only with no coordinator/cloud credentials
- rejects unsupported surfaces like Tailscale and `--actions-runner`

## Verification

- `go test ./internal/providers/...`
- `go test ./internal/cli -run 'TestValidateActionsRunnerCapability|TestMultipass|TestConfigShow|TestPortableOS|TestExplicitProviderImagesSurvivePortableOSDefaults|TestAppleContainerImageFollowsOSImageDefault|TestAppleContainerExplicitImageSurvivesOSDefault|TestProviderFlag'`
- `go test ./internal/cli -run '^$'`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `bin/crabbox providers --json | jq -r '.[] | select(.provider=="multipass")'`
- `bin/crabbox doctor --provider multipass`
- `bin/crabbox warmup --provider multipass --slug multipass-smoke`
- `bin/crabbox run --provider multipass --id multipass-smoke -- sh -lc 'pwd && uname -a && test -d /work/crabbox && test -f go.mod && git --version && rsync --version >/dev/null && jq --version'`
- `bin/crabbox run --provider multipass --slug multipass-cache-smoke --multipass-cpus 2 --multipass-memory 2G --multipass-disk 10G --cache-volume mp-e2e-cache:/var/cache/crabbox/e2e -- sh -lc 'printf cache-ok > /var/cache/crabbox/e2e/probe && test "$(cat /var/cache/crabbox/e2e/probe)" = cache-ok'`
- `bin/crabbox warmup --provider multipass --actions-runner --ttl 1s --slug should-not-start` exits before provisioning with the expected unsupported-provider error
- `bin/crabbox status --provider multipass --id multipass-smoke`
- `bin/crabbox ssh --provider multipass --id multipass-smoke`
- `bin/crabbox stop --provider multipass multipass-smoke`
- `bin/crabbox cleanup --provider multipass --dry-run`
- `multipass list --format json`
- `git diff --check`

## Live E2E Evidence

Multipass version:

```text
multipass   1.16.3+mac
multipassd  1.16.3+mac
```

Warmup provisioned:

```text
provisioned lease=cbx_2fe2671a391d instance=crabbox-multipass-smoke-36ebb60e state=ready
leased cbx_2fe2671a391d slug=multipass-smoke provider=multipass server=crabbox-multipass-smoke-36ebb60e type=26.04 ip=192.168.252.3 idle_timeout=30m0s expires=2026-06-02T04:26:21Z
ready ssh=crabbox@192.168.252.3:22 network=public workroot=/work/crabbox
warmup complete total=38.224s
```

Run/sync executed on the VM:

```text
syncing workspace to crabbox@192.168.252.3:/work/crabbox/cbx_2fe2671a391d/crabbox
sent 602 files / 9.4 MiB
/work/crabbox/cbx_2fe2671a391d/crabbox
Linux crabbox-multipass-smoke-36ebb60e 7.0.0-15-generic #15-Ubuntu SMP PREEMPT_DYNAMIC Wed Apr 22 15:54:12 UTC 2026 aarch64 GNU/Linux
git version 2.53.0
jq-1.8.1
command complete in 74ms total=4.365s
```

Cache-volume smoke passed: the provider launched `crabbox-multipass-cache-smoke-e0fd1aef`, mounted the host cache directory, synced the checkout, wrote/read the mounted probe file, and released the ephemeral VM automatically.

Unsupported actions-runner path fails before provisioning:

```text
--actions-runner is not supported for provider=multipass; use normal crabbox run or a remote SSH provider
```

Final cleanup state:

```json
{"list":[]}
```

## Notes

This is a headless provider, so there is no useful screenshot. The relevant proof is the terminal transcript above showing create, SSH readiness, sync, remote command execution, cache mount, unsupported runner rejection, stop, and empty final inventory.
