### PR TITLE
fix(azure): support native Windows ARM64 leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added `sync.include` / `sync.includes` whitelists for root-relative sync plans, SSH sync, native Windows sync, local Actions hydration, and archive-sync providers. Thanks @anagnorisis2peripeteia.
 - Added generic `kubevirt` SSH leases and a versioned `external` executable provider so private or proprietary VM/devbox control planes can integrate through configuration without provider-specific Crabbox forks.
 - Added Tenki to the live provider smoke harness, including authenticated create/run coverage and a paused-session check that proves `status --wait` does not resume the sandbox.
-- Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and broker configuration for ARM64 validation.
+- Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` broker configuration for ARM64 validation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `sync.include` / `sync.includes` whitelists for root-relative sync plans, SSH sync, native Windows sync, local Actions hydration, and archive-sync providers. Thanks @anagnorisis2peripeteia.
 - Added generic `kubevirt` SSH leases and a versioned `external` executable provider so private or proprietary VM/devbox control planes can integrate through configuration without provider-specific Crabbox forks.
 - Added Tenki to the live provider smoke harness, including authenticated create/run coverage and a paused-session check that proves `status --wait` does not resume the sandbox.
+- Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and broker configuration for ARM64 validation.
 
 ### Changed
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -416,7 +416,7 @@ lease-acting commands):
 --provider <name>            See `crabbox providers` for the full list.
 --profile <name>
 --class <name>
---arch amd64|arm64           CPU architecture; arm64 is Linux-only on AWS/Azure.
+--arch amd64|arm64           CPU architecture; arm64 supports Linux on AWS/Azure and native Windows on Azure.
 --os <selector>              Portable Linux OS image, e.g. ubuntu:26.04
 --type <provider-type>
 --market spot|on-demand

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -192,7 +192,7 @@ warmup, because it also dispatches the workflow and waits for the ready marker.
 --provider <name>                  provider (see crabbox providers); default hetzner
 --profile <name>                   configuration profile
 --class <name>                     machine class; default beast
---arch amd64|arm64                 CPU architecture; arm64 is Linux-only on AWS/Azure
+--arch amd64|arm64                 CPU architecture; arm64 supports Linux on AWS/Azure and native Windows on Azure
 --os ubuntu:26.04|ubuntu:24.04     portable Linux OS image selector
 --type <provider-type>             provider server/instance type
 --market spot|on-demand            capacity market (AWS)

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -60,8 +60,11 @@ large     Standard_D96ads_v6, Standard_D96ds_v6, then D/F 64- and 48-vCPU fallba
 beast     Standard_D192ds_v6, Standard_D128ds_v6, then D/F 96- and 64-vCPU fallbacks
 ```
 
-Linux ARM64 classes use Azure Cobalt Dpsv6/Dpdsv6 candidates and ARM64 Ubuntu
-Marketplace images:
+ARM64 classes use Azure Cobalt Dpsv6/Dpdsv6 candidates. Linux ARM64 also uses
+ARM64 Ubuntu Marketplace images. Windows ARM64 is native Windows only because
+Azure Cobalt ARM64 sizes do not support the nested virtualization WSL2 needs;
+it keeps the normal Windows image selection unless `azure.image` is set
+explicitly:
 
 ```text
 standard  Standard_D32pds_v6, Standard_D32ps_v6, then 16-vCPU fallbacks
@@ -70,8 +73,8 @@ large     Standard_D96pds_v6, Standard_D96ps_v6, then 64/48-vCPU fallbacks
 beast     Standard_D96pds_v6, Standard_D96ps_v6, then 64-vCPU fallbacks
 ```
 
-Native Windows and WSL2 use a smaller scale, and the default candidates support
-the nested virtualization WSL2 needs:
+Native Windows and WSL2 amd64 use a smaller scale, and the default candidates
+support the nested virtualization WSL2 needs:
 
 ```text
 standard  Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, then Standard_D2as_v6
@@ -194,7 +197,8 @@ The default location is `eastus`. The default Linux image is
 `MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest`.
 With `architecture: arm64` or `--arch arm64`, Linux defaults switch to
 `Canonical:ubuntu-26_04-lts:server-arm64:latest` or the matching
-`ubuntu-24_04-lts:server-arm64` image when `--os ubuntu:24.04` is set.
+`ubuntu-24_04-lts:server-arm64` image when `--os ubuntu:24.04` is set. Windows
+ARM64 uses ARM64 VM sizes with the selected Windows Marketplace or custom image.
 Set `azure.image` / `CRABBOX_AZURE_IMAGE` as a `Publisher:Offer:SKU:Version`
 reference to override.
 

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -63,8 +63,9 @@ beast     Standard_D192ds_v6, Standard_D128ds_v6, then D/F 96- and 64-vCPU fallb
 ARM64 classes use Azure Cobalt Dpsv6/Dpdsv6 candidates. Linux ARM64 also uses
 ARM64 Ubuntu Marketplace images. Windows ARM64 is native Windows only because
 Azure Cobalt ARM64 sizes do not support the nested virtualization WSL2 needs;
-it keeps the normal Windows image selection unless `azure.image` is set
-explicitly:
+it requires `azure.image` / `CRABBOX_AZURE_IMAGE` on the request, or
+`CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` on the Worker, to name an ARM64 Windows
+Marketplace or custom image because the built-in Windows default is x64:
 
 ```text
 standard  Standard_D32pds_v6, Standard_D32ps_v6, then 16-vCPU fallbacks
