### PR TITLE
feat(local-container): add native checkpoint support via docker commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added opt-in native Docker local-container checkpoints with immutable image identity, daemon-scope-aware verification and deletion, mounted-workspace guards, and live lifecycle coverage. Thanks @anagnorisis2peripeteia.
 - Added a built-in Incus provider for local or remote Linux containers and virtual machines, including socket, TLS, and OIDC control-plane authentication, optional SSH proxy devices, retained lease reuse, and live lifecycle verification. Thanks @coygeek.
 - Added Tart macOS desktop leases with native Screen Sharing, a token-gated host-side WebVNC bridge, and documented local-network exposure boundaries. Thanks @anagnorisis2peripeteia.
 - Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` broker configuration for ARM64 validation.

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -81,6 +81,24 @@ Images are slower to create but preserve complete launch configuration. Direct
 AWS Linux/macOS leases use the AMI path for native checkpoints because AMIs fork
 directly without a coordinator.
 
+**`docker-commit`** — the `local-container` provider's native primitive (opt in
+with `--mode native`; `auto` keeps the workspace-archive default). `crabbox
+checkpoint create` captures the container filesystem as a Docker image tagged
+`crabbox-checkpoint-<name>-<digest>` (using the immutable image digest as
+identity); `crabbox checkpoint inspect <id> --verify` (or `checkpoint list
+--verify`) confirms the image is still present on its daemon; and `crabbox
+checkpoint delete <id>` removes its verified Crabbox-owned image tag while
+preserving any user-created tags or dependent containers. Crabbox strips lease
+ownership labels from the committed image so derived containers are not
+inventoried as the source lease and replaces the mount-dependent bootstrap
+command with a persistent default command. The Docker context, context-store
+path, resolved daemon endpoint, and Docker system ID used at create time are
+recorded and validated so verify and delete fail closed if that context or
+daemon is later replaced. Native checkpoints are currently Docker-only; Podman
+and nerdctl leases keep using workspace archives. Crabbox rejects native
+checkpoint creation when the workspace is stored in a mounted volume because
+`docker commit` does not capture mounted data.
+
 **Azure notes.** Disk-snapshot checkpoints require managed OS disks, the default
 for new Azure leases. Crabbox refuses native checkpoint creation from Azure
 ephemeral-OS-disk leases (Azure reports success but does not capture live disk

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -168,7 +168,22 @@ metadata updates.
 - Desktop, browser, VNC, WebVNC, screenshot, video, and desktop input helpers
   are local-only. `webvnc` starts noVNC/websockify on the target and tunnels it
   over SSH; it does not use the authenticated Crabbox portal.
-- No code-server, no Tailscale bootstrap, and no native checkpoint support.
+- No code-server and no Tailscale bootstrap.
+- Native checkpoints use `docker commit` (opt in with `--mode native`):
+  `crabbox checkpoint create` captures the container filesystem as a Docker image
+  tagged `crabbox-checkpoint-<name>-<digest>`, `crabbox checkpoint inspect <id>
+  --verify` (or `checkpoint list --verify`) confirms it, and `crabbox checkpoint
+  delete <id>` removes its verified Crabbox-owned tag while preserving
+  user-created tags and dependent containers. Committed images have Crabbox
+  lease ownership labels cleared so derived containers are not inventoried as
+  the source lease, and their mount-dependent bootstrap command is replaced with
+  a persistent default command. `auto` mode keeps the workspace-archive default.
+  Each checkpoint records its Docker context, context-store path, resolved
+  daemon endpoint, and Docker system ID; verify and delete fail closed if that
+  context or daemon is later replaced.
+  This native path is currently Docker-only; Podman and nerdctl keep using
+  workspace archives. Crabbox rejects native checkpoints when the workspace is
+  stored in a mounted volume because `docker commit` omits mounted data.
 - `warmup --actions-runner` is not supported. Use plain `crabbox run` for local
   container smoke tests, or a remote SSH provider for GitHub runner registration.
 - Socket pass-through is opt-in and grants the lease access to the host

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -18,18 +18,19 @@ import (
 )
 
 const (
-	checkpointIDPrefix      = "chk_"
-	checkpointMetaFile      = "checkpoint.json"
-	checkpointArchive       = "workspace.tar.gz"
-	checkpointKindRecipe    = "recipe"
-	checkpointKindArchive   = "workspace-archive"
-	checkpointKindAWSAMI    = "aws-ami"
-	checkpointKindAWSEBS    = "aws-ebs-snapshot"
-	checkpointKindAzure     = "azure-managed-image"
-	checkpointKindAzureOS   = "azure-os-disk-snapshot"
-	checkpointKindGCP       = "gcp-machine-image"
-	checkpointKindGCPDisk   = "gcp-disk-snapshot"
-	checkpointKindParallels = "parallels-snapshot"
+	checkpointIDPrefix         = "chk_"
+	checkpointMetaFile         = "checkpoint.json"
+	checkpointArchive          = "workspace.tar.gz"
+	checkpointKindRecipe       = "recipe"
+	checkpointKindArchive      = "workspace-archive"
+	checkpointKindAWSAMI       = "aws-ami"
+	checkpointKindAWSEBS       = "aws-ebs-snapshot"
+	checkpointKindAzure        = "azure-managed-image"
+	checkpointKindAzureOS      = "azure-os-disk-snapshot"
+	checkpointKindGCP          = "gcp-machine-image"
+	checkpointKindGCPDisk      = "gcp-disk-snapshot"
+	checkpointKindParallels    = "parallels-snapshot"
+	checkpointKindDockerCommit = "docker-commit"
 
 	checkpointStrategyAuto         = "auto"
 	checkpointStrategyImage        = "image"
@@ -53,19 +54,20 @@ type checkpointRecord struct {
 	ArchivePath    string `json:"archivePath,omitempty"`
 	ArchiveBytes   int64  `json:"archiveBytes,omitempty"`
 	Native         struct {
-		Provider    string   `json:"provider,omitempty"`
-		ImageID     string   `json:"imageId,omitempty"`
-		Kind        string   `json:"kind,omitempty"`
-		Name        string   `json:"name,omitempty"`
-		State       string   `json:"state,omitempty"`
-		Region      string   `json:"region,omitempty"`
-		AccountID   string   `json:"accountId,omitempty"`
-		Project     string   `json:"project,omitempty"`
-		Resource    string   `json:"resource,omitempty"`
-		SnapshotIDs []string `json:"snapshotIds,omitempty"`
-		Direct      bool     `json:"direct,omitempty"`
-		Strategy    string   `json:"strategy,omitempty"`
-		NoReboot    bool     `json:"noReboot,omitempty"`
+		Provider    string            `json:"provider,omitempty"`
+		ImageID     string            `json:"imageId,omitempty"`
+		Kind        string            `json:"kind,omitempty"`
+		Name        string            `json:"name,omitempty"`
+		State       string            `json:"state,omitempty"`
+		Region      string            `json:"region,omitempty"`
+		AccountID   string            `json:"accountId,omitempty"`
+		Project     string            `json:"project,omitempty"`
+		Resource    string            `json:"resource,omitempty"`
+		SnapshotIDs []string          `json:"snapshotIds,omitempty"`
+		Direct      bool              `json:"direct,omitempty"`
+		Strategy    string            `json:"strategy,omitempty"`
+		NoReboot    bool              `json:"noReboot,omitempty"`
+		Metadata    map[string]string `json:"metadata,omitempty"`
 	} `json:"native,omitempty"`
 	Repo struct {
 		Root      string `json:"root,omitempty"`
@@ -119,7 +121,16 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	}
 	workdir := strings.TrimSpace(*workdirOverride)
 	if workdir == "" {
-		workdir = remoteJoin(cfg, leaseID, repo.Name)
+		if provider, ok := nativeCheckpointLifecycleProvider(cfg, server); ok {
+			workdir = provider.NativeCheckpointWorkdir(NativeCheckpointWorkdirRequest{
+				Config:   cfg,
+				Server:   server,
+				LeaseID:  leaseID,
+				RepoName: repo.Name,
+			})
+		} else {
+			workdir = remoteJoin(cfg, leaseID, repo.Name)
+		}
 	}
 	record, dir, err := newCheckpointRecord(repo, cfg, server, target, leaseID, workdir, *name)
 	if err != nil {
@@ -131,7 +142,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	}
 	createKind := checkpointCreateMode(*mode, *strategy, cfg, server, target, *recipeOnly)
 	switch createKind {
-	case checkpointKindRecipe, checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindParallels, checkpointKindArchive:
+	case checkpointKindRecipe, checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindParallels, checkpointKindDockerCommit, checkpointKindArchive:
 		record.Kind = createKind
 	default:
 		return exit(2, "checkpoint mode must be auto, native, or archive")
@@ -148,10 +159,11 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	}()
 	switch createKind {
 	case checkpointKindRecipe:
-	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindParallels:
-		image, err := a.createNativeCheckpoint(ctx, cfg, server, target, leaseID, record.Name, repo.Name, checkpointStrategyForKind(createKind), *noReboot, *wait, *waitTimeout)
+	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindParallels, checkpointKindDockerCommit:
+		image, metadata, err := a.createNativeCheckpoint(ctx, cfg, server, target, leaseID, record.Name, repo.Name, workdir, checkpointStrategyForKind(createKind), *noReboot, *wait, *waitTimeout)
 		if image.ID != "" {
 			applyNativeImageCheckpointRecord(&record, image, *noReboot)
+			record.Native.Metadata = metadata
 		}
 		if err != nil {
 			if record.Native.ImageID != "" {
@@ -595,6 +607,9 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 				fmt.Fprintf(a.Stdout, "checkpoint restored id=%s lease=%s snapshot=%s\n", record.ID, blank(server.Labels["lease"], server.CloudID), record.Native.ImageID)
 				return nil
 			}
+			if record.Kind == checkpointKindDockerCommit {
+				return exit(2, "checkpoint %s is a docker-commit image; restore is not supported for docker-commit checkpoints — verify it with crabbox checkpoint inspect %s --verify or remove it with crabbox checkpoint delete %s", record.ID, record.ID, record.ID)
+			}
 			return exit(2, "checkpoint %s is a VM image; use crabbox checkpoint fork %s to create a lease from it", record.ID, record.ID)
 		}
 		return exit(2, "checkpoint %s has kind=%s; restore requires %s", record.ID, record.Kind, checkpointKindArchive)
@@ -923,6 +938,12 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 	}
 	providerID := nativeCheckpointDeleteID(record)
 	if isNativeCheckpointKind(record.Kind) && providerID != "" && !localOnly {
+		if provider, ok := nativeCheckpointLifecycleProvider(Config{Provider: record.nativeProvider()}, Server{}); ok {
+			if err := provider.DeleteNativeCheckpoint(ctx, nativeCheckpointResourceRequest(record)); err != nil {
+				return err
+			}
+			return store.Delete(id)
+		}
 		if record.Kind == checkpointKindParallels {
 			cfg, err := loadConfig()
 			if err != nil {
@@ -1115,6 +1136,19 @@ func (a App) verifyCheckpointRecord(ctx context.Context, store checkpointStore, 
 		if cfg, ok := directAWSCheckpointConfig(record); ok {
 			return verifyDirectAWSCheckpoint(ctx, audit, cfg, providerID, record.Native.AccountID), nil
 		}
+		if provider, ok := nativeCheckpointLifecycleProvider(Config{Provider: record.nativeProvider()}, Server{}); ok {
+			result, err := provider.VerifyNativeCheckpoint(ctx, nativeCheckpointResourceRequest(record))
+			if err != nil {
+				audit.ProviderState = "unknown"
+				audit.NextAction = "check_runtime"
+				audit.Error = err.Error()
+				return audit, nil
+			}
+			audit.ProviderState = result.ProviderState
+			audit.NextAction = result.NextAction
+			audit.Error = result.Error
+			return audit, nil
+		}
 		if record.Kind == checkpointKindParallels {
 			cfg, err := loadConfig()
 			if err != nil {
@@ -1232,29 +1266,28 @@ func checkpointCreateMode(mode, strategy string, cfg Config, server Server, targ
 	if recipeOnly {
 		return checkpointKindRecipe
 	}
-	normalizedStrategy := normalizeCheckpointStrategy(strategy)
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "", "auto":
-		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+		if kind, ok := nativeCheckpointKind(cfg, server, target, strategy); ok {
 			return kind
 		}
-		if kind, ok := parallelsNativeCheckpointKind(cfg, server, normalizedStrategy); ok {
+		if kind, ok := parallelsNativeCheckpointKind(cfg, server, strategy); ok {
 			return kind
 		}
 		if !isAutoCheckpointStrategy(strategy) {
-			if kind, ok := directNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+			if kind, ok := directNativeCheckpointKind(cfg, server, target, strategy); ok {
 				return kind
 			}
 		}
 		return checkpointKindArchive
 	case "native", "provider-native", "vm":
-		if kind, ok := nativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+		if kind, ok := nativeCheckpointKind(cfg, server, target, strategy); ok {
 			return kind
 		}
-		if kind, ok := directNativeCheckpointKind(cfg, server, target, normalizedStrategy); ok {
+		if kind, ok := directNativeCheckpointKind(cfg, server, target, strategy); ok {
 			return kind
 		}
-		if kind, ok := parallelsNativeCheckpointKind(cfg, server, normalizedStrategy); ok {
+		if kind, ok := parallelsNativeCheckpointKind(cfg, server, strategy); ok {
 			return kind
 		}
 		if isAutoCheckpointStrategy(strategy) {
@@ -1335,7 +1368,7 @@ func nativeCheckpointForkWorkdir(cfg Config, leaseID, repoName, override string)
 }
 
 func isNativeCheckpointKind(kind string) bool {
-	return kind == checkpointKindAWSAMI || kind == checkpointKindAWSEBS || kind == checkpointKindAzure || kind == checkpointKindAzureOS || kind == checkpointKindGCP || kind == checkpointKindGCPDisk || kind == checkpointKindParallels
+	return kind == checkpointKindAWSAMI || kind == checkpointKindAWSEBS || kind == checkpointKindAzure || kind == checkpointKindAzureOS || kind == checkpointKindGCP || kind == checkpointKindGCPDisk || kind == checkpointKindParallels || kind == checkpointKindDockerCommit
 }
 
 func checkpointProviderForKind(kind string) string {
@@ -1348,6 +1381,8 @@ func checkpointProviderForKind(kind string) string {
 		return "gcp"
 	case checkpointKindParallels:
 		return "parallels"
+	case checkpointKindDockerCommit:
+		return "local-container"
 	default:
 		return ""
 	}

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -17,6 +17,7 @@ type checkpointNativeCreateRequest struct {
 	LeaseID     string
 	Name        string
 	RepoName    string
+	Workdir     string
 	Strategy    string
 	NoReboot    bool
 	Wait        bool
@@ -68,7 +69,7 @@ func (coordinatorCheckpointDriver) Create(ctx context.Context, req checkpointNat
 		return CoordinatorImage{}, exit(2, "native checkpoints require a configured coordinator")
 	}
 	strategy := normalizeCheckpointStrategy(req.Strategy)
-	capability, ok := providerNativeCheckpointCapability(req.Cfg, req.Server, req.Target, strategy)
+	capability, ok := providerNativeCheckpointCapability(req.Cfg, req.Server, req.Target, req.Strategy)
 	if !ok || capability.Direct || capability.Kind == "" {
 		return CoordinatorImage{}, exit(2, "native checkpoints support brokered AWS Linux/macOS leases and brokered Azure/GCP Linux leases only")
 	}
@@ -169,8 +170,11 @@ func nativeCheckpointCreateDriver(cfg Config, server Server, target SSHTarget, s
 	if _, ok := directParallelsNativeCheckpointKind(cfg, server, target, strategy); ok {
 		return directParallelsCheckpointDriver{}, true
 	}
-	if kind, ok := directNativeCheckpointKind(cfg, server, target, strategy); ok && kind == checkpointKindAWSAMI {
-		return directAWSAMICheckpointDriver{}, true
+	if kind, ok := directNativeCheckpointKind(cfg, server, target, strategy); ok {
+		switch kind {
+		case checkpointKindAWSAMI:
+			return directAWSAMICheckpointDriver{}, true
+		}
 	}
 	if _, ok := nativeCheckpointKind(cfg, server, target, strategy); ok {
 		return coordinatorCheckpointDriver{}, true
@@ -178,31 +182,74 @@ func nativeCheckpointCreateDriver(cfg Config, server Server, target SSHTarget, s
 	return nil, false
 }
 
-func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName, strategy string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
+func (a App) createNativeCheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName, workdir, strategy string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, map[string]string, error) {
+	if provider, ok := nativeCheckpointLifecycleProvider(cfg, server); ok {
+		result, err := provider.CreateNativeCheckpoint(ctx, NativeCheckpointCreateRequest{
+			Config:      cfg,
+			Server:      server,
+			Target:      target,
+			LeaseID:     leaseID,
+			Name:        name,
+			RepoName:    repoName,
+			Workdir:     workdir,
+			Strategy:    strategy,
+			NoReboot:    noReboot,
+			Wait:        wait,
+			WaitTimeout: waitTimeout,
+			Stderr:      a.Stderr,
+		})
+		return coordinatorImageFromNativeCheckpoint(result.Image), result.Metadata, err
+	}
 	driver, ok := nativeCheckpointCreateDriver(cfg, server, target, strategy)
 	if !ok {
 		if cfg.Coordinator == "" {
-			return CoordinatorImage{}, exit(2, "native checkpoints require a configured coordinator")
+			return CoordinatorImage{}, nil, exit(2, "native checkpoints require a configured coordinator")
 		}
-		return CoordinatorImage{}, exit(2, "native checkpoints support brokered AWS Linux/macOS leases and brokered Azure/GCP Linux leases only")
+		return CoordinatorImage{}, nil, exit(2, "native checkpoints support brokered AWS Linux/macOS leases and brokered Azure/GCP Linux leases only")
 	}
-	return driver.Create(ctx, checkpointNativeCreateRequest{
+	image, err := driver.Create(ctx, checkpointNativeCreateRequest{
 		Cfg:         cfg,
 		Server:      server,
 		Target:      target,
 		LeaseID:     leaseID,
 		Name:        name,
 		RepoName:    repoName,
+		Workdir:     workdir,
 		Strategy:    strategy,
 		NoReboot:    noReboot,
 		Wait:        wait,
 		WaitTimeout: waitTimeout,
 		Stderr:      a.Stderr,
 	})
+	return image, nil, err
 }
 
 func (a App) createAWSAMICheckpoint(ctx context.Context, cfg Config, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
-	return a.createNativeCheckpoint(ctx, cfg, Server{Provider: "aws", CloudID: leaseID}, target, leaseID, name, repoName, checkpointStrategyImage, noReboot, wait, waitTimeout)
+	image, _, err := a.createNativeCheckpoint(ctx, cfg, Server{Provider: "aws", CloudID: leaseID}, target, leaseID, name, repoName, "", checkpointStrategyImage, noReboot, wait, waitTimeout)
+	return image, err
+}
+
+func coordinatorImageFromNativeCheckpoint(image NativeCheckpointImage) CoordinatorImage {
+	return CoordinatorImage{
+		ID:         image.ID,
+		Name:       image.Name,
+		State:      image.State,
+		Provider:   image.Provider,
+		Kind:       image.Kind,
+		Region:     image.Region,
+		ResourceID: image.ResourceID,
+		Direct:     image.Direct,
+	}
+}
+
+func nativeCheckpointLifecycleProvider(cfg Config, server Server) (NativeCheckpointLifecycleProvider, bool) {
+	providerName := firstNonBlank(server.Provider, cfg.Provider)
+	provider, err := ProviderFor(providerName)
+	if err != nil {
+		return nil, false
+	}
+	lifecycle, ok := provider.(NativeCheckpointLifecycleProvider)
+	return lifecycle, ok
 }
 
 func (a App) createDirectAWSAMICheckpoint(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID, name, repoName string, noReboot, wait bool, waitTimeout time.Duration) (CoordinatorImage, error) {
@@ -320,10 +367,11 @@ func providerNativeCheckpointCapability(cfg Config, server Server, target SSHTar
 		return NativeCheckpointCapability{}, false
 	}
 	return capabilityProvider.NativeCheckpointCapability(NativeCheckpointRequest{
-		Config:   cfg,
-		Server:   server,
-		Target:   target,
-		Strategy: normalizeCheckpointStrategy(strategy),
+		Config:           cfg,
+		Server:           server,
+		Target:           target,
+		Strategy:         normalizeCheckpointStrategy(strategy),
+		StrategyExplicit: !isAutoCheckpointStrategy(strategy),
 	})
 }
 
@@ -389,6 +437,22 @@ func nativeCheckpointDeleteID(record checkpointRecord) string {
 	return record.nativeDeleteID()
 }
 
+func nativeCheckpointResourceRequest(record checkpointRecord) NativeCheckpointResourceRequest {
+	return NativeCheckpointResourceRequest{
+		Image: NativeCheckpointImage{
+			ID:         record.Native.ImageID,
+			Name:       record.Native.Name,
+			State:      record.Native.State,
+			Provider:   record.nativeProvider(),
+			Kind:       record.Kind,
+			Region:     record.Native.Region,
+			ResourceID: record.Native.Resource,
+			Direct:     record.Native.Direct,
+		},
+		Metadata: record.Native.Metadata,
+	}
+}
+
 func checkpointKindForProviderImage(image CoordinatorImage) string {
 	switch image.Kind {
 	case checkpointKindAWSEBS:
@@ -397,6 +461,8 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 		return checkpointKindAzureOS
 	case checkpointKindGCPDisk:
 		return checkpointKindGCPDisk
+	case checkpointKindDockerCommit:
+		return checkpointKindDockerCommit
 	}
 	switch image.Provider {
 	case "azure":
@@ -405,6 +471,8 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 		return checkpointKindGCP
 	case "parallels":
 		return checkpointKindParallels
+	case "local-container":
+		return checkpointKindDockerCommit
 	default:
 		return checkpointKindAWSAMI
 	}
@@ -412,7 +480,7 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 
 func checkpointStrategyForKind(kind string) string {
 	switch kind {
-	case checkpointKindAWSAMI, checkpointKindAzure, checkpointKindGCP:
+	case checkpointKindAWSAMI, checkpointKindAzure, checkpointKindGCP, checkpointKindDockerCommit:
 		return checkpointStrategyImage
 	case checkpointKindAWSEBS, checkpointKindAzureOS, checkpointKindGCPDisk, checkpointKindParallels:
 		return checkpointStrategyDiskSnapshot

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -171,6 +171,44 @@ func TestCheckpointRestoreDryRunDoesNotResolveLease(t *testing.T) {
 	}
 }
 
+// TestCheckpointRestoreDockerCommitDoesNotPointAtFork is the round-10 regression:
+// restoring a docker-commit checkpoint must not tell users to use `checkpoint
+// fork` (which lands separately) or call the image a "VM image"; it should point
+// at the create/verify/delete support this PR adds.
+func TestCheckpointRestoreDockerCommitDoesNotPointAtFork(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{ID: "chk_dc_restore", Kind: checkpointKindDockerCommit, CreatedAt: time.Now().UTC().Format(time.RFC3339)}
+	record.Native.ImageID = "sha256:deadbeef"
+	if _, err := store.Create(record); err != nil {
+		t.Fatal(err)
+	}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	err = app.checkpointRestore(context.Background(), []string{record.ID, "--id", "cbx_x"})
+	if err == nil {
+		t.Fatal("expected restore of a docker-commit checkpoint to be unsupported")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "fork") {
+		t.Fatalf("docker-commit restore guidance must not point at fork, got %q", msg)
+	}
+	if strings.Contains(msg, "VM image") {
+		t.Fatalf("docker-commit image must not be called a VM image, got %q", msg)
+	}
+	// Must point at commands that actually exist: `inspect <id> --verify` and
+	// `delete <id>` (there is no `checkpoint verify` subcommand).
+	if !strings.Contains(msg, "checkpoint inspect") || !strings.Contains(msg, "--verify") {
+		t.Fatalf("guidance should point at `checkpoint inspect <id> --verify`, got %q", msg)
+	}
+	if !strings.Contains(msg, "checkpoint delete") {
+		t.Fatalf("guidance should point at `checkpoint delete <id>`, got %q", msg)
+	}
+}
+
 func TestCheckpointForkDryRunDoesNotAcquireLease(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
@@ -597,6 +635,41 @@ func TestCheckpointCreateModeParallelsRejectsImageStrategy(t *testing.T) {
 	}
 }
 
