### PR TITLE
[codex] Register direct leases with coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 dist/
 dist-cloudflare/
+/worker/dist-node/
 artifacts/
 .crabbox/
 .clawpatch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added provider-neutral coordinator registration for direct SSH leases, with owner-scoped inventory and sharing, outbound WebVNC, automatic bridge daemons for kept desktops, and coordinator-safe metadata-only release and expiry.
 - Added provider-optional `crabbox pause` and `crabbox resume` lifecycle commands, with Islo sandbox pause/resume support that preserves local lease claims. Thanks @zozo123.
 - Added `provider: anthropic-sandbox-runtime` (`srt`) for local one-shot command execution through Anthropic Sandbox Runtime, including filesystem/network policy handoff, doctor checks, config overrides, and live enforcement coverage. Thanks @coygeek.
 - Added `provider: apple-vz` for full ARM64 Ubuntu VMs through Apple's `Virtualization.framework`, including verified cloud images, secret-safe signed URL handling, loopback VSOCK SSH, retained leases, native helper packaging, failure rollback, and live lifecycle coverage. Thanks @coygeek.

--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ ssh:
     - "22"
 ```
 
+Set `broker.mode: registered` to keep provisioning and cleanup in any direct
+provider while registering lease metadata with the coordinator for inventory,
+sharing, and portal WebVNC. Kept desktop leases start the outbound WebVNC bridge
+automatically by default; set `broker.autoWebVNC: false` to opt out. The
+coordinator never receives provider credentials or deletes registered
+resources.
+
 Forwarded environment is intentionally narrow: `NODE_OPTIONS` and `CI`. Do not
 pass secrets as command-line arguments. For live-secret smoke tests, use
 `crabbox run --env-from-profile <file> --allow-env NAME` so Crabbox forwards

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ Cloudflare Worker  ------------------------------------------>  (provision)
 
 ## Execution Modes
 
-The CLI picks one of three modes per provider in `loadBackend`
+The CLI picks one of four modes per provider in `loadBackend`
 (`internal/cli/provider_backend.go`):
 
 - **Brokered (coordinator) mode** — chosen when the provider declares
@@ -60,6 +60,11 @@ The CLI picks one of three modes per provider in `loadBackend`
   itself; no Worker is involved. The four brokerable providers fall back to this
   when no broker URL is set, and every other SSH-lease provider (`ssh`,
   `parallels`, `proxmox`, `daytona`, `runpod`, and so on) always runs here.
+- **Registered direct mode** — `broker.mode: registered` keeps the same direct
+  SSH provider lifecycle but registers lease metadata and heartbeats with the
+  Worker. The coordinator can list and share portal bridges, but cannot call the
+  provider, delete the resource, charge it to managed usage, or place it in a
+  ready pool.
 - **Delegated mode** — the provider implements a delegated-run backend (e.g.
   `e2b`, `modal`, `cloudflare`, `azure-dynamic-sessions`). The provider owns
   sync and execution end to end; the CLI calls `Warmup`/`Run` and never performs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -253,6 +253,8 @@ User config (machine-wide defaults and broker credentials):
 ```yaml
 broker:
   url: https://broker.example.com
+  mode: managed
+  autoWebVNC: true
   provider: aws
   token: ...
   access:
@@ -424,6 +426,8 @@ This is the canonical environment-variable reference. The most common ones:
 CRABBOX_COORDINATOR                broker URL (enables brokered mode for supported providers)
 CRABBOX_COORDINATOR_TOKEN          broker user/shared token
 CRABBOX_COORDINATOR_ADMIN_TOKEN    broker admin token
+CRABBOX_COORDINATOR_MODE           managed|registered
+CRABBOX_COORDINATOR_AUTO_WEBVNC    auto-start portal bridge for kept registered desktops
 CRABBOX_ADMIN_TOKEN                alias for CRABBOX_COORDINATOR_ADMIN_TOKEN
 CRABBOX_ACCESS_CLIENT_ID           Cloudflare Access service-token id
 CRABBOX_ACCESS_CLIENT_SECRET       Cloudflare Access service-token secret

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -6,7 +6,7 @@ subcommands:
 ```text
 crabbox config path
 crabbox config show [--json]
-crabbox config set-broker --url <url> [--provider hetzner|aws|azure|gcp] [--token-stdin] [--admin-token-stdin]
+crabbox config set-broker --url <url> [--provider <provider>] [--mode managed|registered] [--auto-webvnc=false] [--token-stdin] [--admin-token-stdin]
 ```
 
 ## config path
@@ -59,6 +59,9 @@ Stores the broker URL and optional tokens in the user config file:
 # Set the broker URL and default brokered provider.
 crabbox config set-broker --url https://broker.example.com --provider aws
 
+# Register direct-provider leases without transferring lifecycle ownership.
+crabbox config set-broker --url https://broker.example.com --mode registered
+
 # Store a user token (read from stdin so it never lands in shell history).
 printf '%s' "$TOKEN" | crabbox config set-broker --url https://broker.example.com --token-stdin
 
@@ -69,8 +72,14 @@ printf '%s' "$ADMIN_TOKEN" | crabbox config set-broker --url https://broker.exam
 Flags:
 
 - `--url <url>` (required) — broker URL.
-- `--provider hetzner|aws|azure|gcp` — default provider for brokered leases.
+- `--provider <provider>` — default provider. Managed mode supports the
+  coordinator providers; registered mode accepts any configured direct provider.
   When set, it also becomes the default `provider` in user config.
+- `--mode managed|registered` — `managed` lets supported providers use the
+  broker control plane; `registered` keeps provider lifecycle local and mirrors
+  lease metadata to the broker.
+- `--auto-webvnc=false` — disable automatic portal WebVNC startup for kept
+  registered desktop leases. The default is true.
 - `--token-stdin` — read the broker token from stdin.
 - `--admin-token-stdin` — read the broker admin token from stdin.
 
@@ -80,7 +89,7 @@ the user config file (creating the directory with `0700` and the file with
 `0600`) and prints the resulting path and auth status, for example:
 
 ```text
-wrote /home/alice/.config/crabbox/config.yaml broker=https://broker.example.com auth=configured admin_auth=missing
+wrote /home/alice/.config/crabbox/config.yaml broker=https://broker.example.com mode=registered auth=configured admin_auth=missing
 ```
 
 `crabbox login` performs the same broker write as part of GitHub login; use

--- a/docs/commands/share.md
+++ b/docs/commands/share.md
@@ -7,6 +7,10 @@ not move SSH private keys between machines.
 Sharing requires a configured coordinator. Without one, the command exits with
 `share requires a configured coordinator`.
 
+Direct-provider leases become shareable when `broker.mode: registered` is set.
+The coordinator shares portal capabilities such as WebVNC; it does not gain
+provider lifecycle ownership or the local SSH key.
+
 ## Usage
 
 ```sh

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -52,11 +52,12 @@ file is group- or world-readable.
 
 State that does not belong in either YAML file:
 
-- live lease records (those are coordinator-owned);
+- live lease records (managed records are coordinator-owned; registered records
+  are provider-owned and mirrored to the coordinator);
 - per-lease SSH private keys (they live under the user config dir, but not in
   `config.yaml`);
-- provider secrets (they live in the broker environment, your shell env, or a
-  credential manager).
+- provider secrets (managed-provider secrets live in the broker environment;
+  direct-provider secrets stay in your shell env or credential manager).
 
 ## YAML schema
 
@@ -68,6 +69,8 @@ set in user config. Most repos only need a small subset.
 ```yaml
 broker:
   url: https://broker.example.com
+  mode: managed             # managed | registered
+  autoWebVNC: true          # registered kept desktop leases only
   provider: aws
   token: <signed-github-token-or-shared-token>
   adminToken: <broker-admin-token>     # operators only
@@ -92,6 +95,14 @@ lease:
   idleTimeout: 30m
   ttl: 90m
 ```
+
+`broker.mode` defaults to `managed`. In `registered` mode, every direct SSH
+lease keeps its existing provider lifecycle and is registered with the broker
+for owner-scoped inventory, sharing, heartbeats, and portal bridges. Registration
+is best effort: a broker outage does not fail local provisioning. Releasing the
+local lease removes its registration, and coordinator release/expiry never
+invokes provider deletion. `CRABBOX_COORDINATOR_MODE` and
+`CRABBOX_COORDINATOR_AUTO_WEBVNC` provide environment overrides.
 
 `ttl`, `idleTimeout`, and `workRoot` are also accepted as top-level keys. The
 default class is `beast`, the default TTL is `90m`, and the default idle

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -13,12 +13,20 @@ Fleet Durable Object (`worker/src/fleet.ts`). Together they are the broker: an
 authenticated control plane that owns provider credentials, lease state, run
 records, usage accounting, and the live access bridges.
 
-Only the brokerable providers go through the coordinator: `aws`, `azure`,
-`gcp`, and `hetzner`. Every other adapter runs direct from the CLI. Even a
-brokerable provider runs direct unless a broker URL is configured
-(`CRABBOX_COORDINATOR`, or `config set-broker --url`); the CLI selects brokered
-mode only when the provider's spec is `Coordinator: supported` **and** a broker
-URL is set (`internal/cli/provider_backend.go`, `loadBackend`).
+The default `broker.mode: managed` lets brokerable providers (`aws`, `azure`,
+`gcp`, and `hetzner`) transfer lifecycle operations to the coordinator. Every
+other adapter runs direct from the CLI. A brokerable provider also runs direct
+unless a broker URL is configured (`CRABBOX_COORDINATOR`, or
+`config set-broker --url`).
+
+`broker.mode: registered` is provider-neutral. Provisioning, SSH, touch, and
+cleanup remain in the direct adapter, while the CLI idempotently registers an
+owner-scoped lease record with the coordinator. This enables portal inventory,
+sharing, and outbound WebVNC for external, KubeVirt, static SSH, local, and other
+direct SSH providers without giving the coordinator provider credentials.
+Coordinator release and expiry remove only the registration; they never delete
+the provider resource. Registered records are excluded from provider access
+reconciliation, ready pools, image operations, orphan sweeps, and cost totals.
 
 The coordinator brokers the **control plane**, not the data plane. Lease
 lifecycle, run recording, usage, and bridges flow through the Worker over HTTP.
@@ -86,6 +94,7 @@ GET    /v1/whoami
 GET    /v1/providers/{provider}/readiness
 GET    /v1/control                       (websocket: run events + heartbeats)
 POST   /v1/leases
+PUT    /v1/leases/{id}/registration
 GET    /v1/leases
 GET    /v1/leases/{id-or-slug}
 POST   /v1/leases/{id-or-slug}/heartbeat
@@ -107,6 +116,12 @@ GET    /v1/runners
 POST   /v1/runners/sync
 GET    /v1/usage
 ```