@@ -155,6 +156,7 @@ CRABBOX_AZURE_CLIENT_ID
 CRABBOX_AZURE_LOCATION
 CRABBOX_AZURE_RESOURCE_GROUP
 CRABBOX_AZURE_IMAGE
+CRABBOX_AZURE_WINDOWS_ARM64_IMAGE
 CRABBOX_AZURE_OS_DISK
 CRABBOX_AZURE_VNET
 CRABBOX_AZURE_SUBNET
@@ -200,7 +202,10 @@ With `architecture: arm64` or `--arch arm64`, Linux defaults switch to
 `ubuntu-24_04-lts:server-arm64` image when `--os ubuntu:24.04` is set. Windows
 ARM64 uses ARM64 VM sizes with the selected Windows Marketplace or custom image.
 Set `azure.image` / `CRABBOX_AZURE_IMAGE` as a `Publisher:Offer:SKU:Version`
-reference to override.
+reference to override. In brokered mode, use
+`CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` on the Worker to provide the default ARM64
+Windows image without changing the global Azure image fallback for Linux or
+AMD64 Windows leases.
 
 ## VPN / Private Network
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -77,7 +77,7 @@ broker:
 
 provider: aws            # default provider when --provider is unset
 target: linux            # default target OS: linux | macos | windows
-architecture: amd64      # amd64 | arm64; arm64 is Linux-only on AWS/Azure
+architecture: amd64      # amd64 | arm64; arm64 supports Linux on AWS/Azure and native Windows on Azure
 os: ubuntu:26.04         # OS image; resolved to per-provider images for linux
 windows:
   mode: normal           # normal | wsl2 when target=windows

--- a/docs/features/jobs.md
+++ b/docs/features/jobs.md
@@ -142,7 +142,7 @@ windows:
   mode: wsl2           # normal | wsl2; sets --windows-mode
 profile: project-check
 class: beast
-architecture: amd64    # amd64 | arm64; arm64 is Linux-only on AWS/Azure
+architecture: amd64    # amd64 | arm64; arm64 supports Linux on AWS/Azure and native Windows on Azure
 type: m8i.4xlarge      # alias: serverType
 market: on-demand      # alias: capacity.market
 network: auto

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -96,7 +96,9 @@ from the environment.
 Set `architecture: arm64` or pass `--arch arm64` for Linux ARM leases. Crabbox
 then switches class fallback to Azure Cobalt Dpsv6/Dpdsv6 sizes and uses the
 matching Ubuntu ARM64 Marketplace image unless `azure.image` is explicitly set.
-ARM64 is not supported for native Windows, WSL2, or macOS targets.
+Native Windows ARM64 leases also use Azure Cobalt VM sizes and require an
+explicit ARM64 Windows Marketplace or custom image. Azure Windows ARM64 WSL2 is
+not supported because those VM sizes do not support nested virtualization.
 
 `azure.network` selects which IP the CLI uses for SSH: `public` (default) uses the
 VM public IP, `private` uses the NIC private IP from the vnet. Use `private` when
@@ -128,6 +130,7 @@ CRABBOX_AZURE_BACKEND            # vm | dynamic-sessions
 CRABBOX_AZURE_LOCATION
 CRABBOX_AZURE_RESOURCE_GROUP
 CRABBOX_AZURE_IMAGE
+CRABBOX_AZURE_WINDOWS_ARM64_IMAGE
 CRABBOX_AZURE_OS_DISK            # managed | ephemeral | ephemeral-preview | auto
 CRABBOX_AZURE_VNET
 CRABBOX_AZURE_SUBNET
@@ -182,6 +185,9 @@ Brokered leases reuse the same Azure service-principal secrets on the Worker:
 disk mode, and SSH CIDR defaults through the `CRABBOX_AZURE_*` env vars on the
 Worker. A lease request may override only `azureLocation`, `azureImage`, and
 `azureOSDisk`.
+Set `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` on the Worker when brokered Azure
+Windows ARM64 leases need a default ARM64 Windows image without changing the
+global `CRABBOX_AZURE_IMAGE` fallback used by existing custom-image leases.
 
 Set `CRABBOX_AZURE_REGIONS` on the Worker for Azure-specific capacity fallback;
 `CRABBOX_CAPACITY_REGIONS` remains the AWS region fallback list.

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -178,6 +178,11 @@ func isAzureDefaultLinuxImage(image string) bool {
 	}
 }
 
