### PR TITLE
feat(provider): add OpenComputer sandbox provider (REST API)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,4 @@ History uses Conventional Commit prefixes such as `feat:`, `fix:`, `docs:`, and 
 
 Keep provider and broker tokens out of the repository. Do not pass secrets as command-line arguments. Local config belongs in `~/.config/crabbox/config.yaml`, `~/Library/Application Support/crabbox/config.yaml`, `crabbox.yaml`, or `.crabbox.yaml` as documented.
 Tenki provider SSH uses `tenki sandbox ssh-proxy` with Tenki-managed key/cert files under `~/.config/tenki`; do not use Crabbox per-lease keys for gateway auth.
+OpenComputer provider auth: Crabbox reads the API key from `CRABBOX_OPENCOMPUTER_API_KEY`/`OPENCOMPUTER_API_KEY` or the `oc` CLI config (`~/.oc/config.json`) and sends it only in the `X-API-Key` header — never persist `osb_` keys in Crabbox config or place them on argv.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: opencomputer` for delegated Linux sandbox runs through the OpenComputer REST API, including archive sync, retained leases, status, and cleanup. Thanks @zozo123.
 - Added local-container checkpoint forks that launch a fresh Docker lease from a committed checkpoint image while replaying and validating its recorded daemon scope. Thanks @anagnorisis2peripeteia.
 - Added opt-in native Docker local-container checkpoints with immutable image identity, daemon-scope-aware verification and deletion, mounted-workspace guards, and live lifecycle coverage. Thanks @anagnorisis2peripeteia.
 - Added `provider: morph` for Morph Cloud Linux SSH leases, including snapshot boot, Morph API key/config plumbing, per-instance SSH key retrieval, pause-on-release reuse, and provider docs. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `provider: opencomputer` for delegated Linux sandbox runs through the OpenComputer REST API, including archive sync, retained leases, status, and cleanup. Thanks @zozo123.
+- Added `provider: opencomputer` for delegated Linux sandbox runs through the OpenComputer REST API, including archive sync, retained leases, optional burst capacity, status, and cleanup. Thanks @zozo123.
 - Added local-container checkpoint forks that launch a fresh Docker lease from a committed checkpoint image while replaying and validating its recorded daemon scope. Thanks @anagnorisis2peripeteia.
 - Added opt-in native Docker local-container checkpoints with immutable image identity, daemon-scope-aware verification and deletion, mounted-workspace guards, and live lifecycle coverage. Thanks @anagnorisis2peripeteia.
 - Added `provider: morph` for Morph Cloud Linux SSH leases, including snapshot boot, Morph API key/config plumbing, per-instance SSH key retrieval, pause-on-release reuse, and provider docs. Thanks @coygeek.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ configured); every other provider always runs direct from the CLI.
 | [Islo](docs/providers/islo.md) — `islo` | Linux | Islo sandbox. |
 | [Modal](docs/providers/modal.md) — `modal` | Linux | Modal Sandbox through the local Python client. |
 | [Microsoft Execution Containers](docs/providers/mxc.md) — `mxc` (`execution-container`) | Windows | Policy-driven local Windows process containment. |
+| [OpenComputer](docs/providers/opencomputer.md) — `opencomputer` (`oc`, `open-computer`) | Linux | OpenComputer Linux VMs through the OpenComputer REST API. |
 | [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`) | Linux | Redeploy and stream an existing Railway service. |
 | [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
 | [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux | Upstash Box through the Box REST API. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,7 @@ Pick whichever matches your intent:
   [Tenki](providers/tenki.md),
   [Daytona](providers/daytona.md), [Islo](providers/islo.md),
   [E2B](providers/e2b.md), [Modal](providers/modal.md),
+  [OpenComputer](providers/opencomputer.md),
   [Tensorlake](providers/tensorlake.md), [Upstash Box](providers/upstash-box.md),
   [Weights & Biases](providers/wandb.md), [Cloudflare](providers/cloudflare.md).
 - **Operate it:** [Operations](operations.md),

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -110,6 +110,7 @@ docker-sandbox          Docker Sandboxes through the standalone sbx CLI
 e2b                     E2B Firecracker sandboxes
 islo                    Islo sandboxes
 modal                   Modal Sandboxes
+opencomputer            OpenComputer Linux VMs
 tensorlake              Tensorlake Firecracker sandboxes
 upstash-box             Upstash sandboxes
 blacksmith-testbox      Blacksmith CI test runner (proof/session)
@@ -154,6 +155,7 @@ railway                 Railway service status and stop controls
 - [Islo](../providers/islo.md): delegated Islo sandbox execution.
 - [E2B](../providers/e2b.md): delegated E2B sandbox execution.
 - [Modal](../providers/modal.md): delegated Modal Sandbox execution.
+- [OpenComputer](../providers/opencomputer.md): delegated OpenComputer Linux VM execution through the OpenComputer REST API.
 - [Tensorlake](../providers/tensorlake.md): delegated Tensorlake Firecracker sandbox execution.
 - [Upstash Box](../providers/upstash-box.md): delegated Upstash sandbox execution.
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Blacksmith CI runner.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -211,6 +211,7 @@ internal/providers/blacksmith           # Blacksmith Testbox delegated backend
 internal/providers/e2b                  # E2B delegated backend
 internal/providers/islo                 # Islo delegated backend
 internal/providers/modal                # Modal delegated backend
+internal/providers/opencomputer         # OpenComputer delegated backend
 internal/providers/tensorlake           # Tensorlake delegated backend
 internal/providers/upstashbox           # Upstash Box delegated backend
 internal/providers/cloudflare           # Cloudflare Containers delegated backend

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -91,6 +91,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Islo](islo.md) — `islo` | Linux |
 | [Modal](modal.md) — `modal` | Linux |
 | [Microsoft Execution Containers](mxc.md) — `mxc` (`execution-container`) | Windows |
+| [OpenComputer](opencomputer.md) — `opencomputer` (`oc`, `open-computer`) | Linux |
 | [Railway](railway.md) — `railway` (`rail`, `railwayapp`) | Linux |
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -82,12 +82,14 @@ Provider flags:
 --opencomputer-memory-mb
 --opencomputer-timeout-secs
 --opencomputer-exec-timeout-secs
+--opencomputer-forget-missing
 ```
 
-Each flag has a matching `CRABBOX_OPENCOMPUTER_*` environment override (for
-example `CRABBOX_OPENCOMPUTER_WORKDIR`, `CRABBOX_OPENCOMPUTER_CPU`,
-`CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS`). The API URL also reads
-`OPENCOMPUTER_API_URL`.
+Configuration flags have matching `CRABBOX_OPENCOMPUTER_*` environment
+overrides (for example `CRABBOX_OPENCOMPUTER_WORKDIR`,
+`CRABBOX_OPENCOMPUTER_CPU`, `CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS`). The API
+URL also reads `OPENCOMPUTER_API_URL`. `--opencomputer-forget-missing` is
+deliberately CLI-only so stale-claim removal always requires explicit intent.
 
 > **Sizing tiers.** When both `cpu` and `memoryMB` are set, they must form an
 > allowed tier (for example `1/1024`, `1/4096`, `2/8192`, `4/16384`). When only
@@ -126,7 +128,11 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
    `--keep` was set. `--keep-on-failure` retains a newly created sandbox after a
    failed run and prints a rerun/stop hint. Best-effort cleanup calls are
    bounded to 15 seconds; a failed rollback reports the remote sandbox ID for
-   manual cleanup in the OpenComputer console.
+   manual cleanup in the OpenComputer console. A newly acquired sandbox already
+   removed during automatic cleanup still clears its local claim. For an
+   existing lease, a 404 is account-ambiguous and keeps the claim by default;
+   pass `--opencomputer-forget-missing` to `stop` only after confirming the
+   sandbox is gone in the intended account.
 
 ## Capabilities
 
@@ -150,6 +156,13 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
   checksum semantics. `--sync-only` and `--force-sync-large` are supported.
 - `--no-sync` only ensures the workdir exists. It never applies `sync.delete`,
   so reusing a retained sandbox does not erase its workspace.
+- With `sync.delete`, Crabbox uploads and extracts into a sibling staging
+  directory, then replaces the workdir only after extraction succeeds.
+- `crabbox list` starts from local OpenComputer claims and fetches each remote
+  status, so kept sandboxes remain visible after hibernation. A 404 remains
+  visible as `missing-or-inaccessible` until explicitly forgotten.
+- `warmup --actions-runner` is rejected because OpenComputer is a delegated
+  execution provider, not an SSH runner host.
 - Command and sync-helper requests use a 3600-second timeout by default instead
   of OpenComputer's 60-second API default. Override it with
   `openComputer.execTimeoutSecs` or

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -57,6 +57,12 @@ if already configured). It is sent only in the `X-API-Key` header, never
 persisted in Crabbox config and never placed on argv. If no key is resolvable,
 operations fail with a clear error.
 
+Local lease claims are scoped to the normalized API URL and a SHA-256 fingerprint
+of the API key. The key itself is never stored. This prevents `status`, `run`,
+or `stop` from applying a claim created for another endpoint or account. Restore
+the original endpoint and credential when managing a retained lease after
+switching accounts or rotating keys.
+
 The API base URL defaults to `https://app.opencomputer.dev`. A trusted local
 override can come from `--opencomputer-api-url`,
 `CRABBOX_OPENCOMPUTER_API_URL`, `OPENCOMPUTER_API_URL`, or the `api_url` in the
@@ -132,13 +138,13 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
    are streamed back and the remote exit code is mirrored.
 5. On release the sandbox is deleted (`DELETE /api/sandboxes/<id>`) unless
    `--keep` was set. `--keep-on-failure` retains a newly created sandbox after a
-   failed run and prints a rerun/stop hint. Best-effort cleanup calls are
-   bounded to 15 seconds; a failed rollback reports the remote sandbox ID for
-   manual cleanup in the OpenComputer console. A newly acquired sandbox already
-   removed during automatic cleanup still clears its local claim. For an
-   existing lease, a 404 is account-ambiguous and keeps the claim by default;
-   pass `--opencomputer-forget-missing` to `stop` only after confirming the
-   sandbox is gone in the intended account.
+   sync, workspace setup, or command failure and prints a rerun/stop hint.
+   Best-effort cleanup calls are bounded to 15 seconds; a failed rollback
+   reports the remote sandbox ID for manual cleanup in the OpenComputer console.
+   A newly acquired sandbox already removed during automatic cleanup still
+   clears its local claim. For an existing lease, a 404 is account-ambiguous and
+   keeps the claim by default; pass `--opencomputer-forget-missing` to `stop`
+   only after confirming the sandbox is gone in the intended account.
 
 ## Capabilities
 
@@ -166,7 +172,11 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
   directory, then replaces the workdir only after extraction succeeds.
 - `crabbox list` starts from local OpenComputer claims and fetches each remote
   status, so kept sandboxes remain visible after hibernation. A 404 remains
-  visible as `missing-or-inaccessible` until explicitly forgotten.
+  visible as `missing-or-inaccessible` until explicitly forgotten. A malformed
+  matching claim fails the command instead of silently hiding a retained
+  sandbox.
+- `status --wait` applies its wait timeout to in-flight API requests as well as
+  polling sleeps.
 - `warmup --actions-runner` is rejected because OpenComputer is a delegated
   execution provider, not an SSH runner host.
 - Command and sync-helper requests use a 3600-second timeout by default instead

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -60,9 +60,9 @@ operations fail with a clear error.
 Local lease claims are scoped to the normalized API URL and a random ownership
 marker stored in both the local claim and the sandbox tags. The API key is
 never stored. Before reusing or deleting a retained sandbox, Crabbox verifies
-that both markers match. This prevents a claim from being applied to a sandbox
-at another endpoint or account while allowing API-key rotation within the same
-account.
+that both markers match using the dedicated sandbox-tags endpoint. This
+prevents a claim from being applied to a sandbox at another endpoint or account
+while allowing API-key rotation within the same account.
 
 The API base URL defaults to `https://app.opencomputer.dev`. A trusted local
 override can come from `--opencomputer-api-url`,
@@ -84,6 +84,7 @@ openComputer:
   memoryMB: 0                  # memory; service infers CPU when set alone
   timeoutSecs: 0               # sandbox idle timeout; 0 leaves it to the default
   execTimeoutSecs: 3600        # command/sync-helper timeout
+  burst: false                 # opt into best-effort burst capacity
 ```
 
 Provider flags:
@@ -95,6 +96,7 @@ Provider flags:
 --opencomputer-memory-mb
 --opencomputer-timeout-secs
 --opencomputer-exec-timeout-secs
+--opencomputer-burst
 --opencomputer-forget-missing
 ```
 
@@ -108,6 +110,13 @@ deliberately CLI-only so stale-claim removal always requires explicit intent.
 > allowed tier (for example `1/1024`, `1/4096`, `2/8192`, `4/16384`). When only
 > one is set, OpenComputer infers the matching value. Leaving both at `0` uses
 > the service default tier.
+
+Set `openComputer.burst: true`, `CRABBOX_OPENCOMPUTER_BURST=true`, or pass
+`--opencomputer-burst` to request best-effort burst capacity. Burst is disabled
+by default, so normal on-demand or reserved capacity remains the standard path.
+Burst sandboxes are alpha: filesystem state persists across infrastructure
+restarts, but processes, memory, terminal sessions, and network connections may
+restart. Use burst only for restart-tolerant runs.
 
 ### Environment forwarding
 

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -25,16 +25,19 @@ access, since OpenComputer does not expose SSH through Crabbox.
 
 ## Prerequisites
 
-An OpenComputer API key (`osb_...`). The easiest way to provide it is the `oc`
-CLI's config file, which Crabbox reads automatically:
+An OpenComputer API key (`osb_...`). Prefer loading it from a secret manager or
+prompting into the environment so the value never appears in shell history or
+process arguments:
 
 ```sh
-oc config set api-key osb_...
+export CRABBOX_OPENCOMPUTER_API_KEY="$(
+  python3 -c 'import getpass; print(getpass.getpass("OpenComputer API key: "))'
+)"
 ```
 
-The `oc` binary is **not** required at runtime — Crabbox only reads the key it
-stores. Alternatively set `CRABBOX_OPENCOMPUTER_API_KEY` (or
-`OPENCOMPUTER_API_KEY`) in the environment.
+Crabbox also reads an existing `oc` CLI config file automatically. The `oc`
+binary is **not** required at runtime. `OPENCOMPUTER_API_KEY` is accepted as an
+environment fallback.
 
 ## Commands
 
@@ -50,15 +53,18 @@ crabbox stop --provider opencomputer blue-lobster
 
 Crabbox resolves the API key from, in order, `CRABBOX_OPENCOMPUTER_API_KEY`,
 `OPENCOMPUTER_API_KEY`, then the `oc` CLI config file (`~/.oc/config.json`,
-written by `oc config set api-key`). It is sent only in the `X-API-Key` header,
-never persisted in Crabbox config and never placed on argv. If no key is
-resolvable, operations fail with a clear error.
+if already configured). It is sent only in the `X-API-Key` header, never
+persisted in Crabbox config and never placed on argv. If no key is resolvable,
+operations fail with a clear error.
 
 The API base URL defaults to `https://app.opencomputer.dev`. A trusted local
 override can come from `--opencomputer-api-url`,
 `CRABBOX_OPENCOMPUTER_API_URL`, `OPENCOMPUTER_API_URL`, or the `api_url` in the
 local `oc` config. Repository YAML cannot set the API URL: that prevents a
-checked-in config from redirecting an automatically loaded API key.
+checked-in config from redirecting an automatically loaded API key. Overrides
+must use HTTPS and cannot contain userinfo, query parameters, or fragments;
+plain HTTP is accepted only for `localhost` or a loopback IP during local
+development.
 
 ## Config
 

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -57,11 +57,12 @@ if already configured). It is sent only in the `X-API-Key` header, never
 persisted in Crabbox config and never placed on argv. If no key is resolvable,
 operations fail with a clear error.
 
-Local lease claims are scoped to the normalized API URL and a SHA-256 fingerprint
-of the API key. The key itself is never stored. This prevents `status`, `run`,
-or `stop` from applying a claim created for another endpoint or account. Restore
-the original endpoint and credential when managing a retained lease after
-switching accounts or rotating keys.
+Local lease claims are scoped to the normalized API URL and a random ownership
+marker stored in both the local claim and the sandbox tags. The API key is
+never stored. Before reusing or deleting a retained sandbox, Crabbox verifies
+that both markers match. This prevents a claim from being applied to a sandbox
+at another endpoint or account while allowing API-key rotation within the same
+account.
 
 The API base URL defaults to `https://app.opencomputer.dev`. A trusted local
 override can come from `--opencomputer-api-url`,
@@ -123,7 +124,8 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
 
 1. `warmup` or `run` without `--id` calls `POST /api/sandboxes` with the
    configured timeout and sizing tier and `metadata` tagging the box as
-   Crabbox-owned (`crabbox=true`, `crabbox-name=crabbox-<repo-slug>-<random6>`).
+   Crabbox-owned (`crabbox=true`, `crabbox-name=crabbox-<repo-slug>-<random6>`),
+   then writes the random ownership marker as the `crabbox.claim` sandbox tag.
    The returned sandbox ID (`sb-...`) is the canonical identifier.
 2. The local lease is stored as `ocbx_<sandbox-id>` with a friendly slug and a
    repo claim.
@@ -196,6 +198,9 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
 - IDs accepted by `--id` and `stop` are Crabbox slugs and `ocbx_<sandbox-id>`
   lease IDs that have a local Crabbox claim. Sandboxes without a local claim are
   rejected (the same Crabbox-owned-only safety pattern as Islo).
+- Do not edit the reserved `crabbox.claim` sandbox tag. A missing or changed
+  value fails closed for reuse and deletion; restore it from the local claim or
+  clean up the sandbox explicitly in OpenComputer.
 
 Related docs:
 

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -54,9 +54,11 @@ written by `oc config set api-key`). It is sent only in the `X-API-Key` header,
 never persisted in Crabbox config and never placed on argv. If no key is
 resolvable, operations fail with a clear error.
 
-The API base URL defaults to `https://app.opencomputer.dev` and can be
-overridden with `openComputer.apiUrl` / `--opencomputer-api-url` /
-`OPENCOMPUTER_API_URL` (it also falls back to the `api_url` in the `oc` config).
+The API base URL defaults to `https://app.opencomputer.dev`. A trusted local
+override can come from `--opencomputer-api-url`,
+`CRABBOX_OPENCOMPUTER_API_URL`, `OPENCOMPUTER_API_URL`, or the `api_url` in the
+local `oc` config. Repository YAML cannot set the API URL: that prevents a
+checked-in config from redirecting an automatically loaded API key.
 
 ## Config
 
@@ -64,11 +66,11 @@ overridden with `openComputer.apiUrl` / `--opencomputer-api-url` /
 provider: opencomputer
 target: linux
 openComputer:
-  apiUrl: https://app.opencomputer.dev
   workdir: /workspace/crabbox  # absolute path; sync target and exec cwd
-  cpu: 0                       # vCPUs; 0 leaves it to the OpenComputer default
-  memoryMB: 0                  # memory in MB; 0 leaves it to the default
+  cpu: 0                       # vCPUs; service infers memory when set alone
+  memoryMB: 0                  # memory; service infers CPU when set alone
   timeoutSecs: 0               # sandbox idle timeout; 0 leaves it to the default
+  execTimeoutSecs: 3600        # command/sync-helper timeout
 ```
 
 Provider flags:
@@ -79,16 +81,18 @@ Provider flags:
 --opencomputer-cpu
 --opencomputer-memory-mb
 --opencomputer-timeout-secs
+--opencomputer-exec-timeout-secs
 ```
 
 Each flag has a matching `CRABBOX_OPENCOMPUTER_*` environment override (for
-example `CRABBOX_OPENCOMPUTER_WORKDIR`, `CRABBOX_OPENCOMPUTER_CPU`). The API URL
-also reads `OPENCOMPUTER_API_URL`.
+example `CRABBOX_OPENCOMPUTER_WORKDIR`, `CRABBOX_OPENCOMPUTER_CPU`,
+`CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS`). The API URL also reads
+`OPENCOMPUTER_API_URL`.
 
-> **Sizing tiers.** `cpu` and `memoryMB` must form an allowed tier (for example
-> `1/1024`, `1/4096`, `2/8192`, `4/16384`). They are sent only when both are
-> set; leaving either at `0` uses the OpenComputer default tier, so an invalid
-> partial sizing is never sent.
+> **Sizing tiers.** When both `cpu` and `memoryMB` are set, they must form an
+> allowed tier (for example `1/1024`, `1/4096`, `2/8192`, `4/16384`). When only
+> one is set, OpenComputer infers the matching value. Leaving both at `0` uses
+> the service default tier.
 
 ### Environment forwarding
 
@@ -120,7 +124,9 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
    are streamed back and the remote exit code is mirrored.
 5. On release the sandbox is deleted (`DELETE /api/sandboxes/<id>`) unless
    `--keep` was set. `--keep-on-failure` retains a newly created sandbox after a
-   failed run and prints a rerun/stop hint.
+   failed run and prints a rerun/stop hint. Best-effort cleanup calls are
+   bounded to 15 seconds; a failed rollback reports the remote sandbox ID for
+   manual cleanup in the OpenComputer console.
 
 ## Capabilities
 
@@ -142,6 +148,12 @@ crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
 
 - `--checksum` is rejected because OpenComputer does not expose Crabbox's rsync
   checksum semantics. `--sync-only` and `--force-sync-large` are supported.
