### PR TITLE
test: add guarded SmolVM live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `provider: smolvm` for delegated Linux microVM runs through the hosted smolfleet API, including archive sync, retained leases, status, cleanup, and repository-scoped ownership checks. Thanks @zozo123.
+- Added guarded SmolVM live E2E coverage for retained reuse, archive replacement, environment forwarding, command exit propagation, diagnostics, and targeted cleanup.
 - Added non-mutating Proxmox storage, bridge, pool, template, and cluster inventory readiness diagnostics plus guarded live lifecycle smoke coverage, with safer failed-create and cleanup claim handling. Thanks @coygeek.
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
 

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -120,6 +120,24 @@ Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you
 - No direct `crabbox ssh` / `crabbox vnc` (delegated execution model).
 - Supports `warmup`, `run`, `status`, `stop`, `list`, and `doctor`.
 
+## Live smoke
+
+Run the guarded hosted lifecycle smoke with an exported API key:
+
+```sh
+CRABBOX_SMOLVM_LIVE_SMOKE=1 scripts/live-smolvm-smoke.sh
+```
+
+The smoke creates one uniquely named sandbox, verifies initial archive sync and
+environment forwarding, reuses it for a second sync that adds, updates, and
+deletes files, checks nonzero command exit propagation, runs status/list/doctor,
+then stops the sandbox and verifies that it disappeared from inventory. An exit
+trap retries targeted cleanup by the unique slug up to three times if any
+intermediate step fails, treats a confirmed absent slug as already clean, and
+returns failure if cleanup remains blocked. The smoke leaves SmolVM's default
+open network enabled because a cold worker may need to pull the configured image
+during the first exec.
+
 ## Limitations
 
 - Output from runs appears after the command completes (the smolfleet API provides no live stream for delegated exec).

