### PR TITLE
fix: preserve external lease routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - Fixed `stop` and `pond release` to preserve claims, SSH credentials, lifecycle metadata, and restart routing when providers intentionally retain reusable stopped resources.
+- Fixed external lease commands to reuse each lease's persisted provider routing after the current external configuration changes.
 - Fixed `local-container` stop cleanup when a Docker container was removed externally, including stale claim and stored-key removal. Thanks @hxy91819.
 - Fixed Apple VZ release artifacts to target macOS 13, bounded guest serial logs without blocking noisy VMs, escaped terminal controls in diagnostics, and preserved retained lease state when helper inventory lookup fails.
 - Fixed DigitalOcean capability-tag persistence, provider config visibility and precedence, account-scoped ambiguous Droplet/SSH-key create recovery, retryable cleanup, and unnecessary monitoring-agent installation.

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -69,18 +69,11 @@ func (a App) webCode(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox code --id <lease-id-or-slug>")
 	}
-	cfg, err := loadConfig()
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id})
 	if err != nil {
 		return err
 	}
-	cfg.Provider = *provider
 	cfg.Code = true
-	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
-		return err
-	}
-	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
-		return err
-	}
 	if err := validateRequestedCapabilities(cfg); err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -17,6 +17,7 @@ import (
 type Config struct {
 	Profile                       string
 	Provider                      string
+	providerExplicit              bool
 	TargetOS                      string
 	targetExplicit                bool
 	Architecture                  string
@@ -247,13 +248,14 @@ type KubeVirtConfig struct {
 }
 
 type ExternalConfig struct {
-	Command     string
-	Args        []string
-	Config      map[string]any
-	Lifecycle   ExternalLifecycleConfig
-	Connection  ExternalConnectionConfig
-	WorkRoot    string
-	RoutingFile string
+	Command       string
+	Args          []string
+	Config        map[string]any
+	Lifecycle     ExternalLifecycleConfig
+	Connection    ExternalConnectionConfig
+	WorkRoot      string
+	RoutingFile   string
+	routingLoaded bool
 }
 
 type ExternalLifecycleConfig struct {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	providerExplicit              bool
 	TargetOS                      string
 	targetExplicit                bool
+	targetFlagExplicit            bool
 	Architecture                  string
 	architectureExplicit          bool
 	OSImage                       string
@@ -27,6 +28,7 @@ type Config struct {
 	osImageProviderDefaults       string
 	WindowsMode                   string
 	explicitWindowsMode           string
+	windowsModeFlagExplicit       bool
 	Desktop                       bool
 	DesktopEnv                    string
 	Browser                       bool

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -47,19 +47,11 @@ func (a App) desktopLaunchWithCommand(ctx context.Context, args []string, comman
 		*id = fs.Arg(0)
 		positionalID = true
 	}
-	cfg, err := loadConfig()
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
 		return err
 	}
-	cfg.Provider = *provider
-	cfg.Desktop = true
 	cfg.Browser = *browser
-	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
-		return err
-	}
-	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
-		return err
-	}
 	if err := validateRequestedCapabilities(cfg); err != nil {
 		return err
 	}
@@ -192,16 +184,8 @@ func (a App) desktopTerminal(ctx context.Context, args []string) error {
 		*id = fs.Arg(0)
 		positionalID = true
 	}
-	cfg, err := loadConfig()
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
-		return err
-	}
-	cfg.Provider = *provider
-	cfg.Desktop = true
-	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
-		return err
-	}
-	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
 		return err
 	}
 	if err := validateRequestedCapabilities(cfg); err != nil {
@@ -384,16 +368,8 @@ func (a App) desktopProof(ctx context.Context, args []string) error {
 		*id = fs.Arg(0)
 		positionalID = true
 	}
-	cfg, err := loadConfig()
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: *id, Desktop: true})
 	if err != nil {
-		return err
-	}
-	cfg.Provider = *provider
-	cfg.Desktop = true
-	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
-		return err
-	}
-	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {
 		return err
 	}
 	if err := validateRequestedCapabilities(cfg); err != nil {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -172,6 +172,9 @@ func (a App) doctor(ctx context.Context, args []string) error {
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return err
 	}
+	if err := autoRouteExternalLease(&cfg, fs, resolvedDoctorID); err != nil {
+		return err
+	}
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}

--- a/internal/cli/external_routing.go
+++ b/internal/cli/external_routing.go
@@ -94,14 +94,19 @@ func LoadExternalRouting(path string) (ExternalConfig, error) {
 		return ExternalConfig{}, fmt.Errorf("parse external routing file: %w", err)
 	}
 	return ExternalConfig{
-		Command:     state.Command,
-		Args:        append([]string(nil), state.Args...),
-		Config:      state.Config,
-		Lifecycle:   state.Lifecycle,
-		Connection:  state.Connection,
-		WorkRoot:    state.WorkRoot,
-		RoutingFile: path,
+		Command:       state.Command,
+		Args:          append([]string(nil), state.Args...),
+		Config:        state.Config,
+		Lifecycle:     state.Lifecycle,
+		Connection:    state.Connection,
+		WorkRoot:      state.WorkRoot,
+		RoutingFile:   path,
+		routingLoaded: true,
 	}, nil
