### PR TITLE
feat: add smolvm provider (Smol Machines / smolfleet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: smolvm` for delegated Linux microVM runs through the hosted smolfleet API, including archive sync, retained leases, status, cleanup, and repository-scoped ownership checks. Thanks @zozo123.
 - Added non-mutating Proxmox storage, bridge, pool, template, and cluster inventory readiness diagnostics plus guarded live lifecycle smoke coverage, with safer failed-create and cleanup claim handling. Thanks @coygeek.
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ hardware for macOS VM workflows.
 | [OpenSandbox](docs/providers/opensandbox.md) — `opensandbox` | Linux | OpenSandbox delegated containers through the OpenSandbox Go SDK. |
 | [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`) | Linux | Redeploy and stream an existing Railway service. |
 | [Anthropic Sandbox Runtime](docs/providers/anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux | Local one-shot sandboxing through Anthropic's `srt` CLI. |
+| [SmolVM](docs/providers/smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`) | Linux | Smol Machines microVM sandboxes via the smolfleet API. |
 | [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
 | [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux | Upstash Box through the Box REST API. |
 | [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux | Azure Container Apps dynamic sessions. |

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -125,6 +125,7 @@ islo                    Islo sandboxes
 modal                   Modal Sandboxes
 opencomputer            OpenComputer Linux VMs
 anthropic-sandbox-runtime Anthropic Sandbox Runtime through the local srt CLI
+smolvm                  Smol Machines microVM sandboxes (delegated via smolfleet)
 tensorlake              Tensorlake Firecracker sandboxes
 upstash-box             Upstash sandboxes
 blacksmith-testbox      Blacksmith CI test runner (proof/session)
@@ -178,6 +179,7 @@ railway                 Railway service status and stop controls
 - [OpenComputer](../providers/opencomputer.md): delegated OpenComputer Linux VM execution through the OpenComputer REST API.
 - [Tensorlake](../providers/tensorlake.md): delegated Tensorlake Firecracker sandbox execution.
 - [Upstash Box](../providers/upstash-box.md): delegated Upstash sandbox execution.
+- [SmolVM](../providers/smolvm.md): delegated Smol Machines microVM execution via smolfleet.
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Blacksmith CI runner.
 - [Weights & Biases](../providers/wandb.md): delegated W&B run sandbox execution.
 - [Provider backends](../provider-backends.md): guide for adding a new provider/backend/plugin.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -38,7 +38,7 @@ SSH-lease providers further differ by how they reach the cloud:
   tart, and `hyperv` creates local Windows VMs through Microsoft Hyper-V.
 - **Delegated sandbox** — managed sandbox/proof runners that execute remotely
   without an SSH lease (e.g. `e2b`, `modal`, `islo`, `cloudflare`,
-  `azure-dynamic-sessions`, `docker-sandbox`). `anthropic-sandbox-runtime` is
+  `azure-dynamic-sessions`, `docker-sandbox`, `smolvm`). `anthropic-sandbox-runtime` is
   the local macOS/Linux delegated-run exception: Anthropic's `srt` executes on
   the current machine while still owning sync/run policy end to end.
 
@@ -106,6 +106,7 @@ the built-in adapter needs a separate local smoke contract.
 | [OpenSandbox](opensandbox.md) — `opensandbox` | Linux |
 | [Railway](railway.md) — `railway` (`rail`, `railwayapp`) | Linux |
 | [Anthropic Sandbox Runtime](anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux |
+| [SmolVM](smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`) | Linux |
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |
 | [W&B Sandboxes](wandb.md) — `wandb` (`weights-and-biases`) | Linux |

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -76,6 +76,7 @@ SMOLMACHINES_API_KEY
 CRABBOX_SMOLVM_API_KEY
 SMK_API_KEY
 CRABBOX_SMOLVM_BASE_URL
+CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL
 CRABBOX_SMOLVM_IMAGE
 CRABBOX_SMOLVM_WORKDIR
 CRABBOX_SMOLVM_CPUS
@@ -86,7 +87,9 @@ CRABBOX_SMOLVM_KEEP
 
 The base URL must use `https` (plain `http` is allowed only for localhost
 endpoints) and must not contain userinfo, query, or fragment components; the
-API key is sent as a bearer token only to a validated endpoint.
+API key is sent as a bearer token only to official `smolmachines.com` hosts or
+loopback by default. Set `CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1` only when you
+intend to trust a custom control plane with the API key.
 
 Defaults: image `alpine` (lightweight; provides the standard shell tools needed for direct archive sync via the API), workdir `/workspace`, network open by default.
 

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -1,0 +1,138 @@
+# SmolVM Provider
+
+Read this when:
+- choosing `provider: smolvm`;
+- configuring the SmolVM (smol machines) image, workdir, CPU count, memory, or related options;
+- changing `internal/providers/smolvm`.
+
+SmolVM (smol machines) provides fast microVM sandboxes via the hosted smolfleet API (`api.smolmachines.com`). It is a **delegated-run** provider. Crabbox calls the smolfleet REST API directly for sandbox lifecycle (create/start, status, exec, list, delete) and performs archive sync + file writes via direct `/exec` calls (heredoc + base64 payload for the tar). No guest Python or other interpreters are required for Crabbox operations — only standard shell tools (`sh` + `base64` + `tar`). Smol machines own the sandbox state and process transport; Crabbox owns local config, repo claims, archive sync manifests and guardrails, slugs, timing summaries, and the normalized `list`/`status` output. There is no direct SSH target.
+
+## When to use
+
+Use SmolVM when commands should run in fast microVM sandboxes and you do not need a Crabbox SSH box. It is good for isolated test runs and agent sandboxes. Reach for a provisioned SSH provider (AWS, Hetzner, Azure, GCP, static SSH) or another SSH-capable delegated provider instead when you need `crabbox ssh`, VNC, code-server, or Actions hydration — none of those surfaces exist on SmolVM.
+
+SmolVM is Linux-only. Desktop, browser, code, and SSH-based run options are not available.
+
+## Setup
+
+Create a smol machines API key at https://smolmachines.com/console/keys. Keys are prefixed `smk_...`.
+
+Export the key through the environment using one of the accepted variable names. Crabbox never accepts the key as a command-line flag.
+
+## Auth
+
+```sh
+export SMOLMACHINES_API_KEY=smk_...
+# or
+export CRABBOX_SMOLVM_API_KEY=smk_...
+# or
+export SMK_API_KEY=smk_...
+```
+
+`CRABBOX_SMOLVM_API_KEY` takes precedence when multiple variables are present.
+
+Rotate the key if it was ever pasted into a chat, shell history, issue, or log.
+
+## Commands
+
+```sh
+crabbox warmup --provider smolvm --smolvm-image alpine
+crabbox run --provider smolvm -- pnpm test
+crabbox run --provider smolvm --id swift-crab --shell 'pnpm install && pnpm test'
+crabbox status --provider smolvm --id swift-crab
+crabbox stop --provider smolvm swift-crab
+crabbox list --provider smolvm --json
+```
+
+`warmup` always keeps the sandbox until an explicit `stop`. The lease ID, slug, or SmolVM sandbox identifier printed by `warmup`/`run` can be passed to later commands via `--id`.
+
+## Config
+
+```yaml
+provider: smolvm
+target: linux
+smolvm:
+  image: alpine
+  workdir: /workspace
+  cpus: 1
+  memoryMB: 512
+```
+
+Provider flags (each overrides the matching `smolvm.*` config key):
+
+```text
+--smolvm-image
+--smolvm-workdir
+--smolvm-cpus
+--smolvm-memory-mb
+```
+
+(Additional `--smolvm-*` flags exist for other smolfleet options; run `crabbox run --help` with `--provider smolvm` for the current set.)
+
+Environment overrides:
+
+```text
+SMOLMACHINES_API_KEY
+CRABBOX_SMOLVM_API_KEY
+SMK_API_KEY
+CRABBOX_SMOLVM_BASE_URL
+CRABBOX_SMOLVM_IMAGE
+CRABBOX_SMOLVM_WORKDIR
+CRABBOX_SMOLVM_CPUS
+CRABBOX_SMOLVM_MEMORY_MB
+CRABBOX_SMOLVM_NETWORK
+CRABBOX_SMOLVM_KEEP
+```
+
+The base URL must use `https` (plain `http` is allowed only for localhost
+endpoints) and must not contain userinfo, query, or fragment components; the
+API key is sent as a bearer token only to a validated endpoint.
+
+Defaults: image `alpine` (lightweight; provides the standard shell tools needed for direct archive sync via the API), workdir `/workspace`, network open by default.
+
+## Lifecycle
+
+1. `warmup` / `run` without `--id` creates a microVM sandbox from the configured `--smolvm-image`.
+2. Crabbox stores a local claim with a normal `cbx_...` lease ID and a friendly slug.
+3. By default `run` archive-syncs the working tree using a direct API call to `/exec` (the tarball is base64-encoded and sent in a shell heredoc; the guest decodes + extracts with `base64 -d | tar`).
+4. The user command executes inside the microVM. Because the smolfleet API does not stream live output, command output appears after the command completes.
+5. One-shot sandboxes are deleted after a `run` that did not pass `--keep`. `--keep` and `--keep-on-failure` retain the sandbox until `crabbox stop`.
+
+Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: yes — archive sync via direct `/exec` (heredoc + base64 tar; pure shell on the guest, no Python).
+- Provider sync: no separate SmolVM sync step.
+- Desktop / browser / code: no.
+- Actions hydration: no.
+- Coordinator (broker): no — SmolVM always runs direct from the CLI.
+
+## Notes
+
+- Defaults to the lightweight `alpine` image (provides `sh` + `base64` + `tar` for direct API-driven archive sync; user commands can `apk add` additional packages as needed).
+- Network is open by default.
+- Archive sync and small file writes use direct calls to the smolfleet `/exec` API (heredoc payload).
+- No direct `crabbox ssh` / `crabbox vnc` (delegated execution model).
+- Supports `warmup`, `run`, `status`, `stop`, `list`, and `doctor`.
+
+## Limitations
+
+- Output from runs appears after the command completes (the smolfleet API provides no live stream for delegated exec).
+- Workspace sync is performed via a direct API call (`/exec` with base64 tar in a heredoc).
+- Delegated-run restrictions apply (no SSH surface, no rsync, certain advanced sync/run flags are rejected).
+
+## Gotchas
+
+- `--class` and `--type` are rejected; sizing and image are controlled via `--smolvm-*` flags (and the base image).
+- `--checksum` is rejected because SmolVM has no SSH/rsync target. Large-sync guardrails still apply; `--force-sync-large` may be honored where supported for intentional large archive syncs.
+- Use `--sync-only` to pre-upload the archive into a kept sandbox before a later command (subject to delegated guardrails).
+- Delegated run/sync options that need an SSH target or proof surface are rejected: `--script` / `--script-stdin`, `--fresh-pr`, `--full-resync`, `--env-helper`, `--capture-stdout` / `--capture-stderr`, `--capture-on-fail`, `--download`, `--artifact-glob`, `--emit-proof`, and `--stop-after`.
+- IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw SmolVM identifier (when the sandbox carries Crabbox ownership metadata).
+- Forwarded environment values (if supported by the backend) are handled inside the injected workspace.
+- The direct archive sync sends the (base64) tar inside the `/exec` command body. Very large repos may hit request size limits (the usual preflight checks still apply).
+
+## Related docs
+
+- [Provider backends](../provider-backends.md)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -144,6 +144,7 @@ type Config struct {
 	AnthropicSRT                  AnthropicSRTConfig
 	Modal                         ModalConfig
 	UpstashBox                    UpstashBoxConfig
+	Smolvm                        SmolvmConfig
 	AsciiBox                      AsciiBoxConfig
 	Cloudflare                    CloudflareConfig
 	Semaphore                     SemaphoreConfig
@@ -542,6 +543,17 @@ type UpstashBoxConfig struct {
 	Size      string
 	Workdir   string
 	KeepAlive bool
+}
+
+type SmolvmConfig struct {
+	APIKey   string
+	BaseURL  string
+	Image    string
+	Workdir  string
+	CPUs     int
+	MemoryMB int
+	Network  string
+	Keep     bool
 }
 
 type AsciiBoxConfig struct {
@@ -1699,6 +1711,14 @@ func baseConfig() Config {
 			Size:    "small",
 			Workdir: "/workspace/home/crabbox",
 		},
+		Smolvm: SmolvmConfig{
+			BaseURL:  "https://api.smolmachines.com",
+			Image:    "alpine",
+			Workdir:  "/workspace",
+			CPUs:     2,
+			MemoryMB: 2048,
+			Network:  "open",
+		},
 		AsciiBox: AsciiBoxConfig{
 			BaseURL: "https://ascii.dev",
 			CLIPath: "box",
@@ -1848,6 +1868,7 @@ type fileConfig struct {
 	AnthropicSRT         *fileAnthropicSRTConfig            `yaml:"anthropicSandboxRuntime,omitempty"`
 	Modal                *fileModalConfig                   `yaml:"modal,omitempty"`
 	UpstashBox           *fileUpstashBoxConfig              `yaml:"upstashBox,omitempty"`
+	Smolvm               *fileSmolvmConfig                  `yaml:"smolvm,omitempty"`
 	AsciiBox             *fileAsciiBoxConfig                `yaml:"asciiBox,omitempty"`
 	Cloudflare           *fileCloudflareConfig              `yaml:"cloudflare,omitempty"`
 	Semaphore            *fileSemaphoreConfig               `yaml:"semaphore,omitempty"`
@@ -2327,6 +2348,16 @@ type fileUpstashBoxConfig struct {
 	Size      string `yaml:"size,omitempty"`
 	Workdir   string `yaml:"workdir,omitempty"`
 	KeepAlive *bool  `yaml:"keepAlive,omitempty"`
+}
+
+type fileSmolvmConfig struct {
+	BaseURL  string `yaml:"baseUrl,omitempty"`
+	Image    string `yaml:"image,omitempty"`
+	Workdir  string `yaml:"workdir,omitempty"`
+	CPUs     int    `yaml:"cpus,omitempty"`
+	MemoryMB int    `yaml:"memoryMB,omitempty"`
+	Network  string `yaml:"network,omitempty"`
+	Keep     *bool  `yaml:"keep,omitempty"`
 }
 
 type fileAsciiBoxConfig struct {
@@ -3873,6 +3904,29 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.UpstashBox.KeepAlive = *file.UpstashBox.KeepAlive
 		}
 	}
+	if file.Smolvm != nil {
+		if file.Smolvm.BaseURL != "" {
+			cfg.Smolvm.BaseURL = file.Smolvm.BaseURL
+		}
+		if file.Smolvm.Image != "" {
+			cfg.Smolvm.Image = file.Smolvm.Image
+		}
+		if file.Smolvm.Workdir != "" {
+			cfg.Smolvm.Workdir = file.Smolvm.Workdir
+		}
+		if file.Smolvm.CPUs > 0 {
+			cfg.Smolvm.CPUs = file.Smolvm.CPUs
+		}
+		if file.Smolvm.MemoryMB > 0 {
+			cfg.Smolvm.MemoryMB = file.Smolvm.MemoryMB
+		}
+		if file.Smolvm.Network != "" {
+			cfg.Smolvm.Network = file.Smolvm.Network
+		}
+		if file.Smolvm.Keep != nil {
+			cfg.Smolvm.Keep = *file.Smolvm.Keep
+		}
+	}
 	if file.AsciiBox != nil {
 		if file.AsciiBox.BaseURL != "" {
 			cfg.AsciiBox.BaseURL = file.AsciiBox.BaseURL
@@ -5014,6 +5068,16 @@ func applyEnv(cfg *Config) error {
 	cfg.UpstashBox.Workdir = getenv("CRABBOX_UPSTASH_BOX_WORKDIR", cfg.UpstashBox.Workdir)
 	if value, ok := getenvBool("CRABBOX_UPSTASH_BOX_KEEP_ALIVE"); ok {
 		cfg.UpstashBox.KeepAlive = value
+	}
+	cfg.Smolvm.APIKey = getenv("CRABBOX_SMOLVM_API_KEY", getenv("SMOLMACHINES_API_KEY", getenv("SMK_API_KEY", cfg.Smolvm.APIKey)))
+	cfg.Smolvm.BaseURL = getenv("CRABBOX_SMOLVM_BASE_URL", cfg.Smolvm.BaseURL)
+	cfg.Smolvm.Image = getenv("CRABBOX_SMOLVM_IMAGE", cfg.Smolvm.Image)
+	cfg.Smolvm.Workdir = getenv("CRABBOX_SMOLVM_WORKDIR", cfg.Smolvm.Workdir)
+	cfg.Smolvm.CPUs = getenvInt("CRABBOX_SMOLVM_CPUS", cfg.Smolvm.CPUs)
+	cfg.Smolvm.MemoryMB = getenvInt("CRABBOX_SMOLVM_MEMORY_MB", cfg.Smolvm.MemoryMB)
+	cfg.Smolvm.Network = getenv("CRABBOX_SMOLVM_NETWORK", cfg.Smolvm.Network)
+	if value, ok := getenvBool("CRABBOX_SMOLVM_KEEP"); ok {
+		cfg.Smolvm.Keep = value
 	}
 	cfg.AsciiBox.APIKey = getenv("CRABBOX_ASCII_BOX_API_KEY", getenv("ASCII_BOX_API_KEY", cfg.AsciiBox.APIKey))
 	cfg.AsciiBox.BaseURL = getenv("CRABBOX_ASCII_BOX_BASE_URL", getenv("ASCII_BOX_BASE_URL", cfg.AsciiBox.BaseURL))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -194,6 +194,16 @@ func configShowView(cfg Config) map[string]any {
 			"workdir":   cfg.UpstashBox.Workdir,
 			"keepAlive": cfg.UpstashBox.KeepAlive,
 		},
+		"smolvm": map[string]any{
+			"baseUrl":  cfg.Smolvm.BaseURL,
+			"auth":     tokenState(cfg.Smolvm.APIKey),
+			"image":    cfg.Smolvm.Image,
+			"workdir":  cfg.Smolvm.Workdir,
+			"cpus":     cfg.Smolvm.CPUs,
+			"memoryMB": cfg.Smolvm.MemoryMB,
+			"network":  cfg.Smolvm.Network,
+			"keep":     cfg.Smolvm.Keep,
+		},
 		"asciiBox": map[string]any{
 			"baseUrl": cfg.AsciiBox.BaseURL,
 			"auth":    tokenState(cfg.AsciiBox.APIKey),
@@ -363,6 +373,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "morph api_url=%s snapshot=%s ssh_gateway_host=%s work_root=%s delete_on_release=%t wake_on_ssh=%t auth=%s\n", blank(cfg.Morph.APIURL, "-"), blank(cfg.Morph.Snapshot, "-"), blank(cfg.Morph.SSHGatewayHost, "-"), blank(cfg.Morph.WorkRoot, "-"), cfg.Morph.DeleteOnRelease, cfg.Morph.WakeOnSSH, tokenState(cfg.Morph.APIKey))
 	fmt.Fprintf(w, "e2b api_url=%s domain=%s template=%s workdir=%s user=%s\n", cfg.E2B.APIURL, cfg.E2B.Domain, cfg.E2B.Template, cfg.E2B.Workdir, blank(cfg.E2B.User, "-"))
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
+	fmt.Fprintf(w, "smolvm base_url=%s image=%s workdir=%s cpus=%d memory_mb=%d network=%s keep=%t auth=%s\n", cfg.Smolvm.BaseURL, cfg.Smolvm.Image, cfg.Smolvm.Workdir, cfg.Smolvm.CPUs, cfg.Smolvm.MemoryMB, cfg.Smolvm.Network, cfg.Smolvm.Keep, tokenState(cfg.Smolvm.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1433,6 +1433,116 @@ func TestOpenComputerBurstConfigYAMLAndEnv(t *testing.T) {
 	}
 }
 
+func TestSmolvmConfigYAMLOverrides(t *testing.T) {
+	cfg := baseConfig()
+	var file fileConfig
+	yamlText := strings.Join([]string{
+		"smolvm:",
+		"  baseUrl: https://smol.example",
+		"  image: ubuntu",
+		"  workdir: /srv/app",
+		"  cpus: 4",
+		"  memoryMB: 4096",
+		"  network: closed",
+		"  keep: true",
+	}, "\n")
+	if err := yaml.Unmarshal([]byte(yamlText), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	want := SmolvmConfig{
+		BaseURL:  "https://smol.example",
+		Image:    "ubuntu",
+		Workdir:  "/srv/app",
+		CPUs:     4,
+		MemoryMB: 4096,
+		Network:  "closed",
+		Keep:     true,
+	}
+	if cfg.Smolvm != want {
+		t.Fatalf("smolvm YAML config = %#v, want %#v", cfg.Smolvm, want)
+	}
+}
+
+func TestSmolvmConfigYAMLEmptyKeepsDefaults(t *testing.T) {
+	cfg := baseConfig()
+	defaults := cfg.Smolvm
+	file := fileConfig{Smolvm: &fileSmolvmConfig{}}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Smolvm != defaults {
+		t.Fatalf("empty smolvm YAML changed defaults: %#v, want %#v", cfg.Smolvm, defaults)
+	}
+}
+
+func TestSmolvmConfigYAMLCannotSetAPIKey(t *testing.T) {
+	cfg := baseConfig()
+	var file fileConfig
+	if err := yaml.Unmarshal([]byte("smolvm:\n  apiKey: smk-attacker\n"), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Smolvm.APIKey != "" {
+		t.Fatalf("repository config set smolvm API key to %q", cfg.Smolvm.APIKey)
+	}
+}
+
+func TestSmolvmConfigEnvOverrides(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	t.Setenv("CRABBOX_SMOLVM_API_KEY", "smk-env")
+	t.Setenv("CRABBOX_SMOLVM_BASE_URL", "https://env.smol.example")
+	t.Setenv("CRABBOX_SMOLVM_IMAGE", "debian")
+	t.Setenv("CRABBOX_SMOLVM_WORKDIR", "/env/workdir")
+	t.Setenv("CRABBOX_SMOLVM_CPUS", "8")
+	t.Setenv("CRABBOX_SMOLVM_MEMORY_MB", "8192")
+	t.Setenv("CRABBOX_SMOLVM_NETWORK", "closed")
+	t.Setenv("CRABBOX_SMOLVM_KEEP", "true")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	want := SmolvmConfig{
+		APIKey:   "smk-env",
+		BaseURL:  "https://env.smol.example",
+		Image:    "debian",
+		Workdir:  "/env/workdir",
+		CPUs:     8,
+		MemoryMB: 8192,
+		Network:  "closed",
+		Keep:     true,
+	}
+	if cfg.Smolvm != want {
+		t.Fatalf("smolvm env config = %#v, want %#v", cfg.Smolvm, want)
+	}
+}
+
+func TestSmolvmAPIKeyEnvFallbacks(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	t.Setenv("SMOLMACHINES_API_KEY", "smk-vendor")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Smolvm.APIKey != "smk-vendor" {
+		t.Fatalf("SMOLMACHINES_API_KEY fallback = %q, want smk-vendor", cfg.Smolvm.APIKey)
+	}
+
+	cfg = baseConfig()
+	t.Setenv("SMOLMACHINES_API_KEY", "")
+	t.Setenv("SMK_API_KEY", "smk-short")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Smolvm.APIKey != "smk-short" {
+		t.Fatalf("SMK_API_KEY fallback = %q, want smk-short", cfg.Smolvm.APIKey)
+	}
+}
+
 func TestHostingerPurchaseOptInRequiresTrustedConfig(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/railway"
 	_ "github.com/openclaw/crabbox/internal/providers/runpod"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
+	_ "github.com/openclaw/crabbox/internal/providers/smolvm"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"
 	_ "github.com/openclaw/crabbox/internal/providers/tart"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -134,6 +134,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"runpod",
 		"anthropic-sandbox-runtime",
 		"semaphore",
+		"smolvm",
 		"sprites",
 		"ssh",
 		"tart",

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -386,11 +386,10 @@ func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot
 		if err != nil {
 			return "", "", "", err
 		}
-		return id, machine.ID, machineSlug(id, machine), nil
+		return b.finishResolvedMachine(machine, repoRoot, reclaim)
 	}
 	if machine, err := client.GetMachine(ctx, id); err == nil && isCrabboxMachine(machine) {
-		leaseID := machineLeaseID(machine)
-		return leaseID, machine.ID, machineSlug(leaseID, machine), nil
+		return b.finishResolvedMachine(machine, repoRoot, reclaim)
 	} else if err != nil && !isNotFound(err) {
 		return "", "", "", err
 	}
@@ -402,11 +401,20 @@ func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot
 		if gerr != nil || !isCrabboxMachine(m) {
 			return "", "", "", err
 		}
-		leaseID := machineLeaseID(m)
-		return leaseID, m.ID, machineSlug(leaseID, m), nil
+		return b.finishResolvedMachine(m, repoRoot, reclaim)
 	}
+	return b.finishResolvedMachine(machine, repoRoot, reclaim)
+}
+
+func (b *backend) finishResolvedMachine(machine machineData, repoRoot string, reclaim bool) (string, string, string, error) {
 	leaseID := machineLeaseID(machine)
-	return leaseID, machine.ID, machineSlug(leaseID, machine), nil
+	slug := machineSlug(leaseID, machine)
+	if repoRoot != "" {
+		if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	return leaseID, machine.ID, slug, nil
 }
 
 func resolveMachineByLease(ctx context.Context, client api, leaseID string) (machineData, error) {
@@ -444,12 +452,12 @@ func machineToServer(cfg Config, m machineData) Server {
 	labels := directLeaseLabels(cfg, leaseID, machineSlug(leaseID, m), providerName, "", cfg.Smolvm.Keep, time.Now().UTC())
 	labels["machine_id"] = m.ID
 	labels["machine_name"] = m.Name
-	labels["image"] = blank(m.Image, imageName(cfg))
-	if m.CPUs > 0 {
-		labels["cpus"] = fmt.Sprintf("%d", m.CPUs)
+	labels["image"] = blank(m.Source.Reference, imageName(cfg))
+	if m.Resources.CPUs > 0 {
+		labels["cpus"] = fmt.Sprintf("%d", m.Resources.CPUs)
 	}
-	if m.MemoryMB > 0 {
-		labels["memory_mb"] = fmt.Sprintf("%d", m.MemoryMB)
+	if m.Resources.MemoryMB > 0 {
+		labels["memory_mb"] = fmt.Sprintf("%d", m.Resources.MemoryMB)
 	}
 	labels["state"] = m.State
 	server := Server{

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -1,0 +1,627 @@
+package smolvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	started := b.now()
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, machine, slug, err := b.createMachine(ctx, client, req.Repo, true, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s machine=%s name=%s\n", leaseID, slug, providerName, machine.ID, machine.Name)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: smolvm warmup keeps the machine until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, err := cleanWorkdir(workdir(b.cfg))
+	if err != nil {
+		return RunResult{}, err
+	}
+	folder, err := workspaceFolder(workdir)
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return RunResult{}, err
+	}
+	effectiveKeep := req.Keep || b.cfg.Smolvm.Keep
+	leaseID, machineID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		var machine machineData
+		leaseID, machine, slug, err = b.createMachine(ctx, client, req.Repo, effectiveKeep, req.Reclaim, req.RequestedSlug)
+		if err != nil {
+			return RunResult{}, err
+		}
+		machineID = machine.ID
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s machine=%s name=%s\n", leaseID, slug, providerName, machine.ID, machine.Name)
+		acquired = true
+	} else {
+		leaseID, machineID, slug, err = b.resolveMachineID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	shouldStop := acquired && !effectiveKeep
+	if shouldStop {
+		defer func() {
+			if !shouldStop {
+				return
+			}
+			if err := client.DeleteMachine(context.Background(), machineID); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: smolvm delete failed for %s: %v\n", machineID, err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, machineID, req, workdir, folder)
+		if err != nil {
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, client, machineID, folder, false); err != nil {
+		return RunResult{}, err
+	}
+	if req.SyncOnly {
+		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		if req.TimingJSON {
+			err := writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+				Label:         strings.TrimSpace(req.Label),
+			})
+			return result, err
+		}
+		return result, nil
+	}
+
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	if req.EnvSummary {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	if len(req.Env) > 0 {
+		envPath := path.Join(workdir, ".crabbox-env-"+leaseID+".sh")
+		if err := client.WriteFile(ctx, machineID, envPath, shellEnvProfile(req.Env)); err != nil {
+			return RunResult{}, err
+		}
+		defer func() {
+			_, _ = client.Exec(context.Background(), machineID, "rm -f "+shellQuote(envPath), "")
+		}()
+		command = ". " + shellQuote(envPath) + " && " + command
+	}
+	commandStarted := b.now()
+	exitCode, commandErr := client.ExecStream(ctx, machineID, command, folder, b.rt.Stdout)
+	commandDuration := b.now().Sub(commandStarted)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+		Provider:      providerName,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   strings.Join(req.Command, " "),
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "smolvm run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "smolvm run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      exitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}); err != nil {
+			return result, err
+		}
+	}
+	if commandErr != nil {
+		failureReq := req
+		failureReq.Keep = effectiveKeep
+		handleDelegatedRunFailure(b.rt.Stderr, failureReq, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("smolvm run failed: %v", commandErr)}
+	}
+	if exitCode != 0 {
+		failureReq := req
+		failureReq.Keep = effectiveKeep
+		handleDelegatedRunFailure(b.rt.Stderr, failureReq, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("smolvm run exited %d", exitCode)}
+	}
+	return result, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	machines, err := client.ListMachines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(machines))
+	for _, m := range machines {
+		if isCrabboxMachine(m) {
+			servers = append(servers, machineToServer(b.cfg, m))
+		}
+	}
+	return servers, nil
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, machineID, slug, err := b.resolveMachineID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deadline := b.now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = b.now().Add(5 * time.Minute)
+	}
+	for {
+		machine, err := client.GetMachine(ctx, machineID)
+		if err != nil {
+			return StatusView{}, err
+		}
+		server := machineToServer(b.cfg, machine)
+		view := StatusView{
+			ID:         leaseID,
+			Slug:       blank(slug, server.Labels["slug"]),
+			Provider:   providerName,
+			TargetOS:   targetLinux,
+			State:      machine.State,
+			ServerID:   machine.ID,
+			ServerType: server.ServerType.Name,
+			Network:    networkPublic,
+			Ready:      statusReady(machine.State),
+			Labels:     server.Labels,
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for smolvm %s to become ready", machineID)
+		}
+		select {
+		case <-ctx.Done():
+			return StatusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	client, err := newAPI(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, machineID, _, err := b.resolveMachineID(ctx, client, req.ID, "", false)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteMachine(ctx, machineID); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", leaseID, machineID)
+	return nil
+}
+
+func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, machineData, string, error) {
+	leaseID := newLeaseID()
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return "", machineData{}, "", err
+	}
+	name := machineName(leaseID, slug)
+	cpus := cpusValue(b.cfg)
+	mem := memoryValue(b.cfg)
+	netMode := networkMode(b.cfg)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s cpus=%d memory_mb=%d network=%s keep=%t\n", providerName, leaseID, slug, name, imageName(b.cfg), cpus, mem, netMode, keep)
+	creq := createRequest{
+		Name: name,
+		Source: smolvmMachineSource{
+			Type:      "image",
+			Reference: imageName(b.cfg),
+		},
+		Resources: smolvmMachineResources{
+			CPUs:     cpus,
+			MemoryMB: mem,
+		},
+		Network: &smolvmMachineNetwork{
+			Mode: netMode,
+		},
+		Workdir: workdir(b.cfg),
+	}
+	if !keep {
+		creq.Ephemeral = true
+		creq.TTLSeconds = 3600 // reasonable default; backend stop will delete anyway
+	}
+	machine, err := client.CreateMachine(ctx, creq)
+	if err != nil {
+		return "", machineData{}, "", err
+	}
+	// Machines are created stopped; start explicitly for delegated run/warmup.
+	if err := client.StartMachine(ctx, machine.ID); err != nil {
+		_ = client.DeleteMachine(context.Background(), machine.ID)
+		return "", machineData{}, "", fmt.Errorf("smolvm start %s: %w", machine.ID, err)
+	}
+	// Poll until ready (started/running etc).
+	deadline := time.Now().Add(5 * time.Minute)
+	for {
+		st := strings.ToLower(strings.TrimSpace(machine.State))
+		if createStatusReady(st) {
+			break
+		}
+		if st == "error" || st == "failed" || st == "erroring" {
+			_ = client.DeleteMachine(context.Background(), machine.ID)
+			return "", machineData{}, "", exit(5, "smolvm machine failed for %s status=%s", machine.ID, machine.State)
+		}
+		if time.Now().After(deadline) {
+			_ = client.DeleteMachine(context.Background(), machine.ID)
+			return "", machineData{}, "", exit(5, "smolvm start timed out for %s status=%s", machine.ID, machine.State)
+		}
+		select {
+		case <-ctx.Done():
+			_ = client.DeleteMachine(context.Background(), machine.ID)
+			return "", machineData{}, "", ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+		next, err := client.GetMachine(ctx, machine.ID)
+		if err == nil {
+			machine = next
+		}
+	}
+	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		_ = client.DeleteMachine(context.Background(), machine.ID)
+		return "", machineData{}, "", err
+	}
+	return leaseID, machine, slug, nil
+}
+
+func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot string, reclaim bool) (string, string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or smolvm machine id/name", providerName)
+	}
+	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+		return "", "", "", err
+	} else if ok && claim.Provider == providerName {
+		if repoRoot != "" {
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+				return "", "", "", err
+			}
+		}
+		machine, err := resolveMachineByLease(ctx, client, claim.LeaseID)
+		if err != nil {
+			return "", "", "", err
+		}
+		return claim.LeaseID, machine.ID, claim.Slug, nil
+	}
+	if strings.HasPrefix(id, "cbx_") {
+		machine, err := resolveMachineByLease(ctx, client, id)
+		if err != nil {
+			return "", "", "", err
+		}
+		return id, machine.ID, machineSlug(id, machine), nil
+	}
+	if machine, err := client.GetMachine(ctx, id); err == nil && isCrabboxMachine(machine) {
+		leaseID := machineLeaseID(machine)
+		return leaseID, machine.ID, machineSlug(leaseID, machine), nil
+	} else if err != nil && !isNotFound(err) {
+		return "", "", "", err
+	}
+	// try by slug or direct name
+	machine, err := resolveMachineBySlug(ctx, client, id)
+	if err != nil {
+		// last try: treat id as the machine name/id directly
+		m, gerr := client.GetMachine(ctx, id)
+		if gerr != nil || !isCrabboxMachine(m) {
+			return "", "", "", err
+		}
+		leaseID := machineLeaseID(m)
+		return leaseID, m.ID, machineSlug(leaseID, m), nil
+	}
+	leaseID := machineLeaseID(machine)
+	return leaseID, machine.ID, machineSlug(leaseID, machine), nil
+}
+
+func resolveMachineByLease(ctx context.Context, client api, leaseID string) (machineData, error) {
+	machines, err := client.ListMachines(ctx)
+	if err != nil {
+		return machineData{}, err
+	}
+	for _, m := range machines {
+		if isCrabboxMachine(m) && machineLeaseID(m) == leaseID {
+			return m, nil
+		}
+	}
+	return machineData{}, exit(4, "smolvm lease %q was not found", leaseID)
+}
+
+func resolveMachineBySlug(ctx context.Context, client api, slug string) (machineData, error) {
+	machines, err := client.ListMachines(ctx)
+	if err != nil {
+		return machineData{}, err
+	}
+	for _, m := range machines {
+		if isCrabboxMachine(m) && machineSlug(machineLeaseID(m), m) == slug {
+			return m, nil
+		}
+	}
+	return machineData{}, exit(4, "smolvm %q was not found", slug)
+}
+
+func (b *backend) now() time.Time {
+	return now(b.rt)
+}
+
+func machineToServer(cfg Config, m machineData) Server {
+	leaseID := machineLeaseID(m)
+	labels := directLeaseLabels(cfg, leaseID, machineSlug(leaseID, m), providerName, "", cfg.Smolvm.Keep, time.Now().UTC())
+	labels["machine_id"] = m.ID
+	labels["machine_name"] = m.Name
+	labels["image"] = blank(m.Image, imageName(cfg))
+	if m.CPUs > 0 {
+		labels["cpus"] = fmt.Sprintf("%d", m.CPUs)
+	}
+	if m.MemoryMB > 0 {
+		labels["memory_mb"] = fmt.Sprintf("%d", m.MemoryMB)
+	}
+	labels["state"] = m.State
+	server := Server{
+		Provider: providerName,
+		CloudID:  m.ID,
+		Name:     blank(m.Name, m.ID),
+		Status:   m.State,
+		Labels:   labels,
+	}
+	server.ServerType.Name = fmt.Sprintf("smolvm-%d-%d", cpusValue(cfg), memoryValue(cfg))
+	server.PublicNet.IPv4.IP = machineBaseHost(cfg)
+	return server
+}
+
+func machineBaseHost(cfg Config) string {
+	raw := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), "https://api.smolmachines.com")
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return raw
+	}
+	return parsed.Host
+}
+
+var machineNamePattern = regexp.MustCompile(`^crabbox-(.+)-([0-9a-f]{12})$`)
+
+func isCrabboxMachine(m machineData) bool {
+	return machineNamePattern.MatchString(strings.TrimSpace(m.Name))
+}
+
+func machineLeaseID(m machineData) string {
+	if match := machineNamePattern.FindStringSubmatch(strings.TrimSpace(m.Name)); len(match) == 3 {
+		return "cbx_" + match[2]
+	}
+	return "smolvm_" + m.ID
+}
+
+func machineSlug(leaseID string, m machineData) string {
+	if match := machineNamePattern.FindStringSubmatch(strings.TrimSpace(m.Name)); len(match) == 3 {
+		return match[1]
+	}
+	return newLeaseSlug(leaseID)
+}
+
+func statusReady(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "running", "ready", "idle", "active", "started", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageName(cfg Config) string {
+	return blank(strings.TrimSpace(cfg.Smolvm.Image), "alpine")
+}
+
+func machineName(leaseID, slug string) string {
+	slug = strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
+	if slug == "" {
+		slug = newLeaseSlug(leaseID)
+	}
+	return "crabbox-" + slug + "-" + strings.TrimPrefix(leaseID, "cbx_")
+}
+
+func cpusValue(cfg Config) int {
+	if cfg.Smolvm.CPUs > 0 {
+		return cfg.Smolvm.CPUs
+	}
+	return 2
+}
+
+func memoryValue(cfg Config) int {
+	if cfg.Smolvm.MemoryMB > 0 {
+		return cfg.Smolvm.MemoryMB
+	}
+	return 2048
+}
+
+func networkMode(cfg Config) string {
+	n := strings.ToLower(strings.TrimSpace(cfg.Smolvm.Network))
+	if n == "" {
+		return "blocked"
+	}
+	if n == "open" || n == "public" {
+		return "open"
+	}
+	return "blocked"
+}
+
+func workdir(cfg Config) string {
+	return blank(strings.TrimSpace(cfg.Smolvm.Workdir), "/workspace")
+}
+
+func cleanWorkdir(workdir string) (string, error) {
+	trimmed := strings.TrimSpace(workdir)
+	if trimmed == "" {
+		return "", exit(2, "smolvm workdir is empty")
+	}
+	clean := path.Clean(trimmed)
+	if !strings.HasPrefix(clean, "/") {
+		return "", exit(2, "smolvm workdir %q must resolve to an absolute path", workdir)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
+		return "", exit(2, "smolvm workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
+}
+
+func buildCommand(command []string, shellMode bool) (string, error) {
+	if len(command) == 0 {
+		return "", errors.New("missing command")
+	}
+	var script string
+	if shellMode {
+		script = strings.Join(command, " ")
+	} else if shouldUseShell(command) || leadingEnvAssignment(command) {
+		script = shellScriptFromArgv(command)
+	} else {
+		script = "exec " + strings.Join(shellWords(command), " ")
+	}
+	return script, nil
+}
+
+const workspaceRoot = "/workspace"
+
+func workspaceFolder(workdir string) (string, error) {
+	clean, err := cleanWorkdir(workdir)
+	if err != nil {
+		return "", err
+	}
+	prefix := workspaceRoot + "/"
+	if !strings.HasPrefix(clean, prefix) {
+		// allow exact /workspace too; return absolute for reliable mkdir/exec workdir across API calls
+		if clean == workspaceRoot {
+			return "/workspace", nil
+		}
+		return "", exit(2, "smolvm workdir %q must be under %s or exactly %s", clean, workspaceRoot, workspaceRoot)
+	}
+	return clean, nil
+}
+
+func shellEnvProfile(env map[string]string) string {
+	var b strings.Builder
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if !validEnvName(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	b.WriteString("set -a\n")
+	for _, key := range keys {
+		b.WriteString(key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(env[key]))
+		b.WriteByte('\n')
+	}
+	b.WriteString("set +a\n")
+	return b.String()
+}
+
+func validEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -61,15 +62,15 @@ func TestClientUsesSmolvmRESTShape(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
 					t.Fatal(err)
 				}
-				_ = json.NewEncoder(w).Encode(map[string]any{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"})
+				_ = json.NewEncoder(w).Encode(testMachineResponse("mach_1", "crabbox-blue-123456789abc", "running"))
 			case http.MethodGet:
-				_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"}})
+				_ = json.NewEncoder(w).Encode([]map[string]any{testMachineResponse("mach_1", "crabbox-blue-123456789abc", "running")})
 			default:
 				t.Fatalf("unexpected method %s", r.Method)
 			}
 		case "/v1/machines/mach_1":
 			if r.Method == http.MethodGet {
-				_ = json.NewEncoder(w).Encode(map[string]any{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"})
+				_ = json.NewEncoder(w).Encode(testMachineResponse("mach_1", "crabbox-blue-123456789abc", "running"))
 				return
 			}
 			if r.Method == http.MethodDelete {
@@ -80,7 +81,7 @@ func TestClientUsesSmolvmRESTShape(t *testing.T) {
 		case "/v1/machines/mach_1/exec":
 			var body struct {
 				Command string `json:"command"`
-				Workdir string `json:"workdir"`
+				CWD     string `json:"cwd"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -96,7 +97,7 @@ func TestClientUsesSmolvmRESTShape(t *testing.T) {
 				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "smolvm-direct-write: ok\n"})
 				return
 			}
-			if !strings.Contains(body.Command, "echo hi") || (body.Workdir != "crabbox" && body.Workdir != "/crabbox") {
+			if !strings.Contains(body.Command, "echo hi") || (body.CWD != "crabbox" && body.CWD != "/crabbox") {
 				t.Fatalf("exec body=%#v", body)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "hi\n", "stderr": "warn\n"})
@@ -173,6 +174,25 @@ func TestNewAPIAllowsLoopbackHTTPBaseURL(t *testing.T) {
 	cfg.Smolvm.BaseURL = "http://127.0.0.1:8080"
 	if _, err := newAPI(cfg, Runtime{}); err != nil {
 		t.Fatalf("loopback http rejected: %v", err)
+	}
+}
+
+func TestNewAPIRejectsUntrustedHTTPSBaseURLByDefault(t *testing.T) {
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = "https://smolvm.attacker.example"
+	if _, err := newAPI(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "ALLOW_CUSTOM_BASE_URL") {
+		t.Fatalf("newAPI error=%v, want custom endpoint opt-in requirement", err)
+	}
+}
+
+func TestNewAPIAllowsExplicitCustomHTTPSBaseURL(t *testing.T) {
+	t.Setenv("CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL", "1")
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = "https://smolvm.example.test"
+	if _, err := newAPI(cfg, Runtime{}); err != nil {
+		t.Fatalf("explicit custom endpoint rejected: %v", err)
 	}
 }
 
@@ -372,7 +392,11 @@ func TestSyncWorkspaceUsesInject(t *testing.T) {
 }
 
 func TestStatusMapsMachineName(t *testing.T) {
-	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", Image: "alpine", State: "running", CPUs: 4, MemoryMB: 8192}}
+	fake := &fakeAPI{machine: machineData{
+		ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running",
+		Source:    smolvmMachineSource{Type: "image", Reference: "alpine"},
+		Resources: smolvmMachineResources{CPUs: 4, MemoryMB: 8192},
+	}}
 	withFakeAPI(t, fake)
 	cfg := testConfig()
 	cfg.Smolvm.BaseURL = "https://eu.smolmachines.com"
@@ -399,6 +423,31 @@ func TestStatusRejectsNonCrabboxRawMachine(t *testing.T) {
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
 	if _, err := backend.Status(context.Background(), StatusRequest{ID: "mach_1"}); err == nil {
 		t.Fatal("expected non-Crabbox raw machine id to be rejected")
+	}
+}
+
+func TestRunRawMachineIDEnforcesRepositoryClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "cbx_123456789abc"
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue", providerName, repoA, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}}
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	_, err := backend.Run(context.Background(), RunRequest{
+		ID:      "mach_1",
+		Repo:    Repo{Name: "repo-b", Root: repoB},
+		Command: []string{"echo", "hello"},
+		NoSync:  true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "is claimed by repo") {
+		t.Fatalf("Run error=%v, want cross-repository claim rejection", err)
+	}
+	if len(fake.verbs) != 0 {
+		t.Fatalf("verbs=%v, want no machine mutation or execution", fake.verbs)
 	}
 }
 
@@ -458,10 +507,11 @@ func (f *fakeAPI) CreateMachine(_ context.Context, req createRequest) (machineDa
 	f.createReq = req
 	f.machine = machineData{ID: "mach_1", Name: req.Name, State: "running"}
 	if ref := strings.TrimSpace(req.Source.Reference); ref != "" {
-		f.machine.Image = ref
+		f.machine.Source = req.Source
 	} else if req.Source.Type != "" {
-		f.machine.Image = req.Source.Type
+		f.machine.Source.Reference = req.Source.Type
 	}
+	f.machine.Resources = req.Resources
 	return f.machine, nil
 }
 
@@ -543,5 +593,15 @@ func runGit(t *testing.T, dir string, args ...string) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func testMachineResponse(id, name, state string) map[string]any {
+	return map[string]any{
+		"id": id, "name": name, "state": state,
+		"source":    map[string]any{"type": "image", "reference": "ubuntu:24.04"},
+		"resources": map[string]any{"cpus": 2, "memoryMb": 4096},
+		"network":   map[string]any{"mode": "blocked"},
+		"ephemeral": false, "createdAt": "2026-06-12T20:00:00Z", "updatedAt": "2026-06-12T20:00:00Z",
 	}
 }

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -1,0 +1,547 @@
+package smolvm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %s", p.Name(), providerName)
+	}
+	for _, alias := range []string{"smol", "smolmachines", "smolfleet"} {
+		got, err := core.ProviderFor(alias)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", alias, err)
+		}
+		if got.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", alias, got.Name())
+		}
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%v want delegated-run", spec.Kind)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%v want never", spec.Coordinator)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want linux", spec.Targets)
+	}
+	if !hasFeature(spec.Features, core.FeatureArchiveSync) {
+		t.Fatalf("features=%#v want archive sync", spec.Features)
+	}
+}
+
+func TestClientUsesSmolvmRESTShape(t *testing.T) {
+	var createBody map[string]any
+	injectSeen := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != "smk_key" {
+			t.Fatalf("Authorization=%q want Bearer smk_key", auth)
+		}
+		switch r.URL.Path {
+		case "/v1/machines":
+			switch r.Method {
+			case http.MethodPost:
+				if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+					t.Fatal(err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"})
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"}})
+			default:
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+		case "/v1/machines/mach_1":
+			if r.Method == http.MethodGet {
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": "mach_1", "name": "crabbox-blue-123456789abc", "state": "running"})
+				return
+			}
+			if r.Method == http.MethodDelete {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			t.Fatalf("unexpected method %s on /v1/machines/mach_1", r.Method)
+		case "/v1/machines/mach_1/exec":
+			var body struct {
+				Command string `json:"command"`
+				Workdir string `json:"workdir"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			// Direct heredoc-based archive inject.
+			if strings.Contains(body.Command, "crabbox-sync.tgz") || strings.Contains(body.Command, "smolvm-direct-archive-extract") {
+				injectSeen = true
+				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "smolvm-direct-archive-extract: ok\n"})
+				return
+			}
+			// Direct write (env profile etc) also uses base64 heredoc /exec.
+			if strings.Contains(body.Command, "smolvm-direct-write") || strings.Contains(body.Command, "CRABBOX_WRITE_B64_EOF") {
+				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "smolvm-direct-write: ok\n"})
+				return
+			}
+			if !strings.Contains(body.Command, "echo hi") || (body.Workdir != "crabbox" && body.Workdir != "/crabbox") {
+				t.Fatalf("exec body=%#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "hi\n", "stderr": "warn\n"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &client{apiKey: "smk_key", base: srv.URL, http: srv.Client()}
+	mach, err := client.CreateMachine(context.Background(), createRequest{Name: "crabbox-blue-123456789abc", Source: smolvmMachineSource{Type: "image", Reference: "ubuntu:24.04"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mach.ID != "mach_1" || createBody["name"] != "crabbox-blue-123456789abc" {
+		t.Fatalf("create mach=%#v body=%v", mach, createBody)
+	}
+	if _, err := client.ListMachines(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := client.Exec(context.Background(), "mach_1", "echo hi", "crabbox"); err != nil || result.Output != "hi\n" {
+		t.Fatalf("exec result=%#v err=%v", result, err)
+	}
+	var stdout bytes.Buffer
+	code, err := client.ExecStream(context.Background(), "mach_1", "echo hi", "crabbox", &stdout)
+	if err != nil || code != 0 || stdout.String() != "hi\nwarn\n" {
+		t.Fatalf("stream code=%d stdout=%q err=%v", code, stdout.String(), err)
+	}
+	archive := filepath.Join(t.TempDir(), "archive.tgz")
+	if err := os.WriteFile(archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.InjectArchive(context.Background(), "mach_1", archive, "crabbox"); err != nil {
+		t.Fatal(err)
+	}
+	if !injectSeen {
+		t.Fatal("inject archive not seen")
+	}
+	if err := client.WriteFile(context.Background(), "mach_1", "/tmp/env.sh", "export A=1\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.DeleteMachine(context.Background(), "mach_1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewAPIRejectsBareHTTPBaseURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = "http://api.smolmachines.com"
+	if _, err := newAPI(cfg, Runtime{}); err == nil {
+		t.Fatal("newAPI accepted plaintext http URL")
+	}
+}
+
+func TestNewAPIRejectsUserinfoQueryAndFragment(t *testing.T) {
+	for _, base := range []string{
+		"https://user:pass@api.smolmachines.com",
+		"https://api.smolmachines.com?key=value",
+		"https://api.smolmachines.com#fragment",
+	} {
+		cfg := Config{}
+		cfg.Smolvm.APIKey = "smk_key"
+		cfg.Smolvm.BaseURL = base
+		if _, err := newAPI(cfg, Runtime{}); err == nil {
+			t.Fatalf("newAPI accepted %q", base)
+		}
+	}
+}
+
+func TestNewAPIAllowsLoopbackHTTPBaseURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = "http://127.0.0.1:8080"
+	if _, err := newAPI(cfg, Runtime{}); err != nil {
+		t.Fatalf("loopback http rejected: %v", err)
+	}
+}
+
+func TestNewAPINormalizesBaseURL(t *testing.T) {
+	cfg := Config{}
+	cfg.Smolvm.APIKey = "smk_key"
+	cfg.Smolvm.BaseURL = " https://eu.smolmachines.com/base/ "
+	apiClient, err := newAPI(cfg, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, ok := apiClient.(*client)
+	if !ok {
+		t.Fatalf("api client=%T, want *client", apiClient)
+	}
+	if c.base != "https://eu.smolmachines.com/base" {
+		t.Fatalf("base = %q, want normalized base URL", c.base)
+	}
+}
+
+func TestExecExitCodePropagatesCamelAndSnake(t *testing.T) {
+	cases := []struct {
+		name string
+		resp map[string]any
+		want int
+	}{
+		{"camelCase nonzero", map[string]any{"exitCode": 7, "stdout": "x"}, 7},
+		{"snake_case nonzero", map[string]any{"exit_code": 9, "stdout": "x"}, 9},
+		{"camelCase zero stays zero", map[string]any{"exitCode": 0, "stdout": "ok"}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/machines/mach_1/exec" {
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+				_ = json.NewEncoder(w).Encode(tc.resp)
+			}))
+			defer srv.Close()
+			c := &client{apiKey: "smk_key", base: srv.URL, http: srv.Client()}
+			res, err := c.Exec(context.Background(), "mach_1", "false", "/workspace")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.ExitCode != tc.want {
+				t.Fatalf("Exec ExitCode=%d want %d", res.ExitCode, tc.want)
+			}
+			code, err := c.ExecStream(context.Background(), "mach_1", "false", "/workspace", &bytes.Buffer{})
+			if err != nil || code != tc.want {
+				t.Fatalf("ExecStream code=%d want %d err=%v", code, tc.want, err)
+			}
+		})
+	}
+}
+
+func TestCleanWorkdirAndCommand(t *testing.T) {
+	if got, err := cleanWorkdir(" /workspace "); err != nil || got != "/workspace" {
+		t.Fatalf("workdir=%q err=%v", got, err)
+	}
+	if got, err := workspaceFolder("/workspace/repo"); err != nil || got != "/workspace/repo" {
+		t.Fatalf("workspaceFolder=%q err=%v", got, err)
+	}
+	for _, value := range []string{"", "repo", "/", "/tmp", "/workspace/../etc"} {
+		if _, err := cleanWorkdir(value); err == nil {
+			t.Fatalf("cleanWorkdir(%q) succeeded unexpectedly", value)
+		}
+	}
+	command, err := buildCommand([]string{"go", "test", "./..."}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "exec 'go' 'test' './...'" {
+		t.Fatalf("command=%q", command)
+	}
+	env := shellEnvProfile(map[string]string{"B": "two", "A": "one two", "BAD; id >&2 #": "boom"})
+	if env != "set -a\nA='one two'\nB='two'\nset +a\n" {
+		t.Fatalf("env profile=%q", env)
+	}
+}
+
+func TestWarmupRejectsActionsRunner(t *testing.T) {
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
+		t.Fatalf("err=%v, want actions-runner rejection", err)
+	}
+}
+
+func TestRunCreatesExecsAndDeletesOneShotMachine(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+		Command: []string{"echo", "hello"},
+		NoSync:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 || result.Provider != providerName {
+		t.Fatalf("result=%#v", result)
+	}
+	if fake.createReq.Name == "" || !strings.HasPrefix(fake.createReq.Name, "crabbox-") {
+		t.Fatalf("create req=%#v", fake.createReq)
+	}
+	if !reflect.DeepEqual(fake.verbs, []string{"create", "exec", "stream", "delete"}) {
+		t.Fatalf("verbs=%v", fake.verbs)
+	}
+	if !fake.createReq.Ephemeral || fake.createReq.TTLSeconds == 0 {
+		t.Fatalf("create req should be ephemeral for one-shot run: %#v", fake.createReq)
+	}
+	if !strings.Contains(fake.execCommands[0], "mkdir -p") || strings.Contains(fake.execCommands[0], "rm -rf") {
+		t.Fatalf("prepare command=%q", fake.execCommands[0])
+	}
+	if fake.streamFolders[0] == "" || !strings.Contains(fake.streamCommands[0], "echo") {
+		t.Fatalf("stream folder=%q command=%q", fake.streamFolders[0], fake.streamCommands[0])
+	}
+}
+
+func TestRunHonorsProviderKeepConfig(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	cfg := testConfig()
+	cfg.Smolvm.Keep = true
+	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+		Command: []string{"echo", "hello"},
+		NoSync:  true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.createReq.Ephemeral || fake.createReq.TTLSeconds != 0 {
+		t.Fatalf("provider keep should create retained machine: %#v", fake.createReq)
+	}
+	if reflect.DeepEqual(fake.verbs, []string{"create", "exec", "stream", "delete"}) || fake.deletedID != "" {
+		t.Fatalf("provider keep should not delete machine: verbs=%v deleted=%q", fake.verbs, fake.deletedID)
+	}
+}
+
+func TestWarmupCreatesRetainedMachine(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.createReq.Ephemeral || fake.createReq.TTLSeconds != 0 {
+		t.Fatalf("warmup should create retained machine: %#v", fake.createReq)
+	}
+}
+
+func TestRunKeepsWorkspaceSubdirectoryConsistent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	cfg := testConfig()
+	cfg.Smolvm.Workdir = "/workspace/repo"
+	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "repo", Root: newGitRepo(t)},
+		Command: []string{"pwd"},
+		Env:     map[string]string{"A": "1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.execCommands) == 0 || !strings.Contains(fake.execCommands[0], "mkdir -p '/workspace/repo'") {
+		t.Fatalf("prepare command=%q", fake.execCommands)
+	}
+	if len(fake.injectTargets) != 1 || fake.injectTargets[0] != "/workspace/repo" {
+		t.Fatalf("inject targets=%v", fake.injectTargets)
+	}
+	if len(fake.writePaths) != 1 || !strings.HasPrefix(fake.writePaths[0], "/workspace/repo/.crabbox-env-") {
+		t.Fatalf("write paths=%v", fake.writePaths)
+	}
+	if len(fake.streamFolders) != 1 || fake.streamFolders[0] != "/workspace/repo" {
+		t.Fatalf("stream folders=%v", fake.streamFolders)
+	}
+}
+
+func TestSyncWorkspaceUsesInject(t *testing.T) {
+	fake := &fakeAPI{}
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "mach_1", RunRequest{
+		Repo: Repo{Name: "repo", Root: newGitRepo(t)},
+	}, "/workspace", ".")
+	if err != nil {
+		t.Fatalf("sync err=%v", err)
+	}
+	if !reflect.DeepEqual(fake.verbs, []string{"exec", "inject"}) {
+		t.Fatalf("verbs=%v", fake.verbs)
+	}
+}
+
+func TestStatusMapsMachineName(t *testing.T) {
+	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", Image: "alpine", State: "running", CPUs: 4, MemoryMB: 8192}}
+	withFakeAPI(t, fake)
+	cfg := testConfig()
+	cfg.Smolvm.BaseURL = "https://eu.smolmachines.com"
+	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "mach_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "cbx_123456789abc" || view.Slug != "blue" || view.ServerID != "mach_1" || !view.Ready {
+		t.Fatalf("view=%#v", view)
+	}
+	if view.Labels["image"] != "alpine" {
+		t.Fatalf("labels=%v", view.Labels)
+	}
+	server := machineToServer(cfg, fake.machine)
+	if server.PublicNet.IPv4.IP != "eu.smolmachines.com" {
+		t.Fatalf("host=%q", server.PublicNet.IPv4.IP)
+	}
+}
+
+func TestStatusRejectsNonCrabboxRawMachine(t *testing.T) {
+	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "external-machine", State: "running"}}
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	if _, err := backend.Status(context.Background(), StatusRequest{ID: "mach_1"}); err == nil {
+		t.Fatal("expected non-Crabbox raw machine id to be rejected")
+	}
+}
+
+func hasFeature(features core.FeatureSet, want core.Feature) bool {
+	for _, feature := range features {
+		if feature == want {
+			return true
+		}
+	}
+	return false
+}
+
+func testConfig() Config {
+	return Config{
+		Provider: providerName,
+		Smolvm: SmolvmConfig{
+			APIKey:   "smk_key",
+			BaseURL:  "https://api.smolmachines.com",
+			Image:    "ubuntu:24.04",
+			Workdir:  "/workspace",
+			CPUs:     2,
+			MemoryMB: 4096,
+			Network:  "blocked",
+		},
+	}
+}
+
+func testRuntime() Runtime {
+	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+}
+
+func withFakeAPI(t *testing.T, fake *fakeAPI) {
+	t.Helper()
+	original := newAPI
+	newAPI = func(Config, Runtime) (api, error) { return fake, nil }
+	t.Cleanup(func() { newAPI = original })
+}
+
+type fakeAPI struct {
+	verbs          []string
+	createReq      createRequest
+	machine        machineData
+	execCommands   []string
+	execFolders    []string
+	streamCommands []string
+	streamFolders  []string
+	injectTargets  []string
+	writePaths     []string
+	writeContents  []string
+	execResults    []execResult
+	deletedID      string
+	injected       bool
+}
+
+func (f *fakeAPI) CreateMachine(_ context.Context, req createRequest) (machineData, error) {
+	f.verbs = append(f.verbs, "create")
+	f.createReq = req
+	f.machine = machineData{ID: "mach_1", Name: req.Name, State: "running"}
+	if ref := strings.TrimSpace(req.Source.Reference); ref != "" {
+		f.machine.Image = ref
+	} else if req.Source.Type != "" {
+		f.machine.Image = req.Source.Type
+	}
+	return f.machine, nil
+}
+
+func (f *fakeAPI) GetMachine(context.Context, string) (machineData, error) {
+	if f.machine.ID == "" {
+		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}
+	}
+	return f.machine, nil
+}
+
+func (f *fakeAPI) ListMachines(context.Context) ([]machineData, error) {
+	if f.machine.ID == "" {
+		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}
+	}
+	return []machineData{f.machine}, nil
+}
+
+func (f *fakeAPI) DeleteMachine(_ context.Context, id string) error {
+	f.verbs = append(f.verbs, "delete")
+	f.deletedID = id
+	return nil
+}
+
+func (f *fakeAPI) StartMachine(context.Context, string) error { return nil }
+func (f *fakeAPI) StopMachine(context.Context, string) error  { return nil }
+
+func (f *fakeAPI) Exec(_ context.Context, _ string, command, folder string) (execResult, error) {
+	f.verbs = append(f.verbs, "exec")
+	f.execCommands = append(f.execCommands, command)
+	f.execFolders = append(f.execFolders, folder)
+	if len(f.execResults) == 0 {
+		return execResult{ExitCode: 0}, nil
+	}
+	result := f.execResults[0]
+	f.execResults = f.execResults[1:]
+	return result, nil
+}
+
+func (f *fakeAPI) ExecStream(_ context.Context, _ string, command, folder string, stdout io.Writer) (int, error) {
+	f.verbs = append(f.verbs, "stream")
+	f.streamCommands = append(f.streamCommands, command)
+	f.streamFolders = append(f.streamFolders, folder)
+	_, _ = io.WriteString(stdout, "ok\n")
+	return 0, nil
+}
+
+func (f *fakeAPI) InjectArchive(_ context.Context, _, _, targetDir string) error {
+	f.verbs = append(f.verbs, "inject")
+	f.injectTargets = append(f.injectTargets, targetDir)
+	f.injected = true
+	return nil
+}
+
+func (f *fakeAPI) WriteFile(_ context.Context, _, remotePath, content string) error {
+	f.verbs = append(f.verbs, "write")
+	f.writePaths = append(f.writePaths, remotePath)
+	f.writeContents = append(f.writeContents, content)
+	return nil
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.email", "alice@example.com")
+	runGit(t, root, "config", "user.name", "Alice")
+	if err := os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "hello.txt")
+	runGit(t, root, "commit", "-m", "initial")
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -45,14 +45,15 @@ type createRequest struct {
 }
 
 type machineData struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	Image     string `json:"image,omitempty"`
-	CPUs      int    `json:"cpus,omitempty"`
-	MemoryMB  int    `json:"memory_mb,omitempty"`
-	CreatedAt int64  `json:"created_at,omitempty"`
-	UpdatedAt int64  `json:"updated_at,omitempty"`
+	ID        string                 `json:"id"`
+	Name      string                 `json:"name"`
+	State     string                 `json:"state"`
+	Source    smolvmMachineSource    `json:"source"`
+	Resources smolvmMachineResources `json:"resources"`
+	Network   *smolvmMachineNetwork  `json:"network,omitempty"`
+	Workdir   string                 `json:"workdir,omitempty"`
+	CreatedAt string                 `json:"createdAt,omitempty"`
+	UpdatedAt string                 `json:"updatedAt,omitempty"`
 }
 
 type execResult struct {
@@ -119,7 +120,7 @@ type smolvmCreateMachineRequest struct {
 
 type smolvmExecCommandRequest struct {
 	Command        any               `json:"command"` // CommandSpec accepts array or string (we pass the buildCommand script string for shell forms)
-	Workdir        string            `json:"workdir,omitempty"`
+	CWD            string            `json:"cwd,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 	Stdin          string            `json:"stdin,omitempty"`
 	Stream         bool              `json:"stream,omitempty"`
@@ -158,7 +159,25 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
 		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, base)
 	}
+	if !trustedSmolvmAPIHost(parsed) && !customSmolvmBaseURLAllowed() {
+		return nil, exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
+	}
 	return &client{apiKey: apiKey, base: strings.TrimRight(parsed.String(), "/"), http: httpClient}, nil
+}
+
+func trustedSmolvmAPIHost(parsed *url.URL) bool {
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1" ||
+		host == "smolmachines.com" || strings.HasSuffix(host, ".smolmachines.com")
+}
+
+func customSmolvmBaseURLAllowed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
@@ -238,7 +257,7 @@ func (c *client) Exec(ctx context.Context, machineID, command, folder string) (e
 		if f == "/" || f == "" {
 			f = "/workspace"
 		}
-		execReq.Workdir = f
+		execReq.CWD = f
 	}
 	if err := c.doJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(machineID)+"/exec", nil, execReq, &result); err != nil {
 		return execResult{}, err

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -1,0 +1,429 @@
+package smolvm
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type api interface {
+	CreateMachine(context.Context, createRequest) (machineData, error)
+	GetMachine(context.Context, string) (machineData, error)
+	StartMachine(context.Context, string) error
+	StopMachine(context.Context, string) error
+	DeleteMachine(context.Context, string) error
+	ListMachines(context.Context) ([]machineData, error)
+	Exec(context.Context, string, string, string) (execResult, error)
+	ExecStream(context.Context, string, string, string, io.Writer) (int, error)
+	InjectArchive(context.Context, string, string, string) error
+	WriteFile(context.Context, string, string, string) error
+}
+
+type client struct {
+	apiKey string
+	base   string
+	http   *http.Client
+}
+
+type createRequest struct {
+	Name       string                 `json:"name,omitempty"`
+	Source     smolvmMachineSource    `json:"source"`
+	Resources  smolvmMachineResources `json:"resources,omitempty"`
+	Network    *smolvmMachineNetwork  `json:"network,omitempty"`
+	Workdir    string                 `json:"workdir,omitempty"`
+	Ephemeral  bool                   `json:"ephemeral,omitempty"`
+	TTLSeconds int                    `json:"ttlSeconds,omitempty"`
+}
+
+type machineData struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	Image     string `json:"image,omitempty"`
+	CPUs      int    `json:"cpus,omitempty"`
+	MemoryMB  int    `json:"memory_mb,omitempty"`
+	CreatedAt int64  `json:"created_at,omitempty"`
+	UpdatedAt int64  `json:"updated_at,omitempty"`
+}
+
+type execResult struct {
+	// ExitCode is the canonical (camelCase) field the hosted smolfleet API
+	// returns. exitCodeSnake captures the snake_case spelling used by the
+	// local `smolvm serve` variant; Exec reconciles the two so a non-zero
+	// status is never silently dropped. (A single field can't carry two json
+	// tags — the second is ignored by encoding/json.)
+	ExitCode      int    `json:"exitCode"`
+	ExitCodeSnake int    `json:"exit_code"`
+	Stdout        string `json:"stdout"`
+	Stderr        string `json:"stderr"`
+	// stdout/stderr fallbacks for variants that use output/error keys.
+	Output string `json:"output"`
+	Error  string `json:"error"`
+}
+
+// smolvmAPIError is the structured error returned for non-2xx responses from
+// the smolfleet control plane. It is modeled after runpodAPIError / wandbAPIError
+// so that callers get consistent "API %s: body" messages and the body snippet
+// for debugging (exactly like islo's raw http error paths and runpod).
+type smolvmAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *smolvmAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+// Typed request/response shapes for the smolfleet /v1/machines API,
+// hand-written from the published OpenAPI document.
+type smolvmMachineSource struct {
+	Type      string `json:"type"`
+	Reference string `json:"reference"`
+}
+
+type smolvmMachineResources struct {
+	CPUs     int `json:"cpus,omitempty"`
+	MemoryMB int `json:"memoryMb,omitempty"`
+	DiskGB   int `json:"diskGb,omitempty"`
+}
+
+type smolvmMachineNetwork struct {
+	Mode  string   `json:"mode"`
+	CIDRs []string `json:"cidrs,omitempty"`
+}
+
+type smolvmCreateMachineRequest struct {
+	Name            string                 `json:"name,omitempty"`
+	Source          smolvmMachineSource    `json:"source"`
+	Resources       smolvmMachineResources `json:"resources,omitempty"`
+	Network         *smolvmMachineNetwork  `json:"network,omitempty"`
+	Workdir         string                 `json:"workdir,omitempty"`
+	Env             map[string]string      `json:"env,omitempty"`
+	Ephemeral       bool                   `json:"ephemeral,omitempty"`
+	TTLSeconds      int                    `json:"ttlSeconds,omitempty"`
+	AutoStopSeconds *int                   `json:"autoStopSeconds,omitempty"`
+}
+
+type smolvmExecCommandRequest struct {
+	Command        any               `json:"command"` // CommandSpec accepts array or string (we pass the buildCommand script string for shell forms)
+	Workdir        string            `json:"workdir,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Stdin          string            `json:"stdin,omitempty"`
+	Stream         bool              `json:"stream,omitempty"`
+	TimeoutSeconds *int              `json:"timeoutSeconds,omitempty"`
+}
+
+var newAPI = func(cfg Config, rt Runtime) (api, error) {
+	apiKey := strings.TrimSpace(cfg.Smolvm.APIKey)
+	if apiKey == "" {
+		return nil, exit(2, "provider=%s requires CRABBOX_SMOLVM_API_KEY, SMOLMACHINES_API_KEY, or SMK_API_KEY", providerName)
+	}
+
+	// There is no official Go SDK for the hosted smolfleet control plane
+	// (the published smolvm Go module and SDKs target the local `smolvm serve`
+	// server), so this client talks net/http directly to the documented
+	// OpenAPI, like other direct-API providers. If an official Go client
+	// appears, the transport can be swapped behind the api interface.
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	base := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), "https://api.smolmachines.com")
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return nil, exit(2, "%s url %q is invalid", providerName, base)
+	}
+	if parsed.User != nil {
+		return nil, exit(2, "%s url must not include userinfo", providerName)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, exit(2, "%s url %q is invalid", providerName, base)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, base)
+	}
+	return &client{apiKey: apiKey, base: strings.TrimRight(parsed.String(), "/"), http: httpClient}, nil
+}
+
+func isLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func (c *client) CreateMachine(ctx context.Context, req createRequest) (machineData, error) {
+	apiReq := smolvmCreateMachineRequest{
+		Name:       req.Name,
+		Source:     req.Source,
+		Resources:  req.Resources,
+		Network:    req.Network,
+		Workdir:    req.Workdir,
+		Ephemeral:  req.Ephemeral,
+		TTLSeconds: req.TTLSeconds,
+	}
+	var m machineData
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/machines", nil, apiReq, &m); err != nil {
+		return machineData{}, err
+	}
+	// Return immediately after create (state is typically "stopped"). Caller is
+	// responsible for StartMachine + waiting for ready as needed for exec/sync.
+	return m, nil
+}
+
+func createStatusReady(status string) bool {
+	switch status {
+	case "idle", "running", "ready", "started", "active", "paused":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *client) GetMachine(ctx context.Context, id string) (machineData, error) {
+	var m machineData
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/machines/"+url.PathEscape(id), nil, nil, &m); err != nil {
+		return machineData{}, err
+	}
+	return m, nil
+}
+
+func (c *client) ListMachines(ctx context.Context) ([]machineData, error) {
+	var machines []machineData
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/machines", nil, nil, &machines); err != nil {
+		return nil, err
+	}
+	return machines, nil
+}
+
+func (c *client) DeleteMachine(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/v1/machines/"+url.PathEscape(id), nil, nil, nil)
+}
+
+func (c *client) StartMachine(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(id)+"/start", nil, map[string]any{}, nil)
+}
+
+func (c *client) StopMachine(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(id)+"/stop", nil, map[string]any{}, nil)
+}
+
+func (c *client) Exec(ctx context.Context, machineID, command, folder string) (execResult, error) {
+	var result execResult
+	execReq := smolvmExecCommandRequest{
+		Command: command, // string script or argv slice; the API CommandSpec accepts either
+	}
+	if strings.TrimSpace(folder) != "" {
+		f := strings.TrimSpace(folder)
+		if !strings.HasPrefix(f, "/") {
+			f = "/" + strings.Trim(f, "/")
+		}
+		if f == "/" || f == "" {
+			f = "/workspace"
+		}
+		execReq.Workdir = f
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/machines/"+url.PathEscape(machineID)+"/exec", nil, execReq, &result); err != nil {
+		return execResult{}, err
+	}
+	// Hosted API uses exitCode; the local smolvm serve variant uses exit_code.
+	// Prefer the canonical field, fall back to snake_case so a failing command
+	// is never reported as a success.
+	if result.ExitCode == 0 && result.ExitCodeSnake != 0 {
+		result.ExitCode = result.ExitCodeSnake
+	}
+	if result.Output == "" {
+		result.Output = result.Stdout
+	}
+	if result.Error == "" {
+		result.Error = result.Stderr
+	}
+	return result, nil
+}
+
+func (c *client) ExecStream(ctx context.Context, machineID, command, folder string, stdout io.Writer) (int, error) {
+	// No native stream on this API; fall back to Exec and dump output at end.
+	result, err := c.Exec(ctx, machineID, command, folder)
+	if err != nil {
+		return 0, err
+	}
+	out := result.Stdout
+	if out == "" {
+		out = result.Output
+	}
+	if stdout != nil && out != "" {
+		_, _ = io.WriteString(stdout, out)
+	}
+	if result.Stderr != "" && stdout != nil {
+		_, _ = io.WriteString(stdout, result.Stderr)
+	}
+	return result.ExitCode, nil
+}
+
+func (c *client) InjectArchive(ctx context.Context, machineID, localPath, targetDir string) error {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return err
+	}
+	b64 := base64.StdEncoding.EncodeToString(data)
+
+	// Direct API call: embed the base64 of the tgz in a heredoc inside the exec
+	// command string sent to /exec. The guest only needs sh + base64 + tar (no
+	// Python, no "installing" anything). This is a pure direct call to the
+	// smolfleet exec API with the payload in the request body.
+	// We use a distinctive delimiter that cannot appear in base64 output.
+	const eof = "CRABBOX_SYNC_B64_EOF_9f8e7d6c5b4a"
+	absTarget := targetDir
+	if !strings.HasPrefix(absTarget, "/") {
+		absTarget = "/workspace"
+	}
+	script := fmt.Sprintf(`cat > /tmp/crabbox-sync.tgz << '%s'
+%s
+%s
+base64 -d /tmp/crabbox-sync.tgz | tar -xzf - -C %s && rm -f /tmp/crabbox-sync.tgz
+echo "smolvm-direct-archive-extract: ok"
+`, eof, b64, eof, shellQuote(absTarget))
+
+	res, err := c.Exec(ctx, machineID, script, "")
+	if err != nil {
+		return fmt.Errorf("smolvm direct archive exec: %w", err)
+	}
+	if res.ExitCode != 0 {
+		msg := strings.TrimSpace(res.Error)
+		if msg == "" {
+			msg = strings.TrimSpace(res.Output)
+		}
+		return exit(res.ExitCode, "smolvm direct archive extract: %s", msg)
+	}
+	return nil
+}
+
+func (c *client) WriteFile(ctx context.Context, machineID, remotePath, content string) error {
+	// Direct API: write small text (e.g. env profile) via heredoc in a single
+	// /exec call. Pure shell, no Python or extra interpreters required.
+	absPath := remotePath
+	if !strings.HasPrefix(absPath, "/") {
+		absPath = "/workspace/" + strings.TrimLeft(absPath, "/")
+	}
+	b64 := base64.StdEncoding.EncodeToString([]byte(content))
+	const eof = "CRABBOX_WRITE_B64_EOF_4e2d8a7c9b1f"
+	tmpPath := "/tmp/crabbox-write-" + base64.RawURLEncoding.EncodeToString([]byte(filepath.Base(absPath))) + ".b64"
+	script := fmt.Sprintf(`mkdir -p %s && cat > %s << '%s'
+%s
+%s
+base64 -d %s > %s && rm -f %s
+echo "smolvm-direct-write: ok"
+`, shellQuote(filepath.Dir(absPath)), shellQuote(tmpPath), eof, b64, eof, shellQuote(tmpPath), shellQuote(absPath), shellQuote(tmpPath))
+
+	res, err := c.Exec(ctx, machineID, script, "")
+	if err != nil {
+		return fmt.Errorf("smolvm direct write exec: %w", err)
+	}
+	if res.ExitCode != 0 {
+		msg := strings.TrimSpace(res.Error)
+		if msg == "" {
+			msg = strings.TrimSpace(res.Output)
+		}
+		return exit(res.ExitCode, "smolvm direct write: %s", msg)
+	}
+	return nil
+}
+
+func (c *client) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
+	var input io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		input = bytes.NewReader(data)
+	}
+	u := c.base + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, input)
+	if err != nil {
+		return err
+	}
+	c.addHeaders(req)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(resp)
+	}
+	if out == nil {
+		return nil
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decode smolvm response: %w", err)
+	}
+	return nil
+}
+
+func (c *client) addHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+}
+
+func apiError(resp *http.Response) error {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	msg := strings.TrimSpace(string(data))
+	if msg == "" {
+		msg = resp.Status
+	}
+	return &smolvmAPIError{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Body:       msg,
+	}
+}
+
+func commandExitError(prefix string, result execResult) error {
+	msg := strings.TrimSpace(result.Error)
+	if msg == "" {
+		msg = strings.TrimSpace(result.Output)
+	}
+	if msg == "" {
+		msg = "exit " + strconv.Itoa(result.ExitCode)
+	}
+	return exit(result.ExitCode, "%s: %s", prefix, msg)
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "404") || strings.Contains(msg, "not found")
+}

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -1,0 +1,133 @@
+package smolvm
+
+import (
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type SmolvmConfig = core.SmolvmConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type SyncManifest = core.SyncManifest
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+
+const (
+	providerName = "smolvm"
+	targetLinux  = core.TargetLinux
+
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func newLeaseID() string {
+	return core.NewLeaseID()
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellWords(words []string) []string {
+	return core.ShellWords(words)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+func now(rt Runtime) time.Time {
+	if rt.Clock != nil {
+		return rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/smolvm/flags.go
+++ b/internal/providers/smolvm/flags.go
@@ -1,0 +1,83 @@
+package smolvm
+
+import (
+	"flag"
+	"strings"
+)
+
+type flagValues struct {
+	BaseURL  *string
+	Image    *string
+	Workdir  *string
+	CPUs     *int
+	MemoryMB *int
+	Network  *string
+	Keep     *bool
+}
+
+func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return flagValues{
+		BaseURL:  fs.String("smolvm-base-url", defaults.Smolvm.BaseURL, "SmolVM / SmolFleet API base URL"),
+		Image:    fs.String("smolvm-image", defaults.Smolvm.Image, "source image for smolvm machines (e.g. ubuntu:24.04)"),
+		Workdir:  fs.String("smolvm-workdir", defaults.Smolvm.Workdir, "absolute working directory inside the smolvm machine"),
+		CPUs:     fs.Int("smolvm-cpus", defaults.Smolvm.CPUs, "number of vCPUs for the smolvm machine"),
+		MemoryMB: fs.Int("smolvm-memory-mb", defaults.Smolvm.MemoryMB, "memory in MiB for the smolvm machine"),
+		Network:  fs.String("smolvm-network", defaults.Smolvm.Network, "network mode: open or blocked"),
+		Keep:     fs.Bool("smolvm-keep", defaults.Smolvm.Keep, "keep the smolvm machine after run (do not auto-delete)"),
+	}
+}
+
+func ApplySmolvmProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if cfg.Provider == providerName || cfg.Provider == "smol" || cfg.Provider == "smolmachines" || cfg.Provider == "smolfleet" {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s; use --smolvm-cpus/--smolvm-memory-mb", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s; use --smolvm-image", providerName)
+		}
+	}
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "smolvm-base-url") {
+		cfg.Smolvm.BaseURL = *v.BaseURL
+	}
+	if flagWasSet(fs, "smolvm-image") {
+		cfg.Smolvm.Image = *v.Image
+	}
+	if flagWasSet(fs, "smolvm-workdir") {
+		cfg.Smolvm.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "smolvm-cpus") {
+		cfg.Smolvm.CPUs = *v.CPUs
+	}
+	if flagWasSet(fs, "smolvm-memory-mb") {
+		cfg.Smolvm.MemoryMB = *v.MemoryMB
+	}
+	if flagWasSet(fs, "smolvm-network") {
+		cfg.Smolvm.Network = *v.Network
+	}
+	if flagWasSet(fs, "smolvm-keep") {
+		cfg.Smolvm.Keep = *v.Keep
+	}
+	return validateConfig(*cfg)
+}
+
+func validateConfig(cfg Config) error {
+	if network := strings.TrimSpace(cfg.Smolvm.Network); network != "" {
+		switch strings.ToLower(network) {
+		case "open", "blocked", "public", "private":
+		default:
+			return exit(2, "invalid smolvm network %q (use open or blocked)", network)
+		}
+	}
+	if cpus := cfg.Smolvm.CPUs; cpus < 0 {
+		return exit(2, "smolvm cpus must be >= 0")
+	}
+	if mem := cfg.Smolvm.MemoryMB; mem < 0 {
+		return exit(2, "smolvm memory-mb must be >= 0")
+	}
+	_, err := cleanWorkdir(workdir(cfg))
+	return err
+}

--- a/internal/providers/smolvm/provider.go
+++ b/internal/providers/smolvm/provider.go
@@ -1,0 +1,54 @@
+package smolvm
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"smol", "smolmachines", "smolfleet"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "smolvm",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterSmolvmProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplySmolvmProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "smolvm doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/internal/providers/smolvm/sync.go
+++ b/internal/providers/smolvm/sync.go
@@ -1,0 +1,123 @@
+package smolvm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func (b *backend) syncWorkspace(ctx context.Context, client api, machineID string, req RunRequest, workdir, folder string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+	manifestStarted := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStarted)
+	preflightStarted := b.now()
+	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStarted)
+	prepareStarted := b.now()
+	if err := b.prepareWorkspace(ctx, client, machineID, folder, b.cfg.Sync.Delete); err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStarted)
+	archiveStarted := b.now()
+	archive, err := createSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := b.now().Sub(archiveStarted)
+	uploadStarted := b.now()
+	if err := client.InjectArchive(ctx, machineID, archive.Name(), folder); err != nil {
+		return nil, 0, fmt.Errorf("smolvm inject archive: %w", err)
+	}
+	uploadDuration := b.now().Sub(uploadStarted)
+	total := b.now().Sub(start)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "inject", Ms: uploadDuration.Milliseconds()},
+		{Name: "smolvm_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func (b *backend) prepareWorkspace(ctx context.Context, client api, machineID, folder string, delete bool) error {
+	f := strings.Trim(strings.TrimSpace(folder), "/")
+	if f == "" || strings.Contains(f, "..") {
+		// root case
+		f = "workspace"
+	}
+	absFolder := "/" + strings.Trim(f, "/")
+	if absFolder == "/" {
+		absFolder = "/workspace"
+	}
+	command := "mkdir -p " + shellQuote(absFolder)
+	if delete {
+		if absFolder == "/workspace" {
+			// safe clean for workdir root
+			command = "find /workspace -mindepth 1 -exec rm -rf {} + 2>/dev/null || rm -rf -- /workspace/* 2>/dev/null || true; mkdir -p /workspace"
+		} else {
+			command = "rm -rf " + shellQuote(absFolder) + " && " + command
+		}
+	}
+	return b.execShell(ctx, client, machineID, command, io.Discard)
+}
+
+func (b *backend) execShell(ctx context.Context, client api, machineID, command string, stdout io.Writer) error {
+	result, err := client.Exec(ctx, machineID, command, "")
+	if err != nil {
+		return fmt.Errorf("smolvm exec %q: %w", command, err)
+	}
+	if stdout != nil && result.Output != "" {
+		_, _ = io.WriteString(stdout, result.Output)
+	}
+	if result.ExitCode != 0 {
+		return commandExitError("smolvm exec "+command, result)
+	}
+	return nil
+}
+
+func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
+	var input bytes.Buffer
+	input.Write(manifest.NUL())
+	archive, err := os.CreateTemp("", "crabbox-smolvm-sync-*.tgz")
+	if err != nil {
+		return nil, fmt.Errorf("create sync archive temp file: %w", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := archive.Name()
+			_ = archive.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
+	cmd.Stdin = &input
+	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
+	cmd.Stdout = archive
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, exit(6, "create sync archive: %v", err)
+	}
+	keep = true
+	return archive, nil
+}


