### PR TITLE
feat(islo): expose direct SSH hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
+
 ## 0.29.0 - 2026-06-12
 
 ### Added

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -15,8 +15,10 @@ empty-body `DELETE`), archive upload, shares, and command output — the last vi
 a small SSE reader for the `POST /sandboxes/{name}/exec/stream` endpoint, since
 the SDK's exec helper coalesces streamed output.
 
-Sandboxes are Linux-only. There is no Crabbox-managed SSH lease; commands run
-through Islo's streaming exec endpoint, not through `crabbox ssh`/rsync.
+Sandboxes are Linux-only. `crabbox ssh --provider islo` can print a direct SSH
+command for a Crabbox-created sandbox at `<sandbox>.islo.dev`, but Islo `run`
+commands and sync still use Islo's streaming exec and archive APIs rather than
+SSH/rsync.
 
 ## Auth
 
@@ -189,10 +191,18 @@ instead. `--shell` passes the raw shell string through to the remote shell.
 
 ## SSH access
 
-Crabbox does not provision or route SSH to Islo sandboxes: `crabbox ssh`, `vnc`,
-`code`, rsync, and Actions hydration are not available on `provider: islo`. When
-you need a Crabbox-managed SSH box, use Hetzner, AWS, static SSH, or Daytona
-instead.
+Crabbox can resolve kept Islo sandboxes for direct SSH:
+
+```sh
+crabbox ssh --provider islo --id blue-lobster
+# ssh islo@crabbox-repo-abcdef.islo.dev
+```
+
+By default the rendered target is `islo@<sandbox>.islo.dev` on port `22`.
+Explicit `ssh.user`, `ssh.port`, or `ssh.key` settings are honored. This is a
+login helper only: `vnc`, `code`, Crabbox rsync, and Actions hydration are not
+available on `provider: islo`. When you need a Crabbox-managed SSH box, use
+Hetzner, AWS, static SSH, or Daytona instead.
 
 ## Related docs
 

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -16,7 +16,7 @@ a small SSE reader for the `POST /sandboxes/{name}/exec/stream` endpoint, since
 the SDK's exec helper coalesces streamed output.
 
 Sandboxes are Linux-only. `crabbox ssh --provider islo` can print a direct SSH
-command for a Crabbox-created sandbox at `<sandbox>.islo.dev`, but Islo `run`
+command for a Crabbox-created sandbox at `<sandbox>.islo`, but Islo `run`
 commands and sync still use Islo's streaming exec and archive APIs rather than
 SSH/rsync.
 
@@ -194,11 +194,16 @@ instead. `--shell` passes the raw shell string through to the remote shell.
 Crabbox can resolve kept Islo sandboxes for direct SSH:
 
 ```sh
+islo ssh --setup
 crabbox ssh --provider islo --id blue-lobster
-# ssh islo@crabbox-repo-abcdef.islo.dev
+# ssh islo@crabbox-repo-abcdef.islo
 ```
 
