### PR TITLE
feat: add declarative external provider lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added declarative `external.lifecycle` command configuration for deterministic private devbox CLIs, plus coordinator-free WebVNC over SSH for direct desktop-capable providers.
 - Added Podman runtime compatibility for `provider: local-container`, including runtime selection, provider flags on SSH commands, and Podman-safe local lease claim scopes. Thanks @sallyom.
 - Added `sync.include` / `sync.includes` whitelists for root-relative sync plans, SSH sync, native Windows sync, local Actions hydration, and archive-sync providers. Thanks @anagnorisis2peripeteia.
 - Added generic `kubevirt` SSH leases and a versioned `external` executable provider so private or proprietary VM/devbox control planes can integrate through configuration without provider-specific Crabbox forks.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -222,11 +222,11 @@ and `daemon stop` forms take only `--id`.
 - The local Docker container provider (`--provider local-container`) is also
   supported. It serves noVNC locally over an SSH tunnel rather than through the
   coordinator portal, so it needs no coordinator login.
+- Direct SSH providers that advertise desktop support, including KubeVirt and
+  external providers, use the same local noVNC-over-SSH path and need no
+  coordinator login.
 - Static SSH hosts are intentionally not supported, because the portal cannot
   prove that host-managed VNC credentials and prompts are safe to expose.
-- Direct providers such as KubeVirt and external providers should use
-  `crabbox vnc`, which opens a native VNC client over SSH without serving
-  target-provided browser assets.
 - Blacksmith Testbox still owns its own machine connectivity.
 
 ## Troubleshooting
@@ -237,11 +237,17 @@ Run `crabbox login --url <broker-url>` for the coordinator you are using. Portal
 WebVNC needs both the CLI bridge and the browser portal to authenticate with the
 coordinator. The local container provider is the exception and needs no login.
 
-`webvnc currently supports coordinator-backed hetzner/aws/azure desktop leases`
+`webvnc requires a configured coordinator login`
 
-WebVNC is not available for static SSH hosts, direct KubeVirt/external leases,
-or Blacksmith Testbox. Use `crabbox vnc` for direct providers and for static
-hosts when you explicitly trust the host-managed VNC service.
+The selected provider is coordinator-backed. Direct desktop-capable SSH
+providers do not require coordinator login and serve noVNC locally over the
+provider SSH connection.
+
+`missing websockify` or `missing noVNC web assets`
+
+The direct target exposes VNC but does not have the noVNC package installed.
+Install `novnc` and `websockify` in the provider image or guest bootstrap, then
+retry. `crabbox vnc` remains available as the native-client fallback.
 
 `target does not expose VNC on 127.0.0.1:5900`
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -449,6 +449,8 @@ placeholders, applies it with `kubectl`, and starts it with `virtctl`.
 
 ### External provider
 
+Protocol adapter:
+
 ```yaml
 provider: external
 external:
@@ -467,6 +469,35 @@ operation and returns one JSON response on stdout. This keeps internal control
 plane logic outside Crabbox while preserving normal SSH sync, rsync, WebVNC,
 and command execution. Crabbox writes private per-lease routing state for
 generated stop commands; `routingFile` is normally set only by those commands.
+
+Declarative CLI:
+
+```yaml
+provider: external
+external:
+  lifecycle:
+    acquire:
+      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+    list:
+      argv: [devboxctl, list, --format, json]
+      output: json-name-array
+    release:
+      argv: [devboxctl, rm, --yes, "{{name}}"]
+  connection:
+    cloudId: devboxes/{{name}}
+    serverType: "{{config.size}}"
+    ssh:
+      user: "{{env.DEVBOX_USER}}"
+      host: "{{name}}"
+      sshConfigProxy: true
+  config:
+    size: cpu16
+  workRoot: /home/developer/crabbox
+```
+
+Declarative lifecycle entries are argv arrays, not shell commands. See
+[External Provider](../providers/external.md) for placeholders, inventory
+formats, routing behavior, and security guidance.
 
 ### Daytona
 

--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -1,14 +1,17 @@
 # External Provider
 
 Use `provider: external` when lifecycle and connection discovery belong to an
-internal, proprietary, or separately versioned tool. Crabbox launches one
-configured executable per operation. There is no shell evaluation and no
-provider-specific code in Crabbox.
+internal, proprietary, or separately versioned tool. Choose either:
 
-The executable owns provisioning, inventory, resume, release, and any private
-authentication. It returns an SSH target; Crabbox then owns dirty-tree sync,
-rsync, commands, results, SSH sessions, and native VNC forwarding when the
-provider returns desktop metadata.
+- the versioned JSON protocol for adapters that need arbitrary logic; or
+- declarative lifecycle commands for CLIs whose resource name and SSH target
+  are deterministic.
+
+There is no shell evaluation and no provider-specific code in Crabbox. The
+external tool owns provisioning, inventory, resume, release, and private
+authentication. Crabbox owns dirty-tree sync, rsync, commands, results, SSH
+sessions, native VNC forwarding, and local WebVNC for desktop-capable direct
+SSH leases.
 
 ## Configuration
 
@@ -36,11 +39,86 @@ before the SSH readiness wait, so the printed recovery commands can still
 resolve or release the lease. Routing files use mode `0600` and are removed
 after successful release.
 
-Local claims are scoped to a fingerprint of `external.command`, `external.args`,
-and `external.config`. This lets multiple external backends or namespaces reuse
-the same slug without cleanup for one configuration removing claims or routing
-files owned by another. Legacy unscoped claims are not reconciled by cleanup;
-stop them directly by lease ID or with the generated routing file.
+Local claims are scoped to a fingerprint of the selected protocol command or
+declarative lifecycle, connection templates, and `external.config`. This lets
+multiple external backends or namespaces reuse the same slug without cleanup
+for one configuration removing claims or routing files owned by another.
+Legacy unscoped claims are not reconciled by cleanup; stop them directly by
+lease ID or with the generated routing file.
+
+## Declarative lifecycle
+
+Use declarative lifecycle commands when the provider CLI can create a
+preselected resource name and expose that resource through a deterministic SSH
+alias or hostname:
+
+```yaml
+provider: external
+target: linux
+external:
+  lifecycle:
+    doctor:
+      argv: [devboxctl, list, --format, json]
+    acquire:
+      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+    resolve:
+      argv: [devboxctl, inspect, "{{name}}"]
+    list:
+      argv: [devboxctl, list, --format, json]
+      output: json-name-array
+    release:
+      argv: [devboxctl, rm, --yes, "{{name}}"]
+    touch:
+      argv: [devboxctl, touch, "{{name}}"]
+    cleanup:
+      argv: [devboxctl, gc]
+  connection:
+    cloudId: devboxes/{{name}}
+    serverType: "{{config.size}}"
+    labels:
+      backend: container
+    ssh:
+      user: "{{env.DEVBOX_USER}}"
+      host: "{{name}}"
+      port: "22"
+      sshConfigProxy: true
+      readyCheck: command -v git && command -v rsync && command -v tar
+  config:
+    size: cpu16
+  workRoot: /home/developer/crabbox
+```
+
+`acquire`, `list`, `release`, and `connection.ssh.user` are required.
+`connection.ssh.host` defaults to `{{name}}`. Optional operations are skipped
+when absent; Crabbox still maintains local touch metadata.
+
+Each `argv` item is passed directly to the configured executable. Shell
+operators, pipes, variable expansion, and command substitution are not
+evaluated. Supported placeholders:
+
+```text
+{{leaseId}} {{slug}} {{name}} {{id}} {{state}}
+{{keep}} {{reclaim}} {{releaseOnly}} {{force}}
+{{all}} {{refresh}} {{dryRun}}
+{{repo.root}} {{repo.name}} {{repo.remoteUrl}} {{repo.head}} {{repo.baseRef}}
+{{config.<scalar-key>}}
+{{env.<NAME>}}
+```
+
+Environment placeholders require the named variable to be set. Do not place
+secret environment values in lifecycle arguments: process arguments may be
+visible to other local processes. Provider CLIs should use their normal
+credential store or inherited environment for authentication.
+
+`list.output` accepts:
+
+- `json-name-array`: stdout is a JSON array of resource names;
+- `json-lease-array`: stdout is a JSON array using the protocol lease shape
+  documented below.
+
+Declarative configuration and resolved connection templates are included in
+the private per-lease routing file. This lets generated retry, daemon, SSH, and
+stop commands work without the original config file.
 
 Flags:
 
@@ -67,11 +145,13 @@ The repository live harness can exercise a configured external provider:
 CRABBOX_LIVE=1 \
 CRABBOX_LIVE_COORDINATOR=0 \
 CRABBOX_LIVE_PROVIDERS=external \
-CRABBOX_LIVE_EXTERNAL_COMMAND=/absolute/path/provider \
 scripts/live-smoke.sh
 ```
 