+
+Registration accepts generic provider and SSH metadata. Repeating the same
+owner/org/id/provider tuple refreshes it and reactivates an expired record.
+Changing provider, claiming another owner's ID, or replacing a managed record
+returns `409`. The CLI treats registration as best effort, but an authenticated
+WebVNC/share operation still requires the record to exist.
 
 Bridge ticket and websocket routes (WebVNC, code-server, egress) live under
 `/v1/leases/{id-or-slug}/{webvnc|code|egress}/...`; see

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -108,10 +108,17 @@ crabbox vnc --id blue-lobster --network tailscale
 crabbox vnc --id blue-lobster --open
 ```
 
-WebVNC is available on coordinator-backed Hetzner, AWS, and Azure desktop
-leases, and on local Docker container leases. It is not available for static
-hosts, direct KubeVirt/external leases, or Blacksmith. Native `crabbox vnc`
-works against every managed and host-managed desktop in the support matrix.
+WebVNC is available on coordinator-managed desktop leases and on direct desktop
+providers. Direct providers normally use a localhost viewer. With
+`broker.mode: registered`, direct leases instead use the outbound coordinator
+bridge, so KubeVirt, external, static SSH, local Docker, and other SSH desktop
+leases can appear in and be shared from the portal. Blacksmith remains
+unsupported. Native `crabbox vnc` works against every managed and host-managed
+desktop in the support matrix.
+
+For kept registered desktop leases, `broker.autoWebVNC: true` starts the bridge
+daemon automatically. The daemon heartbeats the registration while connected;
+`crabbox stop` stops it and removes the registration after provider cleanup.
 
 ### Collaborative WebVNC
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -137,6 +137,12 @@ is useful for diagnosing the broker itself, and it is the only mode for the many
 direct-only adapters (sandbox runners, static SSH hosts, local containers, and
 the rest of the provider set).
 
+With `broker.mode: registered`, the provider path stays direct but the CLI
+mirrors owner-scoped lease metadata and heartbeats to the coordinator. That adds
+portal inventory, opt-in sharing, and outbound WebVNC without moving provider
+credentials or cleanup authority into the broker. Registered records do not
+count toward managed provider quotas, costs, images, pools, or maintenance.
+
 Static SSH targets (`provider: ssh`) point at a preexisting machine and bypass
 the broker even when a broker URL exists in config. macOS and Windows WSL2
 targets use the POSIX rsync contract; native Windows uses a PowerShell plus tar

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -283,7 +283,7 @@ func (a App) actionsRegister(ctx context.Context, args []string) error {
 	}
 	applyResolvedServerConfig(&cfg, server)
 	target = targetWithConfigDefaults(target, cfg)
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, slug, cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -168,7 +168,7 @@ func (a App) cacheTarget(ctx context.Context, id string, reclaim bool) (SSHTarge
 		if repoErr != nil {
 			return SSHTarget{}, Config{}, "", repoErr
 		}
-		if claimErr := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, reclaim); claimErr != nil {
+		if claimErr := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); claimErr != nil {
 			return SSHTarget{}, Config{}, "", claimErr
 		}
 		a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -116,7 +116,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	workdir := strings.TrimSpace(*workdirOverride)
@@ -638,7 +638,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
@@ -731,16 +731,16 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	defer func() {
 		if err == nil && !*keep {
-			a.releaseBackendLeaseBestEffort(context.Background(), sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+			a.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		}
 	}()
 	applyResolvedServerConfig(&cfg, server)
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, lease)
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, lease)
 		return err
 	}
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, lease)
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, lease)
 		return err
 	} else {
 		target = resolved.Target
@@ -751,7 +751,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if isNativeCheckpointKind(record.Kind) {
 		workdir := nativeCheckpointForkWorkdir(cfg, leaseID, repo.Name, *workdirOverride)
 		if err := relocateNativeCheckpointWorkdir(ctx, target, record.Workdir, workdir); err != nil {
-			a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+			a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 			return err
 		}
 		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), nativeCheckpointResourceID(record), workdir)
@@ -762,7 +762,7 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s workdir=%s\n", record.ID, leaseID, blank(serverSlug(server), "-"), workdir)
@@ -830,12 +830,12 @@ func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagS
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	defer func() {
 		if err == nil && !keep {
-			a.releaseBackendLeaseBestEffort(context.Background(), sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+			a.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		}
 	}()
 	applyResolvedServerConfig(&cfg, server)
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, lease)
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, lease)
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint forked provider=parallels source=%s snapshot=%s lease=%s slug=%s\n", source, snapshot, leaseID, blank(serverSlug(server), "-"))

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -105,7 +105,7 @@ func (a App) webCode(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	ServerType                    string
 	ServerTypeExplicit            bool
 	Coordinator                   string
+	BrokerMode                    BrokerMode
+	BrokerAutoWebVNC              bool
 	CoordToken                    string
 	CoordAdminToken               string
 	HostID                        string
@@ -909,6 +911,13 @@ type AccessConfig struct {
 	Token        string
 }
 
+type BrokerMode string
+
+const (
+	BrokerModeManaged    BrokerMode = "managed"
+	BrokerModeRegistered BrokerMode = "registered"
+)
+
 func defaultConfig() Config {
 	cfg, err := loadConfig()
 	if err != nil {
@@ -925,6 +934,9 @@ func loadConfig() (Config, error) {
 		}
 	}
 	if err := applyEnv(&cfg); err != nil {
+		return Config{}, err
+	}
+	if err := normalizeBrokerConfig(&cfg); err != nil {
 		return Config{}, err
 	}
 	canonicalizeConfigProvider(&cfg)
@@ -945,6 +957,23 @@ func loadConfig() (Config, error) {
 		cfg.ServerType = serverTypeForConfig(cfg)
 	}
 	return cfg, nil
+}
+
+func normalizeBrokerConfig(cfg *Config) error {
+	mode := BrokerMode(strings.ToLower(strings.TrimSpace(string(cfg.BrokerMode))))
+	if mode == "" {
+		mode = BrokerModeManaged
+	}
+	switch mode {
+	case BrokerModeManaged, BrokerModeRegistered:
+		cfg.BrokerMode = mode
+	default:
+		return exit(2, "broker.mode must be managed or registered")
+	}
+	if mode == BrokerModeRegistered && strings.TrimSpace(cfg.Coordinator) == "" {
+		return exit(2, "broker.mode=registered requires broker.url or coordinator")
+	}
+	return nil
 }
 
 func canonicalizeConfigProvider(cfg *Config) {
@@ -1321,6 +1350,8 @@ func baseConfig() Config {
 		Network:            NetworkAuto,
 		Class:              class,
 		ServerType:         "",
+		BrokerMode:         BrokerModeManaged,
+		BrokerAutoWebVNC:   true,
 		Location:           "fsn1",
 		Image:              hetznerImage,
 		AWSRegion:          "eu-west-1",
@@ -1658,6 +1689,8 @@ type fileWindowsConfig struct {
 
 type fileBrokerConfig struct {
 	URL        string            `yaml:"url,omitempty"`
+	Mode       string            `yaml:"mode,omitempty"`
+	AutoWebVNC *bool             `yaml:"autoWebVNC,omitempty"`
 	Token      string            `yaml:"token,omitempty"`
 	AdminToken string            `yaml:"adminToken,omitempty"`
 	Provider   string            `yaml:"provider,omitempty"`
@@ -2534,6 +2567,12 @@ func applyFileConfig(cfg *Config, file fileConfig) error {
 		}
 		if file.Broker.Token != "" {
 			cfg.CoordToken = file.Broker.Token
+		}
+		if file.Broker.Mode != "" {
+			cfg.BrokerMode = BrokerMode(file.Broker.Mode)
+		}
+		if file.Broker.AutoWebVNC != nil {
+			cfg.BrokerAutoWebVNC = *file.Broker.AutoWebVNC
 		}
 		if file.Broker.AdminToken != "" {
 			cfg.CoordAdminToken = file.Broker.AdminToken
@@ -4076,6 +4115,10 @@ func applyEnv(cfg *Config) error {
 	}
 	cfg.ServerType = getenv("CRABBOX_SERVER_TYPE", cfg.ServerType)
 	cfg.Coordinator = getenv("CRABBOX_COORDINATOR", cfg.Coordinator)
+	cfg.BrokerMode = BrokerMode(getenv("CRABBOX_COORDINATOR_MODE", string(cfg.BrokerMode)))
+	if value, ok := getenvBool("CRABBOX_COORDINATOR_AUTO_WEBVNC"); ok {
+		cfg.BrokerAutoWebVNC = value
+	}
 	cfg.CoordToken = getenv("CRABBOX_COORDINATOR_TOKEN", cfg.CoordToken)
 	cfg.CoordAdminToken = getenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", getenv("CRABBOX_ADMIN_TOKEN", cfg.CoordAdminToken))
 	cfg.HostID = getenv("CRABBOX_HOST_ID", cfg.HostID)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -57,6 +57,8 @@ func configShowView(cfg Config) map[string]any {
 		"serverType":         cfg.ServerType,
 		"serverTypeExplicit": cfg.ServerTypeExplicit,
 		"coordinator":        cfg.Coordinator,
+		"brokerMode":         cfg.BrokerMode,
+		"brokerAutoWebVNC":   cfg.BrokerAutoWebVNC,
 		"brokerAuth":         tokenState(cfg.CoordToken),
 		"brokerAdminAuth":    tokenState(cfg.CoordAdminToken),
 		"accessAuth":         accessAuthState(cfg.Access),
@@ -312,7 +314,7 @@ func configShowView(cfg Config) map[string]any {
 func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "config=%s\n", userConfigPath())
 	fmt.Fprintf(w, "provider=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
-	fmt.Fprintf(w, "broker=%s auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), tokenState(cfg.CoordToken), tokenState(cfg.CoordAdminToken))
+	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, tokenState(cfg.CoordToken), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
 	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), len(syncIncludes(cfg)), cfg.Sync.Timeout)
@@ -416,7 +418,9 @@ func durationString(d time.Duration) string {
 func (a App) configSetBroker(args []string) error {
 	fs := newFlagSet("config set-broker", a.Stderr)
 	url := fs.String("url", "", "broker URL")
-	provider := fs.String("provider", "", "default brokered provider: hetzner, aws, azure, or gcp")
+	provider := fs.String("provider", "", "default provider (managed coordinator provider or registered direct provider)")
+	mode := fs.String("mode", "", "lease mode: managed or registered")
+	autoWebVNC := fs.Bool("auto-webvnc", true, "start a portal WebVNC bridge for kept registered desktop leases")
 	tokenStdin := fs.Bool("token-stdin", false, "read broker token from stdin")
 	adminTokenStdin := fs.Bool("admin-token-stdin", false, "read broker admin token from stdin")
 	if err := parseFlags(fs, args); err != nil {
@@ -424,6 +428,9 @@ func (a App) configSetBroker(args []string) error {
 	}
 	if *url == "" {
 		return exit(2, "config set-broker requires --url")
+	}
+	if *mode != "" && *mode != string(BrokerModeManaged) && *mode != string(BrokerModeRegistered) {
+		return exit(2, "--mode must be managed or registered")
 	}
 	var token string
 	if *tokenStdin {
@@ -459,6 +466,12 @@ func (a App) configSetBroker(args []string) error {
 		file.Broker = &fileBrokerConfig{}
 	}
 	file.Broker.URL = *url
+	if *mode != "" {
+		file.Broker.Mode = *mode
+	}
+	if flagWasSet(fs, "auto-webvnc") {
+		file.Broker.AutoWebVNC = autoWebVNC
+	}
 	if token != "" {
 		file.Broker.Token = token
 	}
@@ -473,7 +486,7 @@ func (a App) configSetBroker(args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(a.Stdout, "wrote %s broker=%s auth=%s admin_auth=%s\n", written, *url, tokenState(file.Broker.Token), tokenState(file.Broker.AdminToken))
+	fmt.Fprintf(a.Stdout, "wrote %s broker=%s mode=%s auth=%s admin_auth=%s\n", written, *url, blank(file.Broker.Mode, string(BrokerModeManaged)), tokenState(file.Broker.Token), tokenState(file.Broker.AdminToken))
 	return nil
 }
 

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -9,6 +9,37 @@ import (
 	"testing"
 )
 
+func TestConfigSetBrokerRegisteredMode(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_PROVIDER", "")
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configSetBroker([]string{
+		"--url", "https://broker.example.test",
+		"--provider", "external",
+		"--mode", "registered",
+		"--auto-webvnc=false",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readFileConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Broker == nil || file.Broker.URL != "https://broker.example.test" || file.Provider != "external" || file.Broker.Mode != "registered" || file.Broker.AutoWebVNC == nil || *file.Broker.AutoWebVNC {
+		t.Fatalf("config=%#v", file)
+	}
+	if !strings.Contains(stdout.String(), "mode=registered") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
 func TestConfigShowIncludesRunPreflightTools(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -15,6 +15,8 @@ func clearConfigEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
 		"CRABBOX_COORDINATOR",
+		"CRABBOX_COORDINATOR_MODE",
+		"CRABBOX_COORDINATOR_AUTO_WEBVNC",
 		"CRABBOX_COORDINATOR_TOKEN",
 		"CRABBOX_COORDINATOR_ADMIN_TOKEN",
 		"CRABBOX_ADMIN_TOKEN",
@@ -1544,6 +1546,8 @@ func TestLoadConfigFromUserFile(t *testing.T) {
 	}
 	if err := os.WriteFile(path, []byte(`broker:
   url: https://crabbox.example.test