+- `--no-sync` only ensures the workdir exists. It never applies `sync.delete`,
+  so reusing a retained sandbox does not erase its workspace.
+- Command and sync-helper requests use a 3600-second timeout by default instead
+  of OpenComputer's 60-second API default. Override it with
+  `openComputer.execTimeoutSecs` or
+  `CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS`.
 - Large-sync guardrails still apply; pass `--force-sync-large` when a large
   archive sync is intentional.
 - `--shell` wraps the command as `bash -lc '<joined args>'`. Plain commands that

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -1,0 +1,161 @@
+# OpenComputer Provider
+
+Read when:
+
+- choosing `provider: opencomputer` (aliases: `oc`, `open-computer`);
+- configuring the OpenComputer sandbox sizing, workdir, or API URL;
+- changing `internal/providers/opencomputer`.
+
+OpenComputer is a delegated run provider. Crabbox talks to the
+[OpenComputer](https://app.opencomputer.dev) REST API directly (no `oc` CLI
+process at runtime) for sandbox lifecycle, command execution, and file sync.
+OpenComputer owns the Linux VM and the command transport; Crabbox owns local
+config, repo claims, sync manifests and guardrails, slugs, timing summaries, and
+normalized list/status rendering.
+
+The API key travels only in the `X-API-Key` header and every payload (command
+env, file content) travels in request bodies, so nothing sensitive is ever
+placed on a process command line.
+
+## When To Use
+
+Use OpenComputer when the remote box should be an OpenComputer full Linux VM.
+Use AWS, Hetzner, Static SSH, or Daytona when you need Crabbox-native SSH
+access, since OpenComputer does not expose SSH through Crabbox.
+
+## Prerequisites
+
+An OpenComputer API key (`osb_...`). The easiest way to provide it is the `oc`
+CLI's config file, which Crabbox reads automatically:
+
+```sh
+oc config set api-key osb_...
+```
+
+The `oc` binary is **not** required at runtime — Crabbox only reads the key it
+stores. Alternatively set `CRABBOX_OPENCOMPUTER_API_KEY` (or
+`OPENCOMPUTER_API_KEY`) in the environment.
+
+## Commands
+
+```sh
+crabbox warmup --provider opencomputer
+crabbox run --provider opencomputer -- pnpm test
+crabbox run --provider opencomputer --id blue-lobster --shell 'pnpm install && pnpm test'
+crabbox status --provider opencomputer --id blue-lobster
+crabbox stop --provider opencomputer blue-lobster
+```
+
+## Auth
+
+Crabbox resolves the API key from, in order, `CRABBOX_OPENCOMPUTER_API_KEY`,
+`OPENCOMPUTER_API_KEY`, then the `oc` CLI config file (`~/.oc/config.json`,
+written by `oc config set api-key`). It is sent only in the `X-API-Key` header,
+never persisted in Crabbox config and never placed on argv. If no key is
+resolvable, operations fail with a clear error.
+
+The API base URL defaults to `https://app.opencomputer.dev` and can be
+overridden with `openComputer.apiUrl` / `--opencomputer-api-url` /
+`OPENCOMPUTER_API_URL` (it also falls back to the `api_url` in the `oc` config).
+
+## Config
+
+```yaml
+provider: opencomputer
+target: linux
+openComputer:
+  apiUrl: https://app.opencomputer.dev
+  workdir: /workspace/crabbox  # absolute path; sync target and exec cwd
+  cpu: 0                       # vCPUs; 0 leaves it to the OpenComputer default
+  memoryMB: 0                  # memory in MB; 0 leaves it to the default
+  timeoutSecs: 0               # sandbox idle timeout; 0 leaves it to the default
+```
+
+Provider flags:
+
+```text
+--opencomputer-api-url
+--opencomputer-workdir
+--opencomputer-cpu
+--opencomputer-memory-mb
+--opencomputer-timeout-secs
+```
+
+Each flag has a matching `CRABBOX_OPENCOMPUTER_*` environment override (for
+example `CRABBOX_OPENCOMPUTER_WORKDIR`, `CRABBOX_OPENCOMPUTER_CPU`). The API URL
+also reads `OPENCOMPUTER_API_URL`.
+
+> **Sizing tiers.** `cpu` and `memoryMB` must form an allowed tier (for example
+> `1/1024`, `1/4096`, `2/8192`, `4/16384`). They are sent only when both are
+> set; leaving either at `0` uses the OpenComputer default tier, so an invalid
+> partial sizing is never sent.
+
+### Environment forwarding
+
+`--allow-env` / `--env-from-profile` are supported and never place values on the
+command line: forwarded env is sent in the body of the exec request (`POST
+/api/sandboxes/<id>/exec/run`, the `envs` field), so values never appear in any
+process argv.
+
+```sh
+crabbox run --provider opencomputer --allow-env API_TOKEN -- printenv API_TOKEN
+```
+
+## Lifecycle
+
+1. `warmup` or `run` without `--id` calls `POST /api/sandboxes` with the
+   configured timeout and sizing tier and `metadata` tagging the box as
+   Crabbox-owned (`crabbox=true`, `crabbox-name=crabbox-<repo-slug>-<random6>`).
+   The returned sandbox ID (`sb-...`) is the canonical identifier.
+2. The local lease is stored as `ocbx_<sandbox-id>` with a friendly slug and a
+   repo claim.
+3. By default `run` archive-syncs the working tree: a `git ls-files`-driven
+   manifest is packed into a gzipped tar locally, uploaded via the file API
+   (`PUT /api/sandboxes/<id>/files?path=...`, content in the request body), and
+   extracted into the configured workdir. `--no-sync` skips the archive step
+   (the workdir is still created); `--sync-only` syncs and stops without running
+   a command.
+4. The command runs via `POST /api/sandboxes/<id>/exec/run` with `cwd` set to
+   the workdir and `envs` carrying any forwarded env; the buffered stdout/stderr
+   are streamed back and the remote exit code is mirrored.
+5. On release the sandbox is deleted (`DELETE /api/sandboxes/<id>`) unless
+   `--keep` was set. `--keep-on-failure` retains a newly created sandbox after a
+   failed run and prints a rerun/stop hint.
+
+## Capabilities
+
+- SSH: not driven by Crabbox.
+- Crabbox sync: yes — gzipped tar uploaded via the file API (off-argv) and
+  extracted in-sandbox. The archive-sync feature is advertised, so
+  `--force-sync-large` and `--sync-only` are honored.
+- Env forwarding: yes — off-argv, in the exec request body.
+- Provider sync: no separate provider-side copy command is required.
+- URL bridge: no — OpenComputer preview URLs are managed by the OpenComputer
+  control plane rather than the Crabbox bridge plane (same honest-unsupported
+  pattern as Modal and Tensorlake).
+- Desktop / browser / code: no Crabbox VNC or code-server surface.
+- Actions hydration: no.
+- Coordinator: no — OpenComputer always runs direct against the API and never
+  goes through the broker.
+
+## Gotchas
+
+- `--checksum` is rejected because OpenComputer does not expose Crabbox's rsync
+  checksum semantics. `--sync-only` and `--force-sync-large` are supported.
+- Large-sync guardrails still apply; pass `--force-sync-large` when a large
+  archive sync is intentional.
+- `--shell` wraps the command as `bash -lc '<joined args>'`. Plain commands that
+  contain shell metacharacters (`&&`, `|`, `>`, etc.) or a leading `KEY=VALUE`
+  assignment are auto-wrapped the same way.
+- `exec/run` is buffered: stdout/stderr are returned when the command finishes
+  rather than streamed line-by-line.
+- `openComputer.workdir` must be an absolute path (default `/workspace/crabbox`)
+  and cannot be a broad system directory such as `/`, `/tmp`, or `/workspace`.
+  It is both the sync target and the exec working directory.
+- IDs accepted by `--id` and `stop` are Crabbox slugs and `ocbx_<sandbox-id>`
+  lease IDs that have a local Crabbox claim. Sandboxes without a local claim are
+  rejected (the same Crabbox-owned-only safety pattern as Islo).
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -85,10 +85,10 @@ SSH-lease providers:
 Delegated-run providers (no SSH lease):
 
 - Cloudflare Containers: `internal/providers/cloudflare`, with the Worker runtime in `worker/src/cloudflare-container-runner.ts`
-- Docker Sandbox, E2B, Islo, Modal, Tensorlake, Upstash, Blacksmith, W&B:
+- Docker Sandbox, E2B, Islo, Modal, OpenComputer, Tensorlake, Upstash, Blacksmith, W&B:
   `internal/providers/dockersandbox`,
   `internal/providers/e2b`, `internal/providers/islo`, `internal/providers/modal`,
