### PR TITLE
feat(local-container): add native checkpoint forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added local-container checkpoint forks that launch a fresh Docker lease from a committed checkpoint image while replaying and validating its recorded daemon scope. Thanks @anagnorisis2peripeteia.
 - Added opt-in native Docker local-container checkpoints with immutable image identity, daemon-scope-aware verification and deletion, mounted-workspace guards, and live lifecycle coverage. Thanks @anagnorisis2peripeteia.
 - Added a built-in Incus provider for local or remote Linux containers and virtual machines, including socket, TLS, and OIDC control-plane authentication, optional SSH proxy devices, retained lease reuse, and live lifecycle verification. Thanks @coygeek.
 - Added Tart macOS desktop leases with native Screen Sharing, a token-gated host-side WebVNC bridge, and documented local-network exposure boundaries. Thanks @anagnorisis2peripeteia.

--- a/docs/features/checkpoints.md
+++ b/docs/features/checkpoints.md
@@ -99,6 +99,14 @@ and nerdctl leases keep using workspace archives. Crabbox rejects native
 checkpoint creation when the workspace is stored in a mounted volume because
 `docker commit` does not capture mounted data.
 
+`crabbox checkpoint fork <id>` starts a fresh local-container lease from the
+checkpoint image, then relocates the saved workspace into the new lease path.
+Fork validates the recorded image tag and Docker system ID before launch and
+replays the checkpoint's Docker runtime, context store, context, and host so a
+changed ambient Docker configuration cannot select another daemon. The forked
+lease persists that scope for later `run`, `ssh`, and `stop` commands and
+reuses the source container user and work root during workspace relocation.
+
 **Azure notes.** Disk-snapshot checkpoints require managed OS disks, the default
 for new Azure leases. Crabbox refuses native checkpoint creation from Azure
 ephemeral-OS-disk leases (Azure reports success but does not capture live disk

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -184,6 +184,13 @@ metadata updates.
   This native path is currently Docker-only; Podman and nerdctl keep using
   workspace archives. Crabbox rejects native checkpoints when the workspace is
   stored in a mounted volume because `docker commit` omits mounted data.
+- `crabbox checkpoint fork <id>` launches a fresh lease from the committed
+  image. Fork validates the checkpoint tag and Docker system ID, replays the
+  recorded Docker runtime and daemon scope, disables Docker socket passthrough,
+  relocates the saved workspace into the new lease path, and persists the scope
+  for later lease commands even when ambient Docker settings change. The source
+  container user and work root are also replayed so relocation keeps ownership
+  and path semantics intact.
 - `warmup --actions-runner` is not supported. Use plain `crabbox run` for local
   container smoke tests, or a remote SSH provider for GitHub runner registration.
 - Socket pass-through is opt-in and grants the lease access to the host

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -608,7 +608,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 				return nil
 			}
 			if record.Kind == checkpointKindDockerCommit {
-				return exit(2, "checkpoint %s is a docker-commit image; restore is not supported for docker-commit checkpoints — verify it with crabbox checkpoint inspect %s --verify or remove it with crabbox checkpoint delete %s", record.ID, record.ID, record.ID)
+				return exit(2, "checkpoint %s is a docker-commit image; use crabbox checkpoint fork %s to create a lease, crabbox checkpoint inspect %s --verify to verify it, or crabbox checkpoint delete %s to remove it", record.ID, record.ID, record.ID, record.ID)
 			}
 			return exit(2, "checkpoint %s is a VM image; use crabbox checkpoint fork %s to create a lease from it", record.ID, record.ID)
 		}

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -563,6 +563,7 @@ func nativeCheckpointForkRecord(record checkpointRecord) NativeCheckpointForkRec
 	return NativeCheckpointForkRecord{
 		Kind:        record.Kind,
 		ImageID:     record.Native.ImageID,
+		Name:        record.Native.Name,
 		Resource:    record.Native.Resource,
 		Region:      record.Native.Region,
 		Project:     record.Native.Project,
@@ -571,6 +572,7 @@ func nativeCheckpointForkRecord(record checkpointRecord) NativeCheckpointForkRec
 		TargetOS:    record.TargetOS,
 		WindowsMode: record.WindowsMode,
 		ServerType:  record.ServerType,
+		Metadata:    record.Native.Metadata,
 	}
 }
 

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -172,10 +172,7 @@ func TestCheckpointRestoreDryRunDoesNotResolveLease(t *testing.T) {
 }
 
 // TestCheckpointRestoreDockerCommitDoesNotPointAtFork is the round-10 regression:
