### PR TITLE
feat: add Hyper-V provider for local Windows VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added `provider: hyperv` for local Windows VM SSH leases through Microsoft Hyper-V, including differencing-disk provisioning, OpenSSH and MinGit bootstrap, password-less dev-image initialization, retained lease reuse, and cleanup. Thanks @anagnorisis2peripeteia.
+
 ### Fixed
 
 - Fixed Namespace Devbox setup instructions to use the current browser workspace approval flow instead of obsolete token environment variables.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -33,7 +33,8 @@ SSH-lease providers further differ by how they reach the cloud:
   a Docker-compatible local runtime (Docker Desktop, OrbStack, Colima),
   `apple-container` uses Apple's native `container` runtime on Apple silicon
   macOS, `multipass` launches local Ubuntu VMs through Canonical Multipass,
-  and `tart` runs macOS VMs on Apple Silicon via Cirrus Labs tart.
+  `tart` runs macOS VMs on Apple Silicon via Cirrus Labs tart, and `hyperv`
+  creates local Windows VMs through Microsoft Hyper-V.
 - **Delegated sandbox** — managed sandbox/proof runners that execute remotely
   without an SSH lease (e.g. `e2b`, `modal`, `islo`, `cloudflare`,
   `azure-dynamic-sessions`, `docker-sandbox`).
@@ -67,6 +68,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Apple Container](apple-container.md) — `apple-container` (`apple`, `applecontainer`) | Linux · local |
 | [Multipass](multipass.md) — `multipass` (`mp`, `canonical-multipass`) | Linux · local |
 | [Tart](tart.md) — `tart` (`local-tart`, `macos-vm`) | macOS · local |
+| [Hyper-V](hyperv.md) — `hyperv` | Windows · local |
 | [exe.dev](exe-dev.md) — `exe-dev` (`exe`, `exedev`) | Linux · direct |
 | [KubeVirt](kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct |
 | [External](external.md) — `external` (`exec-provider`) | Linux · direct |

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -49,6 +49,37 @@ net user Administrator /active:yes
 Then point `--hyperv-image` at the VHDX and set `--hyperv-user Administrator`
 and `CRABBOX_HYPERV_GUEST_PASSWORD=<password>`. The provider handles OpenSSH.
 
+### Password-less templates (Windows dev-environment images)
+
+Microsoft's downloadable Windows dev-environment VHDXs auto-log-on as `User`
+with **no password**, and PowerShell Direct refuses empty credentials — so a
+stock image fails the bootstrap as-is. Pass `--hyperv-init-password` to use one
+unmodified:
+
+```sh
+set CRABBOX_HYPERV_GUEST_PASSWORD=<password>
+crabbox warmup --provider hyperv --hyperv-image C:\Images\WinDev2407Eval.vhdx ^
+  --hyperv-user User --hyperv-init-password
+```
+
+Before first boot the provider mounts the per-lease differencing disk, loads
+its offline registry hive, and writes a `RunOnce` command that sets the guest
+account's password to `CRABBOX_HYPERV_GUEST_PASSWORD` at the template's
+auto-logon. Only the lease disk is modified; the template VHDX stays untouched.
+
+Notes:
+
+- Requires an explicit `CRABBOX_HYPERV_GUEST_PASSWORD` (the provider refuses
+  to stamp its default password onto a guest).
+- The password cannot contain `"` or `%` (it passes through `cmd.exe` at
+  logon).
+- This only works for templates that auto-log-on an administrator account
+  (`RunOnce` fires at logon). Templates without auto-logon need a known
+  password baked in, as above.
+- The password is briefly visible inside the guest (the `RunOnce` registry
+  value, then the `net.exe` command line at first logon). The guest belongs to
+  the lease, and the differencing disk holding it is deleted on release.
+
 ## Configuration
 
 ### Flags
@@ -62,6 +93,7 @@ and `CRABBOX_HYPERV_GUEST_PASSWORD=<password>`. The provider handles OpenSSH.
 | `--hyperv-memory` | `8192` | Memory in MB |
 | `--hyperv-disk` | `50` | Reserved; leases inherit the template's virtual size (differencing disk) |
 | `--hyperv-switch` | `Default Switch` | Hyper-V virtual switch name |
+| `--hyperv-init-password` | `false` | Set the guest password at first boot via the lease disk (password-less auto-logon templates) |
 
 ### Config file
 
@@ -75,6 +107,7 @@ hyperv:
   disk: 50
   switch: Default Switch
   guestPassword: crabbox
+  initPassword: false
 ```
 
 ### Environment variables
@@ -89,6 +122,7 @@ hyperv:
 | `CRABBOX_HYPERV_DISK` | Disk in GB |
 | `CRABBOX_HYPERV_SWITCH` | Virtual switch name |
 | `CRABBOX_HYPERV_GUEST_PASSWORD` | Guest user password for SSH key injection |
+| `CRABBOX_HYPERV_INIT_PASSWORD` | Set the guest password at first boot (`true`/`false`) |
 
 ## Bootstrap contract
 
@@ -96,14 +130,16 @@ During `Acquire`, the provider:
 
 1. Creates a per-lease **differencing disk** backed by the template (near-instant
    and space-thin; the template stays read-only and shared — no multi-GB copy)
-2. Creates and starts the VM
-3. Installs and starts the Windows OpenSSH server in the guest via PowerShell
+2. With `--hyperv-init-password`, mounts the lease disk offline and writes a
+   first-boot `RunOnce` that sets the guest password (password-less templates)
+3. Creates and starts the VM
+4. Installs and starts the Windows OpenSSH server in the guest via PowerShell
    Direct if not already present (`Add-WindowsCapability`, `Start-Service sshd`,
    firewall rule), and installs git (MinGit) if absent — both required for SSH
    readiness and crabbox sync
-4. Injects the per-lease SSH public key via PowerShell Direct
+5. Injects the per-lease SSH public key via PowerShell Direct
    (`Invoke-Command -VMName`) using the configured guest password
-5. Waits for SSH readiness on the injected key
+6. Waits for SSH readiness on the injected key
 
 Both the OpenSSH-install and key-injection steps authenticate over PowerShell
 Direct using the guest administrator password and retry up to 5 times with

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -1,7 +1,6 @@
 # Hyper-V
 
 Provider id: `hyperv`
-Aliases: `local-hyperv`, `hyper-v`, `windows-vm`
 Kind: SSH lease
 Targets: Windows (native)
 Family: `local-vm`

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -21,14 +21,31 @@ reject configuration on non-Windows hosts.
 
 - Windows 10 Pro/Enterprise/Education or Windows Server with Hyper-V enabled
 - PowerShell 5.1 or later (ships with Windows)
-- A pre-configured Windows VHDX template with:
-  - OpenSSH Server installed and running
-  - A known user account (default: `crabbox`) with a known password
+- A Windows VHDX template (Generation 2 / UEFI) with:
+  - A local administrator account whose password is known to Crabbox
+    (`--hyperv-user` / `CRABBOX_HYPERV_GUEST_PASSWORD`)
   - Network configured for DHCP on the Hyper-V virtual switch
+  - Guest internet access (or a Features-on-Demand source) so OpenSSH can be
+    installed on first use
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
 
-ISO images are not supported. The VHDX template must be a fully installed
-Windows image with SSH ready to accept connections.
+OpenSSH does **not** need to be pre-installed: on first acquire the provider
+installs and starts the Windows OpenSSH server in the guest over PowerShell
+Direct, then injects the lease SSH key. If OpenSSH is already present the step
+is a no-op. ISO images are not supported — provide a fully installed VHDX.
+
+### Preparing a template
+
+The only thing a base Windows VHDX needs is a reachable administrator account.
+For example, from an elevated prompt inside the guest before capturing it:
+
+```powershell
+net user Administrator '<password>'   # or your admin account
+net user Administrator /active:yes
+```
+
+Then point `--hyperv-image` at the VHDX and set `--hyperv-user Administrator`
+and `CRABBOX_HYPERV_GUEST_PASSWORD=<password>`. The provider handles OpenSSH.
 
 ## Configuration
 
@@ -75,24 +92,28 @@ During `Acquire`, the provider:
 
 1. Copies the VHDX template to a per-lease path
 2. Creates and starts the VM
-3. Injects the per-lease SSH public key via PowerShell Direct
+3. Installs and starts the Windows OpenSSH server in the guest via PowerShell
+   Direct if it is not already present (`Add-WindowsCapability`, `Start-Service
+   sshd`, firewall rule)
+4. Injects the per-lease SSH public key via PowerShell Direct
    (`Invoke-Command -VMName`) using the configured guest password
-4. Waits for SSH readiness on the injected key
+5. Waits for SSH readiness on the injected key
 
-The SSH key injection retries up to 5 times with backoff to allow the guest OS
-to boot. If injection fails (wrong password, guest not ready), the provider
-falls back to whatever SSH configuration the VHDX template already has.
+Both the OpenSSH-install and key-injection steps authenticate over PowerShell
+Direct using the guest administrator password and retry up to 5 times with
+backoff to allow the guest OS to boot.
 
 Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in config to
-match the password baked into your VHDX template. Default: `crabbox`.
+match the administrator password in your VHDX template. Default: `crabbox`.
 
 ## Lifecycle
 
 1. **Acquire**: Copies the VHDX template, creates a Generation 2 VM (`New-VM`),
-   configures CPU count (`Set-VM`), connects the network adapter to the
-   configured switch (`Connect-VMNetworkAdapter`), starts the VM (`Start-VM`),
-   injects the SSH key via PowerShell Direct, polls for an IP address via
-   `Get-VMNetworkAdapter`, then waits for SSH readiness.
+   configures CPU count and disables automatic checkpoints (`Set-VM`), connects
+   the network adapter to the configured switch (`Connect-VMNetworkAdapter`),
+   starts the VM (`Start-VM`), polls for an IP address via
+   `Get-VMNetworkAdapter`, installs OpenSSH in the guest if needed and injects
+   the SSH key via PowerShell Direct, then waits for SSH readiness.
 2. **Resolve**: Finds a running crabbox VM by lease ID, slug, or instance name.
    Queries live VM state and IP from Hyper-V.
 3. **List**: Lists all VMs with the `crabbox-` name prefix.

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -29,10 +29,12 @@ reject configuration on non-Windows hosts.
     installed on first use
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
 
-OpenSSH does **not** need to be pre-installed: on first acquire the provider
-installs and starts the Windows OpenSSH server in the guest over PowerShell
-Direct, then injects the lease SSH key. If OpenSSH is already present the step
-is a no-op. ISO images are not supported — provide a fully installed VHDX.
+OpenSSH and git do **not** need to be pre-installed: on first acquire the
+provider installs the Windows OpenSSH server (over PowerShell Direct) and, if
+absent, git (portable MinGit) — both are no-ops when already present, so a
+template that pre-bakes them just skips the per-lease download. This keeps the
+template requirement to a plain Windows VHDX with a known admin password. ISO
+images are not supported — provide a fully installed VHDX.
 
 ### Preparing a template
 
@@ -94,8 +96,9 @@ During `Acquire`, the provider:
    and space-thin; the template stays read-only and shared — no multi-GB copy)
 2. Creates and starts the VM
 3. Installs and starts the Windows OpenSSH server in the guest via PowerShell
-   Direct if it is not already present (`Add-WindowsCapability`, `Start-Service
-   sshd`, firewall rule)
+   Direct if not already present (`Add-WindowsCapability`, `Start-Service sshd`,
+   firewall rule), and installs git (MinGit) if absent — both required for SSH
+   readiness and crabbox sync
 4. Injects the per-lease SSH public key via PowerShell Direct
    (`Invoke-Command -VMName`) using the configured guest password
 5. Waits for SSH readiness on the injected key

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -88,7 +88,7 @@ Notes:
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--hyperv-image` | (none) | Path to a Windows VHDX template (required) |
-| `--hyperv-user` | `crabbox` | Guest administrator account for SSH (password via `CRABBOX_HYPERV_GUEST_PASSWORD`) |
+| `--hyperv-user` | `crabbox` | Local guest administrator account for SSH; letters, digits, `.`, `_`, and `-` only (password via `CRABBOX_HYPERV_GUEST_PASSWORD`) |
 | `--hyperv-work-root` | `C:\crabbox` | Crabbox work root inside the guest |
 | `--hyperv-cpu` | `4` | Number of virtual CPUs |
 | `--hyperv-memory` | `8192` | Memory in MB |
@@ -132,15 +132,16 @@ During `Acquire`, the provider:
    and space-thin; the template stays read-only and shared — no multi-GB copy)
 2. With `--hyperv-init-password`, mounts the lease disk offline and writes a
    first-boot `RunOnce` that sets the guest password (password-less templates)
-3. Creates and starts the VM
-4. Installs the Windows OpenSSH server in the guest via PowerShell Direct if
-   not already present, while keeping sshd stopped and its firewall rule
-   disabled
-5. Injects the per-lease SSH public key, applies SID-based ACLs, disables
-   password authentication, validates `sshd_config`, then starts sshd and opens
-   TCP/22
-6. Installs git (MinGit) if absent — required for Crabbox sync
-7. Waits for SSH readiness on the injected key
+3. Creates and starts the VM with its network adapter disconnected
+4. Uses PowerShell Direct to stop/disable sshd, add an inbound TCP/22 block
+   rule, replace authorized keys, discard template `Match` authentication
+   blocks, and restrict SSH to the selected user
+5. Connects the network adapter, installs Windows OpenSSH if absent, and keeps
+   sshd stopped behind the quarantine rule
+6. Reapplies the final key-only config, validates `sshd_config`, regenerates
+   per-lease SSH host keys, starts sshd, and removes the quarantine rule last
+7. Installs git (MinGit) if absent — required for Crabbox sync
+8. Waits for SSH readiness on the injected key
 
 Both the OpenSSH-install and key-injection steps authenticate over PowerShell
 Direct using the guest administrator password and retry up to 5 times with
@@ -155,11 +156,11 @@ installation.
 
 1. **Acquire**: Creates a per-lease differencing disk over the template
    (`New-VHD -Differencing -ParentPath`), creates a Generation 2 VM (`New-VM`),
-   configures CPU count and disables automatic checkpoints (`Set-VM`), connects
-   the network adapter to the configured switch (`Connect-VMNetworkAdapter`),
-   starts the VM (`Start-VM`), polls for an IP address via
-   `Get-VMNetworkAdapter`, installs OpenSSH in the guest if needed and injects
-   the SSH key via PowerShell Direct, then waits for SSH readiness.
+   configures CPU count and disables automatic checkpoints (`Set-VM`), starts
+   the VM disconnected (`Start-VM`), quarantines and replaces SSH credentials
+   through PowerShell Direct, connects the adapter
+   (`Connect-VMNetworkAdapter`), installs OpenSSH if needed, activates the
+   validated key-only configuration, then waits for SSH readiness.
 2. **Resolve**: Finds a running crabbox VM by lease ID, slug, or instance name.
    Queries live VM state and IP from Hyper-V.
 3. **List**: Lists all VMs with the `crabbox-` name prefix.
@@ -172,6 +173,9 @@ installation.
 
 - All VMs are named with a `crabbox-` prefix. Cleanup and release operations
   refuse to touch VMs without this prefix.
+- The selected SSH account must be a local account name containing only letters,
+  digits, `.`, `_`, or `-`. Domain/UPN names and SSH pattern characters are
+  rejected so `AllowUsers` cannot broaden access.
 - VHD files are stored in `%USERPROFILE%\Hyper-V\Virtual Hard Disks\` by
   default. Only the provider-created boot disk is cleaned up on release; other
   attached disks are preserved.

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -109,8 +109,8 @@ match the password baked into your VHDX template. Default: `crabbox`.
 - VHD files are stored in `%USERPROFILE%\Hyper-V\Virtual Hard Disks\` by
   default. Only the provider-created boot disk is cleaned up on release; other
   attached disks are preserved.
-- The SSH ready check uses `powershell -Command "$PSVersionTable.PSVersion |
-  Out-Null"` to verify the Windows guest is responsive.
+- The SSH ready check uses the shared native-Windows readiness probe, which
+  verifies that `git`, `tar`, and the work root are available in the guest.
 - There is no `tart exec` or `prlctl exec` equivalent for Hyper-V; all guest
   interaction after bootstrap happens over SSH.
 

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -31,8 +31,9 @@ reject configuration on non-Windows hosts.
 
 OpenSSH and git do **not** need to be pre-installed: on first acquire the
 provider installs the Windows OpenSSH server (over PowerShell Direct) and, if
-absent, git (portable MinGit) — both are no-ops when already present, so a
-template that pre-bakes them just skips the per-lease download. This keeps the
+absent, git (portable MinGit, pinned to a specific release and SHA-256-verified
+before extraction) — both are no-ops when already present, so a template that
+pre-bakes them just skips the per-lease download. This keeps the
 template requirement to a plain Windows VHDX with a known admin password. ISO
 images are not supported — provide a fully installed VHDX.
 

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -72,8 +72,8 @@ Notes:
 
 - Requires an explicit `CRABBOX_HYPERV_GUEST_PASSWORD` (the provider refuses
   to stamp its default password onto a guest).
-- The password cannot contain `"` or `%` (it passes through `cmd.exe` at
-  logon).
+- Neither the password nor the user name can contain `"` or `%` (both pass
+  through `cmd.exe` at logon).
 - This only works for templates that auto-log-on an administrator account
   (`RunOnce` fires at logon). Templates without auto-logon need a known
   password baked in, as above.

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -22,8 +22,8 @@ reject configuration on non-Windows hosts.
 - Windows 10 Pro/Enterprise/Education or Windows Server with Hyper-V enabled
 - PowerShell 5.1 or later (ships with Windows)
 - A Windows VHDX template (Generation 2 / UEFI) with:
-  - A local administrator account whose password is known to Crabbox
-    (`--hyperv-user` / `CRABBOX_HYPERV_GUEST_PASSWORD`)
+  - A local administrator account selected with `--hyperv-user`, with its
+    password explicitly provided through `CRABBOX_HYPERV_GUEST_PASSWORD`
   - Network configured for DHCP on the Hyper-V virtual switch
   - Guest internet access (or a Features-on-Demand source) so OpenSSH can be
     installed on first use
@@ -105,9 +105,11 @@ hyperv:
   cpus: 4
   memory: 8192
   switch: Default Switch
-  guestPassword: crabbox
   initPassword: false
 ```
+
+Keep `CRABBOX_HYPERV_GUEST_PASSWORD` in the environment or trusted user config,
+not repository config. There is no default guest password.
 
 ### Environment variables
 
@@ -143,8 +145,10 @@ Both the OpenSSH-install and key-injection steps authenticate over PowerShell
 Direct using the guest administrator password and retry up to 5 times with
 backoff to allow the guest OS to boot.
 
-Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in config to
-match the administrator password in your VHDX template. Default: `crabbox`.
+Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in trusted user
+config to match the administrator password in your VHDX template. The provider
+requires an explicit value and disables SSH password authentication after key
+installation.
 
 ## Lifecycle
 

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -133,13 +133,14 @@ During `Acquire`, the provider:
 2. With `--hyperv-init-password`, mounts the lease disk offline and writes a
    first-boot `RunOnce` that sets the guest password (password-less templates)
 3. Creates and starts the VM
-4. Installs and starts the Windows OpenSSH server in the guest via PowerShell
-   Direct if not already present (`Add-WindowsCapability`, `Start-Service sshd`,
-   firewall rule), and installs git (MinGit) if absent — both required for SSH
-   readiness and crabbox sync
-5. Injects the per-lease SSH public key via PowerShell Direct
-   (`Invoke-Command -VMName`) using the configured guest password
-6. Waits for SSH readiness on the injected key
+4. Installs the Windows OpenSSH server in the guest via PowerShell Direct if
+   not already present, while keeping sshd stopped and its firewall rule
+   disabled
+5. Injects the per-lease SSH public key, applies SID-based ACLs, disables
+   password authentication, validates `sshd_config`, then starts sshd and opens
+   TCP/22
+6. Installs git (MinGit) if absent — required for Crabbox sync
+7. Waits for SSH readiness on the injected key
 
 Both the OpenSSH-install and key-injection steps authenticate over PowerShell
 Direct using the guest administrator password and retry up to 5 times with

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -1,0 +1,96 @@
+# Hyper-V
+
+Provider id: `hyperv`
+Aliases: `local-hyperv`, `hyper-v`, `windows-vm`
+Kind: SSH lease
+Targets: Windows (native)
+Family: `local-vm`
+
+## Overview
+
+The Hyper-V provider creates and manages Windows virtual machines on a local
+Windows host using Microsoft Hyper-V. VMs are provisioned as Generation 2 VMs
+with a new VHDX, connected to a configurable virtual switch (default: "Default
+Switch"), and accessed over SSH via the built-in Windows OpenSSH server.
+
+Hyper-V must be enabled on the host (`Enable-WindowsOptionalFeature -Online
+-FeatureName Microsoft-Hyper-V-All`). The provider is Windows-only and will
+reject configuration on non-Windows hosts.
+
+## Requirements
+
+- Windows 10 Pro/Enterprise/Education or Windows Server with Hyper-V enabled
+- PowerShell 5.1 or later (ships with Windows)
+- A Windows VHDX image with OpenSSH Server installed and enabled
+- The Hyper-V PowerShell module (included with the Hyper-V feature)
+
+## Configuration
+
+### Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--hyperv-image` | (none) | Path to a Windows VHDX or ISO for VM creation (required) |
+| `--hyperv-cpu` | `4` | Number of virtual CPUs |
+| `--hyperv-memory` | `8192` | Memory in MB |
+| `--hyperv-disk` | `50` | Disk size in GB |
+| `--hyperv-switch` | `Default Switch` | Hyper-V virtual switch name |
+
+### Config file
+
+```yaml
+hyperv:
+  image: C:\Images\windows-crabbox.vhdx
+  user: crabbox
+  workRoot: C:\crabbox
+  cpus: 4
+  memory: 8192
+  disk: 50
+  switch: Default Switch
+```
+
+### Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `CRABBOX_HYPERV_IMAGE` | VHDX or ISO path |
+| `CRABBOX_HYPERV_USER` | SSH user inside the VM |
+| `CRABBOX_HYPERV_WORK_ROOT` | Work root inside the VM |
+| `CRABBOX_HYPERV_CPUS` | CPU count |
+| `CRABBOX_HYPERV_MEMORY` | Memory in MB |
+| `CRABBOX_HYPERV_DISK` | Disk in GB |
+| `CRABBOX_HYPERV_SWITCH` | Virtual switch name |
+
+## Lifecycle
+
+1. **Acquire**: Creates a Generation 2 VM (`New-VM`), configures CPU count
+   (`Set-VM`), connects the network adapter to the configured switch
+   (`Connect-VMNetworkAdapter`), starts the VM (`Start-VM`), polls for an IP
+   address via `Get-VMNetworkAdapter`, then waits for SSH readiness.
+2. **Resolve**: Finds a running crabbox VM by lease ID, slug, or instance name.
+3. **List**: Lists all VMs with the `crabbox-` name prefix.
+4. **Release**: Stops the VM (`Stop-VM -Force`) and removes it
+   (`Remove-VM -Force`), then cleans up the VHDX file.
+5. **Cleanup**: Scans for stale `crabbox-` prefixed VMs with expired or missing
+   lease claims and removes them.
+
+## Notes
+
+- All VMs are named with a `crabbox-` prefix. Cleanup and release operations
+  refuse to touch VMs without this prefix.
+- VHD files are stored in `%USERPROFILE%\Hyper-V\Virtual Hard Disks\` by
+  default.
+- The SSH ready check uses `powershell -Command "$PSVersionTable.PSVersion |
+  Out-Null"` to verify the Windows guest is responsive.
+- There is no `tart exec` or `prlctl exec` equivalent for Hyper-V; all guest
+  interaction happens over SSH.
+
+## Examples
+
+```sh
+crabbox warmup --provider hyperv --hyperv-image C:\Images\win-server.vhdx
+crabbox run --provider hyperv -- powershell -Command "Get-Process"
+crabbox ssh --provider hyperv
+crabbox stop --provider hyperv --id blue-lobster
+crabbox cleanup --provider hyperv
+```

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -56,7 +56,7 @@ and `CRABBOX_HYPERV_GUEST_PASSWORD=<password>`. The provider handles OpenSSH.
 | `--hyperv-image` | (none) | Path to a Windows VHDX template (required) |
 | `--hyperv-cpu` | `4` | Number of virtual CPUs |
 | `--hyperv-memory` | `8192` | Memory in MB |
-| `--hyperv-disk` | `50` | Disk size in GB |
+| `--hyperv-disk` | `50` | Reserved; leases inherit the template's virtual size (differencing disk) |
 | `--hyperv-switch` | `Default Switch` | Hyper-V virtual switch name |
 
 ### Config file
@@ -90,7 +90,8 @@ hyperv:
 
 During `Acquire`, the provider:
 
-1. Copies the VHDX template to a per-lease path
+1. Creates a per-lease **differencing disk** backed by the template (near-instant
+   and space-thin; the template stays read-only and shared — no multi-GB copy)
 2. Creates and starts the VM
 3. Installs and starts the Windows OpenSSH server in the guest via PowerShell
    Direct if it is not already present (`Add-WindowsCapability`, `Start-Service
@@ -108,7 +109,8 @@ match the administrator password in your VHDX template. Default: `crabbox`.
 
 ## Lifecycle
 
-1. **Acquire**: Copies the VHDX template, creates a Generation 2 VM (`New-VM`),
+1. **Acquire**: Creates a per-lease differencing disk over the template
+   (`New-VHD -Differencing -ParentPath`), creates a Generation 2 VM (`New-VM`),
    configures CPU count and disables automatic checkpoints (`Set-VM`), connects
    the network adapter to the configured switch (`Connect-VMNetworkAdapter`),
    starts the VM (`Start-VM`), polls for an IP address via

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -10,8 +10,9 @@ Family: `local-vm`
 
 The Hyper-V provider creates and manages Windows virtual machines on a local
 Windows host using Microsoft Hyper-V. VMs are provisioned as Generation 2 VMs
-with a new VHDX, connected to a configurable virtual switch (default: "Default
-Switch"), and accessed over SSH via the built-in Windows OpenSSH server.
+from a pre-configured VHDX template, connected to a configurable virtual switch
+(default: "Default Switch"), and accessed over SSH via the built-in Windows
+OpenSSH server.
 
 Hyper-V must be enabled on the host (`Enable-WindowsOptionalFeature -Online
 -FeatureName Microsoft-Hyper-V-All`). The provider is Windows-only and will
@@ -21,8 +22,14 @@ reject configuration on non-Windows hosts.
 
 - Windows 10 Pro/Enterprise/Education or Windows Server with Hyper-V enabled
 - PowerShell 5.1 or later (ships with Windows)
-- A Windows VHDX image with OpenSSH Server installed and enabled
+- A pre-configured Windows VHDX template with:
+  - OpenSSH Server installed and running
+  - A known user account (default: `crabbox`) with a known password
+  - Network configured for DHCP on the Hyper-V virtual switch
 - The Hyper-V PowerShell module (included with the Hyper-V feature)
+
+ISO images are not supported. The VHDX template must be a fully installed
+Windows image with SSH ready to accept connections.
 
 ## Configuration
 
@@ -30,7 +37,7 @@ reject configuration on non-Windows hosts.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--hyperv-image` | (none) | Path to a Windows VHDX or ISO for VM creation (required) |
+| `--hyperv-image` | (none) | Path to a Windows VHDX template (required) |
 | `--hyperv-cpu` | `4` | Number of virtual CPUs |
 | `--hyperv-memory` | `8192` | Memory in MB |
 | `--hyperv-disk` | `50` | Disk size in GB |
@@ -47,30 +54,51 @@ hyperv:
   memory: 8192
   disk: 50
   switch: Default Switch
+  guestPassword: crabbox
 ```
 
 ### Environment variables
 
 | Variable | Description |
 | --- | --- |
-| `CRABBOX_HYPERV_IMAGE` | VHDX or ISO path |
+| `CRABBOX_HYPERV_IMAGE` | VHDX template path |
 | `CRABBOX_HYPERV_USER` | SSH user inside the VM |
 | `CRABBOX_HYPERV_WORK_ROOT` | Work root inside the VM |
 | `CRABBOX_HYPERV_CPUS` | CPU count |
 | `CRABBOX_HYPERV_MEMORY` | Memory in MB |
 | `CRABBOX_HYPERV_DISK` | Disk in GB |
 | `CRABBOX_HYPERV_SWITCH` | Virtual switch name |
+| `CRABBOX_HYPERV_GUEST_PASSWORD` | Guest user password for SSH key injection |
+
+## Bootstrap contract
+
+During `Acquire`, the provider:
+
+1. Copies the VHDX template to a per-lease path
+2. Creates and starts the VM
+3. Injects the per-lease SSH public key via PowerShell Direct
+   (`Invoke-Command -VMName`) using the configured guest password
+4. Waits for SSH readiness on the injected key
+
+The SSH key injection retries up to 5 times with backoff to allow the guest OS
+to boot. If injection fails (wrong password, guest not ready), the provider
+falls back to whatever SSH configuration the VHDX template already has.
+
+Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in config to
+match the password baked into your VHDX template. Default: `crabbox`.
 
 ## Lifecycle
 
-1. **Acquire**: Creates a Generation 2 VM (`New-VM`), configures CPU count
-   (`Set-VM`), connects the network adapter to the configured switch
-   (`Connect-VMNetworkAdapter`), starts the VM (`Start-VM`), polls for an IP
-   address via `Get-VMNetworkAdapter`, then waits for SSH readiness.
+1. **Acquire**: Copies the VHDX template, creates a Generation 2 VM (`New-VM`),
+   configures CPU count (`Set-VM`), connects the network adapter to the
+   configured switch (`Connect-VMNetworkAdapter`), starts the VM (`Start-VM`),
+   injects the SSH key via PowerShell Direct, polls for an IP address via
+   `Get-VMNetworkAdapter`, then waits for SSH readiness.
 2. **Resolve**: Finds a running crabbox VM by lease ID, slug, or instance name.
+   Queries live VM state and IP from Hyper-V.
 3. **List**: Lists all VMs with the `crabbox-` name prefix.
 4. **Release**: Stops the VM (`Stop-VM -Force`) and removes it
-   (`Remove-VM -Force`), then cleans up the VHDX file.
+   (`Remove-VM -Force`), then cleans up the provider-created VHDX file.
 5. **Cleanup**: Scans for stale `crabbox-` prefixed VMs with expired or missing
    lease claims and removes them.
 
@@ -79,11 +107,12 @@ hyperv:
 - All VMs are named with a `crabbox-` prefix. Cleanup and release operations
   refuse to touch VMs without this prefix.
 - VHD files are stored in `%USERPROFILE%\Hyper-V\Virtual Hard Disks\` by
-  default.
+  default. Only the provider-created boot disk is cleaned up on release; other
+  attached disks are preserved.
 - The SSH ready check uses `powershell -Command "$PSVersionTable.PSVersion |
   Out-Null"` to verify the Windows guest is responsive.
 - There is no `tart exec` or `prlctl exec` equivalent for Hyper-V; all guest
-  interaction happens over SSH.
+  interaction after bootstrap happens over SSH.
 
 ## Examples
 

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -91,7 +91,6 @@ Notes:
 | `--hyperv-work-root` | `C:\crabbox` | Crabbox work root inside the guest |
 | `--hyperv-cpu` | `4` | Number of virtual CPUs |
 | `--hyperv-memory` | `8192` | Memory in MB |
-| `--hyperv-disk` | `50` | Reserved; leases inherit the template's virtual size (differencing disk) |
 | `--hyperv-switch` | `Default Switch` | Hyper-V virtual switch name |
 | `--hyperv-init-password` | `false` | Set the guest password at first boot via the lease disk (password-less auto-logon templates) |
 
@@ -104,7 +103,6 @@ hyperv:
   workRoot: C:\crabbox
   cpus: 4
   memory: 8192
-  disk: 50
   switch: Default Switch
   guestPassword: crabbox
   initPassword: false
@@ -119,7 +117,6 @@ hyperv:
 | `CRABBOX_HYPERV_WORK_ROOT` | Work root inside the VM |
 | `CRABBOX_HYPERV_CPUS` | CPU count |
 | `CRABBOX_HYPERV_MEMORY` | Memory in MB |
-| `CRABBOX_HYPERV_DISK` | Disk in GB |
 | `CRABBOX_HYPERV_SWITCH` | Virtual switch name |
 | `CRABBOX_HYPERV_GUEST_PASSWORD` | Guest user password for SSH key injection |
 | `CRABBOX_HYPERV_INIT_PASSWORD` | Set the guest password at first boot (`true`/`false`) |

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -56,6 +56,8 @@ and `CRABBOX_HYPERV_GUEST_PASSWORD=<password>`. The provider handles OpenSSH.
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--hyperv-image` | (none) | Path to a Windows VHDX template (required) |
+| `--hyperv-user` | `crabbox` | Guest administrator account for SSH (password via `CRABBOX_HYPERV_GUEST_PASSWORD`) |
+| `--hyperv-work-root` | `C:\crabbox` | Crabbox work root inside the guest |
 | `--hyperv-cpu` | `4` | Number of virtual CPUs |
 | `--hyperv-memory` | `8192` | Memory in MB |
 | `--hyperv-disk` | `50` | Reserved; leases inherit the template's virtual size (differencing disk) |

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -77,6 +77,7 @@ SSH-lease providers:
 - Local Docker container: `internal/providers/localcontainer`
 - Canonical Multipass local Ubuntu VM: `internal/providers/multipass`
 - Cirrus Labs tart local macOS VM: `internal/providers/tart`
+- Microsoft Hyper-V local Windows VM: `internal/providers/hyperv`
 - Daytona, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites, Railway:
   `internal/providers/daytona`, `internal/providers/exedev`, `internal/providers/kubevirt`, `internal/providers/external`, `internal/providers/tenki`, `internal/providers/namespace`,
   `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`,

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/zitadel/oidc/v3 v3.47.5
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sys v0.45.0
 	google.golang.org/api v0.282.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
 	google.golang.org/grpc v1.81.1
@@ -115,7 +116,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -927,6 +927,25 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		cfg.OSImage = normalized
 	}
 	applyOSImageProviderDefaults(cfg, false)
+	if cfg.Provider == "hyperv" {
+		if IsTargetExplicit(cfg) && normalizeTargetOS(cfg.TargetOS) != targetWindows {
+			return exit(2, "provider=hyperv supports target=windows only")
+		}
+		if normalizeWindowsMode(cfg.WindowsMode) != windowsModeNormal {
+			return exit(2, "provider=hyperv supports windows.mode=normal only")
+		}
+		cfg.TargetOS = targetWindows
+		cfg.WindowsMode = windowsModeNormal
+		cfg.SSHFallbackPorts = nil
+		if cfg.HyperV.User != "" {
+			cfg.SSHUser = cfg.HyperV.User
+		}
+		if cfg.HyperV.WorkRoot != "" {
+			cfg.WorkRoot = cfg.HyperV.WorkRoot
+		}
+		cfg.SSHPort = "22"
+		return nil
+	}
 	if cfg.Provider == "exe-dev" || cfg.Provider == "exedev" || cfg.Provider == "exe" {
 		if cfg.ExeDev.User != "" {
 			cfg.SSHUser = cfg.ExeDev.User

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -589,7 +589,6 @@ type HyperVConfig struct {
 	WorkRoot      string
 	CPUs          int
 	Memory        int
-	Disk          int
 	Switch        string
 	GuestPassword string
 	InitPassword  bool
@@ -1300,7 +1299,6 @@ func baseConfig() Config {
 			WorkRoot: defaultWindowsWorkRoot,
 			CPUs:     4,
 			Memory:   8192,
-			Disk:     50,
 			Switch:   "Default Switch",
 		},
 		Tailscale: TailscaleConfig{
@@ -1851,7 +1849,6 @@ type fileHyperVConfig struct {
 	WorkRoot      string `yaml:"workRoot,omitempty"`
 	CPUs          int    `yaml:"cpus,omitempty"`
 	Memory        int    `yaml:"memory,omitempty"`
-	Disk          int    `yaml:"disk,omitempty"`
 	Switch        string `yaml:"switch,omitempty"`
 	GuestPassword string `yaml:"guestPassword,omitempty"`
 	InitPassword  *bool  `yaml:"initPassword,omitempty"`
@@ -3188,9 +3185,6 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		if file.HyperV.Memory > 0 {
 			cfg.HyperV.Memory = file.HyperV.Memory
 		}
-		if file.HyperV.Disk > 0 {
-			cfg.HyperV.Disk = file.HyperV.Disk
-		}
 		if file.HyperV.Switch != "" {
 			cfg.HyperV.Switch = file.HyperV.Switch
 		}
@@ -4023,7 +4017,6 @@ func applyEnv(cfg *Config) error {
 	cfg.HyperV.WorkRoot = getenv("CRABBOX_HYPERV_WORK_ROOT", cfg.HyperV.WorkRoot)
 	cfg.HyperV.CPUs = getenvInt("CRABBOX_HYPERV_CPUS", cfg.HyperV.CPUs)
 	cfg.HyperV.Memory = getenvInt("CRABBOX_HYPERV_MEMORY", cfg.HyperV.Memory)
-	cfg.HyperV.Disk = getenvInt("CRABBOX_HYPERV_DISK", cfg.HyperV.Disk)
 	cfg.HyperV.Switch = getenv("CRABBOX_HYPERV_SWITCH", cfg.HyperV.Switch)
 	cfg.HyperV.GuestPassword = getenv("CRABBOX_HYPERV_GUEST_PASSWORD", cfg.HyperV.GuestPassword)
 	if value, ok := getenvBool("CRABBOX_HYPERV_INIT_PASSWORD"); ok {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -928,14 +928,9 @@ func applyProviderConfigDefaults(cfg *Config) error {
 	}
 	applyOSImageProviderDefaults(cfg, false)
 	if cfg.Provider == "hyperv" {
-		if IsTargetExplicit(cfg) && normalizeTargetOS(cfg.TargetOS) != targetWindows {
-			return exit(2, "provider=hyperv supports target=windows only")
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetWindows
 		}
-		if normalizeWindowsMode(cfg.WindowsMode) != windowsModeNormal {
-			return exit(2, "provider=hyperv supports windows.mode=normal only")
-		}
-		cfg.TargetOS = targetWindows
-		cfg.WindowsMode = windowsModeNormal
 		cfg.SSHFallbackPorts = nil
 		if cfg.HyperV.User != "" {
 			cfg.SSHUser = cfg.HyperV.User

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -592,6 +592,7 @@ type HyperVConfig struct {
 	Disk          int
 	Switch        string
 	GuestPassword string
+	InitPassword  bool
 }
 
 type StaticConfig struct {
@@ -1853,6 +1854,7 @@ type fileHyperVConfig struct {
 	Disk          int    `yaml:"disk,omitempty"`
 	Switch        string `yaml:"switch,omitempty"`
 	GuestPassword string `yaml:"guestPassword,omitempty"`
+	InitPassword  *bool  `yaml:"initPassword,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -3195,6 +3197,9 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		if file.HyperV.GuestPassword != "" {
 			cfg.HyperV.GuestPassword = file.HyperV.GuestPassword
 		}
