### PR TITLE
feat(provider): add Windows MXC sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added Tart macOS desktop leases with native Screen Sharing, a token-gated host-side WebVNC bridge, and documented local-network exposure boundaries. Thanks @anagnorisis2peripeteia.
 - Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` broker configuration for ARM64 validation.
 - Added persistent Apple Container 1.0 development machines through the local `apple-machine` provider.
+- Added local Windows sandbox execution through Microsoft Execution Containers with explicit filesystem and network policy controls and an execution-backed doctor check.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added Tart macOS desktop leases with native Screen Sharing, a token-gated host-side WebVNC bridge, and documented local-network exposure boundaries. Thanks @anagnorisis2peripeteia.
 - Added native Azure Windows ARM64 lease support with explicit Windows ARM64 images, Cobalt ARM64 SKU inference, and `CRABBOX_AZURE_WINDOWS_ARM64_IMAGE` broker configuration for ARM64 validation.
 - Added persistent Apple Container 1.0 development machines through the local `apple-machine` provider.
-- Added local Windows sandbox execution through Microsoft Execution Containers with explicit filesystem and network policy controls and an execution-backed doctor check.
+- Added local Windows sandbox execution through Microsoft Execution Containers with explicit filesystem, network, DACL-fallback, and Win32k capability controls plus an execution-backed doctor check.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ configured); every other provider always runs direct from the CLI.
 | [E2B](docs/providers/e2b.md) — `e2b` | Linux | E2B Firecracker sandbox. |
 | [Islo](docs/providers/islo.md) — `islo` | Linux | Islo sandbox. |
 | [Modal](docs/providers/modal.md) — `modal` | Linux | Modal Sandbox through the local Python client. |
+| [Microsoft Execution Containers](docs/providers/mxc.md) — `mxc` (`execution-container`) | Windows | Policy-driven local Windows process containment. |
 | [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`) | Linux | Redeploy and stream an existing Railway service. |
 | [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
 | [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux | Upstash Box through the Box REST API. |

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -90,6 +90,7 @@ the built-in adapter needs a separate local smoke contract.
 | [E2B](e2b.md) — `e2b` | Linux |
 | [Islo](islo.md) — `islo` | Linux |
 | [Modal](modal.md) — `modal` | Linux |
+| [Microsoft Execution Containers](mxc.md) — `mxc` (`execution-container`) | Windows |
 | [Railway](railway.md) — `railway` (`rail`, `railwayapp`) | Linux |
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |

--- a/docs/providers/mxc.md
+++ b/docs/providers/mxc.md
@@ -1,0 +1,87 @@
+# Microsoft Execution Containers Provider
+
+Use `provider: mxc` to run a command from a local Windows checkout inside
+Microsoft Execution Containers (MXC). The initial integration targets the stable
+one-shot `processcontainer` backend from MXC schema `0.6.0-alpha`.
+
+MXC is currently public preview software. Microsoft explicitly warns that its
+current generated policies can be overly permissive, so this provider must not
+be treated as a production security boundary yet.
+
+## Prerequisites
+
+- Windows 11 24H2 or newer (build 26100+).
+- Build or install `wxc-exec.exe` from <https://github.com/microsoft/mxc>.
+- Keep the repository on the local Windows filesystem.
+
+`crabbox doctor --provider mxc --target windows` launches a harmless sandbox,
+not just MXC's read-only probe. This matters because MXC 0.6.1 reports the
+BaseContainer tier as present on stock Azure Windows 11 24H2 and 25H2 images,
+but execution still fails with disabled feature keys. MXC's experimental
+`windows_sandbox` backend also requires Windows Sandbox, host Python, nested
+virtualization, and the companion release binaries. Treat image compatibility
+as an upstream preview constraint and require a green doctor before use.
+
+## Usage
+
+```powershell
+crabbox run --provider mxc --target windows -- powershell.exe -NoProfile -Command 'Get-Location'
+```
+
+Outbound network access is blocked by default:
+
+```powershell
+crabbox run --provider mxc --mxc-network allow --shell -- npm test
+```
+
+Use `--shell` for Windows `.cmd` and `.bat` shims such as `npm`, `pnpm`, and
+`yarn`; direct mode fails closed instead of passing unescaped arguments through
+`cmd.exe`.
+
+## Configuration
+
+```yaml
+provider: mxc
+target: windows
+mxc:
+  cliPath: wxc-exec.exe
+  version: 0.6.0-alpha
+  containment: processcontainer
+  network: block
+  readOnlyPaths: []
+  readWritePaths: []
+  allowedHosts: []
+  blockedHosts: []
+  experimental: false
+```
+
+The checkout root is automatically added to `filesystem.readwritePaths`.
+Windows system and Program Files roots are added read-only. Crabbox does not
+blanket-allow every host `PATH` directory: user-installed toolchains and child
+executables outside those roots must be opted in with `--mxc-readonly-paths` or
+`mxc.readOnlyPaths`. Forwarded Crabbox environment variables become MXC process
+environment entries. The MXC JSON and private temporary workspace share a
+per-run directory whose inherited Windows ACLs are removed and replaced with
+current-user-only access, so secret values are not exposed in command-line
+arguments or a permissive shared temp directory.
+MXC's host-DACL mutation fallback is disabled; hosts that cannot provide a
+non-mutating containment tier fail closed.
+
+Provider flags:
+
+```text
+--mxc-cli <path>
+--mxc-version <schema>
+--mxc-containment <backend>
+--mxc-network block|allow
+--mxc-readonly-paths <csv>
+--mxc-readwrite-paths <csv>
+--mxc-allowed-hosts <csv>
+--mxc-blocked-hosts <csv>
+--mxc-experimental
+```
+
+Only `processcontainer` is enabled by default. Other MXC backends require
+`--mxc-experimental`. The provider is one-shot: `warmup`, persistent lease IDs,
+`status`, and `stop` are intentionally unsupported until MXC state-aware
+lifecycles stabilize beyond the current `isolation_session` preview.

--- a/docs/providers/mxc.md
+++ b/docs/providers/mxc.md
@@ -1,7 +1,7 @@
 # Microsoft Execution Containers Provider
 
 Use `provider: mxc` to run a command from a local Windows checkout inside
-Microsoft Execution Containers (MXC). The initial integration targets the stable
+Microsoft Execution Containers (MXC). The initial integration targets the
 one-shot `processcontainer` backend from MXC schema `0.6.0-alpha`.
 
 MXC is currently public preview software. Microsoft explicitly warns that its
@@ -10,22 +10,37 @@ be treated as a production security boundary yet.
 
 ## Prerequisites
 
-- Windows 11 24H2 or newer (build 26100+).
+- Windows build 26100 or newer.
 - Build or install `wxc-exec.exe` from <https://github.com/microsoft/mxc>.
 - Keep the repository on the local Windows filesystem.
 
 `crabbox doctor --provider mxc --target windows` launches a harmless sandbox,
 not just MXC's read-only probe. This matters because MXC 0.6.1 reports the
 BaseContainer tier as present on stock Azure Windows 11 24H2 and 25H2 images,
-but execution still fails with disabled feature keys. MXC's experimental
-`windows_sandbox` backend also requires Windows Sandbox, host Python, nested
-virtualization, and the companion release binaries. Treat image compatibility
-as an upstream preview constraint and require a green doctor before use.
+but execution still fails with disabled feature keys. A Windows Server vNext
+build 29595 host also lacked the BaseContainer and BFS paths and selected MXC's
+AppContainer+DACL fallback instead. Treat image compatibility as an upstream
+preview constraint and require a green doctor before use.
+
+The DACL fallback is disabled by default because it changes host ACLs. To use it
+on an isolated disposable host, first run the companion release tool elevated:
+
+```powershell
+wxc-host-prep.exe prepare-system-drive
+crabbox doctor --provider mxc --target windows --mxc-allow-dacl-mutation
+```
+
+Then pass `--mxc-allow-dacl-mutation` to each run. This opt-in allows MXC to add
+the access-control entries required by its AppContainer fallback to the
+workspace and explicitly allowed tool paths. Do not use it on a shared host.
+
+MXC's experimental `windows_sandbox` backend also requires Windows Sandbox,
+host Python, nested virtualization, and the companion release binaries.
 
 ## Usage
 
 ```powershell
-crabbox run --provider mxc --target windows -- powershell.exe -NoProfile -Command 'Get-Location'
+crabbox run --provider mxc --target windows -- cmd.exe /d /c cd
 ```
 
 Outbound network access is blocked by default:
@@ -52,6 +67,8 @@ mxc:
   readWritePaths: []
   allowedHosts: []
   blockedHosts: []
+  allowDaclMutation: false
+  allowWindowsUI: false
   experimental: false
 ```
 
@@ -64,8 +81,16 @@ environment entries. The MXC JSON and private temporary workspace share a
 per-run directory whose inherited Windows ACLs are removed and replaced with
 current-user-only access, so secret values are not exposed in command-line
 arguments or a permissive shared temp directory.
-MXC's host-DACL mutation fallback is disabled; hosts that cannot provide a
-non-mutating containment tier fail closed.
+MXC's host-DACL mutation fallback is disabled by default; hosts that cannot
+provide a non-mutating containment tier fail closed unless the operator opts in
+explicitly on a disposable host.
+
+Programs that require Win32k system calls, including Windows PowerShell, also
+need `--mxc-allow-windows-ui`. Keep it off for console-only tools:
+
+```powershell
+crabbox run --provider mxc --target windows --mxc-allow-dacl-mutation --mxc-allow-windows-ui -- powershell.exe -NoProfile -Command 'Get-Location'
+```
 
 Provider flags:
 
@@ -78,6 +103,8 @@ Provider flags:
 --mxc-readwrite-paths <csv>
 --mxc-allowed-hosts <csv>
 --mxc-blocked-hosts <csv>
+--mxc-allow-dacl-mutation
+--mxc-allow-windows-ui
 --mxc-experimental
 ```
 

--- a/docs/providers/mxc.md
+++ b/docs/providers/mxc.md
@@ -46,12 +46,13 @@ crabbox run --provider mxc --target windows -- cmd.exe /d /c cd
 Outbound network access is blocked by default:
 
 ```powershell
-crabbox run --provider mxc --mxc-network allow --shell -- npm test
+crabbox run --provider mxc --mxc-network allow --mxc-allow-windows-ui --shell -- npm test
 ```
 
 Use `--shell` for Windows `.cmd` and `.bat` shims such as `npm`, `pnpm`, and
 `yarn`; direct mode fails closed instead of passing unescaped arguments through
-`cmd.exe`.
+`cmd.exe`. Shell mode uses Windows PowerShell and therefore requires the explicit
+`--mxc-allow-windows-ui` capability opt-in.
 
 ## Configuration
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -128,6 +128,7 @@ type Config struct {
 	localContainerImageExplicit   bool
 	AppleContainer                AppleContainerConfig
 	appleContainerImageExplicit   bool
+	MXC                           MXCConfig
 	Multipass                     MultipassConfig
 	multipassImageExplicit        bool
 	Tart                          TartConfig
@@ -559,6 +560,18 @@ type AppleContainerConfig struct {
 	CPUs         int
 	Memory       string
 	ExtraRunArgs []string
+}
+
+type MXCConfig struct {
+	CLIPath        string
+	Version        string
+	Containment    string
+	Network        string
+	ReadOnlyPaths  []string
+	ReadWritePaths []string
+	AllowedHosts   []string
+	BlockedHosts   []string
+	Experimental   bool
 }
 
 type MultipassConfig struct {
@@ -1269,6 +1282,12 @@ func baseConfig() Config {
 			User:     "crabbox",
 			WorkRoot: "/work/crabbox",
 		},
+		MXC: MXCConfig{
+			CLIPath:     "wxc-exec.exe",
+			Version:     "0.6.0-alpha",
+			Containment: "processcontainer",
+			Network:     "block",
+		},
 		Multipass: MultipassConfig{
 			CLIPath:       "multipass",
 			Image:         multipassImage,
@@ -1356,6 +1375,7 @@ type fileConfig struct {
 	Sprites              *fileSpritesConfig                 `yaml:"sprites,omitempty"`
 	LocalContainer       *fileLocalContainerConfig          `yaml:"localContainer,omitempty"`
 	AppleContainer       *fileAppleContainerConfig          `yaml:"appleContainer,omitempty"`
+	MXC                  *fileMXCConfig                     `yaml:"mxc,omitempty"`
 	Multipass            *fileMultipassConfig               `yaml:"multipass,omitempty"`
 	Tart                 *fileTartConfig                    `yaml:"tart,omitempty"`
 	Tailscale            *fileTailscaleConfig               `yaml:"tailscale,omitempty"`
@@ -1804,6 +1824,18 @@ type fileAppleContainerConfig struct {
 	CPUs         int      `yaml:"cpus,omitempty"`
 	Memory       string   `yaml:"memory,omitempty"`
 	ExtraRunArgs []string `yaml:"extraRunArgs,omitempty"`
+}
+
+type fileMXCConfig struct {
+	CLIPath        string   `yaml:"cliPath,omitempty"`
+	Version        string   `yaml:"version,omitempty"`
+	Containment    string   `yaml:"containment,omitempty"`
+	Network        string   `yaml:"network,omitempty"`
+	ReadOnlyPaths  []string `yaml:"readOnlyPaths,omitempty"`
+	ReadWritePaths []string `yaml:"readWritePaths,omitempty"`
+	AllowedHosts   []string `yaml:"allowedHosts,omitempty"`
+	BlockedHosts   []string `yaml:"blockedHosts,omitempty"`
+	Experimental   *bool    `yaml:"experimental,omitempty"`
 }
 
 type fileMultipassConfig struct {
@@ -3088,6 +3120,35 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 			cfg.AppleContainer.ExtraRunArgs = append([]string(nil), file.AppleContainer.ExtraRunArgs...)
 		}
 	}
+	if file.MXC != nil {
+		if file.MXC.CLIPath != "" {
+			cfg.MXC.CLIPath = file.MXC.CLIPath
+		}
+		if file.MXC.Version != "" {
+			cfg.MXC.Version = file.MXC.Version
+		}
+		if file.MXC.Containment != "" {
+			cfg.MXC.Containment = file.MXC.Containment
+		}
+		if file.MXC.Network != "" {
+			cfg.MXC.Network = file.MXC.Network
+		}
+		if file.MXC.ReadOnlyPaths != nil {
+			cfg.MXC.ReadOnlyPaths = append([]string(nil), file.MXC.ReadOnlyPaths...)
+		}
+		if file.MXC.ReadWritePaths != nil {
+			cfg.MXC.ReadWritePaths = append([]string(nil), file.MXC.ReadWritePaths...)
+		}
+		if file.MXC.AllowedHosts != nil {
+			cfg.MXC.AllowedHosts = append([]string(nil), file.MXC.AllowedHosts...)
+		}
+		if file.MXC.BlockedHosts != nil {
+			cfg.MXC.BlockedHosts = append([]string(nil), file.MXC.BlockedHosts...)
+		}
+		if file.MXC.Experimental != nil {
+			cfg.MXC.Experimental = *file.MXC.Experimental
+		}
+	}
 	if file.Multipass != nil {
 		if file.Multipass.CLIPath != "" {
 			cfg.Multipass.CLIPath = file.Multipass.CLIPath
@@ -3926,6 +3987,25 @@ func applyEnv(cfg *Config) error {
 	cfg.AppleContainer.Memory = getenv("CRABBOX_APPLE_CONTAINER_MEMORY", cfg.AppleContainer.Memory)
 	if extra := strings.Fields(os.Getenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS")); len(extra) > 0 {
 		cfg.AppleContainer.ExtraRunArgs = extra
+	}
+	cfg.MXC.CLIPath = getenv("CRABBOX_MXC_CLI", cfg.MXC.CLIPath)
+	cfg.MXC.Version = getenv("CRABBOX_MXC_VERSION", cfg.MXC.Version)
+	cfg.MXC.Containment = getenv("CRABBOX_MXC_CONTAINMENT", cfg.MXC.Containment)
+	cfg.MXC.Network = getenv("CRABBOX_MXC_NETWORK", cfg.MXC.Network)
+	if value := os.Getenv("CRABBOX_MXC_READONLY_PATHS"); value != "" {
+		cfg.MXC.ReadOnlyPaths = splitCommaList(value)
+	}
+	if value := os.Getenv("CRABBOX_MXC_READWRITE_PATHS"); value != "" {
+		cfg.MXC.ReadWritePaths = splitCommaList(value)
+	}
+	if value := os.Getenv("CRABBOX_MXC_ALLOWED_HOSTS"); value != "" {
+		cfg.MXC.AllowedHosts = splitCommaList(value)
+	}
+	if value := os.Getenv("CRABBOX_MXC_BLOCKED_HOSTS"); value != "" {
+		cfg.MXC.BlockedHosts = splitCommaList(value)
+	}
+	if value, ok := getenvBool("CRABBOX_MXC_EXPERIMENTAL"); ok {
+		cfg.MXC.Experimental = value
 	}
 	cfg.Multipass.CLIPath = getenv("CRABBOX_MULTIPASS_CLI", cfg.Multipass.CLIPath)
 	if image := os.Getenv("CRABBOX_MULTIPASS_IMAGE"); image != "" {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -563,15 +563,17 @@ type AppleContainerConfig struct {
 }
 
 type MXCConfig struct {
-	CLIPath        string
-	Version        string
-	Containment    string
-	Network        string
-	ReadOnlyPaths  []string
-	ReadWritePaths []string
-	AllowedHosts   []string
-	BlockedHosts   []string
-	Experimental   bool
+	CLIPath           string
+	Version           string
+	Containment       string
+	Network           string
+	ReadOnlyPaths     []string
+	ReadWritePaths    []string
+	AllowedHosts      []string
+	BlockedHosts      []string
+	AllowDACLMutation bool
+	AllowWindowsUI    bool
+	Experimental      bool
 }
 
 type MultipassConfig struct {
@@ -1827,15 +1829,17 @@ type fileAppleContainerConfig struct {
 }
 
 type fileMXCConfig struct {
-	CLIPath        string   `yaml:"cliPath,omitempty"`
-	Version        string   `yaml:"version,omitempty"`
-	Containment    string   `yaml:"containment,omitempty"`
-	Network        string   `yaml:"network,omitempty"`
-	ReadOnlyPaths  []string `yaml:"readOnlyPaths,omitempty"`
-	ReadWritePaths []string `yaml:"readWritePaths,omitempty"`
-	AllowedHosts   []string `yaml:"allowedHosts,omitempty"`
-	BlockedHosts   []string `yaml:"blockedHosts,omitempty"`
-	Experimental   *bool    `yaml:"experimental,omitempty"`
+	CLIPath           string   `yaml:"cliPath,omitempty"`
+	Version           string   `yaml:"version,omitempty"`
+	Containment       string   `yaml:"containment,omitempty"`
+	Network           string   `yaml:"network,omitempty"`
+	ReadOnlyPaths     []string `yaml:"readOnlyPaths,omitempty"`
+	ReadWritePaths    []string `yaml:"readWritePaths,omitempty"`
+	AllowedHosts      []string `yaml:"allowedHosts,omitempty"`
+	BlockedHosts      []string `yaml:"blockedHosts,omitempty"`
+	AllowDACLMutation *bool    `yaml:"allowDaclMutation,omitempty"`
+	AllowWindowsUI    *bool    `yaml:"allowWindowsUI,omitempty"`
+	Experimental      *bool    `yaml:"experimental,omitempty"`
 }
 
 type fileMultipassConfig struct {
@@ -3144,6 +3148,12 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		}
 		if file.MXC.BlockedHosts != nil {
 			cfg.MXC.BlockedHosts = append([]string(nil), file.MXC.BlockedHosts...)
+		}
+		if file.MXC.AllowDACLMutation != nil {
+			cfg.MXC.AllowDACLMutation = *file.MXC.AllowDACLMutation
+		}
+		if file.MXC.AllowWindowsUI != nil {
+			cfg.MXC.AllowWindowsUI = *file.MXC.AllowWindowsUI
 		}
 		if file.MXC.Experimental != nil {
 			cfg.MXC.Experimental = *file.MXC.Experimental

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -4014,6 +4014,12 @@ func applyEnv(cfg *Config) error {
 	if value := os.Getenv("CRABBOX_MXC_BLOCKED_HOSTS"); value != "" {
 		cfg.MXC.BlockedHosts = splitCommaList(value)
 	}
+	if value, ok := getenvBool("CRABBOX_MXC_ALLOW_DACL_MUTATION"); ok {
+		cfg.MXC.AllowDACLMutation = value
+	}
+	if value, ok := getenvBool("CRABBOX_MXC_ALLOW_WINDOWS_UI"); ok {
+		cfg.MXC.AllowWindowsUI = value
+	}
 	if value, ok := getenvBool("CRABBOX_MXC_EXPERIMENTAL"); ok {
 		cfg.MXC.Experimental = value
 	}

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -155,6 +155,17 @@ func configShowView(cfg Config) map[string]any {
 			"cpus":     cfg.AppleContainer.CPUs,
 			"memory":   cfg.AppleContainer.Memory,
 		},
+		"mxc": map[string]any{
+			"cliPath":        cfg.MXC.CLIPath,
+			"version":        cfg.MXC.Version,
+			"containment":    cfg.MXC.Containment,
+			"network":        cfg.MXC.Network,
+			"readOnlyPaths":  cfg.MXC.ReadOnlyPaths,
+			"readWritePaths": cfg.MXC.ReadWritePaths,
+			"allowedHosts":   cfg.MXC.AllowedHosts,
+			"blockedHosts":   cfg.MXC.BlockedHosts,
+			"experimental":   cfg.MXC.Experimental,
+		},
 		"dockerSandbox": map[string]any{
 			"cliPath":         cfg.DockerSandbox.CLIPath,
 			"agent":           cfg.DockerSandbox.Agent,
@@ -283,6 +294,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
+	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))
 	fmt.Fprintf(w, "multipass cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s disk=%s launch_timeout=%s\n", cfg.Multipass.CLIPath, cfg.Multipass.Image, cfg.Multipass.User, cfg.Multipass.WorkRoot, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), cfg.Multipass.LaunchTimeout)
 	fmt.Fprintf(w, "tart image=%s user=%s work_root=%s cpus=%d memory=%d disk=%d\n", cfg.Tart.Image, cfg.Tart.User, cfg.Tart.WorkRoot, cfg.Tart.CPUs, cfg.Tart.Memory, cfg.Tart.Disk)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -156,15 +156,17 @@ func configShowView(cfg Config) map[string]any {
 			"memory":   cfg.AppleContainer.Memory,
 		},
 		"mxc": map[string]any{
-			"cliPath":        cfg.MXC.CLIPath,
-			"version":        cfg.MXC.Version,
-			"containment":    cfg.MXC.Containment,
-			"network":        cfg.MXC.Network,
-			"readOnlyPaths":  cfg.MXC.ReadOnlyPaths,
-			"readWritePaths": cfg.MXC.ReadWritePaths,
-			"allowedHosts":   cfg.MXC.AllowedHosts,
-			"blockedHosts":   cfg.MXC.BlockedHosts,
-			"experimental":   cfg.MXC.Experimental,
+			"cliPath":           cfg.MXC.CLIPath,
+			"version":           cfg.MXC.Version,
+			"containment":       cfg.MXC.Containment,
+			"network":           cfg.MXC.Network,
+			"readOnlyPaths":     cfg.MXC.ReadOnlyPaths,
+			"readWritePaths":    cfg.MXC.ReadWritePaths,
+			"allowedHosts":      cfg.MXC.AllowedHosts,
+			"blockedHosts":      cfg.MXC.BlockedHosts,
+			"allowDaclMutation": cfg.MXC.AllowDACLMutation,
+			"allowWindowsUI":    cfg.MXC.AllowWindowsUI,
+			"experimental":      cfg.MXC.Experimental,
 		},
 		"dockerSandbox": map[string]any{
 			"cliPath":         cfg.DockerSandbox.CLIPath,
@@ -294,7 +296,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
-	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.Experimental)
+	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))
 	fmt.Fprintf(w, "multipass cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s disk=%s launch_timeout=%s\n", cfg.Multipass.CLIPath, cfg.Multipass.Image, cfg.Multipass.User, cfg.Multipass.WorkRoot, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), cfg.Multipass.LaunchTimeout)
 	fmt.Fprintf(w, "tart image=%s user=%s work_root=%s cpus=%d memory=%d disk=%d\n", cfg.Tart.Image, cfg.Tart.User, cfg.Tart.WorkRoot, cfg.Tart.CPUs, cfg.Tart.Memory, cfg.Tart.Disk)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1413,6 +1413,23 @@ func TestLoadConfigRoutesAzureBackendFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoadConfigMXCCapabilityEnvOverrides(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(home, "missing.yaml"))
+	t.Setenv("CRABBOX_MXC_ALLOW_DACL_MUTATION", "true")
+	t.Setenv("CRABBOX_MXC_ALLOW_WINDOWS_UI", "true")
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.MXC.AllowDACLMutation || !cfg.MXC.AllowWindowsUI {
+		t.Fatalf("mxc=%+v", cfg.MXC)
+	}
+}
+
 func TestLoadConfigTailscaleBlock(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/localcontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/modal"
 	_ "github.com/openclaw/crabbox/internal/providers/multipass"
+	_ "github.com/openclaw/crabbox/internal/providers/mxc"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
 	_ "github.com/openclaw/crabbox/internal/providers/parallels"
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"

--- a/internal/providers/mxc/backend.go
+++ b/internal/providers/mxc/backend.go
@@ -1,0 +1,156 @@
+package mxc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var windowsBuildPattern = regexp.MustCompile(`(?m)CurrentBuildNumber\s+REG_SZ\s+(\d+)`)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if err := requireSupportedWindows(); err != nil {
+		return DoctorResult{}, err
+	}
+	path, err := exec.LookPath(defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"))
+	if err != nil {
+		return DoctorResult{}, exit(3, "MXC executor not found: %v", err)
+	}
+	if err := b.smokeTest(ctx, path); err != nil {
+		return DoctorResult{}, err
+	}
+	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local executor=%s containment=%s version=%s network=%s", path, b.cfg.MXC.Containment, b.cfg.MXC.Version, b.cfg.MXC.Network)}, nil
+}
+
+func (b *backend) smokeTest(ctx context.Context, path string) error {
+	config, configDir, cleanupConfig, err := buildIsolatedConfig(b.cfg, RunRequest{Command: []string{"cmd.exe", "/d", "/c", "exit", "0"}, Options: LeaseOptions{TTL: 30 * time.Second}})
+	if err != nil {
+		return err
+	}
+	defer cleanupConfig()
+	configPath, cleanup, err := writeConfigFile(configDir, config)
+	if err != nil {
+		return exit(3, "write MXC doctor config: %v", err)
+	}
+	defer cleanup()
+	args := []string{}
+	if b.cfg.MXC.Experimental {
+		args = append(args, "--experimental")
+	}
+	args = append(args, configPath)
+	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: path, Args: args})
+	if runErr != nil {
+		return exit(3, "MXC runtime unavailable: %s", failureDetail(result, runErr))
+	}
+	return nil
+}
+func (b *backend) Warmup(context.Context, WarmupRequest) error {
+	return exit(2, "provider=mxc is one-shot; use crabbox run")
+}
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := requireSupportedWindows(); err != nil {
+		return RunResult{}, err
+	}
+	if req.ID != "" || req.Keep || req.KeepOnFailure {
+		return RunResult{}, exit(2, "provider=mxc is one-shot and does not support persistent lease ids")
+	}
+	if req.SyncOnly || req.ApplyLocalPatch || req.FreshPR.Number > 0 {
+		return RunResult{}, exit(2, "provider=mxc executes the local checkout directly; explicit sync and patch preparation are not supported")
+	}
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	started := time.Now()
+	config, configDir, cleanupConfig, err := buildIsolatedConfig(b.cfg, req)
+	if err != nil {
+		return RunResult{}, err
+	}
+	defer cleanupConfig()
+	path, cleanup, err := writeConfigFile(configDir, config)
+	if err != nil {
+		return RunResult{}, exit(2, "write MXC config: %v", err)
+	}
+	defer cleanup()
+	args := []string{}
+	if b.cfg.MXC.Experimental {
+		args = append(args, "--experimental")
+	}
+	args = append(args, path)
+	commandStarted := time.Now()
+	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"), Args: args, Dir: req.Repo.Root, Stdout: b.rt.Stdout, Stderr: b.rt.Stderr})
+	out := RunResult{ExitCode: result.ExitCode, Command: time.Since(commandStarted), Total: time.Since(started), SyncDelegated: true, Provider: providerName, CommandText: strings.Join(req.Command, " ")}
+	if req.TimingJSON {
+		_ = writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, CommandMs: out.Command.Milliseconds(), TotalMs: out.Total.Milliseconds(), ExitCode: out.ExitCode, SyncDelegated: true, SyncSkipped: true})
+	}
+	if runErr != nil {
+		detail := strings.TrimSpace(result.Stderr)
+		if detail == "" {
+			detail = runErr.Error()
+		}
+		return out, exit(result.ExitCode, "MXC command failed: %s", detail)
+	}
+	return out, nil
+}
+func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) { return nil, nil }
+func (b *backend) Status(context.Context, StatusRequest) (StatusView, error) {
+	return StatusView{}, exit(2, "provider=mxc is one-shot and does not support status")
+}
+func (b *backend) Stop(context.Context, StopRequest) error {
+	return exit(2, "provider=mxc is one-shot and does not support stop")
+}
+func requireSupportedWindows() error {
+	if runtime.GOOS != "windows" {
+		return exit(2, "provider=mxc requires a Windows host")
+	}
+	output, err := exec.Command("reg.exe", "query", `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`, "/v", "CurrentBuildNumber").CombinedOutput()
+	if err != nil {
+		return exit(3, "detect Windows build: %v", err)
+	}
+	build, err := parseWindowsBuild(string(output))
+	if err != nil {
+		return exit(3, "%v", err)
+	}
+	if build < 26100 {
+		return exit(2, "provider=mxc requires Windows 11 24H2 or newer (build 26100+); detected build %d", build)
+	}
+	return nil
+}
+
+func parseWindowsBuild(output string) (int, error) {
+	match := windowsBuildPattern.FindStringSubmatch(output)
+	if len(match) != 2 {
+		return 0, fmt.Errorf("could not parse CurrentBuildNumber")
+	}
+	build, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, fmt.Errorf("parse CurrentBuildNumber: %w", err)
+	}
+	return build, nil
+}
+
+func failureDetail(result LocalCommandResult, err error) string {
+	if detail := strings.TrimSpace(result.Stderr); detail != "" {
+		return detail
+	}
+	if detail := strings.TrimSpace(result.Stdout); detail != "" {
+		return detail
+	}
+	return err.Error()
+}

