### PR TITLE
fix: restrict lease metadata writes

### DIFF
--- a/internal/cli/sync_archive.go
+++ b/internal/cli/sync_archive.go
@@ -89,8 +89,32 @@ func appendSyncArchiveMember(ctx context.Context, tw *tar.Writer, root, rel stri
 		return fmt.Errorf("open sync path %s: %w", rel, err)
 	}
 	defer file.Close()
-	if _, err := io.Copy(tw, file); err != nil {
+	if err := copySyncArchiveMember(ctx, tw, file); err != nil {
 		return fmt.Errorf("archive path %s: %w", rel, err)
 	}
 	return nil
+}
+
+func copySyncArchiveMember(ctx context.Context, dst io.Writer, src io.Reader) error {
+	buf := make([]byte, 128*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if _, err := dst.Write(buf[:n]); err != nil {
+				return err
+			}
+		}
+		if readErr == io.EOF {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
 }

--- a/internal/cli/sync_archive.go
+++ b/internal/cli/sync_archive.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func CreateSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	archive, err := os.CreateTemp("", tempPattern)
+	if err != nil {
+		return nil, fmt.Errorf("create sync archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	gz := gzip.NewWriter(archive)
+	tw := tar.NewWriter(gz)
+	for _, rel := range manifest.Files {
+		if err := appendSyncArchiveMember(ctx, tw, repo.Root, rel); err != nil {
+			_ = tw.Close()
+			_ = gz.Close()
+			return nil, exit(6, "create sync archive: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		_ = gz.Close()
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	if _, err := archive.Seek(0, 0); err != nil {
+		return nil, fmt.Errorf("rewind sync archive: %w", err)
+	}
+	keep = true
+	return archive, nil
+}
+
+func appendSyncArchiveMember(ctx context.Context, tw *tar.Writer, root, rel string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	clean := path.Clean(filepath.ToSlash(rel))
+	if clean == "." || clean != filepath.ToSlash(rel) || path.IsAbs(clean) || strings.HasPrefix(clean, "../") {
+		return fmt.Errorf("unsafe sync path %q", rel)
+	}
+	full := filepath.Join(root, filepath.FromSlash(clean))
+	info, err := os.Lstat(full)
+	if err != nil {
+		return fmt.Errorf("stat sync path %s: %w", rel, err)
+	}
+	if info.IsDir() {
+		return nil
+	}
+	linkname := ""
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkname, err = os.Readlink(full)
+		if err != nil {
+			return fmt.Errorf("read symlink %s: %w", rel, err)
+		}
+	}
+	header, err := tar.FileInfoHeader(info, linkname)
+	if err != nil {
+		return fmt.Errorf("archive header %s: %w", rel, err)
+	}
+	header.Name = clean
+	if err := tw.WriteHeader(header); err != nil {
+		return fmt.Errorf("archive header %s: %w", rel, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	file, err := os.Open(full)
+	if err != nil {
+		return fmt.Errorf("open sync path %s: %w", rel, err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(tw, file); err != nil {
+		return fmt.Errorf("archive path %s: %w", rel, err)
+	}
+	return nil
+}

--- a/internal/cli/sync_archive_test.go
+++ b/internal/cli/sync_archive_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateSyncArchiveTreatsOptionLikeNamesAsFiles(t *testing.T) {
+	root := t.TempDir()
+	names := []string{
+		"--checkpoint=1",
+		"--checkpoint-action=exec=sh pwn.sh",
+		"normal.txt",
+	}
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	archive, err := CreateSyncArchive(context.Background(), Repo{Root: root}, SyncManifest{Files: names}, "crabbox-sync-test-*.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(archive.Name())
+	defer archive.Close()
+
+	got := syncArchiveNames(t, archive)
+	for _, name := range names {
+		if !got[name] {
+			t.Fatalf("archive missing %q; got %#v", name, got)
+		}
+	}
+}
+
+func TestCreateSyncArchiveRejectsUnsafePaths(t *testing.T) {
+	_, err := CreateSyncArchive(context.Background(), Repo{Root: t.TempDir()}, SyncManifest{Files: []string{"../secret.txt"}}, "crabbox-sync-test-*.tgz")
+	if err == nil {
+		t.Fatal("expected unsafe path error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 6 {
+		t.Fatalf("err=%#v, want sync exit error", err)
+	}
+}
+
+func syncArchiveNames(t *testing.T, archive *os.File) map[string]bool {
+	t.Helper()
+	if _, err := archive.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	gz, err := gzip.NewReader(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	got := map[string]bool{}
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return got
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		got[header.Name] = true
+	}
+}

--- a/internal/cli/sync_archive_test.go
+++ b/internal/cli/sync_archive_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -50,6 +51,16 @@ func TestCreateSyncArchiveRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
+func TestCopySyncArchiveMemberStopsAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	writer := &cancelAfterFirstWrite{cancel: cancel}
+	err := copySyncArchiveMember(ctx, writer, strings.NewReader(strings.Repeat("x", 256*1024)))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want context canceled", err)
+	}
+}
+
 func syncArchiveNames(t *testing.T, archive *os.File) map[string]bool {
 	t.Helper()
 	if _, err := archive.Seek(0, 0); err != nil {
@@ -72,4 +83,17 @@ func syncArchiveNames(t *testing.T, archive *os.File) map[string]bool {
 		}
 		got[header.Name] = true
 	}
+}
+
+type cancelAfterFirstWrite struct {
+	cancel func()
+	writes int
+}
+
+func (w *cancelAfterFirstWrite) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		w.cancel()
+	}
+	return len(p), nil
 }

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 )
@@ -28,25 +27,20 @@ func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Con
 			return exit(6, "prune seeded Windows sync paths: %v", err)
 		}
 	}
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	cmd := exec.CommandContext(ctx, "tar", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	var archive bytes.Buffer
-	cmd.Stdout = &archive
-	cmd.Stderr = stderr
-	start := time.Now()
-	if err := cmd.Run(); err != nil {
-		return exit(6, "create sync archive: %v", err)
+	archive, err := CreateSyncArchive(ctx, repo, manifest, "crabbox-windows-sync-*.tgz")
+	if err != nil {
+		return err
 	}
+	defer os.Remove(archive.Name())
+	defer archive.Close()
+	start := time.Now()
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 		defer cancel()
 	}
 	stopHeartbeat := startSyncHeartbeat(stderr, start, opts.HeartbeatInterval)
-	err := runSSHInput(ctx, target, windowsExtractArchive(workdir), &archive, stdout, stderr)
+	err = runSSHInput(ctx, target, windowsExtractArchive(workdir), archive, stdout, stderr)
 	stopHeartbeat()
 	if ctx.Err() == context.DeadlineExceeded {
 		return exit(6, "archive sync timed out after %s", opts.Timeout)

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -1,11 +1,13 @@
 package azuredynamicsessions
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -144,6 +146,10 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func summarizeJSON(data []byte) string {

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -1,15 +1,12 @@
 package azuredynamicsessions
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -44,7 +41,7 @@ func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client 
 	}
 	prepareDuration := b.now().Sub(prepareStarted)
 	archiveStarted := b.now()
-	archive, err := createAzureDynamicSessionsSyncArchive(req.Repo, manifest)
+	archive, err := createAzureDynamicSessionsSyncArchive(syncCtx, req.Repo, manifest)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -98,78 +95,8 @@ func (b *azureDynamicSessionsBackend) execShell(ctx context.Context, client azur
 	return nil
 }
 
-func createAzureDynamicSessionsSyncArchive(repo Repo, manifest SyncManifest) (*os.File, error) {
-	archive, err := os.CreateTemp("", "crabbox-azds-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	gz := gzip.NewWriter(archive)
-	tw := tar.NewWriter(gz)
-	for _, rel := range manifest.Files {
-		if err := appendArchiveMember(tw, repo.Root, rel); err != nil {
-			_ = tw.Close()
-			_ = gz.Close()
-			return nil, err
-		}
-	}
-	if err := tw.Close(); err != nil {
-		return nil, fmt.Errorf("create sync archive: %w", err)
-	}
-	if err := gz.Close(); err != nil {
-		return nil, fmt.Errorf("create sync archive: %w", err)
-	}
-	if _, err := archive.Seek(0, 0); err != nil {
-		return nil, fmt.Errorf("rewind sync archive: %w", err)
-	}
-	keep = true
-	return archive, nil
-}
-
-func appendArchiveMember(tw *tar.Writer, root, rel string) error {
-	clean := path.Clean(filepath.ToSlash(rel))
-	if clean == "." || clean != filepath.ToSlash(rel) || path.IsAbs(clean) || strings.HasPrefix(clean, "../") {
-		return exit(6, "unsafe sync path %q", rel)
-	}
-	full := filepath.Join(root, filepath.FromSlash(clean))
-	info, err := os.Lstat(full)
-	if err != nil {
-		return fmt.Errorf("stat sync path %s: %w", rel, err)
-	}
-	linkname := ""
-	if info.Mode()&os.ModeSymlink != 0 {
-		linkname, err = os.Readlink(full)
-		if err != nil {
-			return fmt.Errorf("read symlink %s: %w", rel, err)
-		}
-	}
-	header, err := tar.FileInfoHeader(info, linkname)
-	if err != nil {
-		return fmt.Errorf("archive header %s: %w", rel, err)
-	}
-	header.Name = clean
-	if err := tw.WriteHeader(header); err != nil {
-		return fmt.Errorf("archive header %s: %w", rel, err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil
-	}
-	file, err := os.Open(full)
-	if err != nil {
-		return fmt.Errorf("open sync path %s: %w", rel, err)
-	}
-	defer file.Close()
-	if _, err := io.Copy(tw, file); err != nil {
-		return fmt.Errorf("archive path %s: %w", rel, err)
-	}
-	return nil
+func createAzureDynamicSessionsSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-azds-sync-*.tgz")
 }
 
 func azureDynamicSessionsWorkspace(cfg Config) (string, error) {

--- a/internal/providers/azuredynamicsessions/sync_test.go
+++ b/internal/providers/azuredynamicsessions/sync_test.go
@@ -32,7 +32,7 @@ func TestCleanAzureDynamicSessionsWorkspacePathCleansDedicatedAbsolutePath(t *te
 }
 
 func TestCreateAzureDynamicSessionsSyncArchiveRejectsUnsafeManifestPath(t *testing.T) {
-	_, err := createAzureDynamicSessionsSyncArchive(Repo{Root: t.TempDir()}, SyncManifest{Files: []string{"../secret.txt"}})
+	_, err := createAzureDynamicSessionsSyncArchive(t.Context(), Repo{Root: t.TempDir()}, SyncManifest{Files: []string{"../secret.txt"}})
 	if err == nil || !strings.Contains(err.Error(), "unsafe sync path") {
 		t.Fatalf("err = %v, want unsafe path", err)
 	}
@@ -46,7 +46,7 @@ func TestCreateAzureDynamicSessionsSyncArchiveIncludesFilesAndSymlinks(t *testin
 	if err := os.Symlink("file.txt", filepath.Join(repo, "link.txt")); err != nil {
 		t.Fatal(err)
 	}
-	archive, err := createAzureDynamicSessionsSyncArchive(Repo{Root: repo}, SyncManifest{Files: []string{"file.txt", "link.txt"}})
+	archive, err := createAzureDynamicSessionsSyncArchive(t.Context(), Repo{Root: repo}, SyncManifest{Files: []string{"file.txt", "link.txt"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -1,8 +1,10 @@
 package cloudflare
 
 import (
+	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -138,4 +140,8 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -177,29 +176,6 @@ func cloudflareExtractArchiveCommand(remoteArchive, workdir string) string {
 	}, "; ")
 }
 
-func createCloudflareSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-cloudflare-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createCloudflareSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-cloudflare-sync-*.tgz")
 }

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -1,12 +1,10 @@
 package daytona
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -387,31 +385,8 @@ func daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix string) str
 		"; crabbox_status=$?; rm -f " + shellQuote(archivePath) + "; exit $crabbox_status"
 }
 
-func createDaytonaSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-daytona-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createDaytonaSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-daytona-sync-*.tgz")
 }
 
 func daytonaCommandString(command []string, shellMode bool) string {

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -184,6 +185,10 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func serverTypeForProviderClass(provider, class string) string {

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -1,8 +1,10 @@
 package e2b
 
 import (
+	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -133,6 +135,10 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func summarizeJSON(data []byte) string {

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -1,12 +1,10 @@
 package e2b
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -123,31 +121,8 @@ func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSe
 	return nil
 }
 
-func createE2BSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-e2b-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createE2BSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-e2b-sync-*.tgz")
 }
 
 func e2bRandomSuffix() string {

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -1,13 +1,11 @@
 package islo
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -142,31 +140,8 @@ func (b *isloBackend) execShell(ctx context.Context, client isloAPI, name, comma
 	return nil
 }
 
-func createIsloSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-islo-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createIsloSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, "crabbox-islo-sync-*.tgz")
 }
 
 func isloWorkspacePath(cfg Config) (string, error) {

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -1,8 +1,10 @@
 package modal
 
 import (
+	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -128,6 +130,10 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -1,12 +1,10 @@
 package modal
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -100,31 +98,8 @@ func (b *modalBackend) execShell(ctx context.Context, client modalAPI, sandboxID
 	return nil
 }
 
-func createModalSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-modal-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createModalSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-modal-sync-*.tgz")
 }
 
 func modalRandomSuffix() string {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -1,8 +1,10 @@
 package tensorlake
 
 import (
+	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -129,6 +131,10 @@ func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stde
 }
 
 type SyncManifest = core.SyncManifest
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
+}
 
 func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {
 	return core.CLIDoctorResult(provider, leases, runtime)

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -1,12 +1,9 @@
 package tensorlake
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -112,29 +109,6 @@ func (b *tensorlakeBackend) extractRemoteArchive(ctx context.Context, cli *tenso
 	return cli.execShell(ctx, sandboxID, cmd)
 }
 
-func createTensorlakeSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-tensorlake-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createTensorlakeSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-tensorlake-sync-*.tgz")
 }

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -1,8 +1,10 @@
 package upstashbox
 
 import (
+	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -119,6 +121,10 @@ func syncManifest(root string, excludes, includes []string) (SyncManifest, error
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
 	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -1,12 +1,10 @@
 package upstashbox
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"time"
@@ -96,31 +94,8 @@ func (b *backend) execShell(ctx context.Context, client api, boxID, command stri
 	return nil
 }
 
-func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-upstash-box-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
+func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-upstash-box-sync-*.tgz")
 }
 
 func randomSuffix() string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1275,9 +1275,16 @@ export class FleetDurableObject implements DurableObject {
       return lease ? json({ lease }) : notFound();
     }
     if (method === "POST" && action === "heartbeat") {
-      const lease = await this.resolveLease(leaseID, request, false);
+      const admin = isAdminRequest(request);
+      const lease = await this.resolveLease(leaseID, request, admin);
       if (!lease) {
         return notFound();
+      }
+      if (!this.leaseManageableByRequest(lease, request, admin)) {
+        return json(
+          { error: "forbidden", message: "lease manage access required" },
+          { status: 403 },
+        );
       }
       const body = await optionalJson<{
         idleTimeoutSeconds?: number;
@@ -1287,9 +1294,16 @@ export class FleetDurableObject implements DurableObject {
       return json({ lease: updatedLease });
     }
     if (method === "POST" && action === "tailscale") {
-      const lease = await this.resolveLease(leaseID, request, false);
+      const admin = isAdminRequest(request);
+      const lease = await this.resolveLease(leaseID, request, admin);
       if (!lease) {
         return notFound();
+      }
+      if (!this.leaseManageableByRequest(lease, request, admin)) {
+        return json(
+          { error: "forbidden", message: "lease manage access required" },
+          { status: 403 },
+        );
       }
       const input = await readJson<Partial<TailscaleMetadata>>(request);
       lease.tailscale = mergeTailscaleMetadata(lease.tailscale, input);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1277,6 +1277,48 @@ describe("fleet lease identity and idle", () => {
     expect(stranger.status).toBe(404);
   });
 
+  it("requires manage access for lease metadata writes", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const viewerHeaders = {
+      "x-crabbox-owner": "viewer@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "shared-run",
+        owner: "alice@example.com",
+        org: "example-org",
+        share: { users: { "viewer@example.com": "use" } },
+        tailscale: { enabled: true, state: "requested" },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/leases/shared-run/heartbeat", {
+        headers: viewerHeaders,
+        body: { idleTimeoutSeconds: 3600 },
+      }),
+    );
+    expect(heartbeat.status).toBe(403);
+
+    const tailscale = await fleet.fetch(
+      request("POST", "/v1/leases/shared-run/tailscale", {
+        headers: viewerHeaders,
+        body: { enabled: true, ipv4: "100.64.0.99", state: "ready" },
+      }),
+    );
+    expect(tailscale.status).toBe(403);
+
+    const stored = storage.value<LeaseRecord>("lease:cbx_000000000001");
+    expect(stored?.idleTimeoutSeconds).not.toBe(3600);
+    expect(stored?.tailscale?.ipv4).toBeUndefined();
+    expect(stored?.tailscale?.state).toBe("requested");
+  });
+
   it("mints brokered Tailscale keys, records non-secret metadata, and accepts readiness updates", async () => {
     const storage = new MemoryStorage();
     let providerConfig:


### PR DESCRIPTION
## Summary
- Require owner/manage/admin access for `POST /v1/leases/:id/heartbeat` and `/tailscale`.
- Add regression coverage that shared `use` viewers cannot mutate lease metadata.
- Keep sync archive creation in Go instead of local tar option parsing.

## Security
A shared `use` viewer could mutate visible leases: extend heartbeat expiry, refresh provider access from their source IP, or overwrite Tailscale metadata used for routing. These write paths now require manage-capable access.

## Verification
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `go test ./...`
- `git diff --check`