+		if file.HyperV.InitPassword != nil {
+			cfg.HyperV.InitPassword = *file.HyperV.InitPassword
+		}
 	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
@@ -4021,6 +4026,9 @@ func applyEnv(cfg *Config) error {
 	cfg.HyperV.Disk = getenvInt("CRABBOX_HYPERV_DISK", cfg.HyperV.Disk)
 	cfg.HyperV.Switch = getenv("CRABBOX_HYPERV_SWITCH", cfg.HyperV.Switch)
 	cfg.HyperV.GuestPassword = getenv("CRABBOX_HYPERV_GUEST_PASSWORD", cfg.HyperV.GuestPassword)
+	if value, ok := getenvBool("CRABBOX_HYPERV_INIT_PASSWORD"); ok {
+		cfg.HyperV.InitPassword = value
+	}
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -135,6 +135,7 @@ type Config struct {
 	tartDiskExplicit              bool
 	tartCPUsExplicit              bool
 	tartMemoryExplicit            bool
+	HyperV                        HyperVConfig
 	Tailscale                     TailscaleConfig
 	Static                        StaticConfig
 	Results                       ResultsConfig
@@ -580,6 +581,16 @@ type TartConfig struct {
 	CPUs     int
 	Memory   int
 	Disk     int
+}
+
+type HyperVConfig struct {
+	Image    string
+	User     string
+	WorkRoot string
+	CPUs     int
+	Memory   int
+	Disk     int
+	Switch   string
 }
 
 type StaticConfig struct {
@@ -1282,6 +1293,14 @@ func baseConfig() Config {
 			CPUs:     4,
 			Memory:   8192,
 		},
+		HyperV: HyperVConfig{
+			User:     "crabbox",
+			WorkRoot: defaultWindowsWorkRoot,
+			CPUs:     4,
+			Memory:   8192,
+			Disk:     50,
+			Switch:   "Default Switch",
+		},
 		Tailscale: TailscaleConfig{
 			Tags:             []string{"tag:crabbox"},
 			HostnameTemplate: "crabbox-{slug}",
@@ -1354,6 +1373,7 @@ type fileConfig struct {
 	AppleContainer       *fileAppleContainerConfig          `yaml:"appleContainer,omitempty"`
 	Multipass            *fileMultipassConfig               `yaml:"multipass,omitempty"`
 	Tart                 *fileTartConfig                    `yaml:"tart,omitempty"`
+	HyperV               *fileHyperVConfig                  `yaml:"hyperv,omitempty"`
 	Tailscale            *fileTailscaleConfig               `yaml:"tailscale,omitempty"`
 	Static               *fileStaticConfig                  `yaml:"static,omitempty"`
 	Results              *fileResultsConfig                 `yaml:"results,omitempty"`
@@ -1821,6 +1841,16 @@ type fileTartConfig struct {
 	CPUs     *int   `yaml:"cpus,omitempty"`
 	Memory   *int   `yaml:"memory,omitempty"`
 	Disk     *int   `yaml:"disk,omitempty"`
+}
+
+type fileHyperVConfig struct {
+	Image    string `yaml:"image,omitempty"`
+	User     string `yaml:"user,omitempty"`
+	WorkRoot string `yaml:"workRoot,omitempty"`
+	CPUs     int    `yaml:"cpus,omitempty"`
+	Memory   int    `yaml:"memory,omitempty"`
+	Disk     int    `yaml:"disk,omitempty"`
+	Switch   string `yaml:"switch,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -3138,6 +3168,29 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.tartDiskExplicit = true
 		}
 	}
+	if file.HyperV != nil {
+		if file.HyperV.Image != "" {
+			cfg.HyperV.Image = file.HyperV.Image
+		}
+		if file.HyperV.User != "" {
+			cfg.HyperV.User = file.HyperV.User
+		}
+		if file.HyperV.WorkRoot != "" {
+			cfg.HyperV.WorkRoot = file.HyperV.WorkRoot
+		}
+		if file.HyperV.CPUs > 0 {
+			cfg.HyperV.CPUs = file.HyperV.CPUs
+		}
+		if file.HyperV.Memory > 0 {
+			cfg.HyperV.Memory = file.HyperV.Memory
+		}
+		if file.HyperV.Disk > 0 {
+			cfg.HyperV.Disk = file.HyperV.Disk
+		}
+		if file.HyperV.Switch != "" {
+			cfg.HyperV.Switch = file.HyperV.Switch
+		}
+	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
 			cfg.Tailscale.Enabled = *file.Tailscale.Enabled
@@ -3955,6 +4008,13 @@ func applyEnv(cfg *Config) error {
 		cfg.Tart.Disk = getenvInt("CRABBOX_TART_DISK", cfg.Tart.Disk)
 		cfg.tartDiskExplicit = true
 	}
+	cfg.HyperV.Image = getenv("CRABBOX_HYPERV_IMAGE", cfg.HyperV.Image)
+	cfg.HyperV.User = getenv("CRABBOX_HYPERV_USER", cfg.HyperV.User)
+	cfg.HyperV.WorkRoot = getenv("CRABBOX_HYPERV_WORK_ROOT", cfg.HyperV.WorkRoot)
+	cfg.HyperV.CPUs = getenvInt("CRABBOX_HYPERV_CPUS", cfg.HyperV.CPUs)
+	cfg.HyperV.Memory = getenvInt("CRABBOX_HYPERV_MEMORY", cfg.HyperV.Memory)
+	cfg.HyperV.Disk = getenvInt("CRABBOX_HYPERV_DISK", cfg.HyperV.Disk)
+	cfg.HyperV.Switch = getenv("CRABBOX_HYPERV_SWITCH", cfg.HyperV.Switch)
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -584,13 +584,14 @@ type TartConfig struct {
 }
 
 type HyperVConfig struct {
-	Image    string
-	User     string
-	WorkRoot string
-	CPUs     int
-	Memory   int
-	Disk     int
-	Switch   string
+	Image         string
+	User          string
+	WorkRoot      string
+	CPUs          int
+	Memory        int
+	Disk          int
+	Switch        string
+	GuestPassword string
 }
 
 type StaticConfig struct {
@@ -1844,13 +1845,14 @@ type fileTartConfig struct {
 }
 
 type fileHyperVConfig struct {
-	Image    string `yaml:"image,omitempty"`
-	User     string `yaml:"user,omitempty"`
-	WorkRoot string `yaml:"workRoot,omitempty"`
-	CPUs     int    `yaml:"cpus,omitempty"`
-	Memory   int    `yaml:"memory,omitempty"`
-	Disk     int    `yaml:"disk,omitempty"`
-	Switch   string `yaml:"switch,omitempty"`
+	Image         string `yaml:"image,omitempty"`
+	User          string `yaml:"user,omitempty"`
+	WorkRoot      string `yaml:"workRoot,omitempty"`
+	CPUs          int    `yaml:"cpus,omitempty"`
+	Memory        int    `yaml:"memory,omitempty"`
+	Disk          int    `yaml:"disk,omitempty"`
+	Switch        string `yaml:"switch,omitempty"`
+	GuestPassword string `yaml:"guestPassword,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -3190,6 +3192,9 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		if file.HyperV.Switch != "" {
 			cfg.HyperV.Switch = file.HyperV.Switch
 		}
+		if file.HyperV.GuestPassword != "" {
+			cfg.HyperV.GuestPassword = file.HyperV.GuestPassword
+		}
 	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
@@ -4015,6 +4020,7 @@ func applyEnv(cfg *Config) error {
 	cfg.HyperV.Memory = getenvInt("CRABBOX_HYPERV_MEMORY", cfg.HyperV.Memory)
 	cfg.HyperV.Disk = getenvInt("CRABBOX_HYPERV_DISK", cfg.HyperV.Disk)
 	cfg.HyperV.Switch = getenv("CRABBOX_HYPERV_SWITCH", cfg.HyperV.Switch)
+	cfg.HyperV.GuestPassword = getenv("CRABBOX_HYPERV_GUEST_PASSWORD", cfg.HyperV.GuestPassword)
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}

--- a/internal/cli/config_hyperv_test.go
+++ b/internal/cli/config_hyperv_test.go
@@ -93,3 +93,27 @@ func TestHyperVEnvInitPasswordFalseOverridesTrue(t *testing.T) {
 		t.Fatal("CRABBOX_HYPERV_INIT_PASSWORD=false must override a configured true")
 	}
 }
+
+func TestLoadConfigAppliesHyperVWindowsDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("provider: hyperv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", path)
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_TARGET", "")
+	t.Setenv("CRABBOX_TARGET_OS", "")
+	t.Setenv("CRABBOX_WINDOWS_MODE", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TargetOS != targetWindows || cfg.WindowsMode != windowsModeNormal {
+		t.Fatalf("target=%q windowsMode=%q, want windows/normal", cfg.TargetOS, cfg.WindowsMode)
+	}
+	if cfg.SSHUser != cfg.HyperV.User || cfg.SSHPort != "22" || cfg.WorkRoot != cfg.HyperV.WorkRoot {
+		t.Fatalf("Hyper-V SSH defaults not applied: user=%q port=%q root=%q", cfg.SSHUser, cfg.SSHPort, cfg.WorkRoot)
+	}
+}

--- a/internal/cli/config_hyperv_test.go
+++ b/internal/cli/config_hyperv_test.go
@@ -117,3 +117,23 @@ func TestLoadConfigAppliesHyperVWindowsDefaults(t *testing.T) {
 		t.Fatalf("Hyper-V SSH defaults not applied: user=%q port=%q root=%q", cfg.SSHUser, cfg.SSHPort, cfg.WorkRoot)
 	}
 }
+
+func TestLoadConfigPreservesExplicitHyperVTargetForCLIOverride(t *testing.T) {
+	clearConfigEnv(t)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("provider: hyperv\ntarget: linux\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", path)
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_TARGET", "")
+	t.Setenv("CRABBOX_TARGET_OS", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TargetOS != targetLinux || !IsTargetExplicit(&cfg) {
+		t.Fatalf("explicit target was rewritten: target=%q explicit=%v", cfg.TargetOS, IsTargetExplicit(&cfg))
+	}
+}

--- a/internal/cli/config_hyperv_test.go
+++ b/internal/cli/config_hyperv_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplyFileHyperVConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	data := `hyperv:
+  image: D:\images\win11.vhdx
+  user: Administrator
+  workRoot: D:\crabbox-work
+  cpus: 6
+  memory: 4096
+  switch: Lab Switch
+  guestPassword: file-secret
+  initPassword: true
+`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readFileConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HyperV.Image != `D:\images\win11.vhdx` || cfg.HyperV.User != "Administrator" ||
+		cfg.HyperV.WorkRoot != `D:\crabbox-work` || cfg.HyperV.CPUs != 6 || cfg.HyperV.Memory != 4096 ||
+		cfg.HyperV.Switch != "Lab Switch" || cfg.HyperV.GuestPassword != "file-secret" {
+		t.Fatalf("hyperv=%#v", cfg.HyperV)
+	}
+	if !cfg.HyperV.InitPassword {
+		t.Fatal("hyperv.initPassword: true not applied from config file")
+	}
+}
+
+// initPassword is a *bool in the file config so an absent key must leave the
+// existing value alone while an explicit false must still win.
+func TestApplyFileHyperVInitPasswordTriState(t *testing.T) {
+	cfg := baseConfig()
+	cfg.HyperV.InitPassword = true
+	if err := applyFileConfig(&cfg, fileConfig{HyperV: &fileHyperVConfig{User: "keep"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.HyperV.InitPassword {
+		t.Fatal("absent initPassword key must not reset the configured value")
+	}
+	explicitFalse := false
+	if err := applyFileConfig(&cfg, fileConfig{HyperV: &fileHyperVConfig{InitPassword: &explicitFalse}}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HyperV.InitPassword {
+		t.Fatal("explicit initPassword: false not applied")
+	}
+}
+
+func TestHyperVEnvConfig(t *testing.T) {
+	t.Setenv("CRABBOX_HYPERV_IMAGE", `E:\img\base.vhdx`)
+	t.Setenv("CRABBOX_HYPERV_USER", "EnvUser")
+	t.Setenv("CRABBOX_HYPERV_WORK_ROOT", `E:\work`)
+	t.Setenv("CRABBOX_HYPERV_CPUS", "8")
+	t.Setenv("CRABBOX_HYPERV_MEMORY", "2048")
+	t.Setenv("CRABBOX_HYPERV_SWITCH", "Env Switch")
+	t.Setenv("CRABBOX_HYPERV_GUEST_PASSWORD", "env-secret")
+	t.Setenv("CRABBOX_HYPERV_INIT_PASSWORD", "true")
+	cfg := baseConfig()
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HyperV.Image != `E:\img\base.vhdx` || cfg.HyperV.User != "EnvUser" ||
+		cfg.HyperV.WorkRoot != `E:\work` || cfg.HyperV.CPUs != 8 || cfg.HyperV.Memory != 2048 ||
+		cfg.HyperV.Switch != "Env Switch" || cfg.HyperV.GuestPassword != "env-secret" {
+		t.Fatalf("hyperv=%#v", cfg.HyperV)
+	}
+	if !cfg.HyperV.InitPassword {
+		t.Fatal("CRABBOX_HYPERV_INIT_PASSWORD=true not applied")
+	}
+}
+
+func TestHyperVEnvInitPasswordFalseOverridesTrue(t *testing.T) {
+	t.Setenv("CRABBOX_HYPERV_INIT_PASSWORD", "false")
+	cfg := baseConfig()
+	cfg.HyperV.InitPassword = true
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HyperV.InitPassword {
+		t.Fatal("CRABBOX_HYPERV_INIT_PASSWORD=false must override a configured true")
+	}
+}

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -31,6 +31,7 @@ func init() {
 	RegisterProvider(testDockerSandboxProvider{})
 	RegisterProvider(testMultipassProvider{})
 	RegisterProvider(testTartProvider{})
+	RegisterProvider(testHyperVProvider{})
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 	RegisterProvider(testServiceControlProvider{})
@@ -1226,6 +1227,64 @@ func (testTartProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) er
 	return nil
 }
 func (p testTartProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testHyperVProvider struct{}
+
+func (testHyperVProvider) Name() string      { return "hyperv" }
+func (testHyperVProvider) Aliases() []string { return nil }
+func (testHyperVProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "hyperv",
+		Family:      "local-vm",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetWindows, WindowsMode: windowsModeNormal}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup},
+		Coordinator: CoordinatorNever,
+	}
+}
+
+type testHyperVFlagValues struct {
+	Image  *string
+	CPUs   *int
+	Memory *int
+	Disk   *int
+	Switch *string
+}
+
+func (testHyperVProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return testHyperVFlagValues{
+		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Hyper-V image"),
+		CPUs:   fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "Hyper-V CPUs"),
+		Memory: fs.Int("hyperv-memory", defaults.HyperV.Memory, "Hyper-V memory MB"),
+		Disk:   fs.Int("hyperv-disk", defaults.HyperV.Disk, "Hyper-V disk GB"),
+		Switch: fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V switch"),
+	}
+}
+func (testHyperVProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(testHyperVFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "hyperv-image") {
+		cfg.HyperV.Image = *v.Image
+	}
+	if flagWasSet(fs, "hyperv-cpu") {
+		cfg.HyperV.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "hyperv-memory") {
+		cfg.HyperV.Memory = *v.Memory
+	}
+	if flagWasSet(fs, "hyperv-disk") {
+		cfg.HyperV.Disk = *v.Disk
+	}
+	if flagWasSet(fs, "hyperv-switch") {
+		cfg.HyperV.Switch = *v.Switch
+	}
+	return nil
+}
+func (p testHyperVProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1249,7 +1249,6 @@ type testHyperVFlagValues struct {
 	Image  *string
 	CPUs   *int
 	Memory *int
-	Disk   *int
 	Switch *string
 }
 
@@ -1258,7 +1257,6 @@ func (testHyperVProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
 		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Hyper-V image"),
 		CPUs:   fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "Hyper-V CPUs"),
 		Memory: fs.Int("hyperv-memory", defaults.HyperV.Memory, "Hyper-V memory MB"),
-		Disk:   fs.Int("hyperv-disk", defaults.HyperV.Disk, "Hyper-V disk GB"),
 		Switch: fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V switch"),
 	}
 }
@@ -1275,9 +1273,6 @@ func (testHyperVProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) 
 	}
 	if flagWasSet(fs, "hyperv-memory") {
 		cfg.HyperV.Memory = *v.Memory
-	}
-	if flagWasSet(fs, "hyperv-disk") {
-		cfg.HyperV.Disk = *v.Disk
 	}
 	if flagWasSet(fs, "hyperv-switch") {
 		cfg.HyperV.Switch = *v.Switch

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unicode/utf16"
@@ -315,10 +316,8 @@ func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, r
 		probe := *target
 		probe.Port = port
 		probe.FallbackPorts = []string{}
-		cmd := exec.CommandContext(ctx, "ssh", sshArgsWithOptions(probe, remote, connectTimeout, connectionAttempts)...)
-		cmd.Stdout = io.Discard
-		cmd.Stderr = io.Discard
-		err := cmd.Run()
+		cmd := exec.CommandContext(ctx, "ssh", sshArgsNoInputWithOptions(probe, remote, connectTimeout, connectionAttempts)...)
+		err := runSSHCommand(cmd, io.Discard, io.Discard)
 		if err == nil {
 			target.Port = probe.Port
 			return nil
@@ -338,12 +337,13 @@ func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string,
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		probe := target
 		probe.Port = port
-		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
-		out, err := cmd.Output()
+		cmd := exec.CommandContext(ctx, "ssh", sshArgsNoInput(probe, remote)...)
+		var out bytes.Buffer
+		err := runSSHCommand(cmd, &out, io.Discard)
 		if err == nil {
-			return strings.TrimSpace(string(out)), nil
+			return strings.TrimSpace(out.String()), nil
 		}
-		lastOut = out
+		lastOut = out.Bytes()
 		lastErr = err
 		if !shouldRetrySSHPort(err) {
 			return "", err
@@ -364,15 +364,16 @@ func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) 
 		// before it reaches this boundary; see remoteCommand/shellQuote tests.
 		// codeql[go/command-injection]
 		// lgtm[go/command-injection]
-		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
-		out, err := cmd.CombinedOutput()
+		cmd := exec.CommandContext(ctx, "ssh", sshArgsNoInput(probe, remote)...)
+		var out synchronizedBuffer
+		err := runSSHCommand(cmd, &out, &out)
 		if err == nil {
-			return strings.TrimSpace(string(out)), nil
+			return strings.TrimSpace(out.String()), nil
 		}
-		lastOut = out
+		lastOut = out.Bytes()
 		lastErr = err
 		if !shouldRetrySSHPort(err) {
-			return strings.TrimSpace(string(out)), err
+			return strings.TrimSpace(out.String()), err
 		}
 	}
 	return strings.TrimSpace(string(lastOut)), lastErr
@@ -397,9 +398,7 @@ func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.
 		probe.Port = port
 		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
 		cmd.Stdin = bytes.NewReader(data)
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-		err := cmd.Run()
+		err := runSSHCommand(cmd, stdout, stderr)
 		if err == nil {
 			return nil
 		}
@@ -425,9 +424,7 @@ func runSSHInputStream(ctx context.Context, target SSHTarget, remote string, inp
 		probe.Port = port
 		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
 		cmd.Stdin = input
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-		err := cmd.Run()
+		err := runSSHCommand(cmd, stdout, stderr)
 		if err == nil {
 			return nil
 		}
@@ -451,10 +448,8 @@ func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, st
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		probe := target
 		probe.Port = port
-		cmd := exec.CommandContext(ctx, "ssh", sshArgs(probe, remote)...)
-		cmd.Stdout = stdout
-		cmd.Stderr = stderr
-		err := cmd.Run()
+		cmd := exec.CommandContext(ctx, "ssh", sshArgsNoInput(probe, remote)...)
+		err := runSSHCommand(cmd, stdout, stderr)
 		if err == nil {
 			return 0, nil
 		}
@@ -467,6 +462,33 @@ func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, st
 	return lastCode, lastErr
 }
 
+func runSSHCommand(cmd *exec.Cmd, stdout, stderr io.Writer) error {
+	return runCommandWithPlatformStreams(cmd, stdout, stderr)
+}
+
+type synchronizedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(data)
+}
+
+func (b *synchronizedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Clone(b.buf.Bytes())
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func isSSHCommandExitError(err error) bool {
 	var exitErr *exec.ExitError
 	return asExitError(err, &exitErr)
@@ -476,12 +498,24 @@ func sshArgs(target SSHTarget, remote string) []string {
 	return sshArgsWithOptions(target, remote, "10", "3")
 }
 
+func sshArgsNoInput(target SSHTarget, remote string) []string {
+	return sshArgsNoInputWithOptions(target, remote, "10", "3")
+}
+
 func shouldRetrySSHPort(err error) bool {
 	return exitCode(err) == 255
 }
 
 func sshArgsWithOptions(target SSHTarget, remote, connectTimeout, connectionAttempts string) []string {
 	return append(sshBaseArgsWithOptions(target, connectTimeout, connectionAttempts),
+		target.User+"@"+target.Host,
+		remote,
+	)
+}
+
+func sshArgsNoInputWithOptions(target SSHTarget, remote, connectTimeout, connectionAttempts string) []string {
+	return append(sshBaseArgsWithOptions(target, connectTimeout, connectionAttempts),
+		"-n",
 		target.User+"@"+target.Host,
 		remote,
 	)

--- a/internal/cli/ssh_stream_other.go
+++ b/internal/cli/ssh_stream_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package cli
+
+import (
+	"io"
+	"os/exec"
+)
+
+func runCommandWithPlatformStreams(cmd *exec.Cmd, stdout, stderr io.Writer) error {
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}

--- a/internal/cli/ssh_stream_windows.go
+++ b/internal/cli/ssh_stream_windows.go
@@ -1,0 +1,412 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const commandStreamReadBuffer = 64 * 1024
+
+var commandStreamRotateSize int64 = 64 * 1024 * 1024
+
+// Windows inbox OpenSSH can hang after the remote command exits when Go
+// connects its output to pipes. Regular files preserve the client's EOF
+// behavior; briefly suspending the client lets drained spools rotate in place.
+func runCommandWithPlatformStreams(cmd *exec.Cmd, stdout, stderr io.Writer) error {
+	sharedOutput := stderr != nil && sameCommandStreamWriter(stdout, stderr)
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	stdoutSpool, err := newCommandStreamSpool()
+	if err != nil {
+		return err
+	}
+	defer stdoutSpool.close()
+	spools := []*commandStreamSpool{stdoutSpool}
+	copyCount := 1
+	cmd.Stdout = stdoutSpool.output
+	if sharedOutput {
+		cmd.Stderr = stdoutSpool.output
+	} else {
+		stderrSpool, err := newCommandStreamSpool()
+		if err != nil {
+			return err
+		}
+		defer stderrSpool.close()
+		spools = append(spools, stderrSpool)
+		copyCount++
+		cmd.Stderr = stderrSpool.output
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan struct{})
+	copyResults := make(chan error, copyCount)
+	go stdoutSpool.copyTo(stdout, done, copyResults)
+	if !sharedOutput {
+		go spools[1].copyTo(stderr, done, copyResults)
+	}
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- cmd.Wait()
+	}()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	var suspended []windows.Handle
+	for {
+		select {
+		case waitErr := <-waitResult:
+			closeCommandThreadHandles(suspended)
+			close(done)
+			return errors.Join(append([]error{waitErr}, collectCommandStreamResults(copyResults, copyCount)...)...)
+		case copyErr := <-copyResults:
+			return failCommandStreams(cmd, waitResult, done, copyResults, suspended, copyErr, copyCount-1)
+		case <-ticker.C:
+			if len(suspended) == 0 {
+				rotate, err := commandStreamRotationNeeded(spools...)
+				if err != nil {
+					return failCommandStreams(cmd, waitResult, done, copyResults, nil, err, copyCount)
+				}
+				if rotate {
+					suspended, err = suspendCommandProcess(uint32(cmd.Process.Pid))
+					if err != nil {
+						return failCommandStreams(cmd, waitResult, done, copyResults, nil, err, copyCount)
+					}
+				}
+			}
+			if len(suspended) > 0 {
+				drained, err := commandStreamsDrained(spools...)
+				if err != nil {
+					return failCommandStreams(cmd, waitResult, done, copyResults, suspended, err, copyCount)
+				}
+				if drained {
+					var rotateErrs []error
+					for _, spool := range spools {
+						rotateErrs = append(rotateErrs, spool.rotate())
+					}
+					resumeErr := resumeCommandThreads(suspended)
+					suspended = nil
+					if err := errors.Join(errors.Join(rotateErrs...), resumeErr); err != nil {
+						return failCommandStreams(cmd, waitResult, done, copyResults, nil, err, copyCount)
+					}
+				}
+			}
+		}
+	}
+}
+
+func sameCommandStreamWriter(left, right io.Writer) bool {
+	defer func() {
+		_ = recover()
+	}()
+	return left == right
+}
+
+func collectCommandStreamResults(results <-chan error, count int) []error {
+	errs := make([]error, 0, count)
+	for range count {
+		errs = append(errs, <-results)
+	}
+	return errs
+}
+
+type commandStreamSpool struct {
+	output *os.File
+	reader *os.File
+	mu     sync.Mutex
+	offset int64
+}
+
+func newCommandStreamSpool() (*commandStreamSpool, error) {
+	security, err := commandStreamFileSecurity()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(os.TempDir(), "crabbox-ssh-"+strings.TrimPrefix(newLeaseID(), "cbx_")+".tmp")
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	const shareMode = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE
+	const fileFlags = windows.FILE_ATTRIBUTE_TEMPORARY | windows.FILE_FLAG_DELETE_ON_CLOSE
+	outputHandle, err := windows.CreateFile(
+		pathUTF16,
+		windows.GENERIC_WRITE|windows.DELETE|windows.FILE_READ_ATTRIBUTES,
+		shareMode,
+		security,
+		windows.CREATE_NEW,
+		fileFlags,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	readerHandle, err := windows.CreateFile(
+		pathUTF16,
+		windows.GENERIC_READ|windows.DELETE,
+		shareMode,
+		security,
+		windows.OPEN_EXISTING,
+		fileFlags,
+		0,
+	)
+	if err != nil {
+		_ = windows.CloseHandle(outputHandle)
+		return nil, err
+	}
+	if err := markCommandStreamDeletePending(outputHandle, pathUTF16); err != nil {
+		_ = windows.CloseHandle(readerHandle)
+		_ = windows.CloseHandle(outputHandle)
+		return nil, err
+	}
+	return &commandStreamSpool{
+		output: os.NewFile(uintptr(outputHandle), path+"-output"),
+		reader: os.NewFile(uintptr(readerHandle), path+"-reader"),
+	}, nil
+}
+
+func (s *commandStreamSpool) close() {
+	_ = s.reader.Close()
+	_ = s.output.Close()
+}
+
+func (s *commandStreamSpool) copyTo(dst io.Writer, done <-chan struct{}, result chan<- error) {
+	var buf [commandStreamReadBuffer]byte
+	final := false
+	for {
+		s.mu.Lock()
+		n, readErr := s.reader.Read(buf[:])
+		s.mu.Unlock()
+		if n > 0 {
+			written, writeErr := dst.Write(buf[:n])
+			if writeErr != nil {
+				result <- writeErr
+				return
+			}
+			if written != n {
+				result <- io.ErrShortWrite
+				return
+			}
+			s.mu.Lock()
+			s.offset += int64(n)
+			s.mu.Unlock()
+			continue
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			result <- readErr
+			return
+		}
+		if final {
+			result <- nil
+			return
+		}
+		select {
+		case <-done:
+			final = true
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func commandStreamRotationNeeded(spools ...*commandStreamSpool) (bool, error) {
+	for _, spool := range spools {
+		spool.mu.Lock()
+		info, err := spool.output.Stat()
+		spool.mu.Unlock()
+		if err != nil {
+			return false, err
+		}
+		if info.Size() >= commandStreamRotateSize {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func commandStreamsDrained(spools ...*commandStreamSpool) (bool, error) {
+	for _, spool := range spools {
+		spool.mu.Lock()
+		info, err := spool.output.Stat()
+		drained := err == nil && info.Size() == spool.offset
+		spool.mu.Unlock()
+		if err != nil {
+			return false, err
+		}
+		if !drained {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (s *commandStreamSpool) rotate() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	info, err := s.output.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() != s.offset {
+		return fmt.Errorf("rotate SSH output spool before drain: size=%d offset=%d", info.Size(), s.offset)
+	}
+	if err := s.output.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := s.output.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := s.reader.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	s.offset = 0
+	return nil
+}
+
+func failCommandStreams(cmd *exec.Cmd, waitResult <-chan error, done chan<- struct{}, copyResults <-chan error, suspended []windows.Handle, cause error, remainingCopyResults int) error {
+	closeCommandThreadHandles(suspended)
+	_ = cmd.Process.Kill()
+	waitErr := <-waitResult
+	close(done)
+	errs := []error{cause}
+	if waitErr != nil && !isSSHCommandExitError(waitErr) {
+		errs = append(errs, waitErr)
+	}
+	for range remainingCopyResults {
+		errs = append(errs, <-copyResults)
+	}
+	return errors.Join(errs...)
+}
+
+var suspendThreadProc = windows.NewLazySystemDLL("kernel32.dll").NewProc("SuspendThread")
+
+func suspendCommandProcess(processID uint32) ([]windows.Handle, error) {
+	handles := make([]windows.Handle, 0, 4)
+	seen := make(map[uint32]bool)
+	for {
+		added, err := suspendCommandThreads(processID, seen, &handles)
+		if err != nil {
+			_ = resumeCommandThreads(handles)
+			return nil, err
+		}
+		if added == 0 {
+			break
+		}
+	}
+	if len(handles) == 0 {
+		return nil, nil
+	}
+	return handles, nil
+}
+
+func suspendCommandThreads(processID uint32, seen map[uint32]bool, handles *[]windows.Handle) (int, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer windows.CloseHandle(snapshot)
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	added := 0
+	for {
+		if entry.OwnerProcessID == processID && !seen[entry.ThreadID] {
+			thread, openErr := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if openErr == nil {
+				if err := suspendCommandThread(thread); err != nil {
+					_ = windows.CloseHandle(thread)
+					return added, err
+				}
+				seen[entry.ThreadID] = true
+				*handles = append(*handles, thread)
+				added++
+			} else if !errors.Is(openErr, windows.ERROR_INVALID_PARAMETER) {
+				return added, openErr
+			}
+		}
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return added, err
+		}
+	}
+	return added, nil
+}
+
+func suspendCommandThread(thread windows.Handle) error {
+	result, _, callErr := suspendThreadProc.Call(uintptr(thread))
+	if result != uintptr(^uint32(0)) {
+		return nil
+	}
+	if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+		return callErr
+	}
+	return syscall.EINVAL
+}
+
+func resumeCommandThreads(handles []windows.Handle) error {
+	var errs []error
+	for _, thread := range handles {
+		if _, err := windows.ResumeThread(thread); err != nil {
+			errs = append(errs, err)
+		}
+		if err := windows.CloseHandle(thread); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func closeCommandThreadHandles(handles []windows.Handle) {
+	for _, thread := range handles {
+		_ = windows.CloseHandle(thread)
+	}
+}
+
+func commandStreamFileSecurity() (*windows.SecurityAttributes, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, err
+	}
+	sd, err := windows.SecurityDescriptorFromString("D:P(A;;GA;;;" + user.User.Sid.String() + ")")
+	if err != nil {
+		return nil, err
+	}
+	attributes := &windows.SecurityAttributes{SecurityDescriptor: sd}
+	attributes.Length = uint32(unsafe.Sizeof(*attributes))
+	return attributes, nil
+}
+
+func markCommandStreamDeletePending(handle windows.Handle, path *uint16) error {
+	flags := uint32(windows.FILE_DISPOSITION_DELETE | windows.FILE_DISPOSITION_POSIX_SEMANTICS)
+	if err := windows.SetFileInformationByHandle(
+		handle,
+		windows.FileDispositionInfoEx,
+		(*byte)(unsafe.Pointer(&flags)),
+		uint32(unsafe.Sizeof(flags)),
+	); err == nil {
+		return nil
+	}
+	return windows.DeleteFile(path)
+}

--- a/internal/cli/ssh_stream_windows_test.go
+++ b/internal/cli/ssh_stream_windows_test.go
@@ -1,0 +1,165 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+var errCommandStreamTestWriter = errors.New("stream writer failed")
+
+type commandStreamFailingWriter struct{}
+
+func (commandStreamFailingWriter) Write([]byte) (int, error) {
+	return 0, errCommandStreamTestWriter
+}
+
+func TestRunCommandWithPlatformStreams(t *testing.T) {
+	if os.Getenv("CRABBOX_FILE_STREAM_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "stdout-before-exit\n")
+		time.Sleep(50 * time.Millisecond)
+		fmt.Fprint(os.Stderr, "stderr-before-exit\n")
+		os.Exit(23)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCommandWithPlatformStreams$")
+	cmd.Env = append(os.Environ(), "CRABBOX_FILE_STREAM_HELPER=1")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := runCommandWithPlatformStreams(cmd, &stdout, &stderr)
+	if code := exitCode(err); code != 23 {
+		t.Fatalf("exit code=%d error=%v want 23", code, err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "stdout-before-exit") {
+		t.Fatalf("stdout=%q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "stderr-before-exit") {
+		t.Fatalf("stderr=%q", got)
+	}
+}
+
+func TestRunCommandWithPlatformStreamsPreservesWriterError(t *testing.T) {
+	if os.Getenv("CRABBOX_FAILING_FILE_STREAM_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "trigger writer")
+		time.Sleep(time.Second)
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCommandWithPlatformStreamsPreservesWriterError$")
+	cmd.Env = append(os.Environ(), "CRABBOX_FAILING_FILE_STREAM_HELPER=1")
+	err := runCommandWithPlatformStreams(cmd, commandStreamFailingWriter{}, io.Discard)
+	if !errors.Is(err, errCommandStreamTestWriter) {
+		t.Fatalf("error=%v want writer failure", err)
+	}
+	if isSSHCommandExitError(err) {
+		t.Fatalf("writer failure misclassified as SSH exit: %v", err)
+	}
+}
+
+func TestRunCommandWithPlatformStreamsPreservesCombinedOrder(t *testing.T) {
+	if os.Getenv("CRABBOX_COMBINED_FILE_STREAM_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "a")
+		fmt.Fprint(os.Stderr, "b")
+		fmt.Fprint(os.Stdout, "c")
+		os.Exit(0)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCommandWithPlatformStreamsPreservesCombinedOrder$")
+	cmd.Env = append(os.Environ(), "CRABBOX_COMBINED_FILE_STREAM_HELPER=1")
+	var combined bytes.Buffer
+	if err := runCommandWithPlatformStreams(cmd, &combined, &combined); err != nil {
+		t.Fatal(err)
+	}
+	if got := combined.String(); got != "abc" {
+		t.Fatalf("combined=%q want abc", got)
+	}
+}
+
+func TestRunCommandWithPlatformStreamsAllowsNilWriters(t *testing.T) {
+	if os.Getenv("CRABBOX_NIL_FILE_STREAM_HELPER") == "1" {
+		fmt.Fprint(os.Stdout, "discard stdout")
+		fmt.Fprint(os.Stderr, "discard stderr")
+		os.Exit(0)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCommandWithPlatformStreamsAllowsNilWriters$")
+	cmd.Env = append(os.Environ(), "CRABBOX_NIL_FILE_STREAM_HELPER=1")
+	if err := runCommandWithPlatformStreams(cmd, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommandStreamRotationNeededBoundsSpool(t *testing.T) {
+	spool, err := newCommandStreamSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	path := strings.TrimSuffix(spool.output.Name(), "-output")
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("spool path remains visible: %s", path)
+	}
+	if err := spool.output.Truncate(commandStreamRotateSize); err != nil {
+		t.Fatal(err)
+	}
+	rotate, err := commandStreamRotationNeeded(spool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rotate {
+		t.Fatal("commandStreamRotationNeeded()=false want true")
+	}
+}
+
+func TestCommandStreamSpoolRotateResetsHandles(t *testing.T) {
+	spool, err := newCommandStreamSpool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spool.close()
+	if _, err := spool.output.WriteString("output"); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, len("output"))
+	if _, err := io.ReadFull(spool.reader, buf); err != nil {
+		t.Fatal(err)
+	}
+	spool.offset = int64(len(buf))
+	if err := spool.rotate(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := spool.output.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 || spool.offset != 0 {
+		t.Fatalf("size=%d offset=%d want 0", info.Size(), spool.offset)
+	}
+}
+
+func TestRunCommandWithPlatformStreamsRotatesLargeOutput(t *testing.T) {
+	if os.Getenv("CRABBOX_LARGE_FILE_STREAM_HELPER") == "1" {
+		chunk := bytes.Repeat([]byte("x"), 1024*1024)
+		for range 20 {
+			if _, err := os.Stdout.Write(chunk); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+		return
+	}
+	previousRotateSize := commandStreamRotateSize
+	commandStreamRotateSize = 1024 * 1024
+	defer func() {
+		commandStreamRotateSize = previousRotateSize
+	}()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCommandWithPlatformStreamsRotatesLargeOutput$")
+	cmd.Env = append(os.Environ(), "CRABBOX_LARGE_FILE_STREAM_HELPER=1")
+	if err := runCommandWithPlatformStreams(cmd, io.Discard, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -387,6 +387,16 @@ func TestSSHArgsIncludeReliabilityOptions(t *testing.T) {
 	}
 }
 
+func TestSSHArgsNoInputAddsNativeStdinRedirect(t *testing.T) {
+	target := SSHTarget{User: "crabbox", Host: "203.0.113.10", Port: "22"}
+	if got := strings.Join(sshArgsNoInput(target, "true"), " "); !strings.Contains(" "+got+" ", " -n ") {
+		t.Fatalf("sshArgsNoInput() missing -n: %q", got)
+	}
+	if got := strings.Join(sshArgs(target, "true"), " "); strings.Contains(" "+got+" ", " -n ") {
+		t.Fatalf("sshArgs() unexpectedly contains -n: %q", got)
+	}
+}
+
 func TestSSHArgsIncludeCertificateFile(t *testing.T) {
 	t.Setenv("HOME", "/tmp/crabbox-home")
 	got := strings.Join(sshArgs(SSHTarget{

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/external"
 	_ "github.com/openclaw/crabbox/internal/providers/gcp"
 	_ "github.com/openclaw/crabbox/internal/providers/hetzner"
+	_ "github.com/openclaw/crabbox/internal/providers/hyperv"
 	_ "github.com/openclaw/crabbox/internal/providers/incus"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/kubevirt"

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -66,9 +66,6 @@ func applyDefaults(cfg *Config) {
 	if cfg.HyperV.Memory <= 0 {
 		cfg.HyperV.Memory = 8192
 	}
-	if cfg.HyperV.Disk <= 0 {
-		cfg.HyperV.Disk = 50
-	}
 	if cfg.HyperV.Switch == "" {
 		cfg.HyperV.Switch = "Default Switch"
 	}
@@ -133,8 +130,8 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}()
 	cfg.SSHKey = keyPath
 	name := leaseProviderName(leaseID, slug)
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%dGB switch=%s keep=%v\n",
-		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Disk, cfg.HyperV.Switch, req.Keep)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB switch=%s keep=%v\n",
+		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Switch, req.Keep)
 
 	if err := b.createVM(ctx, cfg, name, publicKey); err != nil {
 		_ = b.removeVM(context.Background(), name)
@@ -413,9 +410,9 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 	// Back each lease with a differencing disk over the template instead of
 	// copying the whole VHDX. Creating the child is near-instant and space-thin
 	// (the lease only stores its own writes); the template stays read-only and is
-	// shared across leases. The lease inherits the template's virtual size, so
-	// --hyperv-disk is not applied here -- size the template instead. On release
-	// only this child disk is deleted; the template is left untouched.
+	// shared across leases. The lease inherits the template's virtual size --
+	// size the template to size the lease. On release only this child disk is
+	// deleted; the template is left untouched.
 	diffScript := fmt.Sprintf(
 		`New-VHD -Path '%s' -ParentPath '%s' -Differencing -ErrorAction Stop | Out-Null`,
 		escapePSString(vhdPath), escapePSString(cfg.HyperV.Image),

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -39,7 +39,7 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 
 func applyDefaults(cfg *Config) {
 	cfg.Provider = providerName
-	if cfg.TargetOS == "" || cfg.TargetOS == "linux" {
+	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetWindows
 	}
 	if cfg.WindowsMode == "" {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -25,6 +25,8 @@ type backend struct {
 
 var hypervHostOS = runtime.GOOS
 
+const hypervMissingState = -1
+
 type hypervVM struct {
 	Name  string `json:"Name"`
 	State int    `json:"State"`
@@ -111,6 +113,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs in the user name; choose a different --hyperv-user", providerName)
 		}
 	}
+	if !validHyperVSSHUser(cfg.HyperV.User) {
+		return LeaseTarget{}, exit(2, "provider=%s --hyperv-user must be a local account name containing only letters, digits, dot, underscore, or hyphen", providerName)
+	}
 	if strings.TrimSpace(req.Repo.Root) == "" {
 		return LeaseTarget{}, exit(2, "provider=%s requires a repository root so the VM claim can be persisted before bootstrap", providerName)
 	}
@@ -153,7 +158,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB switch=%s keep=%v\n",
 		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Switch, req.Keep)
 
-	if err := b.createVM(ctx, cfg, name, publicKey); err != nil {
+	if err := b.createVM(ctx, cfg, name); err != nil {
 		_ = b.removeVM(context.Background(), name)
 		return LeaseTarget{}, err
 	}
@@ -176,6 +181,13 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		removeLeaseClaim(leaseID)
 		removeStoredTestboxKey(leaseID)
 		return nil
+	}
+
+	if err := b.stageSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
+		return LeaseTarget{}, errors.Join(fmt.Errorf("pre-network SSH lockdown failed: %w", err), cleanupFailedLease())
+	}
+	if err := b.connectVMNetwork(ctx, name, cfg.HyperV.Switch); err != nil {
+		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 
 	ip, err := b.waitForIP(ctx, name, 5*time.Minute)
@@ -223,6 +235,9 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	}
 	if req.ReleaseOnly {
 		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+	}
+	if inst.State == hypervMissingState {
+		return LeaseTarget{}, exit(4, "hyperv VM %s from claim %s no longer exists; run `crabbox stop --provider hyperv %s` to prune local lease state", inst.Name, claim.LeaseID, claim.LeaseID)
 	}
 	if claim.LeaseID == "" {
 		return LeaseTarget{}, exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
@@ -296,6 +311,10 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
 	}
+	if lease.LeaseID != "" && lease.Server.Status == "missing" {
+		pruneLeaseState(lease.LeaseID)
+		return nil
+	}
 	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, _, err := b.resolveInstance(ctx, lease.LeaseID)
@@ -311,10 +330,14 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		return err
 	}
 	if lease.LeaseID != "" {
-		removeLeaseClaim(lease.LeaseID)
-		removeStoredTestboxKey(lease.LeaseID)
+		pruneLeaseState(lease.LeaseID)
 	}
 	return nil
+}
+
+func pruneLeaseState(leaseID string) {
+	removeLeaseClaim(leaseID)
+	removeStoredTestboxKey(leaseID)
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -401,9 +424,9 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	return server, nil
 }
 
-// createVM creates and starts a Hyper-V VM from the configured image and
-// injects the SSH public key via PowerShell Direct.
-func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey string) error {
+// createVM creates and starts a disconnected Hyper-V VM. Acquire configures
+// guest SSH over PowerShell Direct before connecting the network adapter.
+func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 	vhdDir := hypervVHDDir()
 	if err := os.MkdirAll(vhdDir, 0o755); err != nil {
 		return exit(2, "create VHD directory %s: %v", vhdDir, err)
@@ -469,27 +492,24 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		return commandError("Set-VM", result, err)
 	}
 
-	switchScript := fmt.Sprintf(
-		`Connect-VMNetworkAdapter -VMName '%s' -SwitchName '%s'`,
-		escapePSString(name), escapePSString(cfg.HyperV.Switch),
-	)
-	result, err = b.powershell(ctx, switchScript)
-	if err != nil {
-		return commandError("Connect-VMNetworkAdapter", result, err)
-	}
-
 	startScript := fmt.Sprintf(`Start-VM -Name '%s'`, escapePSString(name))
 	result, err = b.powershell(ctx, startScript)
 	if err != nil {
 		return commandError("Start-VM", result, err)
 	}
 
-	if publicKey != "" {
-		if err := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: SSH key injection via PowerShell Direct failed (will retry during SSH wait): %v\n", err)
-		}
-	}
+	return nil
+}
 
+func (b *backend) connectVMNetwork(ctx context.Context, name, switchName string) error {
+	script := fmt.Sprintf(
+		`Connect-VMNetworkAdapter -VMName '%s' -SwitchName '%s'`,
+		escapePSString(name), escapePSString(switchName),
+	)
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return commandError("Connect-VMNetworkAdapter", result, err)
+	}
 	return nil
 }
 
@@ -632,51 +652,98 @@ func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "git install")
 }
 
-// injectSSHKey writes the SSH public key into the VM via PowerShell Direct,
-// replacing both the user's authorized_keys and, for admin accounts, the
-// administrators_authorized_keys file so template-baked keys cannot retain
-// access to a new lease.
-func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
-	scriptBlock := fmt.Sprintf(
+func sshAccessScript(user, publicKey string, activate bool) string {
+	script := fmt.Sprintf(
 		`$ErrorActionPreference='Stop'; `+
+			`if (Get-Service -Name sshd -ErrorAction SilentlyContinue) { `+
+			`Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue; `+
+			`Set-Service -Name sshd -StartupType Disabled }; `+
+			`if (Get-NetFirewallRule -Name 'Crabbox-SSH-Quarantine' -ErrorAction SilentlyContinue) { `+
+			`Enable-NetFirewallRule -Name 'Crabbox-SSH-Quarantine' | Out-Null `+
+			`} else { `+
+			`New-NetFirewallRule -Name 'Crabbox-SSH-Quarantine' -DisplayName 'Crabbox SSH quarantine' -Enabled True -Direction Inbound -Protocol TCP -Action Block -LocalPort 22 | Out-Null }; `+
+			`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { `+
+			`Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null }; `+
 			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
 			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
 			`Set-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
+			`$hostKeyDir = Join-Path $env:ProgramData 'ssh'; `+
+			`New-Item -ItemType Directory -Force -Path $hostKeyDir | Out-Null; `+
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
-			`if (Test-Path (Split-Path $adminAK)) { Set-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
+			`Set-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
 			`icacls.exe $adminAK /inheritance:r /grant '*S-1-5-18:F' '*S-1-5-32-544:F' | Out-Null; `+
-			`if ($LASTEXITCODE -ne 0) { throw 'administrators_authorized_keys ACL update failed' } }; `+
+			`if ($LASTEXITCODE -ne 0) { throw 'administrators_authorized_keys ACL update failed' }; `+
 			`$sshdConfig = Join-Path $env:ProgramData 'ssh\sshd_config'; `+
 			`$sshdLines = if (Test-Path $sshdConfig) { Get-Content $sshdConfig } else { @() }; `+
-			`$globalLines = @(); $matchLines = @(); $inMatch = $false; `+
+			`$globalLines = @(); `+
 			`foreach ($line in $sshdLines) { `+
-			`if ($line -match '^\s*Match\s+') { $inMatch = $true }; `+
-			`if (-not $inMatch -and $line -match '^\s*(PasswordAuthentication|PubkeyAuthentication)\s+') { continue }; `+
-			`if ($inMatch) { $matchLines += $line } else { $globalLines += $line } }; `+
+			`if ($line -match '^\s*Match\s+') { break }; `+
+			`if ($line -match '^\s*(AuthenticationMethods|PasswordAuthentication|PubkeyAuthentication|KbdInteractiveAuthentication|AllowUsers|AllowGroups|DenyUsers|DenyGroups|AuthorizedKeysFile|AuthorizedKeysCommand|AuthorizedKeysCommandUser|TrustedUserCAKeys|AuthorizedPrincipalsFile)\s+') { continue }; `+
+			`$globalLines += $line }; `+
 			`$globalLines += 'PubkeyAuthentication yes'; `+
 			`$globalLines += 'PasswordAuthentication no'; `+
-			`if (($matchLines -join [Environment]::NewLine) -notmatch '(?im)^\s*Match\s+Group\s+administrators\b') { `+
-			`$matchLines += 'Match Group administrators'; `+
-			`$matchLines += '       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys' }; `+
-			`Set-Content -Encoding ASCII -Path $sshdConfig -Value (($globalLines + $matchLines) -join [Environment]::NewLine); `+
-			`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; `+
-			`& $sshdExe -t -f $sshdConfig; `+
-			`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; `+
-			`$hostKeyDir = Join-Path $env:ProgramData 'ssh'; `+
-			`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*' -ErrorAction SilentlyContinue | Remove-Item -Force; `+
-			`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; `+
-			`& $sshKeygen -A; `+
-			`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; `+
-			`Set-Service -Name sshd -StartupType Automatic; `+
-			`Start-Service sshd; `+
-			`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { `+
-			`Enable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null `+
-			`} else { `+
-			`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }`,
-		escapePSString(publicKey), escapePSString(publicKey),
+			`$globalLines += 'KbdInteractiveAuthentication no'; `+
+			`$globalLines += 'AuthenticationMethods publickey'; `+
+			`$globalLines += 'AuthorizedKeysFile .ssh/authorized_keys'; `+
+			`$globalLines += 'AllowUsers %s'; `+
+			`$globalLines += 'Match Group administrators'; `+
+			`$globalLines += '       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys'; `+
+			`Set-Content -Encoding ASCII -Path $sshdConfig -Value ($globalLines -join [Environment]::NewLine); `,
+		escapePSString(publicKey), escapePSString(publicKey), escapePSString(user),
 	)
+	if !activate {
+		return script
+	}
+	return script +
+		`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; ` +
+		`& $sshdExe -t -f $sshdConfig; ` +
+		`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; ` +
+		`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*' -ErrorAction SilentlyContinue | Remove-Item -Force; ` +
+		`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; ` +
+		`& $sshKeygen -A; ` +
+		`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; ` +
+		`Set-Service -Name sshd -StartupType Automatic; ` +
+		`Start-Service sshd; ` +
+		`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { ` +
+		`Enable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null ` +
+		`} else { ` +
+		`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }; ` +
+		`Remove-NetFirewallRule -Name 'Crabbox-SSH-Quarantine' -ErrorAction Stop`
+}
+
+// stageSSHKey replaces template credentials while the VM is disconnected. The
+// quarantine rule remains active across capability installation and any guest
+// service restart until injectSSHKey completes.
+func (b *backend) stageSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+	return b.invokeInGuest(ctx, vmName, user, sshAccessScript(user, publicKey, false), "pre-network SSH lockdown")
+}
+
+// injectSSHKey repeats the credential lockdown after OpenSSH installation,
+// validates the final config, rotates host keys, starts sshd, and removes the
+// firewall quarantine last.
+func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+	scriptBlock := sshAccessScript(user, publicKey, true)
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "SSH key injection")
+}
+
+func validHyperVSSHUser(user string) bool {
+	user = strings.TrimSpace(user)
+	if user == "" {
+		return false
+	}
+	for _, r := range user {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '.', '_', '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // waitForIP polls Get-VMNetworkAdapter until an IPv4 address appears.
@@ -877,14 +944,14 @@ func (b *backend) removeVHDFile(path string) {
 }
 
 func (b *backend) queryVM(ctx context.Context, name string) (hypervVM, error) {
-	script := fmt.Sprintf(`Get-VM -Name '%s' | Select-Object Name, State | ConvertTo-Json -Compress`, escapePSString(name))
+	script := fmt.Sprintf(`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq '%s' } | Select-Object Name, State | ConvertTo-Json -Compress`, escapePSString(name))
 	result, err := b.powershell(ctx, script)
 	if err != nil {
 		return hypervVM{}, commandError("Get-VM query", result, err)
 	}
 	stdout := strings.TrimSpace(result.Stdout)
 	if stdout == "" || stdout == "null" {
-		return hypervVM{}, exit(4, "hyperv VM %s not found", name)
+		return hypervVM{Name: name, State: hypervMissingState}, nil
 	}
 	var vm hypervVM
 	if err := json.Unmarshal([]byte(stdout), &vm); err != nil {
@@ -1039,6 +1106,9 @@ func instanceNameFromScope(scope string) string {
 }
 
 func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	if strings.EqualFold(server.Labels["keep"], "true") {
+		return false, "keep=true"
+	}
 	if server.Status != "running" && server.Status != "ready" {
 		return true, "instance state=" + blank(server.Status, "unknown")
 	}
@@ -1072,6 +1142,8 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 // See: https://learn.microsoft.com/en-us/windows/win32/hyperv_v2/msvm-computersystem
 func hypervState(state int) string {
 	switch state {
+	case hypervMissingState:
+		return "missing"
 	case 2:
 		return "running"
 	case 3:

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -1,0 +1,765 @@
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+var hypervHostOS = runtime.GOOS
+
+type hypervVM struct {
+	Name  string `json:"Name"`
+	State int    `json:"State"`
+}
+
+type hypervNetAdapter struct {
+	IPAddresses []string `json:"IPAddresses"`
+}
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	applyDefaults(&cfg)
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func applyDefaults(cfg *Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetWindows
+	}
+	if cfg.WindowsMode == "" {
+		cfg.WindowsMode = core.WindowsModeNormal
+	}
+	cfg.SSHFallbackPorts = []string{}
+	if cfg.HyperV.Image == "" {
+		cfg.HyperV.Image = ""
+	}
+	if cfg.HyperV.User == "" {
+		cfg.HyperV.User = "crabbox"
+	}
+	if cfg.HyperV.WorkRoot == "" {
+		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
+			cfg.HyperV.WorkRoot = cfg.WorkRoot
+		} else {
+			cfg.HyperV.WorkRoot = `C:\crabbox`
+		}
+	}
+	if cfg.HyperV.CPUs <= 0 {
+		cfg.HyperV.CPUs = 4
+	}
+	if cfg.HyperV.Memory <= 0 {
+		cfg.HyperV.Memory = 8192
+	}
+	if cfg.HyperV.Disk <= 0 {
+		cfg.HyperV.Disk = 50
+	}
+	if cfg.HyperV.Switch == "" {
+		cfg.HyperV.Switch = "Default Switch"
+	}
+	cfg.SSHUser = cfg.HyperV.User
+	cfg.SSHPort = sshPort
+	cfg.WorkRoot = cfg.HyperV.WorkRoot
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) configForRun() Config {
+	cfg := b.cfg
+	applyDefaults(&cfg)
+	return cfg
+}
+
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if hypervHostOS != "windows" {
+		return LeaseTarget{}, exit(2, "provider=%s requires a Windows host with Hyper-V enabled", providerName)
+	}
+	cfg := b.configForRun()
+	if cfg.HyperV.Image == "" {
+		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (VHDX or ISO path)", providerName)
+	}
+	leaseID := newLeaseID()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := make([]Server, 0, len(instances))
+	for _, inst := range instances {
+		servers = append(servers, b.serverFromInstance(inst, claims[inst.Name], cfg))
+	}
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cleanupKey := true
+	defer func() {
+		if cleanupKey {
+			removeStoredTestboxKey(leaseID)
+		}
+	}()
+	cfg.SSHKey = keyPath
+	_ = publicKey
+	name := leaseProviderName(leaseID, slug)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%dGB switch=%s keep=%v\n",
+		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Disk, cfg.HyperV.Switch, req.Keep)
+
+	if err := b.createVM(ctx, cfg, name); err != nil {
+		_ = b.removeVM(context.Background(), name)
+		return LeaseTarget{}, err
+	}
+
+	ip, err := b.waitForIP(ctx, name, 5*time.Minute)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	labels["instance"] = name
+	labels["image"] = cfg.HyperV.Image
+	labels["ssh_user"] = cfg.HyperV.User
+	labels["ssh_port"] = sshPort
+	labels["work_root"] = cfg.HyperV.WorkRoot
+
+	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
+	lease, err := b.prepareLease(ctx, cfg, hypervVM{Name: name, State: 2}, ip, claim, true)
+	if err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, err
+	}
+	cleanupKey = false
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
+	return lease, nil
+}
+
+func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	cfg := b.configForRun()
+	inst, claim, err := b.resolveInstance(ctx, req.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.ReleaseOnly {
+		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+	}
+	if claim.LeaseID == "" {
+		return LeaseTarget{}, exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
+	}
+	ip := b.getIPFromClaim(claim)
+	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, false)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" {
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	cfg := b.configForRun()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return nil, err
+	}
+	views := make([]LeaseView, 0, len(instances))
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if claim.LeaseID == "" && !strings.HasPrefix(inst.Name, "crabbox-") {
+			continue
+		}
+		views = append(views, b.serverFromInstance(inst, claim, cfg))
+	}
+	return views, nil
+}
+
+func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+	if hypervHostOS != "windows" {
+		return DoctorResult{}, exit(2, "provider=%s requires a Windows host", providerName)
+	}
+	script := `(Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).State`
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return DoctorResult{}, commandError("hyperv feature check", result, err)
+	}
+	state := strings.TrimSpace(result.Stdout)
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	probe := "unchecked"
+	if req.ProbeSSH {
+		probe = "requires_running_lease"
+	}
+	msg := fmt.Sprintf("hyperv=%s control_plane=local inventory=ready api=powershell mutation=false leases=%d ssh_probe=%s",
+		firstLine(state), len(instances), probe)
+	return DoctorResult{Provider: providerName, Message: msg}, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	lease := req.Lease
+	if lease.LeaseID == "" {
+		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
+	}
+	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	if name == "" && lease.LeaseID != "" {
+		inst, claim, err := b.resolveInstance(ctx, lease.LeaseID)
+		if err != nil {
+			return err
+		}
+		name = inst.Name
+		if lease.LeaseID == "" {
+			lease.LeaseID = claim.LeaseID
+		}
+	}
+	if name == "" {
+		return exit(2, "provider=%s release requires a Hyper-V VM name", providerName)
+	}
+	if err := b.removeVM(ctx, name); err != nil {
+		return err
+	}
+	if lease.LeaseID != "" {
+		removeLeaseClaim(lease.LeaseID)
+		removeStoredTestboxKey(lease.LeaseID)
+	}
+	return nil
+}
+
+func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+}
+
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	cfg := b.configForRun()
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return err
+	}
+	live := map[string]struct{}{}
+	now := time.Now().UTC()
+	removed := 0
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if claim.LeaseID != "" {
+			live[claim.LeaseID] = struct{}{}
+		}
+		server := b.serverFromInstance(inst, claim, cfg)
+		shouldDelete, reason := shouldCleanup(server, claim, claim.LeaseID != "", now)
+		if !shouldDelete {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=%s\n", inst.Name, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+		if err := b.removeVM(ctx, inst.Name); err != nil {
+			return err
+		}
+		if claim.LeaseID != "" {
+			removeLeaseClaim(claim.LeaseID)
+			removeStoredTestboxKey(claim.LeaseID)
+		}
+		removed++
+	}
+	claimsRemoved := 0
+	for _, claim := range claims {
+		if claim.LeaseID == "" {
+			continue
+		}
+		if _, ok := live[claim.LeaseID]; ok {
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+		removeLeaseClaim(claim.LeaseID)
+		removeStoredTestboxKey(claim.LeaseID)
+		claimsRemoved++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(instances))
+	}
+	return nil
+}
+
+func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	original := server.Labels
+	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	for _, key := range []string{"image", "instance", "ssh_user", "ssh_port", "work_root"} {
+		if value := strings.TrimSpace(original[key]); value != "" {
+			server.Labels[key] = value
+		}
+	}
+	return server, nil
+}
+
+// createVM creates and starts a Hyper-V VM with the configured settings.
+func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
+	vhdDir := hypervVHDDir()
+	vhdPath := filepath.Join(vhdDir, name+".vhdx")
+
+	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
+	diskBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
+
+	createScript := fmt.Sprintf(
+		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -NewVHDPath '%s' -NewVHDSizeBytes %d`,
+		escapePSString(name), memBytes, escapePSString(vhdPath), diskBytes,
+	)
+	result, err := b.powershell(ctx, createScript)
+	if err != nil {
+		return commandError("New-VM", result, err)
+	}
+
+	cpuScript := fmt.Sprintf(`Set-VM -Name '%s' -ProcessorCount %d`, escapePSString(name), cfg.HyperV.CPUs)
+	result, err = b.powershell(ctx, cpuScript)
+	if err != nil {
+		return commandError("Set-VM", result, err)
+	}
+
+	switchScript := fmt.Sprintf(
+		`Connect-VMNetworkAdapter -VMName '%s' -SwitchName '%s'`,
+		escapePSString(name), escapePSString(cfg.HyperV.Switch),
+	)
+	result, err = b.powershell(ctx, switchScript)
+	if err != nil {
+		return commandError("Connect-VMNetworkAdapter", result, err)
+	}
+
+	startScript := fmt.Sprintf(`Start-VM -Name '%s'`, escapePSString(name))
+	result, err = b.powershell(ctx, startScript)
+	if err != nil {
+		return commandError("Start-VM", result, err)
+	}
+
+	return nil
+}
+
+// waitForIP polls Get-VMNetworkAdapter until an IPv4 address appears.
+func (b *backend) waitForIP(ctx context.Context, name string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	script := fmt.Sprintf(
+		`Get-VMNetworkAdapter -VMName '%s' | Select-Object -ExpandProperty IPAddresses | ConvertTo-Json`,
+		escapePSString(name),
+	)
+	for {
+		if time.Now().After(deadline) {
+			return "", exit(5, "hyperv VM %s did not acquire an IP within %s", name, timeout)
+		}
+		result, err := b.powershell(ctx, script)
+		if err == nil && strings.TrimSpace(result.Stdout) != "" && strings.TrimSpace(result.Stdout) != "null" {
+			ip := parseFirstIPv4(result.Stdout)
+			if ip != "" {
+				return ip, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+func (b *backend) listInstances(ctx context.Context) ([]hypervVM, error) {
+	if hypervHostOS != "windows" {
+		return nil, nil
+	}
+	script := `Get-VM | Where-Object { $_.Name -like 'crabbox-*' } | Select-Object Name, State | ConvertTo-Json -Compress`
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return nil, commandError("Get-VM list", result, err)
+	}
+	stdout := strings.TrimSpace(result.Stdout)
+	if stdout == "" || stdout == "null" {
+		return nil, nil
+	}
+	return parseVMList(stdout)
+}
+
+func (b *backend) resolveInstance(ctx context.Context, identifier string) (hypervVM, core.LeaseClaim, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return hypervVM{}, core.LeaseClaim{}, exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
+	}
+	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+		return hypervVM{}, core.LeaseClaim{}, err
+	} else if ok {
+		name := instanceNameFromClaim(claim)
+		if name == "" {
+			return hypervVM{}, core.LeaseClaim{}, exit(4, "hyperv lease %s has no instance name in its claim", claim.LeaseID)
+		}
+		return hypervVM{Name: name, State: 2}, claim, nil
+	}
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return hypervVM{}, core.LeaseClaim{}, err
+	}
+	claims, err := providerClaims()
+	if err != nil {
+		return hypervVM{}, core.LeaseClaim{}, err
+	}
+	normalized := normalizeLeaseSlug(identifier)
+	for _, inst := range instances {
+		claim := claims[inst.Name]
+		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && normalizeLeaseSlug(claim.Slug) == normalized) {
+			return inst, claim, nil
+		}
+	}
+	return hypervVM{}, core.LeaseClaim{}, exit(4, "hyperv lease not found: %s", identifier)
+}
+
+func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, ip string, claim core.LeaseClaim, wait bool) (LeaseTarget, error) {
+	server := b.serverFromInstance(inst, claim, cfg)
+	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
+		cfg.HyperV.User = user
+		cfg.SSHUser = user
+	}
+	if root := strings.TrimSpace(server.Labels["work_root"]); root != "" {
+		cfg.HyperV.WorkRoot = root
+		cfg.WorkRoot = root
+	}
+	if ip == "" {
+		return LeaseTarget{}, exit(5, "hyperv instance %s has no IPv4 address", inst.Name)
+	}
+	if claim.LeaseID != "" {
+		keyPath, err := testboxKeyPath(claim.LeaseID)
+		if err == nil {
+			if _, statErr := os.Stat(keyPath); statErr == nil {
+				cfg.SSHKey = keyPath
+			}
+		}
+	}
+	target := sshTargetFromConfig(cfg, ip)
+	target.Port = sshPort
+	target.FallbackPorts = []string{}
+	target.ReadyCheck = core.PowershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
+	if wait {
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "hyperv ssh", bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+		server.Status = "ready"
+		server.Labels["state"] = "ready"
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+}
+
+func (b *backend) removeVM(ctx context.Context, name string) error {
+	if !strings.HasPrefix(name, "crabbox-") {
+		return exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
+	}
+	stopScript := fmt.Sprintf(`Stop-VM -Name '%s' -Force -ErrorAction SilentlyContinue`, escapePSString(name))
+	b.powershell(ctx, stopScript) //nolint:errcheck
+
+	removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force`, escapePSString(name))
+	result, err := b.powershell(ctx, removeScript)
+	if err != nil {
+		return commandError("Remove-VM", result, err)
+	}
+
+	vhdPath := filepath.Join(hypervVHDDir(), name+".vhdx")
+	os.Remove(vhdPath) //nolint:errcheck
+
+	return nil
+}
+
+func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg Config) Server {
+	labels := map[string]string{}
+	for key, value := range claim.Labels {
+		labels[key] = value
+	}
+	if labels["crabbox"] == "" {
+		labels["crabbox"] = "true"
+	}
+	if labels["provider"] == "" {
+		labels["provider"] = providerName
+	}
+	if labels["instance"] == "" {
+		labels["instance"] = inst.Name
+	}
+	if labels["lease"] == "" {
+		labels["lease"] = claim.LeaseID
+	}
+	if labels["slug"] == "" {
+		labels["slug"] = claim.Slug
+	}
+	if labels["state"] == "" {
+		labels["state"] = hypervState(inst.State)
+	}
+	if labels["image"] == "" {
+		labels["image"] = cfg.HyperV.Image
+	}
+	if labels["ssh_user"] == "" {
+		labels["ssh_user"] = cfg.HyperV.User
+	}
+	if labels["ssh_port"] == "" {
+		labels["ssh_port"] = sshPort
+	}
+	if labels["work_root"] == "" {
+		labels["work_root"] = cfg.HyperV.WorkRoot
+	}
+	status := hypervState(inst.State)
+	if inst.State == 2 && labels["state"] == "ready" {
+		status = "ready"
+	}
+	server := Server{
+		CloudID:  inst.Name,
+		Provider: providerName,
+		Name:     inst.Name,
+		Status:   status,
+		Labels:   labels,
+	}
+	server.ServerType.Name = "hyperv"
+	return server
+}
+
+func (b *backend) getIPFromClaim(claim core.LeaseClaim) string {
+	if claim.SSHHost != "" {
+		return claim.SSHHost
+	}
+	return ""
+}
+
+func (b *backend) powershell(ctx context.Context, script string) (LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: "powershell",
+		Args: []string{"-NoProfile", "-NonInteractive", "-Command", script},
+	})
+}
+
+func providerClaims() (map[string]core.LeaseClaim, error) {
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider != providerName {
+			continue
+		}
+		name := instanceNameFromClaim(claim)
+		if name == "" {
+			continue
+		}
+		out[name] = claim
+	}
+	return out, nil
+}
+
+func instanceScope(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	return "instance:" + name
+}
+
+func instanceNameFromClaim(claim core.LeaseClaim) string {
+	if name := strings.TrimSpace(claim.Labels["instance"]); name != "" {
+		return name
+	}
+	return instanceNameFromScope(claim.ProviderScope)
+}
+
+func instanceNameFromScope(scope string) string {
+	return strings.TrimPrefix(strings.TrimSpace(scope), "instance:")
+}
+
+func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	if strings.EqualFold(server.Labels["keep"], "true") {
+		return false, "keep=true"
+	}
+	if server.Status != "running" && server.Status != "ready" {
+		return true, "instance state=" + blank(server.Status, "unknown")
+	}
+	if hasClaim {
+		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+		if err != nil || lastUsed.IsZero() {
+			return false, "claim active"
+		}
+		idle := time.Duration(claim.IdleTimeoutSeconds) * time.Second
+		if idle <= 0 {
+			return false, "claim active"
+		}
+		if now.After(lastUsed.Add(idle).Add(12 * time.Hour)) {
+			return true, "claim expired"
+		}
+		return false, "claim active"
+	}
+	return false, "missing claim"
+}
+
+// hypervState maps Hyper-V State enum values to string labels.
+// See: https://learn.microsoft.com/en-us/windows/win32/hyperv_v2/msvm-computersystem
+func hypervState(state int) string {
+	switch state {
+	case 2:
+		return "running"
+	case 3:
+		return "off"
+	case 6:
+		return "saved"
+	case 9:
+		return "paused"
+	default:
+		return "unknown"
+	}
+}
+
+func hypervVHDDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = `C:\Users\Public`
+	}
+	return filepath.Join(home, "Hyper-V", "Virtual Hard Disks")
+}
+
+func parseVMList(raw string) ([]hypervVM, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil, nil
+	}
+	if strings.HasPrefix(raw, "[") {
+		var vms []hypervVM
+		if err := json.Unmarshal([]byte(raw), &vms); err != nil {
+			return nil, exit(2, "parse hyperv VM list: %v", err)
+		}
+		return vms, nil
+	}
+	var vm hypervVM
+	if err := json.Unmarshal([]byte(raw), &vm); err != nil {
+		return nil, exit(2, "parse hyperv VM: %v", err)
+	}
+	return []hypervVM{vm}, nil
+}
+
+func parseFirstIPv4(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "[") {
+		var ips []string
+		if err := json.Unmarshal([]byte(raw), &ips); err != nil {
+			return ""
+		}
+		for _, ip := range ips {
+			if isIPv4(ip) {
+				return ip
+			}
+		}
+		return ""
+	}
+	raw = strings.Trim(raw, `"`)
+	if isIPv4(raw) {
+		return raw
+	}
+	return ""
+}
+
+func isIPv4(s string) bool {
+	s = strings.TrimSpace(s)
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return false
+		}
+	}
+	return true
+}
+
+func escapePSString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func commandError(action string, result LocalCommandResult, err error) error {
+	code := result.ExitCode
+	if code == 0 {
+		code = 1
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		return exit(code, "%s failed: %v: %s", action, err, detail)
+	}
+	return exit(code, "%s failed: %v", action, err)
+}
+
+func firstLine(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	if idx := strings.IndexByte(value, '\n'); idx >= 0 {
+		value = value[:idx]
+	}
+	return strings.TrimSpace(value)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -86,7 +86,10 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	cfg := b.configForRun()
 	if cfg.HyperV.Image == "" {
-		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (VHDX or ISO path)", providerName)
+		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (path to a VHDX template with OpenSSH pre-configured)", providerName)
+	}
+	if strings.HasSuffix(strings.ToLower(cfg.HyperV.Image), ".iso") {
+		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a pre-configured VHDX template with OpenSSH and a known user", providerName)
 	}
 	leaseID := newLeaseID()
 	instances, err := b.listInstances(ctx)
@@ -361,34 +364,22 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		return commandError("switch validation", result, err)
 	}
 