--- a/internal/providers/mxc/backend.go
+++ b/internal/providers/mxc/backend.go
@@ -128,7 +128,7 @@ func requireSupportedWindows() error {
 		return exit(3, "%v", err)
 	}
 	if build < 26100 {
-		return exit(2, "provider=mxc requires Windows 11 24H2 or newer (build 26100+); detected build %d", build)
+		return exit(2, "provider=mxc requires Windows build 26100 or newer; detected build %d", build)
 	}
 	return nil
 }

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -44,6 +44,9 @@ type mxcUI struct {
 }
 
 func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
+	if req.ShellMode && !cfg.MXC.AllowWindowsUI {
+		return mxcConfig{}, exit(2, "provider=mxc --shell uses Windows PowerShell; rerun with --mxc-allow-windows-ui")
+	}
 	commandLine, err := windowsCommandLine(req.Command, req.ShellMode)
 	if err != nil {
 		return mxcConfig{}, err

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -1,0 +1,225 @@
+package mxc
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+type mxcConfig struct {
+	Version     string        `json:"version"`
+	Containment string        `json:"containment"`
+	Process     mxcProcess    `json:"process"`
+	Filesystem  mxcFilesystem `json:"filesystem"`
+	Network     mxcNetwork    `json:"network"`
+	Fallback    mxcFallback   `json:"fallback"`
+}
+type mxcProcess struct {
+	CommandLine string   `json:"commandLine"`
+	CWD         string   `json:"cwd,omitempty"`
+	Env         []string `json:"env,omitempty"`
+	Timeout     int64    `json:"timeout,omitempty"`
+}
+type mxcFilesystem struct {
+	ReadWritePaths []string `json:"readwritePaths,omitempty"`
+	ReadOnlyPaths  []string `json:"readonlyPaths,omitempty"`
+}
+type mxcNetwork struct {
+	DefaultPolicy   string   `json:"defaultPolicy"`
+	EnforcementMode string   `json:"enforcementMode,omitempty"`
+	AllowedHosts    []string `json:"allowedHosts,omitempty"`
+	BlockedHosts    []string `json:"blockedHosts,omitempty"`
+}
+type mxcFallback struct {
+	AllowDACLMutation bool `json:"allowDaclMutation"`
+}
+
+func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
+	commandLine, err := windowsCommandLine(req.Command, req.ShellMode)
+	if err != nil {
+		return mxcConfig{}, err
+	}
+	readwrite := append([]string(nil), cfg.MXC.ReadWritePaths...)
+	if root := strings.TrimSpace(req.Repo.Root); root != "" {
+		readwrite = append(readwrite, root)
+	}
+	readonly := append(defaultReadOnlyPaths(), cfg.MXC.ReadOnlyPaths...)
+	if !req.ShellMode && len(req.Command) > 0 {
+		if resolved, err := exec.LookPath(req.Command[0]); err == nil {
+			readonly = append(readonly, resolved)
+		}
+	}
+	env := make([]string, 0, len(req.Env))
+	for key, value := range req.Env {
+		env = append(env, key+"="+value)
+	}
+	sort.Strings(env)
+	timeout := req.Options.TTL
+	if timeout <= 0 {
+		timeout = cfg.TTL
+	}
+	return mxcConfig{
+		Version:     defaultString(cfg.MXC.Version, "0.6.0-alpha"),
+		Containment: defaultString(cfg.MXC.Containment, "processcontainer"),
+		Process:     mxcProcess{CommandLine: commandLine, CWD: req.Repo.Root, Env: env, Timeout: timeout.Milliseconds()},
+		Filesystem:  mxcFilesystem{ReadWritePaths: uniquePaths(readwrite), ReadOnlyPaths: uniquePaths(readonly)},
+		Network:     mxcNetwork{DefaultPolicy: defaultString(cfg.MXC.Network, "block"), EnforcementMode: "both", AllowedHosts: cfg.MXC.AllowedHosts, BlockedHosts: cfg.MXC.BlockedHosts},
+		Fallback:    mxcFallback{AllowDACLMutation: false},
+	}, nil
+}
+
+func buildIsolatedConfig(cfg Config, req RunRequest) (mxcConfig, string, func(), error) {
+	tempDir, err := os.MkdirTemp("", "crabbox-mxc-run-*")
+	if err != nil {
+		return mxcConfig{}, "", nil, exit(2, "create MXC temporary directory: %v", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+	if err := secureDirectory(tempDir); err != nil {
+		cleanup()
+		return mxcConfig{}, "", nil, exit(2, "secure MXC temporary directory: %v", err)
+	}
+	cfg.MXC.ReadWritePaths = append(append([]string(nil), cfg.MXC.ReadWritePaths...), tempDir)
+	req.Env = cloneEnv(req.Env)
+	req.Env["TEMP"] = tempDir
+	req.Env["TMP"] = tempDir
+	config, err := buildConfig(cfg, req)
+	if err != nil {
+		cleanup()
+		return mxcConfig{}, "", nil, err
+	}
+	return config, tempDir, cleanup, nil
+}
+
+func secureDirectory(path string) error {
+	if runtime.GOOS != "windows" {
+		return os.Chmod(path, 0o700)
+	}
+	current, err := user.Current()
+	if err != nil {
+		return err
+	}
+	result, err := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", current.Username+`:(OI)(CI)F`).CombinedOutput()
+	if err != nil {
+		return exit(2, "icacls: %s", strings.TrimSpace(string(result)))
+	}
+	return nil
+}
+
+func cloneEnv(env map[string]string) map[string]string {
+	cloned := make(map[string]string, len(env)+2)
+	for key, value := range env {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func writeConfigFile(dir string, config mxcConfig) (string, func(), error) {
+	file, err := os.CreateTemp(dir, "config-*.json")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.Remove(file.Name()) }
+	if runtime.GOOS != "windows" {
+		if err := file.Chmod(0o600); err != nil {
+			file.Close()
+			cleanup()
+			return "", nil, err
+		}
+	}
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(config); err != nil {
+		file.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return file.Name(), cleanup, nil
+}
+
+func defaultReadOnlyPaths() []string {
+	values := []string{os.Getenv("SystemRoot"), os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)")}
+	return uniquePaths(values)
+}
+func uniquePaths(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		clean := filepath.Clean(value)
+		key := strings.ToLower(clean)
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, clean)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+func windowsCommandLine(command []string, shellMode bool) (string, error) {
+	return windowsCommandLineWithLookPath(command, shellMode, exec.LookPath)
+}
+
+func windowsCommandLineWithLookPath(command []string, shellMode bool, lookPath func(string) (string, error)) (string, error) {
+	if len(command) == 0 {
+		return "", exit(2, "provider=mxc requires a command")
+	}
+	if shellMode {
+		return "powershell.exe -NoProfile -NonInteractive -Command " + quoteWindowsArg(strings.Join(command, " ")), nil
+	}
+	parts := make([]string, len(command))
+	for i, arg := range command {
+		parts[i] = quoteWindowsArg(arg)
+	}
+	commandLine := strings.Join(parts, " ")
+	if resolved, err := lookPath(command[0]); err == nil {
+		switch strings.ToLower(filepath.Ext(resolved)) {
+		case ".bat", ".cmd":
+			return "", exit(2, "command %q resolves to a Windows script shim; rerun with --shell or invoke an executable directly", command[0])
+		}
+	}
+	return commandLine, nil
+}
+func quoteWindowsArg(value string) string {
+	if value != "" && !strings.ContainsAny(value, " \t\n\v\"") {
+		return value
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	slashes := 0
+	for _, r := range value {
+		if r == '\\' {
+			slashes++
+			continue
+		}
+		if r == '"' {
+			b.WriteString(strings.Repeat("\\", slashes*2+1))
+			b.WriteRune(r)
+			slashes = 0
+			continue
+		}
+		b.WriteString(strings.Repeat("\\", slashes))
+		slashes = 0
+		b.WriteRune(r)
+	}
+	b.WriteString(strings.Repeat("\\", slashes*2))
+	b.WriteByte('"')
+	return b.String()
+}
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(value)
+}

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -81,8 +81,36 @@ func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 }
 
 func isWindowsVolumeRoot(path string) bool {
-	clean := strings.TrimRight(strings.TrimSpace(path), `\\/`)
-	return len(clean) == 2 && clean[1] == ':'
+	clean := strings.TrimRight(strings.ReplaceAll(strings.TrimSpace(path), "/", `\`), `\`)
+	if isWindowsDriveRoot(clean) {
+		return true
+	}
+	lower := strings.ToLower(clean)
+	if strings.HasPrefix(lower, `\\?\unc\`) {
+		return len(windowsPathParts(clean[len(`\\?\unc\`):])) == 2
+	}
+	if strings.HasPrefix(lower, `\\?\`) {
+		return isWindowsDriveRoot(clean[len(`\\?\`):])
+	}
+	if strings.HasPrefix(clean, `\\`) {
+		return len(windowsPathParts(clean[2:])) == 2
+	}
+	return false
+}
+
+func isWindowsDriveRoot(path string) bool {
+	return len(path) == 2 && path[1] == ':' && ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z'))
+}
+
+func windowsPathParts(path string) []string {
+	parts := strings.Split(path, `\`)
+	out := parts[:0]
+	for _, part := range parts {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func windowsProcessEnvironment(forwarded map[string]string) []string {

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -18,6 +18,7 @@ type mxcConfig struct {
 	Filesystem  mxcFilesystem `json:"filesystem"`
 	Network     mxcNetwork    `json:"network"`
 	Fallback    mxcFallback   `json:"fallback"`
+	UI          mxcUI         `json:"ui"`
 }
 type mxcProcess struct {
 	CommandLine string   `json:"commandLine"`
@@ -38,6 +39,9 @@ type mxcNetwork struct {
 type mxcFallback struct {
 	AllowDACLMutation bool `json:"allowDaclMutation"`
 }
+type mxcUI struct {
+	Disable bool `json:"disable"`
+}
 
 func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 	commandLine, err := windowsCommandLine(req.Command, req.ShellMode)
@@ -46,6 +50,9 @@ func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 	}
 	readwrite := append([]string(nil), cfg.MXC.ReadWritePaths...)
 	if root := strings.TrimSpace(req.Repo.Root); root != "" {
+		if isWindowsVolumeRoot(root) {
+			return mxcConfig{}, exit(2, "refusing to grant MXC read-write access to volume root %q", root)
+		}
 		readwrite = append(readwrite, root)
 	}
 	readonly := append(defaultReadOnlyPaths(), cfg.MXC.ReadOnlyPaths...)
@@ -54,11 +61,7 @@ func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 			readonly = append(readonly, resolved)
 		}
 	}
-	env := make([]string, 0, len(req.Env))
-	for key, value := range req.Env {
-		env = append(env, key+"="+value)
-	}
-	sort.Strings(env)
+	env := windowsProcessEnvironment(req.Env)
 	timeout := req.Options.TTL
 	if timeout <= 0 {
 		timeout = cfg.TTL
@@ -69,8 +72,42 @@ func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 		Process:     mxcProcess{CommandLine: commandLine, CWD: req.Repo.Root, Env: env, Timeout: timeout.Milliseconds()},
 		Filesystem:  mxcFilesystem{ReadWritePaths: uniquePaths(readwrite), ReadOnlyPaths: uniquePaths(readonly)},
 		Network:     mxcNetwork{DefaultPolicy: defaultString(cfg.MXC.Network, "block"), EnforcementMode: "both", AllowedHosts: cfg.MXC.AllowedHosts, BlockedHosts: cfg.MXC.BlockedHosts},
-		Fallback:    mxcFallback{AllowDACLMutation: false},
+		Fallback:    mxcFallback{AllowDACLMutation: cfg.MXC.AllowDACLMutation},
+		UI:          mxcUI{Disable: !cfg.MXC.AllowWindowsUI},
 	}, nil
+}
+
+func isWindowsVolumeRoot(path string) bool {
+	clean := strings.TrimRight(strings.TrimSpace(path), `\\/`)
+	return len(clean) == 2 && clean[1] == ':'
+}
+
+func windowsProcessEnvironment(forwarded map[string]string) []string {
+	type entry struct {
+		key   string
+		value string
+	}
+	entries := make(map[string]entry, len(forwarded)+30)
+	for key, value := range forwarded {
+		entries[strings.ToLower(key)] = entry{key: key, value: value}
+	}
+	for _, key := range []string{
+		"ALLUSERSPROFILE", "APPDATA", "CommonProgramFiles", "CommonProgramFiles(x86)", "CommonProgramW6432",
+		"COMPUTERNAME", "ComSpec", "DriverData", "LOCALAPPDATA", "NUMBER_OF_PROCESSORS", "OS", "Path", "PATHEXT",
+		"PROCESSOR_ARCHITECTURE", "PROCESSOR_IDENTIFIER", "PROCESSOR_LEVEL", "PROCESSOR_REVISION", "ProgramData",
+		"ProgramFiles", "ProgramFiles(x86)", "ProgramW6432", "PROMPT", "PSModulePath", "PUBLIC", "SystemDrive",
+		"SystemRoot", "USERPROFILE", "WINDIR",
+	} {
+		if value, ok := os.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+			entries[strings.ToLower(key)] = entry{key: key, value: value}
+		}
+	}
+	env := make([]string, 0, len(entries))
+	for _, item := range entries {
+		env = append(env, item.key+"="+item.value)
+	}
+	sort.Strings(env)
+	return env
 }
 
 func buildIsolatedConfig(cfg Config, req RunRequest) (mxcConfig, string, func(), error) {
@@ -178,18 +215,19 @@ func windowsCommandLineWithLookPath(command []string, shellMode bool, lookPath f
 	if shellMode {
 		return "powershell.exe -NoProfile -NonInteractive -Command " + quoteWindowsArg(strings.Join(command, " ")), nil
 	}
-	parts := make([]string, len(command))
-	for i, arg := range command {
-		parts[i] = quoteWindowsArg(arg)
-	}
-	commandLine := strings.Join(parts, " ")
+	resolvedCommand := append([]string(nil), command...)
 	if resolved, err := lookPath(command[0]); err == nil {
 		switch strings.ToLower(filepath.Ext(resolved)) {
 		case ".bat", ".cmd":
 			return "", exit(2, "command %q resolves to a Windows script shim; rerun with --shell or invoke an executable directly", command[0])
 		}
+		resolvedCommand[0] = resolved
 	}
-	return commandLine, nil
+	parts := make([]string, len(resolvedCommand))
+	for i, arg := range resolvedCommand {
+		parts[i] = quoteWindowsArg(arg)
+	}
+	return strings.Join(parts, " "), nil
 }
 func quoteWindowsArg(value string) string {
 	if value != "" && !strings.ContainsAny(value, " \t\n\v\"") {

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -122,6 +122,11 @@ func buildIsolatedConfig(cfg Config, req RunRequest) (mxcConfig, string, func(),
 	}
 	cfg.MXC.ReadWritePaths = append(append([]string(nil), cfg.MXC.ReadWritePaths...), tempDir)
 	req.Env = cloneEnv(req.Env)
+	for key := range req.Env {
+		if strings.EqualFold(key, "TEMP") || strings.EqualFold(key, "TMP") {
+			delete(req.Env, key)
+		}
+	}
 	req.Env["TEMP"] = tempDir
 	req.Env["TMP"] = tempDir
 	config, err := buildConfig(cfg, req)

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -1,0 +1,129 @@
+package mxc
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestBuildConfigDefaultsToBlockedProcessContainer(t *testing.T) {
+	t.Setenv("SystemRoot", `C:\Windows`)
+	t.Setenv("ProgramFiles", `C:\Program Files`)
+	t.Setenv("PATH", `C:\Windows\System32;C:\Tools`)
+	cfg := core.BaseConfig()
+	cfg.MXC.ReadOnlyPaths = []string{`C:\Windows`}
+	config, err := buildConfig(cfg, RunRequest{
+		Repo:    core.Repo{Root: `C:\src\example`},
+		Command: []string{"powershell.exe", "-Command", `Write-Output "hello world"`},
+		Env:     map[string]string{"CI": "1"},
+		Options: core.LeaseOptions{TTL: 2 * time.Minute},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Version != "0.6.0-alpha" || config.Containment != "processcontainer" {
+		t.Fatalf("config=%+v", config)
+	}
+	if config.Network.DefaultPolicy != "block" || config.Network.EnforcementMode != "both" {
+		t.Fatalf("network=%+v", config.Network)
+	}
+	if config.Fallback.AllowDACLMutation {
+		t.Fatal("host DACL mutation fallback must be disabled by default")
+	}
+	if config.Process.Timeout != 120000 || len(config.Process.Env) != 1 || config.Process.Env[0] != "CI=1" {
+		t.Fatalf("process=%+v", config.Process)
+	}
+	if !containsFold(config.Filesystem.ReadWritePaths, `C:\src\example`) || !containsFold(config.Filesystem.ReadOnlyPaths, `C:\Windows`) {
+		t.Fatalf("filesystem=%+v", config.Filesystem)
+	}
+	if containsFold(config.Filesystem.ReadOnlyPaths, `C:\Tools`) {
+		t.Fatalf("PATH directory must not be broadly allowlisted: %+v", config.Filesystem.ReadOnlyPaths)
+	}
+	if !strings.Contains(config.Process.CommandLine, `\"hello world\"`) {
+		t.Fatalf("commandLine=%q", config.Process.CommandLine)
+	}
+}
+
+func TestBuildIsolatedConfigUsesPrivateTemporaryDirectory(t *testing.T) {
+	cfg := core.BaseConfig()
+	config, _, cleanup, err := buildIsolatedConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	temp := ""
+	for _, entry := range config.Process.Env {
+		if strings.HasPrefix(entry, "TEMP=") {
+			temp = strings.TrimPrefix(entry, "TEMP=")
+		}
+	}
+	if temp == "" || !containsFold(config.Filesystem.ReadWritePaths, temp) {
+		t.Fatalf("private temp missing: env=%v paths=%v", config.Process.Env, config.Filesystem.ReadWritePaths)
+	}
+	if _, err := os.Stat(temp); err != nil {
+		t.Fatalf("private temp not created: %v", err)
+	}
+}
+
+func TestWriteConfigFileUsesPrivatePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path, cleanup, err := writeConfigFile(dir, mxcConfig{Version: "0.6.0-alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode=%o", info.Mode().Perm())
+	}
+	var decoded mxcConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Version != "0.6.0-alpha" {
+		t.Fatalf("decoded=%+v", decoded)
+	}
+}
+
+func TestQuoteWindowsArg(t *testing.T) {
+	for input, want := range map[string]string{
+		"plain":       "plain",
+		"hello world": `"hello world"`,
+		`a"b`:         `"a\"b"`,
+		`C:\path\`:    `C:\path\`,
+	} {
+		if got := quoteWindowsArg(input); got != want {
+			t.Fatalf("quoteWindowsArg(%q)=%q want %q", input, got, want)
+		}
+	}
+}
+
+func TestWindowsCommandLineRejectsCommandShim(t *testing.T) {
+	_, err := windowsCommandLineWithLookPath([]string{"npm", "test"}, false, func(string) (string, error) {
+		return `C:\Program Files\nodejs\npm.cmd`, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "rerun with --shell") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -101,9 +101,18 @@ func TestBuildConfigShellRequiresWindowsUI(t *testing.T) {
 }
 
 func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
-	_, err := buildConfig(core.BaseConfig(), RunRequest{Repo: core.Repo{Root: `C:\`}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
-	if err == nil || !strings.Contains(err.Error(), "volume root") {
-		t.Fatalf("err=%v", err)
+	for _, root := range []string{`C:\`, `\\server\share\`, `\\?\C:\`, `\\?\UNC\server\share\`} {
+		t.Run(root, func(t *testing.T) {
+			_, err := buildConfig(core.BaseConfig(), RunRequest{Repo: core.Repo{Root: root}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
+			if err == nil || !strings.Contains(err.Error(), "volume root") {
+				t.Fatalf("root=%q err=%v", root, err)
+			}
+		})
+	}
+	for _, root := range []string{`C:\src`, `\\server\share\src`, `\\?\C:\src`, `\\?\UNC\server\share\src`} {
+		if isWindowsVolumeRoot(root) {
+			t.Fatalf("nested path treated as volume root: %q", root)
+		}
 	}
 }
 

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -93,6 +93,13 @@ func TestBuildConfigAllowsExplicitDACLMutationFallback(t *testing.T) {
 	}
 }
 
+func TestBuildConfigShellRequiresWindowsUI(t *testing.T) {
+	_, err := buildConfig(core.BaseConfig(), RunRequest{Command: []string{"npm", "test"}, ShellMode: true})
+	if err == nil || !strings.Contains(err.Error(), "--mxc-allow-windows-ui") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
 	_, err := buildConfig(core.BaseConfig(), RunRequest{Repo: core.Repo{Root: `C:\`}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
 	if err == nil || !strings.Contains(err.Error(), "volume root") {

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -13,8 +13,13 @@ import (
 
 func TestBuildConfigDefaultsToBlockedProcessContainer(t *testing.T) {
 	t.Setenv("SystemRoot", `C:\Windows`)
+	t.Setenv("SystemDrive", `C:`)
+	t.Setenv("WINDIR", `C:\Windows`)
+	t.Setenv("ComSpec", `C:\Windows\System32\cmd.exe`)
 	t.Setenv("ProgramFiles", `C:\Program Files`)
 	t.Setenv("PATH", `C:\Windows\System32;C:\Tools`)
+	t.Setenv("PATHEXT", `.COM;.EXE;.BAT;.CMD`)
+	t.Setenv("OS", `Windows_NT`)
 	cfg := core.BaseConfig()
 	cfg.MXC.ReadOnlyPaths = []string{`C:\Windows`}
 	config, err := buildConfig(cfg, RunRequest{
@@ -35,7 +40,10 @@ func TestBuildConfigDefaultsToBlockedProcessContainer(t *testing.T) {
 	if config.Fallback.AllowDACLMutation {
 		t.Fatal("host DACL mutation fallback must be disabled by default")
 	}
-	if config.Process.Timeout != 120000 || len(config.Process.Env) != 1 || config.Process.Env[0] != "CI=1" {
+	if !config.UI.Disable {
+		t.Fatal("Win32k/UI access must be disabled by default")
+	}
+	if config.Process.Timeout != 120000 || !containsString(config.Process.Env, "CI=1") || !containsString(config.Process.Env, `SystemRoot=C:\Windows`) {
 		t.Fatalf("process=%+v", config.Process)
 	}
 	if !containsFold(config.Filesystem.ReadWritePaths, `C:\src\example`) || !containsFold(config.Filesystem.ReadOnlyPaths, `C:\Windows`) {
@@ -46,6 +54,49 @@ func TestBuildConfigDefaultsToBlockedProcessContainer(t *testing.T) {
 	}
 	if !strings.Contains(config.Process.CommandLine, `\"hello world\"`) {
 		t.Fatalf("commandLine=%q", config.Process.CommandLine)
+	}
+}
+
+func TestWindowsProcessEnvironmentProtectsRequiredValues(t *testing.T) {
+	t.Setenv("SystemRoot", `C:\Windows`)
+	env := windowsProcessEnvironment(map[string]string{"systemroot": `C:\attacker`, "TOKEN": "secret"})
+	if !containsString(env, `SystemRoot=C:\Windows`) || containsString(env, `systemroot=C:\attacker`) {
+		t.Fatalf("env=%v", env)
+	}
+	if !containsString(env, "TOKEN=secret") {
+		t.Fatalf("forwarded environment missing: %v", env)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildConfigAllowsExplicitDACLMutationFallback(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.MXC.AllowDACLMutation = true
+	cfg.MXC.AllowWindowsUI = true
+	config, err := buildConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.Fallback.AllowDACLMutation {
+		t.Fatal("explicit host DACL mutation fallback was not forwarded")
+	}
+	if config.UI.Disable {
+		t.Fatal("explicit Windows UI capability was not forwarded")
+	}
+}
+
+func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
+	_, err := buildConfig(core.BaseConfig(), RunRequest{Repo: core.Repo{Root: `C:\`}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
+	if err == nil || !strings.Contains(err.Error(), "volume root") {
+		t.Fatalf("err=%v", err)
 	}
 }
 
@@ -116,6 +167,18 @@ func TestWindowsCommandLineRejectsCommandShim(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "rerun with --shell") {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWindowsCommandLineUsesResolvedExecutable(t *testing.T) {
+	commandLine, err := windowsCommandLineWithLookPath([]string{"powershell.exe", "-NoProfile"}, false, func(string) (string, error) {
+		return `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(commandLine, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe `) {
+		t.Fatalf("commandLine=%q", commandLine)
 	}
 }
 

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -102,7 +102,7 @@ func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
 
 func TestBuildIsolatedConfigUsesPrivateTemporaryDirectory(t *testing.T) {
 	cfg := core.BaseConfig()
-	config, _, cleanup, err := buildIsolatedConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}})
+	config, _, cleanup, err := buildIsolatedConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}, Env: map[string]string{"Temp": `C:\attacker`, "tmp": `C:\other`}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,6 +115,11 @@ func TestBuildIsolatedConfigUsesPrivateTemporaryDirectory(t *testing.T) {
 	}
 	if temp == "" || !containsFold(config.Filesystem.ReadWritePaths, temp) {
 		t.Fatalf("private temp missing: env=%v paths=%v", config.Process.Env, config.Filesystem.ReadWritePaths)
+	}
+	for _, entry := range config.Process.Env {
+		if strings.Contains(entry, `C:\attacker`) || strings.Contains(entry, `C:\other`) {
+			t.Fatalf("untrusted temp override survived: %v", config.Process.Env)
+		}
 	}
 	if _, err := os.Stat(temp); err != nil {
 		t.Fatalf("private temp not created: %v", err)

--- a/internal/providers/mxc/core.go
+++ b/internal/providers/mxc/core.go
@@ -1,0 +1,39 @@
+package mxc
+
+import (
+	"io"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type LeaseOptions = core.LeaseOptions
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type timingReport = core.TimingReport
+
+const (
+	providerName  = "mxc"
+	targetWindows = core.TargetWindows
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+func writeTimingJSON(w io.Writer, report timingReport) error { return core.WriteTimingJSON(w, report) }
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}

--- a/internal/providers/mxc/flags.go
+++ b/internal/providers/mxc/flags.go
@@ -1,0 +1,79 @@
+package mxc
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	CLIPath      *string
+	Version      *string
+	Containment  *string
+	Network      *string
+	ReadOnly     *string
+	ReadWrite    *string
+	AllowedHosts *string
+	BlockedHosts *string
+	Experimental *bool
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		CLIPath:      fs.String("mxc-cli", defaults.MXC.CLIPath, "path to the MXC executor"),
+		Version:      fs.String("mxc-version", defaults.MXC.Version, "MXC configuration schema version"),
+		Containment:  fs.String("mxc-containment", defaults.MXC.Containment, "MXC containment backend"),
+		Network:      fs.String("mxc-network", defaults.MXC.Network, "MXC network default: block or allow"),
+		ReadOnly:     fs.String("mxc-readonly-paths", strings.Join(defaults.MXC.ReadOnlyPaths, ","), "comma-separated additional read-only paths"),
+		ReadWrite:    fs.String("mxc-readwrite-paths", strings.Join(defaults.MXC.ReadWritePaths, ","), "comma-separated additional read-write paths"),
+		AllowedHosts: fs.String("mxc-allowed-hosts", strings.Join(defaults.MXC.AllowedHosts, ","), "comma-separated allowed outbound hosts"),
+		BlockedHosts: fs.String("mxc-blocked-hosts", strings.Join(defaults.MXC.BlockedHosts, ","), "comma-separated blocked outbound hosts"),
+		Experimental: fs.Bool("mxc-experimental", defaults.MXC.Experimental, "enable experimental MXC containment backends"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "mxc-cli") {
+		cfg.MXC.CLIPath = *v.CLIPath
+	}
+	if core.FlagWasSet(fs, "mxc-version") {
+		cfg.MXC.Version = *v.Version
+	}
+	if core.FlagWasSet(fs, "mxc-containment") {
+		cfg.MXC.Containment = *v.Containment
+	}
+	if core.FlagWasSet(fs, "mxc-network") {
+		cfg.MXC.Network = *v.Network
+	}
+	if core.FlagWasSet(fs, "mxc-readonly-paths") {
+		cfg.MXC.ReadOnlyPaths = splitCSV(*v.ReadOnly)
+	}
+	if core.FlagWasSet(fs, "mxc-readwrite-paths") {
+		cfg.MXC.ReadWritePaths = splitCSV(*v.ReadWrite)
+	}
+	if core.FlagWasSet(fs, "mxc-allowed-hosts") {
+		cfg.MXC.AllowedHosts = splitCSV(*v.AllowedHosts)
+	}
+	if core.FlagWasSet(fs, "mxc-blocked-hosts") {
+		cfg.MXC.BlockedHosts = splitCSV(*v.BlockedHosts)
+	}
+	if core.FlagWasSet(fs, "mxc-experimental") {
+		cfg.MXC.Experimental = *v.Experimental
+	}
+	return nil
+}
+
+func splitCSV(value string) []string {
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/providers/mxc/flags.go
+++ b/internal/providers/mxc/flags.go
@@ -8,28 +8,32 @@ import (
 )
 
 type flagValues struct {
-	CLIPath      *string
-	Version      *string
-	Containment  *string
-	Network      *string
-	ReadOnly     *string
-	ReadWrite    *string
-	AllowedHosts *string
-	BlockedHosts *string
-	Experimental *bool
+	CLIPath           *string
+	Version           *string
+	Containment       *string
+	Network           *string
+	ReadOnly          *string
+	ReadWrite         *string
+	AllowedHosts      *string
+	BlockedHosts      *string
+	AllowDACLMutation *bool
+	AllowWindowsUI    *bool
+	Experimental      *bool
 }
 
 func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
-		CLIPath:      fs.String("mxc-cli", defaults.MXC.CLIPath, "path to the MXC executor"),
-		Version:      fs.String("mxc-version", defaults.MXC.Version, "MXC configuration schema version"),
-		Containment:  fs.String("mxc-containment", defaults.MXC.Containment, "MXC containment backend"),
-		Network:      fs.String("mxc-network", defaults.MXC.Network, "MXC network default: block or allow"),
-		ReadOnly:     fs.String("mxc-readonly-paths", strings.Join(defaults.MXC.ReadOnlyPaths, ","), "comma-separated additional read-only paths"),
-		ReadWrite:    fs.String("mxc-readwrite-paths", strings.Join(defaults.MXC.ReadWritePaths, ","), "comma-separated additional read-write paths"),
-		AllowedHosts: fs.String("mxc-allowed-hosts", strings.Join(defaults.MXC.AllowedHosts, ","), "comma-separated allowed outbound hosts"),
-		BlockedHosts: fs.String("mxc-blocked-hosts", strings.Join(defaults.MXC.BlockedHosts, ","), "comma-separated blocked outbound hosts"),
-		Experimental: fs.Bool("mxc-experimental", defaults.MXC.Experimental, "enable experimental MXC containment backends"),
+		CLIPath:           fs.String("mxc-cli", defaults.MXC.CLIPath, "path to the MXC executor"),
+		Version:           fs.String("mxc-version", defaults.MXC.Version, "MXC configuration schema version"),
+		Containment:       fs.String("mxc-containment", defaults.MXC.Containment, "MXC containment backend"),
+		Network:           fs.String("mxc-network", defaults.MXC.Network, "MXC network default: block or allow"),
+		ReadOnly:          fs.String("mxc-readonly-paths", strings.Join(defaults.MXC.ReadOnlyPaths, ","), "comma-separated additional read-only paths"),
+		ReadWrite:         fs.String("mxc-readwrite-paths", strings.Join(defaults.MXC.ReadWritePaths, ","), "comma-separated additional read-write paths"),
+		AllowedHosts:      fs.String("mxc-allowed-hosts", strings.Join(defaults.MXC.AllowedHosts, ","), "comma-separated allowed outbound hosts"),
+		BlockedHosts:      fs.String("mxc-blocked-hosts", strings.Join(defaults.MXC.BlockedHosts, ","), "comma-separated blocked outbound hosts"),
+		AllowDACLMutation: fs.Bool("mxc-allow-dacl-mutation", defaults.MXC.AllowDACLMutation, "allow MXC to mutate host ACLs for its AppContainer fallback"),
+		AllowWindowsUI:    fs.Bool("mxc-allow-windows-ui", defaults.MXC.AllowWindowsUI, "allow Win32k/UI system calls required by programs such as Windows PowerShell"),
+		Experimental:      fs.Bool("mxc-experimental", defaults.MXC.Experimental, "enable experimental MXC containment backends"),
 	}
 }
 
@@ -61,6 +65,12 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.FlagWasSet(fs, "mxc-blocked-hosts") {
 		cfg.MXC.BlockedHosts = splitCSV(*v.BlockedHosts)
+	}
+	if core.FlagWasSet(fs, "mxc-allow-dacl-mutation") {
+		cfg.MXC.AllowDACLMutation = *v.AllowDACLMutation
+	}
+	if core.FlagWasSet(fs, "mxc-allow-windows-ui") {
+		cfg.MXC.AllowWindowsUI = *v.AllowWindowsUI
 	}
 	if core.FlagWasSet(fs, "mxc-experimental") {
 		cfg.MXC.Experimental = *v.Experimental

--- a/internal/providers/mxc/provider.go
+++ b/internal/providers/mxc/provider.go
@@ -1,0 +1,52 @@
+package mxc
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() { core.RegisterProvider(Provider{}) }
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"execution-container"} }
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "sandbox",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:    core.FeatureSet{},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetWindows {
+		return nil, core.Exit(2, "provider=mxc supports target=windows only")
+	}
+	if cfg.WindowsMode != "" && cfg.WindowsMode != core.WindowsModeNormal {
+		return nil, core.Exit(2, "provider=mxc supports native Windows mode only")
+	}
+	containment := strings.ToLower(strings.TrimSpace(cfg.MXC.Containment))
+	if containment != "processcontainer" && !cfg.MXC.Experimental {
+		return nil, core.Exit(2, "MXC containment %q is experimental; pass --mxc-experimental to enable it", containment)
+	}
+	cfg.MXC.Containment = containment
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	return backend.(core.DoctorBackend), nil
+}

--- a/internal/providers/mxc/provider.go
+++ b/internal/providers/mxc/provider.go
@@ -37,7 +37,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 		return nil, core.Exit(2, "provider=mxc supports native Windows mode only")
 	}
 	containment := strings.ToLower(strings.TrimSpace(cfg.MXC.Containment))
-	if containment != "processcontainer" && !cfg.MXC.Experimental {
+	if containment != "process" && containment != "processcontainer" && !cfg.MXC.Experimental {
 		return nil, core.Exit(2, "MXC containment %q is experimental; pass --mxc-experimental to enable it", containment)
 	}
 	cfg.MXC.Containment = containment

--- a/internal/providers/mxc/provider_test.go
+++ b/internal/providers/mxc/provider_test.go
@@ -57,13 +57,13 @@ func TestFlagsApplyPolicy(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	values := registerFlags(fs, cfg)
-	if err := fs.Parse([]string{"--mxc-network", "allow", "--mxc-readwrite-paths", `C:\src,C:\cache`, "--mxc-experimental"}); err != nil {
+	if err := fs.Parse([]string{"--mxc-network", "allow", "--mxc-readwrite-paths", `C:\src,C:\cache`, "--mxc-allow-dacl-mutation", "--mxc-allow-windows-ui", "--mxc-experimental"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := applyFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MXC.Network != "allow" || len(cfg.MXC.ReadWritePaths) != 2 || !cfg.MXC.Experimental {
+	if cfg.MXC.Network != "allow" || len(cfg.MXC.ReadWritePaths) != 2 || !cfg.MXC.AllowDACLMutation || !cfg.MXC.AllowWindowsUI || !cfg.MXC.Experimental {
 		t.Fatalf("mxc=%+v", cfg.MXC)
 	}
 }

--- a/internal/providers/mxc/provider_test.go
+++ b/internal/providers/mxc/provider_test.go
@@ -1,0 +1,63 @@
+package mxc
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestExperimentalContainmentRequiresOptIn(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
+	cfg.MXC.Containment = "windows_sandbox"
+	_, err := (Provider{}).Configure(cfg, core.Runtime{})
+	if err == nil || !strings.Contains(err.Error(), "--mxc-experimental") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestConfigureNormalizesContainment(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
+	cfg.MXC.Containment = "ProcessContainer"
+	configured, err := (Provider{}).Configure(cfg, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := configured.(*backend).cfg.MXC.Containment; got != "processcontainer" {
+		t.Fatalf("containment=%q", got)
+	}
+}
+
+func TestFlagsApplyPolicy(t *testing.T) {
+	cfg := core.BaseConfig()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := registerFlags(fs, cfg)
+	if err := fs.Parse([]string{"--mxc-network", "allow", "--mxc-readwrite-paths", `C:\src,C:\cache`, "--mxc-experimental"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MXC.Network != "allow" || len(cfg.MXC.ReadWritePaths) != 2 || !cfg.MXC.Experimental {
+		t.Fatalf("mxc=%+v", cfg.MXC)
+	}
+}
+
+func TestParseWindowsBuild(t *testing.T) {
+	build, err := parseWindowsBuild("CurrentBuildNumber    REG_SZ    26100\r\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if build != 26100 {
+		t.Fatalf("build = %d, want 26100", build)
+	}
+}

--- a/internal/providers/mxc/provider_test.go
+++ b/internal/providers/mxc/provider_test.go
@@ -36,6 +36,22 @@ func TestConfigureNormalizesContainment(t *testing.T) {
 	}
 }
 
+func TestConfigureAcceptsStableProcessIntent(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetWindows
+	cfg.WindowsMode = core.WindowsModeNormal
+	cfg.MXC.Containment = "Process"
+
+	configured, err := (Provider{}).Configure(cfg, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := configured.(*backend).cfg.MXC.Containment; got != "process" {
+		t.Fatalf("containment=%q", got)
+	}
+}
+
 func TestFlagsApplyPolicy(t *testing.T) {
 	cfg := core.BaseConfig()
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)


### PR DESCRIPTION
## Summary
- add a one-shot local Windows `mxc` delegated-run provider
- generate deny-by-default network and checkout-scoped filesystem policies
- isolate temporary files and secret-bearing config under a current-user-only Windows ACL
- keep AppContainer DACL mutation and Win32k/UI access disabled unless explicitly requested
- fail closed on volume-root access, broad PATH filesystem exposure, script shims without `--shell`, and unsupported persistence
- add an execution-backed doctor check and document upstream preview/image constraints

## Validation
- `go test -race ./internal/providers/mxc ./internal/providers/all ./internal/providers/railway ./internal/cli`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `GOOS=windows GOARCH=amd64 go build -trimpath -o /tmp/crabbox-mxc.exe ./cmd/crabbox`
- autoreview loop: accepted findings fixed; final structured review clean

## Live Windows proof
Validated with Microsoft MXC 0.6.1 signed binaries on fresh Crabbox Azure hosts:

- Windows 11 24H2 build 26100 and 25H2 build 26200 correctly fail doctor because BaseContainer feature keys `61389575` and `61155944` are disabled
- Windows Server vNext build 29595 selects MXC's AppContainer+DACL fallback
- after elevated `wxc-host-prep.exe prepare-system-drive`, doctor passes with `--mxc-allow-dacl-mutation`
- sandboxed command reads `input.txt`, writes `output.txt`, and reports the checkout as its working directory
- Windows PowerShell runs with the additional explicit `--mxc-allow-windows-ui` capability
- an HTTPS request to `https://example.com` fails inside the default network-blocked sandbox (`network-blocked-ok`)

The successful host used the stock Azure Marketplace preview image plus its required plan metadata; no custom image was baked. MXC remains public preview software and the DACL fallback changes host ACLs, so the opt-in path is intended for isolated disposable hosts, not shared production machines.