+func azureWindowsARM64HasExplicitImage(cfg Config) bool {
+	image := strings.TrimSpace(cfg.AzureImage)
+	return image != "" && image != defaultAzureWindowsImage && !isAzureDefaultLinuxImage(image)
+}
+
 func azureVMSizeCandidatesForTargetModeClass(target, windowsMode, class string) []string {
 	switch target {
 	case targetLinux:
@@ -214,6 +219,12 @@ func azureVMSizeCandidatesForTargetModeArchitectureClass(target, windowsMode, ar
 		return azureVMSizeCandidatesForArchitectureClass(architecture, class)
 	case targetWindows:
 		if windowsMode == windowsModeNormal || windowsMode == windowsModeWSL2 {
+			if architecture == ArchitectureARM64 {
+				if windowsMode == windowsModeWSL2 {
+					return []string{class}
+				}
+				return azureARM64VMSizeCandidatesForClass(class)
+			}
 			return azureWindowsVMSizeCandidatesForClass(class)
 		}
 		return []string{class}
@@ -282,8 +293,8 @@ func azureEphemeralFullCachingCandidates(cfg Config, candidates []string) []stri
 	}
 	if cfg.TargetOS == targetWindows {
 		return filterAzureEphemeralFullCachingCandidates(appendUniqueStrings(
-			azureWindowsVMSizeCandidatesForClass("large"),
-			azureWindowsVMSizeCandidatesForClass("beast")...,
+			azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), "large"),
+			azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), "beast")...,
 		))
 	}
 	return candidates

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -150,6 +150,14 @@ func TestAzureVMSizeCandidatesForTargetModeClass(t *testing.T) {
 	if want := azureWindowsVMSizeCandidatesForClass("standard"); !reflect.DeepEqual(wsl2, want) {
 		t.Fatalf("wsl2 target got %v want %v", wsl2, want)
 	}
+	windowsARM64 := azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, windowsModeNormal, ArchitectureARM64, "standard")
+	if want := azureARM64VMSizeCandidatesForClass("standard"); !reflect.DeepEqual(windowsARM64, want) {
+		t.Fatalf("windows arm64 target got %v want %v", windowsARM64, want)
+	}
+	wsl2ARM64 := azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, windowsModeWSL2, ArchitectureARM64, "standard")
+	if want := []string{"standard"}; !reflect.DeepEqual(wsl2ARM64, want) {
+		t.Fatalf("wsl2 arm64 target got %v want %v", wsl2ARM64, want)
+	}
 }
 
 func TestAzureVMSizeCandidatesForConfigHonorsARM64(t *testing.T) {
@@ -161,6 +169,18 @@ func TestAzureVMSizeCandidatesForConfigHonorsARM64(t *testing.T) {
 	cfg.architectureExplicit = true
 	if got := azureVMSizeCandidatesForConfig(cfg)[0]; got != "Standard_D96pds_v6" {
 		t.Fatalf("first arm64 size=%q", got)
+	}
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	if got := azureVMSizeCandidatesForConfig(cfg)[0]; got != "Standard_D96pds_v6" {
+		t.Fatalf("first windows arm64 size=%q", got)
+	}
+	cfg.architectureExplicit = false
+	cfg.Architecture = ArchitectureAMD64
+	cfg.ServerType = "Standard_D2pds_v6"
+	cfg.ServerTypeExplicit = true
+	if got := effectiveArchitectureForConfig(cfg); got != ArchitectureARM64 {
+		t.Fatalf("windows explicit ARM64 size inferred architecture=%q", got)
 	}
 }
 
@@ -184,6 +204,11 @@ func TestAzureVMSizeCandidatesForConfigFiltersEphemeralPreview(t *testing.T) {
 	windows.AzureOSDisk = AzureOSDiskEphemeralPreview
 	if got := azureVMSizeCandidatesForConfig(windows); !reflect.DeepEqual(got, []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5"}) {
 		t.Fatalf("windows preview candidates=%v", got)
+	}
+	windows.Architecture = ArchitectureARM64
+	windows.architectureExplicit = true
+	if got := azureVMSizeCandidatesForConfig(windows); !reflect.DeepEqual(got, []string{"Standard_D32pds_v6", "Standard_D16pds_v6"}) {
+		t.Fatalf("windows arm64 preview candidates=%v", got)
 	}
 }
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -368,6 +368,18 @@ APT
 rm -rf /var/lib/apt/lists/*
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates curl git rsync jq
+if [ -d /proc/sys/fs/binfmt_misc ]; then
+  if [ ! -e /proc/sys/fs/binfmt_misc/register ]; then
+    mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc 2>/dev/null || true
+  fi
+  if [ -e /proc/sys/fs/binfmt_misc/status ] && ! grep -qx enabled /proc/sys/fs/binfmt_misc/status; then
+    printf '1' >/proc/sys/fs/binfmt_misc/status 2>/dev/null || true
+  fi
+  if [ ! -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+    test -w /proc/sys/fs/binfmt_misc/register
+    printf '%s' ':WSLInterop:M::MZ::/init:PF' >/proc/sys/fs/binfmt_misc/register
+  fi
+fi
 cat >/usr/local/bin/crabbox-ready <<'READY'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -375,6 +387,7 @@ git --version >/dev/null
 rsync --version >/dev/null
 curl --version >/dev/null
 jq --version >/dev/null
+test -e /proc/sys/fs/binfmt_misc/WSLInterop
 test -w ` + shellQuote(workRoot) + `
 READY
 chmod 0755 /usr/local/bin/crabbox-ready

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -555,7 +555,11 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		"WriteAllText($wslSetup",
 		"wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh",
 		"apt-get install -y --no-install-recommends ca-certificates curl git rsync jq",
+		"mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc",
+		"test -w /proc/sys/fs/binfmt_misc/register",
+		":WSLInterop:M::MZ::/init:PF",
 		"cat >/usr/local/bin/crabbox-ready",
+		"test -e /proc/sys/fs/binfmt_misc/WSLInterop",
 		`test -w '/work/crabbox'`,
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/cli/os_image.go
+++ b/internal/cli/os_image.go
@@ -87,10 +87,12 @@ func effectiveArchitectureForConfig(cfg Config) string {
 	if cfg.architectureExplicit {
 		return cfg.Architecture
 	}
-	if cfg.TargetOS == targetLinux {
+	if cfg.TargetOS == targetLinux || cfg.TargetOS == targetWindows {
 		if cfg.Provider == "azure" && azureVMSizeIsARM64(cfg.ServerType) {
 			return ArchitectureARM64
 		}
+	}
+	if cfg.TargetOS == targetLinux {
 		if cfg.Provider == "aws" && awsInstanceTypeIsARM64(cfg.ServerType) {
 			return ArchitectureARM64
 		}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -127,15 +127,21 @@ func validateProviderTarget(cfg Config) error {
 	if !providerSpecSupportsTarget(provider.Spec(), cfg.TargetOS, cfg.WindowsMode) {
 		return exit(2, "%s", unsupportedManagedTargetMessageForConfig(provider.Name(), cfg))
 	}
-	if cfg.Architecture == ArchitectureARM64 {
-		if cfg.TargetOS != targetLinux {
-			return exit(2, "architecture=arm64 currently supports target=linux only")
-		}
+	if effectiveArchitectureForConfig(cfg) == ArchitectureARM64 {
 		if provider.Name() != "azure" && provider.Name() != "aws" {
 			return exit(2, "architecture=arm64 currently supports provider=azure or provider=aws")
 		}
+		if cfg.TargetOS != targetLinux && !(provider.Name() == "azure" && cfg.TargetOS == targetWindows) {
+			return exit(2, "architecture=arm64 currently supports target=linux or provider=azure target=windows only")
+		}
+		if provider.Name() == "azure" && cfg.TargetOS == targetWindows && cfg.WindowsMode == windowsModeWSL2 {
+			return exit(2, "provider=azure target=windows architecture=arm64 supports windows.mode=normal only; windows.mode=wsl2 requires nested virtualization, which Azure Cobalt ARM64 VM sizes do not support")
+		}
+		if provider.Name() == "azure" && cfg.TargetOS == targetWindows && !azureWindowsARM64HasExplicitImage(cfg) {
+			return exit(2, "provider=azure target=windows architecture=arm64 requires azure.image or CRABBOX_AZURE_IMAGE with an ARM64 Windows image; the built-in Windows default is x64")
+		}
 	}
-	if cfg.TargetOS == targetLinux && strings.TrimSpace(cfg.ServerType) != "" {
+	if (cfg.TargetOS == targetLinux || (provider.Name() == "azure" && cfg.TargetOS == targetWindows)) && strings.TrimSpace(cfg.ServerType) != "" {
 		switch provider.Name() {
 		case "aws":
 			if err := validateArchitectureServerType("AWS instance type", cfg, awsInstanceTypeIsARM64(cfg.ServerType)); err != nil {

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -122,6 +122,65 @@ func TestValidateProviderTargetAllowsAzureWindowsModes(t *testing.T) {
 	}
 }
 
+func TestValidateProviderTargetAllowsAzureWindowsARM64(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Architecture = ArchitectureARM64
+	cfg.architectureExplicit = true
+	cfg.ServerType = "Standard_D32pds_v6"
+	cfg.ServerTypeExplicit = true
+	cfg.AzureImage = "Contoso:windows-arm64:server:latest"
+	if err := validateProviderTarget(cfg); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestValidateProviderTargetRejectsAzureWindowsARM64WSL2(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	cfg.Architecture = ArchitectureARM64
+	cfg.architectureExplicit = true
+	cfg.ServerType = "Standard_D32pds_v6"
+	cfg.ServerTypeExplicit = true
+	cfg.AzureImage = "Contoso:windows-arm64:server:latest"
+	err := validateProviderTarget(cfg)
+	if err == nil || !strings.Contains(err.Error(), "supports windows.mode=normal only") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestValidateProviderTargetRejectsAzureWindowsARM64WithoutExplicitImage(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Architecture = ArchitectureARM64
+	cfg.architectureExplicit = true
+	cfg.ServerType = "Standard_D32pds_v6"
+	cfg.ServerTypeExplicit = true
+	err := validateProviderTarget(cfg)
+	if err == nil || !strings.Contains(err.Error(), "requires azure.image") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestValidateProviderTargetRejectsAWSWindowsARM64(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeNormal
+	cfg.Architecture = ArchitectureARM64
+	cfg.architectureExplicit = true
+	err := validateProviderTarget(cfg)
+	if err == nil || !strings.Contains(err.Error(), "provider=azure target=windows") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestValidateRequestedCapabilitiesAllowsAzureWindowsDesktop(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "azure"

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -373,6 +373,18 @@ APT
 rm -rf /var/lib/apt/lists/*
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates curl git rsync jq
+if [ -d /proc/sys/fs/binfmt_misc ]; then
+  if [ ! -e /proc/sys/fs/binfmt_misc/register ]; then
+    mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc 2>/dev/null || true
+  fi
+  if [ -e /proc/sys/fs/binfmt_misc/status ] && ! grep -qx enabled /proc/sys/fs/binfmt_misc/status; then
+    printf '1' >/proc/sys/fs/binfmt_misc/status 2>/dev/null || true
+  fi
+  if [ ! -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+    test -w /proc/sys/fs/binfmt_misc/register
+    printf '%s' ':WSLInterop:M::MZ::/init:PF' >/proc/sys/fs/binfmt_misc/register
+  fi
+fi
 cat >/usr/local/bin/crabbox-ready <<'READY'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -380,6 +392,7 @@ git --version >/dev/null
 rsync --version >/dev/null
 curl --version >/dev/null
 jq --version >/dev/null
+test -e /proc/sys/fs/binfmt_misc/WSLInterop
 test -w ${shellQuote(workRoot)}
 READY
 chmod 0755 /usr/local/bin/crabbox-ready

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -89,6 +89,7 @@ export type Architecture = "amd64" | "arm64";
 
 export interface LeaseConfigDefaults {
   azureOSDisk?: string;
+  azureImage?: string;
 }
 
 const maxRequestedPondNameLength = 41;
@@ -110,6 +111,14 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   const architecture = architectureExplicit
     ? requestedArchitecture
     : inferArchitectureForServerType(provider, target, input.serverType, requestedArchitecture);
+  const azureImage =
+    input.azureImage ??
+    defaults.azureImage ??
+    (target === "linux" && osExplicit
+      ? architecture === "arm64"
+        ? (linuxOSImage?.azureArm64Image ?? "")
+        : (linuxOSImage?.azureImage ?? "")
+      : "");
   if (
     target !== "linux" &&
     !(provider === "aws" && target === "windows") &&
@@ -122,11 +131,27 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     throw new Error(`unsupported target for brokered ${provider}: ${target}`);
   }
   if (architecture === "arm64") {
-    if (target !== "linux") {
-      throw new Error("architecture=arm64 currently supports target=linux only");
-    }
     if (provider !== "azure" && provider !== "aws") {
       throw new Error("architecture=arm64 currently supports provider=azure or provider=aws");
+    }
+    if (target !== "linux" && !(provider === "azure" && target === "windows")) {
+      throw new Error(
+        "architecture=arm64 currently supports target=linux or provider=azure target=windows only",
+      );
+    }
+    if (provider === "azure" && target === "windows" && windowsMode === "wsl2") {
+      throw new Error(
+        "brokered provider=azure target=windows architecture=arm64 supports windowsMode=normal only; windowsMode=wsl2 requires nested virtualization, which Azure Cobalt ARM64 VM sizes do not support",
+      );
+    }
+    if (
+      provider === "azure" &&
+      target === "windows" &&
+      !azureWindowsARM64HasExplicitImage(azureImage)
+    ) {
+      throw new Error(
+        "brokered provider=azure target=windows architecture=arm64 requires azureImage with an ARM64 Windows image; the built-in Windows default is x64",
+      );
     }
   }
   if (
@@ -232,13 +257,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     awsSSHCIDRs,
     awsMacHostID: input.awsMacHostID ?? "",
     azureLocation: input.azureLocation ?? "",
-    azureImage:
-      input.azureImage ??
-      (osExplicit
-        ? architecture === "arm64"
-          ? (linuxOSImage?.azureArm64Image ?? "")
-          : (linuxOSImage?.azureImage ?? "")
-        : ""),
+    azureImage,
     azureSnapshot,
     azureOSDisk,
     gcpProject: input.gcpProject ?? "",
@@ -357,13 +376,17 @@ function inferArchitectureForServerType(
   serverType: string | undefined,
   fallback: Architecture,
 ): Architecture {
-  if (target !== "linux" || !serverType) {
+  if (!serverType) {
     return fallback;
   }
-  if (provider === "azure" && azureVMSizeIsARM64(serverType)) {
+  if (
+    provider === "azure" &&
+    (target === "linux" || target === "windows") &&
+    azureVMSizeIsARM64(serverType)
+  ) {
     return "arm64";
   }
-  if (provider === "aws" && awsInstanceTypeIsARM64(serverType)) {
+  if (provider === "aws" && target === "linux" && awsInstanceTypeIsARM64(serverType)) {
     return "arm64";
   }
   return fallback;
@@ -376,7 +399,7 @@ function validateArchitectureServerType(
   architectureExplicit: boolean,
   serverType: string,
 ): void {
-  if (target !== "linux") {
+  if (target !== "linux" && !(provider === "azure" && target === "windows")) {
     return;
   }
   const serverTypeARM64 =
@@ -402,6 +425,19 @@ function providerServerTypeName(provider: Provider): string {
     return "AWS instance type";
   }
   return "server type";
+}
+
+function azureWindowsARM64HasExplicitImage(image: string | undefined): boolean {
+  const normalized = image?.trim() ?? "";
+  if (!normalized) return false;
+  const defaultImages = new Set([
+    "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest",
+    osImageSpec("ubuntu:24.04").azureImage,
+    osImageSpec("ubuntu:24.04").azureArm64Image,
+    osImageSpec("ubuntu:26.04").azureImage,
+    osImageSpec("ubuntu:26.04").azureArm64Image,
+  ]);
+  return !defaultImages.has(normalized);
 }
 
 export function awsPromotedAMIConfigKey(region: string, serverType: string): string {
@@ -723,12 +759,17 @@ export function azureVMSizeCandidatesForTargetClass(
   if (target === "linux") {
     candidates = azureVMSizeCandidatesForArchitectureClass(architecture, machineClass);
   } else if (target === "windows" && (windowsMode === "normal" || windowsMode === "wsl2")) {
-    candidates = azureWindowsVMSizeCandidatesForClass(machineClass);
+    candidates =
+      architecture === "arm64"
+        ? windowsMode === "wsl2"
+          ? [machineClass]
+          : azureARM64VMSizeCandidatesForClass(machineClass)
+        : azureWindowsVMSizeCandidatesForClass(machineClass);
   } else {
     candidates = [machineClass];
   }
   if (azureOSDisk === "ephemeral-preview") {
-    return azureEphemeralFullCachingCandidates(target, candidates);
+    return azureEphemeralFullCachingCandidates(target, candidates, architecture, windowsMode);
   }
   return candidates;
 }
@@ -871,13 +912,18 @@ function azureVMSizeVCPUCount(vmSize: string): number | undefined {
   return Number.parseInt(match[1], 10);
 }
 
-function azureEphemeralFullCachingCandidates(target: TargetOS, candidates: string[]): string[] {
+function azureEphemeralFullCachingCandidates(
+  target: TargetOS,
+  candidates: string[],
+  architecture: Architecture = "amd64",
+  windowsMode: WindowsMode = "normal",
+): string[] {
   const filtered = candidates.filter(azureSupportsEphemeralFullCaching);
   if (filtered.length > 0) return filtered;
   if (target === "windows") {
     return [
-      ...azureWindowsVMSizeCandidatesForClass("large"),
-      ...azureWindowsVMSizeCandidatesForClass("beast"),
+      ...azureVMSizeCandidatesForTargetClass(target, "large", windowsMode, architecture),
+      ...azureVMSizeCandidatesForTargetClass(target, "beast", windowsMode, architecture),
     ]
       .filter((value, index, values) => values.indexOf(value) === index)
       .filter(azureSupportsEphemeralFullCaching);

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -90,6 +90,7 @@ export type Architecture = "amd64" | "arm64";
 export interface LeaseConfigDefaults {
   azureOSDisk?: string;
   azureImage?: string;
+  azureWindowsARM64Image?: string;
 }
 
 const maxRequestedPondNameLength = 41;
@@ -111,9 +112,14 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   const architecture = architectureExplicit
     ? requestedArchitecture
     : inferArchitectureForServerType(provider, target, input.serverType, requestedArchitecture);
+  const defaultAzureImage =
+    provider === "azure" && target === "windows" && architecture === "arm64"
+      ? defaults.azureWindowsARM64Image
+      : undefined;
+  const inputAzureImage = input.azureImage?.trim() || undefined;
   const azureImage =
-    input.azureImage ??
-    defaults.azureImage ??
+    inputAzureImage ??
+    defaultAzureImage ??
     (target === "linux" && osExplicit
       ? architecture === "arm64"
         ? (linuxOSImage?.azureArm64Image ?? "")
@@ -432,6 +438,8 @@ function azureWindowsARM64HasExplicitImage(image: string | undefined): boolean {
   if (!normalized) return false;
   const defaultImages = new Set([
     "MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest",
+    "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest",
     osImageSpec("ubuntu:24.04").azureImage,
     osImageSpec("ubuntu:24.04").azureArm64Image,
     osImageSpec("ubuntu:26.04").azureImage,

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16,6 +16,7 @@ import {
   leaseConfig,
   validCIDRs,
   type LeaseConfig,
+  type LeaseConfigDefaults,
 } from "./config";
 import { GCPClient } from "./gcp";
 import { HetznerClient } from "./hetzner";
@@ -1025,10 +1026,11 @@ export class FleetDurableObject implements DurableObject {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const input = await readJson<LeaseRequest>(request);
-    let config = leaseConfig(
-      input,
-      this.env.CRABBOX_AZURE_OS_DISK ? { azureOSDisk: this.env.CRABBOX_AZURE_OS_DISK } : undefined,
-    );
+    const defaults: LeaseConfigDefaults = {};
+    const azureImage = this.env.CRABBOX_AZURE_IMAGE?.trim();
+    if (azureImage) defaults.azureImage = azureImage;
+    if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
+    let config = leaseConfig(input, defaults);
     if (!isAdminRequest(request) && hasNativeLeaseSource(config)) {
       return json(
         {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1029,6 +1029,8 @@ export class FleetDurableObject implements DurableObject {
     const defaults: LeaseConfigDefaults = {};
     const azureImage = this.env.CRABBOX_AZURE_IMAGE?.trim();
     if (azureImage) defaults.azureImage = azureImage;
+    const azureWindowsARM64Image = this.env.CRABBOX_AZURE_WINDOWS_ARM64_IMAGE?.trim();
+    if (azureWindowsARM64Image) defaults.azureWindowsARM64Image = azureWindowsARM64Image;
     if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
     let config = leaseConfig(input, defaults);
     if (!isAdminRequest(request) && hasNativeLeaseSource(config)) {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -31,6 +31,7 @@ export interface Env {
   CRABBOX_AZURE_REGIONS?: string;
   CRABBOX_AZURE_RESOURCE_GROUP?: string;
   CRABBOX_AZURE_IMAGE?: string;
+  CRABBOX_AZURE_WINDOWS_ARM64_IMAGE?: string;
   CRABBOX_AZURE_OS_DISK?: string;
   CRABBOX_AZURE_VNET?: string;
   CRABBOX_AZURE_SUBNET?: string;

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -124,6 +124,23 @@ describe("azure provider", () => {
     ).toBeUndefined();
   });
 
+  it("uses the Worker Azure image env fallback when the lease has no image override", () => {
+    const client = new AzureClient({
+      ...baseEnv,
+      CRABBOX_AZURE_IMAGE: "Canonical:custom-linux:image:latest",
+    });
+    const imageForConfig = (
+      client as unknown as { imageForConfig(config: LeaseConfig): string }
+    ).imageForConfig.bind(client);
+
+    expect(imageForConfig(testLeaseConfig({ azureImage: "" }))).toBe(
+      "Canonical:custom-linux:image:latest",
+    );
+    expect(
+      imageForConfig(testLeaseConfig({ azureImage: "Canonical:custom-linux:image:latest" })),
+    ).toBe("Canonical:custom-linux:image:latest");
+  });
+
   it("orders Azure region candidates from defaults, env, and capacity regions", () => {
     expect(
       azureRegionCandidates(

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -480,6 +480,10 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("downloaded WSL rootfs is incomplete");
     expect(got).toContain("wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2");
     expect(got).toContain("wsl.exe --set-default $wslDistro");
+    expect(got).toContain("mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc");
+    expect(got).toContain("test -w /proc/sys/fs/binfmt_misc/register");
+    expect(got).toContain(":WSLInterop:M::MZ::/init:PF");
+    expect(got).toContain("test -e /proc/sys/fs/binfmt_misc/WSLInterop");
     expect(got).toContain("test -w '/work/crabbox'");
     const setupIndex = got.indexOf(
       "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -141,6 +141,10 @@ describe("machine class config", () => {
       expect(azureVMSizeCandidatesForTargetClass("windows", name, "wsl2")).toEqual(
         azureWindows[name],
       );
+      expect(azureVMSizeCandidatesForTargetClass("windows", name, "normal", "arm64")).toEqual(
+        azureLinuxARM64[name],
+      );
+      expect(azureVMSizeCandidatesForTargetClass("windows", name, "wsl2", "arm64")).toEqual([name]);
       expect(awsInstanceTypeCandidatesForTargetClass("windows", name)).toEqual(awsWindows[name]);
       expect(awsInstanceTypeCandidatesForTargetClass("windows", name, "wsl2")).toEqual(
         awsWSL2[name],
@@ -535,15 +539,79 @@ describe("lease config", () => {
     }
   });
 
-  it("rejects ARM leases outside supported Linux providers", () => {
+  it("allows Azure Windows ARM64 leases", () => {
+    const config = leaseConfig({
+      provider: "azure",
+      target: "windows",
+      architecture: "arm64",
+      serverType: "Standard_D32pds_v6",
+      azureImage: "Contoso:windows-arm64:server:latest",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(config.architecture).toBe("arm64");
+    expect(config.serverType).toBe("Standard_D32pds_v6");
+    expect(config.azureImage).toBe("Contoso:windows-arm64:server:latest");
+
+    const marketplace = leaseConfig({
+      provider: "azure",
+      target: "windows",
+      architecture: "arm64",
+      serverType: "Standard_D32pds_v6",
+      azureImage: "Canonical:windows-arm64:server:latest",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    expect(marketplace.azureImage).toBe("Canonical:windows-arm64:server:latest");
+
+    const defaultImage = leaseConfig(
+      {
+        provider: "azure",
+        target: "windows",
+        architecture: "arm64",
+        serverType: "Standard_D32pds_v6",
+        sshPublicKey: "ssh-ed25519 test",
+      },
+      { azureImage: "Contoso:windows-arm64:server:latest" },
+    );
+    expect(defaultImage.azureImage).toBe("Contoso:windows-arm64:server:latest");
+  });
+
+  it("rejects Azure Windows ARM64 leases without an explicit ARM64 image", () => {
     expect(() =>
       leaseConfig({
         provider: "azure",
         target: "windows",
         architecture: "arm64",
+        serverType: "Standard_D32pds_v6",
         sshPublicKey: "ssh-ed25519 test",
       }),
-    ).toThrow("architecture=arm64 currently supports target=linux only");
+    ).toThrow("requires azureImage");
+  });
+
+  it("rejects Azure Windows ARM64 WSL2 leases", () => {
+    expect(() =>
+      leaseConfig({
+        provider: "azure",
+        target: "windows",
+        windowsMode: "wsl2",
+        architecture: "arm64",
+        serverType: "Standard_D32pds_v6",
+        azureImage: "Contoso:windows-arm64:server:latest",
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    ).toThrow("supports windowsMode=normal only");
+  });
+
+  it("rejects ARM leases outside supported providers and targets", () => {
+    expect(() =>
+      leaseConfig({
+        provider: "aws",
+        target: "windows",
+        architecture: "arm64",
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    ).toThrow(
+      "architecture=arm64 currently supports target=linux or provider=azure target=windows only",
+    );
     expect(() =>
       leaseConfig({
         provider: "hetzner",

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -468,6 +468,19 @@ describe("lease config", () => {
     expect(config.azureImage).toBe("Canonical:ubuntu-26_04-lts:server-arm64:latest");
   });
 
+  it("does not apply the Azure Windows ARM64 broker image default to Linux leases", () => {
+    const config = leaseConfig(
+      {
+        provider: "azure",
+        architecture: "arm64",
+        os: "ubuntu:26.04",
+        sshPublicKey: "ssh-ed25519 test",
+      },
+      { azureWindowsARM64Image: "Contoso:windows-arm64:server:latest" },
+    );
+    expect(config.azureImage).toBe("Canonical:ubuntu-26_04-lts:server-arm64:latest");
+  });
+
   it("filters Azure defaults for ephemeral-preview full caching", () => {
     const arm = leaseConfig({
       provider: "azure",
@@ -570,9 +583,22 @@ describe("lease config", () => {
         serverType: "Standard_D32pds_v6",
         sshPublicKey: "ssh-ed25519 test",
       },
-      { azureImage: "Contoso:windows-arm64:server:latest" },
+      { azureWindowsARM64Image: "Contoso:windows-arm64:server:latest" },
     );
     expect(defaultImage.azureImage).toBe("Contoso:windows-arm64:server:latest");
+
+    const emptyRequestImage = leaseConfig(
+      {
+        provider: "azure",
+        target: "windows",
+        architecture: "arm64",
+        serverType: "Standard_D32pds_v6",
+        azureImage: "",
+        sshPublicKey: "ssh-ed25519 test",
+      },
+      { azureWindowsARM64Image: "Contoso:windows-arm64:server:latest" },
+    );
+    expect(emptyRequestImage.azureImage).toBe("Contoso:windows-arm64:server:latest");
   });
 
   it("rejects Azure Windows ARM64 leases without an explicit ARM64 image", () => {
@@ -585,6 +611,35 @@ describe("lease config", () => {
         sshPublicKey: "ssh-ed25519 test",
       }),
     ).toThrow("requires azureImage");
+
+    expect(() =>
+      leaseConfig(
+        {
+          provider: "azure",
+          target: "windows",
+          architecture: "arm64",
+          serverType: "Standard_D32pds_v6",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+        { azureImage: "Contoso:windows-arm64:server:latest" },
+      ),
+    ).toThrow("requires azureImage");
+
+    for (const azureImage of [
+      "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+      "Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:latest",
+    ]) {
+      expect(() =>
+        leaseConfig({
+          provider: "azure",
+          target: "windows",
+          architecture: "arm64",
+          serverType: "Standard_D32pds_v6",
+          azureImage,
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+      ).toThrow("requires azureImage");
+    }
   });
 
   it("rejects Azure Windows ARM64 WSL2 leases", () => {


### PR DESCRIPTION
## Summary
- allow Azure native Windows ARM64 leases with explicit ARM64 Windows images
- reject Azure Windows ARM64 WSL2 because current Cobalt ARM64 sizes do not support nested virtualization
- infer Azure Windows ARM64 from explicit ARM VM sizes and align CLI/worker candidate tables
- repair WSL2 bootstrap by registering WSLInterop through `binfmt_misc` so Windows `.exe` interop works inside WSL
- thread broker `CRABBOX_AZURE_IMAGE` defaults into ARM64 Windows validation
- update docs for native-Windows-only ARM64 support

## Validation
- `go test ./internal/cli ./internal/providers/azure`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run format --prefix worker -- src/bootstrap.ts src/config.ts src/fleet.ts test/bootstrap.test.ts test/config.test.ts`
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker -- bootstrap.test.ts config.test.ts` (3 files, 58 tests passed)
- fresh Azure Windows WSL2 smoke on final branch: POSIX sync/exec, `git`, `rsync`, WSLInterop, PowerShell bridge, and `wsl.exe --list --verbose` passed
- fresh Azure native Windows smoke on final branch: PowerShell, Git, hostname, sync/exec passed
- autoreview local: clean, no accepted/actionable findings