-	imageLower := strings.ToLower(cfg.HyperV.Image)
-	isISO := strings.HasSuffix(imageLower, ".iso")
-
 	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
 
-	var createScript string
-	if isISO {
-		diskBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
-		createScript = fmt.Sprintf(
-			`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -NewVHDPath '%s' -NewVHDSizeBytes %d`,
-			escapePSString(name), memBytes, escapePSString(vhdPath), diskBytes,
-		)
-	} else {
-		copyScript := fmt.Sprintf(`Copy-Item -LiteralPath '%s' -Destination '%s'`, escapePSString(cfg.HyperV.Image), escapePSString(vhdPath))
-		result, err = b.powershell(ctx, copyScript)
-		if err != nil {
-			return commandError("copy VHDX template", result, err)
-		}
-		if cfg.HyperV.Disk > 0 {
-			resizeScript := fmt.Sprintf(`Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction SilentlyContinue`,
-				escapePSString(vhdPath), int64(cfg.HyperV.Disk)*1024*1024*1024)
-			b.powershell(ctx, resizeScript) //nolint:errcheck
-		}
-		createScript = fmt.Sprintf(
-			`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s'`,
-			escapePSString(name), memBytes, escapePSString(vhdPath),
-		)
+	copyScript := fmt.Sprintf(`Copy-Item -LiteralPath '%s' -Destination '%s'`, escapePSString(cfg.HyperV.Image), escapePSString(vhdPath))
+	result, err = b.powershell(ctx, copyScript)
+	if err != nil {
+		return commandError("copy VHDX template", result, err)
 	}
+	if cfg.HyperV.Disk > 0 {
+		resizeScript := fmt.Sprintf(`Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction SilentlyContinue`,
+			escapePSString(vhdPath), int64(cfg.HyperV.Disk)*1024*1024*1024)
+		b.powershell(ctx, resizeScript) //nolint:errcheck
+	}
+	createScript := fmt.Sprintf(
+		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s'`,
+		escapePSString(name), memBytes, escapePSString(vhdPath),
+	)
 	result, err = b.powershell(ctx, createScript)
 	if err != nil {
 		return commandError("New-VM", result, err)
@@ -409,14 +400,6 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		return commandError("Connect-VMNetworkAdapter", result, err)
 	}
 
-	if isISO {
-		dvdScript := fmt.Sprintf(`Add-VMDvdDrive -VMName '%s' -Path '%s'`, escapePSString(name), escapePSString(cfg.HyperV.Image))
-		result, err = b.powershell(ctx, dvdScript)
-		if err != nil {
-			return commandError("Add-VMDvdDrive", result, err)
-		}
-	}
-
 	startScript := fmt.Sprintf(`Start-VM -Name '%s'`, escapePSString(name))
 	result, err = b.powershell(ctx, startScript)
 	if err != nil {
@@ -425,7 +408,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 
 	if publicKey != "" {
 		if err := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: SSH key injection via PowerShell Direct failed: %v (image may need pre-configured SSH)\n", err)
+			fmt.Fprintf(b.rt.Stderr, "warning: SSH key injection via PowerShell Direct failed (will retry during SSH wait): %v\n", err)
 		}
 	}
 
@@ -433,12 +416,18 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 }
 
 // injectSSHKey writes the SSH public key into the VM via PowerShell Direct
-// (Invoke-Command -VMName). This requires the VM to have booted and the guest
-// user to exist. It is best-effort: if the image already has SSH pre-configured
-// the key injection may be redundant.
+// (Invoke-Command -VMName). Retries up to 5 times with backoff to allow the
+// guest OS to boot. The VHDX template must have the configured user with the
+// password matching CRABBOX_HYPERV_GUEST_PASSWORD (default: from config or
+// image-level convention). This is best-effort: images with pre-configured
+// authorized_keys and OpenSSH will work without injection.
 func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+	guestPassword := b.cfg.HyperV.GuestPassword