+func TestCheckpointCreateModeLocalContainerNativeUsesDockerCommit(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "local-container"
+	server := Server{Provider: "local-container", CloudID: "abc123"}
+	target := SSHTarget{TargetOS: targetLinux}
+	// auto keeps the existing workspace-archive default; docker-commit is opt-in via --mode native.
+	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindArchive {
+		t.Fatalf("auto mode=%q, want %q", got, checkpointKindArchive)
+	}
+	if got := checkpointCreateMode("native", "", cfg, server, target, false); got != checkpointKindDockerCommit {
+		t.Fatalf("native mode=%q, want %q", got, checkpointKindDockerCommit)
+	}
+	for _, strategy := range []string{checkpointStrategyImage, checkpointStrategyDiskSnapshot, "disk", "snapshot"} {
+		if got := checkpointCreateMode("native", strategy, cfg, server, target, false); got != "unsupported" {
+			t.Fatalf("native strategy=%q mode=%q, want unsupported", strategy, got)
+		}
+	}
+}
+
+func TestCheckpointDockerCommitUsesImageStrategy(t *testing.T) {
+	if got := checkpointStrategyForKind(checkpointKindDockerCommit); got != checkpointStrategyImage {
+		t.Fatalf("strategy=%q, want %q", got, checkpointStrategyImage)
+	}
+}
+
+func TestCheckpointCreateModeLocalContainerRequiresCloudID(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "local-container"
+	server := Server{Provider: "local-container"}
+	target := SSHTarget{TargetOS: targetLinux}
+	if got := checkpointCreateMode("auto", "", cfg, server, target, false); got != checkpointKindArchive {
+		t.Fatalf("no cloud ID auto mode=%q, want %q", got, checkpointKindArchive)
+	}
+}
+
 func TestDirectAWSCheckpointConfigUsesDirectMarker(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "crabbox.yaml")
 	if err := os.WriteFile(cfgPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
@@ -802,7 +875,7 @@ func TestCreateNativeCheckpointRejectsAzureImageBeforeAdminAndCloudInit(t *testi
 	cfg.Coordinator = "https://coordinator.example"
 	cfg.TargetOS = targetLinux
 
-	_, err := (App{Stdout: io.Discard, Stderr: io.Discard}).createNativeCheckpoint(
+	_, _, err := (App{Stdout: io.Discard, Stderr: io.Discard}).createNativeCheckpoint(
 		context.Background(),
 		cfg,
 		Server{Provider: "azure", CloudID: "crabbox-source"},
@@ -810,6 +883,7 @@ func TestCreateNativeCheckpointRejectsAzureImageBeforeAdminAndCloudInit(t *testi
 		"cbx_123",
 		"",
 		"repo",
+		"",
 		checkpointStrategyImage,
 		true,
 		false,

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -131,14 +131,73 @@ type NativeCheckpointCapability struct {
 }
 
 type NativeCheckpointRequest struct {
-	Config   Config
-	Server   Server
-	Target   SSHTarget
-	Strategy string
+	Config           Config
+	Server           Server
+	Target           SSHTarget
+	Strategy         string
+	StrategyExplicit bool
 }
 
 type NativeCheckpointProvider interface {
 	NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool)
+}
+
+type NativeCheckpointImage struct {
+	ID         string
+	Name       string
+	State      string
+	Provider   string
+	Kind       string
+	Region     string
+	ResourceID string
+	Direct     bool
+}
+
+type NativeCheckpointCreateRequest struct {
+	Config      Config
+	Server      Server
+	Target      SSHTarget
+	LeaseID     string
+	Name        string
+	RepoName    string
+	Workdir     string
+	Strategy    string
+	NoReboot    bool
+	Wait        bool
+	WaitTimeout time.Duration
+	Stderr      io.Writer
+}
+
+type NativeCheckpointCreateResult struct {
+	Image    NativeCheckpointImage
+	Metadata map[string]string
+}
+
+type NativeCheckpointWorkdirRequest struct {
+	Config   Config
+	Server   Server
+	LeaseID  string
+	RepoName string
+	Override string
+}
+
+type NativeCheckpointResourceRequest struct {
+	Config   Config
+	Image    NativeCheckpointImage
+	Metadata map[string]string
+}
+
+type NativeCheckpointVerifyResult struct {
+	ProviderState string
+	NextAction    string
+	Error         string
+}
+
+type NativeCheckpointLifecycleProvider interface {
+	NativeCheckpointWorkdir(req NativeCheckpointWorkdirRequest) string
+	CreateNativeCheckpoint(ctx context.Context, req NativeCheckpointCreateRequest) (NativeCheckpointCreateResult, error)
+	VerifyNativeCheckpoint(ctx context.Context, req NativeCheckpointResourceRequest) (NativeCheckpointVerifyResult, error)
+	DeleteNativeCheckpoint(ctx context.Context, req NativeCheckpointResourceRequest) error
 }
 
 type NativeCheckpointForkRecord struct {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -207,6 +207,7 @@ const (
 	CheckpointKindGCP              = checkpointKindGCP
 	CheckpointKindGCPDisk          = checkpointKindGCPDisk
 	CheckpointKindParallels        = checkpointKindParallels
+	CheckpointKindDockerCommit     = checkpointKindDockerCommit
 	CheckpointStrategyImage        = checkpointStrategyImage
 	CheckpointStrategyDiskSnapshot = checkpointStrategyDiskSnapshot
 )

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1012,7 +1012,7 @@ func (testLocalContainerProvider) Spec() ProviderSpec {
 		Name:        "local-container",
 		Kind:        ProviderKindSSHLease,
 		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCacheVolume},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCacheVolume, FeatureCheckpoint},
 		Coordinator: CoordinatorNever,
 	}
 }
@@ -1079,6 +1079,12 @@ func (testLocalContainerProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, valu
 }
 func (p testLocalContainerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
+}
+func (testLocalContainerProvider) NativeCheckpointCapability(req NativeCheckpointRequest) (NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" || req.StrategyExplicit {
+		return NativeCheckpointCapability{}, false
+	}
+	return NativeCheckpointCapability{Kind: checkpointKindDockerCommit, Direct: true}, true
 }
 
 type testMultipassProvider struct{}

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -1,0 +1,597 @@
+package localcontainer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	checkpointMetadataRuntime  = "runtime"
+	checkpointMetadataHost     = "docker_host"
+	checkpointMetadataContext  = "docker_context"
+	checkpointMetadataConfig   = "docker_config"
+	checkpointMetadataEndpoint = "docker_endpoint"
+	checkpointMetadataDaemonID = "docker_daemon_id"
+)
+
+type checkpointScope struct {
+	Runtime  string
+	Host     string
+	Context  string
+	Config   string
+	Endpoint string
+	DaemonID string
+}
+
+type checkpointMount struct {
+	Destination string `json:"Destination"`
+}
+
+var checkpointLeaseLabelKeys = []string{
+	"bootstrap_dir",
+	"browser",
+	"class",
+	"code",
+	"container_id",
+	"crabbox",
+	"crabbox_exposed_ports",
+	"created_at",
+	"created_by",
+	"desktop",
+	"desktop_env",
+	"docker_socket",
+	"expires_at",
+	"host_work_root",
+	"idle_timeout",
+	"idle_timeout_secs",
+	"image",
+	"keep",
+	"last_touched_at",
+	"lease",
+	"market",
+	"pond",
+	"profile",
+	"provider",
+	"provider_key",
+	"runtime",
+	"runtime_context",
+	"server_type",
+	"slug",
+	"ssh_port",
+	"ssh_user",
+	"state",
+	"tailscale",
+	"tailscale_exit_node",
+	"tailscale_exit_node_allow_lan_access",
+	"tailscale_hostname",
+	"tailscale_state",
+	"tailscale_tags",
+	"target",
+	"ttl_secs",
+	"windows_mode",
+	"work_root",
+}
+
+func (Provider) NativeCheckpointWorkdir(req core.NativeCheckpointWorkdirRequest) string {
+	if override := strings.TrimSpace(req.Override); override != "" {
+		return override
+	}
+	cfg := req.Config
+	if workRoot := strings.TrimSpace(req.Server.Labels["work_root"]); workRoot != "" {
+		cfg.WorkRoot = workRoot
+	}
+	return core.RemoteJoin(cfg, req.LeaseID, req.RepoName)
+}
+
+func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest) (core.NativeCheckpointCreateResult, error) {
+	containerID := strings.TrimSpace(req.Server.CloudID)
+	if containerID == "" {
+		return core.NativeCheckpointCreateResult{}, core.Exit(2, "docker-commit checkpoint requires a running container")
+	}
+	scope, err := checkpointScopeForServer(ctx, req.Config, req.Server)
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	if !isDockerRuntime(scope.Runtime) {
+		return core.NativeCheckpointCreateResult{}, core.Exit(2, "docker-commit checkpoints require the Docker runtime; use --mode archive with %s", scope.Runtime)
+	}
+	canonicalWorkdir, err := checkpointCanonicalWorkdir(ctx, scope, containerID, req.Workdir)
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	mounts, err := checkpointMounts(ctx, scope, containerID)
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	if destination := checkpointMountIntersectingWorkdir(mounts, canonicalWorkdir); destination != "" {
+		return core.NativeCheckpointCreateResult{}, core.Exit(2, "docker-commit checkpoint cannot capture workdir %s because it intersects mounted volume %s; use --mode archive", req.Workdir, destination)
+	}
+
+	var commitStderr strings.Builder
+	commitCmd := checkpointCommand(
+		ctx,
+		scope,
+		"commit",
+		"--change", checkpointResetLeaseLabelsChange(),
+		"--change", checkpointBootableCommandChange(),
+		containerID,
+	)
+	commitCmd.Stderr = &commitStderr
+	out, err := commitCmd.Output()
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, core.Exit(7, "docker commit %s: %v: %s", containerID, err, trimCheckpointFailure(commitStderr.String()))
+	}
+	imageID, err := parseCheckpointImageID(string(out))
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, core.Exit(7, "docker commit %s: %v", containerID, err)
+	}
+	imageName := checkpointImageName(defaultCheckpointName(req), imageID)
+	if tagOut, err := checkpointCommand(ctx, scope, "tag", imageID, imageName).CombinedOutput(); err != nil {
+		cleanupCtx, cancel := checkpointRollbackContext()
+		cleanupOut, cleanupErr := checkpointCommand(cleanupCtx, scope, "rmi", imageID).CombinedOutput()
+		cancel()
+		detail := trimCheckpointFailure(string(tagOut))
+		if cleanupErr != nil {
+			detail += fmt.Sprintf("; cleanup failed: %v: %s", cleanupErr, trimCheckpointFailure(string(cleanupOut)))
+			return core.NativeCheckpointCreateResult{
+				Image: core.NativeCheckpointImage{
+					ID:       imageID,
+					State:    "cleanup_failed",
+					Provider: providerName,
+					Kind:     core.CheckpointKindDockerCommit,
+					Direct:   true,
+				},
+				Metadata: checkpointScopeMetadata(scope),
+			}, core.Exit(7, "docker tag %s: %v: %s", imageID, err, detail)
+		}
+		return core.NativeCheckpointCreateResult{}, core.Exit(7, "docker tag %s: %v: %s", imageID, err, detail)
+	}
+	return core.NativeCheckpointCreateResult{
+		Image: core.NativeCheckpointImage{
+			ID:       imageID,
+			Name:     imageName,
+			State:    "available",
+			Provider: providerName,
+			Kind:     core.CheckpointKindDockerCommit,
+			Direct:   true,
+		},
+		Metadata: checkpointScopeMetadata(scope),
+	}, nil
+}
+
+func checkpointRollbackContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), rollbackTimeout)
+}
+
+func (Provider) VerifyNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) (core.NativeCheckpointVerifyResult, error) {
+	scope := checkpointScopeFromRequest(req)
+	if err := validateCheckpointScope(ctx, scope); err != nil {
+		return core.NativeCheckpointVerifyResult{}, err
+	}
+	currentID, missing, err := inspectCheckpointTag(ctx, scope, req.Image)
+	if err != nil {
+		return core.NativeCheckpointVerifyResult{}, err
+	}
+	if missing {
+		return core.NativeCheckpointVerifyResult{ProviderState: "missing", NextAction: "delete_local"}, nil
+	}
+	if !strings.EqualFold(currentID, req.Image.ID) {
+		return core.NativeCheckpointVerifyResult{
+			ProviderState: "conflict",
+			NextAction:    "restore_tag_or_delete_local",
+			Error:         fmt.Sprintf("checkpoint tag %s points to %s, recorded image is %s", req.Image.Name, currentID, req.Image.ID),
+		}, nil
+	}
+	return core.NativeCheckpointVerifyResult{ProviderState: "available", NextAction: "delete"}, nil
+}
+
+func (Provider) DeleteNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) error {
+	scope := checkpointScopeFromRequest(req)
+	if err := validateCheckpointScope(ctx, scope); err != nil {
+		return err
+	}
+	currentID, missing, err := inspectCheckpointTag(ctx, scope, req.Image)
+	if err != nil {
+		return err
+	}
+	if missing {
+		return nil
+	}
+	if !strings.EqualFold(currentID, req.Image.ID) {
+		return core.Exit(7, "refusing to delete checkpoint tag %s: recorded image %s but tag now points to %s; restore the tag or use --local-only", req.Image.Name, req.Image.ID, currentID)
+	}
+	target := firstCheckpointValue(req.Image.Name, req.Image.ID)
+	args := []string{"rmi"}
+	if req.Image.Name != "" {
+		args = append(args, "-f")
+	}
+	args = append(args, target)
+	if out, err := checkpointCommand(ctx, scope, args...).CombinedOutput(); err != nil {
+		return core.Exit(7, "docker rmi %s: %v: %s", target, err, trimCheckpointFailure(string(out)))
+	}
+	return nil
+}
+
+func inspectCheckpointTag(ctx context.Context, scope checkpointScope, image core.NativeCheckpointImage) (string, bool, error) {
+	target := firstCheckpointValue(image.Name, image.ID)
+	var stderr strings.Builder
+	cmd := checkpointCommand(ctx, scope, "image", "inspect", target, "--format", "{{.Id}}")
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		detail := trimCheckpointFailure(stderr.String())
+		if checkpointInspectReportsMissing(detail) {
+			return "", true, nil
+		}
+		return "", false, core.Exit(7, "docker image inspect %s: %v: %s", target, err, detail)
+	}
+	imageID, err := parseCheckpointImageID(string(out))
+	if err != nil {
+		return "", false, core.Exit(7, "docker image inspect %s: %v", target, err)
+	}
+	return imageID, false, nil
+}
+
+func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.Server) (checkpointScope, error) {
+	runtimeName := leaseRuntime(server, cfg.LocalContainer.Runtime)
+	scope := checkpointScope{Runtime: runtimeName}
+	if !isDockerRuntime(runtimeName) {
+		return scope, nil
+	}
+	if contextName := strings.TrimSpace(server.Labels["runtime_context"]); contextName != "" {
+		scope.Context = contextName
+	} else if contextName := strings.TrimSpace(os.Getenv("DOCKER_CONTEXT")); contextName != "" {
+		scope.Context = contextName
+	} else if host := strings.TrimSpace(os.Getenv("DOCKER_HOST")); host != "" {
+		scope.Host = host
+		scope.Endpoint = host
+	} else {
+		configPath, err := checkpointConfigPath()
+		if err != nil {
+			return checkpointScope{}, err
+		}
+		scope.Config = configPath
+		var stderr strings.Builder
+		cmd := exec.CommandContext(ctx, runtimeName, "context", "show")
+		cmd.Env = checkpointEnvForScope(scope)
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			return checkpointScope{}, core.Exit(7, "resolve Docker context: %v: %s", err, trimCheckpointFailure(stderr.String()))
+		}
+		scope.Context = strings.TrimSpace(string(out))
+		if scope.Context == "" {
+			return checkpointScope{}, core.Exit(7, "resolve Docker context: command returned an empty context")
+		}
+	}
+	if scope.Config == "" && scope.Host == "" {
+		configPath, err := checkpointConfigPath()
+		if err != nil {
+			return checkpointScope{}, err
+		}
+		scope.Config = configPath
+	}
+	if scope.Endpoint == "" {
+		endpoint, err := checkpointContextEndpoint(ctx, scope)
+		if err != nil {
+			return checkpointScope{}, err
+		}
+		scope.Endpoint = endpoint
+	}
+	daemonID, err := checkpointDaemonID(ctx, scope)
+	if err != nil {
+		return checkpointScope{}, err
+	}
+	scope.DaemonID = daemonID
+	return scope, nil
+}
+
+func checkpointScopeFromRequest(req core.NativeCheckpointResourceRequest) checkpointScope {
+	metadata := req.Metadata
+	runtimeName := strings.TrimSpace(metadata[checkpointMetadataRuntime])
+	if runtimeName == "" {
+		runtimeName = firstCheckpointValue(req.Config.LocalContainer.Runtime, "docker")
+	}
+	return checkpointScope{
+		Runtime:  runtimeName,
+		Host:     strings.TrimSpace(metadata[checkpointMetadataHost]),
+		Context:  strings.TrimSpace(metadata[checkpointMetadataContext]),
+		Config:   strings.TrimSpace(metadata[checkpointMetadataConfig]),
+		Endpoint: strings.TrimSpace(metadata[checkpointMetadataEndpoint]),
+		DaemonID: strings.TrimSpace(metadata[checkpointMetadataDaemonID]),
+	}
+}
+
+func checkpointScopeMetadata(scope checkpointScope) map[string]string {
+	return map[string]string{
+		checkpointMetadataRuntime:  scope.Runtime,
+		checkpointMetadataHost:     scope.Host,
+		checkpointMetadataContext:  scope.Context,
+		checkpointMetadataConfig:   scope.Config,
+		checkpointMetadataEndpoint: scope.Endpoint,
+		checkpointMetadataDaemonID: scope.DaemonID,
+	}
+}
+
+func validateCheckpointScope(ctx context.Context, scope checkpointScope) error {
+	if scope.Context != "" && scope.Endpoint != "" {
+		current, err := checkpointContextEndpoint(ctx, scope)
+		if err != nil {
+			return err
+		}
+		if current != scope.Endpoint {
+			return core.Exit(7, "Docker context %s endpoint changed from %s to %s; refusing checkpoint operation", scope.Context, scope.Endpoint, current)
+		}
+	}
+	if scope.DaemonID == "" {
+		return core.Exit(7, "checkpoint is missing its Docker daemon identity; refusing checkpoint operation")
+	}
+	currentDaemonID, err := checkpointDaemonID(ctx, scope)
+	if err != nil {
+		return err
+	}
+	if currentDaemonID != scope.DaemonID {
+		return core.Exit(7, "Docker daemon changed from %s to %s; refusing checkpoint operation", scope.DaemonID, currentDaemonID)
+	}
+	return nil
+}
+
+func checkpointContextEndpoint(ctx context.Context, scope checkpointScope) (string, error) {
+	var stderr strings.Builder
+	cmd := checkpointCommand(ctx, scope, "context", "inspect", scope.Context, "--format", `{{(index .Endpoints "docker").Host}}`)
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", core.Exit(7, "resolve Docker context %s endpoint: %v: %s", scope.Context, err, trimCheckpointFailure(stderr.String()))
+	}
+	endpoint := strings.TrimSpace(string(out))
+	if endpoint == "" {
+		return "", core.Exit(7, "resolve Docker context %s endpoint: command returned an empty endpoint", scope.Context)
+	}
+	return endpoint, nil
+}
+
+func checkpointDaemonID(ctx context.Context, scope checkpointScope) (string, error) {
+	var stderr strings.Builder
+	cmd := checkpointCommand(ctx, scope, "info", "--format", "{{.ID}}")
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", core.Exit(7, "resolve Docker daemon identity: %v: %s", err, trimCheckpointFailure(stderr.String()))
+	}
+	daemonID := strings.TrimSpace(string(out))
+	if daemonID == "" {
+		return "", core.Exit(7, "resolve Docker daemon identity: command returned an empty id")
+	}
+	return daemonID, nil
+}
+
+func checkpointConfigPath() (string, error) {
+	configPath := strings.TrimSpace(os.Getenv("DOCKER_CONFIG"))
+	if configPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", core.Exit(7, "resolve Docker config directory: %v", err)
+		}
+		configPath = filepath.Join(home, ".docker")
+	}
+	if strings.HasPrefix(configPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", core.Exit(7, "resolve Docker config directory: %v", err)
+		}
+		configPath = filepath.Join(home, strings.TrimPrefix(configPath, "~/"))
+	}
+	absolute, err := filepath.Abs(configPath)
+	if err != nil {
+		return "", core.Exit(7, "resolve Docker config directory %s: %v", configPath, err)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func checkpointCommand(ctx context.Context, scope checkpointScope, args ...string) *exec.Cmd {
+	full := args
+	if scope.Context != "" {
+		full = append([]string{"--context", scope.Context}, args...)
+	}
+	cmd := exec.CommandContext(ctx, scope.Runtime, full...)
+	if env := checkpointEnvForScope(scope); env != nil {
+		cmd.Env = env
+	}
+	return cmd
+}
+
+func checkpointEnvForScope(scope checkpointScope) []string {
+	if scope.Config == "" && scope.Host == "" && scope.Context == "" {
+		return nil
+	}
+	base := os.Environ()
+	out := make([]string, 0, len(base)+2)
+	for _, value := range base {
+		if strings.HasPrefix(value, "DOCKER_CONTEXT=") ||
+			(scope.Host != "" || scope.Context != "") && strings.HasPrefix(value, "DOCKER_HOST=") ||
+			scope.Config != "" && strings.HasPrefix(value, "DOCKER_CONFIG=") {
+			continue
+		}
+		out = append(out, value)
+	}
+	if scope.Config != "" {
+		out = append(out, "DOCKER_CONFIG="+scope.Config)
+	}
+	if scope.Host != "" {
+		out = append(out, "DOCKER_HOST="+scope.Host)
+	}
+	return out
+}
+
+func checkpointCanonicalWorkdir(ctx context.Context, scope checkpointScope, containerID, workdir string) (string, error) {
+	workdir = strings.TrimSpace(workdir)
+	if workdir == "" {
+		return "", core.Exit(2, "docker-commit checkpoint requires a workspace path")
+	}
+	out, err := checkpointCommand(ctx, scope, "exec", containerID, "sh", "-c", `cd "$1" && pwd -P`, "sh", workdir).CombinedOutput()
+	if err != nil {
+		return "", core.Exit(7, "resolve docker workdir %s: %v: %s", workdir, err, trimCheckpointFailure(string(out)))
+	}
+	canonical := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(canonical, "/") {
+		return "", core.Exit(7, "resolve docker workdir %s: expected an absolute path, got %q", workdir, canonical)
+	}
+	return path.Clean(canonical), nil
+}
+
+func checkpointMounts(ctx context.Context, scope checkpointScope, containerID string) ([]checkpointMount, error) {
+	out, err := checkpointCommand(ctx, scope, "inspect", containerID, "--format", "{{json .Mounts}}").CombinedOutput()
+	if err != nil {
+		return nil, core.Exit(7, "docker inspect %s mounts: %v: %s", containerID, err, trimCheckpointFailure(string(out)))
+	}
+	var mounts []checkpointMount
+	if err := json.Unmarshal(out, &mounts); err != nil {
+		return nil, core.Exit(7, "decode docker mounts for %s: %v", containerID, err)
+	}
+	return mounts, nil
+}
+
+func checkpointMountIntersectingWorkdir(mounts []checkpointMount, workdir string) string {
+	workdir = path.Clean(strings.TrimSpace(workdir))
+	if workdir == "." {
+		return ""
+	}
+	for _, mount := range mounts {
+		destination := path.Clean(strings.TrimSpace(mount.Destination))
+		if destination == "." {
+			continue
+		}
+		if destination == "/" || workdir == "/" || workdir == destination ||
+			strings.HasPrefix(workdir, destination+"/") ||
+			strings.HasPrefix(destination, workdir+"/") {
+			return destination
+		}
+	}
+	return ""
+}
+
+func checkpointResetLeaseLabelsChange() string {
+	var change strings.Builder
+	change.WriteString("LABEL")
+	for _, key := range checkpointLeaseLabelKeys {
+		fmt.Fprintf(&change, ` %s=""`, key)
+	}
+	return change.String()
+}
+
+func checkpointBootableCommandChange() string {
+	return `CMD ["/bin/sh","-c","while :; do sleep 3600; done"]`
+}
+
+func checkpointImageName(name, imageID string) string {
+	shortID := strings.TrimPrefix(strings.ToLower(imageID), "sha256:")
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	const prefix = "crabbox-checkpoint-"
+	const maxRepositoryLength = 255
+	maxNameLength := maxRepositoryLength - len(prefix) - 1 - len(shortID)
+	return prefix + normalizeCheckpointRepositoryComponent(name, maxNameLength) + "-" + shortID
+}
+
+func normalizeCheckpointRepositoryComponent(value string, maxLength int) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var out strings.Builder
+	out.Grow(min(len(value), maxLength))
+	separator := false
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			required := 1
+			if separator && out.Len() > 0 {
+				required++
+			}
+			if out.Len()+required > maxLength {
+				break
+			}
+			if separator && out.Len() > 0 {
+				out.WriteByte('-')
+			}
+			out.WriteRune(r)
+			separator = false
+			continue
+		}
+		separator = true
+	}
+	normalized := strings.Trim(out.String(), "-")
+	if normalized == "" {
+		return "checkpoint"
+	}
+	return normalized
+}
+
+func parseCheckpointImageID(output string) (string, error) {
+	imageID := ""
+	for _, field := range strings.Fields(output) {
+		if !validCheckpointImageID(field) {
+			continue
+		}
+		if imageID != "" && !strings.EqualFold(imageID, field) {
+			return "", fmt.Errorf("ambiguous image ids in output %q", strings.TrimSpace(output))
+		}
+		imageID = strings.ToLower(field)
+	}
+	if imageID == "" {
+		return "", fmt.Errorf("missing sha256 image id in output %q", strings.TrimSpace(output))
+	}
+	return imageID, nil
+}
+
+func validCheckpointImageID(value string) bool {
+	digest := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), "sha256:")
+	if len(digest) != 64 {
+		return false
+	}
+	for _, r := range digest {
+		if r < '0' || r > '9' && r < 'a' || r > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+func checkpointInspectReportsMissing(output string) bool {
+	value := strings.ToLower(output)
+	return strings.Contains(value, "no such image") ||
+		strings.Contains(value, "no such object") ||
+		strings.Contains(value, "image not found") ||
+		strings.Contains(value, "reference does not exist")
+}
+
+func defaultCheckpointName(req core.NativeCheckpointCreateRequest) string {
+	return firstCheckpointValue(req.Name, req.RepoName, req.LeaseID, "checkpoint")
+}
+
+func firstCheckpointValue(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func trimCheckpointFailure(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	const max = 500
+	if len(value) > max {
+		return value[:max] + "..."
+	}
+	return value
+}

--- a/internal/providers/localcontainer/checkpoint_dockerproof_test.go
+++ b/internal/providers/localcontainer/checkpoint_dockerproof_test.go
@@ -1,0 +1,176 @@
+//go:build dockerproof
+
+package localcontainer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestDockerCommitCheckpointLifecycleProof(t *testing.T) {
+	const runtime = "docker"
+	if _, err := exec.LookPath(runtime); err != nil {
+		t.Skipf("%s not on PATH: %v", runtime, err)
+	}
+
+	bootstrapDir := t.TempDir()
+	if err := os.WriteFile(bootstrapDir+"/bootstrap.sh", []byte("#!/bin/sh\nmkdir -p /work\nexec sleep 600\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(runtime, "run", "-d", "-v", bootstrapDir+":/tmp/crabbox-bootstrap:ro", "alpine:3", "/bin/sh", "/tmp/crabbox-bootstrap/bootstrap.sh").CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run: %v: %s", err, out)
+	}
+	containerID := lastCheckpointLine(string(out))
+	t.Cleanup(func() { _ = exec.Command(runtime, "rm", "-f", containerID).Run() })
+
+	req := core.NativeCheckpointCreateRequest{
+		Server:  core.Server{CloudID: containerID, Labels: map[string]string{"runtime": runtime}},
+		Name:    "proof",
+		Workdir: "/work",
+	}
+	result, err := (Provider{}).CreateNativeCheckpoint(context.Background(), req)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	img := result.Image
+	if img.State != "available" || img.Kind != core.CheckpointKindDockerCommit || !img.Direct {
+		t.Fatalf("unexpected checkpoint image: %+v", img)
+	}
+	t.Cleanup(func() { _ = exec.Command(runtime, "rmi", "-f", img.ID).Run() })
+	t.Logf("CREATE: image=%s id=%s", img.Name, shortCheckpointID(img.ID))
+
+	labelsOut, err := exec.Command(runtime, "image", "inspect", img.Name, "--format", `{{index .Config.Labels "crabbox"}}|{{index .Config.Labels "provider"}}|{{index .Config.Labels "lease"}}`).CombinedOutput()
+	if err != nil {
+		t.Fatalf("inspect checkpoint labels: %v: %s", err, labelsOut)
+	}
+	if got := strings.TrimSpace(string(labelsOut)); got != "||" {
+		t.Fatalf("checkpoint retained lease labels: %q", got)
+	}
+
+	derivedOut, err := exec.Command(runtime, "run", "-d", img.Name).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run derived container: %v: %s", err, derivedOut)
+	}
+	derivedID := lastCheckpointLine(string(derivedOut))
+	t.Cleanup(func() { _ = exec.Command(runtime, "rm", "-f", derivedID).Run() })
+	runningOut, err := exec.Command(runtime, "inspect", derivedID, "--format", "{{.State.Running}}").CombinedOutput()
+	if err != nil || strings.TrimSpace(string(runningOut)) != "true" {
+		t.Fatalf("checkpoint image did not start with its default command: %v: %s", err, runningOut)
+	}
+	inventoryOut, err := exec.Command(runtime, "ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("inventory derived container: %v: %s", err, inventoryOut)
+	}
+	if strings.Contains(string(inventoryOut), shortCheckpointID(derivedID)) {
+		t.Fatalf("derived container %s inherited Crabbox lease ownership", shortCheckpointID(derivedID))
+	}
+
+	result2, err := (Provider{}).CreateNativeCheckpoint(context.Background(), req)
+	if err != nil {
+		t.Fatalf("create #2: %v", err)
+	}
+	img2 := result2.Image
+	t.Cleanup(func() { _ = exec.Command(runtime, "rmi", "-f", img2.Name).Run() })
+	if img2.ID == img.ID || img2.Name == img.Name {
+		t.Fatalf("duplicate name reused identity: #1=%s/%s #2=%s/%s", img.Name, shortCheckpointID(img.ID), img2.Name, shortCheckpointID(img2.ID))
+	}
+
+	resource := core.NativeCheckpointResourceRequest{Image: img, Metadata: result.Metadata}
+	verify, err := (Provider{}).VerifyNativeCheckpoint(context.Background(), resource)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if verify.ProviderState != "available" || verify.NextAction != "delete" {
+		t.Fatalf("verify=%+v", verify)
+	}
+	if err := (Provider{}).DeleteNativeCheckpoint(context.Background(), resource); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := exec.Command(runtime, "image", "inspect", img.Name).Run(); err == nil {
+		t.Fatalf("tag %s still present after delete", img.Name)
+	}
+	if err := exec.Command(runtime, "inspect", derivedID).Run(); err != nil {
+		t.Fatalf("dependent container removed with checkpoint tag: %v", err)
+	}
+
+	mountedWorkdir := t.TempDir()
+	if err := os.WriteFile(mountedWorkdir+"/proof.txt", []byte("mounted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mountOut, err := exec.Command(runtime, "run", "-d", "-v", mountedWorkdir+":/work/repo/node_modules", "alpine:3", "sleep", "600").CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker run mounted workdir: %v: %s", err, mountOut)
+	}
+	mountedContainerID := lastCheckpointLine(string(mountOut))
+	t.Cleanup(func() { _ = exec.Command(runtime, "rm", "-f", mountedContainerID).Run() })
+	_, err = (Provider{}).CreateNativeCheckpoint(context.Background(), core.NativeCheckpointCreateRequest{
+		Server:  core.Server{CloudID: mountedContainerID, Labels: map[string]string{"runtime": runtime}},
+		Name:    "mounted-proof",
+		Workdir: "/work/repo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "mounted volume /work/repo/node_modules") {
+		t.Fatalf("mounted workdir error=%v", err)
+	}
+}
+
+func TestCheckpointScopePinsAndValidatesContextProof(t *testing.T) {
+	runtime, err := exec.LookPath("docker")
+	if err != nil {
+		t.Skip("requires Docker")
+	}
+	t.Setenv("DOCKER_CONTEXT", "")
+	t.Setenv("DOCKER_HOST", "")
+	scope, err := checkpointScopeForServer(context.Background(), core.Config{}, core.Server{
+		Labels: map[string]string{"runtime": runtime},
+	})
+	if err != nil {
+		t.Skipf("requires a running Docker daemon: %v", err)
+	}
+	if scope.Context == "" || scope.Config == "" || scope.Endpoint == "" || scope.DaemonID == "" {
+		t.Fatalf("incomplete scope: %#v", scope)
+	}
+	if err := validateCheckpointScope(context.Background(), scope); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOCKER_CONTEXT", "ambient-context-must-not-win")
+	recordedScope, err := checkpointScopeForServer(context.Background(), core.Config{}, core.Server{
+		Labels: map[string]string{
+			"runtime":         runtime,
+			"runtime_context": scope.Context,
+		},
+	})
+	if err != nil {
+		t.Fatalf("recorded lease context was not preferred: %v", err)
+	}
+	if recordedScope.Context != scope.Context || recordedScope.DaemonID != scope.DaemonID {
+		t.Fatalf("recorded scope=%#v, want context=%q daemon=%q", recordedScope, scope.Context, scope.DaemonID)
+	}
+	scope.Endpoint += ".changed"
+	if err := validateCheckpointScope(context.Background(), scope); err == nil {
+		t.Fatal("expected changed endpoint to fail validation")
+	}
+	scope.Endpoint = strings.TrimSuffix(scope.Endpoint, ".changed")
+	scope.DaemonID += "-changed"
+	if err := validateCheckpointScope(context.Background(), scope); err == nil {
+		t.Fatal("expected changed daemon identity to fail validation")
+	}
+}
+
+func shortCheckpointID(value string) string {
+	value = strings.TrimPrefix(value, "sha256:")
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
+}
+
+func lastCheckpointLine(value string) string {
+	parts := strings.Split(strings.TrimSpace(value), "\n")
+	return strings.TrimSpace(parts[len(parts)-1])
+}

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -1,0 +1,196 @@
+package localcontainer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestNativeCheckpointWorkdirUsesResolvedLeaseRoot(t *testing.T) {
+	cfg := core.Config{Provider: providerName, WorkRoot: "/stale"}
+	got := (Provider{}).NativeCheckpointWorkdir(core.NativeCheckpointWorkdirRequest{
+		Config:   cfg,
+		Server:   core.Server{Labels: map[string]string{"work_root": "/resolved"}},
+		LeaseID:  "cbx_123",
+		RepoName: "my-app",
+	})
+	if got != "/resolved/cbx_123/my-app" {
+		t.Fatalf("workdir=%q", got)
+	}
+}
+
+func TestCheckpointImageNameNormalizesAndBoundsRepository(t *testing.T) {
+	got := checkpointImageName("___", "sha256:ABCDEF0123456789")
+	if got != "crabbox-checkpoint-checkpoint-abcdef012345" {
+		t.Fatalf("punctuation-only name=%q", got)
+	}
+	got = checkpointImageName(strings.Repeat("A_", 300), "sha256:ABCDEF0123456789")
+	if len(got) > 255 || got != strings.ToLower(got) {
+		t.Fatalf("invalid repository name=%q length=%d", got, len(got))
+	}
+}
+
+func TestCheckpointMountIntersectingWorkdir(t *testing.T) {
+	mounts := []checkpointMount{{Destination: "/cache"}, {Destination: "/work/shared"}}
+	for _, tc := range []struct {
+		workdir string
+		want    string
+	}{
+		{workdir: "/work/shared", want: "/work/shared"},
+		{workdir: "/work/shared/repo", want: "/work/shared"},
+		{workdir: "/work", want: "/work/shared"},
+		{workdir: "/work/other", want: ""},
+	} {
+		if got := checkpointMountIntersectingWorkdir(mounts, tc.workdir); got != tc.want {
+			t.Fatalf("workdir=%q got=%q want=%q", tc.workdir, got, tc.want)
+		}
+	}
+}
+
+func TestCheckpointRollbackContextOutlivesRequestCancellation(t *testing.T) {
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	cancelRequest()
+	if requestCtx.Err() == nil {
+		t.Fatal("request context was not canceled")
+	}
+	rollbackCtx, cancelRollback := checkpointRollbackContext()
+	defer cancelRollback()
+	if err := rollbackCtx.Err(); err != nil {
+		t.Fatalf("rollback context inherited request cancellation: %v", err)
+	}
+}
+
+func TestParseCheckpointImageIDIgnoresNonDigestOutput(t *testing.T) {
+	got, err := parseCheckpointImageID("warning\nsha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" {
+		t.Fatalf("image id=%q", got)
+	}
+}
+
+func TestCheckpointResetLeaseLabelsClearsOwnershipSelectors(t *testing.T) {
+	change := checkpointResetLeaseLabelsChange()
+	for _, key := range []string{"crabbox", "provider", "lease", "slug", "keep", "expires_at"} {
+		if !strings.Contains(change, ` `+key+`=""`) {
+			t.Fatalf("label reset missing %s", key)
+		}
+	}
+}
+
+func TestCheckpointBootableCommandDoesNotReferenceBootstrapMount(t *testing.T) {
+	change := checkpointBootableCommandChange()
+	if strings.Contains(change, "crabbox-bootstrap") || !strings.HasPrefix(change, "CMD ") {
+		t.Fatalf("invalid checkpoint command change: %q", change)
+	}
+}
+
+func TestNativeCheckpointCapabilityReturnsDockerCommit(t *testing.T) {
+	cap, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server: core.Server{CloudID: "abc123"},
+	})
+	if !ok {
+		t.Fatal("expected capability to be supported")
+	}
+	if cap.Kind != core.CheckpointKindDockerCommit {
+		t.Fatalf("Kind=%q, want %q", cap.Kind, core.CheckpointKindDockerCommit)
+	}
+	if !cap.Direct {
+		t.Fatal("Direct=false, want true")
+	}
+}
+
+func TestNativeCheckpointCapabilityRequiresCloudID(t *testing.T) {
+	_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server: core.Server{},
+	})
+	if ok {
+		t.Fatal("expected capability to be unsupported without CloudID")
+	}
+}
+
+func TestNativeCheckpointCapabilityRejectsExplicitStrategies(t *testing.T) {
+	for _, strategy := range []string{"image", "ami", "disk-snapshot", "disk", "snapshot"} {
+		t.Run(strategy, func(t *testing.T) {
+			_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+				Server:           core.Server{CloudID: "abc123"},
+				Strategy:         core.NormalizeCheckpointStrategy(strategy),
+				StrategyExplicit: true,
+			})
+			if ok {
+				t.Fatalf("expected capability to be unsupported with strategy=%s", strategy)
+			}
+		})
+	}
+}
+
+func TestNativeCheckpointCapabilityAcceptsNormalizedDefaultStrategy(t *testing.T) {
+	_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server:   core.Server{CloudID: "abc123"},
+		Strategy: core.CheckpointStrategyDiskSnapshot,
+	})
+	if !ok {
+		t.Fatal("expected normalized default strategy to remain supported")
+	}
+}
+
+func TestNativeCheckpointCapabilitySkipsDockerSocket(t *testing.T) {
+	_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server: core.Server{CloudID: "abc123"},
+		Config: core.Config{LocalContainer: core.LocalContainerConfig{DockerSocket: true}},
+	})
+	if ok {
+		t.Fatal("expected capability to be unsupported with docker-socket")
+	}
+}
+
+func TestNativeCheckpointCapabilitySkipsDockerSocketLabel(t *testing.T) {
+	_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server: core.Server{CloudID: "abc123", Labels: map[string]string{"docker_socket": "1"}},
+	})
+	if ok {
+		t.Fatal("expected capability to be unsupported when the lease label marks docker-socket mode")
+	}
+}
+
+func TestNativeCheckpointCapabilityLeaseLabelOverridesDockerSocketConfig(t *testing.T) {
+	_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+		Server: core.Server{
+			CloudID: "abc123",
+			Labels:  map[string]string{"docker_socket": "0"},
+		},
+		Config: core.Config{LocalContainer: core.LocalContainerConfig{DockerSocket: true}},
+	})
+	if !ok {
+		t.Fatal("expected recorded docker_socket=0 to override current config")
+	}
+}
+
+func TestNativeCheckpointCapabilityUsesResolvedLeaseRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		label    string
+		fallback string
+		want     bool
+	}{
+		{name: "detected podman", label: "podman", fallback: "docker", want: false},
+		{name: "detected docker", label: "/usr/local/bin/docker", fallback: "podman", want: true},
+		{name: "configured nerdctl", fallback: "nerdctl", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := Provider{}.NativeCheckpointCapability(core.NativeCheckpointRequest{
+				Server: core.Server{
+					CloudID: "abc123",
+					Labels:  map[string]string{"runtime": tc.label},
+				},
+				Config: core.Config{LocalContainer: core.LocalContainerConfig{Runtime: tc.fallback}},
+			})
+			if ok != tc.want {
+				t.Fatalf("supported=%v, want %v", ok, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -2,6 +2,8 @@ package localcontainer
 
 import (
 	"flag"
+	"path/filepath"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -24,7 +26,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      "container",
 		Kind:        core.ProviderKindSSHLease,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume, core.FeatureCheckpoint},
 		Coordinator: core.CoordinatorNever,
 	}
 }
@@ -45,6 +47,56 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; use a remote SSH provider when tailnet reachability is required", providerName)
 	}
 	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if req.Server.CloudID == "" {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if leaseUsesDockerSocket(req.Server, req.Config.LocalContainer.DockerSocket) {
+		return core.NativeCheckpointCapability{}, false
+	}
+	if !isDockerRuntime(leaseRuntime(req.Server, req.Config.LocalContainer.Runtime)) {
+		return core.NativeCheckpointCapability{}, false
+	}
+	// Docker commit is selected by native/auto mode; explicit VM snapshot
+	// strategies must not silently change meaning.
+	if req.StrategyExplicit {
+		return core.NativeCheckpointCapability{}, false
+	}
+	return core.NativeCheckpointCapability{Kind: core.CheckpointKindDockerCommit, Direct: true}, true
+}
+
+// leaseHasDockerSocket reports whether a resolved lease was created with
+// docker-socket mode (recorded on its labels). docker-commit checkpoints are
+// skipped for those leases because the host work-root mount masks the committed
+// workspace; the config flag alone misses leases whose mode is on the labels.
+func leaseUsesDockerSocket(server core.Server, fallback bool) bool {
+	value, ok := server.Labels["docker_socket"]
+	if !ok {
+		return fallback
+	}
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func leaseRuntime(server core.Server, fallback string) string {
+	if runtime := strings.TrimSpace(server.Labels["runtime"]); runtime != "" {
+		return runtime
+	}
+	if runtime := strings.TrimSpace(fallback); runtime != "" {
+		return runtime
+	}
+	return "docker"
+}
+
+func isDockerRuntime(runtime string) bool {
+	name := strings.TrimSuffix(strings.ToLower(filepath.Base(strings.TrimSpace(runtime))), ".exe")
+	return name == "docker"
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -2,7 +2,6 @@ package railway
 
 import (
 	"flag"
-	"io"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -27,7 +26,6 @@ type Repo = core.Repo
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
-type timingReport = core.TimingReport
 
 const (
 	providerName = "railway"
@@ -46,10 +44,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {


### PR DESCRIPTION
## Summary

Add opt-in native checkpoints for Docker-backed `local-container` leases using `docker commit`.

- `--mode native` captures the container filesystem as an immutable, uniquely tagged image.
- Verify and delete replay the lease's recorded Docker context and fail closed if the endpoint or Docker system ID changes.
- Mounted workspaces, Docker-socket leases, non-Docker runtimes, and explicit VM snapshot strategies are rejected.
- Delete verifies tag ownership before removal and preserves user tags and dependent containers.
- Committed images clear Crabbox lease labels so derived containers are not inventoried as the source lease.

`auto` continues to use workspace archives. Local-container checkpoint fork remains a separate follow-up in https://github.com/openclaw/crabbox/pull/208.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-pr206 ./cmd/crabbox`
- `go test -tags dockerproof -run '^(TestDockerCommitCheckpointLifecycleProof|TestCheckpointScopePinsAndValidatesContextProof)$' -count=1 -v ./internal/providers/localcontainer`
- Worker format, lint, typecheck, 349 tests, and Wrangler build
- Docs build, 150-link validation, and 71 Node script tests
- GoReleaser snapshot
- Autoreview clean

The branch also includes Vincent Koc's existing `fix(ci): remove dead railway
timing helper` commit because the newly enabled repository deadcode gate exposed
that current-`main` baseline failure before this PR's tests could run.

## Live E2E

OrbStack Docker:

1. Created a real `local-container` lease.
2. Wrote a marker into an unmounted workspace.
3. Created a `docker-commit` checkpoint.
4. Verified it with hostile ambient `DOCKER_CONTEXT` / `DOCKER_CONFIG`; recorded context, endpoint, and daemon ID won.
5. Started a container from the committed image and recovered the marker.
6. Confirmed the image starts normally with no command override even though the source used a bind-mounted bootstrap script.
7. Confirmed Crabbox ownership labels were cleared.
8. Deleted the checkpoint image and source lease, then confirmed both were gone.

Proof leases: `cbx_2a5003846142` (`pr206-final-15131`) and `cbx_ee2e71cbbfe7` (`pr206-route-25247`)