-  `internal/providers/tensorlake`, `internal/providers/upstashbox`,
+  `internal/providers/opencomputer`, `internal/providers/tensorlake`, `internal/providers/upstashbox`,
   `internal/providers/blacksmith`, `internal/providers/wandb`
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -494,9 +494,6 @@ func listLeaseClaimsWithPrefix(prefix string) ([]leaseClaim, error) {
 		}
 		claim, err := readLeaseClaim(leaseID)
 		if err != nil {
-			if prefix != "" {
-				continue
-			}
 			return nil, err
 		}
 		if claim.LeaseID != "" {

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -468,6 +468,10 @@ func removeLeaseClaim(leaseID string) {
 }
 
 func listLeaseClaims() ([]leaseClaim, error) {
+	return listLeaseClaimsWithPrefix("")
+}
+
+func listLeaseClaimsWithPrefix(prefix string) ([]leaseClaim, error) {
 	dir, err := crabboxStateDir()
 	if err != nil {
 		return nil, err
@@ -485,8 +489,14 @@ func listLeaseClaims() ([]leaseClaim, error) {
 			continue
 		}
 		leaseID := strings.TrimSuffix(entry.Name(), ".json")
+		if prefix != "" && !strings.HasPrefix(leaseID, prefix) {
+			continue
+		}
 		claim, err := readLeaseClaim(leaseID)
 		if err != nil {
+			if prefix != "" {
+				continue
+			}
 			return nil, err
 		}
 		if claim.LeaseID != "" {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -116,6 +116,7 @@ type Config struct {
 	isloImageExplicit             bool
 	Tenki                         TenkiConfig
 	Tensorlake                    TensorlakeConfig
+	OpenComputer                  OpenComputerConfig
 	DockerSandbox                 DockerSandboxConfig
 	Modal                         ModalConfig
 	UpstashBox                    UpstashBoxConfig
@@ -400,6 +401,19 @@ type TensorlakeConfig struct {
 	DiskMB         int
 	TimeoutSecs    int
 	NoInternet     bool
+}
+
+// OpenComputerConfig configures the delegated OpenComputer provider, which
+// talks to the OpenComputer REST API. The API key is intentionally absent: it
+// is read at runtime from CRABBOX_OPENCOMPUTER_API_KEY / OPENCOMPUTER_API_KEY
+// or the `oc` CLI config (`oc config set api-key`), and sent only in the
+// X-API-Key header — never persisted in Crabbox config or placed on argv.
+type OpenComputerConfig struct {
+	APIURL      string
+	Workdir     string
+	CPU         int
+	MemoryMB    int
+	TimeoutSecs int
 }
 
 type DockerSandboxConfig struct {
@@ -1234,6 +1248,13 @@ func baseConfig() Config {
 			MemoryMB: 1024,
 			DiskMB:   10240,
 		},
+		OpenComputer: OpenComputerConfig{
+			// APIURL is intentionally unset here so the `oc` config file's
+			// api_url is honored before the built-in default; the provider
+			// applies the default (https://app.opencomputer.dev) as the final
+			// fallback in newOCAPIClient.
+			Workdir: "/workspace/crabbox",
+		},
 		DockerSandbox: DockerSandboxConfig{
 			CLIPath: "sbx",
 			Agent:   "shell",
@@ -1368,6 +1389,7 @@ type fileConfig struct {
 	Islo                 *fileIsloConfig                    `yaml:"islo,omitempty"`
 	Tenki                *fileTenkiConfig                   `yaml:"tenki,omitempty"`
 	Tensorlake           *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
+	OpenComputer         *fileOpenComputerConfig            `yaml:"openComputer,omitempty"`
 	DockerSandbox        *fileDockerSandboxConfig           `yaml:"dockerSandbox,omitempty"`
 	Modal                *fileModalConfig                   `yaml:"modal,omitempty"`
 	UpstashBox           *fileUpstashBoxConfig              `yaml:"upstashBox,omitempty"`
@@ -1736,6 +1758,14 @@ type fileTensorlakeConfig struct {
 	DiskMB         int     `yaml:"diskMB,omitempty"`
 	TimeoutSecs    int     `yaml:"timeoutSecs,omitempty"`
 	NoInternet     *bool   `yaml:"noInternet,omitempty"`
+}
+
+type fileOpenComputerConfig struct {
+	APIURL      string `yaml:"apiUrl,omitempty"`
+	Workdir     string `yaml:"workdir,omitempty"`
+	CPU         int    `yaml:"cpu,omitempty"`
+	MemoryMB    int    `yaml:"memoryMB,omitempty"`
+	TimeoutSecs int    `yaml:"timeoutSecs,omitempty"`
 }
 
 type fileDockerSandboxConfig struct {
@@ -2966,6 +2996,23 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.Tensorlake.NoInternet = *file.Tensorlake.NoInternet
 		}
 	}
+	if file.OpenComputer != nil {
+		if file.OpenComputer.APIURL != "" {
+			cfg.OpenComputer.APIURL = file.OpenComputer.APIURL
+		}
+		if file.OpenComputer.Workdir != "" {
+			cfg.OpenComputer.Workdir = file.OpenComputer.Workdir
+		}
+		if file.OpenComputer.CPU > 0 {
+			cfg.OpenComputer.CPU = file.OpenComputer.CPU
+		}
+		if file.OpenComputer.MemoryMB > 0 {
+			cfg.OpenComputer.MemoryMB = file.OpenComputer.MemoryMB
+		}
+		if file.OpenComputer.TimeoutSecs > 0 {
+			cfg.OpenComputer.TimeoutSecs = file.OpenComputer.TimeoutSecs
+		}
+	}
 	if file.DockerSandbox != nil {
 		if file.DockerSandbox.CLIPath != "" {
 			cfg.DockerSandbox.CLIPath = file.DockerSandbox.CLIPath
@@ -3918,6 +3965,11 @@ func applyEnv(cfg *Config) error {
 	if v, ok := getenvBool("CRABBOX_TENSORLAKE_NO_INTERNET"); ok {
 		cfg.Tensorlake.NoInternet = v
 	}
+	cfg.OpenComputer.APIURL = getenv("CRABBOX_OPENCOMPUTER_API_URL", getenv("OPENCOMPUTER_API_URL", cfg.OpenComputer.APIURL))
+	cfg.OpenComputer.Workdir = getenv("CRABBOX_OPENCOMPUTER_WORKDIR", cfg.OpenComputer.Workdir)
+	cfg.OpenComputer.CPU = getenvInt("CRABBOX_OPENCOMPUTER_CPU", cfg.OpenComputer.CPU)
+	cfg.OpenComputer.MemoryMB = getenvInt("CRABBOX_OPENCOMPUTER_MEMORY_MB", cfg.OpenComputer.MemoryMB)
+	cfg.OpenComputer.TimeoutSecs = getenvInt("CRABBOX_OPENCOMPUTER_TIMEOUT_SECS", cfg.OpenComputer.TimeoutSecs)
 	cfg.DockerSandbox.CLIPath = getenv("CRABBOX_DOCKER_SANDBOX_CLI", cfg.DockerSandbox.CLIPath)
 	cfg.DockerSandbox.Agent = getenv("CRABBOX_DOCKER_SANDBOX_AGENT", cfg.DockerSandbox.Agent)
 	cfg.DockerSandbox.Template = getenv("CRABBOX_DOCKER_SANDBOX_TEMPLATE", cfg.DockerSandbox.Template)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -426,6 +426,7 @@ type OpenComputerConfig struct {
 	MemoryMB        int
 	TimeoutSecs     int
 	ExecTimeoutSecs int
+	Burst           bool
 	ForgetMissing   bool
 }
 
@@ -1797,6 +1798,7 @@ type fileOpenComputerConfig struct {
 	MemoryMB        *int   `yaml:"memoryMB,omitempty"`
 	TimeoutSecs     *int   `yaml:"timeoutSecs,omitempty"`
 	ExecTimeoutSecs *int   `yaml:"execTimeoutSecs,omitempty"`
+	Burst           *bool  `yaml:"burst,omitempty"`
 }
 
 type fileDockerSandboxConfig struct {
@@ -3066,6 +3068,9 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		if file.OpenComputer.ExecTimeoutSecs != nil {
 			cfg.OpenComputer.ExecTimeoutSecs = *file.OpenComputer.ExecTimeoutSecs
 		}
+		if file.OpenComputer.Burst != nil {
+			cfg.OpenComputer.Burst = *file.OpenComputer.Burst
+		}
 	}
 	if file.DockerSandbox != nil {
 		if file.DockerSandbox.CLIPath != "" {
@@ -4036,6 +4041,9 @@ func applyEnv(cfg *Config) error {
 	cfg.OpenComputer.MemoryMB = getenvInt("CRABBOX_OPENCOMPUTER_MEMORY_MB", cfg.OpenComputer.MemoryMB)
 	cfg.OpenComputer.TimeoutSecs = getenvInt("CRABBOX_OPENCOMPUTER_TIMEOUT_SECS", cfg.OpenComputer.TimeoutSecs)
 	cfg.OpenComputer.ExecTimeoutSecs = getenvInt("CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS", cfg.OpenComputer.ExecTimeoutSecs)
+	if v, ok := getenvBool("CRABBOX_OPENCOMPUTER_BURST"); ok {
+		cfg.OpenComputer.Burst = v
+	}
 	cfg.DockerSandbox.CLIPath = getenv("CRABBOX_DOCKER_SANDBOX_CLI", cfg.DockerSandbox.CLIPath)
 	cfg.DockerSandbox.Agent = getenv("CRABBOX_DOCKER_SANDBOX_AGENT", cfg.DockerSandbox.Agent)
 	cfg.DockerSandbox.Template = getenv("CRABBOX_DOCKER_SANDBOX_TEMPLATE", cfg.DockerSandbox.Template)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -420,11 +420,12 @@ type TensorlakeConfig struct {
 // or the `oc` CLI config (`oc config set api-key`), and sent only in the
 // X-API-Key header — never persisted in Crabbox config or placed on argv.
 type OpenComputerConfig struct {
-	APIURL      string
-	Workdir     string
-	CPU         int
-	MemoryMB    int
-	TimeoutSecs int
+	APIURL          string
+	Workdir         string
+	CPU             int
+	MemoryMB        int
+	TimeoutSecs     int
+	ExecTimeoutSecs int
 }
 
 type DockerSandboxConfig struct {
@@ -1270,7 +1271,8 @@ func baseConfig() Config {
 			// api_url is honored before the built-in default; the provider
 			// applies the default (https://app.opencomputer.dev) as the final
 			// fallback in newOCAPIClient.
-			Workdir: "/workspace/crabbox",
+			Workdir:         "/workspace/crabbox",
+			ExecTimeoutSecs: 3600,
 		},
 		DockerSandbox: DockerSandboxConfig{
 			CLIPath: "sbx",
@@ -1789,11 +1791,11 @@ type fileTensorlakeConfig struct {
 }
 
 type fileOpenComputerConfig struct {
-	APIURL      string `yaml:"apiUrl,omitempty"`
-	Workdir     string `yaml:"workdir,omitempty"`
-	CPU         int    `yaml:"cpu,omitempty"`
-	MemoryMB    int    `yaml:"memoryMB,omitempty"`
-	TimeoutSecs int    `yaml:"timeoutSecs,omitempty"`
+	Workdir         string `yaml:"workdir,omitempty"`
+	CPU             *int   `yaml:"cpu,omitempty"`
+	MemoryMB        *int   `yaml:"memoryMB,omitempty"`
+	TimeoutSecs     *int   `yaml:"timeoutSecs,omitempty"`
+	ExecTimeoutSecs *int   `yaml:"execTimeoutSecs,omitempty"`
 }
 
 type fileDockerSandboxConfig struct {
@@ -3048,20 +3050,20 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		}
 	}
 	if file.OpenComputer != nil {
-		if file.OpenComputer.APIURL != "" {
-			cfg.OpenComputer.APIURL = file.OpenComputer.APIURL
-		}
 		if file.OpenComputer.Workdir != "" {
 			cfg.OpenComputer.Workdir = file.OpenComputer.Workdir
 		}
-		if file.OpenComputer.CPU > 0 {
-			cfg.OpenComputer.CPU = file.OpenComputer.CPU
+		if file.OpenComputer.CPU != nil {
+			cfg.OpenComputer.CPU = *file.OpenComputer.CPU
 		}
-		if file.OpenComputer.MemoryMB > 0 {
-			cfg.OpenComputer.MemoryMB = file.OpenComputer.MemoryMB
+		if file.OpenComputer.MemoryMB != nil {
+			cfg.OpenComputer.MemoryMB = *file.OpenComputer.MemoryMB
 		}
-		if file.OpenComputer.TimeoutSecs > 0 {
-			cfg.OpenComputer.TimeoutSecs = file.OpenComputer.TimeoutSecs
+		if file.OpenComputer.TimeoutSecs != nil {
+			cfg.OpenComputer.TimeoutSecs = *file.OpenComputer.TimeoutSecs
+		}
+		if file.OpenComputer.ExecTimeoutSecs != nil {
+			cfg.OpenComputer.ExecTimeoutSecs = *file.OpenComputer.ExecTimeoutSecs
 		}
 	}
 	if file.DockerSandbox != nil {
@@ -4032,6 +4034,7 @@ func applyEnv(cfg *Config) error {
 	cfg.OpenComputer.CPU = getenvInt("CRABBOX_OPENCOMPUTER_CPU", cfg.OpenComputer.CPU)
 	cfg.OpenComputer.MemoryMB = getenvInt("CRABBOX_OPENCOMPUTER_MEMORY_MB", cfg.OpenComputer.MemoryMB)
 	cfg.OpenComputer.TimeoutSecs = getenvInt("CRABBOX_OPENCOMPUTER_TIMEOUT_SECS", cfg.OpenComputer.TimeoutSecs)
+	cfg.OpenComputer.ExecTimeoutSecs = getenvInt("CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS", cfg.OpenComputer.ExecTimeoutSecs)
 	cfg.DockerSandbox.CLIPath = getenv("CRABBOX_DOCKER_SANDBOX_CLI", cfg.DockerSandbox.CLIPath)
 	cfg.DockerSandbox.Agent = getenv("CRABBOX_DOCKER_SANDBOX_AGENT", cfg.DockerSandbox.Agent)
 	cfg.DockerSandbox.Template = getenv("CRABBOX_DOCKER_SANDBOX_TEMPLATE", cfg.DockerSandbox.Template)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -426,6 +426,7 @@ type OpenComputerConfig struct {
 	MemoryMB        int
 	TimeoutSecs     int
 	ExecTimeoutSecs int
+	ForgetMissing   bool
 }
 
 type DockerSandboxConfig struct {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -796,6 +796,30 @@ func TestOpenComputerConfigYAMLCannotSetAPIURL(t *testing.T) {
 	}
 }
 
+func TestOpenComputerBurstConfigYAMLAndEnv(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	var file fileConfig
+	if err := yaml.Unmarshal([]byte("openComputer:\n  burst: true\n"), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.OpenComputer.Burst {
+		t.Fatal("openComputer.burst YAML was not applied")
+	}
+
+	cfg.OpenComputer.Burst = false
+	t.Setenv("CRABBOX_OPENCOMPUTER_BURST", "true")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.OpenComputer.Burst {
+		t.Fatal("CRABBOX_OPENCOMPUTER_BURST was not applied")
+	}
+}
+
 func TestTartEnvExplicitFlags(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -761,6 +761,41 @@ func TestTartConfigYAMLMissingFieldsNotOverwritten(t *testing.T) {
 	}
 }
 
+func TestOpenComputerConfigYAMLExplicitZeroPreserved(t *testing.T) {
+	cfg := baseConfig()
+	cfg.OpenComputer.CPU = 8
+	cfg.OpenComputer.MemoryMB = 16384
+	cfg.OpenComputer.TimeoutSecs = 600
+	cfg.OpenComputer.ExecTimeoutSecs = 7200
+	zero := 0
+	file := fileConfig{OpenComputer: &fileOpenComputerConfig{
+		CPU:             &zero,
+		MemoryMB:        &zero,
+		TimeoutSecs:     &zero,
+		ExecTimeoutSecs: &zero,
+	}}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OpenComputer.CPU != 0 || cfg.OpenComputer.MemoryMB != 0 || cfg.OpenComputer.TimeoutSecs != 0 || cfg.OpenComputer.ExecTimeoutSecs != 0 {
+		t.Fatalf("explicit zero values not preserved: %#v", cfg.OpenComputer)
+	}
+}
+
+func TestOpenComputerConfigYAMLCannotSetAPIURL(t *testing.T) {
+	cfg := baseConfig()
+	var file fileConfig
+	if err := yaml.Unmarshal([]byte("openComputer:\n  apiUrl: https://attacker.example\n"), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OpenComputer.APIURL != "" {
+		t.Fatalf("repository config set OpenComputer API URL to %q", cfg.OpenComputer.APIURL)
+	}
+}
+
 func TestTartEnvExplicitFlags(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()
@@ -1174,6 +1209,7 @@ openComputer:
   cpu: 8
   memoryMB: 16384
   timeoutSecs: 600
+  execTimeoutSecs: 7200
 cloudflare:
   apiUrl: https://cloudflare.example.test
   token: cloudflare-token
@@ -1335,7 +1371,7 @@ ssh:
 	if cfg.Tensorlake.APIURL != "https://api.tensorlake.example.test" || cfg.Tensorlake.CLIPath != "/usr/local/bin/tl" || cfg.Tensorlake.Image != "ubuntu-22.04" || cfg.Tensorlake.Snapshot != "snap-tl" || cfg.Tensorlake.OrganizationID != "org-tl" || cfg.Tensorlake.ProjectID != "proj-tl" || cfg.Tensorlake.Namespace != "ns-tl" || cfg.Tensorlake.Workdir != "/workspace/crabbox-test" || cfg.Tensorlake.CPUs != 4 || cfg.Tensorlake.MemoryMB != 8192 || cfg.Tensorlake.DiskMB != 30000 || cfg.Tensorlake.TimeoutSecs != 1800 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("tensorlake config not loaded: %#v", cfg.Tensorlake)
 	}
-	if cfg.OpenComputer.APIURL != "https://opencomputer.example.test" || cfg.OpenComputer.Workdir != "/workspace/oc-test" || cfg.OpenComputer.CPU != 8 || cfg.OpenComputer.MemoryMB != 16384 || cfg.OpenComputer.TimeoutSecs != 600 {
+	if cfg.OpenComputer.APIURL != "" || cfg.OpenComputer.Workdir != "/workspace/oc-test" || cfg.OpenComputer.CPU != 8 || cfg.OpenComputer.MemoryMB != 16384 || cfg.OpenComputer.TimeoutSecs != 600 || cfg.OpenComputer.ExecTimeoutSecs != 7200 {
 		t.Fatalf("opencomputer config not loaded: %#v", cfg.OpenComputer)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare.example.test" || cfg.Cloudflare.Token != "cloudflare-token" || cfg.Cloudflare.Workdir != "/workspace/cf-test" {
@@ -1657,6 +1693,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_OPENCOMPUTER_CPU", "6")
 	t.Setenv("CRABBOX_OPENCOMPUTER_MEMORY_MB", "12288")
 	t.Setenv("CRABBOX_OPENCOMPUTER_TIMEOUT_SECS", "1200")
+	t.Setenv("CRABBOX_OPENCOMPUTER_EXEC_TIMEOUT_SECS", "2400")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_URL", "https://cloudflare-env.example")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", "cloudflare-env-token")
 	t.Setenv("CRABBOX_CLOUDFLARE_WORKDIR", "/workspace/cloudflare-env")
@@ -1811,7 +1848,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	if cfg.Tensorlake.APIKey != "tl-api-env" || cfg.Tensorlake.APIURL != "https://api.tl-env.example" || cfg.Tensorlake.CLIPath != "/opt/tl/bin/tensorlake" || cfg.Tensorlake.Image != "ubuntu:tl-env" || cfg.Tensorlake.Snapshot != "snap-tl-env" || cfg.Tensorlake.OrganizationID != "org-tl-env" || cfg.Tensorlake.ProjectID != "proj-tl-env" || cfg.Tensorlake.Namespace != "ns-tl-env" || cfg.Tensorlake.Workdir != "/workspace/tl-env" || cfg.Tensorlake.CPUs != 2.5 || cfg.Tensorlake.MemoryMB != 4096 || cfg.Tensorlake.DiskMB != 20480 || cfg.Tensorlake.TimeoutSecs != 900 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("unexpected tensorlake env: %#v", cfg.Tensorlake)
 	}
-	if cfg.OpenComputer.APIURL != "https://oc-env.example" || cfg.OpenComputer.Workdir != "/workspace/oc-env" || cfg.OpenComputer.CPU != 6 || cfg.OpenComputer.MemoryMB != 12288 || cfg.OpenComputer.TimeoutSecs != 1200 {
+	if cfg.OpenComputer.APIURL != "https://oc-env.example" || cfg.OpenComputer.Workdir != "/workspace/oc-env" || cfg.OpenComputer.CPU != 6 || cfg.OpenComputer.MemoryMB != 12288 || cfg.OpenComputer.TimeoutSecs != 1200 || cfg.OpenComputer.ExecTimeoutSecs != 2400 {
 		t.Fatalf("unexpected opencomputer env: %#v", cfg.OpenComputer)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare-env.example" || cfg.Cloudflare.Token != "cloudflare-env-token" || cfg.Cloudflare.Workdir != "/workspace/cloudflare-env" {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1152,6 +1152,12 @@ tensorlake:
   diskMB: 30000
   timeoutSecs: 1800
   noInternet: true
+openComputer:
+  apiUrl: https://opencomputer.example.test
+  workdir: /workspace/oc-test
+  cpu: 8
+  memoryMB: 16384
+  timeoutSecs: 600
 cloudflare:
   apiUrl: https://cloudflare.example.test
   token: cloudflare-token
@@ -1309,6 +1315,9 @@ ssh:
 	}
 	if cfg.Tensorlake.APIURL != "https://api.tensorlake.example.test" || cfg.Tensorlake.CLIPath != "/usr/local/bin/tl" || cfg.Tensorlake.Image != "ubuntu-22.04" || cfg.Tensorlake.Snapshot != "snap-tl" || cfg.Tensorlake.OrganizationID != "org-tl" || cfg.Tensorlake.ProjectID != "proj-tl" || cfg.Tensorlake.Namespace != "ns-tl" || cfg.Tensorlake.Workdir != "/workspace/crabbox-test" || cfg.Tensorlake.CPUs != 4 || cfg.Tensorlake.MemoryMB != 8192 || cfg.Tensorlake.DiskMB != 30000 || cfg.Tensorlake.TimeoutSecs != 1800 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("tensorlake config not loaded: %#v", cfg.Tensorlake)
+	}
+	if cfg.OpenComputer.APIURL != "https://opencomputer.example.test" || cfg.OpenComputer.Workdir != "/workspace/oc-test" || cfg.OpenComputer.CPU != 8 || cfg.OpenComputer.MemoryMB != 16384 || cfg.OpenComputer.TimeoutSecs != 600 {
+		t.Fatalf("opencomputer config not loaded: %#v", cfg.OpenComputer)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare.example.test" || cfg.Cloudflare.Token != "cloudflare-token" || cfg.Cloudflare.Workdir != "/workspace/cf-test" {
 		t.Fatalf("cloudflare config not loaded: %#v", cfg.Cloudflare)
@@ -1615,6 +1624,12 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_TENSORLAKE_DISK_MB", "20480")
 	t.Setenv("CRABBOX_TENSORLAKE_TIMEOUT_SECS", "900")
 	t.Setenv("CRABBOX_TENSORLAKE_NO_INTERNET", "true")
+	t.Setenv("OPENCOMPUTER_API_URL", "https://oc-file.example")
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_URL", "https://oc-env.example")
+	t.Setenv("CRABBOX_OPENCOMPUTER_WORKDIR", "/workspace/oc-env")
+	t.Setenv("CRABBOX_OPENCOMPUTER_CPU", "6")
+	t.Setenv("CRABBOX_OPENCOMPUTER_MEMORY_MB", "12288")
+	t.Setenv("CRABBOX_OPENCOMPUTER_TIMEOUT_SECS", "1200")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_URL", "https://cloudflare-env.example")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", "cloudflare-env-token")
 	t.Setenv("CRABBOX_CLOUDFLARE_WORKDIR", "/workspace/cloudflare-env")
@@ -1765,6 +1780,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Tensorlake.APIKey != "tl-api-env" || cfg.Tensorlake.APIURL != "https://api.tl-env.example" || cfg.Tensorlake.CLIPath != "/opt/tl/bin/tensorlake" || cfg.Tensorlake.Image != "ubuntu:tl-env" || cfg.Tensorlake.Snapshot != "snap-tl-env" || cfg.Tensorlake.OrganizationID != "org-tl-env" || cfg.Tensorlake.ProjectID != "proj-tl-env" || cfg.Tensorlake.Namespace != "ns-tl-env" || cfg.Tensorlake.Workdir != "/workspace/tl-env" || cfg.Tensorlake.CPUs != 2.5 || cfg.Tensorlake.MemoryMB != 4096 || cfg.Tensorlake.DiskMB != 20480 || cfg.Tensorlake.TimeoutSecs != 900 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("unexpected tensorlake env: %#v", cfg.Tensorlake)
+	}
+	if cfg.OpenComputer.APIURL != "https://oc-env.example" || cfg.OpenComputer.Workdir != "/workspace/oc-env" || cfg.OpenComputer.CPU != 6 || cfg.OpenComputer.MemoryMB != 12288 || cfg.OpenComputer.TimeoutSecs != 1200 {
+		t.Fatalf("unexpected opencomputer env: %#v", cfg.OpenComputer)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare-env.example" || cfg.Cloudflare.Token != "cloudflare-env-token" || cfg.Cloudflare.Workdir != "/workspace/cloudflare-env" {
 		t.Fatalf("unexpected cloudflare env: %#v", cfg.Cloudflare)

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -655,6 +655,12 @@ func TestLeaseCreateFlagsRejectSnapshotSandboxResourceNoops(t *testing.T) {
 		{name: "modal type", args: []string{"--provider", "modal", "--type", "large"}},
 		{name: "sprites class", args: []string{"--provider", "sprites", "--class", "standard"}},
 		{name: "sprites type", args: []string{"--provider", "sprites", "--type", "large"}},
+		{name: "opencomputer class", args: []string{"--provider", "opencomputer", "--class", "standard"}},
+		{name: "opencomputer type", args: []string{"--provider", "opencomputer", "--type", "large"}},
+		{name: "opencomputer alias class", args: []string{"--provider", "oc", "--class", "standard"}},
+		{name: "opencomputer alias type", args: []string{"--provider", "open-computer", "--type", "large"}},
+		{name: "opencomputer mixed-case class", args: []string{"--provider", "OpenComputer", "--class", "standard"}},
+		{name: "opencomputer spaced alias type", args: []string{"--provider", " OC ", "--type", "large"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := newFlagSet("test", io.Discard)

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -135,6 +135,10 @@ func ListLeaseClaims() ([]LeaseClaim, error) {
 	return listLeaseClaims()
 }
 
+func ListLeaseClaimsWithPrefix(prefix string) ([]LeaseClaim, error) {
+	return listLeaseClaimsWithPrefix(prefix)
+}
+
 func ReadLeaseClaim(leaseID string) (LeaseClaim, error) {
 	return readLeaseClaim(leaseID)
 }

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/multipass"
 	_ "github.com/openclaw/crabbox/internal/providers/mxc"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
+	_ "github.com/openclaw/crabbox/internal/providers/opencomputer"
 	_ "github.com/openclaw/crabbox/internal/providers/parallels"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
 	_ "github.com/openclaw/crabbox/internal/providers/railway"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -80,6 +80,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"multipass",
 		"mxc",
 		"namespace-devbox",
+		"opencomputer",
 		"parallels",
 		"proxmox",
 		"railway",

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ocAPIClient is a thin REST client for the OpenComputer control plane. The
@@ -72,6 +74,12 @@ type ocAPIError struct {
 	err        error
 }
 
+const (
+	defaultOCControlRequestTimeout = 2 * time.Minute
+	defaultOCExecRequestTimeout    = time.Hour
+	ocExecRequestGrace             = 30 * time.Second
+)
+
 func (e *ocAPIError) Error() string { return e.err.Error() }
 func (e *ocAPIError) Unwrap() error { return e.err }
 
@@ -83,20 +91,92 @@ func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 	// API URL precedence: an explicit trusted Crabbox setting, then the `oc` CLI
 	// config file's api_url, then the built-in default. Repository YAML cannot
 	// populate cfg.OpenComputer.APIURL.
-	baseURL := strings.TrimRight(blank(strings.TrimSpace(cfg.OpenComputer.APIURL), blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)), "/")
+	baseURL, err := validateOCAPIURL(blank(strings.TrimSpace(cfg.OpenComputer.APIURL), blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)))
+	if err != nil {
+		return nil, err
+	}
 	apiKey := firstNonEmpty(
 		os.Getenv("CRABBOX_OPENCOMPUTER_API_KEY"),
 		os.Getenv("OPENCOMPUTER_API_KEY"),
 		fileCfg.APIKey,
 	)
 	if apiKey == "" {
-		return nil, exit(2, "provider=opencomputer needs an API key; set it with `oc config set api-key <key>` or CRABBOX_OPENCOMPUTER_API_KEY")
+		return nil, exit(2, "provider=opencomputer needs an API key; load CRABBOX_OPENCOMPUTER_API_KEY from a secret manager or configure an existing oc CLI credential")
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &ocAPIClient{http: httpClient, baseURL: baseURL, apiKey: apiKey}, nil
+	return &ocAPIClient{http: secureOCAPIClient(httpClient, baseURL), baseURL: baseURL, apiKey: apiKey}, nil
+}
+
+func validateOCAPIURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", exit(2, "provider=opencomputer API URL must be an absolute HTTPS URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "provider=opencomputer API URL must not contain userinfo, query parameters, or a fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return "", exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
+	}
+	cleanPath := strings.TrimRight(parsed.Path, "/")
+	if strings.HasSuffix(cleanPath, "/api") {
+		cleanPath = strings.TrimSuffix(cleanPath, "/api")
+	}
+	parsed.Path = cleanPath
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func secureOCAPIClient(source *http.Client, baseURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(baseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameOCOrigin(trusted, req.URL) {
+			return fmt.Errorf("opencomputer refused cross-origin redirect to %s", req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameOCOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveOCPort(a) == effectiveOCPort(b)
+}
+
+func effectiveOCPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func (c *ocAPIClient) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
@@ -111,6 +191,12 @@ func (c *ocAPIClient) newRequest(ctx context.Context, method, path string, body 
 // doJSON sends an optional JSON body and decodes a JSON response into out
 // (out may be nil). Non-2xx responses become errors carrying the response body.
 func (c *ocAPIClient) doJSON(ctx context.Context, method, path string, body, out any) error {
+	return c.doJSONWithTimeout(ctx, defaultOCControlRequestTimeout, method, path, body, out)
+}
+
+func (c *ocAPIClient) doJSONWithTimeout(ctx context.Context, timeout time.Duration, method, path string, body, out any) error {
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	var reader io.Reader
 	if body != nil {
 		buf, err := json.Marshal(body)
@@ -119,7 +205,7 @@ func (c *ocAPIClient) doJSON(ctx context.Context, method, path string, body, out
 		}
 		reader = bytes.NewReader(buf)
 	}
-	req, err := c.newRequest(ctx, method, path, reader)
+	req, err := c.newRequest(requestCtx, method, path, reader)
 	if err != nil {
 		return fmt.Errorf("opencomputer request %s: %w", path, err)
 	}
@@ -174,7 +260,11 @@ func (c *ocAPIClient) killSandbox(ctx context.Context, id string) error {
 
 func (c *ocAPIClient) execRun(ctx context.Context, id string, req execRunRequest) (execRunResult, error) {
 	var res execRunResult
-	if err := c.doJSON(ctx, http.MethodPost, "/api/sandboxes/"+url.PathEscape(id)+"/exec/run", req, &res); err != nil {
+	timeout := defaultOCExecRequestTimeout
+	if req.Timeout > 0 {
+		timeout = time.Duration(req.Timeout) * time.Second
+	}
+	if err := c.doJSONWithTimeout(ctx, timeout+ocExecRequestGrace, http.MethodPost, "/api/sandboxes/"+url.PathEscape(id)+"/exec/run", req, &res); err != nil {
 		return execRunResult{}, err
 	}
 	return res, nil

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,10 +41,6 @@ type sandbox struct {
 	MemoryMB int               `json:"memoryMB,omitempty"`
 }
 
-type sandboxListResponse struct {
-	Sandboxes []sandbox `json:"sandboxes"`
-}
-
 // createSandboxRequest is the POST /api/sandboxes body. When only CPU or memory
 // is set, OpenComputer infers the matching sizing value.
 type createSandboxRequest struct {
@@ -69,6 +66,14 @@ type execRunResult struct {
 	Stdout   string `json:"stdout"`
 	Stderr   string `json:"stderr"`
 }
+
+type ocAPIError struct {
+	StatusCode int
+	err        error
+}
+
+func (e *ocAPIError) Error() string { return e.err.Error() }
+func (e *ocAPIError) Unwrap() error { return e.err }
 
 // newOCAPIClient resolves the API URL and key. Key precedence:
 // CRABBOX_OPENCOMPUTER_API_KEY, OPENCOMPUTER_API_KEY, then the `oc` CLI config
@@ -158,22 +163,9 @@ func (c *ocAPIClient) getSandbox(ctx context.Context, id string) (sandbox, error
 	return sb, nil
 }
 
-func (c *ocAPIClient) listSandboxes(ctx context.Context) ([]sandbox, error) {
-	// The list endpoint may return either a bare array of sandboxes or an object
-	// wrapping them under "sandboxes"; accept both.
+func (c *ocAPIClient) probeSandboxes(ctx context.Context) error {
 	var raw json.RawMessage
-	if err := c.doJSON(ctx, http.MethodGet, "/api/sandboxes", nil, &raw); err != nil {
-		return nil, err
-	}
-	var arr []sandbox
-	if err := json.Unmarshal(raw, &arr); err == nil {
-		return arr, nil
-	}
-	var wrapped sandboxListResponse
-	if err := json.Unmarshal(raw, &wrapped); err == nil {
-		return wrapped.Sandboxes, nil
-	}
-	return nil, exit(5, "opencomputer list: unexpected response shape")
+	return c.doJSON(ctx, http.MethodGet, "/api/sandboxes", nil, &raw)
 }
 
 func (c *ocAPIClient) killSandbox(ctx context.Context, id string) error {
@@ -218,7 +210,15 @@ func apiError(method, path string, resp *http.Response) error {
 	if json.Unmarshal(body, &wrapped) == nil && wrapped.Error != "" {
 		msg = wrapped.Error
 	}
-	return exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg)
+	return &ocAPIError{
+		StatusCode: resp.StatusCode,
+		err:        exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg),
+	}
+}
+
+func isOCNotFound(err error) bool {
+	var apiErr *ocAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
 func readOCFileConfig() ocFileConfig {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -123,6 +123,18 @@ func validateOCAPIURL(raw string) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
 	}
+	host := canonicalOCHostname(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
 	cleanPath := strings.TrimRight(parsed.Path, "/")
 	if strings.HasSuffix(cleanPath, "/api") {
 		cleanPath = strings.TrimSuffix(cleanPath, "/api")
@@ -130,6 +142,13 @@ func validateOCAPIURL(raw string) (string, error) {
 	parsed.Path = cleanPath
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func canonicalOCHostname(host string) string {
+	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
+		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
+	}
+	return strings.ToLower(host)
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -44,9 +44,8 @@ type sandboxListResponse struct {
 	Sandboxes []sandbox `json:"sandboxes"`
 }
 
-// createSandboxRequest is the POST /api/sandboxes body. CPU/memory must form an
-// allowed tier (e.g. 1/1024, 2/8192); they are sent only when both are set, so
-// an unset sizing falls back to the service default tier.
+// createSandboxRequest is the POST /api/sandboxes body. When only CPU or memory
+// is set, OpenComputer infers the matching sizing value.
 type createSandboxRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 	Timeout  int               `json:"timeout,omitempty"`
@@ -76,9 +75,9 @@ type execRunResult struct {
 // (~/.oc/config.json). Returns an error when no key can be found.
 func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 	fileCfg := readOCFileConfig()
-	// API URL precedence: an explicit Crabbox setting (config/flag/env), then the
-	// `oc` CLI config file's api_url, then the built-in default. This honors
-	// `oc config set api-url <custom>` for users who never set it in Crabbox.
+	// API URL precedence: an explicit trusted Crabbox setting, then the `oc` CLI
+	// config file's api_url, then the built-in default. Repository YAML cannot
+	// populate cfg.OpenComputer.APIURL.
 	baseURL := strings.TrimRight(blank(strings.TrimSpace(cfg.OpenComputer.APIURL), blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)), "/")
 	apiKey := firstNonEmpty(
 		os.Getenv("CRABBOX_OPENCOMPUTER_API_KEY"),

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -1,0 +1,248 @@
+package opencomputer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ocAPIClient is a thin REST client for the OpenComputer control plane. The
+// provider talks to the API directly (no `oc` CLI dependency): the API key
+// travels only in the X-API-Key header and all payloads (command env, file
+// content) travel in request bodies, so nothing sensitive ever reaches argv.
+type ocAPIClient struct {
+	http    *http.Client
+	baseURL string
+	apiKey  string
+}
+
+// ocFileConfig mirrors the subset of ~/.oc/config.json that `oc config set`
+// persists. Crabbox reuses that credential rather than introducing a new
+// secret in its own config.
+type ocFileConfig struct {
+	APIURL string `json:"api_url"`
+	APIKey string `json:"api_key"`
+}
+
+// sandbox is the API representation of a sandbox (subset we use).
+type sandbox struct {
+	ID       string            `json:"sandboxID"`
+	Status   string            `json:"status"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+	CPUCount int               `json:"cpuCount,omitempty"`
+	MemoryMB int               `json:"memoryMB,omitempty"`
+}
+
+type sandboxListResponse struct {
+	Sandboxes []sandbox `json:"sandboxes"`
+}
+
+// createSandboxRequest is the POST /api/sandboxes body. CPU/memory must form an
+// allowed tier (e.g. 1/1024, 2/8192); they are sent only when both are set, so
+// an unset sizing falls back to the service default tier.
+type createSandboxRequest struct {
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Timeout  int               `json:"timeout,omitempty"`
+	CPUCount int               `json:"cpuCount,omitempty"`
+	MemoryMB int               `json:"memoryMB,omitempty"`
+	DiskMB   int               `json:"diskMB,omitempty"`
+}
+
+// execRunRequest is the POST /api/sandboxes/:id/exec/run body. Env travels in
+// the body (`envs`), never argv.
+type execRunRequest struct {
+	Cmd     string            `json:"cmd"`
+	Args    []string          `json:"args,omitempty"`
+	Envs    map[string]string `json:"envs,omitempty"`
+	Cwd     string            `json:"cwd,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
+}
+
+type execRunResult struct {
+	ExitCode int    `json:"exitCode"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+}
+
+// newOCAPIClient resolves the API URL and key. Key precedence:
+// CRABBOX_OPENCOMPUTER_API_KEY, OPENCOMPUTER_API_KEY, then the `oc` CLI config
+// (~/.oc/config.json). Returns an error when no key can be found.
+func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
+	fileCfg := readOCFileConfig()
+	// API URL precedence: an explicit Crabbox setting (config/flag/env), then the
+	// `oc` CLI config file's api_url, then the built-in default. This honors
+	// `oc config set api-url <custom>` for users who never set it in Crabbox.
+	baseURL := strings.TrimRight(blank(strings.TrimSpace(cfg.OpenComputer.APIURL), blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)), "/")
+	apiKey := firstNonEmpty(
+		os.Getenv("CRABBOX_OPENCOMPUTER_API_KEY"),
+		os.Getenv("OPENCOMPUTER_API_KEY"),
+		fileCfg.APIKey,
+	)
+	if apiKey == "" {
+		return nil, exit(2, "provider=opencomputer needs an API key; set it with `oc config set api-key <key>` or CRABBOX_OPENCOMPUTER_API_KEY")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &ocAPIClient{http: httpClient, baseURL: baseURL, apiKey: apiKey}, nil
+}
+
+func (c *ocAPIClient) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	return req, nil
+}
+
+// doJSON sends an optional JSON body and decodes a JSON response into out
+// (out may be nil). Non-2xx responses become errors carrying the response body.
+func (c *ocAPIClient) doJSON(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("opencomputer marshal %s: %w", path, err)
+		}
+		reader = bytes.NewReader(buf)
+	}
+	req, err := c.newRequest(ctx, method, path, reader)
+	if err != nil {
+		return fmt.Errorf("opencomputer request %s: %w", path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("opencomputer %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(method, path, resp)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("opencomputer decode %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *ocAPIClient) createSandbox(ctx context.Context, req createSandboxRequest) (sandbox, error) {
+	var sb sandbox
+	if err := c.doJSON(ctx, http.MethodPost, "/api/sandboxes", req, &sb); err != nil {
+		return sandbox{}, err
+	}
+	if sb.ID == "" {
+		return sandbox{}, exit(5, "opencomputer create returned no sandbox id")
+	}
+	return sb, nil
+}
+
+func (c *ocAPIClient) getSandbox(ctx context.Context, id string) (sandbox, error) {
+	var sb sandbox
+	if err := c.doJSON(ctx, http.MethodGet, "/api/sandboxes/"+url.PathEscape(id), nil, &sb); err != nil {
+		return sandbox{}, err
+	}
+	return sb, nil
+}
+
+func (c *ocAPIClient) listSandboxes(ctx context.Context) ([]sandbox, error) {
+	// The list endpoint may return either a bare array of sandboxes or an object
+	// wrapping them under "sandboxes"; accept both.
+	var raw json.RawMessage
+	if err := c.doJSON(ctx, http.MethodGet, "/api/sandboxes", nil, &raw); err != nil {
+		return nil, err
+	}
+	var arr []sandbox
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var wrapped sandboxListResponse
+	if err := json.Unmarshal(raw, &wrapped); err == nil {
+		return wrapped.Sandboxes, nil
+	}
+	return nil, exit(5, "opencomputer list: unexpected response shape")
+}
+
+func (c *ocAPIClient) killSandbox(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/api/sandboxes/"+url.PathEscape(id), nil, nil)
+}
+
+func (c *ocAPIClient) execRun(ctx context.Context, id string, req execRunRequest) (execRunResult, error) {
+	var res execRunResult
+	if err := c.doJSON(ctx, http.MethodPost, "/api/sandboxes/"+url.PathEscape(id)+"/exec/run", req, &res); err != nil {
+		return execRunResult{}, err
+	}
+	return res, nil
+}
+
+// uploadFile writes content to remotePath inside the sandbox via
+// `PUT /api/sandboxes/{id}/files?path=...`; the payload is the raw request body.
+func (c *ocAPIClient) uploadFile(ctx context.Context, id, remotePath string, content io.Reader) error {
+	path := fmt.Sprintf("/api/sandboxes/%s/files?path=%s", url.PathEscape(id), url.QueryEscape(remotePath))
+	req, err := c.newRequest(ctx, http.MethodPut, path, content)
+	if err != nil {
+		return fmt.Errorf("opencomputer file upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("opencomputer file upload %s: %w", remotePath, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(http.MethodPut, "files?path="+remotePath, resp)
+	}
+	return nil
+}
+
+func apiError(method, path string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+	// Surface the API's {"error": "..."} message when present.
+	var wrapped struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &wrapped) == nil && wrapped.Error != "" {
+		msg = wrapped.Error
+	}
+	return exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg)
+}
+
+func readOCFileConfig() ocFileConfig {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ocFileConfig{}
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".oc", "config.json"))
+	if err != nil {
+		return ocFileConfig{}
+	}
+	var cfg ocFileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return ocFileConfig{}
+	}
+	return cfg
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -52,6 +52,11 @@ type createSandboxRequest struct {
 	CPUCount int               `json:"cpuCount,omitempty"`
 	MemoryMB int               `json:"memoryMB,omitempty"`
 	DiskMB   int               `json:"diskMB,omitempty"`
+	Burst    bool              `json:"burst,omitempty"`
+}
+
+type sandboxTagsResponse struct {
+	Tags map[string]string `json:"tags"`
 }
 
 // execRunRequest is the POST /api/sandboxes/:id/exec/run body. Env travels in
@@ -280,6 +285,26 @@ func (c *ocAPIClient) killSandbox(ctx context.Context, id string) error {
 
 func (c *ocAPIClient) replaceSandboxTags(ctx context.Context, id string, tags map[string]string) error {
 	return c.doJSON(ctx, http.MethodPut, "/api/sandboxes/"+url.PathEscape(id)+"/tags", tags, nil)
+}
+
+func (c *ocAPIClient) getSandboxTags(ctx context.Context, id string) (map[string]string, error) {
+	var response sandboxTagsResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/api/sandboxes/"+url.PathEscape(id)+"/tags", nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Tags, nil
+}
+
+func (c *ocAPIClient) getSandboxWithTags(ctx context.Context, id string) (sandbox, error) {
+	sb, err := c.getSandbox(ctx, id)
+	if err != nil {
+		return sandbox{}, err
+	}
+	sb.Tags, err = c.getSandboxTags(ctx, id)
+	if err != nil {
+		return sandbox{}, err
+	}
+	return sb, nil
 }
 
 func (c *ocAPIClient) execRun(ctx context.Context, id string, req execRunRequest) (execRunResult, error) {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -3,6 +3,7 @@ package opencomputer
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,11 @@ type ocAPIClient struct {
 	http    *http.Client
 	baseURL string
 	apiKey  string
+}
+
+func (c *ocAPIClient) claimScope() string {
+	keyHash := sha256.Sum256([]byte(c.apiKey))
+	return fmt.Sprintf("endpoint:%s/key-sha256:%x", c.baseURL, keyHash[:])
 }
 
 // ocFileConfig mirrors the subset of ~/.oc/config.json that `oc config set`

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -3,7 +3,6 @@ package opencomputer
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,11 +26,6 @@ type ocAPIClient struct {
 	apiKey  string
 }
 
-func (c *ocAPIClient) claimScope() string {
-	keyHash := sha256.Sum256([]byte(c.apiKey))
-	return fmt.Sprintf("endpoint:%s/key-sha256:%x", c.baseURL, keyHash[:])
-}
-
 // ocFileConfig mirrors the subset of ~/.oc/config.json that `oc config set`
 // persists. Crabbox reuses that credential rather than introducing a new
 // secret in its own config.
@@ -45,6 +39,7 @@ type sandbox struct {
 	ID       string            `json:"sandboxID"`
 	Status   string            `json:"status"`
 	Metadata map[string]string `json:"metadata,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
 	CPUCount int               `json:"cpuCount,omitempty"`
 	MemoryMB int               `json:"memoryMB,omitempty"`
 }
@@ -262,6 +257,10 @@ func (c *ocAPIClient) probeSandboxes(ctx context.Context) error {
 
 func (c *ocAPIClient) killSandbox(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, "/api/sandboxes/"+url.PathEscape(id), nil, nil)
+}
+
+func (c *ocAPIClient) replaceSandboxTags(ctx context.Context, id string, tags map[string]string) error {
+	return c.doJSON(ctx, http.MethodPut, "/api/sandboxes/"+url.PathEscape(id)+"/tags", tags, nil)
 }
 
 func (c *ocAPIClient) execRun(ctx context.Context, id string, req execRunRequest) (execRunResult, error) {

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -3,6 +3,7 @@ package opencomputer
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 const (
 	openComputerCleanupTimeout  = 15 * time.Second
 	openComputerExecTimeoutSecs = 3600
+	openComputerClaimTagKey     = "crabbox.claim"
 )
 
 func NewOpenComputerBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -83,7 +85,18 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
 		acquired = true
 	} else {
-		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.claimScope())
+		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, "", false, 0, api.baseURL)
+		if err != nil {
+			return RunResult{}, err
+		}
+		if _, err := verifyOpenComputerClaim(ctx, api, leaseID, sandboxID); err != nil {
+			return RunResult{}, err
+		}
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
+		_, _, slug, err = finishResolvedLease(claim, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.baseURL)
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -207,7 +220,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
 		}
-		if claim.ProviderScope != api.claimScope() {
+		if validateOpenComputerClaimScope(claim, api.baseURL) != nil {
 			continue
 		}
 		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
@@ -223,6 +236,9 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 				return nil, getErr
 			}
 		} else {
+			if err := validateOpenComputerSandboxOwnership(claim, sb); err != nil {
+				return nil, err
+			}
 			state = blank(sb.Status, statusViewReady)
 		}
 		servers = append(servers, Server{
@@ -263,11 +279,11 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.claimScope())
+	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.baseURL)
 	if err != nil {
 		return StatusView{}, err
 	}
-	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID, api.claimScope())
+	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID, api.baseURL)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -297,6 +313,9 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 			// Surface real API failures (auth, 5xx, sandbox gone) instead of
 			// masking them as a not-ready status.
 			return StatusView{}, getErr
+		}
+		if err := validateOpenComputerSandboxOwnership(claim, sb); err != nil {
+			return StatusView{}, err
 		}
 		state := strings.ToLower(strings.TrimSpace(sb.Status))
 		view := StatusView{
@@ -341,9 +360,17 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0, api.claimScope())
+	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0, api.baseURL)
 	if err != nil {
 		return err
+	}
+	if _, err := verifyOpenComputerClaim(ctx, api, leaseID, sandboxID); err != nil {
+		if !isOCNotFound(err) || !b.cfg.OpenComputer.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opencomputer sandbox=%s after explicit request\n", sandboxID)
+		removeLeaseClaim(leaseID)
+		return nil
 	}
 	if err := api.killSandbox(ctx, sandboxID); err != nil {
 		if !isOCNotFound(err) || !b.cfg.OpenComputer.ForgetMissing {
@@ -384,9 +411,16 @@ func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient,
 // createSandbox creates a Crabbox-owned sandbox and records the local lease.
 // Returns (leaseID, sandboxID, slug, err).
 func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+	providerScope, err := newOpenComputerClaimScope(api.baseURL)
+	if err != nil {
+		return "", "", "", err
+	}
 	req := createSandboxRequest{
-		Timeout:  b.cfg.OpenComputer.TimeoutSecs,
-		Metadata: map[string]string{"crabbox": "true", "crabbox-name": newSandboxName(repo)},
+		Timeout: b.cfg.OpenComputer.TimeoutSecs,
+		Metadata: map[string]string{
+			"crabbox":      "true",
+			"crabbox-name": newSandboxName(repo),
+		},
 	}
 	if b.cfg.OpenComputer.CPU > 0 {
 		req.CPUCount = b.cfg.OpenComputer.CPU
@@ -398,12 +432,15 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 	if err != nil {
 		return "", "", "", err
 	}
+	if err := api.replaceSandboxTags(ctx, sb.ID, map[string]string{openComputerClaimTagKey: providerScope}); err != nil {
+		return leasePrefix + sb.ID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
 	leaseID := leasePrefix + sb.ID
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, api.claimScope(), b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
@@ -414,7 +451,7 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 // strict: only locally-claimed Crabbox sandboxes are accepted, mirroring islo
 // and tensorlake. Raw IDs are accepted only when a matching `ocbx_<id>` claim
 // exists.
-func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, providerScope string) (string, string, string, error) {
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return "", "", "", exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
@@ -426,26 +463,26 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, providerScope)
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
 	}
-	claim, ok, err := resolveOpenComputerLeaseClaim(id, providerScope)
+	claim, ok, err := resolveOpenComputerLeaseClaim(id, baseURL)
 	if err != nil {
 		return "", "", "", err
 	}
 	if ok {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, providerScope)
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
 	}
 	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func resolveOpenComputerLeaseClaim(identifier, providerScope string) (LeaseClaim, bool, error) {
+func resolveOpenComputerLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
 	claims, err := listOpenComputerLeaseClaims()
 	if err != nil {
 		return LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
-			if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+			if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
 				return LeaseClaim{}, false, err
 			}
 			return claim, true, nil
@@ -455,7 +492,7 @@ func resolveOpenComputerLeaseClaim(identifier, providerScope string) (LeaseClaim
 	if slug != "" {
 		for _, claim := range claims {
 			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
-				if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+				if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
 					return LeaseClaim{}, false, err
 				}
 				return claim, true, nil
@@ -465,12 +502,12 @@ func resolveOpenComputerLeaseClaim(identifier, providerScope string) (LeaseClaim
 	return LeaseClaim{}, false, nil
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, providerScope string) (string, string, string, error) {
-	if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
+	if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
 		return "", "", "", err
 	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, providerScope, claim.Pond, repoRoot,
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
 			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 			return "", "", "", err
 		}
@@ -482,9 +519,47 @@ func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTi
 	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
 }
 
-func validateOpenComputerClaimScope(claim LeaseClaim, providerScope string) error {
-	if strings.TrimSpace(claim.ProviderScope) != providerScope {
-		return exit(4, "opencomputer lease %q belongs to a different API endpoint or account; restore the credentials used to create it", claim.LeaseID)
+func validateOpenComputerClaimScope(claim LeaseClaim, baseURL string) error {
+	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), openComputerEndpointScope(baseURL)+"/ownership:") {
+		return exit(4, "opencomputer lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
+	}
+	return nil
+}
+
+func newOpenComputerClaimScope(baseURL string) (string, error) {
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", exit(5, "generate opencomputer ownership token: %v", err)
+	}
+	return openComputerEndpointScope(baseURL) + "/ownership:" + hex.EncodeToString(token[:]), nil
+}
+
+func openComputerEndpointScope(baseURL string) string {
+	digest := sha256.Sum256([]byte(baseURL))
+	return "endpoint-sha256:" + hex.EncodeToString(digest[:])
+}
+
+func verifyOpenComputerClaim(ctx context.Context, api *ocAPIClient, leaseID, sandboxID string) (sandbox, error) {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return sandbox{}, err
+	}
+	if err := validateOpenComputerClaimScope(claim, api.baseURL); err != nil {
+		return sandbox{}, err
+	}
+	sb, err := api.getSandbox(ctx, sandboxID)
+	if err != nil {
+		return sandbox{}, err
+	}
+	if err := validateOpenComputerSandboxOwnership(claim, sb); err != nil {
+		return sandbox{}, err
+	}
+	return sb, nil
+}
+
+func validateOpenComputerSandboxOwnership(claim LeaseClaim, sb sandbox) error {
+	if sb.Tags[openComputerClaimTagKey] != claim.ProviderScope {
+		return exit(4, "opencomputer sandbox %q ownership tag does not match its local claim", sb.ID)
 	}
 	return nil
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -83,7 +83,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
 		acquired = true
 	} else {
-		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.claimScope())
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -110,10 +110,12 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	if !req.NoSync {
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
 		if err != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return RunResult{}, err
 	}
 
@@ -205,6 +207,9 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
 		}
+		if claim.ProviderScope != api.claimScope() {
+			continue
+		}
 		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
 		if sandboxID == "" {
 			continue
@@ -258,24 +263,37 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.claimScope())
 	if err != nil {
 		return StatusView{}, err
 	}
-	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID)
+	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID, api.claimScope())
 	if err != nil {
 		return StatusView{}, err
 	}
 	if !ok {
 		return StatusView{}, exit(4, "opencomputer sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	deadline := b.now().Add(req.WaitTimeout)
-	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
 	}
+	deadline := b.now().Add(waitTimeout)
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
 	for {
-		sb, getErr := api.getSandbox(ctx, sandboxID)
+		sb, getErr := api.getSandbox(pollCtx, sandboxID)
 		if getErr != nil {
+			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+			}
+			if ctx.Err() != nil {
+				return StatusView{}, ctx.Err()
+			}
 			// Surface real API failures (auth, 5xx, sandbox gone) instead of
 			// masking them as a not-ready status.
 			return StatusView{}, getErr
@@ -308,8 +326,11 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 			return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
 		}
 		select {
-		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
+		case <-pollCtx.Done():
+			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+			}
+			return StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
@@ -320,7 +341,7 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0)
+	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0, api.claimScope())
 	if err != nil {
 		return err
 	}
@@ -382,7 +403,7 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 	if err != nil {
 		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, api.claimScope(), b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
@@ -393,7 +414,7 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 // strict: only locally-claimed Crabbox sandboxes are accepted, mirroring islo
 // and tensorlake. Raw IDs are accepted only when a matching `ocbx_<id>` claim
 // exists.
-func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, providerScope string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return "", "", "", exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
@@ -405,25 +426,28 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, providerScope)
 	}
-	claim, ok, err := resolveOpenComputerLeaseClaim(id)
+	claim, ok, err := resolveOpenComputerLeaseClaim(id, providerScope)
 	if err != nil {
 		return "", "", "", err
 	}
 	if ok {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, providerScope)
 	}
 	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func resolveOpenComputerLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveOpenComputerLeaseClaim(identifier, providerScope string) (LeaseClaim, bool, error) {
 	claims, err := listOpenComputerLeaseClaims()
 	if err != nil {
 		return LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
+			if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+				return LeaseClaim{}, false, err
+			}
 			return claim, true, nil
 		}
 	}
@@ -431,6 +455,9 @@ func resolveOpenComputerLeaseClaim(identifier string) (LeaseClaim, bool, error) 
 	if slug != "" {
 		for _, claim := range claims {
 			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
+				if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+					return LeaseClaim{}, false, err
+				}
 				return claim, true, nil
 			}
 		}
@@ -438,9 +465,12 @@ func resolveOpenComputerLeaseClaim(identifier string) (LeaseClaim, bool, error) 
 	return LeaseClaim{}, false, nil
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, providerScope string) (string, string, string, error) {
+	if err := validateOpenComputerClaimScope(claim, providerScope); err != nil {
+		return "", "", "", err
+	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, providerScope, claim.Pond, repoRoot,
 			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 			return "", "", "", err
 		}
@@ -450,6 +480,13 @@ func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTi
 		slug = newLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+}
+
+func validateOpenComputerClaimScope(claim LeaseClaim, providerScope string) error {
+	if strings.TrimSpace(claim.ProviderScope) != providerScope {
+		return exit(4, "opencomputer lease %q belongs to a different API endpoint or account; restore the credentials used to create it", claim.LeaseID)
+	}
+	return nil
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -402,9 +402,9 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, ok, err := resolveOpenComputerLeaseClaim(exactLeaseID); err != nil {
+	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
-	} else if ok {
+	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
 	claim, ok, err := resolveOpenComputerLeaseClaim(id)

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -32,6 +33,9 @@ type openComputerBackend struct {
 func (b *openComputerBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
 	started := b.now()
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
@@ -92,7 +96,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			}
 			cleanupCtx, cancel := b.cleanupContext(ctx)
 			defer cancel()
-			if killErr := api.killSandbox(cleanupCtx, sandboxID); killErr != nil {
+			if killErr := api.killSandbox(cleanupCtx, sandboxID); killErr != nil && !isOCNotFound(killErr) {
 				fmt.Fprintf(b.rt.Stderr, "warning: opencomputer kill failed for %s: %v\n", sandboxID, killErr)
 				return
 			}
@@ -136,6 +140,9 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	command, err := buildCommand(req.Command, req.ShellMode)
 	if err != nil {
 		return RunResult{}, err
+	}
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	commandStart := b.now()
 	// Env travels in the exec request body (`envs`), never argv. cwd is the
@@ -189,25 +196,34 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 	if err != nil {
 		return nil, err
 	}
-	sandboxes, err := api.listSandboxes(ctx)
+	claims, err := listOpenComputerLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(sandboxes))
-	for _, sb := range sandboxes {
-		if sb.ID == "" {
+	servers := make([]Server, 0, len(claims))
+	for _, claim := range claims {
+		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
 		}
-		leaseID := leasePrefix + sb.ID
-		claim, ok, err := resolveLeaseClaim(leaseID)
-		if err != nil || !ok || claim.Provider != providerName {
+		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
+		if sandboxID == "" {
 			continue
 		}
-		state := blank(sb.Status, statusViewReady)
+		sb, getErr := api.getSandbox(ctx, sandboxID)
+		state := ""
+		if getErr != nil {
+			if isOCNotFound(getErr) {
+				state = "missing-or-inaccessible"
+			} else {
+				return nil, getErr
+			}
+		} else {
+			state = blank(sb.Status, statusViewReady)
+		}
 		servers = append(servers, Server{
 			Provider: providerName,
-			CloudID:  sb.ID,
-			Name:     sb.ID,
+			CloudID:  sandboxID,
+			Name:     sandboxID,
 			Status:   state,
 			Labels: map[string]string{
 				"provider": providerName,
@@ -222,6 +238,13 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 }
 
 func (b *openComputerBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	if err := api.probeSandboxes(ctx); err != nil {
+		return DoctorResult{}, err
+	}
 	servers, err := b.List(ctx, ListRequest{})
 	if err != nil {
 		return DoctorResult{}, err
@@ -292,7 +315,10 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if err := api.killSandbox(ctx, sandboxID); err != nil {
-		return err
+		if !isOCNotFound(err) || !b.cfg.OpenComputer.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opencomputer sandbox=%s after explicit request\n", sandboxID)
 	}
 	removeLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
@@ -362,31 +388,37 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	if id == "" {
 		return "", "", "", exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
 	}
-	probes := []string{id}
-	if !strings.HasPrefix(id, leasePrefix) {
-		probes = append(probes, leasePrefix+id)
+	exactLeaseID := id
+	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
+		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	for _, probe := range probes {
-		claim, ok, err := resolveLeaseClaimForProvider(probe, providerName)
-		if err != nil {
-			return "", "", "", err
-		}
-		if !ok {
-			continue
-		}
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
-				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
-		slug := claim.Slug
-		if strings.TrimSpace(slug) == "" {
-			slug = newLeaseSlug(claim.LeaseID)
-		}
-		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+	if claim, ok, err := resolveLeaseClaim(exactLeaseID); err != nil {
+		return "", "", "", err
+	} else if ok && claim.Provider == providerName {
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
+	}
+	claim, ok, err := resolveLeaseClaimForProvider(id, providerName)
+	if err != nil {
+		return "", "", "", err
+	}
+	if ok {
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
 	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+}
+
+func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+	if repoRoot != "" {
+		if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
+			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	slug := claim.Slug
+	if strings.TrimSpace(slug) == "" {
+		slug = newLeaseSlug(claim.LeaseID)
+	}
+	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
@@ -497,6 +529,9 @@ func (b *openComputerBackend) cleanupCreateFailure(ctx context.Context, api *ocA
 	cleanupCtx, cancel := b.cleanupContext(ctx)
 	defer cancel()
 	if err := api.killSandbox(cleanupCtx, sandboxID); err != nil {
+		if isOCNotFound(err) {
+			return cause
+		}
 		return errors.Join(cause, fmt.Errorf("opencomputer cleanup failed for sandbox %s; delete it in the OpenComputer console: %w", sandboxID, err))
 	}
 	return cause

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -227,7 +227,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if sandboxID == "" {
 			continue
 		}
-		sb, getErr := api.getSandbox(ctx, sandboxID)
+		sb, getErr := api.getSandboxWithTags(ctx, sandboxID)
 		state := ""
 		if getErr != nil {
 			if isOCNotFound(getErr) {
@@ -302,7 +302,7 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 	}
 	defer cancel()
 	for {
-		sb, getErr := api.getSandbox(pollCtx, sandboxID)
+		sb, getErr := api.getSandboxWithTags(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
 				return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
@@ -417,6 +417,7 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 	}
 	req := createSandboxRequest{
 		Timeout: b.cfg.OpenComputer.TimeoutSecs,
+		Burst:   b.cfg.OpenComputer.Burst,
 		Metadata: map[string]string{
 			"crabbox":      "true",
 			"crabbox-name": newSandboxName(repo),
@@ -547,7 +548,7 @@ func verifyOpenComputerClaim(ctx context.Context, api *ocAPIClient, leaseID, san
 	if err := validateOpenComputerClaimScope(claim, api.baseURL); err != nil {
 		return sandbox{}, err
 	}
-	sb, err := api.getSandbox(ctx, sandboxID)
+	sb, err := api.getSandboxWithTags(ctx, sandboxID)
 	if err != nil {
 		return sandbox{}, err
 	}

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -12,7 +12,10 @@ import (
 	"time"
 )
 
-const openComputerCleanupTimeout = 15 * time.Second
+const (
+	openComputerCleanupTimeout  = 15 * time.Second
+	openComputerExecTimeoutSecs = 3600
+)
 
 func NewOpenComputerBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -106,7 +109,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, api, sandboxID, workdir); err != nil {
+	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
 		return RunResult{}, err
 	}
 
@@ -303,10 +306,11 @@ func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient,
 		return 2, errors.New("missing command")
 	}
 	res, err := api.execRun(ctx, sandboxID, execRunRequest{
-		Cmd:  command[0],
-		Args: command[1:],
-		Envs: env,
-		Cwd:  workdir,
+		Cmd:     command[0],
+		Args:    command[1:],
+		Envs:    env,
+		Cwd:     workdir,
+		Timeout: b.execTimeoutSecs(),
 	})
 	if err != nil {
 		return 1, err
@@ -327,11 +331,10 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 		Timeout:  b.cfg.OpenComputer.TimeoutSecs,
 		Metadata: map[string]string{"crabbox": "true", "crabbox-name": newSandboxName(repo)},
 	}
-	// Only send sizing when both are set; CPU/memory must form an allowed tier,
-	// so an unset sizing falls back to the service default rather than risking
-	// an invalid 0/0 combination.
-	if b.cfg.OpenComputer.CPU > 0 && b.cfg.OpenComputer.MemoryMB > 0 {
+	if b.cfg.OpenComputer.CPU > 0 {
 		req.CPUCount = b.cfg.OpenComputer.CPU
+	}
+	if b.cfg.OpenComputer.MemoryMB > 0 {
 		req.MemoryMB = b.cfg.OpenComputer.MemoryMB
 	}
 	sb, err := api.createSandbox(ctx, req)
@@ -341,16 +344,10 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 	leaseID := leasePrefix + sb.ID
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		cleanupCtx, cancel := b.cleanupContext(ctx)
-		defer cancel()
-		_ = api.killSandbox(cleanupCtx, sb.ID)
-		return "", "", "", err
+		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		cleanupCtx, cancel := b.cleanupContext(ctx)
-		defer cancel()
-		_ = api.killSandbox(cleanupCtx, sb.ID)
-		return "", "", "", err
+		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
 }
@@ -431,7 +428,7 @@ func isReadyState(state string) bool {
 // ready, so Status can fail fast instead of polling until a deadline.
 func isTerminalState(state string) bool {
 	switch strings.TrimSpace(strings.ToLower(state)) {
-	case "terminated", "stopped", "failed", "killed", "deleted":
+	case "terminated", "stopped", "failed", "error", "killed", "deleted":
 		return true
 	default:
 		return false
@@ -494,4 +491,20 @@ func (b *openComputerBackend) cleanupContext(ctx context.Context) (context.Conte
 		timeout = b.cleanupTimeoutOverride
 	}
 	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
+}
+
+func (b *openComputerBackend) cleanupCreateFailure(ctx context.Context, api *ocAPIClient, sandboxID string, cause error) error {
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := api.killSandbox(cleanupCtx, sandboxID); err != nil {
+		return errors.Join(cause, fmt.Errorf("opencomputer cleanup failed for sandbox %s; delete it in the OpenComputer console: %w", sandboxID, err))
+	}
+	return cause
+}
+
+func (b *openComputerBackend) execTimeoutSecs() int {
+	if b.cfg.OpenComputer.ExecTimeoutSecs > 0 {
+		return b.cfg.OpenComputer.ExecTimeoutSecs
+	}
+	return openComputerExecTimeoutSecs
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -1,0 +1,480 @@
+package opencomputer
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+)
+
+func NewOpenComputerBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &openComputerBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type openComputerBackend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func (b *openComputerBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	started := b.now()
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, sandboxID, slug, err := b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: opencomputer warmup keeps the sandbox until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, err := openComputerWorkdir(b.cfg)
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return RunResult{}, err
+	}
+	leaseID, sandboxID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		leaseID, sandboxID, slug, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+		if err != nil {
+			return RunResult{}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+		acquired = true
+	} else {
+		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
+		defer func() {
+			if !shouldStop {
+				return
+			}
+			if killErr := api.killSandbox(context.Background(), sandboxID); killErr != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: opencomputer kill failed for %s: %v\n", sandboxID, killErr)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		if err != nil {
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.prepareWorkspace(ctx, api, sandboxID, workdir); err != nil {
+		return RunResult{}, err
+	}
+
+	if req.SyncOnly {
+		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		if req.TimingJSON {
+			return result, writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+				Label:         strings.TrimSpace(req.Label),
+			})
+		}
+		return result, nil
+	}
+
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	commandStart := b.now()
+	// Env travels in the exec request body (`envs`), never argv. cwd is the
+	// synced workspace.
+	exitCode, runErr := b.execCommand(ctx, api, sandboxID, workdir, command, req.Env)
+	commandDuration := b.now().Sub(commandStart)
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "opencomputer run summary sync_skipped=true command=%s total=%s exit=%d\n",
+			result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "opencomputer run summary sync=%s command=%s total=%s exit=%d\n",
+			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     result.Command.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      exitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}); err != nil {
+			return result, err
+		}
+	}
+	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("opencomputer run failed: %v", runErr)}
+	}
+	if exitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("opencomputer run exited %d", exitCode)}
+	}
+	return result, nil
+}
+
+func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	sandboxes, err := api.listSandboxes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]Server, 0, len(sandboxes))
+	for _, sb := range sandboxes {
+		if sb.ID == "" {
+			continue
+		}
+		leaseID := leasePrefix + sb.ID
+		claim, ok, err := resolveLeaseClaim(leaseID)
+		if err != nil || !ok || claim.Provider != providerName {
+			continue
+		}
+		state := blank(sb.Status, statusViewReady)
+		servers = append(servers, Server{
+			Provider: providerName,
+			CloudID:  sb.ID,
+			Name:     sb.ID,
+			Status:   state,
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    claim.LeaseID,
+				"slug":     claim.Slug,
+				"target":   targetLinux,
+				"state":    state,
+			},
+		})
+	}
+	return servers, nil
+}
+
+func (b *openComputerBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
+func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deadline := b.now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = b.now().Add(5 * time.Minute)
+	}
+	for {
+		sb, getErr := api.getSandbox(ctx, sandboxID)
+		if getErr != nil {
+			// Surface real API failures (auth, 5xx, sandbox gone) instead of
+			// masking them as a not-ready status.
+			return StatusView{}, getErr
+		}
+		state := strings.ToLower(strings.TrimSpace(sb.Status))
+		view := StatusView{
+			ID:       leaseID,
+			Slug:     slug,
+			Provider: providerName,
+			TargetOS: targetLinux,
+			State:    state,
+			ServerID: sandboxID,
+			Network:  NetworkPublic,
+			Ready:    isReadyState(state),
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    leaseID,
+				"state":    state,
+			},
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if isTerminalState(state) {
+			return StatusView{}, exit(5, "opencomputer sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+		}
+		select {
+		case <-ctx.Done():
+			return StatusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
+	api, err := newOCAPIClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0)
+	if err != nil {
+		return err
+	}
+	if err := api.killSandbox(ctx, sandboxID); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	return nil
+}
+
+// execCommand runs the user command via POST /exec/run, forwarding env in the
+// request body and streaming the buffered stdout/stderr back to the caller.
+func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient, sandboxID, workdir string, command []string, env map[string]string) (int, error) {
+	if len(command) == 0 {
+		return 2, errors.New("missing command")
+	}
+	res, err := api.execRun(ctx, sandboxID, execRunRequest{
+		Cmd:  command[0],
+		Args: command[1:],
+		Envs: env,
+		Cwd:  workdir,
+	})
+	if err != nil {
+		return 1, err
+	}
+	if res.Stdout != "" {
+		_, _ = io.WriteString(b.rt.Stdout, res.Stdout)
+	}
+	if res.Stderr != "" {
+		_, _ = io.WriteString(b.rt.Stderr, res.Stderr)
+	}
+	return res.ExitCode, nil
+}
+
+// createSandbox creates a Crabbox-owned sandbox and records the local lease.
+// Returns (leaseID, sandboxID, slug, err).
+func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+	req := createSandboxRequest{
+		Timeout:  b.cfg.OpenComputer.TimeoutSecs,
+		Metadata: map[string]string{"crabbox": "true", "crabbox-name": newSandboxName(repo)},
+	}
+	// Only send sizing when both are set; CPU/memory must form an allowed tier,
+	// so an unset sizing falls back to the service default rather than risking
+	// an invalid 0/0 combination.
+	if b.cfg.OpenComputer.CPU > 0 && b.cfg.OpenComputer.MemoryMB > 0 {
+		req.CPUCount = b.cfg.OpenComputer.CPU
+		req.MemoryMB = b.cfg.OpenComputer.MemoryMB
+	}
+	sb, err := api.createSandbox(ctx, req)
+	if err != nil {
+		return "", "", "", err
+	}
+	leaseID := leasePrefix + sb.ID
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		_ = api.killSandbox(context.Background(), sb.ID)
+		return "", "", "", err
+	}
+	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		_ = api.killSandbox(context.Background(), sb.ID)
+		return "", "", "", err
+	}
+	return leaseID, sb.ID, slug, nil
+}
+
+// resolveLeaseID resolves a user-supplied identifier (slug, lease ID, or raw
+// OpenComputer sandbox ID) to a (leaseID, sandboxID, slug) tuple. Resolution is
+// strict: only locally-claimed Crabbox sandboxes are accepted, mirroring islo
+// and tensorlake. Raw IDs are accepted only when a matching `ocbx_<id>` claim
+// exists.
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", "", exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
+	}
+	probes := []string{id}
+	if !strings.HasPrefix(id, leasePrefix) {
+		probes = append(probes, leasePrefix+id)
+	}
+	for _, probe := range probes {
+		claim, ok, err := resolveLeaseClaimForProvider(probe, providerName)
+		if err != nil {
+			return "", "", "", err
+		}
+		if !ok {
+			continue
+		}
+		if repoRoot != "" {
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
+				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+				return "", "", "", err
+			}
+		}
+		slug := claim.Slug
+		if strings.TrimSpace(slug) == "" {
+			slug = newLeaseSlug(claim.LeaseID)
+		}
+		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+	}
+	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+}
+
+func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func newSandboxName(repo Repo) string {
+	base := normalizeLeaseSlug(repo.Name)
+	if base == "" {
+		base = "crabbox"
+	}
+	base = strings.TrimPrefix(base, strings.TrimSuffix(namePrefix, "-")+"-")
+	maxBase := maxSandboxNameLen - len(namePrefix) - 1 - sandboxNameSuffixLen
+	if maxBase < 1 {
+		maxBase = 1
+	}
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+	}
+	if base == "" {
+		base = "crabbox"
+	}
+	return namePrefix + base + "-" + randomSuffix()
+}
+
+func isReadyState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "running", "ready", "started", "active":
+		return true
+	default:
+		return false
+	}
+}
+
+// isTerminalState reports whether a sandbox status will never transition to
+// ready, so Status can fail fast instead of polling until a deadline.
+func isTerminalState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "terminated", "stopped", "failed", "killed", "deleted":
+		return true
+	default:
+		return false
+	}
+}
+
+func randomSuffix() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func buildCommand(command []string, shellMode bool) ([]string, error) {
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if shellMode {
+		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	}
+	return command, nil
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
+}
+
+// openComputerWorkdir returns the configured absolute workspace path inside the
+// sandbox, validating that it isn't relative, empty, or a broad system path.
+func openComputerWorkdir(cfg Config) (string, error) {
+	workdir := strings.TrimSpace(cfg.OpenComputer.Workdir)
+	if workdir == "" {
+		workdir = defaultWorkdir
+	}
+	clean := path.Clean(workdir)
+	if !strings.HasPrefix(clean, "/") {
+		return "", exit(2, "opencomputer workdir %q must be an absolute path", workdir)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
+		return "", exit(2, "opencomputer workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
+}
+
+func (b *openComputerBackend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -229,6 +229,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 				"provider": providerName,
 				"lease":    claim.LeaseID,
 				"slug":     claim.Slug,
+				"pond":     claim.Pond,
 				"target":   targetLinux,
 				"state":    state,
 			},
@@ -261,6 +262,13 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 	if err != nil {
 		return StatusView{}, err
 	}
+	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	if !ok {
+		return StatusView{}, exit(4, "opencomputer sandbox %q is not claimed by Crabbox", req.ID)
+	}
 	deadline := b.now().Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
 		deadline = b.now().Add(5 * time.Minute)
@@ -280,11 +288,13 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 			TargetOS: targetLinux,
 			State:    state,
 			ServerID: sandboxID,
+			Pond:     claim.Pond,
 			Network:  NetworkPublic,
 			Ready:    isReadyState(state),
 			Labels: map[string]string{
 				"provider": providerName,
 				"lease":    leaseID,
+				"pond":     claim.Pond,
 				"state":    state,
 			},
 		}
@@ -392,12 +402,12 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, ok, err := resolveLeaseClaim(exactLeaseID); err != nil {
+	if claim, ok, err := resolveOpenComputerLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
-	} else if ok && claim.Provider == providerName {
+	} else if ok {
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(id, providerName)
+	claim, ok, err := resolveOpenComputerLeaseClaim(id)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -405,6 +415,27 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
 	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+}
+
+func resolveOpenComputerLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+	claims, err := listOpenComputerLeaseClaims()
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	for _, claim := range claims {
+		if claim.Provider == providerName && claim.LeaseID == identifier {
+			return claim, true, nil
+		}
+	}
+	slug := normalizeLeaseSlug(identifier)
+	if slug != "" {
+		for _, claim := range claims {
+			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
+				return claim, true, nil
+			}
+		}
+	}
+	return LeaseClaim{}, false, nil
 }
 
 func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
@@ -483,6 +514,9 @@ func buildCommand(command []string, shellMode bool) ([]string, error) {
 		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
 	}
 	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		if len(command) == 1 {
+			return []string{"bash", "-lc", command[0]}, nil
+		}
 		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
 	}
 	return command, nil

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -12,15 +12,18 @@ import (
 	"time"
 )
 
+const openComputerCleanupTimeout = 15 * time.Second
+
 func NewOpenComputerBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
 	return &openComputerBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type openComputerBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec                   ProviderSpec
+	cfg                    Config
+	rt                     Runtime
+	cleanupTimeoutOverride time.Duration
 }
 
 func (b *openComputerBackend) Spec() ProviderSpec { return b.spec }
@@ -84,7 +87,9 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			if !shouldStop {
 				return
 			}
-			if killErr := api.killSandbox(context.Background(), sandboxID); killErr != nil {
+			cleanupCtx, cancel := b.cleanupContext(ctx)
+			defer cancel()
+			if killErr := api.killSandbox(cleanupCtx, sandboxID); killErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: opencomputer kill failed for %s: %v\n", sandboxID, killErr)
 				return
 			}
@@ -336,11 +341,15 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 	leaseID := leasePrefix + sb.ID
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		_ = api.killSandbox(context.Background(), sb.ID)
+		cleanupCtx, cancel := b.cleanupContext(ctx)
+		defer cancel()
+		_ = api.killSandbox(cleanupCtx, sb.ID)
 		return "", "", "", err
 	}
 	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		_ = api.killSandbox(context.Background(), sb.ID)
+		cleanupCtx, cancel := b.cleanupContext(ctx)
+		defer cancel()
+		_ = api.killSandbox(cleanupCtx, sb.ID)
 		return "", "", "", err
 	}
 	return leaseID, sb.ID, slug, nil
@@ -477,4 +486,12 @@ func (b *openComputerBackend) now() time.Time {
 		return b.rt.Clock.Now()
 	}
 	return time.Now()
+}
+
+func (b *openComputerBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := openComputerCleanupTimeout
+	if b.cleanupTimeoutOverride > 0 {
+		timeout = b.cleanupTimeoutOverride
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
 }

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -207,6 +207,30 @@ func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
 	}
 }
 
+func TestStopSurfacesMalformedExactClaimBeforeSlugFallback(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	exactLeaseID := leasePrefix + "sb-z-exact"
+	if err := claimLeaseForRepoProvider(exactLeaseID, "exact", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProvider(leasePrefix+"sb-a-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claimPath := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", exactLeaseID+".json")
+	if err := os.WriteFile(claimPath, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.Stop(context.Background(), StopRequest{ID: exactLeaseID})
+	if err == nil || !strings.Contains(err.Error(), "parse claim") {
+		t.Fatalf("Stop err=%v, want malformed exact claim error", err)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
+		t.Fatal("stop deleted a slug-colliding sandbox after exact claim parse failure")
+	}
+}
+
 func TestNewSandboxName(t *testing.T) {
 	if name := newSandboxName(Repo{Name: "carbbox"}); !strings.HasPrefix(name, "crabbox-carbbox-") {
 		t.Fatalf("name=%q", name)
@@ -585,6 +609,15 @@ func TestSyncHonorsConfiguredTimeout(t *testing.T) {
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("Run took %s, sync timeout should bound upload", elapsed)
 	}
+	var sawRemoteCleanup bool
+	for _, exec := range f.allExecs() {
+		if strings.Contains(strings.Join(exec.req.Args, " "), "rm -f") && strings.Contains(strings.Join(exec.req.Args, " "), "crabbox-sync-") {
+			sawRemoteCleanup = true
+		}
+	}
+	if !sawRemoteCleanup {
+		t.Fatal("timed-out upload did not attempt remote archive cleanup")
+	}
 }
 
 func TestSyncPreflightGuardsFullArchiveCandidate(t *testing.T) {
@@ -603,7 +636,7 @@ func TestSyncPreflightGuardsFullArchiveCandidate(t *testing.T) {
 	}
 }
 
-func TestSyncDeleteDoesNotTouchWorkspaceBeforeUploadSucceeds(t *testing.T) {
+func TestSyncDeleteDoesNotTouchLiveWorkspaceBeforeUploadSucceeds(t *testing.T) {
 	f := newFakeAPI(t)
 	f.uploadStatus = http.StatusServiceUnavailable
 	backend := newAPIBackend(t, f)
@@ -614,8 +647,14 @@ func TestSyncDeleteDoesNotTouchWorkspaceBeforeUploadSucceeds(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "upload denied") {
 		t.Fatalf("Run err=%v, want upload failure", err)
 	}
-	if execs := f.allExecs(); len(execs) != 0 {
-		t.Fatalf("remote workspace touched before upload succeeded: %#v", execs)
+	for _, exec := range f.allExecs() {
+		command := strings.Join(exec.req.Args, " ")
+		if strings.Contains(command, "mkdir -p") ||
+			strings.Contains(command, "tar -xzf") ||
+			strings.Contains(command, "if mv ") ||
+			strings.Contains(command, "rm -rf '/workspace/crabbox'") {
+			t.Fatalf("live workspace touched before upload succeeded: %q", command)
+		}
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -377,6 +377,11 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, []map[string]any{})
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+		f.mu.Lock()
+		tags := f.tags
+		f.mu.Unlock()
+		writeJSON(w, sandboxTagsResponse{Tags: tags})
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
 		if f.blockGet {
 			<-r.Context().Done()
@@ -389,9 +394,8 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		f.mu.Lock()
 		metadata := f.metadata
-		tags := f.tags
 		f.mu.Unlock()
-		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState, "metadata": metadata, "tags": tags})
+		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState, "metadata": metadata})
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
 		if f.blockDelete {
 			<-r.Context().Done()
@@ -884,6 +888,32 @@ func TestCreateSandboxForwardsPartialSizing(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxForwardsBurst(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	backend.cfg.OpenComputer.Burst = true
+	api, err := newOCAPIClient(backend.cfg, backend.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID, _, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	recorded, ok := f.firstRequest(http.MethodPost, "/api/sandboxes")
+	if !ok {
+		t.Fatal("missing create request")
+	}
+	var req createSandboxRequest
+	if err := json.Unmarshal([]byte(recorded.body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if !req.Burst {
+		t.Fatalf("create request burst=%v want true", req.Burst)
+	}
+}
+
 func TestCreateSandboxReportsCleanupFailureAndSandboxID(t *testing.T) {
 	f := newFakeAPI(t)
 	f.deleteStatus = http.StatusInternalServerError
@@ -1259,6 +1289,9 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	}
 	if f.callsExact(http.MethodGet, "/api/sandboxes/"+f.sandboxID) != 1 {
 		t.Fatalf("want one status fetch, requests=%#v", f.requests)
+	}
+	if f.callsExact(http.MethodGet, "/api/sandboxes/"+f.sandboxID+"/tags") != 1 {
+		t.Fatalf("want one ownership-tag fetch, requests=%#v", f.requests)
 	}
 	status, err := backend.Status(context.Background(), StatusRequest{ID: "slug"})
 	if err != nil {

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -164,19 +164,19 @@ func TestIsTerminalState(t *testing.T) {
 }
 
 func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	if _, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection", err)
 	}
 }
 
 func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("ocbx_sb-unknown", "", false, 0); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	if _, _, _, err := resolveLeaseID("ocbx_sb-unknown", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection", err)
 	}
 }
 
 func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("", "", false, 0); err == nil {
+	if _, _, _, err := resolveLeaseID("", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil {
 		t.Fatalf("expected error for empty id")
 	}
 }
@@ -184,10 +184,10 @@ func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
 func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "ocbx_sb-known123"
-	if err := claimLeaseForRepoProvider(leaseID, "", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0)
+	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0, testOCClaimScope("https://api.example.test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,13 +199,13 @@ func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	exactLeaseID := "ocbx_sb-z-exact"
-	if err := claimLeaseForRepoProvider(exactLeaseID, "exact", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider("ocbx_sb-a-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond("ocbx_sb-a-other", exactLeaseID, providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0)
+	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0, testOCClaimScope("https://api.example.test"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,10 +218,10 @@ func TestStopSurfacesMalformedExactClaimBeforeSlugFallback(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
 	exactLeaseID := leasePrefix + "sb-z-exact"
-	if err := claimLeaseForRepoProvider(exactLeaseID, "exact", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider(leasePrefix+"sb-a-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leasePrefix+"sb-a-other", exactLeaseID, providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	claimPath := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", exactLeaseID+".json")
@@ -235,6 +235,23 @@ func TestStopSurfacesMalformedExactClaimBeforeSlugFallback(t *testing.T) {
 	}
 	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
 		t.Fatal("stop deleted a slug-colliding sandbox after exact claim parse failure")
+	}
+}
+
+func TestStopRejectsClaimFromDifferentAPIAccount(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	leaseID := leasePrefix + f.sandboxID
+	otherScope := (&ocAPIClient{baseURL: f.server.URL, apiKey: "osb_other_account"}).claimScope()
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "different API endpoint or account") {
+		t.Fatalf("Stop err=%v, want endpoint mismatch", err)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
+		t.Fatal("stop contacted the configured endpoint for a claim from another endpoint")
 	}
 }
 
@@ -289,6 +306,7 @@ type fakeAPI struct {
 	listState     string
 	listStatus    int
 	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
+	blockGet      bool
 	blockDelete   bool
 	deleteStatus  int
 	uploadStatus  int
@@ -320,6 +338,10 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, []map[string]any{})
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
+		if f.blockGet {
+			<-r.Context().Done()
+			return
+		}
 		if f.getStatusCode != 0 {
 			w.WriteHeader(f.getStatusCode)
 			_, _ = w.Write([]byte(`{"error":"boom"}`))
@@ -416,6 +438,10 @@ func newTestConfig(apiURL string) Config {
 	cfg.OpenComputer.APIURL = apiURL
 	cfg.OpenComputer.Workdir = "/workspace/crabbox"
 	return cfg
+}
+
+func testOCClaimScope(apiURL string) string {
+	return (&ocAPIClient{baseURL: apiURL, apiKey: "osb_testkey"}).claimScope()
 }
 
 // newAPIBackend wires a backend to the fake API and isolates it from the real
@@ -665,6 +691,32 @@ func TestSyncDeleteDoesNotTouchLiveWorkspaceBeforeUploadSucceeds(t *testing.T) {
 	}
 }
 
+func TestSyncFailureHonorsKeepOnFailure(t *testing.T) {
+	f := newFakeAPI(t)
+	f.uploadStatus = http.StatusServiceUnavailable
+	backend := newAPIBackend(t, f)
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "upload denied") {
+		t.Fatalf("Run err=%v, want upload failure", err)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
+		t.Fatal("sync failure deleted sandbox despite --keep-on-failure")
+	}
+	leaseID := leasePrefix + f.sandboxID
+	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("retained claim=%#v err=%v", claim, err)
+	}
+	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease="+leaseID) {
+		t.Fatalf("stderr=%q, want keep-on-failure hint", stderr.String())
+	}
+}
+
 func TestSyncDeleteStagesBeforeReplacingWorkspace(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
@@ -727,7 +779,7 @@ func TestNoSyncDoesNotDeleteRetainedWorkspace(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	backend.cfg.Sync.Delete = true
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProvider(leaseID, "retained", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "retained", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := backend.Run(context.Background(), RunRequest{
@@ -878,7 +930,7 @@ func TestStopClearsClaimWhenSandboxAlreadyDeleted(t *testing.T) {
 	f.deleteStatus = http.StatusNotFound
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProvider(leaseID, "gone", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "gone", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	backend.cfg.OpenComputer.ForgetMissing = true
@@ -895,7 +947,7 @@ func TestStopPreservesClaimForAmbiguousMissingSandbox(t *testing.T) {
 	f.deleteStatus = http.StatusNotFound
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProvider(leaseID, "possibly-other-account", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "possibly-other-account", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
@@ -1119,7 +1171,7 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	}
 	// The collection endpoint omits hibernated sandboxes, so List must fetch
 	// each locally claimed sandbox by ID.
-	if err := claimLeaseForRepoProviderPond("ocbx_"+f.sandboxID, "slug", providerName, "alpha", "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "alpha", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	views, err = backend.List(context.Background(), ListRequest{})
@@ -1145,7 +1197,7 @@ func TestListKeepsAmbiguousMissingClaimVisible(t *testing.T) {
 	f := newFakeAPI(t)
 	f.getStatusCode = http.StatusNotFound
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProvider(leasePrefix+f.sandboxID, "ambiguous", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "ambiguous", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	views, err := backend.List(context.Background(), ListRequest{})
@@ -1157,22 +1209,19 @@ func TestListKeepsAmbiguousMissingClaimVisible(t *testing.T) {
 	}
 }
 
-func TestListSkipsMalformedClaimAndKeepsValidInventory(t *testing.T) {
+func TestListSurfacesMalformedMatchingClaim(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProvider(leasePrefix+f.sandboxID, "valid", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "valid", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	claimsDir := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
 	if err := os.WriteFile(path.Join(claimsDir, leasePrefix+"broken.json"), []byte("{"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
-	if err != nil {
-		t.Fatalf("List err=%v", err)
-	}
-	if len(views) != 1 || views[0].Labels["slug"] != "valid" {
-		t.Fatalf("views=%#v", views)
+	_, err := backend.List(context.Background(), ListRequest{})
+	if err == nil || !strings.Contains(err.Error(), "parse claim") {
+		t.Fatalf("List err=%v, want malformed matching claim error", err)
 	}
 }
 
@@ -1195,12 +1244,31 @@ func TestStatusSurfacesAPIError(t *testing.T) {
 	f := newFakeAPI(t)
 	f.getStatusCode = http.StatusInternalServerError
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProvider("ocbx_"+f.sandboxID, "slug", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	_, err := backend.Status(context.Background(), StatusRequest{ID: "ocbx_" + f.sandboxID})
 	if err == nil || !strings.Contains(err.Error(), "500") {
 		t.Fatalf("err=%v, want surfaced API error", err)
+	}
+}
+
+func TestStatusWaitTimeoutCancelsBlockedAPIRequest(t *testing.T) {
+	f := newFakeAPI(t)
+	f.blockGet = true
+	backend := newAPIBackend(t, f)
+	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err := backend.Status(context.Background(), StatusRequest{
+		ID: leasePrefix + f.sandboxID, Wait: true, WaitTimeout: 50 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting") {
+		t.Fatalf("Status err=%v, want wait timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Status took %s, wait timeout did not bound API request", elapsed)
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -1091,6 +1091,30 @@ func TestAPIURLNormalizesTrailingAPISuffix(t *testing.T) {
 	}
 }
 
+func TestAPIURLCanonicalizesOrigin(t *testing.T) {
+	for _, tt := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "https://APP.OPENCOMPUTER.DEV:443/api/", want: "https://app.opencomputer.dev"},
+		{raw: "http://LOCALHOST:80/api", want: "http://localhost"},
+		{raw: "http://[::1]:80/api/", want: "http://[::1]"},
+		{raw: "https://[FE80::1%25MyNIC]:8443/api", want: "https://[fe80::1%25MyNIC]:8443"},
+		{raw: "https://[FE80::1%25My%25NIC]:8443/api", want: "https://[fe80::1%25My%25NIC]:8443"},
+		{raw: "https://API.EXAMPLE.TEST:8443/api", want: "https://api.example.test:8443"},
+	} {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := validateOCAPIURL(tt.raw)
+			if err != nil {
+				t.Fatalf("validateOCAPIURL(%q) err=%v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("validateOCAPIURL(%q)=%q want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAPIClientBlocksCrossOriginRedirects(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -1,0 +1,578 @@
+package opencomputer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	osexec "os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// --- pure-function tests -----------------------------------------------------
+
+func TestProviderSpec(t *testing.T) {
+	p := Provider{}
+	if p.Name() != "opencomputer" {
+		t.Fatalf("Name=%q want opencomputer", p.Name())
+	}
+	if len(p.Aliases()) == 0 {
+		t.Fatalf("expected aliases, got none")
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%v want delegated run", spec.Kind)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%v want never", spec.Coordinator)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want [{linux}]", spec.Targets)
+	}
+}
+
+func TestProviderForResolvesNameAndAliases(t *testing.T) {
+	for _, name := range []string{"opencomputer", "oc", "open-computer"} {
+		got, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q) err=%v", name, err)
+		}
+		if got.Name() != "opencomputer" {
+			t.Fatalf("ProviderFor(%q).Name()=%q want opencomputer", name, got.Name())
+		}
+	}
+}
+
+func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm install && pnpm test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "bash" || got[1] != "-lc" {
+		t.Fatalf("command=%#v want bash -lc wrapping", got)
+	}
+}
+
+func TestBuildCommandAutoWrapsLeadingEnvAssignment(t *testing.T) {
+	got, err := buildCommand([]string{"FOO=bar", "pnpm", "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != "bash" {
+		t.Fatalf("command=%#v want bash wrapping for FOO=bar", got)
+	}
+}
+
+func TestBuildCommandShellMode(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm install && pnpm test"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []string{"bash", "-lc", "pnpm install && pnpm test"}) {
+		t.Fatalf("command=%#v", got)
+	}
+}
+
+func TestBuildCommandPassThrough(t *testing.T) {
+	got, err := buildCommand([]string{"pnpm", "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []string{"pnpm", "test"}) {
+		t.Fatalf("command=%#v", got)
+	}
+}
+
+func TestBuildCommandRejectsEmpty(t *testing.T) {
+	if _, err := buildCommand(nil, false); err == nil {
+		t.Fatalf("expected error for empty command")
+	}
+}
+
+func TestOpenComputerWorkdirRejectsRelative(t *testing.T) {
+	cfg := newTestConfig("")
+	cfg.OpenComputer.Workdir = "relative/path"
+	if _, err := openComputerWorkdir(cfg); err == nil {
+		t.Fatalf("expected rejection of relative workdir")
+	}
+}
+
+func TestOpenComputerWorkdirRejectsBroadPaths(t *testing.T) {
+	for _, workdir := range []string{"/", "/tmp", "/workspace", "/workspace/.."} {
+		t.Run(workdir, func(t *testing.T) {
+			cfg := newTestConfig("")
+			cfg.OpenComputer.Workdir = workdir
+			if _, err := openComputerWorkdir(cfg); err == nil || !strings.Contains(err.Error(), "too broad") {
+				t.Fatalf("err=%v, want too broad rejection", err)
+			}
+		})
+	}
+}
+
+func TestOpenComputerWorkdirCleansAndDefaults(t *testing.T) {
+	cfg := newTestConfig("")
+	cfg.OpenComputer.Workdir = " /workspace/crabbox/../project "
+	if got, err := openComputerWorkdir(cfg); err != nil || got != "/workspace/project" {
+		t.Fatalf("got=%q err=%v want /workspace/project", got, err)
+	}
+	cfg.OpenComputer.Workdir = ""
+	if got, err := openComputerWorkdir(cfg); err != nil || got != "/workspace/crabbox" {
+		t.Fatalf("default=%q err=%v want /workspace/crabbox", got, err)
+	}
+}
+
+func TestIsReadyState(t *testing.T) {
+	for state, want := range map[string]bool{
+		"running": true, "  Running ": true, "ready": true,
+		"starting": false, "hibernated": false, "terminated": false, "": false,
+	} {
+		if got := isReadyState(state); got != want {
+			t.Errorf("isReadyState(%q)=%v want %v", state, got, want)
+		}
+	}
+}
+
+func TestIsTerminalState(t *testing.T) {
+	for state, want := range map[string]bool{
+		"terminated": true, "stopped": true, "failed": true, "killed": true,
+		"running": false, "starting": false,
+	} {
+		if got := isTerminalState(state); got != want {
+			t.Errorf("isTerminalState(%q)=%v want %v", state, got, want)
+		}
+	}
+}
+
+func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
+	if _, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v, want rejection", err)
+	}
+}
+
+func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
+	if _, _, _, err := resolveLeaseID("ocbx_sb-unknown", "", false, 0); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v, want rejection", err)
+	}
+}
+
+func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
+	if _, _, _, err := resolveLeaseID("", "", false, 0); err == nil {
+		t.Fatalf("expected error for empty id")
+	}
+}
+
+func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "ocbx_sb-known123"
+	if err := claimLeaseForRepoProvider(leaseID, "", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLease != leaseID || sandboxID != "sb-known123" || slug != newLeaseSlug(leaseID) {
+		t.Fatalf("lease=%q sandbox=%q slug=%q", gotLease, sandboxID, slug)
+	}
+}
+
+func TestNewSandboxName(t *testing.T) {
+	if name := newSandboxName(Repo{Name: "carbbox"}); !strings.HasPrefix(name, "crabbox-carbbox-") {
+		t.Fatalf("name=%q", name)
+	}
+	if name := newSandboxName(Repo{Name: "crabbox-app"}); strings.HasPrefix(name, "crabbox-crabbox-") || !strings.HasPrefix(name, "crabbox-app-") {
+		t.Fatalf("name=%q double/!prefixed", name)
+	}
+	if name := newSandboxName(Repo{Name: strings.Repeat("very-long-repo-name-", 8)}); len(name) > 63 || strings.HasSuffix(name, "-") {
+		t.Fatalf("name len=%d %q", len(name), name)
+	}
+}
+
+func TestSpecAllowsForceSyncLargeAndSyncOnly(t *testing.T) {
+	spec := Provider{}.Spec()
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ForceSyncLarge: true}); err != nil {
+		t.Fatalf("--force-sync-large should be allowed, got %v", err)
+	}
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{SyncOnly: true}); err != nil {
+		t.Fatalf("--sync-only should be allowed, got %v", err)
+	}
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ChecksumSync: true}); err == nil {
+		t.Fatalf("--checksum should be rejected")
+	}
+}
+
+// --- fake API server ---------------------------------------------------------
+
+type recordedRequest struct {
+	method string
+	path   string
+	query  string
+	body   string
+}
+
+type execRecord struct {
+	req  execRunRequest
+	body string
+}
+
+// fakeAPI is an httptest-backed OpenComputer API. It records every request and
+// lets tests script exec/run replies by call order.
+type fakeAPI struct {
+	mu            sync.Mutex
+	server        *httptest.Server
+	requests      []recordedRequest
+	execs         []execRecord
+	execReply     []execRunResult // popped in order; last/zero reused when empty
+	sandboxID     string
+	listState     string
+	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
+}
+
+func newFakeAPI(t *testing.T) *fakeAPI {
+	t.Helper()
+	f := &fakeAPI{sandboxID: "sb-test01", listState: "running"}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	f.mu.Lock()
+	f.requests = append(f.requests, recordedRequest{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery, body: string(body)})
+	f.mu.Unlock()
+
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/api/sandboxes":
+		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": "running"})
+	case r.Method == http.MethodGet && r.URL.Path == "/api/sandboxes":
+		// The real API returns a bare array (not a {"sandboxes":[...]} wrapper).
+		writeJSON(w, []map[string]any{{"sandboxID": f.sandboxID, "status": f.listState}})
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
+		if f.getStatusCode != 0 {
+			w.WriteHeader(f.getStatusCode)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState})
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/files"):
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/exec/run"):
+		var req execRunRequest
+		_ = json.Unmarshal(body, &req)
+		f.mu.Lock()
+		f.execs = append(f.execs, execRecord{req: req, body: string(body)})
+		reply := execRunResult{}
+		if len(f.execReply) > 0 {
+			reply = f.execReply[0]
+			f.execReply = f.execReply[1:]
+		}
+		f.mu.Unlock()
+		writeJSON(w, reply)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (f *fakeAPI) calls(method, pathContains string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, r := range f.requests {
+		if r.method == method && strings.Contains(r.path, pathContains) {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeAPI) callsExact(method, path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, r := range f.requests {
+		if r.method == method && r.path == path {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeAPI) allExecs() []execRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]execRecord(nil), f.execs...)
+}
+
+func newTestConfig(apiURL string) Config {
+	cfg := Config{}
+	cfg.OpenComputer.APIURL = apiURL
+	cfg.OpenComputer.Workdir = "/workspace/crabbox"
+	return cfg
+}
+
+// newAPIBackend wires a backend to the fake API and isolates it from the real
+// ~/.oc/config.json and lease store.
+func newAPIBackend(t *testing.T, f *fakeAPI) *openComputerBackend {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir()) // no real ~/.oc/config.json
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_testkey")
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
+	return NewOpenComputerBackend(Provider{}.Spec(), newTestConfig(f.server.URL), rt).(*openComputerBackend)
+}
+
+// --- API-backed flow tests ---------------------------------------------------
+
+func TestRunCreatesExecsAndKillsEphemeral(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0, Stdout: "hello\n"}} // mkdir, user cmd
+	backend := newAPIBackend(t, f)
+	res, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"echo", "hello"}, NoSync: true,
+	})
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d", res.ExitCode)
+	}
+	if f.callsExact(http.MethodPost, "/api/sandboxes") != 1 {
+		t.Fatalf("want 1 create, got %d", f.callsExact(http.MethodPost, "/api/sandboxes"))
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 1 {
+		t.Fatalf("want 1 kill, got %d", f.calls(http.MethodDelete, "/api/sandboxes/"))
+	}
+	// The user command is the last exec; it must carry cmd + cwd.
+	execs := f.allExecs()
+	last := execs[len(execs)-1].req
+	if last.Cmd != "echo" || !reflect.DeepEqual(last.Args, []string{"hello"}) {
+		t.Fatalf("user exec cmd=%q args=%v", last.Cmd, last.Args)
+	}
+	if last.Cwd != "/workspace/crabbox" {
+		t.Fatalf("user exec cwd=%q", last.Cwd)
+	}
+}
+
+func TestRunForwardsEnvInExecBodyOffArgv(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0, Stdout: "ok\n"}}
+	backend := newAPIBackend(t, f)
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+		Command: []string{"printenv", "SECRET_TOKEN"},
+		NoSync:  true,
+		Env:     map[string]string{"SECRET_TOKEN": "super-secret"},
+		Options: core.LeaseOptions{EnvAllow: []string{"SECRET_TOKEN"}},
+	})
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	execs := f.allExecs()
+	user := execs[len(execs)-1]
+	// Env is delivered in the request body's envs map...
+	if user.req.Envs["SECRET_TOKEN"] != "super-secret" {
+		t.Fatalf("exec body missing envs: %#v", user.req.Envs)
+	}
+	// ...and never in cmd/args (argv).
+	if user.req.Cmd == "super-secret" || strings.Contains(strings.Join(user.req.Args, " "), "super-secret") {
+		t.Fatalf("secret leaked into exec argv: cmd=%q args=%v", user.req.Cmd, user.req.Args)
+	}
+}
+
+func TestRunRequiresAPIKey(t *testing.T) {
+	f := newFakeAPI(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
+	backend := NewOpenComputerBackend(Provider{}.Spec(), newTestConfig(f.server.URL), rt).(*openComputerBackend)
+	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "x", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true})
+	if err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("err=%v, want API-key error", err)
+	}
+	if f.callsExact(http.MethodPost, "/api/sandboxes") != 0 {
+		t.Fatalf("must not create a sandbox without a key")
+	}
+}
+
+func TestRunPerformsArchiveSyncViaFileAPI(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0, Stdout: "done\n"}} // mkdir, extract, user
+	backend := newAPIBackend(t, f)
+	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}})
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if f.calls(http.MethodPut, "/files") != 1 {
+		t.Fatalf("want 1 file upload, got %d", f.calls(http.MethodPut, "/files"))
+	}
+	var sawExtract bool
+	for _, e := range f.allExecs() {
+		if strings.Contains(strings.Join(e.req.Args, " "), "tar -xzf") {
+			sawExtract = true
+		}
+	}
+	if !sawExtract {
+		t.Fatalf("expected a tar extract exec after upload")
+	}
+}
+
+func TestSyncOnlySkipsUserCommand(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}} // mkdir, extract
+	backend := newAPIBackend(t, f)
+	if _, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"echo", "should-not-run"}, SyncOnly: true}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	for _, e := range f.allExecs() {
+		if e.req.Cmd == "echo" {
+			t.Fatalf("--sync-only must not run the user command: %#v", e.req)
+		}
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 1 {
+		t.Fatalf("sync-only should still tear down")
+	}
+}
+
+func TestRunSurfacesNonZeroExit(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 7}} // mkdir, user cmd exits 7
+	backend := newAPIBackend(t, f)
+	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"false"}, NoSync: true})
+	if res.ExitCode != 7 {
+		t.Fatalf("exit=%d want 7", res.ExitCode)
+	}
+	ee, ok := err.(ExitError)
+	if !ok || ee.Code != 7 {
+		t.Fatalf("err=%v want ExitError code 7", err)
+	}
+}
+
+func TestKeepRetainsSandbox(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
+	backend := newAPIBackend(t, f)
+	if _, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Keep: true}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
+		t.Fatalf("kill must not run with --keep")
+	}
+}
+
+func TestStopRejectsUnclaimedID(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	err := backend.Stop(context.Background(), StopRequest{ID: "sb-not-claimed"})
+	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("err=%v want unclaimed rejection", err)
+	}
+}
+
+// TestAPIURLPrecedenceHonorsOCConfig asserts the oc config file's api_url is
+// used before the built-in default, and that an explicit Crabbox setting wins.
+func TestAPIURLPrecedenceHonorsOCConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	if err := os.MkdirAll(home+"/.oc", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(home+"/.oc/config.json", []byte(`{"api_url":"https://oc-file.example","api_key":"osb_fromfile"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No explicit Crabbox API URL → oc config api_url wins over the default.
+	api, err := newOCAPIClient(newTestConfig(""), Runtime{})
+	if err != nil {
+		t.Fatalf("newOCAPIClient err=%v", err)
+	}
+	if api.baseURL != "https://oc-file.example" {
+		t.Fatalf("baseURL=%q want oc-config api_url", api.baseURL)
+	}
+	if api.apiKey != "osb_fromfile" {
+		t.Fatalf("apiKey not read from oc config: %q", api.apiKey)
+	}
+	// Explicit Crabbox API URL takes precedence over the oc config file.
+	api, err = newOCAPIClient(newTestConfig("https://explicit.example"), Runtime{})
+	if err != nil {
+		t.Fatalf("newOCAPIClient err=%v", err)
+	}
+	if api.baseURL != "https://explicit.example" {
+		t.Fatalf("baseURL=%q want explicit override", api.baseURL)
+	}
+}
+
+// TestListParsesBareArrayAndFiltersByClaim asserts List decodes the bare-array
+// list response and returns only locally-claimed Crabbox sandboxes.
+func TestListParsesBareArrayAndFiltersByClaim(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	// Unclaimed: List returns nothing.
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 0 {
+		t.Fatalf("want 0 unclaimed, got %d", len(views))
+	}
+	// Claim it: now List returns exactly that sandbox.
+	if err := claimLeaseForRepoProvider("ocbx_"+f.sandboxID, "slug", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err = backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 1 || views[0].CloudID != f.sandboxID {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+// TestStatusSurfacesAPIError asserts a failing GET is returned, not masked as
+// a not-ready status.
+func TestStatusSurfacesAPIError(t *testing.T) {
+	f := newFakeAPI(t)
+	f.getStatusCode = http.StatusInternalServerError
+	backend := newAPIBackend(t, f)
+	if err := claimLeaseForRepoProvider("ocbx_"+f.sandboxID, "slug", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.Status(context.Background(), StatusRequest{ID: "ocbx_" + f.sandboxID})
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("err=%v, want surfaced API error", err)
+	}
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", root},
+		{"-C", root, "config", "user.email", "t@e.com"},
+		{"-C", root, "config", "user.name", "t"},
+		{"-C", root, "commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		if out, err := osexec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return root
+}

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -186,6 +186,24 @@ func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 	}
 }
 
+func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	exactLeaseID := "ocbx_sb-exact"
+	if err := claimLeaseForRepoProvider(exactLeaseID, "exact", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProvider("ocbx_sb-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != exactLeaseID || sandboxID != "sb-exact" {
+		t.Fatalf("resolved lease=%q sandbox=%q", leaseID, sandboxID)
+	}
+}
+
 func TestNewSandboxName(t *testing.T) {
 	if name := newSandboxName(Repo{Name: "carbbox"}); !strings.HasPrefix(name, "crabbox-carbbox-") {
 		t.Fatalf("name=%q", name)
@@ -235,9 +253,11 @@ type fakeAPI struct {
 	execReply     []execRunResult // popped in order; last/zero reused when empty
 	sandboxID     string
 	listState     string
+	listStatus    int
 	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
 	blockDelete   bool
 	deleteStatus  int
+	uploadStatus  int
 }
 
 func newFakeAPI(t *testing.T) *fakeAPI {
@@ -258,8 +278,12 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodPost && r.URL.Path == "/api/sandboxes":
 		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": "running"})
 	case r.Method == http.MethodGet && r.URL.Path == "/api/sandboxes":
-		// The real API returns a bare array (not a {"sandboxes":[...]} wrapper).
-		writeJSON(w, []map[string]any{{"sandboxID": f.sandboxID, "status": f.listState}})
+		if f.listStatus != 0 {
+			w.WriteHeader(f.listStatus)
+			_, _ = w.Write([]byte(`{"error":"list denied"}`))
+			return
+		}
+		writeJSON(w, []map[string]any{})
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
 		if f.getStatusCode != 0 {
 			w.WriteHeader(f.getStatusCode)
@@ -279,6 +303,11 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/files"):
+		if f.uploadStatus != 0 {
+			w.WriteHeader(f.uploadStatus)
+			_, _ = w.Write([]byte(`{"error":"upload denied"}`))
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/exec/run"):
 		var req execRunRequest
@@ -426,16 +455,34 @@ func TestRunCleanupCannotBlockForever(t *testing.T) {
 	}
 }
 
+func TestRunClearsClaimWhenAcquiredSandboxAlreadyMissingAtCleanup(t *testing.T) {
+	f := newFakeAPI(t)
+	f.deleteStatus = http.StatusNotFound
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
+	backend := newAPIBackend(t, f)
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if _, ok, err := resolveLeaseClaim(leasePrefix + f.sandboxID); err != nil || ok {
+		t.Fatalf("acquired missing sandbox claim remains: ok=%t err=%v", ok, err)
+	}
+}
+
 func TestRunForwardsEnvInExecBodyOffArgv(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0, Stdout: "ok\n"}}
 	backend := newAPIBackend(t, f)
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
 	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
-		Command: []string{"printenv", "SECRET_TOKEN"},
-		NoSync:  true,
-		Env:     map[string]string{"SECRET_TOKEN": "super-secret"},
-		Options: core.LeaseOptions{EnvAllow: []string{"SECRET_TOKEN"}},
+		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+		Command:    []string{"printenv", "SECRET_TOKEN"},
+		NoSync:     true,
+		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
+		EnvSummary: true,
+		Options:    core.LeaseOptions{EnvAllow: []string{"SECRET_TOKEN"}},
 	})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
@@ -449,6 +496,12 @@ func TestRunForwardsEnvInExecBodyOffArgv(t *testing.T) {
 	// ...and never in cmd/args (argv).
 	if user.req.Cmd == "super-secret" || strings.Contains(strings.Join(user.req.Args, " "), "super-secret") {
 		t.Fatalf("secret leaked into exec argv: cmd=%q args=%v", user.req.Cmd, user.req.Args)
+	}
+	if !strings.Contains(stderr.String(), "env forwarding provider=opencomputer") || !strings.Contains(stderr.String(), "secret=true") {
+		t.Fatalf("stderr=%q, want redacted env summary", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "super-secret") {
+		t.Fatalf("secret leaked into stderr: %q", stderr.String())
 	}
 }
 
@@ -505,6 +558,78 @@ func TestRunPerformsArchiveSyncViaFileAPI(t *testing.T) {
 	}
 	if !sawExtract {
 		t.Fatalf("expected a tar extract exec after upload")
+	}
+}
+
+func TestSyncDeleteDoesNotTouchWorkspaceBeforeUploadSucceeds(t *testing.T) {
+	f := newFakeAPI(t)
+	f.uploadStatus = http.StatusServiceUnavailable
+	backend := newAPIBackend(t, f)
+	backend.cfg.Sync.Delete = true
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, Keep: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "upload denied") {
+		t.Fatalf("Run err=%v, want upload failure", err)
+	}
+	if execs := f.allExecs(); len(execs) != 0 {
+		t.Fatalf("remote workspace touched before upload succeeded: %#v", execs)
+	}
+}
+
+func TestSyncDeleteStagesBeforeReplacingWorkspace(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	backend.cfg.Sync.Delete = true
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
+	}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	execs := f.allExecs()
+	extractIndex, replaceIndex := -1, -1
+	backupCleanupIndex := -1
+	for i, exec := range execs {
+		command := strings.Join(exec.req.Args, " ")
+		if strings.Contains(command, "rm -rf '/workspace/crabbox'") {
+			t.Fatalf("sync deleted live workspace directly: %q", command)
+		}
+		if strings.Contains(command, "tar -xzf") && strings.Contains(command, ".crabbox-sync-") {
+			extractIndex = i
+		}
+		if strings.Contains(command, "if mv ") && strings.Contains(command, "/workspace/crabbox") {
+			replaceIndex = i
+		}
+		if strings.Contains(command, ".previous") && strings.Contains(command, "rm -rf ") && !strings.Contains(command, "if mv ") {
+			backupCleanupIndex = i
+		}
+	}
+	if extractIndex < 0 || replaceIndex <= extractIndex {
+		t.Fatalf("execs=%#v, want staged extract before replacement", execs)
+	}
+	if backupCleanupIndex <= replaceIndex {
+		t.Fatalf("execs=%#v, want surfaced backup cleanup after committed swap", execs)
+	}
+}
+
+func TestSyncDeleteWarnsWhenPreviousWorkspaceCleanupFails(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{
+		{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0},
+		{ExitCode: 1, Stderr: "permission denied"},
+		{ExitCode: 0}, {ExitCode: 0},
+	}
+	backend := newAPIBackend(t, f)
+	backend.cfg.Sync.Delete = true
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
+	}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if !strings.Contains(stderr.String(), "previous workspace cleanup failed") || !strings.Contains(stderr.String(), ".previous") {
+		t.Fatalf("stderr=%q, want actionable backup cleanup warning", stderr.String())
 	}
 }
 
@@ -639,12 +764,61 @@ func TestKeepRetainsSandbox(t *testing.T) {
 	}
 }
 
+func TestWarmupRejectsActionsRunnerBeforeCreate(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
+		t.Fatalf("Warmup err=%v", err)
+	}
+	if f.callsExact(http.MethodPost, "/api/sandboxes") != 0 {
+		t.Fatal("unsupported actions runner warmup created a sandbox")
+	}
+}
+
 func TestStopRejectsUnclaimedID(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
 	err := backend.Stop(context.Background(), StopRequest{ID: "sb-not-claimed"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v want unclaimed rejection", err)
+	}
+}
+
+func TestStopClearsClaimWhenSandboxAlreadyDeleted(t *testing.T) {
+	f := newFakeAPI(t)
+	f.deleteStatus = http.StatusNotFound
+	backend := newAPIBackend(t, f)
+	leaseID := leasePrefix + f.sandboxID
+	if err := claimLeaseForRepoProvider(leaseID, "gone", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	backend.cfg.OpenComputer.ForgetMissing = true
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+		t.Fatalf("Stop err=%v", err)
+	}
+	if _, ok, err := resolveLeaseClaim(leaseID); err != nil || ok {
+		t.Fatalf("claim remains after idempotent stop: ok=%t err=%v", ok, err)
+	}
+}
+
+func TestStopPreservesClaimForAmbiguousMissingSandbox(t *testing.T) {
+	f := newFakeAPI(t)
+	f.deleteStatus = http.StatusNotFound
+	backend := newAPIBackend(t, f)
+	leaseID := leasePrefix + f.sandboxID
+	if err := claimLeaseForRepoProvider(leaseID, "possibly-other-account", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("Stop err=%v, want ambiguous missing error", err)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 1 {
+		t.Fatal("stop did not attempt remote deletion")
+	}
+	if _, ok, err := resolveLeaseClaim(leaseID); err != nil || !ok {
+		t.Fatalf("claim removed without explicit forget: ok=%t err=%v", ok, err)
 	}
 }
 
@@ -682,12 +856,18 @@ func TestAPIURLPrecedenceHonorsOCConfig(t *testing.T) {
 	}
 }
 
-// TestListParsesBareArrayAndFiltersByClaim asserts List decodes the bare-array
-// list response and returns only locally-claimed Crabbox sandboxes.
-func TestListParsesBareArrayAndFiltersByClaim(t *testing.T) {
+func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	f := newFakeAPI(t)
+	f.listState = "hibernated"
 	backend := newAPIBackend(t, f)
-	// Unclaimed: List returns nothing.
+	claimsDir := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
+	if err := os.MkdirAll(claimsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(claimsDir, "cbx_unrelated.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Unclaimed sandboxes are not inventory and do not trigger remote calls.
 	views, err := backend.List(context.Background(), ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
@@ -695,7 +875,11 @@ func TestListParsesBareArrayAndFiltersByClaim(t *testing.T) {
 	if len(views) != 0 {
 		t.Fatalf("want 0 unclaimed, got %d", len(views))
 	}
-	// Claim it: now List returns exactly that sandbox.
+	if f.calls(http.MethodGet, "/api/sandboxes") != 0 {
+		t.Fatal("unclaimed list unexpectedly queried remote inventory")
+	}
+	// The collection endpoint omits hibernated sandboxes, so List must fetch
+	// each locally claimed sandbox by ID.
 	if err := claimLeaseForRepoProvider("ocbx_"+f.sandboxID, "slug", providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
@@ -703,8 +887,59 @@ func TestListParsesBareArrayAndFiltersByClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
-	if len(views) != 1 || views[0].CloudID != f.sandboxID {
+	if len(views) != 1 || views[0].CloudID != f.sandboxID || views[0].Status != "hibernated" {
 		t.Fatalf("views=%#v", views)
+	}
+	if f.callsExact(http.MethodGet, "/api/sandboxes/"+f.sandboxID) != 1 {
+		t.Fatalf("want one status fetch, requests=%#v", f.requests)
+	}
+}
+
+func TestListKeepsAmbiguousMissingClaimVisible(t *testing.T) {
+	f := newFakeAPI(t)
+	f.getStatusCode = http.StatusNotFound
+	backend := newAPIBackend(t, f)
+	if err := claimLeaseForRepoProvider(leasePrefix+f.sandboxID, "ambiguous", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 1 || views[0].Status != "missing-or-inaccessible" || views[0].Labels["slug"] != "ambiguous" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestListSkipsMalformedClaimAndKeepsValidInventory(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	if err := claimLeaseForRepoProvider(leasePrefix+f.sandboxID, "valid", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
+	if err := os.WriteFile(path.Join(claimsDir, leasePrefix+"broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 1 || views[0].Labels["slug"] != "valid" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestDoctorProbesControlPlaneWithoutClaims(t *testing.T) {
+	f := newFakeAPI(t)
+	f.listStatus = http.StatusUnauthorized
+	backend := newAPIBackend(t, f)
+	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err == nil || !strings.Contains(err.Error(), "list denied") {
+		t.Fatalf("Doctor err=%v, want control-plane failure", err)
+	}
+	if f.callsExact(http.MethodGet, "/api/sandboxes") != 1 {
+		t.Fatalf("want one collection probe, requests=%#v", f.requests)
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	osexec "os/exec"
+	"path"
 	"reflect"
 	"strings"
 	"sync"
@@ -143,7 +144,7 @@ func TestIsReadyState(t *testing.T) {
 
 func TestIsTerminalState(t *testing.T) {
 	for state, want := range map[string]bool{
-		"terminated": true, "stopped": true, "failed": true, "killed": true,
+		"terminated": true, "stopped": true, "failed": true, "error": true, "killed": true,
 		"running": false, "starting": false,
 	} {
 		if got := isTerminalState(state); got != want {
@@ -236,6 +237,7 @@ type fakeAPI struct {
 	listState     string
 	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
 	blockDelete   bool
+	deleteStatus  int
 }
 
 func newFakeAPI(t *testing.T) *fakeAPI {
@@ -268,6 +270,11 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
 		if f.blockDelete {
 			<-r.Context().Done()
+			return
+		}
+		if f.deleteStatus != 0 {
+			w.WriteHeader(f.deleteStatus)
+			_, _ = w.Write([]byte(`{"error":"cleanup denied"}`))
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -325,6 +332,17 @@ func (f *fakeAPI) allExecs() []execRecord {
 	return append([]execRecord(nil), f.execs...)
 }
 
+func (f *fakeAPI) firstRequest(method, path string) (recordedRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, req := range f.requests {
+		if req.method == method && req.path == path {
+			return req, true
+		}
+	}
+	return recordedRequest{}, false
+}
+
 func newTestConfig(apiURL string) Config {
 	cfg := Config{}
 	cfg.OpenComputer.APIURL = apiURL
@@ -372,6 +390,9 @@ func TestRunCreatesExecsAndKillsEphemeral(t *testing.T) {
 	}
 	if last.Cwd != "/workspace/crabbox" {
 		t.Fatalf("user exec cwd=%q", last.Cwd)
+	}
+	if last.Timeout != openComputerExecTimeoutSecs {
+		t.Fatalf("user exec timeout=%d want %d", last.Timeout, openComputerExecTimeoutSecs)
 	}
 }
 
@@ -431,6 +452,23 @@ func TestRunForwardsEnvInExecBodyOffArgv(t *testing.T) {
 	}
 }
 
+func TestRunUsesConfiguredExecTimeout(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
+	backend := newAPIBackend(t, f)
+	backend.cfg.OpenComputer.ExecTimeoutSecs = 123
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	for _, exec := range f.allExecs() {
+		if exec.req.Timeout != 123 {
+			t.Fatalf("exec timeout=%d want 123: %#v", exec.req.Timeout, exec.req)
+		}
+	}
+}
+
 func TestRunRequiresAPIKey(t *testing.T) {
 	f := newFakeAPI(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -467,6 +505,94 @@ func TestRunPerformsArchiveSyncViaFileAPI(t *testing.T) {
 	}
 	if !sawExtract {
 		t.Fatalf("expected a tar extract exec after upload")
+	}
+}
+
+func TestNoSyncDoesNotDeleteRetainedWorkspace(t *testing.T) {
+	f := newFakeAPI(t)
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
+	backend := newAPIBackend(t, f)
+	backend.cfg.Sync.Delete = true
+	leaseID := leasePrefix + f.sandboxID
+	if err := claimLeaseForRepoProvider(leaseID, "retained", providerName, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.Run(context.Background(), RunRequest{
+		ID: leaseID, Repo: Repo{Name: "carbbox", Root: "/repo"}, Command: []string{"true"}, NoSync: true,
+	}); err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	for _, exec := range f.allExecs() {
+		if strings.Contains(strings.Join(exec.req.Args, " "), "rm -rf") {
+			t.Fatalf("--no-sync deleted retained workspace: %#v", exec.req)
+		}
+	}
+}
+
+func TestCreateSandboxForwardsPartialSizing(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cpu      int
+		memoryMB int
+	}{
+		{name: "cpu only", cpu: 2},
+		{name: "memory only", memoryMB: 4096},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeAPI(t)
+			backend := newAPIBackend(t, f)
+			backend.cfg.OpenComputer.CPU = tc.cpu
+			backend.cfg.OpenComputer.MemoryMB = tc.memoryMB
+			api, err := newOCAPIClient(backend.cfg, backend.rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaseID, _, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { removeLeaseClaim(leaseID) })
+			recorded, ok := f.firstRequest(http.MethodPost, "/api/sandboxes")
+			if !ok {
+				t.Fatal("missing create request")
+			}
+			var req createSandboxRequest
+			if err := json.Unmarshal([]byte(recorded.body), &req); err != nil {
+				t.Fatal(err)
+			}
+			if req.CPUCount != tc.cpu || req.MemoryMB != tc.memoryMB {
+				t.Fatalf("create sizing=%d/%d want %d/%d", req.CPUCount, req.MemoryMB, tc.cpu, tc.memoryMB)
+			}
+		})
+	}
+}
+
+func TestCreateSandboxReportsCleanupFailureAndSandboxID(t *testing.T) {
+	f := newFakeAPI(t)
+	f.deleteStatus = http.StatusInternalServerError
+	backend := newAPIBackend(t, f)
+	claimsPath := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
+	if err := os.MkdirAll(path.Dir(claimsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claimsPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	api, err := newOCAPIClient(backend.cfg, backend.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID, sandboxID, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "taken")
+	if err == nil {
+		t.Fatal("expected claim setup and cleanup failure")
+	}
+	if leaseID != leasePrefix+f.sandboxID || sandboxID != f.sandboxID {
+		t.Fatalf("lease=%q sandbox=%q", leaseID, sandboxID)
+	}
+	for _, want := range []string{"read claims directory", "cleanup failed", f.sandboxID, "cleanup denied"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("err=%v, want %q", err, want)
+		}
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	osexec "os/exec"
 	"path"
@@ -18,6 +19,12 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 // --- pure-function tests -----------------------------------------------------
 
@@ -934,6 +941,157 @@ func TestAPIURLPrecedenceHonorsOCConfig(t *testing.T) {
 	}
 	if api.baseURL != "https://explicit.example" {
 		t.Fatalf("baseURL=%q want explicit override", api.baseURL)
+	}
+}
+
+func TestAPIURLRejectsUnsafeCredentialDestinations(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	for _, apiURL := range []string{
+		"http://api.example.test",
+		"https://user:password@api.example.test",
+		"https://api.example.test?account=other",
+		"https://api.example.test#other",
+		"api.example.test",
+	} {
+		t.Run(apiURL, func(t *testing.T) {
+			if _, err := newOCAPIClient(newTestConfig(apiURL), Runtime{}); err == nil {
+				t.Fatalf("newOCAPIClient(%q) succeeded", apiURL)
+			}
+		})
+	}
+}
+
+func TestAPIURLAllowsLoopbackHTTP(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	for _, apiURL := range []string{
+		"http://localhost:8080/",
+		"http://127.0.0.1:8080/",
+		"http://[::1]:8080/",
+	} {
+		t.Run(apiURL, func(t *testing.T) {
+			api, err := newOCAPIClient(newTestConfig(apiURL), Runtime{})
+			if err != nil {
+				t.Fatalf("newOCAPIClient(%q) err=%v", apiURL, err)
+			}
+			if strings.HasSuffix(api.baseURL, "/") {
+				t.Fatalf("baseURL=%q retains trailing slash", api.baseURL)
+			}
+		})
+	}
+}
+
+func TestAPIURLNormalizesTrailingAPISuffix(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	api, err := newOCAPIClient(newTestConfig("https://api.example.test/gateway/api/"), Runtime{})
+	if err != nil {
+		t.Fatalf("newOCAPIClient err=%v", err)
+	}
+	if api.baseURL != "https://api.example.test/gateway" {
+		t.Fatalf("baseURL=%q want normalized gateway base", api.baseURL)
+	}
+}
+
+func TestAPIClientBlocksCrossOriginRedirects(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	var leaked bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked = r.Header.Get("X-API-Key") != ""
+		writeJSON(w, []map[string]any{})
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusFound)
+	}))
+	defer source.Close()
+
+	api, err := newOCAPIClient(newTestConfig(source.URL), Runtime{HTTP: source.Client()})
+	if err != nil {
+		t.Fatalf("newOCAPIClient err=%v", err)
+	}
+	err = api.probeSandboxes(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+		t.Fatalf("probeSandboxes err=%v, want redirect rejection", err)
+	}
+	if leaked {
+		t.Fatal("API key reached the redirect target")
+	}
+}
+
+func TestSameOCOriginNormalizesDefaultPorts(t *testing.T) {
+	parse := func(raw string) *url.URL {
+		t.Helper()
+		value, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	for _, tc := range []struct {
+		a, b string
+		want bool
+	}{
+		{a: "https://api.example.test", b: "https://api.example.test:443/path", want: true},
+		{a: "http://localhost", b: "http://localhost:80/path", want: true},
+		{a: "https://api.example.test", b: "https://api.example.test:8443", want: false},
+		{a: "https://api.example.test", b: "http://api.example.test:443", want: false},
+		{a: "https://api.example.test", b: "https://other.example.test", want: false},
+	} {
+		if got := sameOCOrigin(parse(tc.a), parse(tc.b)); got != tc.want {
+			t.Errorf("sameOCOrigin(%q, %q)=%t want %t", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestControlAndExecRequestsUseOperationDeadlines(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
+	t.Setenv("OPENCOMPUTER_API_KEY", "")
+	var deadlines []time.Duration
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			t.Fatal("request has no deadline")
+		}
+		deadlines = append(deadlines, time.Until(deadline))
+		body := `{"sandboxID":"sb-test"}`
+		if strings.HasSuffix(req.URL.Path, "/exec/run") {
+			body = `{"exitCode":0}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+	api, err := newOCAPIClient(newTestConfig(""), Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatalf("newOCAPIClient err=%v", err)
+	}
+	if _, err := api.getSandbox(context.Background(), "sb-test"); err != nil {
+		t.Fatalf("getSandbox err=%v", err)
+	}
+	if _, err := api.execRun(context.Background(), "sb-test", execRunRequest{Timeout: 3600}); err != nil {
+		t.Fatalf("execRun err=%v", err)
+	}
+	if len(deadlines) != 2 {
+		t.Fatalf("deadlines=%v", deadlines)
+	}
+	if deadlines[0] <= 0 || deadlines[0] > defaultOCControlRequestTimeout {
+		t.Fatalf("control deadline=%s want <=%s", deadlines[0], defaultOCControlRequestTimeout)
+	}
+	wantExec := time.Hour + ocExecRequestGrace
+	if deadlines[1] < wantExec-time.Second || deadlines[1] > wantExec {
+		t.Fatalf("exec deadline=%s want about %s", deadlines[1], wantExec)
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -60,6 +60,16 @@ func TestProviderForResolvesNameAndAliases(t *testing.T) {
 	}
 }
 
+func TestProviderDoesNotReportServerTypeMetadata(t *testing.T) {
+	p := Provider{}
+	if got := p.ServerTypeForConfig(core.Config{Provider: providerName, Class: "beast"}); got != "" {
+		t.Fatalf("ServerTypeForConfig=%q want empty", got)
+	}
+	if got := p.ServerTypeForClass("beast"); got != "" {
+		t.Fatalf("ServerTypeForClass=%q want empty", got)
+	}
+}
+
 func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
 	got, err := buildCommand([]string{"pnpm install && pnpm test"}, false)
 	if err != nil {

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -61,6 +61,9 @@ func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
 	if len(got) != 3 || got[0] != "bash" || got[1] != "-lc" {
 		t.Fatalf("command=%#v want bash -lc wrapping", got)
 	}
+	if got[2] != "pnpm install && pnpm test" {
+		t.Fatalf("script=%q want unquoted shell expression", got[2])
+	}
 }
 
 func TestBuildCommandAutoWrapsLeadingEnvAssignment(t *testing.T) {
@@ -188,18 +191,18 @@ func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 
 func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	exactLeaseID := "ocbx_sb-exact"
+	exactLeaseID := "ocbx_sb-z-exact"
 	if err := claimLeaseForRepoProvider(exactLeaseID, "exact", providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider("ocbx_sb-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProvider("ocbx_sb-a-other", exactLeaseID, providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if leaseID != exactLeaseID || sandboxID != "sb-exact" {
+	if leaseID != exactLeaseID || sandboxID != "sb-z-exact" {
 		t.Fatalf("resolved lease=%q sandbox=%q", leaseID, sandboxID)
 	}
 }
@@ -258,6 +261,7 @@ type fakeAPI struct {
 	blockDelete   bool
 	deleteStatus  int
 	uploadStatus  int
+	blockUpload   bool
 }
 
 func newFakeAPI(t *testing.T) *fakeAPI {
@@ -303,6 +307,10 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/files"):
+		if f.blockUpload {
+			<-r.Context().Done()
+			return
+		}
 		if f.uploadStatus != 0 {
 			w.WriteHeader(f.uploadStatus)
 			_, _ = w.Write([]byte(`{"error":"upload denied"}`))
@@ -558,6 +566,40 @@ func TestRunPerformsArchiveSyncViaFileAPI(t *testing.T) {
 	}
 	if !sawExtract {
 		t.Fatalf("expected a tar extract exec after upload")
+	}
+}
+
+func TestSyncHonorsConfiguredTimeout(t *testing.T) {
+	f := newFakeAPI(t)
+	f.blockUpload = true
+	backend := newAPIBackend(t, f)
+	backend.cfg.Sync.Timeout = 50 * time.Millisecond
+	started := time.Now()
+
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, Keep: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("Run err=%v, want sync timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Run took %s, sync timeout should bound upload", elapsed)
+	}
+}
+
+func TestSyncPreflightGuardsFullArchiveCandidate(t *testing.T) {
+	cfg := newTestConfig("")
+	cfg.Sync.FailBytes = 100
+	manifest := SyncManifest{
+		Files:        []string{"large.bin", "small.txt"},
+		Bytes:        1000,
+		Changed:      []string{"small.txt"},
+		ChangedBytes: 1,
+	}
+	var stderr bytes.Buffer
+	err := checkOpenComputerSyncPreflight(manifest, cfg, false, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "sync candidate too large") {
+		t.Fatalf("preflight err=%v stderr=%q, want full candidate rejection", err, stderr.String())
 	}
 }
 
@@ -880,18 +922,25 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	}
 	// The collection endpoint omits hibernated sandboxes, so List must fetch
 	// each locally claimed sandbox by ID.
-	if err := claimLeaseForRepoProvider("ocbx_"+f.sandboxID, "slug", providerName, "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderPond("ocbx_"+f.sandboxID, "slug", providerName, "alpha", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	views, err = backend.List(context.Background(), ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
-	if len(views) != 1 || views[0].CloudID != f.sandboxID || views[0].Status != "hibernated" {
+	if len(views) != 1 || views[0].CloudID != f.sandboxID || views[0].Status != "hibernated" || views[0].Labels["pond"] != "alpha" {
 		t.Fatalf("views=%#v", views)
 	}
 	if f.callsExact(http.MethodGet, "/api/sandboxes/"+f.sandboxID) != 1 {
 		t.Fatalf("want one status fetch, requests=%#v", f.requests)
+	}
+	status, err := backend.Status(context.Background(), StatusRequest{ID: "slug"})
+	if err != nil {
+		t.Fatalf("Status err=%v", err)
+	}
+	if status.Pond != "alpha" || status.Labels["pond"] != "alpha" {
+		t.Fatalf("status=%#v, want top-level pond and pond label", status)
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -1,6 +1,7 @@
 package opencomputer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -234,6 +235,7 @@ type fakeAPI struct {
 	sandboxID     string
 	listState     string
 	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
+	blockDelete   bool
 }
 
 func newFakeAPI(t *testing.T) *fakeAPI {
@@ -264,6 +266,10 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState})
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
+		if f.blockDelete {
+			<-r.Context().Done()
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/files"):
 		w.WriteHeader(http.StatusNoContent)
@@ -366,6 +372,36 @@ func TestRunCreatesExecsAndKillsEphemeral(t *testing.T) {
 	}
 	if last.Cwd != "/workspace/crabbox" {
 		t.Fatalf("user exec cwd=%q", last.Cwd)
+	}
+}
+
+func TestRunCleanupCannotBlockForever(t *testing.T) {
+	f := newFakeAPI(t)
+	f.blockDelete = true
+	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
+	backend := newAPIBackend(t, f)
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+	backend.cleanupTimeoutOverride = 20 * time.Millisecond
+	started := time.Now()
+
+	res, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	})
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d", res.ExitCode)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Run took %s, cleanup should be bounded", elapsed)
+	}
+	if f.calls(http.MethodDelete, "/api/sandboxes/") != 1 {
+		t.Fatalf("want 1 kill, got %d", f.calls(http.MethodDelete, "/api/sandboxes/"))
+	}
+	if !strings.Contains(stderr.String(), "context deadline exceeded") {
+		t.Fatalf("stderr=%q, want cleanup deadline warning", stderr.String())
 	}
 }
 

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -164,19 +164,19 @@ func TestIsTerminalState(t *testing.T) {
 }
 
 func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	if _, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0, "https://api.example.test"); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection", err)
 	}
 }
 
 func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("ocbx_sb-unknown", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	if _, _, _, err := resolveLeaseID("ocbx_sb-unknown", "", false, 0, "https://api.example.test"); err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection", err)
 	}
 }
 
 func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("", "", false, 0, testOCClaimScope("https://api.example.test")); err == nil {
+	if _, _, _, err := resolveLeaseID("", "", false, 0, "https://api.example.test"); err == nil {
 		t.Fatalf("expected error for empty id")
 	}
 }