-// restoring a docker-commit checkpoint must not tell users to use `checkpoint
-// fork` (which lands separately) or call the image a "VM image"; it should point
-// at the create/verify/delete support this PR adds.
-func TestCheckpointRestoreDockerCommitDoesNotPointAtFork(t *testing.T) {
+func TestCheckpointRestoreDockerCommitPointsAtFork(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
 	store, err := defaultCheckpointStore()
@@ -193,8 +190,8 @@ func TestCheckpointRestoreDockerCommitDoesNotPointAtFork(t *testing.T) {
 		t.Fatal("expected restore of a docker-commit checkpoint to be unsupported")
 	}
 	msg := err.Error()
-	if strings.Contains(msg, "fork") {
-		t.Fatalf("docker-commit restore guidance must not point at fork, got %q", msg)
+	if !strings.Contains(msg, "checkpoint fork") {
+		t.Fatalf("docker-commit restore guidance should point at fork, got %q", msg)
 	}
 	if strings.Contains(msg, "VM image") {
 		t.Fatalf("docker-commit image must not be called a VM image, got %q", msg)
@@ -657,6 +654,18 @@ func TestCheckpointCreateModeLocalContainerNativeUsesDockerCommit(t *testing.T) 
 func TestCheckpointDockerCommitUsesImageStrategy(t *testing.T) {
 	if got := checkpointStrategyForKind(checkpointKindDockerCommit); got != checkpointStrategyImage {
 		t.Fatalf("strategy=%q, want %q", got, checkpointStrategyImage)
+	}
+}
+
+func TestNativeCheckpointForkRecordCarriesNameAndMetadata(t *testing.T) {
+	metadata := map[string]string{"runtime": "docker"}
+	record := checkpointRecord{Kind: checkpointKindDockerCommit}
+	record.Native.ImageID = "sha256:123"
+	record.Native.Name = "crabbox-checkpoint-demo-123"
+	record.Native.Metadata = metadata
+	got := nativeCheckpointForkRecord(record)
+	if got.Name != "crabbox-checkpoint-demo-123" || got.Metadata["runtime"] != "docker" {
+		t.Fatalf("fork record=%#v", got)
 	}
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -537,14 +537,15 @@ type SpritesConfig struct {
 }
 
 type LocalContainerConfig struct {
-	Runtime      string
-	Image        string
-	User         string
-	WorkRoot     string
-	CPUs         int
-	Memory       string
-	Network      string
-	DockerSocket bool
+	Runtime            string
+	Image              string
+	User               string
+	WorkRoot           string
+	CPUs               int
+	Memory             string
+	Network            string
+	DockerSocket       bool
+	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
 }
 
 type AppleContainerConfig struct {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -203,6 +203,7 @@ type NativeCheckpointLifecycleProvider interface {
 type NativeCheckpointForkRecord struct {
 	Kind        string
 	ImageID     string
+	Name        string
 	Resource    string
 	Region      string
 	Project     string
@@ -211,6 +212,7 @@ type NativeCheckpointForkRecord struct {
 	TargetOS    string
 	WindowsMode string
 	ServerType  string
+	Metadata    map[string]string
 }
 
 type NativeCheckpointForkRequest struct {

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -288,6 +288,9 @@ func TestCreateContainerNoSecretsAsCLIArgs(t *testing.T) {
 }
 
 func TestAcquirePostCreateFailureKeepsRetainedContainerKey(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("apple-container acquire only runs on macOS/Apple silicon")
+	}
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -69,6 +69,9 @@ func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
+	if err := validateCheckpointFork(ctx, cfg); err != nil {
+		return core.LeaseTarget{}, err
+	}
 	leaseID := core.NewLeaseID()
 	containers, err := b.listContainers(ctx)
 	if err != nil {
@@ -130,17 +133,21 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		cleanupContainer()
 		return core.LeaseTarget{}, err
 	}
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		cleanupContainer()
+		return core.LeaseTarget{}, err
+	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, shortID(container.ID))
 	return lease, nil
 }
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
-	cfg := b.configForRun()
 	container, leaseID, slug, err := b.resolveContainer(ctx, req.ID)
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	cfg := b.configForRun()
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: b.serverFromContainer(container, cfg), LeaseID: leaseID}, nil
 	}
@@ -186,6 +193,20 @@ func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.Doct
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	lease := req.Lease
+	appliedScope, err := b.applyCheckpointScopeLabels(ctx, lease.Server.Labels)
+	if err != nil {
+		return err
+	}
+	if !appliedScope {
+		identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"])
+		if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
+			return err
+		} else if ok {
+			if _, err := b.applyCheckpointScopeLabels(ctx, claim.Labels); err != nil {
+				return err
+			}
+		}
+	}
 	id := strings.TrimSpace(req.Lease.Server.CloudID)
 	if id == "" {
 		container, leaseID, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
@@ -316,7 +337,9 @@ func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, 
 	}
 	original := server.Labels
 	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
-	for _, key := range []string{"bootstrap_dir", "container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"} {
+	preservedKeys := []string{"bootstrap_dir", "container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"}
+	preservedKeys = append(preservedKeys, checkpointScopeMetadataKeys...)
+	for _, key := range preservedKeys {
 		if value := strings.TrimSpace(original[key]); value != "" {
 			server.Labels[key] = value
 		}
@@ -391,13 +414,28 @@ func applyDefaults(cfg *core.Config) {
 	cfg.SSHUser = cfg.LocalContainer.User
 	cfg.SSHPort = sshPort
 	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
-	cfg.ServerType = cfg.LocalContainer.Image
+	cfg.ServerType = localContainerDisplayImage(*cfg)
+}
+
+func localContainerDisplayImage(cfg core.Config) string {
+	if name := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataForkName]); name != "" {
+		return name
+	}
+	return cfg.LocalContainer.Image
 }
 
 func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, string, error) {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["runtime"] = cfg.LocalContainer.Runtime
-	labels["image"] = cfg.LocalContainer.Image
+	labels["image"] = localContainerDisplayImage(cfg)
+	for _, key := range checkpointScopeMetadataKeys {
+		if value := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[key]); value != "" {
+			labels[key] = value
+		}
+	}
+	if contextName := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataContext]); contextName != "" {
+		labels["runtime_context"] = contextName
+	}
 	labels["ssh_user"] = cfg.LocalContainer.User
 	labels["ssh_port"] = sshPort
 	labels["docker_socket"] = boolEnv(cfg.LocalContainer.DockerSocket)
@@ -747,26 +785,83 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	if identifier == "" {
 		return inspectContainer{}, "", "", core.Exit(2, "provider=%s requires --id <lease-id-or-slug-or-container>", providerName)
 	}
-	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
+	exactClaim, err := core.ReadLeaseClaim(identifier)
+	if err != nil {
 		return inspectContainer{}, "", "", err
-	} else if ok {
-		return b.findContainerForClaim(ctx, claim)
 	}
-	containers, err := b.listContainers(ctx)
+	if exactClaim.LeaseID == identifier && exactClaim.Provider == providerName {
+		if _, err := b.applyCheckpointScopeLabels(ctx, exactClaim.Labels); err != nil {
+			return inspectContainer{}, "", "", err
+		}
+		return b.findContainerForClaim(ctx, exactClaim)
+	}
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return inspectContainer{}, "", "", err
 	}
 	normalized := core.NormalizeLeaseSlug(identifier)