+  mode: registered
+  autoWebVNC: false
   token: secret
   adminToken: admin-secret
   provider: aws
@@ -1783,6 +1787,9 @@ ssh:
 	if cfg.Coordinator != "https://crabbox.example.test" || cfg.CoordToken != "secret" || cfg.CoordAdminToken != "admin-secret" {
 		t.Fatalf("broker config not loaded: %#v", cfg)
 	}
+	if cfg.BrokerMode != BrokerModeRegistered || cfg.BrokerAutoWebVNC {
+		t.Fatalf("broker registration config not loaded: mode=%q autoWebVNC=%t", cfg.BrokerMode, cfg.BrokerAutoWebVNC)
+	}
 	if cfg.HostID != "h-neutral-file" {
 		t.Fatalf("host id not loaded: %q", cfg.HostID)
 	}
@@ -1894,6 +1901,30 @@ ssh:
 	if len(cfg.Cache.Volumes) != 1 || cfg.Cache.Volumes[0].Name != "pnpm-store" || cfg.Cache.Volumes[0].Key != "my-app-linux-amd64-node24-pnpm10-lock" || cfg.Cache.Volumes[0].Path != "/var/cache/crabbox/pnpm" || cfg.Cache.Volumes[0].SizeGB != 80 || !cfg.Cache.Volumes[0].Required {
 		t.Fatalf("cache volumes config not loaded: %#v", cfg.Cache.Volumes)
 	}
+}
+
+func TestNormalizeBrokerConfig(t *testing.T) {
+	t.Run("defaults to managed", func(t *testing.T) {
+		cfg := Config{}
+		if err := normalizeBrokerConfig(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.BrokerMode != BrokerModeManaged {
+			t.Fatalf("mode=%q", cfg.BrokerMode)
+		}
+	})
+	t.Run("registered requires coordinator", func(t *testing.T) {
+		cfg := Config{BrokerMode: BrokerModeRegistered}
+		if err := normalizeBrokerConfig(&cfg); err == nil || !strings.Contains(err.Error(), "requires broker.url") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+	t.Run("rejects unknown mode", func(t *testing.T) {
+		cfg := Config{BrokerMode: "mirror"}
+		if err := normalizeBrokerConfig(&cfg); err == nil || !strings.Contains(err.Error(), "managed or registered") {
+			t.Fatalf("err=%v", err)
+		}
+	})
 }
 
 func TestLoadConfigExeDevWorkRootDefaults(t *testing.T) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -44,6 +44,7 @@ type CoordinatorLease struct {
 	ID                   string                `json:"id"`
 	Slug                 string                `json:"slug,omitempty"`
 	Provider             string                `json:"provider"`
+	Lifecycle            string                `json:"lifecycle,omitempty"`
 	TargetOS             string                `json:"target,omitempty"`
 	WindowsMode          string                `json:"windowsMode,omitempty"`
 	Desktop              bool                  `json:"desktop,omitempty"`
@@ -84,6 +85,32 @@ type CoordinatorLease struct {
 	ExpiresAt            string                `json:"expiresAt"`
 	Telemetry            *LeaseTelemetry       `json:"telemetry,omitempty"`
 	TelemetryHistory     []*LeaseTelemetry     `json:"telemetryHistory,omitempty"`
+}
+
+type CoordinatorLeaseRegistration struct {
+	Slug               string   `json:"slug,omitempty"`
+	Provider           string   `json:"provider"`
+	TargetOS           string   `json:"target"`
+	WindowsMode        string   `json:"windowsMode,omitempty"`
+	Desktop            bool     `json:"desktop,omitempty"`
+	DesktopEnv         string   `json:"desktopEnv,omitempty"`
+	Browser            bool     `json:"browser,omitempty"`
+	Code               bool     `json:"code,omitempty"`
+	CloudID            string   `json:"cloudID,omitempty"`
+	ServerID           int64    `json:"serverID,omitempty"`
+	ServerName         string   `json:"serverName,omitempty"`
+	ServerType         string   `json:"serverType,omitempty"`
+	Host               string   `json:"host"`
+	SSHUser            string   `json:"sshUser,omitempty"`
+	SSHPort            string   `json:"sshPort,omitempty"`
+	SSHFallbackPorts   []string `json:"sshFallbackPorts,omitempty"`
+	WorkRoot           string   `json:"workRoot,omitempty"`
+	Profile            string   `json:"profile,omitempty"`
+	Class              string   `json:"class,omitempty"`
+	Pond               string   `json:"pond,omitempty"`
+	ExposedPorts       []string `json:"exposedPorts,omitempty"`
+	TTLSeconds         int      `json:"ttlSeconds,omitempty"`
+	IdleTimeoutSeconds int      `json:"idleTimeoutSeconds,omitempty"`
 }
 
 type CoordinatorShareRole string
@@ -709,6 +736,14 @@ func (c *CoordinatorClient) CreateLease(ctx context.Context, cfg Config, publicK
 	}
 	addCoordinatorGCPFields(req, cfg)
 	err = c.do(ctx, http.MethodPost, "/v1/leases", req, &res)
+	return res.Lease, err
+}
+
+func (c *CoordinatorClient) RegisterLease(ctx context.Context, leaseID string, input CoordinatorLeaseRegistration) (CoordinatorLease, error) {
+	var res struct {
+		Lease CoordinatorLease `json:"lease"`
+	}
+	err := c.do(ctx, http.MethodPut, "/v1/leases/"+url.PathEscape(leaseID)+"/registration", input, &res)
 	return res.Lease, err
 }
 

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const coordinatorRegistrationTimeout = 15 * time.Second
+
+func (a App) claimLeaseTargetForRepoAndRegister(
+	ctx context.Context,
+	leaseID, slug string,
+	cfg Config,
+	server Server,
+	target SSHTarget,
+	repoRoot string,
+	reclaim bool,
+) error {
+	if err := claimLeaseTargetForRepoConfig(
+		leaseID,
+		slug,
+		cfg,
+		server,
+		target,
+		repoRoot,
+		cfg.IdleTimeout,
+		reclaim,
+	); err != nil {
+		return err
+	}
+	a.registerCoordinatorLeaseBestEffort(ctx, cfg, LeaseTarget{
+		Server:  server,
+		SSH:     target,
+		LeaseID: leaseID,
+	})
+	return nil
+}
+
+func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config, lease LeaseTarget) {
+	if !shouldRegisterCoordinatorLease(cfg) || strings.TrimSpace(lease.LeaseID) == "" {
+		return
+	}
+	coord, configured, err := newCoordinatorClient(cfg)
+	if err != nil || !configured || coord == nil {
+		fmt.Fprintf(a.Stderr, "warning: coordinator registration skipped for %s: %v\n", lease.LeaseID, err)
+		return
+	}
+	server := lease.Server
+	target := lease.SSH
+	provider := firstNonBlank(server.Provider, cfg.Provider)
+	targetOS := firstNonBlank(target.TargetOS, cfg.TargetOS)
+	registration := CoordinatorLeaseRegistration{
+		Slug:               firstNonBlank(serverSlug(server), lease.LeaseID),
+		Provider:           provider,
+		TargetOS:           targetOS,
+		WindowsMode:        firstNonBlank(target.WindowsMode, cfg.WindowsMode),
+		Desktop:            cfg.Desktop,
+		DesktopEnv:         normalizedDesktopEnv(cfg.DesktopEnv),
+		Browser:            cfg.Browser,
+		Code:               cfg.Code,
+		CloudID:            server.CloudID,
+		ServerID:           server.ID,
+		ServerName:         server.Name,
+		ServerType:         firstNonBlank(server.ServerType.Name, cfg.ServerType),
+		Host:               target.Host,
+		SSHUser:            target.User,
+		SSHPort:            target.Port,
+		SSHFallbackPorts:   append([]string(nil), target.FallbackPorts...),
+		WorkRoot:           cfg.WorkRoot,
+		Profile:            cfg.Profile,
+		Class:              cfg.Class,
+		Pond:               normalizePondName(cfg.Pond),
+		ExposedPorts:       append([]string(nil), cfg.ExposedPorts...),
+		TTLSeconds:         int(cfg.TTL.Seconds()),
+		IdleTimeoutSeconds: int(cfg.IdleTimeout.Seconds()),
+	}
+	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
+	defer cancel()
+	if _, err := coord.RegisterLease(callCtx, lease.LeaseID, registration); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: coordinator registration failed for %s: %v\n", lease.LeaseID, err)
+	}
+}
+
+func (a App) startRegisteredWebVNCDaemonBestEffort(cfg Config, target SSHTarget, leaseID string, keep bool) {
+	if !keep || !cfg.Desktop || !cfg.BrokerAutoWebVNC || !shouldRegisterCoordinatorLease(cfg) {
+		return
+	}
+	if err := a.startWebVNCDaemon(webVNCBridgeArgs(cfg, target, leaseID, false, false), leaseID); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: could not start registered WebVNC bridge for %s: %v\n", leaseID, err)
+	}
+}
+
+func (a App) releaseRegisteredCoordinatorLeaseBestEffort(ctx context.Context, cfg Config, leaseID string) {
+	if !shouldRegisterCoordinatorLease(cfg) || strings.TrimSpace(leaseID) == "" {
+		return
+	}
+	if _, err := a.stopWebVNCDaemonIfRunning(leaseID); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: could not stop registered WebVNC bridge for %s: %v\n", leaseID, err)
+	}
+	coord, configured, err := newCoordinatorClient(cfg)
+	if err != nil || !configured || coord == nil {
+		fmt.Fprintf(a.Stderr, "warning: coordinator deregistration skipped for %s: %v\n", leaseID, err)
+		return
+	}
+	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
+	defer cancel()
+	if _, err := coord.ReleaseLease(callCtx, leaseID, false); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: coordinator deregistration failed for %s: %v\n", leaseID, err)
+	}
+}

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
+	var got CoordinatorLeaseRegistration
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"external","lifecycle":"registered","state":"active"}}`))
+	}))
+	defer server.Close()
+
+	var stderr bytes.Buffer
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "token"
+	cfg.BrokerMode = BrokerModeRegistered
+	cfg.Desktop = true
+	cfg.DesktopEnv = "gnome"
+	cfg.WorkRoot = "/workspace"
+	cfg.ExposedPorts = []string{"3000", "8080"}
+	cfg.TTL = 2 * time.Hour
+	cfg.IdleTimeout = 30 * time.Minute
+	app := App{Stderr: &stderr}
+	lease := LeaseTarget{
+		LeaseID: "cbx_123",
+		Server: Server{
+			Provider: "external",
+			CloudID:  "external-box-123",
+			Name:     "my-box",
+		},
+		SSH: SSHTarget{Host: "192.0.2.10", User: "runner", Port: "22", TargetOS: targetLinux},
+	}
+	lease.Server.ServerType.Name = "cpu16"
+	app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, lease)
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if got.Provider != "external" || got.CloudID != "external-box-123" || got.Host != "192.0.2.10" || got.WorkRoot != "/workspace" || !got.Desktop || got.DesktopEnv != "gnome" || len(got.ExposedPorts) != 2 || got.TTLSeconds != 7200 || got.IdleTimeoutSeconds != 1800 {
+		t.Fatalf("registration=%#v", got)
+	}
+}
+
+func TestReleaseRegisteredCoordinatorLeaseNeverRequestsProviderDeletion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var got struct {
+		Delete bool `json:"delete"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/release" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"external","lifecycle":"registered","state":"released"}}`))
+	}))
+	defer server.Close()
+
+	var stderr bytes.Buffer
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &stderr}
+	app.releaseRegisteredCoordinatorLeaseBestEffort(context.Background(), Config{
+		Coordinator: server.URL,
+		CoordToken:  "token",
+		BrokerMode:  BrokerModeRegistered,
+	}, "cbx_123")
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if got.Delete {
+		t.Fatal("registered coordinator release requested provider deletion")
+	}
+}

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -854,6 +854,38 @@ func TestCoordinatorCreateLeaseSendsAWSSSHCIDRs(t *testing.T) {
 	}
 }
 
