### PR TITLE
fix(provider): collect delegated run artifacts

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -78,7 +78,9 @@ the checkout through the provider's APIs, runs the command through the
 provider, and prints `sync=delegated` in the final timing summary. These
 providers reject the SSH-run-only features `--capture-stdout`,
 `--capture-stderr`, `--capture-on-fail`, `--download`, `--script`,
-`--script-stdin`, `--fresh-pr`, `--artifact-glob`, and `--require-artifact`.
+`--script-stdin`, and `--fresh-pr`. Delegated artifact features
+`--artifact-glob` and `--require-artifact` are accepted only by delegated
+adapters that explicitly advertise bounded run artifact retrieval.
 `--keep-on-failure` is supported for one-shot delegated runs. See the
 per-provider docs under [providers](../features/providers.md) for how `--id`
 resolves and any extra sync limitations.
@@ -294,9 +296,10 @@ parser-sensitive PR wording stays project-owned.
 Use repeatable `--artifact-glob <glob>` to collect matching remote files after a
 successful SSH-backed run. Globs resolve relative to the remote workdir and are
 stored locally under `.crabbox/runs/<run-or-lease>/` as a tarball. Profile and
-preset `artifactGlobs` are collected the same way. Delegated providers, and
-native Windows and macOS targets, reject artifact globs; use Linux or Windows
-WSL2.
+preset `artifactGlobs` are collected the same way. Delegated providers accept
+artifact globs only when their adapter advertises bounded run artifact
+retrieval; otherwise they reject the flag. Native Windows and macOS targets
+reject artifact globs; use Linux or Windows WSL2.
 
 Use repeatable `--require-artifact <glob>` when a successful command must emit a
 proof file, manifest, report, or other evidence artifact. Required artifact globs
@@ -304,7 +307,9 @@ are checked after the remote command exits 0 and before `--download` files are
 written locally. They are also collected into the run artifact tarball. If any
 required glob matches nothing, the run fails even though the command itself
 succeeded. The same SSH-run target limits as
-`--artifact-glob` apply.
+`--artifact-glob` apply. Delegated providers that support bounded run artifact
+retrieval enforce provider-owned file and byte limits before returning local
+artifacts.
 
 Use repeatable `--download remote=local` when the command writes proof files on
 the box. Downloads run only after a successful remote command, paths resolve

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -196,8 +196,7 @@ Because Blacksmith owns sync and execution, Crabbox rejects the following `run` 
 
 - sync flags: `--sync-only`, `--checksum`, `--force-sync-large`, `--full-resync`, `--fresh-pr`;
 - execution flags: `--script`, `--script-stdin`, `--env-helper`, `--capture-stdout`,
-  `--capture-stderr`, `--capture-on-fail`, `--download`, `--artifact-glob`,
-  `--require-artifact`, `--stop-after`;
+  `--capture-stderr`, `--capture-on-fail`, `--download`, `--stop-after`;
 - environment forwarding: `--allow-env` and `CRABBOX_ENV_ALLOW` are unsupported — configure
   secrets in the Testbox workflow instead;
 - `--actions-runner` on `warmup` — Blacksmith owns runner hydration.
