### PR TITLE
refactor(worker): name coordinator provider registry

### DIFF
--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -83,7 +83,7 @@ import type {
   TailscaleMetadata,
   WindowsMode,
 } from "./types";
-import { providers as supportedProviders } from "./types";
+import { coordinatorProviders, coordinatorProviderSpec, isCoordinatorProvider } from "./types";
 import { costLimits, enforceCostLimits, leaseCost, requestOrg, usageSummary } from "./usage";
 
 const fleetID = "default";
@@ -1502,7 +1502,7 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private async providerReadiness(request: Request, provider: string): Promise<Response> {
-    if (!isManagedProvider(provider)) {
+    if (!isCoordinatorProvider(provider)) {
       return json(
         { error: "invalid_provider", message: `unsupported provider: ${provider}` },
         { status: 400 },
@@ -1797,7 +1797,7 @@ export class FleetDurableObject implements DurableObject {
   private async portalAdminProviderStatuses(
     leases: PortalAdminLeaseSummary[],
   ): Promise<PortalAdminProviderStatus[]> {
-    const providerSet = new Set<Provider>(supportedProviders);
+    const providerSet = new Set<Provider>(coordinatorProviders);
     for (const lease of leases) {
       providerSet.add(lease.provider);
     }
@@ -5487,6 +5487,7 @@ interface ProviderReadinessCheck {
 }
 
 function providerReadiness(provider: Provider, env: Env, gcpProject?: string): ProviderReadiness {
+  const spec = coordinatorProviderSpec(provider);
   if (provider === "gcp") {
     const missing = providerRequiredSecrets(provider).filter((name) => !nonSecretString(env[name]));
     if (
@@ -5502,8 +5503,8 @@ function providerReadiness(provider: Provider, env: Env, gcpProject?: string): P
       missing,
       message:
         missing.length === 0
-          ? "gcp coordinator secrets are configured"
-          : `gcp coordinator secrets missing: ${missing.join(", ")}`,
+          ? `${spec.provider} coordinator secrets are configured`
+          : `${spec.provider} coordinator secrets missing: ${missing.join(", ")}`,
     };
   }
   const missing = providerRequiredSecrets(provider).filter((name) => !nonSecretString(env[name]));
@@ -5513,8 +5514,8 @@ function providerReadiness(provider: Provider, env: Env, gcpProject?: string): P
     missing,
     message:
       missing.length === 0
-        ? `${provider} coordinator secrets are configured`
-        : `${provider} coordinator secrets missing: ${missing.join(", ")}`,
+        ? `${spec.provider} coordinator secrets are configured`
+        : `${spec.provider} coordinator secrets missing: ${missing.join(", ")}`,
   };
 }
 
@@ -5537,20 +5538,7 @@ function normalizeReadinessMarket(value: string | null): "spot" | "on-demand" | 
 }
 
 function providerRequiredSecrets(provider: Provider): Array<keyof Env> {
-  switch (provider) {
-    case "aws":
-      return ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
-    case "azure":
-      return ["AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID"];
-    case "gcp":
-      return ["GCP_CLIENT_EMAIL", "GCP_PRIVATE_KEY"];
-    case "hetzner":
-      return ["HETZNER_TOKEN"];
-  }
-}
-
-function isManagedProvider(provider: string): provider is Provider {
-  return supportedProviders.includes(provider as Provider);
+  return [...coordinatorProviderSpec(provider).requiredSecrets];
 }
 
 function portalReturnLocation(request: Request): string {

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -5,6 +5,7 @@ import type {
   RunEventRecord,
   RunRecord,
 } from "./types";
+import { coordinatorProviderSpec } from "./types";
 
 const novncModuleURL = "/portal/assets/novnc/rfb.js";
 const copyIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>`;
@@ -19,6 +20,14 @@ const themeMoonIcon = `<svg class="theme-icon-moon" viewBox="0 0 20 20" aria-hid
 const themeSunIcon = `<svg class="theme-icon-sun" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="10" r="3.4" fill="currentColor"/><g stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><line x1="10" y1="2" x2="10" y2="4"/><line x1="10" y1="16" x2="10" y2="18"/><line x1="2" y1="10" x2="4" y2="10"/><line x1="16" y1="10" x2="18" y2="10"/><line x1="4.2" y1="4.2" x2="5.6" y2="5.6"/><line x1="14.4" y1="14.4" x2="15.8" y2="15.8"/><line x1="4.2" y1="15.8" x2="5.6" y2="14.4"/><line x1="14.4" y1="5.6" x2="15.8" y2="4.2"/></g></svg>`;
 const themeSystemIcon = `<svg class="theme-icon-system" viewBox="0 0 20 20" aria-hidden="true"><rect x="3" y="4" width="14" height="10" rx="1.8" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M7 17h6M10 14v3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>`;
 const portalBrand = "🦀 crabbox";
+const genericProviderIcon = `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v12H4z"/><path d="m7 10 3 2-3 2M12 15h5"/></svg>`;
+const providerIcons: Record<string, string> = {
+  "blacksmith-testbox": `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v5H4z"/><path d="M4 13h16v5H4z"/><path d="M8 8.5h.01M8 15.5h.01M12 8.5h5M12 15.5h5"/></svg>`,
+  aws: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 15.5c3.8 2.2 9.1 2.5 14.8.9"/><path d="M17.5 13.2 20 16l-3.7.7"/><path d="M7 8.5h10l1.8 4H5.2z"/></svg>`,
+  azure: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 17.5h9.2a4 4 0 0 0 .5-8 5.5 5.5 0 0 0-10.5-1.6A4.8 4.8 0 0 0 7.5 17.5Z"/><path d="M9 13h6"/></svg>`,
+  gcp: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 17 3.5 12.5 9.5 2h5L20.5 12.5 18 17z"/><path d="M8.5 17h9.5M9.5 2l3 5.5M14.5 2l-3 5.5"/></svg>`,
+  hetzner: `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 20 7.5v9L12 21l-8-4.5v-9z"/><path d="M8 8v8M16 8v8M8 12h8"/></svg>`,
+};
 
 function themeToggleButton(): string {
   return `<button class="icon-btn theme-toggle" type="button" aria-label="Theme: system" aria-pressed="false" title="Theme: system" data-theme-toggle>${themeMoonIcon}${themeSunIcon}${themeSystemIcon}</button>`;
@@ -293,10 +302,12 @@ function adminLeasesPanel(
     `<a class="admin-filter-chip" data-active="${providerFilter === undefined}" href="/portal/admin/leases">all providers</a>`,
     ...providers.map(
       (provider) =>
-        `<a class="admin-filter-chip" data-active="${providerFilter === provider.provider}" data-provider="${escapeHTML(provider.provider)}" href="/portal/admin/leases?provider=${encodeURIComponent(provider.provider)}">${providerIcon(provider.provider)}<span>${escapeHTML(providerLabel(provider.provider))}</span></a>`,
+        `<a class="admin-filter-chip" data-active="${providerFilter === provider.provider}" data-provider="${escapeHTML(provider.provider)}" href="/portal/admin/leases?provider=${encodeURIComponent(provider.provider)}">${providerIcon(provider.provider)}<span>${escapeHTML(coordinatorProviderSpec(provider.provider).label)}</span></a>`,
     ),
   ].join("");
-  const title = providerFilter ? `${providerLabel(providerFilter)} leases` : "all leases";
+  const title = providerFilter
+    ? `${coordinatorProviderSpec(providerFilter).label} leases`
+    : "all leases";
   return `<section class="panel table-panel admin-full-panel">
     <div class="section-head">
       <h2>${escapeHTML(title)}</h2>
@@ -321,10 +332,10 @@ function providerAdminRow(provider: PortalAdminProviderStatus): string {
   const machineCount = provider.machineCount === undefined ? "-" : String(provider.machineCount);
   const readinessPath = `/v1/providers/${encodeURIComponent(provider.provider)}/readiness`;
   const machinesPath = `/v1/pool?provider=${encodeURIComponent(provider.provider)}`;
-  const auditPath =
-    provider.provider === "aws" || provider.provider === "azure"
-      ? `/v1/admin/lease-audit?provider=${encodeURIComponent(provider.provider)}`
-      : "";
+  const providerSpec = coordinatorProviderSpec(provider.provider);
+  const auditPath = providerSpec.adminAudit
+    ? `/v1/admin/lease-audit?provider=${encodeURIComponent(provider.provider)}`
+    : "";
   const actions = provider.configured
     ? [
         `<a href="${readinessPath}">readiness</a>`,
@@ -354,7 +365,7 @@ function providerAdminRow(provider: PortalAdminProviderStatus): string {
     <div class="provider-status-head">
       <span class="provider-favicon" data-provider="${escapeHTML(provider.provider)}">${providerIcon(provider.provider)}</span>
       <div class="provider-status-title">
-        <strong>${escapeHTML(providerLabel(provider.provider))}</strong>
+        <strong>${escapeHTML(providerSpec.label)}</strong>
         <span><span class="traffic-light" data-tone="${provider.status}" aria-label="${provider.status}"></span>${escapeHTML(provider.configured ? "configured" : "missing config")}</span>
       </div>
       <span class="pill"${tone ? ` data-tone="${tone}"` : ""}>${escapeHTML(provider.status)}</span>
@@ -411,21 +422,6 @@ function normalizeAdminProviderFilter(
   return providers.some((provider) => provider.provider === normalized)
     ? (normalized as Provider)
     : undefined;
-}
-
-function providerLabel(provider: Provider): string {
-  switch (provider) {
-    case "aws":
-      return "AWS";
-    case "azure":
-      return "Azure";
-    case "gcp":
-      return "GCP";
-    case "hetzner":
-      return "Hetzner";
-    default:
-      return provider;
-  }
 }
 
 function portalAdminSummary(input: {
@@ -2777,22 +2773,7 @@ function telemetryStorage(
 }
 
 function providerIcon(provider: string): string {
-  if (provider === "blacksmith-testbox") {
-    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v5H4z"/><path d="M4 13h16v5H4z"/><path d="M8 8.5h.01M8 15.5h.01M12 8.5h5M12 15.5h5"/></svg>`;
-  }
-  if (provider === "aws") {
-    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 15.5c3.8 2.2 9.1 2.5 14.8.9"/><path d="M17.5 13.2 20 16l-3.7.7"/><path d="M7 8.5h10l1.8 4H5.2z"/></svg>`;
-  }
-  if (provider === "azure") {
-    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.5 17.5h9.2a4 4 0 0 0 .5-8 5.5 5.5 0 0 0-10.5-1.6A4.8 4.8 0 0 0 7.5 17.5Z"/><path d="M9 13h6"/></svg>`;
-  }
-  if (provider === "gcp") {
-    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 17 3.5 12.5 9.5 2h5L20.5 12.5 18 17z"/><path d="M8.5 17h9.5M9.5 2l3 5.5M14.5 2l-3 5.5"/></svg>`;
-  }
-  if (provider === "hetzner") {
-    return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 20 7.5v9L12 21l-8-4.5v-9z"/><path d="M8 8v8M16 8v8M8 12h8"/></svg>`;
-  }
-  return `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16v12H4z"/><path d="m7 10 3 2-3 2M12 15h5"/></svg>`;
+  return providerIcons[provider] ?? genericProviderIcon;
 }
 
 function runnerStatusTone(status: string): string {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -169,8 +169,58 @@ export interface LeaseRequest {
   exposedPorts?: string[];
 }
 
-export const providers = ["hetzner", "aws", "azure", "gcp"] as const;
-export type Provider = (typeof providers)[number];
+export const coordinatorProviderRegistry = [
+  {
+    provider: "hetzner",
+    label: "Hetzner",
+    requiredSecrets: ["HETZNER_TOKEN"],
+    adminAudit: false,
+  },
+  {
+    provider: "aws",
+    label: "AWS",
+    requiredSecrets: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+    adminAudit: true,
+  },
+  {
+    provider: "azure",
+    label: "Azure",
+    requiredSecrets: [
+      "AZURE_TENANT_ID",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "AZURE_SUBSCRIPTION_ID",
+    ],
+    adminAudit: true,
+  },
+  {
+    provider: "gcp",
+    label: "GCP",
+    requiredSecrets: ["GCP_CLIENT_EMAIL", "GCP_PRIVATE_KEY"],
+    adminAudit: false,
+  },
+] as const satisfies readonly {
+  provider: string;
+  label: string;
+  requiredSecrets: readonly (keyof Env)[];
+  adminAudit: boolean;
+}[];
+
+export type CoordinatorProviderSpec = (typeof coordinatorProviderRegistry)[number];
+export type Provider = CoordinatorProviderSpec["provider"];
+export const coordinatorProviders = coordinatorProviderRegistry.map(
+  (spec) => spec.provider,
+) as Provider[];
+export const providers = coordinatorProviders;
+
+export function isCoordinatorProvider(provider: string): provider is Provider {
+  return coordinatorProviders.includes(provider as Provider);
+}
+
+export function coordinatorProviderSpec(provider: Provider): CoordinatorProviderSpec {
+  return coordinatorProviderRegistry.find((spec) => spec.provider === provider)!;
+}
+
 export type TargetOS = "linux" | "macos" | "windows";
 export type WindowsMode = "normal" | "wsl2";
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -7222,6 +7222,7 @@ describe("fleet identity", () => {
 
     expect(response.status).toBe(200);
     expect(body).toContain("provider health");
+    expect(body).toContain("4 supported");
     expect(body).toContain("users");
     expect(body).toContain('href="/portal/admin/users"');
     expect(body).not.toContain("all leases");
@@ -7234,6 +7235,7 @@ describe("fleet identity", () => {
     expect(body).toContain("Azure");
     expect(body).toContain("GCP");
     expect(body).toContain("Hetzner");
+    expect(body).not.toContain("Blacksmith");
     expect(body).toContain("GCP_PROJECT_ID");
     expect(body).not.toContain("alice@example.com");
     expect(body).not.toContain("aws-admin");

--- a/worker/test/portal-theme.test.ts
+++ b/worker/test/portal-theme.test.ts
@@ -22,8 +22,8 @@ describe("portal theme", () => {
       new Request("https://crabbox.example/portal", {
         headers: {
           "x-crabbox-admin": "true",
-          "x-crabbox-owner": "vincentkoc@ieee.org",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "admin@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -32,6 +32,6 @@ describe("portal theme", () => {
     expect(body).toContain("admin mode");
     expect(body).toContain("data-admin-panel");
     expect(body).toContain("leases JSON");
-    expect(body).toContain("vincentkoc@ieee.org / openclaw");
+    expect(body).toContain("admin@example.com / example-org");
   });
 });


### PR DESCRIPTION
## Summary
- Add a coordinator provider registry that centralizes provider label, required coordinator secrets, and admin audit support.
- Route provider readiness, admin provider cards, and admin lease filters through registry metadata.
- Keep `providers` as a compatibility alias for the coordinator-backed provider set.

## Verification
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker -- test/fleet.test.ts test/portal-theme.test.ts`
- `npm run lint --prefix worker`
- `npm run build --prefix worker`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Autoreview
- Clean: no accepted/actionable findings reported.