+	if guestPassword == "" {
+		guestPassword = "crabbox"
+	}
 	script := fmt.Sprintf(
-		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString 'crabbox' -AsPlainText -Force)); `+
+		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString '%s' -AsPlainText -Force)); `+
 			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { `+
 			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
@@ -447,13 +436,26 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
 			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' } `+
 			`}`,
-		escapePSString(user), escapePSString(vmName), escapePSString(publicKey), escapePSString(publicKey),
+		escapePSString(user), escapePSString(guestPassword), escapePSString(vmName),
+		escapePSString(publicKey), escapePSString(publicKey),
 	)
-	result, err := b.powershell(ctx, script)
-	if err != nil {
-		return commandError("SSH key injection", result, err)
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(attempt*5) * time.Second):
+			}
+			fmt.Fprintf(b.rt.Stderr, "retrying SSH key injection (%d/5)...\n", attempt+1)
+		}
+		result, err := b.powershell(ctx, script)
+		if err == nil {
+			return nil
+		}
+		lastErr = commandError("SSH key injection", result, err)
 	}
-	return nil
+	return lastErr
 }
 
 // waitForIP polls Get-VMNetworkAdapter until an IPv4 address appears.
@@ -512,7 +514,7 @@ func (b *backend) resolveInstance(ctx context.Context, identifier string) (hyper
 		}
 		vm, queryErr := b.queryVM(ctx, name)
 		if queryErr != nil {
-			return hypervVM{Name: name, State: 2}, claim, nil
+			return hypervVM{}, claim, exit(4, "hyperv VM %s from claim %s not reachable: %v", name, claim.LeaseID, queryErr)
 		}
 		return vm, claim, nil
 	}
@@ -585,13 +587,15 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		return commandError("Remove-VM", result, err)
 	}
 
+	expectedVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
 	if len(vhdPaths) > 0 {
 		for _, p := range vhdPaths {
-			os.Remove(p) //nolint:errcheck
+			if strings.EqualFold(filepath.Clean(p), filepath.Clean(expectedVHD)) {
+				os.Remove(p) //nolint:errcheck
+			}
 		}
 	} else {
-		vhdPath := filepath.Join(hypervVHDDir(), name+".vhdx")
-		os.Remove(vhdPath) //nolint:errcheck
+		os.Remove(expectedVHD) //nolint:errcheck
 	}
 
 	return nil

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -569,12 +569,23 @@ func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error 
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "OpenSSH install")
 }
 
+// MinGit release pinned for the guest git bootstrap. The download runs inside
+// the guest and lands in Program Files + machine PATH, so it must not float
+// with "latest": a changed release response or substituted archive would be
+// privileged guest code execution. Update the URL and SHA-256 together; the
+// hash is the official checksum from the git-for-windows release notes for
+// this exact asset.
+const (
+	minGitURL    = "https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip"
+	minGitSHA256 = "04f937e1f0918b17b9be6f2294cb2bb66e96e1d9832d1c298e2de088a1d0e668"
+)
+
 // ensureGit installs git in the guest when it is absent, so a plain Windows
 // template (only a known admin password) satisfies Crabbox's Windows readiness
 // check, which requires git for sync -- mirroring how the Linux cloud-init path
 // installs git. Idempotent: a no-op when git is already on PATH (so a template
-// that pre-bakes git skips the per-lease download). Uses portable MinGit from
-// the latest git-for-windows release; needs guest internet.
+// that pre-bakes git skips the per-lease download). Uses the pinned MinGit
+// release above, SHA-256-verified before extraction; needs guest internet.
 //
 // MinGit must NOT be extracted to C:\Program Files\Git: MinGit's etc\gitconfig
 // deliberately includes C:/Program Files/Git/etc/gitconfig (to inherit a full
@@ -586,12 +597,10 @@ func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`if (Get-Command git -ErrorAction SilentlyContinue) { return }; ` +
 		`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; ` +
-		`$h=@{'User-Agent'='crabbox'}; ` +
-		`$rel=Invoke-RestMethod -UseBasicParsing -Uri 'https://api.github.com/repos/git-for-windows/git/releases/latest' -Headers $h; ` +
-		`$asset=$rel.assets | Where-Object { $_.name -like 'MinGit-*-64-bit.zip' } | Select-Object -First 1; ` +
-		`if (-not $asset) { throw 'MinGit asset not found' }; ` +
 		`$zip=Join-Path $env:TEMP 'crabbox-mingit.zip'; ` +
-		`Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zip; ` +
+		`Invoke-WebRequest -UseBasicParsing -Uri '` + minGitURL + `' -OutFile $zip; ` +
+		`$hash=(Get-FileHash -Path $zip -Algorithm SHA256).Hash; ` +
+		`if ($hash -ne '` + minGitSHA256 + `') { Remove-Item $zip -Force; throw ('MinGit SHA-256 mismatch: got ' + $hash) }; ` +
 		`$dst='C:\Program Files\MinGit'; ` +
 		`Expand-Archive -Path $zip -DestinationPath $dst -Force; ` +
 		`$cmd=Join-Path $dst 'cmd'; ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -396,22 +396,20 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 
 	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
 
-	copyScript := fmt.Sprintf(`Copy-Item -LiteralPath '%s' -Destination '%s'`, escapePSString(cfg.HyperV.Image), escapePSString(vhdPath))
-	result, err = b.powershell(ctx, copyScript)
+	// Back each lease with a differencing disk over the template instead of
+	// copying the whole VHDX. Creating the child is near-instant and space-thin
+	// (the lease only stores its own writes); the template stays read-only and is
+	// shared across leases. The lease inherits the template's virtual size, so
+	// --hyperv-disk is not applied here -- size the template instead. On release
+	// only this child disk is deleted; the template is left untouched.
+	diffScript := fmt.Sprintf(
+		`New-VHD -Path '%s' -ParentPath '%s' -Differencing -ErrorAction Stop | Out-Null`,
+		escapePSString(vhdPath), escapePSString(cfg.HyperV.Image),
+	)
+	result, err = b.powershell(ctx, diffScript)
 	if err != nil {
-		return commandError("copy VHDX template", result, err)
-	}
-	if cfg.HyperV.Disk > 0 {
-		targetSizeBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
-		resizeScript := fmt.Sprintf(
-			`$vhd = Get-VHD -Path '%s' -ErrorAction Stop; if ($vhd.Size -lt %d) { Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction Stop }`,
-			escapePSString(vhdPath), targetSizeBytes, escapePSString(vhdPath), targetSizeBytes,
-		)
-		result, err = b.powershell(ctx, resizeScript)
-		if err != nil {
-			os.Remove(vhdPath) //nolint:errcheck
-			return commandError("Resize-VHD", result, err)
-		}
+		os.Remove(vhdPath) //nolint:errcheck
+		return commandError("create differencing disk", result, err)
 	}
 	createScript := fmt.Sprintf(
 		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s' -Path '%s'`,

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -111,6 +111,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs in the user name; choose a different --hyperv-user", providerName)
 		}
 	}
+	if strings.TrimSpace(req.Repo.Root) == "" {
+		return LeaseTarget{}, exit(2, "provider=%s requires a repository root so the VM claim can be persisted before bootstrap", providerName)
+	}
 	leaseID := newLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -154,59 +157,50 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		_ = b.removeVM(context.Background(), name)
 		return LeaseTarget{}, err
 	}
-	if req.Keep {
-		retained := LeaseTarget{
-			Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
-			LeaseID: leaseID,
+	provisional := LeaseTarget{
+		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+		LeaseID: leaseID,
+	}
+	if err := persistLease(leaseID, slug, name, cfg, req, provisional); err != nil {
+		_ = b.removeVM(context.Background(), name)
+		return LeaseTarget{}, fmt.Errorf("persist hyperv lease before bootstrap: %w", err)
+	}
+	cleanupKey = false
+	cleanupFailedLease := func() error {
+		if req.Keep {
+			return nil
 		}
-		if err := persistLease(leaseID, slug, name, cfg, req, retained); err != nil {
-			_ = b.removeVM(context.Background(), name)
-			return LeaseTarget{}, fmt.Errorf("persist retained hyperv lease before bootstrap: %w", err)
+		if err := b.removeVM(context.Background(), name); err != nil {
+			return fmt.Errorf("remove failed hyperv lease %s: %w", leaseID, err)
 		}
-		cleanupKey = false
+		removeLeaseClaim(leaseID)
+		removeStoredTestboxKey(leaseID)
+		return nil
 	}
 
 	ip, err := b.waitForIP(ctx, name, 5*time.Minute)
 	if err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 
 	if err := b.ensureOpenSSH(ctx, name, cfg.HyperV.User); err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, fmt.Errorf("guest OpenSSH setup failed: %w", err)
+		return LeaseTarget{}, errors.Join(fmt.Errorf("guest OpenSSH setup failed: %w", err), cleanupFailedLease())
 	}
 
 	if publicKey != "" {
 		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
-			if !req.Keep {
-				_ = b.removeVM(context.Background(), name)
-			}
-			return LeaseTarget{}, fmt.Errorf("post-boot SSH key injection failed: %w", retryErr)
+			return LeaseTarget{}, errors.Join(fmt.Errorf("post-boot SSH key injection failed: %w", retryErr), cleanupFailedLease())
 		}
 	}
 	if err := b.ensureGit(ctx, name, cfg.HyperV.User); err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, fmt.Errorf("guest git setup failed: %w", err)
+		return LeaseTarget{}, errors.Join(fmt.Errorf("guest git setup failed: %w", err), cleanupFailedLease())
 	}
 	lease, err := b.prepareLease(ctx, cfg, hypervVM{Name: name, State: 2}, ip, claim, true)
 	if err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 	if err := persistLease(leaseID, slug, name, cfg, req, lease); err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
@@ -579,12 +573,13 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 	return lastErr
 }
 
-// ensureOpenSSH installs and starts the Windows OpenSSH server inside the guest
-// over PowerShell Direct when it is not already present, then opens the firewall
-// for it. This lets a plain Windows template be used as-is: it only needs a
-// reachable administrator account (CRABBOX_HYPERV_GUEST_PASSWORD), not a
-// pre-baked SSH setup. Idempotent; installing the capability needs guest
-// internet (or a configured Features-on-Demand source).
+// ensureOpenSSH installs the Windows OpenSSH server inside the guest, but keeps
+// sshd stopped and its firewall rule disabled until injectSSHKey replaces the
+// template credentials and host keys. This lets a plain Windows template be
+// used as-is: it only needs a reachable administrator account
+// (CRABBOX_HYPERV_GUEST_PASSWORD), not a pre-baked SSH setup. Idempotent;
+// installing the capability needs guest internet (or a configured
+// Features-on-Demand source).
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*'; ` +
@@ -668,6 +663,11 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; `+
 			`& $sshdExe -t -f $sshdConfig; `+
 			`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; `+
+			`$hostKeyDir = Join-Path $env:ProgramData 'ssh'; `+
+			`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*' -ErrorAction SilentlyContinue | Remove-Item -Force; `+
+			`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; `+
+			`& $sshKeygen -A; `+
+			`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; `+
 			`Set-Service -Name sshd -StartupType Automatic; `+
 			`Start-Service sshd; `+
 			`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { `+
@@ -810,11 +810,9 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		return commandError("Remove-VM", result, err)
 	}
 
-	// Always remove the provider-created boot disk. We can't rely on the attached
-	// disk path matching it: client Hyper-V may have created and attached a
-	// <name>_<guid>.avhdx checkpoint disk instead, in which case the base VHDX
-	// would otherwise be leaked. Also sweep any name-prefixed differencing disks
-	// in our VHD directory, while leaving unrelated attached disks untouched.
+	// Always remove the provider-created boot disk. Client Hyper-V may attach a
+	// <name>_<guid>.avhdx checkpoint disk instead, so remove attached checkpoint
+	// files only when their filename has that exact provider-owned shape.
 	vhdDir := hypervVHDDir()
 	expectedVHD := filepath.Join(vhdDir, name+".vhdx")
 	b.removeVHDFile(expectedVHD)
@@ -823,8 +821,7 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		if strings.EqualFold(clean, filepath.Clean(expectedVHD)) {
 			continue
 		}
-		if strings.HasPrefix(filepath.Base(clean), name) &&
-			strings.EqualFold(filepath.Dir(clean), filepath.Clean(vhdDir)) {
+		if ownedHyperVCheckpoint(clean, vhdDir, name) {
 			b.removeVHDFile(p)
 		}
 	}
@@ -836,6 +833,37 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 	}
 
 	return nil
+}
+
+func ownedHyperVCheckpoint(path, vhdDir, name string) bool {
+	clean := filepath.Clean(path)
+	if !strings.EqualFold(filepath.Dir(clean), filepath.Clean(vhdDir)) {
+		return false
+	}
+	base := filepath.Base(clean)
+	ext := filepath.Ext(base)
+	if !strings.EqualFold(ext, ".avhdx") {
+		return false
+	}
+	stem := strings.TrimSuffix(base, ext)
+	prefix := name + "_"
+	if len(stem) != len(prefix)+36 || !strings.EqualFold(stem[:len(prefix)], prefix) {
+		return false
+	}
+	guid := stem[len(prefix):]
+	for i, r := range guid {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // removeVHDFile deletes a lease VHDX best-effort. The VM is already gone by the
@@ -1011,13 +1039,19 @@ func instanceNameFromScope(scope string) string {
 }
 
 func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
-	if strings.EqualFold(server.Labels["keep"], "true") {
-		return false, "keep=true"
-	}
 	if server.Status != "running" && server.Status != "ready" {
 		return true, "instance state=" + blank(server.Status, "unknown")
 	}
 	if hasClaim {
+		expiresAt := strings.TrimSpace(server.Labels["expires_at"])
+		if expiresAt == "" {
+			expiresAt = strings.TrimSpace(claim.Labels["expires_at"])
+		}
+		if display := core.LeaseLabelTimeDisplay(expiresAt); display != "" {
+			if parsed, err := time.Parse(time.RFC3339, display); err == nil && now.After(parsed) {
+				return true, "claim expired"
+			}
+		}
 		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
 		if err != nil || lastUsed.IsZero() {
 			return false, "claim active"

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -2,6 +2,7 @@ package hyperv
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -512,6 +513,7 @@ func (b *backend) guestPassword() string {
 // a command line; inside the guest it is visible to the guest itself (RunOnce
 // value, then the net.exe command line at first logon), which the lease owns.
 func (b *backend) injectInitPassword(ctx context.Context, vhdPath, user string) error {
+	hiveName := hypervInitHiveName(vhdPath)
 	script := fmt.Sprintf(
 		`$ErrorActionPreference = 'Stop'; `+
 			`$disk = Mount-VHD -Path '%s' -Passthru | Get-Disk; `+
@@ -520,18 +522,18 @@ func (b *backend) injectInitPassword(ctx context.Context, vhdPath, user string) 
 			`$letters = ($disk | Get-Partition | Where-Object DriveLetter).DriveLetter; `+
 			`$sys = $letters | Where-Object { Test-Path ("$_" + ':\Windows\System32\config\SOFTWARE') } | Select-Object -First 1; `+
 			`if (-not $sys) { throw 'no Windows system volume found in template' }; `+
-			`reg.exe load HKLM\crabbox-init ("$sys" + ':\Windows\System32\config\SOFTWARE') | Out-Null; `+
+			`reg.exe load HKLM\%s ("$sys" + ':\Windows\System32\config\SOFTWARE') | Out-Null; `+
 			`if ($LASTEXITCODE -ne 0) { throw 'loading the offline SOFTWARE hive failed' }; `+
 			`try { `+
-			`$runOnce = 'HKLM:\crabbox-init\Microsoft\Windows\CurrentVersion\RunOnce'; `+
+			`$runOnce = 'HKLM:\%s\Microsoft\Windows\CurrentVersion\RunOnce'; `+
 			`if (-not (Test-Path $runOnce)) { New-Item -Path $runOnce -Force | Out-Null }; `+
 			`New-ItemProperty -Path $runOnce -Name 'CrabboxInitPassword' -PropertyType String -Force -Value ('cmd /c net user "%s" "' + $env:_CRABBOX_GP + '" /y') | Out-Null `+
 			`} finally { `+
 			`[gc]::Collect(); [gc]::WaitForPendingFinalizers(); `+
-			`reg.exe unload HKLM\crabbox-init | Out-Null `+
+			`reg.exe unload HKLM\%s | Out-Null `+
 			`} `+
 			`} finally { Dismount-VHD -Path '%s' }`,
-		escapePSString(vhdPath), escapePSString(user), escapePSString(vhdPath),
+		escapePSString(vhdPath), hiveName, hiveName, escapePSString(user), hiveName, escapePSString(vhdPath),
 	)
 	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
 	result, err := b.powershellWithEnv(ctx, script, env)
@@ -539,6 +541,11 @@ func (b *backend) injectInitPassword(ctx context.Context, vhdPath, user string) 
 		return commandError("init-password injection", result, err)
 	}
 	return nil
+}
+
+func hypervInitHiveName(vhdPath string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(vhdPath))))
+	return fmt.Sprintf("crabbox-init-%x", sum[:8])
 }
 
 // invokeInGuest runs a PowerShell script block inside the guest over PowerShell
@@ -631,17 +638,18 @@ func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 }
 
 // injectSSHKey writes the SSH public key into the VM via PowerShell Direct,
-// appending to both the user's authorized_keys and, for admin accounts, the
-// administrators_authorized_keys file.
+// replacing both the user's authorized_keys and, for admin accounts, the
+// administrators_authorized_keys file so template-baked keys cannot retain
+// access to a new lease.
 func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
 	scriptBlock := fmt.Sprintf(
 		`$ErrorActionPreference='Stop'; `+
 			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
 			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
-			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
+			`Set-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
-			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
+			`if (Test-Path (Split-Path $adminAK)) { Set-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
 			`icacls.exe $adminAK /inheritance:r /grant '*S-1-5-18:F' '*S-1-5-32-544:F' | Out-Null; `+
 			`if ($LASTEXITCODE -ne 0) { throw 'administrators_authorized_keys ACL update failed' } }; `+
 			`$sshdConfig = Join-Path $env:ProgramData 'ssh\sshd_config'; `+

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -520,7 +520,8 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
 			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
-			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' }`,
+			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
+			`icacls $adminAK /inheritance:r /grant 'SYSTEM:F' 'BUILTIN\Administrators:F' | Out-Null }`,
 		escapePSString(publicKey), escapePSString(publicKey),
 	)
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "SSH key injection")

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -91,10 +91,10 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	cfg := b.configForRun()
 	if cfg.HyperV.Image == "" {
-		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (path to a VHDX template with OpenSSH pre-configured)", providerName)
+		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (path to a Windows VHDX template with a known administrator password; the provider installs OpenSSH if missing)", providerName)
 	}
 	if strings.HasSuffix(strings.ToLower(cfg.HyperV.Image), ".iso") {
-		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a pre-configured VHDX template with OpenSSH and a known user", providerName)
+		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a Windows VHDX template with a reachable administrator account", providerName)
 	}
 	leaseID := newLeaseID()
 	instances, err := b.listInstances(ctx)
@@ -139,6 +139,13 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 			_ = b.removeVM(context.Background(), name)
 		}
 		return LeaseTarget{}, err
+	}
+
+	if err := b.ensureOpenSSH(ctx, name, cfg.HyperV.User); err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, fmt.Errorf("guest OpenSSH setup failed: %w", err)
 	}
 
 	if publicKey != "" {
@@ -451,32 +458,22 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 	return nil
 }
 
-// injectSSHKey writes the SSH public key into the VM via PowerShell Direct
-// (Invoke-Command -VMName). Retries up to 5 times with backoff to allow the
-// guest OS to boot. The VHDX template must have the configured user with the
-// password matching CRABBOX_HYPERV_GUEST_PASSWORD (default: from config or
-// image-level convention). This is best-effort: images with pre-configured
-// authorized_keys and OpenSSH will work without injection.
-func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+// invokeInGuest runs a PowerShell script block inside the guest over PowerShell
+// Direct, authenticating as user with the configured guest password. It retries
+// with backoff while the guest finishes booting. scriptBlock is the body of an
+// Invoke-Command -ScriptBlock { ... }; the guest password is passed via the
+// _CRABBOX_GP env var, never on the command line.
+func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, label string) error {
 	guestPassword := b.cfg.HyperV.GuestPassword
 	if guestPassword == "" {
 		guestPassword = "crabbox"
 	}
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
-			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { `+
-			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
-			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
-			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
-			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
-			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
-			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' } `+
-			`}`,
-		escapePSString(user), escapePSString(vmName),
-		escapePSString(publicKey), escapePSString(publicKey),
+			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { %s }`,
+		escapePSString(user), escapePSString(vmName), scriptBlock,
 	)
-	env := os.Environ()
-	env = append(env, "_CRABBOX_GP="+guestPassword)
+	env := append(os.Environ(), "_CRABBOX_GP="+guestPassword)
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
 		if attempt > 0 {
@@ -485,15 +482,48 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 				return ctx.Err()
 			case <-time.After(time.Duration(attempt*5) * time.Second):
 			}
-			fmt.Fprintf(b.rt.Stderr, "retrying SSH key injection (%d/5)...\n", attempt+1)
+			fmt.Fprintf(b.rt.Stderr, "retrying %s (%d/5)...\n", label, attempt+1)
 		}
 		result, err := b.powershellWithEnv(ctx, script, env)
 		if err == nil {
 			return nil
 		}
-		lastErr = commandError("SSH key injection", result, err)
+		lastErr = commandError(label, result, err)
 	}
 	return lastErr
+}
+
+// ensureOpenSSH installs and starts the Windows OpenSSH server inside the guest
+// over PowerShell Direct when it is not already present, then opens the firewall
+// for it. This lets a plain Windows template be used as-is: it only needs a
+// reachable administrator account (CRABBOX_HYPERV_GUEST_PASSWORD), not a
+// pre-baked SSH setup. Idempotent; installing the capability needs guest
+// internet (or a configured Features-on-Demand source).
+func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
+	scriptBlock := `$ErrorActionPreference='Stop'; ` +
+		`$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*'; ` +
+		`if ($cap.State -ne 'Installed') { Add-WindowsCapability -Online -Name $cap.Name | Out-Null }; ` +
+		`Set-Service -Name sshd -StartupType Automatic; ` +
+		`Start-Service sshd; ` +
+		`if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) { ` +
+		`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }`
+	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "OpenSSH install")
+}
+
+// injectSSHKey writes the SSH public key into the VM via PowerShell Direct,
+// appending to both the user's authorized_keys and, for admin accounts, the
+// administrators_authorized_keys file.
+func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+	scriptBlock := fmt.Sprintf(
+		`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
+			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
+			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
+			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
+			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
+			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' }`,
+		escapePSString(publicKey), escapePSString(publicKey),
+	)
+	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "SSH key injection")
 }
 
 // waitForIP polls Get-VMNetworkAdapter until an IPv4 address appears.

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -47,7 +47,11 @@ func applyDefaults(cfg *Config) {
 	}
 	cfg.SSHFallbackPorts = []string{}
 	if cfg.HyperV.User == "" {
-		cfg.HyperV.User = "crabbox"
+		if cfg.SSHUser != "" && cfg.SSHUser != "crabbox" {
+			cfg.HyperV.User = cfg.SSHUser
+		} else {
+			cfg.HyperV.User = "crabbox"
+		}
 	}
 	if cfg.HyperV.WorkRoot == "" {
 		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
@@ -241,12 +245,13 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	if err != nil {
 		return DoctorResult{}, err
 	}
+	cfg := b.configForRun()
 	probe := "unchecked"
 	if req.ProbeSSH {
 		probe = "requires_running_lease"
 	}
-	msg := fmt.Sprintf("hyperv=%s control_plane=local inventory=ready api=powershell mutation=false leases=%d ssh_probe=%s",
-		firstLine(state), len(instances), probe)
+	msg := fmt.Sprintf("hyperv=%s control_plane=local inventory=ready api=powershell mutation=false leases=%d image=%s ssh_probe=%s",
+		firstLine(state), len(instances), cfg.HyperV.Image, probe)
 	return DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
@@ -621,14 +626,24 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 	if len(vhdPaths) > 0 {
 		for _, p := range vhdPaths {
 			if strings.EqualFold(filepath.Clean(p), filepath.Clean(expectedVHD)) {
-				os.Remove(p) //nolint:errcheck
+				b.removeVHDFile(p)
 			}
 		}
 	} else {
-		os.Remove(expectedVHD) //nolint:errcheck
+		b.removeVHDFile(expectedVHD)
 	}
 
 	return nil
+}
+
+// removeVHDFile deletes a lease VHDX best-effort. The VM is already gone by the
+// time this runs, so a failure must not abort ReleaseLease (that would strand
+// the lease claim); instead surface it as a warning so an orphaned disk is
+// visible rather than silently leaked.
+func (b *backend) removeVHDFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(b.rt.Stderr, "warning: failed to remove lease VHDX %s: %v\n", path, err)
+	}
 }
 
 func (b *backend) queryVM(ctx context.Context, name string) (hypervVM, error) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,8 +39,12 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 
 func applyDefaults(cfg *Config) {
 	cfg.Provider = providerName
-	cfg.TargetOS = targetWindows
-	cfg.WindowsMode = core.WindowsModeNormal
+	if cfg.TargetOS == "" || cfg.TargetOS == "linux" {
+		cfg.TargetOS = targetWindows
+	}
+	if cfg.WindowsMode == "" {
+		cfg.WindowsMode = core.WindowsModeNormal
+	}
 	cfg.SSHFallbackPorts = []string{}
 	if cfg.HyperV.User == "" {
 		cfg.HyperV.User = "crabbox"
@@ -275,6 +280,10 @@ func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
 	instances, err := b.listInstances(ctx)
+	if errors.Is(err, errNotWindows) {
+		fmt.Fprintf(b.rt.Stderr, "skip cleanup: %v\n", err)
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -489,9 +498,11 @@ func (b *backend) waitForIP(ctx context.Context, name string, timeout time.Durat
 	}
 }
 
+var errNotWindows = fmt.Errorf("hyper-v inventory unavailable: host OS is %s (not windows)", hypervHostOS)
+
 func (b *backend) listInstances(ctx context.Context) ([]hypervVM, error) {
 	if hypervHostOS != "windows" {
-		return nil, nil
+		return nil, errNotWindows
 	}
 	script := `Get-VM | Where-Object { $_.Name -like 'crabbox-*' } | Select-Object Name, State | ConvertTo-Json -Compress`
 	result, err := b.powershell(ctx, script)

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -45,9 +45,6 @@ func applyDefaults(cfg *Config) {
 		cfg.WindowsMode = core.WindowsModeNormal
 	}
 	cfg.SSHFallbackPorts = []string{}
-	if cfg.HyperV.Image == "" {
-		cfg.HyperV.Image = ""
-	}
 	if cfg.HyperV.User == "" {
 		cfg.HyperV.User = "crabbox"
 	}
@@ -119,12 +116,11 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 	}()
 	cfg.SSHKey = keyPath
-	_ = publicKey
 	name := leaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%dGB switch=%s keep=%v\n",
 		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Disk, cfg.HyperV.Switch, req.Keep)
 
-	if err := b.createVM(ctx, cfg, name); err != nil {
+	if err := b.createVM(ctx, cfg, name, publicKey); err != nil {
 		_ = b.removeVM(context.Background(), name)
 		return LeaseTarget{}, err
 	}
@@ -181,7 +177,10 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if claim.LeaseID == "" {
 		return LeaseTarget{}, exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
-	ip := b.getIPFromClaim(claim)
+	ip := b.queryLiveIP(ctx, inst.Name)
+	if ip == "" {
+		ip = b.getIPFromClaim(claim)
+	}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, false)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -245,14 +244,11 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	}
 	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
-		inst, claim, err := b.resolveInstance(ctx, lease.LeaseID)
+		inst, _, err := b.resolveInstance(ctx, lease.LeaseID)
 		if err != nil {
 			return err
 		}
 		name = inst.Name
-		if lease.LeaseID == "" {
-			lease.LeaseID = claim.LeaseID
-		}
 	}
 	if name == "" {
 		return exit(2, "provider=%s release requires a Hyper-V VM name", providerName)
@@ -347,19 +343,53 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	return server, nil
 }
 
-// createVM creates and starts a Hyper-V VM with the configured settings.
-func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
+// createVM creates and starts a Hyper-V VM from the configured image and
+// injects the SSH public key via PowerShell Direct.
+func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey string) error {
 	vhdDir := hypervVHDDir()
+	if err := os.MkdirAll(vhdDir, 0o755); err != nil {
+		return exit(2, "create VHD directory %s: %v", vhdDir, err)
+	}
 	vhdPath := filepath.Join(vhdDir, name+".vhdx")
 
-	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
-	diskBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
-
-	createScript := fmt.Sprintf(
-		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -NewVHDPath '%s' -NewVHDSizeBytes %d`,
-		escapePSString(name), memBytes, escapePSString(vhdPath), diskBytes,
+	switchCheck := fmt.Sprintf(
+		`if (-not (Get-VMSwitch -Name '%s' -ErrorAction SilentlyContinue)) { throw 'Hyper-V switch not found: %s' }`,
+		escapePSString(cfg.HyperV.Switch), escapePSString(cfg.HyperV.Switch),
 	)
-	result, err := b.powershell(ctx, createScript)
+	result, err := b.powershell(ctx, switchCheck)
+	if err != nil {
+		return commandError("switch validation", result, err)
+	}
+
+	imageLower := strings.ToLower(cfg.HyperV.Image)
+	isISO := strings.HasSuffix(imageLower, ".iso")
+
+	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
+
+	var createScript string
+	if isISO {
+		diskBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
+		createScript = fmt.Sprintf(
+			`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -NewVHDPath '%s' -NewVHDSizeBytes %d`,
+			escapePSString(name), memBytes, escapePSString(vhdPath), diskBytes,
+		)
+	} else {
+		copyScript := fmt.Sprintf(`Copy-Item -LiteralPath '%s' -Destination '%s'`, escapePSString(cfg.HyperV.Image), escapePSString(vhdPath))
+		result, err = b.powershell(ctx, copyScript)
+		if err != nil {
+			return commandError("copy VHDX template", result, err)
+		}
+		if cfg.HyperV.Disk > 0 {
+			resizeScript := fmt.Sprintf(`Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction SilentlyContinue`,
+				escapePSString(vhdPath), int64(cfg.HyperV.Disk)*1024*1024*1024)
+			b.powershell(ctx, resizeScript) //nolint:errcheck
+		}
+		createScript = fmt.Sprintf(
+			`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s'`,
+			escapePSString(name), memBytes, escapePSString(vhdPath),
+		)
+	}
+	result, err = b.powershell(ctx, createScript)
 	if err != nil {
 		return commandError("New-VM", result, err)
 	}
@@ -379,12 +409,50 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 		return commandError("Connect-VMNetworkAdapter", result, err)
 	}
 
+	if isISO {
+		dvdScript := fmt.Sprintf(`Add-VMDvdDrive -VMName '%s' -Path '%s'`, escapePSString(name), escapePSString(cfg.HyperV.Image))
+		result, err = b.powershell(ctx, dvdScript)
+		if err != nil {
+			return commandError("Add-VMDvdDrive", result, err)
+		}
+	}
+
 	startScript := fmt.Sprintf(`Start-VM -Name '%s'`, escapePSString(name))
 	result, err = b.powershell(ctx, startScript)
 	if err != nil {
 		return commandError("Start-VM", result, err)
 	}
 
+	if publicKey != "" {
+		if err := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: SSH key injection via PowerShell Direct failed: %v (image may need pre-configured SSH)\n", err)
+		}
+	}
+
+	return nil
+}
+
+// injectSSHKey writes the SSH public key into the VM via PowerShell Direct
+// (Invoke-Command -VMName). This requires the VM to have booted and the guest
+// user to exist. It is best-effort: if the image already has SSH pre-configured
+// the key injection may be redundant.
+func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
+	script := fmt.Sprintf(
+		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString 'crabbox' -AsPlainText -Force)); `+
+			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { `+
+			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
+			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
+			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
+			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
+			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
+			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' } `+
+			`}`,
+		escapePSString(user), escapePSString(vmName), escapePSString(publicKey), escapePSString(publicKey),
+	)
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return commandError("SSH key injection", result, err)
+	}
 	return nil
 }
 
@@ -442,7 +510,11 @@ func (b *backend) resolveInstance(ctx context.Context, identifier string) (hyper
 		if name == "" {
 			return hypervVM{}, core.LeaseClaim{}, exit(4, "hyperv lease %s has no instance name in its claim", claim.LeaseID)
 		}
-		return hypervVM{Name: name, State: 2}, claim, nil
+		vm, queryErr := b.queryVM(ctx, name)
+		if queryErr != nil {
+			return hypervVM{Name: name, State: 2}, claim, nil
+		}
+		return vm, claim, nil
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -501,19 +573,76 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 	if !strings.HasPrefix(name, "crabbox-") {
 		return exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
 	}
-	stopScript := fmt.Sprintf(`Stop-VM -Name '%s' -Force -ErrorAction SilentlyContinue`, escapePSString(name))
+
+	vhdPaths := b.queryVHDPaths(ctx, name)
+
+	stopScript := fmt.Sprintf(`Stop-VM -Name '%s' -Force -Confirm:$false -ErrorAction SilentlyContinue`, escapePSString(name))
 	b.powershell(ctx, stopScript) //nolint:errcheck
 
-	removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force`, escapePSString(name))
+	removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force -Confirm:$false`, escapePSString(name))
 	result, err := b.powershell(ctx, removeScript)
 	if err != nil {
 		return commandError("Remove-VM", result, err)
 	}
 
-	vhdPath := filepath.Join(hypervVHDDir(), name+".vhdx")
-	os.Remove(vhdPath) //nolint:errcheck
+	if len(vhdPaths) > 0 {
+		for _, p := range vhdPaths {
+			os.Remove(p) //nolint:errcheck
+		}
+	} else {
+		vhdPath := filepath.Join(hypervVHDDir(), name+".vhdx")
+		os.Remove(vhdPath) //nolint:errcheck
+	}
 
 	return nil
+}
+
+func (b *backend) queryVM(ctx context.Context, name string) (hypervVM, error) {
+	script := fmt.Sprintf(`Get-VM -Name '%s' | Select-Object Name, State | ConvertTo-Json -Compress`, escapePSString(name))
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return hypervVM{}, commandError("Get-VM query", result, err)
+	}
+	stdout := strings.TrimSpace(result.Stdout)
+	if stdout == "" || stdout == "null" {
+		return hypervVM{}, exit(4, "hyperv VM %s not found", name)
+	}
+	var vm hypervVM
+	if err := json.Unmarshal([]byte(stdout), &vm); err != nil {
+		return hypervVM{}, exit(2, "parse hyperv VM %s: %v", name, err)
+	}
+	return vm, nil
+}
+
+func (b *backend) queryLiveIP(ctx context.Context, name string) string {
+	script := fmt.Sprintf(
+		`Get-VMNetworkAdapter -VMName '%s' | Select-Object -ExpandProperty IPAddresses | ConvertTo-Json`,
+		escapePSString(name),
+	)
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return ""
+	}
+	return parseFirstIPv4(result.Stdout)
+}
+
+func (b *backend) queryVHDPaths(ctx context.Context, name string) []string {
+	script := fmt.Sprintf(
+		`Get-VMHardDiskDrive -VMName '%s' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`,
+		escapePSString(name),
+	)
+	result, err := b.powershell(ctx, script)
+	if err != nil {
+		return nil
+	}
+	var paths []string
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
 }
 
 func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg Config) Server {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -139,7 +139,10 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 
 	if publicKey != "" {
 		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "post-boot SSH key injection failed: %v (image must have pre-configured SSH)\n", retryErr)
+			if !req.Keep {
+				_ = b.removeVM(context.Background(), name)
+			}
+			return LeaseTarget{}, fmt.Errorf("post-boot SSH key injection failed: %w", retryErr)
 		}
 	}
 

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -232,6 +232,9 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if claim.LeaseID == "" {
 		return LeaseTarget{}, exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
+	if req.StatusOnly && !req.ReadyProbe {
+		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+	}
 	ip := b.queryLiveIP(ctx, inst.Name)
 	if ip == "" {
 		ip = b.getIPFromClaim(claim)
@@ -579,10 +582,10 @@ func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error 
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*'; ` +
 		`if ($cap.State -ne 'Installed') { Add-WindowsCapability -Online -Name $cap.Name | Out-Null }; ` +
-		`Set-Service -Name sshd -StartupType Automatic; ` +
-		`Start-Service sshd; ` +
-		`if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) { ` +
-		`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }`
+		`Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue; ` +
+		`Set-Service -Name sshd -StartupType Manual; ` +
+		`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { ` +
+		`Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null }`
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "OpenSSH install")
 }
 
