### PR TITLE
fix(local-container): mount bootstrap directory instead of single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - Fixed malformed AWS, Azure, and GCP SSH CIDR configuration to fail closed instead of falling back to broad SSH access. Thanks @coygeek.
-- Fixed local-container warmup on Windows by mounting the generated bootstrap script instead of passing it inline to Docker. Thanks @anagnorisis2peripeteia.
+- Fixed local-container warmup on Windows by mounting the generated bootstrap directory instead of passing the script inline to Docker. Thanks @anagnorisis2peripeteia.
 - Fixed brokered Azure lease creation to persist in-flight leases before VM provisioning, keep failed creates visible, and sweep orphaned Azure VMs from coordinator maintenance. Fixes https://github.com/openclaw/crabbox/issues/215.
 - Fixed brokered lease release races so leases released while provisioning cannot be reactivated or lose cleanup retry state.
 - Fixed Islo provider status, streaming exec, archive upload, share, and delete handling for the current Islo API contract. Thanks @zozo123.

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -98,30 +98,33 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	cleanupContainer := func() {
+		if req.Keep {
+			return
+		}
+		if c, inspErr := b.inspectContainer(context.Background(), containerID); inspErr == nil {
+			if bd := strings.TrimSpace(c.Config.Labels["bootstrap_dir"]); bd != "" && trustedBootstrapDir(bd) {
+				_ = os.RemoveAll(bd)
+			}
+		}
+		_ = b.removeContainer(context.Background(), containerID)
+	}
 	container, err := b.inspectContainer(ctx, containerID)
 	if err != nil {
-		if !req.Keep {
-			_ = b.removeContainer(context.Background(), containerID)
-		}
+		cleanupContainer()
 		return core.LeaseTarget{}, err
 	}
 	lease, err := b.prepareLease(ctx, cfg, container, leaseID, slug, true)
 	if err != nil {
-		if !req.Keep {
-			_ = b.removeContainer(context.Background(), containerID)
-		}
+		cleanupContainer()
 		return core.LeaseTarget{}, err
 	}
 	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, b.claimScope(ctx), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		if !req.Keep {
-			_ = b.removeContainer(context.Background(), containerID)
-		}
+		cleanupContainer()
 		return core.LeaseTarget{}, err
 	}
 	if err := core.UpdateLeaseClaimCacheVolumes(leaseID, core.CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
-		if !req.Keep {
-			_ = b.removeContainer(context.Background(), containerID)
-		}
+		cleanupContainer()
 		return core.LeaseTarget{}, err
 	}
 	cleanupKey = false
@@ -204,7 +207,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if hostLeaseRoot != "" {
 		cleanupErr = os.RemoveAll(hostLeaseRoot)
 	}
-	if bootstrapDir != "" {
+	if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
 		if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
 			cleanupErr = err
 		}
@@ -262,7 +265,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			cleanupErr = os.RemoveAll(hostLeaseRoot)
 		}
 		bootstrapDir := strings.TrimSpace(server.Labels["bootstrap_dir"])
-		if bootstrapDir != "" {
+		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
 			if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
 				cleanupErr = err
 			}
@@ -993,6 +996,19 @@ func safeLocalContainerLeaseID(leaseID string) bool {
 		return false
 	}
 	return true
+}
+
+func trustedBootstrapDir(dir string) bool {
+	dir = filepath.Clean(dir)
+	if !filepath.IsAbs(dir) {
+		return false
+	}
+	base := filepath.Base(dir)
+	if !strings.HasPrefix(base, "crabbox-bootstrap-") {
+		return false
+	}
+	parent := filepath.Dir(dir)
+	return parent == filepath.Clean(os.TempDir())
 }
 
 func trustedLocalContainerWorkRoot(root string) bool {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -196,12 +196,18 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		return core.Exit(2, "provider=%s release requires a container id", providerName)
 	}
 	hostLeaseRoot := hostLeaseWorkRoot(lease)
+	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
 	if err := b.removeContainer(ctx, id); err != nil {
 		return err
 	}
 	var cleanupErr error
 	if hostLeaseRoot != "" {
 		cleanupErr = os.RemoveAll(hostLeaseRoot)
+	}
+	if bootstrapDir != "" {
+		if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
+			cleanupErr = err
+		}
 	}
 	core.RemoveLeaseClaim(lease.LeaseID)
 	core.RemoveStoredTestboxKey(lease.LeaseID)
