### PR TITLE
fix(worker): avoid regex pond normalization

### DIFF
--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -268,11 +268,32 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
 // `pond` label is a reserved provider-label key that groups leases for
 // peer discovery and lifecycle commands.
 export function normalizePondName(value: string): string {
-  return value
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^a-z0-9]+/g, "-")
-    .replaceAll(/^-+|-+$/g, "");
+  const normalized = value.toLowerCase().trim();
+  const output: string[] = [];
+  let lastDash = false;
+  for (const char of normalized) {
+    const code = char.charCodeAt(0);
+    const isLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (isLetter || isDigit) {
+      output.push(char);
+      lastDash = false;
+      continue;
+    }
+    if (!lastDash) {
+      output.push("-");
+      lastDash = true;
+    }
+  }
+  let start = 0;
+  let end = output.length;
+  while (output[start] === "-") {
+    start += 1;
+  }
+  while (end > start && output[end - 1] === "-") {
+    end -= 1;
+  }
+  return output.slice(start, end).join("");
 }
 
 function requestedPondName(value: string): string {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -259,6 +259,11 @@ describe("lease config", () => {
     expect(empty.pond).toBe("");
     const tagged = leaseConfig({ sshPublicKey: "ssh-ed25519 test", pond: " Alpha Pond " });
     expect(tagged.pond).toBe("alpha-pond");
+    const symbolRun = leaseConfig({
+      sshPublicKey: "ssh-ed25519 test",
+      pond: `alpha${"_".repeat(10_000)}pond`,
+    });
+    expect(symbolRun.pond).toBe("alpha-pond");
     expect(() => leaseConfig({ sshPublicKey: "ssh-ed25519 test", pond: " --- " })).toThrow(
       "pond must contain at least one letter or digit",
     );


### PR DESCRIPTION
## Summary
- Replace pond-name regex normalization with an equivalent character loop to avoid polynomial-regex CodeQL findings on uncontrolled input.
- Add a long symbol-run regression around pond normalization.

## Verification
- `npm ci --prefix worker`
- `npm run format:check --prefix worker -- worker/src/config.ts worker/test/config.test.ts`
- `npm test --prefix worker -- config.test.ts`
- `npm run check --prefix worker`