@@ -657,7 +660,12 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; `+
 			`& $sshdExe -t -f $sshdConfig; `+
 			`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; `+
-			`Restart-Service sshd`,
+			`Set-Service -Name sshd -StartupType Automatic; `+
+			`Start-Service sshd; `+
+			`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { `+
+			`Enable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null `+
+			`} else { `+
+			`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }`,
 		escapePSString(publicKey), escapePSString(publicKey),
 	)
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "SSH key injection")
@@ -900,8 +908,9 @@ func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg C
 	if labels["slug"] == "" {
 		labels["slug"] = claim.Slug
 	}
-	if labels["state"] == "" {
-		labels["state"] = hypervState(inst.State)
+	liveState := hypervState(inst.State)
+	if inst.State != 2 || labels["state"] == "" {
+		labels["state"] = liveState
 	}
 	if labels["image"] == "" {
 		labels["image"] = cfg.HyperV.Image
@@ -915,7 +924,7 @@ func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg C
 	if labels["work_root"] == "" {
 		labels["work_root"] = cfg.HyperV.WorkRoot
 	}
-	status := hypervState(inst.State)
+	status := liveState
 	if inst.State == 2 && labels["state"] == "ready" {
 		status = "ready"
 	}
@@ -1024,7 +1033,7 @@ func hypervState(state int) string {
 	case 2:
 		return "running"
 	case 3:
-		return "off"
+		return "stopped"
 	case 6:
 		return "saved"
 	case 9:

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -710,6 +710,15 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 		`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; ` +
 		`& $sshKeygen -A; ` +
 		`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; ` +
+		`$systemSID = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18'); ` +
+		`$adminsSID = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544'); ` +
+		`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*_key' | ForEach-Object { ` +
+		`$hostKeyACL = New-Object System.Security.AccessControl.FileSecurity; ` +
+		`$hostKeyACL.SetOwner($adminsSID); ` +
+		`$hostKeyACL.SetAccessRuleProtection($true, $false); ` +
+		`$hostKeyACL.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($systemSID, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)); ` +
+		`$hostKeyACL.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($adminsSID, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.Security.AccessControl.AccessControlType]::Allow)); ` +
+		`Set-Acl -LiteralPath $_.FullName -AclObject $hostKeyACL }; ` +
 		`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; ` +
 		`& $sshdExe -t -f $sshdConfig; ` +
 		`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -610,8 +610,9 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 // Features-on-Demand source).
 func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
-		`$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*'; ` +
-		`if ($cap.State -ne 'Installed') { Add-WindowsCapability -Online -Name $cap.Name | Out-Null }; ` +
+		`$capName = 'OpenSSH.Server~~~~0.0.1.0'; ` +
+		`$cap = Get-WindowsCapability -Online -Name $capName; ` +
+		`if ($cap.State -ne 'Installed') { Add-WindowsCapability -Online -Name $capName | Out-Null }; ` +
 		`Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue; ` +
 		`Set-Service -Name sshd -StartupType Manual; ` +
 		`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { ` +
@@ -687,8 +688,10 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 			`$globalLines = @(); `+
 			`foreach ($line in $sshdLines) { `+
 			`if ($line -match '^\s*Match\s+') { break }; `+
-			`if ($line -match '^\s*(AuthenticationMethods|PasswordAuthentication|PubkeyAuthentication|KbdInteractiveAuthentication|AllowUsers|AllowGroups|DenyUsers|DenyGroups|AuthorizedKeysFile|AuthorizedKeysCommand|AuthorizedKeysCommandUser|TrustedUserCAKeys|AuthorizedPrincipalsFile|Include)\s+') { continue }; `+
+			`if ($line -match '^\s*(Port|ListenAddress|AddressFamily|HostKey|AuthenticationMethods|PasswordAuthentication|PubkeyAuthentication|KbdInteractiveAuthentication|AllowUsers|AllowGroups|DenyUsers|DenyGroups|AuthorizedKeysFile|AuthorizedKeysCommand|AuthorizedKeysCommandUser|TrustedUserCAKeys|AuthorizedPrincipalsFile|Include)\s+') { continue }; `+
 			`$globalLines += $line }; `+
+			`$globalLines += 'Port 22'; `+
+			`$globalLines += 'AddressFamily any'; `+
 			`$globalLines += 'PubkeyAuthentication yes'; `+
 			`$globalLines += 'PasswordAuthentication no'; `+
 			`$globalLines += 'AuthenticationMethods publickey'; `+
@@ -703,13 +706,13 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 		return script
 	}
 	return script +
-		`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; ` +
-		`& $sshdExe -t -f $sshdConfig; ` +
-		`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; ` +
 		`Get-ChildItem -Path $hostKeyDir -Filter 'ssh_host_*' -ErrorAction SilentlyContinue | Remove-Item -Force; ` +
 		`$sshKeygen = Join-Path $env:WINDIR 'System32\OpenSSH\ssh-keygen.exe'; ` +
 		`& $sshKeygen -A; ` +
 		`if ($LASTEXITCODE -ne 0) { throw 'SSH host key generation failed' }; ` +
+		`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; ` +
+		`& $sshdExe -t -f $sshdConfig; ` +
+		`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; ` +
 		`Set-Service -Name sshd -StartupType Automatic; ` +
 		`Start-Service sshd; ` +
 		`if (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue) { ` +
@@ -869,7 +872,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, i
 }
 
 func (b *backend) removeVM(ctx context.Context, name string) error {
-	if !strings.HasPrefix(name, "crabbox-") {
+	if !validHyperVVMName(name) {
 		return exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
 	}
 
@@ -893,6 +896,9 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 }
 
 func (b *backend) removeVMStorage(name string, attachedPaths []string) error {
+	if !validHyperVVMName(name) {
+		return exit(2, "refusing to remove storage for invalid Crabbox Hyper-V VM %q", name)
+	}
 	var errs []error
 	vhdDir := hypervVHDDir()
 	expectedVHD := filepath.Join(vhdDir, name+".vhdx")
@@ -926,6 +932,18 @@ func (b *backend) removeVMStorage(name string, attachedPaths []string) error {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
+}
+
+func validHyperVVMName(name string) bool {
+	if name != strings.TrimSpace(name) || len(name) <= len("crabbox-") || len(name) > 64 || !strings.HasPrefix(name, "crabbox-") {
+		return false
+	}
+	for _, r := range name {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return false
+		}
+	}
+	return name[len(name)-1] != '-'
 }
 
 func ownedHyperVCheckpoint(path, vhdDir, name string) bool {
@@ -1179,6 +1197,9 @@ func instanceNameFromScope(scope string) string {
 }
 
 func missingClaimCleanupReady(claim core.LeaseClaim, now time.Time) (bool, string) {
+	if strings.EqualFold(claim.Labels["keep"], "true") {
+		return false, "keep=true"
+	}
 	if !strings.EqualFold(claim.Labels["state"], "provisioning") {
 		return true, ""
 	}

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -136,6 +136,12 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		return LeaseTarget{}, err
 	}
 
+	if publicKey != "" {
+		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
+			fmt.Fprintf(b.rt.Stderr, "post-boot SSH key injection failed: %v (image must have pre-configured SSH)\n", retryErr)
+		}
+	}
+
 	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
 	labels["instance"] = name
 	labels["image"] = cfg.HyperV.Image
@@ -382,6 +388,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 	)
 	result, err = b.powershell(ctx, createScript)
 	if err != nil {
+		os.Remove(vhdPath) //nolint:errcheck
 		return commandError("New-VM", result, err)
 	}
 

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -147,6 +147,12 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 		return LeaseTarget{}, fmt.Errorf("guest OpenSSH setup failed: %w", err)
 	}
+	if err := b.ensureGit(ctx, name, cfg.HyperV.User); err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, fmt.Errorf("guest git setup failed: %w", err)
+	}
 
 	if publicKey != "" {
 		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
@@ -506,6 +512,31 @@ func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error 
 		`if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) { ` +
 		`New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null }`
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "OpenSSH install")
+}
+
+// ensureGit installs git in the guest when it is absent, so a plain Windows
+// template (only a known admin password) satisfies Crabbox's Windows readiness
+// check, which requires git for sync -- mirroring how the Linux cloud-init path
+// installs git. Idempotent: a no-op when git is already on PATH (so a template
+// that pre-bakes git skips the per-lease download). Uses portable MinGit from
+// the latest git-for-windows release; needs guest internet.
+func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
+	scriptBlock := `$ErrorActionPreference='Stop'; ` +
+		`if (Get-Command git -ErrorAction SilentlyContinue) { return }; ` +
+		`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; ` +
+		`$h=@{'User-Agent'='crabbox'}; ` +
+		`$rel=Invoke-RestMethod -UseBasicParsing -Uri 'https://api.github.com/repos/git-for-windows/git/releases/latest' -Headers $h; ` +
+		`$asset=$rel.assets | Where-Object { $_.name -like 'MinGit-*-64-bit.zip' } | Select-Object -First 1; ` +
+		`if (-not $asset) { throw 'MinGit asset not found' }; ` +
+		`$zip=Join-Path $env:TEMP 'crabbox-mingit.zip'; ` +
+		`Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zip; ` +
+		`$dst='C:\Program Files\Git'; ` +
+		`Expand-Archive -Path $zip -DestinationPath $dst -Force; ` +
+		`$cmd=Join-Path $dst 'cmd'; ` +
+		`$p=[Environment]::GetEnvironmentVariable('PATH','Machine'); ` +
+		`if ($p -notlike ('*'+$cmd+'*')) { [Environment]::SetEnvironmentVariable('PATH',($p+';'+$cmd),'Machine') }; ` +
+		`Restart-Service sshd`
+	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "git install")
 }
 
 // injectSSHKey writes the SSH public key into the VM via PowerShell Direct,

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -25,7 +25,10 @@ type backend struct {
 
 var hypervHostOS = runtime.GOOS
 
-const hypervMissingState = -1
+const (
+	hypervMissingState           = -1
+	hypervProvisioningClaimGrace = time.Hour
+)
 
 type hypervVM struct {
 	Name  string `json:"Name"`
@@ -154,23 +157,26 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	labels["ssh_user"] = cfg.HyperV.User
 	labels["ssh_port"] = sshPort
 	labels["work_root"] = cfg.HyperV.WorkRoot
+	labels["state"] = "provisioning"
 	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB switch=%s keep=%v\n",
 		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Switch, req.Keep)
 
-	if err := b.createVM(ctx, cfg, name); err != nil {
-		_ = b.removeVM(context.Background(), name)
-		return LeaseTarget{}, err
-	}
 	provisional := LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: leaseID,
 	}
 	if err := persistLease(leaseID, slug, name, cfg, req, provisional); err != nil {
-		_ = b.removeVM(context.Background(), name)
 		return LeaseTarget{}, fmt.Errorf("persist hyperv lease before bootstrap: %w", err)
 	}
 	cleanupKey = false
+	if err := b.createVM(ctx, cfg, name); err != nil {
+		cleanupErr := b.removeVM(context.Background(), name)
+		if cleanupErr == nil {
+			pruneLeaseState(leaseID)
+		}
+		return LeaseTarget{}, errors.Join(err, cleanupErr)
+	}
 	cleanupFailedLease := func() error {
 		if req.Keep {
 			return nil
@@ -219,10 +225,8 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	return lease, nil
 }
 
-// persistLease records the lease claim and its SSH endpoint in one atomic
-// write. Acquire removes the VM when this fails, so the claim and endpoint
-// must never be written separately: a failure between two writes would leave
-// a claim pointing at a VM that no longer exists.
+// persistLease records ownership before VM creation, then atomically updates
+// the same claim with its SSH endpoint after bootstrap.
 func persistLease(leaseID, slug, name string, cfg Config, req AcquireRequest, lease LeaseTarget) error {
 	return claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH)
 }
@@ -311,10 +315,6 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
 	}
-	if lease.LeaseID != "" && lease.Server.Status == "missing" {
-		pruneLeaseState(lease.LeaseID)
-		return nil
-	}
 	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, _, err := b.resolveInstance(ctx, lease.LeaseID)
@@ -394,13 +394,21 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if _, ok := live[claim.LeaseID]; ok {
 			continue
 		}
+		if ready, reason := missingClaimCleanupReady(claim, now); !ready {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+			continue
+		}
 		if req.DryRun {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
 			continue
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
-		removeLeaseClaim(claim.LeaseID)
-		removeStoredTestboxKey(claim.LeaseID)
+		if name := instanceNameFromClaim(claim); name != "" {
+			if err := b.removeVMStorage(name, nil); err != nil {
+				return err
+			}
+		}
+		pruneLeaseState(claim.LeaseID)
 		claimsRemoved++
 	}
 	if !req.DryRun {
@@ -679,18 +687,17 @@ func sshAccessScript(user, publicKey string, activate bool) string {
 			`$globalLines = @(); `+
 			`foreach ($line in $sshdLines) { `+
 			`if ($line -match '^\s*Match\s+') { break }; `+
-			`if ($line -match '^\s*(AuthenticationMethods|PasswordAuthentication|PubkeyAuthentication|KbdInteractiveAuthentication|AllowUsers|AllowGroups|DenyUsers|DenyGroups|AuthorizedKeysFile|AuthorizedKeysCommand|AuthorizedKeysCommandUser|TrustedUserCAKeys|AuthorizedPrincipalsFile)\s+') { continue }; `+
+			`if ($line -match '^\s*(AuthenticationMethods|PasswordAuthentication|PubkeyAuthentication|KbdInteractiveAuthentication|AllowUsers|AllowGroups|DenyUsers|DenyGroups|AuthorizedKeysFile|AuthorizedKeysCommand|AuthorizedKeysCommandUser|TrustedUserCAKeys|AuthorizedPrincipalsFile|Include)\s+') { continue }; `+
 			`$globalLines += $line }; `+
 			`$globalLines += 'PubkeyAuthentication yes'; `+
 			`$globalLines += 'PasswordAuthentication no'; `+
-			`$globalLines += 'KbdInteractiveAuthentication no'; `+
 			`$globalLines += 'AuthenticationMethods publickey'; `+
 			`$globalLines += 'AuthorizedKeysFile .ssh/authorized_keys'; `+
 			`$globalLines += 'AllowUsers %s'; `+
 			`$globalLines += 'Match Group administrators'; `+
 			`$globalLines += '       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys'; `+
 			`Set-Content -Encoding ASCII -Path $sshdConfig -Value ($globalLines -join [Environment]::NewLine); `,
-		escapePSString(publicKey), escapePSString(publicKey), escapePSString(user),
+		escapePSString(publicKey), escapePSString(publicKey), escapePSString(strings.ToLower(user)),
 	)
 	if !activate {
 		return script
@@ -866,40 +873,59 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		return exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
 	}
 
-	vhdPaths := b.queryVHDPaths(ctx, name)
-
-	stopScript := fmt.Sprintf(`Stop-VM -Name '%s' -Force -Confirm:$false -ErrorAction SilentlyContinue`, escapePSString(name))
-	b.powershell(ctx, stopScript) //nolint:errcheck
-
-	removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force -Confirm:$false`, escapePSString(name))
-	result, err := b.powershell(ctx, removeScript)
+	vm, err := b.queryVM(ctx, name)
 	if err != nil {
-		return commandError("Remove-VM", result, err)
+		return err
 	}
+	var vhdPaths []string
+	if vm.State != hypervMissingState {
+		vhdPaths = b.queryVHDPaths(ctx, name)
+		stopScript := fmt.Sprintf(`Stop-VM -Name '%s' -Force -Confirm:$false -ErrorAction SilentlyContinue`, escapePSString(name))
+		b.powershell(ctx, stopScript) //nolint:errcheck
 
-	// Always remove the provider-created boot disk. Client Hyper-V may attach a
-	// <name>_<guid>.avhdx checkpoint disk instead, so remove attached checkpoint
-	// files only when their filename has that exact provider-owned shape.
+		removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force -Confirm:$false`, escapePSString(name))
+		result, removeErr := b.powershell(ctx, removeScript)
+		if removeErr != nil {
+			return commandError("Remove-VM", result, removeErr)
+		}
+	}
+	return b.removeVMStorage(name, vhdPaths)
+}
+
+func (b *backend) removeVMStorage(name string, attachedPaths []string) error {
+	var errs []error
 	vhdDir := hypervVHDDir()
 	expectedVHD := filepath.Join(vhdDir, name+".vhdx")
-	b.removeVHDFile(expectedVHD)
-	for _, p := range vhdPaths {
+	if err := b.removeVHDFile(expectedVHD); err != nil {
+		errs = append(errs, err)
+	}
+	for _, p := range attachedPaths {
 		clean := filepath.Clean(p)
 		if strings.EqualFold(clean, filepath.Clean(expectedVHD)) {
 			continue
 		}
 		if ownedHyperVCheckpoint(clean, vhdDir, name) {
-			b.removeVHDFile(p)
+			if err := b.removeVHDFile(p); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
-
-	// Remove the per-VM configuration directory created by New-VM -Path; Remove-VM
-	// unregisters the VM but leaves its <vmDir>/<name> folder behind.
-	if err := os.RemoveAll(filepath.Join(hypervVMDir(), name)); err != nil {
-		fmt.Fprintf(b.rt.Stderr, "warning: failed to remove VM directory for %s: %v\n", name, err)
+	if entries, err := os.ReadDir(vhdDir); err == nil {
+		for _, entry := range entries {
+			path := filepath.Join(vhdDir, entry.Name())
+			if ownedHyperVCheckpoint(path, vhdDir, name) {
+				if err := b.removeVHDFile(path); err != nil {
+					errs = append(errs, err)
+				}
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("read Hyper-V VHD directory %s: %w", vhdDir, err))
 	}
-
-	return nil
+	if err := removeHyperVConfigFiles(filepath.Join(hypervVMDir(), name)); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 func ownedHyperVCheckpoint(path, vhdDir, name string) bool {
@@ -933,13 +959,60 @@ func ownedHyperVCheckpoint(path, vhdDir, name string) bool {
 	return true
 }
 
-// removeVHDFile deletes a lease VHDX best-effort. The VM is already gone by the
-// time this runs, so a failure must not abort ReleaseLease (that would strand
-// the lease claim); instead surface it as a warning so an orphaned disk is
-// visible rather than silently leaked.
-func (b *backend) removeVHDFile(path string) {
+func (b *backend) removeVHDFile(path string) error {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(b.rt.Stderr, "warning: failed to remove lease VHDX %s: %v\n", path, err)
+		return fmt.Errorf("remove lease VHDX %s: %w", path, err)
+	}
+	return nil
+}
+
+func removeHyperVConfigFiles(root string) error {
+	var dirs []string
+	var errs []error
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			errs = append(errs, walkErr)
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			dirs = append(dirs, path)
+			return nil
+		}
+		if isVirtualDiskFile(path) {
+			return nil
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("remove Hyper-V config file %s: %w", path, err))
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		errs = append(errs, err)
+	}
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := os.Remove(dirs[i]); err != nil && !os.IsNotExist(err) {
+			entries, readErr := os.ReadDir(dirs[i])
+			if readErr == nil && len(entries) > 0 {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("remove Hyper-V config directory %s: %w", dirs[i], err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func isVirtualDiskFile(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".vhd", ".vhdx", ".avhd", ".avhdx", ".vhds":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1103,6 +1176,23 @@ func instanceNameFromClaim(claim core.LeaseClaim) string {
 
 func instanceNameFromScope(scope string) string {
 	return strings.TrimPrefix(strings.TrimSpace(scope), "instance:")
+}
+
+func missingClaimCleanupReady(claim core.LeaseClaim, now time.Time) (bool, string) {
+	if !strings.EqualFold(claim.Labels["state"], "provisioning") {
+		return true, ""
+	}
+	var createdAt time.Time
+	if display := core.LeaseLabelTimeDisplay(claim.Labels["created_at"]); display != "" {
+		createdAt, _ = time.Parse(time.RFC3339, display)
+	}
+	if createdAt.IsZero() {
+		createdAt, _ = time.Parse(time.RFC3339, strings.TrimSpace(claim.ClaimedAt))
+	}
+	if createdAt.IsZero() || now.Before(createdAt.Add(hypervProvisioningClaimGrace)) {
+		return false, "provisioning grace"
+	}
+	return true, ""
 }
 
 func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -416,7 +416,12 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		return commandError("New-VM", result, err)
 	}
 
-	cpuScript := fmt.Sprintf(`Set-VM -Name '%s' -ProcessorCount %d`, escapePSString(name), cfg.HyperV.CPUs)
+	// Disable automatic checkpoints: client Hyper-V enables them by default, which
+	// makes Start-VM create a <name>_<guid>.avhdx differencing disk and attach it
+	// in place of the base VHDX. That defeats removeVM's disk cleanup (it matches
+	// the base <name>.vhdx) and leaks a disk-sized file on release. Lease VMs are
+	// ephemeral and have no use for checkpoints.
+	cpuScript := fmt.Sprintf(`Set-VM -Name '%s' -ProcessorCount %d -AutomaticCheckpointsEnabled $false`, escapePSString(name), cfg.HyperV.CPUs)
 	result, err = b.powershell(ctx, cpuScript)
 	if err != nil {
 		return commandError("Set-VM", result, err)
@@ -622,15 +627,29 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		return commandError("Remove-VM", result, err)
 	}
 
-	expectedVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
-	if len(vhdPaths) > 0 {
-		for _, p := range vhdPaths {
-			if strings.EqualFold(filepath.Clean(p), filepath.Clean(expectedVHD)) {
-				b.removeVHDFile(p)
-			}
+	// Always remove the provider-created boot disk. We can't rely on the attached
+	// disk path matching it: client Hyper-V may have created and attached a
+	// <name>_<guid>.avhdx checkpoint disk instead, in which case the base VHDX
+	// would otherwise be leaked. Also sweep any name-prefixed differencing disks
+	// in our VHD directory, while leaving unrelated attached disks untouched.
+	vhdDir := hypervVHDDir()
+	expectedVHD := filepath.Join(vhdDir, name+".vhdx")
+	b.removeVHDFile(expectedVHD)
+	for _, p := range vhdPaths {
+		clean := filepath.Clean(p)
+		if strings.EqualFold(clean, filepath.Clean(expectedVHD)) {
+			continue
 		}
-	} else {
-		b.removeVHDFile(expectedVHD)
+		if strings.HasPrefix(filepath.Base(clean), name) &&
+			strings.EqualFold(filepath.Dir(clean), filepath.Clean(vhdDir)) {
+			b.removeVHDFile(p)
+		}
+	}
+
+	// Remove the per-VM configuration directory created by New-VM -Path; Remove-VM
+	// unregisters the VM but leaves its <vmDir>/<name> folder behind.
+	if err := os.RemoveAll(filepath.Join(hypervVMDir(), name)); err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: failed to remove VM directory for %s: %v\n", name, err)
 	}
 
 	return nil

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -427,7 +427,9 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 		guestPassword = "crabbox"
 	}
 	script := fmt.Sprintf(
-		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString '%s' -AsPlainText -Force)); `+
+		`$pw = $env:CRABBOX_HYPERV_GUEST_PASSWORD; `+
+			`if (-not $pw) { $pw = '%s' }; `+
+			`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $pw -AsPlainText -Force)); `+
 			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { `+
 			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
@@ -436,7 +438,7 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
 			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' } `+
 			`}`,
-		escapePSString(user), escapePSString(guestPassword), escapePSString(vmName),
+		escapePSString(guestPassword), escapePSString(user), escapePSString(vmName),
 		escapePSString(publicKey), escapePSString(publicKey),
 	)
 	var lastErr error

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -96,6 +96,14 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if strings.HasSuffix(strings.ToLower(cfg.HyperV.Image), ".iso") {
 		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a Windows VHDX template with a reachable administrator account", providerName)
 	}
+	if cfg.HyperV.InitPassword {
+		if cfg.HyperV.GuestPassword == "" {
+			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD (refusing to set the default password on the guest)", providerName)
+		}
+		if strings.ContainsAny(cfg.HyperV.GuestPassword, `"%`) {
+			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs; choose a different CRABBOX_HYPERV_GUEST_PASSWORD", providerName)
+		}
+	}
 	leaseID := newLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -417,6 +425,14 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		os.Remove(vhdPath) //nolint:errcheck
 		return commandError("create differencing disk", result, err)
 	}
+
+	if cfg.HyperV.InitPassword {
+		if err := b.injectInitPassword(ctx, vhdPath, cfg.HyperV.User); err != nil {
+			os.Remove(vhdPath) //nolint:errcheck
+			return err
+		}
+	}
+
 	createScript := fmt.Sprintf(
 		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s' -Path '%s'`,
 		escapePSString(name), memBytes, escapePSString(vhdPath), escapePSString(vmDir),
@@ -462,22 +478,64 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 	return nil
 }
 
+func (b *backend) guestPassword() string {
+	if password := b.cfg.HyperV.GuestPassword; password != "" {
+		return password
+	}
+	return "crabbox"
+}
+
+// injectInitPassword makes a password-less template (e.g. a stock Windows
+// dev-environment VHDX, which auto-logs-on with no password set) usable:
+// PowerShell Direct refuses empty credentials, so before first boot we mount
+// the per-lease differencing disk, load its offline SOFTWARE hive, and write a
+// RunOnce command that sets the guest account password at the template's
+// auto-logon. Only the lease disk is modified -- the template stays untouched.
+// The password reaches this host script via the _CRABBOX_GP env var, never on
+// a command line; inside the guest it is visible to the guest itself (RunOnce
+// value, then the net.exe command line at first logon), which the lease owns.
+func (b *backend) injectInitPassword(ctx context.Context, vhdPath, user string) error {
+	script := fmt.Sprintf(
+		`$ErrorActionPreference = 'Stop'; `+
+			`$disk = Mount-VHD -Path '%s' -Passthru | Get-Disk; `+
+			`try { `+
+			`if ($disk.IsOffline) { Set-Disk -Number $disk.Number -IsOffline $false }; `+
+			`$letters = ($disk | Get-Partition | Where-Object DriveLetter).DriveLetter; `+
+			`$sys = $letters | Where-Object { Test-Path ("$_" + ':\Windows\System32\config\SOFTWARE') } | Select-Object -First 1; `+
+			`if (-not $sys) { throw 'no Windows system volume found in template' }; `+
+			`reg.exe load HKLM\crabbox-init ("$sys" + ':\Windows\System32\config\SOFTWARE') | Out-Null; `+
+			`if ($LASTEXITCODE -ne 0) { throw 'loading the offline SOFTWARE hive failed' }; `+
+			`try { `+
+			`$runOnce = 'HKLM:\crabbox-init\Microsoft\Windows\CurrentVersion\RunOnce'; `+
+			`if (-not (Test-Path $runOnce)) { New-Item -Path $runOnce -Force | Out-Null }; `+
+			`New-ItemProperty -Path $runOnce -Name 'CrabboxInitPassword' -PropertyType String -Force -Value ('cmd /c net user "%s" "' + $env:_CRABBOX_GP + '" /y') | Out-Null `+
+			`} finally { `+
+			`[gc]::Collect(); [gc]::WaitForPendingFinalizers(); `+
+			`reg.exe unload HKLM\crabbox-init | Out-Null `+
+			`} `+
+			`} finally { Dismount-VHD -Path '%s' }`,
+		escapePSString(vhdPath), escapePSString(user), escapePSString(vhdPath),
+	)
+	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
+	result, err := b.powershellWithEnv(ctx, script, env)
+	if err != nil {
+		return commandError("init-password injection", result, err)
+	}
+	return nil
+}
+
 // invokeInGuest runs a PowerShell script block inside the guest over PowerShell
 // Direct, authenticating as user with the configured guest password. It retries
 // with backoff while the guest finishes booting. scriptBlock is the body of an
 // Invoke-Command -ScriptBlock { ... }; the guest password is passed via the
 // _CRABBOX_GP env var, never on the command line.
 func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, label string) error {
-	guestPassword := b.cfg.HyperV.GuestPassword
-	if guestPassword == "" {
-		guestPassword = "crabbox"
-	}
 	script := fmt.Sprintf(
 		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
 			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { %s }`,
 		escapePSString(user), escapePSString(vmName), scriptBlock,
 	)
-	env := append(os.Environ(), "_CRABBOX_GP="+guestPassword)
+	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
 		if attempt > 0 {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -578,6 +578,13 @@ func (b *backend) ensureOpenSSH(ctx context.Context, vmName, user string) error 
 // installs git. Idempotent: a no-op when git is already on PATH (so a template
 // that pre-bakes git skips the per-lease download). Uses portable MinGit from
 // the latest git-for-windows release; needs guest internet.
+//
+// MinGit must NOT be extracted to C:\Program Files\Git: MinGit's etc\gitconfig
+// deliberately includes C:/Program Files/Git/etc/gitconfig (to inherit a full
+// Git-for-Windows install's system config), so extracting it there makes the
+// include self-referential and every git command fails with "exceeded maximum
+// include depth". At C:\Program Files\MinGit the include points at a missing
+// file, which git ignores.
 func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 	scriptBlock := `$ErrorActionPreference='Stop'; ` +
 		`if (Get-Command git -ErrorAction SilentlyContinue) { return }; ` +
@@ -588,7 +595,7 @@ func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 		`if (-not $asset) { throw 'MinGit asset not found' }; ` +
 		`$zip=Join-Path $env:TEMP 'crabbox-mingit.zip'; ` +
 		`Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zip; ` +
-		`$dst='C:\Program Files\Git'; ` +
+		`$dst='C:\Program Files\MinGit'; ` +
 		`Expand-Archive -Path $zip -DestinationPath $dst -Force; ` +
 		`$cmd=Join-Path $dst 'cmd'; ` +
 		`$p=[Environment]::GetEnvironmentVariable('PATH','Machine'); ` +

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -93,10 +94,10 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if strings.HasSuffix(strings.ToLower(cfg.HyperV.Image), ".iso") {
 		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a Windows VHDX template with a reachable administrator account", providerName)
 	}
+	if strings.TrimSpace(cfg.HyperV.GuestPassword) == "" {
+		return LeaseTarget{}, exit(2, "provider=%s requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD or hyperv.guestPassword in trusted user config", providerName)
+	}
 	if cfg.HyperV.InitPassword {
-		if cfg.HyperV.GuestPassword == "" {
-			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD (refusing to set the default password on the guest)", providerName)
-		}
 		// Both values land inside a double-quoted cmd.exe RunOnce command at
 		// first boot: a double quote would break out of the quoting and a
 		// percent sign would expand as a cmd variable, so reject either in
@@ -138,12 +139,30 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}()
 	cfg.SSHKey = keyPath
 	name := leaseProviderName(leaseID, slug)
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	labels["instance"] = name
+	labels["image"] = cfg.HyperV.Image
+	labels["ssh_user"] = cfg.HyperV.User
+	labels["ssh_port"] = sshPort
+	labels["work_root"] = cfg.HyperV.WorkRoot
+	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB switch=%s keep=%v\n",
 		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Switch, req.Keep)
 
 	if err := b.createVM(ctx, cfg, name, publicKey); err != nil {
 		_ = b.removeVM(context.Background(), name)
 		return LeaseTarget{}, err
+	}
+	if req.Keep {
+		retained := LeaseTarget{
+			Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+			LeaseID: leaseID,
+		}
+		if err := persistLease(leaseID, slug, name, cfg, req, retained); err != nil {
+			_ = b.removeVM(context.Background(), name)
+			return LeaseTarget{}, fmt.Errorf("persist retained hyperv lease before bootstrap: %w", err)
+		}
+		cleanupKey = false
 	}
 
 	ip, err := b.waitForIP(ctx, name, 5*time.Minute)
@@ -160,12 +179,6 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 		return LeaseTarget{}, fmt.Errorf("guest OpenSSH setup failed: %w", err)
 	}
-	if err := b.ensureGit(ctx, name, cfg.HyperV.User); err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, fmt.Errorf("guest git setup failed: %w", err)
-	}
 
 	if publicKey != "" {
 		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
@@ -175,15 +188,12 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 			return LeaseTarget{}, fmt.Errorf("post-boot SSH key injection failed: %w", retryErr)
 		}
 	}
-
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
-	labels["instance"] = name
-	labels["image"] = cfg.HyperV.Image
-	labels["ssh_user"] = cfg.HyperV.User
-	labels["ssh_port"] = sshPort
-	labels["work_root"] = cfg.HyperV.WorkRoot
-
-	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
+	if err := b.ensureGit(ctx, name, cfg.HyperV.User); err != nil {
+		if !req.Keep {
+			_ = b.removeVM(context.Background(), name)
+		}
+		return LeaseTarget{}, fmt.Errorf("guest git setup failed: %w", err)
+	}
 	lease, err := b.prepareLease(ctx, cfg, hypervVM{Name: name, State: 2}, ip, claim, true)
 	if err != nil {
 		if !req.Keep {
@@ -486,10 +496,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 }
 
 func (b *backend) guestPassword() string {
-	if password := b.cfg.HyperV.GuestPassword; password != "" {
-		return password
-	}
-	return "crabbox"
+	return b.cfg.HyperV.GuestPassword
 }
 
 // injectInitPassword makes a password-less template (e.g. a stock Windows
@@ -625,13 +632,32 @@ func (b *backend) ensureGit(ctx context.Context, vmName, user string) error {
 // administrators_authorized_keys file.
 func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey string) error {
 	scriptBlock := fmt.Sprintf(
-		`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
+		`$ErrorActionPreference='Stop'; `+
+			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
 			`$akPath = Join-Path $sshDir 'authorized_keys'; `+
 			`Add-Content -Encoding ASCII -Path $akPath -Value '%s'; `+
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
 			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s'; `+
-			`icacls $adminAK /inheritance:r /grant 'SYSTEM:F' 'BUILTIN\Administrators:F' | Out-Null }`,
+			`icacls.exe $adminAK /inheritance:r /grant '*S-1-5-18:F' '*S-1-5-32-544:F' | Out-Null; `+
+			`if ($LASTEXITCODE -ne 0) { throw 'administrators_authorized_keys ACL update failed' } }; `+
+			`$sshdConfig = Join-Path $env:ProgramData 'ssh\sshd_config'; `+
+			`$sshdLines = if (Test-Path $sshdConfig) { Get-Content $sshdConfig } else { @() }; `+
+			`$globalLines = @(); $matchLines = @(); $inMatch = $false; `+
+			`foreach ($line in $sshdLines) { `+
+			`if ($line -match '^\s*Match\s+') { $inMatch = $true }; `+
+			`if (-not $inMatch -and $line -match '^\s*(PasswordAuthentication|PubkeyAuthentication)\s+') { continue }; `+
+			`if ($inMatch) { $matchLines += $line } else { $globalLines += $line } }; `+
+			`$globalLines += 'PubkeyAuthentication yes'; `+
+			`$globalLines += 'PasswordAuthentication no'; `+
+			`if (($matchLines -join [Environment]::NewLine) -notmatch '(?im)^\s*Match\s+Group\s+administrators\b') { `+
+			`$matchLines += 'Match Group administrators'; `+
+			`$matchLines += '       AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys' }; `+
+			`Set-Content -Encoding ASCII -Path $sshdConfig -Value (($globalLines + $matchLines) -join [Environment]::NewLine); `+
+			`$sshdExe = Join-Path $env:WINDIR 'System32\OpenSSH\sshd.exe'; `+
+			`& $sshdExe -t -f $sshdConfig; `+
+			`if ($LASTEXITCODE -ne 0) { throw 'sshd_config validation failed' }; `+
+			`Restart-Service sshd`,
 		escapePSString(publicKey), escapePSString(publicKey),
 	)
 	return b.invokeInGuest(ctx, vmName, user, scriptBlock, "SSH key injection")
@@ -1054,17 +1080,22 @@ func parseFirstIPv4(raw string) string {
 			return ""
 		}
 		for _, ip := range ips {
-			if isIPv4(ip) {
+			if isUsableIPv4(ip) {
 				return ip
 			}
 		}
 		return ""
 	}
 	raw = strings.Trim(raw, `"`)
-	if isIPv4(raw) {
+	if isUsableIPv4(raw) {
 		return raw
 	}
 	return ""
+}
+
+func isUsableIPv4(s string) bool {
+	addr, err := netip.ParseAddr(strings.TrimSpace(s))
+	return err == nil && addr.Is4() && addr.IsGlobalUnicast()
 }
 
 func isIPv4(s string) bool {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -558,6 +558,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, i
 	if ip == "" {
 		return LeaseTarget{}, exit(5, "hyperv instance %s has no IPv4 address", inst.Name)
 	}
+	server.PublicNet.IPv4.IP = ip
 	if claim.LeaseID != "" {
 		keyPath, err := testboxKeyPath(claim.LeaseID)
 		if err == nil {
@@ -704,6 +705,9 @@ func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg C
 		Labels:   labels,
 	}
 	server.ServerType.Name = "hyperv"
+	if claim.SSHHost != "" {
+		server.PublicNet.IPv4.IP = claim.SSHHost
+	}
 	return server
 }
 

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -38,12 +38,8 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 
 func applyDefaults(cfg *Config) {
 	cfg.Provider = providerName
-	if cfg.TargetOS == "" {
-		cfg.TargetOS = targetWindows
-	}
-	if cfg.WindowsMode == "" {
-		cfg.WindowsMode = core.WindowsModeNormal
-	}
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
 	cfg.SSHFallbackPorts = []string{}
 	if cfg.HyperV.User == "" {
 		cfg.HyperV.User = "crabbox"

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -191,13 +191,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 		return LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		if !req.Keep {
-			_ = b.removeVM(context.Background(), name)
-		}
-		return LeaseTarget{}, err
-	}
-	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+	if err := persistLease(leaseID, slug, name, cfg, req, lease); err != nil {
 		if !req.Keep {
 			_ = b.removeVM(context.Background(), name)
 		}
@@ -206,6 +200,14 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
 	return lease, nil
+}
+
+// persistLease records the lease claim and its SSH endpoint in one atomic
+// write. Acquire removes the VM when this fails, so the claim and endpoint
+// must never be written separately: a failure between two writes would leave
+// a claim pointing at a VM that no longer exists.
+func persistLease(leaseID, slug, name string, cfg Config, req AcquireRequest, lease LeaseTarget) error {
+	return claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH)
 }
 
 func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -367,6 +367,10 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 	if err := os.MkdirAll(vhdDir, 0o755); err != nil {
 		return exit(2, "create VHD directory %s: %v", vhdDir, err)
 	}
+	vmDir := hypervVMDir()
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		return exit(2, "create VM directory %s: %v", vmDir, err)
+	}
 	vhdPath := filepath.Join(vhdDir, name+".vhdx")
 
 	switchCheck := fmt.Sprintf(
@@ -386,13 +390,20 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name, publicKey stri
 		return commandError("copy VHDX template", result, err)
 	}
 	if cfg.HyperV.Disk > 0 {
-		resizeScript := fmt.Sprintf(`Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction SilentlyContinue`,
-			escapePSString(vhdPath), int64(cfg.HyperV.Disk)*1024*1024*1024)
-		b.powershell(ctx, resizeScript) //nolint:errcheck
+		targetSizeBytes := int64(cfg.HyperV.Disk) * 1024 * 1024 * 1024
+		resizeScript := fmt.Sprintf(
+			`$vhd = Get-VHD -Path '%s' -ErrorAction Stop; if ($vhd.Size -lt %d) { Resize-VHD -Path '%s' -SizeBytes %d -ErrorAction Stop }`,
+			escapePSString(vhdPath), targetSizeBytes, escapePSString(vhdPath), targetSizeBytes,
+		)
+		result, err = b.powershell(ctx, resizeScript)
+		if err != nil {
+			os.Remove(vhdPath) //nolint:errcheck
+			return commandError("Resize-VHD", result, err)
+		}
 	}
 	createScript := fmt.Sprintf(
-		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s'`,
-		escapePSString(name), memBytes, escapePSString(vhdPath),
+		`New-VM -Name '%s' -MemoryStartupBytes %d -Generation 2 -VHDPath '%s' -Path '%s'`,
+		escapePSString(name), memBytes, escapePSString(vhdPath), escapePSString(vmDir),
 	)
 	result, err = b.powershell(ctx, createScript)
 	if err != nil {
@@ -828,6 +839,14 @@ func hypervVHDDir() string {
 		home = `C:\Users\Public`
 	}
 	return filepath.Join(home, "Hyper-V", "Virtual Hard Disks")
+}
+
+func hypervVMDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = `C:\Users\Public`
+	}
+	return filepath.Join(home, "Hyper-V", "Virtual Machines")
 }
 
 func parseVMList(raw string) ([]hypervVM, error) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -97,8 +97,16 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if cfg.HyperV.GuestPassword == "" {
 			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD (refusing to set the default password on the guest)", providerName)
 		}
+		// Both values land inside a double-quoted cmd.exe RunOnce command at
+		// first boot: a double quote would break out of the quoting and a
+		// percent sign would expand as a cmd variable, so reject either in
+		// either value rather than emitting a command that does something
+		// other than what was configured.
 		if strings.ContainsAny(cfg.HyperV.GuestPassword, `"%`) {
 			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs; choose a different CRABBOX_HYPERV_GUEST_PASSWORD", providerName)
+		}
+		if strings.ContainsAny(cfg.HyperV.User, `"%`) {
+			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs in the user name; choose a different --hyperv-user", providerName)
 		}
 	}
 	leaseID := newLeaseID()

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -427,9 +427,7 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 		guestPassword = "crabbox"
 	}
 	script := fmt.Sprintf(
-		`$pw = $env:CRABBOX_HYPERV_GUEST_PASSWORD; `+
-			`if (-not $pw) { $pw = '%s' }; `+
-			`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $pw -AsPlainText -Force)); `+
+		`$cred = New-Object PSCredential('%s', (ConvertTo-SecureString $env:_CRABBOX_GP -AsPlainText -Force)); `+
 			`Invoke-Command -VMName '%s' -Credential $cred -ScriptBlock { `+
 			`$sshDir = Join-Path $env:USERPROFILE '.ssh'; `+
 			`New-Item -ItemType Directory -Force -Path $sshDir | Out-Null; `+
@@ -438,9 +436,11 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			`$adminAK = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'; `+
 			`if (Test-Path (Split-Path $adminAK)) { Add-Content -Encoding ASCII -Path $adminAK -Value '%s' } `+
 			`}`,
-		escapePSString(guestPassword), escapePSString(user), escapePSString(vmName),
+		escapePSString(user), escapePSString(vmName),
 		escapePSString(publicKey), escapePSString(publicKey),
 	)
+	env := os.Environ()
+	env = append(env, "_CRABBOX_GP="+guestPassword)
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
 		if attempt > 0 {
@@ -451,7 +451,7 @@ func (b *backend) injectSSHKey(ctx context.Context, vmName, user, publicKey stri
 			}
 			fmt.Fprintf(b.rt.Stderr, "retrying SSH key injection (%d/5)...\n", attempt+1)
 		}
-		result, err := b.powershell(ctx, script)
+		result, err := b.powershellWithEnv(ctx, script, env)
 		if err == nil {
 			return nil
 		}
@@ -712,6 +712,14 @@ func (b *backend) powershell(ctx context.Context, script string) (LocalCommandRe
 	return b.rt.Exec.Run(ctx, LocalCommandRequest{
 		Name: "powershell",
 		Args: []string{"-NoProfile", "-NonInteractive", "-Command", script},
+	})
+}
+
+func (b *backend) powershellWithEnv(ctx context.Context, script string, env []string) (LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: "powershell",
+		Args: []string{"-NoProfile", "-NonInteractive", "-Command", script},
+		Env:  env,
 	})
 }
 

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -569,7 +569,6 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, i
 	target := sshTargetFromConfig(cfg, ip)
 	target.Port = sshPort
 	target.FallbackPorts = []string{}