--- a/scripts/live-smolvm-smoke.sh
+++ b/scripts/live-smolvm-smoke.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+classification="diagnostic_only"
+classification_emitted=0
+invocation_dir="$PWD"
+repo_root=""
+bin=""
+smoke_root=""
+smoke_repo=""
+slug="smolvm-live-smoke-$(date -u +%Y%m%d)-$(printf '%06x%06x' "$$" "$RANDOM")"
+cleanup_needed=0
+cleanup_retry_delay="${CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS:-2}"
+
+classify_and_exit() {
+  trap - ERR
+  if [[ $classification_emitted -ne 0 ]]; then
+    exit 1
+  fi
+  classification_emitted=1
+  classification="$1"
+  reason="${2:-}"
+  if [[ -n "$reason" ]]; then
+    printf 'classification=%s reason=%s\n' "$classification" "$reason"
+  else
+    printf 'classification=%s\n' "$classification"
+  fi
+  case "$classification" in
+    live_smolvm_smoke_passed|environment_blocked|quota_blocked) exit 0 ;;
+    *) exit 1 ;;
+  esac
+}
+
+classify_failure() {
+  local output="$1"
+  local reason="$2"
+  if grep -Eiq 'quota|capacity|rate limit|too many requests|429|insufficient' <<<"$output"; then
+    classify_and_exit quota_blocked "$reason"
+  fi
+  if grep -Eiq 'api key|unauthorized|forbidden|connection refused|no such host|timeout|timed out|TLS|x509' <<<"$output"; then
+    classify_and_exit environment_blocked "$reason"
+  fi
+  classify_and_exit diagnostic_only "$reason"
+}
+
+unexpected_failure() {
+  classify_and_exit diagnostic_only "unexpected_failure_line_$1"
+}
+
+inventory_has_slug() {
+  local inventory
+  if ! inventory="$("$bin" list --provider smolvm --json 2>/dev/null)"; then
+    return 2
+  fi
+  if jq -e --arg slug "$slug" 'any(.[]; ((.slug // .Slug // .labels.slug // "") == $slug))' <<<"$inventory" >/dev/null 2>&1; then
+    return 0
+  fi
+  if jq -e 'type == "array"' <<<"$inventory" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 2
+}
+
+stop_and_confirm() {
+  local attempt
+  local inventory_status
+  for attempt in 1 2 3; do
+    if inventory_has_slug; then
+      inventory_status=0
+    else
+      inventory_status=$?
+    fi
+    if [[ $inventory_status -eq 1 ]]; then
+      return 0
+    fi
+    "$bin" stop --provider smolvm "$slug" >/dev/null 2>&1 || true
+    if [[ $attempt -lt 3 ]]; then
+      sleep "$cleanup_retry_delay"
+    fi
+  done
+  if inventory_has_slug; then
+    inventory_status=0
+  else
+    inventory_status=$?
+  fi
+  [[ $inventory_status -eq 1 ]]
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [[ $cleanup_needed -eq 1 && -n "$bin" && -x "$bin" ]]; then
+    if ! stop_and_confirm; then
+      printf 'cleanup=failed provider=smolvm slug=%s attempts=3\n' "$slug" >&2
+      status=1
+    fi
+  fi
+  if [[ -n "$smoke_root" ]]; then
+    rm -rf -- "$smoke_root"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'unexpected_failure "$LINENO"' ERR
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "${CRABBOX_SMOLVM_LIVE_SMOKE:-0}" != "1" ]]; then
+  classify_and_exit environment_blocked "set_CRABBOX_SMOLVM_LIVE_SMOKE=1"
+fi
+
+if [[ -z "${CRABBOX_SMOLVM_API_KEY:-${SMOLMACHINES_API_KEY:-${SMK_API_KEY:-}}}" ]]; then
+  classify_and_exit environment_blocked "missing_smolvm_api_key"
+fi
+
+bin="${CRABBOX_BIN:-$repo_root/bin/crabbox}"
+if [[ "$bin" != /* ]]; then
+  bin="$invocation_dir/$bin"
+fi
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$bin")"
+  go build -trimpath -o "$bin" ./cmd/crabbox
+fi
+
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/crabbox-smolvm-smoke.XXXXXX")"
+smoke_repo="$smoke_root/repo"
+export XDG_STATE_HOME="$smoke_root/state"
+export CRABBOX_SMOLVM_SMOKE_VALUE="forwarded-ok"
+
+mkdir -p "$smoke_repo"
+cd "$smoke_repo"
+git init -q
+git config user.email smoke@example.com
+git config user.name "Crabbox SmolVM Smoke"
+cat >.crabbox.yaml <<'EOF'
+provider: smolvm
+sync:
+  delete: true
+smolvm:
+  image: alpine
+  workdir: /workspace/crabbox
+  cpus: 1
+  memoryMB: 512
+EOF
+printf 'v1\n' >proof.txt
+printf 'remove-me\n' >stale.txt
+git add .crabbox.yaml proof.txt stale.txt
+git commit -qm "test: seed SmolVM smoke fixture"
+
+cleanup_needed=1
+trap - ERR
+if run_output="$("$bin" run --provider smolvm --keep --slug "$slug" --timing-json \
+  --allow-env CRABBOX_SMOLVM_SMOKE_VALUE -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v1 && test -f stale.txt && test "$CRABBOX_SMOLVM_SMOKE_VALUE" = forwarded-ok && printf SMOLVM_SMOKE_V1_OK' 2>&1)"; then
+  run_status=0
+else
+  run_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $run_status -ne 0 ]]; then
+  classify_failure "$run_output" "initial_run_failed"
+fi
+if ! grep -q 'SMOLVM_SMOKE_V1_OK' <<<"$run_output" || ! grep -q '"provider":"smolvm"' <<<"$run_output"; then
+  classify_and_exit diagnostic_only "initial_run_proof_incomplete"
+fi
+
+"$bin" status --provider smolvm --id "$slug" --wait --json >/dev/null
+"$bin" list --provider smolvm --json |
+  jq -e --arg slug "$slug" 'any(.[]; ((.slug // .Slug // .labels.slug // "") == $slug))' >/dev/null
+"$bin" doctor --provider smolvm --json >/dev/null
+
+printf 'v2\n' >proof.txt
+printf 'second\n' >second.txt
+git add proof.txt second.txt
+git rm -q stale.txt
+git commit -qm "test: update SmolVM smoke fixture"
+
+trap - ERR
+if reuse_output="$("$bin" run --provider smolvm --id "$slug" --timing-json -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v2 && test -f second.txt && test ! -e stale.txt && printf SMOLVM_SMOKE_V2_OK' 2>&1)"; then
+  reuse_status=0
+else
+  reuse_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $reuse_status -ne 0 ]]; then
+  classify_failure "$reuse_output" "reuse_run_failed"
+fi
+if ! grep -q 'SMOLVM_SMOKE_V2_OK' <<<"$reuse_output" || ! grep -q '"provider":"smolvm"' <<<"$reuse_output"; then
+  classify_and_exit diagnostic_only "reuse_run_proof_incomplete"
+fi
+
+trap - ERR
+if exit_output="$("$bin" run --provider smolvm --id "$slug" --no-sync -- \
+  /bin/sh -lc 'printf SMOLVM_SMOKE_EXIT_23; exit 23' 2>&1)"; then
+  exit_status=0
+else
+  exit_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $exit_status -ne 23 ]] || ! grep -q 'SMOLVM_SMOKE_EXIT_23' <<<"$exit_output"; then
+  classify_and_exit diagnostic_only "exit_propagation_failed"
+fi
+
+if ! stop_and_confirm; then
+  classify_and_exit diagnostic_only "lease_cleanup_unconfirmed"
+fi
+cleanup_needed=0
+
+trap - EXIT
+rm -rf -- "$smoke_root"
+classify_and_exit live_smolvm_smoke_passed

--- a/scripts/live-smolvm-smoke.test.js
+++ b/scripts/live-smolvm-smoke.test.js
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+	fs.writeFileSync(file, body, "utf8");
+	fs.chmodSync(file, 0o755);
+}
+
+function setupFakeCrabbox() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-smolvm-live-smoke-"));
+	const calls = path.join(dir, "calls.log");
+	const state = path.join(dir, "lease.state");
+	const fakeCrabbox = path.join(dir, "crabbox");
+	writeExecutable(
+		fakeCrabbox,
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  run)
+    if [[ "$*" == *"SMOLVM_SMOKE_V1_OK"* ]]; then
+      if [[ "\${FAKE_CRABBOX_FAIL_BEFORE_CREATE:-0}" == "1" ]]; then
+        printf 'unauthorized api key\\n' >&2
+        exit 1
+      fi
+      requested_slug=""
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --slug)
+            requested_slug="\${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+      printf '%s\\n' "$requested_slug" >"${state}"
+      if [[ "\${FAKE_CRABBOX_FAIL_INITIAL:-0}" == "1" ]]; then
+        printf 'unexpected create failure\\n' >&2
+        exit 1
+      fi
+      printf 'SMOLVM_SMOKE_V1_OK\\n'
+      printf '{"provider":"smolvm","leaseId":"cbx_test"}\\n' >&2
+    elif [[ "$*" == *"SMOLVM_SMOKE_V2_OK"* ]]; then
+      test -f "${state}"
+      printf 'SMOLVM_SMOKE_V2_OK\\n'
+      printf '{"provider":"smolvm","leaseId":"cbx_test"}\\n' >&2
+    elif [[ "$*" == *"SMOLVM_SMOKE_EXIT_23"* ]]; then
+      test -f "${state}"
+      printf 'SMOLVM_SMOKE_EXIT_23\\n'
+      exit 23
+    else
+      printf 'unexpected run command\\n' >&2
+      exit 64
+    fi
+    ;;
+  status)
+    test -f "${state}"
+    printf '{"id":"cbx_test","slug":"%s","provider":"smolvm","state":"running"}\\n' "$(cat "${state}")"
+    ;;
+  list)
+    if [[ -f "${state}" ]]; then
+      printf '[{"Provider":"smolvm","slug":"%s","state":"running"}]\\n' "$(cat "${state}")"
+    elif [[ "\${FAKE_CRABBOX_FAIL_EMPTY_LIST:-0}" == "1" ]]; then
+      printf 'inventory unavailable\\n' >&2
+      exit 1
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  doctor)
+    printf '{"ok":true,"provider":"smolvm"}\\n'
+    ;;
+  stop)
+    if [[ "\${FAKE_CRABBOX_FAIL_STOP:-0}" == "1" ]]; then
+      printf 'transient stop failure\\n' >&2
+      exit 1
+    fi
+    rm -f "${state}"
+    ;;
+  *)
+    printf 'unexpected command %s\\n' "$1" >&2
+    exit 64
+    ;;
+esac
+`,
+	);
+	return { dir, calls, state, fakeCrabbox };
+}
+
+test("requires explicit live opt-in before mutation", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked/);
+	assert.equal(fs.existsSync(fake.calls), false);
+});
+
+test("runs retained reuse lifecycle and verifies cleanup", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: path.relative(repoRoot, fake.fakeCrabbox),
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+			CRABBOX_SMOLVM_LIVE_SMOKE: "1",
+			CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=live_smolvm_smoke_passed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	const calls = fs.readFileSync(fake.calls, "utf8");
+	assert.match(calls, /^run --provider smolvm --keep --slug smolvm-live-smoke-/m);
+	assert.match(calls, /^status --provider smolvm --id smolvm-live-smoke-.* --wait --json$/m);
+	assert.match(calls, /^doctor --provider smolvm --json$/m);
+	assert.match(calls, /^run --provider smolvm --id smolvm-live-smoke-.* --no-sync -- /m);
+	assert.match(calls, /^stop --provider smolvm smolvm-live-smoke-/m);
+});
+
+test("cleans up a lease left by a failed initial run", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+			CRABBOX_SMOLVM_LIVE_SMOKE: "1",
+			CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_INITIAL: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stdout, /classification=diagnostic_only reason=initial_run_failed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	assert.match(fs.readFileSync(fake.calls, "utf8"), /^stop --provider smolvm smolvm-live-smoke-/m);
+});
+
+test("preserves an auth blocker when no lease was created", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+			CRABBOX_SMOLVM_LIVE_SMOKE: "1",
+			CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_BEFORE_CREATE: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=initial_run_failed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	assert.doesNotMatch(fs.readFileSync(fake.calls, "utf8"), /^stop --provider smolvm /m);
+});
+
+test("fails after three targeted cleanup attempts", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+			CRABBOX_SMOLVM_LIVE_SMOKE: "1",
+			CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_INITIAL: "1",
+			FAKE_CRABBOX_FAIL_STOP: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /cleanup=failed provider=smolvm .* attempts=3/);
+	const stopCalls = fs
+		.readFileSync(fake.calls, "utf8")
+		.split("\n")
+		.filter((line) => line.startsWith("stop --provider smolvm "));
+	assert.equal(stopCalls.length, 3);
+});
+
+test("does not pass when post-stop inventory cannot be confirmed", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-smolvm-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_SMOLVM_API_KEY: "smk_test",
+			CRABBOX_SMOLVM_LIVE_SMOKE: "1",
+			CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_EMPTY_LIST: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.doesNotMatch(result.stdout, /classification=live_smolvm_smoke_passed/);
+	assert.match(result.stdout, /classification=diagnostic_only reason=lease_cleanup_unconfirmed/);
+	assert.match(result.stderr, /cleanup=failed provider=smolvm/);
+});


### PR DESCRIPTION
## Summary

- add an opt-in SmolVM hosted lifecycle smoke with retained reuse, archive replacement, environment forwarding, exit-code propagation, status/list/doctor checks, and confirmed cleanup
- fail closed on uncertain inventory and retry targeted stop operations without touching unrelated machines
- add fake-provider regression coverage, provider documentation, and changelog entry

Fixes https://github.com/openclaw/crabbox/issues/218

## Verification

- `node --test scripts/*.test.js` (166 passed)
- `node --test scripts/live-smolvm-smoke.test.js` (6 passed)
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --thinking high --parallel-tests 'node --test scripts/live-smolvm-smoke.test.js'` (clean)

## Live E2E

- `CRABBOX_SMOLVM_LIVE_SMOKE=1 scripts/live-smolvm-smoke.sh`
- result: `classification=live_smolvm_smoke_passed`
- verified initial sync, retained reuse with add/update/delete, environment forwarding, exit status 23 propagation, status/list/doctor, explicit release
- Smol console after cleanup: `machines 0 / 10`
- disposable 7-day API key revoked; console shows no API keys
