### PR TITLE
fix(proxmox): support PVE 8 bridge readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added non-mutating Proxmox storage, bridge, pool, template, and cluster inventory readiness diagnostics plus guarded live lifecycle smoke coverage, with safer failed-create and cleanup claim handling. Thanks @coygeek.
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
 
+### Fixed
+
+- Fixed Proxmox bridge readiness on PVE 8 by falling back to its compatible local-bridge and SDN-vnet inventory filter.
+
 ## 0.29.0 - 2026-06-12
 
 ### Added

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -437,7 +437,17 @@ func (c *ProxmoxClient) proxmoxNetworkCheck(ctx context.Context, cfg Config) Pro
 	inventoryPath := path + "?type=include_sdn"
 	var networks []proxmoxNetwork
 	if err := c.doRequired(ctx, http.MethodGet, inventoryPath, nil, &networks); err != nil {
-		return c.proxmoxFailedReadiness("bridge", inventoryPath, err, map[string]string{"bridge": cfg.Proxmox.Bridge})
+		var proxErr *ProxmoxError
+		if !errors.As(err, &proxErr) || proxErr.StatusCode != http.StatusBadRequest {
+			return c.proxmoxFailedReadiness("bridge", inventoryPath, err, map[string]string{"bridge": cfg.Proxmox.Bridge})
+		}
+		// include_sdn was added in PVE 9. PVE 8 uses any_bridge for local
+		// bridges and SDN vnets.
+		inventoryPath = path + "?type=any_bridge"
+		networks = nil
+		if err := c.doRequired(ctx, http.MethodGet, inventoryPath, nil, &networks); err != nil {
+			return c.proxmoxFailedReadiness("bridge", inventoryPath, err, map[string]string{"bridge": cfg.Proxmox.Bridge})
+		}
 	}
 	bridges := []string{strings.TrimSpace(cfg.Proxmox.Bridge)}
 	source := "config"

--- a/internal/cli/proxmox_test.go
+++ b/internal/cli/proxmox_test.go
@@ -289,6 +289,45 @@ func TestProxmoxDoctorReadinessAcceptsSDNVNet(t *testing.T) {
 	}
 }
 
+func TestProxmoxDoctorReadinessFallsBackForPVE8NetworkInventory(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/nodes/pve1/network" {
+			t.Fatalf("unexpected %s", r.URL.Path)
+		}
+		requests = append(requests, r.URL.String())
+		switch r.URL.Query().Get("type") {
+		case "include_sdn":
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"errors": map[string]string{"type": "value 'include_sdn' does not have a value in the enumeration"},
+			})
+			return
+		case "any_bridge":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{
+				map[string]any{"iface": "vmbr0", "type": "bridge", "active": 1},
+				map[string]any{"iface": "ci-vnet", "type": "vnet", "active": 1},
+			}})
+		default:
+			t.Fatalf("unexpected %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	client := testProxmoxClient(t, server.URL)
+	cfg := baseConfig()
+	cfg.Proxmox.Node = "pve1"
+	cfg.Proxmox.Bridge = "ci-vnet"
+	check := client.proxmoxNetworkCheck(context.Background(), cfg)
+	if check.Status != "ok" || check.Details["bridge"] != "ci-vnet" || check.Details["type"] != "vnet" {
+		t.Fatalf("bridge check=%#v", check)
+	}
+	want := []string{"/api2/json/nodes/pve1/network?type=include_sdn", "/api2/json/nodes/pve1/network?type=any_bridge"}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("requests=%v, want %v", requests, want)
+	}
+}
+
 func TestProxmoxDoctorReadinessRequiresUsableTemplateBridgeWhenUnset(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

- retry Proxmox network readiness with PVE 8's `type=any_bridge` when PVE rejects the PVE 9 `type=include_sdn` filter
- preserve readiness detection for both local bridges and SDN vnets
- add request-order and SDN-vnet regression coverage

## Verification

- `go test ./internal/cli -run 'TestProxmoxDoctorReadiness(AcceptsSDNVNet|FallsBackForPVE8NetworkInventory|AcceptsOVSBridge)$' -count=1`
- `go test -race ./internal/cli`
- `node --test scripts/proxmox-live-smoke.test.js` (19 passing)
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- autoreview clean, no actionable findings

Independent Proxmox hardware verification was not run because no Proxmox credentials are available in the configured test accounts. The HTTP-level PVE 8/PVE 9 regressions and existing lifecycle smoke harness cover the changed behavior.