+func TestCoordinatorRegisterLease(t *testing.T) {
+	var got CoordinatorLeaseRegistration
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/leases/cbx_123/registration" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"external","lifecycle":"registered","state":"active"}}`))
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Token: "token", Client: server.Client()}
+	lease, err := client.RegisterLease(context.Background(), "cbx_123", CoordinatorLeaseRegistration{
+		Slug:               "my-box",
+		Provider:           "external",
+		TargetOS:           targetLinux,
+		Host:               "192.0.2.10",
+		SSHUser:            "runner",
+		SSHPort:            "22",
+		IdleTimeoutSeconds: 1800,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Lifecycle != "registered" || got.Slug != "my-box" || got.Provider != "external" || got.Host != "192.0.2.10" || got.IdleTimeoutSeconds != 1800 {
+		t.Fatalf("lease=%#v request=%#v", lease, got)
+	}
+}
+
 func TestCoordinatorCreateLeaseOmitsDefaultAzureOSDisk(t *testing.T) {
 	var body map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -80,7 +80,7 @@ func (a App) desktopLaunchWithCommand(ctx context.Context, args []string, comman
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")
@@ -229,7 +229,7 @@ func (a App) desktopTerminal(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")
@@ -421,7 +421,7 @@ func (a App) desktopProof(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -385,7 +385,7 @@ func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server Se
 	if err != nil {
 		return err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -251,7 +251,7 @@ func (a App) releasePrewarmLeaseAfterPoolFailure(ctx context.Context, backend Ba
 		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release skipped: %v\n", leaseID, cause, err)
 		return
 	}
-	if err := a.releaseBackendLeaseBestEffort(ctx, sshBackend, lease); err != nil {
+	if err := a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, lease); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release failed: %v\n", leaseID, cause, err)
 	}
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -865,7 +865,12 @@ func loadBackend(cfg Config, rt Runtime) (Backend, error) {
 }
 
 func shouldUseCoordinator(cfg Config, spec ProviderSpec) bool {
-	return spec.Coordinator == CoordinatorSupported && strings.TrimSpace(cfg.Coordinator) != ""
+	return cfg.BrokerMode != BrokerModeRegistered &&
+		spec.Coordinator == CoordinatorSupported && strings.TrimSpace(cfg.Coordinator) != ""
+}
+
+func shouldRegisterCoordinatorLease(cfg Config) bool {
+	return cfg.BrokerMode == BrokerModeRegistered && strings.TrimSpace(cfg.Coordinator) != ""
 }
 
 func backendCoordinator(backend Backend) *CoordinatorClient {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -252,6 +252,23 @@ func TestLoadBackendWrapsCoordinatorOnlyForSupportedSSHProviders(t *testing.T) {
 	}
 }
 
+func TestRegisteredBrokerKeepsProviderLifecycleDirect(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.Coordinator = "https://coordinator.example"
+	cfg.BrokerMode = BrokerModeRegistered
+	backend, err := loadBackend(cfg, testRuntimeWithRunner(&recordingCommandRunner{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := backend.(*coordinatorLeaseBackend); ok {
+		t.Fatal("registered broker mode must not transfer lifecycle ownership to the coordinator")
+	}
+	if !shouldRegisterCoordinatorLease(cfg) {
+		t.Fatal("registered broker mode should register direct leases")
+	}
+}
+
 func TestProviderFlagsApplyNamespaceWithoutCoreEdits(t *testing.T) {
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -91,8 +91,8 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	}
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	applyResolvedServerConfig(&cfg, server)
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		return err
 	}
 	if serverTailscaleMetadata(server).Enabled {
@@ -105,7 +105,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 		}
 	}
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
-		a.releaseBackendLeaseBestEffort(ctx, sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
+		a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		return err
 	} else {
 		target = resolved.Target
@@ -122,6 +122,7 @@ func (a App) warmup(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s server=%s type=%s ip=%s%s idle_timeout=%s expires=%s\n", leaseID, blank(serverSlug(server), "-"), cfg.Provider, server.DisplayID(), server.ServerType.Name, server.PublicNet.IPv4.IP, tailscaleSummary, cfg.IdleTimeout, blank(leaseLabelTimeDisplay(server.Labels["expires_at"]), server.Labels["expires_at"]))
 	fmt.Fprintf(a.Stdout, "ready ssh=%s@%s:%s network=%s workroot=%s\n", redactedSSHUser(cfg, server, target), target.Host, target.Port, network, cfg.WorkRoot)
+	a.startRegisteredWebVNCDaemonBestEffort(cfg, target, leaseID, *keep)
 	if *actionsRunner {
 		ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo)
 		if err != nil {
@@ -520,6 +521,14 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
 	coord := backendCoordinator(backend)
+	var registrationCoord *CoordinatorClient
+	if shouldRegisterCoordinatorLease(cfg) {
+		if client, configured, coordErr := newCoordinatorClient(cfg); coordErr != nil {
+			fmt.Fprintf(a.Stderr, "warning: registered coordinator heartbeat unavailable: %v\n", coordErr)
+		} else if configured {
+			registrationCoord = client
+		}
+	}
 	var script *RunScriptSpec
 	if scriptRequested {
 		script, err = loadRunScript(*scriptPath, *scriptStdin, a.Stdin)
@@ -639,7 +648,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			releaseApp.Stderr = io.Discard
 		}
 		cleanup.Attempted = true
-		cleanup.Err = releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
+		cleanup.Err = releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
 		cleanup.Stopped = cleanup.Err == nil
 		if cleanup.Err == nil {
 			recorder.Event("lease.released", "released", "")
@@ -655,9 +664,10 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			fmt.Fprintf(a.Stderr, "lease cleanup stopped=true policy=%s lease=%s slug=%s\n", blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"))
 		}
 	}()
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim || borrowedPool != nil); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim || borrowedPool != nil); err != nil {
 		return recordFailure(err)
 	}
+	a.startRegisteredWebVNCDaemonBestEffort(cfg, target, leaseID, acquired && *keep)
 	if !useCoordinator && leaseID != "" {
 		if touched, touchErr := sshBackend.Touch(ctx, TouchRequest{Lease: LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, State: blank(server.Labels["state"], "ready"), IdleTimeout: cfg.IdleTimeout}); touchErr == nil {
 			server = touched
@@ -682,7 +692,13 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 	defer stopRunHeartbeat()
 	startRunHeartbeat := func(updateIdleTimeout *time.Duration) {
 		stopRunHeartbeat()
-		stopHeartbeat = startCoordinatorHeartbeat(ctx, coord, leaseID, cfg.IdleTimeout, updateIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
+		heartbeatCoord := coord
+		if heartbeatCoord == nil {
+			heartbeatCoord = registrationCoord
+		}
+		if heartbeatCoord != nil {
+			stopHeartbeat = startCoordinatorHeartbeat(ctx, heartbeatCoord, leaseID, cfg.IdleTimeout, updateIdleTimeout, leaseTelemetryCollectorForTarget(target), a.Stderr)
+		}
 	}
 	if useCoordinator && leaseID != "" {
 		var heartbeatIdleTimeout *time.Duration
@@ -695,6 +711,8 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			}
 		}
 		startRunHeartbeat(heartbeatIdleTimeout)
+	} else if registrationCoord != nil && leaseID != "" {
+		startRunHeartbeat(nil)
 	}
 
 	if cfg.Sync.BaseRef == "" {
@@ -842,7 +860,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		if *timingJSON {
 			releaseApp.Stderr = io.Discard
 		}
-		if err := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, oldLease); err != nil {
+		if err := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, oldLease); err != nil {
 			recorder.Event("lease.replace.failed", "leasing", err.Error())
 			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, err)
 		}
@@ -875,7 +893,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 			recorder.AttachLease(leaseID, serverSlug(server), cfg)
 			startRunHeartbeat(nil)
 		}
-		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, repo.Root, cfg.IdleTimeout, *reclaim); err != nil {
+		if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
 			return true, err
 		}
 		workdir = remoteJoin(cfg, leaseID, repo.Name)
@@ -2405,13 +2423,14 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 	}
 }
 
-func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, lease LeaseTarget) error {
+func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
 	a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
 	fmt.Fprintf(a.Stderr, "releasing %s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 	if err := backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: release failed for %s: %v\n", lease.LeaseID, err)
 		return err
 	}
+	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, cfg, lease.LeaseID)
 	return nil
 }
 
