### PR TITLE
test(scripts): isolate worker deploy smoke env

### DIFF
--- a/scripts/deploy-worker-smoke.test.js
+++ b/scripts/deploy-worker-smoke.test.js
@@ -67,6 +67,7 @@ esac
 			PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
 			HOME: dir,
 			CRABBOX_BIN: fakeCrabbox,
+			CRABBOX_COORDINATOR: "https://broker.crabbox.test",
 			CRABBOX_DEPLOY_SMOKE_URLS: "https://broker.crabbox.test/v1/health",
 			CRABBOX_DEPLOY_SMOKE_AWS: "1",
 			CRABBOX_LIVE_REPO: liveRepo,


### PR DESCRIPTION
## Summary

- isolate the worker deploy smoke fixture from an ambient `CRABBOX_COORDINATOR`
- preserve the coordinator-origin mismatch guard in production code

## Verification

- `node --test scripts/deploy-worker-smoke.test.js`
- `CRABBOX_COORDINATOR=https://unrelated.example node --test scripts/deploy-worker-smoke.test.js`
- `env CRABBOX_COORDINATOR=https://ambient.invalid CRABBOX_BIN=/bin/false CRABBOX_LIVE_REPO=/tmp/ambient-crabbox-repo node --test scripts/*.test.js`
- `node --test scripts/*.test.js`
- `go test -race ./...`
- `go vet ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- autoreview clean