+	slugClaims := make([]core.LeaseClaim, 0, 1)
+	for i := range claims {
+		claim := claims[i]
+		if claim.Provider != providerName {
+			continue
+		}
+		if normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized {
+			slugClaims = append(slugClaims, claim)
+		}
+	}
+	if len(slugClaims) > 1 {
+		return inspectContainer{}, "", "", core.Exit(2, "local-container slug %s is ambiguous across %d lease claims; use a lease id", identifier, len(slugClaims))
+	}
+	containers, listErr := b.listContainers(ctx)
 	for _, container := range containers {
 		labels := container.Config.Labels
 		leaseID := labels["lease"]
 		slug := labels["slug"]
 		name := strings.TrimPrefix(container.Name, "/")
 		if container.ID == identifier || shortID(container.ID) == identifier || name == identifier || leaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(slug) == normalized) {
+			if len(slugClaims) == 1 && slugClaims[0].LeaseID != leaseID {
+				return inspectContainer{}, "", "", core.Exit(2, "local-container slug %s matches ambient lease %s and scoped lease %s; use a lease id", identifier, leaseID, slugClaims[0].LeaseID)
+			}
+			if len(slugClaims) == 1 {
+				claim := slugClaims[0]
+				if applied, err := b.applyCheckpointScopeLabels(ctx, claim.Labels); err != nil {
+					return inspectContainer{}, "", "", err
+				} else if applied {
+					return b.findContainerForClaim(ctx, claim)
+				}
+			}
 			return container, leaseID, slug, nil
 		}
 	}
+	if len(slugClaims) == 1 {
+		claim := slugClaims[0]
+		if _, err := b.applyCheckpointScopeLabels(ctx, claim.Labels); err != nil {
+			return inspectContainer{}, "", "", err
+		}
+		return b.findContainerForClaim(ctx, claim)
+	}
+	if listErr != nil {
+		return inspectContainer{}, "", "", listErr
+	}
 	return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", identifier)