@@ -254,6 +260,12 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		hostLeaseRoot := hostLeaseWorkRootFromLabels(leaseID, server.Labels)
 		if hostLeaseRoot != "" {
 			cleanupErr = os.RemoveAll(hostLeaseRoot)
+		}
+		bootstrapDir := strings.TrimSpace(server.Labels["bootstrap_dir"])
+		if bootstrapDir != "" {
+			if err := os.RemoveAll(bootstrapDir); err != nil && cleanupErr == nil {
+				cleanupErr = err
+			}
 		}
 		if leaseID != "" {
 			core.RemoveLeaseClaim(leaseID)
@@ -449,26 +461,26 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	for _, mount := range cacheVolumeMounts {
 		args = append(args, "-v", mount)
 	}
-	bootstrapFile, err := os.CreateTemp("", "crabbox-bootstrap-*.sh")
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-*")
 	if err != nil {
-		return "", core.Exit(2, "create bootstrap script file: %v", err)
+		return "", core.Exit(2, "create bootstrap script directory: %v", err)
 	}
-	defer os.Remove(bootstrapFile.Name())
-	if _, err := bootstrapFile.WriteString(bootstrapScript); err != nil {
-		bootstrapFile.Close()
+	bootstrapPath := filepath.Join(bootstrapDir, "bootstrap.sh")
+	if err := os.WriteFile(bootstrapPath, []byte(bootstrapScript), 0o644); err != nil {
+		os.RemoveAll(bootstrapDir)
 		return "", core.Exit(2, "write bootstrap script: %v", err)
 	}
-	if err := bootstrapFile.Close(); err != nil {
-		return "", core.Exit(2, "close bootstrap script: %v", err)
-	}
-	args = append(args, "-v", bootstrapFile.Name()+":/tmp/crabbox-bootstrap.sh:ro")
-	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "/tmp/crabbox-bootstrap.sh")
+	args = append(args, "--label", "bootstrap_dir="+bootstrapDir)
+	args = append(args, "-v", bootstrapDir+":/tmp/crabbox-bootstrap:ro")
+	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "/tmp/crabbox-bootstrap/bootstrap.sh")
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
+		os.RemoveAll(bootstrapDir)
 		return "", commandError("container run", result, err)
 	}
 	id := strings.TrimSpace(result.Stdout)
 	if id == "" {
+		os.RemoveAll(bootstrapDir)
 		return "", core.Exit(2, "%s run did not return a container id", cfg.LocalContainer.Runtime)
 	}
 	return id, nil

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -94,7 +94,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	cfg.SSHKey = keyPath
 	name := core.LeaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s runtime=%s image=%s keep=%v\n", providerName, leaseID, slug, cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, req.Keep)
-	containerID, err := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
+	containerID, bootstrapDir, err := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -102,10 +102,8 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		if req.Keep {
 			return
 		}
-		if c, inspErr := b.inspectContainer(context.Background(), containerID); inspErr == nil {
-			if bd := strings.TrimSpace(c.Config.Labels["bootstrap_dir"]); bd != "" && trustedBootstrapDir(bd) {
-				_ = os.RemoveAll(bd)
-			}
+		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+			_ = os.RemoveAll(bootstrapDir)
 		}
 		_ = b.removeContainer(context.Background(), containerID)
 	}
@@ -313,7 +311,7 @@ func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, 
 	}
 	original := server.Labels
 	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