@@ -2658,6 +2677,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if err := sshBackend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		return err
 	}
+	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, cfg, lease.LeaseID)
 	if backendCoordinator(backend) != nil {
 		fmt.Fprintf(a.Stderr, "released lease=%s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 		return nil

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -224,7 +224,7 @@ func unsupportedManagedTargetMessageForConfig(provider string, cfg Config) strin
 }
 
 func newTargetCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
-	if isStaticProvider(cfg.Provider) {
+	if isStaticProvider(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg) {
 		return nil, false, nil
 	}
 	return newCoordinatorClient(cfg)

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -40,7 +40,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		fmt.Fprintln(fs.Output(), "")
 		fmt.Fprintln(fs.Output(), "Bridge flags:")
 		fmt.Fprintln(fs.Output(), "  --id <lease-id-or-slug>")
-		fmt.Fprintln(fs.Output(), "  --provider hetzner|aws|azure")
+		fmt.Fprintln(fs.Output(), "  --provider <desktop-ssh-provider>")
 		fmt.Fprintln(fs.Output(), "  --target linux|macos|windows")
 		fmt.Fprintln(fs.Output(), "  --windows-mode normal|wsl2")
 		fmt.Fprintln(fs.Output(), "  --static-host <host>")
@@ -53,7 +53,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		fmt.Fprintln(fs.Output(), "  --take-control")
 		fmt.Fprintln(fs.Output(), "  --reclaim")
 	}
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, or azure")
+	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
@@ -89,7 +89,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
-	if supportsDirectSSHWebVNC(cfg.Provider) {
+	if useDirectSSHWebVNC(cfg) {
 		// macOS leases (e.g. tart) have no guest-side noVNC/websockify; serve the
 		// browser viewer from a host-side bridge over the guest's native Screen
 		// Sharing instead of the Linux directSSHWebVNC path.
@@ -98,8 +98,8 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		}
 		return a.directSSHWebVNC(ctx, cfg, *id, *localPort, *openPortal, *takeControl, *reclaim)
 	}
-	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
-		return exit(2, "webvnc currently supports coordinator-backed hetzner/aws/azure desktop leases")
+	if isBlacksmithProvider(cfg.Provider) || (isStaticProvider(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg)) {
+		return exit(2, "webvnc requires a coordinator-managed or registered desktop lease")
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 	if err != nil {
@@ -157,14 +157,16 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
 	opened := false
 	return serveWebVNCBridgePool(ctx, webVNCBridgePoolConfig{
-		Coord:     coord,
-		LeaseID:   leaseID,
-		Host:      connHost,
-		Port:      connPort,
-		PoolSize:  webVNCBridgePoolSizeForTarget(target),
-		RescueCtx: rescueCtx,
-		NativeVNC: nativeVNCOpenCommand(cfg, target, leaseID),
-		Log:       a.Stdout,
+		Coord:       coord,
+		LeaseID:     leaseID,
+		Host:        connHost,
+		Port:        connPort,
+		PoolSize:    webVNCBridgePoolSizeForTarget(target),
+		IdleTimeout: cfg.IdleTimeout,
+		Telemetry:   leaseTelemetryCollectorForTarget(target),
+		RescueCtx:   rescueCtx,
+		NativeVNC:   nativeVNCOpenCommand(cfg, target, leaseID),
+		Log:         a.Stdout,
 		OnReady: func() error {
 			fmt.Fprintln(a.Stdout, "bridge: connected; keep this process running while using WebVNC")
 			fmt.Fprintf(a.Stdout, "webvnc: %s\n", portal)
@@ -197,15 +199,17 @@ func webVNCBridgePoolSizeForTarget(target SSHTarget) int {
 }
 
 type webVNCBridgePoolConfig struct {
-	Coord     *CoordinatorClient
-	LeaseID   string
-	Host      string
-	Port      string
-	PoolSize  int
-	RescueCtx rescueContext
-	NativeVNC string
-	Log       io.Writer
-	OnReady   func() error
+	Coord       *CoordinatorClient
+	LeaseID     string
+	Host        string
+	Port        string
+	PoolSize    int
+	IdleTimeout time.Duration
+	Telemetry   leaseTelemetryCollector
+	RescueCtx   rescueContext
+	NativeVNC   string
+	Log         io.Writer
+	OnReady     func() error
 }
 
 type webVNCBridgePoolEvent struct {
@@ -221,6 +225,10 @@ func serveWebVNCBridgePool(ctx context.Context, cfg webVNCBridgePoolConfig) erro
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	if cfg.Coord != nil && strings.TrimSpace(cfg.LeaseID) != "" {
+		stopHeartbeat := startCoordinatorHeartbeat(ctx, cfg.Coord, cfg.LeaseID, cfg.IdleTimeout, nil, cfg.Telemetry, cfg.Log)
+		defer stopHeartbeat()
+	}
 	events := make(chan webVNCBridgePoolEvent, cfg.PoolSize)
 	for slot := 0; slot < cfg.PoolSize; slot++ {
 		go serveWebVNCBridgeSlot(ctx, cfg, slot, events)
@@ -332,7 +340,7 @@ func (a App) webVNCDaemonCommand(ctx context.Context, args []string) error {
 func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("webvnc daemon start", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, or azure")
+	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
@@ -357,7 +365,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 	}
 	target := SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}
 	bridgeID := *id
-	if supportsDirectSSHWebVNC(cfg.Provider) {
+	if useDirectSSHWebVNC(cfg) {
 		if err := guardMacOSDirectWebVNC(cfg); err != nil {
 			return err
 		}
@@ -379,7 +387,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 		}
 		target = resolvedTarget
 		bridgeID = leaseID
-	} else if !isBlacksmithProvider(cfg.Provider) && !isStaticProvider(cfg.Provider) {
+	} else if !isBlacksmithProvider(cfg.Provider) && (!isStaticProvider(cfg.Provider) || shouldRegisterCoordinatorLease(cfg)) {
 		coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 		if err != nil {
 			return err
@@ -485,7 +493,7 @@ func (a App) webVNCDaemonListCommand(args []string) error {
 func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("webvnc status", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, or azure")
+	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	providerFlags := registerProviderFlags(fs, defaults)
@@ -505,14 +513,14 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
-	if supportsDirectSSHWebVNC(cfg.Provider) {
+	if useDirectSSHWebVNC(cfg) {
 		if err := guardMacOSDirectWebVNC(cfg); err != nil {
 			return err
 		}
 		return a.directSSHWebVNCStatus(ctx, cfg, *id, *localPort)
 	}
-	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
-		return exit(2, "webvnc status currently supports coordinator-backed hetzner/aws/azure desktop leases")
+	if isBlacksmithProvider(cfg.Provider) || (isStaticProvider(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg)) {
+		return exit(2, "webvnc status requires a coordinator-managed or registered desktop lease")
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 	if err != nil {
@@ -606,7 +614,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("webvnc reset", a.Stderr)
-	provider := fs.String("provider", defaults.Provider, "provider: hetzner, aws, or azure")
+	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
 	takeControl := fs.Bool("take-control", false, "ask the portal viewer to take keyboard and mouse control after connecting")
@@ -627,14 +635,14 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
-	if supportsDirectSSHWebVNC(cfg.Provider) {
+	if useDirectSSHWebVNC(cfg) {
 		if err := guardMacOSDirectWebVNC(cfg); err != nil {
 			return err
 		}
 		return a.directSSHWebVNCReset(ctx, cfg, *id, *openPortal, *takeControl)
 	}
-	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) {
-		return exit(2, "webvnc reset currently supports coordinator-backed hetzner/aws/azure desktop leases")
+	if isBlacksmithProvider(cfg.Provider) || (isStaticProvider(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg)) {
+		return exit(2, "webvnc reset requires a coordinator-managed or registered desktop lease")
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 	if err != nil {
@@ -1276,6 +1284,10 @@ func supportsDirectSSHWebVNC(provider string) bool {
 	return spec.Kind == ProviderKindSSHLease &&
 		spec.Coordinator == CoordinatorNever &&
 		spec.Features.Has(FeatureDesktop)
+}
+
+func useDirectSSHWebVNC(cfg Config) bool {
+	return supportsDirectSSHWebVNC(cfg.Provider) && !shouldRegisterCoordinatorLease(cfg)
 }
 
 func (a App) directSSHWebVNC(ctx context.Context, cfg Config, id, localPort string, openViewer, _ bool, reclaim bool) error {

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -107,6 +107,20 @@ func TestGuardMacOSDirectWebVNC(t *testing.T) {
 	}
 }
 
+func TestRegisteredLeaseUsesCoordinatorWebVNC(t *testing.T) {
+	cfg := Config{
+		Provider:    "direct-webvnc-test",
+		Coordinator: "https://broker.example.test",
+		BrokerMode:  BrokerModeRegistered,
+	}
+	if useDirectSSHWebVNC(cfg) {
+		t.Fatal("registered lease should use the coordinator WebVNC bridge")
+	}
+	if !useDirectSSHWebVNC(Config{Provider: "direct-webvnc-test"}) {
+		t.Fatal("unregistered direct provider should keep its local WebVNC bridge")
+	}
+}
+
 func TestIsMacOSDesktopProviderOnlyDedicatedMacOS(t *testing.T) {
 	// tart's only target is macOS -> uses the host-side Screen Sharing bridge.
 	if !isMacOSDesktopProvider(Config{Provider: "tart"}) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -57,6 +57,7 @@ import type {
   ExternalRunnerRecord,
   ExternalRunnerSyncRequest,
   LeaseRecord,
+  LeaseRegistrationRequest,
   LeaseRequest,
   LeaseShare,
   LeaseShareRole,
@@ -233,7 +234,7 @@ interface CodePendingWebSocketFrame {
 interface LeaseCloudAudit {
   leaseID: string;
   slug?: string;
-  provider: Provider;
+  provider: string;
   state: LeaseRecord["state"];
   target: LeaseRecord["target"];
   owner: string;
@@ -1280,6 +1281,9 @@ export class FleetDurableObject implements DurableObject {
 
   private async leaseRoute(request: Request, leaseID: string, action?: string): Promise<Response> {
     const method = request.method.toUpperCase();
+    if (method === "PUT" && action === "registration") {
+      return await this.registerLease(request, leaseID);
+    }
     if (method === "GET" && action === undefined) {
       const lease = await this.resolveLease(leaseID, request, false);
       return lease ? json({ lease }) : notFound();
@@ -1330,6 +1334,128 @@ export class FleetDurableObject implements DurableObject {
     return json({ error: "not_found" }, { status: 404 });
   }
 
+  private async registerLease(request: Request, leaseID: string): Promise<Response> {
+    if (!validRegisteredLeaseID(leaseID)) {
+      return json({ error: "invalid_lease_id" }, { status: 400 });
+    }
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    const input = await readJson<LeaseRegistrationRequest>(request);
+    const provider = sanitizeRunnerProvider(input.provider);
+    const target = sanitizeRegisteredTarget(input.target);
+    const host = sanitizeRegisteredHost(input.host);
+    if (!provider) {
+      return json({ error: "invalid_provider" }, { status: 400 });
+    }
+    if (!target) {
+      return json({ error: "invalid_target" }, { status: 400 });
+    }
+    if (!host) {
+      return json({ error: "host_required" }, { status: 400 });
+    }
+
+    const existing = await this.getLease(leaseID);
+    if (
+      existing &&
+      (existing.owner !== owner || existing.org !== org || !isRegisteredLease(existing))
+    ) {
+      return json(
+        { error: "lease_id_conflict", message: "lease id belongs to another lifecycle or owner" },
+        { status: 409 },
+      );
+    }
+    if (existing && existing.provider !== provider) {
+      return json(
+        { error: "provider_conflict", message: "registered lease provider cannot change" },
+        { status: 409 },
+      );
+    }
+
+    const leases = await this.leaseRecords();
+    const now = new Date();
+    const nowISO = now.toISOString();
+    const ttlSeconds = clampLeaseSeconds(input.ttlSeconds, 86_400);
+    const idleTimeoutSeconds = clampLeaseSeconds(input.idleTimeoutSeconds, 86_400);
+    const slug =
+      existing?.slug ||
+      allocateLeaseSlug(
+        normalizeLeaseSlug(input.slug) || leaseSlugFromID(leaseID),
+        leaseID,
+        owner,
+        org,
+        leases,
+      );
+    const record: LeaseRecord = {
+      ...existing,
+      id: leaseID,
+      slug,
+      provider,
+      lifecycle: "registered",
+      target,
+      ...(target === "windows"
+        ? { windowsMode: input.windowsMode === "wsl2" ? "wsl2" : "normal" }
+        : {}),
+      desktop: input.desktop === true,
+      desktopEnv: nonSecretString(input.desktopEnv),
+      browser: input.browser === true,
+      code: input.code === true,
+      cloudID: nonSecretString(input.cloudID),
+      owner,
+      org,
+      profile: nonSecretString(input.profile) || "default",
+      class: nonSecretString(input.class) || "registered",
+      serverType: nonSecretString(input.serverType) || "registered",
+      serverID:
+        Number.isSafeInteger(input.serverID) && (input.serverID ?? 0) >= 0
+          ? (input.serverID ?? 0)
+          : 0,
+      serverName: nonSecretString(input.serverName) || slug,
+      providerKey: "",
+      host,
+      sshUser: nonSecretString(input.sshUser) || "crabbox",
+      sshPort: sanitizeRegisteredPort(input.sshPort) || "22",
+      workRoot: nonSecretString(input.workRoot) || "/workspaces/crabbox",
+      keep: true,
+      ttlSeconds,
+      idleTimeoutSeconds,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "active",
+      createdAt: existing?.createdAt || nowISO,
+      registeredAt: existing?.registeredAt || nowISO,
+      updatedAt: nowISO,
+      lastTouchedAt: nowISO,
+      expiresAt: registeredLeaseExpiresAt(now, ttlSeconds, idleTimeoutSeconds).toISOString(),
+    };
+    if (input.pond) {
+      record.pond = nonSecretString(input.pond);
+    } else {
+      delete record.pond;
+    }
+    if (target !== "windows") {
+      delete record.windowsMode;
+    }
+    const fallbackPorts = sanitizeRegisteredPorts(input.sshFallbackPorts);
+    if (fallbackPorts) {
+      record.sshFallbackPorts = fallbackPorts;
+    } else {
+      delete record.sshFallbackPorts;
+    }
+    const exposedPorts = sanitizeRegisteredPorts(input.exposedPorts);
+    if (exposedPorts) {
+      record.exposedPorts = exposedPorts;
+    } else {
+      delete record.exposedPorts;
+    }
+    delete record.endedAt;
+    delete record.releasedAt;
+    delete record.releaseDeletesServer;
+    clearLeaseCleanupMetadata(record);
+    await this.putLease(record);
+    await this.scheduleAlarm();
+    return json({ lease: record }, { status: existing ? 200 : 201 });
+  }
+
   private async applyLeaseHeartbeat(
     lease: LeaseRecord,
     input: {
@@ -1357,8 +1483,9 @@ export class FleetDurableObject implements DurableObject {
     lease.expiresAt = recomputeLeaseExpiresAt(lease, now).toISOString();
     clearLeaseCleanupMetadata(lease);
     const requestCIDRs = request ? requestSourceCIDRs(request) : [];
-    if (requestCIDRs.length > 0) {
-      const provider = this.provider(lease.provider, lease.region, lease.providerProject);
+    const managedProvider = managedLeaseProvider(lease);
+    if (requestCIDRs.length > 0 && managedProvider) {
+      const provider = this.provider(managedProvider, lease.region, lease.providerProject);
       const leases = await this.leaseRecords();
       const accessContext = providerAccessContext(
         requestCIDRs,
@@ -1803,7 +1930,9 @@ export class FleetDurableObject implements DurableObject {
   ): Promise<PortalAdminProviderStatus[]> {
     const providerSet = new Set<Provider>(coordinatorProviders);
     for (const lease of leases) {
-      providerSet.add(lease.provider);
+      if (isCoordinatorProvider(lease.provider)) {
+        providerSet.add(lease.provider);
+      }
     }
     return await Promise.all(
       [...providerSet]
@@ -1817,7 +1946,9 @@ export class FleetDurableObject implements DurableObject {
     leases: PortalAdminLeaseSummary[],
   ): Promise<PortalAdminProviderStatus> {
     const readiness = this.providerConfigurationReadiness(provider);
-    const providerLeases = leases.filter((lease) => lease.provider === provider);
+    const providerLeases = leases.filter(
+      (lease) => lease.provider === provider && lease.lifecycle !== "registered",
+    );
     const activeLeases = providerLeases.filter((lease) => lease.state === "active").length;
     const users = new Set(providerLeases.map((lease) => lease.owner || "unknown")).size;
     const recentLeases = providerLeases
@@ -1873,6 +2004,7 @@ export class FleetDurableObject implements DurableObject {
         id: lease.id,
         ...(lease.slug ? { slug: lease.slug } : {}),
         provider: lease.provider,
+        lifecycle: lease.lifecycle,
         state: lease.state,
         target: lease.target || "linux",
         owner: lease.owner,
@@ -3394,6 +3526,15 @@ export class FleetDurableObject implements DurableObject {
     if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
+    if (isRegisteredLease(lease)) {
+      return json(
+        {
+          error: "unsupported_lifecycle",
+          message: "registered leases cannot join coordinator-managed ready pools",
+        },
+        { status: 400 },
+      );
+    }
     if (lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
       return json({ error: "lease_not_active" }, { status: 409 });
     }
@@ -3680,7 +3821,7 @@ export class FleetDurableObject implements DurableObject {
     const org = url.searchParams.get("org") ?? "";
     const limit = clampLimit(url.searchParams.get("limit"), 100);
     const leases = (await this.leaseRecords())
-      .filter((lease) => lease.provider === provider)
+      .filter((lease) => lease.provider === provider && !isRegisteredLease(lease))
       .filter((lease) => !state || lease.state === state)
       .filter((lease) => !owner || lease.owner === owner)
       .filter((lease) => !org || lease.org === org)
@@ -4508,7 +4649,17 @@ export class FleetDurableObject implements DurableObject {
     if (!lease) {
       return notFound();
     }
-    const provider = this.provider(lease.provider, lease.region, lease.providerProject);
+    const managedProvider = managedLeaseProvider(lease);
+    if (!managedProvider) {
+      return json(
+        {
+          error: "unsupported_provider",
+          message: "registered leases do not support coordinator-managed images",
+        },
+        { status: 400 },
+      );
+    }
+    const provider = this.provider(managedProvider, lease.region, lease.providerProject);
     if (!lease.cloudID || !provider.supportsNativeImages()) {
       return json(
         {
@@ -4628,6 +4779,15 @@ export class FleetDurableObject implements DurableObject {
           return;
         }
         const nowISO = new Date().toISOString();
+        if (isRegisteredLease(lease)) {
+          lease.state = "expired";
+          lease.updatedAt = nowISO;
+          lease.endedAt = nowISO;
+          delete lease.releaseDeletesServer;
+          clearLeaseCleanupMetadata(lease);
+          await this.putLease(lease);
+          return;
+        }
         if (lease.state === "provisioning" && !lease.cloudID) {
           lease.state = "failed";
           lease.updatedAt = nowISO;
@@ -4776,7 +4936,7 @@ export class FleetDurableObject implements DurableObject {
     const startedAt = new Date().toISOString();
     const leases = [...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values()];
     const activeAWSLeases = leases.filter(
-      (lease) => lease.provider === "aws" && leaseIsLive(lease),
+      (lease) => lease.provider === "aws" && !isRegisteredLease(lease) && leaseIsLive(lease),
     );
     const activeLeases = new Map(activeAWSLeases.map((lease) => [lease.id, lease]));
     const activeCloudIDs = new Set(activeAWSLeases.map((lease) => lease.cloudID).filter(Boolean));
@@ -4954,7 +5114,7 @@ export class FleetDurableObject implements DurableObject {
     const startedAt = new Date().toISOString();
     const leases = [...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values()];
     const liveAzureLeases = leases.filter(
-      (lease) => lease.provider === "azure" && leaseIsLive(lease),
+      (lease) => lease.provider === "azure" && !isRegisteredLease(lease) && leaseIsLive(lease),
     );
     const liveLeases = new Map(liveAzureLeases.map((lease) => [lease.id, lease]));
     const liveCloudIDs = new Set(liveAzureLeases.map((lease) => lease.cloudID).filter(Boolean));
@@ -5381,7 +5541,11 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private async deleteLeaseServer(lease: LeaseRecord): Promise<void> {
-    await this.provider(lease.provider, lease.region, lease.providerProject).releaseLease(lease);
+    const provider = managedLeaseProvider(lease);
+    if (!provider) {
+      return;
+    }
+    await this.provider(provider, lease.region, lease.providerProject).releaseLease(lease);
   }
 
   private async abortProvisionedLeaseAfterStateChange(
@@ -5445,8 +5609,9 @@ export class FleetDurableObject implements DurableObject {
     options: { deleteServer: boolean; keep?: boolean },
   ): Promise<LeaseRecord> {
     this.clearEgressLease(lease.id);
+    const deleteServer = options.deleteServer && !isRegisteredLease(lease);
     if (
-      options.deleteServer &&
+      deleteServer &&
       lease.cloudID &&
       (leaseIsLive(lease) || lease.releaseDeletesServer !== undefined || lease.cleanupError)
     ) {
@@ -5460,8 +5625,8 @@ export class FleetDurableObject implements DurableObject {
     lease.releasedAt = now;
     lease.endedAt = now;
     if (wasUnprovisionedRelease) {
-      lease.releaseDeletesServer = options.deleteServer;
-    } else if (lease.releaseDeletesServer === false && !options.deleteServer) {
+      lease.releaseDeletesServer = deleteServer;
+    } else if (lease.releaseDeletesServer === false && !deleteServer) {
       lease.releaseDeletesServer = false;
     } else {
       delete lease.releaseDeletesServer;
@@ -5975,6 +6140,10 @@ function validLeaseID(value: string | undefined): value is string {
   return typeof value === "string" && /^cbx_[a-f0-9]{12}$/.test(value);
 }
 
+function validRegisteredLeaseID(value: string | undefined): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}$/.test(value);
+}
+
 function validWebVNCTicket(value: string | undefined): value is string {
   return typeof value === "string" && /^wvnc_[a-f0-9]{32}$/.test(value);
 }
@@ -6287,6 +6456,29 @@ function mergeTailscaleMetadata(
 
 function nonSecretString(value: unknown): string {
   return typeof value === "string" ? value.trim().slice(0, 256) : "";
+}
+
+function sanitizeRegisteredHost(value: unknown): string {
+  const host = nonSecretString(value);
+  return host.length <= 255 && /^[A-Za-z0-9._:[\]%-]+$/.test(host) ? host : "";
+}
+
+function sanitizeRegisteredTarget(value: unknown): TargetOS | undefined {
+  return value === "linux" || value === "macos" || value === "windows" ? value : undefined;
+}
+
+function sanitizeRegisteredPort(value: unknown): string {
+  const raw = nonSecretString(value);
+  const port = Number(raw);
+  return Number.isInteger(port) && port >= 1 && port <= 65_535 ? String(port) : "";
+}
+
+function sanitizeRegisteredPorts(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const ports = [...new Set(value.map(sanitizeRegisteredPort).filter(Boolean))].slice(0, 10);
+  return ports.length > 0 ? ports : undefined;
 }
 
 function sanitizeRunnerProvider(value: unknown): string {
@@ -7023,6 +7215,14 @@ function leaseIdleTimeoutSeconds(lease: LeaseRecord): number {
 }
 
 function recomputeLeaseExpiresAt(lease: LeaseRecord, fallbackNow: Date): Date {
+  if (isRegisteredLease(lease)) {
+    const touchedAt = parseLeaseDate(lease.lastTouchedAt, fallbackNow);
+    return registeredLeaseExpiresAt(
+      touchedAt,
+      leaseTTLSeconds(lease),
+      leaseIdleTimeoutSeconds(lease),
+    );
+  }
   const createdAt = parseLeaseDate(lease.createdAt, fallbackNow);
   const touchedAt = parseLeaseDate(lease.lastTouchedAt, createdAt);
   return leaseExpiresAt(
@@ -7030,6 +7230,16 @@ function recomputeLeaseExpiresAt(lease: LeaseRecord, fallbackNow: Date): Date {
     touchedAt,
     leaseTTLSeconds(lease),
     leaseIdleTimeoutSeconds(lease),
+  );
+}
+
+function registeredLeaseExpiresAt(
+  touchedAt: Date,
+  ttlSeconds: number,
+  idleTimeoutSeconds: number,
+): Date {
+  return new Date(
+    touchedAt.getTime() + Math.min(Math.max(1, ttlSeconds), Math.max(1, idleTimeoutSeconds)) * 1000,
   );
 }
 
@@ -7236,6 +7446,17 @@ function activeSlugCollision(
 
 function leaseIsLive(lease: LeaseRecord): boolean {
   return lease.state === "active" || lease.state === "provisioning";
+}
+
+function isRegisteredLease(lease: LeaseRecord): boolean {
+  return lease.lifecycle === "registered";
+}
+
+function managedLeaseProvider(lease: LeaseRecord): Provider | undefined {
+  // A registered record never grants provider authority, even when its name is aws/azure/etc.
+  return !isRegisteredLease(lease) && isCoordinatorProvider(lease.provider)
+    ? lease.provider
+    : undefined;
 }
 
 function leaseNeedsCleanup(lease: LeaseRecord, now: number): boolean {
@@ -7482,7 +7703,9 @@ function withLeaseSSHSourceCIDRs(
 function activeAWSSSHSourceCIDRs(leases: LeaseRecord[], cidrs: string[]): string[] {
   return uniqueNonEmpty([
     ...leases.flatMap((lease) =>
-      lease.provider === "aws" && leaseIsLive(lease) ? (lease.network?.sshSourceCIDRs ?? []) : [],
+      lease.provider === "aws" && !isRegisteredLease(lease) && leaseIsLive(lease)
+        ? (lease.network?.sshSourceCIDRs ?? [])
+        : [],
     ),
     ...cidrs,
   ]);
@@ -7492,6 +7715,7 @@ function hasUnknownActiveAWSSSHSource(leases: LeaseRecord[]): boolean {
   return leases.some(
     (lease) =>
       lease.provider === "aws" &&
+      !isRegisteredLease(lease) &&
       leaseIsLive(lease) &&
       (lease.network?.sshSourceCIDRs?.length ?? 0) === 0 &&
       !lease.network?.sshSourceCIDRsComplete,
@@ -7934,7 +8158,7 @@ class AzureProvider implements CloudProvider {
   ): Promise<ProviderImage> {
     return this.client.createDiskSnapshot(
       lease.cloudID,
-      providerImageResourceName(lease.provider, name, lease.id),
+      providerImageResourceName("azure", name, lease.id),
     );
   }
 
@@ -8049,13 +8273,10 @@ class GCPProvider implements CloudProvider {
     strategy: "image" | "disk-snapshot",
   ): Promise<ProviderImage> {
     return strategy === "image"
-      ? this.client.createImage(
-          lease.cloudID,
-          providerImageResourceName(lease.provider, name, lease.id),
-        )
+      ? this.client.createImage(lease.cloudID, providerImageResourceName("gcp", name, lease.id))
       : this.client.createDiskSnapshot(
           lease.cloudID,
-          providerImageResourceName(lease.provider, name, lease.id),
+          providerImageResourceName("gcp", name, lease.id),
         );
   }
 

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -82,7 +82,8 @@ export interface PortalAdminProviderStatus {
 export interface PortalAdminLeaseSummary {
   id: string;
   slug?: string;
-  provider: Provider;
+  provider: string;
+  lifecycle?: LeaseRecord["lifecycle"];
   state: LeaseRecord["state"];
   target: string;
   owner: string;
@@ -100,7 +101,7 @@ export interface PortalAdminUserSummary {
   orgs: string[];
   activeLeases: number;
   totalLeases: number;
-  providers: Provider[];
+  providers: string[];
   lastSeenAt: string;
 }
 
@@ -402,6 +403,8 @@ function adminLeaseRow(
   const returnPath = `/portal/admin/leases${providerFilter ? `?provider=${encodeURIComponent(providerFilter)}` : ""}`;
   const canEject =
     lease.state === "active" || lease.state === "provisioning" || lease.state === "failed";
+  const releaseLabel =
+    lease.lifecycle === "registered" ? "Remove registration" : "Emergency release";
   return `<tr data-filter-tags="${escapeHTML([stateGroup, lease.state, lease.provider, lease.owner, lease.org, lease.target, lease.serverType].join(" "))}">
     <td><a class="lease-link" href="/portal/leases/${encodeURIComponent(lease.id)}"><strong>${escapeHTML(lease.slug || lease.id)}</strong><small>${escapeHTML(lease.id)}</small></a></td>
     <td><span class="pill" data-state="${escapeHTML(lease.state)}">${escapeHTML(lease.state)}</span></td>
@@ -410,7 +413,7 @@ function adminLeaseRow(
     <td>${targetBadge(lease.target)}</td>
     <td>${escapeHTML(`${lease.class} / ${lease.serverType}`)}</td>
     ${timeCell(lease.state === "active" || lease.state === "provisioning" ? lease.expiresAt : lease.updatedAt)}
-    <td>${canEject ? `<form class="admin-eject-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=${encodeURIComponent(returnPath)}"><button class="admin-eject" type="submit" title="Emergency release ${escapeHTML(lease.slug || lease.id)}" aria-label="Emergency release ${escapeHTML(lease.slug || lease.id)}">${ejectIcon}</button></form>` : ""}</td>
+    <td>${canEject ? `<form class="admin-eject-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=${encodeURIComponent(returnPath)}"><button class="admin-eject" type="submit" title="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}" aria-label="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}">${ejectIcon}</button></form>` : ""}</td>
   </tr>`;
 }
 
@@ -487,6 +490,7 @@ export function portalLeaseDetail(
   const slug = lease.slug || lease.id;
   const target = lease.target || "linux";
   const active = lease.state === "active";
+  const registered = lease.lifecycle === "registered";
   const runRows = runs.length
     ? runs.map((run) => runRow(run)).join("")
     : `<tr><td colspan="8" class="empty">no recorded runs for this lease</td></tr>`;
@@ -522,7 +526,7 @@ export function portalLeaseDetail(
     `${slug} lease`,
     `<main class="portal-shell lease-shell">
       ${portalHeader({
-        meta: `${escapeHTML(slug)} · ${escapeHTML(lease.provider)} ${escapeHTML(target)} lease <span class="mono">${escapeHTML(lease.id)}</span>`,
+        meta: `${escapeHTML(slug)} · ${escapeHTML(lease.provider)} ${escapeHTML(target)} ${registered ? "registered " : ""}lease <span class="mono">${escapeHTML(lease.id)}</span>`,
         actions: `
           ${
             options.canManage
@@ -541,6 +545,7 @@ export function portalLeaseDetail(
           </div>
           <dl class="meta-grid">
             ${metaHTMLRow("provider", providerBadge(lease.provider))}
+            ${metaRow("lifecycle", registered ? "client managed" : "coordinator managed")}
             ${metaHTMLRow("target", targetBadge(target, lease.windowsMode))}
             ${metaRow("class", lease.class)}
             ${metaRow("host", lease.host || "pending")}
@@ -553,7 +558,7 @@ export function portalLeaseDetail(
           ${
             active && options.canManage
               ? `<form method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release" class="stop-form">
-                  <button class="button danger" type="submit">stop lease</button>
+                  <button class="button ${registered ? "secondary" : "danger"}" type="submit">${registered ? "remove registration" : "stop lease"}</button>
                 </form>`
               : ""
           }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -170,6 +170,32 @@ export interface LeaseRequest {
   exposedPorts?: string[];
 }
 
+export interface LeaseRegistrationRequest {
+  slug?: string;
+  provider?: string;
+  target?: TargetOS;
+  windowsMode?: WindowsMode;
+  desktop?: boolean;
+  desktopEnv?: string;
+  browser?: boolean;
+  code?: boolean;
+  cloudID?: string;
+  serverID?: number;
+  serverName?: string;
+  serverType?: string;
+  host?: string;
+  sshUser?: string;
+  sshPort?: string;
+  sshFallbackPorts?: string[];
+  workRoot?: string;
+  profile?: string;
+  class?: string;
+  pond?: string;
+  exposedPorts?: string[];
+  ttlSeconds?: number;
+  idleTimeoutSeconds?: number;
+}
+
 export const coordinatorProviderRegistry = [
   {
     provider: "hetzner",
@@ -224,6 +250,7 @@ export function coordinatorProviderSpec(provider: Provider): CoordinatorProvider
 
 export type TargetOS = "linux" | "macos" | "windows";
 export type WindowsMode = "normal" | "wsl2";
+export type LeaseLifecycle = "managed" | "registered";
 
 export interface LeaseTelemetry {
   capturedAt: string;
@@ -249,7 +276,8 @@ export interface RunTelemetrySummary {
 export interface LeaseRecord {
   id: string;
   slug?: string;
-  provider: Provider;
+  provider: string;
+  lifecycle?: LeaseLifecycle;
   target: TargetOS;
   os?: string;
   windowsMode?: WindowsMode;
@@ -303,6 +331,7 @@ export interface LeaseRecord {
   releaseDeletesServer?: boolean;
   releasedAt?: string;
   endedAt?: string;
+  registeredAt?: string;
 }
 
 export type ReadyPoolEntryState = "ready" | "busy" | "draining" | "stale";
@@ -318,7 +347,7 @@ export interface ReadyPoolEntry {
   commit?: string;
   fingerprint?: string;
   image?: string;
-  provider?: Provider;
+  provider?: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;
   class?: string;
@@ -449,7 +478,7 @@ export interface RunRecord {
   slug?: string;
   owner: string;
   org: string;
-  provider: Provider;
+  provider: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;
   class: string;
@@ -476,7 +505,7 @@ export interface RunRecord {
 
 export interface RunCreateRequest {
   leaseID?: string;
-  provider?: Provider;
+  provider?: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;
   class?: string;
@@ -559,7 +588,7 @@ export interface RunEventRecord {
   data?: string;
   leaseID?: string;
   slug?: string;
-  provider?: Provider;
+  provider?: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;
   class?: string;
@@ -576,7 +605,7 @@ export interface RunEventRequest {
   data?: string;
   leaseID?: string;
   slug?: string;
-  provider?: Provider;
+  provider?: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;
   class?: string;

--- a/worker/src/usage.ts
+++ b/worker/src/usage.ts
@@ -118,7 +118,8 @@ export function enforceCostLimits(
   limits: CostLimits,
   now: Date,
 ): string {
-  const active = leases.filter((lease) => isActiveLease(lease, now));
+  const managedLeases = leases.filter(isManagedLease);
+  const active = managedLeases.filter((lease) => isActiveLease(lease, now));
   const ownerActive = active.filter((lease) => lease.owner === candidate.owner);
   const orgActive = active.filter((lease) => lease.org === candidate.org);
   if (limits.maxActiveLeases > 0 && active.length + 1 > limits.maxActiveLeases) {
@@ -133,9 +134,13 @@ export function enforceCostLimits(
   }
 
   const month = monthKey(now);
-  const allUsage = usageSummary(leases, { scope: "all", month }, now);
-  const ownerUsage = usageSummary(leases, { scope: "user", owner: candidate.owner, month }, now);
-  const orgUsage = usageSummary(leases, { scope: "org", org: candidate.org, month }, now);
+  const allUsage = usageSummary(managedLeases, { scope: "all", month }, now);
+  const ownerUsage = usageSummary(
+    managedLeases,
+    { scope: "user", owner: candidate.owner, month },
+    now,
+  );
+  const orgUsage = usageSummary(managedLeases, { scope: "org", org: candidate.org, month }, now);
   if (overBudget(allUsage.reservedUSD + candidate.maxEstimatedUSD, limits.maxMonthlyUSD)) {
     return `monthly budget exceeded: ${formatUSD(allUsage.reservedUSD + candidate.maxEstimatedUSD)}/${formatUSD(limits.maxMonthlyUSD)}`;
   }
@@ -151,7 +156,9 @@ export function enforceCostLimits(
 }
 
 export function usageSummary(leases: LeaseRecord[], filter: UsageFilter, now: Date): UsageSummary {
-  const selected = leases.filter((lease) => leaseMatchesUsageFilter(lease, filter));
+  const selected = leases.filter(
+    (lease) => isManagedLease(lease) && leaseMatchesUsageFilter(lease, filter),
+  );
   const total = newAccumulator();
   const byOwner = new Map<string, UsageAccumulator>();
   const byOrg = new Map<string, UsageAccumulator>();
@@ -254,6 +261,10 @@ function isActiveLease(lease: LeaseRecord, now: Date): boolean {
 
 function isLiveLease(lease: LeaseRecord): boolean {
   return lease.state === "active" || lease.state === "provisioning";
+}
+
+function isManagedLease(lease: LeaseRecord): boolean {
+  return lease.lifecycle !== "registered";
 }
 
 function mapAccumulator(map: Map<string, UsageAccumulator>, key: string): UsageAccumulator {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -112,6 +112,148 @@ class FakeWebSocket {
 }
 
 describe("fleet lease identity and idle", () => {
+  it("registers client-owned leases without granting the coordinator provider lifecycle", async () => {
+    const storage = new MemoryStorage();
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async () => {
+        providerReleases += 1;
+      }),
+    });
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    const registered = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000099/registration", {
+        headers: ownerHeaders,
+        body: {
+          slug: "test-box",
+          provider: "aws",
+          target: "linux",
+          desktop: true,
+          browser: true,
+          code: true,
+          cloudID: "i-registered-test",
+          serverName: "test-box",
+          serverType: "cpu16",
+          host: "test-box.example.com",
+          sshUser: "dev-user",
+          sshPort: "22",
+          exposedPorts: ["3000", "8080"],
+          workRoot: "/var/lib/crabbox/work",
+          ttlSeconds: 14_400,
+          idleTimeoutSeconds: 1_800,
+        },
+      }),
+    );
+    expect(registered.status).toBe(201);
+    await expect(registered.json()).resolves.toMatchObject({
+      lease: {
+        id: "cbx_000000000099",
+        slug: "test-box",
+        provider: "aws",
+        lifecycle: "registered",
+        state: "active",
+        estimatedHourlyUSD: 0,
+        exposedPorts: ["3000", "8080"],
+      },
+    });
+
+    const portal = await fleet.fetch(
+      request("GET", "/portal/leases/test-box", { headers: ownerHeaders }),
+    );
+    expect(portal.status).toBe(200);
+    const portalHTML = await portal.text();
+    expect(portalHTML).toContain("client managed");
+    expect(portalHTML).toContain("remove registration");
+
+    const poolRegistration = await fleet.fetch(
+      request("POST", "/v1/ready-pools/example/register", {
+        headers: ownerHeaders,
+        body: { leaseID: "cbx_000000000099" },
+      }),
+    );
+    expect(poolRegistration.status).toBe(400);
+    await expect(poolRegistration.json()).resolves.toMatchObject({
+      error: "unsupported_lifecycle",
+    });
+
+    const shared = await fleet.fetch(
+      request("PUT", "/v1/leases/test-box/share", {
+        headers: ownerHeaders,
+        body: { users: { "friend@example.com": "use" } },
+      }),
+    );
+    expect(shared.status).toBe(200);
+    const friend = await fleet.fetch(
+      request("GET", "/v1/leases/test-box", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(friend.status).toBe(200);
+
+    const released = await fleet.fetch(
+      request("POST", "/v1/leases/test-box/release", {
+        headers: ownerHeaders,
+        body: { delete: true },
+      }),
+    );
+    expect(released.status).toBe(200);
+    expect(providerReleases).toBe(0);
+    await expect(released.json()).resolves.toMatchObject({
+      lease: { lifecycle: "registered", state: "released" },
+    });
+  });
+
+  it("expires registered leases without invoking a provider", async () => {
+    const storage = new MemoryStorage();
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }, async () => {
+        providerReleases += 1;
+      }),
+    });
+    storage.seed(
+      "lease:cbx_000000000098",
+      testLease({
+        id: "cbx_000000000098",
+        provider: "aws",
+        lifecycle: "registered",
+        cloudID: "i-registered-expired",
+        expiresAt: "2026-05-01T00:00:01.000Z",
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerReleases).toBe(0);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000098")?.state).toBe("expired");
+  });
+
+  it("does not let registration overwrite another owner or managed lease", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    storage.seed(
+      "lease:cbx_000000000097",
+      testLease({ id: "cbx_000000000097", owner: "other@example.com" }),
+    );
+    const response = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000097/registration", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { provider: "external", target: "linux", host: "host.example.test" },
+      }),
+    );
+    expect(response.status).toBe(409);
+  });
+
   it("keeps expired leases active when provider cleanup fails and retries later", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {

--- a/worker/test/usage.test.ts
+++ b/worker/test/usage.test.ts
@@ -112,6 +112,7 @@ describe("usage accounting", () => {
       createdAt: "2026-05-01T02:00:00Z",
       expiresAt: "2026-05-01T03:00:00Z",
     });
+
     const limits = {
       ...costLimits({
         CRABBOX_MAX_ACTIVE_LEASES_PER_OWNER: "4",
@@ -125,6 +126,37 @@ describe("usage accounting", () => {
     const error = enforceCostLimits(activeLeases, candidate, limits, now);
 
     expect(error).toContain("active lease limit for owner exceeded: 5/4");
+  });
+
+  it("excludes registered inventory from managed usage and active limits", () => {
+    const now = new Date("2026-05-01T02:00:00Z");
+    const registered = testLease({
+      id: "cbx_registered",
+      lifecycle: "registered",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const candidate = testLease({
+      id: "cbx_managed",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: "2026-05-01T03:00:00Z",
+    });
+    const limits = {
+      ...costLimits({} as never),
+      maxActiveLeases: 1,
+      maxActiveLeasesPerOwner: 1,
+      maxActiveLeasesPerOrg: 1,
+    };
+
+    expect(enforceCostLimits([registered], candidate, limits, now)).toBe("");
+    expect(usageSummary([registered], { scope: "all", month: "2026-05" }, now)).toMatchObject({
+      leases: 0,
+      activeLeases: 0,
+      estimatedUSD: 0,
+      reservedUSD: 0,
+    });
   });
 
   it("supports cost rate overrides", () => {


### PR DESCRIPTION
## Summary

- add provider-neutral coordinator registration for direct SSH providers
- keep provisioning, credentials, and cleanup in the provider while syncing lease metadata and heartbeats
- enable coordinator inventory, sharing, and outbound WebVNC for registered leases
- keep registered records out of managed provider operations, quotas, costs, pools, images, and orphan cleanup
- ignore local `worker/dist-node/` bundle output

## Why

Self-managed and third-party compute should be able to participate in the coordinator without a provider-specific fork or granting the coordinator provider credentials and lifecycle control.

## Behavior

`broker.mode: registered` keeps the direct provider path and registers owner-scoped metadata on a best-effort basis. Coordinator release and expiry remove only the registration and never delete the provider resource. `broker.autoWebVNC` controls automatic bridge startup for kept desktop leases.

## Validation

- `go test -race ./...` with local sandbox-only upload cases skipped
- `go vet ./...`
- `npm test --prefix worker` (353 tests)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- live local Worker registration and portal smoke test

The public diff was also audited for private identifiers, credentials, internal domains, personal paths, and provider-specific assumptions. Examples use reserved domains and test addresses only.
