### PR TITLE
feat(sync): add sync.include whitelist

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -308,6 +308,13 @@ sync:
     - node_modules
     - .turbo
     - dist
+  # include (whitelist): when set, ONLY these paths are synced (after excludes).
+  # Sync a few paths out of a large repo instead of blacklisting everything else.
+  include:
+    - src
+    - scripts
+    - package.json
+    - pnpm-lock.yaml
 env:
   allow:
     - CI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -308,7 +308,7 @@ sync:
     - node_modules
     - .turbo
     - dist
-  # include (whitelist): when set, ONLY these paths are synced (after excludes).
+  # include (root-relative whitelist): when set, ONLY these paths are synced (after excludes).
   # Sync a few paths out of a large repo instead of blacklisting everything else.
   include:
     - src

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,9 +119,9 @@ matter for your repo:
 - `profile`: a name for this lane (the template uses `<repo>-check`);
 - `class`: `standard`, `fast`, `large`, or `beast` (the template uses `beast`);
 - `sync.exclude`: directories that should never be sent to the runner;
-- `sync.include`: an optional whitelist — when set, **only** these paths are
-  synced (after excludes), so you can ship a few paths out of a large repo
-  instead of blacklisting everything else;
+- `sync.include`: an optional root-relative whitelist — when set, **only** these
+  paths are synced (after excludes), so you can ship a few paths out of a large
+  repo instead of blacklisting everything else;
 - `env.allow`: environment variables the remote command is allowed to see.
 
 Pass `--detect` to scan the repo for test commands and write a `jobs.detected`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,9 @@ matter for your repo:
 - `profile`: a name for this lane (the template uses `<repo>-check`);
 - `class`: `standard`, `fast`, `large`, or `beast` (the template uses `beast`);
 - `sync.exclude`: directories that should never be sent to the runner;
+- `sync.include`: an optional whitelist — when set, **only** these paths are
+  synced (after excludes), so you can ship a few paths out of a large repo
+  instead of blacklisting everything else;
 - `env.allow`: environment variables the remote command is allowed to see.
 
 Pass `--detect` to scan the repo for test commands and write a `jobs.detected`

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -495,7 +495,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err != nil {
 		return err
 	}
-	manifest, err := syncManifest(repo.Root, excludes)
+	manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return exit(6, "build sync file list: %v", err)
 	}

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -505,7 +505,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err := runSSHQuiet(ctx, target, remoteMkdir(workdir)); err != nil {
 		return exit(7, "create remote workdir: %v", err)
 	}
