### PR TITLE
[codex] fix Namespace Devbox authentication setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed Namespace Devbox setup instructions to use the current browser workspace approval flow instead of obsolete token environment variables.
+
 ## 0.28.0 - 2026-06-11
 
 ### Added

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -46,7 +46,7 @@ Provider deep-dives that live here in `features/`:
 - [Hetzner](hetzner.md): Linux-only managed Hetzner behavior, classes, and cleanup.
 - [Blacksmith Testbox](blacksmith-testbox.md): delegated Testbox runner behavior.
 - [Namespace Devbox](namespace-devbox.md): Namespace Devbox SSH leases with Crabbox sync/run.
-- [Namespace Devbox setup](namespace-devbox-setup.md): CLI install, auth token profile, and live checks.
+- [Namespace Devbox setup](namespace-devbox-setup.md): CLI install, browser authentication, and live checks.
 - [Semaphore](semaphore.md): Semaphore CI job leases with Crabbox SSH sync/run.
 - [Sprites](sprites.md): Sprites microVM SSH leases through `sprite proxy`.
 - [Daytona](daytona.md): Daytona SDK/toolbox sandbox leases with optional short-lived SSH access.

--- a/docs/features/namespace-devbox-setup.md
+++ b/docs/features/namespace-devbox-setup.md
@@ -26,29 +26,24 @@ devbox login
 devbox auth check-login
 ```
 
-`devbox login` opens a browser. For headless or automation hosts, mint a token
-from the browser token page instead and export it where the CLI expects it,
-without printing it:
+`devbox login` opens a browser. For headless or automation hosts, request a
+workspace handoff URL and approve the login from an authenticated browser:
 
 ```sh
-open https://cloud.namespace.so/login/token
-
-cat >> ~/.profile <<'EOF'
-# Namespace devbox CLI auth
-export NAMESPACE_TOKEN='<token>'
-export NSCLOUD_TOKEN="$NAMESPACE_TOKEN"
-EOF
+devbox login --browser=false
 ```
 
-These are the Namespace CLI's own environment variables. Crabbox reads neither
-of them; it relies entirely on whatever auth state the `devbox` CLI resolves at
-invocation time.
-
-Confirm the profile exports both names without echoing the value:
+Open the printed URL, verify its code matches the terminal, and select the
+workspace to authorize. The CLI stores the resulting session in its platform
+user config directory. Do not copy the browser token-page value into a profile
+or the CLI's credential file.
 
 ```sh
-zsh -lc 'source ~/.profile; test -n "$NAMESPACE_TOKEN"; test "$NSCLOUD_TOKEN" = "$NAMESPACE_TOKEN"'
+devbox auth check-login
 ```
+
+Crabbox does not read or store Namespace credentials; it relies entirely on
+the auth state the `devbox` CLI resolves at invocation time.
 
 ## Live Check
 
@@ -109,5 +104,3 @@ Related docs:
 - [Namespace Devbox](namespace-devbox.md)
 - [Provider: Namespace Devbox](../providers/namespace-devbox.md)
 - [Providers](providers.md)
-</content>
-</invoke>


### PR DESCRIPTION
## Summary

- replace obsolete `NAMESPACE_TOKEN` / `NSCLOUD_TOKEN` setup with the current browser workspace approval flow
- document `devbox login --browser=false` for headless hosts
- remove stray markup from the setup page and update the feature index

## Why

Current Namespace Devbox CLI releases ignore the documented token environment variables. Authentication now completes through a browser workspace handoff and stores CLI-managed session state in the platform user config directory.

## Impact

Operators can authenticate interactive and headless Crabbox hosts using the flow supported by the current `devbox` CLI without manually copying browser tokens into profiles or credential files.

## Verification

- `scripts/check-docs.sh`
- `go test ./internal/providers/namespace ./internal/cli -run 'Namespace|namespace' -count=1`
- `node --test scripts/live-smoke.test.js`
- live Namespace smoke: provisioned an S Devbox, ran `echo crabbox-namespace-ok` over SSH, deleted the Devbox on release, and verified empty provider inventories plus removed SSH artifacts