+}
+
+func (b *backend) applyCheckpointScopeLabels(ctx context.Context, labels map[string]string) (bool, error) {
+	metadata := checkpointScopeMetadataFromLabels(labels)
+	if len(metadata) == 0 {
+		return false, nil
+	}
+	scope := checkpointScopeFromMetadata(metadata, b.cfg.LocalContainer.Runtime)
+	if err := validateCheckpointScope(ctx, scope); err != nil {
+		return false, err
+	}
+	b.cfg.LocalContainer.CheckpointMetadata = metadata
+	if runtimeName := strings.TrimSpace(metadata[checkpointMetadataRuntime]); runtimeName != "" {
+		b.cfg.LocalContainer.Runtime = runtimeName
+		core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	}
+	return true, nil
 }
 
 func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseClaim) (inspectContainer, string, string, error) {
@@ -777,12 +872,6 @@ func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseCla
 	for _, container := range containers {
 		labels := container.Config.Labels
 		if labels["lease"] == claim.LeaseID {
-			return container, labels["lease"], labels["slug"], nil
-		}
-	}
-	for _, container := range containers {
-		labels := container.Config.Labels
-		if claim.Slug != "" && core.NormalizeLeaseSlug(labels["slug"]) == core.NormalizeLeaseSlug(claim.Slug) {
 			return container, labels["lease"], labels["slug"], nil
 		}
 	}
@@ -842,6 +931,14 @@ func (b *backend) runtimeContext(ctx context.Context, runtimeName string) string
 
 func (b *backend) claimScope(ctx context.Context) string {
 	cfg := b.configForRun()
+	if metadata := cfg.LocalContainer.CheckpointMetadata; len(metadata) != 0 {
+		scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
+		contextName := scope.Context
+		if contextName == "" && scope.Host != "" {
+			contextName = "default"
+		}
+		return localContainerClaimScope(scope.Runtime, contextName, scope.Host)
+	}
 	return localContainerClaimScope(
 		cfg.LocalContainer.Runtime,
 		b.runtimeContext(ctx, cfg.LocalContainer.Runtime),
@@ -911,9 +1008,18 @@ func localContainerClaimExpired(claim core.LeaseClaim, now time.Time) bool {
 
 func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	cfg := b.configForRun()
+	var env []string
+	if metadata := cfg.LocalContainer.CheckpointMetadata; len(metadata) != 0 {
+		scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
+		if scope.Context != "" {
+			args = append([]string{"--context", scope.Context}, args...)
+		}
+		env = checkpointEnvForScope(scope)
+	}
 	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   cfg.LocalContainer.Runtime,
 		Args:   args,
+		Env:    env,
 		Stdout: stdout,
 		Stderr: stderr,
 	})
@@ -922,6 +1028,9 @@ func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.W
 func (b *backend) serverFromContainer(container inspectContainer, cfg core.Config) core.Server {
 	labels := map[string]string{}
 	for key, value := range container.Config.Labels {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
 		labels[key] = value
 	}
 	labels["container_id"] = shortID(container.ID)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -2,12 +2,14 @@ package localcontainer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -78,6 +80,197 @@ func testBackend(runner *recordingRunner) *backend {
 		Network:  "bridge",
 	}
 	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+}
+
+func TestDockerPinsCheckpointForkScope(t *testing.T) {
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	b.cfg.LocalContainer.CheckpointMetadata = map[string]string{
+		checkpointMetadataRuntime: "docker",
+		checkpointMetadataContext: "remote-context",
+		checkpointMetadataConfig:  "/tmp/docker-config",
+	}
+	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+	if _, err := b.docker(context.Background(), []string{"image", "inspect", "checkpoint"}, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	last := runner.calls[len(runner.calls)-1]
+	if len(last.Args) < 3 || last.Args[0] != "--context" || last.Args[1] != "remote-context" {
+		t.Fatalf("args=%v", last.Args)
+	}
+	foundConfig := false
+	for _, value := range last.Env {
+		if value == "DOCKER_CONFIG=/tmp/docker-config" {
+			foundConfig = true
+		}
+		if strings.HasPrefix(value, "DOCKER_HOST=") {
+			t.Fatalf("ambient Docker host leaked into pinned context: %q", value)
+		}
+	}
+	if !foundConfig {
+		t.Fatal("Docker config was not pinned")
+	}
+}
+
+func TestClaimScopePinsCheckpointForkDaemon(t *testing.T) {
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	b.cfg.LocalContainer.CheckpointMetadata = map[string]string{
+		checkpointMetadataRuntime: "docker",
+		checkpointMetadataContext: "remote-context",
+	}
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+
+	got := b.claimScope(context.Background())
+	want := "runtime:docker/context:remote-context"
+	if got != want {
+		t.Fatalf("scope=%q, want %q", got, want)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("recorded fork scope should not probe ambient Docker state: calls=%d", len(runner.calls))
+	}
+}
+
+func TestResolveContainerUsesCheckpointScopeFromClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+	binDir := writeCheckpointScopeDocker(t, "unix:///tmp/docker.sock", "daemon-123")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	labels := map[string]string{
+		"crabbox":                  "true",
+		"provider":                 providerName,
+		"lease":                    "cbx_scope",
+		"slug":                     "scope-fork",
+		"state":                    "ready",
+		"runtime":                  "docker",
+		"image":                    "crabbox-checkpoint-demo-123",
+		checkpointMetadataContext:  "remote-context",
+		checkpointMetadataConfig:   "/tmp/docker-config",
+		checkpointMetadataEndpoint: "unix:///tmp/docker.sock",
+		checkpointMetadataDaemonID: "daemon-123",
+		checkpointMetadataForkName: "crabbox-checkpoint-demo-123",
+	}
+	if err := core.ClaimLeaseForRepoProviderScopePond("cbx_scope", "scope-fork", providerName, "runtime:docker/context:remote-context", "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.UpdateLeaseClaimEndpoint("cbx_scope", core.Server{Labels: labels}, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	containerJSON, err := json.Marshal([]inspectContainer{{
+		ID:     "container-123",
+		Name:   "/crabbox-scope-fork",
+		Config: inspectConfig{Image: "sha256:123", Labels: labels},
+		State:  inspectState{Status: "running", Running: true},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch {
+		case slices.Contains(req.Args, "ps"):
+			if len(req.Args) < 2 || req.Args[0] != "--context" {
+				return core.LocalCommandResult{}, errors.New("ambient Docker daemon unavailable")
+			}
+			return core.LocalCommandResult{Stdout: "container-123\n"}, nil
+		case slices.Contains(req.Args, "inspect"):
+			return core.LocalCommandResult{Stdout: string(containerJSON)}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}}
+	b := testBackend(runner)
+	container, leaseID, slug, err := b.resolveContainer(context.Background(), "scope-fork")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if container.ID != "container-123" || leaseID != "cbx_scope" || slug != "scope-fork" {
+		t.Fatalf("resolved container=%q lease=%q slug=%q", container.ID, leaseID, slug)
+	}
+	var scopedCall *core.LocalCommandRequest
+	for i := range runner.calls {
+		if len(runner.calls[i].Args) >= 2 && runner.calls[i].Args[0] == "--context" {
+			scopedCall = &runner.calls[i]
+			break
+		}
+	}
+	if scopedCall == nil {
+		t.Fatal("claim-scoped lookup did not call Docker")
+	}
+	if scopedCall.Args[1] != "remote-context" {
+		t.Fatalf("claim scope was not applied to Docker lookup: args=%v", scopedCall.Args)
+	}
+	for _, value := range scopedCall.Env {
+		if value == "DOCKER_HOST=tcp://ambient.invalid:2376" {
+			t.Fatal("ambient Docker host leaked into claim-scoped lookup")
+		}
+	}
+}
+
+func TestResolveContainerRejectsAmbiguousClaimSlug(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	for _, leaseID := range []string{"cbx_scope_a", "cbx_scope_b"} {
+		if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "shared-slug", providerName, "runtime:docker/context:remote-context", "", "/repo", time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runner := &recordingRunner{}
+	b := testBackend(runner)
+	if _, _, _, err := b.resolveContainer(context.Background(), "shared-slug"); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("ambiguous slug should fail before Docker lookup: calls=%d", len(runner.calls))
+	}
+}
+
+func TestResolveContainerExactLeaseIgnoresMalformedUnrelatedClaim(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	if err := writeLocalContainerClaim(t, "cbx_exact", "exact-slug", "", time.Now().UTC(), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	claimDir := filepath.Join(stateHome, "crabbox", "claims")
+	if err := os.WriteFile(filepath.Join(claimDir, "cbx_unrelated.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inspectJSON := `[{
+		"Id":"container-exact",
+		"Name":"/crabbox-exact",
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_exact","slug":"exact-slug","state":"ready"}},
+		"State":{"Status":"running","Running":true}
+	}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: "container-exact\n"},
+		commandKey([]string{"inspect", "container-exact"}): {Stdout: inspectJSON},
+	}}
+	b := testBackend(runner)
+	container, leaseID, _, err := b.resolveContainer(context.Background(), "cbx_exact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if container.ID != "container-exact" || leaseID != "cbx_exact" {
+		t.Fatalf("container=%q lease=%q", container.ID, leaseID)
+	}
+}
+
+func TestServerFromContainerDropsEmptyInheritedLabels(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromContainer(inspectContainer{
+		ID: "container-123",
+		Config: inspectConfig{
+			Image: "checkpoint-image",
+			Labels: map[string]string{
+				"crabbox":             "true",
+				"provider":            providerName,
+				"lease":               "cbx_123",
+				"tailscale_exit_node": "",
+			},
+		},
+	}, b.cfg)
+	if _, ok := server.Labels["tailscale_exit_node"]; ok {
+		t.Fatalf("empty inherited label survived: %#v", server.Labels)
+	}
 }
 
 func TestProviderAliases(t *testing.T) {
@@ -1198,7 +1391,7 @@ func TestTrustedBootstrapDir(t *testing.T) {
 	}
 }
 
-func TestFindContainerForClaimReturnsMatchedContainerIdentity(t *testing.T) {
+func TestFindContainerForClaimRejectsSlugOnlyMatch(t *testing.T) {
 	inspectJSON := `[{
 		"Id":"newcontainer123456",
 		"Name":"/crabbox-blue-new",
@@ -1214,12 +1407,8 @@ func TestFindContainerForClaimReturnsMatchedContainerIdentity(t *testing.T) {
 	}
 	b := testBackend(runner)
 
-	container, leaseID, slug, err := b.findContainerForClaim(context.Background(), core.LeaseClaim{LeaseID: "cbx_old", Slug: "blue-lobster"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if container.ID != "newcontainer123456" || leaseID != "cbx_new" || slug != "blue-lobster" {
-		t.Fatalf("identity = container=%s lease=%s slug=%s", container.ID, leaseID, slug)
+	if _, _, _, err := b.findContainerForClaim(context.Background(), core.LeaseClaim{LeaseID: "cbx_old", Slug: "blue-lobster"}); err == nil {
+		t.Fatal("expected stale claim lease id to reject a same-slug container")
 	}
 }
 

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -20,7 +20,20 @@ const (
 	checkpointMetadataConfig   = "docker_config"
 	checkpointMetadataEndpoint = "docker_endpoint"
 	checkpointMetadataDaemonID = "docker_daemon_id"
+	checkpointMetadataForkID   = "fork_image_id"
+	checkpointMetadataForkName = "fork_image_name"
+	checkpointMetadataUser     = "container_user"
+	checkpointMetadataWorkRoot = "container_work_root"
 )
+
+var checkpointScopeMetadataKeys = []string{
+	checkpointMetadataRuntime,
+	checkpointMetadataHost,
+	checkpointMetadataContext,
+	checkpointMetadataConfig,
+	checkpointMetadataEndpoint,
+	checkpointMetadataDaemonID,
+}
 
 type checkpointScope struct {
 	Runtime  string
@@ -47,6 +60,11 @@ var checkpointLeaseLabelKeys = []string{
 	"created_by",
 	"desktop",
 	"desktop_env",
+	checkpointMetadataConfig,
+	checkpointMetadataContext,
+	checkpointMetadataDaemonID,
+	checkpointMetadataEndpoint,
+	checkpointMetadataHost,
 	"docker_socket",
 	"expires_at",
 	"host_work_root",
@@ -103,6 +121,7 @@ func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheck
 	if !isDockerRuntime(scope.Runtime) {
 		return core.NativeCheckpointCreateResult{}, core.Exit(2, "docker-commit checkpoints require the Docker runtime; use --mode archive with %s", scope.Runtime)
 	}
+	metadata := checkpointMetadataForServer(scope, req.Config, req.Server)
 	canonicalWorkdir, err := checkpointCanonicalWorkdir(ctx, scope, containerID, req.Workdir)
 	if err != nil {
 		return core.NativeCheckpointCreateResult{}, err
@@ -149,7 +168,7 @@ func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheck
 					Kind:     core.CheckpointKindDockerCommit,
 					Direct:   true,
 				},
-				Metadata: checkpointScopeMetadata(scope),
+				Metadata: metadata,
 			}, core.Exit(7, "docker tag %s: %v: %s", imageID, err, detail)
 		}
 		return core.NativeCheckpointCreateResult{}, core.Exit(7, "docker tag %s: %v: %s", imageID, err, detail)
@@ -163,7 +182,7 @@ func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheck
 			Kind:     core.CheckpointKindDockerCommit,
 			Direct:   true,
 		},
-		Metadata: checkpointScopeMetadata(scope),
+		Metadata: metadata,
 	}, nil
 }
 
@@ -242,6 +261,13 @@ func inspectCheckpointTag(ctx context.Context, scope checkpointScope, image core
 
 func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.Server) (checkpointScope, error) {
 	runtimeName := leaseRuntime(server, cfg.LocalContainer.Runtime)
+	if metadata := checkpointScopeMetadataFromLabels(server.Labels); len(metadata) != 0 {
+		scope := checkpointScopeFromMetadata(metadata, runtimeName)
+		if err := validateCheckpointScope(ctx, scope); err != nil {
+			return checkpointScope{}, err
+		}
+		return scope, nil
+	}
 	scope := checkpointScope{Runtime: runtimeName}
 	if !isDockerRuntime(runtimeName) {
 		return scope, nil
@@ -295,10 +321,13 @@ func checkpointScopeForServer(ctx context.Context, cfg core.Config, server core.
 }
 
 func checkpointScopeFromRequest(req core.NativeCheckpointResourceRequest) checkpointScope {
-	metadata := req.Metadata
+	return checkpointScopeFromMetadata(req.Metadata, req.Config.LocalContainer.Runtime)
+}
+
+func checkpointScopeFromMetadata(metadata map[string]string, fallbackRuntime string) checkpointScope {
 	runtimeName := strings.TrimSpace(metadata[checkpointMetadataRuntime])
 	if runtimeName == "" {
-		runtimeName = firstCheckpointValue(req.Config.LocalContainer.Runtime, "docker")
+		runtimeName = firstCheckpointValue(fallbackRuntime, "docker")
 	}
 	return checkpointScope{
 		Runtime:  runtimeName,
@@ -310,6 +339,16 @@ func checkpointScopeFromRequest(req core.NativeCheckpointResourceRequest) checkp
 	}
 }
 
+func checkpointForkMetadata(metadata map[string]string, image core.NativeCheckpointForkRecord) map[string]string {
+	out := make(map[string]string, len(metadata)+2)
+	for key, value := range metadata {
+		out[key] = value
+	}
+	out[checkpointMetadataForkID] = strings.TrimSpace(image.ImageID)
+	out[checkpointMetadataForkName] = strings.TrimSpace(firstCheckpointValue(image.Name, image.Resource))
+	return out
+}
+
 func checkpointScopeMetadata(scope checkpointScope) map[string]string {
 	return map[string]string{
 		checkpointMetadataRuntime:  scope.Runtime,
@@ -319,6 +358,26 @@ func checkpointScopeMetadata(scope checkpointScope) map[string]string {
 		checkpointMetadataEndpoint: scope.Endpoint,
 		checkpointMetadataDaemonID: scope.DaemonID,
 	}
+}
+
+func checkpointMetadataForServer(scope checkpointScope, cfg core.Config, server core.Server) map[string]string {
+	metadata := checkpointScopeMetadata(scope)
+	metadata[checkpointMetadataUser] = firstCheckpointValue(server.Labels["ssh_user"], cfg.LocalContainer.User, cfg.SSHUser)
+	metadata[checkpointMetadataWorkRoot] = firstCheckpointValue(server.Labels["work_root"], cfg.LocalContainer.WorkRoot, cfg.WorkRoot)
+	return metadata
+}
+
+func checkpointScopeMetadataFromLabels(labels map[string]string) map[string]string {
+	if strings.TrimSpace(labels[checkpointMetadataDaemonID]) == "" {
+		return nil
+	}
+	metadata := make(map[string]string, len(checkpointScopeMetadataKeys))
+	for _, key := range checkpointScopeMetadataKeys {
+		if value := strings.TrimSpace(labels[key]); value != "" {
+			metadata[key] = value
+		}
+	}
+	return metadata
 }
 
 func validateCheckpointScope(ctx context.Context, scope checkpointScope) error {
@@ -340,6 +399,35 @@ func validateCheckpointScope(ctx context.Context, scope checkpointScope) error {
 	}
 	if currentDaemonID != scope.DaemonID {
 		return core.Exit(7, "Docker daemon changed from %s to %s; refusing checkpoint operation", scope.DaemonID, currentDaemonID)
+	}
+	return nil
+}
+
+func validateCheckpointFork(ctx context.Context, cfg core.Config) error {
+	metadata := cfg.LocalContainer.CheckpointMetadata
+	if len(metadata) == 0 {
+		return nil
+	}
+	scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
+	if err := validateCheckpointScope(ctx, scope); err != nil {
+		return err
+	}
+	image := core.NativeCheckpointImage{
+		ID:   strings.TrimSpace(metadata[checkpointMetadataForkID]),
+		Name: strings.TrimSpace(metadata[checkpointMetadataForkName]),
+	}
+	if image.ID == "" || image.Name == "" {
+		return core.Exit(7, "local-container checkpoint fork is missing its recorded image identity")
+	}
+	currentID, missing, err := inspectCheckpointTag(ctx, scope, image)
+	if err != nil {
+		return err
+	}
+	if missing {
+		return core.Exit(7, "local-container checkpoint image %s is missing", image.Name)
+	}
+	if !strings.EqualFold(currentID, image.ID) {
+		return core.Exit(7, "refusing to fork checkpoint tag %s: recorded image %s but tag now points to %s", image.Name, image.ID, currentID)
 	}
 	return nil
 }

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -2,6 +2,9 @@ package localcontainer
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -192,5 +195,155 @@ func TestNativeCheckpointCapabilityUsesResolvedLeaseRuntime(t *testing.T) {
 				t.Fatalf("supported=%v, want %v", ok, tc.want)
 			}
 		})
+	}
+}
+
+func TestSpecAdvertisesForkFeature(t *testing.T) {
+	if !(Provider{}).Spec().Features.Has(core.FeatureFork) {
+		t.Fatal("expected local-container to advertise checkpoint fork support")
+	}
+}
+
+func TestCheckpointForkUsesTagForDisplay(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.LocalContainer.Image = "sha256:123"
+	cfg.LocalContainer.CheckpointMetadata = map[string]string{
+		checkpointMetadataForkName: "crabbox-checkpoint-demo-123",
+	}
+	applyDefaults(&cfg)
+	if cfg.ServerType != "crabbox-checkpoint-demo-123" {
+		t.Fatalf("server type=%q", cfg.ServerType)
+	}
+	if cfg.LocalContainer.Image != "sha256:123" {
+		t.Fatalf("launch image=%q", cfg.LocalContainer.Image)
+	}
+}
+
+func TestCheckpointScopeForServerUsesPersistedLabels(t *testing.T) {
+	binDir := writeCheckpointScopeDocker(t, "unix:///tmp/docker.sock", "daemon-123")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_CONTEXT", "ambient-invalid")
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2376")
+	labels := map[string]string{
+		checkpointMetadataRuntime:  "docker",
+		checkpointMetadataContext:  "remote-context",
+		checkpointMetadataConfig:   "/tmp/docker-config",
+		checkpointMetadataEndpoint: "unix:///tmp/docker.sock",
+		checkpointMetadataDaemonID: "daemon-123",
+	}
+	scope, err := checkpointScopeForServer(context.Background(), core.Config{}, core.Server{Labels: labels})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.Context != "remote-context" || scope.Config != "/tmp/docker-config" || scope.DaemonID != "daemon-123" {
+		t.Fatalf("scope=%#v", scope)
+	}
+	labels[checkpointMetadataDaemonID] = "another-daemon"
+	if _, err := checkpointScopeForServer(context.Background(), core.Config{}, core.Server{Labels: labels}); err == nil {
+		t.Fatal("expected changed persisted daemon identity to fail")
+	}
+}
+
+func TestCheckpointMetadataForServerPreservesUserAndWorkRoot(t *testing.T) {
+	metadata := checkpointMetadataForServer(
+		checkpointScope{Runtime: "docker", DaemonID: "daemon-123"},
+		core.Config{LocalContainer: core.LocalContainerConfig{User: "configured", WorkRoot: "/configured"}},
+		core.Server{Labels: map[string]string{"ssh_user": "runner", "work_root": "/workspace"}},
+	)
+	if metadata[checkpointMetadataUser] != "runner" || metadata[checkpointMetadataWorkRoot] != "/workspace" {
+		t.Fatalf("metadata=%#v", metadata)
+	}
+}
+
+func writeCheckpointScopeDocker(t *testing.T, endpoint, daemonID string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--context" ]; then
+  shift 2
+fi
+case "$1" in
+  context) printf '%%s\n' '%s' ;;
+  info) printf '%%s\n' '%s' ;;
+esac
+`, endpoint, daemonID)
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return binDir
+}
+
+func TestApplyNativeCheckpointForkConfig(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.LocalContainer.DockerSocket = true
+	metadata := map[string]string{
+		checkpointMetadataRuntime:  "docker",
+		checkpointMetadataContext:  "orbstack",
+		checkpointMetadataConfig:   "/tmp/docker-config",
+		checkpointMetadataEndpoint: "unix:///tmp/docker.sock",
+		checkpointMetadataDaemonID: "daemon-123",
+		checkpointMetadataUser:     "runner",
+		checkpointMetadataWorkRoot: "/workspace",
+	}
+	err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{
+		Config: &cfg,
+		Record: core.NativeCheckpointForkRecord{
+			Kind:     core.CheckpointKindDockerCommit,
+			ImageID:  "sha256:123",
+			Name:     "crabbox-checkpoint-demo-123",
+			Metadata: metadata,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LocalContainer.Image != "sha256:123" {
+		t.Fatalf("image=%q", cfg.LocalContainer.Image)
+	}
+	if cfg.LocalContainer.Runtime != "docker" {
+		t.Fatalf("runtime=%q", cfg.LocalContainer.Runtime)
+	}
+	if cfg.LocalContainer.User != "runner" || cfg.SSHUser != "runner" {
+		t.Fatalf("users local=%q ssh=%q", cfg.LocalContainer.User, cfg.SSHUser)
+	}
+	if cfg.LocalContainer.WorkRoot != "/workspace" || cfg.WorkRoot != "/workspace" {
+		t.Fatalf("work roots local=%q generic=%q", cfg.LocalContainer.WorkRoot, cfg.WorkRoot)
+	}
+	if cfg.LocalContainer.DockerSocket {
+		t.Fatal("fork must disable Docker socket passthrough")
+	}
+	if got := cfg.LocalContainer.CheckpointMetadata[checkpointMetadataForkID]; got != "sha256:123" {
+		t.Fatalf("fork image id=%q", got)
+	}
+	if _, ok := metadata[checkpointMetadataForkID]; ok {
+		t.Fatal("fork config mutated persisted checkpoint metadata")
+	}
+}
+
+func TestApplyNativeCheckpointForkConfigRejectsInvalidRecord(t *testing.T) {
+	for _, record := range []core.NativeCheckpointForkRecord{
+		{Kind: "workspace-archive", ImageID: "sha256:123"},
+		{Kind: core.CheckpointKindDockerCommit},
+		{Kind: core.CheckpointKindDockerCommit, ImageID: "sha256:123"},
+		{Kind: core.CheckpointKindDockerCommit, Name: "crabbox-checkpoint-demo-123"},
+		{
+			Kind:     core.CheckpointKindDockerCommit,
+			ImageID:  "sha256:123",
+			Name:     "crabbox-checkpoint-demo-123",
+			Metadata: map[string]string{checkpointMetadataRuntime: "podman"},
+		},
+		{
+			Kind:    core.CheckpointKindDockerCommit,
+			ImageID: "sha256:123",
+			Name:    "crabbox-checkpoint-demo-123",
+			Metadata: map[string]string{
+				checkpointMetadataRuntime: "docker",
+			},
+		},
+	} {
+		cfg := core.BaseConfig()
+		if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &cfg, Record: record}); err == nil {
+			t.Fatalf("expected record to fail: %#v", record)
+		}
 	}
 }

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -26,7 +26,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      "container",
 		Kind:        core.ProviderKindSSHLease,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume, core.FeatureCheckpoint},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume, core.FeatureCheckpoint, core.FeatureFork},
 		Coordinator: core.CoordinatorNever,
 	}
 }