-By default the rendered target is `islo@<sandbox>.islo.dev` on port `22`.
+Install and authenticate the [Islo CLI](https://docs.islo.dev/cli/sandbox-commands),
+then run `islo ssh --setup` once to install its SSH proxy configuration and
+short-lived certificate support. The Islo CLI must remain authenticated through
+`islo login` or `ISLO_API_KEY`; `CRABBOX_ISLO_API_KEY` alone is only read by
+Crabbox. By default the rendered target is `islo@<sandbox>.islo` on port `22`.
 Explicit `ssh.user`, `ssh.port`, or `ssh.key` settings are honored. This is a
 login helper only: `vnc`, `code`, Crabbox rsync, and Actions hydration are not
 available on `provider: islo`. When you need a Crabbox-managed SSH box, use

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -350,7 +350,7 @@ Delegated-run providers (`cloudflare`, `azure-dynamic-sessions`, `e2b`, `islo`,
 the broker for run execution; each owns sandbox lifecycle and command execution
 and syncs through its own API (gzipped archive upload for most). Islo also
 exposes a direct `crabbox ssh` login helper for kept sandboxes at
-`<sandbox>.islo.dev`, but Islo run/sync remains delegated. See the linked
+`<sandbox>.islo`, but Islo run/sync remains delegated. See the linked
 provider pages for per-provider auth and configuration.
 
 ## Static SSH targets

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -347,8 +347,10 @@ list, and cleanup.
 
 Delegated-run providers (`cloudflare`, `azure-dynamic-sessions`, `e2b`, `islo`,
 `modal`, `tensorlake`, `upstash-box`, `blacksmith-testbox`, `wandb`) do not use
-the broker or an SSH lease; each owns sandbox lifecycle and command execution and
-syncs through its own API (gzipped archive upload for most). See the linked
+the broker for run execution; each owns sandbox lifecycle and command execution
+and syncs through its own API (gzipped archive upload for most). Islo also
+exposes a direct `crabbox ssh` login helper for kept sandboxes at
+`<sandbox>.islo.dev`, but Islo run/sync remains delegated. See the linked
 provider pages for per-provider auth and configuration.
 
 ## Static SSH targets

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -115,7 +115,7 @@ sent to Islo when greater than zero; otherwise the sandbox uses Islo's defaults.
 ## Capabilities
 
 - SSH: yes for direct login to existing Crabbox-created sandboxes. `crabbox ssh
-  --provider islo --id <slug>` renders `ssh islo@<sandbox>.islo.dev` on port 22
+  --provider islo --id <slug>` renders `ssh islo@<sandbox>.islo` on port 22
   by default. Crabbox still does not use SSH for Islo `run` or sync.
 - Crabbox sync: yes, archive sync through the Islo files-archive API, with a
   base64 exec-upload fallback.
@@ -131,6 +131,9 @@ sent to Islo when greater than zero; otherwise the sandbox uses Islo's defaults.
 
 ## Gotchas
 
+- Direct SSH requires the authenticated Islo CLI and a one-time `islo ssh
+  --setup`. The Islo CLI reads `islo login` state or `ISLO_API_KEY`;
+  `CRABBOX_ISLO_API_KEY` alone only authenticates Crabbox.
 - `--sync-only` and `--checksum` are rejected because `run` still uses Islo's
   delegated archive/exec transport, not Crabbox-managed rsync.
 - `--full-resync`, `--force-sync-large`, `--script`, `--script-stdin`,

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -114,8 +114,9 @@ sent to Islo when greater than zero; otherwise the sandbox uses Islo's defaults.
 
 ## Capabilities
 
-- SSH: not driven by Crabbox. `crabbox ssh`, rsync, and SSH-based run options are
-  not available for `provider: islo`.
+- SSH: yes for direct login to existing Crabbox-created sandboxes. `crabbox ssh
+  --provider islo --id <slug>` renders `ssh islo@<sandbox>.islo.dev` on port 22
+  by default. Crabbox still does not use SSH for Islo `run` or sync.
 - Crabbox sync: yes, archive sync through the Islo files-archive API, with a
   base64 exec-upload fallback.
 - URL bridge: yes. Exposed ports become public HTTPS shares through Islo's
@@ -130,8 +131,8 @@ sent to Islo when greater than zero; otherwise the sandbox uses Islo's defaults.
 
 ## Gotchas
 
-- `--sync-only` and `--checksum` are rejected because the backend does not expose
-  a Crabbox-managed SSH/rsync target.
+- `--sync-only` and `--checksum` are rejected because `run` still uses Islo's
+  delegated archive/exec transport, not Crabbox-managed rsync.
 - `--full-resync`, `--force-sync-large`, `--script`, `--script-stdin`,
   `--fresh-pr`, `--env-helper`, local stdout/stderr captures,
   `--capture-on-fail`, `--download`, `--artifact-glob`, `--require-artifact`,

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -420,7 +420,7 @@ func (a App) resolveNetworkSSHTargetWithRepoConfig(ctx context.Context, cfg *Con
 	if err != nil {
 		return Server{}, SSHTarget{}, "", err
 	}
-	resolved, err := resolveNetworkTarget(ctx, *cfg, server, target)
+	resolved, err := resolveSSHTargetNetwork(ctx, *cfg, server, target, allowLoginOnly)
 	if err != nil {
 		return Server{}, SSHTarget{}, "", err
 	}
@@ -440,6 +440,13 @@ func (a App) resolveNetworkSSHTargetWithRepoConfig(ctx context.Context, cfg *Con
 		fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 	}
 	return server, target, leaseID, nil
+}
+
+func resolveSSHTargetNetwork(ctx context.Context, cfg Config, server Server, target SSHTarget, allowLoginOnly bool) (resolvedNetworkTarget, error) {
+	if allowLoginOnly && target.SSHConfigProxy {
+		return resolvedNetworkTarget{Target: target, Network: NetworkPublic}, nil
+	}
+	return resolveNetworkTarget(ctx, cfg, server, target)
 }
 
 func resolvedLeaseClaimSnapshot(leaseID string, server Server) (leaseClaim, bool, error) {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -443,7 +443,7 @@ func (a App) resolveNetworkSSHTargetWithRepoConfig(ctx context.Context, cfg *Con
 }
 
 func resolveSSHTargetNetwork(ctx context.Context, cfg Config, server Server, target SSHTarget, allowLoginOnly bool) (resolvedNetworkTarget, error) {
-	if allowLoginOnly && target.SSHConfigProxy {
+	if allowLoginOnly && target.SSHConfigProxy && providerCapabilities(cfg.Provider).TailscaleEgress {
 		return resolvedNetworkTarget{Target: target, Network: NetworkPublic}, nil
 	}
 	return resolveNetworkTarget(ctx, cfg, server, target)

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -383,6 +383,14 @@ func (a App) resolveNetworkLeaseTargetForRepo(ctx context.Context, cfg Config, i
 	return a.resolveNetworkLeaseTargetForRepoWithConfig(ctx, &cfg, id, printFallback, reclaim)
 }
 
+func (a App) resolveNetworkLoginTargetForRepo(ctx context.Context, cfg Config, id string, printFallback, reclaim bool) (Server, SSHTarget, string, error) {
+	repo, err := findRepo()
+	if err != nil {
+		return Server{}, SSHTarget{}, "", err
+	}
+	return a.resolveNetworkSSHTargetWithRepoConfig(ctx, &cfg, id, printFallback, repo, reclaim, true)
+}
+
 func (a App) resolveNetworkLeaseTargetForRepoWithConfig(ctx context.Context, cfg *Config, id string, printFallback, reclaim bool) (Server, SSHTarget, string, error) {
 	repo, err := findRepo()
 	if err != nil {
@@ -392,10 +400,23 @@ func (a App) resolveNetworkLeaseTargetForRepoWithConfig(ctx context.Context, cfg
 }
 
 func (a App) resolveNetworkLeaseTargetWithRepoConfig(ctx context.Context, cfg *Config, id string, printFallback bool, repo Repo, reclaim bool) (Server, SSHTarget, string, error) {
+	return a.resolveNetworkSSHTargetWithRepoConfig(ctx, cfg, id, printFallback, repo, reclaim, false)
+}
+
+func (a App) resolveNetworkSSHTargetWithRepoConfig(ctx context.Context, cfg *Config, id string, printFallback bool, repo Repo, reclaim, allowLoginOnly bool) (Server, SSHTarget, string, error) {
 	if cfg == nil {
 		return Server{}, SSHTarget{}, "", exit(2, "lease target config is required")
 	}
-	server, target, leaseID, err := a.resolveLeaseTargetForRepoWithConfig(ctx, cfg, id, repo, reclaim)
+	req := ResolveRequest{Repo: repo, ID: id, Reclaim: reclaim}
+	var server Server
+	var target SSHTarget
+	var leaseID string
+	var err error
+	if allowLoginOnly {
+		server, target, leaseID, err = a.resolveLoginTargetWithRequestConfig(ctx, cfg, req)
+	} else {
+		server, target, leaseID, err = a.resolveLeaseTargetWithRequestConfig(ctx, cfg, req)
+	}
 	if err != nil {
 		return Server{}, SSHTarget{}, "", err
 	}

--- a/internal/cli/network_test.go
+++ b/internal/cli/network_test.go
@@ -35,6 +35,7 @@ func TestNetworkTailscaleRequiresMetadata(t *testing.T) {
 
 func TestLoginOnlySSHConfigProxyIgnoresInboundTailscaleSelection(t *testing.T) {
 	cfg := baseConfig()
+	cfg.Provider = "islo"
 	cfg.Network = NetworkTailscale
 	server := Server{Labels: map[string]string{
 		"lease":          "isb_crabbox-repo-abcdef",
@@ -48,6 +49,16 @@ func TestLoginOnlySSHConfigProxyIgnoresInboundTailscaleSelection(t *testing.T) {
 	}
 	if got.Target.Host != target.Host || !got.Target.SSHConfigProxy {
 		t.Fatalf("login proxy target=%#v", got.Target)
+	}
+}
+
+func TestSSHConfigProxyStillHonorsInboundTailscaleSelection(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.Network = NetworkTailscale
+	target := SSHTarget{Host: "proxy.example", Port: "22", SSHConfigProxy: true}
+	if _, err := resolveSSHTargetNetwork(context.Background(), cfg, Server{}, target, true); err == nil {
+		t.Fatal("expected non-egress-only proxy target to require tailnet metadata")
 	}
 }
 

--- a/internal/cli/network_test.go
+++ b/internal/cli/network_test.go
@@ -33,6 +33,24 @@ func TestNetworkTailscaleRequiresMetadata(t *testing.T) {
 	}
 }
 
+func TestLoginOnlySSHConfigProxyIgnoresInboundTailscaleSelection(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Network = NetworkTailscale
+	server := Server{Labels: map[string]string{
+		"lease":          "isb_crabbox-repo-abcdef",
+		"tailscale":      "true",
+		"tailscale_fqdn": "outbound-only.example.ts.net",
+	}}
+	target := SSHTarget{Host: "crabbox-repo-abcdef.islo", Port: "22", SSHConfigProxy: true}
+	got, err := resolveSSHTargetNetwork(context.Background(), cfg, server, target, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Target.Host != target.Host || !got.Target.SSHConfigProxy {
+		t.Fatalf("login proxy target=%#v", got.Target)
+	}
+}
+
 func TestBootstrapNetworkPrefersTailscaleForExitNode(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Network = NetworkAuto

--- a/internal/cli/pond.go
+++ b/internal/cli/pond.go
@@ -236,7 +236,9 @@ func claimHasTailscaleMetadata(claim leaseClaim) bool {
 //
 // Capabilities are derived from the provider's own FeatureSet, so a provider
 // opts in to a transport plane by declaring the feature, not by being added
-// to a static table.
+// to a static table. SSH mesh is narrower than FeatureSSH because delegated
+// providers may expose a direct login helper without supporting Crabbox-managed
+// SSH tunnels as their pond transport.
 type ProviderCapabilities struct {
 	Tailscale       bool // bidirectional tailnet peer plane
 	TailscaleEgress bool // outbound-only userspace tailnet access
@@ -255,7 +257,7 @@ func providerCapabilities(provider string) ProviderCapabilities {
 		return ProviderCapabilities{
 			Tailscale:       tailscale && !spec.TailscaleEgressOnly,
 			TailscaleEgress: tailscale && spec.TailscaleEgressOnly,
-			SSHMesh:         featureSetHas(features, FeatureSSH),
+			SSHMesh:         spec.Kind == ProviderKindSSHLease && featureSetHas(features, FeatureSSH),
 			URLBridge:       featureSetHas(features, FeatureURLBridge),
 		}
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -76,13 +76,22 @@ type DoctorBackend interface {
 	Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error)
 }
 
-type SSHLeaseBackend interface {
+type SSHLoginBackend interface {
 	Backend
-	Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error)
 	Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error)
+}
+
+type LeaseTouchBackend interface {
+	Backend
+	Touch(ctx context.Context, req TouchRequest) (Server, error)
+}
+
+type SSHLeaseBackend interface {
+	SSHLoginBackend
+	LeaseTouchBackend
+	Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error)
 	List(ctx context.Context, req ListRequest) ([]LeaseView, error)
 	ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error
-	Touch(ctx context.Context, req TouchRequest) (Server, error)
 }
 
 type ResolvedLeaseTargetRebinder interface {
@@ -1049,7 +1058,7 @@ func (a App) touchLeaseTargetBestEffort(ctx context.Context, cfg Config, lease L
 		fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, err)
 		return lease.Server
 	}
-	sshBackend, ok := backend.(SSHLeaseBackend)
+	sshBackend, ok := backend.(LeaseTouchBackend)
 	if !ok {
 		fmt.Fprintf(a.Stderr, "warning: provider=%s does not support lease touch\n", backend.Spec().Name)
 		return lease.Server

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1038,7 +1038,7 @@ func (testIsloProvider) Spec() ProviderSpec {
 		Name:                "islo",
 		Kind:                ProviderKindDelegatedRun,
 		Targets:             []TargetSpec{{OS: targetLinux}},
-		Features:            FeatureSet{FeatureURLBridge, FeatureRunSession, FeatureTailscale, FeaturePauseResume},
+		Features:            FeatureSet{FeatureSSH, FeatureURLBridge, FeatureRunSession, FeatureTailscale, FeaturePauseResume},
 		Coordinator:         CoordinatorNever,
 		TailscaleEgressOnly: true,
 	}

--- a/internal/cli/ssh_cmd.go
+++ b/internal/cli/ssh_cmd.go
@@ -31,7 +31,7 @@ func (a App) ssh(ctx context.Context, args []string) error {
 	if err := requireLeaseID(*id, "crabbox ssh --id <lease-id-or-slug>", cfg); err != nil {
 		return err
 	}
-	server, target, leaseID, err := a.resolveNetworkLeaseTargetForRepo(ctx, cfg, *id, false, *reclaim)
+	server, target, leaseID, err := a.resolveNetworkLoginTargetForRepo(ctx, cfg, *id, false, *reclaim)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -263,6 +263,14 @@ func (a App) resolveLeaseTargetForRepoWithConfig(ctx context.Context, cfg *Confi
 }
 
 func (a App) resolveLeaseTargetWithRequestConfig(ctx context.Context, cfg *Config, req ResolveRequest) (Server, SSHTarget, string, error) {
+	return a.resolveSSHTargetWithRequestConfig(ctx, cfg, req, false)
+}
+
+func (a App) resolveLoginTargetWithRequestConfig(ctx context.Context, cfg *Config, req ResolveRequest) (Server, SSHTarget, string, error) {
+	return a.resolveSSHTargetWithRequestConfig(ctx, cfg, req, true)
+}
+
+func (a App) resolveSSHTargetWithRequestConfig(ctx context.Context, cfg *Config, req ResolveRequest, allowLoginOnly bool) (Server, SSHTarget, string, error) {
 	if cfg == nil {
 		return Server{}, SSHTarget{}, "", exit(2, "lease target config is required")
 	}
@@ -273,9 +281,14 @@ func (a App) resolveLeaseTargetWithRequestConfig(ctx context.Context, cfg *Confi
 	if err != nil {
 		return Server{}, SSHTarget{}, "", err
 	}
-	sshBackend, ok := backend.(SSHLeaseBackend)
+	sshBackend, ok := backend.(SSHLoginBackend)
 	if !ok {
 		return Server{}, SSHTarget{}, "", exit(2, "provider=%s does not expose an SSH target", backend.Spec().Name)
+	}
+	if !allowLoginOnly {
+		if _, ok := backend.(SSHLeaseBackend); !ok {
+			return Server{}, SSHTarget{}, "", exit(2, "provider=%s exposes SSH login only, not a Crabbox-managed SSH lease", backend.Spec().Name)
+		}
 	}
 	req.Options = leaseOptionsFromConfig(*cfg)
 	req.Options.ProviderScope = providerClaimScope(backend.Spec().Name, *cfg)
@@ -287,7 +300,7 @@ func (a App) resolveLeaseTargetWithRequestConfig(ctx context.Context, cfg *Confi
 	return lease.Server, lease.SSH, lease.LeaseID, nil
 }
 
-func resolveSSHLeaseTarget(ctx context.Context, backend SSHLeaseBackend, req ResolveRequest) (LeaseTarget, error) {
+func resolveSSHLeaseTarget(ctx context.Context, backend SSHLoginBackend, req ResolveRequest) (LeaseTarget, error) {
 	claimsBefore, err := snapshotLeaseClaims()
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -580,6 +580,11 @@ func resolveIsloLeaseID(id, repoRoot string, reclaim bool) (string, string, stri
 		if claim, ok, err := resolveExactIsloLeaseClaim(id); err != nil {
 			return "", "", "", err
 		} else if ok {
+			if repoRoot != "" {
+				if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, isloProvider, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+					return "", "", "", err
+				}
+			}
 			return claim.LeaseID, name, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), nil
 		}
 		return id, name, newLeaseSlug(id), nil

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -284,13 +284,13 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 	if lease.LeaseID != leaseID || lease.Server.Name != "crabbox-repo-abcdef" {
 		t.Fatalf("lease=%q server=%q", lease.LeaseID, lease.Server.Name)
 	}
-	if lease.SSH.Host != "crabbox-repo-abcdef.islo.dev" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
+	if lease.SSH.Host != "crabbox-repo-abcdef.islo" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
 		t.Fatalf("ssh target=%#v", lease.SSH)
 	}
 	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 {
 		t.Fatalf("islo ssh should not force Crabbox's default key or fallback ports: %#v", lease.SSH)
 	}
-	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo.dev" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo.dev" {
+	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo" {
 		t.Fatalf("server ssh labels=%#v public=%q", lease.Server.Labels, lease.Server.PublicNet.IPv4.IP)
 	}
 }

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -346,6 +346,29 @@ func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
 	}
 }
 
+func TestIsloResolveSSHWaitsForStartingSandbox(t *testing.T) {
+	client := &fakeIsloSyncClient{
+		getSandboxes: []*gosdk.SandboxResponse{
+			{Name: "crabbox-repo-abcdef", Status: "starting"},
+			{Name: "crabbox-repo-abcdef", Status: "running"},
+		},
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Status != "running" || len(client.getSandboxes) != 0 {
+		t.Fatalf("status=%q remaining responses=%d", lease.Server.Status, len(client.getSandboxes))
+	}
+}
+
 func TestIsloStatusViewIncludesTailscaleMetadata(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "isb_crabbox-node-a"
@@ -1357,6 +1380,7 @@ type fakeIsloSyncClient struct {
 	createRequest            *gosdk.SandboxCreate
 	createName               string
 	getSandbox               *gosdk.SandboxResponse
+	getSandboxes             []*gosdk.SandboxResponse
 	getSandboxErr            error
 	getSandboxGone           bool
 	resumeErr                error
@@ -1383,6 +1407,11 @@ func (f *fakeIsloSyncClient) GetSandbox(_ context.Context, name string) (*gosdk.
 	}
 	if f.getSandboxGone {
 		return nil, nil
+	}
+	if len(f.getSandboxes) > 0 {
+		sandbox := f.getSandboxes[0]
+		f.getSandboxes = f.getSandboxes[1:]
+		return sandbox, nil
 	}
 	if f.getSandbox != nil {
 		return f.getSandbox, nil

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -297,7 +297,7 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 	if lease.SSH.Host != "crabbox-repo-abcdef.islo" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
 		t.Fatalf("ssh target=%#v", lease.SSH)
 	}
-	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 || !lease.SSH.SSHConfigProxy {
+	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 || !lease.SSH.SSHConfigProxy || !lease.SSH.DisableHostKeyChecking {
 		t.Fatalf("islo ssh should not force Crabbox's default key or fallback ports: %#v", lease.SSH)
 	}
 	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo" {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -346,6 +346,34 @@ func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
 	}
 }
 
+func TestIsloResolveSSHRejectsForeignClaimBeforeResume(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeIsloSyncClient{
+		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{
+		ID:   leaseID,
+		Repo: Repo{Root: t.TempDir()},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--reclaim") {
+		t.Fatalf("expected ownership error, got %v", err)
+	}
+	if client.resumeCalls != 0 {
+		t.Fatalf("resumeCalls=%d, want 0", client.resumeCalls)
+	}
+}
+
 func TestIsloResolveSSHWaitsForStartingSandbox(t *testing.T) {
 	client := &fakeIsloSyncClient{
 		getSandboxes: []*gosdk.SandboxResponse{

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -165,6 +165,16 @@ func TestIsloProviderDeclaresPauseResume(t *testing.T) {
 	}
 }
 
+func TestIsloProviderExposesLoginWithoutSSHLease(t *testing.T) {
+	backend := NewIsloBackend((Provider{}).Spec(), Config{}, Runtime{})
+	if _, ok := backend.(core.SSHLoginBackend); !ok {
+		t.Fatalf("backend=%T does not expose SSH login", backend)
+	}
+	if _, ok := backend.(core.SSHLeaseBackend); ok {
+		t.Fatalf("backend=%T must not expose a Crabbox-managed SSH lease", backend)
+	}
+}
+
 func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
 	if _, _, _, err := resolveIsloLeaseID("production", "", false); err == nil {
 		t.Fatal("expected raw non-Crabbox sandbox to be rejected")
@@ -287,7 +297,7 @@ func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
 	if lease.SSH.Host != "crabbox-repo-abcdef.islo" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
 		t.Fatalf("ssh target=%#v", lease.SSH)
 	}
-	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 {
+	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 || !lease.SSH.SSHConfigProxy {
 		t.Fatalf("islo ssh should not force Crabbox's default key or fallback ports: %#v", lease.SSH)
 	}
 	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo" {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -160,6 +160,9 @@ func TestIsloProviderDeclaresPauseResume(t *testing.T) {
 	if !(Provider{}).Spec().Features.Has(core.FeaturePauseResume) {
 		t.Fatal("islo provider must declare pause-resume")
 	}
+	if !(Provider{}).Spec().Features.Has(core.FeatureSSH) {
+		t.Fatal("islo provider must declare ssh")
+	}
 }
 
 func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
@@ -254,6 +257,82 @@ func TestIsloRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
 	_, err := backend.Run(context.Background(), RunRequest{NoSync: true})
 	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
 		t.Fatalf("Run err=%v, want workdir containment error", err)
+	}
+}
+
+func TestIsloResolveSSHUsesSandboxHostnameDefaults(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "web", isloProvider, root, time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeIsloSyncClient{
+		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", ID: "sandbox-id", Status: "running", Image: "ubuntu"},
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "web", Repo: Repo{Root: root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != leaseID || lease.Server.Name != "crabbox-repo-abcdef" {
+		t.Fatalf("lease=%q server=%q", lease.LeaseID, lease.Server.Name)
+	}
+	if lease.SSH.Host != "crabbox-repo-abcdef.islo.dev" || lease.SSH.User != isloWorkloadUser || lease.SSH.Port != "22" {
+		t.Fatalf("ssh target=%#v", lease.SSH)
+	}
+	if lease.SSH.Key != "" || len(lease.SSH.FallbackPorts) != 0 {
+		t.Fatalf("islo ssh should not force Crabbox's default key or fallback ports: %#v", lease.SSH)
+	}
+	if lease.Server.PublicNet.IPv4.IP != "crabbox-repo-abcdef.islo.dev" || lease.Server.Labels["ssh_host"] != "crabbox-repo-abcdef.islo.dev" {
+		t.Fatalf("server ssh labels=%#v public=%q", lease.Server.Labels, lease.Server.PublicNet.IPv4.IP)
+	}
+}
+
+func TestIsloResolveSSHHonorsExplicitSSHOverrides(t *testing.T) {
+	client := &fakeIsloSyncClient{
+		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "running"},
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	cfg := Config{SSHUser: "alice", SSHPort: "2022", SSHKey: "/tmp/islo-key", Islo: IsloConfig{APIKey: "test"}}
+	core.MarkSSHUserExplicit(&cfg)
+	core.MarkSSHPortExplicit(&cfg)
+	core.MarkSSHKeyExplicit(&cfg)
+	backend := &isloBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.User != "alice" || lease.SSH.Port != "2022" || lease.SSH.Key != "/tmp/islo-key" {
+		t.Fatalf("ssh target=%#v", lease.SSH)
+	}
+}
+
+func TestIsloResolveSSHResumesPausedSandbox(t *testing.T) {
+	client := &fakeIsloSyncClient{
+		getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"},
+	}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{Islo: IsloConfig{APIKey: "test"}},
+		rt:  Runtime{Stderr: io.Discard},
+	}
+
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "crabbox-repo-abcdef"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.resumeCalls != 1 || lease.Server.Status != "running" {
+		t.Fatalf("resumeCalls=%d status=%q", client.resumeCalls, lease.Server.Status)
 	}
 }
 

--- a/internal/providers/islo/provider.go
+++ b/internal/providers/islo/provider.go
@@ -22,7 +22,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:              "islo",
 		Kind:                core.ProviderKindDelegatedRun,
 		Targets:             []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:            core.FeatureSet{core.FeatureURLBridge, core.FeatureRunSession, core.FeatureTailscale, core.FeaturePauseResume},
+		Features:            core.FeatureSet{core.FeatureSSH, core.FeatureURLBridge, core.FeatureRunSession, core.FeatureTailscale, core.FeaturePauseResume},
 		Coordinator:         core.CoordinatorNever,
 		TailscaleEgressOnly: true,
 	}

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -108,13 +108,14 @@ func (b *isloBackend) sshTargetForSandbox(name string) core.SSHTarget {
 		key = b.cfg.SSHKey
 	}
 	return core.SSHTarget{
-		User:           user,
-		Host:           isloSSHHost(name),
-		Key:            key,
-		Port:           port,
-		FallbackPorts:  []string{},
-		TargetOS:       targetLinux,
-		SSHConfigProxy: true,
+		User:                   user,
+		Host:                   isloSSHHost(name),
+		Key:                    key,
+		Port:                   port,
+		FallbackPorts:          []string{},
+		TargetOS:               targetLinux,
+		SSHConfigProxy:         true,
+		DisableHostKeyChecking: true,
 	}
 }
 

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -11,11 +11,7 @@ import (
 
 const isloSSHDomain = "islo"
 
-var _ core.SSHLeaseBackend = (*isloBackend)(nil)
-
-func (b *isloBackend) Acquire(context.Context, core.AcquireRequest) (core.LeaseTarget, error) {
-	return core.LeaseTarget{}, exit(2, "provider=islo SSH resolves existing sandboxes only; create one with `crabbox warmup --provider islo`")
-}
+var _ core.SSHLoginBackend = (*isloBackend)(nil)
 
 func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newIsloClient(b.cfg, b.rt)
@@ -34,24 +30,6 @@ func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (cor
 	applyIsloSSHLabels(&server, leaseID, b.cfg)
 	target := b.sshTargetForSandbox(name)
 	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
-}
-
-func (b *isloBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
-	client, err := newIsloClient(b.cfg, b.rt)
-	if err != nil {
-		return err
-	}
-	name := strings.TrimPrefix(req.Lease.LeaseID, isloLeasePrefix)
-	if req.Lease.Server.Name != "" {
-		name = req.Lease.Server.Name
-	}
-	if name != "" {
-		if err := client.DeleteSandbox(ctx, name); err != nil {
-			return isloError("delete sandbox", err)
-		}
-	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
 }
 
 func (b *isloBackend) Touch(_ context.Context, req core.TouchRequest) (Server, error) {
@@ -133,12 +111,13 @@ func (b *isloBackend) sshTargetForSandbox(name string) core.SSHTarget {
 		key = b.cfg.SSHKey
 	}
 	return core.SSHTarget{
-		User:          user,
-		Host:          isloSSHHost(name),
-		Key:           key,
-		Port:          port,
-		FallbackPorts: []string{},
-		TargetOS:      targetLinux,
+		User:           user,
+		Host:           isloSSHHost(name),
+		Key:            key,
+		Port:           port,
+		FallbackPorts:  []string{},
+		TargetOS:       targetLinux,
+		SSHConfigProxy: true,
 	}
 }
 

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -62,10 +62,7 @@ func (b *isloBackend) resolveSSHReadySandbox(ctx context.Context, client isloAPI
 		}
 		return sandbox, nil
 	}
-	if req.ReadyProbe || req.Prepare {
-		return waitForIsloSandboxRunning(ctx, client, name, 2*time.Minute)
-	}
-	return nil, exit(5, "islo sandbox %s is not running state=%s", name, sandbox.GetStatus())
+	return waitForIsloSandboxRunning(ctx, client, name, 2*time.Minute)
 }
 
 func waitForIsloSandboxRunning(ctx context.Context, client isloAPI, name string, timeout time.Duration) (*gosdk.SandboxResponse, error) {

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-const isloSSHDomain = "islo.dev"
+const isloSSHDomain = "islo"
 
 var _ core.SSHLeaseBackend = (*isloBackend)(nil)
 

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -1,0 +1,164 @@
+package islo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	gosdk "github.com/islo-labs/go-sdk"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const isloSSHDomain = "islo.dev"
+
+var _ core.SSHLeaseBackend = (*isloBackend)(nil)
+
+func (b *isloBackend) Acquire(context.Context, core.AcquireRequest) (core.LeaseTarget, error) {
+	return core.LeaseTarget{}, exit(2, "provider=islo SSH resolves existing sandboxes only; create one with `crabbox warmup --provider islo`")
+}
+
+func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	client, err := newIsloClient(b.cfg, b.rt)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID, name, _, err := resolveIsloLeaseID(req.ID, req.Repo.Root, req.Reclaim)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	sandbox, err := b.resolveSSHReadySandbox(ctx, client, name, req)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := isloSandboxToServer(sandbox)
+	applyIsloSSHLabels(&server, leaseID, b.cfg)
+	target := b.sshTargetForSandbox(name)
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *isloBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	client, err := newIsloClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	name := strings.TrimPrefix(req.Lease.LeaseID, isloLeasePrefix)
+	if req.Lease.Server.Name != "" {
+		name = req.Lease.Server.Name
+	}
+	if name != "" {
+		if err := client.DeleteSandbox(ctx, name); err != nil {
+			return isloError("delete sandbox", err)
+		}
+	}
+	removeLeaseClaim(req.Lease.LeaseID)
+	return nil
+}
+
+func (b *isloBackend) Touch(_ context.Context, req core.TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	server.Labels["state"] = blank(req.State, blank(server.Labels["state"], server.Status))
+	return server, nil
+}
+
+func (b *isloBackend) resolveSSHReadySandbox(ctx context.Context, client isloAPI, name string, req core.ResolveRequest) (*gosdk.SandboxResponse, error) {
+	sandbox, err := client.GetSandbox(ctx, name)
+	if err != nil {
+		return nil, isloError("get sandbox", err)
+	}
+	if sandbox == nil {
+		return nil, exit(4, "islo sandbox %s not found", name)
+	}
+	if req.StatusOnly || isloStatusReady(sandbox.GetStatus()) {
+		return sandbox, nil
+	}
+	if isloStatusTerminal(sandbox.GetStatus()) {
+		return nil, exit(5, "islo sandbox %s entered terminal state=%s", name, sandbox.GetStatus())
+	}
+	if strings.EqualFold(strings.TrimSpace(sandbox.GetStatus()), "paused") {
+		sandbox, err = resumeIsloSandbox(ctx, client, name)
+		if err != nil {
+			return nil, isloError("resume sandbox", err)
+		}
+		return sandbox, nil
+	}
+	if req.ReadyProbe || req.Prepare {
+		return waitForIsloSandboxRunning(ctx, client, name, 2*time.Minute)
+	}
+	return nil, exit(5, "islo sandbox %s is not running state=%s", name, sandbox.GetStatus())
+}
+
+func waitForIsloSandboxRunning(ctx context.Context, client isloAPI, name string, timeout time.Duration) (*gosdk.SandboxResponse, error) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, exit(5, "timed out waiting for islo sandbox %s to become running", name)
+		case <-ticker.C:
+			sandbox, err := client.GetSandbox(ctx, name)
+			if err != nil {
+				return nil, isloError("get sandbox", err)
+			}
+			if sandbox == nil {
+				return nil, exit(4, "islo sandbox %s not found", name)
+			}
+			if isloStatusReady(sandbox.GetStatus()) {
+				return sandbox, nil
+			}
+			if isloStatusTerminal(sandbox.GetStatus()) {
+				return nil, exit(5, "islo sandbox %s entered terminal state=%s", name, sandbox.GetStatus())
+			}
+		}
+	}
+}
+
+func (b *isloBackend) sshTargetForSandbox(name string) core.SSHTarget {
+	user := isloWorkloadUser
+	if core.IsSSHUserExplicit(&b.cfg) && strings.TrimSpace(b.cfg.SSHUser) != "" {
+		user = strings.TrimSpace(b.cfg.SSHUser)
+	}
+	port := "22"
+	if core.IsSSHPortExplicit(&b.cfg) && strings.TrimSpace(b.cfg.SSHPort) != "" {
+		port = strings.TrimSpace(b.cfg.SSHPort)
+	}
+	key := ""
+	if core.IsSSHKeyExplicit(&b.cfg) {
+		key = b.cfg.SSHKey
+	}
+	return core.SSHTarget{
+		User:          user,
+		Host:          isloSSHHost(name),
+		Key:           key,
+		Port:          port,
+		FallbackPorts: []string{},
+		TargetOS:      targetLinux,
+	}
+}
+
+func isloSSHHost(name string) string {
+	return strings.TrimSpace(name) + "." + isloSSHDomain
+}
+
+func applyIsloSSHLabels(server *Server, leaseID string, cfg Config) {
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	name := strings.TrimPrefix(leaseID, isloLeasePrefix)
+	if server.Name != "" {
+		name = server.Name
+	}
+	host := isloSSHHost(name)
+	server.Labels["lease"] = leaseID
+	server.Labels["ssh_host"] = host
+	if workRoot, err := isloWorkspacePath(cfg); err == nil {
+		server.Labels["work_root"] = workRoot
+	}
+	server.PublicNet.IPv4.IP = host
+}


### PR DESCRIPTION
## Summary
- Add Islo SSH target resolution for kept Crabbox-created sandboxes using `<sandbox>.islo.dev` hostnames.
- Keep Islo run/sync on the existing delegated archive and exec APIs while honoring explicit SSH user, port, and key overrides for `crabbox ssh`.
- Update Islo docs and provider capability notes for the new direct login helper.

## Test plan
- `go test ./internal/providers/islo`
- `go test ./internal/cli ./cmd/crabbox`
- `go test ./...`

Note: live Islo SSH probing was not run locally because no `ISLO_API_KEY`/`CRABBOX_ISLO_API_KEY` is configured in this environment.

Made with [Cursor](https://cursor.com)