### PR TITLE
fix(worker): fail closed on invalid SSH CIDRs

### DIFF
--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -6,7 +6,7 @@ import {
   awsPromotedAMIConfigKey,
   awsInstanceTypeCandidatesForTargetClass,
   sshPorts,
-  validCIDRs,
+  validatedCIDRs,
   type LeaseConfig,
 } from "./config";
 import { osImageSpec } from "./os-image";
@@ -1626,7 +1626,7 @@ export class EC2SpotClient {
 
 function awsSSHCIDRs(config: LeaseConfig, env: Env): string[] {
   const configured = [...config.awsSSHCIDRs, ...(env.CRABBOX_AWS_SSH_CIDRS ?? "").split(",")];
-  const cidrs = validCIDRs(configured);
+  const cidrs = validatedCIDRs(configured, "CRABBOX_AWS_SSH_CIDRS");
   if (cidrs.length === 0) {
     throw new Error(
       "AWS SSH source CIDR is required; set CRABBOX_AWS_SSH_CIDRS or use Cloudflare request IP forwarding",

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -4,6 +4,7 @@ import {
   azureSupportsEphemeralOS,
   azureVMSizeCandidatesForTargetClass,
   sshPorts,
+  validatedCIDRs,
   type LeaseConfig,
 } from "./config";
 import { leaseProviderLabels } from "./provider-labels";
@@ -146,10 +147,10 @@ export class AzureClient {
     this.subnet = env.CRABBOX_AZURE_SUBNET?.trim() || "crabbox-subnet";
     this.nsg = options.nsg || env.CRABBOX_AZURE_NSG?.trim() || "crabbox-nsg";
     this.image = env.CRABBOX_AZURE_IMAGE?.trim() || DEFAULT_AZURE_LINUX_IMAGE;
-    this.sshCIDRs = (env.CRABBOX_AZURE_SSH_CIDRS ?? "")
-      .split(",")
-      .map((value) => value.trim())
-      .filter(Boolean);
+    this.sshCIDRs = validatedCIDRs(
+      (env.CRABBOX_AZURE_SSH_CIDRS ?? "").split(","),
+      "CRABBOX_AZURE_SSH_CIDRS",
+    );
     if (this.sshCIDRs.length === 0) this.sshCIDRs.push("0.0.0.0/0");
     this.defaultLocation = options.location || env.CRABBOX_AZURE_LOCATION?.trim() || "eastus";
     this.deferredCleanup = options.deferredCleanup;

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -180,8 +180,14 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   }
   const ttlSeconds = clampTTL(input.ttlSeconds ?? 5400);
   const idleTimeoutSeconds = clampIdleTimeout(input.idleTimeoutSeconds ?? 1800);
-  const awsSSHCIDRs = validatedCIDRs(input.awsSSHCIDRs ?? [], "awsSSHCIDRs");
-  const gcpSSHCIDRs = validatedCIDRs(input.gcpSSHCIDRs ?? [], "gcpSSHCIDRs");
+  const awsSSHCIDRs =
+    provider === "aws"
+      ? validatedCIDRs(input.awsSSHCIDRs ?? [], "awsSSHCIDRs")
+      : validCIDRs(input.awsSSHCIDRs ?? []);
+  const gcpSSHCIDRs =
+    provider === "gcp"
+      ? validatedCIDRs(input.gcpSSHCIDRs ?? [], "gcpSSHCIDRs")
+      : validCIDRs(input.gcpSSHCIDRs ?? []);
   const sshPublicKey = input.sshPublicKey?.trim() ?? "";
   if (!sshPublicKey) {
     throw new Error("sshPublicKey is required");

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -180,6 +180,8 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   }
   const ttlSeconds = clampTTL(input.ttlSeconds ?? 5400);
   const idleTimeoutSeconds = clampIdleTimeout(input.idleTimeoutSeconds ?? 1800);
+  const awsSSHCIDRs = validatedCIDRs(input.awsSSHCIDRs ?? [], "awsSSHCIDRs");
+  const gcpSSHCIDRs = validatedCIDRs(input.gcpSSHCIDRs ?? [], "gcpSSHCIDRs");
   const sshPublicKey = input.sshPublicKey?.trim() ?? "";
   if (!sshPublicKey) {
     throw new Error("sshPublicKey is required");
@@ -221,7 +223,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     awsSubnetID: input.awsSubnetID ?? "",
     awsProfile: input.awsProfile ?? "",
     awsRootGB: input.awsRootGB ?? 400,
-    awsSSHCIDRs: validCIDRs(input.awsSSHCIDRs ?? []),
+    awsSSHCIDRs,
     awsMacHostID: input.awsMacHostID ?? "",
     azureLocation: input.azureLocation ?? "",
     azureImage:
@@ -241,7 +243,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     gcpNetwork: input.gcpNetwork ?? "",
     gcpSubnet: input.gcpSubnet ?? "",
     gcpTags: uniqueStrings(input.gcpTags ?? []),
-    gcpSSHCIDRs: validCIDRs(input.gcpSSHCIDRs ?? []),
+    gcpSSHCIDRs,
     gcpRootGB: input.gcpRootGB ?? 0,
     gcpServiceAccount: input.gcpServiceAccount ?? "",
     capacityMarket: input.capacity?.market ?? "spot",
@@ -515,11 +517,69 @@ export function sshPorts(config: Pick<LeaseConfig, "sshPort" | "sshFallbackPorts
 
 export function validCIDRs(values: string[]): string[] {
   const cidrs = values.map((value) => value.trim()).filter(Boolean);
-  return cidrs.filter(
-    (cidr) =>
-      /^(\d{1,3}\.){3}\d{1,3}\/([0-9]|[1-2][0-9]|3[0-2])$/.test(cidr) ||
-      /^[0-9a-f:]+\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$/i.test(cidr),
+  return cidrs.filter(isValidCIDR);
+}
+
+function validatedCIDRs(values: string[], fieldName: string): string[] {
+  const cidrs = values.map((value) => value.trim()).filter(Boolean);
+  const valid = cidrs.filter(isValidCIDR);
+  if (valid.length !== cidrs.length) {
+    throw new Error(`${fieldName} entries must be valid IPv4 or IPv6 CIDR ranges`);
+  }
+  return valid;
+}
+
+function isValidCIDR(cidr: string): boolean {
+  const firstSlash = cidr.indexOf("/");
+  if (firstSlash <= 0 || firstSlash !== cidr.lastIndexOf("/")) {
+    return false;
+  }
+  const address = cidr.slice(0, firstSlash);
+  const prefixText = cidr.slice(firstSlash + 1);
+  if (!/^[0-9]+$/.test(prefixText)) {
+    return false;
+  }
+  const prefix = Number(prefixText);
+  if (address.includes(":")) {
+    return prefix >= 0 && prefix <= 128 && isValidIPv6Address(address);
+  }
+  return prefix >= 0 && prefix <= 32 && isValidIPv4Address(address);
+}
+
+function isValidIPv4Address(address: string): boolean {
+  const parts = address.split(".");
+  return (
+    parts.length === 4 &&
+    parts.every((part) => {
+      if (!/^[0-9]{1,3}$/.test(part)) {
+        return false;
+      }
+      const octet = Number(part);
+      return Number.isInteger(octet) && octet >= 0 && octet <= 255;
+    })
   );
+}
+
+function isValidIPv6Address(address: string): boolean {
+  if (!/^[0-9A-Fa-f:.]+$/.test(address)) {
+    return false;
+  }
+  if (["[", "]", "@", "/", "?", "#"].some((delimiter) => address.includes(delimiter))) {
+    return false;
+  }
+  try {
+    const parsed = new URL(`http://[${address}]/`);
+    return (
+      parsed.hostname !== "" &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.search === "" &&
+      parsed.hash === "" &&
+      parsed.pathname === "/"
+    );
+  } catch {
+    return false;
+  }
 }
 
 function validPorts(values: string[]): string[] {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -526,7 +526,7 @@ export function validCIDRs(values: string[]): string[] {
   return cidrs.filter(isValidCIDR);
 }
 
-function validatedCIDRs(values: string[], fieldName: string): string[] {
+export function validatedCIDRs(values: string[], fieldName: string): string[] {
   const cidrs = values.map((value) => value.trim()).filter(Boolean);
   const valid = cidrs.filter(isValidCIDR);
   if (valid.length !== cidrs.length) {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -1,5 +1,10 @@
 import { cloudInit } from "./bootstrap";
-import { gcpMachineTypeCandidatesForClass, sshPorts, validCIDRs, type LeaseConfig } from "./config";
+import {
+  gcpMachineTypeCandidatesForClass,
+  sshPorts,
+  validatedCIDRs,
+  type LeaseConfig,
+} from "./config";
 import { leaseProviderLabels } from "./provider-labels";
 import { leaseProviderName } from "./slug";
 import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
@@ -79,7 +84,10 @@ export class GCPClient {
     this.network = env.CRABBOX_GCP_NETWORK?.trim() || "default";
     this.subnet = env.CRABBOX_GCP_SUBNET?.trim() || "";
     this.tags = uniqueStrings((env.CRABBOX_GCP_TAGS ?? "crabbox-ssh").split(","));
-    this.sshCIDRs = validCIDRs((env.CRABBOX_GCP_SSH_CIDRS ?? "").split(","));
+    this.sshCIDRs = validatedCIDRs(
+      (env.CRABBOX_GCP_SSH_CIDRS ?? "").split(","),
+      "CRABBOX_GCP_SSH_CIDRS",
+    );
     if (this.sshCIDRs.length === 0) this.sshCIDRs.push("0.0.0.0/0");
     this.rootGB = numberFromEnv(env.CRABBOX_GCP_ROOT_GB, 400);
     this.serviceAccount = env.CRABBOX_GCP_SERVICE_ACCOUNT?.trim() || "";

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -120,6 +120,45 @@ describe("aws provider", () => {
     );
   });
 
+  it("rejects invalid configured AWS SSH CIDRs before changing ingress", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push(typeof init?.body === "string" ? init.body : String(input));
+        return new Response(
+          `<DescribeSecurityGroupsResponse>
+  <securityGroupInfo>
+    <item>
+      <groupId>sg-123</groupId>
+      <ipPermissions/>
+    </item>
+  </securityGroupInfo>
+</DescribeSecurityGroupsResponse>`,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+        CRABBOX_AWS_SSH_CIDRS: "999.999.999.999/32",
+      } as never,
+      "us-east-1",
+    );
+
+    await expect(
+      client.refreshSSHIngress(
+        leaseConfig({
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+      ),
+    ).rejects.toThrow("CRABBOX_AWS_SSH_CIDRS entries must be valid");
+    expect(calls).toHaveLength(1);
+  });
+
   it("waits through transient EC2 instance visibility after RunInstances", async () => {
     vi.useFakeTimers();
     const client = new EC2SpotClient(

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -448,6 +448,12 @@ describe("azure provider", () => {
     expect(client.defaultLocation).toBe("eastus");
   });
 
+  it("rejects invalid configured Azure SSH CIDRs", () => {
+    expect(
+      () => new AzureClient({ ...baseEnv, CRABBOX_AZURE_SSH_CIDRS: "999.999.999.999/32" }),
+    ).toThrow("CRABBOX_AZURE_SSH_CIDRS entries must be valid");
+  });
+
   it("creates Windows VMs with Windows OS profile and bootstrap extension", async () => {
     const client = new AzureClient(baseEnv);
     const bodies: unknown[] = [];

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -17,6 +17,7 @@ import {
   serverTypeForClass,
   serverTypeForProviderClass,
   sshPorts,
+  validCIDRs,
 } from "../src/config";
 
 describe("machine class config", () => {
@@ -232,6 +233,76 @@ describe("lease config", () => {
     expect(config.browser).toBe(false);
     expect(config.code).toBe(false);
     expect(config.ttlSeconds).toBe(86_400);
+    expect(leaseConfig({ sshPublicKey: "ssh-ed25519 test", ttlSeconds: 0 }).ttlSeconds).toBe(5400);
+    expect(leaseConfig({ sshPublicKey: "ssh-ed25519 test", ttlSeconds: -1 }).ttlSeconds).toBe(5400);
+    expect(leaseConfig({ sshPublicKey: "ssh-ed25519 test", ttlSeconds: 42.9 }).ttlSeconds).toBe(42);
+    expect(
+      leaseConfig({ sshPublicKey: "ssh-ed25519 test", idleTimeoutSeconds: 0 }).idleTimeoutSeconds,
+    ).toBe(1800);
+    expect(
+      leaseConfig({ sshPublicKey: "ssh-ed25519 test", idleTimeoutSeconds: -1 }).idleTimeoutSeconds,
+    ).toBe(1800);
+    expect(
+      leaseConfig({ sshPublicKey: "ssh-ed25519 test", idleTimeoutSeconds: 999_999 })
+        .idleTimeoutSeconds,
+    ).toBe(86_400);
+    expect(
+      leaseConfig({ sshPublicKey: "ssh-ed25519 test", idleTimeoutSeconds: 42.9 })
+        .idleTimeoutSeconds,
+    ).toBe(42);
+  });
+
+  it("filters invalid SSH CIDR values before provider config", () => {
+    expect(
+      validCIDRs([
+        " 203.0.113.7/32 ",
+        "0.0.0.0/0",
+        "255.255.255.255/32",
+        "2001:db8::1/128",
+        "::/0",
+        "999.999.999.999/32",
+        "256.0.0.1/32",
+        "1.2.3/24",
+        "1.2.3.4.5/24",
+        "203.0.113.7/33",
+        "203.0.113.7/-1",
+        "203.0.113.7/x",
+        "203.0.113.7",
+        "203.0.113.7/32/extra",
+        "::::/128",
+        "::1]#junk/128",
+        "::1]@[::2/128",
+        "::\n1/128",
+        "2001:db8::\t1/128",
+        "2001:db8::1/129",
+        "2001:db8::1/-1",
+        "2001:db8::1/x",
+        "not-a-cidr",
+      ]),
+    ).toEqual(["203.0.113.7/32", "0.0.0.0/0", "255.255.255.255/32", "2001:db8::1/128", "::/0"]);
+
+    const config = leaseConfig({
+      provider: "aws",
+      sshPublicKey: "ssh-ed25519 test",
+      awsSSHCIDRs: ["198.51.100.77/32"],
+      gcpSSHCIDRs: ["2001:db8::2/128"],
+    });
+    expect(config.awsSSHCIDRs).toEqual(["198.51.100.77/32"]);
+    expect(config.gcpSSHCIDRs).toEqual(["2001:db8::2/128"]);
+    expect(() =>
+      leaseConfig({
+        provider: "aws",
+        sshPublicKey: "ssh-ed25519 test",
+        awsSSHCIDRs: ["198.51.100.77/32", "999.999.999.999/32"],
+      }),
+    ).toThrow("awsSSHCIDRs entries must be valid");
+    expect(() =>
+      leaseConfig({
+        provider: "gcp",
+        sshPublicKey: "ssh-ed25519 test",
+        gcpSSHCIDRs: ["::::/128"],
+      }),
+    ).toThrow("gcpSSHCIDRs entries must be valid");
   });
 
   it("allows capacity hints to be disabled per lease", () => {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -303,6 +303,30 @@ describe("lease config", () => {
         gcpSSHCIDRs: ["::::/128"],
       }),
     ).toThrow("gcpSSHCIDRs entries must be valid");
+    expect(
+      leaseConfig({
+        provider: "gcp",
+        sshPublicKey: "ssh-ed25519 test",
+        awsSSHCIDRs: ["999.999.999.999/32", "198.51.100.77/32"],
+        gcpSSHCIDRs: ["2001:db8::2/128"],
+      }).awsSSHCIDRs,
+    ).toEqual(["198.51.100.77/32"]);
+    expect(
+      leaseConfig({
+        provider: "aws",
+        sshPublicKey: "ssh-ed25519 test",
+        awsSSHCIDRs: ["198.51.100.77/32"],
+        gcpSSHCIDRs: ["::::/128", "2001:db8::2/128"],
+      }).gcpSSHCIDRs,
+    ).toEqual(["2001:db8::2/128"]);
+    expect(
+      leaseConfig({
+        provider: "hetzner",
+        sshPublicKey: "ssh-ed25519 test",
+        awsSSHCIDRs: ["999.999.999.999/32"],
+        gcpSSHCIDRs: ["::::/128"],
+      }),
+    ).toMatchObject({ awsSSHCIDRs: [], gcpSSHCIDRs: [] });
   });
 
   it("allows capacity hints to be disabled per lease", () => {

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -33,6 +33,12 @@ describe("gcp provider", () => {
     expect(new GCPClient(env, undefined, "request-project").project).toBe("request-project");
   });
 
+  it("rejects invalid configured GCP SSH CIDRs", () => {
+    expect(() => new GCPClient({ ...env, CRABBOX_GCP_SSH_CIDRS: "::::/128" })).toThrow(
+      "CRABBOX_GCP_SSH_CIDRS entries must be valid",
+    );
+  });
+
   it("lists Crabbox machines across aggregated GCP zones", async () => {
     const client = new GCPClient(env);
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {


### PR DESCRIPTION
## Summary
- validate configured AWS and GCP SSH CIDR lists before building Worker lease config
- reject malformed non-empty CIDR entries instead of silently allowing a configured list to collapse to provider defaults
- tighten IPv4/IPv6 CIDR parsing and add regression coverage from a focused mutation campaign

## Compatibility / Security Note
This intentionally changes malformed `awsSSHCIDRs` and `gcpSSHCIDRs` lease input from best-effort filtering to fail-closed request validation. Splitting this from the Docker Sandbox provider PR keeps the upgrade-visible Worker behavior change reviewable on its own.

Related split from https://github.com/openclaw/crabbox/pull/221.

## Mutation Evidence
A focused StrykerJS campaign against `worker/src/config.ts` exposed the malformed CIDR handling path. The final local report after the fix was retained at `/tmp/crabbox-mutation-reports/stryker-config-final3-20260606-042606/stryker-config.json`.

## Verification
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `git diff --check`