-	for _, key := range []string{"container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"} {
+	for _, key := range []string{"bootstrap_dir", "container_id", "docker_socket", "host_work_root", "image", "runtime", "runtime_context", "ssh_port", "ssh_user", "work_root"} {
 		if value := strings.TrimSpace(original[key]); value != "" {
 			server.Labels[key] = value
 		}
@@ -391,7 +389,7 @@ func applyDefaults(cfg *core.Config) {
 	cfg.ServerType = cfg.LocalContainer.Image
 }
 
-func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, error) {
+func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, string, error) {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["runtime"] = cfg.LocalContainer.Runtime
 	labels["image"] = cfg.LocalContainer.Image
@@ -407,7 +405,7 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	labels["work_root"] = containerWorkRoot
 	cacheVolumeMounts, err := localContainerCacheVolumeMounts(cfg.Cache.Volumes)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	args := []string{
 		"run", "-d",
@@ -439,22 +437,22 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	}
 	if cfg.LocalContainer.DockerSocket {
 		if err := os.MkdirAll(hostWorkRoot, 0o755); err != nil {
-			return "", core.Exit(2, "create local-container host work root %s: %v", hostWorkRoot, err)
+			return "", "", core.Exit(2, "create local-container host work root %s: %v", hostWorkRoot, err)
 		}
 		if err := markLocalContainerWorkRoot(hostWorkRoot); err != nil {
-			return "", core.Exit(2, "mark local-container host work root %s: %v", hostWorkRoot, err)
+			return "", "", core.Exit(2, "mark local-container host work root %s: %v", hostWorkRoot, err)
 		}
 		leaseWorkRoot := filepath.Join(hostWorkRoot, leaseID)
 		if err := os.MkdirAll(leaseWorkRoot, 0o777); err != nil {
-			return "", core.Exit(2, "create local-container host lease work root %s: %v", leaseWorkRoot, err)
+			return "", "", core.Exit(2, "create local-container host lease work root %s: %v", leaseWorkRoot, err)
 		}
 		if err := os.Chmod(leaseWorkRoot, 0o777); err != nil {
-			return "", core.Exit(2, "make local-container host lease work root writable %s: %v", leaseWorkRoot, err)
+			return "", "", core.Exit(2, "make local-container host lease work root writable %s: %v", leaseWorkRoot, err)
 		}
 		args = append(args, "-v", hostWorkRoot+":"+containerWorkRoot)
 		socketPath, err := b.dockerSocketMountPath(ctx)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		args = append(args, "-v", socketPath+":"+dockerSocketInGuest)
 		if isPodmanRuntime(cfg.LocalContainer.Runtime) {
@@ -466,12 +464,12 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	}
 	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-*")
 	if err != nil {
-		return "", core.Exit(2, "create bootstrap script directory: %v", err)
+		return "", "", core.Exit(2, "create bootstrap script directory: %v", err)
 	}
 	bootstrapPath := filepath.Join(bootstrapDir, "bootstrap.sh")
 	if err := os.WriteFile(bootstrapPath, []byte(bootstrapScript), 0o644); err != nil {
 		os.RemoveAll(bootstrapDir)
-		return "", core.Exit(2, "write bootstrap script: %v", err)
+		return "", "", core.Exit(2, "write bootstrap script: %v", err)
 	}
 	args = append(args, "--label", "bootstrap_dir="+bootstrapDir)
 	args = append(args, "-v", bootstrapDir+":/tmp/crabbox-bootstrap:ro")
@@ -479,14 +477,14 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
 		os.RemoveAll(bootstrapDir)
-		return "", commandError("container run", result, err)
+		return "", "", commandError("container run", result, err)
 	}
 	id := strings.TrimSpace(result.Stdout)
 	if id == "" {
 		os.RemoveAll(bootstrapDir)
-		return "", core.Exit(2, "%s run did not return a container id", cfg.LocalContainer.Runtime)
+		return "", "", core.Exit(2, "%s run did not return a container id", cfg.LocalContainer.Runtime)
 	}
-	return id, nil
+	return id, bootstrapDir, nil
 }
 
 func localContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string, error) {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -23,6 +23,7 @@ const (
 	sshPort             = "2222"
 	workRootMarkerName  = ".crabbox-local-container-work-root"
 	dockerSocketInGuest = "/var/run/docker.sock"
+	rollbackTimeout     = 10 * time.Second
 )
 
 type backend struct {
@@ -96,16 +97,21 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s runtime=%s image=%s keep=%v\n", providerName, leaseID, slug, cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, req.Keep)
 	containerID, bootstrapDir, err := b.createContainer(ctx, cfg, name, leaseID, slug, publicKey, req.Keep)
 	if err != nil {
+		if req.Keep && containerID != "" {
+			cleanupKey = false
+		}
 		return core.LeaseTarget{}, err
 	}
 	cleanupContainer := func() {
 		if req.Keep {
 			return
 		}
+		if err := b.removeContainer(context.Background(), containerID); err != nil {
+			return
+		}
 		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
 			_ = os.RemoveAll(bootstrapDir)
 		}
-		_ = b.removeContainer(context.Background(), containerID)
 	}
 	container, err := b.inspectContainer(ctx, containerID)
 	if err != nil {
@@ -476,12 +482,36 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 	args = append(args, cfg.LocalContainer.Image, "/bin/sh", "/tmp/crabbox-bootstrap/bootstrap.sh")
 	result, err := b.docker(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
-		os.RemoveAll(bootstrapDir)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+		defer cancel()
+		containerID, owned, inspectErr := b.ownedContainerID(cleanupCtx, leaseID, bootstrapDir)
+		if owned && keep {
+			return containerID, bootstrapDir, commandError("container run", result, err)
+		}
+		if owned {
+			if removeErr := b.removeContainer(cleanupCtx, containerID); removeErr == nil {
+				os.RemoveAll(bootstrapDir)
+			}
+		} else if inspectErr == nil {
+			os.RemoveAll(bootstrapDir)
+		}
 		return "", "", commandError("container run", result, err)
 	}
 	id := strings.TrimSpace(result.Stdout)
 	if id == "" {
-		os.RemoveAll(bootstrapDir)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+		defer cancel()
+		containerID, owned, inspectErr := b.ownedContainerID(cleanupCtx, leaseID, bootstrapDir)
+		if owned {
+			return containerID, bootstrapDir, nil
+		}
+		if inspectErr == nil {
+			os.RemoveAll(bootstrapDir)
+		} else if !keep {
+			if removeErr := b.removeContainer(cleanupCtx, name); removeErr == nil {
+				os.RemoveAll(bootstrapDir)
+			}
+		}
 		return "", "", core.Exit(2, "%s run did not return a container id", cfg.LocalContainer.Runtime)
 	}
 	return id, bootstrapDir, nil
@@ -766,6 +796,29 @@ func (b *backend) removeContainer(ctx context.Context, id string) error {
 		return commandError("container remove", result, err)
 	}
 	return nil
+}
+
+func (b *backend) ownedContainerID(ctx context.Context, leaseID, bootstrapDir string) (string, bool, error) {
+	result, err := b.docker(ctx, []string{"ps", "-aq", "--filter", "label=lease=" + leaseID}, nil, nil)
+	if err != nil {
+		return "", false, err
+	}
+	for _, id := range strings.Fields(result.Stdout) {
+		container, err := b.inspectContainer(ctx, id)
+		if err != nil {
+			return "", false, err
+		}
+		labels := container.Config.Labels
+		if labels["lease"] != leaseID || labels["bootstrap_dir"] != bootstrapDir {
+			continue
+		}
+		containerID := strings.TrimSpace(container.ID)
+		if containerID == "" {
+			containerID = id
+		}
+		return containerID, true, nil
+	}
+	return "", false, nil
 }
 
 func (b *backend) runtimeInfo(ctx context.Context) (string, string) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -109,7 +109,7 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 	cfg := b.configForRun()
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	id, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	id, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestCreateContainerPassesDesktopEnv(t *testing.T) {
 	cfg.DesktopEnv = "wayland"
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	if _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
+	if _, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
 		t.Fatal(err)
 	}
 	args := recordedArgsForCommand(t, runner, "run")
@@ -281,7 +281,7 @@ func TestCreateContainerMountsCacheVolumes(t *testing.T) {
 	}
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	if _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
+	if _, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err != nil {
 		t.Fatal(err)
 	}
 	args := recordedArgsForCommand(t, runner, "run")
@@ -327,7 +327,7 @@ func TestCreateContainerCanMountDockerSocket(t *testing.T) {
 	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	_, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	_, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestCreateContainerMountsDockerHostUnixSocket(t *testing.T) {
 	rootMode := rootInfo.Mode().Perm()
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	_, err = b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	_, _, err = b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestCreateContainerMountsPodmanSocketWithSecurityOpt(t *testing.T) {
 	cfg.WorkRoot = cfg.LocalContainer.WorkRoot
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	_, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	_, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -778,10 +778,12 @@ func TestListAndResolveContainers(t *testing.T) {
 
 func TestTouchPreservesLocalContainerLabels(t *testing.T) {
 	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	bootstrapDir := filepath.Join(os.TempDir(), "crabbox-bootstrap-touchtest")
 	lease := core.LeaseTarget{
 		LeaseID: "cbx_touch",
 		Server: core.Server{
 			Labels: map[string]string{
+				"bootstrap_dir":  bootstrapDir,
 				"docker_socket":  "1",
 				"host_work_root": "/tmp/crabbox-local-container-work",
 				"work_root":      "/tmp/crabbox-local-container-work",
@@ -795,6 +797,9 @@ func TestTouchPreservesLocalContainerLabels(t *testing.T) {
 	}
 	if server.Labels["work_root"] != lease.Server.Labels["work_root"] || server.Labels["host_work_root"] != lease.Server.Labels["host_work_root"] || server.Labels["docker_socket"] != "1" || server.Labels["ssh_user"] != "runner" {
 		t.Fatalf("provider labels not preserved: %#v", server.Labels)
+	}
+	if server.Labels["bootstrap_dir"] != bootstrapDir {
+		t.Fatalf("bootstrap_dir not preserved through touch: got %q want %q", server.Labels["bootstrap_dir"], bootstrapDir)
 	}
 	if server.Labels["state"] != "running" {
 		t.Fatalf("state not touched: %#v", server.Labels)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -19,10 +19,14 @@ import (
 type recordingRunner struct {
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
+	run       func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
+	if r.run != nil {
+		return r.run(req)
+	}
 	if result, ok := r.responses[commandKey(req.Args)]; ok {
 		return result, nil
 	}
@@ -153,6 +157,325 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 	if strings.Contains(args, "-v\n/var/run/docker.sock:/var/run/docker.sock") {
 		t.Fatalf("docker socket should be opt-in:\n%s", args)
 	}
+}
+
+func TestCreateContainerRemovesBootstrapDirOnRunFailure(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stderr: "run failed"}, errors.New("run failed")
+		case "ps":
+			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+		case "rm":
+			if _, err := os.Stat(bootstrapDir); err != nil {
+				t.Fatalf("bootstrap directory removed before container rollback: %v", err)
+			}
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false); err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists after run failure: %v", err)
+	}
+	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "created123") {
+		t.Fatalf("run failure rollback did not remove owned container:\n%s", args)
+	}
+}
+
+func TestCreateContainerPreservesBootstrapDirWhenRollbackFails(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stderr: "run failed"}, errors.New("run failed")
+		case "ps":
+			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+		case "rm":
+			return core.LocalCommandResult{Stderr: "daemon unavailable"}, errors.New("remove failed")
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false); err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("bootstrap directory missing after failed container rollback: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+}
+
+func TestCreateContainerRunFailurePreservesUnownedContainer(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stderr: "name conflict"}, errors.New("run failed")
+		case "ps":
+			return core.LocalCommandResult{}, nil
+		case "rm":
+			t.Fatal("removed unowned container after run failure")
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false); err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists after run failure: %v", err)
+	}
+}
+
+func TestCreateContainerRunFailureKeepsOwnedContainer(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
+		case "ps":
+			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+		case "rm":
+			t.Fatal("removed kept container after run failure")
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	containerID, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	if err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if containerID != "created123" {
+		t.Fatalf("kept container id = %q, want created123", containerID)
+	}
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("kept bootstrap directory missing after run failure: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+}
+
+func TestCreateContainerRunFailureKeepsBootstrapDirWhenOwnershipUnknown(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
+		case "ps":
+			return core.LocalCommandResult{Stderr: "daemon unavailable"}, errors.New("inspect failed")
+		case "rm":
+			t.Fatal("removed container with unknown ownership after run failure")
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("bootstrap directory missing with unknown container ownership: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+}
+
+func TestAcquireRunFailureKeepsOwnedContainerKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	var leaseID string
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			leaseID = labelFromRunArgs(t, req.Args, "lease")
+			return core.LocalCommandResult{Stderr: "connection lost"}, errors.New("run failed")
+		case "ps":
+			if strings.Contains(strings.Join(req.Args, "\n"), "label=lease=") {
+				return core.LocalCommandResult{Stdout: "created123\n"}, nil
+			}
+			return core.LocalCommandResult{}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":` + strconv.Quote(leaseID) + `,"bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+		t.Fatal("Acquire succeeded")
+	}
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("kept container SSH key missing: %v", err)
+	}
+	t.Cleanup(func() {
+		core.RemoveStoredTestboxKey(leaseID)
+		_ = os.RemoveAll(bootstrapDir)
+	})
+}
+
+func TestCreateContainerRecoversEmptyContainerID(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{}, nil
+		case "ps":
+			return core.LocalCommandResult{Stdout: "created123\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: `[{"Id":"created123","Config":{"Labels":{"lease":"cbx_123","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `}}}]`}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	containerID, gotBootstrapDir, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containerID != "created123" {
+		t.Fatalf("container id = %q, want created123", containerID)
+	}
+	if gotBootstrapDir != bootstrapDir {
+		t.Fatalf("bootstrap directory = %q, want %q", gotBootstrapDir, bootstrapDir)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+}
+
+func TestCreateContainerRemovesBootstrapDirWhenEmptyContainerIDIsNotFound(t *testing.T) {
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{}, nil
+		case "ps":
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, _, err := b.createContainer(context.Background(), b.configForRun(), "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true); err == nil {
+		t.Fatal("createContainer succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists without a container: %v", err)
+	}
+}
+
+func TestAcquireRollbackRemovesContainerBeforeBootstrapDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	var bootstrapDir string
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		switch firstArg(req.Args) {
+		case "ps":
+			return core.LocalCommandResult{}, nil
+		case "run":
+			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
+			return core.LocalCommandResult{Stdout: "container123456\n"}, nil
+		case "inspect":
+			return core.LocalCommandResult{Stdout: "{"}, nil
+		case "rm":
+			if _, err := os.Stat(bootstrapDir); err != nil {
+				t.Fatalf("bootstrap directory removed before container rollback: %v", err)
+			}
+			return core.LocalCommandResult{}, nil
+		default:
+			return core.LocalCommandResult{}, nil
+		}
+	}
+	b := testBackend(runner)
+
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+		t.Fatal("Acquire succeeded")
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists after acquire rollback: %v", err)
+	}
+	if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container123456") {
+		t.Fatalf("acquire rollback did not remove container:\n%s", args)
+	}
+}
+
+func firstArg(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	return args[0]
+}
+
+func bootstrapDirFromRunArgs(t *testing.T, calls []core.LocalCommandRequest) string {
+	t.Helper()
+	for _, call := range calls {
+		for i := 0; i+1 < len(call.Args); i++ {
+			if call.Args[i] != "--label" || !strings.HasPrefix(call.Args[i+1], "bootstrap_dir=") {
+				continue
+			}
+			return strings.TrimPrefix(call.Args[i+1], "bootstrap_dir=")
+		}
+	}
+	t.Fatal("bootstrap_dir label not found in docker run args")
+	return ""
+}
+
+func labelFromRunArgs(t *testing.T, args []string, key string) string {
+	t.Helper()
+	prefix := key + "="
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--label" && strings.HasPrefix(args[i+1], prefix) {
+			return strings.TrimPrefix(args[i+1], prefix)
+		}
+	}
+	t.Fatalf("%s label not found in docker run args", key)
+	return ""
 }
 
 func TestConfigForRunFallsBackToPodmanWhenDockerIsUnavailable(t *testing.T) {
@@ -892,6 +1215,69 @@ func TestReleaseLeaseRemovesStoredKey(t *testing.T) {
 	}
 }
 
