### PR TITLE
feat: add experimental --provider wasi delegated-run provider (wazero primary, wasmtime opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ configured); every other provider always runs direct from the CLI.
 | [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux | Azure Container Apps dynamic sessions. |
 | [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`) | Linux | Delegated Blacksmith CI Testbox lifecycle and execution. |
 | [W&B Sandboxes](docs/providers/wandb.md) — `wandb` (`weights-and-biases`) | Linux | Weights & Biases Sandboxes; reuses `wandb login` credentials. |
+| [WASI (experimental)](docs/providers/wasi.md) — `wasi` (`wasm`, `wazero`) | Wasm (WASI preview1/2) | Specialized Wasm sandbox (wazero/wasmtime) for WASI modules and Wasm-first code. Experimental. |
 
 See [Providers](docs/providers/README.md) for the full reference, capabilities,
 and authoring guide.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,7 +210,8 @@ transport to the provider's own API or CLI. For these, SSH-specific options
 (`ssh`, `desktop`, `vnc`, `code`, Actions hydration, `--checksum`, `--sync-only`)
 are unavailable or partly restricted, and sync timing is reported as `delegated`.
 Examples include `blacksmith-testbox`, `azure-dynamic-sessions`, `e2b`, `modal`,
-`islo`, `cloudflare`, `upstash-box`, `tensorlake`, and `wandb`. See
+`islo`, `cloudflare`, `upstash-box`, `tensorlake`, `wandb`, and the specialized
+experimental `wasi` (Wasm). See
 [providers](features/providers.md) for the full adapter list and which surface
 each one supports.
 

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -322,10 +322,12 @@ list, and cleanup.
   SSH through `sprite proxy` for a fast Linux microVM on the standard SSH path.
 
 Delegated-run providers (`cloudflare`, `azure-dynamic-sessions`, `e2b`, `islo`,
-`modal`, `tensorlake`, `upstash-box`, `blacksmith-testbox`, `wandb`) do not use
-the broker or an SSH lease; each owns sandbox lifecycle and command execution and
-syncs through its own API (gzipped archive upload for most). See the linked
-provider pages for per-provider auth and configuration.
+`modal`, `tensorlake`, `upstash-box`, `blacksmith-testbox`, `wandb`, and the
+specialized experimental `wasi`) do not use the broker or an SSH lease; each owns
+sandbox lifecycle and command execution and syncs through its own API (gzipped
+archive upload or local copy for wasi). See the linked provider pages for
+per-provider auth and configuration. (WASI is narrow and experimental — Wasm
+modules + limited builtins only.)
 
 ## Static SSH targets
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -97,6 +97,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |
 | [W&B Sandboxes](wandb.md) — `wandb` (`weights-and-biases`) | Linux |
+| [WASI (experimental)](wasi.md) — `wasi` (`wasm`, `wazero`) | Wasm (WASI preview1/2) |
 
 Run `crabbox providers` (`--json`) to see the live capability set the binary
 reports.

--- a/docs/providers/wasi.md
+++ b/docs/providers/wasi.md
@@ -1,0 +1,99 @@
+# WASI Provider (experimental, specialized)
+
+Read when:
+
+- choosing `provider: wasi` (aliases `wasm`, `wazero`);
+- running WebAssembly modules or Wasm-first workloads with capability-based isolation;
+- using `crabbox run` with lightweight `.wasm` artifacts;
+- evaluating generated or untrusted code that can be compiled to WASI.
+
+WASI is an **experimental delegated-run provider**. It executes `.wasm` (wasm32-wasi / preview1 or preview2) modules inside an embedded wazero runtime (or wasmtime if configured and available). The CLI owns local claims + slugs + an isolated guest root; "sync" copies the manifest into the guest tree and preopens it for the module. There is no SSH, no broker, and no full Linux surface.
+
+See the official [WASI site](https://wasi.dev/) and [WASI specification](https://github.com/WebAssembly/WASI) for the API family, proposals, and versioning. This provider targets Preview 1 / WASI 0.1 for broad toolchain compatibility today, with wasmtime available for runtimes that support newer component-model work.
+
+wazero and wasmtime are both listed by wasi.dev. This provider follows the WASI capability model by granting only the synced guest tree as `/work`, plus stdio, args, and explicit environment variables. Convenience builtins such as `ls` and `cat` use the same `/work` boundary.
+
+It is deliberately specialized for:
+- Projects that cross-compile to `wasm32-wasi` (Go, Rust, C, etc.).
+- Reproducible runs where the main artifact is already `.wasm`.
+- Capability-scoped execution for generated or untrusted code.
+
+For arbitrary `pnpm test`, `cargo test`, native toolchains, or full Linux, use `local-container`, `e2b`, `hetzner`, etc.
+
+## When to use
+
+Use when you want a lightweight, zero-OS, capability-scoped sandbox that participates in the normal `crabbox run --id` / warmup / capsule / timing surface.
+
+Do **not** use for legacy suites that require apt, arbitrary syscalls, heavy FS, or interactive shells.
+
+## For agents and automation
+
+Use `--provider wasi` for capability-scoped runs of generated/untrusted code or portable `.wasm` test binaries: `crabbox run --provider wasi -- ./my-app.wasm`. Guest sees *only* the synced checkout (preopened `/work`); no host ambient authority or POSIX surface. Provides the same "warm, sync diff, run, proof" experience as other providers but as a lightweight local zero-OS sandbox.
+
+## Commands
+
+```sh
+# Run a pre-built wasm (after cargo build --target wasm32-wasi or equivalent)
+crabbox run --provider wasi -- ./target/wasm32-wasi/debug/myapp.wasm --arg1 value
+
+# With warmup + reuse (guest dir is kept)
+crabbox warmup --provider wasi
+crabbox run --provider wasi --id my-wasi -- ./my-tests.wasm
+
+crabbox status --provider wasi --id my-wasi
+crabbox stop --provider wasi my-wasi
+```
+
+## Config
+
+```yaml
+provider: wasi
+target: linux
+wasi:
+  workdir: crabbox
+  runtime: wazero          # wazero (embedded, zero-dep) or wasmtime
+  guestBaseDir: ""         # optional base dir for isolated guest roots
+```
+
+Flags: `--wasi-workdir`, `--wasi-runtime`.
+
+`guestBaseDir` defaults to the system temp directory. When set, it must be an
+absolute path, and guest roots must not overlap the synced repository tree;
+both are rejected before any host-side write so kept guest files can never
+feed back into later sync manifests.
+
+The guest tree is at `<guestBase or /tmp>/crabbox-wasi-<lease>/<workdir>/`. Your module sees it via preopen (typically `/work`).
+
+## Capabilities & limitations
+
+- Sync: archive-style manifest copy (respects excludes, Delete, preflight guards). Fingerprint skip and rsync delta not applicable (local guest copy).
+- Reusable sessions and delegated run proof output are supported.
+- No SSH, desktop, VNC, code-server, Actions hydration, tailscale, broker.
+- `--class`/`--type` rejected.
+- POSIX surface is limited (no apt, limited threads/sockets/FS in preview1; preview2/components better but not universal).
+- CPU-heavy code may be 5-20% slower than native.
+- wasmtime is used when `--wasi-runtime wasmtime` is set and the CLI is in PATH. Plain `.wasm` modules fall back to wazero if wasmtime is missing; `.cwasm` modules require wasmtime.
+
+## Reproducible artifacts
+
+A `.wasm` module plus the synced input tree is a compact replay artifact. Today this provider exposes that through normal `crabbox run`, `--sync-only`, reusable sessions, and delegated proof output. Capsules remain Actions-first failure manifests; use them when you want to replay a command through Crabbox, not as a WASI-specific package format.
+
+## Live smoke (local, no secrets)
+
+```sh
+go build -trimpath -o bin/crabbox ./cmd/crabbox
+bin/crabbox run --provider wasi -- echo 'crabbox-wasi-smoke'
+bin/crabbox doctor --provider wasi --json
+bin/crabbox run --provider wasi -- false || echo "expected non-zero"
+```
+
+For a real module example, see the test or compile a tiny Go program with `GOOS=wasip1 GOARCH=wasm go build`.
+
+## Related
+
+- Provider authoring & backends docs
+- Features: capsules, sync, delegated providers
+- [wasi.dev](https://wasi.dev/) (official intro + runtimes) + [WASI spec](https://github.com/WebAssembly/WASI)
+- wazero / wasmtime docs
+
+**This provider is experimental.** Usage, surface, and runtime support may change. It is a great fit for Wasm-native or agent workloads but will disappoint on traditional full-Linux test suites.

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -85,11 +85,12 @@ SSH-lease providers:
 Delegated-run providers (no SSH lease):
 
 - Cloudflare Containers: `internal/providers/cloudflare`, with the Worker runtime in `worker/src/cloudflare-container-runner.ts`
-- Docker Sandbox, E2B, Islo, Modal, OpenComputer, Tensorlake, Upstash, Blacksmith, W&B:
+- Docker Sandbox, E2B, Islo, Modal, OpenComputer, Tensorlake, Upstash, Blacksmith, W&B, WASI (experimental):
   `internal/providers/dockersandbox`,
   `internal/providers/e2b`, `internal/providers/islo`, `internal/providers/modal`,
   `internal/providers/opencomputer`, `internal/providers/tensorlake`, `internal/providers/upstashbox`,
-  `internal/providers/blacksmith`, `internal/providers/wandb`
+  `internal/providers/blacksmith`, `internal/providers/wandb`,
+  `internal/providers/wasi` (wazero/wasmtime delegated sandbox)
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/islo-labs/go-sdk v0.0.0-20260528125833-04a38f6f507c
 	github.com/lxc/incus/v7 v7.1.0
+	github.com/tetratelabs/wazero v1.12.0
 	github.com/zitadel/oidc/v3 v3.47.5
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZopYU=
+github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -121,6 +121,7 @@ type Config struct {
 	DockerSandbox                 DockerSandboxConfig
 	Modal                         ModalConfig
 	UpstashBox                    UpstashBoxConfig
+	Wasi                          WasiConfig
 	AsciiBox                      AsciiBoxConfig
 	Cloudflare                    CloudflareConfig
 	Semaphore                     SemaphoreConfig
@@ -457,6 +458,12 @@ type UpstashBoxConfig struct {
 	Size      string
 	Workdir   string
 	KeepAlive bool
+}
+
+type WasiConfig struct {
+	Workdir      string
+	Runtime      string // "wazero" (embedded) or "wasmtime"
+	GuestBaseDir string // optional base for guest roots (defaults to os.TempDir)
 }
 
 type AsciiBoxConfig struct {
@@ -1292,6 +1299,10 @@ func baseConfig() Config {
 			Size:    "small",
 			Workdir: "/workspace/home/crabbox",
 		},
+		Wasi: WasiConfig{
+			Workdir: "crabbox",
+			Runtime: "wazero",
+		},
 		AsciiBox: AsciiBoxConfig{
 			BaseURL: "https://ascii.dev",
 			CLIPath: "box",
@@ -1415,6 +1426,7 @@ type fileConfig struct {
 	DockerSandbox        *fileDockerSandboxConfig           `yaml:"dockerSandbox,omitempty"`
 	Modal                *fileModalConfig                   `yaml:"modal,omitempty"`
 	UpstashBox           *fileUpstashBoxConfig              `yaml:"upstashBox,omitempty"`
+	Wasi                 *fileWasiConfig                    `yaml:"wasi,omitempty"`
 	AsciiBox             *fileAsciiBoxConfig                `yaml:"asciiBox,omitempty"`
 	Cloudflare           *fileCloudflareConfig              `yaml:"cloudflare,omitempty"`
 	Semaphore            *fileSemaphoreConfig               `yaml:"semaphore,omitempty"`
@@ -1827,6 +1839,12 @@ type fileUpstashBoxConfig struct {
 	Size      string `yaml:"size,omitempty"`
 	Workdir   string `yaml:"workdir,omitempty"`
 	KeepAlive *bool  `yaml:"keepAlive,omitempty"`
+}
+
+type fileWasiConfig struct {
+	Workdir      string `yaml:"workdir,omitempty"`
+	Runtime      string `yaml:"runtime,omitempty"`
+	GuestBaseDir string `yaml:"guestBaseDir,omitempty"`
 }
 
 type fileAsciiBoxConfig struct {
@@ -3138,6 +3156,17 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.UpstashBox.KeepAlive = *file.UpstashBox.KeepAlive
 		}
 	}
+	if file.Wasi != nil {
+		if file.Wasi.Workdir != "" {
+			cfg.Wasi.Workdir = file.Wasi.Workdir
+		}
+		if file.Wasi.Runtime != "" {
+			cfg.Wasi.Runtime = file.Wasi.Runtime
+		}
+		if file.Wasi.GuestBaseDir != "" {
+			cfg.Wasi.GuestBaseDir = file.Wasi.GuestBaseDir
+		}
+	}
 	if file.AsciiBox != nil {
 		if file.AsciiBox.BaseURL != "" {
 			cfg.AsciiBox.BaseURL = file.AsciiBox.BaseURL
@@ -4080,6 +4109,9 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_UPSTASH_BOX_KEEP_ALIVE"); ok {
 		cfg.UpstashBox.KeepAlive = value
 	}
+	cfg.Wasi.Workdir = getenv("CRABBOX_WASI_WORKDIR", cfg.Wasi.Workdir)
+	cfg.Wasi.Runtime = getenv("CRABBOX_WASI_RUNTIME", cfg.Wasi.Runtime)
+	cfg.Wasi.GuestBaseDir = getenv("CRABBOX_WASI_GUEST_BASE_DIR", cfg.Wasi.GuestBaseDir)
 	cfg.AsciiBox.APIKey = getenv("CRABBOX_ASCII_BOX_API_KEY", getenv("ASCII_BOX_API_KEY", cfg.AsciiBox.APIKey))
 	cfg.AsciiBox.BaseURL = getenv("CRABBOX_ASCII_BOX_BASE_URL", getenv("ASCII_BOX_BASE_URL", cfg.AsciiBox.BaseURL))
 	cfg.AsciiBox.CLIPath = getenv("CRABBOX_ASCII_BOX_CLI", getenv("BOX_CLI", cfg.AsciiBox.CLIPath))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -150,6 +150,11 @@ func configShowView(cfg Config) map[string]any {
 			"workdir":   cfg.UpstashBox.Workdir,
 			"keepAlive": cfg.UpstashBox.KeepAlive,
 		},
+		"wasi": map[string]any{
+			"workdir":      cfg.Wasi.Workdir,
+			"runtime":      cfg.Wasi.Runtime,
+			"guestBaseDir": cfg.Wasi.GuestBaseDir,
+		},
 		"asciiBox": map[string]any{
 			"baseUrl": cfg.AsciiBox.BaseURL,
 			"auth":    tokenState(cfg.AsciiBox.APIKey),
@@ -304,6 +309,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "morph api_url=%s snapshot=%s ssh_gateway_host=%s work_root=%s delete_on_release=%t wake_on_ssh=%t auth=%s\n", blank(cfg.Morph.APIURL, "-"), blank(cfg.Morph.Snapshot, "-"), blank(cfg.Morph.SSHGatewayHost, "-"), blank(cfg.Morph.WorkRoot, "-"), cfg.Morph.DeleteOnRelease, cfg.Morph.WakeOnSSH, tokenState(cfg.Morph.APIKey))
 	fmt.Fprintf(w, "e2b api_url=%s domain=%s template=%s workdir=%s user=%s\n", cfg.E2B.APIURL, cfg.E2B.Domain, cfg.E2B.Template, cfg.E2B.Workdir, blank(cfg.E2B.User, "-"))
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
+	fmt.Fprintf(w, "wasi workdir=%s runtime=%s guest_base_dir=%s\n", blank(cfg.Wasi.Workdir, "-"), blank(cfg.Wasi.Runtime, "-"), blank(cfg.Wasi.GuestBaseDir, "-"))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -365,6 +365,14 @@ func CLIDoctorResult(provider string, leases int, runtime string) DoctorResult {
 
 type execCommandRunner struct{}
 
+// NewExecCommandRunner returns the default real command runner used for
+// subprocess execution in the CLI and delegated providers. It is exported
+// primarily so provider tests (e.g. direct backend e2e tests) can construct
+// a Runtime with a non-nil Exec, matching the load path used by the CLI.
+func NewExecCommandRunner() CommandRunner {
+	return execCommandRunner{}
+}
+
 func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
 	cmd.Env = req.Env
@@ -797,7 +805,7 @@ func loadBackend(cfg Config, rt Runtime) (Backend, error) {
 		rt.Clock = realClock{}
 	}
 	if rt.Exec == nil {
-		rt.Exec = execCommandRunner{}
+		rt.Exec = NewExecCommandRunner()
 	}
 	provider, err := ProviderFor(cfg.Provider)
 	if err != nil {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -35,6 +35,7 @@ func init() {
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 	RegisterProvider(testServiceControlProvider{})
+	RegisterProvider(testWasiProvider{})
 }
 
 type testAzureProvider struct{}
@@ -1460,4 +1461,33 @@ func (b testSSHBackend) ReleaseLease(context.Context, ReleaseLeaseRequest) error
 }
 func (b testSSHBackend) Touch(context.Context, TouchRequest) (Server, error) {
 	return Server{}, nil
+}
+
+type testWasiProvider struct{}
+
+func (testWasiProvider) Name() string      { return "wasi" }
+func (testWasiProvider) Aliases() []string { return []string{"wasm", "wazero"} }
+func (testWasiProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "wasi",
+		Family:      "wasi",
+		Kind:        ProviderKindDelegatedRun,
+		Targets:     []TargetSpec{{OS: TargetLinux}},
+		Features:    FeatureSet{FeatureArchiveSync, FeatureRunSession, FeatureRunProof},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testWasiProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return NoProviderFlags()
+}
+func (testWasiProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error { return nil }
+func (p testWasiProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testDelegatedBackend{spec: p.Spec()}, nil
+}
+func (p testWasiProvider) ConfigureDoctor(cfg Config, rt Runtime) (DoctorBackend, error) {
+	b, _ := p.Configure(cfg, rt)
+	if d, ok := b.(DoctorBackend); ok {
+		return d, nil
+	}
+	return testDoctorDelegatedBackend{testDelegatedBackend: testDelegatedBackend{spec: p.Spec()}}, nil
 }

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -38,4 +38,5 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"
 	_ "github.com/openclaw/crabbox/internal/providers/upstashbox"
 	_ "github.com/openclaw/crabbox/internal/providers/wandb"
+	_ "github.com/openclaw/crabbox/internal/providers/wasi"
 )

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -93,6 +93,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"tensorlake",
 		"upstash-box",
 		"wandb",
+		"wasi",
 	}
 	for _, name := range providers {
 		t.Run(name, func(t *testing.T) {

--- a/internal/providers/wasi/backend.go
+++ b/internal/providers/wasi/backend.go
@@ -1,0 +1,1113 @@
+package wasi
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/sys"
+)
+
+// WASI gives Wasm modules a standards-track system interface while the host
+// decides which capabilities are available. This provider uses wazero by default
+// and wasmtime as an opt-in CLI runtime, then mounts only the synced guest
+// workdir as /work plus stdio, args, and explicit environment variables.
+
+const (
+	defaultWasiWorkdir = "crabbox"
+	defaultWasiRuntime = "wazero"
+)
+
+type wasiFlagValues struct {
+	Workdir *string
+	Runtime *string
+}
+
+func RegisterWasiProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	wd := defaultWasiWorkdir
+	if defaults.Wasi.Workdir != "" {
+		wd = defaults.Wasi.Workdir
+	}
+	rt := defaultWasiRuntime
+	if defaults.Wasi.Runtime != "" {
+		rt = defaults.Wasi.Runtime
+	}
+	return wasiFlagValues{
+		Workdir: fs.String("wasi-workdir", wd, "WASI guest working directory (preopened as /work)"),
+		Runtime: fs.String("wasi-runtime", rt, "WASI runtime: wazero (embedded, default) or wasmtime (if in PATH)"),
+	}
+}
+
+func ApplyWasiProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	// Reject --class/--type for the wasi provider and all its aliases (wasm, wazero).
+	// Apply may be called while cfg.Provider is still an alias (before resolution in loadBackend).
+	if cfg.Provider == providerName || cfg.Provider == "wasm" || cfg.Provider == "wazero" {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s", providerName)
+		}
+	}
+	v, ok := values.(wasiFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "wasi-workdir") {
+		workdir, err := cleanWasiWorkdir(*v.Workdir)
+		if err != nil {
+			return err
+		}
+		cfg.Wasi.Workdir = workdir
+	}
+	if flagWasSet(fs, "wasi-runtime") {
+		runtime, err := normalizeWasiRuntime(*v.Runtime)
+		if err != nil {
+			return err
+		}
+		cfg.Wasi.Runtime = runtime
+	}
+	return nil
+}
+
+func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	if cfg.Wasi.Workdir == "" {
+		cfg.Wasi.Workdir = defaultWasiWorkdir
+	}
+	if cfg.Wasi.Runtime == "" {
+		cfg.Wasi.Runtime = defaultWasiRuntime
+	} else if runtime, err := normalizeWasiRuntime(cfg.Wasi.Runtime); err == nil {
+		cfg.Wasi.Runtime = runtime
+	}
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) now() time.Time { return nowFrom(b.rt) }
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	started := b.now()
+	leaseID, slug, err := b.ensureLease(req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	guestRoot, syncDur, err := b.prepareGuest(ctx, req.Repo.Root, leaseID, false, false)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s guest=%s\n", leaseID, slug, providerName, guestRoot)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: wasi warmup keeps the guest dir until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			SyncMs:   syncDur.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	started := b.now()
+	command := req.Command
+	if !req.SyncOnly && len(command) == 0 {
+		return RunResult{}, exit(2, "missing command (provide a .wasm module)")
+	}
+	pureNoFS := !req.SyncOnly && isPureNoFSBuiltin(command)
+	noSync := req.NoSync || pureNoFS
+
+	leaseID, slug, err := b.ensureLeaseForRun(req)
+	if err != nil {
+		return RunResult{}, err
+	}
+	acquired := req.ID == ""
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
+		defer func() {
+			if !shouldStop {
+				return
+			}
+			b.cleanupGuest(leaseID)
+			removeLeaseClaim(leaseID)
+		}()
+	}
+
+	guestRoot, syncDur, err := b.prepareGuest(ctx, req.Repo.Root, leaseID, noSync, req.ForceSyncLarge)
+	if err != nil {
+		return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+	}
+
+	if req.SyncOnly {
+		result := RunResult{
+			Total:         b.now().Sub(started),
+			SyncDelegated: true,
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			Session: &RunSessionHandle{
+				Provider:       providerName,
+				LeaseID:        leaseID,
+				Slug:           slug,
+				Reused:         !acquired,
+				Kept:           !shouldStop,
+				CleanupCommand: wasiCleanupCommand(leaseID),
+			},
+		}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", guestRoot)
+		if req.TimingJSON {
+			_ = writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDur.Milliseconds(),
+				SyncSkipped:   noSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+			})
+		}
+		return result, nil
+	}
+
+	fmt.Fprintf(b.rt.Stderr, "running on wasi %s\n", strings.Join(command, " "))
+
+	exitCode, cmdDur, runErr := b.executeCommand(ctx, guestRoot, req, command)
+
+	total := b.now().Sub(started)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       cmdDur,
+		Total:         total,
+		SyncDelegated: true,
+		Provider:      providerName,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   strings.Join(command, " "),
+		Session: &RunSessionHandle{
+			Provider:       providerName,
+			LeaseID:        leaseID,
+			Slug:           slug,
+			Reused:         !acquired,
+			Kept:           !shouldStop,
+			CleanupCommand: wasiCleanupCommand(leaseID),
+		},
+	}
+
+	if noSync {
+		fmt.Fprintf(b.rt.Stderr, "wasi run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "wasi run summary sync=%s command=%s total=%s exit=%d\n", syncDur.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	}
+
+	if req.TimingJSON {
+		_ = writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDur.Milliseconds(),
+			SyncSkipped:   noSync,
+			CommandMs:     cmdDur.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+		})
+	}
+
+	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, runErr
+	}
+	if result.ExitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("wasi run exited %d", result.ExitCode)}
+	}
+	return result, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = ctx
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LeaseView, 0, len(claims))
+	for _, claim := range claims {
+		if claim.Provider != providerName {
+			continue
+		}
+		state := b.leaseState(claim.LeaseID)
+		if state == "not-found" && !req.All {
+			continue
+		}
+		out = append(out, wasiClaimToServer(claim, state))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	_ = ctx
+	leaseID := req.ID
+	if leaseID == "" {
+		return StatusView{}, exit(2, "missing --id for wasi status")
+	}
+	canonical, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		return StatusView{}, err
+	}
+	if !ok {
+		return StatusView{ID: leaseID, Provider: providerName, State: "not-found"}, nil
+	}
+	leaseID = canonical.LeaseID
+	guest, err := b.guestRootPath(leaseID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	if _, err := os.Stat(guest); err != nil {
+		if os.IsNotExist(err) {
+			return wasiStatusView(canonical, "not-found"), nil
+		}
+		return wasiStatusView(canonical, "error"), nil
+	}
+	return wasiStatusView(canonical, "ready"), nil
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	_ = ctx
+	leaseID := req.ID
+	if leaseID == "" {
+		return exit(2, "missing id for wasi stop")
+	}
+	canonical, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return exit(4, "wasi lease %q was not found", req.ID)
+	}
+	leaseID = canonical.LeaseID
+	b.cleanupGuest(leaseID)
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "stopped wasi lease=%s\n", leaseID)
+	return nil
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	leases, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(leases)), nil
+}
+
+func (b *backend) ensureLease(repo Repo, keep, reclaim bool, requestedSlug string) (string, string, error) {
+	leaseID := newLeaseID()
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return "", "", err
+	}
+	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		return "", "", err
+	}
+	return leaseID, slug, nil
+}
+
+func (b *backend) ensureLeaseForRun(req RunRequest) (string, string, error) {
+	if req.ID == "" {
+		return b.ensureLease(req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	}
+	claim, ok, err := resolveLeaseClaimForProvider(req.ID, providerName)
+	if err != nil || !ok {
+		return "", "", exit(2, "no wasi lease for %s", req.ID)
+	}
+	return claim.LeaseID, claim.Slug, nil
+}
+
+func (b *backend) prepareGuest(ctx context.Context, repoRoot, leaseID string, noSync, forceSyncLarge bool) (string, time.Duration, error) {
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	guestRoot, err := b.guestRootPath(leaseID)
+	if err != nil {
+		return "", 0, err
+	}
+	if err := assertGuestRootOutsideRepo(guestRoot, repoRoot); err != nil {
+		return "", 0, err
+	}
+	if err := os.MkdirAll(guestRoot, 0o755); err != nil {
+		return "", 0, exit(6, "create wasi guest root: %v", err)
+	}
+	// The guest root is reused across runs (run-session handles). The
+	// per-component no-follow checks below only validate children, so the root
+	// itself must be proven to be a real directory here: a root replaced with a
+	// symlink (e.g. pointing at a host directory) would otherwise be followed by
+	// the workdir mkdir/copy and let sync escape the guest tree.
+	if err := assertRealDir(guestRoot); err != nil {
+		return guestRoot, 0, exit(2, "wasi guest root: %v", err)
+	}
+
+	syncDur := time.Duration(0)
+	target, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return guestRoot, 0, err
+	}
+	if !noSync {
+		excludes, err := syncExcludes(repoRoot, b.cfg)
+		if err != nil {
+			return guestRoot, 0, err
+		}
+		manifest, err := syncManifest(repoRoot, excludes)
+		if err != nil {
+			return guestRoot, 0, exit(6, "build sync manifest: %v", err)
+		}
+		if err := checkSyncPreflight(manifest, b.cfg, forceSyncLarge, b.rt.Stderr); err != nil {
+			return guestRoot, 0, err
+		}
+		if b.cfg.Sync.Delete {
+			if err := removeAllNoFollow(guestRoot, target); err != nil {
+				return guestRoot, 0, exit(6, "wasi delete-sync reset: %v", err)
+			}
+		}
+		start := b.now()
+		if err := b.copyManifestToGuest(repoRoot, guestRoot, manifest); err != nil {
+			return guestRoot, 0, exit(6, "copy to wasi guest: %v", err)
+		}
+		syncDur = b.now().Sub(start)
+		fmt.Fprintf(b.rt.Stderr, "wasi sync complete in %s (guest=%s)\n", syncDur.Round(time.Millisecond), guestRoot)
+	} else {
+		if err := mkdirAllNoFollow(guestRoot, target, 0o755); err != nil {
+			return guestRoot, 0, exit(6, "create wasi guest workdir: %v", err)
+		}
+		fmt.Fprintf(b.rt.Stderr, "wasi sync skipped (guest=%s)\n", guestRoot)
+	}
+	return guestRoot, syncDur, nil
+}
+
+func (b *backend) guestRootPath(leaseID string) (string, error) {
+	base := os.TempDir()
+	if b.cfg.Wasi.GuestBaseDir != "" {
+		base = b.cfg.Wasi.GuestBaseDir
+		if !filepath.IsAbs(base) {
+			return "", exit(2, "wasi guest base dir must be an absolute path: %q", base)
+		}
+	}
+	return filepath.Join(base, "crabbox-wasi-"+leaseID), nil
+}
+
+// assertGuestRootOutsideRepo rejects guest roots that overlap the synced
+// repository tree. A guest root under repoRoot is created before the sync
+// manifest is built and is not covered by the default excludes, so a kept
+// session's copied files would feed back into later manifests and recursively
+// pollute /work; a repo under the guest root would copy into itself.
+func assertGuestRootOutsideRepo(guestRoot, repoRoot string) error {
+	repo := resolveExistingPrefix(repoRoot)
+	guest := resolveExistingPrefix(guestRoot)
+	if pathWithin(repo, guest) || pathWithin(guest, repo) {
+		return exit(2, "wasi guest root %s overlaps repo root %s; set wasi.guestBaseDir outside the repository", guestRoot, repo)
+	}
+	return nil
+}
+
+// resolveExistingPrefix resolves symlinks in the longest existing ancestor of
+// p (the path itself may not exist yet) so overlap checks compare canonical
+// paths, e.g. /var vs /private/var on macOS.
+func resolveExistingPrefix(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	rest := ""
+	for cur := abs; ; {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return abs
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
+}
+
+func (b *backend) leaseState(leaseID string) string {
+	guest, err := b.guestRootPath(leaseID)
+	if err != nil {
+		return "error"
+	}
+	if _, err := os.Stat(guest); err != nil {
+		if os.IsNotExist(err) {
+			return "not-found"
+		}
+		return "error"
+	}
+	return "ready"
+}
+
+func (b *backend) copyManifestToGuest(repoRoot, guestRoot string, manifest SyncManifest) error {
+	if err := assertRealDir(guestRoot); err != nil {
+		return fmt.Errorf("guest root: %w", err)
+	}
+	target, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return err
+	}
+	if err := mkdirAllNoFollow(guestRoot, target, 0o755); err != nil {
+		return err
+	}
+	for _, f := range manifest.Files {
+		src := filepath.Join(repoRoot, filepath.FromSlash(f))
+		dst, err := joinUnder(target, f)
+		if err != nil {
+			return fmt.Errorf("copy %s: %w", f, err)
+		}
+		info, err := os.Lstat(src)
+		if err != nil {
+			return fmt.Errorf("copy %s: %w", f, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Validate that the symlink's ultimate target resolves inside the repo
+			// root (security). Then *rewrite* the stored link target as a clean
+			// relative path (computed via Rel from the symlink location to the
+			// resolved target). This ensures the symlink entry created in the
+			// guest tree is always self-contained/relative (never absolute or
+			// host-absolute), matching the /work preopen and preventing any
+			// bypass of the guest boundary even for included targets. Targets
+			// excluded from the manifest remain dangling (no content leak).
+			resolved, _, err := resolveRepoSymlink(repoRoot, src)
+			if err != nil {
+				return fmt.Errorf("copy %s: %w", f, err)
+			}
+			linkTarget, err := filepath.Rel(filepath.Dir(src), resolved)
+			if err != nil {
+				return fmt.Errorf("copy %s: %w", f, err)
+			}
+			// Use forward slashes for the stored target (WASI/guest expectation;
+			// matches how manifest rels are handled and tar-style providers).
+			linkTarget = filepath.ToSlash(linkTarget)
+			if err := prepareGuestDestination(target, dst); err != nil {
+				return fmt.Errorf("copy %s: %w", f, err)
+			}
+			if err := os.Symlink(linkTarget, dst); err != nil {
+				return fmt.Errorf("copy %s: %w", f, err)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("copy %s: unsupported file mode %s", f, info.Mode())
+		}
+		if err := prepareGuestDestination(target, dst); err != nil {
+			return fmt.Errorf("copy %s: %w", f, err)
+		}
+		if err := copyFileNoFollow(src, dst, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("copy %s: %w", f, err)
+		}
+	}
+	return nil
+}
+
+func prepareGuestDestination(root, dst string) error {
+	parent := filepath.Dir(dst)
+	return mkdirAllNoFollow(root, parent, 0o755)
+}
+
+// assertRealDir verifies that p exists and is a real directory, not a symlink.
+// It is used to validate a (possibly reused) guest root before anything is
+// written underneath it, closing the gap left by the per-component no-follow
+// checks which trust their starting root.
+func assertRealDir(p string) error {
+	info, err := os.Lstat(p)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", p)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", p)
+	}
+	return nil
+}
+
+// removeAllNoFollow removes target only if every path component from root down
+// to target (including target) is a real, non-symlink entry. A reused/tampered
+// guest can replace an intermediate workdir component with a symlink to a host
+// directory; a raw os.RemoveAll would then traverse that symlink and delete
+// host-side paths outside the guest root. Components that do not exist are a
+// no-op (nothing to remove). target must lie within root.
+func removeAllNoFollow(root, target string) error {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	if !pathWithin(root, target) {
+		return fmt.Errorf("delete target %s is outside guest root", target)
+	}
+	if err := assertRealDir(root); err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		// target == root: never wipe the whole guest root through this path.
+		return fmt.Errorf("refusing to delete guest root %s", target)
+	}
+	cur := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if os.IsNotExist(err) {
+			return nil // nothing to remove
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("delete path component %s is a symlink", cur)
+		}
+	}
+	return os.RemoveAll(target)
+}
+
+func mkdirAllNoFollow(root, p string, perm os.FileMode) error {
+	root = filepath.Clean(root)
+	p = filepath.Clean(p)
+	if !pathWithin(root, p) {
+		return fmt.Errorf("destination %s is outside guest root", p)
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+	cur := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(cur, perm); err != nil && !os.IsExist(err) {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("destination component %s is a symlink", cur)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("destination component %s is not a directory", cur)
+		}
+	}
+	return nil
+}
+
+func copyFileNoFollow(src, dst string, perm os.FileMode) error {
+	if info, err := os.Lstat(dst); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("destination %s is a symlink", dst)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return copyFile(src, dst, perm)
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	if perm == 0 {
+		perm = 0o644
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(dst, perm)
+}
+
+func (b *backend) cleanupGuest(leaseID string) {
+	guest, err := b.guestRootPath(leaseID)
+	if err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: wasi cleanup lease=%s: %v\n", leaseID, err)
+		return
+	}
+	if err := os.RemoveAll(guest); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(b.rt.Stderr, "warning: wasi cleanup guest %s: %v\n", guest, err)
+	}
+}
+
+func (b *backend) executeCommand(ctx context.Context, guestRoot string, req RunRequest, command []string) (int, time.Duration, error) {
+	start := b.now()
+	cmd0 := command[0]
+
+	if isWasiModuleCommand(cmd0) {
+		runtime, err := normalizeWasiRuntime(b.cfg.Wasi.Runtime)
+		if err != nil {
+			return 1, b.now().Sub(start), err
+		}
+		wasmPath, err := b.resolveWasmHostPath(guestRoot, cmd0)
+		if err != nil {
+			return 1, b.now().Sub(start), err
+		}
+		if strings.HasSuffix(strings.ToLower(cmd0), ".cwasm") && runtime != "wasmtime" {
+			return 1, b.now().Sub(start), exit(2, "wasi: .cwasm modules require --wasi-runtime wasmtime")
+		}
+		if runtime == "wasmtime" {
+			if bin, err := exec.LookPath("wasmtime"); err == nil {
+				wasmtimeCommand := append([]string{wasmPath}, command[1:]...)
+				return b.runWithWasmtimeCLI(ctx, bin, guestRoot, wasmtimeCommand, req.Env)
+			}
+			if strings.HasSuffix(strings.ToLower(cmd0), ".cwasm") {
+				return 1, b.now().Sub(start), exit(2, "wasi: wasmtime runtime requested but wasmtime was not found in PATH")
+			}
+			fmt.Fprintln(b.rt.Stderr, "warning: wasmtime not found in PATH; falling back to wazero")
+		}
+		data, err := os.ReadFile(wasmPath)
+		if err != nil {
+			return 1, b.now().Sub(start), exit(2, "read wasm %s: %v", wasmPath, err)
+		}
+		exitCode, err := b.runWithWazero(ctx, data, command[1:], req.Env, guestRoot)
+		return exitCode, b.now().Sub(start), err
+	}
+
+	// Builtins (host side, operating on guest tree for ls/cat)
+	switch cmd0 {
+	case "echo":
+		fmt.Fprintln(b.rt.Stdout, strings.Join(command[1:], " "))
+		return 0, b.now().Sub(start), nil
+	case "true":
+		return 0, b.now().Sub(start), nil
+	case "false":
+		return 1, b.now().Sub(start), nil
+	case "ls":
+		dir, err := b.resolveExistingGuestPath(guestRoot, ".")
+		if err != nil {
+			return 1, b.now().Sub(start), err
+		}
+		if len(command) > 1 {
+			dir, err = b.resolveExistingGuestPath(guestRoot, command[1])
+			if err != nil {
+				return 1, b.now().Sub(start), err
+			}
+		}
+		ents, err := os.ReadDir(dir)
+		if err != nil {
+			return 1, b.now().Sub(start), err
+		}
+		for _, e := range ents {
+			fmt.Fprintln(b.rt.Stdout, e.Name())
+		}
+		return 0, b.now().Sub(start), nil
+	case "cat":
+		if len(command) < 2 {
+			return 1, b.now().Sub(start), exit(2, "cat: missing file")
+		}
+		for _, arg := range command[1:] {
+			p, err := b.resolveExistingGuestPath(guestRoot, arg)
+			if err != nil {
+				return 1, b.now().Sub(start), err
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return 1, b.now().Sub(start), err
+			}
+			if _, err := b.rt.Stdout.Write(data); err != nil {
+				return 1, b.now().Sub(start), err
+			}
+		}
+		return 0, b.now().Sub(start), nil
+	default:
+		return 1, b.now().Sub(start), exit(2, "wasi: unsupported command %q (expected .wasm module or echo/true/false/ls/cat). Compile your code to wasm32-wasi.", cmd0)
+	}
+}
+
+func (b *backend) runWithWazero(ctx context.Context, wasmBytes []byte, args []string, env map[string]string, guestRoot string) (int, error) {
+	rt := wazero.NewRuntime(ctx)
+	defer rt.Close(ctx)
+
+	wasi_snapshot_preview1.MustInstantiate(ctx, rt)
+
+	guestWork, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return 1, err
+	}
+	fsConfig := wazero.NewFSConfig().WithDirMount(guestWork, "/work")
+
+	mc := wazero.NewModuleConfig().
+		WithFSConfig(fsConfig).
+		WithArgs(append([]string{"wasi"}, args...)...).
+		WithStdout(b.rt.Stdout).
+		WithStderr(b.rt.Stderr)
+
+	for k, v := range env {
+		mc = mc.WithEnv(k, v)
+	}
+
+	mod, err := rt.CompileModule(ctx, wasmBytes)
+	if err != nil {
+		return 1, exit(2, "compile wasm: %v", err)
+	}
+
+	_, err = rt.InstantiateModule(ctx, mod, mc)
+	if err != nil {
+		if exitErr, ok := err.(*sys.ExitError); ok {
+			return int(exitErr.ExitCode()), nil
+		}
+		return 1, exit(1, "wasi run: %v", err)
+	}
+	return 0, nil
+}
+
+func (b *backend) runWithWasmtimeCLI(ctx context.Context, wasmtimeBin, guestRoot string, command []string, env map[string]string) (int, time.Duration, error) {
+	start := b.now()
+	guestWork, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return 1, b.now().Sub(start), err
+	}
+
+	args, childEnv := buildWasmtimeRunArgsAndEnv(guestWork, command, env)
+
+	if b.rt.Exec == nil {
+		// default should be set by provider backend, but be explicit
+		return 1, b.now().Sub(start), exit(2, "wasi: no Exec runner available for wasmtime")
+	}
+
+	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   wasmtimeBin,
+		Args:   args,
+		Env:    childEnv,
+		Dir:    guestWork,
+		Stdout: b.rt.Stdout,
+		Stderr: b.rt.Stderr,
+	})
+	dur := b.now().Sub(start)
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), dur, nil
+		}
+		return result.ExitCode, dur, runErr
+	}
+	return result.ExitCode, dur, nil
+}
+
+// buildWasmtimeRunArgsAndEnv constructs the argv and child environment for
+// invoking the wasmtime CLI such that:
+//   - No secret *values* ever appear in the wasmtime process argv (only bare
+//     `--env KEY` names).
+//   - The child env for the wasmtime subprocess is restricted to a minimal set
+//     of runtime variables (PATH, HOME, etc.) plus exactly the explicitly allowed
+//     values from the request. Unrelated ambient host env (tokens, config, etc.)
+//     are not present. This keeps the trust boundary narrow for the wasmtime
+//     execution path.
+//   - wasmtime's bare `--env KEY` (listed only for allowed keys) will inherit
+//     the value from its (restricted) environment and expose it to the guest.
+//   - Only the keys we list with `--env` reach the guest.
+//
+// This keeps ambient host state out of the wasmtime subprocess: a full
+// os.Environ would otherwise expose unrelated host variables to the guest.
+func buildWasmtimeRunArgsAndEnv(guestWork string, command []string, env map[string]string) (args []string, childEnv []string) {
+	args = []string{"run", "--dir", "/work::" + guestWork}
+	if len(env) > 0 {
+		// Bare names only in argv. Values come from childEnv below.
+		envKeys := make([]string, 0, len(env))
+		for k := range env {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		for _, k := range envKeys {
+			args = append(args, "--env", k)
+		}
+	}
+	args = append(args, command...)
+
+	// Build restricted child env: only a small set of runtime essentials that
+	// wasmtime (and basic subprocess execution) may need, plus the explicitly
+	// allowed values. No full os.Environ() ambient leak.
+	// Deterministic order via sorted keys.
+	runtimeBase := map[string]bool{
+		"PATH": true, "HOME": true, "USER": true, "LOGNAME": true,
+		"SHELL": true, "TERM": true, "LANG": true, "LC_ALL": true,
+		"TMPDIR": true, "TEMP": true, "TMP": true,
+	}
+	childEnvMap := map[string]string{}
+	for _, e := range os.Environ() {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			if runtimeBase[k] {
+				childEnvMap[k] = v
+			}
+		}
+	}
+	for k, v := range env {
+		childEnvMap[k] = v
+	}
+	keys := make([]string, 0, len(childEnvMap))
+	for k := range childEnvMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	childEnv = make([]string, 0, len(childEnvMap))
+	for _, k := range keys {
+		childEnv = append(childEnv, k+"="+childEnvMap[k])
+	}
+	return args, childEnv
+}
+
+func isPureNoFSBuiltin(command []string) bool {
+	if len(command) == 0 {
+		return false
+	}
+	switch command[0] {
+	case "echo", "true", "false":
+		return true
+	default:
+		return false
+	}
+}
+
+func isWasiModuleCommand(command string) bool {
+	lower := strings.ToLower(command)
+	return strings.HasSuffix(lower, ".wasm") || strings.HasSuffix(lower, ".cwasm")
+}
+
+func cleanWasiWorkdir(value string) (string, error) {
+	workdir := strings.TrimSpace(value)
+	if workdir == "" {
+		return defaultWasiWorkdir, nil
+	}
+	clean := filepath.ToSlash(filepath.Clean(workdir))
+	if clean == "." || strings.HasPrefix(clean, "/") || clean == ".." || strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") {
+		return "", exit(2, "wasi workdir %q must be a relative path below the guest root", value)
+	}
+	for _, part := range strings.Split(clean, "/") {
+		if part == "" || part == "." || part == ".." {
+			return "", exit(2, "wasi workdir %q must be a relative path below the guest root", value)
+		}
+	}
+	return filepath.FromSlash(clean), nil
+}
+
+func normalizeWasiRuntime(value string) (string, error) {
+	runtime := strings.ToLower(strings.TrimSpace(value))
+	if runtime == "" {
+		return defaultWasiRuntime, nil
+	}
+	switch runtime {
+	case "wazero", "wasmtime":
+		return runtime, nil
+	default:
+		return "", exit(2, "unsupported wasi runtime %q (expected wazero or wasmtime)", value)
+	}
+}
+
+func (b *backend) guestWorkdirPath(guestRoot string) (string, error) {
+	workdir, err := cleanWasiWorkdir(b.cfg.Wasi.Workdir)
+	if err != nil {
+		return "", err
+	}
+	target := filepath.Join(guestRoot, workdir)
+	if !pathWithin(guestRoot, target) {
+		return "", exit(2, "wasi workdir %q escapes guest root", b.cfg.Wasi.Workdir)
+	}
+	return target, nil
+}
+
+func (b *backend) resolveWasmHostPath(guestRoot, command string) (string, error) {
+	slashCommand := filepath.ToSlash(command)
+	if slashCommand == "/work" || strings.HasPrefix(slashCommand, "/work/") {
+		return b.resolveExistingGuestPath(guestRoot, slashCommand)
+	}
+	if filepath.IsAbs(command) {
+		return command, nil
+	}
+	return b.resolveExistingGuestPath(guestRoot, command)
+}
+
+func (b *backend) resolveExistingGuestPath(guestRoot, guestPath string) (string, error) {
+	target, err := b.resolveGuestPath(guestRoot, guestPath)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", err
+	}
+	workdir, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return "", err
+	}
+	resolvedWorkdir, err := filepath.EvalSymlinks(workdir)
+	if err != nil {
+		return "", err
+	}
+	if !pathWithin(resolvedWorkdir, resolved) {
+		return "", exit(2, "wasi path %q resolves outside /work", guestPath)
+	}
+	return resolved, nil
+}
+
+func (b *backend) resolveGuestPath(guestRoot, guestPath string) (string, error) {
+	workdir, err := b.guestWorkdirPath(guestRoot)
+	if err != nil {
+		return "", err
+	}
+	arg := filepath.ToSlash(strings.TrimSpace(guestPath))
+	if arg == "" {
+		arg = "."
+	}
+	var rel string
+	switch {
+	case arg == "/work":
+		rel = "."
+	case strings.HasPrefix(arg, "/work/"):
+		rel = strings.TrimPrefix(arg, "/work/")
+	case strings.HasPrefix(arg, "/"):
+		return "", exit(2, "wasi path %q is outside /work", guestPath)
+	default:
+		rel = arg
+	}
+	clean := path.Clean(rel)
+	if clean == "." {
+		return workdir, nil
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", exit(2, "wasi path %q is outside /work", guestPath)
+	}
+	target := filepath.Join(workdir, filepath.FromSlash(clean))
+	if !pathWithin(workdir, target) {
+		return "", exit(2, "wasi path %q is outside /work", guestPath)
+	}
+	return target, nil
+}
+
+func joinUnder(root, rel string) (string, error) {
+	clean := path.Clean(filepath.ToSlash(rel))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || strings.HasPrefix(clean, "/") {
+		return "", fmt.Errorf("unsafe relative path %q", rel)
+	}
+	target := filepath.Join(root, filepath.FromSlash(clean))
+	if !pathWithin(root, target) {
+		return "", fmt.Errorf("path %q escapes %s", rel, root)
+	}
+	return target, nil
+}
+
+func resolveRepoSymlink(repoRoot, src string) (string, os.FileInfo, error) {
+	resolved, err := filepath.EvalSymlinks(src)
+	if err != nil {
+		return "", nil, err
+	}
+	resolvedRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		return "", nil, err
+	}
+	if !pathWithin(resolvedRepoRoot, resolved) {
+		return "", nil, fmt.Errorf("symlink target %s is outside repo root", resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", nil, err
+	}
+	return resolved, info, nil
+}
+
+func pathWithin(root, candidate string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	candidateAbs, err := filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, candidateAbs)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+func wasiCleanupCommand(leaseID string) string {
+	return fmt.Sprintf("crabbox stop --provider %s %s", providerName, shellQuote(leaseID))
+}
+
+func wasiClaimToServer(claim LeaseClaim, state string) Server {
+	labels := map[string]string{
+		"provider": providerName,
+		"lease":    claim.LeaseID,
+		"slug":     blank(claim.Slug, claim.LeaseID),
+		"target":   targetLinux,
+		"state":    state,
+	}
+	server := Server{
+		Provider: providerName,
+		CloudID:  claim.LeaseID,
+		Name:     blank(claim.Slug, claim.LeaseID),
+		Status:   state,
+		Labels:   labels,
+	}
+	server.ServerType.Name = providerName
+	return server
+}
+
+func wasiStatusView(claim LeaseClaim, state string) StatusView {
+	server := wasiClaimToServer(claim, state)
+	return StatusView{
+		ID:         claim.LeaseID,
+		Slug:       claim.Slug,
+		Provider:   providerName,
+		TargetOS:   targetLinux,
+		State:      state,
+		ServerID:   server.CloudID,
+		ServerType: server.ServerType.Name,
+		Labels:     server.Labels,
+		Ready:      state == "ready",
+	}
+}

--- a/internal/providers/wasi/backend_test.go
+++ b/internal/providers/wasi/backend_test.go
@@ -1,0 +1,700 @@
+package wasi
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestWasiProviderRegistration(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("name=%s want=%s", p.Name(), providerName)
+	}
+	if len(p.Aliases()) == 0 {
+		t.Fatal("expected aliases")
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%s want delegated-run", spec.Kind)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) {
+		t.Fatal("expected FeatureArchiveSync")
+	}
+	if !spec.Features.Has(core.FeatureRunSession) || !spec.Features.Has(core.FeatureRunProof) {
+		t.Fatal("expected run-session and run-proof features")
+	}
+}
+
+func TestWasiFlagsAndApply(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	v := RegisterWasiProviderFlags(fs, core.Config{})
+	if v == nil {
+		t.Fatal("flags value nil")
+	}
+	cfg := &core.Config{}
+	if err := ApplyWasiProviderFlags(cfg, fs, v); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	*cfg = core.Config{Provider: providerName}
+	fs2 := flag.NewFlagSet("test2", flag.ContinueOnError)
+	classF := fs2.String("class", "", "")
+	_ = fs2.Parse([]string{"--class=foo"})
+	if *classF == "" {
+		t.Fatal("test setup")
+	}
+	if err := ApplyWasiProviderFlags(cfg, fs2, nil); err == nil {
+		t.Fatal("expected --class reject for wasi")
+	}
+	fs3 := flag.NewFlagSet("test3", flag.ContinueOnError)
+	typeF := fs3.String("type", "", "")
+	_ = fs3.Parse([]string{"--type=foo"})
+	if *typeF == "" {
+		t.Fatal("test setup")
+	}
+	if err := ApplyWasiProviderFlags(cfg, fs3, nil); err == nil {
+		t.Fatal("expected --type reject for wasi")
+	}
+
+	// Aliases must also reject (Apply may see cfg.Provider as alias before canonicalization).
+	for _, alias := range []string{"wasm", "wazero"} {
+		cfgA := &core.Config{Provider: alias}
+		fsA := flag.NewFlagSet("alias-class", flag.ContinueOnError)
+		_ = fsA.String("class", "", "")
+		_ = fsA.Parse([]string{"--class=foo"})
+		if err := ApplyWasiProviderFlags(cfgA, fsA, nil); err == nil {
+			t.Fatalf("expected --class reject for alias %s", alias)
+		}
+		fsT := flag.NewFlagSet("alias-type", flag.ContinueOnError)
+		_ = fsT.String("type", "", "")
+		_ = fsT.Parse([]string{"--type=foo"})
+		if err := ApplyWasiProviderFlags(cfgA, fsT, nil); err == nil {
+			t.Fatalf("expected --type reject for alias %s", alias)
+		}
+	}
+}
+
+func TestWasiBackendBasics(t *testing.T) {
+	spec := core.ProviderSpec{Name: providerName, Kind: core.ProviderKindDelegatedRun, Features: core.FeatureSet{core.FeatureArchiveSync}}
+	b := NewBackend(spec, core.Config{}, core.Runtime{}).(interface {
+		Spec() core.ProviderSpec
+	})
+	if b.Spec().Name != providerName {
+		t.Fatal("backend spec name")
+	}
+	if d, ok := b.(core.DoctorBackend); ok {
+		res, _ := d.Doctor(context.Background(), core.DoctorRequest{})
+		if res.Provider != providerName {
+			t.Fatal("doctor provider")
+		}
+	}
+}
+
+func TestWasiPureBuiltinSkipsSync(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	root := t.TempDir()
+
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: root, Name: "repo"},
+		Command: []string{"echo", "ok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d", result.ExitCode)
+	}
+	if strings.TrimSpace(stdout.String()) != "ok" {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "sync_skipped=true") {
+		t.Fatalf("stderr missing sync skip: %q", stderr.String())
+	}
+}
+
+func TestWasiRunWazeroModuleWithSyncedWorkdir(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	module := buildWasip1Module(t, `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	data, err := os.ReadFile("/work/input.txt")
+	if err != nil {
+		fmt.Printf("read=%v\n", err)
+		os.Exit(3)
+	}
+	fmt.Printf("args=%s,%s env=%s file=%s", os.Args[1], os.Args[2], os.Getenv("CRABBOX_WASI_TEST"), string(data))
+}
+`)
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "input.txt"), "hello from sync")
+	gitInit(t, root)
+
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{
+		Wasi: core.WasiConfig{GuestBaseDir: t.TempDir()},
+	}, &stdout, &stderr)
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: root, Name: "repo"},
+		Keep:    true,
+		Command: []string{module, "one", "two"},
+		Env:     map[string]string{"CRABBOX_WASI_TEST": "yes"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d", result.ExitCode)
+	}
+	want := "args=one,two env=yes file=hello from sync"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout=%q want %q stderr=%q", got, want, stderr.String())
+	}
+	if result.Session == nil || !result.Session.Kept || result.Session.Provider != providerName {
+		t.Fatalf("session=%#v", result.Session)
+	}
+}
+
+func TestWasiBuiltinsRejectGuestPathEscapes(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	guestRoot := t.TempDir()
+	workdir := filepath.Join(guestRoot, defaultWasiWorkdir)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(workdir, "inside.txt"), "inside")
+	writeFile(t, filepath.Join(guestRoot, "secret.txt"), "secret")
+
+	for _, command := range [][]string{
+		{"cat", "../secret.txt"},
+		{"cat", "/etc/passwd"},
+		{"ls", ".."},
+	} {
+		t.Run(strings.Join(command, "_"), func(t *testing.T) {
+			code, _, err := backend.executeCommand(context.Background(), guestRoot, core.RunRequest{}, command)
+			if err == nil || !strings.Contains(err.Error(), "outside /work") {
+				t.Fatalf("code=%d err=%v, want outside /work rejection", code, err)
+			}
+		})
+	}
+}
+
+func TestWasiBuiltinsRejectSymlinkEscapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	guestRoot := t.TempDir()
+	workdir := filepath.Join(guestRoot, defaultWasiWorkdir)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	writeFile(t, outside, "secret")
+	if err := os.Symlink(outside, filepath.Join(workdir, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, err := backend.executeCommand(context.Background(), guestRoot, core.RunRequest{}, []string{"cat", "link.txt"})
+	if err == nil || !strings.Contains(err.Error(), "resolves outside /work") {
+		t.Fatalf("code=%d err=%v, want symlink escape rejection", code, err)
+	}
+}
+
+func TestWasiCopyManifestRejectsRepoSymlinkEscapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	writeFile(t, outside, "secret")
+	if err := os.Symlink(outside, filepath.Join(repo, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.copyManifestToGuest(repo, t.TempDir(), core.SyncManifest{Files: []string{"link.txt"}})
+	if err == nil || !strings.Contains(err.Error(), "outside repo root") {
+		t.Fatalf("err=%v, want symlink escape rejection", err)
+	}
+}
+
+func TestWasiCopyManifestPreservesSymlinksWithoutLeakingIgnoredTargets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	repo := t.TempDir()
+	// secret is "excluded" (not listed in manifest)
+	secret := filepath.Join(repo, "secret.txt")
+	writeFile(t, secret, "VERYSECRET")
+	// symlink to secret; the *link path* is included in manifest (passes exclude)
+	link := filepath.Join(repo, "link-to-secret.txt")
+	if err := os.Symlink("secret.txt", link); err != nil {
+		t.Fatal(err)
+	}
+	// manifest only includes the link (secret excluded)
+	manifest := core.SyncManifest{Files: []string{"link-to-secret.txt"}}
+	guestRoot := t.TempDir()
+	if err := backend.copyManifestToGuest(repo, guestRoot, manifest); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	// guest tree has default workdir "crabbox" subdir
+	guestWork := filepath.Join(guestRoot, "crabbox")
+	linkInGuest := filepath.Join(guestWork, "link-to-secret.txt")
+	fi, err := os.Lstat(linkInGuest)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink at link-to-secret.txt, got mode %v", fi.Mode())
+	}
+	// no leak: reading the link should fail (target not present in guest)
+	if _, err := os.ReadFile(linkInGuest); err == nil {
+		t.Fatal("expected error reading via symlink to excluded target (leak of secret content)")
+	}
+}
+
+func TestWasiCopyManifestRejectsGuestSymlinkDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "file.txt"), "safe")
+	guestRoot := t.TempDir()
+	workdir := filepath.Join(guestRoot, defaultWasiWorkdir)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	writeFile(t, outside, "secret")
+	if err := os.Symlink(outside, filepath.Join(workdir, "file.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.copyManifestToGuest(repo, guestRoot, core.SyncManifest{Files: []string{"file.txt"}})
+	if err == nil || !strings.Contains(err.Error(), "destination") || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err=%v, want symlink destination rejection", err)
+	}
+}
+
+func TestWasiCopyManifestRejectsGuestSymlinkParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "dir", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(repo, "dir", "sub", "file.txt"), "safe")
+	guestRoot := t.TempDir()
+	workdir := filepath.Join(guestRoot, defaultWasiWorkdir)
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workdir, "dir")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.copyManifestToGuest(repo, guestRoot, core.SyncManifest{Files: []string{"dir/sub/file.txt"}})
+	if err == nil || !strings.Contains(err.Error(), "destination") || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err=%v, want symlink parent rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "sub")); !os.IsNotExist(err) {
+		t.Fatalf("symlink parent was followed before rejection; outside/sub stat err=%v", err)
+	}
+}
+
+func TestWasiCopyManifestRejectsSymlinkedGuestRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "file.txt"), "safe")
+
+	// A reused guest root that has been replaced with a symlink pointing at a
+	// host directory must be rejected before any workdir mkdir/copy follows it.
+	outside := t.TempDir()
+	guestRoot := filepath.Join(t.TempDir(), "guest")
+	if err := os.Symlink(outside, guestRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.copyManifestToGuest(repo, guestRoot, core.SyncManifest{Files: []string{"file.txt"}})
+	if err == nil || !strings.Contains(err.Error(), "guest root") || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err=%v, want symlinked guest root rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, defaultWasiWorkdir)); !os.IsNotExist(err) {
+		t.Fatalf("symlinked guest root was followed before rejection; outside/%s stat err=%v", defaultWasiWorkdir, err)
+	}
+}
+
+func TestWasiRemoveAllNoFollowRejectsSymlinkedWorkdirParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires extra privileges on some Windows hosts")
+	}
+	guestRoot := t.TempDir()
+	// Host directory whose contents must survive a delete-sync reset.
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "keep.txt"), "host-secret")
+	// Kept/tampered guest: an intermediate workdir parent is a symlink to the
+	// host directory, and the configured workdir nests below it.
+	if err := os.Symlink(outside, filepath.Join(guestRoot, "work")); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(guestRoot, "work", "sub")
+
+	err := removeAllNoFollow(guestRoot, target)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err=%v, want symlinked component rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "keep.txt")); err != nil {
+		t.Fatalf("host file deleted through symlinked workdir parent: %v", err)
+	}
+}
+
+func TestWasiRemoveAllNoFollowRemovesRealWorkdir(t *testing.T) {
+	guestRoot := t.TempDir()
+	target := filepath.Join(guestRoot, defaultWasiWorkdir)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(target, "stale.txt"), "old")
+
+	if err := removeAllNoFollow(guestRoot, target); err != nil {
+		t.Fatalf("removeAllNoFollow on real workdir: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("real workdir was not removed; stat err=%v", err)
+	}
+	// Removing a non-existent target is a no-op, not an error.
+	if err := removeAllNoFollow(guestRoot, target); err != nil {
+		t.Fatalf("removeAllNoFollow on missing target: %v", err)
+	}
+}
+
+func TestWasiWorkdirRejectsEscapes(t *testing.T) {
+	for _, workdir := range []string{"/work", "/etc", "../etc", "repo/../../../etc", ".", "./.."} {
+		t.Run(workdir, func(t *testing.T) {
+			if got, err := cleanWasiWorkdir(workdir); err == nil {
+				t.Fatalf("workdir=%q, want error for %q", got, workdir)
+			}
+		})
+	}
+}
+
+func TestWasiCleanupCommandQuotesLeaseID(t *testing.T) {
+	got := wasiCleanupCommand("cbx_abc;touch")
+	if got != "crabbox stop --provider wasi 'cbx_abc;touch'" {
+		t.Fatalf("cleanup command=%q", got)
+	}
+}
+
+func TestWasiListStatusAndDoctorUseLocalClaims(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+	root := t.TempDir()
+
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: root, Name: "repo"},
+		Keep:          true,
+		RequestedSlug: "wasi-proof",
+		Command:       []string{"echo", "ok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leases, err := backend.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 || leases[0].CloudID != result.LeaseID || leases[0].Labels["slug"] != "wasi-proof" || leases[0].Status != "ready" {
+		t.Fatalf("leases=%#v result=%#v", leases, result)
+	}
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: "wasi-proof"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ID != result.LeaseID || status.Slug != "wasi-proof" || !status.Ready || status.Provider != providerName {
+		t.Fatalf("status=%#v result=%#v", status, result)
+	}
+	doctor, err := backend.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(doctor.Message, "leases=1") {
+		t.Fatalf("doctor=%#v", doctor)
+	}
+}
+
+func TestWasiStatusAndStopRequireKnownClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{}, &stdout, &stderr)
+
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: "missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ID != "missing" || status.State != "not-found" {
+		t.Fatalf("status=%#v", status)
+	}
+	err = backend.Stop(context.Background(), core.StopRequest{ID: "missing"})
+	if err == nil || !strings.Contains(err.Error(), "was not found") {
+		t.Fatalf("Stop err=%v, want not found", err)
+	}
+}
+
+func TestWasiGuestRootPathDefaultsToTempDir(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	b, ok := NewBackend(Provider{}.Spec(), core.Config{}, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*backend)
+	if !ok {
+		t.Fatal("backend type mismatch")
+	}
+	guest, err := b.guestRootPath("lease")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(guest) != filepath.Clean(os.TempDir()) {
+		t.Fatalf("guest=%q, want under %q", guest, os.TempDir())
+	}
+}
+
+func TestWasiPrepareGuestRejectsRelativeGuestBase(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{
+		Wasi: core.WasiConfig{GuestBaseDir: "guest-roots"},
+	}, &stdout, &stderr)
+	_, _, err := backend.prepareGuest(context.Background(), repo, "lease", false, false)
+	if err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("err=%v, want absolute path rejection", err)
+	}
+}
+
+func TestWasiPrepareGuestRejectsGuestRootInsideRepo(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "input.txt"), "data")
+	gitInit(t, repo)
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{
+		Wasi: core.WasiConfig{GuestBaseDir: filepath.Join(repo, "guest-roots")},
+	}, &stdout, &stderr)
+	_, _, err := backend.prepareGuest(context.Background(), repo, "lease", false, false)
+	if err == nil || !strings.Contains(err.Error(), "overlaps repo root") {
+		t.Fatalf("err=%v, want overlap rejection", err)
+	}
+	// The rejection must land before any host-side write: an in-repo guest
+	// root would otherwise enter later sync manifests and pollute /work.
+	if _, statErr := os.Stat(filepath.Join(repo, "guest-roots")); !os.IsNotExist(statErr) {
+		t.Fatalf("guest root was created inside the repo: stat err=%v", statErr)
+	}
+}
+
+func TestWasiPrepareGuestRejectsRepoInsideGuestRoot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	base := t.TempDir()
+	repo := filepath.Join(base, "crabbox-wasi-lease", "checkout")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	backend := newTestBackend(t, core.Config{
+		Wasi: core.WasiConfig{GuestBaseDir: base},
+	}, &stdout, &stderr)
+	_, _, err := backend.prepareGuest(context.Background(), repo, "lease", false, false)
+	if err == nil || !strings.Contains(err.Error(), "overlaps repo root") {
+		t.Fatalf("err=%v, want overlap rejection", err)
+	}
+}
+
+func newTestBackend(t *testing.T, cfg core.Config, stdout, stderr io.Writer) *backend {
+	t.Helper()
+	if cfg.Wasi.GuestBaseDir == "" {
+		cfg.Wasi.GuestBaseDir = t.TempDir()
+	}
+	rt := core.Runtime{
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	if rt.Exec == nil {
+		rt.Exec = core.NewExecCommandRunner()
+	}
+	b, ok := NewBackend(Provider{}.Spec(), cfg, rt).(*backend)
+	if !ok {
+		t.Fatal("backend type mismatch")
+	}
+	return b
+}
+
+func buildWasip1Module(t *testing.T, source string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.test/wasi\n")
+	writeFile(t, filepath.Join(dir, "main.go"), source)
+	outPath := filepath.Join(dir, "main.wasm")
+	cmd := exec.Command("go", "build", "-trimpath", "-o", outPath, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm", "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build wasip1 module: %v\n%s", err, out)
+	}
+	return outPath
+}
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Concise unit tests for cases previously only in the (now trimmed for conciseness) E2E.
+// These do not require full git sync flows or real module execution.
+
+func TestWasiWarmupRejectsActionsRunner(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	b := newTestBackend(t, core.Config{}, &bytes.Buffer{}, &bytes.Buffer{})
+	err := b.Warmup(context.Background(), core.WarmupRequest{
+		Repo: core.Repo{Root: t.TempDir(), Name: "r"}, ActionsRunner: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "actions-runner") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWasiConfigureRejectsBadRuntime(t *testing.T) {
+	_, err := (Provider{}).Configure(core.Config{Wasi: core.WasiConfig{Runtime: "bad"}}, core.Runtime{})
+	if err == nil {
+		t.Fatal("want configure error")
+	}
+}
+
+// Test that the wasmtime invocation construction never puts secret *values*
+// into the argv (only bare --env KEY names). Values live only in the returned
+// child env. This is the key security property for --allow-env + wasmtime.
+func TestWasiWasmtimeBuildArgsNeverPutsValuesInArgv(t *testing.T) {
+	// Set an unrelated host env var. It must be absent from childEnv (the
+	// wasmtime subprocess must not inherit ambient host state beyond the
+	// explicit allow-list + minimal runtime base). This is the key regression
+	// for the wasmtime child-env P1.
+	t.Setenv("CRABBOX_TEST_UNRELATED_HOST_VAR", "must-not-leak-to-wasmtime")
+
+	args, childEnv := buildWasmtimeRunArgsAndEnv("/guest/work", []string{"mod.wasm", "arg1"}, map[string]string{
+		"SECRET":      "s3cr3t-value",
+		"OTHER":       "public",
+		"CRABBOX_FOO": "bar",
+	})
+
+	// argv must contain bare --env KEY (no =val anywhere in args)
+	for _, a := range args {
+		if strings.Contains(a, "=") && (strings.HasPrefix(a, "SECRET=") || strings.HasPrefix(a, "s3cr3t") || strings.Contains(a, "s3cr3t-value")) {
+			t.Fatalf("secret value leaked into wasmtime argv: %q (full args=%v)", a, args)
+		}
+	}
+	// must have the bare keys
+	if !contains(args, "--env") || !contains(args, "SECRET") || !contains(args, "OTHER") {
+		t.Fatalf("expected bare --env KEY in args, got %v", args)
+	}
+
+	// child env must have the values (but not the argv)
+	envMap := envSliceToMap(childEnv)
+	if envMap["SECRET"] != "s3cr3t-value" || envMap["OTHER"] != "public" {
+		t.Fatalf("child env missing values: %v", childEnv)
+	}
+	if _, hasPath := envMap["PATH"]; !hasPath {
+		t.Fatalf("expected PATH in childEnv for wasmtime binary: %v", childEnv)
+	}
+	// argv must not have the values
+	for _, a := range args {
+		if a == "s3cr3t-value" || a == "public" {
+			t.Fatalf("value appeared in argv: %v", args)
+		}
+	}
+
+	// Unrelated host var must be absent (restriction regression).
+	if _, hasUnrel := envMap["CRABBOX_TEST_UNRELATED_HOST_VAR"]; hasUnrel {
+		t.Fatalf("unrelated host env var leaked into wasmtime childEnv: %v", childEnv)
+	}
+
+	// --dir mapping must use guest::host form with :: (not =) so the guest
+	// preopens exactly /work from the host guestWork dir. Matches wazero
+	// WithDirMount and wasmtime tutorial remap examples (e.g. --dir /var/tmp::/tmp).
+	if !contains(args, "--dir") {
+		t.Fatal("missing --dir")
+	}
+	dirMapping := ""
+	for i, a := range args {
+		if a == "--dir" && i+1 < len(args) {
+			dirMapping = args[i+1]
+			break
+		}
+	}
+	if dirMapping != "/work::/guest/work" {
+		t.Fatalf("bad --dir mapping %q, want /work::/guest/work (guest::host with ::)", dirMapping)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envSliceToMap(env []string) map[string]string {
+	m := map[string]string{}
+	for _, e := range env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			m[k] = v
+		}
+	}
+	return m
+}

--- a/internal/providers/wasi/core.go
+++ b/internal/providers/wasi/core.go
@@ -1,0 +1,113 @@
+package wasi
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type WasiConfig = core.WasiConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type LeaseClaim = core.LeaseClaim
+type SyncManifest = core.SyncManifest
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+type RunSessionHandle = core.RunSessionHandle
+
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type CommandRunner = core.CommandRunner
+
+const (
+	providerName = "wasi"
+	targetLinux  = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, nil)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idle time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idle, reclaim)
+}
+
+func resolveLeaseClaimForProvider(idOrSlug, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(idOrSlug, provider)
+}
+
+func listLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaims()
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func writeTimingJSON(w io.Writer, r timingReport) error {
+	return core.WriteTimingJSON(w, core.TimingReport(r))
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idle, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idle, ttl, acquired, shouldStop)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+func nowFrom(rt Runtime) time.Time {
+	if rt.Clock != nil {
+		return rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/wasi/e2e_test.go
+++ b/internal/providers/wasi/e2e_test.go
@@ -1,0 +1,317 @@
+package wasi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestWasiE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("E2E skipped in -short mode")
+	}
+	module := buildWasip1Module(t, `package main
+
+import ("fmt"; "os")
+
+func main() {
+	b, _ := os.ReadFile("/work/input.txt")
+	fmt.Print(string(b))
+}
+`)
+
+	// Common setup helper to keep subtests concise (addresses boilerplate duplication).
+	newWasi := func(t *testing.T) (*backend, *bytes.Buffer, context.Context) {
+		t.Helper()
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		out := &bytes.Buffer{}
+		b := newTestBackend(t, core.Config{Wasi: core.WasiConfig{GuestBaseDir: t.TempDir()}}, out, &bytes.Buffer{})
+		return b, out, context.Background()
+	}
+
+	t.Run("agent_flow", func(t *testing.T) {
+		b, out, ctx := newWasi(t)
+		repo := initRepo(t, "v1")
+		slug := "agent"
+		req := func(cmd []string) core.RunRequest {
+			return core.RunRequest{Repo: core.Repo{Root: repo, Name: "r"}, ID: slug, Keep: true, Command: cmd}
+		}
+
+		if err := b.Warmup(ctx, core.WarmupRequest{Repo: req(nil).Repo, Keep: true, RequestedSlug: slug}); err != nil {
+			t.Fatal(err)
+		}
+		mustOK(t, b, ctx, req([]string{module}), out, "v1")
+		writeFile(t, filepath.Join(repo, "input.txt"), "v2")
+		mustOK(t, b, ctx, req([]string{module}), out, "v2")
+		if _, err := b.Run(ctx, req([]string{"false"})); err == nil {
+			t.Fatal("want error for false")
+		}
+		mustOK(t, b, ctx, req([]string{module}), out, "v2")
+
+		status, err := b.Status(ctx, core.StatusRequest{ID: slug})
+		if err != nil || !status.Ready {
+			t.Fatalf("status=%#v err=%v", status, err)
+		}
+		if err := b.Stop(ctx, core.StopRequest{ID: slug}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("sync_only", func(t *testing.T) {
+		b, out, ctx := newWasi(t)
+		repo := initRepo(t, "synced")
+
+		r, err := b.Run(ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, Keep: true, RequestedSlug: "sync",
+			SyncOnly: true,
+		})
+		if err != nil || r.ExitCode != 0 || !strings.Contains(out.String(), "synced ") {
+			t.Fatalf("sync-only: err=%v exit=%d out=%q", err, r.ExitCode, out.String())
+		}
+	})
+
+	t.Run("no_sync", func(t *testing.T) {
+		b, out, ctx := newWasi(t)
+		repo := initRepo(t, "old")
+		slug := "nosync"
+
+		if err := b.Warmup(ctx, core.WarmupRequest{Repo: core.Repo{Root: repo, Name: "r"}, Keep: true, RequestedSlug: slug}); err != nil {
+			t.Fatal(err)
+		}
+		mustOK(t, b, ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, ID: slug, Keep: true, Command: []string{module},
+		}, out, "old")
+
+		writeFile(t, filepath.Join(repo, "input.txt"), "new")
+		out.Reset()
+		r, err := b.Run(ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, ID: slug, Keep: true, NoSync: true,
+			Command: []string{module},
+		})
+		if err != nil || r.ExitCode != 0 || out.String() != "old" {
+			t.Fatalf("no-sync: err=%v out=%q want old", err, out.String())
+		}
+	})
+
+	t.Run("custom_workdir", func(t *testing.T) {
+		repo := t.TempDir()
+		gitInit(t, repo)
+		writeFile(t, filepath.Join(repo, "input.txt"), "pkg-data")
+		// custom workdir requires explicit cfg; use direct newTestBackend for this one
+		out := &bytes.Buffer{}
+		b := newTestBackend(t, core.Config{
+			Wasi: core.WasiConfig{GuestBaseDir: t.TempDir(), Workdir: "pkg"},
+		}, out, &bytes.Buffer{})
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		ctx := context.Background()
+
+		mustOK(t, b, ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, Keep: true, Command: []string{module},
+		}, out, "pkg-data")
+	})
+
+	t.Run("builtins_ls_cat", func(t *testing.T) {
+		b, out, ctx := newWasi(t)
+		repo := initRepo(t, "seen")
+		slug := "ls"
+
+		if err := b.Warmup(ctx, core.WarmupRequest{Repo: core.Repo{Root: repo, Name: "r"}, Keep: true, RequestedSlug: slug}); err != nil {
+			t.Fatal(err)
+		}
+		req := core.RunRequest{Repo: core.Repo{Root: repo, Name: "r"}, ID: slug, Keep: true, Command: []string{"ls"}}
+		if _, err := b.Run(ctx, req); err != nil {
+			t.Fatalf("ls: %v", err)
+		}
+		if !strings.Contains(out.String(), "input.txt") {
+			t.Fatalf("ls out=%q", out.String())
+		}
+		out.Reset()
+		req.Command = []string{"cat", "input.txt"}
+		if _, err := b.Run(ctx, req); err != nil {
+			t.Fatalf("cat: %v", err)
+		}
+		if out.String() != "seen" {
+			t.Fatalf("cat out=%q", out.String())
+		}
+	})
+
+	t.Run("wasm_relative_in_repo", func(t *testing.T) {
+		b, out, ctx := newWasi(t)
+		repo := initRepo(t, "rel")
+		dst := filepath.Join(repo, "tool.wasm")
+		if err := copyFile(module, dst, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mustOK(t, b, ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, Keep: true, Command: []string{"tool.wasm"},
+		}, out, "rel")
+	})
+
+	t.Run("timing_json", func(t *testing.T) {
+		// keep this one for now (uses special errOut); can be moved to unit later for more conciseness
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		repo := initRepo(t, "t")
+		errOut := &bytes.Buffer{}
+		b := newTestBackend(t, core.Config{Wasi: core.WasiConfig{GuestBaseDir: t.TempDir()}}, &bytes.Buffer{}, errOut)
+		ctx := context.Background()
+
+		_, err := b.Run(ctx, core.RunRequest{
+			Repo: core.Repo{Root: repo, Name: "r"}, Command: []string{"false"},
+			TimingJSON: true,
+		})
+		if err == nil {
+			t.Fatal("want exit error")
+		}
+		var report timingReport
+		if !parseTimingJSON(t, errOut.String(), &report) {
+			t.Fatalf("no timing json: %q", errOut.String())
+		}
+		if report.Provider != providerName || report.ExitCode != 1 {
+			t.Fatalf("report=%#v", report)
+		}
+	})
+
+	t.Run("wasmtime_runtime", func(t *testing.T) {
+		if _, err := exec.LookPath("wasmtime"); err != nil {
+			t.Skip("wasmtime not in PATH")
+		}
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		repo := initRepo(t, "wt")
+		out := &bytes.Buffer{}
+		b := newTestBackend(t, core.Config{
+			Wasi: core.WasiConfig{GuestBaseDir: t.TempDir(), Runtime: "wasmtime"},
+		}, out, &bytes.Buffer{})
+
+		// Build a dedicated module for this subtest that also exercises env forwarding
+		// (end-to-end for the wasmtime + --allow-env / Env path, using the secure
+		// bare --env KEY + child env mechanism). The common `module` only reads a file.
+		envModule := buildWasip1Module(t, `package main
+
+import ("fmt"; "os")
+
+func main() {
+	b, _ := os.ReadFile("/work/input.txt")
+	fmt.Print(string(b))
+	if e := os.Getenv("CRABBOX_WASI_ENV_TEST"); e != "" {
+		fmt.Print(" env=" + e)
+	}
+}
+`)
+		mustOK(t, b, context.Background(), core.RunRequest{
+			Repo:    core.Repo{Root: repo, Name: "r"},
+			Command: []string{envModule},
+			Env:     map[string]string{"CRABBOX_WASI_ENV_TEST": "foo123"},
+		}, out, "wt env=foo123")
+	})
+}
+
+func TestWasiCLIE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("CLI e2e skipped in -short mode")
+	}
+	root := goModuleRoot(t)
+	bin := filepath.Join(t.TempDir(), "crabbox")
+	build := exec.Command("go", "build", "-trimpath", "-o", bin, "./cmd/crabbox")
+	build.Dir = root
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build cli: %v\n%s", err, out)
+	}
+
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "input.txt"), "cli")
+	gitInit(t, repo)
+	module := buildWasip1Module(t, `package main
+
+import ("fmt"; "os")
+
+func main() {
+	b, _ := os.ReadFile("/work/input.txt")
+	fmt.Print(string(b))
+}
+`)
+	wasm := filepath.Join(repo, "tool.wasm")
+	if err := copyFile(module, wasm, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stateHome := t.TempDir()
+	run := func(args ...string) (string, string, error) {
+		cmd := exec.Command(bin, args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "XDG_STATE_HOME="+stateHome)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		return stdout.String(), stderr.String(), err
+	}
+
+	if _, _, err := run("doctor", "--provider", "wasi", "--json"); err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if out, _, err := run("run", "--provider", "wasi", "--", "echo", "ok"); err != nil || !strings.Contains(out, "ok") {
+		t.Fatalf("echo: err=%v out=%q", err, out)
+	}
+	if _, _, err := run("warmup", "--provider", "wasi", "--slug", "cli-e2e"); err != nil {
+		t.Fatalf("warmup: %v", err)
+	}
+	if stdout, stderr, err := run("run", "--provider", "wasi", "--id", "cli-e2e", "--sync-only"); err != nil || (!strings.Contains(stdout, "synced") && !strings.Contains(stderr, "sync")) {
+		t.Fatalf("sync-only: err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if out, _, err := run("run", "--provider", "wasi", "--id", "cli-e2e", "--keep", "--", "tool.wasm"); err != nil || out != "cli" {
+		t.Fatalf("wasm: err=%v out=%q", err, out)
+	}
+	if _, _, err := run("status", "--provider", "wasi", "--id", "cli-e2e"); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if _, _, err := run("stop", "--provider", "wasi", "cli-e2e"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+func initRepo(t *testing.T, input string) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "input.txt"), input)
+	gitInit(t, repo)
+	return repo
+}
+
+func mustOK(t *testing.T, b *backend, ctx context.Context, req core.RunRequest, out *bytes.Buffer, want string) {
+	t.Helper()
+	out.Reset()
+	r, err := b.Run(ctx, req)
+	if err != nil || r.ExitCode != 0 || out.String() != want {
+		t.Fatalf("run %v: err=%v exit=%d out=%q want %q", req.Command, err, r.ExitCode, out.String(), want)
+	}
+}
+
+func parseTimingJSON(t *testing.T, stderr string, report *timingReport) bool {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(stderr), "\n") {
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), report); err != nil {
+			t.Fatalf("decode timing: %v line=%q", err, line)
+		}
+		return true
+	}
+	return false
+}
+
+func goModuleRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/openclaw/crabbox").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/providers/wasi/provider.go
+++ b/internal/providers/wasi/provider.go
@@ -1,0 +1,60 @@
+package wasi
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"wasm", "wazero"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "wasi",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession, core.FeatureRunProof},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterWasiProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyWasiProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if _, err := cleanWasiWorkdir(cfg.Wasi.Workdir); err != nil {
+		return nil, err
+	}
+	if _, err := normalizeWasiRuntime(cfg.Wasi.Runtime); err != nil {
+		return nil, err
+	}
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "wasi doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/scripts/live-doctor-smoke.sh
+++ b/scripts/live-doctor-smoke.sh
@@ -20,6 +20,7 @@ default_providers=(
   sprites
   ssh
   tensorlake
+  wasi
 )
 
 if [[ -n "${CRABBOX_LIVE_DOCTOR_PROVIDERS:-}" ]]; then

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -944,6 +944,20 @@ if has_provider morph; then
   morph_smoke
 fi
 
+# wasi is a local, zero-credential experimental provider
+wasi_smoke() {
+  run_in_repo "$cb" doctor --provider wasi --json >/dev/null
+  run_in_repo "$cb" run --provider wasi -- echo 'crabbox-wasi-live-smoke-ok'
+  run_in_repo "$cb" warmup --provider wasi --slug wasi-smoke
+  run_in_repo "$cb" run --provider wasi --id wasi-smoke --sync-only
+  run_in_repo "$cb" status --provider wasi --id wasi-smoke
+  run_in_repo "$cb" stop --provider wasi wasi-smoke
+  run_in_repo "$cb" run --provider wasi -- false || echo 'expected non-zero'
+}
+if has_provider wasi; then
+  wasi_smoke
+fi
+
 if needs_admin_audit; then
   admin_status=0
   admin_out="$(run_in_repo "$cb" admin leases --state active --json 2>&1)" || admin_status=$?


### PR DESCRIPTION
## Summary

Adds an experimental `wasi` delegated-run provider, with `wasm` and `wazero` aliases, for running WASI modules through Crabbox.

The provider uses embedded wazero by default and can use the `wasmtime` CLI when requested. It syncs the repository manifest into an isolated guest workdir, exposes that workdir to modules as `/work`, and supports `run`, `warmup`, `status`, `stop`, `list`, `doctor`, reusable run-session handles, and delegated proof output.

## Hardening in this revision

- Validates WASI workdir and runtime config from flags/config/env.
- Makes pure no-FS builtins (`echo`, `true`, `false`) actually skip manifest sync.
- Keeps host-side builtins (`ls`, `cat`) confined to `/work`, including symlink resolution checks.
- Fails sync on copy errors instead of silently producing a partial guest tree.
- Rejects repo symlinks that resolve outside the repo before copying into the guest.
- Wires `list`, `status`, and `doctor` to local lease claims.
- Removes the local PR handoff file and tightens docs to avoid unsupported capsule-specific claims.

## Verification

- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go vet ./...`
- `go test -race ./...`
- `./scripts/check-docs.sh`
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- Binary smokes:
  - `bin/crabbox providers --json` includes `wasi` with aliases `wasm`, `wazero`.
  - `bin/crabbox doctor --provider wasi --json` succeeds.
  - `bin/crabbox run --provider wasi -- echo crabbox-wasi-builtin-ok` reports `sync_skipped=true`.
  - Fresh temp repo builds a `GOOS=wasip1 GOARCH=wasm` module and runs it through `bin/crabbox run --provider wasi --allow-env CRABBOX_WASI_SMOKE -- ./main.wasm argv-ok`, proving `/work` sync, args, and explicit env forwarding.
  - `bin/crabbox run --provider wasi -- cat ../secret.txt` fails closed with an `/work` boundary error.
  - `bin/crabbox run --provider wasi --keep --slug wasi-final -- echo final-ok`, then `status`, then `stop` succeeds.

## Notes

WASI is intentionally narrow. It is useful for Wasm-native artifacts and capability-scoped execution, but not a replacement for full Linux providers when a workload needs package managers, native toolchains, SSH, browsers, or interactive services.


## Live proof (updated after symlink safety fix + tests)

Real terminal output from a wasip1 module executed via the provider (absolute .wasm path; run from a git checkout for manifest):

```
$ bin/crabbox run --provider wasi -- /tmp/.../proof.wasm agent-demo arg2
sync candidate: 603 files, 7.5 MiB
wasi sync complete in 114ms (guest=...)
running on wasi /tmp/.../proof.wasm agent-demo arg2
LIVE PROOF from WASI module: [agent-demo arg2]
Guest /work sees:
  .agents
  .crabbox.yaml
  .github
  ...
wasi run summary sync=114ms command=613ms total=838ms exit=0
```

(See also `TestWasiCopyManifestPreservesSymlinksWithoutLeakingIgnoredTargets` and the minimal-tree variant in CI logs.)

This demonstrates: module execution, arg passing, /work preopen with actual tree contents, and (via unit test) that symlinks to excluded targets no longer leak content.