-	if cfg.Sync.GitSeed && remoteGitSeedCandidate(repo) {
+	if syncGitSeedEnabled(cfg, repo) {
 		if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 		}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -135,6 +135,7 @@ type Config struct {
 
 type SyncConfig struct {
 	Excludes    []string
+	Includes    []string
 	Delete      bool
 	Checksum    bool
 	GitSeed     bool
@@ -1233,6 +1234,8 @@ type fileSSHConfig struct {
 type fileSyncConfig struct {
 	Exclude     []string `yaml:"exclude,omitempty"`
 	Excludes    []string `yaml:"excludes,omitempty"`
+	Include     []string `yaml:"include,omitempty"`
+	Includes    []string `yaml:"includes,omitempty"`
 	Delete      *bool    `yaml:"delete,omitempty"`
 	Checksum    *bool    `yaml:"checksum,omitempty"`
 	GitSeed     *bool    `yaml:"gitSeed,omitempty"`
@@ -2102,6 +2105,8 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 	if file.Sync != nil {
 		cfg.Sync.Excludes = appendUniqueStrings(cfg.Sync.Excludes, file.Sync.Exclude...)
 		cfg.Sync.Excludes = appendUniqueStrings(cfg.Sync.Excludes, file.Sync.Excludes...)
+		cfg.Sync.Includes = appendUniqueStrings(cfg.Sync.Includes, file.Sync.Include...)
+		cfg.Sync.Includes = appendUniqueStrings(cfg.Sync.Includes, file.Sync.Includes...)
 		if file.Sync.Delete != nil {
 			cfg.Sync.Delete = *file.Sync.Delete
 		}

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -49,6 +49,7 @@ func configShowView(cfg Config) map[string]any {
 		"workRoot":           cfg.WorkRoot,
 		"sync": map[string]any{
 			"exclude":     configuredExcludes(cfg),
+			"include":     syncIncludes(cfg),
 			"delete":      cfg.Sync.Delete,
 			"checksum":    cfg.Sync.Checksum,
 			"gitSeed":     cfg.Sync.GitSeed,
@@ -248,7 +249,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "broker=%s auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), tokenState(cfg.CoordToken), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
-	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), cfg.Sync.Timeout)
+	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), len(syncIncludes(cfg)), cfg.Sync.Timeout)
 	fmt.Fprintf(w, "env allow=%s\n", strings.Join(cfg.EnvAllow, ","))
 	fmt.Fprintf(w, "run preflight_tools=%s\n", blank(strings.Join(cfg.Run.PreflightTools, ","), "-"))
 	fmt.Fprintf(w, "capacity market=%s strategy=%s fallback=%s regions=%s hints=%t\n", cfg.Capacity.Market, cfg.Capacity.Strategy, cfg.Capacity.Fallback, blank(strings.Join(cfg.Capacity.Regions, ","), "-"), cfg.Capacity.Hints)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -127,3 +127,40 @@ func TestConfigShowIncludesCloudflareWithoutSecret(t *testing.T) {
 		t.Fatalf("config show json leaked Cloudflare token: %q", stdout.String())
 	}
 }
+
+func TestConfigShowIncludesSyncInclude(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := os.WriteFile(configPath, []byte("sync:\n  include:\n    - src\n    - scripts\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "includes=2") {
+		t.Fatalf("config show text missing includes count: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Sync struct {
+			Include []string `json:"include"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sync.Include) != 2 || got.Sync.Include[0] != "src" || got.Sync.Include[1] != "scripts" {
+		t.Fatalf("config show json sync.include = %#v, want [src scripts]", got.Sync.Include)
+	}
+}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -89,6 +89,19 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return appendUniqueStrings(excludes, ignore...), nil
 }
 
+// syncIncludes returns the configured sync include (whitelist) patterns. When
+// empty the whole working tree is synced (minus excludes); when non-empty only
+// matching paths are synced.
+func syncIncludes(cfg Config) []string {
+	out := make([]string, 0, len(cfg.Sync.Includes))
+	for _, p := range cfg.Sync.Includes {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func SyncExcludes(root string, cfg Config) ([]string, error) {
 	return syncExcludes(root, cfg)
 }
@@ -191,7 +204,7 @@ func syncFingerprint(repo Repo, cfg Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	manifest, err := syncManifest(repo.Root, excludes)
+	manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return "", err
 	}
@@ -245,6 +258,14 @@ type SyncManifest struct {
 }
 
 func syncManifest(root string, excludes []string) (SyncManifest, error) {
+	return syncManifestFiltered(root, excludes, nil)
+}
+
+// syncManifestFiltered builds the sync manifest applying excludes and, when
+// includes is non-empty, a whitelist: only paths matching an include pattern are
+// synced. This lets a job sync a few selected paths instead of the whole working
+// tree (e.g. sync just `src/` and `scripts/` out of a large repo).
+func syncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
 	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard", "-z")
 	cmd.Dir = root
 	out, err := cmd.Output()
@@ -255,7 +276,7 @@ func syncManifest(root string, excludes []string) (SyncManifest, error) {
 	manifest := SyncManifest{}
 	for _, rel := range splitNul(out) {
 		rel = filepath.ToSlash(rel)
-		if !safeRepoRel(rel) || pathExcluded(rel, excludes) || seen[rel] {
+		if !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) || seen[rel] {
 			continue
 		}
 		full := filepath.Join(root, filepath.FromSlash(rel))
@@ -268,12 +289,12 @@ func syncManifest(root string, excludes []string) (SyncManifest, error) {
 		manifest.Bytes += info.Size()
 	}
 	sort.Strings(manifest.Files)
-	deleted, err := syncDeletedPaths(root, excludes)
+	deleted, err := syncDeletedPaths(root, excludes, includes)
 	if err != nil {
 		return SyncManifest{}, err
 	}
 	manifest.Deleted = filterDeletedPaths(deleted, seen)
-	changed, err := changedSyncPaths(root, excludes)
+	changed, err := changedSyncPaths(root, excludes, includes)
 	if err != nil {
 		return SyncManifest{}, err
 	}
@@ -303,7 +324,7 @@ func (m SyncManifest) DeletedNUL() []byte {
 	return b.Bytes()
 }
 
-func syncDeletedPaths(root string, excludes []string) ([]string, error) {
+func syncDeletedPaths(root string, excludes, includes []string) ([]string, error) {
 	sets := [][]string{}
 	for _, args := range [][]string{
 		{"ls-files", "--deleted", "-z"},
@@ -321,7 +342,7 @@ func syncDeletedPaths(root string, excludes []string) ([]string, error) {
 	for _, set := range sets {
 		for _, rel := range set {
 			rel = filepath.ToSlash(rel)
-			if !safeRepoRel(rel) || pathExcluded(rel, excludes) {
+			if !safeRepoRel(rel) || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) {
 				continue
 			}
 			seen[rel] = true
@@ -475,7 +496,7 @@ func humanBytes(n int64) string {
 	return fmt.Sprintf("%.1f PiB", value/unit)
 }
 
-func changedSyncPaths(root string, excludes []string) ([]string, error) {
+func changedSyncPaths(root string, excludes, includes []string) ([]string, error) {
 	sets := [][]string{}
 	for _, args := range [][]string{
 		{"diff", "--name-only", "-z"},
@@ -494,7 +515,7 @@ func changedSyncPaths(root string, excludes []string) ([]string, error) {
 	for _, set := range sets {
 		for _, rel := range set {
 			rel = filepath.ToSlash(rel)
-			if rel == "" || pathExcluded(rel, excludes) {
+			if rel == "" || pathExcluded(rel, excludes) || !pathIncluded(rel, includes) {
 				continue
 			}
 			seen[rel] = true
@@ -557,4 +578,15 @@ func pathExcluded(rel string, excludes []string) bool {
 		}
 	}
 	return false
+}
+
+// pathIncluded reports whether rel should be kept under a sync include
+// (whitelist). With no includes everything is kept; otherwise rel must match an
+// include pattern. Matching mirrors pathExcluded: an include of "src" keeps "src"
+// and everything under it, a file path keeps that exact file, and globs match.
+func pathIncluded(rel string, includes []string) bool {
+	if len(includes) == 0 {
+		return true
+	}
+	return pathExcluded(rel, includes)
 }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -310,6 +310,10 @@ func BuildSyncManifest(root string, excludes []string) (SyncManifest, error) {
 	return syncManifest(root, excludes)
 }
 
+func BuildSyncManifestFiltered(root string, excludes, includes []string) (SyncManifest, error) {
+	return syncManifestFiltered(root, excludes, includes)
+}
+
 func (m SyncManifest) NUL() []byte {
 	var b bytes.Buffer
 	for _, rel := range m.Files {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -102,6 +102,10 @@ func syncIncludes(cfg Config) []string {
 	return out
 }
 
+func syncGitSeedEnabled(cfg Config, repo Repo) bool {
+	return cfg.Sync.GitSeed && len(syncIncludes(cfg)) == 0 && remoteGitSeedCandidate(repo)
+}
+
 func SyncExcludes(root string, cfg Config) ([]string, error) {
 	return syncExcludes(root, cfg)
 }
@@ -581,12 +585,25 @@ func pathExcluded(rel string, excludes []string) bool {
 }
 
 // pathIncluded reports whether rel should be kept under a sync include
-// (whitelist). With no includes everything is kept; otherwise rel must match an
-// include pattern. Matching mirrors pathExcluded: an include of "src" keeps "src"
-// and everything under it, a file path keeps that exact file, and globs match.
+// whitelist. Includes are root-relative: "src" keeps only the top-level src
+// tree, "package.json" keeps only that root file, and globs match the
+// root-relative path.
 func pathIncluded(rel string, includes []string) bool {
 	if len(includes) == 0 {
 		return true
 	}
-	return pathExcluded(rel, includes)
+	rel = strings.Trim(filepath.ToSlash(rel), "/")
+	for _, include := range includes {
+		include = strings.Trim(filepath.ToSlash(strings.TrimSpace(include)), "/")
+		if include == "" {
+			continue
+		}
+		if rel == include || strings.HasPrefix(rel, include+"/") {
+			return true
+		}
+		if ok, _ := filepath.Match(include, rel); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -83,10 +83,51 @@ func TestPathIncluded(t *testing.T) {
 			t.Fatalf("expected %q to be included", in)
 		}
 	}
-	for _, out := range []string{"data/x.bin", "scripts/other.sh", "package.lock"} {
+	for _, out := range []string{"data/x.bin", "scripts/other.sh", "package.lock", "packages/app/src/main.go", "examples/package.json"} {
 		if pathIncluded(out, includes) {
 			t.Fatalf("expected %q to be excluded by whitelist", out)
 		}
+	}
+	globIncludes := []string{"*.go", "docs/*.md"}
+	for _, in := range []string{"main.go", "docs/readme.md"} {
+		if !pathIncluded(in, globIncludes) {
+			t.Fatalf("expected glob to include %q", in)
+		}
+	}
+	for _, out := range []string{"src/main.go", "docs/nested/readme.md"} {
+		if pathIncluded(out, globIncludes) {
+			t.Fatalf("expected root-relative glob to exclude %q", out)
+		}
+	}
+}
+
+func TestSyncGitSeedDisabledByIncludeWhitelist(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	runGit(t, dir, "update-ref", "refs/remotes/origin/main", "HEAD")
+	head := gitOutput(dir, "rev-parse", "HEAD")
+	repo := Repo{Root: dir, RemoteURL: "https://github.com/example-org/my-app.git", Head: head}
+
+	cfg := baseConfig()
+	if !syncGitSeedEnabled(cfg, repo) {
+		t.Fatal("seedable repo without includes should use git seed")
+	}
+	cfg.Sync.Includes = []string{"src"}
+	if syncGitSeedEnabled(cfg, repo) {
+		t.Fatal("sync.include should disable full-repo git seed")
+	}
+	cfg.Sync.Includes = []string{" "}
+	if !syncGitSeedEnabled(cfg, repo) {
+		t.Fatal("blank include entries should not disable git seed")
+	}
+	cfg.Sync.GitSeed = false
+	if syncGitSeedEnabled(cfg, repo) {
+		t.Fatal("gitSeed=false should disable git seed")
 	}
 }
 

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -43,6 +43,53 @@ func TestSyncManifestUsesGitFilesAndIgnoresIgnoredJunk(t *testing.T) {
 	}
 }
 
+func TestSyncManifestIncludeWhitelist(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(dir, "src", "main.go"), "package main\n")
+	writeFile(t, filepath.Join(dir, "scripts", "build.sh"), "echo hi\n")
+	writeFile(t, filepath.Join(dir, "package.json"), "{}\n")
+	writeFile(t, filepath.Join(dir, "data", "huge.bin"), strings.Repeat("x", 4096))
+	writeFile(t, filepath.Join(dir, "notes.txt"), "ignore me\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	manifest, err := syncManifestFiltered(dir, configuredExcludes(baseConfig()), []string{"src", "scripts", "package.json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(manifest.Files, ",")
+	for _, want := range []string{"src/main.go", "scripts/build.sh", "package.json"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("include whitelist dropped wanted path %q: %q", want, got)
+		}
+	}
+	for _, notWant := range []string{"data/huge.bin", "notes.txt"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("include whitelist kept non-included path %q: %q", notWant, got)
+		}
+	}
+}
+
+func TestPathIncluded(t *testing.T) {
+	if !pathIncluded("anything/at/all.txt", nil) {
+		t.Fatal("empty includes should keep all paths")
+	}
+	includes := []string{"src", "scripts/proof", "package.json"}
+	for _, in := range []string{"src/a.go", "src/deep/b.go", "scripts/proof/run.sh", "package.json"} {
+		if !pathIncluded(in, includes) {
+			t.Fatalf("expected %q to be included", in)
+		}
+	}
+	for _, out := range []string{"data/x.bin", "scripts/other.sh", "package.lock"} {
+		if pathIncluded(out, includes) {
+			t.Fatalf("expected %q to be excluded by whitelist", out)
+		}
+	}
+}
+
 func TestSyncManifestPrunesNestedDefaultExcludes(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -966,7 +966,7 @@ retrySync:
 			return recordFailure(err)
 		}
 		stepStart = time.Now()
-		manifest, err := syncManifest(repo.Root, excludes)
+		manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
 		if err != nil {
 			return recordFailure(exit(6, "build sync file list: %v", err))
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1025,7 +1025,7 @@ retrySync:
 			recorder.Event("sync.finished", "synced", fmt.Sprintf("duration=%s mode=archive", timings.sync.Round(time.Millisecond)))
 			goto afterSync
 		}
-		if cfg.Sync.GitSeed && remoteGitSeedCandidate(repo) {
+		if syncGitSeedEnabled(cfg, repo) {
 			stepStart = time.Now()
 			if err := runSSHQuiet(ctx, target, remoteGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1071,7 +1071,7 @@ retrySync:
 		}
 		stepStart = time.Now()
 		finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
-			AllowMassDeletions: hydratedByActions || os.Getenv("CRABBOX_ALLOW_MASS_DELETIONS") == "1",
+			AllowMassDeletions: allowRemoteSyncMassDeletions(cfg, hydratedByActions),
 			HydrateGit:         hydrateGit,
 			BaseRef:            cfg.Sync.BaseRef,
 			BaseSHA:            baseSHA,
@@ -1729,6 +1729,10 @@ func shouldPruneRemoteSync(deleteEnabled, fullResync bool) bool {
 
 func shouldSeedRemotePruneManifest(hydratedByActions, fullResync bool) bool {
 	return hydratedByActions || fullResync
+}
+
+func allowRemoteSyncMassDeletions(cfg Config, hydratedByActions bool) bool {
+	return hydratedByActions || len(syncIncludes(cfg)) > 0 || os.Getenv("CRABBOX_ALLOW_MASS_DELETIONS") == "1"
 }
 
 func commandNeedsHydrationHint(command []string, shellMode bool) bool {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1012,6 +1012,26 @@ func TestFullResyncSeedsPruneManifestFromGit(t *testing.T) {
 	}
 }
 
+func TestAllowRemoteSyncMassDeletionsForIncludeWhitelist(t *testing.T) {
+	cfg := baseConfig()
+	t.Setenv("CRABBOX_ALLOW_MASS_DELETIONS", "")
+	if allowRemoteSyncMassDeletions(cfg, false) {
+		t.Fatal("ordinary sync should keep mass deletion guard enabled")
+	}
+	if !allowRemoteSyncMassDeletions(cfg, true) {
+		t.Fatal("hydrated actions workspace should allow mass deletions")
+	}
+	cfg.Sync.Includes = []string{"src"}
+	if !allowRemoteSyncMassDeletions(cfg, false) {
+		t.Fatal("sync.include should allow intentional whitelist pruning")
+	}
+	cfg.Sync.Includes = nil
+	t.Setenv("CRABBOX_ALLOW_MASS_DELETIONS", "1")
+	if !allowRemoteSyncMassDeletions(cfg, false) {
+		t.Fatal("env override should allow mass deletions")
+	}
+}
+
 func TestRunCommandRejectsApplyLocalPatchWithoutFreshPR(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{"--apply-local-patch", "--", "true"})

--- a/internal/cli/sync_plan.go
+++ b/internal/cli/sync_plan.go
@@ -36,7 +36,7 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	manifest, err := syncManifest(repo.Root, excludes)
+	manifest, err := syncManifestFiltered(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return exit(6, "build sync file list: %v", err)
 	}

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -14,7 +14,7 @@ func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Con
 	if err := runSSHQuiet(ctx, target, windowsPrepareWorkdir(workdir, cfg.Sync.Delete)); err != nil {
 		return exit(7, "prepare remote workdir: %v", err)
 	}
-	gitSeed := cfg.Sync.GitSeed && remoteGitSeedCandidate(repo)
+	gitSeed := syncGitSeedEnabled(cfg, repo)
 	if gitSeed {
 		if err := runSSHQuiet(ctx, target, windowsGitSeed(workdir, repo.RemoteURL, repo.Head)); err != nil {
 			fmt.Fprintf(stderr, "warning: remote git seed failed: %v\n", err)

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -138,8 +138,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -28,7 +28,7 @@ func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client 
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -132,8 +132,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -25,7 +25,7 @@ func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflar
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -320,7 +320,7 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 		return nil, err
 	}
 	manifestStarted := time.Now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -178,8 +178,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -127,8 +127,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -23,7 +23,7 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/islo/core.go
+++ b/internal/providers/islo/core.go
@@ -78,8 +78,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (core.SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -35,7 +35,7 @@ func (b *isloBackend) syncWorkspace(ctx context.Context, client isloAPI, name st
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -122,8 +122,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -23,7 +23,7 @@ func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandb
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -120,8 +120,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (core.SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -40,7 +40,7 @@ func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCL
 	}
 
 	manifestStart := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -113,8 +113,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifest(root, excludes)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -19,7 +19,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, r
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}


### PR DESCRIPTION
## Summary

Sync currently supports only **excludes** (a blacklist). For a large repo where you only want a few paths in the box — e.g. a proof/test job that needs just `src/` and `scripts/` out of a working tree full of unrelated data — blacklisting every junk directory is fragile and endless (every new untracked dir reappears in the sync).

This adds **`sync.include`**: when set, **only** paths matching an include pattern are synced (after excludes).

## How it works

- `SyncConfig.Includes` + YAML `sync.include` / `sync.includes`.
- Filtering happens **inside** the manifest walker (`syncManifestFiltered`), so the size preflight sees the trimmed set — a 136 GiB working tree becomes the few hundred MB you actually selected, instead of being rejected by the large-sync guard.
- `syncManifest(root, excludes)` stays a thin wrapper over `syncManifestFiltered(root, excludes, nil)`, so all existing callers/tests are unchanged.
- Deleted/changed walkers honor includes too (accurate delta + byte accounting).
- Matching mirrors excludes (`pathIncluded`): an include of `src` keeps `src` and everything under it, a file path keeps that exact file, and globs match.

## Example

```yaml
sync:
  include:
    - src
    - scripts
    - package.json
    - pnpm-lock.yaml
```

## Test plan

- [x] `TestSyncManifestIncludeWhitelist` — only included paths land in the manifest; `data/`, `notes.txt` dropped.
- [x] `TestPathIncluded` — empty includes keep everything; dir/file/glob matching; non-matches excluded.
- [x] `go build` / `go vet` / existing sync + config tests pass.

Follow-up (not in this PR): per-job `sync.include` override and an optional `.crabboxinclude` file (parallel to `.crabboxignore`).

---

## Real behavior proof (`crabbox sync-plan`)

Run against a 136 GiB working tree (an openclaw checkout with large unrelated data dirs), showing `sync.include` trimming the candidate set. Redacted to top entries:

**Baseline — no include (whole working tree):**
```
$ crabbox sync-plan -limit 5
sync candidate: 80610 files, 136.0 GiB
top files:
  50.0 GiB   data/polymarket/data.tar
  33.5 GiB   data/polymarket/data.tar.zst
  525.2 MiB  tmp/scx-data.tar.gz
  ...
```

**With `sync.include: [scripts, crabbox.yaml]`:**
```
$ CRABBOX_CONFIG=with-include.yaml crabbox sync-plan -limit 5
sync candidate: 1401 files, 88.3 MiB
top files:
  12.4 MiB   scripts/polymarket_backtest/output/intraday_markets.parquet
  7.4 MiB    scripts/peporacle.mp4
  ...
```

**80,610 files / 136.0 GiB → 1,401 files / 88.3 MiB**, keeping only the whitelisted paths — the large `data/`, `tmp/`, `.archive*/` entries are gone. Without the whitelist this tree is rejected by the large-sync guard; with it the sync is well under the limit.

Also added: `sync.include` now appears in `crabbox config show` (text + `--json`) so the effective whitelist is visible during troubleshooting.
