### PR TITLE
fix: defer Docker Sandbox provider config validation

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -772,13 +772,6 @@ func loadConfig() (Config, error) {
 	if err := applyProviderConfigDefaults(&cfg); err != nil {
 		return Config{}, err
 	}
-	if provider, err := ProviderFor(cfg.Provider); err != nil {
-		return Config{}, err
-	} else if validator, ok := provider.(ProviderConfigValidator); ok {
-		if err := validator.ValidateConfig(cfg); err != nil {
-			return Config{}, err
-		}
-	}
 	normalizeTargetConfig(&cfg)
 	if err := validateTargetConfig(cfg); err != nil {
 		return Config{}, err

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -20,6 +20,9 @@ func (a App) configShow(args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateProviderConfig(cfg); err != nil {
+		return err
+	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(configShowView(cfg))
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1941,7 +1942,7 @@ func TestInvalidNetworkEnvFails(t *testing.T) {
 	}
 }
 
-func TestInvalidDockerSandboxCPUEnvFailsDuringLoad(t *testing.T) {
+func TestDockerSandboxCPUEnvCanBeOverriddenByFlags(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1950,8 +1951,20 @@ func TestInvalidDockerSandboxCPUEnvFailsDuringLoad(t *testing.T) {
 	t.Setenv("CRABBOX_PROVIDER", "docker-sandbox")
 	t.Setenv("CRABBOX_DOCKER_SANDBOX_CPUS", "2.5")
 
-	if _, err := loadConfig(); err == nil || !strings.Contains(err.Error(), "docker-sandbox cpus must be a whole number") {
-		t.Fatalf("loadConfig err=%v, want docker-sandbox whole-number validation", err)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig err=%v, want command flags to get a chance to override provider config", err)
+	}
+	fs := newFlagSet("test", io.Discard)
+	values := registerProviderFlags(fs, cfg)
+	if err := parseFlags(fs, []string{"--docker-sandbox-cpus", "2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("applyProviderFlags err=%v, want valid CLI override to win", err)
+	}
+	if cfg.DockerSandbox.CPUs != 2 {
+		t.Fatalf("cpus=%g, want CLI override 2", cfg.DockerSandbox.CPUs)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -587,6 +587,17 @@ func applyProviderFlags(cfg *Config, fs *flag.FlagSet, values providerFlagValues
 	return after.ApplyFlags(cfg, fs, values[after.Name()])
 }
 
+func validateProviderConfig(cfg Config) error {
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return err
+	}
+	if validator, ok := provider.(ProviderConfigValidator); ok {
+		return validator.ValidateConfig(cfg)
+	}
+	return nil
+}
+
 func routeProviderFlagOverride(cfg *Config, fs *flag.FlagSet, values providerFlagValues) (bool, error) {
 	if fs == nil {
 		return false, nil


### PR DESCRIPTION
## Summary

- defer provider-specific Docker Sandbox validation until after command provider flags can override config/env values
- keep `crabbox config show` validation explicit so diagnostics still reject broken active provider config
- add a regression proving `CRABBOX_DOCKER_SANDBOX_CPUS=2.5` can be corrected by `--docker-sandbox-cpus 2`

## Verification

- `go test ./internal/cli -run 'TestDockerSandboxCPUEnvCanBeOverriddenByFlags|TestInvalidDockerSandboxCPUEnvNonNumericFailsDuringLoad|TestConfigShowRejectsInvalidDockerSandboxCPUConfig|TestConfigShowIncludesDockerSandboxConfig'`
- `go test ./internal/cli ./internal/providers/dockersandbox ./internal/providers/all`
- `go test -race ./internal/cli ./internal/providers/dockersandbox ./internal/providers/all`
- `node --test scripts/docker-sandbox-trust-boundary-smoke.test.js scripts/live-docker-sandbox-smoke.test.js`
- `go build -trimpath -o /tmp/crabbox-docker-sandbox-fix ./cmd/crabbox`
- `git diff --check`
- `scripts/live-docker-sandbox-smoke.sh` -> `classification=live_sbx_smoke_passed ... cleanup=complete`
- `sbx list --json` -> no sandboxes
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, patch correct

## Context

Follow-up to https://github.com/openclaw/crabbox/pull/221. Autoreview found that the landed Docker Sandbox provider validated config before CLI overrides were applied, breaking normal CLI-over-config precedence.