@@ -97,6 +97,41 @@ func leaseRuntime(server core.Server, fallback string) string {
 func isDockerRuntime(runtime string) bool {
 	name := strings.TrimSuffix(strings.ToLower(filepath.Base(strings.TrimSpace(runtime))), ".exe")
 	return name == "docker"
+}
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	if req.Record.Kind != core.CheckpointKindDockerCommit {
+		return core.Exit(2, "provider=%s does not support checkpoint kind=%s", providerName, req.Record.Kind)
+	}
+	imageID := strings.TrimSpace(req.Record.ImageID)
+	if imageID == "" {
+		return core.Exit(2, "local-container checkpoint fork requires a committed image id")
+	}
+	imageName := strings.TrimSpace(firstCheckpointValue(req.Record.Name, req.Record.Resource))
+	if imageName == "" {
+		return core.Exit(2, "local-container checkpoint fork requires a committed image tag")
+	}
+	metadata := checkpointForkMetadata(req.Record.Metadata, req.Record)
+	scope := checkpointScopeFromMetadata(metadata, req.Config.LocalContainer.Runtime)
+	if !isDockerRuntime(scope.Runtime) {
+		return core.Exit(2, "local-container checkpoint fork requires the Docker runtime")
+	}
+	user := strings.TrimSpace(metadata[checkpointMetadataUser])
+	workRoot := strings.TrimSpace(metadata[checkpointMetadataWorkRoot])
+	if user == "" || workRoot == "" {
+		return core.Exit(2, "local-container checkpoint %s predates fork relocation metadata; recreate it from the source lease before forking", imageName)
+	}
+	req.Config.LocalContainer.Image = imageID
+	req.Config.LocalContainer.Runtime = scope.Runtime
+	req.Config.LocalContainer.User = user
+	req.Config.SSHUser = user
+	req.Config.LocalContainer.WorkRoot = workRoot
+	req.Config.WorkRoot = workRoot
+	req.Config.LocalContainer.DockerSocket = false
+	req.Config.LocalContainer.CheckpointMetadata = metadata
+	core.MarkLocalContainerImageExplicit(req.Config)
+	core.MarkLocalContainerRuntimeExplicit(req.Config)
+	return nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -17,9 +17,10 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec                  ProviderSpec
+	cfg                   Config
+	rt                    Runtime
+	startupObserveTimeout time.Duration
 }
 
 type tartInstance struct {
@@ -33,7 +34,12 @@ type tartInstance struct {
 
 func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	applyDefaults(&cfg)
-	return &backend{spec: spec, cfg: cfg, rt: rt}
+	return &backend{
+		spec:                  spec,
+		cfg:                   cfg,
+		rt:                    rt,
+		startupObserveTimeout: defaultStartupObserveTimeout,
+	}
 }
 
 func applyDefaults(cfg *Config) {
@@ -479,7 +485,7 @@ func (b *backend) startVM(ctx context.Context, cfg Config, name string, keep boo
 			return exit(2, "tart run %s failed during startup: %v", name, err)
 		}
 		return exit(2, "tart run %s exited unexpectedly during startup", name)
-	case <-time.After(startupObserveTimeout):
+	case <-time.After(b.startupObserveTimeout):
 		return nil
 	}
 }

