### PR TITLE
fix(status): resolve ssh target while waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed malformed AWS, Azure, and GCP SSH CIDR configuration to fail closed instead of falling back to broad SSH access. Thanks @coygeek.
 - Fixed local-container warmup on Windows by mounting the generated bootstrap directory instead of passing the script inline to Docker. Thanks @anagnorisis2peripeteia.
+- Fixed SSH-backed status waits to honor `--wait-timeout` while allowing Tenki readiness probes without resuming paused sessions. Thanks @aki-luxor.
 - Fixed brokered Azure lease creation to persist in-flight leases before VM provisioning, keep failed creates visible, and sweep orphaned Azure VMs from coordinator maintenance. Fixes https://github.com/openclaw/crabbox/issues/215.
 - Fixed brokered lease release races so leases released while provisioning cannot be reactivated or lose cleanup retry state.
 - Fixed Islo provider status, streaming exec, archive upload, share, and delete handling for the current Islo API contract. Thanks @zozo123.

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -346,6 +346,7 @@ type ResolveRequest struct {
 	Reclaim     bool
 	ReleaseOnly bool
 	StatusOnly  bool
+	ReadyProbe  bool
 }
 
 type ReleaseLeaseRequest struct {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -52,7 +52,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			state, err = delegated.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: !*wait})
+			lease, err = sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(ctx, cfg, lease)
 				if err == nil && *wait {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -42,30 +43,38 @@ func (a App) status(ctx context.Context, args []string) error {
 	})
 	delegated, isDelegated := backend.(DelegatedRunBackend)
 	sshBackend, isSSH := backend.(SSHLeaseBackend)
