### PR TITLE
islo: align provider with current Islo API status/SSE contract

### DIFF
--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -34,7 +34,7 @@ provider: islo
 target: linux
 islo:
   baseUrl: https://api.islo.dev
-  image: docker.io/library/ubuntu:24.04
+  image: docker.io/library/ubuntu:26.04
   workdir: crabbox
   gatewayProfile: ""
   snapshotName: ""
@@ -45,7 +45,7 @@ islo:
 
 Defaults: `baseUrl` `https://api.islo.dev`, `workdir` `crabbox`, `vcpus` `2`,
 `memoryMB` `4096`, `diskGB` `20`. The image default comes from the resolved OS
-target.
+target (the default OS `ubuntu:26.04` resolves to `docker.io/library/ubuntu:26.04`).
 
 `islo.workdir` is a relative directory name under `/workspace`. Absolute paths
 and `..` escapes are rejected before Crabbox prepares or syncs the workspace, so
@@ -66,7 +66,7 @@ variable:
 | `diskGB`         | `--islo-disk-gb`         | `CRABBOX_ISLO_DISK_GB`         |
 
 ```sh
-crabbox warmup --provider islo --islo-image docker.io/library/ubuntu:24.04
+crabbox warmup --provider islo --islo-image docker.io/library/ubuntu:26.04
 crabbox run --provider islo -- pnpm test
 crabbox status --provider islo --id blue-lobster
 crabbox stop --provider islo blue-lobster

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -10,9 +10,10 @@ Read when:
 command transport, while Crabbox owns local config, repo claims, the sync
 manifest and its guardrails, slugs, timing summaries, and normalized
 `list`/`status` rendering. Crabbox uses the Islo Go SDK for auth and sandbox
-lifecycle (create, list, status, stop) and a small SSE reader for the
-`POST /sandboxes/{name}/exec/stream` endpoint, since the SDK's exec helper
-coalesces streamed output.
+lifecycle (create, list, status) and calls the HTTP API directly for stop (an
+empty-body `DELETE`), archive upload, shares, and command output — the last via
+a small SSE reader for the `POST /sandboxes/{name}/exec/stream` endpoint, since
+the SDK's exec helper coalesces streamed output.
 
 Sandboxes are Linux-only. There is no Crabbox-managed SSH lease; commands run
 through Islo's streaming exec endpoint, not through `crabbox ssh`/rsync.
@@ -81,10 +82,10 @@ crabbox stop --provider islo blue-lobster
   `/workspace/<islo.workdir>`, streams stdout/stderr from Islo's SSE exec
   endpoint, and returns the remote exit code. A stream is only treated as
   successful once an exit event arrives.
-- **list**, **status**, and **stop** go through the Islo SDK and only act on
-  Crabbox-created sandboxes. Identifiers may be a Crabbox slug, an `isb_...`
-  lease ID, or a Crabbox-created sandbox name; non-Crabbox sandboxes are
-  rejected.
+- **list** and **status** go through the Islo SDK; **stop** issues a direct
+  `DELETE`. All three act only on Crabbox-created sandboxes. Identifiers may be a
+  Crabbox slug, an `isb_...` lease ID, or a Crabbox-created sandbox name;
+  non-Crabbox sandboxes are rejected.
 - The sandbox is deleted on release unless kept. `--keep-on-failure` keeps a
   newly created failed sandbox until an explicit `stop` or provider-side expiry.
 

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -7,8 +7,9 @@ Read when:
 - changing `internal/providers/islo`.
 
 Islo is a delegated-run provider. Crabbox uses the Islo Go SDK for sandbox
-lifecycle (create, list, status, delete) and reads a Server-Sent Events stream
-from the `POST /sandboxes/{name}/exec/stream` endpoint for command output. Islo
+lifecycle (create, list, status) and calls the HTTP API directly for delete (an
+empty-body `DELETE`), archive upload, shares, and command output — reading a
+Server-Sent Events stream from the `POST /sandboxes/{name}/exec/stream` endpoint. Islo
 owns sandbox state and command transport; Crabbox owns local config, repo
 claims, sync manifests and guardrails, slugs, timing summaries, and normalized
 `list`/`status` rendering. There is no Crabbox SSH lease and no broker

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -302,6 +302,9 @@ func (b *isloBackend) Status(ctx context.Context, req StatusRequest) (statusView
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
+		if isloStatusTerminal(view.State) {
+			return statusView{}, exit(5, "sandbox %s entered terminal state %q before becoming ready", name, view.State)
+		}
 		if b.now().After(deadline) {
 			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", name)
 		}
@@ -539,9 +542,25 @@ func applyIsloClaimLabels(labels map[string]string, leaseID string) {
 	}
 }
 
+// isloStatusReady reports whether a sandbox is ready to accept commands.
+//
+// The Islo API reports exactly one ready state, "running"; the full set of
+// statuses it returns is starting/running/paused/stopping/stopped/failed/
+// deleted/unknown. The legacy "ready"/"started"/"active" values are no longer
+// emitted (a "ready" boot state is normalized to "running" server-side), so
+// matching them is unnecessary and misleading.
 func isloStatusReady(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), "running")
+}
+
+// isloStatusTerminal reports whether a sandbox status is a terminal state that
+// will never transition to ready, so callers can fail fast instead of polling
+// until a deadline. Mirrors the terminal states the Islo API can report:
+// "failed", "stopped", and "deleted" are terminal, and "stopping" is an
+// in-progress teardown that will not recover.
+func isloStatusTerminal(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "ready", "running", "started", "active":
+	case "failed", "stopped", "stopping", "deleted":
 		return true
 	default:
 		return false

--- a/internal/providers/islo/backend_live_test.go
+++ b/internal/providers/islo/backend_live_test.go
@@ -1,3 +1,5 @@
+//go:build smoke
+
 package islo
 
 import (
@@ -16,10 +18,15 @@ import (
 // actually returns today. It is skipped unless ISLO_API_KEY is set, so it never
 // runs in CI without credentials.
 //
+//	go test -tags smoke -run TestLiveIsloStatusClassification -v ./internal/providers/islo
+//
 // This is the live guard for the M1/M2 alignment: the API reports
 // running/paused/failed/etc., never the legacy "ready"/"started"/"active"
 // values crabbox previously treated as ready.
 func TestLiveIsloStatusClassification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("live Islo e2e skipped in -short mode")
+	}
 	apiKey := strings.TrimSpace(os.Getenv("ISLO_API_KEY"))
 	if apiKey == "" {
 		t.Skip("ISLO_API_KEY not set; skipping live Islo e2e")

--- a/internal/providers/islo/backend_live_test.go
+++ b/internal/providers/islo/backend_live_test.go
@@ -1,0 +1,82 @@
+package islo
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLiveIsloStatusClassification is an end-to-end check against the real Islo
+// API (api.islo.dev). It lists live sandboxes through the same SDK path crabbox
+// uses (auth token exchange + GET /sandboxes/) and verifies that the aligned
+// isloStatusReady / isloStatusTerminal classifiers agree with the statuses Islo
+// actually returns today. It is skipped unless ISLO_API_KEY is set, so it never
+// runs in CI without credentials.
+//
+// This is the live guard for the M1/M2 alignment: the API reports
+// running/paused/failed/etc., never the legacy "ready"/"started"/"active"
+// values crabbox previously treated as ready.
+func TestLiveIsloStatusClassification(t *testing.T) {
+	apiKey := strings.TrimSpace(os.Getenv("ISLO_API_KEY"))
+	if apiKey == "" {
+		t.Skip("ISLO_API_KEY not set; skipping live Islo e2e")
+	}
+
+	cfg := Config{}
+	cfg.Islo.APIKey = apiKey
+	cfg.Islo.BaseURL = "https://api.islo.dev"
+
+	rt := Runtime{HTTP: &http.Client{Timeout: 30 * time.Second}}
+	client, err := newIsloClient(cfg, rt)
+	if err != nil {
+		t.Fatalf("new islo client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	sandboxes, err := client.ListSandboxes(ctx)
+	if err != nil {
+		t.Fatalf("live list sandboxes: %v", err)
+	}
+	if len(sandboxes) == 0 {
+		t.Skip("no live sandboxes available to classify")
+	}
+
+	hist := map[string]int{}
+	for _, s := range sandboxes {
+		if s == nil {
+			continue
+		}
+		raw := s.GetStatus()
+		st := strings.ToLower(strings.TrimSpace(raw))
+		hist[st]++
+
+		ready := isloStatusReady(raw)
+		terminal := isloStatusTerminal(raw)
+
+		switch st {
+		case "running":
+			if !ready || terminal {
+				t.Errorf("status %q: ready=%v terminal=%v, want ready & non-terminal", raw, ready, terminal)
+			}
+		case "failed", "stopped", "stopping", "deleted":
+			if ready || !terminal {
+				t.Errorf("status %q: ready=%v terminal=%v, want terminal & not ready", raw, ready, terminal)
+			}
+		case "starting", "paused", "unknown":
+			if ready || terminal {
+				t.Errorf("status %q: ready=%v terminal=%v, want neither", raw, ready, terminal)
+			}
+		}
+
+		// Legacy values the old code accepted must never appear on the live API.
+		if st == "ready" || st == "started" || st == "active" {
+			t.Errorf("live API returned legacy status %q; alignment assumed it is no longer emitted", raw)
+		}
+	}
+	t.Logf("live Islo status histogram: %v", hist)
+}

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -59,6 +59,31 @@ func TestParseIsloSSERequiresExitEvent(t *testing.T) {
 	}
 }
 
+func TestParseIsloSSESurfacesErrorEvent(t *testing.T) {
+	// The Islo exec SSE stream can emit an "error" event for stream/VM-level
+	// failures and may end without an "exit" event. The error payload must
+	// surface instead of the generic missing-exit-event message.
+	body := strings.Join([]string{
+		"event: stdout",
+		"data: starting",
+		"",
+		"event: error",
+		"data: vm exec failed: out of memory",
+		"",
+	}, "\n")
+	var stdout, stderr bytes.Buffer
+	code, err := parseIsloSSE(strings.NewReader(body), &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "out of memory") {
+		t.Fatalf("code=%d err=%v, want surfaced error payload", code, err)
+	}
+	if strings.Contains(err.Error(), "without exit event") {
+		t.Fatalf("err=%v, should prefer the error payload over the generic message", err)
+	}
+	if stdout.String() != "starting" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
 func TestParseIsloSSERejectsInvalidExitEvent(t *testing.T) {
 	body := strings.Join([]string{
 		"event: exit",
@@ -101,13 +126,31 @@ func TestLeadingEnvAssignmentUsesShell(t *testing.T) {
 }
 
 func TestIsloStatusReady(t *testing.T) {
-	for _, status := range []string{"ready", "running", "started", "active"} {
+	// The live Islo API emits exactly one ready state, "running" (case-insensitive).
+	for _, status := range []string{"running", "RUNNING", " running "} {
 		if !isloStatusReady(status) {
 			t.Fatalf("expected %q ready", status)
 		}
 	}
-	if isloStatusReady("stopped") {
-		t.Fatal("stopped should not be ready")
+	// Statuses Islo never reports as ready, including the legacy values crabbox
+	// used to accept ("ready", "started", "active") that the API no longer emits.
+	for _, status := range []string{"starting", "ready", "started", "active", "paused", "stopping", "stopped", "failed", "deleted", "unknown", ""} {
+		if isloStatusReady(status) {
+			t.Fatalf("status %q should not be ready", status)
+		}
+	}
+}
+
+func TestIsloStatusTerminal(t *testing.T) {
+	for _, status := range []string{"failed", "stopped", "stopping", "deleted", "DELETED", " failed "} {
+		if !isloStatusTerminal(status) {
+			t.Fatalf("expected %q terminal", status)
+		}
+	}
+	for _, status := range []string{"starting", "running", "paused", "unknown", ""} {
+		if isloStatusTerminal(status) {
+			t.Fatalf("status %q should not be terminal", status)
+		}
 	}
 }
 

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -303,6 +303,7 @@ func parseIsloSSE(r io.Reader, stdout, stderr io.Writer) (int, error) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	exitCode := 0
 	seenExit := false
+	streamErr := ""
 	event := ""
 	var data []string
 	flush := func() error {
@@ -322,6 +323,14 @@ func parseIsloSSE(r io.Reader, stdout, stderr io.Writer) (int, error) {
 			}
 			exitCode = n
 			seenExit = true
+		case "error":
+			// The Islo exec SSE stream emits an "error" event for stream or
+			// VM-level failures. Capture the last one so we can surface a
+			// meaningful message instead of a generic missing-exit error when
+			// the stream ends without an exit event.
+			if msg := strings.TrimSpace(payload); msg != "" {
+				streamErr = msg
+			}
 		}
 		event = ""
 		data = data[:0]
@@ -358,6 +367,9 @@ func parseIsloSSE(r io.Reader, stdout, stderr io.Writer) (int, error) {
 		return 1, err
 	}
 	if !seenExit {
+		if streamErr != "" {
+			return 1, fmt.Errorf("islo exec stream error: %s", streamErr)
+		}
 		return 1, fmt.Errorf("islo exec stream ended without exit event")
 	}
 	return exitCode, nil

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -114,23 +114,23 @@ func (c *isloSDKClient) DeleteSandbox(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	token, err := c.auth.Token(ctx)
-	if err != nil {
-		return fmt.Errorf("islo auth: %w", err)
+	if err := c.authorize(ctx, httpReq); err != nil {
+		return err
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Accept", "application/json")
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 300 || resp.StatusCode == http.StatusNotFound {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil
+	// Mirror the >=400 failure convention used by the other raw endpoints, with
+	// 404 carved out so an already-gone sandbox is an idempotent success.
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("islo delete sandbox %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
 	}
-	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-	return fmt.Errorf("islo delete sandbox %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
 }
 
 func (c *isloSDKClient) UploadArchive(ctx context.Context, name, targetPath string, archive io.Reader) error {

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -105,8 +105,32 @@ func (c *isloSDKClient) ListSandboxes(ctx context.Context) ([]*gosdk.SandboxResp
 }
 
 func (c *isloSDKClient) DeleteSandbox(ctx context.Context, name string) error {
-	_, err := c.sdk.Sandboxes.DeleteSandbox(ctx, &gosdk.DeleteSandboxRequest{SandboxName: name})
-	return err
+	// The Islo delete endpoint returns an empty body (202/204), which the
+	// generated SDK decoder rejects ("expected a response, but the server
+	// responded with nothing"). Issue the DELETE directly so an empty success
+	// body is handled correctly, and treat an already-gone sandbox (404) as a
+	// successful idempotent delete.
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/sandboxes/"+url.PathEscape(name), nil)
+	if err != nil {
+		return err
+	}
+	token, err := c.auth.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("islo auth: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 300 || resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	return fmt.Errorf("islo delete sandbox %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
 }
 
 func (c *isloSDKClient) UploadArchive(ctx context.Context, name, targetPath string, archive io.Reader) error {

--- a/internal/providers/islo/client_test.go
+++ b/internal/providers/islo/client_test.go
@@ -1,0 +1,66 @@
+package islo
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestIsloClientDeleteSandboxHandlesEmptyAndMissing verifies the raw DELETE
+// path: Islo returns an empty body (202/204) on a successful delete and 404 if
+// the sandbox is already gone. All of these must be treated as success (the
+// generated SDK decoder rejects the empty body, which is why crabbox issues the
+// DELETE directly). A real error status must still surface.
+func TestIsloClientDeleteSandboxHandlesEmptyAndMissing(t *testing.T) {
+	newServer := func(deleteStatus int, deleteBody string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.URL.Path == "/auth/token":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"session_token":"test-token"}`)
+			case r.Method == http.MethodDelete:
+				w.WriteHeader(deleteStatus)
+				if deleteBody != "" {
+					_, _ = io.WriteString(w, deleteBody)
+				}
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+	}
+
+	mkClient := func(t *testing.T, srv *httptest.Server) isloAPI {
+		t.Helper()
+		cfg := Config{}
+		cfg.Islo.APIKey = "test-key"
+		cfg.Islo.BaseURL = srv.URL
+		c, err := newIsloClient(cfg, Runtime{HTTP: srv.Client()})
+		if err != nil {
+			t.Fatalf("new client: %v", err)
+		}
+		return c
+	}
+
+	t.Run("success codes", func(t *testing.T) {
+		for _, code := range []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent, http.StatusNotFound} {
+			srv := newServer(code, "")
+			c := mkClient(t, srv)
+			if err := c.DeleteSandbox(context.Background(), "crabbox-x-aa11"); err != nil {
+				t.Errorf("delete with status %d: unexpected error %v", code, err)
+			}
+			srv.Close()
+		}
+	})
+
+	t.Run("error status surfaces", func(t *testing.T) {
+		srv := newServer(http.StatusInternalServerError, `{"code":"INTERNAL_ERROR","message":"boom"}`)
+		defer srv.Close()
+		c := mkClient(t, srv)
+		err := c.DeleteSandbox(context.Background(), "crabbox-x-bb22")
+		if err == nil {
+			t.Fatal("expected error for 500 delete, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## What

Audited crabbox's **islo provider** against the public Islo Go SDK and the live `api.islo.dev`, then verified the full lifecycle end-to-end with the `crabbox` binary. Most of the integration was already correct (base URL, `/auth/token` exchange, endpoints, `SandboxCreate`/`ExecRequest`/`ShareResponse` shapes, SSE `stdout`/`stderr`/`exit`, `/workspace/<workdir>`). Five points had drifted.

## Changes

**M1 — status enum (correctness).** `isloStatusReady()` accepted `{ready, running, started, active}`, but the Islo API only reports `{starting, running, paused, stopping, stopped, failed, deleted, unknown}` — a boot-time `ready` is normalized to `running` server-side, so `ready`/`started`/`active` are never returned. Ready now means exactly `running`.

**M2 — terminal-state detection (robustness).** The `Status()` wait loop only checked readiness, so a sandbox that went `failed` (a real status) would poll until the 5-minute deadline. Added `isloStatusTerminal` and a fast-fail for `failed`/`stopped`/`stopping`/`deleted`.

**M3 — SSE `error` events.** The Islo exec SSE stream can emit an `error` event for stream/VM failures; `parseIsloSSE` dropped it and reported the generic *"ended without exit event"*. It now surfaces the error payload.

**M4 — stop/delete (correctness).** The Islo `DELETE` endpoint returns `202`/`204` with an empty body, which the generated SDK decoder rejects — so `crabbox stop` always failed (`"expected a response, but the server responded with nothing"`) even though the sandbox was deleted, and never cleared the lease claim. crabbox now issues the `DELETE` directly (as it already does for files-archive/exec/shares), treating an empty `2xx` as success and `404` as an idempotent delete.

**M5 — docs.** `docs/features/islo.md` listed the default image as `ubuntu:24.04`; the resolved default is `ubuntu:26.04` (matches `docs/providers/islo.md` and `os_image.go`).

## Tests

- Updated `TestIsloStatusReady`; added `TestIsloStatusTerminal`, `TestParseIsloSSESurfacesErrorEvent`, and `TestIsloClientDeleteSandboxHandlesEmptyAndMissing` (httptest).
- Added `TestLiveIsloStatusClassification` — an `ISLO_API_KEY`-gated e2e (skips without creds).

## Verified live (api.islo.dev, `crabbox` binary)

`warmup` → `status --wait` (`state=running ready=true`) → `run` (synced files, streamed stdout over SSE, propagated a non-zero exit code) → `stop` (released lease, sandbox `GET` returns `404`). `go build ./...`, `go vet`, `gofmt`, and the full `internal/providers/islo` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)