### PR TITLE
fix: preserve external provider resource identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added declarative `external.lifecycle` command configuration for deterministic private devbox CLIs, plus coordinator-free WebVNC over SSH for direct desktop-capable providers.
+- Added declarative `external.lifecycle` command configuration, provider resource-name mapping, and coordinator-free WebVNC over SSH for deterministic private devbox CLIs.
 - Added Podman runtime compatibility for `provider: local-container`, including runtime selection, provider flags on SSH commands, and Podman-safe local lease claim scopes. Thanks @sallyom.
 - Added `sync.include` / `sync.includes` whitelists for root-relative sync plans, SSH sync, native Windows sync, local Actions hydration, and archive-sync providers. Thanks @anagnorisis2peripeteia.
 - Added generic `kubevirt` SSH leases and a versioned `external` executable provider so private or proprietary VM/devbox control planes can integrate through configuration without provider-specific Crabbox forks.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -477,18 +477,20 @@ provider: external
 external:
   lifecycle:
     acquire:
-      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+      argv: [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
     list:
       argv: [devboxctl, list, --format, json]
       output: json-name-array
+      namePrefix: "cbx-"
     release:
-      argv: [devboxctl, rm, --yes, "{{name}}"]
+      argv: [devboxctl, rm, --yes, "{{resourceName}}"]
   connection:
-    cloudId: devboxes/{{name}}
+    resourceName: "{{leaseIdSlug}}"
+    cloudId: devboxes/{{resourceName}}
     serverType: "{{config.size}}"
     ssh:
       user: "{{env.DEVBOX_USER}}"
-      host: "{{name}}"
+      host: "{{resourceName}}"
       sshConfigProxy: true
   config:
     size: cpu16

--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -60,26 +60,28 @@ external:
     doctor:
       argv: [devboxctl, list, --format, json]
     acquire:
-      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+      argv: [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
     resolve:
-      argv: [devboxctl, inspect, "{{name}}"]
+      argv: [devboxctl, inspect, "{{resourceName}}"]
     list:
       argv: [devboxctl, list, --format, json]
       output: json-name-array
+      namePrefix: "cbx-"
     release:
-      argv: [devboxctl, rm, --yes, "{{name}}"]
+      argv: [devboxctl, rm, --yes, "{{resourceName}}"]
     touch:
-      argv: [devboxctl, touch, "{{name}}"]
+      argv: [devboxctl, touch, "{{resourceName}}"]
     cleanup:
       argv: [devboxctl, gc]
   connection:
-    cloudId: devboxes/{{name}}
+    resourceName: "{{leaseIdSlug}}"
+    cloudId: devboxes/{{resourceName}}
     serverType: "{{config.size}}"
     labels:
       backend: container
     ssh:
       user: "{{env.DEVBOX_USER}}"
-      host: "{{name}}"
+      host: "{{resourceName}}"
       port: "22"
       sshConfigProxy: true
       readyCheck: command -v git && command -v rsync && command -v tar
@@ -89,15 +91,19 @@ external:
 ```
 
 `acquire`, `list`, `release`, and `connection.ssh.user` are required.
-`connection.ssh.host` defaults to `{{name}}`. Optional operations are skipped
-when absent; Crabbox still maintains local touch metadata.
+`connection.resourceName` defaults to `{{name}}`; use it when the provider has
+stricter resource-name limits than Crabbox. Crabbox stores the resolved value
+with the lease so `json-name-array` inventory can recover the original lease
+ID and slug. `connection.ssh.host` defaults to `{{resourceName}}`. Optional
+operations are skipped when absent; Crabbox still maintains local touch
+metadata.
 
 Each `argv` item is passed directly to the configured executable. Shell
 operators, pipes, variable expansion, and command substitution are not
 evaluated. Supported placeholders:
 
 ```text
-{{leaseId}} {{slug}} {{name}} {{id}} {{state}}
+{{leaseId}} {{leaseIdSlug}} {{slug}} {{name}} {{resourceName}} {{id}} {{state}}
 {{keep}} {{reclaim}} {{releaseOnly}} {{force}}
 {{all}} {{refresh}} {{dryRun}}
 {{repo.root}} {{repo.name}} {{repo.remoteUrl}} {{repo.head}} {{repo.baseRef}}
@@ -110,11 +116,19 @@ secret environment values in lifecycle arguments: process arguments may be
 visible to other local processes. Provider CLIs should use their normal
 credential store or inherited environment for authentication.
 
+`leaseIdSlug` is the lease ID normalized as a lowercase slug, suitable for
+providers that require DNS-style names. `resourceName` is the expanded
+`connection.resourceName`.
+
 `list.output` accepts:
 
 - `json-name-array`: stdout is a JSON array of resource names;
 - `json-lease-array`: stdout is a JSON array using the protocol lease shape
   documented below.
+
+For `json-name-array`, optional `list.namePrefix` discards inventory names
+outside the expanded prefix before Crabbox constructs leases. Use it when a
+provider CLI lists resources that are not all owned by this configuration.
 
 Declarative configuration and resolved connection templates are included in
 the private per-lease routing file. This lets generated retry, daemon, SSH, and

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -229,15 +229,17 @@ type ExternalLifecycleConfig struct {
 }
 
 type ExternalLifecycleOperation struct {
-	Argv   []string `yaml:"argv,omitempty" json:"argv,omitempty"`
-	Output string   `yaml:"output,omitempty" json:"output,omitempty"`
+	Argv       []string `yaml:"argv,omitempty" json:"argv,omitempty"`
+	Output     string   `yaml:"output,omitempty" json:"output,omitempty"`
+	NamePrefix string   `yaml:"namePrefix,omitempty" json:"namePrefix,omitempty"`
 }
 
 type ExternalConnectionConfig struct {
-	CloudID    string                      `yaml:"cloudId,omitempty" json:"cloudId,omitempty"`
-	ServerType string                      `yaml:"serverType,omitempty" json:"serverType,omitempty"`
-	Labels     map[string]string           `yaml:"labels,omitempty" json:"labels,omitempty"`
-	SSH        ExternalSSHConnectionConfig `yaml:"ssh,omitempty" json:"ssh,omitempty"`
+	ResourceName string                      `yaml:"resourceName,omitempty" json:"resourceName,omitempty"`
+	CloudID      string                      `yaml:"cloudId,omitempty" json:"cloudId,omitempty"`
+	ServerType   string                      `yaml:"serverType,omitempty" json:"serverType,omitempty"`
+	Labels       map[string]string           `yaml:"labels,omitempty" json:"labels,omitempty"`
+	SSH          ExternalSSHConnectionConfig `yaml:"ssh,omitempty" json:"ssh,omitempty"`
 }
 
 type ExternalSSHConnectionConfig struct {

--- a/internal/cli/config_kubevirt_external_test.go
+++ b/internal/cli/config_kubevirt_external_test.go
@@ -137,9 +137,11 @@ external:
     list:
       argv: [devboxctl, list, --format, json]
       output: json-name-array
+      namePrefix: "cbx-"
     release:
       argv: [devboxctl, rm, --yes, "{{name}}"]
   connection:
+    resourceName: "{{leaseIdSlug}}"
     cloudId: devboxes/{{name}}
     serverType: "{{config.size}}"
     labels:
@@ -170,7 +172,12 @@ external:
 	if cfg.External.Lifecycle.List.Output != "json-name-array" {
 		t.Fatalf("list=%#v", cfg.External.Lifecycle.List)
 	}
-	if cfg.External.Connection.SSH.User != "{{env.DEVBOX_USER}}" || !cfg.External.Connection.SSH.SSHConfigProxy {
+	if cfg.External.Lifecycle.List.NamePrefix != "cbx-" {
+		t.Fatalf("list=%#v", cfg.External.Lifecycle.List)
+	}
+	if cfg.External.Connection.ResourceName != "{{leaseIdSlug}}" ||
+		cfg.External.Connection.SSH.User != "{{env.DEVBOX_USER}}" ||
+		!cfg.External.Connection.SSH.SSHConfigProxy {
 		t.Fatalf("connection=%#v", cfg.External.Connection)
 	}
 	if cfg.External.Config["size"] != "cpu16" || cfg.External.WorkRoot != "/home/developer/crabbox" {

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -90,6 +90,7 @@ func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (co
 func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	id := req.ID
 	var desired *desiredLease
+	var claimedLease *protocolLease
 	var claimLabels map[string]string
 	keep := true
 	if claim, ok, err := b.resolveClaim(req.ID); err != nil {
@@ -99,12 +100,21 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (co
 		id = name
 		desired = &desiredLease{LeaseID: claim.LeaseID, Slug: claim.Slug, Name: name}
 		claimLabels = claim.Labels
+		if lifecycleConfigured(b.cfg.External) {
+			claimedLease = &protocolLease{
+				LeaseID: claim.LeaseID,
+				Slug:    claim.Slug,
+				Name:    name,
+				Labels:  claim.Labels,
+			}
+		}
 		keep = keepFromLabels(claim.Labels, true)
 	}
 	response, err := b.invoke(ctx, protocolRequest{
 		Operation:   "resolve",
 		ID:          id,
 		Desired:     desired,
+		Lease:       claimedLease,
 		Reclaim:     req.Reclaim,
 		ReleaseOnly: req.ReleaseOnly,
 		Repo:        repoForProtocol(req.Repo),
@@ -438,6 +448,7 @@ func validateAndFillDesired(lease *protocolLease, desired *desiredLease) error {
 }
 
 var lifecycleLabelKeys = []string{
+	externalResourceNameLabel,
 	"keep",
 	"created_at",
 	"last_touched_at",

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -141,6 +141,12 @@ func validateLifecycleOperation(name string, operation core.ExternalLifecycleOpe
 	if name != "list" && operation.Output != lifecycleOutputNone {
 		return core.Exit(2, "external.lifecycle.%s.output is only supported for list", name)
 	}
+	if name != "list" && operation.NamePrefix != "" {
+		return core.Exit(2, "external.lifecycle.%s.namePrefix is only supported for list", name)
+	}
+	if operation.NamePrefix != "" && operation.Output != lifecycleOutputJSONNameArray {
+		return core.Exit(2, "external.lifecycle.list.namePrefix requires output %q", lifecycleOutputJSONNameArray)
+	}
 	switch operation.Output {
 	case lifecycleOutputNone, lifecycleOutputJSONNameArray, lifecycleOutputJSONLeaseArray:
 	default:

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -17,6 +17,7 @@ const (
 	lifecycleOutputNone           = ""
 	lifecycleOutputJSONNameArray  = "json-name-array"
 	lifecycleOutputJSONLeaseArray = "json-lease-array"
+	externalResourceNameLabel     = "externalResourceName"
 )
 
 var lifecyclePlaceholderPattern = regexp.MustCompile(`\{\{([A-Za-z_][A-Za-z0-9_.-]*)\}\}`)
@@ -34,7 +35,7 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	if len(operation.Argv) == 0 {
 		return b.defaultLifecycleResponse(request)
 	}
-	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
+	templateCtx, err := b.lifecycleContext(request, "")
 	if err != nil {
 		return protocolResponse{}, err
 	}
@@ -75,6 +76,13 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 		}
 		return b.defaultLifecycleResponse(request)
 	case lifecycleOutputJSONNameArray:
+		namePrefix := ""
+		if operation.NamePrefix != "" {
+			namePrefix, err = expandLifecycleValue(operation.NamePrefix, templateCtx)
+			if err != nil {
+				return protocolResponse{}, core.Exit(2, "external lifecycle list namePrefix: %v", err)
+			}
+		}
 		var names []string
 		if err := json.Unmarshal([]byte(result.Stdout), &names); err != nil {
 			return protocolResponse{}, core.Exit(5, "external lifecycle %s returned invalid JSON name array: %v", request.Operation, err)
@@ -83,6 +91,9 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 		for _, name := range names {
 			name = strings.TrimSpace(name)
 			if name == "" {
+				continue
+			}
+			if namePrefix != "" && !strings.HasPrefix(name, namePrefix) {
 				continue
 			}
 			lease, err := b.lifecycleLeaseForName(name)
@@ -181,6 +192,13 @@ func lifecycleOperation(cfg core.ExternalLifecycleConfig, operation string) core
 }
 
 func (b *leaseBackend) lifecycleLease(request protocolRequest) (protocolLease, error) {
+	resourceName := ""
+	if request.Lease != nil {
+		resourceName = strings.TrimSpace(request.Lease.Labels[externalResourceNameLabel])
+		if resourceName == "" {
+			resourceName = strings.TrimSpace(request.Lease.Name)
+		}
+	}
 	desired := request.Desired
 	if desired == nil && request.Lease != nil {
 		desired = &desiredLease{
@@ -194,11 +212,12 @@ func (b *leaseBackend) lifecycleLease(request protocolRequest) (protocolLease, e
 		desired = &desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
 	}
 	request.Desired = desired
-	return b.lifecycleLeaseForRequest(request)
+	return b.lifecycleLeaseForRequest(request, resourceName)
 }
 
 func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error) {
 	desired := desiredLease{LeaseID: name, Slug: core.NormalizeLeaseSlug(name), Name: name}
+	resourceName := ""
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return protocolLease{}, err
@@ -207,21 +226,20 @@ func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error)
 		if !externalClaimMatchesScope(claim, b.claimScope()) {
 			continue
 		}
-		if strings.TrimSpace(claim.Labels["name"]) == name {
+		if strings.TrimSpace(claim.Labels["name"]) == name ||
+			strings.TrimSpace(claim.Labels[externalResourceNameLabel]) == name {
 			desired.LeaseID = claim.LeaseID
 			desired.Slug = claim.Slug
+			desired.Name = strings.TrimSpace(claim.Labels["name"])
+			resourceName = name
 			break
 		}
 	}
-	return b.lifecycleLeaseForDesired(desired)
+	return b.lifecycleLeaseForRequest(protocolRequest{Desired: &desired}, resourceName)
 }
 
-func (b *leaseBackend) lifecycleLeaseForDesired(desired desiredLease) (protocolLease, error) {
-	return b.lifecycleLeaseForRequest(protocolRequest{Desired: &desired})
-}
-
-func (b *leaseBackend) lifecycleLeaseForRequest(request protocolRequest) (protocolLease, error) {
-	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
+func (b *leaseBackend) lifecycleLeaseForRequest(request protocolRequest, resourceName string) (protocolLease, error) {
+	templateCtx, err := b.lifecycleContext(request, resourceName)
 	if err != nil {
 		return protocolLease{}, err
 	}
@@ -246,6 +264,7 @@ func (b *leaseBackend) lifecycleLeaseForRequest(request protocolRequest) (protoc
 		}
 		labels[key] = expanded
 	}
+	labels[externalResourceNameLabel] = templateCtx.values["resourceName"]
 	ssh, err := lifecycleSSH(connection.SSH, templateCtx)
 	if err != nil {
 		return protocolLease{}, err
@@ -274,7 +293,7 @@ func lifecycleSSH(cfg core.ExternalSSHConnectionConfig, templateCtx lifecycleTem
 	if err != nil {
 		return protocolSSH{}, err
 	}
-	host, err := expand("host", core.Blank(cfg.Host, "{{name}}"))
+	host, err := expand("host", core.Blank(cfg.Host, "{{resourceName}}"))
 	if err != nil {
 		return protocolSSH{}, err
 	}
@@ -357,6 +376,7 @@ func lifecycleContext(request protocolRequest, config map[string]any) (lifecycle
 	if values["leaseId"] == "" {
 		values["leaseId"] = values["id"]
 	}
+	values["leaseIdSlug"] = core.NormalizeLeaseSlug(values["leaseId"])
 	if request.Repo != nil {
 		values["repo.root"] = request.Repo.Root
 		values["repo.name"] = request.Repo.Name
@@ -368,6 +388,30 @@ func lifecycleContext(request protocolRequest, config map[string]any) (lifecycle
 		addLifecycleConfigValues(values, "config."+key, value)
 	}
 	return lifecycleTemplateContext{values: values}, nil
+}
+
+func (b *leaseBackend) lifecycleContext(request protocolRequest, resourceName string) (lifecycleTemplateContext, error) {
+	templateCtx, err := lifecycleContext(request, b.cfg.External.Config)
+	if err != nil {
+		return lifecycleTemplateContext{}, err
+	}
+	if resourceName == "" && request.Lease != nil {
+		resourceName = strings.TrimSpace(request.Lease.Labels[externalResourceNameLabel])
+		if resourceName == "" {
+			resourceName = strings.TrimSpace(request.Lease.Name)
+		}
+	}
+	if resourceName == "" {
+		resourceName, err = expandLifecycleValue(
+			core.Blank(b.cfg.External.Connection.ResourceName, "{{name}}"),
+			templateCtx,
+		)
+		if err != nil {
+			return lifecycleTemplateContext{}, core.Exit(2, "external connection resourceName: %v", err)
+		}
+	}
+	templateCtx.values["resourceName"] = resourceName
+	return templateCtx, nil
 }
 
 func addLifecycleConfigValues(values map[string]string, key string, value any) {

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -210,7 +210,7 @@ func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
 		Config: map[string]any{"size": "cpu16"},
 		Lifecycle: core.ExternalLifecycleConfig{
 			Acquire: core.ExternalLifecycleOperation{
-				Argv: []string{"devboxctl", "new", "{{name}}", "--size", "{{config.size}}"},
+				Argv: []string{"devboxctl", "new", "{{resourceName}}", "--size", "{{config.size}}"},
 			},
 			List: core.ExternalLifecycleOperation{
 				Argv:   []string{"devboxctl", "list", "--format", "json"},
@@ -221,12 +221,13 @@ func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
 			},
 		},
 		Connection: core.ExternalConnectionConfig{
-			CloudID:    "devboxes/{{name}}",
-			ServerType: "{{config.size}}",
-			Labels:     map[string]string{"backend": "pod"},
+			ResourceName: "{{leaseIdSlug}}",
+			CloudID:      "devboxes/{{name}}",
+			ServerType:   "{{config.size}}",
+			Labels:       map[string]string{"backend": "pod"},
 			SSH: core.ExternalSSHConnectionConfig{
 				User:           "developer",
-				Host:           "{{name}}",
+				Host:           "{{resourceName}}",
 				SSHConfigProxy: true,
 			},
 		},
@@ -245,16 +246,16 @@ func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "new|crabbox-fast-coral-deadbeef|--size|cpu16" {
+	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "new|cbx-abcdef123456|--size|cpu16" {
 		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
 	}
 	if response.Lease == nil || response.Lease.CloudID != "devboxes/crabbox-fast-coral-deadbeef" || response.Lease.ServerType != "cpu16" {
 		t.Fatalf("response=%#v", response)
 	}
-	if response.Lease.SSH == nil || response.Lease.SSH.User != "developer" || response.Lease.SSH.Host != "crabbox-fast-coral-deadbeef" || !response.Lease.SSH.SSHConfigProxy {
+	if response.Lease.SSH == nil || response.Lease.SSH.User != "developer" || response.Lease.SSH.Host != "cbx-abcdef123456" || !response.Lease.SSH.SSHConfigProxy {
 		t.Fatalf("ssh=%#v", response.Lease.SSH)
 	}
-	if response.Lease.Labels["backend"] != "pod" {
+	if response.Lease.Labels["backend"] != "pod" || response.Lease.Labels[externalResourceNameLabel] != "cbx-abcdef123456" {
 		t.Fatalf("labels=%#v", response.Lease.Labels)
 	}
 }
@@ -356,7 +357,11 @@ func TestInvokeDeclarativeLifecycleParsesNameInventory(t *testing.T) {
 	claimExternalLease(t, cfg, "cbx_abcdef123456", "fast-coral", t.TempDir(), time.Minute, false)
 	if err := core.UpdateLeaseClaimEndpoint(
 		"cbx_abcdef123456",
-		core.Server{Name: "devbox-fast-coral", Labels: map[string]string{"name": "devbox-fast-coral", "slug": "fast-coral"}},
+		core.Server{Name: "crabbox-fast-coral-deadbeef", Labels: map[string]string{
+			"name":                    "crabbox-fast-coral-deadbeef",
+			"slug":                    "fast-coral",
+			externalResourceNameLabel: "devbox-fast-coral",
+		}},
 		core.SSHTarget{},
 	); err != nil {
 		t.Fatal(err)
@@ -443,6 +448,35 @@ func TestDeclarativeLifecycleDefaultTouchUpdatesLocalLabels(t *testing.T) {
 	}
 }
 
+func TestInvokeDeclarativeLifecycleFiltersNameInventory(t *testing.T) {
+	isolateCrabboxState(t)
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:       []string{"devboxctl", "list", "--format", "json"},
+				Output:     lifecycleOutputJSONNameArray,
+				NamePrefix: "cbx-",
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{name}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	runner := &recordingRunner{stdout: `["cbx-owned","manual-box"]`}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invoke(context.Background(), protocolRequest{Operation: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Leases) != 1 || response.Leases[0].Name != "cbx-owned" {
+		t.Fatalf("leases=%#v", response.Leases)
+	}
+}
+
 func TestDeclarativeLifecycleExpandsExplicitEnvironmentPlaceholder(t *testing.T) {
 	t.Setenv("DEVBOX_USER", "alice")
 	templateCtx, err := lifecycleContext(protocolRequest{}, nil)
@@ -472,12 +506,174 @@ func TestDeclarativeLifecycleIDFallsBackToLeaseID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := expandLifecycleValue("{{id}}", templateCtx)
+	got, err := expandLifecycleValue("{{id}}|{{leaseIdSlug}}", templateCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "cbx_abcdef123456" {
+	if got != "cbx_abcdef123456|cbx-abcdef123456" {
 		t.Fatalf("expanded=%q", got)
+	}
+}
+
+func TestDeclarativeLifecycleReusesPersistedResourceName(t *testing.T) {
+	t.Setenv("DEVBOX_RESOURCE", "new-resource")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{resourceName}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{env.DEVBOX_RESOURCE}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer"},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	if _, err := backend.invoke(context.Background(), protocolRequest{
+		Operation: "release",
+		Lease: &protocolLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+			Labels:  map[string]string{externalResourceNameLabel: "original-resource"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "rm|original-resource" {
+		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
+	}
+}
+
+func TestDeclarativeLifecycleUsesLegacyLeaseNameWhenResourceLabelMissing(t *testing.T) {
+	t.Setenv("DEVBOX_RESOURCE", "new-resource")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{resourceName}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{env.DEVBOX_RESOURCE}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer"},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	if _, err := backend.invoke(context.Background(), protocolRequest{
+		Operation: "release",
+		Lease: &protocolLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "legacy-resource",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "rm|legacy-resource" {
+		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
+	}
+}
+
+func TestDeclarativeInventoryUsesListedNameForLegacyClaim(t *testing.T) {
+	isolateCrabboxState(t)
+	t.Setenv("DEVBOX_RESOURCE", "new-resource")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{resourceName}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{env.DEVBOX_RESOURCE}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer"},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	claimExternalLease(t, cfg, "cbx_abcdef123456", "fast-coral", t.TempDir(), time.Minute, false)
+	if err := core.UpdateLeaseClaimEndpoint(
+		"cbx_abcdef123456",
+		core.Server{Name: "legacy-resource", Labels: map[string]string{
+			"name": "legacy-resource",
+			"slug": "fast-coral",
+		}},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{stdout: `["legacy-resource"]`}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invoke(context.Background(), protocolRequest{Operation: "list"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Leases) != 1 ||
+		response.Leases[0].LeaseID != "cbx_abcdef123456" ||
+		response.Leases[0].SSH == nil ||
+		response.Leases[0].SSH.Host != "legacy-resource" ||
+		response.Leases[0].Labels[externalResourceNameLabel] != "legacy-resource" {
+		t.Fatalf("leases=%#v", response.Leases)
+	}
+}
+
+func TestDeclarativeResolveThenReleaseReusesPersistedResourceName(t *testing.T) {
+	isolateCrabboxState(t)
+	t.Setenv("DEVBOX_RESOURCE", "new-resource")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{resourceName}}"}},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{env.DEVBOX_RESOURCE}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer"},
+		},
+		WorkRoot: "/home/developer/crabbox",
+	}
+	claimExternalLease(t, cfg, "cbx_abcdef123456", "fast-coral", t.TempDir(), time.Minute, false)
+	if err := core.UpdateLeaseClaimEndpoint(
+		"cbx_abcdef123456",
+		core.Server{Name: "crabbox-fast-coral-deadbeef", Labels: map[string]string{
+			"name":                    "crabbox-fast-coral-deadbeef",
+			"slug":                    "fast-coral",
+			externalResourceNameLabel: "original-resource",
+		}},
+		core.SSHTarget{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "fast-coral", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Labels[externalResourceNameLabel] != "original-resource" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "rm|original-resource" {
+		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
 	}
 }
 
@@ -502,6 +698,12 @@ func TestValidateConfigRejectsMixedOrIncompleteDeclarativeModes(t *testing.T) {
 	cfg.External.Lifecycle.Acquire.Output = lifecycleOutputJSONNameArray
 	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "only supported for list") {
 		t.Fatalf("non-list output err=%v", err)
+	}
+	cfg.External.Lifecycle.Acquire.Output = ""
+	cfg.External.Lifecycle.List.NamePrefix = "cbx-"
+	cfg.External.Lifecycle.List.Output = lifecycleOutputJSONLeaseArray
+	if err := validateConfig(cfg); err == nil || !strings.Contains(err.Error(), "namePrefix requires") {
+		t.Fatalf("list name prefix err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a configurable external resource-name template with DNS-safe lease placeholders
- persist provider resource identity across inventory, resolve, and release, with legacy-claim fallback
- allow JSON name-array inventory to filter resources by an expanded ownership prefix

## Verification

- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- live external-provider provision, inventory, resolve, desktop, WebVNC, terminal, and cleanup E2E
- branch autoreview: clean, no actionable findings