-	deadline := time.Now().Add(*waitTimeout)
+	statusCtx := ctx
+	cancel := func() {}
+	if *wait {
+		statusCtx, cancel = context.WithTimeout(ctx, *waitTimeout)
+	}
+	defer cancel()
 	for {
 		var state statusView
 		var err error
 		if isStatus {
-			state, err = statusBackend.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
+			state, err = statusBackend.Status(statusCtx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isDelegated {
-			state, err = delegated.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
+			state, err = delegated.Status(statusCtx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait})
+			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait})
 			if err == nil {
-				state, err = statusViewFromLeaseTarget(ctx, cfg, lease)
+				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
-					_, touchErr := sshBackend.Touch(ctx, TouchRequest{Lease: lease, State: state.State, IdleTimeout: cfg.IdleTimeout})
+					_, touchErr := sshBackend.Touch(statusCtx, TouchRequest{Lease: lease, State: state.State, IdleTimeout: cfg.IdleTimeout})
 					if touchErr != nil {
 						fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, touchErr)
 					}
 				}
 			}
 		} else {
-			state, err = a.leaseStatus(ctx, cfg, *id)
+			state, err = a.leaseStatus(statusCtx, cfg, *id)
 		}
 		if err != nil {
+			if *wait && errors.Is(statusCtx.Err(), context.DeadlineExceeded) {
+				return exit(5, "timed out waiting for %s to become ready", *id)
+			}
 			return err
 		}
 		if *jsonOut {
@@ -97,10 +106,14 @@ func (a App) status(ctx context.Context, args []string) error {
 		if !*wait || statusWaitDone(state) {
 			return nil
 		}
-		if time.Now().After(deadline) {
-			return exit(5, "timed out waiting for %s to become ready", *id)
+		select {
+		case <-statusCtx.Done():
+			if errors.Is(statusCtx.Err(), context.DeadlineExceeded) {
+				return exit(5, "timed out waiting for %s to become ready", *id)
+			}
+			return statusCtx.Err()
+		case <-time.After(5 * time.Second):
 		}
-		time.Sleep(5 * time.Second)
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -52,7 +52,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			state, err = delegated.Status(ctx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true})
+			lease, err = sshBackend.Resolve(ctx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: !*wait})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(ctx, cfg, lease)
 				if err == nil && *wait {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -36,7 +36,7 @@ func TestStatusWaitTerminalErrorFailsNonReadyTerminalState(t *testing.T) {
 	}
 }
 
-func TestStatusWaitUsesFullSSHResolve(t *testing.T) {
+func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
 	t.Setenv("CRABBOX_COORDINATOR", "")
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
@@ -54,6 +54,9 @@ func TestStatusWaitUsesFullSSHResolve(t *testing.T) {
 	if !backend.requests[0].StatusOnly {
 		t.Fatal("plain status should use status-only resolve")
 	}
+	if backend.requests[0].ReadyProbe {
+		t.Fatal("plain status should not request a readiness probe")
+	}
 
 	backend.requests = nil
 	err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
@@ -64,8 +67,11 @@ func TestStatusWaitUsesFullSSHResolve(t *testing.T) {
 	if len(backend.requests) != 1 {
 		t.Fatalf("resolve calls=%d want 1", len(backend.requests))
 	}
-	if backend.requests[0].StatusOnly {
-		t.Fatal("status --wait should use full resolve so providers can return SSH readiness data")
+	if !backend.requests[0].StatusOnly {
+		t.Fatal("status --wait should still use status-only resolve")
+	}
+	if !backend.requests[0].ReadyProbe {
+		t.Fatal("status --wait should request SSH readiness data")
 	}
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestStatusWaitDoneTreatsTerminalStatesAsDone(t *testing.T) {
@@ -75,13 +76,42 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 }
 
+func TestStatusWaitBoundsResolveByTimeout(t *testing.T) {
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &statusResolveRecordingBackend{block: true}
+	testAWSBackendOverride = backend
+	defer func() { testAWSBackendOverride = nil }()
+
+	app := App{Stdout: io.Discard, Stderr: &bytes.Buffer{}}
+	start := time.Now()
+	err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "20ms"})
+	elapsed := time.Since(start)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("status --wait error = %#v, want timeout exit 5", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("status --wait ignored timeout: elapsed=%s", elapsed)
+	}
+	if len(backend.requests) != 1 {
+		t.Fatalf("resolve calls=%d want 1", len(backend.requests))
+	}
+}
+
 type statusResolveRecordingBackend struct {
 	testSSHBackend
 	requests []ResolveRequest
+	block    bool
 }
 
-func (b *statusResolveRecordingBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
 	b.requests = append(b.requests, req)
+	if b.block {
+		<-ctx.Done()
+		return LeaseTarget{}, ctx.Err()
+	}
 	return LeaseTarget{
 		Server: Server{
 			Provider: "aws",

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,6 +1,12 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+)
 
 func TestStatusWaitDoneTreatsTerminalStatesAsDone(t *testing.T) {
 	for _, state := range []string{"expired", "failed", "released", "stopped", "stopped_with_code", "terminated"} {
@@ -28,4 +34,57 @@ func TestStatusWaitTerminalErrorFailsNonReadyTerminalState(t *testing.T) {
 	if err := statusWaitTerminalError("cbx_123", statusView{State: "provisioning"}); err != nil {
 		t.Fatalf("non-terminal state returned error: %v", err)
 	}
+}
+
+func TestStatusWaitUsesFullSSHResolve(t *testing.T) {
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &statusResolveRecordingBackend{}
+	testAWSBackendOverride = backend
+	defer func() { testAWSBackendOverride = nil }()
+
+	app := App{Stdout: io.Discard, Stderr: &bytes.Buffer{}}
+	if err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status"}); err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if len(backend.requests) != 1 {
+		t.Fatalf("resolve calls=%d want 1", len(backend.requests))
+	}
+	if !backend.requests[0].StatusOnly {
+		t.Fatal("plain status should use status-only resolve")
+	}
+
+	backend.requests = nil
+	err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 {
+		t.Fatalf("status --wait error = %#v, want timeout exit 5", err)
+	}
+	if len(backend.requests) != 1 {
+		t.Fatalf("resolve calls=%d want 1", len(backend.requests))
+	}
+	if backend.requests[0].StatusOnly {
+		t.Fatal("status --wait should use full resolve so providers can return SSH readiness data")
+	}
+}
+
+type statusResolveRecordingBackend struct {
+	testSSHBackend
+	requests []ResolveRequest
+}
+
+func (b *statusResolveRecordingBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+	b.requests = append(b.requests, req)
+	return LeaseTarget{
+		Server: Server{
+			Provider: "aws",
+			Status:   "running",
+			Labels: map[string]string{
+				"state":             "ready",
+				"idle_timeout_secs": "60",
+			},
+		},
+		LeaseID: "cbx_status",
+	}, nil
 }

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -171,8 +171,17 @@ func (b *tenkiBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
-		return LeaseTarget{Server: b.sessionToServer(cfg, session, leaseID, slug, session.Sticky), LeaseID: leaseID}, nil
+	if req.ReleaseOnly || req.StatusOnly {
+		lease := LeaseTarget{Server: b.sessionToServer(cfg, session, leaseID, slug, session.Sticky), LeaseID: leaseID}
+		if !req.ReadyProbe || !tenkiSessionReady(session) {
+			return lease, nil
+		}
+		target, err := b.resolveSSHTarget(ctx, cfg, session.ID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		lease.SSH = target
+		return lease, nil
 	}
 	lease, err := b.prepareLease(ctx, cfg, session, leaseID, slug, true, true)
 	if err != nil {
@@ -317,12 +326,10 @@ func (b *tenkiBackend) prepareLease(ctx context.Context, cfg Config, session ten
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	sshCommand, err := b.waitForTenkiSSHCommand(ctx, session.ID, bootstrapWaitTimeout(cfg))
+	target, err := b.resolveSSHTarget(ctx, cfg, session.ID)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	target := b.sshTarget(sshCommand)
-	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null"
 	server := b.sessionToServer(cfg, session, leaseID, slug, keep)
 	if waitSSH {
 		if err := waitForSSHReadyFunc(ctx, &target, b.rt.Stderr, "tenki sandbox ssh", bootstrapWaitTimeout(cfg)); err != nil {
@@ -330,6 +337,16 @@ func (b *tenkiBackend) prepareLease(ctx context.Context, cfg Config, session ten
 		}
 	}
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *tenkiBackend) resolveSSHTarget(ctx context.Context, cfg Config, sessionID string) (SSHTarget, error) {
+	sshCommand, err := b.waitForTenkiSSHCommand(ctx, sessionID, bootstrapWaitTimeout(cfg))
+	if err != nil {
+		return SSHTarget{}, err
+	}
+	target := b.sshTarget(sshCommand)
+	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null"
+	return target, nil
 }
 
 func (b *tenkiBackend) getSession(ctx context.Context, sessionID string) (tenkiSession, error) {

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -171,7 +171,7 @@ func (b *tenkiBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	if req.ReleaseOnly || req.StatusOnly {
+	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
 		return LeaseTarget{Server: b.sessionToServer(cfg, session, leaseID, slug, session.Sticky), LeaseID: leaseID}, nil
 	}
 	lease, err := b.prepareLease(ctx, cfg, session, leaseID, slug, true, true)

--- a/internal/providers/tenki/backend_test.go
+++ b/internal/providers/tenki/backend_test.go
@@ -147,12 +147,6 @@ func TestTenkiResolveReadyProbePreparesSSH(t *testing.T) {
 	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
-		return nil
-	}
-	defer func() { waitForSSHReadyFunc = oldWait }()
-
 	runner := &fakeRunner{}
 	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
 		runner.calls = append(runner.calls, req)
@@ -180,6 +174,35 @@ func TestTenkiResolveReadyProbePreparesSSH(t *testing.T) {
 	}
 	if len(runner.calls) != 2 {
 		t.Fatalf("calls=%d want 2", len(runner.calls))
+	}
+}
+
+func TestTenkiResolveReadyProbeDoesNotResumePausedSession(t *testing.T) {
+	runner := &fakeRunner{}
+	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		runner.calls = append(runner.calls, req)
+		switch strings.Join(req.Args, " ") {
+		case "sandbox list --output json --tags crabbox,crabbox-provider-tenki":
+			return LocalCommandResult{Stdout: `[{"id":"session-1","name":"crabbox-blue","state":"PAUSED","metadata":{"crabbox_provider":"tenki","crabbox_lease_id":"cbx_123","crabbox_slug":"blue"},"tags":["crabbox-provider-tenki"]}]`}, nil
+		default:
+			t.Fatalf("paused readiness probe mutated session: %s %s", req.Name, strings.Join(req.Args, " "))
+		}
+		return LocalCommandResult{}, nil
+	}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "cbx_123", StatusOnly: true, ReadyProbe: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Status != "paused" || lease.SSH.Host != "" {
+		t.Fatalf("unexpected paused readiness probe lease: %#v", lease)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls=%d want 1", len(runner.calls))
 	}
 }
 

--- a/internal/providers/tenki/backend_test.go
+++ b/internal/providers/tenki/backend_test.go
@@ -137,6 +137,52 @@ func TestTenkiResolveStatusOnlyDoesNotPrepareSSH(t *testing.T) {
 	}
 }
 
+func TestTenkiResolveReadyProbePreparesSSH(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	certPath := filepath.Join(dir, "id_ed25519-cert.pub")
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldWait := waitForSSHReadyFunc
+	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+		return nil
+	}
+	defer func() { waitForSSHReadyFunc = oldWait }()
+
+	runner := &fakeRunner{}
+	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		runner.calls = append(runner.calls, req)
+		switch strings.Join(req.Args, " ") {
+		case "sandbox list --output json --tags crabbox,crabbox-provider-tenki":
+			return LocalCommandResult{Stdout: `[{"id":"session-1","name":"crabbox-blue","state":"RUNNING","metadata":{"crabbox_provider":"tenki","crabbox_lease_id":"cbx_123","crabbox_slug":"blue"},"tags":["crabbox-provider-tenki"]}]`}, nil
+		case "sandbox ssh-command --output json --session session-1 --user tenki --batch-mode --connect-timeout 10s":
+			return LocalCommandResult{Stdout: `{"session_id":"session-1","user":"tenki","host":"sandbox","port":22,"identity_file":"` + keyPath + `","certificate_file":"` + certPath + `","proxy_command":"tenki sandbox ssh-proxy --session session-1"}`}, nil
+		default:
+			t.Fatalf("unexpected command: %s %s", req.Name, strings.Join(req.Args, " "))
+		}
+		return LocalCommandResult{}, nil
+	}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "cbx_123", StatusOnly: true, ReadyProbe: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Host != "sandbox" || lease.SSH.Key != keyPath {
+		t.Fatalf("ready probe did not prepare SSH target: %#v", lease.SSH)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls=%d want 2", len(runner.calls))
+	}
+}
+
 func TestTenkiResolveClaimUsesStoredSessionID(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "tenki_session-1"


### PR DESCRIPTION
## Summary
- Keep SSH-backed `crabbox status` on the read-only `StatusOnly` resolve path.
- Keep `crabbox status --wait` status-only too, but pass `ReadyProbe: true` so providers that need SSH material for readiness can opt in.
- Make Tenki use `ReadyProbe` to prepare the `tenki sandbox ssh-proxy` target only for running sessions, allowing `status --wait` to prove `ready=true` without resuming paused sessions.
- Bound provider resolution, SSH probing, and polling by `--wait-timeout`.
- Add regression coverage for the CLI resolve contract, timeout propagation, and non-mutating Tenki readiness probes.

This follows up the Tenki provider merge in https://github.com/openclaw/crabbox/pull/231. Tenki status-only resolution is intentionally read-only, but the wait path needs SSH material because Crabbox readiness is proven by probing SSH.

## Verification
- Verified `tart --version` reports `2.32.1`.
- Compared `upstream/main` vs this branch against a disposable stopped Tart VM plus temporary Crabbox claim state. Plain `status` and stopped `status --wait` behavior match upstream, so Tart keeps its read-only stopped-state path.
- Live-tested Tenki earlier with the installed `tenki` CLI: `status --wait` now reaches `ready=true` and a reused Tenki lease can run a command over the prepared SSH target.
- `go test ./internal/cli ./internal/providers/tart ./internal/providers/tenki`
- `go test ./internal/providers/all`
- `go test ./...`
- `go vet ./...`

### Maintainer verification
- `go test ./internal/cli ./internal/providers/tenki ./internal/providers/tart`
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- Autoreview clean
- Process E2E, paused session: exit 5 in 172 ms with one `sandbox list` call and no `resume` or `ssh-command` (`PR234_PAUSED_E2E_OK`)
- Process E2E, running session: real local SSH protocol server reached through the fake Tenki `ssh-proxy`; status reported `ready=true` (`PR234_READY_E2E_OK`)
- Real Tenki CLI/auth were unavailable on the maintainer host; the contributor's earlier live Tenki verification remains documented above.