-	target.ReadyCheck = core.PowershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
 	if wait {
 		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "hyperv ssh", bootstrapWaitTimeout(cfg)); err != nil {
 			return LeaseTarget{}, err

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -74,6 +74,10 @@ func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, 
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }
 
+func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server, target SSHTarget) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
+}
+
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
@@ -84,10 +88,6 @@ func listLeaseClaims() ([]core.LeaseClaim, error) {
 
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
-}
-
-func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
 }
 
 func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -1,0 +1,115 @@
+package hyperv
+
+import (
+	"context"
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type HyperVConfig = core.HyperVConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+
+const (
+	providerName  = "hyperv"
+	targetWindows = core.TargetWindows
+	sshPort       = "22"
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func leaseProviderName(leaseID, slug string) string {
+	return core.LeaseProviderName(leaseID, slug)
+}
+
+func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
+	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
+	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
+}
+
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, provider)
+}
+
+func listLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaims()
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
+	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
+}
+
+func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
+	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
+}
+
+func testboxKeyPath(leaseID string) (string, error) {
+	return core.TestboxKeyPath(leaseID)
+}
+
+func removeStoredTestboxKey(leaseID string) {
+	core.RemoveStoredTestboxKey(leaseID)
+}
+
+func sshTargetFromConfig(cfg Config, host string) SSHTarget {
+	return core.SSHTargetFromConfig(cfg, host)
+}
+
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+}
+
+func bootstrapWaitTimeout(cfg Config) time.Duration {
+	return core.BootstrapWaitTimeout(cfg)
+}

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -56,14 +56,11 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		cfg.HyperV.InitPassword = *v.InitPassword
 	}
 	if isHyperVProviderName(cfg.Provider) {
-		// Reject an explicitly-set non-Windows target from any source (CLI flag,
-		// YAML, or env) rather than silently rewriting it to windows. Only adopt
-		// windows when the target was never set (baseConfig defaults to linux).
-		if flagWasSet(fs, "target") || core.IsTargetExplicit(cfg) {
-			if cfg.TargetOS != targetWindows {
-				return exit(2, "provider=%s supports target=%s only (got target=%s)", providerName, targetWindows, cfg.TargetOS)
-			}
-		} else {
+		// Target flags are applied after provider flags on several lifecycle
+		// commands. Leave target validation to the centralized provider-target
+		// check after all flag sources have been applied. When no target source
+		// is explicit, adopt the provider's Windows default here.
+		if !core.IsTargetExplicit(cfg) && !flagWasSet(fs, "target") {
 			cfg.TargetOS = targetWindows
 		}
 		applyDefaults(cfg)

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -53,7 +53,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 
 func isHyperVProviderName(provider string) bool {
 	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "local-hyperv", "hyper-v", "windows-vm":
+	case providerName:
 		return true
 	default:
 		return false

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -1,0 +1,61 @@
+package hyperv
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	Image  *string
+	CPUs   *int
+	Memory *int
+	Disk   *int
+	Switch *string
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX or ISO path for Hyper-V VM creation"),
+		CPUs:   fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
+		Memory: fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
+		Disk:   fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
+		Switch: fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "hyperv-image") {
+		cfg.HyperV.Image = *v.Image
+	}
+	if flagWasSet(fs, "hyperv-cpu") {
+		cfg.HyperV.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "hyperv-memory") {
+		cfg.HyperV.Memory = *v.Memory
+	}
+	if flagWasSet(fs, "hyperv-disk") {
+		cfg.HyperV.Disk = *v.Disk
+	}
+	if flagWasSet(fs, "hyperv-switch") {
+		cfg.HyperV.Switch = *v.Switch
+	}
+	if isHyperVProviderName(cfg.Provider) {
+		applyDefaults(cfg)
+	}
+	return nil
+}
+
+func isHyperVProviderName(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case providerName, "local-hyperv", "hyper-v", "windows-vm":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -8,24 +8,26 @@ import (
 )
 
 type flagValues struct {
-	Image    *string
-	User     *string
-	WorkRoot *string
-	CPUs     *int
-	Memory   *int
-	Disk     *int
-	Switch   *string
+	Image        *string
+	User         *string
+	WorkRoot     *string
+	CPUs         *int
+	Memory       *int
+	Disk         *int
+	Switch       *string
+	InitPassword *bool
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
-		Image:    fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX template path for Hyper-V VM creation"),
-		User:     fs.String("hyperv-user", defaults.HyperV.User, "guest administrator account for SSH (password via CRABBOX_HYPERV_GUEST_PASSWORD)"),
-		WorkRoot: fs.String("hyperv-work-root", defaults.HyperV.WorkRoot, "Crabbox work root inside the guest"),
-		CPUs:     fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
-		Memory:   fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
-		Disk:     fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
-		Switch:   fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
+		Image:        fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX template path for Hyper-V VM creation"),
+		User:         fs.String("hyperv-user", defaults.HyperV.User, "guest administrator account for SSH (password via CRABBOX_HYPERV_GUEST_PASSWORD)"),
+		WorkRoot:     fs.String("hyperv-work-root", defaults.HyperV.WorkRoot, "Crabbox work root inside the guest"),
+		CPUs:         fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
+		Memory:       fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
+		Disk:         fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
+		Switch:       fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
+		InitPassword: fs.Bool("hyperv-init-password", defaults.HyperV.InitPassword, "set the guest password at first boot via the lease disk (for password-less auto-logon templates, e.g. Windows dev-environment VHDXs)"),
 	}
 }
 
@@ -54,6 +56,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "hyperv-switch") {
 		cfg.HyperV.Switch = *v.Switch
+	}
+	if flagWasSet(fs, "hyperv-init-password") {
+		cfg.HyperV.InitPassword = *v.InitPassword
 	}
 	if isHyperVProviderName(cfg.Provider) {
 		// Reject an explicitly-set non-Windows target from any source (CLI flag,

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -13,7 +13,6 @@ type flagValues struct {
 	WorkRoot     *string
 	CPUs         *int
 	Memory       *int
-	Disk         *int
 	Switch       *string
 	InitPassword *bool
 }
@@ -25,7 +24,6 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 		WorkRoot:     fs.String("hyperv-work-root", defaults.HyperV.WorkRoot, "Crabbox work root inside the guest"),
 		CPUs:         fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
 		Memory:       fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
-		Disk:         fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
 		Switch:       fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
 		InitPassword: fs.Bool("hyperv-init-password", defaults.HyperV.InitPassword, "set the guest password at first boot via the lease disk (for password-less auto-logon templates, e.g. Windows dev-environment VHDXs)"),
 	}
@@ -50,9 +48,6 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "hyperv-memory") {
 		cfg.HyperV.Memory = *v.Memory
-	}
-	if flagWasSet(fs, "hyperv-disk") {
-		cfg.HyperV.Disk = *v.Disk
 	}
 	if flagWasSet(fs, "hyperv-switch") {
 		cfg.HyperV.Switch = *v.Switch

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -8,20 +8,24 @@ import (
 )
 
 type flagValues struct {
-	Image  *string
-	CPUs   *int
-	Memory *int
-	Disk   *int
-	Switch *string
+	Image    *string
+	User     *string
+	WorkRoot *string
+	CPUs     *int
+	Memory   *int
+	Disk     *int
+	Switch   *string
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
-		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX template path for Hyper-V VM creation"),
-		CPUs:   fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
-		Memory: fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
-		Disk:   fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
-		Switch: fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
+		Image:    fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX template path for Hyper-V VM creation"),
+		User:     fs.String("hyperv-user", defaults.HyperV.User, "guest administrator account for SSH (password via CRABBOX_HYPERV_GUEST_PASSWORD)"),
+		WorkRoot: fs.String("hyperv-work-root", defaults.HyperV.WorkRoot, "Crabbox work root inside the guest"),
+		CPUs:     fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
+		Memory:   fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
+		Disk:     fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),
+		Switch:   fs.String("hyperv-switch", defaults.HyperV.Switch, "Hyper-V virtual switch name"),
 	}
 }
 
@@ -32,6 +36,12 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "hyperv-image") {
 		cfg.HyperV.Image = *v.Image
+	}
+	if flagWasSet(fs, "hyperv-user") {
+		cfg.HyperV.User = *v.User
+	}
+	if flagWasSet(fs, "hyperv-work-root") {
+		cfg.HyperV.WorkRoot = *v.WorkRoot
 	}
 	if flagWasSet(fs, "hyperv-cpu") {
 		cfg.HyperV.CPUs = *v.CPUs

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -17,7 +17,7 @@ type flagValues struct {
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
-		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX or ISO path for Hyper-V VM creation"),
+		Image:  fs.String("hyperv-image", defaults.HyperV.Image, "Windows VHDX template path for Hyper-V VM creation"),
 		CPUs:   fs.Int("hyperv-cpu", defaults.HyperV.CPUs, "CPU count for Hyper-V leases"),
 		Memory: fs.Int("hyperv-memory", defaults.HyperV.Memory, "memory in MB for Hyper-V leases"),
 		Disk:   fs.Int("hyperv-disk", defaults.HyperV.Disk, "disk size in GB for Hyper-V leases"),

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -46,6 +46,12 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		cfg.HyperV.Switch = *v.Switch
 	}
 	if isHyperVProviderName(cfg.Provider) {
+		if flagWasSet(fs, "target") && cfg.TargetOS != targetWindows {
+			return exit(2, "provider=%s supports target=%s only (got --%s %s)", providerName, targetWindows, "target", cfg.TargetOS)
+		}
+		if !flagWasSet(fs, "target") && cfg.TargetOS == "linux" {
+			cfg.TargetOS = targetWindows
+		}
 		applyDefaults(cfg)
 	}
 	return nil

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -46,10 +46,14 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		cfg.HyperV.Switch = *v.Switch
 	}
 	if isHyperVProviderName(cfg.Provider) {
-		if flagWasSet(fs, "target") && cfg.TargetOS != targetWindows {
-			return exit(2, "provider=%s supports target=%s only (got --%s %s)", providerName, targetWindows, "target", cfg.TargetOS)
-		}
-		if !flagWasSet(fs, "target") && cfg.TargetOS == "linux" {
+		// Reject an explicitly-set non-Windows target from any source (CLI flag,
+		// YAML, or env) rather than silently rewriting it to windows. Only adopt
+		// windows when the target was never set (baseConfig defaults to linux).
+		if flagWasSet(fs, "target") || core.IsTargetExplicit(cfg) {
+			if cfg.TargetOS != targetWindows {
+				return exit(2, "provider=%s supports target=%s only (got target=%s)", providerName, targetWindows, cfg.TargetOS)
+			}
+		} else {
 			cfg.TargetOS = targetWindows
 		}
 		applyDefaults(cfg)

--- a/internal/providers/hyperv/provider.go
+++ b/internal/providers/hyperv/provider.go
@@ -1,0 +1,63 @@
+package hyperv
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"local-hyperv", "hyper-v", "windows-vm"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "local-vm",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetWindows {
+		return nil, core.Exit(2, "provider=%s supports target=windows only", providerName)
+	}
+	if cfg.TargetOS == core.TargetWindows && cfg.WindowsMode != "" && cfg.WindowsMode != core.WindowsModeNormal {
+		return nil, core.Exit(2, "provider=%s supports windows.mode=normal only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; use a remote SSH provider when tailnet reachability is required", providerName)
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}

--- a/internal/providers/hyperv/provider.go
+++ b/internal/providers/hyperv/provider.go
@@ -14,9 +14,7 @@ type Provider struct{}
 
 func (Provider) Name() string { return providerName }
 
-func (Provider) Aliases() []string {
-	return []string{"local-hyperv", "hyper-v", "windows-vm"}
-}
+func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -586,6 +586,9 @@ func TestCreateVMInitPasswordInjectsRunOnceBeforeBoot(t *testing.T) {
 					t.Errorf("init-password script missing %q", want)
 				}
 			}
+			if !strings.Contains(script, "HKLM\\crabbox-init-") || !strings.Contains(script, "HKLM:\\crabbox-init-") {
+				t.Errorf("init-password script missing unique hive name: %s", script)
+			}
 			if strings.Contains(script, `C:\Images\windows.vhdx`) {
 				t.Error("init-password script must mount the lease disk, not the template")
 			}
@@ -613,6 +616,19 @@ func TestCreateVMInitPasswordInjectsRunOnceBeforeBoot(t *testing.T) {
 	}
 	if newVMIdx < 0 || newVMIdx < injectIdx {
 		t.Fatalf("password injection (call %d) must happen before New-VM (call %d)", injectIdx, newVMIdx)
+	}
+}
+
+func TestHyperVInitHiveNameIsUniqueAndSafe(t *testing.T) {
+	first := hypervInitHiveName(`C:\Hyper-V\one.vhdx`)
+	second := hypervInitHiveName(`C:\Hyper-V\two.vhdx`)
+	if first == second {
+		t.Fatalf("hive names collide: %q", first)
+	}
+	for _, name := range []string{first, second} {
+		if !strings.HasPrefix(name, "crabbox-init-") || strings.ContainsAny(name, `\/: `) {
+			t.Fatalf("unsafe hive name %q", name)
+		}
 	}
 }
 
@@ -1006,6 +1022,12 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
 	}
+	if strings.Contains(script, "Add-Content") {
+		t.Fatalf("SSH key injection retained template keys: %s", script)
+	}
+	if strings.Count(script, "Set-Content -Encoding ASCII") < 3 {
+		t.Fatalf("SSH key injection should replace user, administrator, and config files: %s", script)
+	}
 }
 
 func TestInjectSSHKeyPasswordNotInArgs(t *testing.T) {
@@ -1244,60 +1266,30 @@ func TestApplyDefaultsPreservesExplicitTarget(t *testing.T) {
 	}
 }
 
-func TestApplyFlagsRejectsExplicitLinuxTarget(t *testing.T) {
+func TestApplyFlagsDefersTargetValidation(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
-
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.String("target", "linux", "")
-	if err := fs.Set("target", "linux"); err != nil {
-		t.Fatal(err)
-	}
-
-	err := applyFlags(&cfg, fs, flagValues{})
-	if err == nil {
-		t.Fatal("applyFlags should reject explicit --target linux")
-	}
-}
-
-func TestApplyFlagsRejectsExplicitMacOSTarget(t *testing.T) {
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.TargetOS = core.TargetMacOS
-
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.String("target", "linux", "")
-	if err := fs.Set("target", "macos"); err != nil {
-		t.Fatal(err)
-	}
-
-	err := applyFlags(&cfg, fs, flagValues{})
-	if err == nil {
-		t.Fatal("applyFlags should reject explicit --target macos")
-	}
-}
-
-func TestApplyFlagsDefaultsLinuxToWindows(t *testing.T) {
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
+	core.MarkTargetExplicit(&cfg)
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.String("target", "linux", "")
 
-	err := applyFlags(&cfg, fs, flagValues{})
-	if err != nil {
-		t.Fatalf("applyFlags failed: %v", err)
+	if err := applyFlags(&cfg, fs, flagValues{}); err != nil {
+		t.Fatalf("applyFlags should defer target validation: %v", err)
 	}
-	if cfg.TargetOS != core.TargetWindows {
-		t.Fatalf("TargetOS=%s want windows (should default baseConfig linux to windows)", cfg.TargetOS)
+	if cfg.TargetOS != core.TargetLinux {
+		t.Fatalf("applyFlags rewrote explicit target to %s", cfg.TargetOS)
+	}
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("central provider configuration should reject target=linux")
 	}
 }
 
-func TestApplyFlagsAcceptsExplicitWindows(t *testing.T) {
+func TestApplyFlagsAllowsLaterWindowsOverride(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
-	cfg.TargetOS = core.TargetWindows
+	cfg.TargetOS = core.TargetLinux
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.String("target", "linux", "")
@@ -1307,28 +1299,29 @@ func TestApplyFlagsAcceptsExplicitWindows(t *testing.T) {
 
 	err := applyFlags(&cfg, fs, flagValues{})
 	if err != nil {
-		t.Fatalf("applyFlags should accept explicit --target windows: %v", err)
+		t.Fatalf("applyFlags should not reject a target flag before it is applied: %v", err)
 	}
+	cfg.TargetOS = core.TargetWindows
 	if cfg.TargetOS != core.TargetWindows {
 		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
 	}
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
+		t.Fatalf("provider should accept target after override: %v", err)
+	}
 }
 
-// A non-Windows target set via YAML or env (no CLI --target flag) must be
-// rejected, not silently rewritten to windows.
-func TestApplyFlagsRejectsExplicitConfigTarget(t *testing.T) {
-	for _, target := range []string{core.TargetLinux, core.TargetMacOS} {
-		cfg := core.BaseConfig()
-		cfg.Provider = providerName
-		cfg.TargetOS = target
-		core.MarkTargetExplicit(&cfg) // simulates target set from YAML/env
+func TestApplyFlagsDefaultsImplicitTargetToWindows(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
 
-		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		fs.String("target", "linux", "") // present but NOT set (no CLI flag)
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
 
-		if err := applyFlags(&cfg, fs, flagValues{}); err == nil {
-			t.Fatalf("applyFlags should reject explicit config target=%s, got TargetOS=%s", target, cfg.TargetOS)
-		}
+	if err := applyFlags(&cfg, fs, flagValues{}); err != nil {
+		t.Fatalf("applyFlags: %v", err)
+	}
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -55,7 +55,6 @@ func testBackend(runner *recordingRunner) *backend {
 		WorkRoot: `C:\crabbox`,
 		CPUs:     4,
 		Memory:   8192,
-		Disk:     50,
 		Switch:   "Default Switch",
 	}
 	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
@@ -153,8 +152,8 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.WindowsMode != core.WindowsModeNormal {
 		t.Fatalf("windowsMode=%s want normal", cfg.WindowsMode)
 	}
-	if cfg.HyperV.CPUs != 4 || cfg.HyperV.Memory != 8192 || cfg.HyperV.Disk != 50 {
-		t.Fatalf("defaults not applied: cpus=%d memory=%d disk=%d", cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Disk)
+	if cfg.HyperV.CPUs != 4 || cfg.HyperV.Memory != 8192 {
+		t.Fatalf("defaults not applied: cpus=%d memory=%d", cfg.HyperV.CPUs, cfg.HyperV.Memory)
 	}
 	if cfg.HyperV.Switch != "Default Switch" {
 		t.Fatalf("switch=%s want Default Switch", cfg.HyperV.Switch)
@@ -506,7 +505,6 @@ func TestCreateVMDoesNotCopyOrResizeTemplate(t *testing.T) {
 	b := testBackend(runner)
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
-	cfg.HyperV.Disk = 25
 
 	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
 		t.Fatalf("createVM: %v", err)

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"testing"

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -459,6 +459,36 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	}
 }
 
+func TestInjectSSHKeyPasswordNotInArgs(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+	}
+	b := testBackend(runner)
+	b.cfg.HyperV.GuestPassword = "s3cret-pa$$word"
+
+	_ = b.injectSSHKey(context.Background(), "crabbox-blue-1234", "crabbox", "ssh-ed25519 AAAA test")
+
+	for _, call := range runner.calls {
+		for _, arg := range call.Args {
+			if strings.Contains(arg, "s3cret-pa$$word") {
+				t.Fatal("guest password found in command args; should be passed via environment only")
+			}
+		}
+		if len(call.Env) == 0 {
+			t.Fatal("injectSSHKey should pass password via Env, not Args")
+		}
+		var foundEnv bool
+		for _, e := range call.Env {
+			if strings.Contains(e, "_CRABBOX_GP=s3cret-pa$$word") {
+				foundEnv = true
+			}
+		}
+		if !foundEnv {
+			t.Fatal("_CRABBOX_GP env var not found in command Env")
+		}
+	}
+}
+
 func TestResolveInstancePropagatesQueryError(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"strings"
@@ -141,6 +142,7 @@ func TestConfigureAcceptsEmpty(t *testing.T) {
 func TestApplyDefaults(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
+	cfg.TargetOS = ""
 	cfg.HyperV = core.HyperVConfig{}
 	applyDefaults(&cfg)
 	if cfg.TargetOS != core.TargetWindows {
@@ -607,5 +609,75 @@ func TestApplyDefaultsPreservesExplicitTarget(t *testing.T) {
 	applyDefaults(&cfg)
 	if cfg.TargetOS != core.TargetWindows {
 		t.Fatalf("applyDefaults changed explicit TargetOS to %s", cfg.TargetOS)
+	}
+}
+
+func TestApplyFlagsRejectsExplicitLinuxTarget(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+	if err := fs.Set("target", "linux"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFlags(&cfg, fs, flagValues{})
+	if err == nil {
+		t.Fatal("applyFlags should reject explicit --target linux")
+	}
+}
+
+func TestApplyFlagsRejectsExplicitMacOSTarget(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetMacOS
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+	if err := fs.Set("target", "macos"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFlags(&cfg, fs, flagValues{})
+	if err == nil {
+		t.Fatal("applyFlags should reject explicit --target macos")
+	}
+}
+
+func TestApplyFlagsDefaultsLinuxToWindows(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+
+	err := applyFlags(&cfg, fs, flagValues{})
+	if err != nil {
+		t.Fatalf("applyFlags failed: %v", err)
+	}
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("TargetOS=%s want windows (should default baseConfig linux to windows)", cfg.TargetOS)
+	}
+}
+
+func TestApplyFlagsAcceptsExplicitWindows(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+	if err := fs.Set("target", "windows"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := applyFlags(&cfg, fs, flagValues{})
+	if err != nil {
+		t.Fatalf("applyFlags should accept explicit --target windows: %v", err)
+	}
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -838,3 +838,38 @@ func TestApplyFlagsAcceptsExplicitWindows(t *testing.T) {
 		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
 	}
 }
+
+// A non-Windows target set via YAML or env (no CLI --target flag) must be
+// rejected, not silently rewritten to windows.
+func TestApplyFlagsRejectsExplicitConfigTarget(t *testing.T) {
+	for _, target := range []string{core.TargetLinux, core.TargetMacOS} {
+		cfg := core.BaseConfig()
+		cfg.Provider = providerName
+		cfg.TargetOS = target
+		core.MarkTargetExplicit(&cfg) // simulates target set from YAML/env
+
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("target", "linux", "") // present but NOT set (no CLI flag)
+
+		if err := applyFlags(&cfg, fs, flagValues{}); err == nil {
+			t.Fatalf("applyFlags should reject explicit config target=%s, got TargetOS=%s", target, cfg.TargetOS)
+		}
+	}
+}
+
+func TestApplyFlagsAcceptsExplicitConfigWindows(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	core.MarkTargetExplicit(&cfg)
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+
+	if err := applyFlags(&cfg, fs, flagValues{}); err != nil {
+		t.Fatalf("applyFlags should accept explicit config target=windows: %v", err)
+	}
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
+	}
+}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -426,35 +426,16 @@ func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 	}
 }
 
-func TestCreateVMISOAttachesDVD(t *testing.T) {
-	runner := &recordingRunner{
-		responses: map[string]core.LocalCommandResult{},
-		errors:    map[string]error{},
-	}
-	b := testBackend(runner)
-	cfg := b.configForRun()
-	cfg.HyperV.Image = `C:\Images\win-server.iso`
+func TestAcquireRejectsISO(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
 
-	err := b.createVM(context.Background(), cfg, "crabbox-red-5678", "ssh-ed25519 AAAA test")
-	if err != nil {
-		t.Fatalf("createVM: %v", err)
-	}
-
-	var foundNewVHD, foundDVD bool
-	for _, call := range runner.calls {
-		script := call.Args[len(call.Args)-1]
-		if strings.Contains(script, "New-VM") && strings.Contains(script, "-NewVHDPath") {
-			foundNewVHD = true
-		}
-		if strings.Contains(script, "Add-VMDvdDrive") && strings.Contains(script, "win-server.iso") {
-			foundDVD = true
-		}
-	}
-	if !foundNewVHD {
-		t.Error("ISO mode should create a new blank VHD")
-	}
-	if !foundDVD {
-		t.Error("ISO mode should attach the ISO as a DVD drive")
+	b.cfg.HyperV.Image = `C:\Images\win-server.iso`
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+	if err == nil || !strings.Contains(err.Error(), "does not support ISO") {
+		t.Fatalf("Acquire should reject ISO images, got: %v", err)
 	}
 }
 
@@ -474,6 +455,32 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	}
 	if vm.State != 3 {
 		t.Fatalf("state=%d want 3 (off)", vm.State)
+	}
+}
+
+func TestResolveInstancePropagatesQueryError(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+		errors:    map[string]error{},
+	}
+	runner.errors[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		fmt.Errorf("powershell exec failed")
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		core.LocalCommandResult{Stderr: "VM not found"}
+
+	b := testBackend(runner)
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	_, _, err := b.resolveInstance(context.Background(), "crabbox-blue-1234")
+	if err == nil {
+		t.Fatal("resolveInstance should propagate VM query failure, not return synthetic State=2")
+	}
+	if !strings.Contains(err.Error(), "not reachable") && !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -580,6 +580,30 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	}
 }
 
+func TestEnsureGitInstallsWhenMissing(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+
+	if err := b.ensureGit(context.Background(), "crabbox-blue-1234", "crabbox"); err != nil {
+		t.Fatalf("ensureGit: %v", err)
+	}
+	var script string
+	for _, call := range runner.calls {
+		s := call.Args[len(call.Args)-1]
+		if strings.Contains(s, "Invoke-Command") && strings.Contains(s, "MinGit") {
+			script = s
+		}
+	}
+	if script == "" {
+		t.Fatal("ensureGit should install git over PowerShell Direct when missing")
+	}
+	for _, want := range []string{"Get-Command git", "git-for-windows", "Expand-Archive", "SetEnvironmentVariable"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("ensureGit script missing %q", want)
+		}
+	}
+}
+
 func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -713,6 +713,80 @@ func TestEnsureGitInstallsWhenMissing(t *testing.T) {
 	}
 }
 
+func ensureGitScript(t *testing.T) string {
+	t.Helper()
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	if err := b.ensureGit(context.Background(), "crabbox-blue-1234", "crabbox"); err != nil {
+		t.Fatalf("ensureGit: %v", err)
+	}
+	for _, call := range runner.calls {
+		s := call.Args[len(call.Args)-1]
+		if strings.Contains(s, "Invoke-Command") && strings.Contains(s, "MinGit") {
+			return s
+		}
+	}
+	t.Fatal("ensureGit install script not found")
+	return ""
+}
+
+// The MinGit archive is extracted into Program Files and added to the machine
+// PATH inside the guest, so the download must be pinned to an immutable
+// release asset -- never the floating "latest" API -- and verified against
+// the release's published SHA-256 before extraction.
+func TestEnsureGitPinsImmutableMinGitRelease(t *testing.T) {
+	script := ensureGitScript(t)
+	if !strings.Contains(script, minGitURL) {
+		t.Error("ensureGit must download the pinned MinGit release asset")
+	}
+	if !strings.Contains(script, minGitSHA256) {
+		t.Error("ensureGit must embed the expected MinGit SHA-256")
+	}
+	for _, banned := range []string{"releases/latest", "Invoke-RestMethod"} {
+		if strings.Contains(script, banned) {
+			t.Errorf("ensureGit must not resolve MinGit via %q (mutable release reference)", banned)
+		}
+	}
+	if !strings.Contains(minGitURL, "/releases/download/v") {
+		t.Errorf("minGitURL %q is not an immutable release asset URL", minGitURL)
+	}
+	if len(minGitSHA256) != 64 {
+		t.Errorf("minGitSHA256 length = %d, want 64 hex chars", len(minGitSHA256))
+	}
+}
+
+// Success path: the hash must be computed and compared BEFORE Expand-Archive
+// runs, so a tampered archive is never extracted.
+func TestEnsureGitVerifiesChecksumBeforeExtraction(t *testing.T) {
+	script := ensureGitScript(t)
+	idxHash := strings.Index(script, "Get-FileHash")
+	idxCompare := strings.Index(script, minGitSHA256)
+	idxExtract := strings.Index(script, "Expand-Archive")
+	if idxHash < 0 || idxCompare < 0 || idxExtract < 0 {
+		t.Fatalf("ensureGit script missing verification steps: hash=%d compare=%d extract=%d", idxHash, idxCompare, idxExtract)
+	}
+	if !(idxHash < idxExtract && idxCompare < idxExtract) {
+		t.Errorf("checksum verification (hash@%d, compare@%d) must precede extraction (@%d)", idxHash, idxCompare, idxExtract)
+	}
+}
+
+// Mismatch path: a wrong hash must fail closed -- delete the downloaded
+// archive and throw (PowerShell Direct surfaces the throw as a non-zero exit,
+// which ensureGit returns as an error after retries).
+func TestEnsureGitFailsClosedOnChecksumMismatch(t *testing.T) {
+	script := ensureGitScript(t)
+	mismatch := strings.Index(script, "MinGit SHA-256 mismatch")
+	if mismatch < 0 {
+		t.Fatal("ensureGit script has no checksum-mismatch branch")
+	}
+	branch := script[strings.Index(script, "$hash"):strings.Index(script, "Expand-Archive")]
+	for _, want := range []string{"Remove-Item $zip", "throw"} {
+		if !strings.Contains(branch, want) {
+			t.Errorf("checksum-mismatch branch missing %q", want)
+		}
+	}
+}
+
 func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -668,6 +668,75 @@ func TestAcquireInitPasswordRejectsCmdUnsafeUser(t *testing.T) {
 	}
 }
 
+// Acquire persists the lease claim and its SSH endpoint in ONE atomic write.
+// Success must leave a claim that already carries the endpoint -- there is no
+// separate endpoint update whose failure could strand a half-written claim.
+func TestPersistLeaseWritesClaimAndEndpointAtomically(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	b := testBackend(&recordingRunner{})
+	cfg := b.configForRun()
+	lease := LeaseTarget{LeaseID: "cbx_atomic123456"}
+	lease.Server = b.serverFromInstance(hypervVM{Name: "crabbox-atom-1234", State: 2}, core.LeaseClaim{}, cfg)
+	lease.Server.PublicNet.IPv4.IP = "172.20.0.9"
+	lease.SSH = sshTargetFromConfig(cfg, "172.20.0.9")
+
+	req := AcquireRequest{}
+	req.Repo.Root = t.TempDir()
+	if err := persistLease("cbx_atomic123456", "atomslug", "crabbox-atom-1234", cfg, req, lease); err != nil {
+		t.Fatalf("persistLease: %v", err)
+	}
+	t.Cleanup(func() { removeLeaseClaim("cbx_atomic123456") })
+
+	claims, err := listLeaseClaims()
+	if err != nil {
+		t.Fatalf("listLeaseClaims: %v", err)
+	}
+	var found *core.LeaseClaim
+	for i := range claims {
+		if claims[i].LeaseID == "cbx_atomic123456" {
+			found = &claims[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("persistLease did not write the claim")
+	}
+	if found.SSHHost != "172.20.0.9" {
+		t.Fatalf("claim SSHHost=%q want 172.20.0.9 (endpoint must be in the same write as the claim)", found.SSHHost)
+	}
+	if instanceNameFromClaim(*found) != "crabbox-atom-1234" {
+		t.Fatalf("claim instance=%q want crabbox-atom-1234", instanceNameFromClaim(*found))
+	}
+}
+
+// When the atomic persist fails, NO claim may remain: Acquire's error path
+// removes the VM, so any surviving lease state would point at a resource that
+// no longer exists.
+func TestPersistLeaseFailureLeavesNoStaleClaim(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "state-not-a-dir")
+	if err := os.WriteFile(blocker, []byte("plain file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// crabboxStateDir joins XDG_STATE_HOME with "crabbox"; pointing it at a
+	// plain file makes every claim write fail.
+	t.Setenv("XDG_STATE_HOME", blocker)
+
+	b := testBackend(&recordingRunner{})
+	cfg := b.configForRun()
+	lease := LeaseTarget{LeaseID: "cbx_atomfail12345"}
+	lease.Server = b.serverFromInstance(hypervVM{Name: "crabbox-atom-fail", State: 2}, core.LeaseClaim{}, cfg)
+	lease.SSH = sshTargetFromConfig(cfg, "172.20.0.10")
+
+	req := AcquireRequest{}
+	req.Repo.Root = t.TempDir()
+	if err := persistLease("cbx_atomfail12345", "atomfail", "crabbox-atom-fail", cfg, req, lease); err == nil {
+		t.Fatal("persistLease should fail when the state directory is unwritable")
+	}
+	info, err := os.Stat(blocker)
+	if err != nil || info.IsDir() {
+		t.Fatalf("state path mutated: err=%v isDir=%v -- nothing may be persisted on failure", err, info.IsDir())
+	}
+}
+
 func TestAcquireRejectsISO(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -1,0 +1,393 @@
+package hyperv
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls     []core.LocalCommandRequest
+	responses map[string]core.LocalCommandResult
+	errors    map[string]error
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	key := commandKey(req.Args)
+	if err, ok := r.errors[key]; ok {
+		return r.responses[key], err
+	}
+	if result, ok := r.responses[key]; ok {
+		return result, nil
+	}
+	if len(req.Args) > 0 {
+		if err, ok := r.errors[req.Args[len(req.Args)-1]]; ok {
+			return r.responses[req.Args[len(req.Args)-1]], err
+		}
+		if result, ok := r.responses[req.Args[len(req.Args)-1]]; ok {
+			return result, nil
+		}
+	}
+	return core.LocalCommandResult{}, nil
+}
+
+func commandKey(args []string) string {
+	return strings.Join(args, "\x00")
+}
+
+func testBackend(runner *recordingRunner) *backend {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.HyperV = core.HyperVConfig{
+		Image:    `C:\Images\windows.vhdx`,
+		User:     "crabbox",
+		WorkRoot: `C:\crabbox`,
+		CPUs:     4,
+		Memory:   8192,
+		Disk:     50,
+		Switch:   "Default Switch",
+	}
+	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+}
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %s", p.Name(), providerName)
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Family != "local-vm" {
+		t.Fatalf("unexpected spec: %#v", spec)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%s want never", spec.Coordinator)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetWindows || spec.Targets[0].WindowsMode != core.WindowsModeNormal {
+		t.Fatalf("unexpected targets: %#v", spec.Targets)
+	}
+}
+
+func TestProviderAliasesResolve(t *testing.T) {
+	for _, alias := range []string{"hyperv", "local-hyperv", "hyper-v", "windows-vm"} {
+		got, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if got.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", alias, got.Name())
+		}
+	}
+}
+
+func TestConfigureRejectsLinux(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted linux target")
+	}
+}
+
+func TestConfigureRejectsMacOS(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetMacOS
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted macos target")
+	}
+}
+
+func TestConfigureRejectsTailscale(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Tailscale.Enabled = true
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted tailscale")
+	}
+}
+
+func TestConfigureAcceptsWindows(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}}); err != nil {
+		t.Fatalf("Configure rejected windows target: %v", err)
+	}
+}
+
+func TestConfigureAcceptsEmpty(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = ""
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}}); err != nil {
+		t.Fatalf("Configure rejected empty target: %v", err)
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.HyperV = core.HyperVConfig{}
+	applyDefaults(&cfg)
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("target=%s want windows", cfg.TargetOS)
+	}
+	if cfg.WindowsMode != core.WindowsModeNormal {
+		t.Fatalf("windowsMode=%s want normal", cfg.WindowsMode)
+	}
+	if cfg.HyperV.CPUs != 4 || cfg.HyperV.Memory != 8192 || cfg.HyperV.Disk != 50 {
+		t.Fatalf("defaults not applied: cpus=%d memory=%d disk=%d", cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Disk)
+	}
+	if cfg.HyperV.Switch != "Default Switch" {
+		t.Fatalf("switch=%s want Default Switch", cfg.HyperV.Switch)
+	}
+	if cfg.HyperV.User != "crabbox" {
+		t.Fatalf("user=%s want crabbox", cfg.HyperV.User)
+	}
+	if cfg.SSHUser != "crabbox" || cfg.SSHPort != sshPort {
+		t.Fatalf("ssh user=%s port=%s", cfg.SSHUser, cfg.SSHPort)
+	}
+	if cfg.WorkRoot != `C:\crabbox` {
+		t.Fatalf("workRoot=%s want C:\\crabbox", cfg.WorkRoot)
+	}
+}
+
+func TestCleanupScopedToCrabboxPrefix(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	vms := []hypervVM{
+		{Name: "crabbox-blue-1234", State: 2},
+		{Name: "my-personal-vm", State: 2},
+		{Name: "crabbox-red-5678", State: 3},
+	}
+	cfg := b.configForRun()
+	claims := map[string]core.LeaseClaim{}
+	var views []LeaseView
+	for _, vm := range vms {
+		claim := claims[vm.Name]
+		if claim.LeaseID == "" && !strings.HasPrefix(vm.Name, "crabbox-") {
+			continue
+		}
+		views = append(views, b.serverFromInstance(vm, claim, cfg))
+	}
+
+	if len(views) != 2 {
+		t.Fatalf("list should filter to crabbox- prefix, got %d views", len(views))
+	}
+	for _, v := range views {
+		if !strings.HasPrefix(v.Name, "crabbox-") {
+			t.Fatalf("list included non-crabbox VM: %s", v.Name)
+		}
+	}
+}
+
+func TestRemoveVMRefuseNonCrabbox(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	err := b.removeVM(context.Background(), "my-personal-vm")
+	if err == nil || !strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("removeVM should refuse non-crabbox VM, err=%v", err)
+	}
+}
+
+func TestParseVMListSingle(t *testing.T) {
+	raw := `{"Name":"crabbox-blue-1234","State":2}`
+	vms, err := parseVMList(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vms) != 1 || vms[0].Name != "crabbox-blue-1234" || vms[0].State != 2 {
+		t.Fatalf("unexpected: %#v", vms)
+	}
+}
+
+func TestParseVMListArray(t *testing.T) {
+	raw := `[{"Name":"crabbox-blue-1234","State":2},{"Name":"crabbox-red-5678","State":3}]`
+	vms, err := parseVMList(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("expected 2 VMs, got %d", len(vms))
+	}
+	if vms[0].Name != "crabbox-blue-1234" || vms[1].Name != "crabbox-red-5678" {
+		t.Fatalf("unexpected: %#v", vms)
+	}
+}
+
+func TestParseVMListEmpty(t *testing.T) {
+	for _, raw := range []string{"", "null"} {
+		vms, err := parseVMList(raw)
+		if err != nil {
+			t.Fatalf("raw=%q err=%v", raw, err)
+		}
+		if len(vms) != 0 {
+			t.Fatalf("raw=%q expected empty, got %d", raw, len(vms))
+		}
+	}
+}
+
+func TestParseFirstIPv4(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{`["172.20.0.5","fe80::1"]`, "172.20.0.5"},
+		{`["fe80::1","192.168.1.100"]`, "192.168.1.100"},
+		{`"10.0.0.1"`, "10.0.0.1"},
+		{`null`, ""},
+		{`""`, ""},
+		{`["fe80::1"]`, ""},
+	}
+	for _, tc := range tests {
+		got := parseFirstIPv4(tc.raw)
+		if got != tc.want {
+			t.Fatalf("parseFirstIPv4(%q)=%q want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestIsIPv4(t *testing.T) {
+	for _, good := range []string{"192.168.1.1", "10.0.0.1", "172.20.0.5", "0.0.0.0", "255.255.255.255"} {
+		if !isIPv4(good) {
+			t.Fatalf("isIPv4(%q) should be true", good)
+		}
+	}
+	for _, bad := range []string{"fe80::1", "abc", "192.168.1", "192.168.1.1.1", "300.0.0.1"} {
+		if isIPv4(bad) {
+			t.Fatalf("isIPv4(%q) should be false", bad)
+		}
+	}
+}
+
+func TestHypervState(t *testing.T) {
+	tests := map[int]string{
+		2:  "running",
+		3:  "off",
+		6:  "saved",
+		9:  "paused",
+		99: "unknown",
+	}
+	for state, want := range tests {
+		if got := hypervState(state); got != want {
+			t.Fatalf("hypervState(%d)=%q want %q", state, got, want)
+		}
+	}
+}
+
+func TestInstanceScopeRoundTrip(t *testing.T) {
+	name := "crabbox-blue-1234abcd"
+	if got := instanceNameFromScope(instanceScope(name)); got != name {
+		t.Fatalf("instance name=%q want %q", got, name)
+	}
+}
+
+func TestShouldCleanupRespectsKeepLabel(t *testing.T) {
+	server := Server{Status: "off", Labels: map[string]string{"keep": "true"}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now()); ok || reason != "keep=true" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupExpiredClaim(t *testing.T) {
+	server := Server{Status: "running", Labels: map[string]string{}}
+	claim := core.LeaseClaim{
+		LeaseID:            "cbx_123",
+		LastUsedAt:         time.Now().Add(-48 * time.Hour).Format(time.RFC3339),
+		IdleTimeoutSeconds: int((30 * time.Minute).Seconds()),
+	}
+	if ok, reason := shouldCleanup(server, claim, true, time.Now()); !ok || reason != "claim expired" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
+	server := Server{Status: "running", Labels: map[string]string{}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupStoppedVM(t *testing.T) {
+	server := Server{Status: "off", Labels: map[string]string{}}
+	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); !ok {
+		t.Fatalf("should cleanup stopped VM, got cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestEscapePSString(t *testing.T) {
+	tests := map[string]string{
+		"hello":       "hello",
+		"it's a test": "it''s a test",
+		"no'pe":       "no''pe",
+	}
+	for input, want := range tests {
+		if got := escapePSString(input); got != want {
+			t.Fatalf("escapePSString(%q)=%q want %q", input, got, want)
+		}
+	}
+}
+
+func TestVMListJSONRoundTrip(t *testing.T) {
+	vms := []hypervVM{
+		{Name: "crabbox-blue-1234", State: 2},
+		{Name: "crabbox-red-5678", State: 3},
+	}
+	data, err := json.Marshal(vms)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := parseVMList(string(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed) != 2 || parsed[0].Name != vms[0].Name || parsed[1].State != vms[1].State {
+		t.Fatalf("round-trip mismatch: %#v", parsed)
+	}
+}
+
+func TestServerFromInstanceLabels(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromInstance(
+		hypervVM{Name: "crabbox-blue-1234", State: 2},
+		core.LeaseClaim{},
+		b.configForRun(),
+	)
+	if server.CloudID != "crabbox-blue-1234" {
+		t.Fatalf("cloudID=%q", server.CloudID)
+	}
+	if server.Labels["provider"] != providerName {
+		t.Fatalf("provider label=%q", server.Labels["provider"])
+	}
+	if server.Labels["instance"] != "crabbox-blue-1234" {
+		t.Fatalf("instance label=%q", server.Labels["instance"])
+	}
+	if server.Status != "running" {
+		t.Fatalf("status=%q want running", server.Status)
+	}
+}
+
+func TestConfigureRejectsWSL2Mode(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeWSL2
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+		t.Fatal("Configure accepted WSL2 mode")
+	}
+}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -717,9 +717,18 @@ func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
 	t.Cleanup(func() { hypervHostOS = oldOS })
 
 	ctx, cancel := context.WithCancel(context.Background())
+	var claimSeenBeforeStart bool
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	runner.onRun = func(req core.LocalCommandRequest) {
-		if len(req.Args) > 0 && strings.Contains(req.Args[len(req.Args)-1], "Connect-VMNetworkAdapter") {
+		if len(req.Args) == 0 {
+			return
+		}
+		script := req.Args[len(req.Args)-1]
+		if strings.Contains(script, "Start-VM") {
+			claims, err := listLeaseClaims()
+			claimSeenBeforeStart = err == nil && len(claims) == 1
+		}
+		if strings.Contains(script, "Connect-VMNetworkAdapter") {
 			cancel()
 		}
 	}
@@ -739,6 +748,9 @@ func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Acquire unexpectedly succeeded after test cancellation")
+	}
+	if !claimSeenBeforeStart {
+		t.Fatal("Acquire started the VM before persisting its provisional claim")
 	}
 
 	startIdx, stageIdx, connectIdx, activateIdx := -1, -1, -1, -1
@@ -1030,6 +1042,9 @@ func TestQueryVMParsesSingle(t *testing.T) {
 func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	oldOS := hypervHostOS
 	hypervHostOS = "windows"
 	t.Cleanup(func() { hypervHostOS = oldOS })
@@ -1057,6 +1072,20 @@ func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 	if err := persistLease(leaseID, claim.Slug, name, cfg, req, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
+	baseVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
+	vmConfig := filepath.Join(hypervVMDir(), name, "Virtual Machines", "lease.vmcx")
+	if err := os.MkdirAll(filepath.Dir(baseVHD), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(vmConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(baseVHD, []byte("disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vmConfig, []byte("config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
@@ -1078,10 +1107,84 @@ func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("missing VM release left key %s: %v", keyPath, err)
 	}
+	for _, path := range []string{baseVHD, vmConfig} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("missing VM release left storage %s: %v", path, err)
+		}
+	}
 	for _, call := range runner.calls {
 		if len(call.Args) > 0 && strings.Contains(call.Args[len(call.Args)-1], "Remove-VM") {
 			t.Fatal("missing VM release should prune local state without calling Remove-VM")
 		}
+	}
+}
+
+func TestCleanupMissingClaimRemovesDeterministicStorage(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	const leaseID = "cbx_cleanupmissing"
+	const name = "crabbox-cleanup-missing"
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	cfg := b.configForRun()
+	claim := core.LeaseClaim{
+		LeaseID:       leaseID,
+		Slug:          "cleanup-missing",
+		Provider:      providerName,
+		ProviderScope: instanceScope(name),
+		Labels: map[string]string{
+			"instance":   name,
+			"lease":      leaseID,
+			"state":      "provisioning",
+			"created_at": core.LeaseLabelTime(time.Now().Add(-2 * hypervProvisioningClaimGrace)),
+		},
+	}
+	lease := LeaseTarget{
+		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+		LeaseID: leaseID,
+	}
+	if err := persistLease(leaseID, claim.Slug, name, cfg, AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}, lease); err != nil {
+		t.Fatalf("persistLease: %v", err)
+	}
+	baseVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
+	if err := os.MkdirAll(filepath.Dir(baseVHD), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(baseVHD, []byte("disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(baseVHD); !os.IsNotExist(err) {
+		t.Fatalf("cleanup left deterministic disk %s: %v", baseVHD, err)
+	}
+	if claims, err := listLeaseClaims(); err != nil || len(claims) != 0 {
+		t.Fatalf("claims after cleanup=%#v err=%v", claims, err)
+	}
+}
+
+func TestMissingClaimCleanupWaitsForProvisioningGrace(t *testing.T) {
+	now := time.Now().UTC()
+	claim := core.LeaseClaim{
+		LeaseID: "cbx_provisioning",
+		Labels: map[string]string{
+			"state":      "provisioning",
+			"created_at": core.LeaseLabelTime(now),
+		},
+	}
+	if ready, reason := missingClaimCleanupReady(claim, now); ready || reason != "provisioning grace" {
+		t.Fatalf("ready=%v reason=%q", ready, reason)
+	}
+	claim.Labels["created_at"] = core.LeaseLabelTime(now.Add(-2 * hypervProvisioningClaimGrace))
+	if ready, reason := missingClaimCleanupReady(claim, now); !ready || reason != "" {
+		t.Fatalf("stale claim ready=%v reason=%q", ready, reason)
 	}
 }
 
@@ -1211,10 +1314,13 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers Administrator", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers administrator", "|Include)", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
+	}
+	if strings.Contains(script, "$globalLines += 'KbdInteractiveAuthentication") {
+		t.Fatal("Windows OpenSSH does not support KbdInteractiveAuthentication")
 	}
 	if strings.Index(script, "ssh-keygen.exe") > strings.Index(script, "Start-Service sshd") {
 		t.Fatal("SSH host keys must be regenerated before sshd starts")
@@ -1358,6 +1464,9 @@ func TestRemoveVMQueriesActualVHDPaths(t *testing.T) {
 		responses: map[string]core.LocalCommandResult{},
 	}
 	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		core.LocalCommandResult{Stdout: `{"Name":"crabbox-blue-1234","State":2}`}
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
 		`Get-VMHardDiskDrive -VMName 'crabbox-blue-1234' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`})] =
 		core.LocalCommandResult{Stdout: customPath + "\n"}
 	b := testBackend(runner)
@@ -1424,6 +1533,9 @@ func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
 	}
 
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		core.LocalCommandResult{Stdout: `{"Name":"crabbox-blue-1234","State":2}`}
 	// The attached disk reported by Hyper-V is the checkpoint .avhdx, not the base.
 	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
 		`Get-VMHardDiskDrive -VMName 'crabbox-blue-1234' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`})] =
@@ -1440,6 +1552,41 @@ func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
 	}
 	if _, err := os.Stat(dataDisk); err != nil {
 		t.Fatalf("removeVM deleted attached user data disk %s: %v", dataDisk, err)
+	}
+}
+
+func TestRemoveVMPreservesDataDiskInsideVMDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	name := "crabbox-blue-1234"
+	vmDir := filepath.Join(hypervVMDir(), name)
+	dataDisk := filepath.Join(vmDir, "Virtual Hard Disks", "user-data.vhdx")
+	configFile := filepath.Join(vmDir, "Virtual Machines", "lease.vmcx")
+	for _, path := range []string{dataDisk, configFile} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		core.LocalCommandResult{Stdout: `{"Name":"crabbox-blue-1234","State":2}`}
+	b := testBackend(runner)
+
+	if err := b.removeVM(context.Background(), name); err != nil {
+		t.Fatalf("removeVM: %v", err)
+	}
+	if _, err := os.Stat(dataDisk); err != nil {
+		t.Fatalf("removeVM deleted user data disk: %v", err)
+	}
+	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
+		t.Fatalf("removeVM left Hyper-V config file: %v", err)
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -325,7 +325,7 @@ func TestIsIPv4(t *testing.T) {
 func TestHypervState(t *testing.T) {
 	tests := map[int]string{
 		2:  "running",
-		3:  "off",
+		3:  "stopped",
 		6:  "saved",
 		9:  "paused",
 		99: "unknown",
@@ -450,6 +450,18 @@ func TestServerFromInstanceNoIPWithoutClaim(t *testing.T) {
 	)
 	if server.PublicNet.IPv4.IP != "" {
 		t.Fatalf("PublicNet.IPv4.IP=%q want empty", server.PublicNet.IPv4.IP)
+	}
+}
+
+func TestServerFromInstanceOverridesStaleReadyState(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromInstance(
+		hypervVM{Name: "crabbox-blue-1234", State: 3},
+		core.LeaseClaim{Labels: map[string]string{"state": "ready"}},
+		b.configForRun(),
+	)
+	if server.Status != "stopped" || server.Labels["state"] != "stopped" {
+		t.Fatalf("status=%q state=%q, want stopped", server.Status, server.Labels["state"])
 	}
 }
 
@@ -796,6 +808,41 @@ func TestPersistLeaseFailureLeavesNoStaleClaim(t *testing.T) {
 	}
 }
 
+func TestResolveStatusOnlyAllowsRetainedLeaseWithoutIP(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	name := "crabbox-retained-no-ip"
+	queryScript := fmt.Sprintf(`Get-VM -Name '%s' | Select-Object Name, State | ConvertTo-Json -Compress`, name)
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		queryScript: {Stdout: `{"Name":"crabbox-retained-no-ip","State":2}`},
+	}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}
+	claim := core.LeaseClaim{
+		LeaseID:       "cbx_retained12345",
+		Slug:          "retained-no-ip",
+		Provider:      providerName,
+		ProviderScope: instanceScope(name),
+		Labels:        map[string]string{"instance": name, "state": "leased"},
+	}
+	lease := LeaseTarget{
+		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+		LeaseID: claim.LeaseID,
+	}
+	if err := persistLease(claim.LeaseID, claim.Slug, name, cfg, req, lease); err != nil {
+		t.Fatalf("persistLease: %v", err)
+	}
+	t.Cleanup(func() { removeLeaseClaim(claim.LeaseID) })
+
+	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: claim.LeaseID, StatusOnly: true})
+	if err != nil {
+		t.Fatalf("Resolve status-only: %v", err)
+	}
+	if resolved.LeaseID != claim.LeaseID || resolved.Server.PublicNet.IPv4.IP != "" {
+		t.Fatalf("resolved=%#v, want endpoint-less retained lease", resolved)
+	}
+}
+
 func TestAcquireRejectsISO(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS
@@ -954,7 +1001,7 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
@@ -991,7 +1038,7 @@ func TestInjectSSHKeyPasswordNotInArgs(t *testing.T) {
 	}
 }
 
