### PR TITLE
feat: add Windows Sandbox provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: windows-sandbox` for disposable native Windows runs through Microsoft Windows Sandbox, including mapped workspace sync, streamed output, timeout and cancellation cleanup, and keep-on-failure inspection. Thanks @zozo123.
 - Added `provider: smolvm` for delegated Linux microVM runs through the hosted smolfleet API, including archive sync, retained leases, status, cleanup, and repository-scoped ownership checks. Thanks @zozo123.
 - Added non-mutating Proxmox storage, bridge, pool, template, and cluster inventory readiness diagnostics plus guarded live lifecycle smoke coverage, with safer failed-create and cleanup claim handling. Thanks @coygeek.
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ hardware for macOS VM workflows.
 | [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux | Azure Container Apps dynamic sessions. |
 | [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`) | Linux | Delegated Blacksmith CI Testbox lifecycle and execution. |
 | [W&B Sandboxes](docs/providers/wandb.md) — `wandb` (`weights-and-biases`) | Linux | Weights & Biases Sandboxes; reuses `wandb login` credentials. |
+| [Windows Sandbox](docs/providers/windows-sandbox.md) — `windows-sandbox` (`wsb`, `windows-sandbox-provider`) | Windows | Disposable Microsoft Windows Sandbox sessions through generated `.wsb` configs. |
 
 See [Providers](docs/providers/README.md) for the full reference, capabilities,
 and authoring guide.

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -113,7 +113,8 @@ provider on Apple hardware for macOS VM workflows.
 These run the command inside a sandbox/proof runner; Crabbox does not lease or
 SSH into a box. Local sync options (`--no-sync`, rsync flags) are rejected - the
 provider owns sync. Most are Linux-only. `anthropic-sandbox-runtime` is local
-to the current macOS or Linux host.
+to the current macOS or Linux host; `windows-sandbox` is local to a Windows
+host.
 
 ```text
 cloudflare              Cloudflare Containers (Worker runtime)
@@ -130,6 +131,7 @@ tensorlake              Tensorlake Firecracker sandboxes
 upstash-box             Upstash sandboxes
 blacksmith-testbox      Blacksmith CI test runner (proof/session)
 wandb                   Weights & Biases run sandboxes
+windows-sandbox         Windows Sandbox on the local Windows host
 ```
 
 ## Service-control providers
@@ -182,6 +184,7 @@ railway                 Railway service status and stop controls
 - [SmolVM](../providers/smolvm.md): delegated Smol Machines microVM execution via smolfleet.
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Blacksmith CI runner.
 - [Weights & Biases](../providers/wandb.md): delegated W&B run sandbox execution.
+- [Windows Sandbox](../providers/windows-sandbox.md): delegated Windows Sandbox execution on a local Windows host.
 - [Provider backends](../provider-backends.md): guide for adding a new provider/backend/plugin.
 
 ## Machine classes

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -41,6 +41,7 @@ SSH-lease providers further differ by how they reach the cloud:
   `azure-dynamic-sessions`, `docker-sandbox`, `smolvm`). `anthropic-sandbox-runtime` is
   the local macOS/Linux delegated-run exception: Anthropic's `srt` executes on
   the current machine while still owning sync/run policy end to end.
+  `windows-sandbox` is the local Windows delegated-run exception.
 
 Select a provider per command with `--provider <name>` (env `CRABBOX_PROVIDER`),
 or set `provider: <name>` in config. Provider flags are registered before
@@ -110,6 +111,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |
 | [W&B Sandboxes](wandb.md) — `wandb` (`weights-and-biases`) | Linux |
+| [Windows Sandbox](windows-sandbox.md) — `windows-sandbox` (`wsb`, `windows-sandbox-provider`) | Windows |
 
 Run `crabbox providers` (`--json`) to see the live capability set the binary
 reports.

--- a/docs/providers/windows-sandbox.md
+++ b/docs/providers/windows-sandbox.md
@@ -93,3 +93,8 @@ Flags:
 
 Environment variables use the same names with a `CRABBOX_WINDOWS_SANDBOX_`
 prefix, for example `CRABBOX_WINDOWS_SANDBOX_NETWORKING=disable`.
+
+Host paths, device redirection, networking, vGPU, protected-client mode, and
+memory settings are accepted only from trusted user config, environment
+variables, or explicit flags. Repository-local config may set only the sandbox
+workdir; it cannot redirect host temporary files or loosen host sandbox policy.

--- a/docs/providers/windows-sandbox.md
+++ b/docs/providers/windows-sandbox.md
@@ -1,0 +1,95 @@
+# Windows Sandbox
+
+Windows Sandbox is a local delegated-run provider for disposable native Windows
+test runs on a Windows host. Crabbox generates a temporary `.wsb` file, maps a
+host workspace into the sandbox, runs the requested command through the sandbox
+logon command, streams mapped stdout/stderr files back to the terminal, then
+shuts the sandbox down unless `--keep` or `--keep-on-failure` asks to leave it
+open.
+
+Provider id: `windows-sandbox`
+
+Aliases: `wsb`, `windows-sandbox-provider`
+
+Targets: native Windows only (`--target windows --windows-mode normal`)
+
+Brokered: no. This provider runs entirely from the local CLI and does not use
+the Cloudflare Worker coordinator.
+
+## Requirements
+
+- A Windows host that supports and has enabled the Windows Sandbox optional
+  feature.
+- `WindowsSandbox.exe` available on `PATH`.
+- No other Windows Sandbox session already running. Windows Sandbox supports one
+  instance at a time.
+
+The implementation follows Microsoft's `.wsb` configuration model:
+[Windows Sandbox](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/windows-sandbox/).
+
+## Usage
+
+```sh
+crabbox run --provider windows-sandbox --target windows -- powershell -NoProfile -Command "Write-Host ok"
+crabbox run --provider wsb --shell "go test ./..."
+crabbox run --provider windows-sandbox --keep-on-failure -- npm test
+crabbox doctor --provider windows-sandbox
+```
+
+When `--target` is omitted, `provider=windows-sandbox` defaults to native
+Windows. `--windows-mode wsl2` is intentionally rejected because Windows
+Sandbox exposes a disposable Windows desktop session, not a reusable WSL2 VM.
+
+## Sync and lifecycle
+
+Crabbox copies the local sync manifest into a temporary host workspace and maps
+that directory into the sandbox at `C:\crabbox-work` by default. The sandbox also
+receives a mapped control directory for the generated run script, stdout/stderr
+logs, and exit-code sentinel.
+
+`--force-sync-large` is supported for unusually large workspace copies.
+`--sync-only` is rejected because each Windows Sandbox workspace is created for a
+single run and has no stable lease id to reuse.
+Tracked symlinks are rejected before launch because the Windows host copy step
+must not require Developer Mode or administrator symlink privileges. Exclude the
+path or replace it with a regular file before using this provider.
+
+The temporary workspace is removed after successful runs. With `--keep`, or with
+`--keep-on-failure` after a non-zero exit, Crabbox leaves both the sandbox window
+and the host temp directory in place for inspection.
+
+`warmup`, `list`, `status`, and `stop` are not persistent lifecycle operations
+for this provider. Close the Windows Sandbox window to end a kept session.
+
+## Configuration
+
+```yaml
+provider: windows-sandbox
+windowsSandbox:
+  workdir: C:\crabbox-work
+  tempRoot: C:\crabbox-temp
+  networking: enable
+  vgpu: disable
+  clipboard: disable
+  protectedClient: default
+  audioInput: disable
+  videoInput: disable
+  printerRedirection: disable
+  memoryMB: 4096
+```
+
+Flags:
+
+- `--windows-sandbox-workdir`
+- `--windows-sandbox-temp-root`
+- `--windows-sandbox-networking enable|disable|default`
+- `--windows-sandbox-vgpu enable|disable|default`
+- `--windows-sandbox-clipboard enable|disable|default`
+- `--windows-sandbox-protected-client enable|disable|default`
+- `--windows-sandbox-audio-input enable|disable|default`
+- `--windows-sandbox-video-input enable|disable|default`
+- `--windows-sandbox-printer-redirection enable|disable|default`
+- `--windows-sandbox-memory-mb`
+
+Environment variables use the same names with a `CRABBOX_WINDOWS_SANDBOX_`
+prefix, for example `CRABBOX_WINDOWS_SANDBOX_NETWORKING=disable`.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -4230,32 +4230,34 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.WindowsSandbox.Workdir != "" {
 			cfg.WindowsSandbox.Workdir = file.WindowsSandbox.Workdir
 		}