+func TestReleaseLeaseRemovesBootstrapDirAfterContainer(t *testing.T) {
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-release-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
+	if err := os.WriteFile(filepath.Join(bootstrapDir, "bootstrap.sh"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if commandKey(req.Args) == commandKey([]string{"rm", "-f", "container123"}) {
+			if _, err := os.Stat(bootstrapDir); err != nil {
+				t.Fatalf("bootstrap directory removed before container teardown: %v", err)
+			}
+		}
+		return core.LocalCommandResult{}, nil
+	}
+	b := testBackend(runner)
+	lease := core.LeaseTarget{
+		LeaseID: "cbx_release",
+		Server: core.Server{
+			CloudID: "container123",
+			Labels:  map[string]string{"bootstrap_dir": bootstrapDir},
+		},
+	}
+
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists after release: %v", err)
+	}
+}
+
+func TestReleaseLeaseDoesNotRemoveUntrustedBootstrapDir(t *testing.T) {
+	parent := t.TempDir()
+	bootstrapDir := filepath.Join(parent, "crabbox-bootstrap-forged")
+	if err := os.MkdirAll(bootstrapDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{
+		responses: map[string]core.LocalCommandResult{
+			commandKey([]string{"rm", "-f", "container123"}): {},
+		},
+	}
+	b := testBackend(runner)
+	lease := core.LeaseTarget{
+		LeaseID: "cbx_release",
+		Server: core.Server{
+			CloudID: "container123",
+			Labels:  map[string]string{"bootstrap_dir": bootstrapDir},
+		},
+	}
+
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bootstrapDir); err != nil {
+		t.Fatalf("untrusted bootstrap directory removed: %v", err)
+	}
+}
+
 func TestReleaseLeaseRemovesDockerSocketHostWorkRoot(t *testing.T) {
 	hostRoot := t.TempDir()
 	markTestLocalContainerWorkRoot(t, hostRoot)
@@ -959,6 +1345,11 @@ func TestReleaseLeaseWithIDResolvesHostWorkRoot(t *testing.T) {
 func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-cleanup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
 	hostRoot := t.TempDir()
 	markTestLocalContainerWorkRoot(t, hostRoot)
 	leaseRoot := filepath.Join(hostRoot, "cbx_cleanup")
@@ -969,7 +1360,7 @@ func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
 	inspectJSON := `[{
 		"Id":"abcdef1234567890",
 		"Name":"/crabbox-cleanup",
-		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_cleanup","slug":"old-cleanup","state":"ready","server_type":"ubuntu:24.04","ssh_user":"runner","work_root":"` + hostRoot + `","docker_socket":"1","expires_at":"` + strconv.FormatInt(created, 10) + `"}},
+		"Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":"cbx_cleanup","slug":"old-cleanup","state":"ready","server_type":"ubuntu:24.04","ssh_user":"runner","work_root":"` + hostRoot + `","docker_socket":"1","bootstrap_dir":` + strconv.Quote(bootstrapDir) + `,"expires_at":"` + strconv.FormatInt(created, 10) + `"}},
 		"State":{"Status":"running","Running":true},
 		"NetworkSettings":{"Ports":{"2222/tcp":[{"HostIp":"127.0.0.1","HostPort":"49153"}]}}
 	}]`
@@ -986,6 +1377,9 @@ func TestCleanupRemovesExpiredLocalContainers(t *testing.T) {
 	}
 	if _, err := os.Stat(leaseRoot); !os.IsNotExist(err) {
 		t.Fatalf("host lease root still exists after cleanup: %v", err)
+	}
+	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap directory still exists after cleanup: %v", err)
 	}
 	args := recordedArgsForCommand(t, runner, "rm")
 	if !strings.Contains(args, "abcdef1234567890") {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -816,6 +816,26 @@ func TestHostLeaseWorkRootRequiresTrustedLabels(t *testing.T) {
 	}
 }
 
+func TestTrustedBootstrapDir(t *testing.T) {
+	tmpDir := os.TempDir()
+	good := filepath.Join(tmpDir, "crabbox-bootstrap-abc123")
+	if !trustedBootstrapDir(good) {
+		t.Fatalf("should trust %q", good)
+	}
+	for _, bad := range []string{
+		"",
+		"crabbox-bootstrap-abc123",
+		filepath.Join(tmpDir, "not-crabbox-dir"),
+		filepath.Join(tmpDir, "crabbox-bootstrap-abc123", ".."),
+		filepath.Join("/some/other/path", "crabbox-bootstrap-abc123"),
+		"/etc/passwd",
+	} {
+		if trustedBootstrapDir(bad) {
+			t.Fatalf("should reject %q", bad)
+		}
+	}
+}
+
 func TestFindContainerForClaimReturnsMatchedContainerIdentity(t *testing.T) {
 	inspectJSON := `[{
 		"Id":"newcontainer123456",

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -142,9 +142,9 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 		"--label\nslug=blue-lobster",
 		"--label\nssh_user=runner",
 		"--label\nwork_root=/workspace/crabbox",
-		":/tmp/crabbox-bootstrap.sh:ro",
+		":/tmp/crabbox-bootstrap:ro",
 		"ubuntu:24.04",
-		"/bin/sh\n/tmp/crabbox-bootstrap.sh",
+		"/bin/sh\n/tmp/crabbox-bootstrap/bootstrap.sh",
 	} {
 		if !strings.Contains(args, want) {
 			t.Fatalf("docker run args missing %q:\n%s", want, args)


### PR DESCRIPTION
## Summary

Mount the bootstrap script's parent temp directory instead of the single file itself, fixing `docker cp` failures on Windows Docker Desktop WSL2 introduced by #204.

## What to review

| Area | Files | Lines | What it does |
|------|-------|-------|-------------|
| **Fix** (review this) | `backend.go` | ~50 | Dir mount, label-tracked cleanup, `trustedBootstrapDir` validation, acquire-failure cleanup |
| **Tests** (skim) | `backend_test.go` | ~20 | `TestTrustedBootstrapDir` covering valid, relative, traversal, wrong-prefix, wrong-parent |

## How it works

- **Create**: `os.MkdirTemp` instead of `os.CreateTemp`; bootstrap script written as `bootstrap.sh` inside the dir; dir path stored in a `bootstrap_dir` container label
- **Mount**: `-v tmpdir:/tmp/crabbox-bootstrap:ro` (directory, not single file); entrypoint `/bin/sh /tmp/crabbox-bootstrap/bootstrap.sh`
- **Cleanup (release/gc)**: `ReleaseLease` and `Cleanup` read `bootstrap_dir` label, validate with `trustedBootstrapDir()`, then `os.RemoveAll`
- **Cleanup (acquire failure)**: `cleanupContainer` closure inspects container for label before removing both container and bootstrap dir
- **Cleanup (createContainer failure)**: error paths call `os.RemoveAll(bootstrapDir)` directly (no label needed, path is local)
- **Validation**: `trustedBootstrapDir` requires absolute path, parent == `os.TempDir()`, base matches `crabbox-bootstrap-*`

## Motivation

PR #204 replaced inline bootstrap args with a single-file bind mount to fix the Windows 32K `CreateProcessW` limit. This caused:

1. **`docker cp` broken on WSL2** (P1): WSL2 tries `mkdir` on the single-file mount path and gets `EEXIST`
2. **Temp file deleted while container running** (P2): `defer os.Remove()` fires after `docker run -d`, not container exit
3. **Bootstrap not in `docker commit`** (P3, benign): bind mounts excluded by Docker semantics; harmless since bootstrap has `exec`'d sshd by commit time

## Host smoke (b239408, Windows 11, Docker Desktop 29.0.1)

### docker info
```
OS: Docker Desktop / Kernel: 6.6.87.2-microsoft-standard-WSL2 / Driver: overlayfs
```

### docker cp with directory mount (FIXED)
```
$ docker run -d --name proof -v "$TEMP\crabbox-bootstrap-proof:/tmp/crabbox-bootstrap:ro" ubuntu:24.04 sleep 3600
cc3f3233f2cd...

$ docker inspect proof --format "{{range .Mounts}}Type={{.Type}} Src={{.Source}} Dst={{.Destination}}{{end}}"
Type=bind Src=C:\Users\Cameron\AppData\Local\Temp\crabbox-bootstrap-proof Dst=/tmp/crabbox-bootstrap

$ docker cp test.txt proof:/tmp/dockercp-test.txt
(exit 0)

$ docker exec proof cat /tmp/dockercp-test.txt
proof-file-content
```

### go test
```
ok  github.com/openclaw/crabbox/internal/providers/localcontainer  0.36s
```

### go build
```
go build -o crabbox-dev.exe ./cmd/crabbox
(exit 0, go1.26.4 windows/amd64)
```

## Fixes addressed

1. **Directory mount** (9a5b854): `os.MkdirTemp` + dir bind mount replaces single-file mount; avoids WSL2 path resolution bug
2. **Deferred cleanup** (9a5b854): bootstrap dir lifetime tied to container release/cleanup, not `docker run -d` return
3. **Error-path cleanup** (9a5b854): `createContainer` cleans up bootstrap dir on docker run failure and empty container ID
4. **Label validation** (064ad84): `trustedBootstrapDir()` validates absolute path, system temp parent, `crabbox-bootstrap-*` prefix before `RemoveAll`
5. **Acquire-failure cleanup** (064ad84): `cleanupContainer` closure in `Acquire` inspects container for bootstrap_dir label, cleans up on post-create failures (inspect, prepareLease, claim)
6. **Touch label preservation** (b239408): `bootstrap_dir` added to Touch label allowlist so release can still find and clean the temp directory after lease status touches
7. **Direct bootstrap path in acquire cleanup** (b239408): `createContainer` returns `bootstrapDir` directly; `cleanupContainer` uses the local path instead of re-inspecting a possibly-failed container

## Not included (follow-up)

- Capturing bootstrap script content in `docker commit` snapshots (requires copying into the container layer; deferred since bootstrap has already `exec`'d sshd)