--- a/internal/providers/tart/core.go
+++ b/internal/providers/tart/core.go
@@ -88,10 +88,6 @@ func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
 
-func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
-}
-
 func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
 	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
 }

--- a/internal/providers/tart/core.go
+++ b/internal/providers/tart/core.go
@@ -29,12 +29,11 @@ type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
 
 const (
-	providerName = "tart"
-	targetMacOS  = core.TargetMacOS
-	sshPort      = "22"
+	providerName                 = "tart"
+	targetMacOS                  = core.TargetMacOS
+	sshPort                      = "22"
+	defaultStartupObserveTimeout = 2 * time.Second
 )
-
-var startupObserveTimeout = 2 * time.Second
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)

--- a/internal/providers/tart/process_unix_test.go
+++ b/internal/providers/tart/process_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -35,6 +36,7 @@ func TestStartVMKeepPreservesStartupStderr(t *testing.T) {
 		core.BaseConfig(),
 		core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	).(*backend)
+	backend.startupObserveTimeout = 10 * time.Second
 	err := backend.startVM(context.Background(), core.BaseConfig(), "test-vm", true)
 	if err == nil || !strings.Contains(err.Error(), "vm is locked") {
 		t.Fatalf("err=%v", err)

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -273,10 +273,6 @@ func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	originalStartupObserve := startupObserveTimeout
-	startupObserveTimeout = 20 * time.Millisecond
-	t.Cleanup(func() { startupObserveTimeout = originalStartupObserve })
-
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
 			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: "[]"},
