### PR TITLE
Add direct Linode provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: linode` for direct Linux SSH leases with per-lease keys, account-bound cleanup, preserved operator tags, interface-aware existing firewalls, and guarded live smoke coverage. Thanks @coygeek.
 - Added `provider: windows-sandbox` for disposable native Windows runs through Microsoft Windows Sandbox, including mapped workspace sync, streamed output, timeout and cancellation cleanup, and keep-on-failure inspection. Thanks @zozo123.
 - Added `provider: smolvm` for delegated Linux microVM runs through the hosted smolfleet API, including archive sync, retained leases, status, cleanup, and repository-scoped ownership checks. Thanks @zozo123.
 - Added guarded SmolVM live E2E coverage for retained reuse, archive replacement, environment forwarding, command exit propagation, diagnostics, and targeted cleanup.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ CLI to the runner. The broker only manages leases, cost, and observability.
 Only `aws`, `azure`, `gcp`, and `hetzner` can be brokered through the Worker,
 and even those run direct from the CLI when no broker URL is configured. Every
 other provider always runs direct. A direct-provider mode
-(`--provider hetzner|aws|azure|gcp|proxmox` with local credentials) exists for
-debugging the broker itself or using private infrastructure.
+(`--provider hetzner|aws|azure|gcp|digitalocean|linode|proxmox` with local
+credentials) exists for debugging the broker itself or using private
+infrastructure.
 
 For the full mental model, see [How Crabbox Works](docs/how-it-works.md). For
 the doc-to-code map, see [Source Map](docs/source-map.md).
@@ -125,6 +126,8 @@ configured); every other provider always runs direct from the CLI.
 | [Azure](docs/providers/azure.md) — `azure` | Linux, Windows · brokered | VMs with Tailscale support; native Windows and WSL2. |
 | [Google Cloud](docs/providers/gcp.md) — `gcp` (`google`, `google-cloud`) | Linux · brokered | Compute Engine VMs with Tailscale support. |
 | [Hetzner Cloud](docs/providers/hetzner.md) — `hetzner` | Linux · brokered | VMs with desktop/browser/code and Tailscale. |
+| [DigitalOcean](docs/providers/digitalocean.md) — `digitalocean` | Linux · direct | Droplets with per-lease SSH keys and Crabbox tags. |
+| [Linode](docs/providers/linode.md) — `linode` | Linux · direct | Linode instances with metadata user-data, optional existing firewall attachment, and Crabbox tags. |
 | [Parallels](docs/providers/parallels.md) — `parallels` | Linux, macOS, Windows · direct | Local or remote macOS host; checkpoint/fork/restore/snapshot. |
 | [Proxmox](docs/providers/proxmox.md) — `proxmox` | Linux · direct | Clone QEMU templates on a private Proxmox VE cluster. |
 | [XCP-ng](docs/providers/xcp-ng.md) — `xcp-ng` | Linux · direct | Self-hosted XCP-ng pool on dedicated x86_64 server hardware. |
@@ -457,7 +460,7 @@ Worker deployment, required secrets, and DNS routing live in
 
 - **Get the model:** [How Crabbox Works](docs/how-it-works.md), [Architecture](docs/architecture.md), [Concepts](docs/concepts.md), [Orchestrator](docs/orchestrator.md)
 - **Use the CLI:** [CLI](docs/cli.md), [Commands](docs/commands/README.md), [Features](docs/features/README.md), [Configuration](docs/features/configuration.md)
-- **Choose a provider:** [Providers](docs/providers/README.md), [AWS](docs/providers/aws.md), [Azure](docs/providers/azure.md), [GCP](docs/providers/gcp.md), [Hetzner](docs/providers/hetzner.md)
+- **Choose a provider:** [Providers](docs/providers/README.md), [AWS](docs/providers/aws.md), [Azure](docs/providers/azure.md), [GCP](docs/providers/gcp.md), [Hetzner](docs/providers/hetzner.md), [DigitalOcean](docs/providers/digitalocean.md), [Linode](docs/providers/linode.md)
 - **Advanced features:** [Actions hydration](docs/features/actions-hydration.md), [Capsules](docs/features/capsules.md), [Checkpoints](docs/features/checkpoints.md), [Jobs](docs/features/jobs.md), [Pond](docs/features/pond.md)
 - **Interactive QA:** [Interactive Desktop and VNC](docs/features/interactive-desktop-vnc.md), [Artifacts](docs/features/artifacts.md), [Portal](docs/features/portal.md)
 - **Operate it:** [Operations](docs/operations.md), [Observability](docs/observability.md), [Troubleshooting](docs/troubleshooting.md), [Performance](docs/performance.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ Pick whichever matches your intent:
   Per-provider: [AWS](providers/aws.md), [Azure](providers/azure.md),
   [Azure Dynamic Sessions](providers/azure-dynamic-sessions.md),
   [Google Cloud](providers/gcp.md), [Hetzner](providers/hetzner.md),
+  [DigitalOcean](providers/digitalocean.md), [Linode](providers/linode.md),
   [Proxmox](providers/proxmox.md), [XCP-ng](providers/xcp-ng.md),
   [Incus](providers/incus.md), [Parallels](providers/parallels.md),
   [Local Container](providers/local-container.md),

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -71,9 +71,9 @@ Sessions backend with `azure.backend: dynamic-sessions` or
 When no coordinator is configured, these providers still work in **direct mode**:
 the CLI talks to the cloud API itself using local credentials (AWS SDK chain,
 Azure credentials, Google Application Default Credentials,
-`HCLOUD_TOKEN`/`HETZNER_TOKEN`, or `DIGITALOCEAN_TOKEN` for DigitalOcean).
-Direct mode has no Durable Object alarm; cleanup
-is best-effort through provider labels and manual `crabbox cleanup`. Prefer the
+`HCLOUD_TOKEN`/`HETZNER_TOKEN`, `DIGITALOCEAN_TOKEN` for DigitalOcean, or
+`LINODE_TOKEN` for Linode). Direct mode has no Durable Object alarm; cleanup is
+best-effort through provider labels and manual `crabbox cleanup`. Prefer the
 brokered path when a broker is available.
 
 ## Direct SSH-lease providers
@@ -84,6 +84,7 @@ sync/run/release path. None of them go through the Worker.
 ```text
 ssh              Existing SSH host (no provisioning)      Linux, macOS, Windows
 digitalocean     DigitalOcean Droplets                    Linux
+linode           Linode instances                         Linux
 parallels        Parallels Desktop linked clones          Linux, macOS, Windows
 proxmox          Proxmox VE QEMU VM clones                Linux
 xcp-ng           Self-hosted XCP-ng pool over XAPI        Linux (normal leases)
@@ -148,6 +149,7 @@ railway                 Railway service status and stop controls
 - [Google Cloud](../providers/gcp.md): GCP Compute Engine SSH leases.
 - [Hetzner](../providers/hetzner.md): Linux-only managed provider, classes, cleanup.
 - [DigitalOcean](../providers/digitalocean.md): direct Linux Droplet leases.
+- [Linode](../providers/linode.md): direct Linux instance leases.
 - [Static SSH](../providers/ssh.md): existing Linux, macOS, and Windows SSH hosts.
 - [Parallels](../providers/parallels.md): local or remote Mac Parallels Desktop VM clones and small Mac fleets.
 - [Proxmox](../providers/proxmox.md): direct Proxmox VE Linux QEMU VM clones.
@@ -241,6 +243,9 @@ instance type. Drop `--type` and use a class when you want fallback. See
 DigitalOcean maps every class to the smallest Phase 1 default size
 `s-1vcpu-1gb`. Use `--type <droplet-size-slug>` when you need a larger exact
 Droplet size.
+
+Linode maps every class to the smallest Phase 1 default size `g6-standard-1`.
+Use `--type <linode-type-slug>` when you need a different exact instance type.
 
 ## Brokered provider behavior
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -206,6 +206,7 @@ internal/providers/azure                # Azure VM SSH lease backend (coordinato
 internal/providers/azuredynamicsessions # Azure Container Apps delegated runner
 internal/providers/gcp                  # GCP Compute Engine SSH lease backend (coordinator)
 internal/providers/hetzner              # Hetzner Cloud SSH lease backend (coordinator)
+internal/providers/linode               # Linode SSH lease backend
 internal/providers/proxmox              # Proxmox VE SSH lease backend
 internal/providers/parallels            # Parallels macOS VM host SSH lease backend
 internal/providers/localcontainer       # local Docker container SSH backend

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -24,9 +24,10 @@ SSH-lease providers further differ by how they reach the cloud:
   normal shared-team path. Set with `config set-broker` and a broker URL
   (`CRABBOX_COORDINATOR`).
 - **Direct cloud** — the same four providers without a configured broker, plus
-  cloud providers that never broker (e.g. `proxmox`, `runpod`, `namespace-devbox`,
-  `semaphore`, `sprites`, `exe-dev`, `daytona`, `morph`). The CLI talks to the provider
-  API itself and cleans up best-effort via provider labels.
+  cloud providers that never broker (e.g. `digitalocean`, `linode`, `proxmox`,
+  `runpod`, `namespace-devbox`, `semaphore`, `sprites`, `exe-dev`, `daytona`,
+  `morph`). The CLI talks to the provider API itself and cleans up best-effort
+  via provider labels.
 - **Static SSH** — `ssh` connects to a preexisting machine you supply; no
   provisioning, no cleanup.
 - **Local runtime** — `local-container` starts a labeled Linux container through
@@ -64,6 +65,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Google Cloud](gcp.md) — `gcp` (`google`, `google-cloud`) | Linux · brokered |
 | [Hetzner](hetzner.md) — `hetzner` | Linux · brokered |
 | [DigitalOcean](digitalocean.md) — `digitalocean` | Linux · direct |
+| [Linode](linode.md) — `linode` | Linux · direct |
 | [Proxmox](proxmox.md) — `proxmox` | Linux · direct |
 | [XCP-ng](xcp-ng.md) — `xcp-ng` | Linux · direct |
 | [Incus](incus.md) — `incus` | Linux · direct |
@@ -147,6 +149,10 @@ reports.
 - DigitalOcean is a direct-only Linux Droplet provider. It uses
   `DIGITALOCEAN_TOKEN`, per-lease SSH keys, and Crabbox-owned flat tags; it does
   not run through the Worker broker in Phase 1.
+- Linode is a direct-only Linux instance provider. It uses `LINODE_TOKEN`,
+  per-lease SSH keys, metadata user-data, optional attachment to an existing
+  firewall, and Crabbox-owned tags; it does not run through the Worker broker in
+  Phase 1.
 - Capability flags (`--desktop`, `--browser`, `--code`, VNC) are validated
   against each provider's declared feature set. Among the SSH-lease providers,
   desktop/browser/code surfaces are richest on `aws`, `azure`, `hetzner`,
@@ -161,6 +167,7 @@ reports.
 crabbox warmup --provider aws --class beast
 crabbox run --provider hetzner -- pnpm test
 crabbox run --provider digitalocean --type s-1vcpu-1gb -- pnpm test
+crabbox run --provider linode --type g6-standard-1 -- pnpm test
 crabbox run --provider docker -- pnpm test
 crabbox run --provider docker-sandbox -- go test ./...
 crabbox run --provider apple-vz -- go test ./...

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -100,8 +100,8 @@ linodes:read_write
 
 Add firewall access when using `linode.firewall` /
 `CRABBOX_LINODE_FIREWALL`. Crabbox uses account identity to bind local cleanup
-claims to the creating Linode account and refuses claim-only deletion after an
-account switch.
+claims to the creating Linode account's stable EUUID and refuses claim-only
+deletion after an account switch.
 
 If a live smoke fails with a permission error, keep the error output secret-safe
 and adjust token scopes before retrying. Do not broaden scopes inside scripts.
@@ -142,8 +142,9 @@ Release and cleanup require a complete ownership predicate: Crabbox marker,
 provider marker, lease id, slug, and Linux target. Linodes with partial,
 foreign, or malformed Crabbox-like tags are skipped/refused.
 
