### PR TITLE
docs: simplify provider tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,50 +111,49 @@ human-readable name.
 
 ## Providers
 
-`Coordinator: brokered` providers can run through the Worker (or direct when no
-broker is configured); every other provider always runs direct from the CLI.
-Targets: **L**inux, **M**acOS, **W**indows.
+`Brokered` providers can run through the Worker (or direct when no broker is
+configured); every other provider always runs direct from the CLI.
 
 ### SSH-lease providers (provision or connect a box, full lifecycle)
 
-| Provider | `provider:` (aliases) | Targets | Coordinator | Notes |
-| --- | --- | --- | --- | --- |
-| [AWS EC2](docs/providers/aws.md) | `aws` | L / M / W | brokered | EC2 instances and EC2 Mac; native AMI/EBS checkpoints. |
-| [Azure](docs/providers/azure.md) | `azure` | L / W | brokered | VMs with Tailscale support; native Windows and WSL2. |
-| [Google Cloud](docs/providers/gcp.md) | `gcp` (`google`, `google-cloud`) | L | brokered | Linux Compute Engine VMs with Tailscale support. |
-| [Hetzner Cloud](docs/providers/hetzner.md) | `hetzner` | L | brokered | Linux VMs with desktop/browser/code and Tailscale. |
-| [Parallels](docs/providers/parallels.md) | `parallels` | L / M / W | direct | Local or remote macOS host; checkpoint/fork/restore/snapshot. |
-| [Proxmox](docs/providers/proxmox.md) | `proxmox` | L | direct | Clone Linux QEMU templates on a private Proxmox VE cluster. |
-| [Incus](docs/providers/incus.md) | `incus` | L | direct | Direct Incus Linux SSH leases through the official Incus Go client. |
-| [Static SSH](docs/providers/ssh.md) | `ssh` (`static`, `static-ssh`) | L / M / W | direct | Existing machines; no provisioning. |
-| [Local Container](docs/providers/local-container.md) | `local-container` (`docker`, `container`, `local-docker`) | L | direct | Local Docker-compatible runtime (Docker Desktop, OrbStack, Colima, Podman). |
-| [Apple Container](docs/providers/apple-container.md) | `apple-container` (`apple`, `applecontainer`) | L | direct | Apple's native `container` runtime on Apple silicon macOS. |
-| [exe.dev](docs/providers/exe-dev.md) | `exe-dev` (`exe`, `exedev`) | L | direct | exe.dev VMs exposed as public SSH leases. |
-| [KubeVirt](docs/providers/kubevirt.md) | `kubevirt` (`kubernetes-vm`) | L | direct | Generic KubeVirt VMs through `kubectl`, `virtctl`, and control-plane SSH forwarding. |
-| [External](docs/providers/external.md) | `external` (`exec-provider`) | L | direct | Configured executable implementing the Crabbox provider protocol. |
-| [Namespace Devbox](docs/providers/namespace-devbox.md) | `namespace-devbox` (`namespace`, `namespace-devboxes`) | L | direct | Namespace.so Devboxes over SSH. |
-| [Semaphore](docs/providers/semaphore.md) | `semaphore` (`sem`) | L | direct | A Semaphore CI job leased as a testbox. |
-| [Sprites](docs/providers/sprites.md) | `sprites` | L | direct | Sprites microVMs through `sprite proxy`. |
-| [Tenki](docs/providers/tenki.md) | `tenki` | L | direct | Tenki sandbox VMs through `tenki sandbox ssh-proxy`. |
-| [Daytona](docs/providers/daytona.md) | `daytona` | L | direct | Daytona-managed dev sandbox over SSH. |
-| [RunPod](docs/providers/runpod.md) | `runpod` (`run-pod`, `runpodio`) | L | direct | RunPod GPU pods with public SSH. |
-| [ASCII Box](docs/providers/ascii-box.md) | `ascii-box` (`ascii`, `asciibox`) | L | direct | ASCII Box Ubuntu sandboxes exposed as SSH leases. |
+| Provider and aliases | Runs on / mode | Notes |
+| --- | --- | --- |
+| [AWS EC2](docs/providers/aws.md) — `aws` | Linux, macOS, Windows · brokered | EC2 instances and EC2 Mac; native AMI/EBS checkpoints. |
+| [Azure](docs/providers/azure.md) — `azure` | Linux, Windows · brokered | VMs with Tailscale support; native Windows and WSL2. |
+| [Google Cloud](docs/providers/gcp.md) — `gcp` (`google`, `google-cloud`) | Linux · brokered | Compute Engine VMs with Tailscale support. |
+| [Hetzner Cloud](docs/providers/hetzner.md) — `hetzner` | Linux · brokered | VMs with desktop/browser/code and Tailscale. |
+| [Parallels](docs/providers/parallels.md) — `parallels` | Linux, macOS, Windows · direct | Local or remote macOS host; checkpoint/fork/restore/snapshot. |
+| [Proxmox](docs/providers/proxmox.md) — `proxmox` | Linux · direct | Clone QEMU templates on a private Proxmox VE cluster. |
+| [Incus](docs/providers/incus.md) — `incus` | Linux · direct | SSH leases through the official Incus Go client. |
+| [Static SSH](docs/providers/ssh.md) — `ssh` (`static`, `static-ssh`) | Linux, macOS, Windows · direct | Existing machines; no provisioning. |
+| [Local Container](docs/providers/local-container.md) — `local-container` (`docker`, `container`, `local-docker`) | Linux · direct | Local Docker-compatible runtime (Docker Desktop, OrbStack, Colima, Podman). |
+| [Apple Container](docs/providers/apple-container.md) — `apple-container` (`apple`, `applecontainer`) | Linux · direct | Apple's native `container` runtime on Apple silicon macOS. |
+| [exe.dev](docs/providers/exe-dev.md) — `exe-dev` (`exe`, `exedev`) | Linux · direct | exe.dev VMs exposed as public SSH leases. |
+| [KubeVirt](docs/providers/kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct | Generic KubeVirt VMs through `kubectl`, `virtctl`, and control-plane SSH forwarding. |
+| [External](docs/providers/external.md) — `external` (`exec-provider`) | Linux · direct | Configured executable implementing the Crabbox provider protocol. |
+| [Namespace Devbox](docs/providers/namespace-devbox.md) — `namespace-devbox` (`namespace`, `namespace-devboxes`) | Linux · direct | Namespace.so Devboxes over SSH. |
+| [Semaphore](docs/providers/semaphore.md) — `semaphore` (`sem`) | Linux · direct | A Semaphore CI job leased as a testbox. |
+| [Sprites](docs/providers/sprites.md) — `sprites` | Linux · direct | Sprites microVMs through `sprite proxy`. |
+| [Tenki](docs/providers/tenki.md) — `tenki` | Linux · direct | Tenki sandbox VMs through `tenki sandbox ssh-proxy`. |
+| [Daytona](docs/providers/daytona.md) — `daytona` | Linux · direct | Daytona-managed dev sandbox over SSH. |
+| [RunPod](docs/providers/runpod.md) — `runpod` (`run-pod`, `runpodio`) | Linux · direct | RunPod GPU pods with public SSH. |
+| [ASCII Box](docs/providers/ascii-box.md) — `ascii-box` (`ascii`, `asciibox`) | Linux · direct | ASCII Box Ubuntu sandboxes exposed as SSH leases. |
 
 ### Delegated-run providers (sandbox/proof runners, no SSH lease)
 
-| Provider | `provider:` (aliases) | Targets | Notes |
-| --- | --- | --- | --- |
-| [Cloudflare](docs/providers/cloudflare.md) | `cloudflare` (`cf`) | L | Cloudflare Containers via the Worker runtime. |
-| [Docker Sandbox](docs/providers/docker-sandbox.md) | `docker-sandbox` | L | Docker Sandboxes through the standalone `sbx` CLI. |
-| [E2B](docs/providers/e2b.md) | `e2b` | L | E2B Firecracker sandbox. |
-| [Islo](docs/providers/islo.md) | `islo` | L | Islo sandbox. |
-| [Modal](docs/providers/modal.md) | `modal` | L | Modal Sandbox through the local Python client. |
-| [Railway](docs/providers/railway.md) | `railway` (`rail`, `railwayapp`) | L | Redeploy and stream an existing Railway service. |
-| [Tensorlake](docs/providers/tensorlake.md) | `tensorlake` (`tl`, `tensorlake-sbx`) | L | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
-| [Upstash Box](docs/providers/upstash-box.md) | `upstash-box` (`upstash`, `box`, `upstashbox`) | L | Upstash Box through the Box REST API. |
-| [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) | `azure-dynamic-sessions` | L | Azure Container Apps dynamic sessions. |
-| [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) | `blacksmith-testbox` (`blacksmith`) | L | Delegated Blacksmith CI Testbox lifecycle and execution. |
-| [W&B Sandboxes](docs/providers/wandb.md) | `wandb` (`weights-and-biases`) | L | Weights & Biases Sandboxes; reuses `wandb login` credentials. |
+| Provider and aliases | Runs on | Notes |
+| --- | --- | --- |
+| [Cloudflare](docs/providers/cloudflare.md) — `cloudflare` (`cf`) | Linux | Cloudflare Containers via the Worker runtime. |
+| [Docker Sandbox](docs/providers/docker-sandbox.md) — `docker-sandbox` | Linux | Docker Sandboxes through the standalone `sbx` CLI. |
+| [E2B](docs/providers/e2b.md) — `e2b` | Linux | E2B Firecracker sandbox. |
+| [Islo](docs/providers/islo.md) — `islo` | Linux | Islo sandbox. |
+| [Modal](docs/providers/modal.md) — `modal` | Linux | Modal Sandbox through the local Python client. |
+| [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`) | Linux | Redeploy and stream an existing Railway service. |
+| [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
+| [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux | Upstash Box through the Box REST API. |
+| [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux | Azure Container Apps dynamic sessions. |
+| [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`) | Linux | Delegated Blacksmith CI Testbox lifecycle and execution. |
+| [W&B Sandboxes](docs/providers/wandb.md) — `wandb` (`weights-and-biases`) | Linux | Weights & Biases Sandboxes; reuses `wandb login` credentials. |
 
 See [Providers](docs/providers/README.md) for the full reference, capabilities,
 and authoring guide.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -45,54 +45,54 @@ the default. Most names accept aliases (listed below).
 
 ## Provider pages
 
-Each page below maps to an adapter under `internal/providers/<dir>`. The
-**Provider id** is the canonical `--provider` value; **Aliases** also resolve.
+Each page below maps to an adapter under `internal/providers/<dir>`. The first
+code value is the canonical `--provider` value; parenthesized values are aliases.
 
 Some provider pages also preserve environment-specific validation runbooks when
 the built-in adapter needs a separate local smoke contract.
 
 ### SSH lease
 
-| Page | Provider id | Aliases | Targets | Brokered? |
-| --- | --- | --- | --- | --- |
-| [AWS](aws.md) | `aws` | — | Linux, macOS, Windows | yes |
-| [Azure](azure.md) | `azure` | — | Linux, Windows | yes |
-| [Google Cloud](gcp.md) | `gcp` | `google`, `google-cloud` | Linux | yes |
-| [Hetzner](hetzner.md) | `hetzner` | — | Linux | yes |
-| [Proxmox](proxmox.md) | `proxmox` | — | Linux | no (direct) |
-| [Incus](incus.md) | `incus` | — | Linux | no (direct) |
-| [Parallels](parallels.md) | `parallels` | — | Linux, macOS, Windows | no (direct) |
-| [Static SSH](ssh.md) | `ssh` | `static`, `static-ssh` | Linux, macOS, Windows | no (static) |
-| [Local Container](local-container.md) | `local-container` | `docker`, `container`, `local-docker` | Linux | no (local) |
-| [Apple Container](apple-container.md) | `apple-container` | `apple`, `applecontainer` | Linux | no (local) |
-| [Multipass](multipass.md) | `multipass` | `mp`, `canonical-multipass` | Linux | no (local) |
-| [Tart](tart.md) | `tart` | `local-tart`, `macos-vm` | macOS | no (local) |
-| [exe.dev](exe-dev.md) | `exe-dev` | `exe`, `exedev` | Linux | no (direct) |
-| [KubeVirt](kubevirt.md) | `kubevirt` | `kubernetes-vm` | Linux | no (direct) |
-| [External](external.md) | `external` | `exec-provider` | Linux | no (direct) |
-| [Namespace Devbox](namespace-devbox.md) | `namespace-devbox` | `namespace`, `namespace-devboxes` | Linux | no (direct) |
-| [Semaphore](semaphore.md) | `semaphore` | `sem` | Linux | no (direct) |
-| [Sprites](sprites.md) | `sprites` | — | Linux | no (direct) |
-| [Tenki](tenki.md) | `tenki` | — | Linux | no (direct) |
-| [Daytona](daytona.md) | `daytona` | — | Linux | no (direct) |
-| [RunPod](runpod.md) | `runpod` | `run-pod`, `runpodio` | Linux | no (direct) |
-| [ASCII Box](ascii-box.md) | `ascii-box` | `ascii`, `asciibox` | Linux | no (direct) |
+| Provider and aliases | Runs on / mode |
+| --- | --- |
+| [AWS](aws.md) — `aws` | Linux, macOS, Windows · brokered |
+| [Azure](azure.md) — `azure` | Linux, Windows · brokered |
+| [Google Cloud](gcp.md) — `gcp` (`google`, `google-cloud`) | Linux · brokered |
+| [Hetzner](hetzner.md) — `hetzner` | Linux · brokered |
+| [Proxmox](proxmox.md) — `proxmox` | Linux · direct |
+| [Incus](incus.md) — `incus` | Linux · direct |
+| [Parallels](parallels.md) — `parallels` | Linux, macOS, Windows · direct |
+| [Static SSH](ssh.md) — `ssh` (`static`, `static-ssh`) | Linux, macOS, Windows · static |
+| [Local Container](local-container.md) — `local-container` (`docker`, `container`, `local-docker`) | Linux · local |
+| [Apple Container](apple-container.md) — `apple-container` (`apple`, `applecontainer`) | Linux · local |
+| [Multipass](multipass.md) — `multipass` (`mp`, `canonical-multipass`) | Linux · local |
+| [Tart](tart.md) — `tart` (`local-tart`, `macos-vm`) | macOS · local |
+| [exe.dev](exe-dev.md) — `exe-dev` (`exe`, `exedev`) | Linux · direct |
+| [KubeVirt](kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct |
+| [External](external.md) — `external` (`exec-provider`) | Linux · direct |
+| [Namespace Devbox](namespace-devbox.md) — `namespace-devbox` (`namespace`, `namespace-devboxes`) | Linux · direct |
+| [Semaphore](semaphore.md) — `semaphore` (`sem`) | Linux · direct |
+| [Sprites](sprites.md) — `sprites` | Linux · direct |
+| [Tenki](tenki.md) — `tenki` | Linux · direct |
+| [Daytona](daytona.md) — `daytona` | Linux · direct |
+| [RunPod](runpod.md) — `runpod` (`run-pod`, `runpodio`) | Linux · direct |
+| [ASCII Box](ascii-box.md) — `ascii-box` (`ascii`, `asciibox`) | Linux · direct |
 
 ### Delegated run
 
-| Page | Provider id | Aliases | Targets |
-| --- | --- | --- | --- |
-| [Azure Dynamic Sessions](azure-dynamic-sessions.md) | `azure-dynamic-sessions` | — | Linux |
-| [Blacksmith Testbox](blacksmith-testbox.md) | `blacksmith-testbox` | `blacksmith` | Linux |
-| [Cloudflare](cloudflare.md) | `cloudflare` | `cf` | Linux |
-| [Docker Sandbox](docker-sandbox.md) | `docker-sandbox` | — | Linux |
-| [E2B](e2b.md) | `e2b` | — | Linux |
-| [Islo](islo.md) | `islo` | — | Linux |
-| [Modal](modal.md) | `modal` | — | Linux |
-| [Railway](railway.md) | `railway` | `rail`, `railwayapp` | Linux |
-| [Tensorlake](tensorlake.md) | `tensorlake` | `tl`, `tensorlake-sbx` | Linux |
-| [Upstash Box](upstash-box.md) | `upstash-box` | `upstash`, `box`, `upstashbox` | Linux |
-| [W&B Sandboxes](wandb.md) | `wandb` | `weights-and-biases` | Linux |
+| Provider and aliases | Runs on |
+| --- | --- |
+| [Azure Dynamic Sessions](azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux |
+| [Blacksmith Testbox](blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`) | Linux |
+| [Cloudflare](cloudflare.md) — `cloudflare` (`cf`) | Linux |
+| [Docker Sandbox](docker-sandbox.md) — `docker-sandbox` | Linux |
+| [E2B](e2b.md) — `e2b` | Linux |
+| [Islo](islo.md) — `islo` | Linux |
+| [Modal](modal.md) — `modal` | Linux |
+| [Railway](railway.md) — `railway` (`rail`, `railwayapp`) | Linux |
+| [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
+| [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |
+| [W&B Sandboxes](wandb.md) — `wandb` (`weights-and-biases`) | Linux |
 
 Run `crabbox providers` (`--json`) to see the live capability set the binary
 reports.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -536,6 +536,7 @@ main{min-width:0;padding:28px clamp(20px,4.5vw,60px) 72px;max-width:1180px;margi
 .doc table{width:100%;border-collapse:collapse;margin:1.2em 0;font-size:.94em}
 .doc th,.doc td{border-bottom:1px solid var(--line);padding:9px 10px;text-align:left}
 .doc th{font-weight:600;color:var(--reef)}
+.doc td code{overflow-wrap:anywhere;word-break:break-word}
 .doc hr{border:0;border-top:1px solid var(--line);margin:2em 0}
 
 /* toc */


### PR DESCRIPTION
## Summary
- combine provider names, canonical IDs, and aliases into one column
- replace abbreviated targets with full OS names and combine routing mode
- let long inline-code values wrap inside generated docs tables

## Verification
- `node scripts/build-docs-site.mjs`
- `scripts/check-docs.sh`
- `node --test scripts/*.test.js`
- `git diff --check`
- autoreview clean

## Visual proof
Browser automation was unavailable. Generated HTML was inspected, and the docs build, link, and test gates passed.