+}
+
+func ExternalRoutingLoaded(cfg ExternalConfig) bool {
+	return cfg.routingLoaded
 }
 
 func RemoveExternalRouting(leaseID string) {

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"context"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestExternalRoutingRoundTripUsesPrivateHashedPath(t *testing.T) {
@@ -96,5 +100,200 @@ func TestLoadExternalRoutingRejectsBroadPermissions(t *testing.T) {
 	}
 	if _, err := LoadExternalRouting(path); err == nil {
 		t.Fatal("expected insecure routing file rejection")
+	}
+}
+
+func TestAutoRouteExternalLeaseUsesPersistedClaimRouting(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	leaseID := "cbx_abcdef123456"
+	oldRouting := ExternalConfig{
+		Command:  "old-provider",
+		Args:     []string{"release"},
+		WorkRoot: "/old/work",
+	}
+	wantPath, err := PersistExternalRouting(leaseID, oldRouting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(
+		leaseID,
+		"old-box",
+		"external",
+		"old-scope",
+		root,
+		time.Minute,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.External = ExternalConfig{Command: "new-provider", WorkRoot: "/new/work"}
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	fs := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&cfg, fs, "old-box"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.RoutingFile != wantPath {
+		t.Fatalf("routing file=%q, want %q", cfg.External.RoutingFile, wantPath)
+	}
+	if cfg.External.Command != oldRouting.Command || cfg.External.WorkRoot != oldRouting.WorkRoot || cfg.WorkRoot != oldRouting.WorkRoot {
+		t.Fatalf("config=%#v", cfg)
+	}
+	if cfg.TargetOS != targetLinux || cfg.WindowsMode != windowsModeNormal {
+		t.Fatalf("target=%s windows-mode=%s", cfg.TargetOS, cfg.WindowsMode)
+	}
+}
+
+func TestAutoRouteExternalLeaseRejectsAmbiguousAlias(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
+		if _, err := PersistExternalRouting(leaseID, ExternalConfig{Command: "provider", WorkRoot: "/work/crabbox"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := claimLeaseForRepoProviderScope(leaseID, "shared-alias", "external", leaseID, root, time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exact := baseConfig()
+	exactFS := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&exact, exactFS, "cbx_111111111111"); err != nil {
+		t.Fatalf("exact lease id should remain authoritative: %v", err)
+	}
+	cfg := baseConfig()
+	fs := newFlagSet("test", os.Stderr)
+	err := autoRouteExternalLease(&cfg, fs, "shared-alias")
+	if err == nil || !strings.Contains(err.Error(), "multiple lease claims") {
+		t.Fatalf("err=%v", err)
+	}
+	selected := baseConfig()
+	selected.Provider = "external"
+	selectedFS := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&selected, selectedFS, "shared-alias"); err != nil {
+		t.Fatalf("configured external scope should resolve duplicate aliases: %v", err)
+	}
+	if selected.External.RoutingFile != "" {
+		t.Fatalf("duplicate alias should defer to configured scope, routing=%q", selected.External.RoutingFile)
+	}
+}
+
+func TestAutoRouteExternalLeaseRejectsCrossProviderAliasCollision(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	if _, err := PersistExternalRouting("cbx_111111111111", ExternalConfig{Command: "provider", WorkRoot: "/work/crabbox"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		leaseID  string
+		provider string
+	}{{"cbx_111111111111", "external"}, {"cbx_222222222222", "aws"}} {
+		if err := claimLeaseForRepoProviderScope(tc.leaseID, "shared-alias", tc.provider, tc.leaseID, root, time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := baseConfig()
+	fs := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&cfg, fs, "shared-alias"); err == nil || !strings.Contains(err.Error(), "multiple lease claims") {
+		t.Fatalf("err=%v", err)
+	}
+
+	explicit := baseConfig()
+	explicit.Provider = "external"
+	explicitFS := newFlagSet("test", os.Stderr)
+	explicitFS.String("provider", "external", "")
+	if err := explicitFS.Set("provider", "external"); err != nil {
+		t.Fatal(err)
+	}
+	if err := autoRouteExternalLease(&explicit, explicitFS, "shared-alias"); err != nil {
+		t.Fatalf("explicit external provider should disambiguate: %v", err)
+	}
+}
+
+func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	var selectedPath string
+	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
+		path, err := PersistExternalRouting(leaseID, ExternalConfig{Command: leaseID, WorkRoot: "/work/crabbox"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if selectedPath == "" {
+			selectedPath = path
+		}
+		if err := claimLeaseForRepoProviderScope(leaseID, "shared-alias", "external", leaseID, root, time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.External.RoutingFile = selectedPath
+	fs := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&cfg, fs, "shared-alias"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.RoutingFile != selectedPath {
+		t.Fatalf("routing file=%q, want %q", cfg.External.RoutingFile, selectedPath)
+	}
+}
+
+func TestRunExistingExternalLeaseLoadsPersistedRoutingBeforeValidation(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	leaseID := "cbx_abcdef123456"
+	oldRouting := ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}
+	if _, err := PersistExternalRouting(leaseID, oldRouting); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(leaseID, "old-box", "external", "old-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+
+	defaults := baseConfig()
+	defaults.Provider = "external"
+	defaults.External = ExternalConfig{WorkRoot: "/new/work"}
+	fs := newFlagSet("run", os.Stderr)
+	values := registerLeaseCreateFlags(fs, defaults)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaults
+	if err := applyLeaseCreateFlagsForLease(&cfg, fs, values, "old-box"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.Command != oldRouting.Command || cfg.WorkRoot != oldRouting.WorkRoot {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
+func TestResolveLeaseTargetUsesPersistedExternalRouting(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	leaseID := "cbx_abcdef123456"
+	oldRouting := ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}
+	if _, err := PersistExternalRouting(leaseID, oldRouting); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(leaseID, "old-box", "external", "old-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	app := App{Stdout: os.Stdout, Stderr: os.Stderr}
+	server, _, gotLeaseID, err := app.resolveLeaseTargetWithConfig(context.Background(), &cfg, "old-box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "external" || cfg.External.Command != oldRouting.Command || server.Name != oldRouting.Command || gotLeaseID != "old-box" {
+		t.Fatalf("config=%#v server=%#v lease=%q", cfg, server, gotLeaseID)
 	}
 }

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -231,6 +231,12 @@ func TestAutoRouteExternalLeaseFailsClosedWithoutRoutingState(t *testing.T) {
 	if err := autoRouteExternalLease(&cfg, fs, "old-box"); err == nil || !strings.Contains(err.Error(), "routing state is missing") {
 		t.Fatalf("err=%v", err)
 	}
+	selected := baseConfig()
+	selected.Provider = "external"
+	selected.External = ExternalConfig{Command: "current-provider", WorkRoot: "/work/crabbox"}
+	if err := routeExternalLeaseClaim(&selected, leaseID); err == nil || !strings.Contains(err.Error(), "refusing unverified cleanup") {
+		t.Fatalf("forced route err=%v", err)
+	}
 }
 
 func TestTargetLinuxClearsAmbientWindowsMode(t *testing.T) {
@@ -247,6 +253,25 @@ func TestTargetLinuxClearsAmbientWindowsMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.TargetOS != targetLinux || cfg.WindowsMode != windowsModeNormal || cfg.explicitWindowsMode != "" {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
+func TestExplicitExternalRoutingRestoresLinuxTarget(t *testing.T) {
+	cfg := baseConfig()
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	fs := newFlagSet("test", os.Stderr)
+	provider := fs.String("provider", cfg.Provider, "")
+	fs.String("external-routing-file", "", "")
+	if err := parseFlags(fs, []string{"--provider", "external", "--external-routing-file", "/tmp/route.json"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Provider = *provider
+	if err := autoRouteExternalLease(&cfg, fs, "old-box"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "external" || cfg.TargetOS != targetLinux || cfg.WindowsMode != windowsModeNormal {
 		t.Fatalf("config=%#v", cfg)
 	}
 }

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -375,7 +375,7 @@ func TestResolveLeaseTargetUsesPersistedExternalRouting(t *testing.T) {
 	}
 	cfg := baseConfig()
 	app := App{Stdout: os.Stdout, Stderr: os.Stderr}
-	server, _, gotLeaseID, err := app.resolveLeaseTargetWithConfig(context.Background(), &cfg, "old-box")
+	server, _, gotLeaseID, err := app.resolveLeaseTargetWithRequestConfig(context.Background(), &cfg, ResolveRequest{ID: "old-box"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -245,6 +245,36 @@ func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
 	}
 }
 
+func TestRouteExternalLeaseClaimOverridesAmbientRouting(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	paths := map[string]string{}
+	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
+		path, err := PersistExternalRouting(leaseID, ExternalConfig{Command: leaseID, WorkRoot: "/work/crabbox"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		paths[leaseID] = path
+		if err := claimLeaseForRepoProviderScope(leaseID, leaseID, "external", leaseID, root, time.Minute, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ambient, err := LoadExternalRouting(paths["cbx_111111111111"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.External = ambient
+	if err := routeExternalLeaseClaim(&cfg, "cbx_222222222222"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.RoutingFile != paths["cbx_222222222222"] || cfg.External.Command != "cbx_222222222222" {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
 func TestRunExistingExternalLeaseLoadsPersistedRoutingBeforeValidation(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", root)

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -133,7 +133,9 @@ func TestAutoRouteExternalLeaseUsesPersistedClaimRouting(t *testing.T) {
 	cfg.Provider = "external"
 	cfg.External = ExternalConfig{Command: "new-provider", WorkRoot: "/new/work"}
 	cfg.TargetOS = targetWindows
+	cfg.targetExplicit = true
 	cfg.WindowsMode = windowsModeWSL2
+	cfg.explicitWindowsMode = windowsModeWSL2
 	fs := newFlagSet("test", os.Stderr)
 	if err := autoRouteExternalLease(&cfg, fs, "old-box"); err != nil {
 		t.Fatal(err)
@@ -242,6 +244,9 @@ func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
 	}
 	if cfg.External.RoutingFile != selectedPath {
 		t.Fatalf("routing file=%q, want %q", cfg.External.RoutingFile, selectedPath)
+	}
+	if cfg.External.Command != "cbx_111111111111" || !cfg.External.routingLoaded {
+		t.Fatalf("configured routing was not loaded: %#v", cfg.External)
 	}
 }
 

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -297,3 +297,31 @@ func TestResolveLeaseTargetUsesPersistedExternalRouting(t *testing.T) {
 		t.Fatalf("config=%#v server=%#v lease=%q", cfg, server, gotLeaseID)
 	}
 }
+
+func TestLeaseTargetConfigPreservesExplicitNonExternalProvider(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	leaseID := "cbx_abcdef123456"
+	if _, err := PersistExternalRouting(leaseID, ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseForRepoProviderScope(leaseID, "old-box", "external", "old-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	defaults := baseConfig()
+	fs := newFlagSet("code", os.Stderr)
+	provider := fs.String("provider", defaults.Provider, "")
+	targetFlags := registerTargetFlags(fs, defaults)
+	networkFlags := registerNetworkModeFlag(fs, defaults)
+	if err := parseFlags(fs, []string{"--provider", "aws"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLeaseTargetConfig(fs, *provider, targetFlags, networkFlags, leaseTargetConfigOptions{LeaseID: "old-box"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "aws" || cfg.External.RoutingFile != "" || !cfg.providerExplicit {
+		t.Fatalf("config=%#v", cfg)
+	}
+}

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -9,8 +9,17 @@ import (
 	"time"
 )
 
+func setExternalRoutingTestHome(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	return root
+}
+
 func TestExternalRoutingRoundTripUsesPrivateHashedPath(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setExternalRoutingTestHome(t)
 	cfg := ExternalConfig{
 		Command:  "node",
 		Args:     []string{"/tmp/provider.mjs", "--token", "secret-arg"},
@@ -43,7 +52,7 @@ func TestExternalRoutingRoundTripUsesPrivateHashedPath(t *testing.T) {
 }
 
 func TestDeclarativeExternalRoutingRoundTrip(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setExternalRoutingTestHome(t)
 	cfg := ExternalConfig{
 		Config: map[string]any{"size": "cpu16"},
 		Lifecycle: ExternalLifecycleConfig{
@@ -104,9 +113,7 @@ func TestLoadExternalRoutingRejectsBroadPermissions(t *testing.T) {
 }
 
 func TestAutoRouteExternalLeaseUsesPersistedClaimRouting(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	leaseID := "cbx_abcdef123456"
 	oldRouting := ExternalConfig{
 		Command:  "old-provider",
@@ -152,9 +159,7 @@ func TestAutoRouteExternalLeaseUsesPersistedClaimRouting(t *testing.T) {
 }
 
 func TestAutoRouteExternalLeaseRejectsAmbiguousAlias(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
 		if _, err := PersistExternalRouting(leaseID, ExternalConfig{Command: "provider", WorkRoot: "/work/crabbox"}); err != nil {
 			t.Fatal(err)
@@ -186,9 +191,7 @@ func TestAutoRouteExternalLeaseRejectsAmbiguousAlias(t *testing.T) {
 }
 
 func TestAutoRouteExternalLeaseRejectsCrossProviderAliasCollision(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	if _, err := PersistExternalRouting("cbx_111111111111", ExternalConfig{Command: "provider", WorkRoot: "/work/crabbox"}); err != nil {
 		t.Fatal(err)
 	}
@@ -219,9 +222,7 @@ func TestAutoRouteExternalLeaseRejectsCrossProviderAliasCollision(t *testing.T) 
 }
 
 func TestAutoRouteExternalLeaseFailsClosedWithoutRoutingState(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	leaseID := "cbx_abcdef123456"
 	if err := claimLeaseForRepoProviderScope(leaseID, "old-box", "external", "old-scope", root, time.Minute, false); err != nil {
 		t.Fatal(err)
@@ -277,9 +278,7 @@ func TestExplicitExternalRoutingRestoresLinuxTarget(t *testing.T) {
 }
 
 func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	var selectedPath string
 	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
 		path, err := PersistExternalRouting(leaseID, ExternalConfig{Command: leaseID, WorkRoot: "/work/crabbox"})
@@ -309,9 +308,7 @@ func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
 }
 
 func TestRouteExternalLeaseClaimOverridesAmbientRouting(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	paths := map[string]string{}
 	for _, leaseID := range []string{"cbx_111111111111", "cbx_222222222222"} {
 		path, err := PersistExternalRouting(leaseID, ExternalConfig{Command: leaseID, WorkRoot: "/work/crabbox"})
@@ -339,9 +336,7 @@ func TestRouteExternalLeaseClaimOverridesAmbientRouting(t *testing.T) {
 }
 
 func TestRunExistingExternalLeaseLoadsPersistedRoutingBeforeValidation(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	leaseID := "cbx_abcdef123456"
 	oldRouting := ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}
 	if _, err := PersistExternalRouting(leaseID, oldRouting); err != nil {
@@ -369,9 +364,7 @@ func TestRunExistingExternalLeaseLoadsPersistedRoutingBeforeValidation(t *testin
 }
 
 func TestResolveLeaseTargetUsesPersistedExternalRouting(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	leaseID := "cbx_abcdef123456"
 	oldRouting := ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}
 	if _, err := PersistExternalRouting(leaseID, oldRouting); err != nil {
@@ -392,9 +385,7 @@ func TestResolveLeaseTargetUsesPersistedExternalRouting(t *testing.T) {
 }
 
 func TestLeaseTargetConfigPreservesExplicitNonExternalProvider(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	root := setExternalRoutingTestHome(t)
 	leaseID := "cbx_abcdef123456"
 	if _, err := PersistExternalRouting(leaseID, ExternalConfig{Command: "old-provider", WorkRoot: "/old/work"}); err != nil {
 		t.Fatal(err)

--- a/internal/cli/external_routing_test.go
+++ b/internal/cli/external_routing_test.go
@@ -218,6 +218,39 @@ func TestAutoRouteExternalLeaseRejectsCrossProviderAliasCollision(t *testing.T) 
 	}
 }
 
+func TestAutoRouteExternalLeaseFailsClosedWithoutRoutingState(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	leaseID := "cbx_abcdef123456"
+	if err := claimLeaseForRepoProviderScope(leaseID, "old-box", "external", "old-scope", root, time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	fs := newFlagSet("test", os.Stderr)
+	if err := autoRouteExternalLease(&cfg, fs, "old-box"); err == nil || !strings.Contains(err.Error(), "routing state is missing") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestTargetLinuxClearsAmbientWindowsMode(t *testing.T) {
+	cfg := baseConfig()
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	cfg.explicitWindowsMode = windowsModeWSL2
+	fs := newFlagSet("test", os.Stderr)
+	flags := registerTargetFlags(fs, cfg)
+	if err := parseFlags(fs, []string{"--target", "linux"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyTargetFlagOverrides(&cfg, fs, flags); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TargetOS != targetLinux || cfg.WindowsMode != windowsModeNormal || cfg.explicitWindowsMode != "" {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
 func TestAutoRouteExternalLeaseHonorsConfiguredRoutingFile(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", root)

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -103,6 +103,9 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	if err := autoRouteStaticLease(cfg, fs, existingLeaseID); err != nil {
 		return err
 	}
+	if err := autoRouteExternalLease(cfg, fs, existingLeaseID); err != nil {
+		return err
+	}
 	if flagWasSet(fs, "os") {
 		osImage, err := normalizeOSImage(*values.OSImage)
 		if err != nil {
@@ -330,6 +333,9 @@ func loadLeaseTargetConfig(fs *flag.FlagSet, provider string, targetFlags target
 		return Config{}, err
 	}
 	if err := autoRouteStaticLease(&cfg, fs, opts.LeaseID); err != nil {
+		return Config{}, err
+	}
+	if err := autoRouteExternalLease(&cfg, fs, opts.LeaseID); err != nil {
 		return Config{}, err
 	}
 	if err := applyNetworkModeFlagOverride(&cfg, fs, networkFlags); err != nil {

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -33,6 +33,9 @@ func (a App) pauseResume(ctx context.Context, args []string, action string) erro
 		return err
 	}
 	cfg.Provider = *provider
+	if err := autoRouteExternalLease(&cfg, fs, *id); err != nil {
+		return err
+	}
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -192,6 +192,13 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 			continue
 		}
 		cfg.Provider = claim.Provider
+		if cerr := autoRouteExternalLeaseForConfig(&cfg, claim.LeaseID); cerr != nil {
+			if firstErr == nil {
+				firstErr = cerr
+			}
+			fmt.Fprintf(a.Stderr, "warning: skip %s/%s: route lease: %v\n", claim.Provider, claim.LeaseID, cerr)
+			continue
+		}
 		backend, berr := loadBackend(cfg, runtimeForApp(a))
 		if berr != nil {
 			if firstErr == nil {

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -192,11 +192,17 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 			continue
 		}
 		cfg.Provider = claim.Provider
-		if cerr := autoRouteExternalLeaseForConfig(&cfg, claim.LeaseID); cerr != nil {
+		var routeErr error
+		if claim.Provider == "external" {
+			routeErr = routeExternalLeaseClaim(&cfg, claim.LeaseID)
+		} else {
+			routeErr = autoRouteExternalLeaseForConfig(&cfg, claim.LeaseID)
+		}
+		if routeErr != nil {
 			if firstErr == nil {
-				firstErr = cerr
+				firstErr = routeErr
 			}
-			fmt.Fprintf(a.Stderr, "warning: skip %s/%s: route lease: %v\n", claim.Provider, claim.LeaseID, cerr)
+			fmt.Fprintf(a.Stderr, "warning: skip %s/%s: route lease: %v\n", claim.Provider, claim.LeaseID, routeErr)
 			continue
 		}
 		backend, berr := loadBackend(cfg, runtimeForApp(a))

--- a/internal/cli/ports.go
+++ b/internal/cli/ports.go
@@ -80,13 +80,16 @@ func loadPortsConfig(fs *flag.FlagSet, provider string, providerFlags providerFl
 		return Config{}, err
 	}
 	cfg.Provider = provider
-	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
-		return Config{}, err
-	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
 		return Config{}, err
 	}
 	if err := autoRouteStaticLease(&cfg, fs, id); err != nil {
+		return Config{}, err
+	}
+	if err := autoRouteExternalLease(&cfg, fs, id); err != nil {
+		return Config{}, err
+	}
+	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -770,6 +770,9 @@ func applyProviderRoutingFlags(cfg *Config, fs *flag.FlagSet, values providerFla
 }
 
 func applyProviderFlags(cfg *Config, fs *flag.FlagSet, values providerFlagValues) error {
+	if flagWasSet(fs, "provider") {
+		cfg.providerExplicit = true
+	}
 	if _, err := routeProviderFlagOverride(cfg, fs, values); err != nil {
 		return err
 	}

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -21,6 +21,7 @@ func init() {
 	RegisterProvider(testProxmoxProvider{})
 	RegisterProvider(testXCPNgProvider{})
 	RegisterProvider(testStaticSSHProvider{})
+	RegisterProvider(testExternalProvider{})
 	RegisterProvider(testExeDevProvider{})
 	RegisterProvider(testRunPodProvider{})
 	RegisterProvider(testBlacksmithProvider{})
@@ -42,6 +43,52 @@ func init() {
 	RegisterProvider(testParallelsProvider{})
 	RegisterProvider(testWandbProvider{})
 	RegisterProvider(testServiceControlProvider{})
+}
+
+type testExternalProvider struct{}
+
+func (testExternalProvider) Name() string      { return "external" }
+func (testExternalProvider) Aliases() []string { return nil }
+func (testExternalProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "external",
+		Family:      "external",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testExternalProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return fs.String("external-routing-file", defaults.External.RoutingFile, "")
+}
+func (testExternalProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if flagWasSet(fs, "external-routing-file") {
+		path, _ := values.(*string)
+		if path != nil {
+			routing, err := LoadExternalRouting(*path)
+			if err != nil {
+				return err
+			}
+			cfg.External = routing
+		}
+	}
+	if strings.TrimSpace(cfg.External.Command) == "" {
+		return exit(2, "external command is required")
+	}
+	return nil
+}
+func (p testExternalProvider) Configure(cfg Config, _ Runtime) (Backend, error) {
+	return testExternalSSHBackend{testSSHBackend: testSSHBackend{spec: p.Spec()}, cfg: cfg}, nil
+}
+
+type testExternalSSHBackend struct {
+	testSSHBackend
+	cfg Config
+}
+
+func (b testExternalSSHBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+	return LeaseTarget{LeaseID: req.ID, Server: Server{Name: b.cfg.External.Command}}, nil
 }
 
 type testAzureProvider struct{}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2734,13 +2734,16 @@ func (a App) stop(ctx context.Context, args []string) error {
 		return err
 	}
 	cfg.Provider = *provider
+	if err := autoRouteStaticLease(&cfg, fs, *id); err != nil {
+		return err
+	}
+	if err := autoRouteExternalLease(&cfg, fs, *id); err != nil {
+		return err
+	}
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
 	if err := applyTargetFlagOverrides(&cfg, fs, targetFlags); err != nil {
-		return err
-	}
-	if err := autoRouteStaticLease(&cfg, fs, *id); err != nil {
 		return err
 	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))

--- a/internal/cli/static.go
+++ b/internal/cli/static.go
@@ -32,10 +32,12 @@ func applyTargetFlagOverrides(cfg *Config, fs *flag.FlagSet, values targetFlagVa
 	if flagWasSet(fs, "target") {
 		cfg.TargetOS = *values.Target
 		cfg.targetExplicit = true
+		cfg.targetFlagExplicit = true
 	}
 	if flagWasSet(fs, "windows-mode") {
 		cfg.WindowsMode = *values.WindowsMode
 		cfg.explicitWindowsMode = *values.WindowsMode
+		cfg.windowsModeFlagExplicit = true
 	}
 	if flagWasSet(fs, "static-host") {
 		cfg.Static.Host = *values.StaticHost

--- a/internal/cli/static.go
+++ b/internal/cli/static.go
@@ -33,6 +33,10 @@ func applyTargetFlagOverrides(cfg *Config, fs *flag.FlagSet, values targetFlagVa
 		cfg.TargetOS = *values.Target
 		cfg.targetExplicit = true
 		cfg.targetFlagExplicit = true
+		if normalizeTargetOS(cfg.TargetOS) != targetWindows && !flagWasSet(fs, "windows-mode") {
+			cfg.WindowsMode = windowsModeNormal
+			cfg.explicitWindowsMode = ""
+		}
 	}
 	if flagWasSet(fs, "windows-mode") {
 		cfg.WindowsMode = *values.WindowsMode

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -266,7 +266,7 @@ func (a App) resolveLeaseTargetWithRequestConfig(ctx context.Context, cfg *Confi
 	if cfg == nil {
 		return Server{}, SSHTarget{}, "", exit(2, "lease target config is required")
 	}
-	if err := autoRouteExternalLeaseForConfig(cfg, id); err != nil {
+	if err := autoRouteExternalLeaseForConfig(cfg, req.ID); err != nil {
 		return Server{}, SSHTarget{}, "", err
 	}
 	backend, err := loadBackend(*cfg, runtimeForApp(a))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -266,6 +266,9 @@ func (a App) resolveLeaseTargetWithRequestConfig(ctx context.Context, cfg *Confi
 	if cfg == nil {
 		return Server{}, SSHTarget{}, "", exit(2, "lease target config is required")
 	}
+	if err := autoRouteExternalLeaseForConfig(cfg, id); err != nil {
+		return Server{}, SSHTarget{}, "", err
+	}
 	backend, err := loadBackend(*cfg, runtimeForApp(a))
 	if err != nil {
 		return Server{}, SSHTarget{}, "", err

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"os"
 	"path"
 	"strings"
 )
@@ -282,6 +283,124 @@ func autoRouteStaticLease(cfg *Config, fs *flag.FlagSet, id string) error {
 	}
 	normalizeTargetConfig(cfg)
 	return validateTargetConfig(*cfg)
+}
+
+// autoRouteExternalLease restores the provider configuration captured when an
+// external lease was acquired. This keeps existing leases addressable after
+// the user's current external configuration changes.
+func autoRouteExternalLease(cfg *Config, fs *flag.FlagSet, id string) error {
+	providerExplicit := flagWasSet(fs, "provider")
+	if providerExplicit {
+		cfg.providerExplicit = true
+	}
+	return autoRouteExternalLeaseWithHints(
+		cfg,
+		id,
+		flagWasSet(fs, "external-routing-file"),
+		flagWasSet(fs, "target") || cfg.targetExplicit,
+		flagWasSet(fs, "windows-mode") || cfg.explicitWindowsMode != "",
+	)
+}
+
+func autoRouteExternalLeaseForConfig(cfg *Config, id string) error {
+	return autoRouteExternalLeaseWithHints(cfg, id, false, cfg.targetExplicit, cfg.explicitWindowsMode != "")
+}
+
+func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, targetExplicit, windowsModeExplicit bool) error {
+	id = strings.TrimSpace(id)
+	if id == "" || routingExplicit {
+		return nil
+	}
+	provider, providerErr := ProviderFor(cfg.Provider)
+	providerSelected := providerErr == nil && provider.Name() == "external"
+	if cfg.providerExplicit {
+		if providerErr != nil || provider.Name() != "external" {
+			return nil
+		}
+	}
+	if providerSelected && strings.TrimSpace(cfg.External.RoutingFile) != "" {
+		return nil
+	}
+	claim, ok, err := uniqueExternalLeaseClaim(id, providerSelected)
+	if err != nil || !ok {
+		return err
+	}
+	path, err := ExternalRoutingPath(claim.LeaseID)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !cfg.providerExplicit {
+		cfg.Provider = "external"
+	}
+	routing, err := LoadExternalRouting(path)
+	if err != nil {
+		return err
+	}
+	cfg.External = routing
+	if strings.TrimSpace(routing.WorkRoot) != "" {
+		cfg.WorkRoot = routing.WorkRoot
+	}
+	if !targetExplicit {
+		cfg.TargetOS = targetLinux
+		if !windowsModeExplicit {
+			cfg.WindowsMode = windowsModeNormal
+		}
+	}
+	normalizeTargetConfig(cfg)
+	return validateTargetConfig(*cfg)
+}
+
+func uniqueExternalLeaseClaim(identifier string, providerSelected bool) (leaseClaim, bool, error) {
+	exact, exists, err := readLeaseClaimWithPresence(identifier)
+	if err != nil {
+		return leaseClaim{}, false, err
+	}
+	if exists {
+		if exact.Provider != "external" {
+			return leaseClaim{}, false, nil
+		}
+		return exact, true, nil
+	}
+	claims, err := listLeaseClaims()
+	if err != nil {
+		return leaseClaim{}, false, err
+	}
+	matches := make([]leaseClaim, 0, 1)
+	externalMatches := make([]leaseClaim, 0, 1)
+	for _, claim := range claims {
+		if !leaseClaimMatchesIdentifier(claim, identifier) {
+			continue
+		}
+		matches = append(matches, claim)
+		if claim.Provider == "external" {
+			externalMatches = append(externalMatches, claim)
+		}
+	}
+	if len(externalMatches) == 0 {
+		return leaseClaim{}, false, nil
+	}
+	candidates := matches
+	if providerSelected {
+		candidates = externalMatches
+	}
+	if len(candidates) > 1 {
+		if providerSelected {
+			// The configured external lifecycle scope remains the tiebreaker.
+			return leaseClaim{}, false, nil
+		}
+		ids := make([]string, 0, len(candidates))
+		for _, claim := range candidates {
+			ids = append(ids, claim.LeaseID)
+		}
+		return leaseClaim{}, false, exit(2, "multiple lease claims match %q: %s; use a lease id or an explicit provider", identifier, strings.Join(ids, ", "))
+	}
+	return externalMatches[0], true, nil
 }
 
 func staticLeaseClaim(id string) (leaseClaim, bool, error) {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -306,6 +306,12 @@ func autoRouteExternalLeaseForConfig(cfg *Config, id string) error {
 	return autoRouteExternalLeaseWithHints(cfg, id, false, cfg.targetExplicit, cfg.explicitWindowsMode != "")
 }
 
+func routeExternalLeaseClaim(cfg *Config, leaseID string) error {
+	cfg.External.RoutingFile = ""
+	cfg.External.routingLoaded = false
+	return autoRouteExternalLeaseForConfig(cfg, leaseID)
+}
+
 func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, targetExplicit, windowsModeExplicit bool) error {
 	id = strings.TrimSpace(id)
 	if id == "" || routingExplicit {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -313,6 +313,16 @@ func autoRouteExternalLeaseForConfig(cfg *Config, id string) error {
 }
 
 func routeExternalLeaseClaim(cfg *Config, leaseID string) error {
+	path, err := ExternalRoutingPath(leaseID)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return exit(2, "external routing state is missing for lease %s; refusing unverified cleanup", leaseID)
+		}
+		return err
+	}
 	cfg.External.RoutingFile = ""
 	cfg.External.routingLoaded = false
 	return autoRouteExternalLeaseForConfig(cfg, leaseID)
@@ -320,7 +330,7 @@ func routeExternalLeaseClaim(cfg *Config, leaseID string) error {
 
 func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, targetExplicit, windowsModeExplicit bool) error {
 	id = strings.TrimSpace(id)
-	if id == "" || routingExplicit {
+	if id == "" {
 		return nil
 	}
 	provider, providerErr := ProviderFor(cfg.Provider)
@@ -329,6 +339,12 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 		if providerErr != nil || provider.Name() != "external" {
 			return nil
 		}
+	}
+	if routingExplicit {
+		if !cfg.providerExplicit {
+			cfg.Provider = "external"
+		}
+		return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
 	}
 	if providerSelected && strings.TrimSpace(cfg.External.RoutingFile) != "" {
 		if !cfg.External.routingLoaded {

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -348,7 +348,10 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	}
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			if providerSelected {
+				return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
+			}
+			return exit(2, "external routing state is missing for lease %s; select provider=external explicitly only if the current lifecycle still owns it", claim.LeaseID)
 		}
 		return err
 	}
@@ -376,9 +379,9 @@ func loadExternalRoutingConfig(cfg *Config, path string) error {
 func restoreExternalLeaseTarget(cfg *Config, targetExplicit, windowsModeExplicit bool) error {
 	if !targetExplicit {
 		cfg.TargetOS = targetLinux
-		if !windowsModeExplicit {
-			cfg.WindowsMode = windowsModeNormal
-		}
+	}
+	if !windowsModeExplicit {
+		cfg.WindowsMode = windowsModeNormal
 	}
 	normalizeTargetConfig(cfg)
 	return validateTargetConfig(*cfg)

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -293,17 +293,23 @@ func autoRouteExternalLease(cfg *Config, fs *flag.FlagSet, id string) error {
 	if providerExplicit {
 		cfg.providerExplicit = true
 	}
+	if flagWasSet(fs, "target") {
+		cfg.targetFlagExplicit = true
+	}
+	if flagWasSet(fs, "windows-mode") {
+		cfg.windowsModeFlagExplicit = true
+	}
 	return autoRouteExternalLeaseWithHints(
 		cfg,
 		id,
 		flagWasSet(fs, "external-routing-file"),
-		flagWasSet(fs, "target") || cfg.targetExplicit,
-		flagWasSet(fs, "windows-mode") || cfg.explicitWindowsMode != "",
+		cfg.targetFlagExplicit,
+		cfg.windowsModeFlagExplicit,
 	)
 }
 
 func autoRouteExternalLeaseForConfig(cfg *Config, id string) error {
-	return autoRouteExternalLeaseWithHints(cfg, id, false, cfg.targetExplicit, cfg.explicitWindowsMode != "")
+	return autoRouteExternalLeaseWithHints(cfg, id, false, cfg.targetFlagExplicit, cfg.windowsModeFlagExplicit)
 }
 
 func routeExternalLeaseClaim(cfg *Config, leaseID string) error {
@@ -325,7 +331,12 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 		}
 	}
 	if providerSelected && strings.TrimSpace(cfg.External.RoutingFile) != "" {
-		return nil
+		if !cfg.External.routingLoaded {
+			if err := loadExternalRoutingConfig(cfg, cfg.External.RoutingFile); err != nil {
+				return err
+			}
+		}
+		return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
 	}
 	claim, ok, err := uniqueExternalLeaseClaim(id, providerSelected)
 	if err != nil || !ok {
@@ -344,6 +355,13 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	if !cfg.providerExplicit {
 		cfg.Provider = "external"
 	}
+	if err := loadExternalRoutingConfig(cfg, path); err != nil {
+		return err
+	}
+	return restoreExternalLeaseTarget(cfg, targetExplicit, windowsModeExplicit)
+}
+
+func loadExternalRoutingConfig(cfg *Config, path string) error {
 	routing, err := LoadExternalRouting(path)
 	if err != nil {
 		return err
@@ -352,6 +370,10 @@ func autoRouteExternalLeaseWithHints(cfg *Config, id string, routingExplicit, ta
 	if strings.TrimSpace(routing.WorkRoot) != "" {
 		cfg.WorkRoot = routing.WorkRoot
 	}
+	return nil
+}
+
+func restoreExternalLeaseTarget(cfg *Config, targetExplicit, windowsModeExplicit bool) error {
 	if !targetExplicit {
 		cfg.TargetOS = targetLinux
 		if !windowsModeExplicit {

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -671,7 +671,7 @@ func (b *leaseBackend) resolveClaim(identifier string) (core.LeaseClaim, bool, e
 	scope := b.claimScope()
 	if claim, err := core.ReadLeaseClaim(identifier); err != nil {
 		return core.LeaseClaim{}, false, err
-	} else if externalClaimMatchesScope(claim, scope) {
+	} else if b.claimMatchesScopeOrRouting(claim, scope) {
 		return claim, true, nil
 	} else if claim.LeaseID != "" && strings.HasPrefix(identifier, "cbx_") {
 		return core.LeaseClaim{}, false, nil
@@ -680,13 +680,12 @@ func (b *leaseBackend) resolveClaim(identifier string) (core.LeaseClaim, bool, e
 	if err != nil {
 		return core.LeaseClaim{}, false, err
 	}
-	slug := core.NormalizeLeaseSlug(identifier)
 	var match core.LeaseClaim
 	for _, claim := range claims {
-		if !externalClaimMatchesScope(claim, scope) {
+		if !b.claimMatchesScopeOrRouting(claim, scope) {
 			continue
 		}
-		if claim.LeaseID == identifier || (slug != "" && core.NormalizeLeaseSlug(claim.Slug) == slug) {
+		if core.LeaseClaimMatchesIdentifier(claim, identifier) {
 			if match.LeaseID != "" && match.LeaseID != claim.LeaseID {
 				return core.LeaseClaim{}, false, core.Exit(4, "external provider claim %q is ambiguous in this lifecycle scope", identifier)
 			}
@@ -697,6 +696,17 @@ func (b *leaseBackend) resolveClaim(identifier string) (core.LeaseClaim, bool, e
 		return match, true, nil
 	}
 	return core.LeaseClaim{}, false, nil
+}
+
+func (b *leaseBackend) claimMatchesScopeOrRouting(claim core.LeaseClaim, scope string) bool {
+	if externalClaimMatchesScope(claim, scope) {
+		return true
+	}
+	if claim.LeaseID == "" || claim.Provider != providerName || strings.TrimSpace(b.cfg.External.RoutingFile) == "" {
+		return false
+	}
+	path, err := core.ExternalRoutingPath(claim.LeaseID)
+	return err == nil && filepath.Clean(path) == filepath.Clean(b.cfg.External.RoutingFile)
 }
 
 func externalClaimMatchesScope(claim core.LeaseClaim, scope string) bool {

--- a/internal/providers/external/flags.go
+++ b/internal/providers/external/flags.go
@@ -39,6 +39,22 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if !ok {
 		return nil
 	}
+	if core.FlagWasSet(fs, "external-routing-file") {
+		cfg.External.RoutingFile = *v.RoutingFile
+		routing, err := core.LoadExternalRouting(cfg.External.RoutingFile)
+		if err != nil {
+			return core.Exit(2, "%v", err)
+		}
+		cfg.External = routing
+		cfg.WorkRoot = externalWorkRoot(*cfg)
+	} else if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !core.ExternalRoutingLoaded(cfg.External) {
+		routing, err := core.LoadExternalRouting(path)
+		if err != nil {
+			return core.Exit(2, "%v", err)
+		}
+		cfg.External = routing
+		cfg.WorkRoot = externalWorkRoot(*cfg)
+	}
 	if core.FlagWasSet(fs, "external-command") {
 		cfg.External.Command = *v.Command
 	}
@@ -55,15 +71,6 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.FlagWasSet(fs, "external-work-root") {
 		cfg.External.WorkRoot = *v.WorkRoot
 		cfg.WorkRoot = *v.WorkRoot
-	}
-	if core.FlagWasSet(fs, "external-routing-file") {
-		cfg.External.RoutingFile = *v.RoutingFile
-		routing, err := core.LoadExternalRouting(cfg.External.RoutingFile)
-		if err != nil {
-			return core.Exit(2, "%v", err)
-		}
-		cfg.External = routing
-		cfg.WorkRoot = externalWorkRoot(*cfg)
 	}
 	return validateConfig(*cfg)
 }

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -288,7 +288,7 @@ func (b *leaseBackend) lifecycleLeaseForName(name string) (protocolLease, error)
 		return protocolLease{}, err
 	}
 	for _, claim := range claims {
-		if !externalClaimMatchesScope(claim, b.claimScope()) {
+		if !b.claimMatchesScopeOrRouting(claim, b.claimScope()) {
 			continue
 		}
 		if strings.TrimSpace(claim.Labels["name"]) == name ||

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -59,8 +59,8 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
-	loadedRouting := false
-	if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" {
+	loadedRouting := core.ExternalRoutingLoaded(cfg.External)
+	if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !loadedRouting {
 		routing, err := core.LoadExternalRouting(path)
 		if err != nil {
 			return nil, core.Exit(2, "%v", err)

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -37,13 +37,6 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 }
 
 func (Provider) RouteConfig(cfg *core.Config, _ *flag.FlagSet, _ any) error {
-	if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !core.ExternalRoutingLoaded(cfg.External) {
-		routing, err := core.LoadExternalRouting(path)
-		if err != nil {
-			return core.Exit(2, "%v", err)
-		}
-		cfg.External = routing
-	}
 	if cfg.WorkRoot == core.BaseConfig().WorkRoot && cfg.External.WorkRoot != "" {
 		cfg.WorkRoot = cfg.External.WorkRoot
 	}

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -37,6 +37,13 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 }
 
 func (Provider) RouteConfig(cfg *core.Config, _ *flag.FlagSet, _ any) error {
+	if path := strings.TrimSpace(cfg.External.RoutingFile); path != "" && !core.ExternalRoutingLoaded(cfg.External) {
+		routing, err := core.LoadExternalRouting(path)
+		if err != nil {
+			return core.Exit(2, "%v", err)
+		}
+		cfg.External = routing
+	}
 	if cfg.WorkRoot == core.BaseConfig().WorkRoot && cfg.External.WorkRoot != "" {
 		cfg.WorkRoot = cfg.External.WorkRoot
 	}

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -84,6 +84,51 @@ func TestCommandRoutingArgsUsesPrivateLeaseState(t *testing.T) {
 	}
 }
 
+func TestConfigurePreservesOverridesAppliedToLoadedRouting(t *testing.T) {
+	isolateCrabboxState(t)
+	saved := testConfig()
+	path, err := core.PersistExternalRouting("cbx_abcdef123456", saved.External)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := core.LoadExternalRouting(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Command = "override-provider"
+	loaded.WorkRoot = "/override/work"
+	cfg := core.BaseConfig()
+	cfg.External = loaded
+	cfg.WorkRoot = loaded.WorkRoot
+	backend, err := (Provider{}).Configure(cfg, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := backend.(*leaseBackend).cfg
+	if got.External.Command != loaded.Command || got.WorkRoot != loaded.WorkRoot {
+		t.Fatalf("config=%#v", got)
+	}
+}
+
+func TestConfigureLoadsConfiguredRoutingFile(t *testing.T) {
+	isolateCrabboxState(t)
+	saved := testConfig()
+	path, err := core.PersistExternalRouting("cbx_abcdef123456", saved.External)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.External.RoutingFile = path
+	backend, err := (Provider{}).Configure(cfg, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := backend.(*leaseBackend).cfg
+	if got.External.Command != saved.External.Command || got.WorkRoot != saved.External.WorkRoot {
+		t.Fatalf("config=%#v", got)
+	}
+}
+
 func TestProtocolClaimScopeIgnoresZeroLifecycleConnection(t *testing.T) {
 	cfg := testConfig()
 	before := externalClaimScope(cfg)
@@ -1111,6 +1156,14 @@ func TestDeclarativeResolveThenReleaseReusesPersistedResourceName(t *testing.T) 
 	); err != nil {
 		t.Fatal(err)
 	}
+	// A private per-lease route remains authoritative when a provider upgrade
+	// changes the lifecycle scope encoded in the current routing state.
+	cfg.External.Config = map[string]any{"cluster": "new-cluster"}
+	routingPath, err := core.PersistExternalRouting("cbx_abcdef123456", cfg.External)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.External.RoutingFile = routingPath
 	runner := &recordingRunner{}
 	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
 	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "fast-coral", ReleaseOnly: true})
@@ -1125,6 +1178,24 @@ func TestDeclarativeResolveThenReleaseReusesPersistedResourceName(t *testing.T) 
 	}
 	if runner.name != "devboxctl" || strings.Join(runner.args, "|") != "rm|original-resource" {
 		t.Fatalf("command=%q args=%#v", runner.name, runner.args)
+	}
+}
+
+func TestResolveClaimMatchesCloudID(t *testing.T) {
+	root := isolateCrabboxState(t)
+	cfg := testConfig()
+	leaseID := "cbx_abcdef123456"
+	claimExternalLease(t, cfg, leaseID, "fast-coral", root, time.Minute, false)
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, core.Server{CloudID: "provider/resource-123"}, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	backend := &leaseBackend{cfg: cfg}
+	claim, ok, err := backend.resolveClaim("provider/resource-123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || claim.LeaseID != leaseID {
+		t.Fatalf("claim=%#v ok=%v", claim, ok)
 	}
 }
 

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -129,7 +129,7 @@ func TestConfigureLoadsConfiguredRoutingFile(t *testing.T) {
 	}
 }
 
-func TestRouteConfigLoadsConfiguredRoutingFile(t *testing.T) {
+func TestApplyFlagsLoadsConfiguredRoutingFile(t *testing.T) {
 	isolateCrabboxState(t)
 	saved := testConfig()
 	path, err := core.PersistExternalRouting("cbx_abcdef123456", saved.External)
@@ -139,10 +139,35 @@ func TestRouteConfigLoadsConfiguredRoutingFile(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.External.RoutingFile = path
-	if err := (Provider{}).RouteConfig(&cfg, nil, nil); err != nil {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := registerFlags(fs, cfg)
+	if err := applyFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
 	if cfg.External.Command != saved.External.Command || cfg.WorkRoot != saved.External.WorkRoot || !core.ExternalRoutingLoaded(cfg.External) {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
+func TestApplyFlagsExplicitRoutingOverridesStaleConfiguredPath(t *testing.T) {
+	isolateCrabboxState(t)
+	saved := testConfig()
+	path, err := core.PersistExternalRouting("cbx_abcdef123456", saved.External)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.External.RoutingFile = filepath.Join(t.TempDir(), "missing.json")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := registerFlags(fs, cfg)
+	if err := fs.Parse([]string{"--external-routing-file", path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.RoutingFile != path || cfg.External.Command != saved.External.Command {
 		t.Fatalf("config=%#v", cfg)
 	}
 }

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -129,6 +129,24 @@ func TestConfigureLoadsConfiguredRoutingFile(t *testing.T) {
 	}
 }
 
+func TestRouteConfigLoadsConfiguredRoutingFile(t *testing.T) {
+	isolateCrabboxState(t)
+	saved := testConfig()
+	path, err := core.PersistExternalRouting("cbx_abcdef123456", saved.External)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.External.RoutingFile = path
+	if err := (Provider{}).RouteConfig(&cfg, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.External.Command != saved.External.Command || cfg.WorkRoot != saved.External.WorkRoot || !core.ExternalRoutingLoaded(cfg.External) {
+		t.Fatalf("config=%#v", cfg)
+	}
+}
+
 func TestProtocolClaimScopeIgnoresZeroLifecycleConnection(t *testing.T) {
 	cfg := testConfig()
 	before := externalClaimScope(cfg)


### PR DESCRIPTION
## Summary

- restore each external lease's persisted provider routing when the current external configuration changes
- preserve explicit provider, target, and external routing overrides while failing closed on ambiguous or missing lease state
- apply the same routing behavior across run, SSH, desktop, cache, code, stop, pause, ports, and per-lease pond cleanup paths

## Verification

- `go vet ./...`
- `go test ./internal/cli ./internal/providers/external`
- `go test -race ./...`
- structured Codex autoreview: clean, no accepted/actionable findings

## Configuration and security

No new secrets or provider-specific configuration are introduced. Persisted external routing remains private local state and missing state now fails closed before destructive operations.
