### PR TITLE
feat(provider): add Apple container machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a built-in Incus provider for local or remote Linux containers and virtual machines, including socket, TLS, and OIDC control-plane authentication, optional SSH proxy devices, retained lease reuse, and live lifecycle verification. Thanks @coygeek.
 - Added Tart macOS desktop leases with native Screen Sharing, a token-gated host-side WebVNC bridge, and documented local-network exposure boundaries. Thanks @anagnorisis2peripeteia.
 - Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` broker configuration for ARM64 validation.
+- Added persistent Apple Container 1.0 development machines through the local `apple-machine` provider.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ configured); every other provider always runs direct from the CLI.
 | [Static SSH](docs/providers/ssh.md) — `ssh` (`static`, `static-ssh`) | Linux, macOS, Windows · direct | Existing machines; no provisioning. |
 | [Local Container](docs/providers/local-container.md) — `local-container` (`docker`, `container`, `local-docker`) | Linux · direct | Local Docker-compatible runtime (Docker Desktop, OrbStack, Colima, Podman). |
 | [Apple Container](docs/providers/apple-container.md) — `apple-container` (`apple`, `applecontainer`) | Linux · direct | Apple's native `container` runtime on Apple silicon macOS. |
+| [Apple Container Machine](docs/providers/apple-machine.md) — `apple-machine` (`applemachine`) | Linux · direct | Persistent Linux development machines from Apple Container 1.0, defaulting to Alpine. |
 | [exe.dev](docs/providers/exe-dev.md) — `exe-dev` (`exe`, `exedev`) | Linux · direct | exe.dev VMs exposed as public SSH leases. |
 | [KubeVirt](docs/providers/kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct | Generic KubeVirt VMs through `kubectl`, `virtctl`, and control-plane SSH forwarding. |
 | [External](docs/providers/external.md) — `external` (`exec-provider`) | Linux · direct | Configured executable implementing the Crabbox provider protocol. |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -65,6 +65,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Static SSH](ssh.md) — `ssh` (`static`, `static-ssh`) | Linux, macOS, Windows · static |
 | [Local Container](local-container.md) — `local-container` (`docker`, `container`, `local-docker`) | Linux · local |
 | [Apple Container](apple-container.md) — `apple-container` (`apple`, `applecontainer`) | Linux · local |
+| [Apple Container Machine](apple-machine.md) — `apple-machine` (`applemachine`) | Linux · local |
 | [Multipass](multipass.md) — `multipass` (`mp`, `canonical-multipass`) | Linux · local |
 | [Tart](tart.md) — `tart` (`local-tart`, `macos-vm`) | macOS · local |
 | [exe.dev](exe-dev.md) — `exe-dev` (`exe`, `exedev`) | Linux · direct |

--- a/docs/providers/apple-machine.md
+++ b/docs/providers/apple-machine.md
@@ -1,0 +1,67 @@
+# Apple Container Machine Provider
+
+Use `provider: apple-machine` for persistent Linux development environments on
+Apple silicon macOS with Apple Container 1.0 or newer.
+
+Unlike `apple-container`, this provider uses the native `container machine`
+lifecycle. It does not install or expose SSH. Apple mounts the macOS user's home
+directory into the machine, and Crabbox executes directly with
+`container machine run`.
+
+## Prerequisites
+
+- Apple silicon with macOS 26 or newer.
+- Apple Container 1.0 or newer.
+- Start the service once with `container system start`.
+- Keep the repository under the current user's home directory.
+
+## Usage
+
+```sh
+crabbox warmup --provider apple-machine --slug linux-dev
+crabbox run --provider apple-machine --id linux-dev -- pnpm test
+crabbox status --provider apple-machine --id linux-dev
+crabbox stop --provider apple-machine linux-dev
+```
+
+A one-shot run creates and removes the machine automatically:
+
+```sh
+crabbox run --provider apple-machine -- go test ./...
+```
+
+## Configuration
+
+The provider shares the `appleContainer` image and runtime settings with the
+disposable Apple Container provider:
+
+```yaml
+provider: apple-machine
+appleContainer:
+  cliPath: container
+  image: alpine:latest
+  cpus: 4
+  memory: 8G
+```
+
+Provider flags:
+
+```text
+--apple-machine-cli <path-or-name>
+--apple-machine-image <image>
+--apple-machine-cpus <n>
+--apple-machine-memory <size>
+```
+
+## Behavior and limits
+
+- `warmup` maps to `container machine create`.
+- `run` maps to `container machine run` and preserves the host repository path.
+- `status` and `list` use machine JSON inspection.
+- `stop` deletes the machine and its persistent storage with `container machine rm`.
+- The home directory is mounted read-write. Use `apple-container` when a narrower
+  disposable filesystem boundary is more important than persistence.
+- The default is `alpine:latest`. Custom images must include `/sbin/init`, as
+  required by Apple Container's machine runtime.
+- Explicit sync, patch upload, fresh-PR preparation, desktop, browser, Tailscale,
+  and coordinator routing are not supported.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1016,6 +1016,10 @@ func MarkAppleContainerImageExplicit(cfg *Config) {
 	cfg.appleContainerImageExplicit = true
 }
 
+func AppleContainerImageExplicit(cfg Config) bool {
+	return cfg.appleContainerImageExplicit
+}
+
 func MarkMultipassImageExplicit(cfg *Config) {
 	cfg.multipassImageExplicit = true
 }

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	_ "github.com/openclaw/crabbox/internal/providers/applecontainer"
+	_ "github.com/openclaw/crabbox/internal/providers/applemachine"
 	_ "github.com/openclaw/crabbox/internal/providers/asciibox"
 	_ "github.com/openclaw/crabbox/internal/providers/aws"
 	_ "github.com/openclaw/crabbox/internal/providers/azure"

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -1,0 +1,353 @@
+package applemachine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+var hostGOOS, hostGOARCH = runtime.GOOS, runtime.GOARCH
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if err := requireHost(); err != nil {
+		return DoctorResult{}, err
+	}
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: blank(b.cfg.AppleContainer.CLIPath, "container"), Args: []string{"--version"}})
+	if err != nil {
+		return DoctorResult{}, exit(3, "Apple container CLI unavailable: %s", failureDetail(result, err))
+	}
+	machines, err := b.listMachines(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local inventory=ready leases=%d version=%s", len(machines), strings.TrimSpace(result.Stdout))}, nil
+}
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	started := time.Now()
+	leaseID, slug, name, err := b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s machine=%s\n", leaseID, slug, providerName, name)
+	total := time.Since(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, TotalMs: total.Milliseconds(), ExitCode: 0})
+	}
+	return nil
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := requireHost(); err != nil {
+		return RunResult{}, err
+	}
+	if req.SyncOnly || req.ApplyLocalPatch || req.FreshPR.Number > 0 {
+		return RunResult{}, exit(2, "provider=%s uses the host home mount; sync-only, patch upload, and fresh-PR preparation are not supported", providerName)
+	}
+	if err := validateRepoMount(req.Repo.Root); err != nil {
+		return RunResult{}, err
+	}
+	started := time.Now()
+	leaseID, slug, name := "", "", ""
+	acquired := false
+	var err error
+	if strings.TrimSpace(req.ID) == "" {
+		leaseID, slug, name, err = b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+		acquired = err == nil
+	} else {
+		leaseID, slug, name, err = b.resolveLease(req.ID, req.Repo.Root, req.Reclaim)
+	}
+	if err != nil {
+		return RunResult{}, err
+	}
+	failed := false
+	if acquired && !req.Keep {
+		defer func() {
+			if failed && req.KeepOnFailure {
+				fmt.Fprintf(b.rt.Stderr, "kept failed apple-machine lease=%s slug=%s\n", leaseID, slug)
+				return
+			}
+			if err := b.removeMachine(context.Background(), name); err != nil {
+				fmt.Fprintf(b.rt.Stderr, "warning: %v\n", err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+	args := []string{"machine", "run", "--name", name}
+	if root := strings.TrimSpace(req.Repo.Root); root != "" {
+		args = append(args, "--cwd", root)
+	}
+	envFile, cleanup, err := writeEnvFile(req.Env, req.Options.EnvAllow)
+	if err != nil {
+		return RunResult{}, err
+	}
+	if cleanup != nil {
+		defer cleanup()
+		args = append(args, "--env-file", envFile)
+	}
+	command := req.Command
+	if req.ShellMode {
+		command = []string{"/bin/sh", "-lc", shellScriptFromArgv(req.Command)}
+	}
+	if len(command) == 0 {
+		return RunResult{}, exit(2, "provider=%s requires a command", providerName)
+	}
+	args = append(args, command...)
+	commandStarted := time.Now()
+	result, runErr := b.command(ctx, args, req.Repo.Root)
+	commandDuration := time.Since(commandStarted)
+	out := RunResult{ExitCode: result.ExitCode, Command: commandDuration, Total: time.Since(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug, CommandText: strings.Join(req.Command, " ")}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, SyncSkipped: true, CommandMs: out.Command.Milliseconds(), TotalMs: out.Total.Milliseconds(), ExitCode: out.ExitCode, Label: strings.TrimSpace(req.Label)}); err != nil {
+			return out, err
+		}
+	}
+	if runErr != nil {
+		failed = true
+		return out, exit(result.ExitCode, "apple-machine command failed: %s", failureDetail(result, runErr))
+	}
+	return out, nil
+}
+
+func writeEnvFile(env map[string]string, explicitlyAllowed []string) (string, func(), error) {
+	explicit := map[string]bool{}
+	for _, key := range explicitlyAllowed {
+		explicit[strings.ToUpper(strings.TrimSpace(key))] = true
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if machineOwnedEnv(key) {
+			if explicit[strings.ToUpper(strings.TrimSpace(key))] {
+				return "", nil, exit(2, "provider=%s cannot forward host-owned environment variable %s; set it inside the machine command instead", providerName, key)
+			}
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return "", nil, nil
+	}
+	sort.Strings(keys)
+	file, err := os.CreateTemp("", "crabbox-apple-machine-env-*.env")
+	if err != nil {
+		return "", nil, exit(2, "create apple-machine env file: %v", err)
+	}
+	cleanup := func() { _ = os.Remove(file.Name()) }
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		cleanup()
+		return "", nil, exit(2, "secure apple-machine env file: %v", err)
+	}
+	for _, key := range keys {
+		if strings.ContainsAny(key, "=\r\n") || strings.ContainsAny(env[key], "\r\n") {
+			file.Close()
+			cleanup()
+			return "", nil, exit(2, "apple-machine environment values cannot contain newlines")
+		}
+		if _, err := fmt.Fprintf(file, "%s=%s\n", key, env[key]); err != nil {
+			file.Close()
+			cleanup()
+			return "", nil, exit(2, "write apple-machine env file: %v", err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, exit(2, "close apple-machine env file: %v", err)
+	}
+	return file.Name(), cleanup, nil
+}
+
+func machineOwnedEnv(key string) bool {
+	switch strings.ToUpper(strings.TrimSpace(key)) {
+	case "HOME", "LOGNAME", "OLDPWD", "PATH", "PWD", "SHELL", "TMPDIR", "USER":
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	machines, err := b.listMachines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims, err := coreClaims()
+	if err != nil {
+		return nil, err
+	}
+	byName := map[string]claimView{}
+	for _, claim := range claims {
+		if claim.Provider == providerName {
+			byName[machineName(claim.LeaseID)] = claimView{leaseID: claim.LeaseID, slug: claim.Slug}
+		}
+	}
+	views := make([]LeaseView, 0)
+	for _, item := range machines {
+		claim, ok := byName[item.ID]
+		if !ok {
+			continue
+		}
+		views = append(views, machineServer(item, claim.leaseID, claim.slug, b.cfg))
+	}
+	return views, nil
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	leaseID, slug, name, err := b.resolveLease(req.ID, "", false)
+	if err != nil {
+		return StatusView{}, err
+	}
+	item, err := b.inspectMachine(ctx, name)
+	if err != nil {
+		return StatusView{}, err
+	}
+	server := machineServer(item, leaseID, slug, b.cfg)
+	return StatusView{ID: leaseID, Slug: slug, Provider: providerName, TargetOS: targetLinux, State: server.Status, ServerID: name, ServerType: server.ServerType.Name, Ready: machineReady(item.Status), Labels: server.Labels}, nil
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	leaseID, _, name, err := b.resolveLease(req.ID, "", false)
+	if err != nil {
+		return err
+	}
+	if err := b.removeMachine(ctx, name); err != nil {
+		return err
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", leaseID, name)
+	return nil
+}
+
+func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+	if err := requireHost(); err != nil {
+		return "", "", "", err
+	}
+	if err := validateRepoMount(repo.Root); err != nil {
+		return "", "", "", err
+	}
+	leaseID := newLeaseID()
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return "", "", "", err
+	}
+	name := machineName(leaseID)
+	if err := b.createMachine(ctx, name); err != nil {
+		return "", "", "", err
+	}
+	if err := b.waitMachineReady(ctx, name); err != nil {
+		_ = b.removeMachine(context.Background(), name)
+		return "", "", "", err
+	}
+	if err := claimLease(leaseID, slug, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		_ = b.removeMachine(context.Background(), name)
+		return "", "", "", err
+	}
+	return leaseID, slug, name, nil
+}
+
+func (b *backend) waitMachineReady(ctx context.Context, name string) error {
+	deadline := time.NewTimer(30 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+			Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+			Args: []string{"machine", "run", "--name", name, ":"},
+		})
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return exit(5, "Apple container machine %q did not become ready: %s", name, failureDetail(result, err))
+		case <-ticker.C:
+		}
+	}
+}
+
+func (b *backend) resolveLease(identifier, repoRoot string, reclaim bool) (string, string, string, error) {
+	claim, ok, err := resolveLeaseClaim(identifier)
+	if err != nil {
+		return "", "", "", err
+	}
+	if !ok {
+		return "", "", "", exit(4, "apple-machine lease %q was not found", identifier)
+	}
+	if repoRoot != "" {
+		if err := claimLease(claim.LeaseID, claim.Slug, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	return claim.LeaseID, claim.Slug, machineName(claim.LeaseID), nil
+}
+
+func machineName(leaseID string) string {
+	return "crabbox-" + strings.TrimPrefix(leaseID, "cbx_")
+}
+
+func machineServer(item machine, leaseID, slug string, cfg Config) Server {
+	labels := map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux}
+	server := Server{Provider: providerName, CloudID: item.ID, Name: item.ID, Status: item.Status, Labels: labels}
+	server.ServerType.Name = blank(cfg.AppleContainer.Image, "ubuntu:26.04")
+	return server
+}
+
+func machineReady(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "ready":
+		return true
+	default:
+		return false
+	}
+}
+
+func requireHost() error {
+	if hostGOOS != "darwin" || hostGOARCH != "arm64" {
+		return exit(2, "provider=%s requires Apple silicon macOS", providerName)
+	}
+	return nil
+}
+
+func validateRepoMount(root string) error {
+	if strings.TrimSpace(root) == "" {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return exit(2, "resolve home directory: %v", err)
+	}
+	rel, err := filepath.Rel(home, root)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return exit(2, "provider=%s requires the repository under %s because container machine shares the host home directory", providerName, home)
+	}
+	return nil
+}
+
+type claimView struct{ leaseID, slug string }
+
+func coreClaims() ([]core.LeaseClaim, error) { return core.ListLeaseClaims() }

--- a/internal/providers/applemachine/backend_test.go
+++ b/internal/providers/applemachine/backend_test.go
@@ -1,0 +1,120 @@
+package applemachine
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	requests  []core.LocalCommandRequest
+	responses map[string]core.LocalCommandResult
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.requests = append(r.requests, req)
+	result := r.responses[strings.Join(req.Args, "\x00")]
+	if req.Stdout != nil {
+		_, _ = io.WriteString(req.Stdout, result.Stdout)
+	}
+	if req.Stderr != nil {
+		_, _ = io.WriteString(req.Stderr, result.Stderr)
+	}
+	return result, nil
+}
+
+func testBackend(runner *recordingRunner) *backend {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.AppleContainer.Image = "ubuntu:26.04"
+	cfg.AppleContainer.CPUs = 4
+	cfg.AppleContainer.Memory = "8G"
+	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+}
+
+func TestCreateMachineArgs(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	if err := b.createMachine(t.Context(), "crabbox-test"); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(runner.requests[0].Args, " ")
+	want := "machine create --name crabbox-test --home-mount rw --cpus 4 --memory 8G ubuntu:26.04"
+	if got != want {
+		t.Fatalf("args=%q want %q", got, want)
+	}
+}
+
+func TestInspectMachineDecodesAppleJSON(t *testing.T) {
+	args := []string{"machine", "inspect", "crabbox-test"}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		strings.Join(args, "\x00"): {Stdout: `[{"id":"crabbox-test","status":"running","ipAddress":"192.0.2.4","cpus":4,"memory":8589934592}]`},
+	}}
+	item, err := testBackend(runner).inspectMachine(t.Context(), "crabbox-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.ID != "crabbox-test" || item.Status != "running" || item.CPUs != 4 {
+		t.Fatalf("machine=%+v", item)
+	}
+}
+
+func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
+	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	t.Cleanup(func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH })
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(home, "src", "example")
+	leaseID := "cbx_123456789abc"
+	slug := "blue-crab"
+	if err := claimLease(leaseID, slug, repo, 0, true); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	b := testBackend(runner)
+	result, err := b.Run(t.Context(), RunRequest{
+		Repo:    Repo{Root: repo},
+		ID:      leaseID,
+		Keep:    true,
+		Command: []string{"go", "test", "./..."},
+		Env:     map[string]string{"CI": "1", "PATH": "/opt/homebrew/bin"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.LeaseID != leaseID || !result.SyncDelegated {
+		t.Fatalf("result=%+v", result)
+	}
+	got := strings.Join(runner.requests[0].Args, " ")
+	if !strings.Contains(got, "machine run --name crabbox-123456789abc --cwd "+repo+" --env-file ") || !strings.HasSuffix(got, " go test ./...") {
+		t.Fatalf("args=%q", got)
+	}
+	if strings.Contains(got, "CI=1") || strings.Contains(got, "/opt/homebrew/bin") {
+		t.Fatalf("environment leaked into argv: %q", got)
+	}
+	if runner.requests[0].Dir != repo {
+		t.Fatalf("dir=%q", runner.requests[0].Dir)
+	}
+}
+
+func TestValidateRepoMountRejectsOutsideHome(t *testing.T) {
+	if err := validateRepoMount("/var/tmp/example"); err == nil || !strings.Contains(err.Error(), "requires the repository under") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWriteEnvFileRejectsExplicitHostOwnedVariable(t *testing.T) {
+	_, _, err := writeEnvFile(map[string]string{"PATH": "/custom/bin"}, []string{"PATH"})
+	if err == nil || !strings.Contains(err.Error(), "cannot forward host-owned") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/providers/applemachine/client.go
+++ b/internal/providers/applemachine/client.go
@@ -1,0 +1,93 @@
+package applemachine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type machine struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	IPAddress string `json:"ipAddress,omitempty"`
+	CPUs      int    `json:"cpus,omitempty"`
+	Memory    uint64 `json:"memory,omitempty"`
+}
+
+func (b *backend) command(ctx context.Context, args []string, dir string) (LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:   blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+		Args:   args,
+		Dir:    dir,
+		Stdout: b.rt.Stdout,
+		Stderr: b.rt.Stderr,
+	})
+}
+
+func (b *backend) createMachine(ctx context.Context, name string) error {
+	args := []string{"machine", "create", "--name", name, "--home-mount", "rw"}
+	if b.cfg.AppleContainer.CPUs > 0 {
+		args = append(args, "--cpus", fmt.Sprintf("%d", b.cfg.AppleContainer.CPUs))
+	}
+	if memory := strings.TrimSpace(b.cfg.AppleContainer.Memory); memory != "" {
+		args = append(args, "--memory", memory)
+	}
+	args = append(args, blank(strings.TrimSpace(b.cfg.AppleContainer.Image), "ubuntu:26.04"))
+	result, err := b.command(ctx, args, "")
+	if err != nil {
+		return exit(5, "create Apple container machine: %s", failureDetail(result, err))
+	}
+	return nil
+}
+
+func (b *backend) inspectMachine(ctx context.Context, name string) (machine, error) {
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+		Args: []string{"machine", "inspect", name},
+	})
+	if err != nil {
+		return machine{}, exit(4, "Apple container machine %q not found: %s", name, failureDetail(result, err))
+	}
+	var machines []machine
+	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil || len(machines) != 1 {
+		return machine{}, exit(5, "decode Apple container machine %q: %v", name, err)
+	}
+	return machines[0], nil
+}
+
+func (b *backend) listMachines(ctx context.Context) ([]machine, error) {
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+		Args: []string{"machine", "list", "--format", "json"},
+	})
+	if err != nil {
+		return nil, exit(5, "list Apple container machines: %s", failureDetail(result, err))
+	}
+	var machines []machine
+	if strings.TrimSpace(result.Stdout) == "" {
+		return nil, nil
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil {
+		return nil, exit(5, "decode Apple container machine list: %v", err)
+	}
+	return machines, nil
+}
+
+func (b *backend) removeMachine(ctx context.Context, name string) error {
+	result, err := b.command(ctx, []string{"machine", "rm", name}, "")
+	if err != nil {
+		return exit(5, "delete Apple container machine %q: %s", name, failureDetail(result, err))
+	}
+	return nil
+}
+
+func failureDetail(result LocalCommandResult, err error) string {
+	if detail := strings.TrimSpace(result.Stderr); detail != "" {
+		return detail
+	}
+	if detail := strings.TrimSpace(result.Stdout); detail != "" {
+		return detail
+	}
+	return err.Error()
+}

--- a/internal/providers/applemachine/core.go
+++ b/internal/providers/applemachine/core.go
@@ -1,0 +1,60 @@
+package applemachine
+
+import (
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type Server = core.Server
+type Repo = core.Repo
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type timingReport = core.TimingReport
+
+const (
+	providerName = "apple-machine"
+	targetLinux  = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func blank(value, fallback string) string { return core.Blank(value, fallback) }
+func newLeaseID() string                  { return core.NewLeaseID() }
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func claimLease(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repoRoot, idleTimeout, reclaim)
+}
+
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, providerName)
+}
+
+func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func shellScriptFromArgv(command []string) string { return core.ShellScriptFromArgv(command) }

--- a/internal/providers/applemachine/flags.go
+++ b/internal/providers/applemachine/flags.go
@@ -1,0 +1,44 @@
+package applemachine
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	CLIPath *string
+	Image   *string
+	CPUs    *int
+	Memory  *string
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		CLIPath: fs.String("apple-machine-cli", defaults.AppleContainer.CLIPath, "path to Apple's container CLI"),
+		Image:   fs.String("apple-machine-image", defaults.AppleContainer.Image, "OCI image for apple-machine leases"),
+		CPUs:    fs.Int("apple-machine-cpus", defaults.AppleContainer.CPUs, "CPU count for apple-machine leases"),
+		Memory:  fs.String("apple-machine-memory", defaults.AppleContainer.Memory, "memory for apple-machine leases, for example 8G"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "apple-machine-cli") {
+		cfg.AppleContainer.CLIPath = *v.CLIPath
+	}
+	if core.FlagWasSet(fs, "apple-machine-image") {
+		cfg.AppleContainer.Image = *v.Image
+		core.MarkAppleContainerImageExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "apple-machine-cpus") {
+		cfg.AppleContainer.CPUs = *v.CPUs
+	}
+	if core.FlagWasSet(fs, "apple-machine-memory") {
+		cfg.AppleContainer.Memory = *v.Memory
+	}
+	return nil
+}

--- a/internal/providers/applemachine/provider.go
+++ b/internal/providers/applemachine/provider.go
@@ -1,0 +1,54 @@
+package applemachine
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() { core.RegisterProvider(Provider{}) }
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"applemachine"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "container",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s", providerName)
+	}
+	if !core.AppleContainerImageExplicit(cfg) {
+		cfg.AppleContainer.Image = "alpine:latest"
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	return backend.(core.DoctorBackend), nil
+}


### PR DESCRIPTION
## Summary
- add a persistent `apple-machine` provider backed by Apple Container 1.0 machine lifecycle
- share the host home checkout without SSH or sync
- keep forwarded secrets out of process argv via protected env files
- document lifecycle, image requirements, and limitations

## Validation
- `go test ./internal/providers/applemachine ./internal/providers/all ./internal/cli`
- `go vet ./internal/providers/applemachine ./internal/providers/all ./internal/cli`
- live Apple Container 1.0 proof on Apple silicon macOS: doctor, warmup, repo read/write, environment forwarding, timing JSON, status, stop
- autoreview: four accepted findings fixed; final remaining cwd finding rejected against Apple upstream docs and live `/Users/...` repo-path execution proof

## Full-suite note
- `go test -race ./...` passed changed packages and failed only the unrelated existing Tart timing test `TestStartVMKeepPreservesStartupStderr`.