@@ -187,7 +187,7 @@ func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 	if err := claimLeaseForRepoProviderScopePond(leaseID, "", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0, testOCClaimScope("https://api.example.test"))
+	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0, "https://api.example.test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
 	if err := claimLeaseForRepoProviderScopePond("ocbx_sb-a-other", exactLeaseID, providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0, testOCClaimScope("https://api.example.test"))
+	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0, "https://api.example.test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,16 +242,39 @@ func TestStopRejectsClaimFromDifferentAPIAccount(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
-	otherScope := (&ocAPIClient{baseURL: f.server.URL, apiKey: "osb_other_account"}).claimScope()
+	otherScope := openComputerEndpointScope(f.server.URL) + "/ownership:11111111111111111111111111111111"
 	if err := claimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
-	if err == nil || !strings.Contains(err.Error(), "different API endpoint or account") {
-		t.Fatalf("Stop err=%v, want endpoint mismatch", err)
+	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
+		t.Fatalf("Stop err=%v, want ownership mismatch", err)
 	}
 	if f.calls(http.MethodDelete, "/api/sandboxes/") != 0 {
 		t.Fatal("stop contacted the configured endpoint for a claim from another endpoint")
+	}
+}
+
+func TestRunVerifiesOwnershipBeforeReclaim(t *testing.T) {
+	f := newFakeAPI(t)
+	backend := newAPIBackend(t, f)
+	leaseID := leasePrefix + f.sandboxID
+	otherScope := openComputerEndpointScope(f.server.URL) + "/ownership:11111111111111111111111111111111"
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/original", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.Run(context.Background(), RunRequest{
+		ID: leaseID, Repo: Repo{Name: "carbbox", Root: "/replacement"}, Reclaim: true, NoSync: true, Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
+		t.Fatalf("Run err=%v, want ownership mismatch", err)
+	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.RepoRoot != "/original" {
+		t.Fatalf("repo root=%q changed before ownership verification", claim.RepoRoot)
 	}
 }
 
