### PR TITLE
fix(providers): drop unreachable Railway writeTimingJSON wrapper

### DIFF
--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -2,7 +2,6 @@ package railway
 
 import (
 	"flag"
-	"io"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -27,7 +26,6 @@ type Repo = core.Repo
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
-type timingReport = core.TimingReport
 
 const (
 	providerName = "railway"
@@ -46,10 +44,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {


### PR DESCRIPTION
## Summary

CI on `main` is currently red: the Deadcode gate fails with

```
internal/providers/railway/core.go:51:6: unreachable func: writeTimingJSON
```

(e.g. https://github.com/openclaw/crabbox/actions/runs/27262278401). The last Railway-internal caller of the package-local `writeTimingJSON` wrapper was removed in https://github.com/openclaw/crabbox/commit/36a2c29, leaving the wrapper, the `timingReport` alias, and the `io` import orphaned. This removes all three.

This also unblocks the Go check on other open PRs (it fails on any branch containing current main, e.g. https://github.com/openclaw/crabbox/pull/211).

## Verification

- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` — clean (was failing before this change)
- `go build ./...`, `go vet ./internal/providers/railway/`, `gofmt` clean
- `go test -race ./internal/providers/railway/ ./internal/cli` — pass