-func TestEnsureOpenSSHInstallsAndStartsSshd(t *testing.T) {
+func TestEnsureOpenSSHInstallsWithSshdClosed(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)
 
@@ -1009,9 +1056,14 @@ func TestEnsureOpenSSHInstallsAndStartsSshd(t *testing.T) {
 	if script == "" {
 		t.Fatal("ensureOpenSSH should invoke an OpenSSH install over PowerShell Direct")
 	}
-	for _, want := range []string{"Add-WindowsCapability", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
+	for _, want := range []string{"Add-WindowsCapability", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("ensureOpenSSH script missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"Start-Service sshd", "New-NetFirewallRule"} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("ensureOpenSSH exposes SSH before key-only configuration: %s", script)
 		}
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -451,7 +451,7 @@ func TestServerFromInstanceNoIPWithoutClaim(t *testing.T) {
 	}
 }
 
-func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
+func TestCreateVMUsesDifferencingDisk(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -465,11 +465,12 @@ func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 		t.Fatalf("createVM: %v", err)
 	}
 
-	var foundCopy, foundNewVM, foundStart, foundInject bool
+	var foundDiff, foundNewVM, foundStart, foundInject bool
 	for _, call := range runner.calls {
 		script := call.Args[len(call.Args)-1]
-		if strings.Contains(script, "Copy-Item") && strings.Contains(script, "windows.vhdx") {
-			foundCopy = true
+		if strings.Contains(script, "New-VHD") && strings.Contains(script, "-Differencing") &&
+			strings.Contains(script, `-ParentPath 'C:\Images\windows.vhdx'`) {
+			foundDiff = true
 		}
 		if strings.Contains(script, "New-VM") && strings.Contains(script, "-VHDPath") && !strings.Contains(script, "-NewVHDPath") {
 			foundNewVM = true
@@ -481,8 +482,8 @@ func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 			foundInject = true
 		}
 	}
-	if !foundCopy {
-		t.Error("createVM did not copy the VHDX template")
+	if !foundDiff {
+		t.Error("createVM should back the lease with a differencing disk over the template")
 	}
 	if !foundNewVM {
 		t.Error("createVM did not use -VHDPath (existing VHD)")
@@ -495,7 +496,9 @@ func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 	}
 }
 
-func TestCreateVMOnlyGrowsVHDXTemplate(t *testing.T) {
+// Leases must not copy or resize the template: the differencing disk avoids the
+// multi-GB per-lease copy and inherits the template's virtual size.
+func TestCreateVMDoesNotCopyOrResizeTemplate(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		errors:    map[string]error{},
@@ -508,16 +511,14 @@ func TestCreateVMOnlyGrowsVHDXTemplate(t *testing.T) {
 	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
-
-	var foundGuardedResize bool
 	for _, call := range runner.calls {
 		script := call.Args[len(call.Args)-1]
-		if strings.Contains(script, "Get-VHD") && strings.Contains(script, "if ($vhd.Size -lt") && strings.Contains(script, "Resize-VHD") {
-			foundGuardedResize = true
+		if strings.Contains(script, "Copy-Item") {
+			t.Error("createVM should not copy the template (use a differencing disk)")
 		}
-	}
-	if !foundGuardedResize {
-		t.Fatal("createVM should guard Resize-VHD so templates are only grown, never shrunk")
+		if strings.Contains(script, "Resize-VHD") {
+			t.Error("createVM should not resize the lease disk (it inherits the template size)")
+		}
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -639,11 +639,31 @@ func TestAcquireInitPasswordRejectsCmdUnsafePassword(t *testing.T) {
 	t.Cleanup(func() { hypervHostOS = oldOS })
 
 	b.cfg.HyperV.InitPassword = true
-	for _, password := range []string{`pa"ss`, `pa%ss`} {
+	for _, password := range []string{`pa"ss`, `pa%ss`, `%TEMP%`, `a"&calc&"b`} {
 		b.cfg.HyperV.GuestPassword = password
 		_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 		if err == nil || !strings.Contains(err.Error(), "cannot carry") {
 			t.Fatalf("Acquire should reject cmd-unsafe init password %q, got: %v", password, err)
+		}
+	}
+}
+
+// The user name lands inside the same double-quoted cmd.exe RunOnce command
+// as the password, so it gets the same metacharacter validation -- an
+// embedded quote must not be able to alter the elevated first-boot command.
+func TestAcquireInitPasswordRejectsCmdUnsafeUser(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	b.cfg.HyperV.InitPassword = true
+	b.cfg.HyperV.GuestPassword = "SafePass1!"
+	for _, user := range []string{`us"er`, `us%er`, `u" & calc & "`, `%PATH%`} {
+		b.cfg.HyperV.User = user
+		_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+		if err == nil || !strings.Contains(err.Error(), "user name") {
+			t.Fatalf("Acquire should reject cmd-unsafe init user %q, got: %v", user, err)
 		}
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -704,6 +704,15 @@ func TestEnsureGitInstallsWhenMissing(t *testing.T) {
 			t.Errorf("ensureGit script missing %q", want)
 		}
 	}
+	// MinGit's etc\gitconfig includes C:/Program Files/Git/etc/gitconfig, so
+	// extracting it to that path makes the include self-referential and every
+	// guest git command fails with "exceeded maximum include depth".
+	if !strings.Contains(script, `C:\Program Files\MinGit`) {
+		t.Error("ensureGit must extract MinGit to its own directory")
+	}
+	if strings.Contains(script, `$dst='C:\Program Files\Git'`) {
+		t.Error("ensureGit must not extract MinGit to C:\\Program Files\\Git (self-referential gitconfig include)")
+	}
 }
 
 func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -260,6 +260,27 @@ func TestRemoveVMRefuseNonCrabbox(t *testing.T) {
 	}
 }
 
+func TestRemoveVMStorageRefusesMalformedCrabboxNames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	b := testBackend(&recordingRunner{})
+
+	for _, name := range []string{
+		"crabbox-",
+		"crabbox-../../target",
+		`crabbox-..\..\target`,
+		"crabbox-Blue-1234",
+		"crabbox-blue-1234 ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := b.removeVMStorage(name, nil); err == nil || !strings.Contains(err.Error(), "refusing") {
+				t.Fatalf("removeVMStorage(%q) err=%v, want refusal", name, err)
+			}
+		})
+	}
+}
+
 func TestParseVMListSingle(t *testing.T) {
 	raw := `{"Name":"crabbox-blue-1234","State":2}`
 	vms, err := parseVMList(raw)
@@ -1170,6 +1191,58 @@ func TestCleanupMissingClaimRemovesDeterministicStorage(t *testing.T) {
 	}
 }
 
+func TestCleanupMissingKeepClaimPreservesStorage(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	const leaseID = "cbx_cleanupkeep"
+	const name = "crabbox-cleanup-keep"
+	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	cfg := b.configForRun()
+	claim := core.LeaseClaim{
+		LeaseID:       leaseID,
+		Slug:          "cleanup-keep",
+		Provider:      providerName,
+		ProviderScope: instanceScope(name),
+		Labels: map[string]string{
+			"instance":   name,
+			"lease":      leaseID,
+			"state":      "ready",
+			"keep":       "true",
+			"created_at": core.LeaseLabelTime(time.Now().Add(-2 * hypervProvisioningClaimGrace)),
+		},
+	}
+	lease := LeaseTarget{
+		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+		LeaseID: leaseID,
+	}
+	if err := persistLease(leaseID, claim.Slug, name, cfg, AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}, lease); err != nil {
+		t.Fatalf("persistLease: %v", err)
+	}
+	baseVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
+	if err := os.MkdirAll(filepath.Dir(baseVHD), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(baseVHD, []byte("disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(baseVHD); err != nil {
+		t.Fatalf("cleanup removed retained disk %s: %v", baseVHD, err)
+	}
+	if claims, err := listLeaseClaims(); err != nil || len(claims) != 1 || claims[0].LeaseID != leaseID {
+		t.Fatalf("claims after cleanup=%#v err=%v", claims, err)
+	}
+}
+
 func TestMissingClaimCleanupWaitsForProvisioningGrace(t *testing.T) {
 	now := time.Now().UTC()
 	claim := core.LeaseClaim{
@@ -1185,6 +1258,10 @@ func TestMissingClaimCleanupWaitsForProvisioningGrace(t *testing.T) {
 	claim.Labels["created_at"] = core.LeaseLabelTime(now.Add(-2 * hypervProvisioningClaimGrace))
 	if ready, reason := missingClaimCleanupReady(claim, now); !ready || reason != "" {
 		t.Fatalf("stale claim ready=%v reason=%q", ready, reason)
+	}
+	claim.Labels["keep"] = "true"
+	if ready, reason := missingClaimCleanupReady(claim, now); ready || reason != "keep=true" {
+		t.Fatalf("retained claim ready=%v reason=%q", ready, reason)
 	}
 }
 
@@ -1314,7 +1391,7 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers administrator", "|Include)", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "Port|ListenAddress|AddressFamily|HostKey|", "Port 22", "AddressFamily any", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers administrator", "|Include)", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
@@ -1324,6 +1401,9 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	if strings.Index(script, "ssh-keygen.exe") > strings.Index(script, "Start-Service sshd") {
 		t.Fatal("SSH host keys must be regenerated before sshd starts")
+	}
+	if strings.Index(script, "ssh-keygen.exe") > strings.Index(script, "& $sshdExe -t") {
+		t.Fatal("SSH host keys must be regenerated before sshd_config validation")
 	}
 	if strings.Contains(script, "Add-Content") {
 		t.Fatalf("SSH key injection retained template keys: %s", script)
@@ -1404,9 +1484,14 @@ func TestEnsureOpenSSHInstallsWithSshdClosed(t *testing.T) {
 	if script == "" {
 		t.Fatal("ensureOpenSSH should invoke an OpenSSH install over PowerShell Direct")
 	}
-	for _, want := range []string{"Add-WindowsCapability", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
+	for _, want := range []string{"OpenSSH.Server~~~~0.0.1.0", "Add-WindowsCapability", "Stop-Service", "StartupType Manual", "Disable-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("ensureOpenSSH script missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"OpenSSH.Server*", "Add-WindowsCapability -Online -Name $cap.Name"} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("ensureOpenSSH uses ambiguous capability selection: %s", script)
 		}
 	}
 	for _, unwanted := range []string{"Start-Service sshd", "New-NetFirewallRule"} {

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -21,12 +21,18 @@ type recordingRunner struct {
 	responses map[string]core.LocalCommandResult
 	errors    map[string]error
 	onRun     func(core.LocalCommandRequest)
+	respond   func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.onRun != nil {
 		r.onRun(req)
+	}
+	if r.respond != nil {
+		if result, err, ok := r.respond(req); ok {
+			return result, err
+		}
 	}
 	key := commandKey(req.Args)
 	if err, ok := r.errors[key]; ok {
@@ -348,26 +354,14 @@ func TestInstanceScopeRoundTrip(t *testing.T) {
 	}
 }
 
-func TestShouldCleanupKeepsUnexpiredRetainedLease(t *testing.T) {
+func TestShouldCleanupProtectsRetainedLease(t *testing.T) {
 	now := time.Now().UTC()
-	server := Server{Status: "running", Labels: map[string]string{
+	server := Server{Status: "stopped", Labels: map[string]string{
 		"keep":       "true",
-		"expires_at": core.LeaseLabelTime(now.Add(time.Hour)),
+		"expires_at": core.LeaseLabelTime(now.Add(-time.Hour)),
 	}}
 	claim := core.LeaseClaim{LeaseID: "cbx_123", Labels: server.Labels}
-	if ok, reason := shouldCleanup(server, claim, true, now); ok || reason != "claim active" {
-		t.Fatalf("cleanup=%v reason=%s", ok, reason)
-	}
-}
-
-func TestShouldCleanupExpiresRetainedLease(t *testing.T) {
-	now := time.Now().UTC()
-	server := Server{Status: "running", Labels: map[string]string{
-		"keep":       "true",
-		"expires_at": core.LeaseLabelTime(now.Add(-time.Minute)),
-	}}
-	claim := core.LeaseClaim{LeaseID: "cbx_123", Labels: server.Labels}
-	if ok, reason := shouldCleanup(server, claim, true, now); !ok || reason != "claim expired" {
+	if ok, reason := shouldCleanup(server, claim, true, now); ok || reason != "keep=true" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
@@ -495,12 +489,12 @@ func TestCreateVMUsesDifferencingDisk(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", "ssh-ed25519 AAAA test")
+	err := b.createVM(context.Background(), cfg, "crabbox-blue-1234")
 	if err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 
-	var foundDiff, foundNewVM, foundStart, foundInject bool
+	var foundDiff, foundNewVM, foundStart, foundConnect, foundInject bool
 	for _, call := range runner.calls {
 		script := call.Args[len(call.Args)-1]
 		if strings.Contains(script, "New-VHD") && strings.Contains(script, "-Differencing") &&
@@ -512,6 +506,9 @@ func TestCreateVMUsesDifferencingDisk(t *testing.T) {
 		}
 		if strings.Contains(script, "Start-VM") {
 			foundStart = true
+		}
+		if strings.Contains(script, "Connect-VMNetworkAdapter") {
+			foundConnect = true
 		}
 		if strings.Contains(script, "Invoke-Command") && strings.Contains(script, "authorized_keys") {
 			foundInject = true
@@ -526,8 +523,8 @@ func TestCreateVMUsesDifferencingDisk(t *testing.T) {
 	if !foundStart {
 		t.Error("createVM did not start the VM")
 	}
-	if !foundInject {
-		t.Error("createVM did not inject SSH key via PowerShell Direct")
+	if foundConnect || foundInject {
+		t.Error("createVM must leave the VM disconnected and defer guest SSH configuration to Acquire")
 	}
 }
 
@@ -542,7 +539,7 @@ func TestCreateVMDoesNotCopyOrResizeTemplate(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234"); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 	for _, call := range runner.calls {
@@ -565,7 +562,7 @@ func TestCreateVMPlacesVMFilesUnderHypervVMDir(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234"); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 
@@ -593,7 +590,7 @@ func TestCreateVMInitPasswordInjectsRunOnceBeforeBoot(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234"); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 
@@ -659,7 +656,7 @@ func TestCreateVMNoInitPasswordByDefault(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234"); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 	for _, call := range runner.calls {
@@ -694,6 +691,78 @@ func TestAcquireRequiresExplicitGuestPassword(t *testing.T) {
 	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 	if err == nil || !strings.Contains(err.Error(), "requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD") {
 		t.Fatalf("Acquire should require an explicit guest password, got: %v", err)
+	}
+}
+
+func TestAcquireRejectsUnsafeSSHUser(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	for _, user := range []string{"user name", `DOMAIN\user`, "user@domain", "user*", "user?"} {
+		b.cfg.HyperV.User = user
+		_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+		if err == nil || !strings.Contains(err.Error(), "--hyperv-user must be a local account name") {
+			t.Fatalf("Acquire should reject SSH user %q, got: %v", user, err)
+		}
+	}
+}
+
+func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.onRun = func(req core.LocalCommandRequest) {
+		if len(req.Args) > 0 && strings.Contains(req.Args[len(req.Args)-1], "Connect-VMNetworkAdapter") {
+			cancel()
+		}
+	}
+	runner.respond = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if len(req.Args) > 0 {
+			script := req.Args[len(req.Args)-1]
+			if strings.Contains(script, "Get-VMNetworkAdapter") && strings.Contains(script, "ConvertTo-Json") {
+				return core.LocalCommandResult{Stdout: `["192.0.2.10"]`}, nil, true
+			}
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	b := testBackend(runner)
+	_, err := b.Acquire(ctx, core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "network-order",
+	})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded after test cancellation")
+	}
+
+	startIdx, stageIdx, connectIdx, activateIdx := -1, -1, -1, -1
+	for i, call := range runner.calls {
+		if len(call.Args) == 0 {
+			continue
+		}
+		script := call.Args[len(call.Args)-1]
+		switch {
+		case strings.Contains(script, "Start-VM"):
+			startIdx = i
+		case strings.Contains(script, "Crabbox-SSH-Quarantine") && !strings.Contains(script, "Remove-NetFirewallRule"):
+			stageIdx = i
+		case strings.Contains(script, "Connect-VMNetworkAdapter"):
+			connectIdx = i
+		case strings.Contains(script, "Remove-NetFirewallRule") && strings.Contains(script, "Start-Service sshd"):
+			activateIdx = i
+		}
+	}
+	if startIdx < 0 || stageIdx < 0 || connectIdx < 0 || activateIdx < 0 {
+		t.Fatalf("missing lifecycle calls start=%d stage=%d connect=%d activate=%d", startIdx, stageIdx, connectIdx, activateIdx)
+	}
+	if !(startIdx < stageIdx && stageIdx < connectIdx && connectIdx < activateIdx) {
+		t.Fatalf("unsafe lifecycle order start=%d stage=%d connect=%d activate=%d", startIdx, stageIdx, connectIdx, activateIdx)
 	}
 }
 
@@ -894,7 +963,7 @@ func TestPersistLeaseFailureLeavesNoStaleClaim(t *testing.T) {
 func TestResolveStatusOnlyAllowsRetainedLeaseWithoutIP(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	name := "crabbox-retained-no-ip"
-	queryScript := fmt.Sprintf(`Get-VM -Name '%s' | Select-Object Name, State | ConvertTo-Json -Compress`, name)
+	queryScript := fmt.Sprintf(`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq '%s' } | Select-Object Name, State | ConvertTo-Json -Compress`, name)
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
 		queryScript: {Stdout: `{"Name":"crabbox-retained-no-ip","State":2}`},
 	}}
@@ -943,7 +1012,7 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
 			commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
-				`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`}): {
+				`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`}): {
 				Stdout: `{"Name":"crabbox-blue-1234","State":3}`,
 			},
 		},
@@ -955,6 +1024,64 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	}
 	if vm.State != 3 {
 		t.Fatalf("state=%d want 3 (off)", vm.State)
+	}
+}
+
+func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	const leaseID = "cbx_missing123456"
+	const name = "crabbox-missing-1234"
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	if _, _, err := ensureTestboxKeyForConfig(cfg, leaseID); err != nil {
+		t.Fatalf("ensureTestboxKeyForConfig: %v", err)
+	}
+	claim := core.LeaseClaim{
+		LeaseID:       leaseID,
+		Slug:          "missing-vm",
+		Provider:      providerName,
+		ProviderScope: instanceScope(name),
+		Labels:        map[string]string{"instance": name, "lease": leaseID},
+	}
+	lease := LeaseTarget{
+		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
+		LeaseID: leaseID,
+	}
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}
+	if err := persistLease(leaseID, claim.Slug, name, cfg, req, lease); err != nil {
+		t.Fatalf("persistLease: %v", err)
+	}
+
+	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatalf("Resolve release-only: %v", err)
+	}
+	if resolved.Server.Status != "missing" {
+		t.Fatalf("resolved status=%q want missing", resolved.Server.Status)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatalf("ReleaseLease: %v", err)
+	}
+	if claims, err := listLeaseClaims(); err != nil || len(claims) != 0 {
+		t.Fatalf("claims after release=%#v err=%v", claims, err)
+	}
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatalf("testboxKeyPath: %v", err)
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("missing VM release left key %s: %v", keyPath, err)
+	}
+	for _, call := range runner.calls {
+		if len(call.Args) > 0 && strings.Contains(call.Args[len(call.Args)-1], "Remove-VM") {
+			t.Fatal("missing VM release should prune local state without calling Remove-VM")
+		}
 	}
 }
 
@@ -1084,7 +1211,7 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers Administrator", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
@@ -1097,6 +1224,29 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	if strings.Count(script, "Set-Content -Encoding ASCII") < 3 {
 		t.Fatalf("SSH key injection should replace user, administrator, and config files: %s", script)
+	}
+	if strings.Index(script, "Remove-NetFirewallRule") < strings.Index(script, "Start-Service sshd") {
+		t.Fatal("SSH quarantine must be removed only after sshd starts with the final config")
+	}
+}
+
+func TestStageSSHKeyKeepsPortQuarantined(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+
+	if err := b.stageSSHKey(context.Background(), "crabbox-blue-1234", "crabbox", "ssh-ed25519 AAAA test"); err != nil {
+		t.Fatalf("stageSSHKey: %v", err)
+	}
+	script := runner.calls[len(runner.calls)-1].Args[len(runner.calls[len(runner.calls)-1].Args)-1]
+	for _, want := range []string{"Crabbox-SSH-Quarantine", "Action Block", "Stop-Service", "StartupType Disabled", "AllowUsers crabbox"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("pre-network SSH lockdown missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"Start-Service sshd", "Remove-NetFirewallRule", "ssh-keygen.exe"} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("pre-network SSH lockdown must not activate SSH: %s", script)
+		}
 	}
 }
 
@@ -1182,10 +1332,10 @@ func TestResolveInstancePropagatesQueryError(t *testing.T) {
 		errors:    map[string]error{},
 	}
 	runner.errors[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
-		`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`})] =
 		fmt.Errorf("powershell exec failed")
 	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
-		`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`})] =
+		`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq 'crabbox-blue-1234' } | Select-Object Name, State | ConvertTo-Json -Compress`})] =
 		core.LocalCommandResult{Stderr: "VM not found"}
 
 	b := testBackend(runner)
@@ -1231,7 +1381,7 @@ func TestCreateVMDisablesAutomaticCheckpoints(t *testing.T) {
 	cfg := b.configForRun()
 	cfg.HyperV.Image = `C:\Images\windows.vhdx`
 
-	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234"); err != nil {
 		t.Fatalf("createVM: %v", err)
 	}
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -579,6 +579,32 @@ func TestQueryVMParsesSingle(t *testing.T) {
 	}
 }
 
+func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+
+	if err := b.injectSSHKey(context.Background(), "crabbox-blue-1234", "Administrator", "ssh-ed25519 AAAA test"); err != nil {
+		t.Fatalf("injectSSHKey: %v", err)
+	}
+	var script string
+	for _, call := range runner.calls {
+		s := call.Args[len(call.Args)-1]
+		if strings.Contains(s, "administrators_authorized_keys") {
+			script = s
+		}
+	}
+	if script == "" {
+		t.Fatal("injectSSHKey should write administrators_authorized_keys")
+	}
+	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
+	// only by SYSTEM + Administrators with inheritance disabled.
+	for _, want := range []string{"icacls", "/inheritance:r", "SYSTEM:F", `BUILTIN\Administrators:F`} {
+		if !strings.Contains(script, want) {
+			t.Errorf("admin-key ACL lockdown missing %q\nscript: %s", want, script)
+		}
+	}
+}
+
 func TestInjectSSHKeyPasswordNotInArgs(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -548,6 +548,108 @@ func TestCreateVMPlacesVMFilesUnderHypervVMDir(t *testing.T) {
 	}
 }
 