-The command may also come from `external.command` in the Crabbox config.
+The provider may come from declarative lifecycle configuration or
+`external.command` in the Crabbox config. Set
+`CRABBOX_LIVE_EXTERNAL_COMMAND=/absolute/path/provider` to override the
+protocol command.
 `CRABBOX_LIVE_EXTERNAL_ARG` adds one command argument through
 `CRABBOX_EXTERNAL_ARG` for quick local smoke runs; use config `external.args`
 for repeatable multi-argument setups.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -212,8 +212,45 @@ type ExternalConfig struct {
 	Command     string
 	Args        []string
 	Config      map[string]any
+	Lifecycle   ExternalLifecycleConfig
+	Connection  ExternalConnectionConfig
 	WorkRoot    string
 	RoutingFile string
+}
+
+type ExternalLifecycleConfig struct {
+	Doctor  ExternalLifecycleOperation `yaml:"doctor,omitempty" json:"doctor,omitempty"`
+	Acquire ExternalLifecycleOperation `yaml:"acquire,omitempty" json:"acquire,omitempty"`
+	Resolve ExternalLifecycleOperation `yaml:"resolve,omitempty" json:"resolve,omitempty"`
+	List    ExternalLifecycleOperation `yaml:"list,omitempty" json:"list,omitempty"`
+	Release ExternalLifecycleOperation `yaml:"release,omitempty" json:"release,omitempty"`
+	Touch   ExternalLifecycleOperation `yaml:"touch,omitempty" json:"touch,omitempty"`
+	Cleanup ExternalLifecycleOperation `yaml:"cleanup,omitempty" json:"cleanup,omitempty"`
+}
+
+type ExternalLifecycleOperation struct {
+	Argv   []string `yaml:"argv,omitempty" json:"argv,omitempty"`
+	Output string   `yaml:"output,omitempty" json:"output,omitempty"`
+}
+
+type ExternalConnectionConfig struct {
+	CloudID    string                      `yaml:"cloudId,omitempty" json:"cloudId,omitempty"`
+	ServerType string                      `yaml:"serverType,omitempty" json:"serverType,omitempty"`
+	Labels     map[string]string           `yaml:"labels,omitempty" json:"labels,omitempty"`
+	SSH        ExternalSSHConnectionConfig `yaml:"ssh,omitempty" json:"ssh,omitempty"`
+}
+
+type ExternalSSHConnectionConfig struct {
+	User            string   `yaml:"user,omitempty" json:"user,omitempty"`
+	Host            string   `yaml:"host,omitempty" json:"host,omitempty"`
+	Key             string   `yaml:"key,omitempty" json:"key,omitempty"`
+	Port            string   `yaml:"port,omitempty" json:"port,omitempty"`
+	FallbackPorts   []string `yaml:"fallbackPorts,omitempty" json:"fallbackPorts,omitempty"`
+	ReadyCheck      string   `yaml:"readyCheck,omitempty" json:"readyCheck,omitempty"`
+	AuthSecret      bool     `yaml:"authSecret,omitempty" json:"authSecret,omitempty"`
+	NoControlMaster bool     `yaml:"noControlMaster,omitempty" json:"noControlMaster,omitempty"`
+	SSHConfigProxy  bool     `yaml:"sshConfigProxy,omitempty" json:"sshConfigProxy,omitempty"`
+	ProxyCommand    string   `yaml:"proxyCommand,omitempty" json:"proxyCommand,omitempty"`
 }
 
 type NamespaceConfig struct {
@@ -1467,11 +1504,13 @@ type fileKubeVirtConfig struct {
 }
 
 type fileExternalConfig struct {
-	Command     string         `yaml:"command,omitempty"`
-	Args        []string       `yaml:"args,omitempty"`
-	Config      map[string]any `yaml:"config,omitempty"`
-	WorkRoot    string         `yaml:"workRoot,omitempty"`
-	RoutingFile string         `yaml:"routingFile,omitempty"`
+	Command     string                    `yaml:"command,omitempty"`
+	Args        []string                  `yaml:"args,omitempty"`
+	Config      map[string]any            `yaml:"config,omitempty"`
+	Lifecycle   *ExternalLifecycleConfig  `yaml:"lifecycle,omitempty"`
+	Connection  *ExternalConnectionConfig `yaml:"connection,omitempty"`
+	WorkRoot    string                    `yaml:"workRoot,omitempty"`
+	RoutingFile string                    `yaml:"routingFile,omitempty"`
 }
 
 type fileNamespaceConfig struct {
@@ -2486,6 +2525,12 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		}
 		if file.External.Config != nil {
 			cfg.External.Config = file.External.Config
+		}
+		if file.External.Lifecycle != nil {
+			cfg.External.Lifecycle = *file.External.Lifecycle
+		}
+		if file.External.Connection != nil {
+			cfg.External.Connection = *file.External.Connection
 		}
 		if file.External.WorkRoot != "" {
 			cfg.External.WorkRoot = file.External.WorkRoot

--- a/internal/cli/config_kubevirt_external_test.go
+++ b/internal/cli/config_kubevirt_external_test.go
@@ -126,3 +126,54 @@ func TestExternalArgEnvOverridesConfigArgs(t *testing.T) {
 		t.Fatalf("external args=%#v", cfg.External.Args)
 	}
 }
+
+func TestLoadDeclarativeExternalConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	data := `provider: external
+external:
+  lifecycle:
+    acquire:
+      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+    list:
+      argv: [devboxctl, list, --format, json]
+      output: json-name-array
+    release:
+      argv: [devboxctl, rm, --yes, "{{name}}"]
+  connection:
+    cloudId: devboxes/{{name}}
+    serverType: "{{config.size}}"
+    labels:
+      backend: pod
+    ssh:
+      user: "{{env.DEVBOX_USER}}"
+      host: "{{name}}"
+      port: "22"
+      sshConfigProxy: true
+  config:
+    size: cpu16
+  workRoot: /home/developer/crabbox
+`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readFileConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, file); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(cfg.External.Lifecycle.Acquire.Argv, "|"); got != "devboxctl|new|{{name}}|--size|{{config.size}}" {
+		t.Fatalf("acquire argv=%q", got)
+	}
+	if cfg.External.Lifecycle.List.Output != "json-name-array" {
+		t.Fatalf("list=%#v", cfg.External.Lifecycle.List)
+	}
+	if cfg.External.Connection.SSH.User != "{{env.DEVBOX_USER}}" || !cfg.External.Connection.SSH.SSHConfigProxy {
+		t.Fatalf("connection=%#v", cfg.External.Connection)
+	}
+	if cfg.External.Config["size"] != "cpu16" || cfg.External.WorkRoot != "/home/developer/crabbox" {
+		t.Fatalf("external=%#v", cfg.External)
+	}
+}

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -64,7 +64,7 @@ func (a App) desktopLaunchWithCommand(ctx context.Context, args []string, comman
 		return err
 	}
 	if *webvnc && (isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider)) {
-		return exit(2, "desktop launch --webvnc currently supports coordinator-backed hetzner/aws/azure desktop leases")
+		return exit(2, "desktop launch --webvnc is unavailable for provider=%s", cfg.Provider)
 	}
 	if *id == "" && !isStaticProvider(cfg.Provider) {
 		return exit(2, "usage: crabbox desktop launch --id <lease-id-or-slug> [--browser] [--url <url>] -- <command...>")

--- a/internal/cli/external_routing.go
+++ b/internal/cli/external_routing.go
@@ -11,10 +11,12 @@ import (
 )
 
 type externalRoutingState struct {
-	Command  string         `json:"command"`
-	Args     []string       `json:"args,omitempty"`
-	Config   map[string]any `json:"config,omitempty"`
-	WorkRoot string         `json:"workRoot,omitempty"`
+	Command    string                   `json:"command,omitempty"`
+	Args       []string                 `json:"args,omitempty"`
+	Config     map[string]any           `json:"config,omitempty"`
+	Lifecycle  ExternalLifecycleConfig  `json:"lifecycle,omitempty"`
+	Connection ExternalConnectionConfig `json:"connection,omitempty"`
+	WorkRoot   string                   `json:"workRoot,omitempty"`
 }
 
 func ExternalRoutingPath(leaseID string) (string, error) {
@@ -37,10 +39,12 @@ func PersistExternalRouting(leaseID string, cfg ExternalConfig) (string, error) 
 		return "", err
 	}
 	data, err := json.MarshalIndent(externalRoutingState{
-		Command:  cfg.Command,
-		Args:     append([]string(nil), cfg.Args...),
-		Config:   cfg.Config,
-		WorkRoot: cfg.WorkRoot,
+		Command:    cfg.Command,
+		Args:       append([]string(nil), cfg.Args...),
+		Config:     cfg.Config,
+		Lifecycle:  cfg.Lifecycle,
+		Connection: cfg.Connection,
+		WorkRoot:   cfg.WorkRoot,
 	}, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("encode external routing: %w", err)
@@ -93,6 +97,8 @@ func LoadExternalRouting(path string) (ExternalConfig, error) {
 		Command:     state.Command,
 		Args:        append([]string(nil), state.Args...),
 		Config:      state.Config,
+		Lifecycle:   state.Lifecycle,
+		Connection:  state.Connection,
 		WorkRoot:    state.WorkRoot,
 		RoutingFile: path,
 	}, nil

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -38,6 +38,43 @@ func TestExternalRoutingRoundTripUsesPrivateHashedPath(t *testing.T) {
 	}
 }
 
+func TestDeclarativeExternalRoutingRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := ExternalConfig{
+		Config: map[string]any{"size": "cpu16"},
+		Lifecycle: ExternalLifecycleConfig{
+			Acquire: ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: "json-name-array",
+			},
+			Release: ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: ExternalConnectionConfig{
+			SSH: ExternalSSHConnectionConfig{
+				User:           "{{env.DEVBOX_USER}}",
+				Host:           "{{name}}",
+				SSHConfigProxy: true,
+			},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	path, err := PersistExternalRouting("cbx_abcdef123456", cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadExternalRouting(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Lifecycle.Acquire.Argv; len(got) != 3 || got[0] != "devboxctl" || got[2] != "{{name}}" {
+		t.Fatalf("acquire=%#v", got)
+	}
+	if loaded.Connection.SSH.User != "{{env.DEVBOX_USER}}" || !loaded.Connection.SSH.SSHConfigProxy {
+		t.Fatalf("connection=%#v", loaded.Connection)
+	}
+}
+
 func TestLoadExternalRoutingRejectsBroadPermissions(t *testing.T) {
 	path := t.TempDir() + "/routing.json"
 	if err := os.WriteFile(path, []byte(`{"command":"provider"}`), 0o644); err != nil {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -34,6 +34,10 @@ type ProviderRoutingFlagProvider interface {
 	RoutingFlagNames() []string
 }
 
+type ProviderCommandRoutingArgs interface {
+	CommandRoutingArgs(cfg Config, leaseID string) []string
+}
+
 type ProviderServerTypeProvider interface {
 	ServerTypeForConfig(cfg Config) string
 	ServerTypeForClass(class string) string
@@ -615,6 +619,18 @@ func validateProviderConfig(cfg Config) error {
 		return validator.ValidateConfig(cfg)
 	}
 	return nil
+}
+
+func providerCommandRoutingArgs(cfg Config, leaseID string) []string {
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return nil
+	}
+	router, ok := provider.(ProviderCommandRoutingArgs)
+	if !ok {
+		return nil
+	}
+	return router.CommandRoutingArgs(cfg, leaseID)
 }
 
 func routeProviderFlagOverride(cfg *Config, fs *flag.FlagSet, values providerFlagValues) (bool, error) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -847,7 +847,7 @@ exit 0
 		"--no-sync",
 		"--require-artifact", "reports/data/manifest.json",
 		"--artifact-glob", "reports/data/*.txt",
-		"--", "bash", "-lc", "mkdir -p reports/data && printf '{}\n' > reports/data/manifest.json && printf 'ok\n' > reports/data/quality.txt && printf 'data run complete\n'",
+		"--", "sh", "-c", "mkdir -p reports/data && printf '{}\n' > reports/data/manifest.json && printf 'ok\n' > reports/data/quality.txt && printf 'data run complete\n'",
 	})
 	if err != nil {
 		t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -18,6 +18,7 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	openClient := fs.Bool("open", false, "open the VNC client locally")
 	hostManaged := fs.Bool("host-managed", false, "allow opening host-managed static VNC")
+	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -26,6 +27,9 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	setIDFromFirstArg(fs, id)
 	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
+		return err
+	}
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
 	if isBlacksmithProvider(cfg.Provider) {
@@ -168,7 +172,6 @@ func startVNCTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost
 
 func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) []string {
 	args := []string{
-		"-o", "IdentitiesOnly=yes",
 		"-o", "BatchMode=yes",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "UserKnownHostsFile=" + sshConfigFileValue(knownHostsFile(target)),
@@ -180,7 +183,7 @@ func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) [
 		"-p", target.Port,
 	}
 	if target.Key != "" {
-		args = append([]string{"-i", target.Key}, args...)
+		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
 	}
 	if target.ProxyCommand != "" {
 		args = append(args, "-o", "ProxyCommand="+target.ProxyCommand)

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -15,6 +15,9 @@ func TestVNCTunnelCommandQuotesKeyPath(t *testing.T) {
 	if !strings.Contains(got, "'-i' '/tmp/Application Support/crabbox/id_ed25519'") {
 		t.Fatalf("tunnel key path should be shell-quoted: %q", got)
 	}
+	if !strings.Contains(got, "IdentitiesOnly=yes") {
+		t.Fatalf("key-backed tunnel should restrict SSH identities: %q", got)
+	}
 	if !strings.Contains(got, "'-L' '5907:127.0.0.1:5900'") {
 		t.Fatalf("tunnel should forward VNC loopback: %q", got)
 	}
@@ -29,6 +32,9 @@ func TestVNCTunnelCommandForwardsProxyCommand(t *testing.T) {
 	}, "5907")
 	if strings.Contains(got, "'-i' ''") {
 		t.Fatalf("empty key must not emit -i: %q", got)
+	}
+	if strings.Contains(got, "IdentitiesOnly=yes") {
+		t.Fatalf("SSH-config-backed tunnel must allow agent identities: %q", got)
 	}
 	if !strings.Contains(got, "ProxyCommand=ssh -W 10.211.55.3:%p mac-host") {
 		t.Fatalf("tunnel should preserve proxy command: %q", got)

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -63,6 +63,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	background := fs.Bool("background", false, "compatibility alias for daemon start")
 	daemonStatus := fs.Bool("status", false, "compatibility alias for daemon status")
 	stopDaemon := fs.Bool("stop", false, "compatibility alias for daemon stop")
+	providerFlags := registerProviderFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -85,8 +86,11 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if isLocalContainerProvider(cfg.Provider) {
-		return a.localContainerWebVNC(ctx, cfg, *id, *localPort, *openPortal, *takeControl, *reclaim)
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
+		return err
+	}
+	if supportsDirectSSHWebVNC(cfg.Provider) {
+		return a.directSSHWebVNC(ctx, cfg, *id, *localPort, *openPortal, *takeControl, *reclaim)
 	}
 	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
 		return exit(2, "webvnc currently supports coordinator-backed hetzner/aws/azure desktop leases")
@@ -328,6 +332,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
 	takeControl := fs.Bool("take-control", false, "ask the portal viewer to take keyboard and mouse control after connecting")
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
+	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -341,9 +346,31 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
+		return err
+	}
 	target := SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}
 	bridgeID := *id
-	if !isBlacksmithProvider(cfg.Provider) && !isStaticProvider(cfg.Provider) {
+	if supportsDirectSSHWebVNC(cfg.Provider) {
+		server, resolvedTarget, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false)
+		if err != nil {
+			return err
+		}
+		if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
+			return err
+		}
+		if server.Provider != "" {
+			cfg.Provider = server.Provider
+		}
+		if resolvedTarget.TargetOS != "" {
+			cfg.TargetOS = resolvedTarget.TargetOS
+		}
+		if resolvedTarget.WindowsMode != "" {
+			cfg.WindowsMode = resolvedTarget.WindowsMode
+		}
+		target = resolvedTarget
+		bridgeID = leaseID
+	} else if !isBlacksmithProvider(cfg.Provider) && !isStaticProvider(cfg.Provider) {
 		coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 		if err != nil {
 			return err
@@ -452,6 +479,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, or azure")
 	id := fs.String("id", "", "lease id or slug")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
+	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -465,8 +493,11 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if isLocalContainerProvider(cfg.Provider) {
-		return a.localContainerWebVNCStatus(ctx, cfg, *id, *localPort)
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
+		return err
+	}
+	if supportsDirectSSHWebVNC(cfg.Provider) {
+		return a.directSSHWebVNCStatus(ctx, cfg, *id, *localPort)
 	}
 	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
 		return exit(2, "webvnc status currently supports coordinator-backed hetzner/aws/azure desktop leases")
@@ -567,6 +598,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	id := fs.String("id", "", "lease id or slug")
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
 	takeControl := fs.Bool("take-control", false, "ask the portal viewer to take keyboard and mouse control after connecting")
+	providerFlags := registerProviderFlags(fs, defaults)
 	targetFlags := registerTargetFlags(fs, defaults)
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
@@ -580,8 +612,11 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if isLocalContainerProvider(cfg.Provider) {
-		return a.localContainerWebVNCReset(ctx, cfg, *id, *openPortal, *takeControl)
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
+		return err
+	}
+	if supportsDirectSSHWebVNC(cfg.Provider) {
+		return a.directSSHWebVNCReset(ctx, cfg, *id, *openPortal, *takeControl)
 	}
 	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
 		return exit(2, "webvnc reset currently supports coordinator-backed hetzner/aws/azure desktop leases")
@@ -908,6 +943,7 @@ func nativeVNCOpenCommand(cfg Config, target SSHTarget, leaseID string) string {
 	if targetOS == targetWindows && windowsMode != "" {
 		args = append(args, "--windows-mode", windowsMode)
 	}
+	args = append(args, providerCommandRoutingArgs(cfg, leaseID)...)
 	args = append(args, "--id", leaseID, "--open")
 	return strings.Join(readableShellWords(args), " ")
 }
@@ -978,6 +1014,7 @@ func webVNCBridgeArgs(cfg Config, target SSHTarget, leaseID string, openPortal, 
 	if targetOS == targetWindows && windowsMode != "" {
 		args = append(args, "--windows-mode", windowsMode)
 	}
+	args = append(args, providerCommandRoutingArgs(cfg, leaseID)...)
 	args = append(args, "--id", leaseID)
 	if openPortal {
 		args = append(args, "--open")
@@ -1180,7 +1217,18 @@ func isLocalContainerProvider(provider string) bool {
 	return err == nil && p.Name() == "local-container"
 }
 
-func (a App) localContainerWebVNC(ctx context.Context, cfg Config, id, localPort string, openViewer, _ bool, reclaim bool) error {
+func supportsDirectSSHWebVNC(provider string) bool {
+	p, err := ProviderFor(provider)
+	if err != nil || isBlacksmithProvider(provider) || isStaticProvider(provider) {
+		return false
+	}
+	spec := p.Spec()
+	return spec.Kind == ProviderKindSSHLease &&
+		spec.Coordinator == CoordinatorNever &&
+		spec.Features.Has(FeatureDesktop)
+}
+
+func (a App) directSSHWebVNC(ctx context.Context, cfg Config, id, localPort string, openViewer, _ bool, reclaim bool) error {
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, id, false)
 	if err != nil {
 		return err
@@ -1194,10 +1242,10 @@ func (a App) localContainerWebVNC(ctx context.Context, cfg Config, id, localPort
 	if _, err := resolveVNCEndpoint(ctx, cfg, &target); err != nil {
 		return err
 	}
-	if out, err := runSSHCombinedOutput(ctx, target, localContainerNoVNCRemoteCommand()); err != nil {
+	if out, err := runSSHCombinedOutput(ctx, target, directSSHNoVNCRemoteCommand()); err != nil {
 		rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueCtx))
-		return exit(5, "start local WebVNC bridge: %v", err)
+		return exit(5, "start direct SSH WebVNC bridge: %v", err)
 	}
 	if localPort == "" {
 		localPort = availableLocalVNCPort()
@@ -1210,7 +1258,7 @@ func (a App) localContainerWebVNC(ctx context.Context, cfg Config, id, localPort
 	}
 	defer stopProcess(tunnel)
 	password, _ := runSSHOutput(ctx, target, vncPasswordCommand(target))
-	viewerURL := localContainerWebVNCURL(localPort, strings.TrimSpace(password))
+	viewerURL := directSSHWebVNCURL(localPort, strings.TrimSpace(password))
 	fmt.Fprintln(a.Stdout, "bridge: connected; keep this process running while using WebVNC")
 	fmt.Fprintf(a.Stdout, "webvnc: %s\n", viewerURL)
 	if strings.TrimSpace(password) != "" {
@@ -1226,7 +1274,7 @@ func (a App) localContainerWebVNC(ctx context.Context, cfg Config, id, localPort
 	return context.Cause(ctx)
 }
 
-func (a App) localContainerWebVNCStatus(ctx context.Context, cfg Config, id, localPort string) error {
+func (a App) directSSHWebVNCStatus(ctx context.Context, cfg Config, id, localPort string) error {
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, id, false)
 	if err != nil {
 		return err
@@ -1253,9 +1301,9 @@ func (a App) localContainerWebVNCStatus(ctx context.Context, cfg Config, id, loc
 	} else {
 		fmt.Fprintf(a.Stdout, "vnc target: reachable %s:%s managed=%t\n", endpoint.Host, endpoint.Port, endpoint.Managed)
 	}
-	fmt.Fprintf(a.Stdout, "local webvnc: %s\n", blank(websockify, "unknown"))
+	fmt.Fprintf(a.Stdout, "direct ssh webvnc: %s\n", blank(websockify, "unknown"))
 	fmt.Fprintf(a.Stdout, "ssh tunnel: %s\n", vncTunnelCommandTo(target, localPort, "127.0.0.1", "6080"))
-	fmt.Fprintf(a.Stdout, "webvnc: %s\n", localContainerWebVNCURL(localPort, strings.TrimSpace(password)))
+	fmt.Fprintf(a.Stdout, "webvnc: %s\n", directSSHWebVNCURL(localPort, strings.TrimSpace(password)))
 	if strings.TrimSpace(password) != "" {
 		fmt.Fprintf(a.Stdout, "password: %s\n", strings.TrimSpace(password))
 	}
@@ -1263,7 +1311,7 @@ func (a App) localContainerWebVNCStatus(ctx context.Context, cfg Config, id, loc
 	return nil
 }
 
-func (a App) localContainerWebVNCReset(ctx context.Context, cfg Config, id string, openViewer, takeControl bool) error {
+func (a App) directSSHWebVNCReset(ctx context.Context, cfg Config, id string, openViewer, takeControl bool) error {
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, id, false)
 	if err != nil {
 		return err
@@ -1271,20 +1319,20 @@ func (a App) localContainerWebVNCReset(ctx context.Context, cfg Config, id strin
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	if out, err := runSSHCombinedOutput(ctx, target, localContainerWebVNCResetRemoteCommand()); err != nil {
+	if out, err := runSSHCombinedOutput(ctx, target, directSSHWebVNCResetRemoteCommand()); err != nil {
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}))
-		return exit(5, "reset local WebVNC/input stack: %v", err)
+		return exit(5, "reset direct SSH WebVNC/input stack: %v", err)
 	}
 	fmt.Fprintf(a.Stdout, "webvnc reset: lease=%s slug=%s\n", leaseID, blank(serverSlug(server), "-"))
 	if openViewer {
-		return a.localContainerWebVNC(ctx, cfg, leaseID, "", true, takeControl, false)
+		return a.directSSHWebVNC(ctx, cfg, leaseID, "", true, takeControl, false)
 	}
 	command := append([]string{"crabbox", "webvnc"}, webVNCBridgeArgs(cfg, target, leaseID, false, false)...)
 	fmt.Fprintf(a.Stdout, "webvnc: run %s\n", readableShellCommand(command))
 	return nil
 }
 
-func localContainerWebVNCURL(localPort, password string) string {
+func directSSHWebVNCURL(localPort, password string) string {
 	values := url.Values{}
 	values.Set("host", "127.0.0.1")
 	values.Set("port", localPort)
@@ -1303,7 +1351,7 @@ func vncTunnelCommandTo(target SSHTarget, localPort, remoteHost, remotePort stri
 	return strings.Join(shellWords(append([]string{"ssh"}, vncTunnelArgs(target, localPort, remoteHost, remotePort)...)), " ")
 }
 
-func localContainerNoVNCRemoteCommand() string {
+func directSSHNoVNCRemoteCommand() string {
 	return `set -eu
 if ! command -v websockify >/dev/null 2>&1; then
   echo "missing websockify; warm a new --desktop lease or install novnc websockify" >&2
@@ -1333,13 +1381,13 @@ cat /tmp/crabbox-websockify.log >&2 || true
 exit 1`
 }
 
-func localContainerWebVNCResetRemoteCommand() string {
+func directSSHWebVNCResetRemoteCommand() string {
 	return `set -eu
 pkill -f 'websockify.*127.0.0.1:6080' >/dev/null 2>&1 || true
 if [ -x /usr/local/bin/crabbox-start-desktop ]; then
   sudo CRABBOX_SSH_USER="$(id -un)" /usr/local/bin/crabbox-start-desktop
 fi
-` + localContainerNoVNCRemoteCommand()
+` + directSSHNoVNCRemoteCommand()
 }
 
 func webVNCReconnectDelay(attempt int) time.Duration {

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"io"
 	"net"
 	"net/http"
@@ -18,6 +19,10 @@ import (
 
 	"nhooyr.io/websocket"
 )
+
+func init() {
+	RegisterProvider(directWebVNCTestProvider{})
+}
 
 func TestWebVNCURLs(t *testing.T) {
 	if got := webVNCAgentURL("https://broker.example.com", "cbx_abcdef123456"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent" {
@@ -65,12 +70,58 @@ func TestWebVNCURLs(t *testing.T) {
 	if values.Get("password") != "JVS/yMb%2B" {
 		t.Fatalf("decoded portal password=%q", values.Get("password"))
 	}
-	if got := localContainerWebVNCURL("5901", "p+a ss"); got != "http://127.0.0.1:5901/vnc.html?autoconnect=1&compression=0&host=127.0.0.1&password=p%2Ba+ss&path=websockify&port=5901&quality=6&resize=scale" {
+	if got := directSSHWebVNCURL("5901", "p+a ss"); got != "http://127.0.0.1:5901/vnc.html?autoconnect=1&compression=0&host=127.0.0.1&password=p%2Ba+ss&path=websockify&port=5901&quality=6&resize=scale" {
 		t.Fatalf("local container WebVNC URL=%q", got)
 	}
 	if !isLocalContainerProvider("docker") || !isLocalContainerProvider("local-container") {
 		t.Fatal("local-container aliases should use local WebVNC")
 	}
+	for _, provider := range []string{"local-container", "direct-webvnc-test"} {
+		if !supportsDirectSSHWebVNC(provider) {
+			t.Fatalf("provider %s should support direct SSH WebVNC", provider)
+		}
+	}
+	if supportsDirectSSHWebVNC("static") || supportsDirectSSHWebVNC("aws") {
+		t.Fatal("static and coordinator-backed providers should not use direct SSH WebVNC")
+	}
+}
+
+func TestWebVNCBridgeArgsPreserveProviderRouting(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	args := webVNCBridgeArgs(
+		Config{Provider: "direct-webvnc-test", TargetOS: targetLinux},
+		SSHTarget{TargetOS: targetLinux},
+		"cbx_abcdef123456",
+		false,
+		false,
+	)
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "--direct-webvnc-routing route-cbx_abcdef123456") {
+		t.Fatalf("args=%#v", args)
+	}
+}
+
+type directWebVNCTestProvider struct{}
+
+func (directWebVNCTestProvider) Name() string      { return "direct-webvnc-test" }
+func (directWebVNCTestProvider) Aliases() []string { return nil }
+func (directWebVNCTestProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "direct-webvnc-test",
+		Kind:        ProviderKindSSHLease,
+		Features:    FeatureSet{FeatureSSH, FeatureDesktop},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (directWebVNCTestProvider) RegisterFlags(fs *flag.FlagSet, _ Config) any {
+	return fs.String("direct-webvnc-routing", "", "test routing value")
+}
+func (directWebVNCTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (directWebVNCTestProvider) Configure(Config, Runtime) (Backend, error) { return nil, nil }
+func (directWebVNCTestProvider) CommandRoutingArgs(_ Config, leaseID string) []string {
+	return []string{"--direct-webvnc-routing", "route-" + leaseID}
 }
 
 func TestWebVNCResetRemoteCommandHandlesWaylandAndX11(t *testing.T) {

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -300,21 +300,24 @@ func (b *leaseBackend) claimScope() string {
 }
 
 type externalClaimScopeData struct {
-	Command    string                        `json:"command,omitempty"`
-	Args       []string                      `json:"args,omitempty"`
-	Config     map[string]any                `json:"config,omitempty"`
-	Lifecycle  core.ExternalLifecycleConfig  `json:"lifecycle,omitempty"`
-	Connection core.ExternalConnectionConfig `json:"connection,omitempty"`
+	Command    string                         `json:"command,omitempty"`
+	Args       []string                       `json:"args,omitempty"`
+	Config     map[string]any                 `json:"config,omitempty"`
+	Lifecycle  *core.ExternalLifecycleConfig  `json:"lifecycle,omitempty"`
+	Connection *core.ExternalConnectionConfig `json:"connection,omitempty"`
 }
 
 func externalClaimScope(cfg core.Config) string {
-	data, err := json.Marshal(externalClaimScopeData{
-		Command:    strings.TrimSpace(cfg.External.Command),
-		Args:       append([]string(nil), cfg.External.Args...),
-		Config:     cfg.External.Config,
-		Lifecycle:  cfg.External.Lifecycle,
-		Connection: cfg.External.Connection,
-	})
+	scope := externalClaimScopeData{
+		Command: strings.TrimSpace(cfg.External.Command),
+		Args:    append([]string(nil), cfg.External.Args...),
+		Config:  cfg.External.Config,
+	}
+	if lifecycleConfigured(cfg.External) {
+		scope.Lifecycle = &cfg.External.Lifecycle
+		scope.Connection = &cfg.External.Connection
+	}
+	data, err := json.Marshal(scope)
 	if err != nil {
 		data = []byte(strings.TrimSpace(cfg.External.Command) + "\x00" + strings.Join(cfg.External.Args, "\x00"))
 	}

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -256,6 +256,13 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) err
 }
 
 func (b *leaseBackend) invoke(ctx context.Context, request protocolRequest) (protocolResponse, error) {
+	if lifecycleConfigured(b.cfg.External) {
+		return b.invokeLifecycle(ctx, request)
+	}
+	return b.invokeProtocol(ctx, request)
+}
+
+func (b *leaseBackend) invokeProtocol(ctx context.Context, request protocolRequest) (protocolResponse, error) {
 	request.ProtocolVersion = protocolVersion
 	request.Config = b.cfg.External.Config
 	var stdin bytes.Buffer
@@ -293,22 +300,30 @@ func (b *leaseBackend) claimScope() string {
 }
 
 type externalClaimScopeData struct {
-	Command string         `json:"command"`
-	Args    []string       `json:"args,omitempty"`
-	Config  map[string]any `json:"config,omitempty"`
+	Command    string                        `json:"command,omitempty"`
+	Args       []string                      `json:"args,omitempty"`
+	Config     map[string]any                `json:"config,omitempty"`
+	Lifecycle  core.ExternalLifecycleConfig  `json:"lifecycle,omitempty"`
+	Connection core.ExternalConnectionConfig `json:"connection,omitempty"`
 }
 
 func externalClaimScope(cfg core.Config) string {
 	data, err := json.Marshal(externalClaimScopeData{
-		Command: strings.TrimSpace(cfg.External.Command),
-		Args:    append([]string(nil), cfg.External.Args...),
-		Config:  cfg.External.Config,
+		Command:    strings.TrimSpace(cfg.External.Command),
+		Args:       append([]string(nil), cfg.External.Args...),
+		Config:     cfg.External.Config,
+		Lifecycle:  cfg.External.Lifecycle,
+		Connection: cfg.External.Connection,
 	})
 	if err != nil {
 		data = []byte(strings.TrimSpace(cfg.External.Command) + "\x00" + strings.Join(cfg.External.Args, "\x00"))
 	}
 	sum := sha256.Sum256(data)
 	return "sha256:" + fmt.Sprintf("%x", sum[:12])
+}
+
+func lifecycleConfigured(cfg core.ExternalConfig) bool {
+	return len(cfg.Lifecycle.Acquire.Argv) > 0
 }
 
 func (b *leaseBackend) claimLeaseForRepo(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool) error {

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -86,15 +86,44 @@ func (f *stringListFlag) Set(value string) error {
 }
 
 func validateConfig(cfg core.Config) error {
-	if strings.TrimSpace(cfg.External.Command) == "" {
-		return core.Exit(2, "external.command is required")
+	hasCommand := strings.TrimSpace(cfg.External.Command) != ""
+	hasLifecycle := lifecycleConfigured(cfg.External)
+	if hasCommand == hasLifecycle {
+		return core.Exit(2, "configure exactly one of external.command or external.lifecycle.acquire")
 	}
-	if strings.ContainsRune(cfg.External.Command, '\x00') {
+	if hasCommand && strings.ContainsRune(cfg.External.Command, '\x00') {
 		return core.Exit(2, "external.command contains a NUL byte")
 	}
 	for _, arg := range cfg.External.Args {
 		if strings.ContainsRune(arg, '\x00') {
 			return core.Exit(2, "external.args contains a NUL byte")
+		}
+	}
+	if hasLifecycle {
+		if len(cfg.External.Lifecycle.Release.Argv) == 0 {
+			return core.Exit(2, "external.lifecycle.release.argv is required")
+		}
+		if len(cfg.External.Lifecycle.List.Argv) == 0 {
+			return core.Exit(2, "external.lifecycle.list.argv is required")
+		}
+		for name, operation := range map[string]core.ExternalLifecycleOperation{
+			"doctor":  cfg.External.Lifecycle.Doctor,
+			"acquire": cfg.External.Lifecycle.Acquire,
+			"resolve": cfg.External.Lifecycle.Resolve,
+			"list":    cfg.External.Lifecycle.List,
+			"release": cfg.External.Lifecycle.Release,
+			"touch":   cfg.External.Lifecycle.Touch,
+			"cleanup": cfg.External.Lifecycle.Cleanup,
+		} {
+			if err := validateLifecycleOperation(name, operation); err != nil {
+				return err
+			}
+		}
+		if strings.TrimSpace(cfg.External.Connection.SSH.User) == "" {
+			return core.Exit(2, "external.connection.ssh.user is required")
+		}
+		if cfg.External.Lifecycle.List.Output != lifecycleOutputJSONNameArray && cfg.External.Lifecycle.List.Output != lifecycleOutputJSONLeaseArray {
+			return core.Exit(2, "external.lifecycle.list.output must be %q or %q", lifecycleOutputJSONNameArray, lifecycleOutputJSONLeaseArray)
 		}
 	}
 	clean := path.Clean(externalWorkRoot(cfg))
@@ -104,6 +133,26 @@ func validateConfig(cfg core.Config) error {
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
 		return core.Exit(2, "external.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return nil
+}
+
+func validateLifecycleOperation(name string, operation core.ExternalLifecycleOperation) error {
+	if name != "list" && operation.Output != lifecycleOutputNone {
+		return core.Exit(2, "external.lifecycle.%s.output is only supported for list", name)
+	}
+	switch operation.Output {
+	case lifecycleOutputNone, lifecycleOutputJSONNameArray, lifecycleOutputJSONLeaseArray:
+	default:
+		return core.Exit(2, "external.lifecycle.%s.output %q is unsupported", name, operation.Output)
+	}
+	for index, arg := range operation.Argv {
+		if strings.ContainsRune(arg, '\x00') {
+			return core.Exit(2, "external.lifecycle.%s.argv[%d] contains a NUL byte", name, index)
+		}
+	}
+	if len(operation.Argv) > 0 && strings.TrimSpace(operation.Argv[0]) == "" {
+		return core.Exit(2, "external.lifecycle.%s.argv executable is empty", name)
 	}
 	return nil
 }

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -1,0 +1,391 @@
+package external
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	lifecycleOutputNone           = ""
+	lifecycleOutputJSONNameArray  = "json-name-array"
+	lifecycleOutputJSONLeaseArray = "json-lease-array"
+)
+
+var lifecyclePlaceholderPattern = regexp.MustCompile(`\{\{([A-Za-z_][A-Za-z0-9_.-]*)\}\}`)
+var lifecycleEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type lifecycleTemplateContext struct {
+	values map[string]string
+}
+
+func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequest) (protocolResponse, error) {
+	operation := lifecycleOperation(b.cfg.External.Lifecycle, request.Operation)
+	if len(operation.Argv) == 0 {
+		return b.defaultLifecycleResponse(request)
+	}
+	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
+	if err != nil {
+		return protocolResponse{}, err
+	}
+	argv, err := expandLifecycleArgv(operation.Argv, templateCtx)
+	if err != nil {
+		return protocolResponse{}, core.Exit(2, "external lifecycle %s: %v", request.Operation, err)
+	}
+	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
+		Name:   argv[0],
+		Args:   argv[1:],
+		Stderr: b.rt.Stderr,
+	})
+	if err != nil {
+		message := strings.TrimSpace(result.Stderr)
+		if message == "" {
+			message = strings.TrimSpace(result.Stdout)
+		}
+		return protocolResponse{}, core.Exit(result.ExitCode, "external lifecycle %s failed: %v: %s", request.Operation, err, message)
+	}
+	if operation.Output == lifecycleOutputNone && strings.TrimSpace(result.Stdout) != "" && b.rt.Stderr != nil {
+		_, _ = io.WriteString(b.rt.Stderr, result.Stdout)
+		if !strings.HasSuffix(result.Stdout, "\n") {
+			_, _ = io.WriteString(b.rt.Stderr, "\n")
+		}
+	}
+	switch operation.Output {
+	case lifecycleOutputNone:
+		return b.defaultLifecycleResponse(request)
+	case lifecycleOutputJSONNameArray:
+		var names []string
+		if err := json.Unmarshal([]byte(result.Stdout), &names); err != nil {
+			return protocolResponse{}, core.Exit(5, "external lifecycle %s returned invalid JSON name array: %v", request.Operation, err)
+		}
+		leases := make([]protocolLease, 0, len(names))
+		for _, name := range names {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			lease, err := b.lifecycleLeaseForName(name)
+			if err != nil {
+				return protocolResponse{}, err
+			}
+			leases = append(leases, lease)
+		}
+		return protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}, nil
+	case lifecycleOutputJSONLeaseArray:
+		var leases []protocolLease
+		if err := json.Unmarshal([]byte(result.Stdout), &leases); err != nil {
+			return protocolResponse{}, core.Exit(5, "external lifecycle %s returned invalid JSON lease array: %v", request.Operation, err)
+		}
+		return protocolResponse{ProtocolVersion: protocolVersion, Leases: leases}, nil
+	default:
+		return protocolResponse{}, core.Exit(2, "external lifecycle %s has unsupported output %q", request.Operation, operation.Output)
+	}
+}
+
+func (b *leaseBackend) defaultLifecycleResponse(request protocolRequest) (protocolResponse, error) {
+	response := protocolResponse{ProtocolVersion: protocolVersion}
+	switch request.Operation {
+	case "doctor":
+		response.Message = "declarative external provider ready"
+	case "acquire", "resolve", "touch":
+		lease, err := b.lifecycleLease(request)
+		if err != nil {
+			return protocolResponse{}, err
+		}
+		response.Lease = &lease
+	case "list":
+		response.Leases = []protocolLease{}
+	case "release", "cleanup":
+	default:
+		return protocolResponse{}, core.Exit(2, "external lifecycle operation %q is unsupported", request.Operation)
+	}
+	return response, nil
+}
+
+func lifecycleOperation(cfg core.ExternalLifecycleConfig, operation string) core.ExternalLifecycleOperation {
+	switch operation {
+	case "doctor":
+		return cfg.Doctor
+	case "acquire":
+		return cfg.Acquire
+	case "resolve":
+		return cfg.Resolve
+	case "list":
+		return cfg.List
+	case "release":
+		return cfg.Release
+	case "touch":
+		return cfg.Touch
+	case "cleanup":
+		return cfg.Cleanup
+	default:
+		return core.ExternalLifecycleOperation{}
+	}
+}
+
+func (b *leaseBackend) lifecycleLease(request protocolRequest) (protocolLease, error) {
+	desired := request.Desired
+	if desired == nil && request.Lease != nil {
+		desired = &desiredLease{
+			LeaseID: request.Lease.LeaseID,
+			Slug:    request.Lease.Slug,
+			Name:    request.Lease.Name,
+		}
+	}
+	if desired == nil {
+		name := strings.TrimSpace(request.ID)
+		desired = &desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
+	}
+	return b.lifecycleLeaseForDesired(*desired)
+}
+
+func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error) {
+	desired := desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return protocolLease{}, err
+	}
+	for _, claim := range claims {
+		if !externalClaimMatchesScope(claim, b.claimScope()) {
+			continue
+		}
+		if strings.TrimSpace(claim.Labels["name"]) == name {
+			desired.LeaseID = claim.LeaseID
+			desired.Slug = claim.Slug
+			break
+		}
+	}
+	return b.lifecycleLeaseForDesired(desired)
+}
+
+func (b *leaseBackend) lifecycleLeaseForDesired(desired desiredLease) (protocolLease, error) {
+	request := protocolRequest{Desired: &desired}
+	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
+	if err != nil {
+		return protocolLease{}, err
+	}
+	connection := b.cfg.External.Connection
+	cloudID, err := expandLifecycleValue(core.Blank(connection.CloudID, "{{name}}"), templateCtx)
+	if err != nil {
+		return protocolLease{}, core.Exit(2, "external connection cloudId: %v", err)
+	}
+	serverType, err := expandLifecycleValue(core.Blank(connection.ServerType, "external"), templateCtx)
+	if err != nil {
+		return protocolLease{}, core.Exit(2, "external connection serverType: %v", err)
+	}
+	labels := make(map[string]string, len(connection.Labels))
+	for key, value := range connection.Labels {
+		expanded, err := expandLifecycleValue(value, templateCtx)
+		if err != nil {
+			return protocolLease{}, core.Exit(2, "external connection label %s: %v", key, err)
+		}
+		labels[key] = expanded
+	}
+	ssh, err := lifecycleSSH(connection.SSH, templateCtx)
+	if err != nil {
+		return protocolLease{}, err
+	}
+	return protocolLease{
+		LeaseID:    desired.LeaseID,
+		Slug:       desired.Slug,
+		Name:       desired.Name,
+		CloudID:    cloudID,
+		Status:     "ready",
+		ServerType: serverType,
+		Labels:     labels,
+		SSH:        &ssh,
+	}, nil
+}
+
+func lifecycleSSH(cfg core.ExternalSSHConnectionConfig, templateCtx lifecycleTemplateContext) (protocolSSH, error) {
+	expand := func(label, value string) (string, error) {
+		expanded, err := expandLifecycleValue(value, templateCtx)
+		if err != nil {
+			return "", core.Exit(2, "external connection ssh.%s: %v", label, err)
+		}
+		return expanded, nil
+	}
+	user, err := expand("user", cfg.User)
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	host, err := expand("host", core.Blank(cfg.Host, "{{name}}"))
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	key, err := expand("key", cfg.Key)
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	port, err := expand("port", core.Blank(cfg.Port, "22"))
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	readyCheck, err := expand("readyCheck", core.Blank(cfg.ReadyCheck, externalDefaultReadyCheck))
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	proxyCommand, err := expand("proxyCommand", cfg.ProxyCommand)
+	if err != nil {
+		return protocolSSH{}, err
+	}
+	fallbackPorts := make([]string, 0, len(cfg.FallbackPorts))
+	for _, fallback := range cfg.FallbackPorts {
+		expanded, err := expand("fallbackPorts", fallback)
+		if err != nil {
+			return protocolSSH{}, err
+		}
+		fallbackPorts = append(fallbackPorts, expanded)
+	}
+	return protocolSSH{
+		User:            user,
+		Host:            host,
+		Key:             key,
+		Port:            port,
+		FallbackPorts:   fallbackPorts,
+		ReadyCheck:      readyCheck,
+		AuthSecret:      cfg.AuthSecret,
+		NoControlMaster: cfg.NoControlMaster,
+		SSHConfigProxy:  cfg.SSHConfigProxy,
+		ProxyCommand:    proxyCommand,
+	}, nil
+}
+
+func lifecycleContext(request protocolRequest, config map[string]any) (lifecycleTemplateContext, error) {
+	values := map[string]string{
+		"id":          strings.TrimSpace(request.ID),
+		"state":       strings.TrimSpace(request.State),
+		"keep":        strconv.FormatBool(request.Keep),
+		"reclaim":     strconv.FormatBool(request.Reclaim),
+		"releaseOnly": strconv.FormatBool(request.ReleaseOnly),
+		"force":       strconv.FormatBool(request.Force),
+		"all":         strconv.FormatBool(request.All),
+		"refresh":     strconv.FormatBool(request.Refresh),
+		"dryRun":      strconv.FormatBool(request.DryRun),
+	}
+	if request.Desired != nil {
+		values["leaseId"] = request.Desired.LeaseID
+		values["slug"] = request.Desired.Slug
+		values["name"] = request.Desired.Name
+	}
+	if request.Lease != nil {
+		if values["leaseId"] == "" {
+			values["leaseId"] = request.Lease.LeaseID
+		}
+		if values["slug"] == "" {
+			values["slug"] = request.Lease.Slug
+		}
+		if values["name"] == "" {
+			values["name"] = request.Lease.Name
+		}
+		values["cloudId"] = request.Lease.CloudID
+	}
+	if values["id"] == "" {
+		values["id"] = values["leaseId"]
+	}
+	if values["name"] == "" {
+		values["name"] = values["id"]
+	}
+	if values["slug"] == "" {
+		values["slug"] = core.NormalizeLeaseSlug(values["name"])
+	}
+	if values["leaseId"] == "" {
+		values["leaseId"] = values["id"]
+	}
+	if request.Repo != nil {
+		values["repo.root"] = request.Repo.Root
+		values["repo.name"] = request.Repo.Name
+		values["repo.remoteUrl"] = request.Repo.RemoteURL
+		values["repo.head"] = request.Repo.Head
+		values["repo.baseRef"] = request.Repo.BaseRef
+	}
+	for key, value := range config {
+		addLifecycleConfigValues(values, "config."+key, value)
+	}
+	return lifecycleTemplateContext{values: values}, nil
+}
+
+func addLifecycleConfigValues(values map[string]string, key string, value any) {
+	switch typed := value.(type) {
+	case string:
+		values[key] = typed
+	case bool:
+		values[key] = strconv.FormatBool(typed)
+	case float64:
+		values[key] = strconv.FormatFloat(typed, 'f', -1, 64)
+	case float32:
+		values[key] = strconv.FormatFloat(float64(typed), 'f', -1, 32)
+	case int:
+		values[key] = strconv.Itoa(typed)
+	case int64:
+		values[key] = strconv.FormatInt(typed, 10)
+	case nil:
+		values[key] = ""
+	case map[string]any:
+		for nestedKey, nestedValue := range typed {
+			addLifecycleConfigValues(values, key+"."+nestedKey, nestedValue)
+		}
+	}
+}
+
+func expandLifecycleArgv(argv []string, templateCtx lifecycleTemplateContext) ([]string, error) {
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("argv is empty")
+	}
+	expanded := make([]string, len(argv))
+	for index, value := range argv {
+		item, err := expandLifecycleValue(value, templateCtx)
+		if err != nil {
+			return nil, fmt.Errorf("argv[%d]: %w", index, err)
+		}
+		if strings.ContainsRune(item, '\x00') {
+			return nil, fmt.Errorf("argv[%d] contains a NUL byte", index)
+		}
+		expanded[index] = item
+	}
+	if strings.TrimSpace(expanded[0]) == "" {
+		return nil, fmt.Errorf("argv executable is empty")
+	}
+	return expanded, nil
+}
+
+func expandLifecycleValue(value string, templateCtx lifecycleTemplateContext) (string, error) {
+	var expansionErr error
+	expanded := lifecyclePlaceholderPattern.ReplaceAllStringFunc(value, func(match string) string {
+		parts := lifecyclePlaceholderPattern.FindStringSubmatch(match)
+		key := parts[1]
+		if strings.HasPrefix(key, "env.") {
+			name := strings.TrimPrefix(key, "env.")
+			if !lifecycleEnvNamePattern.MatchString(name) {
+				expansionErr = fmt.Errorf("invalid environment placeholder %q", key)
+				return ""
+			}
+			envValue, ok := os.LookupEnv(name)
+			if !ok {
+				expansionErr = fmt.Errorf("environment variable %s is not set", name)
+				return ""
+			}
+			return envValue
+		}
+		replacement, ok := templateCtx.values[key]
+		if !ok {
+			expansionErr = fmt.Errorf("unknown placeholder %q", key)
+			return ""
+		}
+		return replacement
+	})
+	if expansionErr != nil {
+		return "", expansionErr
+	}
+	if strings.Contains(expanded, "{{") || strings.Contains(expanded, "}}") {
+		return "", fmt.Errorf("invalid placeholder syntax in %q", value)
+	}
+	return expanded, nil
+}

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -28,6 +28,9 @@ type lifecycleTemplateContext struct {
 
 func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequest) (protocolResponse, error) {
 	operation := lifecycleOperation(b.cfg.External.Lifecycle, request.Operation)
+	if request.Operation == "cleanup" && request.DryRun {
+		return b.defaultLifecycleResponse(request)
+	}
 	if len(operation.Argv) == 0 {
 		return b.defaultLifecycleResponse(request)
 	}
@@ -38,6 +41,14 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	argv, err := expandLifecycleArgv(operation.Argv, templateCtx)
 	if err != nil {
 		return protocolResponse{}, core.Exit(2, "external lifecycle %s: %v", request.Operation, err)
+	}
+	var defaultResponse *protocolResponse
+	if operation.Output == lifecycleOutputNone && lifecycleDefaultLeaseResponseOperation(request.Operation) {
+		response, err := b.defaultLifecycleResponse(request)
+		if err != nil {
+			return protocolResponse{}, err
+		}
+		defaultResponse = &response
 	}
 	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   argv[0],
@@ -59,6 +70,9 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	}
 	switch operation.Output {
 	case lifecycleOutputNone:
+		if defaultResponse != nil {
+			return *defaultResponse, nil
+		}
 		return b.defaultLifecycleResponse(request)
 	case lifecycleOutputJSONNameArray:
 		var names []string
@@ -89,17 +103,32 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	}
 }
 
+func lifecycleDefaultLeaseResponseOperation(operation string) bool {
+	switch operation {
+	case "acquire", "resolve", "touch":
+		return true
+	default:
+		return false
+	}
+}
+
 func (b *leaseBackend) defaultLifecycleResponse(request protocolRequest) (protocolResponse, error) {
 	response := protocolResponse{ProtocolVersion: protocolVersion}
 	switch request.Operation {
 	case "doctor":
 		response.Message = "declarative external provider ready"
-	case "acquire", "resolve", "touch":
+	case "acquire", "resolve":
+		if request.Operation == "resolve" && request.ReleaseOnly && len(b.cfg.External.Lifecycle.Resolve.Argv) == 0 {
+			lease := lifecycleMinimalLease(request)
+			response.Lease = &lease
+			break
+		}
 		lease, err := b.lifecycleLease(request)
 		if err != nil {
 			return protocolResponse{}, err
 		}
 		response.Lease = &lease
+	case "touch":
 	case "list":
 		response.Leases = []protocolLease{}
 	case "release", "cleanup":
@@ -107,6 +136,27 @@ func (b *leaseBackend) defaultLifecycleResponse(request protocolRequest) (protoc
 		return protocolResponse{}, core.Exit(2, "external lifecycle operation %q is unsupported", request.Operation)
 	}
 	return response, nil
+}
+
+func lifecycleMinimalLease(request protocolRequest) protocolLease {
+	desired := request.Desired
+	if desired == nil && request.Lease != nil {
+		desired = &desiredLease{
+			LeaseID: request.Lease.LeaseID,
+			Slug:    request.Lease.Slug,
+			Name:    request.Lease.Name,
+		}
+	}
+	if desired == nil {
+		name := strings.TrimSpace(request.ID)
+		desired = &desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
+	}
+	return protocolLease{
+		LeaseID: desired.LeaseID,
+		Slug:    desired.Slug,
+		Name:    desired.Name,
+		Status:  "ready",
+	}
 }
 
 func lifecycleOperation(cfg core.ExternalLifecycleConfig, operation string) core.ExternalLifecycleOperation {
@@ -143,7 +193,8 @@ func (b *leaseBackend) lifecycleLease(request protocolRequest) (protocolLease, e
 		name := strings.TrimSpace(request.ID)
 		desired = &desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
 	}
-	return b.lifecycleLeaseForDesired(*desired)
+	request.Desired = desired
+	return b.lifecycleLeaseForRequest(request)
 }
 
 func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error) {
@@ -166,10 +217,17 @@ func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error)
 }
 
 func (b *leaseBackend) lifecycleLeaseForDesired(desired desiredLease) (protocolLease, error) {
-	request := protocolRequest{Desired: &desired}
+	return b.lifecycleLeaseForRequest(protocolRequest{Desired: &desired})
+}
+
+func (b *leaseBackend) lifecycleLeaseForRequest(request protocolRequest) (protocolLease, error) {
 	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
 	if err != nil {
 		return protocolLease{}, err
+	}
+	desired := request.Desired
+	if desired == nil {
+		return protocolLease{}, core.Exit(2, "external lifecycle lease requires desired identity")
 	}
 	connection := b.cfg.External.Connection
 	cloudID, err := expandLifecycleValue(core.Blank(connection.CloudID, "{{name}}"), templateCtx)

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -43,6 +43,18 @@ func (Provider) RouteConfig(cfg *core.Config, _ *flag.FlagSet, _ any) error {
 	return nil
 }
 
+func (Provider) CommandRoutingArgs(cfg core.Config, leaseID string) []string {
+	path := strings.TrimSpace(cfg.External.RoutingFile)
+	if path == "" {
+		var err error
+		path, err = core.ExternalRoutingPath(leaseID)
+		if err != nil {
+			return nil
+		}
+	}
+	return []string{"--external-routing-file", path}
+}
+
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -74,6 +74,25 @@ func TestCommandRoutingArgsUsesPrivateLeaseState(t *testing.T) {
 	}
 }
 
+func TestProtocolClaimScopeIgnoresZeroLifecycleConnection(t *testing.T) {
+	cfg := testConfig()
+	before := externalClaimScope(cfg)
+	cfg.External.Connection.SSH.User = "developer"
+	if after := externalClaimScope(cfg); after != before {
+		t.Fatalf("protocol scope changed after zero lifecycle connection: before=%s after=%s", before, after)
+	}
+	cfg.External.Command = ""
+	cfg.External.Lifecycle.Acquire.Argv = []string{"devboxctl", "new", "{{name}}"}
+	cfg.External.Lifecycle.List.Argv = []string{"devboxctl", "list"}
+	cfg.External.Lifecycle.List.Output = lifecycleOutputJSONNameArray
+	cfg.External.Lifecycle.Release.Argv = []string{"devboxctl", "rm", "{{name}}"}
+	lifecycleScope := externalClaimScope(cfg)
+	cfg.External.Connection.SSH.Host = "{{name}}.example"
+	if after := externalClaimScope(cfg); after == lifecycleScope {
+		t.Fatalf("lifecycle scope did not include connection: %s", after)
+	}
+}
+
 func TestConfigurePreservesExplicitTopLevelWorkRoot(t *testing.T) {
 	cfg := testConfig()
 	cfg.WorkRoot = "/workspace/top-level"
@@ -240,6 +259,83 @@ func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
 	}
 }
 
+func TestInvokeDeclarativeLifecycleValidatesConnectionBeforeAcquire(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{
+				User: "{{env.MISSING_DEVBOX_USER}}",
+				Host: "{{name}}",
+			},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invoke(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "external connection ssh.user") || !strings.Contains(err.Error(), "MISSING_DEVBOX_USER") {
+		t.Fatalf("err=%v", err)
+	}
+	if runner.name != "" {
+		t.Fatalf("acquire command ran before connection validation: %s %#v", runner.name, runner.args)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleConnectionTemplatesUseRequestContext(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}", "--repo", "{{repo.name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{
+				User: "developer",
+				Host: "{{repo.name}}-{{name}}",
+			},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invoke(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+		Repo: &protocolRepo{Name: "my-app"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Lease == nil || response.Lease.SSH == nil || response.Lease.SSH.Host != "my-app-crabbox-fast-coral-deadbeef" {
+		t.Fatalf("response=%#v", response)
+	}
+	if strings.Join(runner.args, "|") != "new|crabbox-fast-coral-deadbeef|--repo|my-app" {
+		t.Fatalf("args=%#v", runner.args)
+	}
+}
+
 func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
 	isolateCrabboxState(t)
 	cfg := core.BaseConfig()
@@ -279,6 +375,71 @@ func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
 	}
 	if response.Leases[1].LeaseID != "unclaimed-box" || response.Leases[1].Name != "unclaimed-box" {
 		t.Fatalf("unclaimed lease=%#v", response.Leases[1])
+	}
+}
+
+func TestDeclarativeLifecycleCleanupDryRunDoesNotRunCommand(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+			Cleanup: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "gc"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.name != "" {
+		t.Fatalf("cleanup command ran during dry-run: %s %#v", runner.name, runner.args)
+	}
+}
+
+func TestDeclarativeLifecycleDefaultTouchUpdatesLocalLabels(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.IdleTimeout = time.Minute
+	cfg.TTL = time.Hour
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+		},
+	}
+	created := time.Now().UTC().Add(-10 * time.Minute)
+	labels := core.DirectLeaseLabels(cfg, "cbx_abcdef123456", "fast-coral", providerName, "", false, created)
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: &recordingRunner{}}}
+	server, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{
+			LeaseID: "cbx_abcdef123456",
+			Server:  core.Server{Name: "devbox-fast-coral", Labels: labels},
+		},
+		State:       "ready",
+		IdleTimeout: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.Labels["last_touched_at"] == labels["last_touched_at"] {
+		t.Fatalf("last_touched_at was not refreshed: %#v", server.Labels)
+	}
+	if server.Labels["state"] != "ready" || server.Labels["expires_at"] == labels["expires_at"] {
+		t.Fatalf("touch labels not refreshed: %#v", server.Labels)
 	}
 }
 
@@ -597,6 +758,41 @@ func TestResolvePreservesClaimedLifecycleLabels(t *testing.T) {
 	}
 	if lease.Server.Labels["keep"] != "false" || lease.Server.Labels["created_at"] != "100" || lease.Server.Labels["expires_at"] != "200" {
 		t.Fatalf("labels=%#v", lease.Server.Labels)
+	}
+}
+
+func TestDeclarativeReleaseOnlyResolveSkipsSSHConnectionExpansion(t *testing.T) {
+	isolateCrabboxState(t)
+	repo := t.TempDir()
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{
+				User: "{{env.MISSING_DEVBOX_USER}}",
+				Host: "{{name}}",
+			},
+		},
+	}
+	claimExternalLease(t, cfg, "cbx_000000000006", "ephemeral", repo, time.Minute, false)
+	server := core.Server{Name: "devbox-ephemeral", Labels: map[string]string{"name": "devbox-ephemeral", "slug": "ephemeral"}}
+	if err := core.UpdateLeaseClaimEndpoint("cbx_000000000006", server, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: &recordingRunner{}}}
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "ephemeral", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_000000000006" || lease.Server.Name != "devbox-ephemeral" {
+		t.Fatalf("lease=%#v", lease)
 	}
 }
 

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -66,6 +66,14 @@ func TestRouteConfigUsesProviderWorkRoot(t *testing.T) {
 	}
 }
 
+func TestCommandRoutingArgsUsesPrivateLeaseState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	args := (Provider{}).CommandRoutingArgs(testConfig(), "cbx_abcdef123456")
+	if len(args) != 2 || args[0] != "--external-routing-file" || !strings.HasSuffix(args[1], ".json") {
+		t.Fatalf("args=%#v", args)
+	}
+}
+
 func TestConfigurePreservesExplicitTopLevelWorkRoot(t *testing.T) {
 	cfg := testConfig()
 	cfg.WorkRoot = "/workspace/top-level"
@@ -174,6 +182,165 @@ func TestInvokeReportsErrorOnlyResponse(t *testing.T) {
 	backend := &leaseBackend{cfg: testConfig(), rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.invoke(context.Background(), protocolRequest{Operation: "doctor"}); err == nil || !strings.Contains(err.Error(), "quota exhausted") || strings.Contains(err.Error(), "protocol version") {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Config: map[string]any{"size": "cpu16"},
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Argv: []string{"devboxctl", "new", "{{name}}", "--size", "{{config.size}}"},
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{
+				Argv: []string{"devboxctl", "rm", "--yes", "{{name}}"},
+			},
+		},
+		Connection: core.ExternalConnectionConfig{
+			CloudID:    "devboxes/{{name}}",
+			ServerType: "{{config.size}}",
+			Labels:     map[string]string{"backend": "pod"},
+			SSH: core.ExternalSSHConnectionConfig{
+				User:           "developer",
+				Host:           "{{name}}",
+				SSHConfigProxy: true,
+			},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invoke(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "new|crabbox-fast-coral-deadbeef|--size|cpu16" {
+		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
+	}
+	if response.Lease == nil || response.Lease.CloudID != "devboxes/crabbox-fast-coral-deadbeef" || response.Lease.ServerType != "cpu16" {
+		t.Fatalf("response=%#v", response)
+	}
+	if response.Lease.SSH == nil || response.Lease.SSH.User != "developer" || response.Lease.SSH.Host != "crabbox-fast-coral-deadbeef" || !response.Lease.SSH.SSHConfigProxy {
+		t.Fatalf("ssh=%#v", response.Lease.SSH)
+	}
+	if response.Lease.Labels["backend"] != "pod" {
+		t.Fatalf("labels=%#v", response.Lease.Labels)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
+	isolateCrabboxState(t)
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list", "--format", "json"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}", SSHConfigProxy: true},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	claimExternalLease(t, cfg, "cbx_abcdef123456", "fast-coral", t.TempDir(), time.Minute, false)
+	if err := core.UpdateLeaseClaimEndpoint(
+		"cbx_abcdef123456",
+		core.Server{Name: "devbox-fast-coral", Labels: map[string]string{"name": "devbox-fast-coral", "slug": "fast-coral"}},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{stdout: `["devbox-fast-coral","unclaimed-box"]`}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invoke(context.Background(), protocolRequest{Operation: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Leases) != 2 {
+		t.Fatalf("leases=%#v", response.Leases)
+	}
+	if response.Leases[0].LeaseID != "cbx_abcdef123456" || response.Leases[0].Slug != "fast-coral" {
+		t.Fatalf("claimed lease=%#v", response.Leases[0])
+	}
+	if response.Leases[1].LeaseID != "unclaimed-box" || response.Leases[1].Name != "unclaimed-box" {
+		t.Fatalf("unclaimed lease=%#v", response.Leases[1])
+	}
+}
+
+func TestDeclarativeLifecycleExpandsExplicitEnvironmentPlaceholder(t *testing.T) {
+	t.Setenv("DEVBOX_USER", "alice")
+	templateCtx, err := lifecycleContext(protocolRequest{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := expandLifecycleValue("{{env.DEVBOX_USER}}@{{name}}", templateCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "alice@" {
+		t.Fatalf("expanded=%q", got)
+	}
+	if _, err := expandLifecycleValue("{{env.MISSING_DEVBOX_USER}}", templateCtx); err == nil || !strings.Contains(err.Error(), "is not set") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestDeclarativeLifecycleIDFallsBackToLeaseID(t *testing.T) {
+	templateCtx, err := lifecycleContext(protocolRequest{
+		Lease: &protocolLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "devbox-fast-coral",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := expandLifecycleValue("{{id}}", templateCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "cbx_abcdef123456" {
+		t.Fatalf("expanded=%q", got)
+	}
+}
+
+func TestValidateConfigRejectsMixedOrIncompleteDeclarativeModes(t *testing.T) {
+	cfg := testConfig()
+	cfg.External.Lifecycle.Acquire.Argv = []string{"devboxctl", "new", "{{name}}"}
+	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("mixed mode err=%v", err)
+	}
+	cfg.External.Command = ""
+	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "release.argv") {
+		t.Fatalf("missing release err=%v", err)
+	}
+	cfg.External.Lifecycle.Release.Argv = []string{"devboxctl", "rm", "{{name}}"}
+	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "list.argv") {
+		t.Fatalf("missing list err=%v", err)
+	}
+	cfg.External.Lifecycle.List = core.ExternalLifecycleOperation{
+		Argv:   []string{"devboxctl", "list"},
+		Output: lifecycleOutputJSONNameArray,
+	}
+	cfg.External.Lifecycle.Acquire.Output = lifecycleOutputJSONNameArray
+	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "only supported for list") {
+		t.Fatalf("non-list output err=%v", err)
 	}
 }
 

--- a/internal/providers/kubevirt/provider.go
+++ b/internal/providers/kubevirt/provider.go
@@ -2,6 +2,7 @@ package kubevirt
 
 import (
 	"flag"
+	"strconv"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -41,6 +42,34 @@ func (Provider) RouteConfig(cfg *core.Config, _ *flag.FlagSet, _ any) error {
 		cfg.WorkRoot = cfg.KubeVirt.WorkRoot
 	}
 	return nil
+}
+
+func (Provider) CommandRoutingArgs(cfg core.Config, _ string) []string {
+	values := cfg.KubeVirt
+	args := []string{
+		"--kubevirt-kubectl", values.Kubectl,
+		"--kubevirt-virtctl", values.Virtctl,
+		"--kubevirt-context", values.Context,
+		"--kubevirt-namespace", values.Namespace,
+		"--kubevirt-ssh-user", values.SSHUser,
+		"--kubevirt-ssh-port", values.SSHPort,
+		"--kubevirt-work-root", values.WorkRoot,
+		"--kubevirt-delete-on-release=" + strconv.FormatBool(values.DeleteOnRelease),
+	}
+	for _, optional := range []struct {
+		flagName string
+		value    string
+	}{
+		{flagName: "--kubevirt-kubeconfig", value: values.Kubeconfig},
+		{flagName: "--kubevirt-template", value: values.Template},
+		{flagName: "--kubevirt-ssh-key", value: values.SSHKey},
+		{flagName: "--kubevirt-ssh-public-key", value: values.SSHPublicKey},
+	} {
+		if strings.TrimSpace(optional.value) != "" {
+			args = append(args, optional.flagName, optional.value)
+		}
+	}
+	return args
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/kubevirt/provider_test.go
+++ b/internal/providers/kubevirt/provider_test.go
@@ -94,6 +94,30 @@ func TestRouteConfigUsesProviderWorkRoot(t *testing.T) {
 	}
 }
 
+func TestCommandRoutingArgsPreservesEffectiveConfig(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.KubeVirt.Kubeconfig = "/tmp/kube config"
+	cfg.KubeVirt.Template = "/tmp/vm.yaml"
+	cfg.KubeVirt.SSHKey = "/tmp/id_ed25519"
+	cfg.KubeVirt.SSHPublicKey = "/tmp/id_ed25519.pub"
+	cfg.KubeVirt.DeleteOnRelease = false
+	got := strings.Join((Provider{}).CommandRoutingArgs(cfg, "cbx_abcdef123456"), "\n")
+	for _, want := range []string{
+		"--kubevirt-kubectl\nkubectl-custom",
+		"--kubevirt-context\ntest-context",
+		"--kubevirt-namespace\ntest-ns",
+		"--kubevirt-kubeconfig\n/tmp/kube config",
+		"--kubevirt-template\n/tmp/vm.yaml",
+		"--kubevirt-ssh-key\n/tmp/id_ed25519",
+		"--kubevirt-ssh-public-key\n/tmp/id_ed25519.pub",
+		"--kubevirt-delete-on-release=false",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("routing args missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestConfigurePreservesExplicitTopLevelWorkRoot(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.WorkRoot = "/workspace/top-level"

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -83,11 +83,11 @@ has_provider() {
 }
 
 extract_lease() {
-  rg -o '(cbx_[a-f0-9]{12}|sem_[A-Za-z0-9][A-Za-z0-9._-]*)' | head -1
+  grep -Eo '(cbx_[a-f0-9]{12}|sem_[A-Za-z0-9][A-Za-z0-9._-]*)' | head -1
 }
 
 extract_slug() {
-  sed -n 's/.*slug=\([^ ]*\).*/\1/p' | rg -v '^-$' | tail -1
+  sed -n 's/.*slug=\([^ ]*\).*/\1/p' | grep -Ev '^-$' | tail -1
 }
 
 extract_tenki_session() {

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -557,12 +557,17 @@ external_smoke() {
   need_tool rg
 
   local command="${CRABBOX_LIVE_EXTERNAL_COMMAND:-${CRABBOX_EXTERNAL_COMMAND:-$(config_value external.command || true)}}"
-  if [[ -z "$command" ]]; then
-    echo "external smoke requires CRABBOX_LIVE_EXTERNAL_COMMAND, CRABBOX_EXTERNAL_COMMAND, or external.command" >&2
+  local lifecycle_acquire
+  lifecycle_acquire="$(config_value external.lifecycle.acquire.argv || true)"
+  if [[ -z "$command" && -z "$lifecycle_acquire" ]]; then
+    echo "external smoke requires an external command or external.lifecycle.acquire configuration" >&2
     return 2
   fi
 
-  local external_env=(CRABBOX_EXTERNAL_COMMAND="$command")
+  local external_env=()
+  if [[ -n "$command" ]]; then
+    external_env+=(CRABBOX_EXTERNAL_COMMAND="$command")
+  fi
   local route_args=(--provider external)
   if [[ -n "${CRABBOX_LIVE_EXTERNAL_ARG:-}" ]]; then
     external_env+=(CRABBOX_EXTERNAL_ARG="$CRABBOX_LIVE_EXTERNAL_ARG")
@@ -572,7 +577,11 @@ external_smoke() {
   fi
   local lease_args=("${route_args[@]}" --ttl "${CRABBOX_LIVE_EXTERNAL_TTL:-15m}" --idle-timeout "${CRABBOX_LIVE_EXTERNAL_IDLE_TIMEOUT:-5m}")
   external_run() {
-    (cd "$repo" && env "${external_env[@]}" "$cb" "$@")
+    if (( ${#external_env[@]} )); then
+      (cd "$repo" && env "${external_env[@]}" "$cb" "$@")
+    else
+      (cd "$repo" && "$cb" "$@")
+    fi
   }
 
   local lease=""

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -145,3 +145,93 @@ esac
   assert.doesNotMatch(tenkiCalls, /sandbox resume/);
   assert.equal(fs.readFileSync(stateFile, "utf8").trim(), "PAUSED");
 });
+
+test("external live smoke accepts declarative lifecycle configuration", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-external-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  const config = path.join(dir, "crabbox.yaml");
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    config,
+    `provider: external
+external:
+  lifecycle:
+    acquire:
+      argv: [devboxctl, new, "{{name}}"]
+    list:
+      argv: [devboxctl, list]
+      output: json-name-array
+    release:
+      argv: [devboxctl, rm, "{{name}}"]
+  connection:
+    ssh:
+      user: developer
+      host: "{{name}}"
+`,
+    "utf8",
+  );
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'external_command=%s args=%s\\n' "\${CRABBOX_EXTERNAL_COMMAND:-}" "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+case "$1" in
+  doctor)
+    printf 'ok provider=external\\n'
+    ;;
+  warmup)
+    printf 'provisioning provider=external lease=cbx_123456789abc slug=external-smoke-test\\n'
+    ;;
+  status)
+    printf 'lease=cbx_123456789abc slug=external-smoke-test provider=external state=ready ready=true\\n'
+    ;;
+  inspect)
+    printf '{"id":"cbx_123456789abc","slug":"external-smoke-test","provider":"external","state":"ready"}\\n'
+    ;;
+  run)
+    printf 'crabbox-live-ok\\n'
+    ;;
+  list)
+    printf '[{"id":"cbx_123456789abc","slug":"external-smoke-test","provider":"external","state":"ready"}]\\n'
+    ;;
+  stop)
+    printf 'stopped %s\\n' "\${*: -1}"
+    ;;
+  admin)
+    printf '[]\\n'
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: config,
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "external",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /crabbox-live-ok/);
+  const crabboxCalls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(crabboxCalls, /args=doctor --provider external/);
+  assert.match(crabboxCalls, /args=warmup --provider external/);
+  assert.match(crabboxCalls, /args=stop --provider external external-smoke-test/);
+  assert.doesNotMatch(crabboxCalls, /external_command=[^ \n]+/);
+});


### PR DESCRIPTION
## Summary

- add a declarative `external.lifecycle` mode for CLIs that provision deterministic SSH-addressable environments
- persist private routing state and replay provider-specific routing flags for generated commands
- support coordinator-free WebVNC for direct desktop-capable SSH providers
- extend live-smoke coverage for declarative external-provider configuration

Lifecycle operations use argv arrays and structured JSON output. Connection metadata supports config, repository, lease, and environment placeholders without invoking a shell.

## Verification

- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false go test -race ./...`
- `go vet ./...`
- `node --test scripts/live-smoke.test.js`
- `bash -n scripts/live-smoke.sh`
- Worker format, lint, typecheck, Vitest, and Wrangler dry-run build
- docs site build
- live external-provider E2E: provision, SSH, git, rsync, tar, desktop bootstrap, WebVNC tunnel, terminal launch, routing-state cleanup
- autoreview: clean

## Configuration and security

- no new dependency or secret
- lifecycle commands execute directly from argv; no shell expansion
- routing state remains private local state
- environment placeholders read exact named variables from user configuration
