### PR TITLE
fix(local-container): mount bootstrap script instead of passing inline

### DIFF
--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -422,7 +422,20 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	for _, mount := range cacheVolumeMounts {
 		args = append(args, "-v", mount)
 	}
-	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "-lc", bootstrapScript)
+	bootstrapFile, err := os.CreateTemp("", "crabbox-bootstrap-*.sh")
+	if err != nil {
+		return "", core.Exit(2, "create bootstrap script file: %v", err)
+	}
+	defer os.Remove(bootstrapFile.Name())
+	if _, err := bootstrapFile.WriteString(bootstrapScript); err != nil {
+		bootstrapFile.Close()
+		return "", core.Exit(2, "write bootstrap script: %v", err)
+	}
+	if err := bootstrapFile.Close(); err != nil {
+		return "", core.Exit(2, "close bootstrap script: %v", err)
+	}
+	args = append(args, "-v", bootstrapFile.Name()+":/tmp/crabbox-bootstrap.sh:ro")
+	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "/tmp/crabbox-bootstrap.sh")
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
 		return "", commandError("container run", result, err)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -126,9 +126,9 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 		"--label\nslug=blue-lobster",
 		"--label\nssh_user=runner",
 		"--label\nwork_root=/workspace/crabbox",
+		":/tmp/crabbox-bootstrap.sh:ro",
 		"ubuntu:24.04",
-		"/bin/sh",
-		"-lc",
+		"/bin/sh\n/tmp/crabbox-bootstrap.sh",
 	} {
 		if !strings.Contains(args, want) {
 			t.Fatalf("docker run args missing %q:\n%s", want, args)


### PR DESCRIPTION
## Summary

The local-container provider's `createContainer()` passes a 39K bootstrap shell script as an inline argument to `docker run`. On Windows, this exceeds the 32K-character `CreateProcessW` command-line limit, making `crabbox warmup --provider local-container` fail unconditionally.

Write the bootstrap script to a host temp file and bind-mount it read-only into the container instead. This replaces the 39K inline argument with a ~60-character volume mount flag.

**Changes:** 2 files, +16/-3 lines
- `internal/providers/localcontainer/backend.go`: write bootstrap to temp file, mount as `/tmp/crabbox-bootstrap.sh:ro`, execute from mount
- `internal/providers/localcontainer/backend_test.go`: update test assertions to check for mounted bootstrap path

## After-fix proof

Windows Docker Desktop, crabbox built from this branch:

```
> crabbox warmup --provider local-container --desktop --idle-timeout 90m
provisioning provider=local-container lease=cbx_c6f5dde7066a slug=amber-crab runtime=docker image=ubuntu:26.04 keep=true
waiting for 127.0.0.1:52662 local container ssh ssh-auth... elapsed=0s remaining=45m0s ports=52662:tcp
waiting for 127.0.0.1:52662 local container ssh ssh-auth... elapsed=10s remaining=44m50s ports=52662:tcp
...
waiting for 127.0.0.1:52662 local container ssh ssh-auth... elapsed=1m31s remaining=43m29s ports=52662:tcp
provisioned lease=cbx_c6f5dde7066a container=5e0c52caea43 state=ready
leased cbx_c6f5dde7066a slug=amber-crab provider=local-container server=5e0c52caea43... type=ubuntu_26.04 ip=127.0.0.1 idle_timeout=1h30m0s
ready ssh=crabbox@127.0.0.1:52662 network=public workroot=/work/crabbox
warmup complete total=1m41.681s
```

Before this fix, the same command fails with:
```
container run failed: fork/exec C:\Program Files\Docker\Docker\resources\bin\docker.exe: The filename or extension is too long.
```

## Test plan

- [x] `go build ./...` compiles clean (Go 1.26)
- [x] `go test ./internal/providers/localcontainer/ -run TestCreateContainer` passes (5/5, 1 skipped for missing Docker socket)
- [x] `crabbox warmup --provider local-container --desktop` succeeds on Windows Docker Desktop
- [x] `crabbox job run proof-89834` provisions a desktop container and reaches SSH-ready state
- [x] Linux/macOS smoke test (no behavior change expected â€” inline arg was already under limits)