@@ -207,6 +206,12 @@ persists a local proof bundle (stdout/stderr logs, `timing.json`, `metadata.json
 detected GitHub Actions run URL when one appears in the output. Failed runs always save a local
 failure bundle with stdout/stderr, timing, and redacted env/config metadata. `--keep-on-failure`
 keeps a failed one-shot Testbox inspectable until its idle timeout or an explicit `crabbox stop`.
+
+`--artifact-glob` and `--require-artifact` are supported through Blacksmith's delegated
+run-artifact adapter. After the command succeeds, Crabbox asks the same Testbox to validate
+required globs and stream one bounded tarball back to the local
+`.crabbox/runs/<lease>/blacksmith-artifacts.tgz` path. The adapter caps retrieval at 256 files and
+10 MiB by default and still excludes `.git` and `.crabbox` paths.
 
 ## Desktop and VNC
 

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -210,10 +210,12 @@ visibility-only detail page.
 
 - `--sync-only`, `--checksum`, and `--force-sync-large` do not apply because
   Blacksmith owns sync.
-- `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr captures,
-  `--download`, `--artifact-glob`, and `--require-artifact` are rejected because
-  Blacksmith owns command transport and remote artifact handling. Use
-  `--emit-proof` for PR-ready transcript proof.
+- `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr captures, and
+  `--download` are rejected because Blacksmith owns command transport and remote
+  file transport. Use `--emit-proof` for PR-ready transcript proof.
+- `--artifact-glob` and `--require-artifact` run through the Blacksmith adapter:
+  after command success, Crabbox asks the same Testbox to validate required
+  globs and stream one bounded local tarball under `.crabbox/runs/<lease>/`.
 - `--actions-runner` is rejected; Blacksmith owns runner hydration.
 - `--tailscale`, desktop helpers, screenshots, VNC, and `artifacts collect` are
   rejected because Blacksmith owns machine connectivity.

--- a/docs/refactor/provider.md
+++ b/docs/refactor/provider.md
@@ -318,6 +318,7 @@ const (
 	FeatureSnapshot    Feature = "provider-snapshot"
 	FeatureRunProof    Feature = "run-proof"
 	FeatureRunSession  Feature = "run-session"
+	FeatureRunArtifacts Feature = "run-artifacts"
 )
 ```
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -756,7 +756,7 @@ func TestSafeArtifactGlob(t *testing.T) {
 	if !safeArtifactGlob(".artifacts/qa-e2e/**") {
 		t.Fatal("expected QA artifact glob to be accepted")
 	}
-	for _, glob := range []string{"", "../secret", "/etc/passwd", ".artifacts/$(id)", "-C/tmp", "{/,}etc/passwd", ".{.,}/secret"} {
+	for _, glob := range []string{"", "../secret", "/etc/passwd", ".//etc/passwd", ".artifacts/$(id)", "-C/tmp", "{/,}etc/passwd", ".{.,}/secret"} {
 		if safeArtifactGlob(glob) {
 			t.Fatalf("expected unsafe glob %q to be rejected", glob)
 		}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -71,6 +71,11 @@ type DelegatedRunBackend interface {
 	Stop(ctx context.Context, req StopRequest) error
 }
 
+type DelegatedRunArtifactBackend interface {
+	Backend
+	CollectRunArtifacts(ctx context.Context, req DelegatedRunArtifactRequest) (DelegatedRunArtifactResult, error)
+}
+
 type PortsRequest struct {
 	Options   LeaseOptions
 	ID        string
@@ -184,22 +189,23 @@ type TargetSpec struct {
 type Feature string
 
 const (
-	FeatureSSH         Feature = "ssh"
-	FeatureCrabboxSync Feature = "crabbox-sync"
-	FeatureArchiveSync Feature = "archive-sync"
-	FeatureCleanup     Feature = "cleanup"
-	FeatureDesktop     Feature = "desktop"
-	FeatureBrowser     Feature = "browser"
-	FeatureCode        Feature = "code"
-	FeatureTailscale   Feature = "tailscale"
-	FeatureURLBridge   Feature = "url-bridge"
-	FeatureCheckpoint  Feature = "workspace-checkpoint"
-	FeatureFork        Feature = "workspace-fork"
-	FeatureRestore     Feature = "workspace-restore"
-	FeatureSnapshot    Feature = "provider-snapshot"
-	FeatureCacheVolume Feature = "cache-volume"
-	FeatureRunProof    Feature = "run-proof"
-	FeatureRunSession  Feature = "run-session"
+	FeatureSSH          Feature = "ssh"
+	FeatureCrabboxSync  Feature = "crabbox-sync"
+	FeatureArchiveSync  Feature = "archive-sync"
+	FeatureCleanup      Feature = "cleanup"
+	FeatureDesktop      Feature = "desktop"
+	FeatureBrowser      Feature = "browser"
+	FeatureCode         Feature = "code"
+	FeatureTailscale    Feature = "tailscale"
+	FeatureURLBridge    Feature = "url-bridge"
+	FeatureCheckpoint   Feature = "workspace-checkpoint"
+	FeatureFork         Feature = "workspace-fork"
+	FeatureRestore      Feature = "workspace-restore"
+	FeatureSnapshot     Feature = "provider-snapshot"
+	FeatureCacheVolume  Feature = "cache-volume"
+	FeatureRunProof     Feature = "run-proof"
+	FeatureRunSession   Feature = "run-session"
+	FeatureRunArtifacts Feature = "run-artifacts"
 )
 
 type FeatureSet []Feature
@@ -444,6 +450,18 @@ type RunResult struct {
 	LogExcerpt    string
 	ActionsURL    string
 	Artifacts     []RunArtifact
+}
+
+type DelegatedRunArtifactRequest struct {
+	RunReq   RunRequest
+	Result   RunResult
+	MaxFiles int
+	MaxBytes int64
+}
+
+type DelegatedRunArtifactResult struct {
+	Artifacts []RunArtifact
+	Output    string
 }
 
 type RunSessionHandle struct {
@@ -784,10 +802,11 @@ func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error 
 	if len(req.Downloads) > 0 {
 		return exit(2, "%s delegates run execution; --download is not supported", provider)
 	}
-	if len(req.ArtifactGlobs) > 0 {
+	runArtifacts := featureSetHas(spec.Features, FeatureRunArtifacts)
+	if len(req.ArtifactGlobs) > 0 && !runArtifacts {
 		return exit(2, "%s delegates run execution; --artifact-glob is not supported", provider)
 	}
-	if len(req.RequiredArtifactGlobs) > 0 {
+	if len(req.RequiredArtifactGlobs) > 0 && !runArtifacts {
 		return exit(2, "%s delegates run execution; --require-artifact is not supported", provider)
 	}
 	if req.EmitProof != "" && !featureSetHas(spec.Features, FeatureRunProof) {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -672,6 +672,13 @@ func TestRejectDelegatedSyncOptionsAllowsArchiveSyncControls(t *testing.T) {
 	if err := RejectDelegatedSyncOptionsForSpec(spec, RunRequest{RequiredArtifactGlobs: []string{"reports/data/manifest.json"}}); err == nil {
 		t.Fatal("archive sync provider should reject --require-artifact")
 	}
+	spec.Features = append(spec.Features, FeatureRunArtifacts)
+	if err := RejectDelegatedSyncOptionsForSpec(spec, RunRequest{RequiredArtifactGlobs: []string{"reports/data/manifest.json"}}); err != nil {
+		t.Fatalf("delegated artifact provider should allow --require-artifact: %v", err)
+	}
+	if err := RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ArtifactGlobs: []string{"reports/data/**"}}); err != nil {
+		t.Fatalf("delegated artifact provider should allow --artifact-glob: %v", err)
+	}
 	if err := RejectDelegatedSyncOptionsForSpec(ProviderSpec{Name: "islo"}, RunRequest{SyncOnly: true}); err == nil {
 		t.Fatal("plain delegated provider should reject --sync-only")
 	}

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -12,6 +12,13 @@ import (
 	"time"
 )
 
+const (
+	DelegatedRunArtifactDefaultMaxFiles = 256
+	DelegatedRunArtifactDefaultMaxBytes = int64(10 * 1024 * 1024)
+	DelegatedRunArtifactBeginMarker     = "__CRABBOX_ARTIFACT_TAR_BEGIN__"
+	DelegatedRunArtifactEndMarker       = "__CRABBOX_ARTIFACT_TAR_END__"
+)
+
 type RunArtifact struct {
 	Kind     string `json:"kind"`
 	Path     string `json:"path"`
@@ -91,6 +98,14 @@ func validateRequiredRunArtifactGlobs(globs []string) error {
 	return validateRunArtifactGlobsForFlag("--require-artifact", globs)
 }
 
+func ValidateRunArtifactGlobs(globs []string) error {
+	return validateRunArtifactGlobs(globs)
+}
+
+func ValidateRequiredRunArtifactGlobs(globs []string) error {
+	return validateRequiredRunArtifactGlobs(globs)
+}
+
 func validateRunArtifactGlobsForFlag(flag string, globs []string) error {
 	for _, glob := range globs {
 		if !safeArtifactGlob(glob) {
@@ -123,6 +138,10 @@ func safeArtifactGlob(glob string) bool {
 	if glob == "" || strings.HasPrefix(glob, "-") || strings.HasPrefix(glob, "/") || strings.Contains(glob, "..") || strings.ContainsAny(glob, "{}") {
 		return false
 	}
+	rel := strings.TrimPrefix(filepath.ToSlash(glob), "./")
+	if strings.HasPrefix(rel, "/") {
+		return false
+	}
 	return regexp.MustCompile(`^[A-Za-z0-9_./*?@+=:,-]+$`).MatchString(glob)
 }
 
@@ -140,8 +159,9 @@ func runArtifactRequireScript(workdir string, globs []string) string {
 	b.WriteString("cd " + shellQuote(workdir) + "\n")
 	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("missing=()\n")
-	b.WriteString("check_artifact_file() { local f=\"$1\" rel; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 1; rel=${f#./}; case \"$rel\" in .git|.git/*|.crabbox|.crabbox/*) return 1;; esac; return 0; }\n")
-	b.WriteString("add_required_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=${f#./}; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
+	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	b.WriteString("check_artifact_file() { local f=\"$1\" rel; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
+	b.WriteString("add_required_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
 	for _, glob := range globs {
 		b.WriteString("matches=()\n")
 		b.WriteString("for f in " + glob + "; do add_required_artifact_match \"$f\"; done\n")
@@ -150,7 +170,7 @@ func runArtifactRequireScript(workdir string, globs []string) string {
 				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_required_artifact_match \"$f\"; done\n")
 			}
 			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_required_artifact_match \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_required_artifact_match \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 		}
 		b.WriteString("if [ ${#matches[@]} -eq 0 ]; then missing+=(" + shellQuote(glob) + "); else printf 'required artifact %s matched=%s\\n' " + shellQuote(glob) + " \"${#matches[@]}\"; fi\n")
 	}
@@ -165,7 +185,8 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	b.WriteString("mkdir -p .crabbox\n")
 	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("files=()\n")
-	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 0; rel=${f#./}; case \"$rel\" in .git|.git/*|.crabbox|.crabbox/*|" + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
+	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 0; rel=$(artifact_rel_path \"$f\") || return 0; case \"$rel\" in " + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
 	for _, glob := range globs {
 		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
 		if strings.Contains(glob, "**") {
@@ -173,10 +194,60 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_artifact_file \"$f\"; done\n")
 			}
 			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=${f#./}; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 		}
 	}
 	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
+	return b.String()
+}
+
+func DelegatedRunArtifactScript(requiredGlobs, artifactGlobs []string, maxFiles int, maxBytes int64) string {
+	if maxFiles <= 0 {
+		maxFiles = DelegatedRunArtifactDefaultMaxFiles
+	}
+	if maxBytes <= 0 {
+		maxBytes = DelegatedRunArtifactDefaultMaxBytes
+	}
+	var b strings.Builder
+	b.WriteString("set -euo pipefail\n")
+	b.WriteString("shopt -s nullglob dotglob\n")
+	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	b.WriteString("check_artifact_file() { local f=\"$1\" rel; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
+	b.WriteString("dedupe_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
+	appendArtifactGlobMatches := func(glob string) {
+		b.WriteString("for f in " + glob + "; do dedupe_artifact_match \"$f\"; done\n")
+		if strings.Contains(glob, "**") {
+			if strings.Contains(glob, "**/") {
+				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do dedupe_artifact_match \"$f\"; done\n")
+			}
+			searchRoot := artifactGlobSearchRoot(glob)
+			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then dedupe_artifact_match \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+		}
+	}
+	if len(requiredGlobs) > 0 {
+		b.WriteString("missing=()\n")
+		for _, glob := range requiredGlobs {
+			b.WriteString("matches=()\n")
+			appendArtifactGlobMatches(glob)
+			b.WriteString("if [ ${#matches[@]} -eq 0 ]; then missing+=(" + shellQuote(glob) + "); else printf 'required artifact %s matched=%s\\n' " + shellQuote(glob) + " \"${#matches[@]}\"; fi\n")
+		}
+		b.WriteString("if [ ${#missing[@]} -gt 0 ]; then for f in \"${missing[@]}\"; do printf 'missing required artifact: %s\\n' \"$f\" >&2; done; exit 8; fi\n")
+	}
+	if len(artifactGlobs) == 0 {
+		return b.String()
+	}
+	b.WriteString("matches=()\n")
+	for _, glob := range artifactGlobs {
+		appendArtifactGlobMatches(glob)
+	}
+	b.WriteString("if [ ${#matches[@]} -gt " + fmt.Sprint(maxFiles) + " ]; then printf 'artifact-glob matched too many files: %s > %s\\n' \"${#matches[@]}\" " + shellQuote(fmt.Sprint(maxFiles)) + " >&2; exit 9; fi\n")
+	b.WriteString("tmp=$(mktemp -t crabbox-artifacts.XXXXXX.tgz); trap 'rm -f \"$tmp\"' EXIT\n")
+	b.WriteString("if [ ${#matches[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf \"$tmp\" --files-from /dev/null; else tar -czf \"$tmp\" -- \"${matches[@]}\"; fi\n")
+	b.WriteString("bytes=$(wc -c < \"$tmp\" | tr -d ' ')\n")
+	b.WriteString("if [ \"$bytes\" -gt " + shellQuote(fmt.Sprint(maxBytes)) + " ]; then printf 'artifact-glob archive too large: %s > %s bytes\\n' \"$bytes\" " + shellQuote(fmt.Sprint(maxBytes)) + " >&2; exit 9; fi\n")
+	b.WriteString("printf '" + DelegatedRunArtifactBeginMarker + "\\n'\n")
+	b.WriteString("base64 < \"$tmp\"\n")
+	b.WriteString("printf '\\n" + DelegatedRunArtifactEndMarker + "\\n'\n")
 	return b.String()
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -887,6 +887,52 @@ exit 0
 	}
 }
 
+func TestDelegatedRunArtifactScriptSkipsSlashNormalizedMatches(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "etc", "passwd"), []byte("repo fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tarLog := filepath.Join(dir, "tar.log")
+	tarPath := filepath.Join(binDir, "tar")
+	if err := os.WriteFile(tarPath, []byte(`#!/bin/sh
+printf '%s\n' "$@" > "$CRABBOX_FAKE_TAR_LOG"
+out=""
+prev=""
+for arg do
+  if [ "$prev" = "-czf" ]; then out="$arg"; break; fi
+  prev="$arg"
+done
+: > "$out"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_TAR_LOG", tarLog)
+	cmd := exec.Command("bash", "-c", DelegatedRunArtifactScript(nil, []string{".//etc/passwd"}, 16, 1024*1024))
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("delegated artifact script failed: %v\n%s", err, out)
+	}
+	logData, err := os.ReadFile(tarLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(logData), "/etc/passwd") {
+		t.Fatalf("tar received slash-normalized path:\n%s", logData)
+	}
+	if !strings.Contains(string(logData), "--files-from\n/dev/null") {
+		t.Fatalf("tar should receive an empty archive after rejecting slash-normalized matches:\n%s", logData)
+	}
+}
+
 func TestRunCommandCleansEnvProfileWhenProbeFails(t *testing.T) {
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -1,7 +1,9 @@
 package blacksmith
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -61,6 +63,8 @@ type blacksmithBackend struct {
 	cfg  Config
 	rt   Runtime
 }
+
+var _ core.DelegatedRunArtifactBackend = (*blacksmithBackend)(nil)
 
 func (b *blacksmithBackend) Spec() ProviderSpec { return b.spec }
 
@@ -179,9 +183,49 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	commandDuration := finished.Sub(commandStart)
 	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, finished)
 	total := finished.Sub(started)
+	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
+	result := RunResult{
+		Provider:      blacksmithTestboxProvider,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   blacksmithCommandString(req.Command, req.ShellMode),
+		LogExcerpt:    core.SelectProofLogExcerpt(strings.TrimSpace(string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes()))),
+		ActionsURL:    firstNonBlank(actionsURL, firstBlacksmithActionsURL(string(stdoutProof.Bytes())+"\n"+string(stderrProof.Bytes()))),
+		ExitCode:      code,
+		Command:       commandDuration,
+		Total:         total,
+		SyncDelegated: true,
+	}
+	var artifactErr error
+	if code == 0 && (len(req.ArtifactGlobs) > 0 || len(req.RequiredArtifactGlobs) > 0) {
+		collected, err := b.CollectRunArtifacts(ctx, core.DelegatedRunArtifactRequest{
+			RunReq:   req,
+			Result:   result,
+			MaxFiles: core.DelegatedRunArtifactDefaultMaxFiles,
+			MaxBytes: core.DelegatedRunArtifactDefaultMaxBytes,
+		})
+		if err != nil {
+			artifactErr = err
+			fmt.Fprintf(b.rt.Stderr, "blacksmith artifact retrieval failed: %v\n", err)
+			code = blacksmithArtifactFailureExitCode(err)
+			result.ExitCode = code
+		} else {
+			if strings.TrimSpace(collected.Output) != "" {
+				fmt.Fprintln(b.rt.Stderr, strings.TrimSpace(collected.Output))
+			}
+			for _, artifact := range collected.Artifacts {
+				fmt.Fprintf(b.rt.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
+			}
+			result.Artifacts = append(result.Artifacts, collected.Artifacts...)
+		}
+	}
 	report := delegatedTimingReport(blacksmithTestboxProvider, leaseID, slug, "blacksmith-testbox owns sync", commandDuration, commandPhases, total, code)
 	if code != 0 {
-		classification := core.ClassifyRunFailure(code, string(stdoutProof.Bytes())+"\n"+string(stderrProof.Bytes()), commandPhases)
+		classificationInput := string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes())
+		if artifactErr != nil {
+			classificationInput += "\n" + artifactErr.Error()
+		}
+		classification := core.ClassifyRunFailure(code, classificationInput, commandPhases)
 		core.ApplyFailureClassification(&report, classification)
 	}
 	fmt.Fprintf(b.rt.Stderr, "blacksmith run summary sync=delegated command=%s total=%s exit=%d%s\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code, core.FormatFailureClassificationFields(core.FailureClassification{BlockedStage: report.BlockedStage, RetryLikely: report.RetryLikely}))
@@ -191,16 +235,19 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			return RunResult{}, err
 		}
 	}
-	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
 	proof, proofErr := b.blacksmithProofResult(req, leaseID, slug, code, commandDuration, total, report, stdoutProof.Bytes(), stderrProof.Bytes(), actionsURL)
 	if proofErr != nil && code == 0 {
 		return RunResult{}, proofErr
 	}
-	result := proof
-	result.ExitCode = code
-	result.Command = commandDuration
-	result.Total = total
-	result.SyncDelegated = true
+	if proofErr == nil {
+		result.Provider = proof.Provider
+		result.LeaseID = proof.LeaseID
+		result.Slug = proof.Slug
+		result.CommandText = proof.CommandText
+		result.LogExcerpt = proof.LogExcerpt
+		result.ActionsURL = proof.ActionsURL
+		result.Artifacts = append(result.Artifacts, proof.Artifacts...)
+	}
 	result.Session = &core.RunSessionHandle{
 		Provider:       blacksmithTestboxProvider,
 		LeaseID:        leaseID,
@@ -235,6 +282,122 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		return result, ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
 	}
 	return result, nil
+}
+
+func blacksmithArtifactFailureExitCode(err error) int {
+	var exitErr ExitError
+	if core.AsExitError(err, &exitErr) && exitErr.Code != 0 {
+		return exitErr.Code
+	}
+	return 7
+}
+
+func (b *blacksmithBackend) CollectRunArtifacts(ctx context.Context, req core.DelegatedRunArtifactRequest) (core.DelegatedRunArtifactResult, error) {
+	leaseID := strings.TrimSpace(firstNonBlank(req.Result.LeaseID, req.RunReq.ID))
+	if leaseID == "" {
+		return core.DelegatedRunArtifactResult{}, exit(2, "blacksmith artifact retrieval requires a testbox id")
+	}
+	if err := core.ValidateRunArtifactGlobs(req.RunReq.ArtifactGlobs); err != nil {
+		return core.DelegatedRunArtifactResult{}, err
+	}
+	if err := core.ValidateRequiredRunArtifactGlobs(req.RunReq.RequiredArtifactGlobs); err != nil {
+		return core.DelegatedRunArtifactResult{}, err
+	}
+	collectGlobs := append([]string{}, req.RunReq.ArtifactGlobs...)
+	collectGlobs = append(collectGlobs, req.RunReq.RequiredArtifactGlobs...)
+	script := core.DelegatedRunArtifactScript(req.RunReq.RequiredArtifactGlobs, collectGlobs, req.MaxFiles, req.MaxBytes)
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return core.DelegatedRunArtifactResult{}, err
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	args := blacksmithRunArgs(b.cfg, leaseID, keyPath, []string{script}, b.cfg.Blacksmith.Debug, true)
+	_, timedOut, err := b.runCommandWithSyncGuard(ctx, args, &stdout, &stderr)
+	output := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+	if timedOut {
+		fmt.Fprintf(
+			b.rt.Stderr,
+			"Blacksmith Testbox sync did not print a completion marker for %s during artifact retrieval; terminating local runner. "+
+				"Rerun with CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS=0 to disable this guard.\n",
+			blacksmithSyncTimeout(os.Getenv),
+		)
+		return core.DelegatedRunArtifactResult{}, exit(124, "blacksmith artifact retrieval sync timed out: %s", output)
+	}
+	if err != nil {
+		return core.DelegatedRunArtifactResult{}, exit(7, "blacksmith artifact retrieval failed: %v: %s", err, output)
+	}
+	if len(collectGlobs) == 0 {
+		return core.DelegatedRunArtifactResult{Output: output}, nil
+	}
+	archive, cleanOutput, err := blacksmithExtractArtifactArchive(output)
+	if err != nil {
+		return core.DelegatedRunArtifactResult{}, err
+	}
+	maxBytes := req.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = core.DelegatedRunArtifactDefaultMaxBytes
+	}
+	if int64(len(archive)) > maxBytes {
+		return core.DelegatedRunArtifactResult{}, exit(7, "blacksmith artifact archive too large: %d > %d bytes", len(archive), maxBytes)
+	}
+	path := core.LocalRunArtifactPath(req.RunReq.Repo.Root, "", leaseID, "blacksmith-artifacts.tgz")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return core.DelegatedRunArtifactResult{}, exit(2, "blacksmith artifact create %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, archive, 0o600); err != nil {
+		return core.DelegatedRunArtifactResult{}, exit(2, "blacksmith artifact write %s: %v", path, err)
+	}
+	return core.DelegatedRunArtifactResult{
+		Output: strings.TrimSpace(cleanOutput),
+		Artifacts: []core.RunArtifact{{
+			Kind:  "artifact-glob",
+			Path:  path,
+			Bytes: len(archive),
+		}},
+	}, nil
+}
+
+func blacksmithExtractArtifactArchive(output string) ([]byte, string, error) {
+	begin := blacksmithArtifactMarkerLineIndex(output, core.DelegatedRunArtifactBeginMarker, 0)
+	end := -1
+	if begin >= 0 {
+		end = blacksmithArtifactMarkerLineIndex(output, core.DelegatedRunArtifactEndMarker, begin+len(core.DelegatedRunArtifactBeginMarker))
+	}
+	if begin < 0 || end < 0 {
+		return nil, output, exit(7, "blacksmith artifact retrieval did not return a bounded artifact archive")
+	}
+	before := strings.TrimSpace(output[:begin])
+	encodedStart := begin + len(core.DelegatedRunArtifactBeginMarker)
+	encoded := output[encodedStart:end]
+	after := strings.TrimSpace(output[end+len(core.DelegatedRunArtifactEndMarker):])
+	compact := strings.NewReplacer("\n", "", "\r", "", "\t", "", " ", "").Replace(encoded)
+	archive, err := base64.StdEncoding.DecodeString(compact)
+	if err != nil {
+		return nil, "", exit(7, "blacksmith artifact archive decode failed: %v", err)
+	}
+	return archive, strings.TrimSpace(strings.TrimSpace(before) + "\n" + strings.TrimSpace(after)), nil
+}
+
+func blacksmithArtifactMarkerLineIndex(output, marker string, start int) int {
+	if start < 0 {
+		start = 0
+	}
+	for offset := start; offset < len(output); {
+		idx := strings.Index(output[offset:], marker)
+		if idx < 0 {
+			return -1
+		}
+		pos := offset + idx
+		beforeLine := pos == 0 || output[pos-1] == '\n'
+		after := pos + len(marker)
+		afterLine := after == len(output) || output[after] == '\n' || output[after] == '\r'
+		if beforeLine && afterLine {
+			return pos
+		}
+		offset = after
+	}
+	return -1
 }
 
 var githubActionsRunURLPattern = regexp.MustCompile(`https://github\.com/[^\s"'<>]+/actions/runs/[0-9]+[^\s"'<>]*`)

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -713,6 +714,231 @@ func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 	}
 }
 
+func TestBlacksmithCollectRunArtifactsWritesBoundedArchive(t *testing.T) {
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	archive := makeTarGz(t, map[string]string{"reports/manifest.json": `{"ok":true}`})
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			if req.Stdout != nil {
+				_, _ = req.Stdout.Write([]byte("required artifact reports/manifest.json matched=1\n"))
+				_, _ = req.Stdout.Write([]byte(core.DelegatedRunArtifactBeginMarker + "\n"))
+				_, _ = req.Stdout.Write([]byte(base64.StdEncoding.EncodeToString(archive)))
+				_, _ = req.Stdout.Write([]byte("\n" + core.DelegatedRunArtifactEndMarker + "\n"))
+			}
+			return LocalCommandResult{}, nil
+		}
+		return LocalCommandResult{}, nil
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := newTestBlacksmithBackend(cfg, runner)
+	result, err := backend.CollectRunArtifacts(context.Background(), core.DelegatedRunArtifactRequest{
+		RunReq: core.RunRequest{
+			Repo:                  core.Repo{Root: repo},
+			ArtifactGlobs:         []string{"reports/**"},
+			RequiredArtifactGlobs: []string{"reports/manifest.json"},
+		},
+		Result:   core.RunResult{LeaseID: "tbx_artifacts"},
+		MaxFiles: 16,
+		MaxBytes: int64(len(archive) + 128),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Output, "required artifact reports/manifest.json matched=1") {
+		t.Fatalf("output=%q", result.Output)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("artifacts=%#v", result.Artifacts)
+	}
+	artifact := result.Artifacts[0]
+	if artifact.Kind != "artifact-glob" || artifact.Bytes != len(archive) {
+		t.Fatalf("artifact=%#v", artifact)
+	}
+	got, err := os.ReadFile(artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, archive) {
+		t.Fatalf("archive mismatch bytes=%d want=%d", len(got), len(archive))
+	}
+	if len(runner.calls) != 1 || !strings.Contains(runner.calls[0][len(runner.calls[0])-1], core.DelegatedRunArtifactBeginMarker) {
+		t.Fatalf("runner calls=%#v", runner.calls)
+	}
+}
+
+func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	archive := makeTarGz(t, map[string]string{"reports/manifest.json": `{"ok":true}`})
+	runCalls := 0
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
+			return LocalCommandResult{Stdout: "ready tbx_artifacts\n"}, nil
+		}
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			runCalls++
+			if runCalls == 2 && req.Stdout != nil {
+				_, _ = req.Stdout.Write([]byte("required artifact reports/manifest.json matched=1\n"))
+				_, _ = req.Stdout.Write([]byte(core.DelegatedRunArtifactBeginMarker + "\n"))
+				_, _ = req.Stdout.Write([]byte(base64.StdEncoding.EncodeToString(archive)))
+				_, _ = req.Stdout.Write([]byte("\n" + core.DelegatedRunArtifactEndMarker + "\n"))
+			}
+			return LocalCommandResult{}, nil
+		}
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
+			return LocalCommandResult{}, nil
+		}
+		return LocalCommandResult{}, nil
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := newTestBlacksmithBackend(cfg, runner)
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:                  Repo{Root: repo},
+		Command:               []string{"true"},
+		ArtifactGlobs:         []string{"reports/**"},
+		RequiredArtifactGlobs: []string{"reports/manifest.json"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("artifacts=%#v", result.Artifacts)
+	}
+	if len(runner.calls) != 5 {
+		t.Fatalf("calls=%#v", runner.calls)
+	}
+	if runner.calls[0][1] != "list" || runner.calls[1][1] != "warmup" || runner.calls[2][1] != "run" || runner.calls[3][1] != "run" || runner.calls[4][1] != "stop" {
+		t.Fatalf("unexpected call order: %#v", runner.calls)
+	}
+	if !strings.Contains(runner.calls[3][len(runner.calls[3])-1], core.DelegatedRunArtifactBeginMarker) {
+		t.Fatalf("second run was not artifact collection: %#v", runner.calls[3])
+	}
+}
+
+func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Chdir(repo)
+	runCalls := 0
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
+			return LocalCommandResult{Stdout: "ready tbx_artifactfail\n"}, nil
+		}
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			runCalls++
+			if runCalls == 2 {
+				if req.Stderr != nil {
+					_, _ = req.Stderr.Write([]byte("missing required artifact reports/manifest.json\n"))
+				}
+				return LocalCommandResult{ExitCode: 8}, errors.New("artifact missing")
+			}
+			return LocalCommandResult{}, nil
+		}
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
+			t.Fatalf("stop should not run after artifact failure with keep-on-failure: %#v", req.Args)
+		}
+		return LocalCommandResult{}, nil
+	}}
+	var stderr bytes.Buffer
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:                  Repo{Root: repo},
+		Command:               []string{"true"},
+		RequiredArtifactGlobs: []string{"reports/manifest.json"},
+		KeepOnFailure:         true,
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("err=%v want artifact exit 7", err)
+	}
+	if len(runner.calls) != 4 {
+		t.Fatalf("blacksmith calls=%d want list/warmup/run/artifact-run without stop: %#v", len(runner.calls), runner.calls)
+	}
+	if result.Session == nil || !result.Session.Kept {
+		t.Fatalf("session=%#v, want kept after artifact failure", result.Session)
+	}
+	got := stderr.String()
+	for _, want := range []string{"blacksmith artifact retrieval failed", "missing required artifact reports/manifest.json", "blacksmith run summary", "exit=7", "failure-bundle local=", "keep-on-failure: kept lease=tbx_artifactfail"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stderr missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBlacksmithExtractArtifactArchiveRejectsMissingEnvelope(t *testing.T) {
+	_, _, err := blacksmithExtractArtifactArchive("no marker")
+	if err == nil || !strings.Contains(err.Error(), "did not return a bounded artifact archive") {
+		t.Fatalf("err=%v, want missing envelope", err)
+	}
+}
+
+func TestBlacksmithExtractArtifactArchiveIgnoresPreambleMarkerText(t *testing.T) {
+	archive := makeTarGz(t, map[string]string{"reports/manifest.json": `{"ok":true}`})
+	output := strings.Join([]string{
+		"required artifact " + core.DelegatedRunArtifactBeginMarker + " matched=1",
+		"required artifact " + core.DelegatedRunArtifactEndMarker + " matched=1",
+		core.DelegatedRunArtifactBeginMarker,
+		base64.StdEncoding.EncodeToString(archive),
+		core.DelegatedRunArtifactEndMarker,
+	}, "\n")
+	got, clean, err := blacksmithExtractArtifactArchive(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, archive) {
+		t.Fatalf("archive mismatch bytes=%d want=%d", len(got), len(archive))
+	}
+	for _, want := range []string{
+		"required artifact " + core.DelegatedRunArtifactBeginMarker + " matched=1",
+		"required artifact " + core.DelegatedRunArtifactEndMarker + " matched=1",
+	} {
+		if !strings.Contains(clean, want) {
+			t.Fatalf("clean output missing %q:\n%s", want, clean)
+		}
+	}
+}
+
+func makeTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		data := []byte(content)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
 func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -830,6 +1056,40 @@ func TestBlacksmithRunTerminatesSyncStall(t *testing.T) {
 		t.Fatalf("exit=%d want 124", code)
 	}
 	if !strings.Contains(stderr.String(), "Blacksmith Testbox sync did not print a completion marker") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestBlacksmithCollectRunArtifactsTerminatesSyncStall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "1")
+	if _, _, err := ensureTestboxKey("tbx_artifactstall"); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  baseConfig(),
+		rt: Runtime{
+			Stdout: io.Discard,
+			Stderr: &stderr,
+			Clock:  testClock{},
+			Exec:   blockingSyncRunner{},
+		},
+	}
+	_, err := backend.CollectRunArtifacts(context.Background(), core.DelegatedRunArtifactRequest{
+		RunReq: core.RunRequest{
+			ArtifactGlobs: []string{"reports/**"},
+		},
+		Result: core.RunResult{LeaseID: "tbx_artifactstall"},
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 124 {
+		t.Fatalf("err=%v want exit 124", err)
+	}
+	if !strings.Contains(stderr.String(), "during artifact retrieval") {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
 }

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -22,7 +22,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      "blacksmith",
 		Kind:        core.ProviderKindDelegatedRun,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureCacheVolume, core.FeatureRunProof, core.FeatureRunSession},
+		Features:    core.FeatureSet{core.FeatureCacheVolume, core.FeatureRunProof, core.FeatureRunSession, core.FeatureRunArtifacts},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary
- add a delegated run-artifacts provider contract and advertise it for Blacksmith Testbox
- collect `--artifact-glob` / `--require-artifact` from the same Testbox before one-shot cleanup
- harden artifact path normalization, size/file limits, marker parsing, sync timeout handling, and keep-on-failure behavior
- update Blacksmith/provider docs for delegated run artifacts

Fixes https://github.com/openclaw/crabbox/issues/227

## Verification
- `go test ./internal/cli ./internal/providers/blacksmith`
- `go test ./...`
- `go vet ./...`
- `scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean

## Crabbox proof
Attempted with this branch's `bin/crabbox`:
- Blacksmith Testbox with `--require-artifact` / `--artifact-glob`: queued and was stopped cleanly after no capacity became available (`tbx_01ktna4hsanex2qktbb3zmbrtq`, `tbx_01ktnac096xkjmn04a8qg3pvwh`)
- AWS fallback: coordinator HTTPS timed out before lease creation (`https://crabbox.openclaw.ai/v1/leases`)
- local-container fallback: Docker daemon unavailable on this machine