-Tag updates apply only Crabbox's normalized tag set for the instance being
-touched. Direct mode has no coordinator alarm. Use:
+Tag updates replace only Crabbox's namespaced tags and preserve unrelated
+operator tags already attached to the instance. Direct mode has no coordinator
+alarm. Use:
 
 ```sh
 crabbox list --provider linode --json
@@ -155,7 +156,9 @@ crabbox cleanup --provider linode
 
 Phase 1 does not create or manage Linode firewall rules. If `linode.firewall`
 or `CRABBOX_LINODE_FIREWALL` is set to a numeric firewall id, Crabbox attaches
-that existing firewall when creating the instance. Operators own the firewall
+that existing firewall when creating the instance. Crabbox reads the account's
+new-Linode interface setting and attaches the firewall either to the legacy
+Linode or its public Linode interface as required. Operators own the firewall
 policy, including SSH source restrictions.
 
 Use account-default firewall policy, an existing firewall, short TTLs, and

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -1,0 +1,217 @@
+# Linode Provider
+
+Read this when you are:
+
+- choosing `provider: linode`;
+- validating a direct Linode SSH lease;
+- changing `internal/providers/linode` or the guarded live smoke.
+
+Linode is a Linux-only **SSH lease** provider. Crabbox creates a Linode
+instance, injects a per-lease SSH key through Linode metadata/cloud-init, writes
+Crabbox ownership metadata as namespaced Linode tags, waits for SSH/bootstrap
+readiness, and then uses the normal Crabbox SSH sync/run/stop/cleanup path.
+
+Linode is **direct-only** in this release. It does not run through the
+Cloudflare Worker broker, so the local CLI must have a Linode API token and
+direct cleanup remains the operator's responsibility.
+
+## When To Use It
+
+Use Linode for simple Linux lease work when a Linode instance is the desired
+execution surface and direct local credentials are acceptable. Prefer AWS,
+Azure, GCP, or Hetzner when you need a brokered team path, coordinator-side
+credentials, or cloud-specific capacity and cost accounting.
+
+## Commands
+
+```sh
+crabbox warmup --provider linode --class standard
+crabbox run --provider linode --type g6-standard-1 -- pnpm test
+crabbox ssh --provider linode --id my-app
+crabbox stop --provider linode my-app
+crabbox cleanup --provider linode --dry-run
+```
+
+`--id` accepts the canonical lease id (`cbx_...`), the friendly slug, or the
+numeric Linode instance id. `--type` is the exact Linode type slug; there is no
+separate Linode size flag.
+
+## Configuration
+
+```yaml
+provider: linode
+target: linux
+class: standard
+linode:
+  region: us-ord
+  image: linode/ubuntu24.04
+  type: g6-standard-1
+  firewall: ""
+  sshCIDRs: []
+```
+
+Config keys under `linode:`:
+
+| Key | Maps to | Default | Notes |
+| --- | --- | --- | --- |
+| `region` | `cfg.Linode.Region` | `us-ord` | Linode region slug. |
+| `image` | `cfg.Linode.Image` | `linode/ubuntu24.04` | Linode image slug. |
+| `type` | `cfg.Linode.Type` | `g6-standard-1` | Linode instance type slug. |
+| `firewall` | `cfg.Linode.FirewallID` | empty | Optional numeric existing Linode firewall id to attach at create time. |
+| `sshCIDRs` | `cfg.Linode.SSHCIDRs` | empty | Reserved for firewall-aware follow-up work; Phase 1 does not create firewall rules. |
+
+The portable `--os ubuntu:24.04` selector maps to `linode/ubuntu24.04`. Linode
+does not currently offer the portable default Ubuntu 26.04 image in this
+provider, so provisioning with an explicit `--os ubuntu:26.04` is rejected
+unless `linode.image` or `CRABBOX_LINODE_IMAGE` provides an explicit image slug.
+Validation occurs when Crabbox acquires a new Linode, after CLI overrides;
+`config show`, provider overrides, and cleanup commands remain available when
+the configured portable selector is unsupported.
+
+Linode leases default to `root` on SSH port `22` with no fallback port. Explicit
+generic `ssh.user` and `ssh.port` values remain authoritative. The effective
+values appear in `crabbox config show` without retaining defaults from another
+provider.
+
+Environment overrides:
+
+```text
+LINODE_TOKEN                 Linode API token for direct mode
+CRABBOX_LINODE_REGION        Override the region slug
+CRABBOX_LINODE_IMAGE         Override the image slug
+CRABBOX_LINODE_TYPE          Override the instance type slug
+CRABBOX_LINODE_FIREWALL      Optional numeric existing firewall id
+CRABBOX_LINODE_SSH_CIDRS     Comma-separated SSH CIDRs, reserved for firewall follow-up
+```
+
+Do not pass the Linode token as a command-line argument. Keep it in the
+environment or in a local secret manager.
+
+## Token Scopes
+
+The Phase 1 provider uses account identity, Linode instances, tags, metadata
+user-data, and optional existing firewalls. A custom Linode token needs at
+least:
+
+```text
+account:read_only
+linodes:read_write
+```
+
+Add firewall access when using `linode.firewall` /
+`CRABBOX_LINODE_FIREWALL`. Crabbox uses account identity to bind local cleanup
+claims to the creating Linode account and refuses claim-only deletion after an
+account switch.
+
+If a live smoke fails with a permission error, keep the error output secret-safe
+and adjust token scopes before retrying. Do not broaden scopes inside scripts.
+
+## Lifecycle
+
+1. Generate a per-lease SSH key under the Crabbox testbox key directory.
+2. Create a Linode instance with `region`, `image`, `type`, authorized SSH key,
+   cloud-init `user_data`, optional existing `firewall`, and Crabbox tags.
+3. Wait for a public IPv4 address and Crabbox SSH bootstrap readiness.
+4. Add ready-state Crabbox tags and claim the lease locally.
+5. Run normal Crabbox sync/run/ssh workflows over SSH.
+6. Delete the Linode instance on `stop`; `cleanup` deletes only resources with a
+   complete Crabbox Linode ownership tag set.
+
+If instance creation returns an indeterminate transport or server failure,
+Crabbox retains the SSH credentials and records a pending local recovery claim.
+`crabbox stop --provider linode <lease-or-slug>` reconciles that claim and
+deletes a late-created Linode when the API exposes it. Empty inventory is not
+treated as proof that creation failed while the outcome remains indeterminate:
+Crabbox retains the claim and credentials and asks the operator to retry rather
+than risk orphaning a billed instance without its SSH key.
+
+## Ownership And Cleanup
+
+Crabbox encodes owned leases with Linode tags such as:
+
+```text
+crabbox
+crabbox:provider:linode
+crabbox:lease:cbx_abcdef123456
+crabbox:slug:my-app
+crabbox:target:linux
+crabbox:expires_at:<unix-seconds>
+```
+
+Release and cleanup require a complete ownership predicate: Crabbox marker,
+provider marker, lease id, slug, and Linux target. Linodes with partial,
+foreign, or malformed Crabbox-like tags are skipped/refused.
+
+Tag updates apply only Crabbox's normalized tag set for the instance being
+touched. Direct mode has no coordinator alarm. Use:
+
+```sh
+crabbox list --provider linode --json
+crabbox cleanup --provider linode --dry-run
+crabbox cleanup --provider linode
+```
+
+## Firewall Scope
+
+Phase 1 does not create or manage Linode firewall rules. If `linode.firewall`
+or `CRABBOX_LINODE_FIREWALL` is set to a numeric firewall id, Crabbox attaches
+that existing firewall when creating the instance. Operators own the firewall
+policy, including SSH source restrictions.
+
+Use account-default firewall policy, an existing firewall, short TTLs, and
+cleanup dry-runs for validation. `linode.sshCIDRs` and
+`CRABBOX_LINODE_SSH_CIDRS` are reserved for follow-up firewall work and do not
+create ingress rules in this phase.
+
+## Guarded Live Smoke
+
+The repeatable live check is opt-in:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-linode-smoke.sh
+```
+
+The script builds `bin/crabbox`, uses `LINODE_TOKEN` from the environment,
+requires an empty Crabbox-owned Linode inventory, creates a small
+`g6-standard-1` instance, waits for ready status, runs `echo ok`, verifies
+`list --json`, stops the lease, runs dry-run cleanup, and verifies the
+Crabbox-owned inventory is empty afterward.
+
+Final classifications include:
+
+```text
+classification=live_linode_smoke_passed
+classification=environment_blocked
+classification=quota_blocked
+classification=validation_failed
+```
+
+If cleanup fails, use the reported slug and Crabbox tags to inspect the instance
+in `crabbox list --provider linode --json` or the Linode console.
+
+## Capabilities
+
+- **SSH** and **Crabbox sync**: yes.
+- **Tailscale**: yes through the standard Linux cloud-init path when a direct
+  Tailscale auth key is configured.
+- **Desktop / browser / code**: not advertised in Phase 1.
+- **Cleanup**: yes, tag-owned only.
+- **Coordinator**: never; direct CLI only.
+
+## Gotchas
+
+- `linode` is direct-only. Worker broker secrets and cost accounting do not
+  cover these instances.
+- `--type` must be a valid Linode type slug such as `g6-standard-1`.
+- Crabbox decodes the highest-priority state when stale tags coexist, but
+  cleanup relies on `expires_at` and ownership tags, not tag order.
+- Phase 1 can attach an existing firewall by id, but it does not create or
+  mutate firewall rules. Restrict SSH exposure through account/default firewall
+  policy where needed, and prefer short TTLs for live validation.
+
+## Related Docs
+
+- [Provider reference](README.md)
+- [Provider backends](../provider-backends.md)
+- [Provider feature overview](../features/providers.md)
+- [Operations](../operations.md)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -93,6 +93,9 @@ type Config struct {
 	GCPServiceAccount             string
 	DigitalOcean                  DigitalOceanConfig
 	digitalOceanImageExplicit     bool
+	Linode                        LinodeConfig
+	linodeImageExplicit           bool
+	linodeTypeExplicit            bool
 	Incus                         IncusConfig
 	Proxmox                       ProxmoxConfig
 	XCPNg                         XCPNgConfig
@@ -204,6 +207,14 @@ type DigitalOceanConfig struct {
 	Image    string
 	VPCUUID  string
 	SSHCIDRs []string
+}
+
+type LinodeConfig struct {
+	Region     string
+	Image      string
+	Type       string
+	FirewallID string
+	SSHCIDRs   []string
 }
 
 type ActionsConfig struct {
@@ -1104,6 +1115,48 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "linode" {
+		if cfg.Linode.Region == "" {
+			cfg.Linode.Region = "us-ord"
+		}
+		if cfg.osImageExplicit && !cfg.linodeImageExplicit {
+			if cfg.OSImage == "ubuntu:24.04" {
+				cfg.Linode.Image = "linode/ubuntu24.04"
+			} else {
+				cfg.Linode.Image = ""
+			}
+		} else if cfg.Linode.Image == "" {
+			cfg.Linode.Image = "linode/ubuntu24.04"
+		}
+		if cfg.Linode.Type == "" {
+			cfg.Linode.Type = "g6-standard-1"
+		}
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+		} else {
+			cfg.WorkRoot = defaultPOSIXWorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else {
+			cfg.SSHUser = baseConfig().SSHUser
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = baseConfig().SSHPort
+		}
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "hyperv" {
 		if !IsTargetExplicit(cfg) {
 			cfg.TargetOS = targetWindows
@@ -1241,7 +1294,7 @@ func applyOSImageProviderDefaults(cfg *Config, force bool) {
 	if normalizeTargetOS(cfg.TargetOS) != targetLinux {
 		return
 	}
-	hetznerImage, azureImage, gcpImage, isloImage, containerImage, err := osImageDefaultProviderImagesForArchitecture(cfg.OSImage, effectiveArchitectureForConfig(*cfg))
+	hetznerImage, azureImage, gcpImage, linodeImage, isloImage, containerImage, err := osImageDefaultProviderImagesForArchitecture(cfg.OSImage, effectiveArchitectureForConfig(*cfg))
 	if err != nil {
 		return
 	}
@@ -1267,6 +1320,9 @@ func applyOSImageProviderDefaults(cfg *Config, force bool) {
 	}
 	if force || cfg.GCPImage == "" || (!cfg.gcpImageExplicit && (cfg.GCPImage == base.GCPImage || wasOSDefault)) {
 		cfg.GCPImage = gcpImage
+	}
+	if force || cfg.Linode.Image == "" || (!cfg.linodeImageExplicit && (cfg.Linode.Image == base.Linode.Image || wasOSDefault)) {
+		cfg.Linode.Image = linodeImage
 	}
 	if force || cfg.Islo.Image == "" || (!cfg.isloImageExplicit && (cfg.Islo.Image == base.Islo.Image || wasOSDefault)) {
 		cfg.Islo.Image = isloImage
@@ -1416,7 +1472,7 @@ func baseConfig() Config {
 	class := "beast"
 	provider := "hetzner"
 	osImage := defaultOSImage
-	hetznerImage, azureImage, gcpImage, isloImage, containerImage, _ := osImageDefaultProviderImages(osImage)
+	hetznerImage, azureImage, gcpImage, linodeImage, isloImage, containerImage, _ := osImageDefaultProviderImages(osImage)
 	multipassImage, _ := osImageDefaultMultipassImage(osImage)
 	return Config{
 		Profile:            "default",
@@ -1453,6 +1509,11 @@ func baseConfig() Config {
 		GCPNetwork: "default",
 		GCPTags:    []string{"crabbox-ssh"},
 		GCPRootGB:  400,
+		Linode: LinodeConfig{
+			Region: "us-ord",
+			Image:  linodeImage,
+			Type:   "g6-standard-1",
+		},
 		Incus: IncusConfig{
 			Remote:          "local",
 			Project:         "",
@@ -1725,6 +1786,7 @@ type fileConfig struct {
 	Broker               *fileBrokerConfig                  `yaml:"broker,omitempty"`
 	Hetzner              *fileHetznerConfig                 `yaml:"hetzner,omitempty"`
 	DigitalOcean         *fileDigitalOceanConfig            `yaml:"digitalocean,omitempty"`
+	Linode               *fileLinodeConfig                  `yaml:"linode,omitempty"`
 	AWS                  *fileAWSConfig                     `yaml:"aws,omitempty"`
 	Azure                *fileAzureConfig                   `yaml:"azure,omitempty"`
 	AzureDynamicSessions *fileAzureDynamicSessionsConfig    `yaml:"azureDynamicSessions,omitempty"`
@@ -1816,6 +1878,14 @@ type fileDigitalOceanConfig struct {
 	Image    string   `yaml:"image,omitempty"`
 	VPCUUID  string   `yaml:"vpc,omitempty"`
 	SSHCIDRs []string `yaml:"sshCIDRs,omitempty"`
+}
+
+type fileLinodeConfig struct {
+	Region     string   `yaml:"region,omitempty"`
+	Image      string   `yaml:"image,omitempty"`
+	Type       string   `yaml:"type,omitempty"`
+	FirewallID string   `yaml:"firewall,omitempty"`
+	SSHCIDRs   []string `yaml:"sshCIDRs,omitempty"`
 }
 
 type fileAWSConfig struct {
@@ -2777,6 +2847,25 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if len(file.DigitalOcean.SSHCIDRs) > 0 {
 			cfg.DigitalOcean.SSHCIDRs = file.DigitalOcean.SSHCIDRs
+		}
+	}
+	if file.Linode != nil {
+		if file.Linode.Region != "" {
+			cfg.Linode.Region = file.Linode.Region
+		}
+		if file.Linode.Image != "" {
+			cfg.Linode.Image = file.Linode.Image
+			cfg.linodeImageExplicit = true
+		}
+		if file.Linode.Type != "" {
+			cfg.Linode.Type = file.Linode.Type
+			cfg.linodeTypeExplicit = true
+		}
+		if file.Linode.FirewallID != "" {
+			cfg.Linode.FirewallID = file.Linode.FirewallID
+		}
+		if len(file.Linode.SSHCIDRs) > 0 {
+			cfg.Linode.SSHCIDRs = file.Linode.SSHCIDRs
 		}
 	}
 	if file.AWS != nil {
@@ -4519,6 +4608,19 @@ func applyEnv(cfg *Config) error {
 	cfg.DigitalOcean.VPCUUID = getenv("CRABBOX_DIGITALOCEAN_VPC", cfg.DigitalOcean.VPCUUID)
 	if cidrs := os.Getenv("CRABBOX_DIGITALOCEAN_SSH_CIDRS"); cidrs != "" {
 		cfg.DigitalOcean.SSHCIDRs = splitCommaList(cidrs)
+	}
+	cfg.Linode.Region = getenv("CRABBOX_LINODE_REGION", cfg.Linode.Region)
+	if image := os.Getenv("CRABBOX_LINODE_IMAGE"); image != "" {
+		cfg.Linode.Image = image
+		cfg.linodeImageExplicit = true
+	}
+	if linodeType := os.Getenv("CRABBOX_LINODE_TYPE"); linodeType != "" {
+		cfg.Linode.Type = linodeType
+		cfg.linodeTypeExplicit = true
+	}
+	cfg.Linode.FirewallID = getenv("CRABBOX_LINODE_FIREWALL", cfg.Linode.FirewallID)
+	if cidrs := os.Getenv("CRABBOX_LINODE_SSH_CIDRS"); cidrs != "" {
+		cfg.Linode.SSHCIDRs = splitCommaList(cidrs)
 	}
 	cfg.Proxmox.APIURL = getenv("CRABBOX_PROXMOX_API_URL", cfg.Proxmox.APIURL)
 	cfg.Proxmox.TokenID = getenv("CRABBOX_PROXMOX_TOKEN_ID", cfg.Proxmox.TokenID)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -33,7 +33,7 @@ func (a App) configShow(args []string) error {
 }
 
 func effectiveConfigForShow(cfg Config) Config {
-	if cfg.Provider == "digitalocean" {
+	if cfg.Provider == "digitalocean" || cfg.Provider == "linode" {
 		base := baseConfig()
 		if !IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == base.SSHUser) {
 			cfg.SSHUser = "root"
@@ -119,6 +119,13 @@ func configShowView(cfg Config) map[string]any {
 			"image":    cfg.DigitalOcean.Image,
 			"vpc":      cfg.DigitalOcean.VPCUUID,
 			"sshCIDRs": cfg.DigitalOcean.SSHCIDRs,
+		},
+		"linode": map[string]any{
+			"region":   cfg.Linode.Region,
+			"image":    cfg.Linode.Image,
+			"type":     cfg.Linode.Type,
+			"firewall": cfg.Linode.FirewallID,
+			"sshCIDRs": cfg.Linode.SSHCIDRs,
 		},
 		"azureDynamicSessions": map[string]any{
 			"endpoint":        cfg.AzureDynamicSessions.Endpoint,
@@ -364,6 +371,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "aws region=%s root_gb=%d ssh_cidrs=%s\n", cfg.AWSRegion, cfg.AWSRootGB, blank(strings.Join(cfg.AWSSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "azure location=%s resource_group=%s os_disk=%s network=%s ssh_cidrs=%s\n", cfg.AzureLocation, cfg.AzureResourceGroup, cfg.AzureOSDisk, blank(cfg.AzureNetwork, "-"), blank(strings.Join(cfg.AzureSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "digitalocean region=%s image=%s vpc=%s ssh_cidrs=%s\n", cfg.DigitalOcean.Region, cfg.DigitalOcean.Image, blank(cfg.DigitalOcean.VPCUUID, "-"), blank(strings.Join(cfg.DigitalOcean.SSHCIDRs, ","), "-"))
+	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(cfg.AzureDynamicSessions.Endpoint, "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)
 	fmt.Fprintf(w, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(cfg.Proxmox.APIURL, "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -57,6 +57,11 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_DIGITALOCEAN_IMAGE",
 		"CRABBOX_DIGITALOCEAN_VPC",
 		"CRABBOX_DIGITALOCEAN_SSH_CIDRS",
+		"CRABBOX_LINODE_REGION",
+		"CRABBOX_LINODE_IMAGE",
+		"CRABBOX_LINODE_TYPE",
+		"CRABBOX_LINODE_FIREWALL",
+		"CRABBOX_LINODE_SSH_CIDRS",
 		"CRABBOX_DAYTONA_API_KEY",
 		"DAYTONA_API_KEY",
 		"CRABBOX_DAYTONA_JWT_TOKEN",
@@ -599,6 +604,130 @@ func TestDigitalOceanDefaultsDoNotLeakAcrossProviderOverride(t *testing.T) {
 		cfg.SSHUser != wantSSHUser || cfg.SSHPort != wantSSHPort ||
 		strings.Join(cfg.SSHFallbackPorts, ",") != strings.Join(wantFallbackPorts, ",") {
 		t.Fatalf("digitalocean defaults leaked after provider override: %#v", cfg)
+	}
+}
+
+func TestLinodeConfigFileAndEnv(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	applyFileConfig(&cfg, fileConfig{
+		Provider: "linode",
+		Linode: &fileLinodeConfig{
+			Region:     "us-sea",
+			Image:      "linode/ubuntu24.04",
+			Type:       "g6-standard-2",
+			FirewallID: "12345",
+			SSHCIDRs:   []string{"203.0.113.0/24"},
+		},
+	})
+	if cfg.Provider != "linode" || cfg.Linode.Region != "us-sea" || cfg.Location == "us-sea" || cfg.Linode.Image != "linode/ubuntu24.04" || cfg.Image == "linode/ubuntu24.04" || cfg.Linode.Type != "g6-standard-2" || cfg.Linode.FirewallID != "12345" {
+		t.Fatalf("file linode config not applied: cfg=%#v linode=%#v", cfg, cfg.Linode)
+	}
+	if strings.Join(cfg.Linode.SSHCIDRs, ",") != "203.0.113.0/24" {
+		t.Fatalf("file linode ssh cidrs=%v", cfg.Linode.SSHCIDRs)
+	}
+
+	t.Setenv("CRABBOX_LINODE_REGION", "us-ord")
+	t.Setenv("CRABBOX_LINODE_IMAGE", "private/999")
+	t.Setenv("CRABBOX_LINODE_TYPE", "g6-nanode-1")
+	t.Setenv("CRABBOX_LINODE_FIREWALL", "67890")
+	t.Setenv("CRABBOX_LINODE_SSH_CIDRS", "198.51.100.0/24,2001:db8::/64")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatalf("applyEnv err=%v", err)
+	}
+	if cfg.Linode.Region != "us-ord" || cfg.Location == "us-ord" || cfg.Linode.Image != "private/999" || cfg.Image == "private/999" || cfg.Linode.Type != "g6-nanode-1" || cfg.Linode.FirewallID != "67890" {
+		t.Fatalf("env linode config not applied: cfg=%#v linode=%#v", cfg, cfg.Linode)
+	}
+	if strings.Join(cfg.Linode.SSHCIDRs, ",") != "198.51.100.0/24,2001:db8::/64" {
+		t.Fatalf("env linode ssh cidrs=%v", cfg.Linode.SSHCIDRs)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatalf("applyProviderConfigDefaults err=%v", err)
+	}
+	base := baseConfig()
+	if cfg.Location != base.Location || cfg.Image != base.Image {
+		t.Fatalf("linode defaults leaked into generic fields: cfg=%#v", cfg)
+	}
+	if got := serverTypeForConfig(cfg); got != "g6-nanode-1" {
+		t.Fatalf("serverTypeForConfig=%q", got)
+	}
+}
+
+func TestLinodePortableOSSelection(t *testing.T) {
+	t.Run("supported selector maps to provider image", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "linode"
+		cfg.OSImage = "ubuntu:24.04"
+		cfg.osImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Linode.Image != "linode/ubuntu24.04" {
+			t.Fatalf("Linode.Image=%q", cfg.Linode.Image)
+		}
+	})
+
+	t.Run("unsupported selector is deferred to acquisition", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "linode"
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Linode.Image != "linode/ubuntu24.04" {
+			t.Fatalf("default Linode.Image=%q", cfg.Linode.Image)
+		}
+		cfg.OSImage = "ubuntu:26.04"
+		cfg.osImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Linode.Image != "" {
+			t.Fatalf("Linode.Image=%q, want unresolved provider image", cfg.Linode.Image)
+		}
+	})
+
+	t.Run("provider image overrides portable selector", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "linode"
+		cfg.OSImage = "ubuntu:26.04"
+		cfg.osImageExplicit = true
+		cfg.Linode.Image = "private/123"
+		cfg.linodeImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Linode.Image != "private/123" {
+			t.Fatalf("Linode.Image=%q", cfg.Linode.Image)
+		}
+	})
+}
+
+func TestLinodeDefaultsPreserveExplicitGenericWorkRoot(t *testing.T) {
+	cfg := baseConfig()
+	applyFileConfig(&cfg, fileConfig{
+		Provider: "ssh",
+		WorkRoot: "/srv/crabbox",
+		SSH:      &fileSSHConfig{User: "alice", Port: "2200"},
+		Static: &fileStaticConfig{
+			User:     "builder",
+			Port:     "2202",
+			WorkRoot: "/srv/static",
+		},
+	})
+	normalizeTargetConfig(&cfg)
+
+	cfg.Provider = "linode"
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorkRoot != "/srv/crabbox" {
+		t.Fatalf("Linode WorkRoot=%q want explicit generic root", cfg.WorkRoot)
+	}
+	if cfg.SSHUser != "alice" {
+		t.Fatalf("Linode SSHUser=%q want explicit generic user", cfg.SSHUser)
+	}
+	if cfg.SSHPort != "2200" {
+		t.Fatalf("Linode SSHPort=%q want explicit generic port", cfg.SSHPort)
 	}
 }
 

--- a/internal/cli/os_image.go
+++ b/internal/cli/os_image.go
@@ -18,6 +18,7 @@ type osImageSpec struct {
 	AzureArm64Image string
 	GCPImage        string
 	HetznerImage    string
+	LinodeImage     string
 	DockerImage     string
 	ContainerName   string
 	AppleVZImage    string
@@ -34,6 +35,7 @@ var osImageSpecs = map[string]osImageSpec{
 		AzureArm64Image: "Canonical:ubuntu-24_04-lts:server-arm64:latest",
 		GCPImage:        "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64",
 		HetznerImage:    "ubuntu-24.04",
+		LinodeImage:     "linode/ubuntu24.04",
 		DockerImage:     "docker.io/library/ubuntu:24.04",
 		ContainerName:   "ubuntu:24.04",
 		AppleVZImage:    "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
@@ -128,19 +130,19 @@ func awsLinuxAMIQueryForOS(value string, architecture string) (name string, labe
 	return spec.AWSName, spec.AWSLabel, nil
 }
 
-func osImageDefaultProviderImages(value string) (hetzner, azure, gcp, docker, container string, err error) {
+func osImageDefaultProviderImages(value string) (hetzner, azure, gcp, linode, docker, container string, err error) {
 	return osImageDefaultProviderImagesForArchitecture(value, ArchitectureAMD64)
 }
 
-func osImageDefaultProviderImagesForArchitecture(value string, architecture string) (hetzner, azure, gcp, docker, container string, err error) {
+func osImageDefaultProviderImagesForArchitecture(value string, architecture string) (hetzner, azure, gcp, linode, docker, container string, err error) {
 	spec, err := osImageSpecFor(value)
 	if err != nil {
-		return "", "", "", "", "", err
+		return "", "", "", "", "", "", err
 	}
 	if architecture == ArchitectureARM64 {
-		return spec.HetznerImage, spec.AzureArm64Image, spec.GCPImage, spec.DockerImage, spec.ContainerName, nil
+		return spec.HetznerImage, spec.AzureArm64Image, spec.GCPImage, spec.LinodeImage, spec.DockerImage, spec.ContainerName, nil
 	}
-	return spec.HetznerImage, spec.AzureImage, spec.GCPImage, spec.DockerImage, spec.ContainerName, nil
+	return spec.HetznerImage, spec.AzureImage, spec.GCPImage, spec.LinodeImage, spec.DockerImage, spec.ContainerName, nil
 }
 
 func osImageDefaultMultipassImage(value string) (string, error) {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	RegisterProvider(testHetznerProvider{})
 	RegisterProvider(testDigitalOceanProvider{})
+	RegisterProvider(testLinodeProvider{})
 	RegisterProvider(testAWSProvider{})
 	RegisterProvider(testAzureProvider{})
 	RegisterProvider(testAzureDynamicSessionsProvider{})
@@ -231,6 +232,38 @@ func (testDigitalOceanProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 func (testDigitalOceanProvider) ServerTypeForConfig(Config) string { return "s-1vcpu-1gb" }
 func (testDigitalOceanProvider) ServerTypeForClass(string) string  { return "s-1vcpu-1gb" }
 func (p testDigitalOceanProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testLinodeProvider struct{}
+
+func (testLinodeProvider) Name() string      { return "linode" }
+func (testLinodeProvider) Aliases() []string { return nil }
+func (testLinodeProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "linode",
+		Family:      "linode",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testLinodeProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (testLinodeProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (testLinodeProvider) ServerTypeForConfig(cfg Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.Linode.Type != "" {
+		return cfg.Linode.Type
+	}
+	return "g6-standard-1"
+}
+func (testLinodeProvider) ServerTypeForClass(string) string { return "g6-standard-1" }
+func (p testLinodeProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -13,6 +13,7 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	var aws *providerMatrixEntry
 	var incus *providerMatrixEntry
 	var digitalOcean *providerMatrixEntry
+	var linode *providerMatrixEntry
 	for i := range entries {
 		if entries[i].Provider == "aws" {
 			aws = &entries[i]
@@ -23,6 +24,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		if entries[i].Provider == "digitalocean" {
 			digitalOcean = &entries[i]
 		}
+		if entries[i].Provider == "linode" {
+			linode = &entries[i]
+		}
 	}
 	if aws == nil {
 		t.Fatal("aws provider not found")
@@ -32,6 +36,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if digitalOcean == nil {
 		t.Fatal("digitalocean provider not found")
+	}
+	if linode == nil {
+		t.Fatal("linode provider not found")
 	}
 	if aws.Kind != ProviderKindSSHLease {
 		t.Fatalf("aws kind=%q", aws.Kind)
@@ -61,6 +68,12 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if !containsString(digitalOcean.Targets, targetLinux) {
 		t.Fatalf("digitalocean targets=%v", digitalOcean.Targets)
+	}
+	if linode.Kind != ProviderKindSSHLease || linode.Family != "linode" || linode.Coordinator != string(CoordinatorNever) {
+		t.Fatalf("linode kind/family/coordinator=%q/%q/%q", linode.Kind, linode.Family, linode.Coordinator)
+	}
+	if !containsString(linode.Targets, targetLinux) {
+		t.Fatalf("linode targets=%v", linode.Targets)
 	}
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/incus"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/kubevirt"
+	_ "github.com/openclaw/crabbox/internal/providers/linode"
 	_ "github.com/openclaw/crabbox/internal/providers/localcontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/modal"
 	_ "github.com/openclaw/crabbox/internal/providers/morph"

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -2,6 +2,8 @@ package linode
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -119,6 +121,10 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	rootPass, err := generateLinodeRootPass()
+	if err != nil {
+		return core.LeaseTarget{}, fmt.Errorf("generate linode root password: %w", err)
+	}
 	now := b.now()
 	created := linodeInstance{}
 	committed := false
@@ -161,6 +167,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 		Label:          core.LeaseProviderName(leaseID, slug),
 		Tags:           leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now),
 		AuthorizedKeys: []string{publicKey},
+		RootPass:       rootPass,
 		Metadata:       &linodeMetadata{UserData: linodeUserData(cfg, publicKey)},
 		FirewallID:     firewallID,
 	})
@@ -934,6 +941,14 @@ func parseLinodeFirewallID(value string) (int64, error) {
 		return 0, core.Exit(2, "linode firewall must be a positive numeric firewall ID")
 	}
 	return id, nil
+}
+
+func generateLinodeRootPass() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return "Cbx1!" + base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
 func providerKeyForLease(leaseID string) string {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -88,6 +88,10 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
 		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", cfg.Tailscale.AuthKeyEnv)
 	}
+	firewallID, err := parseLinodeFirewallID(cfg.Linode.FirewallID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
 		return core.LeaseTarget{}, err
@@ -158,7 +162,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 		Tags:           leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now),
 		AuthorizedKeys: []string{publicKey},
 		Metadata:       &linodeMetadata{UserData: linodeUserData(cfg, publicKey)},
-		FirewallID:     parseLinodeFirewallID(cfg.Linode.FirewallID),
+		FirewallID:     firewallID,
 	})
 	if err != nil {
 		if isLinodeCreateAmbiguous(err) {
@@ -920,16 +924,16 @@ func parseLinodeID(id string) (int64, bool) {
 	return parsed, true
 }
 
-func parseLinodeFirewallID(value string) int64 {
+func parseLinodeFirewallID(value string) (int64, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return 0
+		return 0, nil
 	}
 	id, err := strconv.ParseInt(value, 10, 64)
 	if err != nil || id <= 0 {
-		return 0
+		return 0, core.Exit(2, "linode firewall must be a positive numeric firewall ID")
 	}
-	return id
+	return id, nil
 }
 
 func providerKeyForLease(leaseID string) string {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -17,6 +17,7 @@ import (
 
 type linodeAPI interface {
 	AccountID(context.Context) (string, error)
+	AccountSettings(context.Context) (accountSettings, error)
 	ListLinodes(context.Context) ([]linodeInstance, error)
 	GetLinode(context.Context, int64) (linodeInstance, error)
 	CreateLinode(context.Context, createLinodeRequest) (linodeInstance, error)
@@ -159,8 +160,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
-	fmt.Fprintf(b.RT.Stderr, "provisioning provider=linode lease=%s slug=%s type=%s region=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, linodeRegionForConfig(cfg), linodeImageForConfig(cfg), req.Keep)
-	created, err = client.CreateLinode(ctx, createLinodeRequest{
+	createReq := createLinodeRequest{
 		Region:         linodeRegionForConfig(cfg),
 		Type:           linodeServerTypeForConfig(cfg),
 		Image:          linodeImageForConfig(cfg),
@@ -169,8 +169,18 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 		AuthorizedKeys: []string{publicKey},
 		RootPass:       rootPass,
 		Metadata:       &linodeMetadata{UserData: linodeUserData(cfg, publicKey)},
-		FirewallID:     firewallID,
-	})
+	}
+	if firewallID > 0 {
+		settings, settingsErr := client.AccountSettings(ctx)
+		if settingsErr != nil {
+			return core.LeaseTarget{}, settingsErr
+		}
+		if configureErr := configureLinodeFirewall(&createReq, firewallID, settings.InterfacesForNewLinodes); configureErr != nil {
+			return core.LeaseTarget{}, configureErr
+		}
+	}
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=linode lease=%s slug=%s type=%s region=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, linodeRegionForConfig(cfg), linodeImageForConfig(cfg), req.Keep)
+	created, err = client.CreateLinode(ctx, createReq)
 	if err != nil {
 		if isLinodeCreateAmbiguous(err) {
 			if claimErr := b.persistAcquireRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, accountID, req.Keep, now); claimErr != nil {
@@ -192,7 +202,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	}
 	readyLabels := labelsFromTags(leaseTags(cfg, leaseID, slug, "ready", req.Keep, now))
 	readyLabels[linodeAccountLabel] = accountID
-	if err := client.UpdateLinodeTags(ctx, created.ID, tagsFromLabels(readyLabels)); err != nil {
+	if err := client.UpdateLinodeTags(ctx, created.ID, replaceCrabboxTags(created.Tags, tagsFromLabels(readyLabels))); err != nil {
 		return core.LeaseTarget{}, err
 	}
 	server.Labels = readyLabels
@@ -566,7 +576,7 @@ func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (
 	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
 		labels[linodeAccountLabel] = accountID
 	}
-	if err := client.UpdateLinodeTags(ctx, server.ID, tagsFromLabels(labels)); err != nil {
+	if err := client.UpdateLinodeTags(ctx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
 		return core.Server{}, err
 	}
 	server.Labels = labels
@@ -594,7 +604,7 @@ func (b *linodeLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, lease 
 		labels[linodeAccountLabel] = accountID
 	}
 	applyTailscaleMetadata(labels, meta)
-	if err := client.UpdateLinodeTags(ctx, server.ID, tagsFromLabels(labels)); err != nil {
+	if err := client.UpdateLinodeTags(ctx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
 		return core.Server{}, err
 	}
 	server.Labels = labels
@@ -963,6 +973,20 @@ func parseLinodeFirewallID(value string) (int64, error) {
 		return 0, core.Exit(2, "linode firewall must be a positive numeric firewall ID")
 	}
 	return id, nil
+}
+
+func configureLinodeFirewall(req *createLinodeRequest, firewallID int64, interfaceSetting string) error {
+	switch strings.TrimSpace(interfaceSetting) {
+	case "legacy_config_only", "legacy_config_default_but_linode_allowed":
+		req.InterfaceGeneration = "legacy_config"
+		req.FirewallID = firewallID
+	case "linode_default_but_legacy_config_allowed", "linode_only":
+		req.InterfaceGeneration = "linode"
+		req.Interfaces = []linodeInterface{{FirewallID: &firewallID, Public: &struct{}{}}}
+	default:
+		return core.Exit(3, "linode account returned unsupported interfaces_for_new_linodes value %q", interfaceSetting)
+	}
+	return nil
 }
 
 func generateLinodeRootPass() (string, error) {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -269,6 +269,13 @@ func (b *linodeLeaseBackend) Resolve(ctx context.Context, req core.ResolveReques
 		servers = append(servers, server)
 		byID[server.ID] = item
 	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if leaseID != "" {
+		return b.targetFromLinode(byID[server.ID], req, linodes, accountID)
+	}
 	if id, ok := parseLinodeID(req.ID); ok {
 		if item, found := byID[id]; found {
 			return b.targetFromLinode(item, req, linodes, accountID)
@@ -282,13 +289,6 @@ func (b *linodeLeaseBackend) Resolve(ctx context.Context, req core.ResolveReques
 		}
 		return b.targetFromLinode(item, req, appendLinodeIfMissing(linodes, item), accountID)
 	}
-	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
-	if err != nil {
-		return core.LeaseTarget{}, err
-	}
-	if leaseID != "" {
-		return b.targetFromLinode(byID[server.ID], req, linodes, accountID)
-	}
 	if req.ReleaseOnly {
 		return b.releaseTargetFromClaim(ctx, client, req.ID, accountID)
 	}
@@ -301,14 +301,15 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 		ok    bool
 		err   error
 	)
-	if linodeID, numeric := parseLinodeID(id); numeric {
-		id = strconv.FormatInt(linodeID, 10)
-		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
-	} else {
-		var exact bool
-		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-		if err == nil && exact && (!ok || claim.LeaseID != id) {
-			return core.LeaseTarget{}, core.Exit(2, "linode exact lease identifier %q does not match a valid linode claim", id)
+	var exact bool
+	claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+	if err == nil && exact && (!ok || claim.LeaseID != id) {
+		return core.LeaseTarget{}, core.Exit(2, "linode exact lease identifier %q does not match a valid linode claim", id)
+	}
+	if err == nil && !ok {
+		if linodeID, numeric := parseLinodeID(id); numeric {
+			id = strconv.FormatInt(linodeID, 10)
+			claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
 		}
 	}
 	if err != nil {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -540,7 +540,28 @@ func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (
 	if err := validateLiveLinode(item, server); err != nil {
 		return core.Server{}, err
 	}
-	labels := core.TouchDirectLeaseLabels(normalizedLinodeLabels(item.Tags), b.Cfg, req.State, b.now())
+	cfg := b.Cfg
+	labels := normalizedLinodeLabels(item.Tags)
+	liveTailscale := map[string]string{}
+	for _, key := range tagLabelKeys() {
+		if value, ok := labels[key]; ok && exactTagValueKey(key) {
+			liveTailscale[key] = value
+		}
+	}
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+		updated := make(map[string]string, len(labels))
+		for key, value := range labels {
+			updated[key] = value
+		}
+		labels = updated
+		delete(labels, "idle_timeout")
+		delete(labels, "idle_timeout_secs")
+	}
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now())
+	for key, value := range liveTailscale {
+		labels[key] = value
+	}
 	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
 		labels[linodeAccountLabel] = accountID
 	}

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -154,7 +154,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = providerKeyForLease(leaseID)
 	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
-		cfg.ServerType = linodeServerTypeForClass(cfg.Class)
+		cfg.ServerType = linodeServerTypeForConfig(cfg)
 	}
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
@@ -665,7 +665,7 @@ func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, se
 		}
 	}
 	foreignClaim := claim.Provider != providerName
-	if server.ID != 0 {
+	if item.ID != 0 {
 		if err := client.DeleteLinode(ctx, server.ID); err != nil {
 			return err
 		}

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -1,0 +1,985 @@
+package linode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type linodeAPI interface {
+	AccountID(context.Context) (string, error)
+	ListLinodes(context.Context) ([]linodeInstance, error)
+	GetLinode(context.Context, int64) (linodeInstance, error)
+	CreateLinode(context.Context, createLinodeRequest) (linodeInstance, error)
+	DeleteLinode(context.Context, int64) error
+	UpdateLinodeTags(context.Context, int64, []string) error
+}
+
+type linodeLeaseBackend struct {
+	shared.DirectSSHBackend
+	clientFactory             func(core.Runtime) (linodeAPI, error)
+	waitSSH                   func(context.Context, *core.SSHTarget, string, time.Duration) error
+	recoveryGrace             time.Duration
+	recoveryReconcilePolls    int
+	recoveryReconcileInterval time.Duration
+	acquireConfigErr          error
+}
+
+const (
+	ambiguousCreateRecoveryGrace    = 2 * time.Minute
+	ambiguousCreateRecoveryPolls    = 3
+	ambiguousCreateRecoveryInterval = 2 * time.Second
+	linodeAccountLabel              = "provider_account"
+)
+
+type ambiguousLinodeCreateError struct {
+	err error
+}
+
+func (e *ambiguousLinodeCreateError) Error() string {
+	return fmt.Sprintf("linode instance creation remains indeterminate; preserving SSH credentials for recovery: %v", e.err)
+}
+
+func (e *ambiguousLinodeCreateError) Unwrap() error {
+	return e.err
+}
+
+func NewLinodeLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
+	return newLinodeLeaseBackend(spec, cfg, rt)
+}
+
+func newLinodeLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) *linodeLeaseBackend {
+	cfg.Provider = providerName
+	acquireConfigErr := validateFoundationConfig(cfg)
+	applyLinodeDefaults(&cfg)
+	b := &linodeLeaseBackend{
+		DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt},
+		acquireConfigErr: acquireConfigErr,
+	}
+	b.clientFactory = func(rt core.Runtime) (linodeAPI, error) { return newLinodeClient(rt) }
+	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
+	}
+	b.Delete = b.deleteServer
+	return b
+}
+
+func (b *linodeLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
+}
+
+func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
+	if b.acquireConfigErr != nil {
+		return core.LeaseTarget{}, b.acquireConfigErr
+	}
+	cfg := b.Cfg
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return core.LeaseTarget{}, core.Exit(2, "provider=linode only supports target=linux")
+	}
+	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", cfg.Tailscale.AuthKeyEnv)
+	}
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	linodes, err := client.ListLinodes(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(linodes))
+	for _, item := range linodes {
+		if isOwnedLinode(item) {
+			servers = append(servers, serverFromLinode(item, cfg))
+		}
+	}
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	now := b.now()
+	created := linodeInstance{}
+	committed := false
+	defer func() {
+		if err == nil || committed {
+			return
+		}
+		var ambiguous *ambiguousLinodeCreateError
+		if errors.As(err, &ambiguous) {
+			return
+		}
+		if created.ID == 0 {
+			core.RemoveStoredTestboxKey(leaseID)
+			return
+		}
+		claimErr := b.persistAcquireCleanupClaim(leaseID, slug, cfg, created, req.Repo.Root, accountID, req.Keep, now)
+		claimPersisted := claimErr == nil
+		if cleanupErr := rollbackLinodeAcquire(client, created.ID); cleanupErr != nil {
+			err = fmt.Errorf("%v; linode cleanup failed: %w", err, errors.Join(claimErr, cleanupErr))
+			return
+		}
+		if claimPersisted {
+			core.RemoveLeaseClaim(leaseID)
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+	}()
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = providerKeyForLease(leaseID)
+	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
+		cfg.ServerType = linodeServerTypeForClass(cfg.Class)
+	}
+	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=linode lease=%s slug=%s type=%s region=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, linodeRegionForConfig(cfg), linodeImageForConfig(cfg), req.Keep)
+	created, err = client.CreateLinode(ctx, createLinodeRequest{
+		Region:         linodeRegionForConfig(cfg),
+		Type:           linodeServerTypeForConfig(cfg),
+		Image:          linodeImageForConfig(cfg),
+		Label:          core.LeaseProviderName(leaseID, slug),
+		Tags:           leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now),
+		AuthorizedKeys: []string{publicKey},
+		Metadata:       &linodeMetadata{UserData: linodeUserData(cfg, publicKey)},
+		FirewallID:     parseLinodeFirewallID(cfg.Linode.FirewallID),
+	})
+	if err != nil {
+		if isLinodeCreateAmbiguous(err) {
+			if claimErr := b.persistAcquireRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, accountID, req.Keep, now); claimErr != nil {
+				return core.LeaseTarget{}, errors.Join(&ambiguousLinodeCreateError{err: err}, fmt.Errorf("persist linode ambiguous-create recovery: %w", claimErr))
+			}
+			return core.LeaseTarget{}, &ambiguousLinodeCreateError{err: err}
+		}
+		return core.LeaseTarget{}, err
+	}
+	waited, waitErr := b.waitForLinodeIP(ctx, client, created.ID)
+	if waitErr != nil {
+		return core.LeaseTarget{}, waitErr
+	}
+	created = waited
+	server := serverFromLinode(created, cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := b.waitSSH(ctx, &ssh, "linode bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	readyLabels := labelsFromTags(leaseTags(cfg, leaseID, slug, "ready", req.Keep, now))
+	readyLabels[linodeAccountLabel] = accountID
+	if err := client.UpdateLinodeTags(ctx, created.ID, tagsFromLabels(readyLabels)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server.Labels = readyLabels
+	server.Labels[linodeAccountLabel] = accountID
+	server.Status = "ready"
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	committed = true
+	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s linode=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *linodeLeaseBackend) persistAcquireRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot, accountID string, keep bool, now time.Time) error {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = "provisioning"
+	labels["recovery"] = "ambiguous-create"
+	labels[linodeAccountLabel] = accountID
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("resolve recovery working directory: %w", err)
+		}
+	}
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
+}
+
+func (b *linodeLeaseBackend) persistAcquireCleanupClaim(leaseID, slug string, cfg core.Config, created linodeInstance, repoRoot, accountID string, keep bool, now time.Time) error {
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug)}
+	if created.ID != 0 {
+		server = serverFromLinode(created, cfg)
+	}
+	if err := validateLinodeLabels(server.Labels); err != nil {
+		server.Labels = core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+		server.Labels["state"] = "provisioning"
+	}
+	server.Labels["recovery"] = "rollback-cleanup"
+	server.Labels[linodeAccountLabel] = accountID
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("resolve rollback cleanup working directory: %w", err)
+		}
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false); err != nil {
+		return fmt.Errorf("persist linode rollback cleanup claim: %w", err)
+	}
+	return nil
+}
+
+func (b *linodeLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	linodes, err := client.ListLinodes(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := make([]core.Server, 0, len(linodes))
+	byID := map[int64]linodeInstance{}
+	for _, item := range linodes {
+		if !isOwnedLinode(item) {
+			continue
+		}
+		server := serverFromLinode(item, b.Cfg)
+		servers = append(servers, server)
+		byID[server.ID] = item
+	}
+	if id, ok := parseLinodeID(req.ID); ok {
+		if item, found := byID[id]; found {
+			return b.targetFromLinode(item, req, linodes, accountID)
+		}
+		item, err := client.GetLinode(ctx, id)
+		if err != nil {
+			if req.ReleaseOnly && isLinodeNotFound(err) {
+				return b.releaseTargetFromClaim(ctx, client, req.ID, accountID)
+			}
+			return core.LeaseTarget{}, err
+		}
+		return b.targetFromLinode(item, req, appendLinodeIfMissing(linodes, item), accountID)
+	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if leaseID != "" {
+		return b.targetFromLinode(byID[server.ID], req, linodes, accountID)
+	}
+	if req.ReleaseOnly {
+		return b.releaseTargetFromClaim(ctx, client, req.ID, accountID)
+	}
+	return core.LeaseTarget{}, core.Exit(4, "lease/linode not found: %s", req.ID)
+}
+
+func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client linodeAPI, id, accountID string) (core.LeaseTarget, error) {
+	var (
+		claim core.LeaseClaim
+		ok    bool
+		err   error
+	)
+	if linodeID, numeric := parseLinodeID(id); numeric {
+		id = strconv.FormatInt(linodeID, 10)
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+	} else {
+		var exact bool
+		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+		if err == nil && exact && (!ok || claim.LeaseID != id) {
+			return core.LeaseTarget{}, core.Exit(2, "linode exact lease identifier %q does not match a valid linode claim", id)
+		}
+	}
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if !ok || claim.LeaseID == "" {
+		return core.LeaseTarget{}, core.Exit(4, "lease/linode not found: %s", id)
+	}
+	if !core.LeaseClaimMatchesIdentifier(claim, id) {
+		return core.LeaseTarget{}, core.Exit(2, "linode lease claim does not match requested identifier %q", id)
+	}
+	if err := validateLinodeLabels(claim.Labels); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if err := validateLinodeClaimIdentity(claim, claim.LeaseID, claim.Slug); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	expectedAccountID := strings.TrimSpace(claim.Labels[linodeAccountLabel])
+	if expectedAccountID == "" {
+		return core.LeaseTarget{}, core.Exit(3, "linode lease claim has no account identity; refusing claim-only recovery")
+	}
+	if expectedAccountID != accountID {
+		return core.LeaseTarget{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", accountID, expectedAccountID)
+	}
+	if strings.TrimSpace(claim.CloudID) == "" {
+		recovery := claim.Labels["recovery"]
+		if recovery == "rollback-cleanup" {
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, Name: claim.Slug, Labels: claim.Labels}}, nil
+		}
+		if recovery != "ambiguous-create" {
+			return core.LeaseTarget{}, core.Exit(2, "linode lease claim has invalid recovery state %q for lease=%s", recovery, claim.LeaseID)
+		}
+		grace := b.recoveryGrace
+		if grace <= 0 {
+			grace = ambiguousCreateRecoveryGrace
+		}
+		createdAt, _ := strconv.ParseInt(claim.Labels["created_at"], 10, 64)
+		if createdAt <= 0 || b.now().Before(time.Unix(createdAt, 0).Add(grace)) {
+			return core.LeaseTarget{}, core.Exit(4, "linode ambiguous-create recovery is still pending for lease=%s; retry stop later", claim.LeaseID)
+		}
+		if target, found, err := b.reconcilePendingRecovery(ctx, client, claim, accountID); err != nil {
+			return core.LeaseTarget{}, err
+		} else if found {
+			return target, nil
+		}
+		return core.LeaseTarget{}, core.Exit(4, "linode ambiguous create remains indeterminate for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+	}
+	linodeID, ok := parseLinodeID(claim.CloudID)
+	if !ok {
+		return core.LeaseTarget{}, core.Exit(4, "lease/linode not found: %s", id)
+	}
+	if item, err := client.GetLinode(ctx, linodeID); err == nil {
+		labels := labelsFromTags(item.Tags)
+		if err := validateLinodeLabels(labels); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if item.Label != core.LeaseProviderName(claim.LeaseID, claim.Slug) ||
+			labels["provider"] != providerName ||
+			labels["lease"] != claim.LeaseID ||
+			labels["slug"] != claim.Slug {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to release Linode instance %d from stale local claim", linodeID)
+		}
+		server := serverFromLinode(item, core.Config{})
+		server.Labels[linodeAccountLabel] = accountID
+		return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+	} else if !isLinodeNotFound(err) {
+		return core.LeaseTarget{}, err
+	}
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, CloudID: claim.CloudID, ID: linodeID, Name: claim.Slug, Labels: claim.Labels}}, nil
+}
+
+func (b *linodeLeaseBackend) reconcilePendingRecovery(ctx context.Context, client linodeAPI, claim core.LeaseClaim, accountID string) (core.LeaseTarget, bool, error) {
+	polls := b.recoveryReconcilePolls
+	if polls <= 0 {
+		polls = ambiguousCreateRecoveryPolls
+	}
+	interval := b.recoveryReconcileInterval
+	if interval <= 0 {
+		interval = ambiguousCreateRecoveryInterval
+	}
+	for poll := 0; poll < polls; poll++ {
+		linodes, err := client.ListLinodes(ctx)
+		if err != nil {
+			return core.LeaseTarget{}, false, err
+		}
+		matches := pendingRecoveryMatches(linodes, claim)
+		switch len(matches) {
+		case 1:
+			server := serverFromLinode(matches[0], b.Cfg)
+			server.Labels[linodeAccountLabel] = accountID
+			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
+				return core.LeaseTarget{}, false, fmt.Errorf("persist recovered linode instance: %w", err)
+			}
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, true, nil
+		case 0:
+		default:
+			return core.LeaseTarget{}, false, core.Exit(2, "linode ambiguous create recovery found multiple instances for lease=%s", claim.LeaseID)
+		}
+		if poll+1 < polls {
+			timer := time.NewTimer(interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return core.LeaseTarget{}, false, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return core.LeaseTarget{}, false, nil
+}
+
+func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.ResolveRequest, linodes []linodeInstance, accountID string) (core.LeaseTarget, error) {
+	if err := validateLinodeLabels(labelsFromTags(item.Tags)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := serverFromLinode(item, b.Cfg)
+	server.Labels[linodeAccountLabel] = accountID
+	leaseID := server.Labels["lease"]
+	claim, claimExists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil {
+		return core.LeaseTarget{}, fmt.Errorf("read linode lease claim: %w", claimErr)
+	}
+	if claimExists {
+		if claim.Provider != providerName {
+			return core.LeaseTarget{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing linode claim rewrite", leaseID, claim.Provider)
+		}
+		if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		expectedAccountID := strings.TrimSpace(claim.Labels[linodeAccountLabel])
+		if expectedAccountID == "" {
+			return core.LeaseTarget{}, core.Exit(3, "linode lease claim has no account identity; refusing to bind it to the current account")
+		}
+		if expectedAccountID != accountID {
+			return core.LeaseTarget{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", accountID, expectedAccountID)
+		}
+		liveCloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
+		if claim.CloudID != "" && claim.CloudID != liveCloudID {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Linode instance %d from stale local claim", server.ID)
+		}
+		if claim.CloudID == "" && !isPendingRecoveryClaim(claim, leaseID) {
+			return core.LeaseTarget{}, core.Exit(2, "linode lease claim has no instance identity or valid pending recovery state for lease=%s", leaseID)
+		}
+	}
+	if req.ReleaseOnly {
+		target := core.LeaseTarget{Server: server, LeaseID: leaseID}
+		if err := b.persistPendingRecoveryServer(server, linodes, claim); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		return target, nil
+	}
+	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			ssh.Key = keyPath
+		}
+	}
+	if req.Repo.Root != "" {
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *linodeLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
+	_ = req
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return nil, err
+	}
+	linodes, err := client.ListLinodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.LeaseView, 0, len(linodes))
+	for _, item := range linodes {
+		if isOwnedLinode(item) {
+			out = append(out, serverFromLinode(item, b.Cfg))
+		}
+	}
+	return out, nil
+}
+
+func (b *linodeLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	if _, err := client.AccountID(ctx); err != nil {
+		return core.DoctorResult{}, err
+	}
+	linodes, err := client.ListLinodes(ctx)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	count := 0
+	for _, item := range linodes {
+		if isOwnedLinode(item) {
+			count++
+		}
+	}
+	result := core.InventoryDoctorResult(providerName, count)
+	result.Message += fmt.Sprintf(" default_type=%s region=%s image=%s", b.Cfg.ServerType, linodeRegionForConfig(b.Cfg), linodeImageForConfig(b.Cfg))
+	return result, nil
+}
+
+func (b *linodeLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
+}
+
+func (b *linodeLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s linode=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	server := req.Lease.Server
+	if err := validateLinodeLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetLinode(ctx, server.ID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveLinode(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := core.TouchDirectLeaseLabels(normalizedLinodeLabels(item.Tags), b.Cfg, req.State, b.now())
+	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
+		labels[linodeAccountLabel] = accountID
+	}
+	if err := client.UpdateLinodeTags(ctx, server.ID, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *linodeLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseTarget, meta core.TailscaleMetadata) (core.Server, error) {
+	server := lease.Server
+	if err := validateLinodeLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.GetLinode(ctx, server.ID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateLiveLinode(item, server); err != nil {
+		return core.Server{}, err
+	}
+	labels := normalizedLinodeLabels(item.Tags)
+	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
+		labels[linodeAccountLabel] = accountID
+	}
+	applyTailscaleMetadata(labels, meta)
+	if err := client.UpdateLinodeTags(ctx, server.ID, tagsFromLabels(labels)); err != nil {
+		return core.Server{}, err
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *linodeLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
+	if err != nil {
+		return err
+	}
+	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
+	if err := validateLinodeLabels(server.Labels); err != nil {
+		return err
+	}
+	client, err := b.clientFactory(b.RT)
+	if err != nil {
+		return err
+	}
+	cleanupServer := server
+	cleanupServer.Labels = make(map[string]string, len(server.Labels)+1)
+	for key, value := range server.Labels {
+		cleanupServer.Labels[key] = value
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return err
+	}
+	if expected := strings.TrimSpace(cleanupServer.Labels[linodeAccountLabel]); expected != "" && expected != accountID {
+		return core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	cleanupServer.Labels[linodeAccountLabel] = accountID
+	item := linodeInstance{}
+	if server.ID != 0 {
+		item, err = client.GetLinode(ctx, server.ID)
+		if err == nil {
+			if err := validateLiveLinode(item, server); err != nil {
+				return err
+			}
+			cleanupServer = serverFromLinode(item, b.Cfg)
+			cleanupServer.Labels[linodeAccountLabel] = accountID
+		} else if !isLinodeNotFound(err) {
+			return err
+		}
+	}
+	leaseID := cleanupServer.Labels["lease"]
+	claim, err := b.ensureCleanupClaim(cleanupServer, item.ID != 0)
+	if err != nil {
+		return err
+	}
+	if isPendingRecoveryClaim(claim, leaseID) {
+		if item.ID != 0 {
+			linodes, err := client.ListLinodes(ctx)
+			if err != nil {
+				return err
+			}
+			claim, err = persistPendingRecoveryClaim(cleanupServer, linodes, claim)
+			if err != nil {
+				return err
+			}
+		} else {
+			claim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, cleanupServer, core.SSHTarget{})
+			if err != nil {
+				return fmt.Errorf("persist recovered linode instance: %w", err)
+			}
+		}
+	}
+	foreignClaim := claim.Provider != providerName
+	if server.ID != 0 {
+		if err := client.DeleteLinode(ctx, server.ID); err != nil {
+			return err
+		}
+	}
+	if foreignClaim {
+		return nil
+	}
+	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+		return fmt.Errorf("finalize linode cleanup claim: %w", err)
+	}
+	core.RemoveStoredTestboxKey(leaseID)
+	return nil
+}
+
+func (b *linodeLeaseBackend) ensureCleanupClaim(server core.Server, liveLinodeVerified bool) (core.LeaseClaim, error) {
+	leaseID := server.Labels["lease"]
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.LeaseClaim{}, fmt.Errorf("read linode cleanup claim: %w", err)
+	}
+	if claimExists {
+		if claim.LeaseID != leaseID || claim.Provider == "" {
+			return core.LeaseClaim{}, core.Exit(2, "linode lease claim is incomplete for lease=%s", leaseID)
+		}
+	} else {
+		repoRoot, err := os.Getwd()
+		if err != nil {
+			return core.LeaseClaim{}, fmt.Errorf("resolve cleanup claim working directory: %w", err)
+		}
+		claim, err = core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, core.SSHTarget{}, repoRoot, b.Cfg.IdleTimeout, false, claim, false)
+		if err != nil {
+			return core.LeaseClaim{}, fmt.Errorf("persist linode cleanup claim: %w", err)
+		}
+	}
+	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
+	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
+		return core.LeaseClaim{}, core.Exit(2, "refusing to release Linode instance %d from stale local claim", server.ID)
+	}
+	if claim.Provider != providerName {
+		return claim, nil
+	}
+	if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if claim.CloudID == "" {
+		recovery := claim.Labels["recovery"]
+		validRecovery := (liveLinodeVerified && recovery == "ambiguous-create") ||
+			(server.ID == 0 && recovery == "rollback-cleanup")
+		if !validRecovery {
+			return core.LeaseClaim{}, core.Exit(2, "linode lease claim has no instance identity or valid cleanup recovery state for lease=%s", leaseID)
+		}
+	}
+	currentAccountID := strings.TrimSpace(server.Labels[linodeAccountLabel])
+	expectedAccountID := strings.TrimSpace(claim.Labels[linodeAccountLabel])
+	if expectedAccountID == "" {
+		return core.LeaseClaim{}, core.Exit(3, "linode lease claim has no account identity; refusing cleanup")
+	}
+	if currentAccountID != "" && expectedAccountID != currentAccountID {
+		return core.LeaseClaim{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", currentAccountID, expectedAccountID)
+	}
+	return claim, nil
+}
+
+func (b *linodeLeaseBackend) persistPendingRecoveryServer(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) error {
+	leaseID := server.Labels["lease"]
+	if !isPendingRecoveryClaim(claim, leaseID) {
+		return nil
+	}
+	if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+		return err
+	}
+	expected := strings.TrimSpace(claim.Labels[linodeAccountLabel])
+	if expected == "" {
+		return core.Exit(3, "linode recovery claim has no account identity; refusing to bind it to the current account")
+	}
+	if expected != server.Labels[linodeAccountLabel] {
+		return core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", server.Labels[linodeAccountLabel], expected)
+	}
+	_, err := persistPendingRecoveryClaim(server, linodes, claim)
+	return err
+}
+
+func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
+	return claim.LeaseID == leaseID &&
+		claim.Provider == providerName &&
+		strings.TrimSpace(claim.CloudID) == "" &&
+		claim.Labels["recovery"] == "ambiguous-create"
+}
+
+func validateLinodeClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
+	if claim.LeaseID != leaseID ||
+		claim.Provider != providerName ||
+		claim.Slug == "" ||
+		(slug != "" && claim.Slug != slug) ||
+		claim.Labels["lease"] != leaseID ||
+		claim.Labels["slug"] != claim.Slug ||
+		claim.Labels["provider"] != providerName {
+		return core.Exit(2, "linode lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+	}
+	return nil
+}
+
+func persistPendingRecoveryClaim(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) (core.LeaseClaim, error) {
+	matches := pendingRecoveryMatches(linodes, claim)
+	if len(matches) > 1 {
+		return core.LeaseClaim{}, core.Exit(2, "linode ambiguous create recovery found multiple instances for lease=%s", claim.LeaseID)
+	}
+	if len(matches) != 1 || matches[0].ID != server.ID {
+		return core.LeaseClaim{}, core.Exit(2, "refusing to bind linode ambiguous create recovery to mismatched linode=%d lease=%s", server.ID, claim.LeaseID)
+	}
+	updated, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{})
+	if err != nil {
+		return core.LeaseClaim{}, fmt.Errorf("persist recovered linode instance: %w", err)
+	}
+	return updated, nil
+}
+
+func pendingRecoveryMatches(linodes []linodeInstance, claim core.LeaseClaim) []linodeInstance {
+	name := core.LeaseProviderName(claim.LeaseID, claim.Slug)
+	matches := make([]linodeInstance, 0, 1)
+	for _, item := range linodes {
+		labels := labelsFromTags(item.Tags)
+		if isOwnedLinode(item) &&
+			item.Label == name &&
+			labels["lease"] == claim.LeaseID &&
+			labels["slug"] == claim.Slug {
+			matches = append(matches, item)
+		}
+	}
+	return matches
+}
+
+func appendLinodeIfMissing(linodes []linodeInstance, item linodeInstance) []linodeInstance {
+	for _, existing := range linodes {
+		if existing.ID == item.ID {
+			return linodes
+		}
+	}
+	return append(linodes, item)
+}
+
+func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
+	if meta.Enabled {
+		labels["tailscale"] = "true"
+	}
+	if meta.Hostname != "" {
+		labels["tailscale_hostname"] = meta.Hostname
+	}
+	if meta.FQDN != "" {
+		labels["tailscale_fqdn"] = meta.FQDN
+	}
+	if meta.IPv4 != "" {
+		labels["tailscale_ipv4"] = meta.IPv4
+	}
+	if len(meta.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
+	}
+	if meta.State != "" {
+		labels["tailscale_state"] = meta.State
+	}
+	if meta.Error != "" {
+		labels["tailscale_error"] = meta.Error
+	} else {
+		delete(labels, "tailscale_error")
+	}
+	if meta.ExitNode != "" {
+		labels["tailscale_exit_node"] = meta.ExitNode
+	}
+	if meta.ExitNodeAllowLANAccess {
+		labels["tailscale_exit_node_allow_lan_access"] = "true"
+	}
+}
+
+func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeAPI, id int64) (linodeInstance, error) {
+	deadline := b.now().Add(5 * time.Minute)
+	for {
+		item, err := client.GetLinode(ctx, id)
+		if err != nil {
+			return linodeInstance{}, err
+		}
+		if publicIPv4(item) != "" {
+			return item, nil
+		}
+		if b.now().After(deadline) {
+			return linodeInstance{}, core.Exit(5, "timed out waiting for Linode instance IP")
+		}
+		timer := time.NewTimer(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return linodeInstance{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *linodeLeaseBackend) now() time.Time {
+	if b.RT.Clock != nil {
+		return b.RT.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func rollbackLinodeAcquire(client linodeAPI, linodeID int64) error {
+	if linodeID == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return client.DeleteLinode(ctx, linodeID)
+}
+
+func validateLiveLinode(item linodeInstance, expected core.Server) error {
+	labels := normalizedLinodeLabels(item.Tags)
+	if err := validateLinodeLabels(labels); err != nil {
+		return err
+	}
+	expectedProviderKey := expected.Labels["provider_key"]
+	if expectedProviderKey == "" && expected.Labels["lease"] != "" {
+		expectedProviderKey = providerKeyForLease(expected.Labels["lease"])
+	}
+	if item.ID != expected.ID ||
+		item.Label != expected.Name ||
+		labels["lease"] != expected.Labels["lease"] ||
+		labels["slug"] != expected.Labels["slug"] ||
+		labels["provider_key"] != expectedProviderKey {
+		return core.Exit(2, "refusing to operate on changed Linode instance %d", expected.ID)
+	}
+	return nil
+}
+
+func serverFromLinode(item linodeInstance, cfg core.Config) core.Server {
+	labels := normalizedLinodeLabels(item.Tags)
+	server := core.Server{
+		CloudID:  strconv.FormatInt(item.ID, 10),
+		Provider: providerName,
+		ID:       item.ID,
+		Name:     item.Label,
+		Status:   normalizeLinodeStatus(item.Status),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = publicIPv4(item)
+	server.ServerType.Name = firstNonBlank(item.Type, cfg.ServerType)
+	return server
+}
+
+func normalizedLinodeLabels(tags []string) map[string]string {
+	labels := labelsFromTags(tags)
+	if labels["provider_key"] == "" && labels["lease"] != "" {
+		labels["provider_key"] = providerKeyForLease(labels["lease"])
+	}
+	return labels
+}
+
+func publicIPv4(item linodeInstance) string {
+	for _, ip := range item.IPv4 {
+		if strings.Contains(ip, ".") {
+			return ip
+		}
+	}
+	return ""
+}
+
+func normalizeLinodeStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running":
+		return "ready"
+	case "":
+		return "unknown"
+	default:
+		return status
+	}
+}
+
+func parseLinodeID(id string) (int64, bool) {
+	id = strings.TrimSpace(id)
+	if id == "" || strings.HasPrefix(id, "cbx_") {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(id, 10, 64)
+	if err != nil || parsed <= 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func parseLinodeFirewallID(value string) int64 {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || id <= 0 {
+		return 0
+	}
+	return id
+}
+
+func providerKeyForLease(leaseID string) string {
+	return "crabbox-" + leaseID
+}
+
+func applyLinodeDefaults(cfg *core.Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = core.TargetLinux
+	}
+	if cfg.Linode.Region == "" {
+		cfg.Linode.Region = defaultRegion
+	}
+	if cfg.Linode.Image == "" {
+		cfg.Linode.Image = defaultImage
+	}
+	if cfg.Linode.Type == "" {
+		cfg.Linode.Type = linodeServerTypeForClass(cfg.Class)
+	}
+	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
+		cfg.ServerType = linodeServerTypeForClass(cfg.Class)
+	}
+	if !core.IsSSHUserExplicit(cfg) && (cfg.SSHUser == "" || cfg.SSHUser == "crabbox") {
+		cfg.SSHUser = "root"
+	}
+	if !core.IsSSHPortExplicit(cfg) && (cfg.SSHPort == "" || cfg.SSHPort == core.BaseConfig().SSHPort) {
+		cfg.SSHPort = "22"
+	}
+	cfg.SSHFallbackPorts = nil
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isLinodeNotFound(err error) bool {
+	var apiErr *linodeAPIError
+	return errors.As(err, &apiErr) && apiErr.Status == 404
+}
+
+func isLinodeCreateAmbiguous(err error) bool {
+	var apiErr *linodeAPIError
+	if errors.As(err, &apiErr) && apiErr.Status >= 500 {
+		return true
+	}
+	return !errors.As(err, &apiErr)
+}

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -181,6 +181,49 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 	}
 }
 
+func TestAcquireRejectsInvalidFirewallBeforeCreate(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.Linode.FirewallID = "prod-ssh"
+
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "bad-firewall"})
+	if err == nil || !strings.Contains(err.Error(), "linode firewall must be a positive numeric firewall ID") {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	if len(api.createRequests) != 0 {
+		t.Fatalf("createRequests=%#v", api.createRequests)
+	}
+}
+
+func TestAcquireRejectsUnsupportedExplicitPortableOSBeforeCreate(t *testing.T) {
+	home := t.TempDir()
+	configPath := home + "/config.yaml"
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := os.WriteFile(configPath, []byte("provider: linode\nos: ubuntu:26.04\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := core.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Linode.Image != "" {
+		t.Fatalf("Linode.Image=%q, want unresolved provider image", cfg.Linode.Image)
+	}
+	api := &fakeLinodeAPI{}
+	backend := newLinodeLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard})
+	backend.clientFactory = func(core.Runtime) (linodeAPI, error) { return api, nil }
+
+	_, err = backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "bad-os"})
+	if err == nil || !strings.Contains(err.Error(), `provider=linode does not support os "ubuntu:26.04"`) {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	if len(api.createRequests) != 0 {
+		t.Fatalf("createRequests=%#v", api.createRequests)
+	}
+}
+
 func TestListFiltersForeignAndPartialLinodes(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -302,6 +302,54 @@ func TestResolveBySlugAndReleaseDeleteOwnedLinode(t *testing.T) {
 	}
 }
 
+func TestResolveNumericSlugBeforeRawLinodeID(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	item := linodeInstance{ID: 456, Label: core.LeaseProviderName("cbx_abcdef123456", "123"), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.123"}, Tags: leaseTags(cfg, "cbx_abcdef123456", "123", "ready", false, time.Now())}
+	api := &fakeLinodeAPI{linodes: []linodeInstance{item}}
+	backend := newTestBackend(t, api)
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_abcdef123456" || lease.Server.ID != 456 || lease.Server.Labels["slug"] != "123" {
+		t.Fatalf("lease=%#v", lease)
+	}
+}
+
+func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
+	leaseID := "cbx_numeric"
+	slug := "123"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, time.Now())
+	labels[linodeAccountLabel] = "email:alice@example.com"
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  "456",
+		ID:       456,
+		Name:     core.LeaseProviderName(leaseID, slug),
+		Labels:   labels,
+	}
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, t.TempDir(), cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.ID != 456 || lease.Server.Labels["slug"] != slug {
+		t.Fatalf("lease=%#v", lease)
+	}
+}
+
 func TestReleaseRefusesAccountMismatch(t *testing.T) {
 	api := &fakeLinodeAPI{accountID: "email:first@example.com"}
 	backend := newTestBackend(t, api)

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -1,0 +1,322 @@
+package linode
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeClock struct {
+	t time.Time
+}
+
+func (c fakeClock) Now() time.Time { return c.t }
+
+type fakeLinodeAPI struct {
+	linodes        []linodeInstance
+	accountID      string
+	accountErr     error
+	nextID         int64
+	createErr      error
+	getErr         error
+	deleteErr      error
+	created        []linodeInstance
+	deleted        []int64
+	updated        []int64
+	updatedTags    [][]string
+	createRequests []createLinodeRequest
+}
+
+func (f *fakeLinodeAPI) AccountID(context.Context) (string, error) {
+	if f.accountErr != nil {
+		return "", f.accountErr
+	}
+	if f.accountID != "" {
+		return f.accountID, nil
+	}
+	return "email:alice@example.com", nil
+}
+
+func (f *fakeLinodeAPI) ListLinodes(context.Context) ([]linodeInstance, error) {
+	return append(append([]linodeInstance(nil), f.linodes...), f.created...), nil
+}
+
+func (f *fakeLinodeAPI) GetLinode(_ context.Context, id int64) (linodeInstance, error) {
+	if f.getErr != nil {
+		return linodeInstance{}, f.getErr
+	}
+	for _, item := range append(append([]linodeInstance(nil), f.linodes...), f.created...) {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return linodeInstance{}, &linodeAPIError{Status: 404}
+}
+
+func (f *fakeLinodeAPI) CreateLinode(_ context.Context, req createLinodeRequest) (linodeInstance, error) {
+	f.createRequests = append(f.createRequests, req)
+	if f.createErr != nil {
+		return linodeInstance{}, f.createErr
+	}
+	if f.nextID == 0 {
+		f.nextID = 100
+	}
+	item := linodeInstance{
+		ID:     f.nextID,
+		Label:  req.Label,
+		Status: "running",
+		Region: req.Region,
+		Type:   req.Type,
+		Image:  req.Image,
+		Tags:   append([]string(nil), req.Tags...),
+		IPv4:   []string{"203.0.113.10"},
+	}
+	f.created = append(f.created, item)
+	f.nextID++
+	return item, nil
+}
+
+func (f *fakeLinodeAPI) DeleteLinode(_ context.Context, id int64) error {
+	f.deleted = append(f.deleted, id)
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.linodes = removeLinodeByID(f.linodes, id)
+	f.created = removeLinodeByID(f.created, id)
+	return nil
+}
+
+func (f *fakeLinodeAPI) UpdateLinodeTags(_ context.Context, id int64, tags []string) error {
+	f.updated = append(f.updated, id)
+	f.updatedTags = append(f.updatedTags, append([]string(nil), tags...))
+	for i := range f.linodes {
+		if f.linodes[i].ID == id {
+			f.linodes[i].Tags = append([]string(nil), tags...)
+		}
+	}
+	for i := range f.created {
+		if f.created[i].ID == id {
+			f.created[i].Tags = append([]string(nil), tags...)
+		}
+	}
+	return nil
+}
+
+func removeLinodeByID(items []linodeInstance, id int64) []linodeInstance {
+	out := items[:0]
+	for _, item := range items {
+		if item.ID != id {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func newTestBackend(t *testing.T, api *fakeLinodeAPI) *linodeLeaseBackend {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = "g6-standard-1"
+	cfg.SSHUser = "root"
+	cfg.WorkRoot = "/work/crabbox"
+	backend := newLinodeLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{
+		Stderr: io.Discard,
+		Clock:  fakeClock{t: time.Unix(1700000000, 0).UTC()},
+	})
+	backend.clientFactory = func(core.Runtime) (linodeAPI, error) { return api, nil }
+	backend.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
+	return backend
+}
+
+func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "my-app", Keep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID == "" || lease.Server.ID != 100 || lease.SSH.Host != "203.0.113.10" || lease.SSH.User != "root" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if len(api.createRequests) != 1 {
+		t.Fatalf("createRequests=%#v", api.createRequests)
+	}
+	req := api.createRequests[0]
+	if req.Label != core.LeaseProviderName(lease.LeaseID, "my-app") || req.Region != defaultRegion || req.Type != defaultType || req.Image != defaultImage {
+		t.Fatalf("request=%#v", req)
+	}
+	if len(req.AuthorizedKeys) != 1 || !strings.HasPrefix(req.AuthorizedKeys[0], "ssh-ed25519 ") {
+		t.Fatalf("authorized_keys=%v", req.AuthorizedKeys)
+	}
+	if req.Metadata == nil || req.Metadata.UserData == "" {
+		t.Fatalf("metadata=%#v", req.Metadata)
+	}
+	if labels := labelsFromTags(req.Tags); labels["lease"] != lease.LeaseID || labels["slug"] != "my-app" || labels["state"] != "provisioning" {
+		t.Fatalf("create labels=%v", labels)
+	}
+	if lease.Server.Labels["state"] != "ready" || lease.Server.Labels[linodeAccountLabel] != "email:alice@example.com" {
+		t.Fatalf("lease labels=%v", lease.Server.Labels)
+	}
+	if len(api.updated) != 1 || api.updated[0] != 100 {
+		t.Fatalf("updated=%v", api.updated)
+	}
+	if labels := labelsFromTags(api.updatedTags[0]); labels["state"] != "ready" || labels["lease"] != lease.LeaseID {
+		t.Fatalf("ready tags labels=%v", labels)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("my-app", providerName)
+	if err != nil || !ok || claim.CloudID != "100" || claim.Labels[linodeAccountLabel] != "email:alice@example.com" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestListFiltersForeignAndPartialLinodes(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	owned := linodeInstance{ID: 1, Label: "crabbox-cbx_one-owned", Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.1"}, Tags: leaseTags(cfg, "cbx_one", "owned", "ready", false, time.Unix(1, 0))}
+	partial := linodeInstance{ID: 2, Label: "partial", Tags: []string{tagCrabbox, "crabbox:provider:linode"}}
+	foreign := linodeInstance{ID: 3, Label: "foreign", Tags: []string{tagCrabbox, "crabbox:provider:aws", "crabbox:target:linux", "crabbox:lease:cbx_two", "crabbox:slug:foreign"}}
+	backend := newTestBackend(t, &fakeLinodeAPI{linodes: []linodeInstance{owned, partial, foreign}})
+
+	views, err := backend.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].ID != 1 || views[0].Status != "ready" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestResolveBySlugAndReleaseDeleteOwnedLinode(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "delete-me"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "delete-me", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.LeaseID != lease.LeaseID || resolved.Server.ID != lease.Server.ID {
+		t.Fatalf("resolved=%#v lease=%#v", resolved, lease)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != 100 {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("delete-me", providerName); err != nil || ok {
+		t.Fatalf("claim after release ok=%v err=%v", ok, err)
+	}
+	keyPath, pathErr := core.TestboxKeyPath(lease.LeaseID)
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(keyPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("local key retained after release: %v", statErr)
+	}
+}
+
+func TestReleaseRefusesAccountMismatch(t *testing.T) {
+	api := &fakeLinodeAPI{accountID: "email:first@example.com"}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "mismatch"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	api.accountID = "email:second@example.com"
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+}
+
+func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	expiredLabels := core.DirectLeaseLabels(cfg, "cbx_expired", "expired", providerName, "", false, now.Add(-2*time.Hour))
+	expiredLabels["state"] = "ready"
+	expiredLabels[linodeAccountLabel] = "email:alice@example.com"
+	expiredLabels["expires_at"] = "1"
+	keepLabels := core.DirectLeaseLabels(cfg, "cbx_keep", "keep", providerName, "", true, now.Add(-2*time.Hour))
+	keepLabels["state"] = "ready"
+	keepLabels[linodeAccountLabel] = "email:alice@example.com"
+	api := &fakeLinodeAPI{linodes: []linodeInstance{
+		{ID: 10, Label: core.LeaseProviderName("cbx_expired", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
+		{ID: 11, Label: core.LeaseProviderName("cbx_keep", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
+	}}
+	backend := newTestBackend(t, api)
+	backend.RT.Clock = fakeClock{t: now}
+
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("dry-run deleted=%v", api.deleted)
+	}
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != 10 {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+}
+
+func TestAmbiguousCreatePersistsRecoveryClaimAndRetainsKey(t *testing.T) {
+	api := &fakeLinodeAPI{createErr: &linodeAPIError{Status: 500, Body: "server error"}}
+	backend := newTestBackend(t, api)
+
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous"})
+	var ambiguous *ambiguousLinodeCreateError
+	if !errors.As(err, &ambiguous) {
+		t.Fatalf("Acquire err=%v, want ambiguousLinodeCreateError", err)
+	}
+	if len(api.createRequests) != 1 || len(api.deleted) != 0 {
+		t.Fatalf("createRequests=%d deleted=%v", len(api.createRequests), api.deleted)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" || claim.Labels[linodeAccountLabel] != "email:alice@example.com" {
+		t.Fatalf("recovery claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	keyPath, pathErr := core.TestboxKeyPath(claim.LeaseID)
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		t.Fatalf("local key removed during ambiguous create: %v", statErr)
+	}
+
+	if _, resolveErr := backend.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous", ReleaseOnly: true}); resolveErr == nil || !strings.Contains(resolveErr.Error(), "still pending") {
+		t.Fatalf("immediate recovery resolve err=%v", resolveErr)
+	}
+	createdAt, parseErr := strconv.ParseInt(claim.Labels["created_at"], 10, 64)
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	backend.RT.Clock = fakeClock{t: time.Unix(createdAt, 0).Add(ambiguousCreateRecoveryGrace + time.Second)}
+	backend.recoveryReconcilePolls = 1
+	if _, resolveErr := backend.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous", ReleaseOnly: true}); resolveErr == nil || !strings.Contains(resolveErr.Error(), "remains indeterminate") {
+		t.Fatalf("empty recovery resolve err=%v", resolveErr)
+	}
+}

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -160,6 +160,9 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 	if len(req.AuthorizedKeys) != 1 || !strings.HasPrefix(req.AuthorizedKeys[0], "ssh-ed25519 ") {
 		t.Fatalf("authorized_keys=%v", req.AuthorizedKeys)
 	}
+	if req.RootPass == "" || len(req.RootPass) < 16 {
+		t.Fatalf("root_pass not generated safely: %q", req.RootPass)
+	}
 	if req.Metadata == nil || req.Metadata.UserData == "" {
 		t.Fatalf("metadata=%#v", req.Metadata)
 	}

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -329,6 +329,63 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	}
 }
 
+func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	cfg.TTL = time.Hour
+	cfg.IdleTimeout = time.Minute
+	item := linodeInstance{ID: 99, Label: core.LeaseProviderName("cbx_abcdef123456", "touch-me"), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.10"}, Tags: leaseTags(cfg, "cbx_abcdef123456", "touch-me", "ready", false, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))}
+	server := serverFromLinode(item, cfg)
+	server.Labels["tailscale_ipv4"] = "100.64.1.1"
+	server.Labels["tailscale_fqdn"] = "stale.example.ts.net"
+	server.Labels["tailscale_state"] = "requested"
+	server.Labels["tailscale_tags"] = "tag:stale"
+	server.Labels["tailscale_exit_node"] = "stale.example.ts.net"
+	server.Labels[linodeAccountLabel] = "team:test-account"
+	liveLabels := normalizedLinodeLabels(item.Tags)
+	liveLabels["tailscale_ipv4"] = "100.64.1.2"
+	liveLabels["tailscale_fqdn"] = "touch-me.example.ts.net"
+	liveLabels["tailscale_state"] = "ready"
+	liveLabels["tailscale_error"] = "last probe failed: retrying"
+	liveLabels["tailscale_tags"] = "tag:ci,tag:crabbox"
+	liveLabels["tailscale_exit_node"] = "exit.example.ts.net"
+	item.Tags = tagsFromLabels(liveLabels)
+	api := &fakeLinodeAPI{linodes: []linodeInstance{item}}
+	backend := newTestBackend(t, api)
+	backend.RT.Clock = fakeClock{t: time.Date(2026, 6, 10, 12, 10, 0, 0, time.UTC)}
+
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease:       core.LeaseTarget{Server: server, LeaseID: "cbx_abcdef123456"},
+		State:       "running",
+		IdleTimeout: 20 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if touched.Labels["state"] != "running" || touched.Labels["idle_timeout_secs"] != "1200" {
+		t.Fatalf("touched labels=%v", touched.Labels)
+	}
+	if touched.Labels[linodeAccountLabel] != "team:test-account" {
+		t.Fatalf("account label=%q", touched.Labels[linodeAccountLabel])
+	}
+	if len(api.updated) != 1 || api.updated[0] != 99 {
+		t.Fatalf("updated=%v", api.updated)
+	}
+	decoded := labelsFromTags(api.updatedTags[0])
+	if decoded["state"] != "running" ||
+		decoded["idle_timeout_secs"] != "1200" ||
+		decoded["tailscale_ipv4"] != "100.64.1.2" ||
+		decoded["tailscale_fqdn"] != "touch-me.example.ts.net" ||
+		decoded["tailscale_state"] != "ready" ||
+		decoded["tailscale_error"] != "last probe failed: retrying" ||
+		decoded["tailscale_tags"] != "tag:ci,tag:crabbox" ||
+		decoded["tailscale_exit_node"] != "exit.example.ts.net" {
+		t.Fatalf("persisted labels=%v tags=%v", decoded, api.updatedTags[0])
+	}
+}
+
 func TestAmbiguousCreatePersistsRecoveryClaimAndRetainsKey(t *testing.T) {
 	api := &fakeLinodeAPI{createErr: &linodeAPIError{Status: 500, Body: "server error"}}
 	backend := newTestBackend(t, api)

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -20,18 +20,20 @@ type fakeClock struct {
 func (c fakeClock) Now() time.Time { return c.t }
 
 type fakeLinodeAPI struct {
-	linodes        []linodeInstance
-	accountID      string
-	accountErr     error
-	nextID         int64
-	createErr      error
-	getErr         error
-	deleteErr      error
-	created        []linodeInstance
-	deleted        []int64
-	updated        []int64
-	updatedTags    [][]string
-	createRequests []createLinodeRequest
+	linodes            []linodeInstance
+	accountID          string
+	accountErr         error
+	accountSettings    accountSettings
+	accountSettingsErr error
+	nextID             int64
+	createErr          error
+	getErr             error
+	deleteErr          error
+	created            []linodeInstance
+	deleted            []int64
+	updated            []int64
+	updatedTags        [][]string
+	createRequests     []createLinodeRequest
 }
 
 func (f *fakeLinodeAPI) AccountID(context.Context) (string, error) {
@@ -41,7 +43,17 @@ func (f *fakeLinodeAPI) AccountID(context.Context) (string, error) {
 	if f.accountID != "" {
 		return f.accountID, nil
 	}
-	return "email:alice@example.com", nil
+	return "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56", nil
+}
+
+func (f *fakeLinodeAPI) AccountSettings(context.Context) (accountSettings, error) {
+	if f.accountSettingsErr != nil {
+		return accountSettings{}, f.accountSettingsErr
+	}
+	if f.accountSettings.InterfacesForNewLinodes == "" {
+		return accountSettings{InterfacesForNewLinodes: "legacy_config_default_but_linode_allowed"}, nil
+	}
+	return f.accountSettings, nil
 }
 
 func (f *fakeLinodeAPI) ListLinodes(context.Context) ([]linodeInstance, error) {
@@ -169,7 +181,7 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 	if labels := labelsFromTags(req.Tags); labels["lease"] != lease.LeaseID || labels["slug"] != "my-app" || labels["state"] != "provisioning" {
 		t.Fatalf("create labels=%v", labels)
 	}
-	if lease.Server.Labels["state"] != "ready" || lease.Server.Labels[linodeAccountLabel] != "email:alice@example.com" {
+	if lease.Server.Labels["state"] != "ready" || lease.Server.Labels[linodeAccountLabel] != "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56" {
 		t.Fatalf("lease labels=%v", lease.Server.Labels)
 	}
 	if len(api.updated) != 1 || api.updated[0] != 100 {
@@ -179,7 +191,7 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 		t.Fatalf("ready tags labels=%v", labels)
 	}
 	claim, ok, err := core.ResolveLeaseClaimForProvider("my-app", providerName)
-	if err != nil || !ok || claim.CloudID != "100" || claim.Labels[linodeAccountLabel] != "email:alice@example.com" {
+	if err != nil || !ok || claim.CloudID != "100" || claim.Labels[linodeAccountLabel] != "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56" {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 }
@@ -219,6 +231,39 @@ func TestAcquireRejectsInvalidFirewallBeforeCreate(t *testing.T) {
 	}
 	if len(api.createRequests) != 0 {
 		t.Fatalf("createRequests=%#v", api.createRequests)
+	}
+}
+
+func TestAcquireConfiguresFirewallForLegacyInterfaces(t *testing.T) {
+	api := &fakeLinodeAPI{
+		accountSettings: accountSettings{InterfacesForNewLinodes: "legacy_config_default_but_linode_allowed"},
+	}
+	backend := newTestBackend(t, api)
+	backend.Cfg.Linode.FirewallID = "123"
+
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "legacy-firewall"}); err != nil {
+		t.Fatal(err)
+	}
+	req := api.createRequests[0]
+	if req.InterfaceGeneration != "legacy_config" || req.FirewallID != 123 || len(req.Interfaces) != 0 {
+		t.Fatalf("request=%#v", req)
+	}
+}
+
+func TestAcquireConfiguresFirewallForLinodeInterfaces(t *testing.T) {
+	api := &fakeLinodeAPI{
+		accountSettings: accountSettings{InterfacesForNewLinodes: "linode_only"},
+	}
+	backend := newTestBackend(t, api)
+	backend.Cfg.Linode.FirewallID = "456"
+
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "linode-firewall"}); err != nil {
+		t.Fatal(err)
+	}
+	req := api.createRequests[0]
+	if req.InterfaceGeneration != "linode" || req.FirewallID != 0 || len(req.Interfaces) != 1 ||
+		req.Interfaces[0].FirewallID == nil || *req.Interfaces[0].FirewallID != 456 || req.Interfaces[0].Public == nil {
+		t.Fatalf("request=%#v", req)
 	}
 }
 
@@ -327,7 +372,7 @@ func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, time.Now())
-	labels[linodeAccountLabel] = "email:alice@example.com"
+	labels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	server := core.Server{
 		Provider: providerName,
 		CloudID:  "456",
@@ -351,14 +396,14 @@ func TestResolveReleaseOnlyNumericSlugClaimBeforeRawLinodeID(t *testing.T) {
 }
 
 func TestReleaseRefusesAccountMismatch(t *testing.T) {
-	api := &fakeLinodeAPI{accountID: "email:first@example.com"}
+	api := &fakeLinodeAPI{accountID: "euuid:first"}
 	backend := newTestBackend(t, api)
 	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "mismatch"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	api.accountID = "email:second@example.com"
+	api.accountID = "euuid:second"
 	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("ReleaseLease err=%v", err)
@@ -374,7 +419,7 @@ func TestReleaseMissingLiveLinodeFinalizesLocalClaim(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	labels := core.DirectLeaseLabels(cfg, leaseID, "gone", providerName, "", false, time.Now())
-	labels[linodeAccountLabel] = "email:alice@example.com"
+	labels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	server := core.Server{
 		Provider: providerName,
 		CloudID:  "123",
@@ -413,11 +458,11 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	cfg.TargetOS = core.TargetLinux
 	expiredLabels := core.DirectLeaseLabels(cfg, "cbx_expired", "expired", providerName, "", false, now.Add(-2*time.Hour))
 	expiredLabels["state"] = "ready"
-	expiredLabels[linodeAccountLabel] = "email:alice@example.com"
+	expiredLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	expiredLabels["expires_at"] = "1"
 	keepLabels := core.DirectLeaseLabels(cfg, "cbx_keep", "keep", providerName, "", true, now.Add(-2*time.Hour))
 	keepLabels["state"] = "ready"
-	keepLabels[linodeAccountLabel] = "email:alice@example.com"
+	keepLabels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
 	api := &fakeLinodeAPI{linodes: []linodeInstance{
 		{ID: 10, Label: core.LeaseProviderName("cbx_expired", "expired"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.10"}, Tags: tagsFromLabels(expiredLabels)},
 		{ID: 11, Label: core.LeaseProviderName("cbx_keep", "keep"), Status: "running", Type: "g6-standard-1", IPv4: []string{"203.0.113.11"}, Tags: tagsFromLabels(keepLabels)},
@@ -446,7 +491,7 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 	cfg.ServerType = defaultType
 	cfg.TTL = time.Hour
 	cfg.IdleTimeout = time.Minute
-	item := linodeInstance{ID: 99, Label: core.LeaseProviderName("cbx_abcdef123456", "touch-me"), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.10"}, Tags: leaseTags(cfg, "cbx_abcdef123456", "touch-me", "ready", false, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC))}
+	item := linodeInstance{ID: 99, Label: core.LeaseProviderName("cbx_abcdef123456", "touch-me"), Status: "running", Type: defaultType, IPv4: []string{"203.0.113.10"}, Tags: append(leaseTags(cfg, "cbx_abcdef123456", "touch-me", "ready", false, time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)), "customer:production")}
 	server := serverFromLinode(item, cfg)
 	server.Labels["tailscale_ipv4"] = "100.64.1.1"
 	server.Labels["tailscale_fqdn"] = "stale.example.ts.net"
@@ -461,7 +506,7 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 	liveLabels["tailscale_error"] = "last probe failed: retrying"
 	liveLabels["tailscale_tags"] = "tag:ci,tag:crabbox"
 	liveLabels["tailscale_exit_node"] = "exit.example.ts.net"
-	item.Tags = tagsFromLabels(liveLabels)
+	item.Tags = append(tagsFromLabels(liveLabels), "customer:production")
 	api := &fakeLinodeAPI{linodes: []linodeInstance{item}}
 	backend := newTestBackend(t, api)
 	backend.RT.Clock = fakeClock{t: time.Date(2026, 6, 10, 12, 10, 0, 0, time.UTC)}
@@ -483,6 +528,9 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 	if len(api.updated) != 1 || api.updated[0] != 99 {
 		t.Fatalf("updated=%v", api.updated)
 	}
+	if !containsString(api.updatedTags[0], "customer:production") {
+		t.Fatalf("external tags not preserved: %v", api.updatedTags[0])
+	}
 	decoded := labelsFromTags(api.updatedTags[0])
 	if decoded["state"] != "running" ||
 		decoded["idle_timeout_secs"] != "1200" ||
@@ -494,6 +542,15 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 		decoded["tailscale_exit_node"] != "exit.example.ts.net" {
 		t.Fatalf("persisted labels=%v tags=%v", decoded, api.updatedTags[0])
 	}
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAmbiguousCreatePersistsRecoveryClaimAndRetainsKey(t *testing.T) {
@@ -509,7 +566,7 @@ func TestAmbiguousCreatePersistsRecoveryClaimAndRetainsKey(t *testing.T) {
 		t.Fatalf("createRequests=%d deleted=%v", len(api.createRequests), api.deleted)
 	}
 	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous", providerName)
-	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" || claim.Labels[linodeAccountLabel] != "email:alice@example.com" {
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" || claim.Labels[linodeAccountLabel] != "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56" {
 		t.Fatalf("recovery claim=%#v ok=%v err=%v", claim, ok, claimErr)
 	}
 	keyPath, pathErr := core.TestboxKeyPath(claim.LeaseID)

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -184,6 +184,30 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 	}
 }
 
+func TestAcquireRecordsConfiguredLinodeTypeInMetadata(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.Linode.Type = "g6-standard-2"
+
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "custom-type"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(api.createRequests) != 1 || api.createRequests[0].Type != "g6-standard-2" {
+		t.Fatalf("createRequests=%#v", api.createRequests)
+	}
+	if lease.Server.ServerType.Name != "g6-standard-2" || lease.Server.Labels["server_type"] != "g6-standard-2" {
+		t.Fatalf("lease server type=%#v labels=%v", lease.Server.ServerType, lease.Server.Labels)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("custom-type", providerName)
+	if err != nil || !ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+	if claim.Labels["server_type"] != "g6-standard-2" {
+		t.Fatalf("claim labels=%v", claim.Labels)
+	}
+}
+
 func TestAcquireRejectsInvalidFirewallBeforeCreate(t *testing.T) {
 	api := &fakeLinodeAPI{}
 	backend := newTestBackend(t, api)
@@ -293,6 +317,44 @@ func TestReleaseRefusesAccountMismatch(t *testing.T) {
 	}
 	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
+	}
+}
+
+func TestReleaseMissingLiveLinodeFinalizesLocalClaim(t *testing.T) {
+	leaseID := "cbx_missing"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	labels := core.DirectLeaseLabels(cfg, leaseID, "gone", providerName, "", false, time.Now())
+	labels[linodeAccountLabel] = "email:alice@example.com"
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  "123",
+		ID:       123,
+		Name:     core.LeaseProviderName(leaseID, "gone"),
+		Labels:   labels,
+	}
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "gone", cfg, server, core.SSHTarget{}, t.TempDir(), cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("deleted missing linode=%v", api.deleted)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+		t.Fatalf("claim after release ok=%v err=%v", ok, err)
+	}
+	if _, statErr := os.Stat(keyPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("local key retained after release: %v", statErr)
 	}
 }
 

--- a/internal/providers/linode/client.go
+++ b/internal/providers/linode/client.go
@@ -1,0 +1,261 @@
+package linode
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const apiBaseURL = "https://api.linode.com/v4"
+
+type linodeClient struct {
+	token   string
+	client  *http.Client
+	baseURL string
+}
+
+type linodeAPIError struct {
+	Operation string
+	Status    int
+	Body      string
+}
+
+func (e *linodeAPIError) Error() string {
+	return fmt.Sprintf("linode %s: http %d: %s", e.Operation, e.Status, e.Body)
+}
+
+func newLinodeClient(rt core.Runtime) (*linodeClient, error) {
+	token, err := requireToken()
+	if err != nil {
+		return nil, err
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &linodeClient{token: token, client: httpClient, baseURL: apiBaseURL}, nil
+}
+
+func (c *linodeClient) do(ctx context.Context, method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+		reader = &buf
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if len(data) > 400 {
+			data = data[:400]
+		}
+		body := c.redactErrorBody(strings.TrimSpace(string(data)))
+		if readErr != nil {
+			if body != "" {
+				body += "; "
+			}
+			body += "response body read failed: " + readErr.Error()
+		}
+		return &linodeAPIError{Operation: method + " " + path, Status: resp.StatusCode, Body: body}
+	}
+	if readErr != nil {
+		return fmt.Errorf("linode %s %s response body: %w", method, path, readErr)
+	}
+	if out == nil || len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("linode %s %s decode: %w", method, path, err)
+	}
+	return nil
+}
+
+func (c *linodeClient) redactErrorBody(body string) string {
+	if c.token != "" {
+		body = strings.ReplaceAll(body, c.token, "<redacted>")
+	}
+	for _, field := range []string{"root_pass", "user_data"} {
+		body = redactJSONishField(body, field)
+		body = redactInlineField(body, field)
+	}
+	return body
+}
+
+func redactJSONishField(body, field string) string {
+	pattern := regexp.MustCompile(`("` + regexp.QuoteMeta(field) + `"\s*:\s*")[^"]*(")`)
+	return pattern.ReplaceAllString(body, `${1}<redacted>${2}`)
+}
+
+func redactInlineField(body, field string) string {
+	pattern := regexp.MustCompile(`(?i)(` + regexp.QuoteMeta(field) + `\s*[=: ]\s*)[^",\s]+`)
+	return pattern.ReplaceAllString(body, `${1}<redacted>`)
+}
+
+func (c *linodeClient) AccountID(ctx context.Context) (string, error) {
+	var res account
+	if err := c.do(ctx, http.MethodGet, "/account", nil, &res); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(res.Email) == "" {
+		return "", core.Exit(3, "linode account response did not include email identity")
+	}
+	return "email:" + strings.TrimSpace(res.Email), nil
+}
+
+func (c *linodeClient) ListLinodes(ctx context.Context) ([]linodeInstance, error) {
+	var out []linodeInstance
+	err := c.listPaged(ctx, "/linode/instances", func(page linodePage) {
+		out = append(out, page.Linodes...)
+	})
+	return out, err
+}
+
+func (c *linodeClient) GetLinode(ctx context.Context, id int64) (linodeInstance, error) {
+	var out linodeInstance
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/linode/instances/%d", id), nil, &out); err != nil {
+		return linodeInstance{}, err
+	}
+	return out, nil
+}
+
+func (c *linodeClient) CreateLinode(ctx context.Context, req createLinodeRequest) (linodeInstance, error) {
+	var out linodeInstance
+	if err := c.do(ctx, http.MethodPost, "/linode/instances", req, &out); err != nil {
+		return linodeInstance{}, err
+	}
+	return out, nil
+}
+
+func (c *linodeClient) DeleteLinode(ctx context.Context, id int64) error {
+	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/linode/instances/%d", id), nil, nil)
+}
+
+func (c *linodeClient) ListTypes(ctx context.Context) ([]linodeType, error) {
+	var out []linodeType
+	err := c.listPaged(ctx, "/linode/types", func(page linodePage) {
+		out = append(out, page.Types...)
+	})
+	return out, err
+}
+
+func (c *linodeClient) ListImages(ctx context.Context) ([]linodeImage, error) {
+	var out []linodeImage
+	err := c.listPaged(ctx, "/images", func(page linodePage) {
+		out = append(out, page.Images...)
+	})
+	return out, err
+}
+
+func (c *linodeClient) ListRegions(ctx context.Context) ([]linodeRegion, error) {
+	var out []linodeRegion
+	err := c.listPaged(ctx, "/regions", func(page linodePage) {
+		out = append(out, page.Regions...)
+	})
+	return out, err
+}
+
+func (c *linodeClient) ListFirewalls(ctx context.Context) ([]linodeFirewall, error) {
+	var out []linodeFirewall
+	err := c.listPaged(ctx, "/networking/firewalls", func(page linodePage) {
+		out = append(out, page.Firewalls...)
+	})
+	return out, err
+}
+
+func (c *linodeClient) AddFirewallDevice(ctx context.Context, firewallID int64, req firewallDeviceRequest) error {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/networking/firewalls/%d/devices", firewallID), req, nil)
+}
+
+type linodePage struct {
+	Page      int              `json:"page"`
+	Pages     int              `json:"pages"`
+	Results   int              `json:"results"`
+	Linodes   []linodeInstance `json:"data,omitempty"`
+	Types     []linodeType     `json:"-"`
+	Images    []linodeImage    `json:"-"`
+	Regions   []linodeRegion   `json:"-"`
+	Firewalls []linodeFirewall `json:"-"`
+}
+
+func (c *linodeClient) listPaged(ctx context.Context, path string, consume func(linodePage)) error {
+	page := 1
+	for {
+		nextPath := withPage(path, page)
+		var raw struct {
+			Page    int             `json:"page"`
+			Pages   int             `json:"pages"`
+			Results int             `json:"results"`
+			Data    json.RawMessage `json:"data"`
+		}
+		if err := c.do(ctx, http.MethodGet, nextPath, nil, &raw); err != nil {
+			return err
+		}
+		parsed := linodePage{Page: raw.Page, Pages: raw.Pages, Results: raw.Results}
+		switch path {
+		case "/linode/instances":
+			if err := json.Unmarshal(raw.Data, &parsed.Linodes); err != nil {
+				return fmt.Errorf("linode %s decode data: %w", nextPath, err)
+			}
+		case "/linode/types":
+			if err := json.Unmarshal(raw.Data, &parsed.Types); err != nil {
+				return fmt.Errorf("linode %s decode data: %w", nextPath, err)
+			}
+		case "/images":
+			if err := json.Unmarshal(raw.Data, &parsed.Images); err != nil {
+				return fmt.Errorf("linode %s decode data: %w", nextPath, err)
+			}
+		case "/regions":
+			if err := json.Unmarshal(raw.Data, &parsed.Regions); err != nil {
+				return fmt.Errorf("linode %s decode data: %w", nextPath, err)
+			}
+		case "/networking/firewalls":
+			if err := json.Unmarshal(raw.Data, &parsed.Firewalls); err != nil {
+				return fmt.Errorf("linode %s decode data: %w", nextPath, err)
+			}
+		default:
+			return core.Exit(2, "linode unsupported paged path %s", path)
+		}
+		consume(parsed)
+		if parsed.Pages <= 0 || page >= parsed.Pages {
+			return nil
+		}
+		page++
+	}
+}
+
+func withPage(path string, page int) string {
+	u, err := url.Parse(path)
+	if err != nil {
+		return path
+	}
+	q := u.Query()
+	q.Set("page", strconv.Itoa(page))
+	q.Set("page_size", "500")
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/internal/providers/linode/client.go
+++ b/internal/providers/linode/client.go
@@ -155,6 +155,10 @@ func (c *linodeClient) DeleteLinode(ctx context.Context, id int64) error {
 	return c.do(ctx, http.MethodDelete, fmt.Sprintf("/linode/instances/%d", id), nil, nil)
 }
 
+func (c *linodeClient) UpdateLinodeTags(ctx context.Context, id int64, tags []string) error {
+	return c.do(ctx, http.MethodPut, fmt.Sprintf("/linode/instances/%d", id), map[string]any{"tags": tags}, nil)
+}
+
 func (c *linodeClient) ListTypes(ctx context.Context) ([]linodeType, error) {
 	var out []linodeType
 	err := c.listPaged(ctx, "/linode/types", func(page linodePage) {

--- a/internal/providers/linode/client.go
+++ b/internal/providers/linode/client.go
@@ -121,10 +121,18 @@ func (c *linodeClient) AccountID(ctx context.Context) (string, error) {
 	if err := c.do(ctx, http.MethodGet, "/account", nil, &res); err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(res.Email) == "" {
-		return "", core.Exit(3, "linode account response did not include email identity")
+	if strings.TrimSpace(res.EUUID) == "" {
+		return "", core.Exit(3, "linode account response did not include euuid identity")
 	}
-	return "email:" + strings.TrimSpace(res.Email), nil
+	return "euuid:" + strings.TrimSpace(res.EUUID), nil
+}
+
+func (c *linodeClient) AccountSettings(ctx context.Context) (accountSettings, error) {
+	var out accountSettings
+	if err := c.do(ctx, http.MethodGet, "/account/settings", nil, &out); err != nil {
+		return accountSettings{}, err
+	}
+	return out, nil
 }
 
 func (c *linodeClient) ListLinodes(ctx context.Context) ([]linodeInstance, error) {

--- a/internal/providers/linode/client_test.go
+++ b/internal/providers/linode/client_test.go
@@ -82,7 +82,7 @@ func TestLinodeClientAccountID(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/account" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
 		}
-		_, _ = w.Write([]byte(`{"email":"alice@example.com"}`))
+		_, _ = w.Write([]byte(`{"euuid":"A1BC2DEF-34GH-567I-J890KLMN12O34P56"}`))
 	}))
 	defer server.Close()
 
@@ -96,8 +96,32 @@ func TestLinodeClientAccountID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if accountID != "email:alice@example.com" {
+	if accountID != "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56" {
 		t.Fatalf("accountID=%q", accountID)
+	}
+}
+
+func TestLinodeClientAccountSettings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/account/settings" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		_, _ = w.Write([]byte(`{"interfaces_for_new_linodes":"linode_only"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	settings, err := client.AccountSettings(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.InterfacesForNewLinodes != "linode_only" {
+		t.Fatalf("settings=%#v", settings)
 	}
 }
 

--- a/internal/providers/linode/client_test.go
+++ b/internal/providers/linode/client_test.go
@@ -1,0 +1,162 @@
+package linode
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestLinodeClientCreateRequestShape(t *testing.T) {
+	var captured struct {
+		Method      string
+		Path        string
+		Auth        string
+		Accept      string
+		ContentType string
+		Body        map[string]any
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.RequestURI()
+		captured.Auth = r.Header.Get("Authorization")
+		captured.Accept = r.Header.Get("Accept")
+		captured.ContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&captured.Body); err != nil {
+			t.Fatal(err)
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/linode/instances" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"id":123,"label":"crabbox-cbx-test","status":"provisioning","region":"us-ord","type":"g6-standard-1","image":"linode/ubuntu24.04","tags":["crabbox"]}`))
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "secret-token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	got, err := client.CreateLinode(context.Background(), createLinodeRequest{
+		Region:         "us-ord",
+		Type:           "g6-standard-1",
+		Image:          "linode/ubuntu24.04",
+		Label:          "crabbox-cbx-test",
+		Tags:           []string{"crabbox", "lease:cbx_test"},
+		AuthorizedKeys: []string{"ssh-ed25519 test"},
+		Metadata:       &linodeMetadata{UserData: "I2Nsb3VkLWNvbmZpZw=="},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != 123 || got.Label != "crabbox-cbx-test" {
+		t.Fatalf("instance=%#v", got)
+	}
+	if captured.Method != http.MethodPost || captured.Path != "/linode/instances" {
+		t.Fatalf("request=%s %s", captured.Method, captured.Path)
+	}
+	if captured.Auth != "Bearer secret-token" || captured.Accept != "application/json" || !strings.HasPrefix(captured.ContentType, "application/json") {
+		t.Fatalf("headers auth=%q accept=%q content-type=%q", captured.Auth, captured.Accept, captured.ContentType)
+	}
+	if captured.Body["region"] != "us-ord" || captured.Body["type"] != "g6-standard-1" || captured.Body["image"] != "linode/ubuntu24.04" {
+		t.Fatalf("body=%v", captured.Body)
+	}
+	keys, _ := captured.Body["authorized_keys"].([]any)
+	if len(keys) != 1 || keys[0] != "ssh-ed25519 test" {
+		t.Fatalf("authorized_keys=%v", captured.Body["authorized_keys"])
+	}
+	metadata, _ := captured.Body["metadata"].(map[string]any)
+	if metadata["user_data"] != "I2Nsb3VkLWNvbmZpZw==" {
+		t.Fatalf("metadata=%v", captured.Body["metadata"])
+	}
+}
+
+func TestLinodeClientAccountID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/account" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		_, _ = w.Write([]byte(`{"email":"alice@example.com"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	accountID, err := client.AccountID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accountID != "email:alice@example.com" {
+		t.Fatalf("accountID=%q", accountID)
+	}
+}
+
+func TestLinodeClientPagination(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"one"}],"page":1,"pages":2,"results":2}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"data":[{"id":2,"label":"two"}],"page":2,"pages":2,"results":2}`))
+		default:
+			t.Fatalf("unexpected page path %s", r.URL.RequestURI())
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	linodes, err := client.ListLinodes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(linodes) != 2 || linodes[0].ID != 1 || linodes[1].ID != 2 {
+		t.Fatalf("linodes=%v", linodes)
+	}
+	if strings.Join(paths, ",") != "/linode/instances?page=1&page_size=500,/linode/instances?page=2&page_size=500" {
+		t.Fatalf("paths=%v", paths)
+	}
+}
+
+func TestLinodeClientErrorRedaction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errors":[{"reason":"token secret-token root_pass hunter2 user_data I2Nsb3VkLWNvbmZpZw=="}],"root_pass":"hunter2","user_data":"I2Nsb3VkLWNvbmZpZw=="}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "secret-token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	err = client.do(context.Background(), http.MethodPost, "/linode/instances", createLinodeRequest{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	text := err.Error()
+	for _, secret := range []string{"secret-token", "hunter2", "I2Nsb3VkLWNvbmZpZw=="} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("error leaked %q: %s", secret, text)
+		}
+	}
+	if !strings.Contains(text, "<redacted>") {
+		t.Fatalf("error not redacted: %s", text)
+	}
+}

--- a/internal/providers/linode/client_test.go
+++ b/internal/providers/linode/client_test.go
@@ -101,6 +101,41 @@ func TestLinodeClientAccountID(t *testing.T) {
 	}
 }
 
+func TestLinodeClientUpdateTagsRequestShape(t *testing.T) {
+	var captured struct {
+		Method string
+		Path   string
+		Body   map[string]any
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Method = r.Method
+		captured.Path = r.URL.RequestURI()
+		if err := json.NewDecoder(r.Body).Decode(&captured.Body); err != nil {
+			t.Fatal(err)
+		}
+		if r.Method != http.MethodPut || r.URL.Path != "/linode/instances/123" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	t.Setenv(tokenEnv, "token")
+	client, err := newLinodeClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	if err := client.UpdateLinodeTags(context.Background(), 123, []string{"crabbox", "crabbox:state:ready"}); err != nil {
+		t.Fatal(err)
+	}
+	tags, _ := captured.Body["tags"].([]any)
+	if captured.Method != http.MethodPut || captured.Path != "/linode/instances/123" || len(tags) != 2 || tags[1] != "crabbox:state:ready" {
+		t.Fatalf("captured=%#v", captured)
+	}
+}
+
 func TestLinodeClientPagination(t *testing.T) {
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/linode/cloudinit.go
+++ b/internal/providers/linode/cloudinit.go
@@ -1,0 +1,11 @@
+package linode
+
+import (
+	"encoding/base64"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func linodeUserData(cfg core.Config, publicKey string) string {
+	return base64.StdEncoding.EncodeToString([]byte(core.CloudInitUserData(cfg, publicKey)))
+}

--- a/internal/providers/linode/config.go
+++ b/internal/providers/linode/config.go
@@ -63,11 +63,17 @@ func validateFoundationConfig(cfg core.Config) error {
 	if strings.TrimSpace(linodeRegionForConfig(cfg)) == "" {
 		return core.Exit(2, "linode region is required")
 	}
+	if core.OSImageWasExplicit(cfg) && strings.TrimSpace(cfg.Linode.Image) == "" {
+		return core.Exit(2, "provider=linode does not support os %q; set linode.image or CRABBOX_LINODE_IMAGE to an explicit Linode image", cfg.OSImage)
+	}
 	if strings.TrimSpace(linodeImageForConfig(cfg)) == "" {
 		return core.Exit(2, "linode image is required")
 	}
 	if strings.TrimSpace(linodeServerTypeForConfig(cfg)) == "" {
 		return core.Exit(2, "linode type is required")
+	}
+	if _, err := parseLinodeFirewallID(cfg.Linode.FirewallID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/providers/linode/config.go
+++ b/internal/providers/linode/config.go
@@ -1,0 +1,73 @@
+package linode
+
+import (
+	"os"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	defaultRegion = "us-ord"
+	defaultImage  = "linode/ubuntu24.04"
+	defaultType   = "g6-standard-1"
+	tokenEnv      = "LINODE_TOKEN"
+)
+
+func tokenFromEnv() string {
+	return strings.TrimSpace(os.Getenv(tokenEnv))
+}
+
+func requireToken() (string, error) {
+	token := tokenFromEnv()
+	if token == "" {
+		return "", core.Exit(3, "%s is required", tokenEnv)
+	}
+	return token, nil
+}
+
+func linodeRegionForConfig(cfg core.Config) string {
+	if strings.TrimSpace(cfg.Linode.Region) != "" {
+		return strings.TrimSpace(cfg.Linode.Region)
+	}
+	return defaultRegion
+}
+
+func linodeImageForConfig(cfg core.Config) string {
+	if strings.TrimSpace(cfg.Linode.Image) != "" {
+		return strings.TrimSpace(cfg.Linode.Image)
+	}
+	return defaultImage
+}
+
+func linodeServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if strings.TrimSpace(cfg.Linode.Type) != "" {
+		return strings.TrimSpace(cfg.Linode.Type)
+	}
+	return linodeServerTypeForClass(cfg.Class)
+}
+
+func linodeServerTypeForClass(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "standard", "fast", "large", "beast":
+		return defaultType
+	default:
+		return defaultType
+	}
+}
+
+func validateFoundationConfig(cfg core.Config) error {
+	if strings.TrimSpace(linodeRegionForConfig(cfg)) == "" {
+		return core.Exit(2, "linode region is required")
+	}
+	if strings.TrimSpace(linodeImageForConfig(cfg)) == "" {
+		return core.Exit(2, "linode image is required")
+	}
+	if strings.TrimSpace(linodeServerTypeForConfig(cfg)) == "" {
+		return core.Exit(2, "linode type is required")
+	}
+	return nil
+}

--- a/internal/providers/linode/provider.go
+++ b/internal/providers/linode/provider.go
@@ -1,7 +1,6 @@
 package linode
 
 import (
-	"context"
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -48,25 +47,9 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
-	return linodeFoundationBackend{spec: p.Spec()}, nil
+	return NewLinodeLeaseBackend(p.Spec(), cfg, rt), nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	return linodeFoundationBackend{spec: p.Spec()}, nil
-}
-
-type linodeFoundationBackend struct {
-	spec core.ProviderSpec
-}
-
-func (b linodeFoundationBackend) Spec() core.ProviderSpec {
-	return b.spec
-}
-
-func (b linodeFoundationBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
-	return core.DoctorResult{Provider: providerName, Status: "ok", Message: "provider foundation registered; lifecycle implemented in a later plan", Checks: []core.DoctorCheck{{
-		Check:   "linode-provider-foundation",
-		Status:  "ok",
-		Message: "provider foundation registered; lifecycle implemented in a later plan",
-	}}}, nil
+	return newLinodeLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/linode/provider.go
+++ b/internal/providers/linode/provider.go
@@ -1,0 +1,72 @@
+package linode
+
+import (
+	"context"
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const providerName = "linode"
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
+func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
+	return nil
+}
+
+func (p Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.Linode.Type != "" {
+		return cfg.Linode.Type
+	}
+	return linodeServerTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	return linodeServerTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return linodeFoundationBackend{spec: p.Spec()}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	return linodeFoundationBackend{spec: p.Spec()}, nil
+}
+
+type linodeFoundationBackend struct {
+	spec core.ProviderSpec
+}
+
+func (b linodeFoundationBackend) Spec() core.ProviderSpec {
+	return b.spec
+}
+
+func (b linodeFoundationBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
+	return core.DoctorResult{Provider: providerName, Status: "ok", Message: "provider foundation registered; lifecycle implemented in a later plan", Checks: []core.DoctorCheck{{
+		Check:   "linode-provider-foundation",
+		Status:  "ok",
+		Message: "provider foundation registered; lifecycle implemented in a later plan",
+	}}}, nil
+}

--- a/internal/providers/linode/provider_test.go
+++ b/internal/providers/linode/provider_test.go
@@ -1,0 +1,82 @@
+package linode
+
+import (
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName || spec.Family != providerName || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+}
+
+func TestProviderServerTypeDefaults(t *testing.T) {
+	if got := (Provider{}).ServerTypeForClass("standard"); got != defaultType {
+		t.Fatalf("ServerTypeForClass standard=%q", got)
+	}
+	if got := (Provider{}).ServerTypeForConfig(core.Config{ServerType: "g6-standard-2", ServerTypeExplicit: true}); got != "g6-standard-2" {
+		t.Fatalf("explicit ServerTypeForConfig=%q", got)
+	}
+	if got := (Provider{}).ServerTypeForConfig(core.Config{Linode: core.LinodeConfig{Type: "g6-nanode-1"}}); got != "g6-nanode-1" {
+		t.Fatalf("linode Type ServerTypeForConfig=%q", got)
+	}
+	if got := (Provider{}).ServerTypeForConfig(core.Config{ServerType: "cpx51"}); got != defaultType {
+		t.Fatalf("implicit cross-provider ServerTypeForConfig=%q", got)
+	}
+}
+
+func TestProviderForLinode(t *testing.T) {
+	provider, err := core.ProviderFor(providerName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.Name() != providerName {
+		t.Fatalf("provider=%s", provider.Name())
+	}
+}
+
+func TestConfigHelpers(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Linode = core.LinodeConfig{}
+	if got := linodeRegionForConfig(cfg); got != defaultRegion {
+		t.Fatalf("region=%q", got)
+	}
+	if got := linodeImageForConfig(cfg); got != defaultImage {
+		t.Fatalf("image=%q", got)
+	}
+	if got := linodeServerTypeForConfig(cfg); got != defaultType {
+		t.Fatalf("type=%q", got)
+	}
+	cfg.Linode.Region = "us-sea"
+	cfg.Linode.Image = "private/123"
+	cfg.Linode.Type = "g6-standard-2"
+	if err := validateFoundationConfig(cfg); err != nil {
+		t.Fatalf("validateFoundationConfig err=%v", err)
+	}
+}
+
+func TestRequireTokenUsesLinodeTokenOnly(t *testing.T) {
+	t.Setenv(tokenEnv, "")
+	if _, err := requireToken(); err == nil {
+		t.Fatal("requireToken succeeded without LINODE_TOKEN")
+	}
+	t.Setenv(tokenEnv, " secret ")
+	got, err := requireToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "secret" {
+		t.Fatalf("token=%q", got)
+	}
+}

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -1,0 +1,308 @@
+package linode
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	tagCrabbox                = "crabbox"
+	tagPrefix                 = "crabbox:"
+	ownershipTagConflictLabel = "_linode_ownership_tag_conflict"
+)
+
+var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
+
+func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
+	}
+	return tagsFromLabels(labels)
+}
+
+func tagsFromLabels(labels map[string]string) []string {
+	tags := []string{
+		tagCrabbox,
+		"crabbox:provider:" + providerName,
+		"crabbox:target:" + core.TargetLinux,
+	}
+	for _, key := range tagLabelKeys() {
+		if value := labels[key]; value != "" {
+			tags = append(tags, encodeTagKV(key, value))
+		}
+	}
+	return normalizeTags(tags)
+}
+
+func tagLabelKeys() []string {
+	return []string{
+		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
+		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
+		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
+		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
+		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
+	}
+}
+
+func encodeTagKV(key, value string) string {
+	key = sanitizeTagPart(key)
+	if exactTagValueKey(key) {
+		key += "_v1"
+		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
+	}
+	return tagPrefix + key + ":" + sanitizeTagPart(value)
+}
+
+func sanitizeTagPart(value string) string {
+	value = strings.TrimSpace(value)
+	value = tagSafeRe.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "unknown"
+	}
+	if len(value) > 64 {
+		return value[:64]
+	}
+	return value
+}
+
+func exactTagValueKey(key string) bool {
+	switch key {
+	case "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node":
+		return true
+	default:
+		return false
+	}
+}
+
+func versionedExactTagValueKey(key string) (string, bool) {
+	logical := strings.TrimSuffix(key, "_v1")
+	return logical, logical != key && exactTagValueKey(logical)
+}
+
+func legacyEncodedExactTagValueKey(key string) bool {
+	switch key {
+	case "tailscale_ipv4", "tailscale_fqdn", "tailscale_error":
+		return true
+	default:
+		return false
+	}
+}
+
+func encodeExactTagValue(value string, maxLen int) string {
+	value = strings.TrimSpace(value)
+	const hex = "0123456789abcdef"
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if (ch >= 'a' && ch <= 'z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == ':' {
+			if out.Len()+1 > maxLen {
+				break
+			}
+			out.WriteByte(ch)
+			continue
+		}
+		if out.Len()+3 > maxLen {
+			break
+		}
+		out.WriteByte('_')
+		out.WriteByte(hex[ch>>4])
+		out.WriteByte(hex[ch&0x0f])
+	}
+	if out.Len() == 0 {
+		return "unknown"
+	}
+	return out.String()
+}
+
+func decodeExactTagValue(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '_' && i+2 < len(value) {
+			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
+			if err == nil {
+				out.WriteByte(byte(decoded))
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(value[i])
+	}
+	return out.String()
+}
+
+func normalizeTags(tags []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func labelsFromTags(tags []string) map[string]string {
+	labels := map[string]string{}
+	ownershipConflicts := map[string]bool{}
+	versionedExact := map[string]string{}
+	versionedExactConflict := map[string]bool{}
+	legacyExact := map[string]string{}
+	legacyExactConflict := map[string]bool{}
+	for _, tag := range tags {
+		lowerTag := strings.ToLower(tag)
+		switch {
+		case lowerTag == tagCrabbox:
+			labels["crabbox"] = "true"
+			labels["created_by"] = "crabbox"
+		case strings.HasPrefix(lowerTag, tagPrefix):
+			parts := strings.SplitN(tag[len(tagPrefix):], ":", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			key := strings.ToLower(parts[0])
+			if logical, ok := versionedExactTagValueKey(key); ok {
+				recordExactTagValue(versionedExact, versionedExactConflict, logical, decodeExactTagValue(parts[1]))
+				continue
+			}
+			if exactTagValueKey(key) {
+				value := parts[1]
+				if legacyEncodedExactTagValueKey(key) {
+					value = decodeExactTagValue(value)
+				}
+				recordExactTagValue(legacyExact, legacyExactConflict, key, value)
+				continue
+			}
+			switch key {
+			case "provider", "lease", "slug", "target":
+				value := parts[1]
+				if key == "provider" || key == "target" {
+					value = strings.ToLower(value)
+				}
+				recordOwnershipTagValue(labels, ownershipConflicts, key, value)
+			case "keep", "class", "server_type", "provider_key", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
+				value := parts[1]
+				switch key {
+				case "keep", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
+					value = strings.ToLower(value)
+				}
+				labels[key] = value
+			case "state":
+				value := strings.ToLower(parts[1])
+				if statePriority(value) >= statePriority(labels["state"]) {
+					labels["state"] = value
+				}
+			case "expires_at", "last_touched_at":
+				if numericTagValue(parts[1]) >= numericTagValue(labels[key]) {
+					labels[key] = parts[1]
+				}
+			}
+		}
+	}
+	if len(ownershipConflicts) > 0 {
+		keys := make([]string, 0, len(ownershipConflicts))
+		for key := range ownershipConflicts {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
+	}
+	for _, key := range tagLabelKeys() {
+		if !exactTagValueKey(key) {
+			continue
+		}
+		if value, ok := versionedExact[key]; ok || versionedExactConflict[key] {
+			if ok && !versionedExactConflict[key] {
+				labels[key] = value
+			}
+			continue
+		}
+		if value, ok := legacyExact[key]; ok && !legacyExactConflict[key] {
+			labels[key] = value
+		}
+	}
+	return labels
+}
+
+func recordOwnershipTagValue(labels map[string]string, conflicts map[string]bool, key, value string) {
+	if conflicts[key] {
+		return
+	}
+	if existing, ok := labels[key]; ok && existing != value {
+		delete(labels, key)
+		conflicts[key] = true
+		return
+	}
+	labels[key] = value
+}
+
+func recordExactTagValue(values map[string]string, conflicts map[string]bool, key, value string) {
+	if conflicts[key] {
+		return
+	}
+	if existing, ok := values[key]; ok && existing != value {
+		delete(values, key)
+		conflicts[key] = true
+		return
+	}
+	values[key] = value
+}
+
+func statePriority(state string) int64 {
+	switch state {
+	case "running":
+		return 50
+	case "ready", "active":
+		return 40
+	case "leased":
+		return 30
+	case "provisioning":
+		return 20
+	case "":
+		return 0
+	default:
+		return 10
+	}
+}
+
+func numericTagValue(value string) int64 {
+	var n int64
+	for _, ch := range value {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		n = n*10 + int64(ch-'0')
+	}
+	return n
+}
+
+func isOwnedLinode(item linodeInstance) bool {
+	return validateLinodeLabels(labelsFromTags(item.Tags)) == nil
+}
+
+func validateLinodeLabels(labels map[string]string) error {
+	if labels == nil ||
+		labels[ownershipTagConflictLabel] != "" ||
+		labels["crabbox"] != "true" ||
+		labels["created_by"] != "crabbox" ||
+		labels["provider"] != providerName ||
+		labels["lease"] == "" ||
+		labels["slug"] == "" ||
+		labels["target"] != core.TargetLinux {
+		return core.Exit(2, "refusing to operate on non-Crabbox Linode instance")
+	}
+	return nil
+}

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -1,6 +1,7 @@
 package linode
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -14,6 +15,10 @@ const (
 	tagCrabbox                = "crabbox"
 	tagPrefix                 = "crabbox:"
 	ownershipTagConflictLabel = "_linode_ownership_tag_conflict"
+	maxLinodeTagLength        = 50
+	maxEncodedTagValueLength  = 255
+	tagChunkSuffix            = "_v2"
+	tagChunkHeaderLength      = 5
 )
 
 var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
@@ -35,7 +40,7 @@ func tagsFromLabels(labels map[string]string) []string {
 	}
 	for _, key := range tagLabelKeys() {
 		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
+			tags = append(tags, encodeTagKV(key, value)...)
 		}
 	}
 	return normalizeTags(tags)
@@ -51,13 +56,13 @@ func tagLabelKeys() []string {
 	}
 }
 
-func encodeTagKV(key, value string) string {
+func encodeTagKV(key, value string) []string {
 	key = sanitizeTagPart(key)
-	if exactTagValueKey(key) {
-		key += "_v1"
-		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
+	plain := tagPrefix + key + ":" + sanitizeTagPart(value)
+	if !exactTagValueKey(key) && len(plain) <= maxLinodeTagLength {
+		return []string{plain}
 	}
-	return tagPrefix + key + ":" + sanitizeTagPart(value)
+	return encodeChunkedTagKV(key, value)
 }
 
 func sanitizeTagPart(value string) string {
@@ -67,10 +72,31 @@ func sanitizeTagPart(value string) string {
 	if value == "" {
 		return "unknown"
 	}
-	if len(value) > 64 {
-		return value[:64]
-	}
 	return value
+}
+
+func encodeChunkedTagKV(key, value string) []string {
+	base := tagPrefix + key + tagChunkSuffix + ":"
+	chunkSize := maxLinodeTagLength - len(base) - tagChunkHeaderLength
+	if chunkSize <= 0 {
+		return nil
+	}
+	encoded := encodeExactTagValue(value, maxEncodedTagValueLength)
+	chunkCount := (len(encoded) + chunkSize - 1) / chunkSize
+	if chunkCount == 0 {
+		chunkCount = 1
+	}
+	if chunkCount > 99 {
+		chunkCount = 99
+		encoded = encoded[:chunkSize*chunkCount]
+	}
+	tags := make([]string, 0, chunkCount)
+	for index := 0; index < chunkCount; index++ {
+		start := index * chunkSize
+		end := min(start+chunkSize, len(encoded))
+		tags = append(tags, base+fmt.Sprintf("%02d%02d:", index, chunkCount)+encoded[start:end])
+	}
+	return tags
 }
 
 func exactTagValueKey(key string) bool {
@@ -85,6 +111,19 @@ func exactTagValueKey(key string) bool {
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
 	return logical, logical != key && exactTagValueKey(logical)
+}
+
+func chunkedTagValueKey(key string) (string, bool) {
+	logical := strings.TrimSuffix(key, tagChunkSuffix)
+	if logical == key {
+		return "", false
+	}
+	for _, candidate := range tagLabelKeys() {
+		if logical == candidate {
+			return logical, true
+		}
+	}
+	return "", false
 }
 
 func legacyEncodedExactTagValueKey(key string) bool {
@@ -155,9 +194,16 @@ func normalizeTags(tags []string) []string {
 	return out
 }
 
+type tagChunkSet struct {
+	total    int
+	parts    map[int]string
+	conflict bool
+}
+
 func labelsFromTags(tags []string) map[string]string {
 	labels := map[string]string{}
 	ownershipConflicts := map[string]bool{}
+	chunkedExact := map[string]*tagChunkSet{}
 	versionedExact := map[string]string{}
 	versionedExactConflict := map[string]bool{}
 	legacyExact := map[string]string{}
@@ -174,6 +220,10 @@ func labelsFromTags(tags []string) map[string]string {
 				continue
 			}
 			key := strings.ToLower(parts[0])
+			if logical, ok := chunkedTagValueKey(key); ok {
+				recordTagChunk(chunkedExact, logical, parts[1])
+				continue
+			}
 			if logical, ok := versionedExactTagValueKey(key); ok {
 				recordExactTagValue(versionedExact, versionedExactConflict, logical, decodeExactTagValue(parts[1]))
 				continue
@@ -186,29 +236,43 @@ func labelsFromTags(tags []string) map[string]string {
 				recordExactTagValue(legacyExact, legacyExactConflict, key, value)
 				continue
 			}
-			switch key {
-			case "provider", "lease", "slug", "target":
-				value := parts[1]
-				if key == "provider" || key == "target" {
-					value = strings.ToLower(value)
-				}
-				recordOwnershipTagValue(labels, ownershipConflicts, key, value)
-			case "keep", "class", "server_type", "provider_key", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
-				value := parts[1]
-				switch key {
-				case "keep", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
-					value = strings.ToLower(value)
-				}
-				labels[key] = value
-			case "state":
-				value := strings.ToLower(parts[1])
-				if statePriority(value) >= statePriority(labels["state"]) {
-					labels["state"] = value
-				}
-			case "expires_at", "last_touched_at":
-				if numericTagValue(parts[1]) >= numericTagValue(labels[key]) {
-					labels[key] = parts[1]
-				}
+			applyDecodedTagLabel(labels, ownershipConflicts, key, parts[1])
+		}
+	}
+	for key, chunks := range chunkedExact {
+		if chunks.conflict || chunks.total == 0 || len(chunks.parts) != chunks.total {
+			versionedExactConflict[key] = true
+			continue
+		}
+		var encoded strings.Builder
+		for index := 0; index < chunks.total; index++ {
+			part, ok := chunks.parts[index]
+			if !ok {
+				versionedExactConflict[key] = true
+				break
+			}
+			encoded.WriteString(part)
+		}
+		if !versionedExactConflict[key] {
+			recordExactTagValue(versionedExact, versionedExactConflict, key, decodeExactTagValue(encoded.String()))
+		}
+	}
+	for _, key := range tagLabelKeys() {
+		if value, ok := versionedExact[key]; ok || versionedExactConflict[key] {
+			delete(labels, key)
+			if ok && !versionedExactConflict[key] {
+				applyDecodedTagLabel(labels, ownershipConflicts, key, value)
+			} else if isOwnershipTagKey(key) {
+				ownershipConflicts[key] = true
+			}
+			continue
+		}
+		if value, ok := legacyExact[key]; ok || legacyExactConflict[key] {
+			delete(labels, key)
+			if ok && !legacyExactConflict[key] {
+				applyDecodedTagLabel(labels, ownershipConflicts, key, value)
+			} else if isOwnershipTagKey(key) {
+				ownershipConflicts[key] = true
 			}
 		}
 	}
@@ -220,21 +284,70 @@ func labelsFromTags(tags []string) map[string]string {
 		sort.Strings(keys)
 		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
 	}
-	for _, key := range tagLabelKeys() {
-		if !exactTagValueKey(key) {
-			continue
+	return labels
+}
+
+func recordTagChunk(chunks map[string]*tagChunkSet, key, value string) {
+	set := chunks[key]
+	if set == nil {
+		set = &tagChunkSet{parts: map[int]string{}}
+		chunks[key] = set
+	}
+	if len(value) < tagChunkHeaderLength || value[4] != ':' {
+		set.conflict = true
+		return
+	}
+	index, indexErr := strconv.Atoi(value[:2])
+	total, totalErr := strconv.Atoi(value[2:4])
+	if indexErr != nil || totalErr != nil || total < 1 || index >= total {
+		set.conflict = true
+		return
+	}
+	if set.total != 0 && set.total != total {
+		set.conflict = true
+		return
+	}
+	set.total = total
+	part := value[tagChunkHeaderLength:]
+	if existing, ok := set.parts[index]; ok && existing != part {
+		set.conflict = true
+		return
+	}
+	set.parts[index] = part
+}
+
+func applyDecodedTagLabel(labels map[string]string, ownershipConflicts map[string]bool, key, value string) {
+	switch key {
+	case "provider", "lease", "slug", "target":
+		if key == "provider" || key == "target" {
+			value = strings.ToLower(value)
 		}
-		if value, ok := versionedExact[key]; ok || versionedExactConflict[key] {
-			if ok && !versionedExactConflict[key] {
-				labels[key] = value
-			}
-			continue
+		recordOwnershipTagValue(labels, ownershipConflicts, key, value)
+	case "keep", "class", "server_type", "provider_key", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports", "tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node", "tailscale_exit_node_allow_lan_access":
+		switch key {
+		case "keep", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
+			value = strings.ToLower(value)
 		}
-		if value, ok := legacyExact[key]; ok && !legacyExactConflict[key] {
+		labels[key] = value
+	case "state":
+		value = strings.ToLower(value)
+		if statePriority(value) >= statePriority(labels["state"]) {
+			labels["state"] = value
+		}
+	case "expires_at", "last_touched_at":
+		if numericTagValue(value) >= numericTagValue(labels[key]) {
 			labels[key] = value
 		}
 	}
-	return labels
+}
+
+func isOwnershipTagKey(key string) bool {
+	switch key {
+	case "provider", "lease", "slug", "target":
+		return true
+	default:
+		return false
+	}
 }
 
 func recordOwnershipTagValue(labels map[string]string, conflicts map[string]bool, key, value string) {
@@ -259,6 +372,18 @@ func recordExactTagValue(values map[string]string, conflicts map[string]bool, ke
 		return
 	}
 	values[key] = value
+}
+
+func replaceCrabboxTags(existing, desired []string) []string {
+	tags := append([]string(nil), desired...)
+	for _, tag := range existing {
+		lower := strings.ToLower(strings.TrimSpace(tag))
+		if lower == tagCrabbox || strings.HasPrefix(lower, tagPrefix) {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+	return normalizeTags(tags)
 }
 
 func statePriority(state string) int64 {

--- a/internal/providers/linode/tags_test.go
+++ b/internal/providers/linode/tags_test.go
@@ -1,0 +1,88 @@
+package linode
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestLinodeLeaseTagsRoundTripOwnershipLabels(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = "g6-standard-1"
+	cfg.Tailscale.Enabled = true
+	cfg.Tailscale.Tags = []string{"tag:crabbox", "tag:ci runner"}
+	now := time.Unix(1700000000, 0).UTC()
+
+	labels := labelsFromTags(leaseTags(cfg, "cbx_test", "my-app", "ready", true, now))
+	for _, key := range []string{"crabbox", "created_by", "provider", "target", "lease", "slug", "state", "keep", "server_type", "provider_key"} {
+		if labels[key] == "" {
+			t.Fatalf("labels missing %s: %v", key, labels)
+		}
+	}
+	if labels["provider"] != providerName || labels["target"] != core.TargetLinux || labels["lease"] != "cbx_test" || labels["slug"] != "my-app" || labels["state"] != "ready" || labels["keep"] != "true" {
+		t.Fatalf("labels=%v", labels)
+	}
+	if labels["tailscale_tags"] != "tag:crabbox,tag:ci runner" {
+		t.Fatalf("tailscale_tags=%q", labels["tailscale_tags"])
+	}
+	if err := validateLinodeLabels(labels); err != nil {
+		t.Fatalf("validateLinodeLabels: %v", err)
+	}
+}
+
+func TestLinodeOwnershipConflictFailsClosed(t *testing.T) {
+	tags := []string{
+		tagCrabbox,
+		"crabbox:provider:linode",
+		"crabbox:provider:digitalocean",
+		"crabbox:target:linux",
+		"crabbox:lease:cbx_test",
+		"crabbox:slug:my-app",
+	}
+	labels := labelsFromTags(tags)
+	if labels[ownershipTagConflictLabel] != "provider" {
+		t.Fatalf("conflict label=%q labels=%v", labels[ownershipTagConflictLabel], labels)
+	}
+	if err := validateLinodeLabels(labels); err == nil || !strings.Contains(err.Error(), "non-Crabbox Linode") {
+		t.Fatalf("validate err=%v", err)
+	}
+}
+
+func TestLinodeOwnedPredicateRequiresCompleteTags(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	item := linodeInstance{ID: 1, Label: "crabbox-cbx_test-my-app", Tags: leaseTags(cfg, "cbx_test", "my-app", "ready", false, time.Unix(1, 0))}
+	if !isOwnedLinode(item) {
+		t.Fatalf("expected owned item")
+	}
+	item.Tags = []string{tagCrabbox, "crabbox:provider:linode", "crabbox:target:linux", "crabbox:lease:cbx_test"}
+	if isOwnedLinode(item) {
+		t.Fatalf("partial tags should not be owned")
+	}
+	item.Tags = []string{tagCrabbox, "crabbox:provider:aws", "crabbox:target:linux", "crabbox:lease:cbx_test", "crabbox:slug:my-app"}
+	if isOwnedLinode(item) {
+		t.Fatalf("foreign provider should not be owned")
+	}
+}
+
+func TestLinodeStateAndExpirationPreferSaferNewestValues(t *testing.T) {
+	labels := labelsFromTags([]string{
+		tagCrabbox,
+		"crabbox:provider:linode",
+		"crabbox:target:linux",
+		"crabbox:lease:cbx_test",
+		"crabbox:slug:my-app",
+		"crabbox:state:provisioning",
+		"crabbox:state:ready",
+		"crabbox:expires_at:100",
+		"crabbox:expires_at:200",
+	})
+	if labels["state"] != "ready" || labels["expires_at"] != "200" {
+		t.Fatalf("labels=%v", labels)
+	}
+}

--- a/internal/providers/linode/tags_test.go
+++ b/internal/providers/linode/tags_test.go
@@ -86,3 +86,49 @@ func TestLinodeStateAndExpirationPreferSaferNewestValues(t *testing.T) {
 		t.Fatalf("labels=%v", labels)
 	}
 }
+
+func TestLinodeTagsRespectLengthLimitAndRoundTripLongSlug(t *testing.T) {
+	slug := strings.Repeat("long-slug-", 6)
+	tags := tagsFromLabels(map[string]string{
+		"lease": "cbx_test",
+		"slug":  slug,
+	})
+	for _, tag := range tags {
+		if len(tag) > maxLinodeTagLength {
+			t.Fatalf("tag length=%d tag=%q", len(tag), tag)
+		}
+	}
+	if got := labelsFromTags(tags)["slug"]; got != slug {
+		t.Fatalf("slug=%q, want %q; tags=%v", got, slug, tags)
+	}
+}
+
+func TestLinodeMissingOwnershipTagChunkFailsClosed(t *testing.T) {
+	tags := tagsFromLabels(map[string]string{
+		"lease": "cbx_test",
+		"slug":  strings.Repeat("long-slug-", 6),
+	})
+	for i, tag := range tags {
+		if strings.HasPrefix(tag, "crabbox:slug_v2:") {
+			tags = append(tags[:i], tags[i+1:]...)
+			break
+		}
+	}
+	labels := labelsFromTags(tags)
+	if labels[ownershipTagConflictLabel] != "slug" {
+		t.Fatalf("labels=%v tags=%v", labels, tags)
+	}
+	if err := validateLinodeLabels(labels); err == nil {
+		t.Fatal("missing ownership chunk should fail closed")
+	}
+}
+
+func TestReplaceCrabboxTagsPreservesExternalTags(t *testing.T) {
+	got := replaceCrabboxTags(
+		[]string{"customer:production", "crabbox", "crabbox:state:ready"},
+		[]string{"crabbox", "crabbox:state:running"},
+	)
+	if !containsString(got, "customer:production") || containsString(got, "crabbox:state:ready") || !containsString(got, "crabbox:state:running") {
+		t.Fatalf("tags=%v", got)
+	}
+}

--- a/internal/providers/linode/types.go
+++ b/internal/providers/linode/types.go
@@ -1,0 +1,95 @@
+package linode
+
+type account struct {
+	Email string `json:"email"`
+}
+
+type linodeInstance struct {
+	ID      int64    `json:"id"`
+	Label   string   `json:"label"`
+	Status  string   `json:"status"`
+	Region  string   `json:"region"`
+	Type    string   `json:"type"`
+	Image   string   `json:"image"`
+	Tags    []string `json:"tags"`
+	IPv4    []string `json:"ipv4"`
+	IPv6    string   `json:"ipv6"`
+	Group   string   `json:"group"`
+	Created string   `json:"created"`
+	Updated string   `json:"updated"`
+}
+
+type createLinodeRequest struct {
+	Region         string             `json:"region"`
+	Type           string             `json:"type"`
+	Image          string             `json:"image"`
+	Label          string             `json:"label,omitempty"`
+	Tags           []string           `json:"tags,omitempty"`
+	AuthorizedKeys []string           `json:"authorized_keys,omitempty"`
+	RootPass       string             `json:"root_pass,omitempty"`
+	Metadata       *linodeMetadata    `json:"metadata,omitempty"`
+	FirewallID     int64              `json:"firewall_id,omitempty"`
+	Interfaces     []linodeInterface  `json:"interfaces,omitempty"`
+	PrivateIP      bool               `json:"private_ip,omitempty"`
+	StackScriptID  int64              `json:"stackscript_id,omitempty"`
+	StackScriptData map[string]string `json:"stackscript_data,omitempty"`
+}
+
+type linodeMetadata struct {
+	UserData string `json:"user_data,omitempty"`
+}
+
+type linodeInterface struct {
+	Purpose string `json:"purpose"`
+	Label   string `json:"label,omitempty"`
+}
+
+type linodeType struct {
+	ID       string  `json:"id"`
+	Label    string  `json:"label"`
+	Class    string  `json:"class"`
+	Memory   int     `json:"memory"`
+	Disk     int     `json:"disk"`
+	VCPUs    int     `json:"vcpus"`
+	Network  int     `json:"network_out"`
+	Price    linodePrice `json:"price"`
+	Addons   any     `json:"addons,omitempty"`
+}
+
+type linodePrice struct {
+	Hourly  float64 `json:"hourly"`
+	Monthly float64 `json:"monthly"`
+}
+
+type linodeImage struct {
+	ID          string   `json:"id"`
+	Label       string   `json:"label"`
+	Vendor      string   `json:"vendor"`
+	Deprecated  bool     `json:"deprecated"`
+	IsPublic    bool     `json:"is_public"`
+	Regions     []string `json:"regions"`
+	Description string   `json:"description"`
+}
+
+type linodeRegion struct {
+	ID      string   `json:"id"`
+	Label   string   `json:"label"`
+	Country string   `json:"country"`
+	Status  string   `json:"status"`
+	SiteType string   `json:"site_type"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type linodeFirewall struct {
+	ID      int64    `json:"id"`
+	Label   string   `json:"label"`
+	Status  string   `json:"status"`
+	Tags    []string `json:"tags"`
+	Created string   `json:"created"`
+	Updated string   `json:"updated"`
+}
+
+type firewallDeviceRequest struct {
+	ID   int64  `json:"id"`
+	Type string `json:"type"`
+}

--- a/internal/providers/linode/types.go
+++ b/internal/providers/linode/types.go
@@ -1,7 +1,11 @@
 package linode
 
 type account struct {
-	Email string `json:"email"`
+	EUUID string `json:"euuid"`
+}
+
+type accountSettings struct {
+	InterfacesForNewLinodes string `json:"interfaces_for_new_linodes"`
 }
 
 type linodeInstance struct {
@@ -20,19 +24,20 @@ type linodeInstance struct {
 }
 
 type createLinodeRequest struct {
-	Region          string            `json:"region"`
-	Type            string            `json:"type"`
-	Image           string            `json:"image"`
-	Label           string            `json:"label,omitempty"`
-	Tags            []string          `json:"tags,omitempty"`
-	AuthorizedKeys  []string          `json:"authorized_keys,omitempty"`
-	RootPass        string            `json:"root_pass,omitempty"`
-	Metadata        *linodeMetadata   `json:"metadata,omitempty"`
-	FirewallID      int64             `json:"firewall_id,omitempty"`
-	Interfaces      []linodeInterface `json:"interfaces,omitempty"`
-	PrivateIP       bool              `json:"private_ip,omitempty"`
-	StackScriptID   int64             `json:"stackscript_id,omitempty"`
-	StackScriptData map[string]string `json:"stackscript_data,omitempty"`
+	Region              string            `json:"region"`
+	Type                string            `json:"type"`
+	Image               string            `json:"image"`
+	Label               string            `json:"label,omitempty"`
+	Tags                []string          `json:"tags,omitempty"`
+	AuthorizedKeys      []string          `json:"authorized_keys,omitempty"`
+	RootPass            string            `json:"root_pass,omitempty"`
+	Metadata            *linodeMetadata   `json:"metadata,omitempty"`
+	FirewallID          int64             `json:"firewall_id,omitempty"`
+	InterfaceGeneration string            `json:"interface_generation,omitempty"`
+	Interfaces          []linodeInterface `json:"interfaces,omitempty"`
+	PrivateIP           bool              `json:"private_ip,omitempty"`
+	StackScriptID       int64             `json:"stackscript_id,omitempty"`
+	StackScriptData     map[string]string `json:"stackscript_data,omitempty"`
 }
 
 type linodeMetadata struct {
@@ -40,8 +45,10 @@ type linodeMetadata struct {
 }
 
 type linodeInterface struct {
-	Purpose string `json:"purpose"`
-	Label   string `json:"label,omitempty"`
+	Purpose    string    `json:"purpose,omitempty"`
+	Label      string    `json:"label,omitempty"`
+	FirewallID *int64    `json:"firewall_id,omitempty"`
+	Public     *struct{} `json:"public,omitempty"`
 }
 
 type linodeType struct {

--- a/internal/providers/linode/types.go
+++ b/internal/providers/linode/types.go
@@ -20,18 +20,18 @@ type linodeInstance struct {
 }
 
 type createLinodeRequest struct {
-	Region         string             `json:"region"`
-	Type           string             `json:"type"`
-	Image          string             `json:"image"`
-	Label          string             `json:"label,omitempty"`
-	Tags           []string           `json:"tags,omitempty"`
-	AuthorizedKeys []string           `json:"authorized_keys,omitempty"`
-	RootPass       string             `json:"root_pass,omitempty"`
-	Metadata       *linodeMetadata    `json:"metadata,omitempty"`
-	FirewallID     int64              `json:"firewall_id,omitempty"`
-	Interfaces     []linodeInterface  `json:"interfaces,omitempty"`
-	PrivateIP      bool               `json:"private_ip,omitempty"`
-	StackScriptID  int64              `json:"stackscript_id,omitempty"`
+	Region          string            `json:"region"`
+	Type            string            `json:"type"`
+	Image           string            `json:"image"`
+	Label           string            `json:"label,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	AuthorizedKeys  []string          `json:"authorized_keys,omitempty"`
+	RootPass        string            `json:"root_pass,omitempty"`
+	Metadata        *linodeMetadata   `json:"metadata,omitempty"`
+	FirewallID      int64             `json:"firewall_id,omitempty"`
+	Interfaces      []linodeInterface `json:"interfaces,omitempty"`
+	PrivateIP       bool              `json:"private_ip,omitempty"`
+	StackScriptID   int64             `json:"stackscript_id,omitempty"`
 	StackScriptData map[string]string `json:"stackscript_data,omitempty"`
 }
 
@@ -45,15 +45,15 @@ type linodeInterface struct {
 }
 
 type linodeType struct {
-	ID       string  `json:"id"`
-	Label    string  `json:"label"`
-	Class    string  `json:"class"`
-	Memory   int     `json:"memory"`
-	Disk     int     `json:"disk"`
-	VCPUs    int     `json:"vcpus"`
-	Network  int     `json:"network_out"`
-	Price    linodePrice `json:"price"`
-	Addons   any     `json:"addons,omitempty"`
+	ID      string      `json:"id"`
+	Label   string      `json:"label"`
+	Class   string      `json:"class"`
+	Memory  int         `json:"memory"`
+	Disk    int         `json:"disk"`
+	VCPUs   int         `json:"vcpus"`
+	Network int         `json:"network_out"`
+	Price   linodePrice `json:"price"`
+	Addons  any         `json:"addons,omitempty"`
 }
 
 type linodePrice struct {
@@ -72,11 +72,11 @@ type linodeImage struct {
 }
 
 type linodeRegion struct {
-	ID      string   `json:"id"`
-	Label   string   `json:"label"`
-	Country string   `json:"country"`
-	Status  string   `json:"status"`
-	SiteType string   `json:"site_type"`
+	ID           string   `json:"id"`
+	Label        string   `json:"label"`
+	Country      string   `json:"country"`
+	Status       string   `json:"status"`
+	SiteType     string   `json:"site_type"`
 	Capabilities []string `json:"capabilities"`
 }
 

--- a/scripts/live-linode-smoke.sh
+++ b/scripts/live-linode-smoke.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-linode}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ "$item" == "linode" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *capacity* || "$lower" == *"insufficient funds"* || "$lower" == *"account limit"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("Linode Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+raw_linode_has_slug() {
+  CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+import urllib.request
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+token = os.environ["LINODE_TOKEN"]
+slug_tag = f"crabbox:slug:{slug}".lower()
+name = f"crabbox-{slug}".lower()
+url = "https://api.linode.com/v4/linode/instances?page=1&page_size=500"
+
+try:
+    while url:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+        for item in payload.get("data", []):
+            tags = [str(tag).lower() for tag in item.get("tags", [])]
+            label = str(item.get("label", "")).lower()
+            if slug_tag in tags or label == name:
+                sys.exit(0)
+        page = int(payload.get("page") or 1)
+        pages = int(payload.get("pages") or page)
+        url = f"https://api.linode.com/v4/linode/instances?page={page + 1}&page_size=500" if page < pages else ""
+except Exception:
+    sys.exit(2)
+
+sys.exit(1)
+'
+}
+
+local_testbox_key_snapshot() {
+  local roots=(
+    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
+    "$HOME/Library/Application Support/crabbox/testboxes"
+  )
+  local root
+  for root in "${roots[@]}"; do
+    if [ -d "$root" ]; then
+      find "$root" -type f -print
+    fi
+  done | sort -u
+}
+
+cleanup_armed=0
+slug="linode-smoke-$(date +%Y%m%d%H%M%S)-$$"
+config_file=""
+initial_local_key_snapshot=""
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    local cleanup_output=""
+    local cleanup_status=1
+    local attempt
+    for attempt in 1 2 3; do
+      set +e
+      cleanup_output="$(bin/crabbox stop --provider linode "$slug" 2>&1)"
+      cleanup_status=$?
+      set -e
+      if [ "$cleanup_status" -eq 0 ]; then
+        cleanup_armed=0
+        break
+      fi
+      local lower_cleanup_output
+      lower_cleanup_output="$(printf '%s' "$cleanup_output" | tr '[:upper:]' '[:lower:]')"
+      if [ "$cleanup_status" -ne 4 ] || [[ "$lower_cleanup_output" != *"lease/linode not found:"* ]]; then
+        sleep 2
+        continue
+      fi
+      local slug_status=2
+      set +e
+      raw_linode_has_slug >/dev/null 2>&1
+      slug_status=$?
+      set -e
+      if [ "$slug_status" -eq 1 ]; then
+        local current_local_key_snapshot
+        current_local_key_snapshot="$(local_testbox_key_snapshot)"
+        if [ "$current_local_key_snapshot" = "$initial_local_key_snapshot" ]; then
+          cleanup_status=0
+          cleanup_armed=0
+          break
+        fi
+      fi
+      sleep 2
+    done
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider linode $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  if [ -n "$config_file" ]; then
+    rm -f "$config_file"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=linode_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+if [[ -z "${LINODE_TOKEN:-}" ]]; then
+  printf 'classification=environment_blocked reason=LINODE_TOKEN_missing\n'
+  exit 0
+fi
+
+mkdir -p bin
+go build -trimpath -o bin/crabbox ./cmd/crabbox
+
+config_file="$(mktemp)"
+cat >"$config_file" <<'YAML'
+provider: linode
+target: linux
+linode:
+  region: us-ord
+  image: linode/ubuntu24.04
+  type: g6-standard-1
+YAML
+
+export CRABBOX_CONFIG="$config_file"
+export CRABBOX_COORDINATOR=
+export LINODE_TOKEN
+
+doctor_output="$(run_capture "bin/crabbox doctor --provider linode" bin/crabbox doctor --provider linode)"
+printf '%s\n' "$doctor_output"
+initial_list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
+validate_list_json_empty "bin/crabbox list --provider linode --json" "$initial_list_output"
+initial_local_key_snapshot="$(local_testbox_key_snapshot)"
+cleanup_armed=1
+run_capture "bin/crabbox warmup --provider linode --slug $slug --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider linode --slug "$slug" --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "bin/crabbox status --provider linode --id $slug --wait --wait-timeout 300s" bin/crabbox status --provider linode --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_capture "bin/crabbox run --provider linode --id $slug --no-sync -- echo ok" bin/crabbox run --provider linode --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
+printf '%s\n' "$list_output"
+validate_list_json_contains_slug "bin/crabbox list --provider linode --json" "$list_output"
+run_capture "bin/crabbox stop --provider linode $slug" bin/crabbox stop --provider linode "$slug" >/dev/null
+cleanup_armed=0
+cleanup_output="$(run_capture "bin/crabbox cleanup --provider linode --dry-run" bin/crabbox cleanup --provider linode --dry-run)"
+post_list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
+validate_list_json_empty "bin/crabbox list --provider linode --json" "$post_list_output"
+printf '%s\n' "$cleanup_output"
+printf '%s\n' "$post_list_output"
+printf 'classification=live_linode_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-linode-smoke.sh
+++ b/scripts/live-linode-smoke.sh
@@ -184,7 +184,9 @@ cleanup() {
     local cleanup_output=""
     local cleanup_status=1
     local attempt
-    for attempt in 1 2 3; do
+    local cleanup_attempts=65
+    local cleanup_poll_seconds=2
+    for ((attempt = 1; attempt <= cleanup_attempts; attempt++)); do
       set +e
       cleanup_output="$(bin/crabbox stop --provider linode "$slug" 2>&1)"
       cleanup_status=$?
@@ -196,7 +198,9 @@ cleanup() {
       local lower_cleanup_output
       lower_cleanup_output="$(printf '%s' "$cleanup_output" | tr '[:upper:]' '[:lower:]')"
       if [ "$cleanup_status" -ne 4 ] || [[ "$lower_cleanup_output" != *"lease/linode not found:"* ]]; then
-        sleep 2
+        if [ "$attempt" -lt "$cleanup_attempts" ]; then
+          sleep "$cleanup_poll_seconds"
+        fi
         continue
       fi
       local slug_status=2
@@ -213,7 +217,9 @@ cleanup() {
           break
         fi
       fi
-      sleep 2
+      if [ "$attempt" -lt "$cleanup_attempts" ]; then
+        sleep "$cleanup_poll_seconds"
+      fi
     done
     if [ "$cleanup_status" -ne 0 ]; then
       printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider linode $slug" "$cleanup_status" "$slug" >&2

--- a/scripts/live-linode-smoke.test.js
+++ b/scripts/live-linode-smoke.test.js
@@ -243,6 +243,62 @@ exit 99
   assert.doesNotMatch(fs.readFileSync(calls, "utf8"), /^cleanup /m);
 });
 
+test("live linode smoke retries cleanup through ambiguous-create recovery", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-recovery-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopAttempts = path.join(dir, "stop-attempts.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 0);
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf 'indeterminate create\\n' >&2
+    exit 37
+    ;;
+  stop)
+    printf 'attempt\\n' >>"${stopAttempts}"
+    attempts="$(wc -l <"${stopAttempts}" | tr -d ' ')"
+    if [[ "$attempts" -lt 4 ]]; then
+      printf 'lease/linode not found: %s\\n' "$4" >&2
+      exit 4
+    fi
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.equal(fs.readFileSync(stopAttempts, "utf8"), "attempt\nattempt\nattempt\nattempt\n");
+  assert.doesNotMatch(result.stderr, /classification=cleanup_failed/);
+});
+
 test("live linode smoke refuses a non-empty inventory before mutation", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-nonempty-"));
   const binDir = path.join(dir, "bin");

--- a/scripts/live-linode-smoke.test.js
+++ b/scripts/live-linode-smoke.test.js
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function writeRawInventoryPythonStub(binDir, rawStatus) {
+  const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(python, "python3 is required for smoke tests");
+  writeExecutable(
+    path.join(binDir, "python3"),
+    `#!/usr/bin/env bash
+if [[ "$*" == *"urllib.request"* ]]; then
+  exit ${rawStatus}
+fi
+exec ${JSON.stringify(python)} "$@"
+`,
+  );
+}
+
+function prepareSmokeRepo(dir) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, "live-linode-smoke.sh");
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, "scripts", "live-linode-smoke.sh"), smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}
+
+test("live linode smoke skips unless opted in", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-skip-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: { ...process.env, CRABBOX_LIVE: "", LINODE_TOKEN: "" },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_LIVE_not_enabled/);
+});
+
+test("live linode smoke skips unless provider filter selects linode", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-filter-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "aws,digitalocean",
+      LINODE_TOKEN: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=linode_not_selected/);
+});
+
+test("live linode smoke requires token before building", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-token-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=LINODE_TOKEN_missing/);
+});
+
+test("live linode smoke runs guarded lifecycle and redacts token", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${LINODE_TOKEN:-}" != "test-secret-token" ]]; then
+  printf 'missing token\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 runtime=unchecked default_type=g6-standard-1 region=us-ord image=linode/ubuntu24.04\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip server id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_linode_smoke_passed/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-secret-token/);
+
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider linode");
+  assert.equal(seen[1], "list --provider linode --json");
+  assert.match(seen[2], /^warmup --provider linode --slug linode-smoke-\d{14}-\d+ --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider linode --id linode-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider linode --id linode-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider linode --json");
+  assert.match(seen[6], /^stop --provider linode linode-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "cleanup --provider linode --dry-run");
+  assert.equal(seen[8], "list --provider linode --json");
+});
+
+test("live linode smoke attempts cleanup after partial failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopped = path.join(dir, "stopped.log");
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "$1" == "doctor" ]]; then
+  printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "list" ]]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'created linode before failing\\n' >&2
+  exit 37
+fi
+if [[ "$1" == "stop" ]]; then
+  printf '%s\\n' "$4" >>"${stopped}"
+  exit 0
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=environment_blocked/);
+  assert.match(result.stderr, /created linode before failing/);
+  assert.match(fs.readFileSync(stopped, "utf8"), /^linode-smoke-\d{14}-\d+\n$/);
+  assert.doesNotMatch(fs.readFileSync(calls, "utf8"), /^cleanup /m);
+});
+
+test("live linode smoke refuses a non-empty inventory before mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-nonempty-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[{"labels":{"slug":"existing"}}]\\n'
+    ;;
+  *)
+    printf 'mutation must not run\\n' >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /inventory is not empty/);
+  assert.deepEqual(fs.readFileSync(calls, "utf8").trim().split("\n"), [
+    "doctor --provider linode",
+    "list --provider linode --json",
+  ]);
+});


### PR DESCRIPTION
## Summary

Adds a direct SSH lease provider for Linode/Akamai as `provider: linode`, modeled after the existing direct cloud lease providers.

- Registers the Linode provider for Linux SSH leases with config/env support for region, image, type, firewall ID, and SSH CIDR metadata.
- Implements Linode create/list/resolve/touch/release/cleanup flows with ownership tags, local lease claims, recovery handling, account checks, SSH key cleanup, Tailscale metadata, and fail-closed validation.
- Adds provider docs plus a guarded live smoke script that is skipped unless explicitly opted in with live credentials.

## Safety and behavior notes

- Invalid non-empty Linode firewall IDs fail before provisioning instead of silently creating without the requested firewall.
- Unsupported explicit portable OS selectors fail before provisioning unless an explicit Linode image is supplied.
- Linode image creates include a generated root password only in the API create request; SSH access still uses Crabbox-managed keys, and error redaction covers `root_pass`.
- The live smoke path is credential-bound and opt-in only; it does not run during normal tests.

## Verification

- `gofmt -w $(git ls-files '*.go') && git diff --exit-code -- '*.go'`
- `go test ./internal/providers/linode ./internal/cli ./internal/providers/digitalocean ./internal/providers/hetzner`
- `go test ./...`
- `go vet ./...`
- `node --test scripts/live-linode-smoke.test.js`
- `node scripts/check-docs-links.mjs`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings

Live Linode provisioning was not run because it requires explicit credentials and would create cloud resources. The included smoke script and unit tests cover the guarded behavior, redaction, cleanup-on-failure path, and refusal to mutate when inventory is non-empty.

## Related

- Closes https://github.com/openclaw/crabbox/issues/275
- Follows up on https://github.com/openclaw/crabbox/issues/275#issuecomment-4688116411