@@ -285,7 +281,10 @@ func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	b.startupObserveTimeout = 20 * time.Millisecond
+	// Keep setup outside the deadline race under coverage while still forcing
+	// waitForIP to fail promptly after the VM starts.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	if _, err := b.Acquire(ctx, core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {


### PR DESCRIPTION
## Summary

Restacks https://github.com/openclaw/crabbox/pull/208 on the landed checkpoint foundation from https://github.com/openclaw/crabbox/pull/206.

- Adds native local-container checkpoint forks.
- Replays and validates the recorded Docker runtime, context store, context, host, endpoint, and daemon identity.
- Validates the owned checkpoint tag, then launches from the recorded immutable image ID.
- Disables Docker socket passthrough and relocates the committed workspace into the new lease path.
- Keeps claim bookkeeping on the recorded daemon scope and preserves the checkpoint tag for user-facing display.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -tags dockerproof -run '^(TestDockerCommitCheckpointLifecycleProof|TestCheckpointScopePinsAndValidatesContextProof)$' -count=1 -v ./internal/providers/localcontainer`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `scripts/check-docs.sh`
- `node --test scripts/*.test.js`
- `goreleaser release --snapshot --clean --skip=publish`

## Live Docker proof

OrbStack Docker lifecycle passed:

1. Created a source local-container lease and wrote persisted workspace state.
2. Created native checkpoint `chk_345ea3899b520ab9`.
3. Forked while hostile ambient `DOCKER_CONTEXT`, `DOCKER_HOST`, and `DOCKER_CONFIG` values were set.
4. Confirmed launch used immutable image `sha256:8613447de49c0eaca0d09655e6b11b5bcf2e5cd6056bcb2ad21e9ca0045986fc` while the lease displayed its checkpoint tag.
5. Verified the relocated state from a fresh command with the same hostile ambient Docker settings.
6. Created and deleted descendant checkpoint `chk_a8a190bb02712ca6` from the fork with hostile ambient Docker settings.
7. Deleted the original checkpoint image.
8. Verified the running fork retained the state after deletion, again with hostile ambient Docker settings.
9. Deleted the fork with hostile ambient Docker settings, then deleted the source lease.

Result: `FORK_FINAL_E2E_OK source=pr208-final-source-32731 fork=pr208-final-fork-15104 checkpoint=chk_345ea3899b520ab9 descendant=chk_a8a190bb02712ca6 hostile=fork,run,checkpoint-create,delete,run,stop`

A second lifecycle created the source with `user=runner` and
`work_root=/workspace`, forked under default config, and verified the fork still
used `runner` and `/workspace/...` before deletion:

`FORK_USER_ROOT_E2E_OK source=pr208-user-source-13540 fork=pr208-user-fork-1493 checkpoint=chk_d6051ddc9cec39e9 user=runner work_root=/workspace hostile=fork,run,delete,stop`
