### PR TITLE
feat: add external lifecycle steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added ordered declarative external lifecycle steps with optional acquire rollback, allowing multi-command private provider setup without shell wrappers.
+
 ## 0.26.1 - 2026-06-09
 
 ### Added

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -477,7 +477,10 @@ provider: external
 external:
   lifecycle:
     acquire:
-      argv: [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
+      steps:
+        - [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
+        - [devboxctl, setup, "{{resourceName}}"]
+      rollbackOnFailure: true
     list:
       argv: [devboxctl, list, --format, json]
       output: json-name-array
@@ -497,9 +500,11 @@ external:
   workRoot: /home/developer/crabbox
 ```
 
-Declarative lifecycle entries are argv arrays, not shell commands. See
-[External Provider](../providers/external.md) for placeholders, inventory
-formats, routing behavior, and security guidance.
+Declarative lifecycle entries use one `argv` array or an ordered `steps` list,
+not shell commands. Acquire steps can opt into release cleanup with
+`rollbackOnFailure: true`. See [External Provider](../providers/external.md)
+for placeholders, output semantics, inventory formats, routing behavior, and
+security guidance.
 
 ### Daytona
 

--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -60,7 +60,10 @@ external:
     doctor:
       argv: [devboxctl, list, --format, json]
     acquire:
-      argv: [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
+      steps:
+        - [devboxctl, new, "{{resourceName}}", --size, "{{config.size}}"]
+        - [devboxctl, setup, "{{resourceName}}"]
+      rollbackOnFailure: true
     resolve:
       argv: [devboxctl, inspect, "{{resourceName}}"]
     list:
@@ -91,6 +94,13 @@ external:
 ```
 
 `acquire`, `list`, `release`, and `connection.ssh.user` are required.
+Lifecycle operations configure exactly one of `argv` or `steps`. Steps run in
+order and stop at the first failure. For structured list output, only the final
+step's stdout is parsed; earlier stdout is forwarded as diagnostic output.
+`acquire.rollbackOnFailure: true` runs the configured release operation when a
+later acquire step fails after at least one successful step, unless the caller
+requested `--keep`.
+
 `connection.resourceName` defaults to `{{name}}`; use it when the provider has
 stricter resource-name limits than Crabbox. Crabbox stores the resolved value
 with the lease so `json-name-array` inventory can recover the original lease
@@ -98,8 +108,8 @@ ID and slug. `connection.ssh.host` defaults to `{{resourceName}}`. Optional
 operations are skipped when absent; Crabbox still maintains local touch
 metadata.
 
-Each `argv` item is passed directly to the configured executable. Shell
-operators, pipes, variable expansion, and command substitution are not
+Each `argv` or `steps` item is passed directly to the configured executable.
+Shell operators, pipes, variable expansion, and command substitution are not
 evaluated. Supported placeholders:
 
 ```text

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -229,9 +229,11 @@ type ExternalLifecycleConfig struct {
 }
 
 type ExternalLifecycleOperation struct {
-	Argv       []string `yaml:"argv,omitempty" json:"argv,omitempty"`
-	Output     string   `yaml:"output,omitempty" json:"output,omitempty"`
-	NamePrefix string   `yaml:"namePrefix,omitempty" json:"namePrefix,omitempty"`
+	Argv              []string   `yaml:"argv,omitempty" json:"argv,omitempty"`
+	Steps             [][]string `yaml:"steps,omitempty" json:"steps,omitempty"`
+	Output            string     `yaml:"output,omitempty" json:"output,omitempty"`
+	NamePrefix        string     `yaml:"namePrefix,omitempty" json:"namePrefix,omitempty"`
+	RollbackOnFailure bool       `yaml:"rollbackOnFailure,omitempty" json:"rollbackOnFailure,omitempty"`
 }
 
 type ExternalConnectionConfig struct {

--- a/internal/cli/config_kubevirt_external_test.go
+++ b/internal/cli/config_kubevirt_external_test.go
@@ -133,7 +133,10 @@ func TestLoadDeclarativeExternalConfig(t *testing.T) {
 external:
   lifecycle:
     acquire:
-      argv: [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+      steps:
+        - [devboxctl, new, "{{name}}", --size, "{{config.size}}"]
+        - [devboxctl, setup, "{{name}}"]
+      rollbackOnFailure: true
     list:
       argv: [devboxctl, list, --format, json]
       output: json-name-array
@@ -166,8 +169,11 @@ external:
 	if err := applyFileConfig(&cfg, file); err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Join(cfg.External.Lifecycle.Acquire.Argv, "|"); got != "devboxctl|new|{{name}}|--size|{{config.size}}" {
-		t.Fatalf("acquire argv=%q", got)
+	if len(cfg.External.Lifecycle.Acquire.Steps) != 2 ||
+		strings.Join(cfg.External.Lifecycle.Acquire.Steps[0], "|") != "devboxctl|new|{{name}}|--size|{{config.size}}" ||
+		strings.Join(cfg.External.Lifecycle.Acquire.Steps[1], "|") != "devboxctl|setup|{{name}}" ||
+		!cfg.External.Lifecycle.Acquire.RollbackOnFailure {
+		t.Fatalf("acquire=%#v", cfg.External.Lifecycle.Acquire)
 	}
 	if cfg.External.Lifecycle.List.Output != "json-name-array" {
 		t.Fatalf("list=%#v", cfg.External.Lifecycle.List)

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -43,7 +43,13 @@ func TestDeclarativeExternalRoutingRoundTrip(t *testing.T) {
 	cfg := ExternalConfig{
 		Config: map[string]any{"size": "cpu16"},
 		Lifecycle: ExternalLifecycleConfig{
-			Acquire: ExternalLifecycleOperation{Argv: []string{"devboxctl", "new", "{{name}}"}},
+			Acquire: ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{name}}"},
+					{"devboxctl", "setup", "{{name}}"},
+				},
+				RollbackOnFailure: true,
+			},
 			List: ExternalLifecycleOperation{
 				Argv:   []string{"devboxctl", "list", "--format", "json"},
 				Output: "json-name-array",
@@ -67,8 +73,11 @@ func TestDeclarativeExternalRoutingRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := loaded.Lifecycle.Acquire.Argv; len(got) != 3 || got[0] != "devboxctl" || got[2] != "{{name}}" {
-		t.Fatalf("acquire=%#v", got)
+	if got := loaded.Lifecycle.Acquire.Steps; len(got) != 2 ||
+		len(got[0]) != 3 || got[0][0] != "devboxctl" || got[0][2] != "{{name}}" ||
+		len(got[1]) != 3 || got[1][1] != "setup" ||
+		!loaded.Lifecycle.Acquire.RollbackOnFailure {
+		t.Fatalf("acquire=%#v", loaded.Lifecycle.Acquire)
 	}
 	if loaded.Connection.SSH.User != "{{env.DEVBOX_USER}}" || !loaded.Connection.SSH.SSHConfigProxy {
 		t.Fatalf("connection=%#v", loaded.Connection)

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -336,7 +336,7 @@ func externalClaimScope(cfg core.Config) string {
 }
 
 func lifecycleConfigured(cfg core.ExternalConfig) bool {
-	return len(cfg.Lifecycle.Acquire.Argv) > 0
+	return lifecycleOperationConfigured(cfg.Lifecycle.Acquire)
 }
 
 func (b *leaseBackend) claimLeaseForRepo(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool) error {

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -3,6 +3,7 @@ package external
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"path"
 	"strings"
 
@@ -100,11 +101,11 @@ func validateConfig(cfg core.Config) error {
 		}
 	}
 	if hasLifecycle {
-		if len(cfg.External.Lifecycle.Release.Argv) == 0 {
-			return core.Exit(2, "external.lifecycle.release.argv is required")
+		if !lifecycleOperationConfigured(cfg.External.Lifecycle.Release) {
+			return core.Exit(2, "external.lifecycle.release.argv or steps is required")
 		}
-		if len(cfg.External.Lifecycle.List.Argv) == 0 {
-			return core.Exit(2, "external.lifecycle.list.argv is required")
+		if !lifecycleOperationConfigured(cfg.External.Lifecycle.List) {
+			return core.Exit(2, "external.lifecycle.list.argv or steps is required")
 		}
 		for name, operation := range map[string]core.ExternalLifecycleOperation{
 			"doctor":  cfg.External.Lifecycle.Doctor,
@@ -138,6 +139,9 @@ func validateConfig(cfg core.Config) error {
 }
 
 func validateLifecycleOperation(name string, operation core.ExternalLifecycleOperation) error {
+	if len(operation.Argv) > 0 && len(operation.Steps) > 0 {
+		return core.Exit(2, "external.lifecycle.%s configures both argv and steps", name)
+	}
 	if name != "list" && operation.Output != lifecycleOutputNone {
 		return core.Exit(2, "external.lifecycle.%s.output is only supported for list", name)
 	}
@@ -152,13 +156,29 @@ func validateLifecycleOperation(name string, operation core.ExternalLifecycleOpe
 	default:
 		return core.Exit(2, "external.lifecycle.%s.output %q is unsupported", name, operation.Output)
 	}
-	for index, arg := range operation.Argv {
-		if strings.ContainsRune(arg, '\x00') {
-			return core.Exit(2, "external.lifecycle.%s.argv[%d] contains a NUL byte", name, index)
-		}
+	if operation.RollbackOnFailure && name != "acquire" {
+		return core.Exit(2, "external.lifecycle.%s.rollbackOnFailure is only supported for acquire", name)
 	}
-	if len(operation.Argv) > 0 && strings.TrimSpace(operation.Argv[0]) == "" {
-		return core.Exit(2, "external.lifecycle.%s.argv executable is empty", name)
+	commands := lifecycleOperationCommands(operation)
+	if operation.RollbackOnFailure && len(commands) < 2 {
+		return core.Exit(2, "external.lifecycle.acquire.rollbackOnFailure requires at least two steps")
+	}
+	for commandIndex, command := range commands {
+		label := "argv"
+		if len(operation.Steps) > 0 {
+			label = fmt.Sprintf("steps[%d]", commandIndex)
+		}
+		if len(command) == 0 {
+			return core.Exit(2, "external.lifecycle.%s.%s is empty", name, label)
+		}
+		for index, arg := range command {
+			if strings.ContainsRune(arg, '\x00') {
+				return core.Exit(2, "external.lifecycle.%s.%s[%d] contains a NUL byte", name, label, index)
+			}
+		}
+		if strings.TrimSpace(command[0]) == "" {
+			return core.Exit(2, "external.lifecycle.%s.%s executable is empty", name, label)
+		}
 	}
 	return nil
 }

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -18,6 +19,7 @@ const (
 	lifecycleOutputJSONNameArray  = "json-name-array"
 	lifecycleOutputJSONLeaseArray = "json-lease-array"
 	externalResourceNameLabel     = "externalResourceName"
+	lifecycleRollbackTimeout      = 30 * time.Second
 )
 
 var lifecyclePlaceholderPattern = regexp.MustCompile(`\{\{([A-Za-z_][A-Za-z0-9_.-]*)\}\}`)
@@ -32,16 +34,21 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	if request.Operation == "cleanup" && request.DryRun {
 		return b.defaultLifecycleResponse(request)
 	}
-	if len(operation.Argv) == 0 {
+	commands := lifecycleOperationCommands(operation)
+	if len(commands) == 0 {
 		return b.defaultLifecycleResponse(request)
 	}
 	templateCtx, err := b.lifecycleContext(request, "")
 	if err != nil {
 		return protocolResponse{}, err
 	}
-	argv, err := expandLifecycleArgv(operation.Argv, templateCtx)
-	if err != nil {
-		return protocolResponse{}, core.Exit(2, "external lifecycle %s: %v", request.Operation, err)
+	expandedCommands := make([][]string, len(commands))
+	for index, command := range commands {
+		argv, err := expandLifecycleArgv(command, templateCtx)
+		if err != nil {
+			return protocolResponse{}, core.Exit(2, "external lifecycle %s step %d: %v", request.Operation, index+1, err)
+		}
+		expandedCommands[index] = argv
 	}
 	var defaultResponse *protocolResponse
 	if operation.Output == lifecycleOutputNone && lifecycleDefaultLeaseResponseOperation(request.Operation) {
@@ -51,22 +58,40 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 		}
 		defaultResponse = &response
 	}
-	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
-		Name:   argv[0],
-		Args:   argv[1:],
-		Stderr: b.rt.Stderr,
-	})
-	if err != nil {
-		message := strings.TrimSpace(result.Stderr)
-		if message == "" {
-			message = strings.TrimSpace(result.Stdout)
+	var result core.LocalCommandResult
+	for index, argv := range expandedCommands {
+		result, err = b.rt.Exec.Run(ctx, core.LocalCommandRequest{
+			Name:   argv[0],
+			Args:   argv[1:],
+			Stderr: b.rt.Stderr,
+		})
+		if err != nil {
+			var rollbackErr error
+			if operation.RollbackOnFailure && index > 0 && !request.Keep {
+				rollbackErr = b.rollbackLifecycleAcquire(ctx, request)
+			}
+			message := strings.TrimSpace(result.Stderr)
+			if message == "" {
+				message = strings.TrimSpace(result.Stdout)
+			}
+			if rollbackErr != nil {
+				message = fmt.Sprintf("%s; rollback failed: %v", message, rollbackErr)
+			}
+			return protocolResponse{}, core.Exit(
+				result.ExitCode,
+				"external lifecycle %s step %d failed: %v: %s",
+				request.Operation,
+				index+1,
+				err,
+				message,
+			)
 		}
-		return protocolResponse{}, core.Exit(result.ExitCode, "external lifecycle %s failed: %v: %s", request.Operation, err, message)
-	}
-	if operation.Output == lifecycleOutputNone && strings.TrimSpace(result.Stdout) != "" && b.rt.Stderr != nil {
-		_, _ = io.WriteString(b.rt.Stderr, result.Stdout)
-		if !strings.HasSuffix(result.Stdout, "\n") {
-			_, _ = io.WriteString(b.rt.Stderr, "\n")
+		if (index < len(expandedCommands)-1 || operation.Output == lifecycleOutputNone) &&
+			strings.TrimSpace(result.Stdout) != "" && b.rt.Stderr != nil {
+			_, _ = io.WriteString(b.rt.Stderr, result.Stdout)
+			if !strings.HasSuffix(result.Stdout, "\n") {
+				_, _ = io.WriteString(b.rt.Stderr, "\n")
+			}
 		}
 	}
 	switch operation.Output {
@@ -114,6 +139,35 @@ func (b *leaseBackend) invokeLifecycle(ctx context.Context, request protocolRequ
 	}
 }
 
+func lifecycleOperationConfigured(operation core.ExternalLifecycleOperation) bool {
+	return len(operation.Argv) > 0 || len(operation.Steps) > 0
+}
+
+func lifecycleOperationCommands(operation core.ExternalLifecycleOperation) [][]string {
+	if len(operation.Steps) > 0 {
+		return operation.Steps
+	}
+	if len(operation.Argv) > 0 {
+		return [][]string{operation.Argv}
+	}
+	return nil
+}
+
+func (b *leaseBackend) rollbackLifecycleAcquire(ctx context.Context, request protocolRequest) error {
+	lease, err := b.lifecycleLease(request)
+	if err != nil {
+		return err
+	}
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), lifecycleRollbackTimeout)
+	defer cancel()
+	_, err = b.invokeLifecycle(rollbackCtx, protocolRequest{
+		Operation: "release",
+		Lease:     &lease,
+		Force:     true,
+	})
+	return err
+}
+
 func lifecycleDefaultLeaseResponseOperation(operation string) bool {
 	switch operation {
 	case "acquire", "resolve", "touch":
@@ -129,7 +183,8 @@ func (b *leaseBackend) defaultLifecycleResponse(request protocolRequest) (protoc
 	case "doctor":
 		response.Message = "declarative external provider ready"
 	case "acquire", "resolve":
-		if request.Operation == "resolve" && request.ReleaseOnly && len(b.cfg.External.Lifecycle.Resolve.Argv) == 0 {
+		if request.Operation == "resolve" && request.ReleaseOnly &&
+			!lifecycleOperationConfigured(b.cfg.External.Lifecycle.Resolve) {
 			lease := lifecycleMinimalLease(request)
 			response.Lease = &lease
 			break

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"io"
 	"os"
@@ -257,6 +258,220 @@ func TestInvokeDeclarativeLifecycleExpandsArgvAndBuildsLease(t *testing.T) {
 	}
 	if response.Lease.Labels["backend"] != "pod" || response.Lease.Labels[externalResourceNameLabel] != "cbx-abcdef123456" {
 		t.Fatalf("labels=%#v", response.Lease.Labels)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleRunsOrderedSteps(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Config: map[string]any{"size": "cpu16"},
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{resourceName}}", "--size", "{{config.size}}"},
+					{"devboxctl", "setup", "{{resourceName}}"},
+				},
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{leaseIdSlug}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	response, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.requests) != 2 {
+		t.Fatalf("requests=%#v", runner.requests)
+	}
+	if got := runner.requests[0]; got.Name != "devboxctl" || strings.Join(got.Args, "|") != "new|cbx-abcdef123456|--size|cpu16" {
+		t.Fatalf("first=%#v", got)
+	}
+	if got := runner.requests[1]; got.Name != "devboxctl" || strings.Join(got.Args, "|") != "setup|cbx-abcdef123456" {
+		t.Fatalf("second=%#v", got)
+	}
+	if response.Lease == nil || response.Lease.Labels[externalResourceNameLabel] != "cbx-abcdef123456" {
+		t.Fatalf("response=%#v", response)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleRollsBackFailedAcquireStep(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{resourceName}}"},
+					{"devboxctl", "setup", "{{resourceName}}"},
+				},
+				RollbackOnFailure: true,
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "--yes", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{leaseIdSlug}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+		},
+	}
+	runner := &failingLifecycleStepRunner{failAt: 2}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "acquire step 2 failed") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.requests) != 3 {
+		t.Fatalf("requests=%#v", runner.requests)
+	}
+	if got := runner.requests[2]; got.Name != "devboxctl" || strings.Join(got.Args, "|") != "rm|--yes|cbx-abcdef123456" {
+		t.Fatalf("rollback=%#v", got)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleKeepsFailedAcquireWhenRequested(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{resourceName}}"},
+					{"devboxctl", "setup", "{{resourceName}}"},
+				},
+				RollbackOnFailure: true,
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "--yes", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{leaseIdSlug}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+		},
+	}
+	runner := &failingLifecycleStepRunner{failAt: 2}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Keep:      true,
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "acquire step 2 failed") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.requests) != 2 {
+		t.Fatalf("keep=true unexpectedly ran rollback: %#v", runner.requests)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleReportsFailedRollback(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{resourceName}}"},
+					{"devboxctl", "setup", "{{resourceName}}"},
+				},
+				RollbackOnFailure: true,
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "--yes", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{leaseIdSlug}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+		},
+	}
+	runner := &failingLifecycleRollbackRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "acquire step 2 failed") ||
+		!strings.Contains(err.Error(), "rollback failed") || !strings.Contains(err.Error(), "delete failed") {
+		t.Fatalf("err=%v", err)
+	}
+	if !runner.rollbackHasDeadline {
+		t.Fatal("rollback command did not receive a bounded context")
+	}
+}
+
+func TestInvokeDeclarativeLifecycleExpandsAllStepsBeforeRunning(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Steps: [][]string{
+					{"devboxctl", "new", "{{resourceName}}"},
+					{"devboxctl", "setup", "{{env.MISSING_DEVBOX_SETUP}}"},
+				},
+				RollbackOnFailure: true,
+			},
+			List: core.ExternalLifecycleOperation{
+				Argv:   []string{"devboxctl", "list"},
+				Output: lifecycleOutputJSONNameArray,
+			},
+			Release: core.ExternalLifecycleOperation{Argv: []string{"devboxctl", "rm", "--yes", "{{resourceName}}"}},
+		},
+		Connection: core.ExternalConnectionConfig{
+			ResourceName: "{{leaseIdSlug}}",
+			SSH:          core.ExternalSSHConnectionConfig{User: "developer", Host: "{{resourceName}}"},
+		},
+	}
+	runner := &recordingRunner{}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+	_, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired: &desiredLease{
+			LeaseID: "cbx_abcdef123456",
+			Slug:    "fast-coral",
+			Name:    "crabbox-fast-coral-deadbeef",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "acquire step 2") || !strings.Contains(err.Error(), "MISSING_DEVBOX_SETUP") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.requests) != 0 {
+		t.Fatalf("commands ran before all steps expanded: %#v", runner.requests)
 	}
 }
 
@@ -1077,19 +1292,52 @@ func TestExternalProviderHelperProcess(t *testing.T) {
 }
 
 type recordingRunner struct {
-	name   string
-	args   []string
-	stdin  []byte
-	stdout string
+	name     string
+	args     []string
+	stdin    []byte
+	stdout   string
+	requests []core.LocalCommandRequest
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.name = req.Name
 	r.args = append([]string(nil), req.Args...)
+	r.requests = append(r.requests, req)
 	if req.Stdin != nil {
 		r.stdin, _ = io.ReadAll(req.Stdin)
 	}
 	return core.LocalCommandResult{Stdout: r.stdout}, nil
+}
+
+type failingLifecycleStepRunner struct {
+	requests []core.LocalCommandRequest
+	failAt   int
+}
+
+func (r *failingLifecycleStepRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.requests = append(r.requests, req)
+	if len(r.requests) == r.failAt {
+		return core.LocalCommandResult{ExitCode: 17, Stderr: "setup failed"}, errors.New("exit status 17")
+	}
+	return core.LocalCommandResult{}, nil
+}
+
+type failingLifecycleRollbackRunner struct {
+	requests            []core.LocalCommandRequest
+	rollbackHasDeadline bool
+}
+
+func (r *failingLifecycleRollbackRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.requests = append(r.requests, req)
+	switch len(r.requests) {
+	case 2:
+		return core.LocalCommandResult{ExitCode: 17, Stderr: "setup failed"}, errors.New("exit status 17")
+	case 3:
+		_, r.rollbackHasDeadline = ctx.Deadline()
+		return core.LocalCommandResult{ExitCode: 18, Stderr: "delete failed"}, errors.New("exit status 18")
+	default:
+		return core.LocalCommandResult{}, nil
+	}
 }
 
 type processRunner struct{}


### PR DESCRIPTION
## Summary

- add ordered command steps to declarative external lifecycle operations
- preserve final-step structured output while forwarding intermediate diagnostics
- support bounded acquire rollback after later-step failures, with rollback errors surfaced
- pre-expand every step before execution and honor `--keep`

## Verification

- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- focused lifecycle regression tests
- live external-provider provision, setup, sync, command, and cleanup E2E
- structured autoreview, clean after fixes