-		if file.WindowsSandbox.TempRoot != "" {
-			cfg.WindowsSandbox.TempRoot = expandUserPath(file.WindowsSandbox.TempRoot)
-		}
-		if file.WindowsSandbox.Networking != "" {
-			cfg.WindowsSandbox.Networking = file.WindowsSandbox.Networking
-		}
-		if file.WindowsSandbox.VGPU != "" {
-			cfg.WindowsSandbox.VGPU = file.WindowsSandbox.VGPU
-		}
-		if file.WindowsSandbox.Clipboard != "" {
-			cfg.WindowsSandbox.Clipboard = file.WindowsSandbox.Clipboard
-		}
-		if file.WindowsSandbox.ProtectedClient != "" {
-			cfg.WindowsSandbox.ProtectedClient = file.WindowsSandbox.ProtectedClient
-		}
-		if file.WindowsSandbox.AudioInput != "" {
-			cfg.WindowsSandbox.AudioInput = file.WindowsSandbox.AudioInput
-		}
-		if file.WindowsSandbox.VideoInput != "" {
-			cfg.WindowsSandbox.VideoInput = file.WindowsSandbox.VideoInput
-		}
-		if file.WindowsSandbox.PrinterRedirection != "" {
-			cfg.WindowsSandbox.PrinterRedirection = file.WindowsSandbox.PrinterRedirection
-		}
-		if file.WindowsSandbox.MemoryMB > 0 {
-			cfg.WindowsSandbox.MemoryMB = file.WindowsSandbox.MemoryMB
+		if trusted {
+			if file.WindowsSandbox.TempRoot != "" {
+				cfg.WindowsSandbox.TempRoot = expandUserPath(file.WindowsSandbox.TempRoot)
+			}
+			if file.WindowsSandbox.Networking != "" {
+				cfg.WindowsSandbox.Networking = file.WindowsSandbox.Networking
+			}
+			if file.WindowsSandbox.VGPU != "" {
+				cfg.WindowsSandbox.VGPU = file.WindowsSandbox.VGPU
+			}
+			if file.WindowsSandbox.Clipboard != "" {
+				cfg.WindowsSandbox.Clipboard = file.WindowsSandbox.Clipboard
+			}
+			if file.WindowsSandbox.ProtectedClient != "" {
+				cfg.WindowsSandbox.ProtectedClient = file.WindowsSandbox.ProtectedClient
+			}
+			if file.WindowsSandbox.AudioInput != "" {
+				cfg.WindowsSandbox.AudioInput = file.WindowsSandbox.AudioInput
+			}
+			if file.WindowsSandbox.VideoInput != "" {
+				cfg.WindowsSandbox.VideoInput = file.WindowsSandbox.VideoInput
+			}
+			if file.WindowsSandbox.PrinterRedirection != "" {
+				cfg.WindowsSandbox.PrinterRedirection = file.WindowsSandbox.PrinterRedirection
+			}
+			if file.WindowsSandbox.MemoryMB > 0 {
+				cfg.WindowsSandbox.MemoryMB = file.WindowsSandbox.MemoryMB
+			}
 		}
 	}
 	if file.Tailscale != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -169,6 +169,7 @@ type Config struct {
 	tartCPUsExplicit              bool
 	tartMemoryExplicit            bool
 	HyperV                        HyperVConfig
+	WindowsSandbox                WindowsSandboxConfig
 	Tailscale                     TailscaleConfig
 	Static                        StaticConfig
 	Results                       ResultsConfig
@@ -761,6 +762,19 @@ type HyperVConfig struct {
 	InitPassword  bool
 }
 
+type WindowsSandboxConfig struct {
+	Workdir            string
+	TempRoot           string
+	Networking         string
+	VGPU               string
+	Clipboard          string
+	ProtectedClient    string
+	AudioInput         string
+	VideoInput         string
+	PrinterRedirection string
+	MemoryMB           int
+}
+
 type StaticConfig struct {
 	ID       string
 	Name     string
@@ -1152,6 +1166,23 @@ func applyProviderConfigDefaults(cfg *Config) error {
 			cfg.WorkRoot = cfg.HyperV.WorkRoot
 		}
 		cfg.SSHPort = "22"
+		return nil
+	}
+	if cfg.Provider == "windows-sandbox" || cfg.Provider == "wsb" || cfg.Provider == "windows-sandbox-provider" {
+		if IsTargetExplicit(cfg) && normalizeTargetOS(cfg.TargetOS) != targetWindows {
+			return exit(2, "provider=windows-sandbox supports target=windows only")
+		}
+		if cfg.TargetOS == "" || (!IsTargetExplicit(cfg) && cfg.TargetOS == targetLinux) {
+			cfg.TargetOS = targetWindows
+		}
+		if cfg.explicitWindowsMode != "" && normalizeWindowsMode(cfg.explicitWindowsMode) != windowsModeNormal {
+			return exit(2, "provider=windows-sandbox supports windows.mode=normal only")
+		}
+		cfg.WindowsMode = windowsModeNormal
+		if cfg.WindowsSandbox.Workdir == "" {
+			cfg.WindowsSandbox.Workdir = `C:\crabbox-work`
+		}
+		cfg.WorkRoot = cfg.WindowsSandbox.Workdir
 		return nil
 	}
 	if cfg.Provider == "exe-dev" || cfg.Provider == "exedev" || cfg.Provider == "exe" {
@@ -1796,6 +1827,16 @@ func baseConfig() Config {
 			Memory:   8192,
 			Switch:   "Default Switch",
 		},
+		WindowsSandbox: WindowsSandboxConfig{
+			Workdir:            `C:\crabbox-work`,
+			Networking:         "Enable",
+			VGPU:               "Disable",
+			Clipboard:          "Disable",
+			ProtectedClient:    "Default",
+			AudioInput:         "Disable",
+			VideoInput:         "Disable",
+			PrinterRedirection: "Disable",
+		},
 		Tailscale: TailscaleConfig{
 			Tags:             []string{"tag:crabbox"},
 			HostnameTemplate: "crabbox-{slug}",
@@ -1880,6 +1921,7 @@ type fileConfig struct {
 	Multipass            *fileMultipassConfig               `yaml:"multipass,omitempty"`
 	Tart                 *fileTartConfig                    `yaml:"tart,omitempty"`
 	HyperV               *fileHyperVConfig                  `yaml:"hyperv,omitempty"`
+	WindowsSandbox       *fileWindowsSandboxConfig          `yaml:"windowsSandbox,omitempty"`
 	Tailscale            *fileTailscaleConfig               `yaml:"tailscale,omitempty"`
 	Static               *fileStaticConfig                  `yaml:"static,omitempty"`
 	Results              *fileResultsConfig                 `yaml:"results,omitempty"`
@@ -2477,6 +2519,19 @@ type fileHyperVConfig struct {
 	Switch        string `yaml:"switch,omitempty"`
 	GuestPassword string `yaml:"guestPassword,omitempty"`
 	InitPassword  *bool  `yaml:"initPassword,omitempty"`
+}
+
+type fileWindowsSandboxConfig struct {
+	Workdir            string `yaml:"workdir,omitempty"`
+	TempRoot           string `yaml:"tempRoot,omitempty"`
+	Networking         string `yaml:"networking,omitempty"`
+	VGPU               string `yaml:"vgpu,omitempty"`
+	Clipboard          string `yaml:"clipboard,omitempty"`
+	ProtectedClient    string `yaml:"protectedClient,omitempty"`
+	AudioInput         string `yaml:"audioInput,omitempty"`
+	VideoInput         string `yaml:"videoInput,omitempty"`
+	PrinterRedirection string `yaml:"printerRedirection,omitempty"`
+	MemoryMB           int    `yaml:"memoryMB,omitempty"`
 }
 
 type fileTailscaleConfig struct {
@@ -4171,6 +4226,38 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.HyperV.InitPassword = *file.HyperV.InitPassword
 		}
 	}
+	if file.WindowsSandbox != nil {
+		if file.WindowsSandbox.Workdir != "" {
+			cfg.WindowsSandbox.Workdir = file.WindowsSandbox.Workdir
+		}
+		if file.WindowsSandbox.TempRoot != "" {
+			cfg.WindowsSandbox.TempRoot = expandUserPath(file.WindowsSandbox.TempRoot)
+		}
+		if file.WindowsSandbox.Networking != "" {
+			cfg.WindowsSandbox.Networking = file.WindowsSandbox.Networking
+		}
+		if file.WindowsSandbox.VGPU != "" {
+			cfg.WindowsSandbox.VGPU = file.WindowsSandbox.VGPU
+		}
+		if file.WindowsSandbox.Clipboard != "" {
+			cfg.WindowsSandbox.Clipboard = file.WindowsSandbox.Clipboard
+		}
+		if file.WindowsSandbox.ProtectedClient != "" {
+			cfg.WindowsSandbox.ProtectedClient = file.WindowsSandbox.ProtectedClient
+		}
+		if file.WindowsSandbox.AudioInput != "" {
+			cfg.WindowsSandbox.AudioInput = file.WindowsSandbox.AudioInput
+		}
+		if file.WindowsSandbox.VideoInput != "" {
+			cfg.WindowsSandbox.VideoInput = file.WindowsSandbox.VideoInput
+		}
+		if file.WindowsSandbox.PrinterRedirection != "" {
+			cfg.WindowsSandbox.PrinterRedirection = file.WindowsSandbox.PrinterRedirection
+		}
+		if file.WindowsSandbox.MemoryMB > 0 {
+			cfg.WindowsSandbox.MemoryMB = file.WindowsSandbox.MemoryMB
+		}
+	}
 	if file.Tailscale != nil {
 		if file.Tailscale.Enabled != nil {
 			cfg.Tailscale.Enabled = *file.Tailscale.Enabled
@@ -5227,6 +5314,16 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_HYPERV_INIT_PASSWORD"); ok {
 		cfg.HyperV.InitPassword = value
 	}
+	cfg.WindowsSandbox.Workdir = getenv("CRABBOX_WINDOWS_SANDBOX_WORKDIR", cfg.WindowsSandbox.Workdir)
+	cfg.WindowsSandbox.TempRoot = expandUserPath(getenv("CRABBOX_WINDOWS_SANDBOX_TEMP_ROOT", cfg.WindowsSandbox.TempRoot))
+	cfg.WindowsSandbox.Networking = getenv("CRABBOX_WINDOWS_SANDBOX_NETWORKING", cfg.WindowsSandbox.Networking)
+	cfg.WindowsSandbox.VGPU = getenv("CRABBOX_WINDOWS_SANDBOX_VGPU", cfg.WindowsSandbox.VGPU)
+	cfg.WindowsSandbox.Clipboard = getenv("CRABBOX_WINDOWS_SANDBOX_CLIPBOARD", cfg.WindowsSandbox.Clipboard)
+	cfg.WindowsSandbox.ProtectedClient = getenv("CRABBOX_WINDOWS_SANDBOX_PROTECTED_CLIENT", cfg.WindowsSandbox.ProtectedClient)
+	cfg.WindowsSandbox.AudioInput = getenv("CRABBOX_WINDOWS_SANDBOX_AUDIO_INPUT", cfg.WindowsSandbox.AudioInput)
+	cfg.WindowsSandbox.VideoInput = getenv("CRABBOX_WINDOWS_SANDBOX_VIDEO_INPUT", cfg.WindowsSandbox.VideoInput)
+	cfg.WindowsSandbox.PrinterRedirection = getenv("CRABBOX_WINDOWS_SANDBOX_PRINTER_REDIRECTION", cfg.WindowsSandbox.PrinterRedirection)
+	cfg.WindowsSandbox.MemoryMB = getenvInt("CRABBOX_WINDOWS_SANDBOX_MEMORY_MB", cfg.WindowsSandbox.MemoryMB)
 	if value, ok := getenvBool("CRABBOX_TAILSCALE"); ok {
 		cfg.Tailscale.Enabled = value
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -190,6 +190,16 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_MULTIPASS_MEMORY",
 		"CRABBOX_MULTIPASS_DISK",
 		"CRABBOX_MULTIPASS_LAUNCH_TIMEOUT",
+		"CRABBOX_WINDOWS_SANDBOX_WORKDIR",
+		"CRABBOX_WINDOWS_SANDBOX_TEMP_ROOT",
+		"CRABBOX_WINDOWS_SANDBOX_NETWORKING",
+		"CRABBOX_WINDOWS_SANDBOX_VGPU",
+		"CRABBOX_WINDOWS_SANDBOX_CLIPBOARD",
+		"CRABBOX_WINDOWS_SANDBOX_PROTECTED_CLIENT",
+		"CRABBOX_WINDOWS_SANDBOX_AUDIO_INPUT",
+		"CRABBOX_WINDOWS_SANDBOX_VIDEO_INPUT",
+		"CRABBOX_WINDOWS_SANDBOX_PRINTER_REDIRECTION",
+		"CRABBOX_WINDOWS_SANDBOX_MEMORY_MB",
 		"CRABBOX_WANDB_API_KEY",
 		"WANDB_API_KEY",
 		"CRABBOX_WANDB_DEFAULT_IMAGE",
@@ -1629,6 +1639,70 @@ func TestTartEnvExplicitFlags(t *testing.T) {
 	}
 	if !IsTartMemoryExplicit(&cfg) {
 		t.Fatal("tartMemoryExplicit must be true after env sets CRABBOX_TART_MEMORY")
+	}
+}
+
+func TestWindowsSandboxConfigDefaultsFileEnvAndProviderTarget(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if cfg.WindowsSandbox.Workdir != `C:\crabbox-work` || cfg.WindowsSandbox.Networking != "Enable" || cfg.WindowsSandbox.VGPU != "Disable" {
+		t.Fatalf("windows sandbox defaults not applied: %#v", cfg.WindowsSandbox)
+	}
+	applyFileConfig(&cfg, fileConfig{
+		Provider: "windows-sandbox",
+		WindowsSandbox: &fileWindowsSandboxConfig{
+			Workdir:            `C:\repo`,
+			TempRoot:           `C:\tmp\crabbox`,
+			Networking:         "disable",
+			VGPU:               "default",
+			Clipboard:          "disable",
+			ProtectedClient:    "enable",
+			AudioInput:         "disable",
+			VideoInput:         "disable",
+			PrinterRedirection: "disable",
+			MemoryMB:           8192,
+		},
+	})
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "windows-sandbox" || cfg.TargetOS != targetWindows || cfg.WindowsMode != windowsModeNormal || cfg.WorkRoot != `C:\repo` {
+		t.Fatalf("provider target/workroot not applied: provider=%s target=%s mode=%s workroot=%s", cfg.Provider, cfg.TargetOS, cfg.WindowsMode, cfg.WorkRoot)
+	}
+	if cfg.WindowsSandbox.Workdir != `C:\repo` || cfg.WindowsSandbox.TempRoot != `C:\tmp\crabbox` || cfg.WindowsSandbox.MemoryMB != 8192 {
+		t.Fatalf("file windowsSandbox config not applied: %#v", cfg.WindowsSandbox)
+	}
+
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_WORKDIR", `C:\env\repo`)
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_TEMP_ROOT", `C:\env\tmp`)
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_NETWORKING", "enable")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_VGPU", "disable")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_CLIPBOARD", "default")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_PROTECTED_CLIENT", "default")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_AUDIO_INPUT", "disable")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_VIDEO_INPUT", "disable")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_PRINTER_REDIRECTION", "disable")
+	t.Setenv("CRABBOX_WINDOWS_SANDBOX_MEMORY_MB", "4096")
+	applyEnv(&cfg)
+	if cfg.WindowsSandbox.Workdir != `C:\env\repo` || cfg.WindowsSandbox.TempRoot != `C:\env\tmp` || cfg.WindowsSandbox.Networking != "enable" || cfg.WindowsSandbox.Clipboard != "default" || cfg.WindowsSandbox.MemoryMB != 4096 {
+		t.Fatalf("env windowsSandbox config not applied: %#v", cfg.WindowsSandbox)
+	}
+
+	badTarget := baseConfig()
+	badTarget.Provider = "windows-sandbox"
+	badTarget.TargetOS = targetLinux
+	badTarget.targetExplicit = true
+	if err := applyProviderConfigDefaults(&badTarget); err == nil || !strings.Contains(err.Error(), "target=windows") {
+		t.Fatalf("target linux err=%v, want windows-sandbox target rejection", err)
+	}
+
+	badMode := baseConfig()
+	badMode.Provider = "windows-sandbox"
+	badMode.TargetOS = targetWindows
+	badMode.WindowsMode = windowsModeWSL2
+	badMode.explicitWindowsMode = windowsModeWSL2
+	if err := applyProviderConfigDefaults(&badMode); err == nil || !strings.Contains(err.Error(), "windows.mode=normal") {
+		t.Fatalf("wsl2 err=%v, want windows-sandbox windows mode rejection", err)
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1706,6 +1706,52 @@ func TestWindowsSandboxConfigDefaultsFileEnvAndProviderTarget(t *testing.T) {
 	}
 }
 
+func TestRepositoryConfigCannotLoosenWindowsSandboxHostPolicy(t *testing.T) {
+	cfg := baseConfig()
+	cfg.WindowsSandbox.TempRoot = `C:\trusted-temp`
+	cfg.WindowsSandbox.Networking = "Disable"
+	cfg.WindowsSandbox.VGPU = "Disable"
+	cfg.WindowsSandbox.Clipboard = "Disable"
+	cfg.WindowsSandbox.ProtectedClient = "Enable"
+	cfg.WindowsSandbox.AudioInput = "Disable"
+	cfg.WindowsSandbox.VideoInput = "Disable"
+	cfg.WindowsSandbox.PrinterRedirection = "Disable"
+	cfg.WindowsSandbox.MemoryMB = 4096
+
+	if err := applyFileConfigWithTrust(&cfg, fileConfig{
+		WindowsSandbox: &fileWindowsSandboxConfig{
+			Workdir:            `C:\repo-work`,
+			TempRoot:           `\\server\share`,
+			Networking:         "enable",
+			VGPU:               "enable",
+			Clipboard:          "enable",
+			ProtectedClient:    "disable",
+			AudioInput:         "enable",
+			VideoInput:         "enable",
+			PrinterRedirection: "enable",
+			MemoryMB:           65536,
+		},
+	}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.WindowsSandbox.Workdir != `C:\repo-work` {
+		t.Fatalf("repository workdir=%q, want sandbox-local override", cfg.WindowsSandbox.Workdir)
+	}
+	if cfg.WindowsSandbox.TempRoot != `C:\trusted-temp` || cfg.WindowsSandbox.MemoryMB != 4096 {
+		t.Fatalf("repository config changed host resources: %#v", cfg.WindowsSandbox)
+	}
+	if cfg.WindowsSandbox.Networking != "Disable" ||
+		cfg.WindowsSandbox.VGPU != "Disable" ||
+		cfg.WindowsSandbox.Clipboard != "Disable" ||
+		cfg.WindowsSandbox.ProtectedClient != "Enable" ||
+		cfg.WindowsSandbox.AudioInput != "Disable" ||
+		cfg.WindowsSandbox.VideoInput != "Disable" ||
+		cfg.WindowsSandbox.PrinterRedirection != "Disable" {
+		t.Fatalf("repository config loosened sandbox policy: %#v", cfg.WindowsSandbox)
+	}
+}
+
 func TestRepoConfigBareEnvWildcardDoesNotForwardEveryLocalVariable(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -43,6 +43,7 @@ func init() {
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 	RegisterProvider(testServiceControlProvider{})
+	RegisterProvider(testWindowsSandboxProvider{})
 }
 
 type testExternalProvider struct{}
@@ -233,6 +234,32 @@ func (testWandbProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (p testWandbProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testDelegatedBackend{spec: p.Spec()}, nil
+}
+
+type testWindowsSandboxProvider struct{}
+
+func (testWindowsSandboxProvider) Name() string { return "windows-sandbox" }
+func (testWindowsSandboxProvider) Aliases() []string {
+	return []string{"wsb", "windows-sandbox-provider"}
+}
+func (testWindowsSandboxProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "windows-sandbox",
+		Family:      "local-sandbox",
+		Kind:        ProviderKindDelegatedRun,
+		Targets:     []TargetSpec{{OS: targetWindows, WindowsMode: windowsModeNormal}},
+		Features:    FeatureSet{FeatureArchiveSync},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testWindowsSandboxProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (testWindowsSandboxProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p testWindowsSandboxProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testDelegatedBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -46,5 +46,6 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"
 	_ "github.com/openclaw/crabbox/internal/providers/upstashbox"
 	_ "github.com/openclaw/crabbox/internal/providers/wandb"
+	_ "github.com/openclaw/crabbox/internal/providers/windowssandbox"
 	_ "github.com/openclaw/crabbox/internal/providers/xcpng"
 )

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -142,6 +142,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"tensorlake",
 		"upstash-box",
 		"wandb",
+		"windows-sandbox",
 		"xcp-ng",
 	}
 	for _, name := range providers {

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -441,7 +441,7 @@ func windowsSandboxConfigXML(cfg Config, run preparedRun) ([]byte, error) {
 
 type wsbConfiguration struct {
 	XMLName            xml.Name         `xml:"Configuration"`
-	VGPU               string           `xml:"VGpu,omitempty"`
+	VGPU               string           `xml:"vGPU,omitempty"`
 	Networking         string           `xml:"Networking,omitempty"`
 	MappedFolders      wsbMappedFolders `xml:"MappedFolders"`
 	LogonCommand       wsbLogonCommand  `xml:"LogonCommand"`

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -1,0 +1,766 @@
+package windowssandbox
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+var windowsSandboxHostOS = runtime.GOOS
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	applyDefaults(&cfg)
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func applyDefaults(cfg *Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetWindows
+	}
+	if cfg.WindowsMode == "" {
+		cfg.WindowsMode = windowsModeNormal
+	}
+	if cfg.WindowsSandbox.Workdir == "" {
+		cfg.WindowsSandbox.Workdir = `C:\crabbox-work`
+	}
+	if cfg.WindowsSandbox.Networking == "" {
+		cfg.WindowsSandbox.Networking = "Enable"
+	}
+	if cfg.WindowsSandbox.VGPU == "" {
+		cfg.WindowsSandbox.VGPU = "Disable"
+	}
+	if cfg.WindowsSandbox.Clipboard == "" {
+		cfg.WindowsSandbox.Clipboard = "Disable"
+	}
+	if cfg.WindowsSandbox.ProtectedClient == "" {
+		cfg.WindowsSandbox.ProtectedClient = "Default"
+	}
+	if cfg.WindowsSandbox.AudioInput == "" {
+		cfg.WindowsSandbox.AudioInput = "Disable"
+	}
+	if cfg.WindowsSandbox.VideoInput == "" {
+		cfg.WindowsSandbox.VideoInput = "Disable"
+	}
+	if cfg.WindowsSandbox.PrinterRedirection == "" {
+		cfg.WindowsSandbox.PrinterRedirection = "Disable"
+	}
+	cfg.WindowsSandbox.Networking = normalizeWSBStateBestEffort(cfg.WindowsSandbox.Networking)
+	cfg.WindowsSandbox.VGPU = normalizeWSBStateBestEffort(cfg.WindowsSandbox.VGPU)
+	cfg.WindowsSandbox.Clipboard = normalizeWSBStateBestEffort(cfg.WindowsSandbox.Clipboard)
+	cfg.WindowsSandbox.ProtectedClient = normalizeWSBStateBestEffort(cfg.WindowsSandbox.ProtectedClient)
+	cfg.WindowsSandbox.AudioInput = normalizeWSBStateBestEffort(cfg.WindowsSandbox.AudioInput)
+	cfg.WindowsSandbox.VideoInput = normalizeWSBStateBestEffort(cfg.WindowsSandbox.VideoInput)
+	cfg.WindowsSandbox.PrinterRedirection = normalizeWSBStateBestEffort(cfg.WindowsSandbox.PrinterRedirection)
+	cfg.ServerType = providerName
+	cfg.WorkRoot = cfg.WindowsSandbox.Workdir
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) configForRun() Config {
+	cfg := b.cfg
+	applyDefaults(&cfg)
+	return cfg
+}
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s does not support warmup; Windows Sandbox is launched per run", providerName)
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := rejectWindowsSandboxRunOptions(b.spec, req); err != nil {
+		return RunResult{}, err
+	}
+	if len(req.Command) == 0 {
+		return RunResult{}, exit(2, "missing command")
+	}
+	if err := requireWindowsHost(); err != nil {
+		return RunResult{}, err
+	}
+
+	started := b.now()
+	cfg := b.configForRun()
+	run, syncPhases, syncDuration, err := b.prepareRun(ctx, cfg, req)
+	if err != nil {
+		return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName}, err
+	}
+	keepWorkspace := req.Keep
+	defer func() {
+		if keepWorkspace {
+			return
+		}
+		if err := os.RemoveAll(run.root); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: remove windows-sandbox temp dir %s: %v\n", run.root, err)
+		}
+	}()
+
+	if req.EnvSummary {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=%s workdir=%s host_workspace=%s networking=%s vgpu=%s\n", providerName, cfg.WindowsSandbox.Workdir, run.hostWorkspace, cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU)
+
+	commandStarted := b.now()
+	execResult, execErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   "powershell.exe",
+		Args:   hostRunnerArgs(run, cfg, req),
+		Stdout: b.rt.Stdout,
+		Stderr: b.rt.Stderr,
+	})
+	commandDuration := b.now().Sub(commandStarted)
+	exitCode := execResult.ExitCode
+	if execErr != nil && exitCode == 0 {
+		exitCode = 1
+	}
+	keepWorkspace = req.Keep || (req.KeepOnFailure && exitCode != 0)
+	if keepWorkspace {
+		fmt.Fprintf(b.rt.Stderr, "windows-sandbox temp preserved path=%s policy=%s\n", run.root, keepPolicy(req, exitCode))
+	}
+
+	result := RunResult{
+		ExitCode:      exitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+		Provider:      providerName,
+		Slug:          filepath.Base(run.root),
+		CommandText:   windowsSandboxCommandText(req),
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "windows-sandbox run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "windows-sandbox run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			Slug:          result.Slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     commandDuration.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}); err != nil {
+			return result, err
+		}
+	}
+	if execErr != nil || result.ExitCode != 0 {
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
+	}
+	return result, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = ctx
+	_ = req
+	return nil, exit(2, "provider=%s does not expose persistent inventory; Windows Sandbox supports one disposable session at a time", providerName)
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	_ = ctx
+	_ = req
+	return StatusView{}, exit(2, "provider=%s does not expose persistent status; close the Windows Sandbox window or rerun the command", providerName)
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s stop is not supported; close the Windows Sandbox window", providerName)
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if err := requireWindowsHost(); err != nil {
+		return DoctorResult{}, err
+	}
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: "powershell.exe",
+		Args: []string{
+			"-NoProfile",
+			"-ExecutionPolicy",
+			"Bypass",
+			"-Command",
+			`if (Get-Command WindowsSandbox.exe -ErrorAction SilentlyContinue) { Write-Output "WindowsSandbox.exe" } else { Write-Error "Windows Sandbox is not available. Enable the Windows Sandbox optional feature on Windows Pro, Enterprise, or Education."; exit 2 }`,
+		},
+	})
+	if err != nil {
+		code := result.ExitCode
+		if code == 0 {
+			code = 2
+		}
+		return DoctorResult{}, exit(code, "provider=%s doctor failed: %s", providerName, commandDetail(result, err))
+	}
+	cfg := b.configForRun()
+	msg := fmt.Sprintf("cli=ready control_plane=local sandbox=ready mutation=false runtime=%s networking=%s vgpu=%s workdir=%s", strings.TrimSpace(result.Stdout), cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU, cfg.WindowsSandbox.Workdir)
+	return DoctorResult{Provider: providerName, Message: msg}, nil
+}
+
+func (b *backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}
+
+type preparedRun struct {
+	root          string
+	hostWorkspace string
+	hostControl   string
+	wsbPath       string
+	hostRunner    string
+}
+
+func (b *backend) prepareRun(ctx context.Context, cfg Config, req RunRequest) (preparedRun, []timingPhase, time.Duration, error) {
+	root, err := os.MkdirTemp(strings.TrimSpace(cfg.WindowsSandbox.TempRoot), "crabbox-wsb-*")
+	if err != nil {
+		return preparedRun{}, nil, 0, fmt.Errorf("create windows-sandbox temp dir: %w", err)
+	}
+	if absRoot, err := filepath.Abs(root); err == nil {
+		root = absRoot
+	}
+	run := preparedRun{
+		root:          root,
+		hostWorkspace: filepath.Join(root, "workspace"),
+		hostControl:   filepath.Join(root, "control"),
+		wsbPath:       filepath.Join(root, "crabbox.wsb"),
+		hostRunner:    filepath.Join(root, "host-runner.ps1"),
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(root)
+		}
+	}()
+	for _, dir := range []string{run.hostWorkspace, run.hostControl} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return preparedRun{}, nil, 0, fmt.Errorf("create windows-sandbox dir %s: %w", dir, err)
+		}
+	}
+	syncPhases, syncDuration, err := b.syncWorkspace(ctx, cfg, req, run.hostWorkspace)
+	if err != nil {
+		return preparedRun{}, nil, 0, err
+	}
+	sandboxScript, err := sandboxRunScript(cfg, req)
+	if err != nil {
+		return preparedRun{}, nil, 0, err
+	}
+	if err := os.WriteFile(filepath.Join(run.hostControl, "run.ps1"), []byte(sandboxScript), 0o600); err != nil {
+		return preparedRun{}, nil, 0, fmt.Errorf("write windows-sandbox run script: %w", err)
+	}
+	if err := os.WriteFile(run.hostRunner, []byte(hostRunnerScript()), 0o600); err != nil {
+		return preparedRun{}, nil, 0, fmt.Errorf("write windows-sandbox host runner: %w", err)
+	}
+	wsb, err := windowsSandboxConfigXML(cfg, run)
+	if err != nil {
+		return preparedRun{}, nil, 0, err
+	}
+	if err := os.WriteFile(run.wsbPath, wsb, 0o600); err != nil {
+		return preparedRun{}, nil, 0, fmt.Errorf("write windows-sandbox config: %w", err)
+	}
+	keep = true
+	return run, syncPhases, syncDuration, nil
+}
+
+func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest, hostWorkspace string) ([]timingPhase, time.Duration, error) {
+	started := b.now()
+	if req.NoSync {
+		if err := os.MkdirAll(hostWorkspace, 0o700); err != nil {
+			return nil, 0, fmt.Errorf("create windows-sandbox workspace: %w", err)
+		}
+		return []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}, 0, nil
+	}
+	syncCtx := ctx
+	cancel := func() {}
+	if cfg.Sync.Timeout > 0 {
+		syncCtx, cancel = context.WithTimeout(ctx, cfg.Sync.Timeout)
+	}
+	defer cancel()
+
+	excludes, err := syncExcludes(req.Repo.Root, cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+	manifestStarted := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStarted)
+	preflightStarted := b.now()
+	if err := checkSyncPreflight(manifest, cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStarted)
+	copyStarted := b.now()
+	if cfg.Sync.Delete {
+		if err := os.RemoveAll(hostWorkspace); err != nil {
+			return nil, 0, fmt.Errorf("reset windows-sandbox workspace: %w", err)
+		}
+	}
+	if err := os.MkdirAll(hostWorkspace, 0o700); err != nil {
+		return nil, 0, fmt.Errorf("create windows-sandbox workspace: %w", err)
+	}
+	if err := copyManifest(syncCtx, req.Repo.Root, hostWorkspace, manifest); err != nil {
+		return nil, 0, err
+	}
+	copyDuration := b.now().Sub(copyStarted)
+	total := b.now().Sub(started)
+	return []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "copy", Ms: copyDuration.Milliseconds()},
+		{Name: "windows_sandbox_sync", Ms: total.Milliseconds()},
+	}, total, nil
+}
+
+func copyManifest(ctx context.Context, root, dstRoot string, manifest SyncManifest) error {
+	for _, rel := range manifest.Files {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		clean := path.Clean(filepath.ToSlash(rel))
+		if clean == "." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") || clean != filepath.ToSlash(rel) {
+			return exit(6, "unsafe sync path %q", rel)
+		}
+		src := filepath.Join(root, filepath.FromSlash(clean))
+		dst := filepath.Join(dstRoot, filepath.FromSlash(clean))
+		if err := copyWorkspaceEntry(src, dst, clean); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyWorkspaceEntry(src, dst, rel string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat sync path %s: %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+		return fmt.Errorf("create sync parent %s: %w", filepath.Dir(dst), err)
+	}
+	mode := info.Mode()
+	if mode&os.ModeSymlink != 0 {
+		return exit(6, "provider=%s does not support syncing symlink %q; exclude it or replace it with a regular file before using Windows Sandbox", providerName, filepath.ToSlash(rel))
+	}
+	if !mode.IsRegular() {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open sync path %s: %w", src, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("create sync path %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy sync path %s: %w", src, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close sync path %s: %w", dst, err)
+	}
+	return nil
+}
+
+func hostRunnerArgs(run preparedRun, cfg Config, req RunRequest) []string {
+	timeout := durationSecondsCeil(cfg.TTL)
+	if timeout <= 0 {
+		timeout = 5400
+	}
+	args := []string{
+		"-NoProfile",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-File",
+		run.hostRunner,
+		"-WsbPath",
+		run.wsbPath,
+		"-ControlDir",
+		run.hostControl,
+		"-TimeoutSeconds",
+		fmt.Sprintf("%d", timeout),
+	}
+	if req.Keep {
+		args = append(args, "-Keep")
+	}
+	if req.KeepOnFailure {
+		args = append(args, "-KeepOnFailure")
+	}
+	return args
+}
+
+func windowsSandboxConfigXML(cfg Config, run preparedRun) ([]byte, error) {
+	workdir, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
+	if err != nil {
+		return nil, err
+	}
+	doc := wsbConfiguration{
+		VGPU:               cfg.WindowsSandbox.VGPU,
+		Networking:         cfg.WindowsSandbox.Networking,
+		AudioInput:         cfg.WindowsSandbox.AudioInput,
+		VideoInput:         cfg.WindowsSandbox.VideoInput,
+		ProtectedClient:    cfg.WindowsSandbox.ProtectedClient,
+		PrinterRedirection: cfg.WindowsSandbox.PrinterRedirection,
+		Clipboard:          cfg.WindowsSandbox.Clipboard,
+		MappedFolders: wsbMappedFolders{Folders: []wsbMappedFolder{
+			{HostFolder: run.hostWorkspace, SandboxFolder: workdir, ReadOnly: false},
+			{HostFolder: run.hostControl, SandboxFolder: `C:\crabbox-control`, ReadOnly: false},
+		}},
+		LogonCommand: wsbLogonCommand{Command: `powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\crabbox-control\run.ps1`},
+		MemoryInMB:   cfg.WindowsSandbox.MemoryMB,
+	}
+	data, err := xml.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal windows-sandbox config: %w", err)
+	}
+	return append([]byte(xml.Header), data...), nil
+}
+
+type wsbConfiguration struct {
+	XMLName            xml.Name         `xml:"Configuration"`
+	VGPU               string           `xml:"VGpu,omitempty"`
+	Networking         string           `xml:"Networking,omitempty"`
+	MappedFolders      wsbMappedFolders `xml:"MappedFolders"`
+	LogonCommand       wsbLogonCommand  `xml:"LogonCommand"`
+	AudioInput         string           `xml:"AudioInput,omitempty"`
+	VideoInput         string           `xml:"VideoInput,omitempty"`
+	ProtectedClient    string           `xml:"ProtectedClient,omitempty"`
+	PrinterRedirection string           `xml:"PrinterRedirection,omitempty"`
+	Clipboard          string           `xml:"ClipboardRedirection,omitempty"`
+	MemoryInMB         int              `xml:"MemoryInMB,omitempty"`
+}
+
+type wsbMappedFolders struct {
+	Folders []wsbMappedFolder `xml:"MappedFolder"`
+}
+
+type wsbMappedFolder struct {
+	HostFolder    string `xml:"HostFolder"`
+	SandboxFolder string `xml:"SandboxFolder"`
+	ReadOnly      bool   `xml:"ReadOnly"`
+}
+
+type wsbLogonCommand struct {
+	Command string `xml:"Command"`
+}
+
+func sandboxRunScript(cfg Config, req RunRequest) (string, error) {
+	workdir, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
+	if err != nil {
+		return "", err
+	}
+	envLines, err := powershellEnvLines(req.Env)
+	if err != nil {
+		return "", err
+	}
+	command, err := sandboxCommand(req)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{
+		"$ErrorActionPreference = 'Continue'",
+		"$stdout = 'C:\\crabbox-control\\stdout.log'",
+		"$stderr = 'C:\\crabbox-control\\stderr.log'",
+		"$exitFile = 'C:\\crabbox-control\\exit-code.txt'",
+		"Remove-Item -LiteralPath $stdout,$stderr,$exitFile -Force -ErrorAction SilentlyContinue",
+		"New-Item -ItemType Directory -Force -Path 'C:\\crabbox-control' | Out-Null",
+		"Set-Location -LiteralPath " + psSingleQuote(workdir),
+		envLines,
+		"$exitCode = 0",
+		"try {",
+		"  $global:LASTEXITCODE = $null",
+		"  " + command + " 1>> $stdout 2>> $stderr",
+		"  if ($null -ne $global:LASTEXITCODE) { $exitCode = [int]$global:LASTEXITCODE } elseif ($?) { $exitCode = 0 } else { $exitCode = 1 }",
+		"} catch {",
+		"  $_ | Out-File -FilePath $stderr -Append",
+		"  $exitCode = 1",
+		"}",
+		"Set-Content -LiteralPath $exitFile -Value $exitCode -Encoding ASCII",
+		"$keep = " + psBool(req.Keep),
+		"$keepOnFailure = " + psBool(req.KeepOnFailure),
+		"if (-not $keep -and -not ($keepOnFailure -and $exitCode -ne 0)) {",
+		"  Start-Process -FilePath \"$env:WINDIR\\System32\\shutdown.exe\" -ArgumentList '/s','/t','0','/f' -WindowStyle Hidden",
+		"}",
+		"",
+	}, "\r\n"), nil
+}
+
+func sandboxCommand(req RunRequest) (string, error) {
+	if len(req.Command) == 0 {
+		return "", exit(2, "missing command")
+	}
+	if req.ShellMode {
+		return "& powershell.exe -NoProfile -ExecutionPolicy Bypass -Command " + psSingleQuote(strings.Join(req.Command, " ")), nil
+	}
+	parts := make([]string, 0, len(req.Command))
+	for _, part := range req.Command {
+		parts = append(parts, psSingleQuote(part))
+	}
+	return "& " + strings.Join(parts, " "), nil
+}
+
+func powershellEnvLines(env map[string]string) (string, error) {
+	if len(env) == 0 {
+		return "", nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if !validEnvName(key) {
+			return "", exit(2, "invalid environment variable name %q for provider=%s", key, providerName)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, key := range keys {
+		fmt.Fprintf(&b, "$env:%s = %s\r\n", key, psSingleQuote(env[key]))
+	}
+	return strings.TrimRight(b.String(), "\r\n"), nil
+}
+
+func hostRunnerScript() string {
+	return strings.ReplaceAll(`param(
+  [Parameter(Mandatory=$true)][string]$WsbPath,
+  [Parameter(Mandatory=$true)][string]$ControlDir,
+  [int]$TimeoutSeconds = 5400,
+  [switch]$Keep,
+  [switch]$KeepOnFailure
+)
+$ErrorActionPreference = 'Stop'
+$stdout = Join-Path $ControlDir 'stdout.log'
+$stderr = Join-Path $ControlDir 'stderr.log'
+$exitFile = Join-Path $ControlDir 'exit-code.txt'
+Remove-Item -LiteralPath $stdout,$stderr,$exitFile -Force -ErrorAction SilentlyContinue
+
+$running = Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue
+if ($running) {
+  Write-Error 'Windows Sandbox is already running. Microsoft Windows Sandbox allows one instance at a time; close it before running Crabbox with provider=windows-sandbox.'
+  exit 2
+}
+
+$process = Start-Process -FilePath $WsbPath -PassThru
+$started = Get-Date
+$deadline = $started.AddSeconds($TimeoutSeconds)
+$outOffset = 0
+$errOffset = 0
+
+function Stop-SandboxSession {
+  if ($process -and -not $process.HasExited) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+  }
+  Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Flush-Log([string]$Path, [ref]$Offset, [bool]$IsError) {
+  if (-not (Test-Path -LiteralPath $Path)) { return }
+  $content = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
+  if ($null -eq $content) { return }
+  if ($content.Length -lt $Offset.Value) { $Offset.Value = 0 }
+  if ($content.Length -le $Offset.Value) { return }
+  $chunk = $content.Substring($Offset.Value)
+  $Offset.Value = $content.Length
+  if ($IsError) {
+    [Console]::Error.Write($chunk)
+  } else {
+    [Console]::Out.Write($chunk)
+  }
+}
+
+while ($true) {
+  Flush-Log $stdout ([ref]$outOffset) $false
+  Flush-Log $stderr ([ref]$errOffset) $true
+  if (Test-Path -LiteralPath $exitFile) {
+    Start-Sleep -Milliseconds 300
+    Flush-Log $stdout ([ref]$outOffset) $false
+    Flush-Log $stderr ([ref]$errOffset) $true
+    $raw = (Get-Content -LiteralPath $exitFile -Raw).Trim()
+    [int]$exitCode = 1
+    [void][int]::TryParse($raw, [ref]$exitCode)
+    $keepOpen = $Keep.IsPresent -or ($KeepOnFailure.IsPresent -and $exitCode -ne 0)
+    if (-not $keepOpen -and $process -and -not $process.HasExited) {
+      Wait-Process -Id $process.Id -Timeout 20 -ErrorAction SilentlyContinue
+    }
+    exit $exitCode
+  }
+  if ((Get-Date) -gt $deadline) {
+    Stop-SandboxSession
+    Write-Error "Windows Sandbox timed out after ${TimeoutSeconds}s"
+    exit 124
+  }
+  if ($process -and $process.HasExited) {
+    if (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue) {
+      Start-Sleep -Milliseconds 500
+      continue
+    }
+    Start-Sleep -Seconds 2
+    Flush-Log $stdout ([ref]$outOffset) $false
+    Flush-Log $stderr ([ref]$errOffset) $true
+    if (-not (Test-Path -LiteralPath $exitFile)) {
+      Write-Error 'Windows Sandbox closed before Crabbox received an exit code.'
+      exit 1
+    }
+  }
+  Start-Sleep -Milliseconds 500
+}
+`, "\n", "\r\n")
+}
+
+func rejectWindowsSandboxRunOptions(spec ProviderSpec, req RunRequest) error {
+	if err := rejectDelegatedSyncOptionsForSpec(spec, req); err != nil {
+		return err
+	}
+	if req.ID != "" {
+		return exit(2, "provider=%s does not support --id; Windows Sandbox sessions are disposable", providerName)
+	}
+	if req.SyncOnly {
+		return exit(2, "provider=%s does not support --sync-only; Windows Sandbox workspaces are created per run", providerName)
+	}
+	if req.Reclaim {
+		return exit(2, "provider=%s does not support --reclaim; Windows Sandbox sessions are disposable", providerName)
+	}
+	return nil
+}
+
+func requireWindowsHost() error {
+	if windowsSandboxHostOS != "windows" {
+		return exit(2, "provider=%s requires a Windows host with the Windows Sandbox optional feature enabled", providerName)
+	}
+	return nil
+}
+
+func normalizeWSBState(value, flagName string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "default":
+		return "Default", nil
+	case "enable", "enabled", "true", "yes", "on":
+		return "Enable", nil
+	case "disable", "disabled", "false", "no", "off":
+		return "Disable", nil
+	default:
+		return "", exit(2, "%s must be enable, disable, or default", flagName)
+	}
+}
+
+func normalizeWSBStateBestEffort(value string) string {
+	normalized, err := normalizeWSBState(value, "")
+	if err != nil {
+		return value
+	}
+	return normalized
+}
+
+func validateWindowsSandboxConfig(cfg Config) error {
+	checks := map[string]string{
+		"windows-sandbox.networking":         cfg.WindowsSandbox.Networking,
+		"windows-sandbox.vgpu":               cfg.WindowsSandbox.VGPU,
+		"windows-sandbox.clipboard":          cfg.WindowsSandbox.Clipboard,
+		"windows-sandbox.protectedClient":    cfg.WindowsSandbox.ProtectedClient,
+		"windows-sandbox.audioInput":         cfg.WindowsSandbox.AudioInput,
+		"windows-sandbox.videoInput":         cfg.WindowsSandbox.VideoInput,
+		"windows-sandbox.printerRedirection": cfg.WindowsSandbox.PrinterRedirection,
+	}
+	for name, value := range checks {
+		if _, err := normalizeWSBState(value, name); err != nil {
+			return err
+		}
+	}
+	if cfg.WindowsSandbox.MemoryMB < 0 {
+		return exit(2, "windows-sandbox.memoryMB must be non-negative")
+	}
+	_, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
+	return err
+}
+
+func cleanWindowsSandboxPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", exit(2, "windows-sandbox workdir must not be empty")
+	}
+	if strings.Contains(value, "/") {
+		value = strings.ReplaceAll(value, "/", `\`)
+	}
+	if len(value) < 3 || value[1] != ':' || value[2] != '\\' {
+		return "", exit(2, "windows-sandbox workdir %q must be an absolute Windows path like C:\\crabbox-work", value)
+	}
+	clean := filepath.Clean(value)
+	switch strings.ToUpper(clean) {
+	case `C:\`, `C:\WINDOWS`, `C:\USERS`, `C:\PROGRAM FILES`, `C:\PROGRAM FILES (X86)`:
+		return "", exit(2, "windows-sandbox workdir %q is too broad; choose a dedicated directory", clean)
+	}
+	return clean, nil
+}
+
+func psSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func psBool(value bool) string {
+	if value {
+		return "$true"
+	}
+	return "$false"
+}
+
+func validEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		ok := r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func windowsSandboxCommandText(req RunRequest) string {
+	if req.ShellMode {
+		return strings.Join(req.Command, " ")
+	}
+	return strings.Join(req.Command, " ")
+}
+
+func keepPolicy(req RunRequest, exitCode int) string {
+	if req.Keep {
+		return "keep"
+	}
+	if req.KeepOnFailure && exitCode != 0 {
+		return "keep-on-failure"
+	}
+	return "none"
+}
+
+func commandDetail(result LocalCommandResult, err error) string {
+	text := strings.TrimSpace(result.Stderr)
+	if text == "" {
+		text = strings.TrimSpace(result.Stdout)
+	}
+	if text == "" && err != nil {
+		text = err.Error()
+	}
+	return blank(text, "unknown error")
+}

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -569,6 +569,8 @@ $sandboxExe = (Get-Command WindowsSandbox.exe -ErrorAction Stop).Source
 $process = Start-Process -FilePath $sandboxExe -ArgumentList ('"{0}"' -f $WsbPath) -PassThru
 $started = Get-Date
 $deadline = $started.AddSeconds($TimeoutSeconds)
+$startupGraceSeconds = [Math]::Min($TimeoutSeconds, 120)
+$startupDeadline = $started.AddSeconds($startupGraceSeconds)
 $outOffset = 0
 $errOffset = 0
 $sandboxSeen = $false
@@ -637,6 +639,12 @@ while ($true) {
       continue
     }
     if (-not $sandboxSeen) {
+      if ((Get-Date) -gt $startupDeadline) {
+        Flush-Log $stdout ([ref]$outOffset) $false
+        Flush-Log $stderr ([ref]$errOffset) $true
+        Write-Error "Windows Sandbox launcher exited before any sandbox process was observed after ${startupGraceSeconds}s."
+        exit 1
+      }
       Start-Sleep -Milliseconds 500
       continue
     }

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -629,7 +629,9 @@ while ($true) {
     exit $exitCode
   }
   if ((Get-Date) -gt $deadline) {
-    Stop-SandboxSession
+    if (-not ($Keep.IsPresent -or $KeepOnFailure.IsPresent)) {
+      Stop-SandboxSession
+    }
     Write-Error "Windows Sandbox timed out after ${TimeoutSeconds}s"
     exit 124
   }
@@ -799,9 +801,6 @@ func validEnvName(name string) bool {
 }
 
 func windowsSandboxCommandText(req RunRequest) string {
-	if req.ShellMode {
-		return strings.Join(req.Command, " ")
-	}
 	return strings.Join(req.Command, " ")
 }
 

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -555,28 +555,34 @@ $stderr = Join-Path $ControlDir 'stderr.log'
 $exitFile = Join-Path $ControlDir 'exit-code.txt'
 Remove-Item -LiteralPath $stdout,$stderr,$exitFile -Force -ErrorAction SilentlyContinue
 
-$running = Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue
+function Get-SandboxProcesses {
+  Get-Process -Name WindowsSandbox,WindowsSandboxClient -ErrorAction SilentlyContinue
+}
+
+$running = Get-SandboxProcesses
 if ($running) {
   Write-Error 'Windows Sandbox is already running. Microsoft Windows Sandbox allows one instance at a time; close it before running Crabbox with provider=windows-sandbox.'
   exit 2
 }
 
-$process = Start-Process -FilePath $WsbPath -PassThru
+$sandboxExe = (Get-Command WindowsSandbox.exe -ErrorAction Stop).Source
+$process = Start-Process -FilePath $sandboxExe -ArgumentList ('"{0}"' -f $WsbPath) -PassThru
 $started = Get-Date
 $deadline = $started.AddSeconds($TimeoutSeconds)
 $outOffset = 0
 $errOffset = 0
+$sandboxSeen = $false
 
 function Stop-SandboxSession {
   if ($process -and -not $process.HasExited) {
     Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
   }
-  Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  Get-SandboxProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
 }
 
 function Wait-SandboxSession([int]$TimeoutSeconds) {
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
-  while (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue) {
+  while (Get-SandboxProcesses) {
     if ((Get-Date) -gt $deadline) {
       Stop-SandboxSession
       return
@@ -603,6 +609,10 @@ function Flush-Log([string]$Path, [ref]$Offset, [bool]$IsError) {
 while ($true) {
   Flush-Log $stdout ([ref]$outOffset) $false
   Flush-Log $stderr ([ref]$errOffset) $true
+  $sandboxRunning = Get-SandboxProcesses
+  if ($sandboxRunning) {
+    $sandboxSeen = $true
+  }
   if (Test-Path -LiteralPath $exitFile) {
     Start-Sleep -Milliseconds 300
     Flush-Log $stdout ([ref]$outOffset) $false
@@ -622,13 +632,20 @@ while ($true) {
     exit 124
   }
   if ($process -and $process.HasExited) {
-    if (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue) {
+    if ($sandboxRunning) {
+      Start-Sleep -Milliseconds 500
+      continue
+    }
+    if (-not $sandboxSeen) {
       Start-Sleep -Milliseconds 500
       continue
     }
     Start-Sleep -Seconds 2
     Flush-Log $stdout ([ref]$outOffset) $false
     Flush-Log $stderr ([ref]$errOffset) $true
+    if (Get-SandboxProcesses) {
+      continue
+    }
     if (-not (Test-Path -LiteralPath $exitFile)) {
       Write-Error 'Windows Sandbox closed before Crabbox received an exit code.'
       exit 1

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -117,12 +117,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	fmt.Fprintf(b.rt.Stderr, "provider=%s workdir=%s host_workspace=%s networking=%s vgpu=%s\n", providerName, cfg.WindowsSandbox.Workdir, run.hostWorkspace, cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU)
 
 	commandStarted := b.now()
-	execResult, execErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name:   "powershell.exe",
-		Args:   hostRunnerArgs(run, cfg, req),
-		Stdout: b.rt.Stdout,
-		Stderr: b.rt.Stderr,
-	})
+	execResult, execErr := b.runHostRunner(ctx, LocalCommandRequest{
+		Name:                 "powershell.exe",
+		Args:                 hostRunnerArgs(run, cfg, req),
+		Stdout:               b.rt.Stdout,
+		Stderr:               b.rt.Stderr,
+		DisableOutputCapture: true,
+	}, filepath.Join(run.hostControl, "cancel.txt"), req.Keep || req.KeepOnFailure)
 	commandDuration := b.now().Sub(commandStarted)
 	exitCode := execResult.ExitCode
 	if execErr != nil && exitCode == 0 {
@@ -299,7 +300,7 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 		return nil, 0, err
 	}
 	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes)
+	manifest, err := syncManifest(req.Repo.Root, excludes, cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}
@@ -412,6 +413,77 @@ func hostRunnerArgs(run preparedRun, cfg Config, req RunRequest) []string {
 	return args
 }
 
+type localCommandOutcome struct {
+	result LocalCommandResult
+	err    error
+}
+
+func (b *backend) runHostRunner(ctx context.Context, command LocalCommandRequest, cancelPath string, keepOnCancel bool) (LocalCommandResult, error) {
+	runCtx, cancelRun := context.WithCancel(context.WithoutCancel(ctx))
+	defer cancelRun()
+	done := make(chan localCommandOutcome, 1)
+	go func() {
+		result, err := b.rt.Exec.Run(runCtx, command)
+		done <- localCommandOutcome{result: result, err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		return outcome.result, outcome.err
+	case <-ctx.Done():
+		if err := os.WriteFile(cancelPath, []byte("cancel\r\n"), 0o600); err != nil {
+			cancelRun()
+			outcome := <-done
+			if !keepOnCancel {
+				b.stopCanceledSandbox(ctx)
+			}
+			outcome.result.ExitCode = 130
+			return outcome.result, fmt.Errorf("signal windows-sandbox cancellation: %w", err)
+		}
+
+		timer := time.NewTimer(30 * time.Second)
+		defer timer.Stop()
+		select {
+		case outcome := <-done:
+			outcome.result.ExitCode = 130
+			if outcome.err == nil {
+				outcome.err = ctx.Err()
+			}
+			return outcome.result, outcome.err
+		case <-timer.C:
+			cancelRun()
+			outcome := <-done
+			if !keepOnCancel {
+				b.stopCanceledSandbox(ctx)
+			}
+			outcome.result.ExitCode = 130
+			if outcome.err == nil {
+				outcome.err = ctx.Err()
+			}
+			return outcome.result, outcome.err
+		}
+	}
+}
+
+func (b *backend) stopCanceledSandbox(ctx context.Context) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+	defer cancel()
+	result, err := b.rt.Exec.Run(cleanupCtx, LocalCommandRequest{
+		Name: "powershell.exe",
+		Args: []string{
+			"-NoProfile",
+			"-ExecutionPolicy",
+			"Bypass",
+			"-Command",
+			`Get-Process -Name WindowsSandbox,WindowsSandboxClient -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue`,
+		},
+		DisableOutputCapture: true,
+	})
+	if err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: stop canceled windows-sandbox session: %s\n", commandDetail(result, err))
+	}
+}
+
 func windowsSandboxConfigXML(cfg Config, run preparedRun) ([]byte, error) {
 	workdir, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
 	if err != nil {
@@ -482,6 +554,7 @@ func sandboxRunScript(cfg Config, req RunRequest) (string, error) {
 	}
 	return strings.Join([]string{
 		"$ErrorActionPreference = 'Continue'",
+		"$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'",
 		"$stdout = 'C:\\crabbox-control\\stdout.log'",
 		"$stderr = 'C:\\crabbox-control\\stderr.log'",
 		"$exitFile = 'C:\\crabbox-control\\exit-code.txt'",
@@ -498,9 +571,11 @@ func sandboxRunScript(cfg Config, req RunRequest) (string, error) {
 		"  $_ | Out-File -FilePath $stderr -Append",
 		"  $exitCode = 1",
 		"}",
-		"Set-Content -LiteralPath $exitFile -Value $exitCode -Encoding ASCII",
 		"$keep = " + psBool(req.Keep),
 		"$keepOnFailure = " + psBool(req.KeepOnFailure),
+		"$canceled = Test-Path -LiteralPath 'C:\\crabbox-control\\cancel.txt'",
+		"if ($canceled -and $exitCode -eq 0) { $exitCode = 130 }",
+		"Set-Content -LiteralPath $exitFile -Value $exitCode -Encoding ASCII",
 		"if (-not $keep -and -not ($keepOnFailure -and $exitCode -ne 0)) {",
 		"  Start-Process -FilePath \"$env:WINDIR\\System32\\shutdown.exe\" -ArgumentList '/s','/t','0','/f' -WindowStyle Hidden",
 		"}",
@@ -553,6 +628,7 @@ $ErrorActionPreference = 'Stop'
 $stdout = Join-Path $ControlDir 'stdout.log'
 $stderr = Join-Path $ControlDir 'stderr.log'
 $exitFile = Join-Path $ControlDir 'exit-code.txt'
+$cancelFile = Join-Path $ControlDir 'cancel.txt'
 Remove-Item -LiteralPath $stdout,$stderr,$exitFile -Force -ErrorAction SilentlyContinue
 
 function Get-SandboxProcesses {
@@ -561,7 +637,7 @@ function Get-SandboxProcesses {
 
 $running = Get-SandboxProcesses
 if ($running) {
-  Write-Error 'Windows Sandbox is already running. Microsoft Windows Sandbox allows one instance at a time; close it before running Crabbox with provider=windows-sandbox.'
+  [Console]::Error.WriteLine('Windows Sandbox is already running. Microsoft Windows Sandbox allows one instance at a time; close it before running Crabbox with provider=windows-sandbox.')
   exit 2
 }
 
@@ -595,12 +671,27 @@ function Wait-SandboxSession([int]$TimeoutSeconds) {
 
 function Flush-Log([string]$Path, [ref]$Offset, [bool]$IsError) {
   if (-not (Test-Path -LiteralPath $Path)) { return }
-  $content = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
-  if ($null -eq $content) { return }
-  if ($content.Length -lt $Offset.Value) { $Offset.Value = 0 }
-  if ($content.Length -le $Offset.Value) { return }
-  $chunk = $content.Substring($Offset.Value)
-  $Offset.Value = $content.Length
+  try {
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      if ($stream.Length -lt $Offset.Value) { $Offset.Value = 0 }
+      if ($stream.Length -le $Offset.Value) { return }
+      [void]$stream.Seek($Offset.Value, [System.IO.SeekOrigin]::Begin)
+      $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true, 4096, $true)
+      try {
+        $chunk = $reader.ReadToEnd()
+        $Offset.Value = $stream.Position
+      } finally {
+        $reader.Dispose()
+      }
+    } finally {
+      $stream.Dispose()
+    }
+  } catch [System.IO.IOException] {
+    return
+  } catch [System.UnauthorizedAccessException] {
+    return
+  }
   if ($IsError) {
     [Console]::Error.Write($chunk)
   } else {
@@ -614,6 +705,15 @@ while ($true) {
   $sandboxRunning = Get-SandboxProcesses
   if ($sandboxRunning) {
     $sandboxSeen = $true
+  }
+  if (Test-Path -LiteralPath $cancelFile) {
+    $keepOpen = $Keep.IsPresent -or $KeepOnFailure.IsPresent
+    if (-not $keepOpen) {
+      Stop-SandboxSession
+      Wait-SandboxSession 20
+    }
+    [Console]::Error.WriteLine('Windows Sandbox run canceled.')
+    exit 130
   }
   if (Test-Path -LiteralPath $exitFile) {
     Start-Sleep -Milliseconds 300
@@ -632,7 +732,7 @@ while ($true) {
     if (-not ($Keep.IsPresent -or $KeepOnFailure.IsPresent)) {
       Stop-SandboxSession
     }
-    Write-Error "Windows Sandbox timed out after ${TimeoutSeconds}s"
+    [Console]::Error.WriteLine("Windows Sandbox timed out after ${TimeoutSeconds}s")
     exit 124
   }
   if ($process -and $process.HasExited) {
@@ -644,7 +744,7 @@ while ($true) {
       if ((Get-Date) -gt $startupDeadline) {
         Flush-Log $stdout ([ref]$outOffset) $false
         Flush-Log $stderr ([ref]$errOffset) $true
-        Write-Error "Windows Sandbox launcher exited before any sandbox process was observed after ${startupGraceSeconds}s."
+        [Console]::Error.WriteLine("Windows Sandbox launcher exited before any sandbox process was observed after ${startupGraceSeconds}s.")
         exit 1
       }
       Start-Sleep -Milliseconds 500
@@ -657,7 +757,7 @@ while ($true) {
       continue
     }
     if (-not (Test-Path -LiteralPath $exitFile)) {
-      Write-Error 'Windows Sandbox closed before Crabbox received an exit code.'
+      [Console]::Error.WriteLine('Windows Sandbox closed before Crabbox received an exit code.')
       exit 1
     }
   }

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -574,6 +574,17 @@ function Stop-SandboxSession {
   Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 }
 
+function Wait-SandboxSession([int]$TimeoutSeconds) {
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue) {
+    if ((Get-Date) -gt $deadline) {
+      Stop-SandboxSession
+      return
+    }
+    Start-Sleep -Milliseconds 500
+  }
+}
+
 function Flush-Log([string]$Path, [ref]$Offset, [bool]$IsError) {
   if (-not (Test-Path -LiteralPath $Path)) { return }
   $content = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
@@ -600,8 +611,8 @@ while ($true) {
     [int]$exitCode = 1
     [void][int]::TryParse($raw, [ref]$exitCode)
     $keepOpen = $Keep.IsPresent -or ($KeepOnFailure.IsPresent -and $exitCode -ne 0)
-    if (-not $keepOpen -and $process -and -not $process.HasExited) {
-      Wait-Process -Id $process.Id -Timeout 20 -ErrorAction SilentlyContinue
+    if (-not $keepOpen) {
+      Wait-SandboxSession 20
     }
     exit $exitCode
   }
@@ -705,12 +716,37 @@ func cleanWindowsSandboxPath(value string) (string, error) {
 	if len(value) < 3 || value[1] != ':' || value[2] != '\\' {
 		return "", exit(2, "windows-sandbox workdir %q must be an absolute Windows path like C:\\crabbox-work", value)
 	}
-	clean := filepath.Clean(value)
+	drive := value[0]
+	if !((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) {
+		return "", exit(2, "windows-sandbox workdir %q must start with a Windows drive letter like C:\\crabbox-work", value)
+	}
+	clean := cleanWindowsPath(value)
 	switch strings.ToUpper(clean) {
 	case `C:\`, `C:\WINDOWS`, `C:\USERS`, `C:\PROGRAM FILES`, `C:\PROGRAM FILES (X86)`:
 		return "", exit(2, "windows-sandbox workdir %q is too broad; choose a dedicated directory", clean)
 	}
 	return clean, nil
+}
+
+func cleanWindowsPath(value string) string {
+	drive := strings.ToUpper(value[:1])
+	parts := make([]string, 0)
+	for _, part := range strings.Split(value[3:], `\`) {
+		switch part {
+		case "", ".":
+			continue
+		case "..":
+			if len(parts) > 0 {
+				parts = parts[:len(parts)-1]
+			}
+		default:
+			parts = append(parts, part)
+		}
+	}
+	if len(parts) == 0 {
+		return drive + `:\`
+	}
+	return drive + `:\` + strings.Join(parts, `\`)
 }
 
 func psSingleQuote(value string) string {

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -126,11 +126,16 @@ func TestSandboxRunScriptQuotesCommandEnvAndKeepOnFailure(t *testing.T) {
 func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 	script := hostRunnerScript()
 	for _, want := range []string{
+		"function Get-SandboxProcesses",
 		"function Stop-SandboxSession",
 		"function Wait-SandboxSession",
+		"Get-Process -Name WindowsSandbox,WindowsSandboxClient -ErrorAction SilentlyContinue",
+		"$sandboxExe = (Get-Command WindowsSandbox.exe -ErrorAction Stop).Source",
+		"Start-Process -FilePath $sandboxExe",
+		"$sandboxSeen = $false",
 		"Wait-SandboxSession 20",
-		"Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force",
-		"if (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue)",
+		"Get-SandboxProcesses | Stop-Process -Force",
+		"if (-not $sandboxSeen)",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("host runner missing %q:\n%s", want, script)

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -1,0 +1,236 @@
+package windowssandbox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName {
+		t.Fatalf("Name=%q", spec.Name)
+	}
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("Kind=%q, want delegated-run", spec.Kind)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetWindows || spec.Targets[0].WindowsMode != core.WindowsModeNormal {
+		t.Fatalf("Targets=%#v, want native Windows only", spec.Targets)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("Coordinator=%q, want never", spec.Coordinator)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) {
+		t.Fatalf("Features=%#v, want archive sync support", spec.Features)
+	}
+}
+
+func TestApplyDefaultsSelectsNativeWindowsAndSecureWSBDefaults(t *testing.T) {
+	cfg := Config{}
+	applyDefaults(&cfg)
+	if cfg.Provider != providerName {
+		t.Fatalf("Provider=%q", cfg.Provider)
+	}
+	if cfg.TargetOS != core.TargetWindows || cfg.WindowsMode != core.WindowsModeNormal {
+		t.Fatalf("target=%s mode=%s, want native Windows", cfg.TargetOS, cfg.WindowsMode)
+	}
+	if cfg.WindowsSandbox.Networking != "Enable" {
+		t.Fatalf("Networking=%q", cfg.WindowsSandbox.Networking)
+	}
+	for name, got := range map[string]string{
+		"vgpu":               cfg.WindowsSandbox.VGPU,
+		"clipboard":          cfg.WindowsSandbox.Clipboard,
+		"audioInput":         cfg.WindowsSandbox.AudioInput,
+		"videoInput":         cfg.WindowsSandbox.VideoInput,
+		"printerRedirection": cfg.WindowsSandbox.PrinterRedirection,
+	} {
+		if got != "Disable" {
+			t.Fatalf("%s=%q, want Disable", name, got)
+		}
+	}
+}
+
+func TestWindowsSandboxConfigXML(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.WindowsSandbox.Workdir = `C:\work\repo`
+	cfg.WindowsSandbox.Networking = "Disable"
+	cfg.WindowsSandbox.VGPU = "Disable"
+	cfg.WindowsSandbox.Clipboard = "Disable"
+	cfg.WindowsSandbox.ProtectedClient = "Default"
+	cfg.WindowsSandbox.AudioInput = "Disable"
+	cfg.WindowsSandbox.VideoInput = "Disable"
+	cfg.WindowsSandbox.PrinterRedirection = "Disable"
+	cfg.WindowsSandbox.MemoryMB = 4096
+	run := preparedRun{
+		hostWorkspace: `C:\host\workspace`,
+		hostControl:   `C:\host\control`,
+	}
+	data, err := windowsSandboxConfigXML(cfg, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	xml := string(data)
+	for _, want := range []string{
+		"<Configuration>",
+		"<Networking>Disable</Networking>",
+		"<VGpu>Disable</VGpu>",
+		"<ClipboardRedirection>Disable</ClipboardRedirection>",
+		"<MemoryInMB>4096</MemoryInMB>",
+		"<HostFolder>C:\\host\\workspace</HostFolder>",
+		"<SandboxFolder>C:\\work\\repo</SandboxFolder>",
+		"<HostFolder>C:\\host\\control</HostFolder>",
+		"<SandboxFolder>C:\\crabbox-control</SandboxFolder>",
+		"<Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\crabbox-control\\run.ps1</Command>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Fatalf("wsb xml missing %q:\n%s", want, xml)
+		}
+	}
+}
+
+func TestSandboxRunScriptQuotesCommandEnvAndKeepOnFailure(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.WindowsSandbox.Workdir = `C:\work\repo`
+	script, err := sandboxRunScript(cfg, RunRequest{
+		Command:       []string{"pwsh", "-NoProfile", "-Command", "Write-Output 'hi'"},
+		KeepOnFailure: true,
+		Env: map[string]string{
+			"CI":     "true",
+			"SECRET": "can't leak",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Set-Location -LiteralPath 'C:\\work\\repo'",
+		"$env:CI = 'true'",
+		"$env:SECRET = 'can''t leak'",
+		"& 'pwsh' '-NoProfile' '-Command' 'Write-Output ''hi''' 1>> $stdout 2>> $stderr",
+		"$keepOnFailure = $true",
+		"Set-Content -LiteralPath $exitFile -Value $exitCode -Encoding ASCII",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
+	script := hostRunnerScript()
+	for _, want := range []string{
+		"function Stop-SandboxSession",
+		"Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force",
+		"if (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue)",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("host runner missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestRejectWindowsSandboxSyncOnly(t *testing.T) {
+	err := rejectWindowsSandboxRunOptions(Provider{}.Spec(), RunRequest{SyncOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "--sync-only") {
+		t.Fatalf("err=%v, want --sync-only rejection", err)
+	}
+}
+
+func TestCopyManifestRejectsSymlinks(t *testing.T) {
+	repo := t.TempDir()
+	dst := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "target.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(repo, "link.txt")); err != nil {
+		t.Skipf("symlink creation unavailable on this host: %v", err)
+	}
+	err := copyManifest(context.Background(), repo, dst, SyncManifest{Files: []string{"link.txt"}})
+	if err == nil || !strings.Contains(err.Error(), "does not support syncing symlink") {
+		t.Fatalf("err=%v, want symlink rejection", err)
+	}
+}
+
+func TestRunInvokesHostRunnerWithNoSync(t *testing.T) {
+	oldOS := windowsSandboxHostOS
+	windowsSandboxHostOS = "windows"
+	defer func() { windowsSandboxHostOS = oldOS }()
+
+	runner := &recordingRunner{}
+	cfg := core.BaseConfig()
+	cfg.WindowsSandbox.TempRoot = t.TempDir()
+	cfg.TTL = 2 * time.Minute
+	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	result, err := be.(*backend).Run(context.Background(), RunRequest{
+		NoSync:  true,
+		Command: []string{"cmd.exe", "/c", "echo ok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 || !result.SyncDelegated {
+		t.Fatalf("result=%#v", result)
+	}
+	if runner.name != "powershell.exe" {
+		t.Fatalf("runner name=%q", runner.name)
+	}
+	joined := strings.Join(runner.args, "\n")
+	for _, want := range []string{"-File", "host-runner.ps1", "-TimeoutSeconds\n120"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %#v", want, runner.args)
+		}
+	}
+}
+
+func TestRunKeepsWorkspaceOnFailureWithKeepOnFailure(t *testing.T) {
+	oldOS := windowsSandboxHostOS
+	windowsSandboxHostOS = "windows"
+	defer func() { windowsSandboxHostOS = oldOS }()
+
+	runner := &recordingRunner{result: LocalCommandResult{ExitCode: 7}, err: errors.New("exit status 7")}
+	cfg := core.BaseConfig()
+	cfg.WindowsSandbox.TempRoot = t.TempDir()
+	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	result, err := be.(*backend).Run(context.Background(), RunRequest{
+		NoSync:        true,
+		KeepOnFailure: true,
+		Command:       []string{"cmd.exe", "/c", "exit 7"},
+	})
+	if err == nil {
+		t.Fatal("expected run error")
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("ExitCode=%d", result.ExitCode)
+	}
+	entries, readErr := os.ReadDir(cfg.WindowsSandbox.TempRoot)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("temp entries=%d, want preserved workspace", len(entries))
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg.WindowsSandbox.TempRoot, entries[0].Name(), "control", "run.ps1")); statErr != nil {
+		t.Fatalf("preserved run script missing: %v", statErr)
+	}
+}
+
+type recordingRunner struct {
+	name   string
+	args   []string
+	result LocalCommandResult
+	err    error
+}
+
+func (r *recordingRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	_ = ctx
+	r.name = req.Name
+	r.args = append([]string(nil), req.Args...)
+	return r.result, r.err
+}

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -132,10 +132,12 @@ func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 		"Get-Process -Name WindowsSandbox,WindowsSandboxClient -ErrorAction SilentlyContinue",
 		"$sandboxExe = (Get-Command WindowsSandbox.exe -ErrorAction Stop).Source",
 		"Start-Process -FilePath $sandboxExe",
+		"$startupGraceSeconds = [Math]::Min($TimeoutSeconds, 120)",
 		"$sandboxSeen = $false",
 		"Wait-SandboxSession 20",
 		"Get-SandboxProcesses | Stop-Process -Force",
 		"if (-not $sandboxSeen)",
+		"Windows Sandbox launcher exited before any sandbox process was observed",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("host runner missing %q:\n%s", want, script)

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -127,12 +127,28 @@ func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 	script := hostRunnerScript()
 	for _, want := range []string{
 		"function Stop-SandboxSession",
+		"function Wait-SandboxSession",
+		"Wait-SandboxSession 20",
 		"Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue | Stop-Process -Force",
 		"if (Get-Process -Name WindowsSandbox -ErrorAction SilentlyContinue)",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("host runner missing %q:\n%s", want, script)
 		}
+	}
+}
+
+func TestCleanWindowsSandboxPathUsesWindowsSemantics(t *testing.T) {
+	got, err := cleanWindowsSandboxPath(`c:/repo/../work/./project`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `C:\work\project` {
+		t.Fatalf("clean path=%q, want C:\\work\\project", got)
+	}
+
+	if _, err := cleanWindowsSandboxPath(`C:/work/../Windows`); err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("err=%v, want broad path rejection", err)
 	}
 }
 

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -145,6 +145,14 @@ func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 	}
 }
 
+func TestHostRunnerScriptHonorsKeepFlagsOnTimeout(t *testing.T) {
+	script := hostRunnerScript()
+	timeoutBranch := "if ((Get-Date) -gt $deadline) {\r\n    if (-not ($Keep.IsPresent -or $KeepOnFailure.IsPresent)) {\r\n      Stop-SandboxSession\r\n    }\r\n    Write-Error \"Windows Sandbox timed out after ${TimeoutSeconds}s\"\r\n    exit 124\r\n  }"
+	if !strings.Contains(script, timeoutBranch) {
+		t.Fatalf("host runner timeout branch must gate Stop-SandboxSession on keep flags:\n%s", script)
+	}
+}
+
 func TestCleanWindowsSandboxPathUsesWindowsSemantics(t *testing.T) {
 	got, err := cleanWindowsSandboxPath(`c:/repo/../work/./project`)
 	if err != nil {

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -115,6 +116,8 @@ func TestSandboxRunScriptQuotesCommandEnvAndKeepOnFailure(t *testing.T) {
 		"$env:SECRET = 'can''t leak'",
 		"& 'pwsh' '-NoProfile' '-Command' 'Write-Output ''hi''' 1>> $stdout 2>> $stderr",
 		"$keepOnFailure = $true",
+		"$canceled = Test-Path -LiteralPath 'C:\\crabbox-control\\cancel.txt'",
+		"if ($canceled -and $exitCode -eq 0) { $exitCode = 130 }",
 		"Set-Content -LiteralPath $exitFile -Value $exitCode -Encoding ASCII",
 	} {
 		if !strings.Contains(script, want) {
@@ -136,6 +139,9 @@ func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 		"$sandboxSeen = $false",
 		"Wait-SandboxSession 20",
 		"Get-SandboxProcesses | Stop-Process -Force",
+		"Test-Path -LiteralPath $cancelFile",
+		"Windows Sandbox run canceled.",
+		"exit 130",
 		"if (-not $sandboxSeen)",
 		"Windows Sandbox launcher exited before any sandbox process was observed",
 	} {
@@ -143,13 +149,61 @@ func TestHostRunnerScriptStopsActualSandboxProcessOnTimeout(t *testing.T) {
 			t.Fatalf("host runner missing %q:\n%s", want, script)
 		}
 	}
+	if strings.Contains(script, "Write-Error") {
+		t.Fatalf("host runner must not terminate before explicit lifecycle exit codes:\n%s", script)
+	}
+}
+
+func TestHostRunnerScriptReadsOnlyAppendedLogBytes(t *testing.T) {
+	script := hostRunnerScript()
+	for _, want := range []string{
+		"[System.IO.File]::Open",
+		"$stream.Seek($Offset.Value",
+		"[System.IO.StreamReader]::new",
+		"catch [System.IO.IOException]",
+		"catch [System.UnauthorizedAccessException]",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("host runner missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, "Get-Content -LiteralPath $Path -Raw") {
+		t.Fatalf("host runner still rereads complete logs:\n%s", script)
+	}
 }
 
 func TestHostRunnerScriptHonorsKeepFlagsOnTimeout(t *testing.T) {
 	script := hostRunnerScript()
-	timeoutBranch := "if ((Get-Date) -gt $deadline) {\r\n    if (-not ($Keep.IsPresent -or $KeepOnFailure.IsPresent)) {\r\n      Stop-SandboxSession\r\n    }\r\n    Write-Error \"Windows Sandbox timed out after ${TimeoutSeconds}s\"\r\n    exit 124\r\n  }"
+	timeoutBranch := "if ((Get-Date) -gt $deadline) {\r\n    if (-not ($Keep.IsPresent -or $KeepOnFailure.IsPresent)) {\r\n      Stop-SandboxSession\r\n    }\r\n    [Console]::Error.WriteLine(\"Windows Sandbox timed out after ${TimeoutSeconds}s\")\r\n    exit 124\r\n  }"
 	if !strings.Contains(script, timeoutBranch) {
 		t.Fatalf("host runner timeout branch must gate Stop-SandboxSession on keep flags:\n%s", script)
+	}
+}
+
+func TestGeneratedPowerShellScriptsParse(t *testing.T) {
+	powershell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Skip("powershell.exe not available")
+	}
+	cfg := core.BaseConfig()
+	sandboxScript, err := sandboxRunScript(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "echo ok"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, script := range map[string]string{
+		"host-runner.ps1": hostRunnerScript(),
+		"run.ps1":         sandboxScript,
+	} {
+		path := filepath.Join(t.TempDir(), name)
+		if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		parse := `$tokens = $null; $errors = $null; [System.Management.Automation.Language.Parser]::ParseFile(` +
+			psSingleQuote(path) +
+			`, [ref]$tokens, [ref]$errors) | Out-Null; if ($errors.Count -gt 0) { $errors | ForEach-Object { [Console]::Error.WriteLine($_.ToString()) }; exit 1 }`
+		if output, err := exec.Command(powershell, "-NoProfile", "-NonInteractive", "-Command", parse).CombinedOutput(); err != nil {
+			t.Fatalf("%s parse failed: %v\n%s", name, err, output)
+		}
 	}
 }
 
@@ -189,6 +243,33 @@ func TestCopyManifestRejectsSymlinks(t *testing.T) {
 	}
 }
 
+func TestSyncManifestHonorsIncludes(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "-C", repo, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	for name, data := range map[string]string{
+		"keep.txt":       "keep",
+		"skip.txt":       "skip",
+		"nested/keep.go": "package nested",
+	} {
+		path := filepath.Join(repo, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest, err := syncManifest(repo, nil, []string{"keep.txt", "nested/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(manifest.Files, ","); got != "keep.txt,nested/keep.go" {
+		t.Fatalf("manifest files=%q", got)
+	}
+}
+
 func TestRunInvokesHostRunnerWithNoSync(t *testing.T) {
 	oldOS := windowsSandboxHostOS
 	windowsSandboxHostOS = "windows"
@@ -212,11 +293,85 @@ func TestRunInvokesHostRunnerWithNoSync(t *testing.T) {
 	if runner.name != "powershell.exe" {
 		t.Fatalf("runner name=%q", runner.name)
 	}
+	if !runner.disableOutputCapture {
+		t.Fatal("host runner must stream without retaining output")
+	}
 	joined := strings.Join(runner.args, "\n")
 	for _, want := range []string{"-File", "host-runner.ps1", "-TimeoutSeconds\n120"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("args missing %q: %#v", want, runner.args)
 		}
+	}
+}
+
+func TestRunSignalsCancellationAndWaitsForHostCleanup(t *testing.T) {
+	oldOS := windowsSandboxHostOS
+	windowsSandboxHostOS = "windows"
+	defer func() { windowsSandboxHostOS = oldOS }()
+
+	runner := &cancelAwareRunner{
+		started:        make(chan struct{}),
+		observedCancel: make(chan struct{}),
+	}
+	cfg := core.BaseConfig()
+	cfg.WindowsSandbox.TempRoot = t.TempDir()
+	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := be.(*backend).Run(ctx, RunRequest{
+			NoSync:  true,
+			Command: []string{"cmd.exe", "/c", "timeout /t 30"},
+		})
+		done <- err
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("host runner did not start")
+	}
+	cancel()
+	select {
+	case <-runner.observedCancel:
+	case <-time.After(5 * time.Second):
+		t.Fatal("host runner did not observe cancellation sentinel")
+	}
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "exited 130") {
+			t.Fatalf("err=%v, want cancellation exit 130", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not wait for canceled host runner")
+	}
+	entries, err := os.ReadDir(cfg.WindowsSandbox.TempRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("temp entries=%d, want canceled workspace removed", len(entries))
+	}
+}
+
+func TestRunHostRunnerNormalizesCancellationFallbackExitCode(t *testing.T) {
+	runner := &cancelOnContextRunner{started: make(chan struct{})}
+	be := &backend{rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelPath := filepath.Join(t.TempDir(), "missing", "cancel.txt")
+	done := make(chan localCommandOutcome, 1)
+	go func() {
+		result, err := be.runHostRunner(ctx, LocalCommandRequest{Name: "powershell.exe"}, cancelPath, true)
+		done <- localCommandOutcome{result: result, err: err}
+	}()
+	<-runner.started
+	cancel()
+	outcome := <-done
+	if outcome.err == nil || !strings.Contains(outcome.err.Error(), "signal windows-sandbox cancellation") {
+		t.Fatalf("err=%v, want cancellation sentinel failure", outcome.err)
+	}
+	if outcome.result.ExitCode != 130 {
+		t.Fatalf("ExitCode=%d, want 130", outcome.result.ExitCode)
 	}
 }
 
@@ -253,15 +408,59 @@ func TestRunKeepsWorkspaceOnFailureWithKeepOnFailure(t *testing.T) {
 }
 
 type recordingRunner struct {
-	name   string
-	args   []string
-	result LocalCommandResult
-	err    error
+	name                 string
+	args                 []string
+	disableOutputCapture bool
+	result               LocalCommandResult
+	err                  error
 }
 
 func (r *recordingRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	_ = ctx
 	r.name = req.Name
 	r.args = append([]string(nil), req.Args...)
+	r.disableOutputCapture = req.DisableOutputCapture
 	return r.result, r.err
+}
+
+type cancelAwareRunner struct {
+	started        chan struct{}
+	observedCancel chan struct{}
+}
+
+type cancelOnContextRunner struct {
+	started chan struct{}
+}
+
+func (r *cancelOnContextRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	_ = req
+	close(r.started)
+	<-ctx.Done()
+	return LocalCommandResult{ExitCode: 1}, ctx.Err()
+}
+
+func (r *cancelAwareRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	if req.Name != "powershell.exe" {
+		return LocalCommandResult{}, nil
+	}
+	close(r.started)
+	var controlDir string
+	for i, arg := range req.Args {
+		if arg == "-ControlDir" && i+1 < len(req.Args) {
+			controlDir = req.Args[i+1]
+			break
+		}
+	}
+	cancelPath := filepath.Join(controlDir, "cancel.txt")
+	for {
+		if _, err := os.Stat(cancelPath); err == nil {
+			close(r.observedCancel)
+			return LocalCommandResult{ExitCode: 130}, errors.New("exit status 130")
+		}
+		select {
+		case <-ctx.Done():
+			return LocalCommandResult{ExitCode: 1}, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
 }

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -80,7 +80,7 @@ func TestWindowsSandboxConfigXML(t *testing.T) {
 	for _, want := range []string{
 		"<Configuration>",
 		"<Networking>Disable</Networking>",
-		"<VGpu>Disable</VGpu>",
+		"<vGPU>Disable</vGPU>",
 		"<ClipboardRedirection>Disable</ClipboardRedirection>",
 		"<MemoryInMB>4096</MemoryInMB>",
 		"<HostFolder>C:\\host\\workspace</HostFolder>",

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -55,8 +55,8 @@ func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
 
-func syncManifest(root string, excludes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, nil)
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
 }
 
 func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -1,0 +1,75 @@
+package windowssandbox
+
+import (
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type WindowsSandboxConfig = core.WindowsSandboxConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type ExitError = core.ExitError
+type SyncManifest = core.SyncManifest
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+
+const (
+	providerName      = "windows-sandbox"
+	targetWindows     = core.TargetWindows
+	windowsModeNormal = core.WindowsModeNormal
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error {
+	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, nil)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func durationSecondsCeil(duration time.Duration) int {
+	if duration <= 0 {
+		return 0
+	}
+	return int((duration + time.Second - 1) / time.Second)
+}

--- a/internal/providers/windowssandbox/flags.go
+++ b/internal/providers/windowssandbox/flags.go
@@ -1,0 +1,122 @@
+package windowssandbox
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	Workdir            *string
+	TempRoot           *string
+	Networking         *string
+	VGPU               *string
+	Clipboard          *string
+	ProtectedClient    *string
+	AudioInput         *string
+	VideoInput         *string
+	PrinterRedirection *string
+	MemoryMB           *int
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		Workdir:            fs.String("windows-sandbox-workdir", defaults.WindowsSandbox.Workdir, "absolute working directory inside Windows Sandbox"),
+		TempRoot:           fs.String("windows-sandbox-temp-root", defaults.WindowsSandbox.TempRoot, "host directory for temporary Windows Sandbox workspaces"),
+		Networking:         fs.String("windows-sandbox-networking", defaults.WindowsSandbox.Networking, "Windows Sandbox networking: enable, disable, or default"),
+		VGPU:               fs.String("windows-sandbox-vgpu", defaults.WindowsSandbox.VGPU, "Windows Sandbox vGPU: enable, disable, or default"),
+		Clipboard:          fs.String("windows-sandbox-clipboard", defaults.WindowsSandbox.Clipboard, "Windows Sandbox clipboard redirection: enable, disable, or default"),
+		ProtectedClient:    fs.String("windows-sandbox-protected-client", defaults.WindowsSandbox.ProtectedClient, "Windows Sandbox protected client: enable, disable, or default"),
+		AudioInput:         fs.String("windows-sandbox-audio-input", defaults.WindowsSandbox.AudioInput, "Windows Sandbox audio input: enable, disable, or default"),
+		VideoInput:         fs.String("windows-sandbox-video-input", defaults.WindowsSandbox.VideoInput, "Windows Sandbox video input: enable, disable, or default"),
+		PrinterRedirection: fs.String("windows-sandbox-printer-redirection", defaults.WindowsSandbox.PrinterRedirection, "Windows Sandbox printer redirection: enable, disable, or default"),
+		MemoryMB:           fs.Int("windows-sandbox-memory-mb", defaults.WindowsSandbox.MemoryMB, "Windows Sandbox memory in MB; 0 leaves the platform default"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	selected := cfg.Provider == providerName || cfg.Provider == "wsb" || cfg.Provider == "windows-sandbox-provider"
+	if selected {
+		if core.FlagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s; Windows Sandbox sizing is controlled by the host", providerName)
+		}
+		if core.FlagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s; Windows Sandbox sizing is controlled by the host", providerName)
+		}
+		if !core.FlagWasSet(fs, "target") {
+			cfg.TargetOS = targetWindows
+		}
+		if !core.FlagWasSet(fs, "windows-mode") {
+			cfg.WindowsMode = windowsModeNormal
+		}
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-workdir") {
+		cfg.WindowsSandbox.Workdir = *v.Workdir
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-temp-root") {
+		cfg.WindowsSandbox.TempRoot = *v.TempRoot
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-networking") {
+		normalized, err := normalizeWSBState(*v.Networking, "windows-sandbox-networking")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.Networking = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-vgpu") {
+		normalized, err := normalizeWSBState(*v.VGPU, "windows-sandbox-vgpu")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.VGPU = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-clipboard") {
+		normalized, err := normalizeWSBState(*v.Clipboard, "windows-sandbox-clipboard")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.Clipboard = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-protected-client") {
+		normalized, err := normalizeWSBState(*v.ProtectedClient, "windows-sandbox-protected-client")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.ProtectedClient = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-audio-input") {
+		normalized, err := normalizeWSBState(*v.AudioInput, "windows-sandbox-audio-input")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.AudioInput = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-video-input") {
+		normalized, err := normalizeWSBState(*v.VideoInput, "windows-sandbox-video-input")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.VideoInput = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-printer-redirection") {
+		normalized, err := normalizeWSBState(*v.PrinterRedirection, "windows-sandbox-printer-redirection")
+		if err != nil {
+			return err
+		}
+		cfg.WindowsSandbox.PrinterRedirection = normalized
+	}
+	if core.FlagWasSet(fs, "windows-sandbox-memory-mb") {
+		if *v.MemoryMB < 0 {
+			return exit(2, "--windows-sandbox-memory-mb must be non-negative")
+		}
+		cfg.WindowsSandbox.MemoryMB = *v.MemoryMB
+	}
+	if selected {
+		applyDefaults(cfg)
+	}
+	return nil
+}

--- a/internal/providers/windowssandbox/provider.go
+++ b/internal/providers/windowssandbox/provider.go
@@ -1,0 +1,64 @@
+package windowssandbox
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"wsb", "windows-sandbox-provider"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "local-sandbox",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	applyDefaults(&cfg)
+	if err := validateWindowsSandboxConfig(cfg); err != nil {
+		return nil, err
+	}
+	if cfg.TargetOS != core.TargetWindows || cfg.WindowsMode != core.WindowsModeNormal {
+		return nil, core.Exit(2, "provider=%s supports target=windows windows.mode=normal only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; Windows Sandbox networking is controlled by --windows-sandbox-networking", providerName)
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}


### PR DESCRIPTION
## Summary
- add a built-in `windows-sandbox` / `wsb` delegated-run provider for local Microsoft Windows Sandbox sessions
- generate per-run `.wsb` configs with mapped workspace/control folders, PowerShell command execution, streamed logs, exit-code sentinel, timeout cleanup, and keep-on-failure behavior
- wire config, env vars, flags, provider docs, provider matrix, and regression tests
- reject tracked symlink sync up front so Windows hosts do not need Developer Mode/admin symlink privileges before launching Sandbox

This intentionally models WSB as a local delegated-run provider rather than an SSH lease because Windows Sandbox is disposable, single-instance, and does not expose a persistent inventory/SSH lifecycle.

Fixes https://github.com/openclaw/crabbox/issues/237

## Verification
- `go test ./internal/providers/windowssandbox ./internal/cli ./internal/providers/all`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0` (`Go core coverage 91.1% >= 90.0%`)
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node --test scripts/*.test.js`
- `node scripts/check-docs-links.mjs`
- `scripts/check-docs.sh`
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `go run github.com/goreleaser/goreleaser/v2@v2.16.0 release --snapshot --clean --skip=publish`

## CLI smoke
- `bin/crabbox providers --json | rg 'windows-sandbox|wsb|local-sandbox|delegated-run|windows'` shows `windows-sandbox` as `local-sandbox`, `delegated-run`, aliases `wsb`/`windows-sandbox-provider`, target `windows/normal`, coordinator `never`.
- `bin/crabbox doctor --provider windows-sandbox` on this macOS host fails as expected with `provider=windows-sandbox requires a Windows host with the Windows Sandbox optional feature enabled`.
- `bin/crabbox run --provider windows-sandbox --no-sync -- powershell -NoProfile -Command "Write-Host ok"` on this macOS host fails fast with the same Windows-host prerequisite.
- `bin/crabbox run --provider windows-sandbox --target linux --no-sync -- true` rejects `target=linux`.
- `bin/crabbox run --provider windows-sandbox --target windows --windows-mode wsl2 --no-sync -- true` rejects `windows.mode=wsl2`.

## Live Windows Sandbox proof
Maintainer validation on exact head `adbe36391c9800b229a22f744ba8105cafeae56e`:

- Cross-compiled Windows ARM64 provider test and CLI binaries; SHA-256 hashes matched after transfer into a Windows 11 Pro ARM64 VM.
- Ran the focused provider suite inside Windows, including real `powershell.exe` parser validation for both generated scripts, cancellation cleanup, cancellation fallback exit normalization, keep-on-failure handling, XML/config generation, and host process arguments.
- Ran `crabbox doctor --provider windows-sandbox` inside Windows; it correctly diagnosed that the Windows Sandbox optional feature is unavailable.
- Repeatedly attempted to enable `Containers-DisposableClientVM`. Windows rolled the feature back with `0x800f0922`; `CmService` reported `0xc0351000`, confirming this Parallels-on-Apple-Silicon VM has no nested Hyper-V despite nested virtualization being configured.

An actual `WindowsSandbox.exe` launch remains unproven because the available Windows host cannot expose nested Hyper-V. The patch has Windows-native binary, PowerShell, diagnostics, lifecycle, and exact-head CI proof, but not a successful Sandbox session.

## Maintainer hardening

- repository config cannot select host temp paths or loosen networking/device/resource policy
- sync include allowlists are honored
- Ctrl+C signals the host runner, stops or preserves the sandbox according to keep policy, and consistently reports exit 130
- streamed output no longer accumulates duplicate in-memory copies or rereads complete growing log files
- transient mapped-log read failures retry without bypassing sandbox cleanup
- user-visible provider entry added to `CHANGELOG.md`, thanking `@zozo123`
- local autoreview completed with no actionable findings