@@ -303,6 +326,8 @@ type fakeAPI struct {
 	execs         []execRecord
 	execReply     []execRunResult // popped in order; last/zero reused when empty
 	sandboxID     string
+	metadata      map[string]string
+	tags          map[string]string
 	listState     string
 	listStatus    int
 	getStatusCode int // when non-zero, GET /api/sandboxes/:id returns this code
@@ -329,6 +354,11 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case r.Method == http.MethodPost && r.URL.Path == "/api/sandboxes":
+		var req createSandboxRequest
+		_ = json.Unmarshal(body, &req)
+		f.mu.Lock()
+		f.metadata = req.Metadata
+		f.mu.Unlock()
 		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": "running"})
 	case r.Method == http.MethodGet && r.URL.Path == "/api/sandboxes":
 		if f.listStatus != 0 {
@@ -347,7 +377,11 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"error":"boom"}`))
 			return
 		}
-		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState})
+		f.mu.Lock()
+		metadata := f.metadata
+		tags := f.tags
+		f.mu.Unlock()
+		writeJSON(w, map[string]any{"sandboxID": f.sandboxID, "status": f.listState, "metadata": metadata, "tags": tags})
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/sandboxes/"):
 		if f.blockDelete {
 			<-r.Context().Done()
@@ -359,6 +393,13 @@ func (f *fakeAPI) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/tags"):
+		var tags map[string]string
+		_ = json.Unmarshal(body, &tags)
+		f.mu.Lock()
+		f.tags = tags
+		f.mu.Unlock()
+		writeJSON(w, map[string]any{"tags": tags})
 	case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/files"):
 		if f.blockUpload {
 			<-r.Context().Done()
@@ -441,7 +482,7 @@ func newTestConfig(apiURL string) Config {
 }
 
 func testOCClaimScope(apiURL string) string {
-	return (&ocAPIClient{baseURL: apiURL, apiKey: "osb_testkey"}).claimScope()
+	return openComputerEndpointScope(apiURL) + "/ownership:00000000000000000000000000000000"
 }
 
 // newAPIBackend wires a backend to the fake API and isolates it from the real
@@ -451,6 +492,7 @@ func newAPIBackend(t *testing.T, f *fakeAPI) *openComputerBackend {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir()) // no real ~/.oc/config.json
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_testkey")
+	f.tags = map[string]string{openComputerClaimTagKey: testOCClaimScope(f.server.URL)}
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
 	return NewOpenComputerBackend(Provider{}.Spec(), newTestConfig(f.server.URL), rt).(*openComputerBackend)
 }

--- a/internal/providers/opencomputer/bridge.go
+++ b/internal/providers/opencomputer/bridge.go
@@ -1,0 +1,27 @@
+package opencomputer
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// OpenComputer exposes preview URLs through its own `oc preview` surface and
+// central control plane rather than the Crabbox bridge plane. As with modal,
+// cloudflare, and tensorlake, the adapter implements core.BridgeProvider only
+// to return core.ErrBridgeNotImplemented so the resolver flags the peer with
+// BridgeState="unsupported" instead of silently emitting an empty Targets
+// slice that callers could misread as "no shares yet".
+
+// PublishPeer reports that OpenComputer does not participate in the bridge plane.
+func (b *openComputerBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
+	_, _, _, _ = ctx, leaseID, port, ttl
+	return core.BridgePeerTarget{}, core.ErrBridgeNotImplemented
+}
+
+// ListPeerTargets reports that OpenComputer does not participate in the bridge plane.
+func (b *openComputerBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]core.BridgePeerTarget, error) {
+	_, _ = ctx, leaseID
+	return nil, core.ErrBridgeNotImplemented
+}

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -1,0 +1,130 @@
+package opencomputer
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+type SyncManifest = core.SyncManifest
+
+const (
+	providerName    = "opencomputer"
+	leasePrefix     = "ocbx_"
+	namePrefix      = "crabbox-"
+	defaultAPIURL   = "https://app.opencomputer.dev"
+	defaultWorkdir  = "/workspace/crabbox"
+	targetLinux     = core.TargetLinux
+	NetworkPublic   = core.NetworkPublic
+	statusViewReady = "running"
+
+	maxSandboxNameLen    = 63
+	sandboxNameSuffixLen = 6
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
+}
+
+func claimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaim(identifier)
+}
+
+func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, provider)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shellQuote(s string) string {
+	return core.ShellQuote(s)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes, includes []string) (core.SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
+}
+
+func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -78,12 +78,8 @@ func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }
 
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot, idleTimeout, reclaim)
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -90,8 +90,8 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }
 
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
+func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
+	return core.ReadLeaseClaim(leaseID)
 }
 
 func listOpenComputerLeaseClaims() ([]core.LeaseClaim, error) {

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -26,6 +26,7 @@ type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type Server = core.Server
 type Repo = core.Repo
+type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
 type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
@@ -93,8 +94,16 @@ func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim,
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
+func listOpenComputerLeaseClaims() ([]core.LeaseClaim, error) {
+	return core.ListLeaseClaimsWithPrefix(leasePrefix)
+}
+
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
 func shouldUseShell(command []string) bool {

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -3,20 +3,22 @@ package opencomputer
 import "flag"
 
 type openComputerFlagValues struct {
-	APIURL      *string
-	Workdir     *string
-	CPU         *int
-	MemoryMB    *int
-	TimeoutSecs *int
+	APIURL          *string
+	Workdir         *string
+	CPU             *int
+	MemoryMB        *int
+	TimeoutSecs     *int
+	ExecTimeoutSecs *int
 }
 
 func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	return openComputerFlagValues{
-		APIURL:      fs.String("opencomputer-api-url", defaults.OpenComputer.APIURL, "OpenComputer API base URL"),
-		Workdir:     fs.String("opencomputer-workdir", defaults.OpenComputer.Workdir, "Absolute working directory inside the sandbox (also used as sync target)"),
-		CPU:         fs.Int("opencomputer-cpu", defaults.OpenComputer.CPU, "OpenComputer sandbox vCPU count (0 = service default; CPU+memory must form an allowed tier)"),
-		MemoryMB:    fs.Int("opencomputer-memory-mb", defaults.OpenComputer.MemoryMB, "OpenComputer sandbox memory in MB (0 = service default; CPU+memory must form an allowed tier)"),
-		TimeoutSecs: fs.Int("opencomputer-timeout-secs", defaults.OpenComputer.TimeoutSecs, "OpenComputer sandbox idle timeout in seconds (0 = service default)"),
+		APIURL:          fs.String("opencomputer-api-url", defaults.OpenComputer.APIURL, "Trusted OpenComputer API base URL; not accepted from repository config"),
+		Workdir:         fs.String("opencomputer-workdir", defaults.OpenComputer.Workdir, "Absolute working directory inside the sandbox (also used as sync target)"),
+		CPU:             fs.Int("opencomputer-cpu", defaults.OpenComputer.CPU, "OpenComputer sandbox vCPU count (0 = service default; the service infers memory when omitted)"),
+		MemoryMB:        fs.Int("opencomputer-memory-mb", defaults.OpenComputer.MemoryMB, "OpenComputer sandbox memory in MB (0 = service default; the service infers CPU when omitted)"),
+		TimeoutSecs:     fs.Int("opencomputer-timeout-secs", defaults.OpenComputer.TimeoutSecs, "OpenComputer sandbox idle timeout in seconds (0 = service default)"),
+		ExecTimeoutSecs: fs.Int("opencomputer-exec-timeout-secs", defaults.OpenComputer.ExecTimeoutSecs, "OpenComputer command timeout in seconds (0 = Crabbox default 3600)"),
 	}
 }
 
@@ -39,6 +41,9 @@ func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) e
 	}
 	if flagWasSet(fs, "opencomputer-timeout-secs") {
 		cfg.OpenComputer.TimeoutSecs = *v.TimeoutSecs
+	}
+	if flagWasSet(fs, "opencomputer-exec-timeout-secs") {
+		cfg.OpenComputer.ExecTimeoutSecs = *v.ExecTimeoutSecs
 	}
 	return nil
 }

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -12,6 +12,7 @@ type openComputerFlagValues struct {
 	MemoryMB        *int
 	TimeoutSecs     *int
 	ExecTimeoutSecs *int
+	Burst           *bool
 	ForgetMissing   *bool
 }
 
@@ -23,6 +24,7 @@ func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		MemoryMB:        fs.Int("opencomputer-memory-mb", defaults.OpenComputer.MemoryMB, "OpenComputer sandbox memory in MB (0 = service default; the service infers CPU when omitted)"),
 		TimeoutSecs:     fs.Int("opencomputer-timeout-secs", defaults.OpenComputer.TimeoutSecs, "OpenComputer sandbox idle timeout in seconds (0 = service default)"),
 		ExecTimeoutSecs: fs.Int("opencomputer-exec-timeout-secs", defaults.OpenComputer.ExecTimeoutSecs, "OpenComputer command timeout in seconds (0 = Crabbox default 3600)"),
+		Burst:           fs.Bool("opencomputer-burst", defaults.OpenComputer.Burst, "use alpha best-effort burst capacity; filesystem persists but processes may restart"),
 		ForgetMissing:   fs.Bool("opencomputer-forget-missing", defaults.OpenComputer.ForgetMissing, "remove the local claim when stop gets 404 (explicit stale-claim cleanup)"),
 	}
 }
@@ -58,6 +60,9 @@ func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) e
 	}
 	if flagWasSet(fs, "opencomputer-exec-timeout-secs") {
 		cfg.OpenComputer.ExecTimeoutSecs = *v.ExecTimeoutSecs
+	}
+	if flagWasSet(fs, "opencomputer-burst") {
+		cfg.OpenComputer.Burst = *v.Burst
 	}
 	if flagWasSet(fs, "opencomputer-forget-missing") {
 		cfg.OpenComputer.ForgetMissing = *v.ForgetMissing

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -9,6 +9,7 @@ type openComputerFlagValues struct {
 	MemoryMB        *int
 	TimeoutSecs     *int
 	ExecTimeoutSecs *int
+	ForgetMissing   *bool
 }
 
 func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -19,6 +20,7 @@ func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		MemoryMB:        fs.Int("opencomputer-memory-mb", defaults.OpenComputer.MemoryMB, "OpenComputer sandbox memory in MB (0 = service default; the service infers CPU when omitted)"),
 		TimeoutSecs:     fs.Int("opencomputer-timeout-secs", defaults.OpenComputer.TimeoutSecs, "OpenComputer sandbox idle timeout in seconds (0 = service default)"),
 		ExecTimeoutSecs: fs.Int("opencomputer-exec-timeout-secs", defaults.OpenComputer.ExecTimeoutSecs, "OpenComputer command timeout in seconds (0 = Crabbox default 3600)"),
+		ForgetMissing:   fs.Bool("opencomputer-forget-missing", defaults.OpenComputer.ForgetMissing, "remove the local claim when stop gets 404 (explicit stale-claim cleanup)"),
 	}
 }
 
@@ -44,6 +46,9 @@ func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) e
 	}
 	if flagWasSet(fs, "opencomputer-exec-timeout-secs") {
 		cfg.OpenComputer.ExecTimeoutSecs = *v.ExecTimeoutSecs
+	}
+	if flagWasSet(fs, "opencomputer-forget-missing") {
+		cfg.OpenComputer.ForgetMissing = *v.ForgetMissing
 	}
 	return nil
 }

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -1,6 +1,9 @@
 package opencomputer
 
-import "flag"
+import (
+	"flag"
+	"strings"
+)
 
 type openComputerFlagValues struct {
 	APIURL          *string
@@ -25,6 +28,15 @@ func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
+	case providerName, "oc", "open-computer":
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=opencomputer; use --opencomputer-cpu and --opencomputer-memory-mb")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=opencomputer; use --opencomputer-cpu and --opencomputer-memory-mb")
+		}
+	}
 	v, ok := values.(openComputerFlagValues)
 	if !ok {
 		return nil

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -1,0 +1,44 @@
+package opencomputer
+
+import "flag"
+
+type openComputerFlagValues struct {
+	APIURL      *string
+	Workdir     *string
+	CPU         *int
+	MemoryMB    *int
+	TimeoutSecs *int
+}
+
+func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return openComputerFlagValues{
+		APIURL:      fs.String("opencomputer-api-url", defaults.OpenComputer.APIURL, "OpenComputer API base URL"),
+		Workdir:     fs.String("opencomputer-workdir", defaults.OpenComputer.Workdir, "Absolute working directory inside the sandbox (also used as sync target)"),
+		CPU:         fs.Int("opencomputer-cpu", defaults.OpenComputer.CPU, "OpenComputer sandbox vCPU count (0 = service default; CPU+memory must form an allowed tier)"),
+		MemoryMB:    fs.Int("opencomputer-memory-mb", defaults.OpenComputer.MemoryMB, "OpenComputer sandbox memory in MB (0 = service default; CPU+memory must form an allowed tier)"),
+		TimeoutSecs: fs.Int("opencomputer-timeout-secs", defaults.OpenComputer.TimeoutSecs, "OpenComputer sandbox idle timeout in seconds (0 = service default)"),
+	}
+}
+
+func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(openComputerFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "opencomputer-api-url") {
+		cfg.OpenComputer.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "opencomputer-workdir") {
+		cfg.OpenComputer.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "opencomputer-cpu") {
+		cfg.OpenComputer.CPU = *v.CPU
+	}
+	if flagWasSet(fs, "opencomputer-memory-mb") {
+		cfg.OpenComputer.MemoryMB = *v.MemoryMB
+	}
+	if flagWasSet(fs, "opencomputer-timeout-secs") {
+		cfg.OpenComputer.TimeoutSecs = *v.TimeoutSecs
+	}
+	return nil
+}

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -15,6 +15,9 @@ type Provider struct{}
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"oc", "open-computer"} }
 
+func (Provider) ServerTypeForConfig(core.Config) string { return "" }
+func (Provider) ServerTypeForClass(string) string       { return "" }
+
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Name:        providerName,

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -1,0 +1,51 @@
+package opencomputer
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"oc", "open-computer"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "opencomputer",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterOpenComputerProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyOpenComputerProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewOpenComputerBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "opencomputer doctor backend unavailable")
+	}
+	return doctor, nil
+}

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -2,6 +2,7 @@ package opencomputer
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -34,12 +35,6 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	}
 	preflightDuration := b.now().Sub(preflightStart)
 
-	prepareStart := b.now()
-	if err := b.prepareWorkspace(ctx, api, sandboxID, workdir); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStart)
-
 	archiveStart := b.now()
 	archive, err := createOpenComputerSyncArchive(ctx, req.Repo, manifest)
 	if err != nil {
@@ -61,41 +56,96 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	}
 	uploadDuration := b.now().Sub(uploadStart)
 
-	extractStart := b.now()
-	// Extract must succeed; cleanup is best-effort. The uploaded archive is
-	// written by the file API as a different owner than the exec user, so a
-	// `rm` may be denied — and it does not matter on an ephemeral box.
-	if err := b.execShell(ctx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(workdir)); err != nil {
+	extractDir := workdir
+	stagingDir := ""
+	if b.cfg.Sync.Delete {
+		stagingDir = path.Join(path.Dir(workdir), "."+path.Base(workdir)+".crabbox-sync-"+randomSuffix())
+		extractDir = stagingDir
+	}
+	cleanupRemote := func() {
+		cleanupCtx, cancel := b.cleanupContext(ctx)
+		defer cancel()
+		command := "rm -f " + shellQuote(remoteArchive) + " 2>/dev/null || true"
+		if stagingDir != "" {
+			command += "; rm -rf " + shellQuote(stagingDir) + " 2>/dev/null || true"
+		}
+		_ = b.execShell(cleanupCtx, api, sandboxID, command)
+	}
+	cleanupPending := true
+	defer func() {
+		if cleanupPending {
+			cleanupRemote()
+		}
+	}()
+
+	prepareStart := b.now()
+	if stagingDir == "" {
+		err = b.ensureWorkspace(ctx, api, sandboxID, workdir)
+	} else {
+		err = b.execShell(ctx, api, sandboxID, "rm -rf "+shellQuote(stagingDir)+" && mkdir -p "+shellQuote(stagingDir))
+	}
+	if err != nil {
 		return nil, 0, err
 	}
-	cleanupCtx, cancel := b.cleanupContext(ctx)
-	defer cancel()
-	_ = b.execShell(cleanupCtx, api, sandboxID, "rm -f "+shellQuote(remoteArchive)+" 2>/dev/null || true")
+	prepareDuration := b.now().Sub(prepareStart)
+
+	extractStart := b.now()
+	if err := b.execShell(ctx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(extractDir)); err != nil {
+		return nil, 0, err
+	}
 	extractDuration := b.now().Sub(extractStart)
 
+	replaceDuration := time.Duration(0)
+	if stagingDir != "" {
+		replaceStart := b.now()
+		if err := b.replaceWorkspace(ctx, api, sandboxID, stagingDir, workdir); err != nil {
+			return nil, 0, err
+		}
+		replaceDuration = b.now().Sub(replaceStart)
+	}
+
+	cleanupStart := b.now()
+	cleanupRemote()
+	cleanupPending = false
+	cleanupDuration := b.now().Sub(cleanupStart)
+
 	total := b.now().Sub(start)
-	return []timingPhase{
+	phases := []timingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
 		{Name: "archive", Ms: archiveDuration.Milliseconds()},
 		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
 		{Name: "extract", Ms: extractDuration.Milliseconds()},
-		{Name: "opencomputer_sync", Ms: total.Milliseconds()},
-	}, total, nil
-}
-
-func (b *openComputerBackend) prepareWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
-	if !b.cfg.Sync.Delete {
-		return b.ensureWorkspace(ctx, api, sandboxID, workdir)
 	}
-	command := "rm -rf " + shellQuote(workdir) + " && mkdir -p " + shellQuote(workdir)
-	return b.execShell(ctx, api, sandboxID, command)
+	if stagingDir != "" {
+		phases = append(phases, timingPhase{Name: "replace", Ms: replaceDuration.Milliseconds()})
+	}
+	phases = append(phases, timingPhase{Name: "cleanup", Ms: cleanupDuration.Milliseconds()})
+	phases = append(phases, timingPhase{Name: "opencomputer_sync", Ms: total.Milliseconds()})
+	return phases, total, nil
 }
 
 func (b *openComputerBackend) ensureWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
 	// --no-sync must never apply sync.delete to a retained workspace.
 	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+}
+
+func (b *openComputerBackend) replaceWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, stagingDir, workdir string) error {
+	backupDir := stagingDir + ".previous"
+	command := "rm -rf " + shellQuote(backupDir) +
+		" && if [ -e " + shellQuote(workdir) + " ]; then mv " + shellQuote(workdir) + " " + shellQuote(backupDir) + "; fi" +
+		" && if mv " + shellQuote(stagingDir) + " " + shellQuote(workdir) +
+		"; then exit 0" +
+		"; else rc=$?; if [ -e " + shellQuote(backupDir) + " ]; then mv " + shellQuote(backupDir) + " " + shellQuote(workdir) +
+		"; fi; exit \"$rc\"; fi"
+	if err := b.execShell(ctx, api, sandboxID, command); err != nil {
+		return err
+	}
+	if err := b.execShell(ctx, api, sandboxID, "rm -rf "+shellQuote(backupDir)); err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: opencomputer previous workspace cleanup failed path=%s: %v\n", backupDir, err)
+	}
+	return nil
 }
 
 // execShell runs `bash -lc <command>` via exec/run and returns an error for

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -1,0 +1,109 @@
+package opencomputer
+
+import (
+	"context"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+// syncWorkspace builds a gzipped tar archive of the repo, uploads it into the
+// sandbox via the file API (`PUT /files`, content in the request body — never
+// argv), and extracts it into the configured workdir via `exec/run`. Returns
+// per-phase timings so warmup/run summaries break the sync down the same way
+// islo and tensorlake do.
+func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	manifestStart := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStart)
+
+	preflightStart := b.now()
+	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStart)
+
+	prepareStart := b.now()
+	if err := b.prepareWorkspace(ctx, api, sandboxID, workdir); err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStart)
+
+	archiveStart := b.now()
+	archive, err := createOpenComputerSyncArchive(ctx, req.Repo, manifest)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := b.now().Sub(archiveStart)
+
+	uploadStart := b.now()
+	if _, err := archive.Seek(0, 0); err != nil {
+		return nil, 0, exit(6, "rewind sync archive: %v", err)
+	}
+	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
+	if err := api.uploadFile(ctx, sandboxID, remoteArchive, archive); err != nil {
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStart)
+
+	extractStart := b.now()
+	// Extract must succeed; cleanup is best-effort. The uploaded archive is
+	// written by the file API as a different owner than the exec user, so a
+	// `rm` may be denied — and it does not matter on an ephemeral box.
+	if err := b.execShell(ctx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(workdir)); err != nil {
+		return nil, 0, err
+	}
+	_ = b.execShell(context.Background(), api, sandboxID, "rm -f "+shellQuote(remoteArchive)+" 2>/dev/null || true")
+	extractDuration := b.now().Sub(extractStart)
+
+	total := b.now().Sub(start)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "extract", Ms: extractDuration.Milliseconds()},
+		{Name: "opencomputer_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func (b *openComputerBackend) prepareWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
+	command := "mkdir -p " + shellQuote(workdir)
+	if b.cfg.Sync.Delete {
+		command = "rm -rf " + shellQuote(workdir) + " && " + command
+	}
+	return b.execShell(ctx, api, sandboxID, command)
+}
+
+// execShell runs `bash -lc <command>` via exec/run and returns an error for
+// non-zero exits. Used for sync helpers (mkdir, extract, cleanup).
+func (b *openComputerBackend) execShell(ctx context.Context, api *ocAPIClient, sandboxID, command string) error {
+	res, err := api.execRun(ctx, sandboxID, execRunRequest{Cmd: "bash", Args: []string{"-lc", command}})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return exit(res.ExitCode, "opencomputer exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func createOpenComputerSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-opencomputer-sync-*.tgz")
+}

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -68,7 +68,9 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	if err := b.execShell(ctx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(workdir)); err != nil {
 		return nil, 0, err
 	}
-	_ = b.execShell(context.Background(), api, sandboxID, "rm -f "+shellQuote(remoteArchive)+" 2>/dev/null || true")
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	_ = b.execShell(cleanupCtx, api, sandboxID, "rm -f "+shellQuote(remoteArchive)+" 2>/dev/null || true")
 	extractDuration := b.now().Sub(extractStart)
 
 	total := b.now().Sub(start)

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -86,17 +86,26 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 }
 
 func (b *openComputerBackend) prepareWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
-	command := "mkdir -p " + shellQuote(workdir)
-	if b.cfg.Sync.Delete {
-		command = "rm -rf " + shellQuote(workdir) + " && " + command
+	if !b.cfg.Sync.Delete {
+		return b.ensureWorkspace(ctx, api, sandboxID, workdir)
 	}
+	command := "rm -rf " + shellQuote(workdir) + " && mkdir -p " + shellQuote(workdir)
 	return b.execShell(ctx, api, sandboxID, command)
+}
+
+func (b *openComputerBackend) ensureWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
+	// --no-sync must never apply sync.delete to a retained workspace.
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
 }
 
 // execShell runs `bash -lc <command>` via exec/run and returns an error for
 // non-zero exits. Used for sync helpers (mkdir, extract, cleanup).
 func (b *openComputerBackend) execShell(ctx context.Context, api *ocAPIClient, sandboxID, command string) error {
-	res, err := api.execRun(ctx, sandboxID, execRunRequest{Cmd: "bash", Args: []string{"-lc", command}})
+	res, err := api.execRun(ctx, sandboxID, execRunRequest{
+		Cmd:     "bash",
+		Args:    []string{"-lc", command},
+		Timeout: b.execTimeoutSecs(),
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -3,6 +3,7 @@ package opencomputer
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -16,6 +17,12 @@ import (
 // islo and tensorlake do.
 func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
 	start := b.now()
+	syncCtx := ctx
+	cancel := func() {}
+	if b.cfg.Sync.Timeout > 0 {
+		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
+	}
+	defer cancel()
 
 	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
 	if err != nil {
@@ -30,13 +37,13 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	manifestDuration := b.now().Sub(manifestStart)
 
 	preflightStart := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+	if err := checkOpenComputerSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, 0, err
 	}
 	preflightDuration := b.now().Sub(preflightStart)
 
 	archiveStart := b.now()
-	archive, err := createOpenComputerSyncArchive(ctx, req.Repo, manifest)
+	archive, err := createOpenComputerSyncArchive(syncCtx, req.Repo, manifest)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -51,7 +58,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 		return nil, 0, exit(6, "rewind sync archive: %v", err)
 	}
 	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
-	if err := api.uploadFile(ctx, sandboxID, remoteArchive, archive); err != nil {
+	if err := api.uploadFile(syncCtx, sandboxID, remoteArchive, archive); err != nil {
 		return nil, 0, err
 	}
 	uploadDuration := b.now().Sub(uploadStart)
@@ -80,9 +87,9 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 
 	prepareStart := b.now()
 	if stagingDir == "" {
-		err = b.ensureWorkspace(ctx, api, sandboxID, workdir)
+		err = b.ensureWorkspace(syncCtx, api, sandboxID, workdir)
 	} else {
-		err = b.execShell(ctx, api, sandboxID, "rm -rf "+shellQuote(stagingDir)+" && mkdir -p "+shellQuote(stagingDir))
+		err = b.execShell(syncCtx, api, sandboxID, "rm -rf "+shellQuote(stagingDir)+" && mkdir -p "+shellQuote(stagingDir))
 	}
 	if err != nil {
 		return nil, 0, err
@@ -90,7 +97,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	prepareDuration := b.now().Sub(prepareStart)
 
 	extractStart := b.now()
-	if err := b.execShell(ctx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(extractDir)); err != nil {
+	if err := b.execShell(syncCtx, api, sandboxID, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(extractDir)); err != nil {
 		return nil, 0, err
 	}
 	extractDuration := b.now().Sub(extractStart)
@@ -98,7 +105,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	replaceDuration := time.Duration(0)
 	if stagingDir != "" {
 		replaceStart := b.now()
-		if err := b.replaceWorkspace(ctx, api, sandboxID, stagingDir, workdir); err != nil {
+		if err := b.replaceWorkspace(syncCtx, api, sandboxID, stagingDir, workdir); err != nil {
 			return nil, 0, err
 		}
 		replaceDuration = b.now().Sub(replaceStart)
@@ -124,6 +131,15 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	phases = append(phases, timingPhase{Name: "cleanup", Ms: cleanupDuration.Milliseconds()})
 	phases = append(phases, timingPhase{Name: "opencomputer_sync", Ms: total.Milliseconds()})
 	return phases, total, nil
+}
+
+func checkOpenComputerSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	// OpenComputer uploads a full archive even when only a small dirty delta
+	// exists, so guardrails must evaluate the full candidate.
+	archiveManifest := manifest
+	archiveManifest.Changed = nil
+	archiveManifest.ChangedBytes = 0
+	return checkSyncPreflight(archiveManifest, cfg, force, stderr)
 }
 
 func (b *openComputerBackend) ensureWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -53,16 +53,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 	}()
 	archiveDuration := b.now().Sub(archiveStart)
 
-	uploadStart := b.now()
-	if _, err := archive.Seek(0, 0); err != nil {
-		return nil, 0, exit(6, "rewind sync archive: %v", err)
-	}
 	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
-	if err := api.uploadFile(syncCtx, sandboxID, remoteArchive, archive); err != nil {
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStart)
-
 	extractDir := workdir
 	stagingDir := ""
 	if b.cfg.Sync.Delete {
@@ -84,6 +75,15 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 			cleanupRemote()
 		}
 	}()
+
+	uploadStart := b.now()
+	if _, err := archive.Seek(0, 0); err != nil {
+		return nil, 0, exit(6, "rewind sync archive: %v", err)
+	}
+	if err := api.uploadFile(syncCtx, sandboxID, remoteArchive, archive); err != nil {
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStart)
 
 	prepareStart := b.now()
 	if stagingDir == "" {


### PR DESCRIPTION
## What

Adds `provider: opencomputer` (aliases `oc`, `open-computer`): a delegated-run provider for [OpenComputer](https://app.opencomputer.dev) full Linux VMs that runs **entirely on the OpenComputer REST API** — no `oc` CLI process at runtime. Crabbox owns local config, repo claims, sync manifests/guardrails, slugs, timing, and normalized list/status rendering; OpenComputer owns the VM and transport.

## Everything is off-argv

- **Auth** — API key sent only in the `X-API-Key` header. Resolved from `CRABBOX_OPENCOMPUTER_API_KEY` / `OPENCOMPUTER_API_KEY` / the `oc` config file (`~/.oc/config.json`, written by `oc config set api-key`). Never persisted in Crabbox config, never on argv.
- **Env forwarding** — `--allow-env`/`--env-from-profile` ride in the exec request body (`POST /api/sandboxes/<id>/exec/run`, `envs` field), so values never touch a command line.
- **Sync** — the working-tree tar is uploaded via `PUT /api/sandboxes/<id>/files` (content in the request body), then extracted in-sandbox. Archive-sync feature advertised, so `--force-sync-large` and `--sync-only` are honored; `--checksum` rejected.

## Lifecycle (all REST)

`POST /api/sandboxes` (sizing only as a valid CPU/memory tier, else the service default) → file-API sync → `POST .../exec/run` (cwd = workspace, env in body, exit code mirrored) → `DELETE /api/sandboxes/<id>` (skipped with `--keep`).

## Why API instead of the CLI

Per the maintainer suggestion: there is no Go SDK (TS/Python only), but the REST surface is complete and was confirmed live. Going API-only removes the `oc` binary dependency, keeps every secret/payload off argv, makes env forwarding native, gives reliable exit codes, and is a net **−500 LOC** vs the CLI hybrid.

## Verification

- `gofmt`, `go vet`, `go test -race`, `scripts/check-docs.sh` clean; core coverage 91% ≥ 90%.
- Unit tests run against an httptest fake API (assert env in the exec body not argv, sync via file API, exit-code propagation, `--sync-only` skips the command, `--keep` retains, missing key errors before any create).
- **e2e against app.opencomputer.dev**: create → file-API archive sync (multi-file, read back inside the box) → `exec/run` → native env (`--allow-env` value printed from inside) → `--sync-only` → teardown — all over REST, no leftover sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)