### PR DESCRIPTION
## Summary

Adds full support for the **smolvm** (Smol Machines / smolfleet) provider as a delegated-run sandbox.

- Implements https://github.com/openclaw/crabbox/issues/218
- Uses the hosted smolfleet REST API (`https://api.smolmachines.com`) with `smk_*` / `SMOLMACHINES_API_KEY` bearer tokens.
- Complete delegated lifecycle: `run`, `warmup`, `stop`, `list`, `status`, `doctor`.
- **Archive sync and file writes use direct API calls only** (`/exec` with heredoc + base64 payload). No Python, no guest interpreters, no "installing" anything — only standard `sh` + `base64` + `tar` (works on default `alpine` and most Linux images).
- Config via flags (`--smolvm-image`, `--smolvm-workdir`, etc.), env vars, and `.crabbox.yaml` / user config.
- Aliases: `smol`, `smolmachines`, `smolfleet`.
- Follows patterns from `islo`, `exe.dev`, `wandb`, `runpod` (typed requests, clean error types, direct client, test seam via `api` interface).

## Verification

- `go test -race ./internal/providers/smolvm` + build/vet pass.
- Live end-to-end with provided key (multiple runs, sync + exec, cleanup).
- Zero machines left open after runs.
- `crabbox doctor --provider smolvm` and `providers` list work.
- Default image is now lightweight `alpine`.

## Test plan

- [x] New provider package + unit tests (fakes + HTTP shape)
- [x] Integration with core (config, registration, run/warmup paths)
- [x] Docs + README + CHANGELOG
- [x] Live smoke with real API key (alpine image, direct sync)
- [x] No lingering resources

Co-authored-by: Grok (multi-subagent implementation)