+// --hyperv-init-password must write the first-boot RunOnce into the lease disk
+// BEFORE the VM is created/booted, keep the password out of host command lines,
+// and leave the template (ParentPath) untouched.
+func TestCreateVMInitPasswordInjectsRunOnceBeforeBoot(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	b.cfg.HyperV.InitPassword = true
+	b.cfg.HyperV.GuestPassword = "s3cret-pa$$word"
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	injectIdx, newVMIdx := -1, -1
+	for i, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Mount-VHD") && strings.Contains(script, "RunOnce") {
+			injectIdx = i
+			for _, want := range []string{`net user "crabbox"`, "reg.exe load", "reg.exe unload", "Dismount-VHD", "$env:_CRABBOX_GP"} {
+				if !strings.Contains(script, want) {
+					t.Errorf("init-password script missing %q", want)
+				}
+			}
+			if strings.Contains(script, `C:\Images\windows.vhdx`) {
+				t.Error("init-password script must mount the lease disk, not the template")
+			}
+			var foundEnv bool
+			for _, e := range call.Env {
+				if strings.Contains(e, "_CRABBOX_GP=s3cret-pa$$word") {
+					foundEnv = true
+				}
+			}
+			if !foundEnv {
+				t.Error("_CRABBOX_GP env var not found on the injection call")
+			}
+		}
+		for _, arg := range call.Args {
+			if strings.Contains(arg, "s3cret-pa$$word") {
+				t.Fatal("guest password found in command args; should be passed via environment only")
+			}
+		}
+		if strings.Contains(script, "New-VM ") {
+			newVMIdx = i
+		}
+	}
+	if injectIdx < 0 {
+		t.Fatal("createVM should inject the first-boot password RunOnce when init-password is enabled")
+	}
+	if newVMIdx < 0 || newVMIdx < injectIdx {
+		t.Fatalf("password injection (call %d) must happen before New-VM (call %d)", injectIdx, newVMIdx)
+	}
+}
+
+func TestCreateVMNoInitPasswordByDefault(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Mount-VHD") || strings.Contains(script, "RunOnce") {
+			t.Fatal("createVM must not touch the lease disk offline unless --hyperv-init-password is set")
+		}
+	}
+}
+
+func TestAcquireInitPasswordRequiresExplicitPassword(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	b.cfg.HyperV.InitPassword = true
+	b.cfg.HyperV.GuestPassword = ""
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+	if err == nil || !strings.Contains(err.Error(), "CRABBOX_HYPERV_GUEST_PASSWORD") {
+		t.Fatalf("Acquire should require an explicit guest password with init-password, got: %v", err)
+	}
+}
+
+func TestAcquireInitPasswordRejectsCmdUnsafePassword(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	b.cfg.HyperV.InitPassword = true
+	for _, password := range []string{`pa"ss`, `pa%ss`} {
+		b.cfg.HyperV.GuestPassword = password
+		_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+		if err == nil || !strings.Contains(err.Error(), "cannot carry") {
+			t.Fatalf("Acquire should reject cmd-unsafe init password %q, got: %v", password, err)
+		}
+	}
+}
+
 func TestAcquireRejectsISO(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS
@@ -986,5 +1088,22 @@ func TestApplyFlagsHyperVUserAndWorkRoot(t *testing.T) {
 	}
 	if cfg.HyperV.WorkRoot != `C:\work` {
 		t.Fatalf("--hyperv-work-root not applied: %q", cfg.HyperV.WorkRoot)
+	}
+}
+
+func TestApplyFlagsHyperVInitPassword(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+	vals := registerFlags(fs, core.BaseConfig())
+	if err := fs.Set("hyperv-init-password", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFlags(&cfg, fs, vals); err != nil {
+		t.Fatalf("applyFlags: %v", err)
+	}
+	if !cfg.HyperV.InitPassword {
+		t.Fatal("--hyperv-init-password not applied")
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -1391,7 +1391,7 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "Port|ListenAddress|AddressFamily|HostKey|", "Port 22", "AddressFamily any", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers administrator", "|Include)", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "Port|ListenAddress|AddressFamily|HostKey|", "Port 22", "AddressFamily any", "PasswordAuthentication no", "PubkeyAuthentication yes", "AuthenticationMethods publickey", "AllowUsers administrator", "|Include)", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "SecurityIdentifier]::new('S-1-5-18')", "SecurityIdentifier]::new('S-1-5-32-544')", "$hostKeyACL.SetOwner($adminsSID)", "SetAccessRuleProtection($true, $false)", "Set-Acl -LiteralPath $_.FullName", "Start-Service sshd", "OpenSSH-Server-In-TCP", "Crabbox-SSH-Quarantine", "Remove-NetFirewallRule"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
@@ -1404,6 +1404,9 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	if strings.Index(script, "ssh-keygen.exe") > strings.Index(script, "& $sshdExe -t") {
 		t.Fatal("SSH host keys must be regenerated before sshd_config validation")
+	}
+	if strings.Index(script, "Set-Acl -LiteralPath $_.FullName") > strings.Index(script, "& $sshdExe -t") {
+		t.Fatal("SSH host key ACLs must be locked down before sshd_config validation")
 	}
 	if strings.Contains(script, "Add-Content") {
 		t.Fatalf("SSH key injection retained template keys: %s", script)

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -454,6 +454,58 @@ func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 	}
 }
 
+func TestCreateVMOnlyGrowsVHDXTemplate(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+		errors:    map[string]error{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+	cfg.HyperV.Disk = 25
+
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	var foundGuardedResize bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Get-VHD") && strings.Contains(script, "if ($vhd.Size -lt") && strings.Contains(script, "Resize-VHD") {
+			foundGuardedResize = true
+		}
+	}
+	if !foundGuardedResize {
+		t.Fatal("createVM should guard Resize-VHD so templates are only grown, never shrunk")
+	}
+}
+
+func TestCreateVMPlacesVMFilesUnderHypervVMDir(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+		errors:    map[string]error{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	wantVMDir := hypervVMDir()
+	var foundPathedNewVM bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "New-VM") && strings.Contains(script, "-Path '"+wantVMDir+"'") {
+			foundPathedNewVM = true
+		}
+	}
+	if !foundPathedNewVM {
+		t.Fatalf("createVM should pass New-VM -Path %q so VM config/runtime files don't default to the system drive", wantVMDir)
+	}
+}
+
 func TestAcquireRejectsISO(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -965,3 +965,26 @@ func TestApplyFlagsAcceptsExplicitConfigWindows(t *testing.T) {
 		t.Fatalf("TargetOS=%s want windows", cfg.TargetOS)
 	}
 }
+
+func TestApplyFlagsHyperVUserAndWorkRoot(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("target", "linux", "")
+	vals := registerFlags(fs, core.BaseConfig())
+	if err := fs.Set("hyperv-user", "Administrator"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Set("hyperv-work-root", `C:\work`); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFlags(&cfg, fs, vals); err != nil {
+		t.Fatalf("applyFlags: %v", err)
+	}
+	if cfg.HyperV.User != "Administrator" {
+		t.Fatalf("--hyperv-user not applied: %q", cfg.HyperV.User)
+	}
+	if cfg.HyperV.WorkRoot != `C:\work` {
+		t.Fatalf("--hyperv-work-root not applied: %q", cfg.HyperV.WorkRoot)
+	}
+}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -50,12 +50,13 @@ func testBackend(runner *recordingRunner) *backend {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.HyperV = core.HyperVConfig{
-		Image:    `C:\Images\windows.vhdx`,
-		User:     "crabbox",
-		WorkRoot: `C:\crabbox`,
-		CPUs:     4,
-		Memory:   8192,
-		Switch:   "Default Switch",
+		Image:         `C:\Images\windows.vhdx`,
+		User:          "crabbox",
+		WorkRoot:      `C:\crabbox`,
+		CPUs:          4,
+		Memory:        8192,
+		Switch:        "Default Switch",
+		GuestPassword: "test-password",
 	}
 	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
 }
@@ -294,9 +295,11 @@ func TestParseFirstIPv4(t *testing.T) {
 		{`["172.20.0.5","fe80::1"]`, "172.20.0.5"},
 		{`["fe80::1","192.168.1.100"]`, "192.168.1.100"},
 		{`"10.0.0.1"`, "10.0.0.1"},
+		{`["0.0.0.0","127.0.0.1","169.254.1.2","224.0.0.1","192.168.1.20"]`, "192.168.1.20"},
 		{`null`, ""},
 		{`""`, ""},
 		{`["fe80::1"]`, ""},
+		{`["0.0.0.0","127.0.0.1","169.254.1.2","224.0.0.1"]`, ""},
 	}
 	for _, tc := range tests {
 		got := parseFirstIPv4(tc.raw)
@@ -632,6 +635,62 @@ func TestAcquireInitPasswordRequiresExplicitPassword(t *testing.T) {
 	}
 }
 
+func TestAcquireRequiresExplicitGuestPassword(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	b.cfg.HyperV.GuestPassword = ""
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
+	if err == nil || !strings.Contains(err.Error(), "requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD") {
+		t.Fatalf("Acquire should require an explicit guest password, got: %v", err)
+	}
+}
+
+func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := b.Acquire(ctx, core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "retained-failure",
+		Keep:          true,
+	})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+
+	claims, claimErr := listLeaseClaims()
+	if claimErr != nil {
+		t.Fatalf("listLeaseClaims: %v", claimErr)
+	}
+	if len(claims) != 1 {
+		t.Fatalf("claims=%#v, want retained lease claim", claims)
+	}
+	claim := claims[0]
+	t.Cleanup(func() {
+		removeLeaseClaim(claim.LeaseID)
+		removeStoredTestboxKey(claim.LeaseID)
+	})
+	if claim.Provider != providerName || instanceNameFromClaim(claim) == "" {
+		t.Fatalf("retained claim missing provider identity: %#v", claim)
+	}
+	keyPath, keyErr := testboxKeyPath(claim.LeaseID)
+	if keyErr != nil {
+		t.Fatalf("testboxKeyPath: %v", keyErr)
+	}
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		t.Fatalf("retained lease key missing: %v", statErr)
+	}
+}
+
 func TestAcquireInitPasswordRejectsCmdUnsafePassword(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS
@@ -895,9 +954,9 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls", "/inheritance:r", "SYSTEM:F", `BUILTIN\Administrators:F`} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed"} {
 		if !strings.Contains(script, want) {
-			t.Errorf("admin-key ACL lockdown missing %q\nscript: %s", want, script)
+			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -653,6 +655,70 @@ func TestRemoveVMQueriesActualVHDPaths(t *testing.T) {
 	}
 	if !foundVHDQuery {
 		t.Error("removeVM did not query actual VHD paths before deletion")
+	}
+}
+
+func TestCreateVMDisablesAutomaticCheckpoints(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+
+	if err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", ""); err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	var found bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Set-VM") && strings.Contains(script, "-AutomaticCheckpointsEnabled $false") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("createVM should disable automatic checkpoints on lease VMs")
+	}
+}
+
+// Regression: client Hyper-V auto-checkpoints attach a <name>_<guid>.avhdx in
+// place of the base disk. removeVM must still delete the base VHDX and the
+// per-VM config directory, or every lease leaks a disk-sized file on release.
+func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	name := "crabbox-blue-1234"
+	vhdDir := hypervVHDDir()
+	vmDir := filepath.Join(hypervVMDir(), name)
+	if err := os.MkdirAll(vhdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	baseVHD := filepath.Join(vhdDir, name+".vhdx")
+	checkpoint := filepath.Join(vhdDir, name+"_4F2A.avhdx")
+	for _, p := range []string{baseVHD, checkpoint} {
+		if err := os.WriteFile(p, []byte("disk"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	// The attached disk reported by Hyper-V is the checkpoint .avhdx, not the base.
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VMHardDiskDrive -VMName 'crabbox-blue-1234' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`})] =
+		core.LocalCommandResult{Stdout: checkpoint + "\n"}
+	b := testBackend(runner)
+
+	if err := b.removeVM(context.Background(), name); err != nil {
+		t.Fatalf("removeVM: %v", err)
+	}
+	for _, p := range []string{baseVHD, checkpoint, vmDir} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("removeVM left %s behind (err=%v)", p, err)
+		}
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -168,6 +168,45 @@ func TestApplyDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultsHonorsExplicitSSHUser(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.HyperV = core.HyperVConfig{}
+	cfg.SSHUser = "devuser"
+	applyDefaults(&cfg)
+	if cfg.HyperV.User != "devuser" {
+		t.Fatalf("explicit --ssh-user not inherited: HyperV.User=%s want devuser", cfg.HyperV.User)
+	}
+	if cfg.SSHUser != "devuser" {
+		t.Fatalf("SSHUser=%s want devuser", cfg.SSHUser)
+	}
+
+	// An explicit --hyperv-user still wins over --ssh-user.
+	cfg = core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.HyperV = core.HyperVConfig{User: "winuser"}
+	cfg.SSHUser = "devuser"
+	applyDefaults(&cfg)
+	if cfg.HyperV.User != "winuser" || cfg.SSHUser != "winuser" {
+		t.Fatalf("explicit --hyperv-user not preserved: HyperV.User=%s SSHUser=%s want winuser", cfg.HyperV.User, cfg.SSHUser)
+	}
+}
+
+func TestDoctorReportsConfiguredImage(t *testing.T) {
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	b := testBackend(&recordingRunner{})
+	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if !strings.Contains(result.Message, `image=C:\Images\windows.vhdx`) {
+		t.Fatalf("doctor message missing configured image: %q", result.Message)
+	}
+}
+
 func TestCleanupScopedToCrabboxPrefix(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -382,6 +382,124 @@ func TestServerFromInstanceLabels(t *testing.T) {
 	}
 }
 
+func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+		errors:    map[string]error{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\windows.vhdx`
+
+	err := b.createVM(context.Background(), cfg, "crabbox-blue-1234", "ssh-ed25519 AAAA test")
+	if err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	var foundCopy, foundNewVM, foundStart, foundInject bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Copy-Item") && strings.Contains(script, "windows.vhdx") {
+			foundCopy = true
+		}
+		if strings.Contains(script, "New-VM") && strings.Contains(script, "-VHDPath") && !strings.Contains(script, "-NewVHDPath") {
+			foundNewVM = true
+		}
+		if strings.Contains(script, "Start-VM") {
+			foundStart = true
+		}
+		if strings.Contains(script, "Invoke-Command") && strings.Contains(script, "authorized_keys") {
+			foundInject = true
+		}
+	}
+	if !foundCopy {
+		t.Error("createVM did not copy the VHDX template")
+	}
+	if !foundNewVM {
+		t.Error("createVM did not use -VHDPath (existing VHD)")
+	}
+	if !foundStart {
+		t.Error("createVM did not start the VM")
+	}
+	if !foundInject {
+		t.Error("createVM did not inject SSH key via PowerShell Direct")
+	}
+}
+
+func TestCreateVMISOAttachesDVD(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+		errors:    map[string]error{},
+	}
+	b := testBackend(runner)
+	cfg := b.configForRun()
+	cfg.HyperV.Image = `C:\Images\win-server.iso`
+
+	err := b.createVM(context.Background(), cfg, "crabbox-red-5678", "ssh-ed25519 AAAA test")
+	if err != nil {
+		t.Fatalf("createVM: %v", err)
+	}
+
+	var foundNewVHD, foundDVD bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "New-VM") && strings.Contains(script, "-NewVHDPath") {
+			foundNewVHD = true
+		}
+		if strings.Contains(script, "Add-VMDvdDrive") && strings.Contains(script, "win-server.iso") {
+			foundDVD = true
+		}
+	}
+	if !foundNewVHD {
+		t.Error("ISO mode should create a new blank VHD")
+	}
+	if !foundDVD {
+		t.Error("ISO mode should attach the ISO as a DVD drive")
+	}
+}
+
+func TestQueryVMParsesSingle(t *testing.T) {
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+				`Get-VM -Name 'crabbox-blue-1234' | Select-Object Name, State | ConvertTo-Json -Compress`}): {
+				Stdout: `{"Name":"crabbox-blue-1234","State":3}`,
+			},
+		},
+	}
+	b := testBackend(runner)
+	vm, err := b.queryVM(context.Background(), "crabbox-blue-1234")
+	if err != nil {
+		t.Fatalf("queryVM: %v", err)
+	}
+	if vm.State != 3 {
+		t.Fatalf("state=%d want 3 (off)", vm.State)
+	}
+}
+
+func TestRemoveVMQueriesActualVHDPaths(t *testing.T) {
+	customPath := `D:\VMs\crabbox-blue-1234.vhdx`
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{},
+	}
+	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
+		`Get-VMHardDiskDrive -VMName 'crabbox-blue-1234' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`})] =
+		core.LocalCommandResult{Stdout: customPath + "\n"}
+	b := testBackend(runner)
+	_ = b.removeVM(context.Background(), "crabbox-blue-1234")
+
+	var foundVHDQuery bool
+	for _, call := range runner.calls {
+		script := call.Args[len(call.Args)-1]
+		if strings.Contains(script, "Get-VMHardDiskDrive") {
+			foundVHDQuery = true
+		}
+	}
+	if !foundVHDQuery {
+		t.Error("removeVM did not query actual VHD paths before deletion")
+	}
+}
+
 func TestConfigureRejectsWSL2Mode(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -609,6 +609,47 @@ func TestInjectSSHKeyPasswordNotInArgs(t *testing.T) {
 	}
 }
 
+func TestEnsureOpenSSHInstallsAndStartsSshd(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+
+	if err := b.ensureOpenSSH(context.Background(), "crabbox-blue-1234", "crabbox"); err != nil {
+		t.Fatalf("ensureOpenSSH: %v", err)
+	}
+
+	var script string
+	for _, call := range runner.calls {
+		s := call.Args[len(call.Args)-1]
+		if strings.Contains(s, "Invoke-Command") && strings.Contains(s, "OpenSSH.Server") {
+			script = s
+		}
+	}
+	if script == "" {
+		t.Fatal("ensureOpenSSH should invoke an OpenSSH install over PowerShell Direct")
+	}
+	for _, want := range []string{"Add-WindowsCapability", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("ensureOpenSSH script missing %q", want)
+		}
+	}
+}
+
+func TestEnsureOpenSSHPasswordNotInArgs(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	b.cfg.HyperV.GuestPassword = "s3cret-pa$$word"
+
+	_ = b.ensureOpenSSH(context.Background(), "crabbox-blue-1234", "crabbox")
+
+	for _, call := range runner.calls {
+		for _, arg := range call.Args {
+			if strings.Contains(arg, "s3cret-pa$$word") {
+				t.Fatal("guest password found in command args; should be passed via environment only")
+			}
+		}
+	}
+}
+
 func TestResolveInstancePropagatesQueryError(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -20,10 +20,14 @@ type recordingRunner struct {
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
 	errors    map[string]error
+	onRun     func(core.LocalCommandRequest)
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
+	if r.onRun != nil {
+		r.onRun(req)
+	}
 	key := commandKey(req.Args)
 	if err, ok := r.errors[key]; ok {
 		return r.responses[key], err
@@ -344,9 +348,26 @@ func TestInstanceScopeRoundTrip(t *testing.T) {
 	}
 }
 
-func TestShouldCleanupRespectsKeepLabel(t *testing.T) {
-	server := Server{Status: "off", Labels: map[string]string{"keep": "true"}}
-	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now()); ok || reason != "keep=true" {
+func TestShouldCleanupKeepsUnexpiredRetainedLease(t *testing.T) {
+	now := time.Now().UTC()
+	server := Server{Status: "running", Labels: map[string]string{
+		"keep":       "true",
+		"expires_at": core.LeaseLabelTime(now.Add(time.Hour)),
+	}}
+	claim := core.LeaseClaim{LeaseID: "cbx_123", Labels: server.Labels}
+	if ok, reason := shouldCleanup(server, claim, true, now); ok || reason != "claim active" {
+		t.Fatalf("cleanup=%v reason=%s", ok, reason)
+	}
+}
+
+func TestShouldCleanupExpiresRetainedLease(t *testing.T) {
+	now := time.Now().UTC()
+	server := Server{Status: "running", Labels: map[string]string{
+		"keep":       "true",
+		"expires_at": core.LeaseLabelTime(now.Add(-time.Minute)),
+	}}
+	claim := core.LeaseClaim{LeaseID: "cbx_123", Labels: server.Labels}
+	if ok, reason := shouldCleanup(server, claim, true, now); !ok || reason != "claim expired" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
@@ -719,6 +740,52 @@ func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
 	}
 }
 
+func TestAcquirePersistsProvisionalClaimThenRollsBackFailedLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	oldOS := hypervHostOS
+	hypervHostOS = "windows"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	var observed core.LeaseClaim
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.onRun = func(req core.LocalCommandRequest) {
+		if len(req.Args) == 0 || !strings.Contains(req.Args[len(req.Args)-1], "Get-VMNetworkAdapter") {
+			return
+		}
+		claims, err := listLeaseClaims()
+		if err == nil && len(claims) == 1 {
+			observed = claims[0]
+		}
+	}
+	b := testBackend(runner)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := b.Acquire(ctx, core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "rollback-failure",
+	})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	if observed.LeaseID == "" || observed.Provider != providerName || instanceNameFromClaim(observed) == "" {
+		t.Fatalf("bootstrap started without a provisional claim: %#v", observed)
+	}
+	claims, claimErr := listLeaseClaims()
+	if claimErr != nil {
+		t.Fatalf("listLeaseClaims: %v", claimErr)
+	}
+	if len(claims) != 0 {
+		t.Fatalf("failed non-retained lease left claims: %#v", claims)
+	}
+	keyPath, keyErr := testboxKeyPath(observed.LeaseID)
+	if keyErr != nil {
+		t.Fatalf("testboxKeyPath: %v", keyErr)
+	}
+	if _, statErr := os.Stat(keyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("failed non-retained lease left key at %s: %v", keyPath, statErr)
+	}
+}
+
 func TestAcquireInitPasswordRejectsCmdUnsafePassword(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	oldOS := hypervHostOS
@@ -1017,10 +1084,13 @@ func TestInjectSSHKeyLocksAdminKeyACL(t *testing.T) {
 	}
 	// Windows OpenSSH ignores administrators_authorized_keys unless it is owned
 	// only by SYSTEM + Administrators with inheritance disabled.
-	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
+	for _, want := range []string{"icacls.exe", "/inheritance:r", "*S-1-5-18:F", "*S-1-5-32-544:F", "$LASTEXITCODE", "PasswordAuthentication no", "PubkeyAuthentication yes", "sshd_config validation failed", "ssh_host_*", "ssh-keygen.exe", "-A", "SSH host key generation failed", "Start-Service sshd", "OpenSSH-Server-In-TCP"} {
 		if !strings.Contains(script, want) {
 			t.Errorf("admin-key SSH lockdown missing %q\nscript: %s", want, script)
 		}
+	}
+	if strings.Index(script, "ssh-keygen.exe") > strings.Index(script, "Start-Service sshd") {
+		t.Fatal("SSH host keys must be regenerated before sshd starts")
 	}
 	if strings.Contains(script, "Add-Content") {
 		t.Fatalf("SSH key injection retained template keys: %s", script)
@@ -1195,8 +1265,9 @@ func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	baseVHD := filepath.Join(vhdDir, name+".vhdx")
-	checkpoint := filepath.Join(vhdDir, name+"_4F2A.avhdx")
-	for _, p := range []string{baseVHD, checkpoint} {
+	checkpoint := filepath.Join(vhdDir, name+"_4F2A4D3E-59D0-42B4-9D33-CA8B34C7CB4A.avhdx")
+	dataDisk := filepath.Join(vhdDir, name+"-data.vhdx")
+	for _, p := range []string{baseVHD, checkpoint, dataDisk} {
 		if err := os.WriteFile(p, []byte("disk"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -1206,7 +1277,7 @@ func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
 	// The attached disk reported by Hyper-V is the checkpoint .avhdx, not the base.
 	runner.responses[commandKey([]string{"-NoProfile", "-NonInteractive", "-Command",
 		`Get-VMHardDiskDrive -VMName 'crabbox-blue-1234' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path`})] =
-		core.LocalCommandResult{Stdout: checkpoint + "\n"}
+		core.LocalCommandResult{Stdout: checkpoint + "\n" + dataDisk + "\n"}
 	b := testBackend(runner)
 
 	if err := b.removeVM(context.Background(), name); err != nil {
@@ -1216,6 +1287,9 @@ func TestRemoveVMCleansBaseDiskAndDirDespiteCheckpoint(t *testing.T) {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
 			t.Errorf("removeVM left %s behind (err=%v)", p, err)
 		}
+	}
+	if _, err := os.Stat(dataDisk); err != nil {
+		t.Fatalf("removeVM deleted attached user data disk %s: %v", dataDisk, err)
 	}
 }
 

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -3,6 +3,7 @@ package hyperv
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -569,5 +570,42 @@ func TestConfigureRejectsWSL2Mode(t *testing.T) {
 	cfg.WindowsMode = core.WindowsModeWSL2
 	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
 		t.Fatal("Configure accepted WSL2 mode")
+	}
+}
+
+func TestCleanupNoOpOnNonWindows(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "linux"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	err := b.Cleanup(context.Background(), core.CleanupRequest{})
+	if err != nil {
+		t.Fatalf("Cleanup on non-Windows should succeed (skip), got: %v", err)
+	}
+}
+
+func TestListInstancesErrorOnNonWindows(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	oldOS := hypervHostOS
+	hypervHostOS = "linux"
+	t.Cleanup(func() { hypervHostOS = oldOS })
+
+	_, err := b.listInstances(context.Background())
+	if err == nil {
+		t.Fatal("listInstances should return error on non-Windows")
+	}
+	if !errors.Is(err, errNotWindows) {
+		t.Fatalf("expected errNotWindows, got: %v", err)
+	}
+}
+
+func TestApplyDefaultsPreservesExplicitTarget(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
+	applyDefaults(&cfg)
+	if cfg.TargetOS != core.TargetWindows {
+		t.Fatalf("applyDefaults changed explicit TargetOS to %s", cfg.TargetOS)
 	}
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -383,6 +383,30 @@ func TestServerFromInstanceLabels(t *testing.T) {
 	}
 }
 
+func TestServerFromInstancePopulatesIPFromClaim(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromInstance(
+		hypervVM{Name: "crabbox-blue-1234", State: 2},
+		core.LeaseClaim{SSHHost: "192.168.1.50"},
+		b.configForRun(),
+	)
+	if server.PublicNet.IPv4.IP != "192.168.1.50" {
+		t.Fatalf("PublicNet.IPv4.IP=%q want 192.168.1.50", server.PublicNet.IPv4.IP)
+	}
+}
+
+func TestServerFromInstanceNoIPWithoutClaim(t *testing.T) {
+	b := testBackend(&recordingRunner{})
+	server := b.serverFromInstance(
+		hypervVM{Name: "crabbox-blue-1234", State: 2},
+		core.LeaseClaim{},
+		b.configForRun(),
+	)
+	if server.PublicNet.IPv4.IP != "" {
+		t.Fatalf("PublicNet.IPv4.IP=%q want empty", server.PublicNet.IPv4.IP)
+	}
+}
+
 func TestCreateVMCopiesVHDXTemplate(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -81,7 +81,7 @@ func TestProviderSpecAndAliases(t *testing.T) {
 }
 
 func TestProviderAliasesResolve(t *testing.T) {
-	for _, alias := range []string{"hyperv", "local-hyperv", "hyper-v", "windows-vm"} {
+	for _, alias := range []string{"hyperv"} {
 		got, err := core.ProviderFor(alias)
 		if err != nil {
 			t.Fatalf("ProviderFor(%q): %v", alias, err)


### PR DESCRIPTION
## Summary

A `hyperv` provider for running Crabbox leases on local Windows VMs via Microsoft Hyper-V and PowerShell Direct — the Windows-native counterpart to `tart` (macOS), with no external CLI or cloud account. The design goal is "bring a plain Windows VHDX with a known administrator password, and it just works": the provider supplies everything else. With `--hyperv-init-password` even that requirement drops away for auto-logon images: a **stock, password-less** Microsoft dev-environment VHDX works completely unmodified.

## How it works

`crabbox warmup --provider hyperv --hyperv-image <vhdx>`:

1. **Thin clone, not a copy.** Each lease is backed by a *differencing disk* over the template (`New-VHD -Differencing -ParentPath`) — near-instant and space-thin (a few MB up front), so the template stays read-only and shared instead of copying tens of GB per lease.
2. **(Opt-in) first-boot password for password-less templates.** Microsoft's downloadable dev-environment VHDXs auto-log-on with **no password**, and PowerShell Direct refuses empty credentials — so stock images used to be unusable. With `--hyperv-init-password` the provider mounts the *lease's own differencing disk* offline, loads its registry hive, and writes a `RunOnce` command that sets the guest password to `CRABBOX_HYPERV_GUEST_PASSWORD` at the template's auto-logon. The template VHDX is never modified. Guard rails: requires an explicit `CRABBOX_HYPERV_GUEST_PASSWORD` (refuses to stamp the default password onto a guest), rejects `"`/`%` in the password and the user name (both pass through cmd.exe), and the password reaches the host-side script via env, never argv.
3. **Create + place off the system drive.** `New-VM -Generation 2 -Path <vmDir>` puts the VM config and the multi-GB `.VMRS` runtime files on the same (data) drive as the VHD rather than defaulting to `C:\ProgramData`, and automatic checkpoints are disabled (`Set-VM -AutomaticCheckpointsEnabled $false`) so a lease never spawns a `.avhdx` that would strand a disk on release.
4. **Make the guest reachable.** Over PowerShell Direct (authenticating with the guest admin password, passed via env — never argv) the provider installs the OpenSSH server if absent (`Add-WindowsCapability`, `Start-Service sshd`, firewall) and installs git if absent (portable MinGit, pinned to an immutable release asset and SHA-256-verified before extraction) — mirroring how the Linux cloud-init path provisions a guest. Both are no-ops when already present, so a template that pre-bakes them just skips the download. MinGit is extracted to `C:\Program Files\MinGit`, **not** `C:\Program Files\Git`: MinGit's `etc\gitconfig` deliberately includes `C:/Program Files/Git/etc/gitconfig`, so extracting it there makes the include self-referential and every guest git command dies with "exceeded maximum include depth" (caught live by the second proof below; fixed in this PR).
5. **Inject the lease key.** The SSH public key is written to the user's `authorized_keys` and, for admin accounts, `administrators_authorized_keys` with the SYSTEM+Administrators-only ACL that Windows OpenSSH requires (otherwise sshd silently ignores it).
6. **Wait for readiness**, then run/sync/release normally. On release the VM is removed and only the lease's own differencing disk + per-VM config dir are deleted; the template is untouched. Cleanup is scoped to the `crabbox-` name prefix.

Net template requirement: **a Generation-2 Windows VHDX** — either with an administrator password known to Crabbox (`--hyperv-user` / `CRABBOX_HYPERV_GUEST_PASSWORD`), or, for auto-logon images, none at all with `--hyperv-init-password`. Non-Windows targets are rejected (from CLI, YAML, or env), and ISO images are rejected.

## Live proof 1 — passworded template (existing path), Windows 11 Pro host, Go 1.26.4

Captured on the latest head. Plain Windows 11 VHDX with only an admin password set; C: deliberately full so storage is redirected to D: (which also exercises the off-system-drive placement):

```
$ crabbox doctor --provider hyperv
ok  provider  provider=hyperv hyperv=Enabled inventory=ready api=powershell leases=0 image=… ssh_probe=unchecked

$ crabbox warmup --provider hyperv --hyperv-image D:\hyperv-templates\win11-ssh-ready.vhdx --hyperv-cpu 2 --hyperv-memory 3072
provisioned lease=cbx_e70a9aac5441 instance=crabbox-hvproofa-240c4232 state=ready
ready ssh=Administrator@172.22.155.0:22 network=public workroot=C:\crabbox

$ crabbox run --provider hyperv --id cbx_e70a9aac5441 -- cmd /c ver
sync candidate: 1 files, 27 B
sync complete in 12.056s
Microsoft Windows [Version 10.0.22621.3880]
run summary sync=12.056s command=6.513s total=21.454s sync_skipped=false exit=0

$ crabbox list --provider hyperv
crabbox-hvproofa-240c4232 ready hyperv 172.22.155.0 lease=cbx_e70a9aac5441 slug=hvproofa keep=true target=windows

$ crabbox stop --provider hyperv --id cbx_e70a9aac5441
released lease=cbx_e70a9aac5441 instance=crabbox-hvproofa-240c4232
# verify: crabbox- VMs remaining: 0   (VM, differencing disk, and config dir all removed)
```

## Live proof 2 — broader template coverage: STOCK password-less Microsoft image + `--hyperv-init-password`

The template here is Microsoft's downloadable `WinDev2407Eval.vhdx` **exactly as downloaded** (file mtime 2024-07-25 before and after the run — never written): auto-logon `User`, no password, no OpenSSH, no git. One flag makes it a working lease:

```
$ crabbox warmup --provider hyperv --hyperv-image C:\Users\…\WinDev2407Eval.vhdx ^
    --hyperv-user User --hyperv-init-password --hyperv-cpu 2 --hyperv-memory 3072
provisioned lease=cbx_48ec029c0094 instance=crabbox-hvproofb-5412dc36 state=ready
ready ssh=User@172.22.145.28:22 network=public workroot=C:\crabbox
warmup complete total=9m31.274s

$ crabbox run --provider hyperv --id cbx_48ec029c0094 -- git --version
sync complete in 14.581s
git version 2.54.0.windows.1
run summary sync=14.581s command=9.902s total=27.016s sync_skipped=false exit=0

$ crabbox stop --provider hyperv --id cbx_48ec029c0094
released lease=cbx_48ec029c0094 instance=crabbox-hvproofb-5412dc36
# verify: crabbox- VMs remaining: 0; template mtime unchanged (2024-07-25)
```

Reaching `state=ready` here exercises the full chain on a guest that started with **nothing** — first-boot password injection, OpenSSH install, pinned + checksum-verified MinGit install (to the corrected path; `git --version` exiting 0 in-guest is the regression proof for the MinGit fix), ACL-correct key injection, and the Windows readiness check over SSH.

## Configuration

CLI: `--hyperv-image` (required), `--hyperv-cpu`, `--hyperv-memory`, `--hyperv-switch`, `--hyperv-user`, `--hyperv-work-root`, `--hyperv-init-password`. YAML `hyperv:` and `CRABBOX_HYPERV_*` env equivalents, incl. `CRABBOX_HYPERV_GUEST_PASSWORD` and `CRABBOX_HYPERV_INIT_PASSWORD`.

## Not included (follow-up)

- A configurable storage root (today storage follows `%USERPROFILE%`).
- ISO install / autounattend (templates are pre-installed VHDX).
- WSL2 mode (native Windows only).
