### PR TITLE
feat(superserve): add delegated provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `provider: superserve` for delegated Linux sandbox runs through the Superserve control and data planes, including archive sync, retained leases, ownership-guarded lifecycle operations, and credentialed live smoke coverage. Thanks @coygeek.
 - Added `provider: windows-sandbox` for disposable native Windows runs through Microsoft Windows Sandbox, including mapped workspace sync, streamed output, timeout and cancellation cleanup, and keep-on-failure inspection. Thanks @zozo123.
 - Added `provider: smolvm` for delegated Linux microVM runs through the hosted smolfleet API, including archive sync, retained leases, status, cleanup, and repository-scoped ownership checks. Thanks @zozo123.
 - Added guarded SmolVM live E2E coverage for retained reuse, archive replacement, environment forwarding, command exit propagation, diagnostics, and targeted cleanup.

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -127,6 +127,7 @@ modal                   Modal Sandboxes
 opencomputer            OpenComputer Linux VMs
 anthropic-sandbox-runtime Anthropic Sandbox Runtime through the local srt CLI
 smolvm                  Smol Machines microVM sandboxes (delegated via smolfleet)
+superserve              Superserve hosted Linux sandboxes
 tensorlake              Tensorlake Firecracker sandboxes
 upstash-box             Upstash sandboxes
 blacksmith-testbox      Blacksmith CI test runner (proof/session)
@@ -182,6 +183,7 @@ railway                 Railway service status and stop controls
 - [Tensorlake](../providers/tensorlake.md): delegated Tensorlake Firecracker sandbox execution.
 - [Upstash Box](../providers/upstash-box.md): delegated Upstash sandbox execution.
 - [SmolVM](../providers/smolvm.md): delegated Smol Machines microVM execution via smolfleet.
+- [Superserve](../providers/superserve.md): delegated Superserve hosted Linux sandbox execution.
 - [Blacksmith Testbox](../providers/blacksmith-testbox.md): delegated Blacksmith CI runner.
 - [Weights & Biases](../providers/wandb.md): delegated W&B run sandbox execution.
 - [Windows Sandbox](../providers/windows-sandbox.md): delegated Windows Sandbox execution on a local Windows host.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -108,6 +108,7 @@ the built-in adapter needs a separate local smoke contract.
 | [Railway](railway.md) — `railway` (`rail`, `railwayapp`) | Linux |
 | [Anthropic Sandbox Runtime](anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux |
 | [SmolVM](smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`) | Linux |
+| [Superserve](superserve.md) — `superserve` | Linux |
 | [Tensorlake](tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux |
 | [Upstash Box](upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux |
 | [W&B Sandboxes](wandb.md) — `wandb` (`weights-and-biases`) | Linux |
@@ -130,6 +131,9 @@ reports.
 - OpenSandbox is a delegated-run provider using the OpenSandbox Go SDK for
   lifecycle, file upload, and execd command execution. It has no aliases in v1,
   so `osb` remains reserved.
+- Superserve is a delegated-run provider using Superserve's control plane for
+  sandbox lifecycle and a sandbox data plane for file upload and command
+  execution. It has no aliases in v1.
 - Anthropic Sandbox Runtime is a local one-shot delegated-run provider driven
   by the standalone `srt` CLI. It has no SSH lease, no persistent lifecycle,
   and no remote sync surface.

--- a/docs/providers/superserve.md
+++ b/docs/providers/superserve.md
@@ -79,11 +79,12 @@ target: linux
 superserve:
   template: superserve/base
   workdir: /workspace/crabbox
+  timeoutSecs: 5400              # 0 derives the sandbox lifetime from Crabbox TTL
   execTimeoutSecs: 600
   networkAllowOut:
     - api.example.com
   networkDenyOut:
-    - metadata.google.internal
+    - 169.254.169.254/32
 ```
 
 Trusted user config may also set `superserve.baseUrl`. Repository config cannot

--- a/docs/providers/superserve.md
+++ b/docs/providers/superserve.md
@@ -123,11 +123,14 @@ CRABBOX_SUPERSERVE_FORGET_MISSING
 ```
 
 Defaults: API URL `https://api.superserve.ai`, template `superserve/base`,
-workdir `/workspace/crabbox`, command timeout `600` seconds, and service
-default sandbox lifetime.
+workdir `/workspace/crabbox`, command timeout `600` seconds, and a sandbox
+lifetime derived from Crabbox's TTL. Superserve caps sandbox lifetimes at
+`604800` seconds (7 days).
 
 The base URL must be absolute, must not include userinfo, query parameters, or
 a fragment, and must use HTTPS except for loopback development endpoints.
+Like the official SDK, custom control-plane URLs use Superserve's production
+sandbox data plane.
 
 ## Lifecycle
 

--- a/docs/providers/superserve.md
+++ b/docs/providers/superserve.md
@@ -1,0 +1,202 @@
+# Superserve Provider
+
+Read this when:
+- choosing `provider: superserve`;
+- configuring the Superserve API endpoint, template, snapshot, workdir, network allow or deny lists, or cleanup behavior;
+- changing `internal/providers/superserve`.
+
+Superserve provides hosted Linux sandboxes through the Superserve API. It is a
+**delegated-run** provider: Crabbox calls the Superserve control plane for
+sandbox lifecycle and metadata ownership, activates the sandbox for data-plane
+access, uploads a portable archive, and runs the command through Superserve's
+exec API. There is no direct Crabbox SSH target and no local rsync.
+
+Crabbox owns local config, repo claims, slug allocation, archive sync
+guardrails, metadata ownership, run timing summaries, and normalized
+`list`/`status` output. Superserve owns sandbox state, file upload, command
+transport, and sandbox deletion.
+
+## When To Use
+
+Use Superserve when commands should run in a hosted Linux sandbox and you do
+not need a full Crabbox SSH lease. It fits isolated test runs, quick remote
+proofs, and agent-style command execution where archive sync plus delegated
+exec is enough.
+
+Use an SSH-lease provider such as AWS, Hetzner, Azure, Google Cloud, Static SSH,
+or Local Container when you need `crabbox ssh`, VNC, code-server, Actions
+hydration, direct rsync behavior, or desktop/browser/code capability flags.
+
+Superserve is Linux-only. Desktop, browser, code, VNC, SSH, Tailscale, and
+Actions runner hydration are not available.
+
+## Setup
+
+Create a Superserve API key in the Superserve console, then export it through
+the environment. Crabbox never accepts the key as a command-line flag and does
+not persist it in `crabbox.yaml`, `.crabbox.yaml`, or trusted user config.
+
+## Auth
+
+```sh
+export CRABBOX_SUPERSERVE_API_KEY=ss_live_...
+# or
+export SUPERSERVE_API_KEY=ss_live_...
+```
+
+`CRABBOX_SUPERSERVE_API_KEY` takes precedence when both variables are present.
+The key is sent only in the `X-API-Key` header to the configured Superserve
+control plane. Data-plane requests use the short-lived sandbox access token
+from Superserve in the `X-Access-Token` header. Neither token is stored in
+Crabbox claims or config.
+
+Rotate the key if it was ever pasted into a chat, shell history, issue, PR,
+log, or persistent artifact.
+
+## Commands
+
+```sh
+crabbox doctor --provider superserve
+crabbox warmup --provider superserve --superserve-template superserve/base
+crabbox run --provider superserve -- pnpm test
+crabbox run --provider superserve --id quiet-river --no-sync -- echo reused
+crabbox run --provider superserve --id quiet-river --sync-only
+crabbox status --provider superserve --id quiet-river --wait
+crabbox list --provider superserve --json
+crabbox stop --provider superserve quiet-river
+crabbox cleanup --provider superserve --dry-run
+```
+
+`warmup` always keeps the sandbox until an explicit `stop`. A `run` without
+`--id` creates a sandbox and deletes it after the command unless `--keep` or
+`--keep-on-failure` asks Crabbox to retain it.
+
+## Config
+
+```yaml
+provider: superserve
+target: linux
+superserve:
+  template: superserve/base
+  workdir: /workspace/crabbox
+  execTimeoutSecs: 600
+  networkAllowOut:
+    - api.example.com
+  networkDenyOut:
+    - metadata.google.internal
+```
+
+Trusted user config may also set `superserve.baseUrl`. Repository config cannot
+set the base URL, because redirecting API-key traffic from a checked-in file is
+not trusted.
+
+Provider flags, each overriding the matching config key:
+
+```text
+--superserve-base-url
+--superserve-template
+--superserve-snapshot
+--superserve-workdir
+--superserve-timeout-secs
+--superserve-exec-timeout-secs
+--superserve-network-allow-out
+--superserve-network-deny-out
+--superserve-forget-missing
+```
+
+Environment overrides:
+
+```text
+CRABBOX_SUPERSERVE_API_KEY
+SUPERSERVE_API_KEY
+CRABBOX_SUPERSERVE_BASE_URL
+SUPERSERVE_BASE_URL
+CRABBOX_SUPERSERVE_TEMPLATE
+CRABBOX_SUPERSERVE_SNAPSHOT
+CRABBOX_SUPERSERVE_WORKDIR
+CRABBOX_SUPERSERVE_TIMEOUT_SECS
+CRABBOX_SUPERSERVE_EXEC_TIMEOUT_SECS
+CRABBOX_SUPERSERVE_NETWORK_ALLOW_OUT
+CRABBOX_SUPERSERVE_NETWORK_DENY_OUT
+CRABBOX_SUPERSERVE_FORGET_MISSING
+```
+
+Defaults: API URL `https://api.superserve.ai`, template `superserve/base`,
+workdir `/workspace/crabbox`, command timeout `600` seconds, and service
+default sandbox lifetime.
+
+The base URL must be absolute, must not include userinfo, query parameters, or
+a fragment, and must use HTTPS except for loopback development endpoints.
+
+## Lifecycle
+
+1. `warmup` or `run` without `--id` creates one Superserve sandbox from the
+   configured template or snapshot.
+2. Crabbox writes Superserve metadata that identifies the sandbox as
+   Crabbox-owned, records the API endpoint scope, claim, slug, and repo path,
+   then stores a local claim with an `ssbx_...` lease ID.
+3. `run` activates the sandbox to obtain a short-lived data-plane token.
+4. Unless `--no-sync` is set, Crabbox builds a portable archive and uploads it
+   through Superserve's file API.
+5. When `sync.delete: true` is configured, Crabbox extracts into a staging
+   directory and atomically replaces the configured workdir.
+6. The user command executes through Superserve's exec API. Streamed output is
+   used when available; otherwise Crabbox falls back to buffered exec output.
+7. One-shot sandboxes are deleted after successful `run` unless `--keep` is set.
+   Retained sandboxes can be reused with `--id` and later removed with `stop`.
+
+## Capabilities
+
+- SSH: no.
+- Crabbox sync: yes, delegated archive upload and remote extraction.
+- Provider sync: no separate provider-native sync step.
+- Desktop / browser / code / VNC: no.
+- Actions hydration: no.
+- Coordinator broker: no, Superserve always runs direct from the CLI.
+- Pause/resume: not advertised in v1.
+
+## Live Smoke
+
+Run the guarded hosted lifecycle smoke only when you intend to create a real
+short-lived Superserve sandbox:
+
+```sh
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=superserve \
+CRABBOX_SUPERSERVE_API_KEY=ss_live_... \
+scripts/live-superserve-smoke.sh
+```
+
+The smoke builds `bin/crabbox` unless `CRABBOX_BIN` points at an existing
+binary, creates one uniquely named Crabbox-owned sandbox, verifies initial
+archive sync and environment forwarding, checks `doctor`, `status`, and
+`list`, reuses the same sandbox for a second sync that adds, updates, and
+deletes files, proves nonzero exit-code propagation, then stops the sandbox and
+confirms that no matching Crabbox-owned inventory remains.
+
+The script exits with `classification=environment_blocked` when live mode,
+provider selection, or an API key is missing. Authentication, DNS, TLS, and
+connectivity failures are also classified as environment blocked. Quota,
+capacity, admission, and rate-limit failures are classified separately. A
+successful live proof prints `classification=live_superserve_smoke_passed`.
+
+## Limitations
+
+- Output may be buffered when Superserve's streaming exec endpoint is not
+  available.
+- Very large repositories may hit upload or request-size limits; normal
+  Crabbox large-sync guardrails still apply.
+- `--class` and `--type` are rejected for Superserve; choose
+  `--superserve-template` or `--superserve-snapshot` instead.
+- `--checksum` and SSH/rsync-specific sync options are not supported.
+- Delegated run options that require an SSH target or local proof surface are
+  rejected, including script injection, fresh PR hydration, full rsync, env
+  helpers, output capture artifacts, downloads, artifact globs, emitted proof
+  bundles, and `--stop-after`.
+- IDs must be a Crabbox slug, an `ssbx_...` lease ID, or a raw Superserve
+  sandbox ID that has matching Crabbox ownership metadata.
+
+## Related Docs
+
+- [Provider backends](../provider-backends.md)
+- [Provider feature overview](../features/providers.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -97,6 +97,8 @@ Delegated-run providers (no SSH lease):
   `internal/providers/opencomputer`, `internal/providers/anthropicsandboxruntime`,
   `internal/providers/tensorlake`, `internal/providers/upstashbox`,
   `internal/providers/blacksmith`, `internal/providers/wandb`
+- Superserve delegated lifecycle, archive sync, data-plane file upload, exec,
+  and live smoke: `internal/providers/superserve`, `scripts/live-superserve-smoke.sh`
 - Anthropic Sandbox Runtime live local enforcement smoke: `scripts/live-anthropic-sandbox-runtime-smoke.sh`
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`
@@ -131,7 +133,7 @@ Actions hydration or repo scripts.
 Provider docs:
 
 - Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
-- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, and `docs/providers/incus.md` for the separate local live validation contract
+- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/incus.md` for the separate local live validation contract, and `docs/providers/superserve.md` for delegated Superserve execution and live proof
 - Provider/backend authoring guide: `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`
 
@@ -212,5 +214,5 @@ Provider docs:
 - Release workflow and Homebrew tap fallback: `.github/workflows/release.yml`
 - GoReleaser archives and Homebrew formula config: `.goreleaser.yaml`
 - Docs command-surface check, link check, site builder, and Pages deploy: `scripts/check-command-docs.mjs`, `scripts/check-docs-links.mjs`, `scripts/build-docs-site.mjs`, `.github/workflows/pages.yml`
-- Live provider smoke coverage: `scripts/live-smoke.sh`, plus provider-specific guarded smokes such as `scripts/live-digitalocean-smoke.sh`
+- Live provider smoke coverage: `scripts/live-smoke.sh`, plus provider-specific guarded smokes such as `scripts/live-digitalocean-smoke.sh` and `scripts/live-superserve-smoke.sh`
 - Live coordinator auth smoke coverage: `scripts/live-auth-smoke.sh`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -140,6 +140,7 @@ type Config struct {
 	Tensorlake                    TensorlakeConfig
 	OpenComputer                  OpenComputerConfig
 	OpenSandbox                   OpenSandboxConfig
+	Superserve                    SuperserveConfig
 	DockerSandbox                 DockerSandboxConfig
 	AnthropicSRT                  AnthropicSRTConfig
 	Modal                         ModalConfig
@@ -508,6 +509,22 @@ type OpenSandboxConfig struct {
 	PlatformArch    string
 	SecureAccess    bool
 	UseServerProxy  bool
+	ForgetMissing   bool
+}
+
+// SuperserveConfig configures the delegated Superserve provider. The API key is
+// intentionally absent: it is read at runtime from
+// CRABBOX_SUPERSERVE_API_KEY / SUPERSERVE_API_KEY and sent only in request
+// headers, never persisted in Crabbox config or placed on argv.
+type SuperserveConfig struct {
+	BaseURL         string
+	Template        string
+	Snapshot        string
+	Workdir         string
+	TimeoutSecs     int
+	ExecTimeoutSecs int
+	NetworkAllowOut []string
+	NetworkDenyOut  []string
 	ForgetMissing   bool
 }
 
@@ -1723,6 +1740,12 @@ func baseConfig() Config {
 			PlatformOS:      "linux",
 			PlatformArch:    "amd64",
 		},
+		Superserve: SuperserveConfig{
+			BaseURL:         "https://api.superserve.ai",
+			Template:        "superserve/base",
+			Workdir:         "/workspace/crabbox",
+			ExecTimeoutSecs: 600,
+		},
 		DockerSandbox: DockerSandboxConfig{
 			CLIPath: "sbx",
 			Agent:   "shell",
@@ -1905,6 +1928,7 @@ type fileConfig struct {
 	Tensorlake           *fileTensorlakeConfig              `yaml:"tensorlake,omitempty"`
 	OpenComputer         *fileOpenComputerConfig            `yaml:"openComputer,omitempty"`
 	OpenSandbox          *fileOpenSandboxConfig             `yaml:"openSandbox,omitempty"`
+	Superserve           *fileSuperserveConfig              `yaml:"superserve,omitempty"`
 	DockerSandbox        *fileDockerSandboxConfig           `yaml:"dockerSandbox,omitempty"`
 	AnthropicSRT         *fileAnthropicSRTConfig            `yaml:"anthropicSandboxRuntime,omitempty"`
 	Modal                *fileModalConfig                   `yaml:"modal,omitempty"`
@@ -2356,6 +2380,18 @@ type fileOpenSandboxConfig struct {
 	PlatformArch    *string `yaml:"platformArch,omitempty"`
 	SecureAccess    *bool   `yaml:"secureAccess,omitempty"`
 	UseServerProxy  *bool   `yaml:"useServerProxy,omitempty"`
+}
+
+type fileSuperserveConfig struct {
+	BaseURL         string   `yaml:"baseUrl,omitempty"`
+	Template        *string  `yaml:"template,omitempty"`
+	Snapshot        *string  `yaml:"snapshot,omitempty"`
+	Workdir         *string  `yaml:"workdir,omitempty"`
+	TimeoutSecs     *int     `yaml:"timeoutSecs,omitempty"`
+	ExecTimeoutSecs *int     `yaml:"execTimeoutSecs,omitempty"`
+	NetworkAllowOut []string `yaml:"networkAllowOut,omitempty"`
+	NetworkDenyOut  []string `yaml:"networkDenyOut,omitempty"`
+	ForgetMissing   *bool    `yaml:"forgetMissing,omitempty"`
 }
 
 type fileDockerSandboxConfig struct {
@@ -3882,6 +3918,41 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.OpenSandbox.UseServerProxy = *file.OpenSandbox.UseServerProxy
 		}
 	}
+	if file.Superserve != nil {
+		if trusted && strings.TrimSpace(file.Superserve.BaseURL) != "" {
+			cfg.Superserve.BaseURL = file.Superserve.BaseURL
+		}
+		if file.Superserve.Template != nil {
+			cfg.Superserve.Template = *file.Superserve.Template
+		}
+		if file.Superserve.Snapshot != nil {
+			cfg.Superserve.Snapshot = *file.Superserve.Snapshot
+		}
+		if file.Superserve.Workdir != nil {
+			cfg.Superserve.Workdir = *file.Superserve.Workdir
+		}
+		if file.Superserve.TimeoutSecs != nil {
+			if *file.Superserve.TimeoutSecs < 0 {
+				return exit(2, "superserve timeoutSecs must be non-negative")
+			}
+			cfg.Superserve.TimeoutSecs = *file.Superserve.TimeoutSecs
+		}
+		if file.Superserve.ExecTimeoutSecs != nil {
+			if *file.Superserve.ExecTimeoutSecs < 0 {
+				return exit(2, "superserve execTimeoutSecs must be non-negative")
+			}
+			cfg.Superserve.ExecTimeoutSecs = *file.Superserve.ExecTimeoutSecs
+		}
+		if file.Superserve.NetworkAllowOut != nil {
+			cfg.Superserve.NetworkAllowOut = normalizeList(file.Superserve.NetworkAllowOut)
+		}
+		if file.Superserve.NetworkDenyOut != nil {
+			cfg.Superserve.NetworkDenyOut = normalizeList(file.Superserve.NetworkDenyOut)
+		}
+		if file.Superserve.ForgetMissing != nil {
+			cfg.Superserve.ForgetMissing = *file.Superserve.ForgetMissing
+		}
+	}
 	if file.DockerSandbox != nil {
 		if file.DockerSandbox.CLIPath != "" {
 			cfg.DockerSandbox.CLIPath = file.DockerSandbox.CLIPath
@@ -5116,6 +5187,27 @@ func applyEnv(cfg *Config) error {
 	}
 	if v, ok := getenvBool("CRABBOX_OPENSANDBOX_USE_SERVER_PROXY"); ok {
 		cfg.OpenSandbox.UseServerProxy = v
+	}
+	cfg.Superserve.BaseURL = getenv("CRABBOX_SUPERSERVE_BASE_URL", getenv("SUPERSERVE_BASE_URL", cfg.Superserve.BaseURL))
+	cfg.Superserve.Template = getenv("CRABBOX_SUPERSERVE_TEMPLATE", cfg.Superserve.Template)
+	cfg.Superserve.Snapshot = getenv("CRABBOX_SUPERSERVE_SNAPSHOT", cfg.Superserve.Snapshot)
+	cfg.Superserve.Workdir = getenv("CRABBOX_SUPERSERVE_WORKDIR", cfg.Superserve.Workdir)
+	cfg.Superserve.TimeoutSecs, err = getenvNonNegativeInt("CRABBOX_SUPERSERVE_TIMEOUT_SECS", cfg.Superserve.TimeoutSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Superserve.ExecTimeoutSecs, err = getenvNonNegativeInt("CRABBOX_SUPERSERVE_EXEC_TIMEOUT_SECS", cfg.Superserve.ExecTimeoutSecs)
+	if err != nil {
+		return err
+	}
+	if allowOut := os.Getenv("CRABBOX_SUPERSERVE_NETWORK_ALLOW_OUT"); allowOut != "" {
+		cfg.Superserve.NetworkAllowOut = splitCommaList(allowOut)
+	}
+	if denyOut := os.Getenv("CRABBOX_SUPERSERVE_NETWORK_DENY_OUT"); denyOut != "" {
+		cfg.Superserve.NetworkDenyOut = splitCommaList(denyOut)
+	}
+	if v, ok := getenvBool("CRABBOX_SUPERSERVE_FORGET_MISSING"); ok {
+		cfg.Superserve.ForgetMissing = v
 	}
 	cfg.DockerSandbox.CLIPath = getenv("CRABBOX_DOCKER_SANDBOX_CLI", cfg.DockerSandbox.CLIPath)
 	cfg.DockerSandbox.Agent = getenv("CRABBOX_DOCKER_SANDBOX_AGENT", cfg.DockerSandbox.Agent)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -218,7 +218,7 @@ func configShowView(cfg Config) map[string]any {
 			"workdir": cfg.AsciiBox.Workdir,
 		},
 		"superserve": map[string]any{
-			"baseUrl":         cfg.Superserve.BaseURL,
+			"baseUrl":         redactedConfigURL(cfg.Superserve.BaseURL),
 			"auth":            superserveAuthState(),
 			"template":        cfg.Superserve.Template,
 			"snapshot":        cfg.Superserve.Snapshot,
@@ -394,7 +394,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "smolvm base_url=%s image=%s workdir=%s cpus=%d memory_mb=%d network=%s keep=%t auth=%s\n", cfg.Smolvm.BaseURL, cfg.Smolvm.Image, cfg.Smolvm.Workdir, cfg.Smolvm.CPUs, cfg.Smolvm.MemoryMB, cfg.Smolvm.Network, cfg.Smolvm.Keep, tokenState(cfg.Smolvm.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
-	fmt.Fprintf(w, "superserve base_url=%s template=%s snapshot=%s workdir=%s timeout_secs=%d exec_timeout_secs=%d network_allow_out=%s network_deny_out=%s forget_missing=%t auth=%s\n", cfg.Superserve.BaseURL, blank(cfg.Superserve.Template, "-"), blank(cfg.Superserve.Snapshot, "-"), cfg.Superserve.Workdir, cfg.Superserve.TimeoutSecs, cfg.Superserve.ExecTimeoutSecs, blank(strings.Join(cfg.Superserve.NetworkAllowOut, ","), "-"), blank(strings.Join(cfg.Superserve.NetworkDenyOut, ","), "-"), cfg.Superserve.ForgetMissing, superserveAuthState())
+	fmt.Fprintf(w, "superserve base_url=%s template=%s snapshot=%s workdir=%s timeout_secs=%d exec_timeout_secs=%d network_allow_out=%s network_deny_out=%s forget_missing=%t auth=%s\n", redactedConfigURL(cfg.Superserve.BaseURL), blank(cfg.Superserve.Template, "-"), blank(cfg.Superserve.Snapshot, "-"), cfg.Superserve.Workdir, cfg.Superserve.TimeoutSecs, cfg.Superserve.ExecTimeoutSecs, blank(strings.Join(cfg.Superserve.NetworkAllowOut, ","), "-"), blank(strings.Join(cfg.Superserve.NetworkDenyOut, ","), "-"), cfg.Superserve.ForgetMissing, superserveAuthState())
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -210,6 +210,18 @@ func configShowView(cfg Config) map[string]any {
 			"cliPath": cfg.AsciiBox.CLIPath,
 			"workdir": cfg.AsciiBox.Workdir,
 		},
+		"superserve": map[string]any{
+			"baseUrl":         cfg.Superserve.BaseURL,
+			"auth":            superserveAuthState(),
+			"template":        cfg.Superserve.Template,
+			"snapshot":        cfg.Superserve.Snapshot,
+			"workdir":         cfg.Superserve.Workdir,
+			"timeoutSecs":     cfg.Superserve.TimeoutSecs,
+			"execTimeoutSecs": cfg.Superserve.ExecTimeoutSecs,
+			"networkAllowOut": cfg.Superserve.NetworkAllowOut,
+			"networkDenyOut":  cfg.Superserve.NetworkDenyOut,
+			"forgetMissing":   cfg.Superserve.ForgetMissing,
+		},
 		"appleContainer": map[string]any{
 			"cliPath":  cfg.AppleContainer.CLIPath,
 			"image":    cfg.AppleContainer.Image,
@@ -375,6 +387,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "upstash_box base_url=%s runtime=%s size=%s workdir=%s keep_alive=%t auth=%s\n", cfg.UpstashBox.BaseURL, cfg.UpstashBox.Runtime, cfg.UpstashBox.Size, cfg.UpstashBox.Workdir, cfg.UpstashBox.KeepAlive, tokenState(cfg.UpstashBox.APIKey))
 	fmt.Fprintf(w, "smolvm base_url=%s image=%s workdir=%s cpus=%d memory_mb=%d network=%s keep=%t auth=%s\n", cfg.Smolvm.BaseURL, cfg.Smolvm.Image, cfg.Smolvm.Workdir, cfg.Smolvm.CPUs, cfg.Smolvm.MemoryMB, cfg.Smolvm.Network, cfg.Smolvm.Keep, tokenState(cfg.Smolvm.APIKey))
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", cfg.AsciiBox.BaseURL, cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
+	fmt.Fprintf(w, "superserve base_url=%s template=%s snapshot=%s workdir=%s timeout_secs=%d exec_timeout_secs=%d network_allow_out=%s network_deny_out=%s forget_missing=%t auth=%s\n", cfg.Superserve.BaseURL, blank(cfg.Superserve.Template, "-"), blank(cfg.Superserve.Snapshot, "-"), cfg.Superserve.Workdir, cfg.Superserve.TimeoutSecs, cfg.Superserve.ExecTimeoutSecs, blank(strings.Join(cfg.Superserve.NetworkAllowOut, ","), "-"), blank(strings.Join(cfg.Superserve.NetworkDenyOut, ","), "-"), cfg.Superserve.ForgetMissing, superserveAuthState())
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))
@@ -639,6 +652,10 @@ func tokenState(token string) string {
 		return "missing"
 	}
 	return "configured"
+}
+
+func superserveAuthState() string {
+	return tokenState(firstNonBlank(os.Getenv("CRABBOX_SUPERSERVE_API_KEY"), os.Getenv("SUPERSERVE_API_KEY")))
 }
 
 func accessAuthState(access AccessConfig) string {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -318,7 +318,7 @@ func TestConfigShowIncludesSuperserveWithoutSecret(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("CRABBOX_CONFIG", configPath)
 	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "superserve-secret-token")
-	if err := os.WriteFile(configPath, []byte("superserve:\n  baseUrl: https://superserve.example.test\n  template: superserve/custom\n  workdir: /workspace/test\n"), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("superserve:\n  baseUrl: https://user:base-url-secret@superserve.example.test\n  template: superserve/custom\n  workdir: /workspace/test\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -328,11 +328,11 @@ func TestConfigShowIncludesSuperserveWithoutSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := stdout.String()
-	if !strings.Contains(text, "superserve base_url=https://superserve.example.test template=superserve/custom snapshot=- workdir=/workspace/test") || !strings.Contains(text, "auth=configured") {
+	if !strings.Contains(text, "superserve base_url=https://<redacted>@superserve.example.test template=superserve/custom snapshot=- workdir=/workspace/test") || !strings.Contains(text, "auth=configured") {
 		t.Fatalf("config show missing superserve summary: %q", text)
 	}
-	if strings.Contains(text, "superserve-secret-token") {
-		t.Fatalf("config show leaked Superserve token: %q", text)
+	if strings.Contains(text, "superserve-secret-token") || strings.Contains(text, "base-url-secret") {
+		t.Fatalf("config show leaked Superserve credential: %q", text)
 	}
 
 	stdout.Reset()
@@ -350,11 +350,11 @@ func TestConfigShowIncludesSuperserveWithoutSecret(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Superserve.BaseURL != "https://superserve.example.test" || got.Superserve.Template != "superserve/custom" || got.Superserve.Workdir != "/workspace/test" || got.Superserve.Auth != "configured" {
+	if got.Superserve.BaseURL != "https://<redacted>@superserve.example.test" || got.Superserve.Template != "superserve/custom" || got.Superserve.Workdir != "/workspace/test" || got.Superserve.Auth != "configured" {
 		t.Fatalf("unexpected superserve json: %#v", got.Superserve)
 	}
-	if strings.Contains(stdout.String(), "superserve-secret-token") {
-		t.Fatalf("config show json leaked Superserve token: %q", stdout.String())
+	if strings.Contains(stdout.String(), "superserve-secret-token") || strings.Contains(stdout.String(), "base-url-secret") {
+		t.Fatalf("config show json leaked Superserve credential: %q", stdout.String())
 	}
 }
 

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -310,6 +310,54 @@ func TestConfigShowIncludesCloudflareWithoutSecret(t *testing.T) {
 	}
 }
 
+func TestConfigShowIncludesSuperserveWithoutSecret(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "superserve-secret-token")
+	if err := os.WriteFile(configPath, []byte("superserve:\n  baseUrl: https://superserve.example.test\n  template: superserve/custom\n  workdir: /workspace/test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "superserve base_url=https://superserve.example.test template=superserve/custom snapshot=- workdir=/workspace/test") || !strings.Contains(text, "auth=configured") {
+		t.Fatalf("config show missing superserve summary: %q", text)
+	}
+	if strings.Contains(text, "superserve-secret-token") {
+		t.Fatalf("config show leaked Superserve token: %q", text)
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Superserve struct {
+			BaseURL  string `json:"baseUrl"`
+			Auth     string `json:"auth"`
+			Template string `json:"template"`
+			Workdir  string `json:"workdir"`
+		} `json:"superserve"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Superserve.BaseURL != "https://superserve.example.test" || got.Superserve.Template != "superserve/custom" || got.Superserve.Workdir != "/workspace/test" || got.Superserve.Auth != "configured" {
+		t.Fatalf("unexpected superserve json: %#v", got.Superserve)
+	}
+	if strings.Contains(stdout.String(), "superserve-secret-token") {
+		t.Fatalf("config show json leaked Superserve token: %q", stdout.String())
+	}
+}
+
 func TestConfigShowIncludesDigitalOceanProviderConfig(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -2363,7 +2363,7 @@ superserve:
     - ""
     - pkg.example.test
   networkDenyOut:
-    - metadata.google.internal
+    - 169.254.169.254/32
   forgetMissing: true
 cloudflare:
   apiUrl: https://cloudflare.example.test
@@ -2555,7 +2555,7 @@ ssh:
 	if cfg.Superserve.BaseURL != "https://superserve-file-ignored.example.test" || cfg.Superserve.Template != "superserve/custom" || cfg.Superserve.Snapshot != "snap-file" || cfg.Superserve.Workdir != "/workspace/ss-test" || cfg.Superserve.TimeoutSecs != 777 || cfg.Superserve.ExecTimeoutSecs != 888 || !cfg.Superserve.ForgetMissing {
 		t.Fatalf("superserve config not loaded safely: %#v", cfg.Superserve)
 	}
-	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.example.test" || cfg.Superserve.NetworkAllowOut[1] != "pkg.example.test" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "metadata.google.internal" {
+	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.example.test" || cfg.Superserve.NetworkAllowOut[1] != "pkg.example.test" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "169.254.169.254/32" {
 		t.Fatalf("superserve network config not normalized: %#v", cfg.Superserve)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare.example.test" || cfg.Cloudflare.Token != "cloudflare-token" || cfg.Cloudflare.Workdir != "/workspace/cf-test" {
@@ -2937,7 +2937,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_SUPERSERVE_TIMEOUT_SECS", "321")
 	t.Setenv("CRABBOX_SUPERSERVE_EXEC_TIMEOUT_SECS", "654")
 	t.Setenv("CRABBOX_SUPERSERVE_NETWORK_ALLOW_OUT", "api.env.example, ,pkg.env.example")
-	t.Setenv("CRABBOX_SUPERSERVE_NETWORK_DENY_OUT", "metadata.env.example")
+	t.Setenv("CRABBOX_SUPERSERVE_NETWORK_DENY_OUT", "169.254.169.254/32")
 	t.Setenv("CRABBOX_SUPERSERVE_FORGET_MISSING", "true")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_URL", "https://cloudflare-env.example")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", "cloudflare-env-token")
@@ -3118,7 +3118,7 @@ func TestEnvOverridesConfig(t *testing.T) {
 	if cfg.Superserve.BaseURL != "https://superserve-env.example" || cfg.Superserve.Template != "superserve/env-template" || cfg.Superserve.Snapshot != "snap-env" || cfg.Superserve.Workdir != "/workspace/ss-env" || cfg.Superserve.TimeoutSecs != 321 || cfg.Superserve.ExecTimeoutSecs != 654 || !cfg.Superserve.ForgetMissing {
 		t.Fatalf("unexpected superserve env: %#v", cfg.Superserve)
 	}
-	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.env.example" || cfg.Superserve.NetworkAllowOut[1] != "pkg.env.example" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "metadata.env.example" {
+	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.env.example" || cfg.Superserve.NetworkAllowOut[1] != "pkg.env.example" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "169.254.169.254/32" {
 		t.Fatalf("unexpected superserve env network lists: %#v", cfg.Superserve)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare-env.example" || cfg.Cloudflare.Token != "cloudflare-env-token" || cfg.Cloudflare.Workdir != "/workspace/cloudflare-env" {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +97,18 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_OPENSANDBOX_PLATFORM_ARCH",
 		"CRABBOX_OPENSANDBOX_SECURE_ACCESS",
 		"CRABBOX_OPENSANDBOX_USE_SERVER_PROXY",
+		"CRABBOX_SUPERSERVE_API_KEY",
+		"SUPERSERVE_API_KEY",
+		"CRABBOX_SUPERSERVE_BASE_URL",
+		"SUPERSERVE_BASE_URL",
+		"CRABBOX_SUPERSERVE_TEMPLATE",
+		"CRABBOX_SUPERSERVE_SNAPSHOT",
+		"CRABBOX_SUPERSERVE_WORKDIR",
+		"CRABBOX_SUPERSERVE_TIMEOUT_SECS",
+		"CRABBOX_SUPERSERVE_EXEC_TIMEOUT_SECS",
+		"CRABBOX_SUPERSERVE_NETWORK_ALLOW_OUT",
+		"CRABBOX_SUPERSERVE_NETWORK_DENY_OUT",
+		"CRABBOX_SUPERSERVE_FORGET_MISSING",
 		"CRABBOX_ISLO_API_KEY",
 		"ISLO_API_KEY",
 		"CRABBOX_ISLO_BASE_URL",
@@ -1419,6 +1432,51 @@ func TestOpenComputerConfigYAMLCannotSetAPIURL(t *testing.T) {
 	}
 }
 
+func TestSuperserveConfigDefaultsAndNoPersistentSecretSurface(t *testing.T) {
+	cfg := baseConfig()
+	if cfg.Superserve.BaseURL != "https://api.superserve.ai" || cfg.Superserve.Template != "superserve/base" || cfg.Superserve.Workdir != "/workspace/crabbox" || cfg.Superserve.ExecTimeoutSecs != 600 {
+		t.Fatalf("unexpected superserve defaults: %#v", cfg.Superserve)
+	}
+	fieldName := "API" + "Key"
+	if _, ok := reflect.TypeOf(SuperserveConfig{}).FieldByName(fieldName); ok {
+		t.Fatal("provider config must not persist API keys")
+	}
+	if _, ok := reflect.TypeOf(fileSuperserveConfig{}).FieldByName(fieldName); ok {
+		t.Fatal("file config must not accept API keys")
+	}
+}
+
+func TestSuperserveRepoConfigCannotSetBaseURL(t *testing.T) {
+	cfg := baseConfig()
+	var file fileConfig
+	if err := yaml.Unmarshal([]byte("superserve:\n  baseUrl: https://attacker.example\n  template: superserve/repo\n"), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Superserve.BaseURL != "https://api.superserve.ai" {
+		t.Fatalf("repository config set Superserve base URL to %q", cfg.Superserve.BaseURL)
+	}
+	if cfg.Superserve.Template != "superserve/repo" {
+		t.Fatalf("repository config did not set non-secret template: %#v", cfg.Superserve)
+	}
+}
+
+func TestSuperserveTrustedConfigCanSetBaseURL(t *testing.T) {
+	cfg := baseConfig()
+	var file fileConfig
+	if err := yaml.Unmarshal([]byte("superserve:\n  baseUrl: https://trusted.example\n"), &file); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyFileConfigWithTrust(&cfg, file, true); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Superserve.BaseURL != "https://trusted.example" {
+		t.Fatalf("trusted config base URL=%q", cfg.Superserve.BaseURL)
+	}
+}
+
 func TestOpenComputerBurstConfigYAMLAndEnv(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()
@@ -2293,6 +2351,20 @@ openSandbox:
   platformArch: arm64
   secureAccess: true
   useServerProxy: true
+superserve:
+  baseUrl: https://superserve-file-ignored.example.test
+  template: superserve/custom
+  snapshot: snap-file
+  workdir: /workspace/ss-test
+  timeoutSecs: 777
+  execTimeoutSecs: 888
+  networkAllowOut:
+    - api.example.test
+    - ""
+    - pkg.example.test
+  networkDenyOut:
+    - metadata.google.internal
+  forgetMissing: true
 cloudflare:
   apiUrl: https://cloudflare.example.test
   token: cloudflare-token
@@ -2479,6 +2551,12 @@ ssh:
 	}
 	if cfg.OpenSandbox.APIURL != "" || cfg.OpenSandbox.Image != "docker.io/library/python:3.12" || cfg.OpenSandbox.Workdir != "/workspace/osb-test" || cfg.OpenSandbox.CPU != "2" || cfg.OpenSandbox.Memory != "4Gi" || cfg.OpenSandbox.TimeoutSecs != 900 || cfg.OpenSandbox.ExecTimeoutSecs != 1800 || cfg.OpenSandbox.PlatformOS != "linux" || cfg.OpenSandbox.PlatformArch != "arm64" || !cfg.OpenSandbox.SecureAccess || !cfg.OpenSandbox.UseServerProxy {
 		t.Fatalf("opensandbox config not loaded safely: %#v", cfg.OpenSandbox)
+	}
+	if cfg.Superserve.BaseURL != "https://superserve-file-ignored.example.test" || cfg.Superserve.Template != "superserve/custom" || cfg.Superserve.Snapshot != "snap-file" || cfg.Superserve.Workdir != "/workspace/ss-test" || cfg.Superserve.TimeoutSecs != 777 || cfg.Superserve.ExecTimeoutSecs != 888 || !cfg.Superserve.ForgetMissing {
+		t.Fatalf("superserve config not loaded safely: %#v", cfg.Superserve)
+	}
+	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.example.test" || cfg.Superserve.NetworkAllowOut[1] != "pkg.example.test" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "metadata.google.internal" {
+		t.Fatalf("superserve network config not normalized: %#v", cfg.Superserve)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare.example.test" || cfg.Cloudflare.Token != "cloudflare-token" || cfg.Cloudflare.Workdir != "/workspace/cf-test" {
 		t.Fatalf("cloudflare config not loaded: %#v", cfg.Cloudflare)
@@ -2849,6 +2927,18 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_OPENSANDBOX_PLATFORM_ARCH", "amd64")
 	t.Setenv("CRABBOX_OPENSANDBOX_SECURE_ACCESS", "true")
 	t.Setenv("CRABBOX_OPENSANDBOX_USE_SERVER_PROXY", "true")
+	t.Setenv("SUPERSERVE_BASE_URL", "https://superserve-file.example")
+	t.Setenv("CRABBOX_SUPERSERVE_BASE_URL", "https://superserve-env.example")
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "superserve-key-ignored-by-config")
+	t.Setenv("SUPERSERVE_API_KEY", "superserve-vendor-key-ignored-by-config")
+	t.Setenv("CRABBOX_SUPERSERVE_TEMPLATE", "superserve/env-template")
+	t.Setenv("CRABBOX_SUPERSERVE_SNAPSHOT", "snap-env")
+	t.Setenv("CRABBOX_SUPERSERVE_WORKDIR", "/workspace/ss-env")
+	t.Setenv("CRABBOX_SUPERSERVE_TIMEOUT_SECS", "321")
+	t.Setenv("CRABBOX_SUPERSERVE_EXEC_TIMEOUT_SECS", "654")
+	t.Setenv("CRABBOX_SUPERSERVE_NETWORK_ALLOW_OUT", "api.env.example, ,pkg.env.example")
+	t.Setenv("CRABBOX_SUPERSERVE_NETWORK_DENY_OUT", "metadata.env.example")
+	t.Setenv("CRABBOX_SUPERSERVE_FORGET_MISSING", "true")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_URL", "https://cloudflare-env.example")
 	t.Setenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", "cloudflare-env-token")
 	t.Setenv("CRABBOX_CLOUDFLARE_WORKDIR", "/workspace/cloudflare-env")
@@ -3024,6 +3114,12 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.OpenSandbox.APIURL != "https://opensandbox-env.example" || cfg.OpenSandbox.Image != "ubuntu:osb-env" || cfg.OpenSandbox.Workdir != "/workspace/osb-env" || cfg.OpenSandbox.CPU != "750m" || cfg.OpenSandbox.Memory != "1536Mi" || cfg.OpenSandbox.TimeoutSecs != 123 || cfg.OpenSandbox.ExecTimeoutSecs != 456 || cfg.OpenSandbox.PlatformOS != "linux" || cfg.OpenSandbox.PlatformArch != "amd64" || !cfg.OpenSandbox.SecureAccess || !cfg.OpenSandbox.UseServerProxy {
 		t.Fatalf("unexpected opensandbox env: %#v", cfg.OpenSandbox)
+	}
+	if cfg.Superserve.BaseURL != "https://superserve-env.example" || cfg.Superserve.Template != "superserve/env-template" || cfg.Superserve.Snapshot != "snap-env" || cfg.Superserve.Workdir != "/workspace/ss-env" || cfg.Superserve.TimeoutSecs != 321 || cfg.Superserve.ExecTimeoutSecs != 654 || !cfg.Superserve.ForgetMissing {
+		t.Fatalf("unexpected superserve env: %#v", cfg.Superserve)
+	}
+	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[0] != "api.env.example" || cfg.Superserve.NetworkAllowOut[1] != "pkg.env.example" || len(cfg.Superserve.NetworkDenyOut) != 1 || cfg.Superserve.NetworkDenyOut[0] != "metadata.env.example" {
+		t.Fatalf("unexpected superserve env network lists: %#v", cfg.Superserve)
 	}
 	if cfg.Cloudflare.APIURL != "https://cloudflare-env.example" || cfg.Cloudflare.Token != "cloudflare-env-token" || cfg.Cloudflare.Workdir != "/workspace/cloudflare-env" {
 		t.Fatalf("unexpected cloudflare env: %#v", cfg.Cloudflare)

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/smolvm"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"
 	_ "github.com/openclaw/crabbox/internal/providers/ssh"
+	_ "github.com/openclaw/crabbox/internal/providers/superserve"
 	_ "github.com/openclaw/crabbox/internal/providers/tart"
 	_ "github.com/openclaw/crabbox/internal/providers/tenki"
 	_ "github.com/openclaw/crabbox/internal/providers/tensorlake"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -60,6 +60,28 @@ func TestOpenSandboxRegistersWithoutAliasCollision(t *testing.T) {
 	}
 }
 
+func TestSuperserveRegistersWithoutAliases(t *testing.T) {
+	provider, err := core.ProviderFor("superserve")
+	if err != nil {
+		t.Fatalf("ProviderFor(superserve): %v", err)
+	}
+	if provider.Name() != "superserve" {
+		t.Fatalf("ProviderFor(superserve).Name=%q", provider.Name())
+	}
+	spec := provider.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun || spec.Coordinator != core.CoordinatorNever || len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("superserve spec=%#v", spec)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("superserve features=%v", spec.Features)
+	}
+	for _, alias := range []string{"ss", "sup", "super-serve"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == "superserve" {
+			t.Fatalf("%q alias unexpectedly resolves to superserve", alias)
+		}
+	}
+}
+
 func TestAnthropicSandboxRuntimeRegistersCanonicalAndAlias(t *testing.T) {
 	for _, name := range []string{"anthropic-sandbox-runtime", "srt"} {
 		provider, err := core.ProviderFor(name)
@@ -137,6 +159,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"smolvm",
 		"sprites",
 		"ssh",
+		"superserve",
 		"tart",
 		"tenki",
 		"tensorlake",

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"time"
 )
@@ -242,14 +243,18 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return RunResult{}, err
 	}
 	commandText := commandScript(command)
+	commandEnv, strippedAuthEnv := superserveCommandEnv(req.Env)
+	if len(strippedAuthEnv) > 0 {
+		fmt.Fprintf(b.rt.Stderr, "warning: provider=superserve did not forward provider authentication variables: %s\n", strings.Join(strippedAuthEnv, ","))
+	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
 	}
 	commandStart := b.now()
 	execRes, runErr := api.Exec(ctx, &access, execRequest{
 		Command:     commandText,
 		WorkingDir:  workdir,
-		Env:         req.Env,
+		Env:         commandEnv,
 		TimeoutSecs: b.execTimeoutSecs(),
 	}, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(commandStart)
@@ -292,7 +297,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		if result.ExitCode == 0 {
 			result.ExitCode = 1
 		}
-		commandErr = errorsJoin(commandErr, cleanupErr)
+		commandErr = errors.Join(commandErr, cleanupErr)
 	}
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
@@ -578,7 +583,7 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 		Name:           newSandboxName(repo),
 		FromTemplate:   fromTemplate,
 		FromSnapshot:   fromSnapshot,
-		TimeoutSeconds: b.cfg.Superserve.TimeoutSecs,
+		TimeoutSeconds: b.sandboxTimeoutSecs(),
 		Metadata:       initialMetadata,
 		Network:        superserveNetworkConfig(b.cfg),
 	})
@@ -884,6 +889,35 @@ func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.
 
 func (b *backend) execTimeoutSecs() int {
 	return b.cfg.Superserve.ExecTimeoutSecs
+}
+
+func (b *backend) sandboxTimeoutSecs() int {
+	if b.cfg.Superserve.TimeoutSecs > 0 {
+		return b.cfg.Superserve.TimeoutSecs
+	}
+	lifetime := b.cfg.TTL
+	if lifetime <= 0 {
+		lifetime = 90 * time.Minute
+	}
+	return int((lifetime + time.Second - 1) / time.Second)
+}
+
+func superserveCommandEnv(env map[string]string) (map[string]string, []string) {
+	if len(env) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(env))
+	var stripped []string
+	for name, value := range env {
+		switch name {
+		case "CRABBOX_SUPERSERVE_API_KEY", "SUPERSERVE_API_KEY":
+			stripped = append(stripped, name)
+		default:
+			out[name] = value
+		}
+	}
+	slices.Sort(stripped)
+	return out, stripped
 }
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -80,10 +80,11 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, slug, err := b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+	leaseID, sandboxID, slug, unlockOperation, err := b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	defer unlockOperation()
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: superserve warmup keeps the sandbox until explicit stop\n")
@@ -102,7 +103,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
 	if req.Options.Tailscale.Enabled {
 		return RunResult{}, exit(2, "provider=superserve is delegated-run only and does not support Tailscale options")
 	}
@@ -117,15 +118,29 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
+	var unlockOperation func()
+	defer func() {
+		if unlockOperation != nil {
+			unlockOperation()
+		}
+	}()
 	if req.ID == "" {
-		leaseID, sandboxID, slug, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+		leaseID, sandboxID, slug, unlockOperation, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
 		acquired = true
 	} else {
-		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+		leaseID, sandboxID, _, err = resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+		if err != nil {
+			return RunResult{}, err
+		}
+		unlockOperation, err = lockSuperserveLeaseOperation(ctx, leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
+		leaseID, sandboxID, _, err = resolveLeaseID(leaseID, "", false, 0, api.BaseURL())
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -154,16 +169,16 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
 		defer func() {
-			if !shouldStop {
-				return
+			if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+				if result.ExitCode == 0 {
+					result.ExitCode = 1
+				}
+				if retErr == nil {
+					retErr = exit(1, "%v", cleanupErr)
+				} else {
+					retErr = errors.Join(retErr, cleanupErr)
+				}
 			}
-			cleanupCtx, cancel := b.cleanupContext(ctx)
-			defer cancel()
-			if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isSuperserveNotFound(err) {
-				fmt.Fprintf(b.rt.Stderr, "warning: superserve delete failed for %s: %v\n", sandboxID, err)
-				return
-			}
-			removeLeaseClaim(leaseID)
 		}()
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
@@ -195,6 +210,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if activityErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: refresh superserve lease activity failed lease=%s: %v\n", leaseID, activityErr)
 			result.ExitCode = 1
+		}
+		if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+			result.ExitCode = 1
+			return result, cleanupErr
 		}
 		if req.TimingJSON {
 			if err := writeTimingJSON(b.rt.Stderr, timingReport{
@@ -234,7 +253,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		TimeoutSecs: b.execTimeoutSecs(),
 	}, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(commandStart)
-	result := RunResult{
+	result = RunResult{
 		Provider:      providerName,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -268,6 +287,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		if commandErr == nil {
 			result.ExitCode = 1
 		}
+	}
+	if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+		if result.ExitCode == 0 {
+			result.ExitCode = 1
+		}
+		commandErr = errorsJoin(commandErr, cleanupErr)
 	}
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
@@ -413,7 +438,16 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+	leaseID, _, _, err := resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+	if err != nil {
+		return err
+	}
+	unlockOperation, err := lockSuperserveLeaseOperation(ctx, leaseID)
+	if err != nil {
+		return err
+	}
+	defer unlockOperation()
+	leaseID, sandboxID, _, err := resolveLeaseID(leaseID, "", false, 0, api.BaseURL())
 	if err != nil {
 		return err
 	}
@@ -453,51 +487,76 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if listed.Provider != providerName || !superserveClaimMatchesEndpoint(listed, api.BaseURL()) {
 			continue
 		}
-		claim, err := readLeaseClaim(listed.LeaseID)
+		var removedOne, claimRemovedOne, checkedOne bool
+		err := func() error {
+			unlockOperation, err := lockSuperserveLeaseOperation(ctx, listed.LeaseID)
+			if err != nil {
+				return err
+			}
+			defer unlockOperation()
+			claim, err := readLeaseClaim(listed.LeaseID)
+			if err != nil {
+				return err
+			}
+			if claim.LeaseID == "" || claim.Provider != providerName || !superserveClaimMatchesEndpoint(claim, api.BaseURL()) {
+				return nil
+			}
+			checkedOne = true
+			sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
+			sb, getErr := api.GetSandbox(ctx, sandboxID)
+			if getErr != nil {
+				if !isSuperserveNotFound(getErr) {
+					return getErr
+				}
+				if !b.cfg.Superserve.ForgetMissing {
+					fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set superserve forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
+					return nil
+				}
+				if req.DryRun {
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					return nil
+				}
+				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+					return err
+				}
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				claimRemovedOne = true
+				return nil
+			}
+			due, reason := superserveClaimCleanupDue(claim, now)
+			if !due {
+				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+				return nil
+			}
+			if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
+				return err
+			}
+			if req.DryRun {
+				fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+				return nil
+			}
+			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isSuperserveNotFound(err) {
+				return err
+			}
+			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				return err
+			}
+			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+			removedOne = true
+			return nil
+		}()
 		if err != nil {
 			return err
 		}
-		if claim.LeaseID == "" || claim.Provider != providerName || !superserveClaimMatchesEndpoint(claim, api.BaseURL()) {
-			continue
+		if checkedOne {
+			checked++
 		}
-		checked++
-		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
-		sb, getErr := api.GetSandbox(ctx, sandboxID)
-		if getErr != nil {
-			if !isSuperserveNotFound(getErr) {
-				return getErr
-			}
-			if !b.cfg.Superserve.ForgetMissing {
-				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set superserve forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
-				continue
-			}
-			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
-				continue
-			}
-			removeLeaseClaim(claim.LeaseID)
-			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+		if removedOne {
+			removed++
+		}
+		if claimRemovedOne {
 			claimsRemoved++
-			continue
 		}
-		due, reason := superserveClaimCleanupDue(claim, now)
-		if !due {
-			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			continue
-		}
-		if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
-			return err
-		}
-		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			continue
-		}
-		if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isSuperserveNotFound(err) {
-			return err
-		}
-		removeLeaseClaim(claim.LeaseID)
-		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-		removed++
 	}
 	if !req.DryRun {
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
@@ -505,13 +564,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, func(), error) {
 	providerScope, err := newSuperserveClaimScope(api.BaseURL())
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", nil, err
 	}
 	if _, err := superserveWorkdir(b.cfg); err != nil {
-		return "", "", "", err
+		return "", "", "", nil, err
 	}
 	initialMetadata := b.ownershipMetadata(api.BaseURL(), providerScope, "", "", repo)
 	fromTemplate, fromSnapshot := superserveCreateSource(b.cfg)
@@ -524,25 +583,36 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 		Network:        superserveNetworkConfig(b.cfg),
 	})
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", nil, err
 	}
 	leaseID := leasePrefix + sb.ID
+	unlockOperation, err := lockSuperserveLeaseOperation(ctx, leaseID)
+	if err != nil {
+		return leaseID, sb.ID, "", nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
+	keepLock := false
+	defer func() {
+		if !keepLock {
+			unlockOperation()
+		}
+	}()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
+		return leaseID, sb.ID, "", nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	metadata := b.ownershipMetadata(api.BaseURL(), providerScope, leaseID, slug, repo)
 	sb, err = api.UpdateSandboxMetadata(ctx, sb.ID, metadata)
 	if err != nil {
-		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+		return leaseID, sb.ID, slug, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	if err := validateSuperserveSandboxOwnership(LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
-		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+		return leaseID, sb.ID, slug, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+		return leaseID, sb.ID, slug, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	return leaseID, sb.ID, slug, nil
+	keepLock = true
+	return leaseID, sb.ID, slug, unlockOperation, nil
 }
 
 func superserveCreateSource(cfg Config) (string, string) {
@@ -790,6 +860,20 @@ func (b *backend) cleanupClaimedRunFailure(ctx context.Context, api superserveCl
 	return cause
 }
 
+func (b *backend) cleanupCreatedRun(ctx context.Context, api superserveClient, leaseID, sandboxID string, shouldStop *bool) error {
+	if !*shouldStop {
+		return nil
+	}
+	*shouldStop = false
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isSuperserveNotFound(err) {
+		return fmt.Errorf("superserve delete failed for %s: %w", sandboxID, err)
+	}
+	removeLeaseClaim(leaseID)
+	return nil
+}
+
 func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	timeout := superserveCleanupTimeout
 	if b.cleanupTimeoutOverride > 0 {
@@ -799,10 +883,7 @@ func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.
 }
 
 func (b *backend) execTimeoutSecs() int {
-	if b.cfg.Superserve.ExecTimeoutSecs > 0 {
-		return b.cfg.Superserve.ExecTimeoutSecs
-	}
-	return 600
+	return b.cfg.Superserve.ExecTimeoutSecs
 }
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -5,8 +5,10 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -101,8 +103,173 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	_ = req
-	return RunResult{}, notImplemented(ctx, "run")
+	if req.Options.Tailscale.Enabled {
+		return RunResult{}, exit(2, "provider=superserve is delegated-run only and does not support Tailscale options")
+	}
+	workdir, err := superserveWorkdir(b.cfg)
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	api, err := b.client()
+	if err != nil {
+		return RunResult{}, err
+	}
+	leaseID, sandboxID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		leaseID, sandboxID, slug, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+		if err != nil {
+			return RunResult{}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+		acquired = true
+	} else {
+		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+		if err != nil {
+			return RunResult{}, err
+		}
+		if _, err := verifySuperserveClaim(ctx, api, leaseID, sandboxID); err != nil {
+			return RunResult{}, err
+		}
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
+		_, _, slug, err = finishResolvedLease(claim, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.BaseURL())
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
+	access, err := api.ActivateSandbox(ctx, sandboxID)
+	if err != nil {
+		if acquired {
+			return RunResult{}, b.cleanupClaimedRunFailure(ctx, api, leaseID, sandboxID, err)
+		}
+		return RunResult{}, err
+	}
+	if access.Sandbox.ID == "" {
+		access.Sandbox.ID = sandboxID
+	}
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
+		defer func() {
+			if !shouldStop {
+				return
+			}
+			cleanupCtx, cancel := b.cleanupContext(ctx)
+			defer cancel()
+			if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isSuperserveNotFound(err) {
+				fmt.Fprintf(b.rt.Stderr, "warning: superserve delete failed for %s: %v\n", sandboxID, err)
+				return
+			}
+			removeLeaseClaim(leaseID)
+		}()
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, &access, req, workdir)
+		if err != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.ensureWorkspace(ctx, api, &access, workdir); err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return RunResult{}, err
+	}
+
+	if req.SyncOnly {
+		result := RunResult{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			Total:         b.now().Sub(started),
+			SyncDelegated: true,
+		}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		if req.TimingJSON {
+			return result, writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      0,
+				Label:         strings.TrimSpace(req.Label),
+			})
+		}
+		return result, nil
+	}
+
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{}, err
+	}
+	commandText := commandScript(command)
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+	}
+	commandStart := b.now()
+	execRes, runErr := api.Exec(ctx, &access, execRequest{
+		Command:     commandText,
+		WorkingDir:  workdir,
+		Env:         req.Env,
+		TimeoutSecs: b.execTimeoutSecs(),
+	}, b.rt.Stdout, b.rt.Stderr)
+	commandDuration := b.now().Sub(commandStart)
+	result := RunResult{
+		Provider:      providerName,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   commandText,
+		ExitCode:      execRes.ExitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "superserve run summary sync_skipped=true command=%s total=%s exit=%d\n",
+			result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "superserve run summary sync=%s command=%s total=%s exit=%d\n",
+			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     result.Command.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}); err != nil {
+			return result, err
+		}
+	}
+	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		if result.ExitCode == 0 {
+			result.ExitCode = 1
+		}
+		return result, ExitError{Code: 1, Message: fmt.Sprintf("superserve run failed: %v", runErr)}
+	}
+	if result.ExitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("superserve run exited %d", result.ExitCode)}
+	}
+	return result, nil
 }
 
 func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
@@ -543,12 +710,49 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, api superserveClient
 	return cause
 }
 
+func (b *backend) cleanupClaimedRunFailure(ctx context.Context, api superserveClient, leaseID, sandboxID string, cause error) error {
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isSuperserveNotFound(err) {
+		return errors.Join(cause, fmt.Errorf("superserve cleanup failed for sandbox %s; delete it in the Superserve console: %w", sandboxID, err))
+	}
+	removeLeaseClaim(leaseID)
+	return cause
+}
+
 func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	timeout := superserveCleanupTimeout
 	if b.cleanupTimeoutOverride > 0 {
 		timeout = b.cleanupTimeoutOverride
 	}
 	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
+}
+
+func (b *backend) execTimeoutSecs() int {
+	if b.cfg.Superserve.ExecTimeoutSecs > 0 {
+		return b.cfg.Superserve.ExecTimeoutSecs
+	}
+	return 600
+}
+
+func buildCommand(command []string, shellMode bool) ([]string, error) {
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if shellMode {
+		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		if len(command) == 1 {
+			return []string{"bash", "-lc", command[0]}, nil
+		}
+		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	}
+	return command, nil
+}
+
+func commandScript(command []string) string {
+	return shellScriptFromArgv(command)
 }
 
 func (b *backend) now() time.Time {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -1,0 +1,651 @@
+package superserve
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	superserveCleanupTimeout = 15 * time.Second
+	statusViewReady          = "running"
+	NetworkPublic            = "public"
+
+	metadataProviderKey = "crabbox.provider"
+	metadataEndpointKey = "crabbox.endpoint"
+	metadataScopeKey    = "crabbox.scope"
+	metadataClaimKey    = "crabbox.claim"
+	metadataRepoKey     = "crabbox.repo"
+	metadataPondKey     = "crabbox.pond"
+	metadataSlugKey     = "crabbox.slug"
+	metadataNameKey     = "crabbox.name"
+)
+
+func NewSuperserveBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt, newClient: newSuperserveClient}
+}
+
+type backend struct {
+	spec                   ProviderSpec
+	cfg                    Config
+	rt                     Runtime
+	newClient              func(Config, Runtime) (superserveClient, error)
+	cleanupTimeoutOverride time.Duration
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) client() (superserveClient, error) {
+	if b.newClient != nil {
+		return b.newClient(b.cfg, b.rt)
+	}
+	return newSuperserveClient(b.cfg, b.rt)
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	api, err := b.client()
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	if err := api.Probe(ctx); err != nil {
+		return DoctorResult{}, err
+	}
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	if req.Options.Tailscale.Enabled {
+		return exit(2, "provider=superserve is delegated-run only and does not support Tailscale options")
+	}
+	if _, err := superserveWorkdir(b.cfg); err != nil {
+		return err
+	}
+	started := b.now()
+	api, err := b.client()
+	if err != nil {
+		return err
+	}
+	leaseID, sandboxID, slug, err := b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: superserve warmup keeps the sandbox until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	_ = req
+	return RunResult{}, notImplemented(ctx, "run")
+}
+
+func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	api, err := b.client()
+	if err != nil {
+		return nil, err
+	}
+	sandboxes, err := api.ListSandboxes(ctx, b.baseMetadataFilter(api.BaseURL()))
+	if err != nil {
+		return nil, err
+	}
+	views := make([]LeaseView, 0, len(sandboxes))
+	for _, sb := range sandboxes {
+		leaseID := strings.TrimSpace(sb.Metadata[metadataClaimKey])
+		if leaseID == "" {
+			continue
+		}
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			return nil, err
+		}
+		if claim.LeaseID == "" || claim.Provider != providerName {
+			continue
+		}
+		if err := validateSuperserveClaimScope(claim, api.BaseURL()); err != nil {
+			return nil, err
+		}
+		if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
+			return nil, err
+		}
+		views = append(views, b.serverFromSandbox(claim, sb))
+	}
+	return views, nil
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	api, err := b.client()
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+	if err != nil {
+		return StatusView{}, err
+	}
+	claim, ok, err := resolveSuperserveLeaseClaim(leaseID, api.BaseURL())
+	if err != nil {
+		return StatusView{}, err
+	}
+	if !ok {
+		return StatusView{}, exit(4, "superserve sandbox %q is not claimed by Crabbox", req.ID)
+	}
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
+	}
+	deadline := b.now().Add(waitTimeout)
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+	for {
+		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		if getErr != nil {
+			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
+				return StatusView{}, exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
+			}
+			if ctx.Err() != nil {
+				return StatusView{}, ctx.Err()
+			}
+			return StatusView{}, getErr
+		}
+		if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
+			return StatusView{}, err
+		}
+		state := normalizedSandboxState(sb)
+		view := StatusView{
+			ID:       leaseID,
+			Slug:     slug,
+			Provider: providerName,
+			TargetOS: targetLinux,
+			State:    state,
+			ServerID: sandboxID,
+			Pond:     claim.Pond,
+			Network:  NetworkPublic,
+			Ready:    isReadyState(state),
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    leaseID,
+				"slug":     slug,
+				"pond":     claim.Pond,
+				"state":    state,
+			},
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if isTerminalState(state) {
+			return StatusView{}, exit(5, "superserve sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
+		}
+		select {
+		case <-pollCtx.Done():
+			if ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
+			}
+			return StatusView{}, pollCtx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	api, err := b.client()
+	if err != nil {
+		return err
+	}
+	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+	if err != nil {
+		return err
+	}
+	if _, err := verifySuperserveClaim(ctx, api, leaseID, sandboxID); err != nil {
+		if !isSuperserveNotFound(err) || !b.cfg.Superserve.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing superserve sandbox=%s after explicit request\n", sandboxID)
+		removeLeaseClaim(leaseID)
+		return nil
+	}
+	if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
+		if !isSuperserveNotFound(err) || !b.cfg.Superserve.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing superserve sandbox=%s after explicit request\n", sandboxID)
+	}
+	removeLeaseClaim(leaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	return nil
+}
+
+func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	api, err := b.client()
+	if err != nil {
+		return err
+	}
+	claims, err := listSuperserveLeaseClaims()
+	if err != nil {
+		return err
+	}
+	now := b.now().UTC()
+	checked := 0
+	removed := 0
+	claimsRemoved := 0
+	for _, listed := range claims {
+		if listed.Provider != providerName || !superserveClaimMatchesEndpoint(listed, api.BaseURL()) {
+			continue
+		}
+		claim, err := readLeaseClaim(listed.LeaseID)
+		if err != nil {
+			return err
+		}
+		if claim.LeaseID == "" || claim.Provider != providerName || !superserveClaimMatchesEndpoint(claim, api.BaseURL()) {
+			continue
+		}
+		checked++
+		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
+		sb, getErr := api.GetSandbox(ctx, sandboxID)
+		if getErr != nil {
+			if !isSuperserveNotFound(getErr) {
+				return getErr
+			}
+			if !b.cfg.Superserve.ForgetMissing {
+				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set superserve forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
+				continue
+			}
+			if req.DryRun {
+				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				continue
+			}
+			removeLeaseClaim(claim.LeaseID)
+			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+			claimsRemoved++
+			continue
+		}
+		due, reason := superserveClaimCleanupDue(claim, now)
+		if !due {
+			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+			continue
+		}
+		if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
+			return err
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+			continue
+		}
+		if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isSuperserveNotFound(err) {
+			return err
+		}
+		removeLeaseClaim(claim.LeaseID)
+		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+		removed++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
+	}
+	return nil
+}
+
+func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+	providerScope, err := newSuperserveClaimScope(api.BaseURL())
+	if err != nil {
+		return "", "", "", err
+	}
+	workdir, err := superserveWorkdir(b.cfg)
+	if err != nil {
+		return "", "", "", err
+	}
+	initialMetadata := b.ownershipMetadata(api.BaseURL(), providerScope, "", "", repo)
+	sb, err := api.CreateSandbox(ctx, createSandboxRequest{
+		Template:    strings.TrimSpace(b.cfg.Superserve.Template),
+		Snapshot:    strings.TrimSpace(b.cfg.Superserve.Snapshot),
+		Workdir:     workdir,
+		TimeoutSecs: b.cfg.Superserve.TimeoutSecs,
+		Metadata:    initialMetadata,
+	})
+	if err != nil {
+		return "", "", "", err
+	}
+	leaseID := leasePrefix + sb.ID
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
+	metadata := b.ownershipMetadata(api.BaseURL(), providerScope, leaseID, slug, repo)
+	sb, err = api.UpdateSandboxMetadata(ctx, sb.ID, metadata)
+	if err != nil {
+		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
+	if err := validateSuperserveSandboxOwnership(LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
+		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
+	}
+	return leaseID, sb.ID, slug, nil
+}
+
+func (b *backend) ownershipMetadata(baseURL, providerScope, leaseID, slug string, repo Repo) map[string]string {
+	out := map[string]string{
+		metadataProviderKey: providerName,
+		metadataEndpointKey: superserveEndpointScope(baseURL),
+		metadataScopeKey:    providerScope,
+		metadataNameKey:     newSandboxName(repo),
+		metadataRepoKey:     repoScope(repo),
+	}
+	if leaseID != "" {
+		out[metadataClaimKey] = leaseID
+	}
+	if slug != "" {
+		out[metadataSlugKey] = slug
+	}
+	if pond := strings.TrimSpace(b.cfg.Pond); pond != "" {
+		out[metadataPondKey] = pond
+	}
+	return out
+}
+
+func (b *backend) baseMetadataFilter(baseURL string) map[string]string {
+	return map[string]string{
+		metadataProviderKey: providerName,
+		metadataEndpointKey: superserveEndpointScope(baseURL),
+	}
+}
+
+func (b *backend) serverFromSandbox(claim LeaseClaim, sb superserveSandbox) Server {
+	state := normalizedSandboxState(sb)
+	return Server{
+		Provider: providerName,
+		CloudID:  sb.ID,
+		Name:     sb.ID,
+		Status:   state,
+		Labels: map[string]string{
+			"provider": providerName,
+			"lease":    claim.LeaseID,
+			"slug":     claim.Slug,
+			"pond":     claim.Pond,
+			"target":   targetLinux,
+			"state":    state,
+		},
+	}
+}
+
+func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", "", exit(2, "provider=superserve requires a Crabbox-created sandbox slug or lease id")
+	}
+	exactLeaseID := id
+	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
+		exactLeaseID = leasePrefix + exactLeaseID
+	}
+	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
+		return "", "", "", err
+	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
+	}
+	claim, ok, err := resolveSuperserveLeaseClaim(id, baseURL)
+	if err != nil {
+		return "", "", "", err
+	}
+	if ok {
+		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
+	}
+	return "", "", "", exit(4, "superserve sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+}
+
+func resolveSuperserveLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
+	claims, err := listSuperserveLeaseClaims()
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	for _, claim := range claims {
+		if claim.Provider == providerName && claim.LeaseID == identifier {
+			if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
+				return LeaseClaim{}, false, err
+			}
+			return claim, true, nil
+		}
+	}
+	slug := normalizeLeaseSlug(identifier)
+	if slug != "" {
+		for _, claim := range claims {
+			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
+				if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
+					return LeaseClaim{}, false, err
+				}
+				return claim, true, nil
+			}
+		}
+	}
+	return LeaseClaim{}, false, nil
+}
+
+func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
+	if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
+		return "", "", "", err
+	}
+	if repoRoot != "" {
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
+			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	slug := claim.Slug
+	if strings.TrimSpace(slug) == "" {
+		slug = newLeaseSlug(claim.LeaseID)
+	}
+	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+}
+
+func newSuperserveClaimScope(baseURL string) (string, error) {
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", exit(5, "generate superserve ownership token: %v", err)
+	}
+	return superserveEndpointScope(baseURL) + "/ownership:" + hex.EncodeToString(token[:]), nil
+}
+
+func validateSuperserveClaimScope(claim LeaseClaim, baseURL string) error {
+	if !superserveClaimMatchesEndpoint(claim, baseURL) {
+		return exit(4, "superserve lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
+	}
+	return nil
+}
+
+func superserveClaimMatchesEndpoint(claim LeaseClaim, baseURL string) bool {
+	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), superserveEndpointScope(baseURL)+"/ownership:")
+}
+
+func verifySuperserveClaim(ctx context.Context, api superserveClient, leaseID, sandboxID string) (superserveSandbox, error) {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return superserveSandbox{}, err
+	}
+	if err := validateSuperserveClaimScope(claim, api.BaseURL()); err != nil {
+		return superserveSandbox{}, err
+	}
+	sb, err := api.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return superserveSandbox{}, err
+	}
+	if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
+		return superserveSandbox{}, err
+	}
+	return sb, nil
+}
+
+func validateSuperserveSandboxOwnership(claim LeaseClaim, sb superserveSandbox) error {
+	if sb.ID == "" {
+		return exit(5, "superserve returned a sandbox without an id")
+	}
+	if sb.Metadata[metadataProviderKey] != providerName ||
+		sb.Metadata[metadataScopeKey] != claim.ProviderScope ||
+		sb.Metadata[metadataClaimKey] != claim.LeaseID {
+		return exit(4, "superserve sandbox %q ownership metadata does not match its local claim", sb.ID)
+	}
+	return nil
+}
+
+func superserveClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
+	if claim.IdleTimeoutSeconds <= 0 {
+		return false, "idle timeout disabled"
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil {
+		return false, "invalid last-used time"
+	}
+	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
+	if now.Before(deadline) {
+		return false, "idle timeout not reached"
+	}
+	return true, "idle timeout"
+}
+
+func (b *backend) cleanupCreateFailure(ctx context.Context, api superserveClient, sandboxID string, cause error) error {
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil {
+		if isSuperserveNotFound(err) {
+			return cause
+		}
+		return errorsJoin(cause, fmt.Errorf("superserve cleanup failed for sandbox %s; delete it in the Superserve console: %w", sandboxID, err))
+	}
+	return cause
+}
+
+func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := superserveCleanupTimeout
+	if b.cleanupTimeoutOverride > 0 {
+		timeout = b.cleanupTimeoutOverride
+	}
+	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
+}
+
+func (b *backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}
+
+func normalizedSandboxState(sb superserveSandbox) string {
+	return strings.ToLower(blank(strings.TrimSpace(sb.Status), blank(strings.TrimSpace(sb.State), statusViewReady)))
+}
+
+func isReadyState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "running", "ready", "started", "active":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTerminalState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "terminated", "stopped", "failed", "error", "killed", "deleted":
+		return true
+	default:
+		return false
+	}
+}
+
+func newSandboxName(repo Repo) string {
+	base := normalizeLeaseSlug(repo.Name)
+	if base == "" {
+		base = "crabbox"
+	}
+	base = strings.TrimPrefix(base, strings.TrimSuffix(namePrefix, "-")+"-")
+	if base == "" {
+		base = "crabbox"
+	}
+	if len(base) > 40 {
+		base = strings.Trim(base[:40], "-")
+	}
+	return namePrefix + base + "-" + randomSuffix()
+}
+
+func repoScope(repo Repo) string {
+	value := strings.TrimSpace(repo.Root)
+	if value == "" {
+		value = strings.TrimSpace(repo.Name)
+	}
+	sum := sha256.Sum256([]byte(value))
+	return "repo-sha256:" + hex.EncodeToString(sum[:8])
+}
+
+func randomSuffix() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func errorsJoin(errs ...error) error {
+	var out error
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if out == nil {
+			out = err
+			continue
+		}
+		out = fmt.Errorf("%v; %w", out, err)
+	}
+	return out
+}
+
+func dataPlaneHostForSandbox(sandboxID, sandboxHost string) string {
+	sandboxID = strings.TrimSpace(sandboxID)
+	sandboxHost = strings.TrimSpace(sandboxHost)
+	if sandboxID == "" || sandboxHost == "" {
+		return ""
+	}
+	if strings.Contains(sandboxHost, "://") {
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(sandboxHost); err == nil {
+		host, _, _ := net.SplitHostPort(sandboxHost)
+		sandboxHost = host
+	}
+	return "boxd-" + sandboxID + "." + sandboxHost
+}

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -191,8 +191,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			SyncDelegated: true,
 		}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		activityErr := b.refreshSuperserveActivityIfRetained(leaseID, shouldStop)
+		if activityErr != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: refresh superserve lease activity failed lease=%s: %v\n", leaseID, activityErr)
+			result.ExitCode = 1
+		}
 		if req.TimingJSON {
-			return result, writeTimingJSON(b.rt.Stderr, timingReport{
+			if err := writeTimingJSON(b.rt.Stderr, timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -201,9 +206,14 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				SyncPhases:    syncPhases,
 				SyncSkipped:   req.NoSync,
 				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
+				ExitCode:      result.ExitCode,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}); err != nil {
+				return result, err
+			}
+		}
+		if activityErr != nil {
+			return result, activityErr
 		}
 		return result, nil
 	}
@@ -241,6 +251,24 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		fmt.Fprintf(b.rt.Stderr, "superserve run summary sync=%s command=%s total=%s exit=%d\n",
 			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
+	var commandErr error
+	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		if result.ExitCode == 0 {
+			result.ExitCode = 1
+		}
+		commandErr = ExitError{Code: 1, Message: fmt.Sprintf("superserve run failed: %v", runErr)}
+	} else if result.ExitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		commandErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("superserve run exited %d", result.ExitCode)}
+	}
+	activityErr := b.refreshSuperserveActivityIfRetained(leaseID, shouldStop)
+	if activityErr != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: refresh superserve lease activity failed lease=%s: %v\n", leaseID, activityErr)
+		if commandErr == nil {
+			result.ExitCode = 1
+		}
+	}
 	if req.TimingJSON {
 		if err := writeTimingJSON(b.rt.Stderr, timingReport{
 			Provider:      providerName,
@@ -258,16 +286,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return result, err
 		}
 	}
-	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		if result.ExitCode == 0 {
-			result.ExitCode = 1
-		}
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("superserve run failed: %v", runErr)}
+	if commandErr != nil {
+		return result, commandErr
 	}
-	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("superserve run exited %d", result.ExitCode)}
+	if activityErr != nil {
+		return result, activityErr
 	}
 	return result, nil
 }
@@ -491,10 +514,11 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 		return "", "", "", err
 	}
 	initialMetadata := b.ownershipMetadata(api.BaseURL(), providerScope, "", "", repo)
+	fromTemplate, fromSnapshot := superserveCreateSource(b.cfg)
 	sb, err := api.CreateSandbox(ctx, createSandboxRequest{
 		Name:           newSandboxName(repo),
-		FromTemplate:   strings.TrimSpace(b.cfg.Superserve.Template),
-		FromSnapshot:   strings.TrimSpace(b.cfg.Superserve.Snapshot),
+		FromTemplate:   fromTemplate,
+		FromSnapshot:   fromSnapshot,
 		TimeoutSeconds: b.cfg.Superserve.TimeoutSecs,
 		Metadata:       initialMetadata,
 		Network:        superserveNetworkConfig(b.cfg),
@@ -519,6 +543,14 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
+}
+
+func superserveCreateSource(cfg Config) (string, string) {
+	snapshot := strings.TrimSpace(cfg.Superserve.Snapshot)
+	if snapshot != "" {
+		return "", snapshot
+	}
+	return strings.TrimSpace(cfg.Superserve.Template), ""
 }
 
 func superserveNetworkConfig(cfg Config) *createSandboxNetworkCfg {
@@ -706,6 +738,34 @@ func superserveClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
 		return false, "idle timeout not reached"
 	}
 	return true, "idle timeout"
+}
+
+func (b *backend) refreshSuperserveLeaseActivity(leaseID string) error {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return err
+	}
+	if claim.LeaseID == "" {
+		return nil
+	}
+	idleTimeout := timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second)
+	return claimLeaseForRepoProviderScopePond(
+		claim.LeaseID,
+		claim.Slug,
+		providerName,
+		claim.ProviderScope,
+		claim.Pond,
+		claim.RepoRoot,
+		idleTimeout,
+		false,
+	)
+}
+
+func (b *backend) refreshSuperserveActivityIfRetained(leaseID string, shouldStop bool) error {
+	if shouldStop {
+		return nil
+	}
+	return b.refreshSuperserveLeaseActivity(leaseID)
 }
 
 func (b *backend) cleanupCreateFailure(ctx context.Context, api superserveClient, sandboxID string, cause error) error {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -487,17 +487,17 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 	if err != nil {
 		return "", "", "", err
 	}
-	workdir, err := superserveWorkdir(b.cfg)
-	if err != nil {
+	if _, err := superserveWorkdir(b.cfg); err != nil {
 		return "", "", "", err
 	}
 	initialMetadata := b.ownershipMetadata(api.BaseURL(), providerScope, "", "", repo)
 	sb, err := api.CreateSandbox(ctx, createSandboxRequest{
-		Template:    strings.TrimSpace(b.cfg.Superserve.Template),
-		Snapshot:    strings.TrimSpace(b.cfg.Superserve.Snapshot),
-		Workdir:     workdir,
-		TimeoutSecs: b.cfg.Superserve.TimeoutSecs,
-		Metadata:    initialMetadata,
+		Name:           newSandboxName(repo),
+		FromTemplate:   strings.TrimSpace(b.cfg.Superserve.Template),
+		FromSnapshot:   strings.TrimSpace(b.cfg.Superserve.Snapshot),
+		TimeoutSeconds: b.cfg.Superserve.TimeoutSecs,
+		Metadata:       initialMetadata,
+		Network:        superserveNetworkConfig(b.cfg),
 	})
 	if err != nil {
 		return "", "", "", err
@@ -519,6 +519,16 @@ func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo 
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
+}
+
+func superserveNetworkConfig(cfg Config) *createSandboxNetworkCfg {
+	if len(cfg.Superserve.NetworkAllowOut) == 0 && len(cfg.Superserve.NetworkDenyOut) == 0 {
+		return nil
+	}
+	return &createSandboxNetworkCfg{
+		AllowOut: append([]string(nil), cfg.Superserve.NetworkAllowOut...),
+		DenyOut:  append([]string(nil), cfg.Superserve.NetworkDenyOut...),
+	}
 }
 
 func (b *backend) ownershipMetadata(baseURL, providerScope, leaseID, slug string, repo Repo) map[string]string {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -157,17 +157,20 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			return RunResult{}, err
 		}
 	}
+	shouldStop := acquired && !req.Keep
 	access, err := api.ActivateSandbox(ctx, sandboxID)
 	if err != nil {
 		if acquired {
-			return RunResult{}, b.cleanupClaimedRunFailure(ctx, api, leaseID, sandboxID, err)
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+			if shouldStop {
+				return RunResult{}, b.cleanupClaimedRunFailure(ctx, api, leaseID, sandboxID, err)
+			}
 		}
 		return RunResult{}, err
 	}
 	if access.Sandbox.ID == "" {
 		access.Sandbox.ID = sandboxID
 	}
-	shouldStop := acquired && !req.Keep
 	if shouldStop {
 		defer func() {
 			if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
@@ -948,7 +951,7 @@ func (b *backend) now() time.Time {
 }
 
 func normalizedSandboxState(sb superserveSandbox) string {
-	return strings.ToLower(blank(strings.TrimSpace(sb.Status), blank(strings.TrimSpace(sb.State), statusViewReady)))
+	return strings.ToLower(blank(strings.TrimSpace(sb.Status), blank(strings.TrimSpace(sb.State), "unknown")))
 }
 
 func isReadyState(state string) bool {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -573,6 +573,9 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 }
 
 func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, func(), error) {
+	if err := validateSuperserveConfig(b.cfg); err != nil {
+		return "", "", "", nil, err
+	}
 	providerScope, err := newSuperserveClaimScope(api.BaseURL())
 	if err != nil {
 		return "", "", "", nil, err
@@ -895,14 +898,8 @@ func (b *backend) execTimeoutSecs() int {
 }
 
 func (b *backend) sandboxTimeoutSecs() int {
-	if b.cfg.Superserve.TimeoutSecs > 0 {
-		return b.cfg.Superserve.TimeoutSecs
-	}
-	lifetime := b.cfg.TTL
-	if lifetime <= 0 {
-		lifetime = 90 * time.Minute
-	}
-	return int((lifetime + time.Second - 1) / time.Second)
+	timeout, _ := superserveSandboxTimeoutSecs(b.cfg)
+	return timeout
 }
 
 func superserveCommandEnv(env map[string]string) (map[string]string, []string) {

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -445,6 +445,29 @@ func TestRunKeepOnFailureRetainsCreatedSandboxAndExitCode(t *testing.T) {
 	}
 }
 
+func TestRunPropagatesOneShotDeleteFailureAndPreservesClaim(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	fake.execResults = []execResult{{}, {ExitCode: 0}}
+	fake.deleteErr = errors.New("delete denied")
+	backend := newSuperserveTestBackend(t, fake)
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:  true,
+		Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "delete denied") {
+		t.Fatalf("Run err=%v, want delete failure", err)
+	}
+	if result.ExitCode != 1 {
+		t.Fatalf("result=%#v, want cleanup failure exit 1", result)
+	}
+	leaseID := leasePrefix + fake.sandbox.ID
+	if claim, claimErr := readLeaseClaim(leaseID); claimErr != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim should remain for cleanup retry: %#v err=%v", claim, claimErr)
+	}
+}
+
 func TestRunRefreshesRetainedClaimActivityAfterSuccessfulCommand(t *testing.T) {
 	fake := newFakeSuperserveClient()
 	fake.execResults = []execResult{
@@ -500,6 +523,59 @@ func TestRunRefreshesRetainedClaimActivityAfterSuccessfulCommand(t *testing.T) {
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("retained run deleted sandbox: %#v", fake.deleted)
+	}
+}
+
+func TestCleanupSerializesAndRechecksLeaseActivity(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "active")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "active")
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim.LastUsedAt = time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	claim.IdleTimeoutSeconds = 60
+	writeClaimFixture(t, claim)
+
+	unlock, err := lockSuperserveLeaseOperation(context.Background(), leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupDone := make(chan error, 1)
+	go func() {
+		cleanupDone <- backend.Cleanup(context.Background(), CleanupRequest{})
+	}()
+	select {
+	case err := <-cleanupDone:
+		t.Fatalf("cleanup completed while lease operation lock was held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	claim.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	writeClaimFixture(t, claim)
+	unlock()
+	if err := <-cleanupDone; err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup deleted refreshed active sandbox: %#v", fake.deleted)
+	}
+}
+
+func TestSuperserveOperationLockHonorsContextCancellation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	unlock, err := lockSuperserveLeaseOperation(context.Background(), leasePrefix+"lock-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := lockSuperserveLeaseOperation(ctx, leasePrefix+"lock-test"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v, want context deadline", err)
 	}
 }
 

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -21,19 +22,32 @@ type fakeSuperserveClient struct {
 	mu          sync.Mutex
 	baseURL     string
 	sandbox     superserveSandbox
+	accessToken string
 	created     []createSandboxRequest
 	updates     []map[string]string
 	listFilters []map[string]string
 	deleted     []string
+	activated   []string
+	uploads     []fakeSuperserveUpload
+	execs       []execRequest
+	execResults []execResult
+	execErr     error
 	probes      int
 	getErr      error
 	deleteErr   error
 	updateErr   error
 }
 
+type fakeSuperserveUpload struct {
+	sandboxID string
+	path      string
+	size      int
+}
+
 func newFakeSuperserveClient() *fakeSuperserveClient {
 	return &fakeSuperserveClient{
-		baseURL: "https://api.superserve.test",
+		baseURL:     "https://api.superserve.test",
+		accessToken: "ss_test_token",
 		sandbox: superserveSandbox{
 			ID:     "sb_test01",
 			Status: "running",
@@ -73,7 +87,10 @@ func (f *fakeSuperserveClient) GetSandbox(context.Context, string) (superserveSa
 }
 
 func (f *fakeSuperserveClient) ActivateSandbox(context.Context, string) (sandboxAccess, error) {
-	return sandboxAccess{Sandbox: cloneSandbox(f.sandbox), AccessToken: "ss_test_token"}, nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.activated = append(f.activated, f.sandbox.ID)
+	return sandboxAccess{Sandbox: cloneSandbox(f.sandbox), AccessToken: f.accessToken}, nil
 }
 
 func (f *fakeSuperserveClient) UpdateSandboxMetadata(_ context.Context, _ string, metadata map[string]string) (superserveSandbox, error) {
@@ -103,6 +120,38 @@ func (f *fakeSuperserveClient) DeleteSandbox(_ context.Context, id string) error
 	}
 	f.deleted = append(f.deleted, id)
 	return nil
+}
+
+func (f *fakeSuperserveClient) UploadFile(_ context.Context, access *sandboxAccess, remotePath string, content io.Reader) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	f.uploads = append(f.uploads, fakeSuperserveUpload{sandboxID: access.Sandbox.ID, path: remotePath, size: len(data)})
+	return nil
+}
+
+func (f *fakeSuperserveClient) Exec(_ context.Context, _ *sandboxAccess, req execRequest, stdout, stderr io.Writer) (execResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execs = append(f.execs, req)
+	if f.execErr != nil {
+		return execResult{}, f.execErr
+	}
+	result := execResult{}
+	if len(f.execResults) > 0 {
+		result = f.execResults[0]
+		f.execResults = f.execResults[1:]
+	}
+	if result.Stdout != "" {
+		_, _ = io.WriteString(stdout, result.Stdout)
+	}
+	if result.Stderr != "" {
+		_, _ = io.WriteString(stderr, result.Stderr)
+	}
+	return result, nil
 }
 
 func (f *fakeSuperserveClient) Probe(context.Context) error {
@@ -289,12 +338,143 @@ func TestDoctorIsNonMutating(t *testing.T) {
 	}
 }
 
-func TestRunRemainsDeferredToPlan03(t *testing.T) {
-	backend := newSuperserveTestBackend(t, newFakeSuperserveClient())
-	_, err := backend.Run(context.Background(), RunRequest{})
-	if err == nil || !strings.Contains(err.Error(), "run is not implemented yet") {
+func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	fake.execResults = []execResult{
+		{},
+		{Stdout: "ok\n", Stderr: "warn\n", ExitCode: 0},
+	}
+	backend := newSuperserveTestBackend(t, fake)
+	var stdout, stderr bytes.Buffer
+	backend.rt.Stdout = &stdout
+	backend.rt.Stderr = &stderr
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:     true,
+		Command:    []string{"go", "test", "./..."},
+		Env:        map[string]string{"SUPERSERVE_API_KEY": "ss_test_not_real", "CI": "1"},
+		EnvSummary: true,
+	})
+	if err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
+	if result.ExitCode != 0 || result.Provider != providerName || result.LeaseID == "" || !result.SyncDelegated {
+		t.Fatalf("result=%#v", result)
+	}
+	if stdout.String() != "ok\n" || !strings.Contains(stderr.String(), "warn\n") {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "ss_test_not_real") {
+		t.Fatalf("env summary leaked value: %q", stderr.String())
+	}
+	if len(fake.execs) != 2 {
+		t.Fatalf("execs=%#v", fake.execs)
+	}
+	commandReq := fake.execs[1]
+	if commandReq.Command != "'go' 'test' './...'" || commandReq.WorkingDir != defaultWorkdir || commandReq.TimeoutSecs != backend.cfg.Superserve.ExecTimeoutSecs {
+		t.Fatalf("command req=%#v", commandReq)
+	}
+	if commandReq.Env["SUPERSERVE_API_KEY"] != "ss_test_not_real" {
+		t.Fatalf("env not forwarded in body: %#v", commandReq.Env)
+	}
+	if strings.Contains(commandReq.Command, "ss_test_not_real") {
+		t.Fatalf("secret env value appeared in command argv: %q", commandReq.Command)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
+		t.Fatalf("one-shot run should delete sandbox: %#v", fake.deleted)
+	}
+}
+
+func TestRunKeepOnFailureRetainsCreatedSandboxAndExitCode(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	fake.execResults = []execResult{
+		{},
+		{Stderr: "boom\n", ExitCode: 7},
+	}
+	backend := newSuperserveTestBackend(t, fake)
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:          Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:        true,
+		Command:       []string{"false"},
+		KeepOnFailure: true,
+	})
+	if err == nil {
+		t.Fatal("expected nonzero run error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("err=%T %[1]v, want ExitError 7", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("keep-on-failure deleted sandbox: %#v", fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=") {
+		t.Fatalf("stderr=%q, want keep-on-failure hint", stderr.String())
+	}
+}
+
+func TestRunSyncOnlyUploadsArchiveExtractsAndCleansRemoteArchive(t *testing.T) {
+	repo := tempSuperserveGitRepo(t)
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	var stdout bytes.Buffer
+	backend.rt.Stdout = &stdout
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:     Repo{Name: "my-app", Root: repo},
+		SyncOnly: true,
+		Keep:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run sync-only err=%v", err)
+	}
+	if result.ExitCode != 0 || !strings.Contains(stdout.String(), "synced "+defaultWorkdir) {
+		t.Fatalf("result=%#v stdout=%q", result, stdout.String())
+	}
+	if len(fake.uploads) != 1 || !strings.HasPrefix(fake.uploads[0].path, "/tmp/crabbox-sync-") || fake.uploads[0].size == 0 {
+		t.Fatalf("uploads=%#v", fake.uploads)
+	}
+	commands := execCommands(fake.execs)
+	if !containsCommandAll(commands, "mkdir -p", defaultWorkdir) {
+		t.Fatalf("commands=%#v, want workdir prepare", commands)
+	}
+	if !containsCommand(commands, "tar -xzf ") {
+		t.Fatalf("commands=%#v, want tar extraction", commands)
+	}
+	if !containsCommandAll(commands, "rm -f", fake.uploads[0].path) {
+		t.Fatalf("commands=%#v, want remote archive cleanup", commands)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("--keep sync-only deleted sandbox: %#v", fake.deleted)
+	}
+}
+
+func TestRunRejectsTailscaleBeforeCreate(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "my-app", Root: "/repo"},
+		Options: core.LeaseOptions{
+			Tailscale: core.TailscaleConfig{Enabled: true},
+		},
+		Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not support Tailscale") {
+		t.Fatalf("Run err=%v, want Tailscale rejection", err)
+	}
+	if len(fake.created) != 0 {
+		t.Fatalf("created despite guardrail: %#v", fake.created)
+	}
+}
+
+func TestProviderDoesNotAdvertisePauseResume(t *testing.T) {
 	if (Provider{}).Spec().Features.Has(core.FeaturePauseResume) {
 		t.Fatal("superserve must not advertise pause/resume until backend methods are implemented")
 	}
@@ -357,6 +537,62 @@ func writeClaimFixture(t *testing.T, claim LeaseClaim) {
 	if err := os.WriteFile(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", claim.LeaseID+".json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func tempSuperserveGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.test/my-app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "init")
+	runGit(t, dir, "add", ".")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func execCommands(reqs []execRequest) []string {
+	out := make([]string, 0, len(reqs))
+	for _, req := range reqs {
+		out = append(out, req.Command)
+	}
+	return out
+}
+
+func containsCommand(commands []string, needle string) bool {
+	for _, command := range commands {
+		if strings.Contains(command, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCommandAll(commands []string, needles ...string) bool {
+	for _, command := range commands {
+		ok := true
+		for _, needle := range needles {
+			if !strings.Contains(command, needle) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneMap(in map[string]string) map[string]string {

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -192,7 +192,7 @@ func TestWarmupCreatesClaimAndOwnershipMetadataWithoutToken(t *testing.T) {
 	if len(fake.created) != 1 || fake.created[0].Metadata[metadataProviderKey] != providerName || fake.created[0].Metadata[metadataScopeKey] == "" {
 		t.Fatalf("create metadata=%#v", fake.created)
 	}
-	if !strings.HasPrefix(fake.created[0].Name, "crabbox-my-app-") || fake.created[0].FromTemplate != backend.cfg.Superserve.Template || fake.created[0].TimeoutSeconds != backend.cfg.Superserve.TimeoutSecs {
+	if !strings.HasPrefix(fake.created[0].Name, "crabbox-my-app-") || fake.created[0].FromTemplate != backend.cfg.Superserve.Template || fake.created[0].TimeoutSeconds != backend.sandboxTimeoutSecs() {
 		t.Fatalf("create request did not use Superserve API fields: %#v", fake.created[0])
 	}
 	if len(fake.updates) != 1 || fake.updates[0][metadataClaimKey] != leaseID || fake.updates[0][metadataSlugKey] == "" {
@@ -375,10 +375,15 @@ func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
 	backend.rt.Stderr = &stderr
 
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
-		NoSync:     true,
-		Command:    []string{"go", "test", "./..."},
-		Env:        map[string]string{"SUPERSERVE_API_KEY": "ss_test_not_real", "CI": "1"},
+		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:  true,
+		Command: []string{"go", "test", "./..."},
+		Env: map[string]string{
+			"CRABBOX_SUPERSERVE_API_KEY": "crabbox_ss_test_not_real",
+			"SUPERSERVE_API_KEY":         "ss_test_not_real",
+			"PROJECT_TOKEN":              "project_test_not_real",
+			"CI":                         "1",
+		},
 		EnvSummary: true,
 	})
 	if err != nil {
@@ -390,8 +395,11 @@ func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
 	if stdout.String() != "ok\n" || !strings.Contains(stderr.String(), "warn\n") {
 		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
-	if strings.Contains(stderr.String(), "ss_test_not_real") {
+	if strings.Contains(stderr.String(), "ss_test_not_real") || strings.Contains(stderr.String(), "project_test_not_real") {
 		t.Fatalf("env summary leaked value: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "CRABBOX_SUPERSERVE_API_KEY,SUPERSERVE_API_KEY") {
+		t.Fatalf("stderr=%q, want stripped provider auth warning", stderr.String())
 	}
 	if len(fake.execs) != 2 {
 		t.Fatalf("execs=%#v", fake.execs)
@@ -400,8 +408,14 @@ func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
 	if commandReq.Command != "'go' 'test' './...'" || commandReq.WorkingDir != defaultWorkdir || commandReq.TimeoutSecs != backend.cfg.Superserve.ExecTimeoutSecs {
 		t.Fatalf("command req=%#v", commandReq)
 	}
-	if commandReq.Env["SUPERSERVE_API_KEY"] != "ss_test_not_real" {
-		t.Fatalf("env not forwarded in body: %#v", commandReq.Env)
+	if commandReq.Env["PROJECT_TOKEN"] != "project_test_not_real" || commandReq.Env["CI"] != "1" {
+		t.Fatalf("safe env not forwarded in body: %#v", commandReq.Env)
+	}
+	if _, ok := commandReq.Env["SUPERSERVE_API_KEY"]; ok {
+		t.Fatalf("provider auth forwarded in body: %#v", commandReq.Env)
+	}
+	if _, ok := commandReq.Env["CRABBOX_SUPERSERVE_API_KEY"]; ok {
+		t.Fatalf("provider auth forwarded in body: %#v", commandReq.Env)
 	}
 	if strings.Contains(commandReq.Command, "ss_test_not_real") {
 		t.Fatalf("secret env value appeared in command argv: %q", commandReq.Command)
@@ -465,6 +479,26 @@ func TestRunPropagatesOneShotDeleteFailureAndPreservesClaim(t *testing.T) {
 	leaseID := leasePrefix + fake.sandbox.ID
 	if claim, claimErr := readLeaseClaim(leaseID); claimErr != nil || claim.LeaseID != leaseID {
 		t.Fatalf("claim should remain for cleanup retry: %#v err=%v", claim, claimErr)
+	}
+}
+
+func TestRunPreservesCommandExitCodeWhenDeleteFails(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	fake.execResults = []execResult{{}, {ExitCode: 23}}
+	fake.deleteErr = errors.New("delete denied")
+	backend := newSuperserveTestBackend(t, fake)
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:  true,
+		Command: []string{"false"},
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 23 {
+		t.Fatalf("Run err=%T %[1]v, want wrapped ExitError 23", err)
+	}
+	if !strings.Contains(err.Error(), "delete denied") || result.ExitCode != 23 {
+		t.Fatalf("Run result=%#v err=%v, want exit 23 and cleanup failure", result, err)
 	}
 }
 

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -32,6 +32,7 @@ type fakeSuperserveClient struct {
 	execs       []execRequest
 	execResults []execResult
 	execErr     error
+	activateErr error
 	onExec      func(count int, req execRequest)
 	probes      int
 	getErr      error
@@ -91,6 +92,9 @@ func (f *fakeSuperserveClient) ActivateSandbox(context.Context, string) (sandbox
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.activated = append(f.activated, f.sandbox.ID)
+	if f.activateErr != nil {
+		return sandboxAccess{}, f.activateErr
+	}
 	return sandboxAccess{Sandbox: cloneSandbox(f.sandbox), AccessToken: f.accessToken}, nil
 }
 
@@ -260,6 +264,23 @@ func TestStatusAndStopRequireOwnershipBeforeDelete(t *testing.T) {
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted despite ownership mismatch: %#v", fake.deleted)
+	}
+}
+
+func TestStatusMissingRemoteStateIsUnknownAndNotReady(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "unknown")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "unknown")
+	fake.sandbox.Status = ""
+	fake.sandbox.State = ""
+
+	status, err := backend.Status(context.Background(), StatusRequest{ID: "unknown"})
+	if err != nil {
+		t.Fatalf("Status err=%v", err)
+	}
+	if status.State != "unknown" || status.Ready {
+		t.Fatalf("status=%#v, want unknown and not ready", status)
 	}
 }
 
@@ -456,6 +477,54 @@ func TestRunKeepOnFailureRetainsCreatedSandboxAndExitCode(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=") {
 		t.Fatalf("stderr=%q, want keep-on-failure hint", stderr.String())
+	}
+}
+
+func TestRunActivationFailureHonorsRetentionFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		keep            bool
+		keepOnFailure   bool
+		wantDeleted     bool
+		wantFailureHint bool
+	}{
+		{name: "default cleanup", wantDeleted: true},
+		{name: "keep", keep: true},
+		{name: "keep on failure", keepOnFailure: true, wantFailureHint: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := newFakeSuperserveClient()
+			fake.activateErr = errors.New("activation unavailable")
+			backend := newSuperserveTestBackend(t, fake)
+			var stderr bytes.Buffer
+			backend.rt.Stderr = &stderr
+
+			_, err := backend.Run(context.Background(), RunRequest{
+				Repo:          Repo{Name: "my-app", Root: t.TempDir()},
+				NoSync:        true,
+				Command:       []string{"true"},
+				Keep:          tt.keep,
+				KeepOnFailure: tt.keepOnFailure,
+			})
+			if err == nil || !strings.Contains(err.Error(), "activation unavailable") {
+				t.Fatalf("Run err=%v, want activation failure", err)
+			}
+			if got := len(fake.deleted) == 1; got != tt.wantDeleted {
+				t.Fatalf("deleted=%#v, wantDeleted=%t", fake.deleted, tt.wantDeleted)
+			}
+			leaseID := leasePrefix + fake.sandbox.ID
+			claim, claimErr := readLeaseClaim(leaseID)
+			if tt.wantDeleted {
+				if claimErr != nil || claim.LeaseID != "" {
+					t.Fatalf("claim=%#v err=%v, want removed claim", claim, claimErr)
+				}
+			} else if claimErr != nil || claim.LeaseID != leaseID {
+				t.Fatalf("claim=%#v err=%v, want retained claim", claim, claimErr)
+			}
+			if got := strings.Contains(stderr.String(), "keep-on-failure: kept lease="); got != tt.wantFailureHint {
+				t.Fatalf("stderr=%q, wantFailureHint=%t", stderr.String(), tt.wantFailureHint)
+			}
+		})
 	}
 }
 

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -32,6 +32,7 @@ type fakeSuperserveClient struct {
 	execs       []execRequest
 	execResults []execResult
 	execErr     error
+	onExec      func(count int, req execRequest)
 	probes      int
 	getErr      error
 	deleteErr   error
@@ -137,6 +138,7 @@ func (f *fakeSuperserveClient) Exec(_ context.Context, _ *sandboxAccess, req exe
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.execs = append(f.execs, req)
+	execCount := len(f.execs)
 	if f.execErr != nil {
 		return execResult{}, f.execErr
 	}
@@ -150,6 +152,9 @@ func (f *fakeSuperserveClient) Exec(_ context.Context, _ *sandboxAccess, req exe
 	}
 	if result.Stderr != "" {
 		_, _ = io.WriteString(stderr, result.Stderr)
+	}
+	if f.onExec != nil {
+		f.onExec(execCount, req)
 	}
 	return result, nil
 }
@@ -192,6 +197,23 @@ func TestWarmupCreatesClaimAndOwnershipMetadataWithoutToken(t *testing.T) {
 	}
 	if len(fake.updates) != 1 || fake.updates[0][metadataClaimKey] != leaseID || fake.updates[0][metadataSlugKey] == "" {
 		t.Fatalf("update metadata=%#v", fake.updates)
+	}
+}
+
+func TestWarmupSnapshotClearsDefaultTemplate(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	backend.cfg.Superserve.Template = "superserve/base"
+	backend.cfg.Superserve.Snapshot = "snap-123"
+
+	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+		t.Fatalf("Warmup err=%v", err)
+	}
+	if len(fake.created) != 1 {
+		t.Fatalf("created=%#v", fake.created)
+	}
+	if fake.created[0].FromTemplate != "" || fake.created[0].FromSnapshot != "snap-123" {
+		t.Fatalf("snapshot create sent wrong source: %#v", fake.created[0])
 	}
 }
 
@@ -420,6 +442,64 @@ func TestRunKeepOnFailureRetainsCreatedSandboxAndExitCode(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=") {
 		t.Fatalf("stderr=%q, want keep-on-failure hint", stderr.String())
+	}
+}
+
+func TestRunRefreshesRetainedClaimActivityAfterSuccessfulCommand(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	fake.execResults = []execResult{
+		{},
+		{ExitCode: 0},
+	}
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "retained")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "retained")
+	stale := time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	fake.onExec = func(count int, _ execRequest) {
+		if count != 2 {
+			return
+		}
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		claim.LastUsedAt = stale
+		writeClaimFixture(t, claim)
+	}
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		ID:      "retained",
+		Repo:    Repo{Name: "my-app", Root: "/repo"},
+		NoSync:  true,
+		Keep:    true,
+		Command: []string{"true"},
+	})
+	if err != nil {
+		t.Fatalf("Run err=%v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("result=%#v", result)
+	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LastUsedAt == stale {
+		t.Fatalf("claim activity was not refreshed after command: %#v", claim)
+	}
+	refreshed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleTime, err := time.Parse(time.RFC3339, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !refreshed.After(staleTime) {
+		t.Fatalf("last_used_at=%s should be after stale marker %s", claim.LastUsedAt, stale)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("retained run deleted sandbox: %#v", fake.deleted)
 	}
 }
 

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -187,6 +187,9 @@ func TestWarmupCreatesClaimAndOwnershipMetadataWithoutToken(t *testing.T) {
 	if len(fake.created) != 1 || fake.created[0].Metadata[metadataProviderKey] != providerName || fake.created[0].Metadata[metadataScopeKey] == "" {
 		t.Fatalf("create metadata=%#v", fake.created)
 	}
+	if !strings.HasPrefix(fake.created[0].Name, "crabbox-my-app-") || fake.created[0].FromTemplate != backend.cfg.Superserve.Template || fake.created[0].TimeoutSeconds != backend.cfg.Superserve.TimeoutSecs {
+		t.Fatalf("create request did not use Superserve API fields: %#v", fake.created[0])
+	}
 	if len(fake.updates) != 1 || fake.updates[0][metadataClaimKey] != leaseID || fake.updates[0][metadataSlugKey] == "" {
 		t.Fatalf("update metadata=%#v", fake.updates)
 	}

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -1,0 +1,376 @@
+package superserve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeSuperserveClient struct {
+	mu          sync.Mutex
+	baseURL     string
+	sandbox     superserveSandbox
+	created     []createSandboxRequest
+	updates     []map[string]string
+	listFilters []map[string]string
+	deleted     []string
+	probes      int
+	getErr      error
+	deleteErr   error
+	updateErr   error
+}
+
+func newFakeSuperserveClient() *fakeSuperserveClient {
+	return &fakeSuperserveClient{
+		baseURL: "https://api.superserve.test",
+		sandbox: superserveSandbox{
+			ID:     "sb_test01",
+			Status: "running",
+			Metadata: map[string]string{
+				metadataProviderKey: providerName,
+			},
+		},
+	}
+}
+
+func (f *fakeSuperserveClient) BaseURL() string { return f.baseURL }
+
+func (f *fakeSuperserveClient) CreateSandbox(_ context.Context, req createSandboxRequest) (superserveSandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.created = append(f.created, req)
+	sb := f.sandbox
+	sb.Metadata = cloneMap(req.Metadata)
+	f.sandbox = sb
+	return sb, nil
+}
+
+func (f *fakeSuperserveClient) ListSandboxes(_ context.Context, filter map[string]string) ([]superserveSandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listFilters = append(f.listFilters, cloneMap(filter))
+	return []superserveSandbox{cloneSandbox(f.sandbox)}, nil
+}
+
+func (f *fakeSuperserveClient) GetSandbox(context.Context, string) (superserveSandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return superserveSandbox{}, f.getErr
+	}
+	return cloneSandbox(f.sandbox), nil
+}
+
+func (f *fakeSuperserveClient) ActivateSandbox(context.Context, string) (sandboxAccess, error) {
+	return sandboxAccess{Sandbox: cloneSandbox(f.sandbox), AccessToken: "ss_test_token"}, nil
+}
+
+func (f *fakeSuperserveClient) UpdateSandboxMetadata(_ context.Context, _ string, metadata map[string]string) (superserveSandbox, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updateErr != nil {
+		return superserveSandbox{}, f.updateErr
+	}
+	f.updates = append(f.updates, cloneMap(metadata))
+	f.sandbox.Metadata = cloneMap(metadata)
+	return cloneSandbox(f.sandbox), nil
+}
+
+func (f *fakeSuperserveClient) PauseSandbox(context.Context, string) (superserveSandbox, error) {
+	return cloneSandbox(f.sandbox), nil
+}
+
+func (f *fakeSuperserveClient) ResumeSandbox(context.Context, string) (sandboxAccess, error) {
+	return sandboxAccess{Sandbox: cloneSandbox(f.sandbox), AccessToken: "ss_test_token"}, nil
+}
+
+func (f *fakeSuperserveClient) DeleteSandbox(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+func (f *fakeSuperserveClient) Probe(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.probes++
+	return nil
+}
+
+func TestWarmupCreatesClaimAndOwnershipMetadataWithoutToken(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	var stdout bytes.Buffer
+	backend.rt.Stdout = &stdout
+
+	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+		t.Fatalf("Warmup err=%v", err)
+	}
+	leaseID := leasePrefix + fake.sandbox.ID
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.LeaseID != leaseID || claim.Provider != providerName || claim.ProviderScope == "" {
+		t.Fatalf("claim=%#v", claim)
+	}
+	if strings.Contains(stdout.String(), "ss_test_token") {
+		t.Fatalf("warmup output leaked token: %q", stdout.String())
+	}
+	if strings.Contains(mustReadClaimJSON(t, leaseID), "access_token") || strings.Contains(mustReadClaimJSON(t, leaseID), "ss_test_token") {
+		t.Fatalf("claim persisted token: %s", mustReadClaimJSON(t, leaseID))
+	}
+	if len(fake.created) != 1 || fake.created[0].Metadata[metadataProviderKey] != providerName || fake.created[0].Metadata[metadataScopeKey] == "" {
+		t.Fatalf("create metadata=%#v", fake.created)
+	}
+	if len(fake.updates) != 1 || fake.updates[0][metadataClaimKey] != leaseID || fake.updates[0][metadataSlugKey] == "" {
+		t.Fatalf("update metadata=%#v", fake.updates)
+	}
+}
+
+func TestListRequiresLocalClaimAndMatchingRemoteMetadata(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "listed")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "listed")
+
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 1 || views[0].CloudID != fake.sandbox.ID || views[0].Labels["lease"] != leaseID {
+		t.Fatalf("views=%#v", views)
+	}
+	if len(fake.listFilters) != 1 || fake.listFilters[0][metadataProviderKey] != providerName || fake.listFilters[0][metadataEndpointKey] == "" {
+		t.Fatalf("list filters=%#v", fake.listFilters)
+	}
+
+	fake.sandbox.Metadata[metadataScopeKey] = "different"
+	if _, err := backend.List(context.Background(), ListRequest{}); err == nil || !strings.Contains(err.Error(), "ownership metadata") {
+		t.Fatalf("List err=%v, want ownership mismatch", err)
+	}
+}
+
+func TestStatusAndStopRequireOwnershipBeforeDelete(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "owned")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "owned")
+
+	status, err := backend.Status(context.Background(), StatusRequest{ID: "owned"})
+	if err != nil {
+		t.Fatalf("Status err=%v", err)
+	}
+	if status.ID != leaseID || !status.Ready || status.ServerID != fake.sandbox.ID {
+		t.Fatalf("status=%#v", status)
+	}
+
+	fake.sandbox.Metadata[metadataScopeKey] = "foreign"
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err == nil || !strings.Contains(err.Error(), "ownership metadata") {
+		t.Fatalf("Stop err=%v, want ownership mismatch", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted despite ownership mismatch: %#v", fake.deleted)
+	}
+}
+
+func TestStopForgetMissingRequiresExplicitFlag(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "missing")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "missing")
+	fake.getErr = notFoundErr()
+
+	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("Stop err=%v, want missing error", err)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim should remain: %#v err=%v", claim, err)
+	}
+
+	backend.cfg.Superserve.ForgetMissing = true
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+		t.Fatalf("Stop forget missing err=%v", err)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim should be removed: %#v err=%v", claim, err)
+	}
+}
+
+func TestCleanupDryRunSkipsFreshAndDeletesExpiredOwnedOnly(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	backend.cfg.IdleTimeout = time.Minute
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "expired")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "expired")
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim.LastUsedAt = time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	claim.IdleTimeoutSeconds = 60
+	writeClaimFixture(t, claim)
+	var stdout bytes.Buffer
+	backend.rt.Stdout = &stdout
+
+	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run err=%v", err)
+	}
+	if !strings.Contains(stdout.String(), "would delete sandbox="+fake.sandbox.ID) {
+		t.Fatalf("stdout=%q, want dry-run delete", stdout.String())
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("dry-run deleted: %#v", fake.deleted)
+	}
+
+	stdout.Reset()
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup err=%v", err)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
+		t.Fatalf("deleted=%#v", fake.deleted)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim should be gone: %#v err=%v", claim, err)
+	}
+}
+
+func TestCleanupRejectsNonOwnedRemote(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	leaseID, scope := createSuperserveClaim(t, backend, fake, "foreign")
+	fake.sandbox.Metadata = ownedMetadata(fake.baseURL, scope, leaseID, "foreign")
+	fake.sandbox.Metadata[metadataClaimKey] = leasePrefix + "other"
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim.LastUsedAt = time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	claim.IdleTimeoutSeconds = 60
+	writeClaimFixture(t, claim)
+
+	err = backend.Cleanup(context.Background(), CleanupRequest{})
+	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
+		t.Fatalf("Cleanup err=%v, want ownership mismatch", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("cleanup deleted non-owned remote: %#v", fake.deleted)
+	}
+}
+
+func TestDoctorIsNonMutating(t *testing.T) {
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor err=%v", err)
+	}
+	if result.Provider != providerName || !strings.Contains(result.Message, "mutation=false") {
+		t.Fatalf("doctor result=%#v", result)
+	}
+	if fake.probes != 1 || len(fake.created) != 0 || len(fake.deleted) != 0 {
+		t.Fatalf("doctor mutated: probes=%d created=%d deleted=%d", fake.probes, len(fake.created), len(fake.deleted))
+	}
+}
+
+func TestRunRemainsDeferredToPlan03(t *testing.T) {
+	backend := newSuperserveTestBackend(t, newFakeSuperserveClient())
+	_, err := backend.Run(context.Background(), RunRequest{})
+	if err == nil || !strings.Contains(err.Error(), "run is not implemented yet") {
+		t.Fatalf("Run err=%v", err)
+	}
+	if (Provider{}).Spec().Features.Has(core.FeaturePauseResume) {
+		t.Fatal("superserve must not advertise pause/resume until backend methods are implemented")
+	}
+}
+
+func newSuperserveTestBackend(t *testing.T, fake *fakeSuperserveClient) *backend {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := testConfig()
+	cfg.Superserve.BaseURL = fake.baseURL
+	cfg.IdleTimeout = time.Minute
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	b := NewSuperserveBackend((Provider{}).Spec(), cfg, rt).(*backend)
+	b.newClient = func(Config, Runtime) (superserveClient, error) { return fake, nil }
+	return b
+}
+
+func createSuperserveClaim(t *testing.T, b *backend, fake *fakeSuperserveClient, slug string) (string, string) {
+	t.Helper()
+	scope, err := newSuperserveClaimScope(fake.baseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseID := leasePrefix + fake.sandbox.ID
+	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, scope, "", "/repo", b.cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	return leaseID, scope
+}
+
+func ownedMetadata(baseURL, scope, leaseID, slug string) map[string]string {
+	return map[string]string{
+		metadataProviderKey: providerName,
+		metadataEndpointKey: superserveEndpointScope(baseURL),
+		metadataScopeKey:    scope,
+		metadataClaimKey:    leaseID,
+		metadataSlugKey:     slug,
+	}
+}
+
+func notFoundErr() error {
+	return &superserveAPIError{StatusCode: http.StatusNotFound, err: errors.New("not found")}
+}
+
+func mustReadClaimJSON(t *testing.T, leaseID string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", leaseID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func writeClaimFixture(t *testing.T, claim LeaseClaim) {
+	t.Helper()
+	data, err := json.MarshalIndent(claim, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", claim.LeaseID+".json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneSandbox(in superserveSandbox) superserveSandbox {
+	in.Metadata = cloneMap(in.Metadata)
+	return in
+}

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -1,6 +1,7 @@
 package superserve
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -17,7 +18,10 @@ import (
 	"time"
 )
 
-const defaultSuperserveRequestTimeout = 2 * time.Minute
+const (
+	defaultSuperserveRequestTimeout = 2 * time.Minute
+	maxExecStreamCaptureBytes       = 16 * 1024
+)
 
 type superserveClient interface {
 	BaseURL() string
@@ -29,6 +33,8 @@ type superserveClient interface {
 	PauseSandbox(context.Context, string) (superserveSandbox, error)
 	ResumeSandbox(context.Context, string) (sandboxAccess, error)
 	DeleteSandbox(context.Context, string) error
+	UploadFile(context.Context, *sandboxAccess, string, io.Reader) error
+	Exec(context.Context, *sandboxAccess, execRequest, io.Writer, io.Writer) (execResult, error)
 	Probe(context.Context) error
 }
 
@@ -60,6 +66,28 @@ type superserveSandbox struct {
 type sandboxAccess struct {
 	Sandbox     superserveSandbox
 	AccessToken string
+}
+
+type execRequest struct {
+	Command    string            `json:"command"`
+	WorkingDir string            `json:"working_dir,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	// Superserve data-plane exec uses timeout_s; sandbox lifetime uses timeout_secs.
+	TimeoutSecs int `json:"timeout_s,omitempty"`
+}
+
+type execResult struct {
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	ExitCode int    `json:"exit_code"`
+}
+
+type execStreamEvent struct {
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
+	Finished bool   `json:"finished,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 type superserveAPIError struct {
@@ -240,6 +268,61 @@ func (c *httpSuperserveClient) DeleteSandbox(ctx context.Context, id string) err
 	return c.doJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(id), nil, nil)
 }
 
+func (c *httpSuperserveClient) UploadFile(ctx context.Context, access *sandboxAccess, remotePath string, content io.Reader) error {
+	if strings.TrimSpace(remotePath) == "" || !strings.HasPrefix(remotePath, "/") || strings.Contains(remotePath, "..") {
+		return exit(2, "superserve file path must be absolute and must not contain '..': %q", remotePath)
+	}
+	seeker, canSeek := content.(io.Seeker)
+	return c.withAccessRetry(ctx, access, func(token string) error {
+		if canSeek {
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return exit(6, "rewind sync archive: %v", err)
+			}
+		}
+		target, err := c.dataPlaneTarget(access.Sandbox.ID)
+		if err != nil {
+			return err
+		}
+		apiPath := "/files?path=" + url.QueryEscape(remotePath)
+		requestCtx, cancel := context.WithTimeout(ctx, defaultSuperserveRequestTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, target.baseURL+apiPath, content)
+		if err != nil {
+			return fmt.Errorf("superserve file upload request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("X-Access-Token", token)
+		for k, v := range target.headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return fmt.Errorf("superserve file upload %s: %w", remotePath, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return c.apiError(http.MethodPost, "files?path="+remotePath, resp, token)
+		}
+		return nil
+	})
+}
+
+func (c *httpSuperserveClient) Exec(ctx context.Context, access *sandboxAccess, req execRequest, stdout, stderr io.Writer) (execResult, error) {
+	var result execResult
+	err := c.withAccessRetry(ctx, access, func(token string) error {
+		var err error
+		result, err = c.execStream(ctx, access.Sandbox.ID, token, req, stdout, stderr)
+		if isSuperserveUnsupportedStream(err) {
+			result, err = c.execBuffered(ctx, access.Sandbox.ID, token, req)
+			if err == nil {
+				writeExecResultOutput(result, stdout, stderr)
+			}
+		}
+		return err
+	})
+	return result, err
+}
+
 func (c *httpSuperserveClient) Probe(ctx context.Context) error {
 	var raw json.RawMessage
 	return c.doJSON(ctx, http.MethodGet, "/sandboxes", nil, &raw)
@@ -278,17 +361,290 @@ func (c *httpSuperserveClient) postAccess(ctx context.Context, apiPath string) (
 	return sandboxAccess{Sandbox: sb, AccessToken: token}, nil
 }
 
-func (c *httpSuperserveClient) apiError(method, apiPath string, resp *http.Response) error {
+func (c *httpSuperserveClient) withAccessRetry(ctx context.Context, access *sandboxAccess, send func(token string) error) error {
+	if access == nil || strings.TrimSpace(access.Sandbox.ID) == "" {
+		return exit(5, "superserve data-plane request needs an activated sandbox")
+	}
+	if strings.TrimSpace(access.AccessToken) == "" {
+		return exit(5, "superserve activated sandbox %s returned no access token", access.Sandbox.ID)
+	}
+	err := send(access.AccessToken)
+	if !isSuperserveUnauthorized(err) {
+		return err
+	}
+	fresh, refreshErr := c.ActivateSandbox(ctx, access.Sandbox.ID)
+	if refreshErr != nil {
+		return refreshErr
+	}
+	access.AccessToken = fresh.AccessToken
+	if fresh.Sandbox.ID != "" {
+		access.Sandbox = fresh.Sandbox
+	}
+	return send(access.AccessToken)
+}
+
+type dataPlaneTarget struct {
+	baseURL string
+	headers map[string]string
+}
+
+func (c *httpSuperserveClient) dataPlaneTarget(sandboxID string) (dataPlaneTarget, error) {
+	parsed, err := url.Parse(c.baseURL)
+	if err != nil {
+		return dataPlaneTarget{}, err
+	}
+	if isLoopbackHost(parsed.Hostname()) {
+		return dataPlaneTarget{
+			baseURL: strings.TrimRight(parsed.String(), "/"),
+			headers: map[string]string{
+				"X-Superserve-Sandbox-Id": sandboxID,
+			},
+		}, nil
+	}
+	sandboxHost, ok := deriveSuperserveSandboxHost(parsed.Hostname())
+	if !ok {
+		return dataPlaneTarget{}, exit(2, "provider=superserve cannot derive a data-plane sandbox host from base URL %s; use the production/staging Superserve API or a loopback development endpoint", c.baseURL)
+	}
+	if supportsSuperserveSharedHost(sandboxHost) {
+		return dataPlaneTarget{
+			baseURL: "https://" + sandboxHost,
+			headers: map[string]string{
+				"X-Superserve-Sandbox-Id": sandboxID,
+			},
+		}, nil
+	}
+	return dataPlaneTarget{baseURL: "https://" + dataPlaneSubdomainHost(sandboxID, sandboxHost)}, nil
+}
+
+func deriveSuperserveSandboxHost(apiHost string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(apiHost)) {
+	case "api-staging.superserve.ai":
+		return "staging-sandbox.superserve.ai", true
+	case "api.superserve.ai":
+		return "sandbox.superserve.ai", true
+	default:
+		return "", false
+	}
+}
+
+func supportsSuperserveSharedHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "sandbox.superserve.ai", "staging-sandbox.superserve.ai":
+		return true
+	default:
+		return false
+	}
+}
+
+func dataPlaneSubdomainHost(sandboxID, sandboxHost string) string {
+	return "boxd-" + strings.TrimSpace(sandboxID) + "." + strings.TrimSpace(sandboxHost)
+}
+
+func (c *httpSuperserveClient) execBuffered(ctx context.Context, sandboxID, token string, body execRequest) (execResult, error) {
+	target, err := c.dataPlaneTarget(sandboxID)
+	if err != nil {
+		return execResult{}, err
+	}
+	var result execResult
+	timeout := c.execRequestTimeout(body.TimeoutSecs)
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := c.doDataPlaneJSON(requestCtx, http.MethodPost, target, "/exec", token, body, &result, envSecretValues(body.Env)...); err != nil {
+		return execResult{}, err
+	}
+	return result, nil
+}
+
+func (c *httpSuperserveClient) execStream(ctx context.Context, sandboxID, token string, body execRequest, stdout, stderr io.Writer) (execResult, error) {
+	target, err := c.dataPlaneTarget(sandboxID)
+	if err != nil {
+		return execResult{}, err
+	}
+	timeout := c.execRequestTimeout(body.TimeoutSecs)
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var reader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return execResult{}, fmt.Errorf("superserve marshal /exec/stream: %w", err)
+	}
+	reader = bytes.NewReader(buf)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, target.baseURL+"/exec/stream", reader)
+	if err != nil {
+		return execResult{}, fmt.Errorf("superserve request /exec/stream: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("X-Access-Token", token)
+	for k, v := range target.headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return execResult{}, fmt.Errorf("superserve POST /exec/stream: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		return execResult{}, &superserveStreamUnsupportedError{err: c.apiError(http.MethodPost, "/exec/stream", resp, append([]string{token}, envSecretValues(body.Env)...)...)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return execResult{}, c.apiError(http.MethodPost, "/exec/stream", resp, append([]string{token}, envSecretValues(body.Env)...)...)
+	}
+	return consumeSuperserveExecStream(resp.Body, stdout, stderr)
+}
+
+func (c *httpSuperserveClient) doDataPlaneJSON(ctx context.Context, method string, target dataPlaneTarget, apiPath, token string, body, out any, secrets ...string) error {
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("superserve marshal %s: %w", apiPath, err)
+		}
+		reader = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, target.baseURL+apiPath, reader)
+	if err != nil {
+		return fmt.Errorf("superserve request %s: %w", apiPath, err)
+	}
+	req.Header.Set("X-Access-Token", token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range target.headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("superserve %s %s: %w", method, apiPath, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.apiError(method, apiPath, resp, append([]string{token}, secrets...)...)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("superserve decode %s: %w", apiPath, err)
+	}
+	return nil
+}
+
+func (c *httpSuperserveClient) execRequestTimeout(timeoutSecs int) time.Duration {
+	if timeoutSecs > 0 {
+		return time.Duration(timeoutSecs)*time.Second + 5*time.Second
+	}
+	return defaultSuperserveRequestTimeout
+}
+
+type superserveStreamUnsupportedError struct {
+	err error
+}
+
+func (e *superserveStreamUnsupportedError) Error() string { return e.err.Error() }
+func (e *superserveStreamUnsupportedError) Unwrap() error { return e.err }
+
+func isSuperserveUnsupportedStream(err error) bool {
+	var streamErr *superserveStreamUnsupportedError
+	return errors.As(err, &streamErr)
+}
+
+func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer) (execResult, error) {
+	var result execResult
+	sawFinished := false
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if raw == "" || raw == "[DONE]" {
+			continue
+		}
+		var event execStreamEvent
+		if err := json.Unmarshal([]byte(raw), &event); err != nil {
+			continue
+		}
+		if event.Stdout != "" {
+			result.Stdout = appendBounded(result.Stdout, event.Stdout, maxExecStreamCaptureBytes)
+			_, _ = io.WriteString(stdout, event.Stdout)
+		}
+		if event.Stderr != "" {
+			result.Stderr = appendBounded(result.Stderr, event.Stderr, maxExecStreamCaptureBytes)
+			_, _ = io.WriteString(stderr, event.Stderr)
+		}
+		if event.Finished {
+			sawFinished = true
+			result.ExitCode = event.ExitCode
+			if event.Error != "" {
+				result.Stderr = appendBounded(result.Stderr, event.Error, maxExecStreamCaptureBytes)
+				_, _ = io.WriteString(stderr, event.Error)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return execResult{}, fmt.Errorf("superserve read /exec/stream: %w", err)
+	}
+	if !sawFinished {
+		return execResult{}, exit(5, "superserve command stream ended without a finished event")
+	}
+	return result, nil
+}
+
+func appendBounded(current, chunk string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len(chunk) >= limit {
+		return chunk[len(chunk)-limit:]
+	}
+	if len(current)+len(chunk) <= limit {
+		return current + chunk
+	}
+	combined := current + chunk
+	return combined[len(combined)-limit:]
+}
+
+func writeExecResultOutput(result execResult, stdout, stderr io.Writer) {
+	if result.Stdout != "" {
+		_, _ = io.WriteString(stdout, result.Stdout)
+	}
+	if result.Stderr != "" {
+		_, _ = io.WriteString(stderr, result.Stderr)
+	}
+}
+
+func envSecretValues(env map[string]string) []string {
+	secrets := make([]string, 0, len(env))
+	for _, value := range env {
+		if strings.TrimSpace(value) != "" {
+			secrets = append(secrets, value)
+		}
+	}
+	return secrets
+}
+
+func (c *httpSuperserveClient) apiError(method, apiPath string, resp *http.Response, secrets ...string) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	msg := strings.TrimSpace(string(body))
 	var wrapped struct {
-		Error   string `json:"error"`
+		Error   any    `json:"error"`
 		Message string `json:"message"`
 	}
 	if json.Unmarshal(body, &wrapped) == nil {
-		msg = blank(wrapped.Error, blank(wrapped.Message, msg))
+		switch value := wrapped.Error.(type) {
+		case string:
+			msg = blank(value, blank(wrapped.Message, msg))
+		case map[string]any:
+			if message, ok := value["message"].(string); ok {
+				msg = blank(message, blank(wrapped.Message, msg))
+			}
+		}
 	}
-	msg = redactSuperserveSecrets(msg, c.apiKey)
+	msg = redactSuperserveSecrets(msg, append([]string{c.apiKey}, secrets...)...)
 	return &superserveAPIError{
 		StatusCode: resp.StatusCode,
 		err:        exit(5, "superserve %s %s failed: %s: %s", method, apiPath, resp.Status, msg),
@@ -298,6 +654,11 @@ func (c *httpSuperserveClient) apiError(method, apiPath string, resp *http.Respo
 func isSuperserveNotFound(err error) bool {
 	var apiErr *superserveAPIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+func isSuperserveUnauthorized(err error) bool {
+	var apiErr *superserveAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized
 }
 
 func redactSuperserveSecrets(value string, secrets ...string) string {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -470,8 +470,7 @@ func (c *httpSuperserveClient) execBuffered(ctx context.Context, sandboxID, toke
 		return execResult{}, err
 	}
 	var result execResult
-	timeout := c.execRequestTimeout(body.TimeoutSecs)
-	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	requestCtx, cancel := superserveExecRequestContext(ctx, body.TimeoutSecs)
 	defer cancel()
 	if err := c.doDataPlaneJSON(requestCtx, http.MethodPost, target, "/exec", token, body, &result, envSecretValues(body.Env)...); err != nil {
 		return execResult{}, err
@@ -484,8 +483,7 @@ func (c *httpSuperserveClient) execStream(ctx context.Context, sandboxID, token 
 	if err != nil {
 		return execResult{}, err
 	}
-	timeout := c.execRequestTimeout(body.TimeoutSecs)
-	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	requestCtx, cancel := superserveExecRequestContext(ctx, body.TimeoutSecs)
 	defer cancel()
 	var reader io.Reader
 	buf, err := json.Marshal(body)
@@ -555,11 +553,11 @@ func (c *httpSuperserveClient) doDataPlaneJSON(ctx context.Context, method strin
 	return nil
 }
 
-func (c *httpSuperserveClient) execRequestTimeout(timeoutSecs int) time.Duration {
+func superserveExecRequestContext(ctx context.Context, timeoutSecs int) (context.Context, context.CancelFunc) {
 	if timeoutSecs > 0 {
-		return time.Duration(timeoutSecs)*time.Second + 5*time.Second
+		return context.WithTimeout(ctx, time.Duration(timeoutSecs)*time.Second+5*time.Second)
 	}
-	return defaultSuperserveRequestTimeout
+	return context.WithCancel(ctx)
 }
 
 type superserveStreamUnsupportedError struct {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -302,7 +302,11 @@ func (c *httpSuperserveClient) UploadFile(ctx context.Context, access *sandboxAc
 			return err
 		}
 		apiPath := "/files?path=" + url.QueryEscape(remotePath)
-		requestCtx, cancel := context.WithTimeout(ctx, defaultSuperserveRequestTimeout)
+		requestCtx := ctx
+		cancel := func() {}
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			requestCtx, cancel = context.WithTimeout(ctx, defaultSuperserveRequestTimeout)
+		}
 		defer cancel()
 		req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, target.baseURL+apiPath, content)
 		if err != nil {
@@ -333,7 +337,7 @@ func (c *httpSuperserveClient) Exec(ctx context.Context, access *sandboxAccess, 
 		if isSuperserveUnsupportedStream(err) {
 			result, err = c.execBuffered(ctx, access.Sandbox.ID, token, req)
 			if err == nil {
-				writeExecResultOutput(result, stdout, stderr)
+				err = writeExecResultOutput(result, stdout, stderr)
 			}
 		}
 		return err
@@ -588,18 +592,24 @@ func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer) (exec
 		}
 		if event.Stdout != "" {
 			result.Stdout = appendBounded(result.Stdout, event.Stdout, maxExecStreamCaptureBytes)
-			_, _ = io.WriteString(stdout, event.Stdout)
+			if _, err := io.WriteString(stdout, event.Stdout); err != nil {
+				return execResult{}, fmt.Errorf("superserve write command stdout: %w", err)
+			}
 		}
 		if event.Stderr != "" {
 			result.Stderr = appendBounded(result.Stderr, event.Stderr, maxExecStreamCaptureBytes)
-			_, _ = io.WriteString(stderr, event.Stderr)
+			if _, err := io.WriteString(stderr, event.Stderr); err != nil {
+				return execResult{}, fmt.Errorf("superserve write command stderr: %w", err)
+			}
 		}
 		if event.Finished {
 			sawFinished = true
 			result.ExitCode = event.ExitCode
 			if event.Error != "" {
 				result.Stderr = appendBounded(result.Stderr, event.Error, maxExecStreamCaptureBytes)
-				_, _ = io.WriteString(stderr, event.Error)
+				if _, err := io.WriteString(stderr, event.Error); err != nil {
+					return execResult{}, fmt.Errorf("superserve write command stderr: %w", err)
+				}
 			}
 		}
 	}
@@ -626,13 +636,18 @@ func appendBounded(current, chunk string, limit int) string {
 	return combined[len(combined)-limit:]
 }
 
-func writeExecResultOutput(result execResult, stdout, stderr io.Writer) {
+func writeExecResultOutput(result execResult, stdout, stderr io.Writer) error {
 	if result.Stdout != "" {
-		_, _ = io.WriteString(stdout, result.Stdout)
+		if _, err := io.WriteString(stdout, result.Stdout); err != nil {
+			return fmt.Errorf("superserve write command stdout: %w", err)
+		}
 	}
 	if result.Stderr != "" {
-		_, _ = io.WriteString(stderr, result.Stderr)
+		if _, err := io.WriteString(stderr, result.Stderr); err != nil {
+			return fmt.Errorf("superserve write command stderr: %w", err)
+		}
 	}
+	return nil
 }
 
 func envSecretValues(env map[string]string) []string {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -1,0 +1,332 @@
+package superserve
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const defaultSuperserveRequestTimeout = 2 * time.Minute
+
+type superserveClient interface {
+	BaseURL() string
+	CreateSandbox(context.Context, createSandboxRequest) (superserveSandbox, error)
+	ListSandboxes(context.Context, map[string]string) ([]superserveSandbox, error)
+	GetSandbox(context.Context, string) (superserveSandbox, error)
+	ActivateSandbox(context.Context, string) (sandboxAccess, error)
+	UpdateSandboxMetadata(context.Context, string, map[string]string) (superserveSandbox, error)
+	PauseSandbox(context.Context, string) (superserveSandbox, error)
+	ResumeSandbox(context.Context, string) (sandboxAccess, error)
+	DeleteSandbox(context.Context, string) error
+	Probe(context.Context) error
+}
+
+type httpSuperserveClient struct {
+	http    *http.Client
+	baseURL string
+	apiKey  string
+}
+
+type createSandboxRequest struct {
+	Template    string            `json:"template,omitempty"`
+	Snapshot    string            `json:"snapshot,omitempty"`
+	Workdir     string            `json:"workdir,omitempty"`
+	TimeoutSecs int               `json:"timeout_secs,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+type updateSandboxRequest struct {
+	Metadata map[string]string `json:"metadata"`
+}
+
+type superserveSandbox struct {
+	ID       string            `json:"id"`
+	Status   string            `json:"status,omitempty"`
+	State    string            `json:"state,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type sandboxAccess struct {
+	Sandbox     superserveSandbox
+	AccessToken string
+}
+
+type superserveAPIError struct {
+	StatusCode int
+	err        error
+}
+
+func (e *superserveAPIError) Error() string { return e.err.Error() }
+func (e *superserveAPIError) Unwrap() error { return e.err }
+
+func newSuperserveClient(cfg Config, rt Runtime) (superserveClient, error) {
+	baseURL, err := validateSuperserveBaseURL(cfg.Superserve.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	apiKey := firstNonEmpty(
+		os.Getenv("CRABBOX_SUPERSERVE_API_KEY"),
+		os.Getenv("SUPERSERVE_API_KEY"),
+	)
+	if apiKey == "" {
+		return nil, exit(2, "provider=superserve needs an API key; load CRABBOX_SUPERSERVE_API_KEY or SUPERSERVE_API_KEY from a secret manager")
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &httpSuperserveClient{http: secureSuperserveHTTPClient(httpClient, baseURL), baseURL: baseURL, apiKey: apiKey}, nil
+}
+
+func secureSuperserveHTTPClient(source *http.Client, baseURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(baseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameSuperserveOrigin(trusted, req.URL) {
+			return fmt.Errorf("superserve refused cross-origin redirect to %s", req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameSuperserveOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveSuperservePort(a) == effectiveSuperservePort(b)
+}
+
+func effectiveSuperservePort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func (c *httpSuperserveClient) BaseURL() string { return c.baseURL }
+
+func (c *httpSuperserveClient) doJSON(ctx context.Context, method, apiPath string, body, out any) error {
+	requestCtx, cancel := context.WithTimeout(ctx, defaultSuperserveRequestTimeout)
+	defer cancel()
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("superserve marshal %s: %w", apiPath, err)
+		}
+		reader = bytes.NewReader(buf)
+	}
+	req, err := http.NewRequestWithContext(requestCtx, method, c.baseURL+apiPath, reader)
+	if err != nil {
+		return fmt.Errorf("superserve request %s: %w", apiPath, err)
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("superserve %s %s: %w", method, apiPath, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.apiError(method, apiPath, resp)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("superserve decode %s: %w", apiPath, err)
+	}
+	return nil
+}
+
+func (c *httpSuperserveClient) CreateSandbox(ctx context.Context, req createSandboxRequest) (superserveSandbox, error) {
+	var sb superserveSandbox
+	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes", req, &sb); err != nil {
+		return superserveSandbox{}, err
+	}
+	if sb.ID == "" {
+		return superserveSandbox{}, exit(5, "superserve create returned no sandbox id")
+	}
+	return sb, nil
+}
+
+func (c *httpSuperserveClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]superserveSandbox, error) {
+	values := url.Values{}
+	for k, v := range metadata {
+		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
+			continue
+		}
+		values.Set("metadata."+k, v)
+	}
+	apiPath := "/sandboxes"
+	if encoded := values.Encode(); encoded != "" {
+		apiPath += "?" + encoded
+	}
+	var out []superserveSandbox
+	if err := c.doJSON(ctx, http.MethodGet, apiPath, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *httpSuperserveClient) GetSandbox(ctx context.Context, id string) (superserveSandbox, error) {
+	var sb superserveSandbox
+	if err := c.doJSON(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(id), nil, &sb); err != nil {
+		return superserveSandbox{}, err
+	}
+	return sb, nil
+}
+
+func (c *httpSuperserveClient) ActivateSandbox(ctx context.Context, id string) (sandboxAccess, error) {
+	return c.postAccess(ctx, "/sandboxes/"+url.PathEscape(id)+"/activate")
+}
+
+func (c *httpSuperserveClient) UpdateSandboxMetadata(ctx context.Context, id string, metadata map[string]string) (superserveSandbox, error) {
+	var sb superserveSandbox
+	if err := c.doJSON(ctx, http.MethodPatch, "/sandboxes/"+url.PathEscape(id), updateSandboxRequest{Metadata: metadata}, &sb); err != nil {
+		return superserveSandbox{}, err
+	}
+	if sb.ID == "" {
+		sb.ID = id
+	}
+	return sb, nil
+}
+
+func (c *httpSuperserveClient) PauseSandbox(ctx context.Context, id string) (superserveSandbox, error) {
+	var sb superserveSandbox
+	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(id)+"/pause", nil, &sb); err != nil {
+		return superserveSandbox{}, err
+	}
+	if sb.ID == "" {
+		sb.ID = id
+	}
+	return sb, nil
+}
+
+func (c *httpSuperserveClient) ResumeSandbox(ctx context.Context, id string) (sandboxAccess, error) {
+	return c.postAccess(ctx, "/sandboxes/"+url.PathEscape(id)+"/resume")
+}
+
+func (c *httpSuperserveClient) DeleteSandbox(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(id), nil, nil)
+}
+
+func (c *httpSuperserveClient) Probe(ctx context.Context) error {
+	var raw json.RawMessage
+	return c.doJSON(ctx, http.MethodGet, "/sandboxes", nil, &raw)
+}
+
+func (c *httpSuperserveClient) postAccess(ctx context.Context, apiPath string) (sandboxAccess, error) {
+	var raw struct {
+		AccessToken string            `json:"access_token"`
+		Token       string            `json:"token"`
+		Sandbox     superserveSandbox `json:"sandbox"`
+		ID          string            `json:"id"`
+		Status      string            `json:"status"`
+		State       string            `json:"state"`
+		Metadata    map[string]string `json:"metadata"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, apiPath, nil, &raw); err != nil {
+		return sandboxAccess{}, err
+	}
+	token := blank(raw.AccessToken, raw.Token)
+	if token == "" {
+		return sandboxAccess{}, exit(5, "superserve %s returned no access token", apiPath)
+	}
+	sb := raw.Sandbox
+	if sb.ID == "" {
+		sb.ID = raw.ID
+	}
+	if sb.Status == "" {
+		sb.Status = raw.Status
+	}
+	if sb.State == "" {
+		sb.State = raw.State
+	}
+	if sb.Metadata == nil {
+		sb.Metadata = raw.Metadata
+	}
+	return sandboxAccess{Sandbox: sb, AccessToken: token}, nil
+}
+
+func (c *httpSuperserveClient) apiError(method, apiPath string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+	var wrapped struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &wrapped) == nil {
+		msg = blank(wrapped.Error, blank(wrapped.Message, msg))
+	}
+	msg = redactSuperserveSecrets(msg, c.apiKey)
+	return &superserveAPIError{
+		StatusCode: resp.StatusCode,
+		err:        exit(5, "superserve %s %s failed: %s: %s", method, apiPath, resp.Status, msg),
+	}
+}
+
+func isSuperserveNotFound(err error) bool {
+	var apiErr *superserveAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+func redactSuperserveSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		if strings.TrimSpace(secret) != "" {
+			redacted = strings.ReplaceAll(redacted, secret, "[redacted]")
+		}
+	}
+	redacted = redactJSONSecretField(redacted, "access_token")
+	redacted = redactJSONSecretField(redacted, "token")
+	return redacted
+}
+
+func redactJSONSecretField(value, key string) string {
+	pattern := regexp.MustCompile(`"` + regexp.QuoteMeta(key) + `"\s*:\s*"[^"]*"`)
+	return pattern.ReplaceAllString(value, `"`+key+`":"[redacted]"`)
+}
+
+func superserveEndpointScope(baseURL string) string {
+	digest := sha256.Sum256([]byte(baseURL))
+	return "endpoint-sha256:" + hex.EncodeToString(digest[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -445,7 +445,9 @@ func deriveSuperserveSandboxHost(apiHost string) (string, bool) {
 	case "api.superserve.ai":
 		return "sandbox.superserve.ai", true
 	default:
-		return "", false
+		// Match the official SDK: custom control-plane URLs use the production
+		// sandbox data plane unless the caller is using a loopback endpoint.
+		return "sandbox.superserve.ai", true
 	}
 }
 
@@ -512,7 +514,7 @@ func (c *httpSuperserveClient) execStream(ctx context.Context, sandboxID, token 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return execResult{}, c.apiError(http.MethodPost, "/exec/stream", resp, append([]string{token}, envSecretValues(body.Env)...)...)
 	}
-	return consumeSuperserveExecStream(resp.Body, stdout, stderr)
+	return consumeSuperserveExecStream(resp.Body, stdout, stderr, envSecretValues(body.Env)...)
 }
 
 func (c *httpSuperserveClient) doDataPlaneJSON(ctx context.Context, method string, target dataPlaneTarget, apiPath, token string, body, out any, secrets ...string) error {
@@ -572,7 +574,7 @@ func isSuperserveUnsupportedStream(err error) bool {
 	return errors.As(err, &streamErr)
 }
 
-func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer) (execResult, error) {
+func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer, secrets ...string) (execResult, error) {
 	var result execResult
 	sawFinished := false
 	scanner := bufio.NewScanner(body)
@@ -606,10 +608,12 @@ func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer) (exec
 			sawFinished = true
 			result.ExitCode = event.ExitCode
 			if event.Error != "" {
-				result.Stderr = appendBounded(result.Stderr, event.Error, maxExecStreamCaptureBytes)
-				if _, err := io.WriteString(stderr, event.Error); err != nil {
+				streamErr := redactSuperserveSecrets(event.Error, secrets...)
+				result.Stderr = appendBounded(result.Stderr, streamErr, maxExecStreamCaptureBytes)
+				if _, err := io.WriteString(stderr, streamErr); err != nil {
 					return execResult{}, fmt.Errorf("superserve write command stderr: %w", err)
 				}
+				return result, exit(5, "superserve command stream failed: %s", streamErr)
 			}
 		}
 	}

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -613,7 +613,9 @@ func consumeSuperserveExecStream(body io.Reader, stdout, stderr io.Writer, secre
 				if _, err := io.WriteString(stderr, streamErr); err != nil {
 					return execResult{}, fmt.Errorf("superserve write command stderr: %w", err)
 				}
-				return result, exit(5, "superserve command stream failed: %s", streamErr)
+				if result.ExitCode == 0 {
+					return result, exit(5, "superserve command stream failed: %s", streamErr)
+				}
 			}
 		}
 	}

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -45,11 +45,17 @@ type httpSuperserveClient struct {
 }
 
 type createSandboxRequest struct {
-	Template    string            `json:"template,omitempty"`
-	Snapshot    string            `json:"snapshot,omitempty"`
-	Workdir     string            `json:"workdir,omitempty"`
-	TimeoutSecs int               `json:"timeout_secs,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	Name           string                   `json:"name,omitempty"`
+	FromTemplate   string                   `json:"from_template,omitempty"`
+	FromSnapshot   string                   `json:"from_snapshot,omitempty"`
+	TimeoutSeconds int                      `json:"timeout_seconds,omitempty"`
+	Metadata       map[string]string        `json:"metadata,omitempty"`
+	Network        *createSandboxNetworkCfg `json:"network,omitempty"`
+}
+
+type createSandboxNetworkCfg struct {
+	AllowOut []string `json:"allow_out,omitempty"`
+	DenyOut  []string `json:"deny_out,omitempty"`
 }
 
 type updateSandboxRequest struct {
@@ -160,19 +166,24 @@ func effectiveSuperservePort(value *url.URL) string {
 func (c *httpSuperserveClient) BaseURL() string { return c.baseURL }
 
 func (c *httpSuperserveClient) doJSON(ctx context.Context, method, apiPath string, body, out any) error {
+	_, err := c.doJSONMaybeEmpty(ctx, method, apiPath, body, out, false)
+	return err
+}
+
+func (c *httpSuperserveClient) doJSONMaybeEmpty(ctx context.Context, method, apiPath string, body, out any, allowEmpty bool) (bool, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, defaultSuperserveRequestTimeout)
 	defer cancel()
 	var reader io.Reader
 	if body != nil {
 		buf, err := json.Marshal(body)
 		if err != nil {
-			return fmt.Errorf("superserve marshal %s: %w", apiPath, err)
+			return false, fmt.Errorf("superserve marshal %s: %w", apiPath, err)
 		}
 		reader = bytes.NewReader(buf)
 	}
 	req, err := http.NewRequestWithContext(requestCtx, method, c.baseURL+apiPath, reader)
 	if err != nil {
-		return fmt.Errorf("superserve request %s: %w", apiPath, err)
+		return false, fmt.Errorf("superserve request %s: %w", apiPath, err)
 	}
 	req.Header.Set("X-API-Key", c.apiKey)
 	if body != nil {
@@ -180,20 +191,23 @@ func (c *httpSuperserveClient) doJSON(ctx context.Context, method, apiPath strin
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("superserve %s %s: %w", method, apiPath, err)
+		return false, fmt.Errorf("superserve %s %s: %w", method, apiPath, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.apiError(method, apiPath, resp)
+		return false, c.apiError(method, apiPath, resp)
 	}
 	if out == nil {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil
+		return false, nil
 	}
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return fmt.Errorf("superserve decode %s: %w", apiPath, err)
+		if allowEmpty && errors.Is(err, io.EOF) {
+			return true, nil
+		}
+		return false, fmt.Errorf("superserve decode %s: %w", apiPath, err)
 	}
-	return nil
+	return false, nil
 }
 
 func (c *httpSuperserveClient) CreateSandbox(ctx context.Context, req createSandboxRequest) (superserveSandbox, error) {
@@ -240,8 +254,12 @@ func (c *httpSuperserveClient) ActivateSandbox(ctx context.Context, id string) (
 
 func (c *httpSuperserveClient) UpdateSandboxMetadata(ctx context.Context, id string, metadata map[string]string) (superserveSandbox, error) {
 	var sb superserveSandbox
-	if err := c.doJSON(ctx, http.MethodPatch, "/sandboxes/"+url.PathEscape(id), updateSandboxRequest{Metadata: metadata}, &sb); err != nil {
+	empty, err := c.doJSONMaybeEmpty(ctx, http.MethodPatch, "/sandboxes/"+url.PathEscape(id), updateSandboxRequest{Metadata: metadata}, &sb, true)
+	if err != nil {
 		return superserveSandbox{}, err
+	}
+	if empty {
+		return c.GetSandbox(ctx, id)
 	}
 	if sb.ID == "" {
 		sb.ID = id

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -1,0 +1,169 @@
+package superserve
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSuperserveClientCreateListActivateAndDelete(t *testing.T) {
+	var requests []struct {
+		method string
+		path   string
+		query  string
+		body   string
+		key    string
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, struct {
+			method string
+			path   string
+			query  string
+			body   string
+			key    string
+		}{r.Method, r.URL.Path, r.URL.RawQuery, string(body), r.Header.Get("X-API-Key")})
+		if r.Header.Get("Authorization") != "" {
+			t.Fatalf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			writeTestJSON(w, map[string]any{"id": "sb_123", "status": "running"})
+		case r.Method == http.MethodGet && r.URL.Path == "/sandboxes":
+			if r.URL.Query().Get("metadata."+metadataProviderKey) != providerName || r.URL.Query().Get("metadata."+metadataEndpointKey) == "" {
+				t.Fatalf("metadata filters missing: %s", r.URL.RawQuery)
+			}
+			writeTestJSON(w, []map[string]any{{"id": "sb_123", "status": "running", "metadata": map[string]string{metadataProviderKey: providerName}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/sb_123/activate":
+			writeTestJSON(w, map[string]any{"access_token": "ss_test_token", "sandbox": map[string]any{"id": "sb_123", "status": "running"}})
+		case r.Method == http.MethodPatch && r.URL.Path == "/sandboxes/sb_123":
+			writeTestJSON(w, map[string]any{"id": "sb_123", "metadata": map[string]string{metadataProviderKey: providerName}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/sandboxes/sb_123":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.CreateSandbox(context.Background(), createSandboxRequest{Template: "superserve/base"}); err != nil {
+		t.Fatalf("CreateSandbox err=%v", err)
+	}
+	if _, err := client.ListSandboxes(context.Background(), map[string]string{metadataProviderKey: providerName, metadataEndpointKey: "endpoint"}); err != nil {
+		t.Fatalf("ListSandboxes err=%v", err)
+	}
+	access, err := client.ActivateSandbox(context.Background(), "sb_123")
+	if err != nil {
+		t.Fatalf("ActivateSandbox err=%v", err)
+	}
+	if access.AccessToken != "ss_test_token" {
+		t.Fatalf("access token=%q", access.AccessToken)
+	}
+	if _, err := client.UpdateSandboxMetadata(context.Background(), "sb_123", map[string]string{metadataProviderKey: providerName}); err != nil {
+		t.Fatalf("UpdateSandboxMetadata err=%v", err)
+	}
+	if err := client.DeleteSandbox(context.Background(), "sb_123"); err != nil {
+		t.Fatalf("DeleteSandbox err=%v", err)
+	}
+	for _, req := range requests {
+		if req.key != "ss_test_key" {
+			t.Fatalf("%s %s X-API-Key=%q", req.method, req.path, req.key)
+		}
+	}
+}
+
+func TestSuperserveClientRejectsCrossOriginRedirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("cross-origin redirect target should not be reached")
+	}))
+	defer target.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/sandboxes", http.StatusFound)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Probe(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("err=%v, want cross-origin redirect refusal", err)
+	}
+}
+
+func TestSuperserveClientRedactsSecretsFromErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"bad ss_test_key token {\"access_token\": \"ss_test_token\"}"}`)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Probe(context.Background())
+	if err == nil {
+		t.Fatal("expected probe error")
+	}
+	if strings.Contains(err.Error(), "ss_test_key") || strings.Contains(err.Error(), "ss_test_token") {
+		t.Fatalf("secret leaked in error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("error was not redacted: %v", err)
+	}
+}
+
+func TestSuperserveClientUpdateDoesNotFabricateMissingMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/sandboxes/sb_123" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		writeTestJSON(w, map[string]any{"id": "sb_123"})
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb, err := client.UpdateSandboxMetadata(context.Background(), "sb_123", map[string]string{metadataClaimKey: leasePrefix + "sb_123"})
+	if err != nil {
+		t.Fatalf("UpdateSandboxMetadata err=%v", err)
+	}
+	if sb.Metadata != nil {
+		t.Fatalf("metadata was fabricated from request: %#v", sb.Metadata)
+	}
+}
+
+func TestDataPlaneHostForSandbox(t *testing.T) {
+	got := dataPlaneHostForSandbox("sb_123", "sandbox.example.test")
+	if got != "boxd-sb_123.sandbox.example.test" {
+		t.Fatalf("host=%q", got)
+	}
+	if dataPlaneHostForSandbox("", "sandbox.example.test") != "" {
+		t.Fatal("empty sandbox id should not derive host")
+	}
+}
+
+func writeTestJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func testConfigWithBaseURL(baseURL string) Config {
+	cfg := testConfig()
+	cfg.Superserve.BaseURL = baseURL
+	return cfg
+}

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -411,6 +411,25 @@ func TestSuperserveUploadHonorsCallerDeadline(t *testing.T) {
 	}
 }
 
+func TestSuperserveExecRequestContextPreservesServiceDefault(t *testing.T) {
+	ctx, cancel := superserveExecRequestContext(context.Background(), 0)
+	defer cancel()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("service-default exec timeout added an absolute client deadline")
+	}
+
+	ctx, cancel = superserveExecRequestContext(context.Background(), 12)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("positive exec timeout did not add a client deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining < 16*time.Second || remaining > 18*time.Second {
+		t.Fatalf("positive exec timeout remaining=%s, want about 17s", remaining)
+	}
+}
+
 func TestSuperserveClientStreamDoesNotRetainUnboundedOutput(t *testing.T) {
 	chunk := strings.Repeat("x", maxExecStreamCaptureBytes+2048)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -147,6 +147,321 @@ func TestSuperserveClientUpdateDoesNotFabricateMissingMetadata(t *testing.T) {
 	}
 }
 
+func TestSuperserveClientDataPlaneUploadAndStreamUseAccessTokenRouting(t *testing.T) {
+	var requests []struct {
+		method      string
+		path        string
+		query       string
+		apiKey      string
+		accessToken string
+		sandboxID   string
+		body        string
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, struct {
+			method      string
+			path        string
+			query       string
+			apiKey      string
+			accessToken string
+			sandboxID   string
+			body        string
+		}{
+			method:      r.Method,
+			path:        r.URL.Path,
+			query:       r.URL.RawQuery,
+			apiKey:      r.Header.Get("X-API-Key"),
+			accessToken: r.Header.Get("X-Access-Token"),
+			sandboxID:   r.Header.Get("X-Superserve-Sandbox-Id"),
+			body:        string(body),
+		})
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/files":
+			if r.URL.Query().Get("path") != "/tmp/crabbox-sync-test.tgz" {
+				t.Fatalf("upload path query=%q", r.URL.RawQuery)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && r.URL.Path == "/exec/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "data: {\"stdout\":\"out\\n\"}\n\n")
+			_, _ = io.WriteString(w, "data: {\"stderr\":\"err\\n\"}\n\n")
+			_, _ = io.WriteString(w, "data: {\"finished\":true,\"exit_code\":3}\n\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	access := &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"}
+	if err := client.UploadFile(context.Background(), access, "/tmp/crabbox-sync-test.tgz", strings.NewReader("archive")); err != nil {
+		t.Fatalf("UploadFile err=%v", err)
+	}
+	var stdout, stderr strings.Builder
+	result, err := client.Exec(context.Background(), access, execRequest{
+		Command:     "go test ./...",
+		WorkingDir:  "/workspace/crabbox",
+		Env:         map[string]string{"SUPERSERVE_API_KEY": "ss_test_not_real"},
+		TimeoutSecs: 12,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Exec err=%v", err)
+	}
+	if result.ExitCode != 3 || stdout.String() != "out\n" || stderr.String() != "err\n" {
+		t.Fatalf("result=%#v stdout=%q stderr=%q", result, stdout.String(), stderr.String())
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests=%#v", requests)
+	}
+	for _, req := range requests {
+		if req.apiKey != "" {
+			t.Fatalf("data-plane request used API key: %#v", req)
+		}
+		if req.accessToken != "ss_test_token" || req.sandboxID != "sb_123" {
+			t.Fatalf("data-plane auth/routing headers wrong: %#v", req)
+		}
+	}
+	if !strings.Contains(requests[1].body, `"env":{"SUPERSERVE_API_KEY":"ss_test_not_real"}`) || strings.Contains(requests[1].body, "X-API-Key") {
+		t.Fatalf("exec body=%q", requests[1].body)
+	}
+}
+
+func TestSuperserveClientRefreshesAccessTokenOnDataPlane401(t *testing.T) {
+	execAttempts := 0
+	var tokens []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/exec/stream":
+			execAttempts++
+			tokens = append(tokens, r.Header.Get("X-Access-Token"))
+			if execAttempts == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = io.WriteString(w, `{"error":{"message":"expired token"}}`)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "data: {\"stdout\":\"fresh\\n\"}\n\n")
+			_, _ = io.WriteString(w, "data: {\"finished\":true,\"exit_code\":0}\n\n")
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes/sb_123/activate":
+			if r.Header.Get("X-API-Key") != "ss_test_key" {
+				t.Fatalf("activate X-API-Key=%q", r.Header.Get("X-API-Key"))
+			}
+			writeTestJSON(w, map[string]any{"access_token": "ss_test_token_fresh", "sandbox": map[string]any{"id": "sb_123", "status": "running"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	access := &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token_old"}
+	var stdout strings.Builder
+	result, err := client.Exec(context.Background(), access, execRequest{Command: "true"}, &stdout, io.Discard)
+	if err != nil {
+		t.Fatalf("Exec err=%v", err)
+	}
+	if result.ExitCode != 0 || stdout.String() != "fresh\n" {
+		t.Fatalf("result=%#v stdout=%q", result, stdout.String())
+	}
+	if strings.Join(tokens, ",") != "ss_test_token_old,ss_test_token_fresh" || access.AccessToken != "ss_test_token_fresh" {
+		t.Fatalf("tokens=%#v access=%#v", tokens, access)
+	}
+}
+
+func TestSuperserveClientFallsBackToBufferedExecWhenStreamUnsupported(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/exec/stream":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"error":{"message":"missing"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/exec":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body["command"] != "printf hi" || body["working_dir"] != "/workspace/crabbox" {
+				t.Fatalf("body=%#v", body)
+			}
+			writeTestJSON(w, map[string]any{"stdout": "hi", "stderr": "warn", "exit_code": 4})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr strings.Builder
+	result, err := client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		execRequest{Command: "printf hi", WorkingDir: "/workspace/crabbox"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("Exec err=%v", err)
+	}
+	if strings.Join(paths, ",") != "/exec/stream,/exec" {
+		t.Fatalf("paths=%#v", paths)
+	}
+	if result.ExitCode != 4 || stdout.String() != "hi" || stderr.String() != "warn" {
+		t.Fatalf("result=%#v stdout=%q stderr=%q", result, stdout.String(), stderr.String())
+	}
+}
+
+func TestSuperserveClientRejectsUnknownDataPlaneHost(t *testing.T) {
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL("https://api.example.test"), Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	access := &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"}
+	err = client.UploadFile(context.Background(), access, "/tmp/archive.tgz", strings.NewReader("archive"))
+	if err == nil || !strings.Contains(err.Error(), "cannot derive a data-plane sandbox host") {
+		t.Fatalf("UploadFile err=%v, want fail-closed data-plane host rejection", err)
+	}
+	_, err = client.Exec(context.Background(), access, execRequest{Command: "true"}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "cannot derive a data-plane sandbox host") {
+		t.Fatalf("Exec err=%v, want fail-closed data-plane host rejection", err)
+	}
+}
+
+func TestSuperserveClientStreamDoesNotRetainUnboundedOutput(t *testing.T) {
+	chunk := strings.Repeat("x", maxExecStreamCaptureBytes+2048)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/exec/stream" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_ = json.NewEncoder(w).Encode(map[string]string{})
+		_, _ = io.WriteString(w, "data: "+mustJSONLine(t, map[string]string{"stdout": chunk})+"\n\n")
+		_, _ = io.WriteString(w, "data: {\"finished\":true,\"exit_code\":0}\n\n")
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout strings.Builder
+	result, err := client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		execRequest{Command: "yes"}, &stdout, io.Discard)
+	if err != nil {
+		t.Fatalf("Exec err=%v", err)
+	}
+	if stdout.Len() != len(chunk) {
+		t.Fatalf("stdout len=%d want %d", stdout.Len(), len(chunk))
+	}
+	if len(result.Stdout) != maxExecStreamCaptureBytes {
+		t.Fatalf("captured stdout len=%d want %d", len(result.Stdout), maxExecStreamCaptureBytes)
+	}
+	if result.Stdout != chunk[len(chunk)-maxExecStreamCaptureBytes:] {
+		t.Fatal("captured stdout is not the bounded tail")
+	}
+}
+
+func TestSuperserveClientRedactsForwardedEnvValuesFromExecErrors(t *testing.T) {
+	t.Run("stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/exec/stream" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"message":"bad env ss_test_not_real"}}`)
+		}))
+		defer server.Close()
+
+		t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+		client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+			execRequest{Command: "true", Env: map[string]string{"SECRET_TOKEN": "ss_test_not_real"}}, io.Discard, io.Discard)
+		if err == nil {
+			t.Fatal("expected exec error")
+		}
+		if strings.Contains(err.Error(), "ss_test_not_real") || !strings.Contains(err.Error(), "[redacted]") {
+			t.Fatalf("error was not redacted: %v", err)
+		}
+	})
+
+	t.Run("buffered fallback", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/exec/stream":
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"error":{"message":"stream unavailable"}}`)
+			case "/exec":
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"error":{"message":"bad env ss_test_not_real"}}`)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+		client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+			execRequest{Command: "true", Env: map[string]string{"SECRET_TOKEN": "ss_test_not_real"}}, io.Discard, io.Discard)
+		if err == nil {
+			t.Fatal("expected exec error")
+		}
+		if strings.Contains(err.Error(), "ss_test_not_real") || !strings.Contains(err.Error(), "[redacted]") {
+			t.Fatalf("error was not redacted: %v", err)
+		}
+	})
+}
+
+func TestSuperserveClientStreamRequiresFinishedEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/exec/stream" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"stdout\":\"partial\"}\n\n")
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		execRequest{Command: "long"}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "without a finished event") {
+		t.Fatalf("err=%v, want unfinished stream error", err)
+	}
+}
+
+func mustJSONLine(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
 func TestDataPlaneHostForSandbox(t *testing.T) {
 	got := dataPlaneHostForSandbox("sb_123", "sandbox.example.test")
 	if got != "boxd-sb_123.sandbox.example.test" {

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -55,8 +55,29 @@ func TestSuperserveClientCreateListActivateAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.CreateSandbox(context.Background(), createSandboxRequest{Template: "superserve/base"}); err != nil {
+	if _, err := client.CreateSandbox(context.Background(), createSandboxRequest{
+		Name:           "crabbox-my-app",
+		FromTemplate:   "superserve/base",
+		FromSnapshot:   "snap_123",
+		TimeoutSeconds: 300,
+		Metadata:       map[string]string{metadataProviderKey: providerName},
+		Network:        &createSandboxNetworkCfg{AllowOut: []string{"api.example.test"}, DenyOut: []string{"metadata.example.test"}},
+	}); err != nil {
 		t.Fatalf("CreateSandbox err=%v", err)
+	}
+	var createBody map[string]any
+	if err := json.Unmarshal([]byte(requests[0].body), &createBody); err != nil {
+		t.Fatalf("create body json=%q err=%v", requests[0].body, err)
+	}
+	if createBody["name"] != "crabbox-my-app" || createBody["from_template"] != "superserve/base" || createBody["from_snapshot"] != "snap_123" || createBody["timeout_seconds"].(float64) != 300 {
+		t.Fatalf("create body used wrong API fields: %#v", createBody)
+	}
+	network, ok := createBody["network"].(map[string]any)
+	if !ok || len(network["allow_out"].([]any)) != 1 || len(network["deny_out"].([]any)) != 1 {
+		t.Fatalf("create network body=%#v", createBody["network"])
+	}
+	if _, ok := createBody["template"]; ok {
+		t.Fatalf("create body sent legacy template field: %#v", createBody)
 	}
 	if _, err := client.ListSandboxes(context.Background(), map[string]string{metadataProviderKey: providerName, metadataEndpointKey: "endpoint"}); err != nil {
 		t.Fatalf("ListSandboxes err=%v", err)
@@ -144,6 +165,32 @@ func TestSuperserveClientUpdateDoesNotFabricateMissingMetadata(t *testing.T) {
 	}
 	if sb.Metadata != nil {
 		t.Fatalf("metadata was fabricated from request: %#v", sb.Metadata)
+	}
+}
+
+func TestSuperserveClientUpdateFetchesSandboxAfterEmptyPatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/sandboxes/sb_123":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/sandboxes/sb_123":
+			writeTestJSON(w, map[string]any{"id": "sb_123", "metadata": map[string]string{metadataClaimKey: leasePrefix + "sb_123"}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb, err := client.UpdateSandboxMetadata(context.Background(), "sb_123", map[string]string{metadataClaimKey: leasePrefix + "sb_123"})
+	if err != nil {
+		t.Fatalf("UpdateSandboxMetadata err=%v", err)
+	}
+	if sb.Metadata[metadataClaimKey] != leasePrefix+"sb_123" {
+		t.Fatalf("metadata was not fetched after empty patch: %#v", sb.Metadata)
 	}
 }
 

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -368,20 +368,14 @@ func TestSuperserveClientFallsBackToBufferedExecWhenStreamUnsupported(t *testing
 	}
 }
 
-func TestSuperserveClientRejectsUnknownDataPlaneHost(t *testing.T) {
-	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
-	client, err := newSuperserveClient(testConfigWithBaseURL("https://api.example.test"), Runtime{})
+func TestSuperserveClientCustomControlPlaneUsesProductionDataPlane(t *testing.T) {
+	client := &httpSuperserveClient{baseURL: "https://api.example.test"}
+	target, err := client.dataPlaneTarget("sb_123")
 	if err != nil {
 		t.Fatal(err)
 	}
-	access := &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"}
-	err = client.UploadFile(context.Background(), access, "/tmp/archive.tgz", strings.NewReader("archive"))
-	if err == nil || !strings.Contains(err.Error(), "cannot derive a data-plane sandbox host") {
-		t.Fatalf("UploadFile err=%v, want fail-closed data-plane host rejection", err)
-	}
-	_, err = client.Exec(context.Background(), access, execRequest{Command: "true"}, io.Discard, io.Discard)
-	if err == nil || !strings.Contains(err.Error(), "cannot derive a data-plane sandbox host") {
-		t.Fatalf("Exec err=%v, want fail-closed data-plane host rejection", err)
+	if target.baseURL != "https://sandbox.superserve.ai" || target.headers["X-Superserve-Sandbox-Id"] != "sb_123" {
+		t.Fatalf("target=%#v, want official SDK production data-plane fallback", target)
 	}
 }
 
@@ -596,6 +590,36 @@ func TestSuperserveClientStreamRequiresFinishedEvent(t *testing.T) {
 		execRequest{Command: "long"}, io.Discard, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "without a finished event") {
 		t.Fatalf("err=%v, want unfinished stream error", err)
+	}
+}
+
+func TestSuperserveClientRejectsTerminalStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/exec/stream" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"finished\":true,\"error\":\"failed with project_test_not_real\"}\n\n")
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	result, err := client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		execRequest{Command: "false", Env: map[string]string{"PROJECT_TOKEN": "project_test_not_real"}}, io.Discard, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "command stream failed") {
+		t.Fatalf("result=%#v err=%v, want terminal stream failure", result, err)
+	}
+	if strings.Contains(err.Error(), "project_test_not_real") || strings.Contains(stderr.String(), "project_test_not_real") {
+		t.Fatalf("terminal stream error leaked env value: err=%v stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "[redacted]") {
+		t.Fatalf("stderr=%q, want redacted terminal error", stderr.String())
 	}
 }
 

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -3,11 +3,13 @@ package superserve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSuperserveClientCreateListActivateAndDelete(t *testing.T) {
@@ -383,6 +385,38 @@ func TestSuperserveClientRejectsUnknownDataPlaneHost(t *testing.T) {
 	}
 }
 
+func TestSuperserveUploadHonorsCallerDeadline(t *testing.T) {
+	var remaining time.Duration
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			t.Fatal("upload request has no deadline")
+		}
+		remaining = time.Until(deadline)
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Status:     "204 No Content",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	})}
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL("http://localhost"), Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	if err := client.UploadFile(ctx, &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		"/tmp/archive.tgz", strings.NewReader("archive")); err != nil {
+		t.Fatal(err)
+	}
+	if remaining < 9*time.Minute {
+		t.Fatalf("upload deadline remaining=%s, caller deadline was shortened", remaining)
+	}
+}
+
 func TestSuperserveClientStreamDoesNotRetainUnboundedOutput(t *testing.T) {
 	chunk := strings.Repeat("x", maxExecStreamCaptureBytes+2048)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -416,6 +450,57 @@ func TestSuperserveClientStreamDoesNotRetainUnboundedOutput(t *testing.T) {
 	}
 	if result.Stdout != chunk[len(chunk)-maxExecStreamCaptureBytes:] {
 		t.Fatal("captured stdout is not the bounded tail")
+	}
+}
+
+func TestSuperserveClientPropagatesOutputWriterFailures(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		stream     bool
+		failStdout bool
+		want       string
+	}{
+		{name: "stream stdout", stream: true, failStdout: true, want: "write command stdout"},
+		{name: "stream stderr", stream: true, want: "write command stderr"},
+		{name: "buffered stdout", failStdout: true, want: "write command stdout"},
+		{name: "buffered stderr", want: "write command stderr"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/exec/stream":
+					if !test.stream {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = io.WriteString(w, "data: {\"stdout\":\"out\",\"stderr\":\"err\"}\n\n")
+					_, _ = io.WriteString(w, "data: {\"finished\":true,\"exit_code\":0}\n\n")
+				case "/exec":
+					writeTestJSON(w, map[string]any{"stdout": "out", "stderr": "err", "exit_code": 0})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+			client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			stdout, stderr := io.Writer(io.Discard), io.Writer(io.Discard)
+			if test.failStdout {
+				stdout = failingWriter{err: errors.New("stdout closed")}
+			} else {
+				stderr = failingWriter{err: errors.New("stderr closed")}
+			}
+			_, err = client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+				execRequest{Command: "true"}, stdout, stderr)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Exec err=%v, want %q", err, test.want)
+			}
+		})
 	}
 }
 
@@ -475,6 +560,20 @@ func TestSuperserveClientRedactsForwardedEnvValuesFromExecErrors(t *testing.T) {
 			t.Fatalf("error was not redacted: %v", err)
 		}
 	})
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func TestSuperserveClientStreamRequiresFinishedEvent(t *testing.T) {

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -623,6 +623,33 @@ func TestSuperserveClientRejectsTerminalStreamError(t *testing.T) {
 	}
 }
 
+func TestSuperserveClientPreservesExitCodeWithTerminalStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/exec/stream" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"finished\":true,\"exit_code\":23,\"error\":\"command failed\"}\n\n")
+	}))
+	defer server.Close()
+
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "ss_test_key")
+	client, err := newSuperserveClient(testConfigWithBaseURL(server.URL), Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	result, err := client.Exec(context.Background(), &sandboxAccess{Sandbox: superserveSandbox{ID: "sb_123"}, AccessToken: "ss_test_token"},
+		execRequest{Command: "false"}, io.Discard, &stderr)
+	if err != nil {
+		t.Fatalf("Exec err=%v", err)
+	}
+	if result.ExitCode != 23 || !strings.Contains(stderr.String(), "command failed") {
+		t.Fatalf("result=%#v stderr=%q, want exit 23 and terminal error output", result, stderr.String())
+	}
+}
+
 func mustJSONLine(t *testing.T, v any) string {
 	t.Helper()
 	data, err := json.Marshal(v)

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -29,6 +30,8 @@ type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
 type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
+type SyncManifest = core.SyncManifest
 
 const (
 	providerName   = "superserve"
@@ -85,6 +88,46 @@ func listSuperserveLeaseClaims() ([]LeaseClaim, error) {
 
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
+}
+
+func syncExcludes(root string, cfg Config) ([]string, error) {
+	return core.SyncExcludes(root, cfg)
+}
+
+func syncManifest(root string, excludes, includes []string) (SyncManifest, error) {
+	return core.BuildSyncManifestFiltered(root, excludes, includes)
+}
+
+func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
+}
+
+func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
+}
+
+func shellQuote(value string) string {
+	return core.ShellQuote(value)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
 func notImplemented(ctx context.Context, action string) error {

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -1,0 +1,57 @@
+package superserve
+
+import (
+	"context"
+	"flag"
+	"io"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type CleanupRequest = core.CleanupRequest
+
+const (
+	providerName   = "superserve"
+	leasePrefix    = "ssbx_"
+	namePrefix     = "crabbox-"
+	defaultBaseURL = "https://api.superserve.ai"
+	defaultWorkdir = "/workspace/crabbox"
+	targetLinux    = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func writeTimingJSON(w io.Writer, report core.TimingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}
+
+func notImplemented(ctx context.Context, action string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return exit(2, "provider=superserve %s is not implemented yet; lifecycle support lands in the Superserve client/lifecycle plan", action)
+}

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -90,6 +90,10 @@ func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
 
+func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
+}
+
 func syncExcludes(root string, cfg Config) ([]string, error) {
 	return core.SyncExcludes(root, cfg)
 }
@@ -128,11 +132,4 @@ func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, s
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func notImplemented(ctx context.Context, action string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	return exit(2, "provider=superserve %s is not implemented yet; lifecycle support lands in the Superserve client/lifecycle plan", action)
 }

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -23,6 +24,11 @@ type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type CleanupRequest = core.CleanupRequest
+type Server = core.Server
+type Repo = core.Repo
+type LeaseClaim = core.LeaseClaim
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
 
 const (
 	providerName   = "superserve"
@@ -47,6 +53,38 @@ func writeTimingJSON(w io.Writer, report core.TimingReport) error {
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func readLeaseClaim(leaseID string) (LeaseClaim, error) {
+	return core.ReadLeaseClaim(leaseID)
+}
+
+func listSuperserveLeaseClaims() ([]LeaseClaim, error) {
+	return core.ListLeaseClaimsWithPrefix(leasePrefix)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
 }
 
 func notImplemented(ctx context.Context, action string) error {

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -124,7 +124,7 @@ func superserveWorkdir(cfg Config) (string, error) {
 	}
 	clean := path.Clean(workdir)
 	switch clean {
-	case "/", "/tmp", "/workspace":
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
 		return "", exit(2, "superserve workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -1,0 +1,163 @@
+package superserve
+
+import (
+	"flag"
+	"net"
+	"net/url"
+	"path"
+	"strings"
+)
+
+type superserveFlagValues struct {
+	BaseURL         *string
+	Template        *string
+	Snapshot        *string
+	Workdir         *string
+	TimeoutSecs     *int
+	ExecTimeoutSecs *int
+	NetworkAllowOut *string
+	NetworkDenyOut  *string
+	ForgetMissing   *bool
+}
+
+func RegisterSuperserveProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return superserveFlagValues{
+		BaseURL:         fs.String("superserve-base-url", defaults.Superserve.BaseURL, "Trusted Superserve API base URL"),
+		Template:        fs.String("superserve-template", defaults.Superserve.Template, "Superserve sandbox template"),
+		Snapshot:        fs.String("superserve-snapshot", defaults.Superserve.Snapshot, "Superserve snapshot ID or name"),
+		Workdir:         fs.String("superserve-workdir", defaults.Superserve.Workdir, "Absolute working directory inside the sandbox"),
+		TimeoutSecs:     fs.Int("superserve-timeout-secs", defaults.Superserve.TimeoutSecs, "Superserve sandbox lifetime cap in seconds (0 = service default)"),
+		ExecTimeoutSecs: fs.Int("superserve-exec-timeout-secs", defaults.Superserve.ExecTimeoutSecs, "Superserve command timeout in seconds (0 = service default)"),
+		NetworkAllowOut: fs.String("superserve-network-allow-out", strings.Join(defaults.Superserve.NetworkAllowOut, ","), "comma-separated outbound network allow list"),
+		NetworkDenyOut:  fs.String("superserve-network-deny-out", strings.Join(defaults.Superserve.NetworkDenyOut, ","), "comma-separated outbound network deny list"),
+		ForgetMissing:   fs.Bool("superserve-forget-missing", defaults.Superserve.ForgetMissing, "remove the local claim when stop gets 404 (explicit stale-claim cleanup)"),
+	}
+}
+
+func ApplySuperserveProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=superserve; use --superserve-template or --superserve-snapshot")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=superserve; use --superserve-template or --superserve-snapshot")
+		}
+	}
+	v, ok := values.(superserveFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "superserve-base-url") {
+		cfg.Superserve.BaseURL = *v.BaseURL
+	}
+	if flagWasSet(fs, "superserve-template") {
+		cfg.Superserve.Template = *v.Template
+	}
+	if flagWasSet(fs, "superserve-snapshot") {
+		cfg.Superserve.Snapshot = *v.Snapshot
+	}
+	if flagWasSet(fs, "superserve-workdir") {
+		cfg.Superserve.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "superserve-timeout-secs") {
+		cfg.Superserve.TimeoutSecs = *v.TimeoutSecs
+	}
+	if flagWasSet(fs, "superserve-exec-timeout-secs") {
+		cfg.Superserve.ExecTimeoutSecs = *v.ExecTimeoutSecs
+	}
+	if flagWasSet(fs, "superserve-network-allow-out") {
+		cfg.Superserve.NetworkAllowOut = splitSuperserveList(*v.NetworkAllowOut)
+	}
+	if flagWasSet(fs, "superserve-network-deny-out") {
+		cfg.Superserve.NetworkDenyOut = splitSuperserveList(*v.NetworkDenyOut)
+	}
+	if flagWasSet(fs, "superserve-forget-missing") {
+		cfg.Superserve.ForgetMissing = *v.ForgetMissing
+	}
+	return validateSuperserveConfig(*cfg)
+}
+
+func validateSuperserveConfig(cfg Config) error {
+	if _, err := validateSuperserveBaseURL(cfg.Superserve.BaseURL); err != nil {
+		return err
+	}
+	if _, err := superserveWorkdir(cfg); err != nil {
+		return err
+	}
+	if cfg.Superserve.TimeoutSecs < 0 {
+		return exit(2, "superserve timeoutSecs must be non-negative")
+	}
+	if cfg.Superserve.ExecTimeoutSecs < 0 {
+		return exit(2, "superserve execTimeoutSecs must be non-negative")
+	}
+	return nil
+}
+
+func validateSuperserveBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = defaultBaseURL
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", exit(2, "provider=superserve base URL must be an absolute URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", exit(2, "provider=superserve base URL must not contain userinfo, query parameters, or a fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return "", exit(2, "provider=superserve base URL must use HTTPS except for loopback development endpoints")
+	}
+	parsed.Host = canonicalHostPort(parsed)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return parsed.String(), nil
+}
+
+func superserveWorkdir(cfg Config) (string, error) {
+	workdir := strings.TrimSpace(cfg.Superserve.Workdir)
+	if workdir == "" {
+		workdir = defaultWorkdir
+	}
+	if !path.IsAbs(workdir) {
+		return "", exit(2, "superserve workdir must be absolute")
+	}
+	clean := path.Clean(workdir)
+	switch clean {
+	case "/", "/tmp", "/workspace":
+		return "", exit(2, "superserve workdir %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return clean, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func canonicalHostPort(parsed *url.URL) string {
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		return host
+	}
+	if port == "" {
+		return host
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func splitSuperserveList(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -168,9 +168,12 @@ func canonicalHostPort(parsed *url.URL) string {
 	host := strings.ToLower(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		return host
+		port = ""
 	}
 	if port == "" {
+		if strings.Contains(host, ":") {
+			return "[" + host + "]"
+		}
 		return host
 	}
 	return net.JoinHostPort(host, port)

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -26,7 +26,7 @@ func RegisterSuperserveProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		Template:        fs.String("superserve-template", defaults.Superserve.Template, "Superserve sandbox template"),
 		Snapshot:        fs.String("superserve-snapshot", defaults.Superserve.Snapshot, "Superserve snapshot ID or name"),
 		Workdir:         fs.String("superserve-workdir", defaults.Superserve.Workdir, "Absolute working directory inside the sandbox"),
-		TimeoutSecs:     fs.Int("superserve-timeout-secs", defaults.Superserve.TimeoutSecs, "Superserve sandbox lifetime cap in seconds (0 = service default)"),
+		TimeoutSecs:     fs.Int("superserve-timeout-secs", defaults.Superserve.TimeoutSecs, "Superserve sandbox lifetime cap in seconds (0 = Crabbox TTL)"),
 		ExecTimeoutSecs: fs.Int("superserve-exec-timeout-secs", defaults.Superserve.ExecTimeoutSecs, "Superserve command timeout in seconds (0 = service default)"),
 		NetworkAllowOut: fs.String("superserve-network-allow-out", strings.Join(defaults.Superserve.NetworkAllowOut, ","), "comma-separated outbound network allow list"),
 		NetworkDenyOut:  fs.String("superserve-network-deny-out", strings.Join(defaults.Superserve.NetworkDenyOut, ","), "comma-separated outbound network deny list"),
@@ -89,6 +89,11 @@ func validateSuperserveConfig(cfg Config) error {
 	}
 	if cfg.Superserve.ExecTimeoutSecs < 0 {
 		return exit(2, "superserve execTimeoutSecs must be non-negative")
+	}
+	for _, deny := range cfg.Superserve.NetworkDenyOut {
+		if _, _, err := net.ParseCIDR(deny); err != nil {
+			return exit(2, "superserve networkDenyOut entry %q must be a CIDR", deny)
+		}
 	}
 	return nil
 }

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -116,6 +116,8 @@ func superserveSandboxTimeoutSecs(cfg Config) (int, error) {
 	if timeout > maxSuperserveSandboxTimeoutSecs {
 		return 0, exit(2, "superserve sandbox lifetime must not exceed %d seconds (7 days)", maxSuperserveSandboxTimeoutSecs)
 	}
+	// Sandbox lifetime is an independent hard resource cap. It may intentionally
+	// be shorter than the command timeout to bound billing and remote lifetime.
 	return timeout, nil
 }
 

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 )
 
 type superserveFlagValues struct {
@@ -19,6 +20,8 @@ type superserveFlagValues struct {
 	NetworkDenyOut  *string
 	ForgetMissing   *bool
 }
+
+const maxSuperserveSandboxTimeoutSecs = 7 * 24 * 60 * 60
 
 func RegisterSuperserveProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	return superserveFlagValues{
@@ -90,12 +93,30 @@ func validateSuperserveConfig(cfg Config) error {
 	if cfg.Superserve.ExecTimeoutSecs < 0 {
 		return exit(2, "superserve execTimeoutSecs must be non-negative")
 	}
+	if _, err := superserveSandboxTimeoutSecs(cfg); err != nil {
+		return err
+	}
 	for _, deny := range cfg.Superserve.NetworkDenyOut {
 		if _, _, err := net.ParseCIDR(deny); err != nil {
 			return exit(2, "superserve networkDenyOut entry %q must be a CIDR", deny)
 		}
 	}
 	return nil
+}
+
+func superserveSandboxTimeoutSecs(cfg Config) (int, error) {
+	timeout := cfg.Superserve.TimeoutSecs
+	if timeout == 0 {
+		lifetime := cfg.TTL
+		if lifetime <= 0 {
+			lifetime = 90 * time.Minute
+		}
+		timeout = int((lifetime + time.Second - 1) / time.Second)
+	}
+	if timeout > maxSuperserveSandboxTimeoutSecs {
+		return 0, exit(2, "superserve sandbox lifetime must not exceed %d seconds (7 days)", maxSuperserveSandboxTimeoutSecs)
+	}
+	return timeout, nil
 }
 
 func validateSuperserveBaseURL(raw string) (string, error) {

--- a/internal/providers/superserve/operation_lock.go
+++ b/internal/providers/superserve/operation_lock.go
@@ -1,0 +1,72 @@
+package superserve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+var superserveOperationLocks sync.Map
+
+type superserveOperationSemaphore struct {
+	token chan struct{}
+}
+
+func newSuperserveOperationSemaphore() *superserveOperationSemaphore {
+	semaphore := &superserveOperationSemaphore{token: make(chan struct{}, 1)}
+	semaphore.token <- struct{}{}
+	return semaphore
+}
+
+func lockSuperserveLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
+	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
+		filepath.Base(leaseID) != leaseID || leaseID == "." {
+		return nil, exit(2, "invalid superserve lease id %q", leaseID)
+	}
+	stateDir, err := core.CrabboxStateDir()
+	if err != nil {
+		return nil, err
+	}
+	lockDir := filepath.Join(stateDir, "claim-locks")
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, exit(2, "create superserve lock directory: %v", err)
+	}
+	lockPath := filepath.Join(lockDir, leaseID+".superserve-operation.lock")
+	value, _ := superserveOperationLocks.LoadOrStore(lockPath, newSuperserveOperationSemaphore())
+	semaphore := value.(*superserveOperationSemaphore)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-semaphore.token:
+	}
+
+	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
+	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
+	if err != nil {
+		semaphore.token <- struct{}{}
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, err
+	}
+	if !locked {
+		semaphore.token <- struct{}{}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return nil, exit(2, "lock superserve lease %s was not acquired", leaseID)
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = fileLock.Unlock()
+			semaphore.token <- struct{}{}
+		})
+	}, nil
+}

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -1,0 +1,105 @@
+package superserve
+
+import (
+	"context"
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) ServerTypeForConfig(core.Config) string { return "" }
+func (Provider) ServerTypeForClass(string) string       { return "" }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "superserve",
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterSuperserveProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplySuperserveProviderFlags(cfg, fs, values)
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	return validateSuperserveConfig(cfg)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if err := p.ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	cfg.Provider = providerName
+	return &backend{spec: p.Spec(), cfg: cfg, rt: rt}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "superserve doctor backend unavailable")
+	}
+	return doctor, nil
+}
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+	if err := ctx.Err(); err != nil {
+		return DoctorResult{}, err
+	}
+	result := inventoryDoctorResult(providerName, 0)
+	result.Status = "ok"
+	result.Message = "config=ready lifecycle=not_implemented control_plane=not_contacted"
+	return result, nil
+}
+
+func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	return notImplemented(ctx, "warmup")
+}
+
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	return RunResult{}, notImplemented(ctx, "run")
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	return nil, notImplemented(ctx, "list")
+}
+
+func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	return StatusView{}, notImplemented(ctx, "status")
+}
+
+func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+	return notImplemented(ctx, "stop")
+}
+
+func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	return notImplemented(ctx, "cleanup")
+}

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -1,7 +1,6 @@
 package superserve
 
 import (
-	"context"
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -46,8 +45,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, err
 	}
-	cfg.Provider = providerName
-	return &backend{spec: p.Spec(), cfg: cfg, rt: rt}, nil
+	return NewSuperserveBackend(p.Spec(), cfg, rt), nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
@@ -60,46 +58,4 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 		return nil, core.Exit(2, "superserve doctor backend unavailable")
 	}
 	return doctor, nil
-}
-
-type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
-}
-
-func (b *backend) Spec() ProviderSpec { return b.spec }
-
-func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
-	if err := ctx.Err(); err != nil {
-		return DoctorResult{}, err
-	}
-	result := inventoryDoctorResult(providerName, 0)
-	result.Status = "ok"
-	result.Message = "config=ready lifecycle=not_implemented control_plane=not_contacted"
-	return result, nil
-}
-
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
-	return notImplemented(ctx, "warmup")
-}
-
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	return RunResult{}, notImplemented(ctx, "run")
-}
-
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
-	return nil, notImplemented(ctx, "list")
-}
-
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
-	return StatusView{}, notImplemented(ctx, "status")
-}
-
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
-	return notImplemented(ctx, "stop")
-}
-
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	return notImplemented(ctx, "cleanup")
 }

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -157,7 +157,9 @@ func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
 	}
 }
 
-func TestConfigureReturnsStubbedDelegatedBackendAndDoctor(t *testing.T) {
+func TestConfigureReturnsLifecycleBackendAndCredentialedDoctor(t *testing.T) {
+	t.Setenv("CRABBOX_SUPERSERVE_API_KEY", "")
+	t.Setenv("SUPERSERVE_API_KEY", "")
 	provider := Provider{}
 	cfg := testConfig()
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
@@ -169,26 +171,20 @@ func TestConfigureReturnsStubbedDelegatedBackendAndDoctor(t *testing.T) {
 	if !ok {
 		t.Fatalf("configured backend does not implement DelegatedRunBackend: %T", configured)
 	}
-	if err := delegated.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "warmup is not implemented yet") {
-		t.Fatalf("Warmup err=%v", err)
+	if _, err := delegated.Run(context.Background(), RunRequest{}); err == nil || !strings.Contains(err.Error(), "run is not implemented yet") {
+		t.Fatalf("Run err=%v", err)
 	}
 	cleanup, ok := configured.(core.CleanupBackend)
 	if !ok {
 		t.Fatalf("configured backend does not implement CleanupBackend: %T", configured)
 	}
-	if err := cleanup.Cleanup(context.Background(), CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "cleanup is not implemented yet") {
-		t.Fatalf("Cleanup err=%v", err)
-	}
+	_ = cleanup
 	doctor, err := provider.ConfigureDoctor(cfg, rt)
 	if err != nil {
 		t.Fatalf("ConfigureDoctor err=%v", err)
 	}
-	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
-	if err != nil {
-		t.Fatalf("Doctor err=%v", err)
-	}
-	if result.Provider != providerName || result.Status != "ok" || !strings.Contains(result.Message, "not_implemented") {
-		t.Fatalf("doctor result=%#v", result)
+	if _, err := doctor.Doctor(context.Background(), DoctorRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("Doctor err=%v, want API key requirement", err)
 	}
 }
 

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -171,8 +171,8 @@ func TestConfigureReturnsLifecycleBackendAndCredentialedDoctor(t *testing.T) {
 	if !ok {
 		t.Fatalf("configured backend does not implement DelegatedRunBackend: %T", configured)
 	}
-	if _, err := delegated.Run(context.Background(), RunRequest{}); err == nil || !strings.Contains(err.Error(), "run is not implemented yet") {
-		t.Fatalf("Run err=%v", err)
+	if _, err := delegated.Run(context.Background(), RunRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
+		t.Fatalf("Run err=%v, want API key requirement", err)
 	}
 	cleanup, ok := configured.(core.CleanupBackend)
 	if !ok {

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -65,7 +66,7 @@ func TestApplyFlagsUpdatesSuperserveConfig(t *testing.T) {
 		"--superserve-timeout-secs", "300",
 		"--superserve-exec-timeout-secs", "120",
 		"--superserve-network-allow-out", "api.example.test, pkg.example.test",
-		"--superserve-network-deny-out", "metadata.example.test",
+		"--superserve-network-deny-out", "169.254.169.254/32",
 		"--superserve-forget-missing",
 	}); err != nil {
 		t.Fatal(err)
@@ -145,6 +146,7 @@ func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
 		{name: "system workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "/etc" }, wantErr: "too broad"},
 		{name: "negative timeout", mutate: func(cfg *Config) { cfg.Superserve.TimeoutSecs = -1 }, wantErr: "timeoutSecs must be non-negative"},
 		{name: "negative exec timeout", mutate: func(cfg *Config) { cfg.Superserve.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
+		{name: "deny hostname", mutate: func(cfg *Config) { cfg.Superserve.NetworkDenyOut = []string{"metadata.example.test"} }, wantErr: "must be a CIDR"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -164,6 +166,24 @@ func TestSuperserveExecTimeoutPreservesExplicitZero(t *testing.T) {
 	backend := NewSuperserveBackend((Provider{}).Spec(), cfg, Runtime{}).(*backend)
 	if got := backend.execTimeoutSecs(); got != 0 {
 		t.Fatalf("exec timeout=%d, want service default marker 0", got)
+	}
+}
+
+func TestSuperserveSandboxTimeoutUsesConfiguredValueOrTTL(t *testing.T) {
+	cfg := testConfig()
+	cfg.TTL = 2*time.Minute + time.Millisecond
+	backend := NewSuperserveBackend((Provider{}).Spec(), cfg, Runtime{}).(*backend)
+	if got := backend.sandboxTimeoutSecs(); got != 121 {
+		t.Fatalf("sandbox timeout=%d, want rounded TTL 121", got)
+	}
+	backend.cfg.Superserve.TimeoutSecs = 300
+	if got := backend.sandboxTimeoutSecs(); got != 300 {
+		t.Fatalf("sandbox timeout=%d, want explicit 300", got)
+	}
+	backend.cfg.Superserve.TimeoutSecs = 0
+	backend.cfg.TTL = 0
+	if got := backend.sandboxTimeoutSecs(); got != 5400 {
+		t.Fatalf("sandbox timeout=%d, want safe fallback 5400", got)
 	}
 }
 

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -1,0 +1,203 @@
+package superserve
+
+import (
+	"context"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecIsDelegatedLinuxAndAliasFree(t *testing.T) {
+	provider := Provider{}
+	if provider.Name() != providerName {
+		t.Fatalf("Name=%q want %q", provider.Name(), providerName)
+	}
+	if aliases := provider.Aliases(); len(aliases) != 0 {
+		t.Fatalf("aliases=%v want none", aliases)
+	}
+	spec := provider.Spec()
+	if spec.Name != providerName || spec.Family != "superserve" {
+		t.Fatalf("spec identity = %#v", spec)
+	}
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("kind=%q want delegated-run", spec.Kind)
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("coordinator=%q want never", spec.Coordinator)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v want linux only", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("features=%v want archive-sync and cleanup", spec.Features)
+	}
+}
+
+func TestProviderForResolvesCanonicalOnly(t *testing.T) {
+	got, err := core.ProviderFor("superserve")
+	if err != nil {
+		t.Fatalf("ProviderFor(superserve): %v", err)
+	}
+	if got.Name() != providerName {
+		t.Fatalf("ProviderFor(superserve).Name=%q", got.Name())
+	}
+	for _, alias := range []string{"ss", "sup", "super-serve"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == providerName {
+			t.Fatalf("%q alias unexpectedly resolves to superserve", alias)
+		}
+	}
+}
+
+func TestApplyFlagsUpdatesSuperserveConfig(t *testing.T) {
+	cfg := testConfig()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("class", "", "")
+	fs.String("type", "", "")
+	values := (Provider{}).RegisterFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--superserve-base-url", "https://api.example.test/",
+		"--superserve-template", "superserve/custom",
+		"--superserve-snapshot", "snap-123",
+		"--superserve-workdir", "/workspace/custom",
+		"--superserve-timeout-secs", "300",
+		"--superserve-exec-timeout-secs", "120",
+		"--superserve-network-allow-out", "api.example.test, pkg.example.test",
+		"--superserve-network-deny-out", "metadata.example.test",
+		"--superserve-forget-missing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatalf("ApplyFlags err=%v", err)
+	}
+	if cfg.Superserve.BaseURL != "https://api.example.test/" || cfg.Superserve.Template != "superserve/custom" || cfg.Superserve.Snapshot != "snap-123" || cfg.Superserve.Workdir != "/workspace/custom" || cfg.Superserve.TimeoutSecs != 300 || cfg.Superserve.ExecTimeoutSecs != 120 || !cfg.Superserve.ForgetMissing {
+		t.Fatalf("cfg=%#v", cfg.Superserve)
+	}
+	if len(cfg.Superserve.NetworkAllowOut) != 2 || cfg.Superserve.NetworkAllowOut[1] != "pkg.example.test" || len(cfg.Superserve.NetworkDenyOut) != 1 {
+		t.Fatalf("network config=%#v", cfg.Superserve)
+	}
+}
+
+func TestApplyFlagsRejectsGenericSizingForSuperserve(t *testing.T) {
+	for _, flagName := range []string{"class", "type"} {
+		t.Run(flagName, func(t *testing.T) {
+			cfg := testConfig()
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			fs.String("class", "", "")
+			fs.String("type", "", "")
+			values := (Provider{}).RegisterFlags(fs, cfg)
+			if err := fs.Parse([]string{"--" + flagName, "large"}); err != nil {
+				t.Fatal(err)
+			}
+			err := (Provider{}).ApplyFlags(&cfg, fs, values)
+			if err == nil || !strings.Contains(err.Error(), "--"+flagName+" is not supported for provider=superserve") {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSuperserveBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{name: "default", raw: "", want: defaultBaseURL},
+		{name: "https default port", raw: "HTTPS://API.EXAMPLE.TEST:443/", want: "https://api.example.test"},
+		{name: "loopback http", raw: "http://localhost:8080/", want: "http://localhost:8080"},
+		{name: "userinfo", raw: "https://user:pass@api.example.test", wantErr: "must not contain userinfo"},
+		{name: "query", raw: "https://api.example.test?token=secret", wantErr: "must not contain userinfo"},
+		{name: "fragment", raw: "https://api.example.test/#secret", wantErr: "must not contain userinfo"},
+		{name: "plain http", raw: "http://api.example.test", wantErr: "must use HTTPS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateSuperserveBaseURL(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err=%v want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err=%v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got=%q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{name: "relative workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "workspace" }, wantErr: "workdir must be absolute"},
+		{name: "broad workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "/workspace" }, wantErr: "too broad"},
+		{name: "negative timeout", mutate: func(cfg *Config) { cfg.Superserve.TimeoutSecs = -1 }, wantErr: "timeoutSecs must be non-negative"},
+		{name: "negative exec timeout", mutate: func(cfg *Config) { cfg.Superserve.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			tt.mutate(&cfg)
+			err := validateSuperserveConfig(cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err=%v want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfigureReturnsStubbedDelegatedBackendAndDoctor(t *testing.T) {
+	provider := Provider{}
+	cfg := testConfig()
+	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	configured, err := provider.Configure(cfg, rt)
+	if err != nil {
+		t.Fatalf("Configure err=%v", err)
+	}
+	delegated, ok := configured.(core.DelegatedRunBackend)
+	if !ok {
+		t.Fatalf("configured backend does not implement DelegatedRunBackend: %T", configured)
+	}
+	if err := delegated.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "warmup is not implemented yet") {
+		t.Fatalf("Warmup err=%v", err)
+	}
+	cleanup, ok := configured.(core.CleanupBackend)
+	if !ok {
+		t.Fatalf("configured backend does not implement CleanupBackend: %T", configured)
+	}
+	if err := cleanup.Cleanup(context.Background(), CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "cleanup is not implemented yet") {
+		t.Fatalf("Cleanup err=%v", err)
+	}
+	doctor, err := provider.ConfigureDoctor(cfg, rt)
+	if err != nil {
+		t.Fatalf("ConfigureDoctor err=%v", err)
+	}
+	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor err=%v", err)
+	}
+	if result.Provider != providerName || result.Status != "ok" || !strings.Contains(result.Message, "not_implemented") {
+		t.Fatalf("doctor result=%#v", result)
+	}
+}
+
+func testConfig() Config {
+	cfg := Config{}
+	cfg.Provider = providerName
+	cfg.Superserve.BaseURL = defaultBaseURL
+	cfg.Superserve.Template = "superserve/base"
+	cfg.Superserve.Workdir = defaultWorkdir
+	cfg.Superserve.ExecTimeoutSecs = 600
+	return cfg
+}

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -146,6 +146,8 @@ func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
 		{name: "system workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "/etc" }, wantErr: "too broad"},
 		{name: "negative timeout", mutate: func(cfg *Config) { cfg.Superserve.TimeoutSecs = -1 }, wantErr: "timeoutSecs must be non-negative"},
 		{name: "negative exec timeout", mutate: func(cfg *Config) { cfg.Superserve.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
+		{name: "timeout over seven days", mutate: func(cfg *Config) { cfg.Superserve.TimeoutSecs = maxSuperserveSandboxTimeoutSecs + 1 }, wantErr: "must not exceed 604800"},
+		{name: "derived TTL over seven days", mutate: func(cfg *Config) { cfg.TTL = 7*24*time.Hour + time.Millisecond }, wantErr: "must not exceed 604800"},
 		{name: "deny hostname", mutate: func(cfg *Config) { cfg.Superserve.NetworkDenyOut = []string{"metadata.example.test"} }, wantErr: "must be a CIDR"},
 	}
 	for _, tt := range tests {

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -111,6 +111,8 @@ func TestValidateSuperserveBaseURL(t *testing.T) {
 		{name: "default", raw: "", want: defaultBaseURL},
 		{name: "https default port", raw: "HTTPS://API.EXAMPLE.TEST:443/", want: "https://api.example.test"},
 		{name: "loopback http", raw: "http://localhost:8080/", want: "http://localhost:8080"},
+		{name: "IPv6 loopback", raw: "http://[::1]/", want: "http://[::1]"},
+		{name: "IPv6 loopback default port", raw: "http://[::1]:80/", want: "http://[::1]"},
 		{name: "userinfo", raw: "https://user:pass@api.example.test", wantErr: "must not contain userinfo"},
 		{name: "query", raw: "https://api.example.test?token=secret", wantErr: "must not contain userinfo"},
 		{name: "fragment", raw: "https://api.example.test/#secret", wantErr: "must not contain userinfo"},

--- a/internal/providers/superserve/provider_test.go
+++ b/internal/providers/superserve/provider_test.go
@@ -142,6 +142,7 @@ func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
 	}{
 		{name: "relative workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "workspace" }, wantErr: "workdir must be absolute"},
 		{name: "broad workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "/workspace" }, wantErr: "too broad"},
+		{name: "system workdir", mutate: func(cfg *Config) { cfg.Superserve.Workdir = "/etc" }, wantErr: "too broad"},
 		{name: "negative timeout", mutate: func(cfg *Config) { cfg.Superserve.TimeoutSecs = -1 }, wantErr: "timeoutSecs must be non-negative"},
 		{name: "negative exec timeout", mutate: func(cfg *Config) { cfg.Superserve.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
 	}
@@ -154,6 +155,15 @@ func TestValidateSuperserveConfigRejectsBadValues(t *testing.T) {
 				t.Fatalf("err=%v want %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestSuperserveExecTimeoutPreservesExplicitZero(t *testing.T) {
+	cfg := testConfig()
+	cfg.Superserve.ExecTimeoutSecs = 0
+	backend := NewSuperserveBackend((Provider{}).Spec(), cfg, Runtime{}).(*backend)
+	if got := backend.execTimeoutSecs(); got != 0 {
+		t.Fatalf("exec timeout=%d, want service default marker 0", got)
 	}
 }
 

--- a/internal/providers/superserve/sync.go
+++ b/internal/providers/superserve/sync.go
@@ -1,0 +1,175 @@
+package superserve
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+func (b *backend) syncWorkspace(ctx context.Context, api superserveClient, access *sandboxAccess, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+	start := b.now()
+	syncCtx := ctx
+	cancel := func() {}
+	if b.cfg.Sync.Timeout > 0 {
+		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
+	}
+	defer cancel()
+
+	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	manifestStart := b.now()
+	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
+	if err != nil {
+		return nil, 0, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := b.now().Sub(manifestStart)
+
+	preflightStart := b.now()
+	if err := checkSuperserveSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+		return nil, 0, err
+	}
+	preflightDuration := b.now().Sub(preflightStart)
+
+	archiveStart := b.now()
+	archive, err := createSuperserveSyncArchive(syncCtx, req.Repo, manifest)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archive.Name())
+	}()
+	archiveDuration := b.now().Sub(archiveStart)
+
+	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
+	extractDir := workdir
+	stagingDir := ""
+	if b.cfg.Sync.Delete {
+		stagingDir = path.Join(path.Dir(workdir), "."+path.Base(workdir)+".crabbox-sync-"+randomSuffix())
+		extractDir = stagingDir
+	}
+	cleanupRemote := func() {
+		cleanupCtx, cancel := b.cleanupContext(ctx)
+		defer cancel()
+		command := "rm -f " + shellQuote(remoteArchive) + " 2>/dev/null || true"
+		if stagingDir != "" {
+			command += "; rm -rf " + shellQuote(stagingDir) + " 2>/dev/null || true"
+		}
+		_ = b.execShell(cleanupCtx, api, access, command)
+	}
+	cleanupPending := true
+	defer func() {
+		if cleanupPending {
+			cleanupRemote()
+		}
+	}()
+
+	uploadStart := b.now()
+	if _, err := archive.Seek(0, 0); err != nil {
+		return nil, 0, exit(6, "rewind sync archive: %v", err)
+	}
+	if err := api.UploadFile(syncCtx, access, remoteArchive, archive); err != nil {
+		return nil, 0, err
+	}
+	uploadDuration := b.now().Sub(uploadStart)
+
+	prepareStart := b.now()
+	if stagingDir == "" {
+		err = b.ensureWorkspace(syncCtx, api, access, workdir)
+	} else {
+		err = b.execShell(syncCtx, api, access, "rm -rf "+shellQuote(stagingDir)+" && mkdir -p "+shellQuote(stagingDir))
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	prepareDuration := b.now().Sub(prepareStart)
+
+	extractStart := b.now()
+	if err := b.execShell(syncCtx, api, access, "tar -xzf "+shellQuote(remoteArchive)+" -C "+shellQuote(extractDir)); err != nil {
+		return nil, 0, err
+	}
+	extractDuration := b.now().Sub(extractStart)
+
+	replaceDuration := time.Duration(0)
+	if stagingDir != "" {
+		replaceStart := b.now()
+		if err := b.replaceWorkspace(syncCtx, api, access, stagingDir, workdir); err != nil {
+			return nil, 0, err
+		}
+		replaceDuration = b.now().Sub(replaceStart)
+	}
+
+	cleanupStart := b.now()
+	cleanupRemote()
+	cleanupPending = false
+	cleanupDuration := b.now().Sub(cleanupStart)
+
+	total := b.now().Sub(start)
+	phases := []timingPhase{
+		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
+		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
+		{Name: "archive", Ms: archiveDuration.Milliseconds()},
+		{Name: "upload", Ms: uploadDuration.Milliseconds()},
+		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
+		{Name: "extract", Ms: extractDuration.Milliseconds()},
+	}
+	if stagingDir != "" {
+		phases = append(phases, timingPhase{Name: "replace", Ms: replaceDuration.Milliseconds()})
+	}
+	phases = append(phases, timingPhase{Name: "cleanup", Ms: cleanupDuration.Milliseconds()})
+	phases = append(phases, timingPhase{Name: "superserve_sync", Ms: total.Milliseconds()})
+	return phases, total, nil
+}
+
+func checkSuperserveSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
+	archiveManifest := manifest
+	archiveManifest.Changed = nil
+	archiveManifest.ChangedBytes = 0
+	return checkSyncPreflight(archiveManifest, cfg, force, stderr)
+}
+
+func (b *backend) ensureWorkspace(ctx context.Context, api superserveClient, access *sandboxAccess, workdir string) error {
+	return b.execShell(ctx, api, access, "mkdir -p "+shellQuote(workdir))
+}
+
+func (b *backend) replaceWorkspace(ctx context.Context, api superserveClient, access *sandboxAccess, stagingDir, workdir string) error {
+	backupDir := stagingDir + ".previous"
+	command := "rm -rf " + shellQuote(backupDir) +
+		" && if [ -e " + shellQuote(workdir) + " ]; then mv " + shellQuote(workdir) + " " + shellQuote(backupDir) + "; fi" +
+		" && if mv " + shellQuote(stagingDir) + " " + shellQuote(workdir) +
+		"; then exit 0" +
+		"; else rc=$?; if [ -e " + shellQuote(backupDir) + " ]; then mv " + shellQuote(backupDir) + " " + shellQuote(workdir) +
+		"; fi; exit \"$rc\"; fi"
+	if err := b.execShell(ctx, api, access, command); err != nil {
+		return err
+	}
+	if err := b.execShell(ctx, api, access, "rm -rf "+shellQuote(backupDir)); err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: superserve previous workspace cleanup failed path=%s: %v\n", backupDir, err)
+	}
+	return nil
+}
+
+func (b *backend) execShell(ctx context.Context, api superserveClient, access *sandboxAccess, command string) error {
+	res, err := api.Exec(ctx, access, execRequest{
+		Command:     "sh -lc " + shellQuote(command),
+		TimeoutSecs: b.execTimeoutSecs(),
+	}, io.Discard, io.Discard)
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return exit(res.ExitCode, "superserve exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+func createSuperserveSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest) (*os.File, error) {
+	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-superserve-sync-*.tgz")
+}

--- a/internal/providers/superserve/sync_test.go
+++ b/internal/providers/superserve/sync_test.go
@@ -1,0 +1,27 @@
+package superserve
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCheckSuperserveSyncPreflightUsesFullArchiveCandidate(t *testing.T) {
+	cfg := testConfig()
+	cfg.Sync.FailBytes = 100
+	manifest := SyncManifest{
+		Files:        []string{"large.bin"},
+		Changed:      []string{"small.txt"},
+		Bytes:        200,
+		ChangedBytes: 1,
+	}
+	var stderr bytes.Buffer
+
+	err := checkSuperserveSyncPreflight(manifest, cfg, false, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "candidate too large") {
+		t.Fatalf("err=%v, want full archive candidate guardrail", err)
+	}
+	if strings.Contains(stderr.String(), "dirty_delta") {
+		t.Fatalf("stderr=%q, want full candidate preflight, not dirty delta", stderr.String())
+	}
+}

--- a/scripts/live-superserve-smoke.sh
+++ b/scripts/live-superserve-smoke.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+classification="diagnostic_only"
+classification_emitted=0
+invocation_dir="$PWD"
+repo_root=""
+bin=""
+smoke_root=""
+smoke_repo=""
+slug="ss-live-$(date -u +%Y%m%d)-$(printf '%06x%06x' "$$" "$RANDOM")"
+cleanup_needed=0
+cleanup_retry_delay="${CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS:-2}"
+
+classify_and_exit() {
+  trap - ERR
+  if [[ $classification_emitted -ne 0 ]]; then
+    exit 1
+  fi
+  classification_emitted=1
+  classification="$1"
+  reason="${2:-}"
+  if [[ -n "$reason" ]]; then
+    printf 'classification=%s reason=%s\n' "$classification" "$reason"
+  else
+    printf 'classification=%s\n' "$classification"
+  fi
+  case "$classification" in
+    live_superserve_smoke_passed|environment_blocked|quota_blocked) exit 0 ;;
+    *) exit 1 ;;
+  esac
+}
+
+classify_failure() {
+  local output="$1"
+  local reason="$2"
+  print_debug_detail "$output"
+  if grep -Eiq 'quota|capacity|admission|rate limit|too many requests|429|insufficient|limit exceeded' <<<"$output"; then
+    classify_and_exit quota_blocked "$reason"
+  fi
+  if grep -Eiq 'api key|unauthorized|forbidden|connection refused|no such host|timeout|timed out|TLS|x509|certificate|authentication|permission denied' <<<"$output"; then
+    classify_and_exit environment_blocked "$reason"
+  fi
+  classify_and_exit diagnostic_only "$reason"
+}
+
+print_debug_detail() {
+  if [[ "${CRABBOX_SUPERSERVE_SMOKE_DEBUG:-0}" != "1" ]]; then
+    return 0
+  fi
+  local detail="$1"
+  local secret
+  for secret in "${CRABBOX_SUPERSERVE_API_KEY:-}" "${SUPERSERVE_API_KEY:-}"; do
+    if [[ -n "$secret" ]]; then
+      detail="${detail//$secret/[redacted]}"
+    fi
+  done
+  detail="$(printf '%s' "$detail" |
+    perl -0pe 's/"(access_token|token)"\s*:\s*"[^"]*"/"$1":"[redacted]"/g; s/[[:space:]]+/ /g' |
+    cut -c 1-800)"
+  if [[ -n "$detail" ]]; then
+    printf 'debug_detail=%s\n' "$detail" >&2
+  fi
+}
+
+unexpected_failure() {
+  classify_and_exit diagnostic_only "unexpected_failure_line_$1"
+}
+
+need_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    classify_and_exit environment_blocked "missing_required_tool_$1"
+  fi
+}
+
+inventory_has_slug() {
+  local inventory
+  if ! inventory="$("$bin" list --provider superserve --json 2>/dev/null)"; then
+    return 2
+  fi
+  if jq -e --arg slug "$slug" 'any(.[]; ((.slug // .Slug // .labels.slug // .Labels.slug // "") == $slug))' <<<"$inventory" >/dev/null 2>&1; then
+    return 0
+  fi
+  if jq -e 'type == "array"' <<<"$inventory" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 2
+}
+
+stop_and_confirm() {
+  local attempt
+  local inventory_status
+  for attempt in 1 2 3; do
+    if inventory_has_slug; then
+      inventory_status=0
+    else
+      inventory_status=$?
+    fi
+    if [[ $inventory_status -eq 1 ]]; then
+      return 0
+    fi
+    "$bin" stop --provider superserve "$slug" >/dev/null 2>&1 || true
+    if [[ $attempt -lt 3 ]]; then
+      sleep "$cleanup_retry_delay"
+    fi
+  done
+  if inventory_has_slug; then
+    inventory_status=0
+  else
+    inventory_status=$?
+  fi
+  [[ $inventory_status -eq 1 ]]
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  if [[ $cleanup_needed -eq 1 && -n "$bin" && -x "$bin" ]]; then
+    if ! stop_and_confirm; then
+      printf 'cleanup=failed provider=superserve slug=%s attempts=3\n' "$slug" >&2
+      status=1
+    fi
+  fi
+  if [[ -n "$smoke_root" ]]; then
+    rm -rf -- "$smoke_root"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'unexpected_failure "$LINENO"' ERR
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "${CRABBOX_LIVE:-0}" != "1" ]]; then
+  classify_and_exit environment_blocked "set_CRABBOX_LIVE=1"
+fi
+
+providers=",${CRABBOX_LIVE_PROVIDERS:-},"
+if [[ "$providers" != *",superserve,"* ]]; then
+  classify_and_exit environment_blocked "set_CRABBOX_LIVE_PROVIDERS=superserve"
+fi
+
+if [[ -z "${CRABBOX_SUPERSERVE_API_KEY:-${SUPERSERVE_API_KEY:-}}" ]]; then
+  classify_and_exit environment_blocked "missing_superserve_api_key"
+fi
+
+need_tool git
+need_tool jq
+
+bin="${CRABBOX_BIN:-$repo_root/bin/crabbox}"
+if [[ "$bin" != /* ]]; then
+  bin="$invocation_dir/$bin"
+fi
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$bin")"
+  go build -trimpath -o "$bin" ./cmd/crabbox
+fi
+
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/crabbox-superserve-smoke.XXXXXX")"
+smoke_repo="$smoke_root/repo"
+export XDG_STATE_HOME="$smoke_root/state"
+export CRABBOX_SUPERSERVE_SMOKE_VALUE="forwarded-ok"
+
+mkdir -p "$smoke_repo"
+cd "$smoke_repo"
+git init -q
+git config user.email smoke@example.com
+git config user.name "Crabbox Superserve Smoke"
+cat >.crabbox.yaml <<EOF
+provider: superserve
+sync:
+  delete: true
+superserve:
+  template: ${CRABBOX_SUPERSERVE_SMOKE_TEMPLATE:-superserve/base}
+  workdir: /workspace/crabbox
+EOF
+printf 'v1\n' >proof.txt
+printf 'remove-me\n' >stale.txt
+git add .crabbox.yaml proof.txt stale.txt
+git commit -qm "test: seed Superserve smoke fixture"
+
+trap - ERR
+if doctor_output="$("$bin" doctor --provider superserve --json 2>&1)"; then
+  doctor_status=0
+else
+  doctor_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $doctor_status -ne 0 ]]; then
+  classify_failure "$doctor_output" "doctor_failed"
+fi
+
+cleanup_needed=1
+trap - ERR
+if run_output="$("$bin" run --provider superserve --keep --slug "$slug" --timing-json \
+  --allow-env CRABBOX_SUPERSERVE_SMOKE_VALUE -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v1 && test -f stale.txt && test "$CRABBOX_SUPERSERVE_SMOKE_VALUE" = forwarded-ok && printf SUPERSERVE_SMOKE_STDOUT && printf SUPERSERVE_SMOKE_STDERR >&2 && printf SUPERSERVE_SMOKE_V1_OK' 2>&1)"; then
+  run_status=0
+else
+  run_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $run_status -ne 0 ]]; then
+  classify_failure "$run_output" "initial_run_failed"
+fi
+if ! grep -q 'SUPERSERVE_SMOKE_V1_OK' <<<"$run_output" || ! grep -q 'SUPERSERVE_SMOKE_STDOUT' <<<"$run_output" || ! grep -q 'SUPERSERVE_SMOKE_STDERR' <<<"$run_output"; then
+  classify_and_exit diagnostic_only "initial_run_proof_incomplete"
+fi
+if ! grep -q '"provider":"superserve"' <<<"$run_output"; then
+  classify_and_exit diagnostic_only "initial_timing_provider_missing"
+fi
+
+"$bin" status --provider superserve --id "$slug" --wait --json >/dev/null
+"$bin" list --provider superserve --json |
+  jq -e --arg slug "$slug" 'any(.[]; ((.slug // .Slug // .labels.slug // .Labels.slug // "") == $slug))' >/dev/null
+
+printf 'v2\n' >proof.txt
+printf 'second\n' >second.txt
+git add proof.txt second.txt
+git rm -q stale.txt
+git commit -qm "test: update Superserve smoke fixture"
+
+trap - ERR
+if reuse_output="$("$bin" run --provider superserve --id "$slug" --timing-json -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v2 && test -f second.txt && test ! -e stale.txt && printf SUPERSERVE_SMOKE_V2_OK' 2>&1)"; then
+  reuse_status=0
+else
+  reuse_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $reuse_status -ne 0 ]]; then
+  classify_failure "$reuse_output" "reuse_run_failed"
+fi
+if ! grep -q 'SUPERSERVE_SMOKE_V2_OK' <<<"$reuse_output" || ! grep -q '"provider":"superserve"' <<<"$reuse_output"; then
+  classify_and_exit diagnostic_only "reuse_run_proof_incomplete"
+fi
+
+trap - ERR
+if exit_output="$("$bin" run --provider superserve --id "$slug" --no-sync -- \
+  /bin/sh -lc 'printf SUPERSERVE_SMOKE_EXIT_23; exit 23' 2>&1)"; then
+  exit_status=0
+else
+  exit_status=$?
+fi
+trap 'unexpected_failure "$LINENO"' ERR
+if [[ $exit_status -ne 23 ]] || ! grep -q 'SUPERSERVE_SMOKE_EXIT_23' <<<"$exit_output"; then
+  classify_and_exit diagnostic_only "exit_propagation_failed"
+fi
+
+if ! stop_and_confirm; then
+  classify_and_exit diagnostic_only "lease_cleanup_unconfirmed"
+fi
+cleanup_needed=0
+printf 'cleanup=confirmed provider=superserve slug=%s\n' "$slug"
+
+trap - EXIT
+rm -rf -- "$smoke_root"
+classify_and_exit live_superserve_smoke_passed

--- a/scripts/live-superserve-smoke.test.js
+++ b/scripts/live-superserve-smoke.test.js
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+	fs.writeFileSync(file, body, "utf8");
+	fs.chmodSync(file, 0o755);
+}
+
+function setupFakeCrabbox() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-superserve-live-smoke-"));
+	const calls = path.join(dir, "calls.log");
+	const state = path.join(dir, "lease.state");
+	const fakeCrabbox = path.join(dir, "crabbox");
+	writeExecutable(
+		fakeCrabbox,
+		`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    if [[ "\${FAKE_CRABBOX_FAIL_DOCTOR:-0}" == "1" ]]; then
+      printf 'forbidden api key\\n' >&2
+      exit 1
+    fi
+    printf '{"ok":true,"provider":"superserve"}\\n'
+    ;;
+  run)
+    if [[ "$*" == *"SUPERSERVE_SMOKE_V1_OK"* ]]; then
+      if [[ "\${FAKE_CRABBOX_FAIL_BEFORE_CREATE:-0}" == "1" ]]; then
+        printf 'unauthorized api key\\n' >&2
+        exit 1
+      fi
+      requested_slug=""
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --slug)
+            requested_slug="\${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+      printf '%s\\n' "$requested_slug" >"${state}"
+      if [[ "\${FAKE_CRABBOX_FAIL_INITIAL:-0}" == "1" ]]; then
+        printf 'unexpected create failure\\n' >&2
+        exit 1
+      fi
+      printf 'SUPERSERVE_SMOKE_STDOUT\\n'
+      printf 'SUPERSERVE_SMOKE_STDERR\\n' >&2
+      printf 'SUPERSERVE_SMOKE_V1_OK\\n'
+      printf '{"provider":"superserve","leaseId":"ssbx_test"}\\n' >&2
+    elif [[ "$*" == *"SUPERSERVE_SMOKE_V2_OK"* ]]; then
+      test -f "${state}"
+      printf 'SUPERSERVE_SMOKE_V2_OK\\n'
+      printf '{"provider":"superserve","leaseId":"ssbx_test"}\\n' >&2
+    elif [[ "$*" == *"SUPERSERVE_SMOKE_EXIT_23"* ]]; then
+      test -f "${state}"
+      printf 'SUPERSERVE_SMOKE_EXIT_23\\n'
+      exit 23
+    else
+      printf 'unexpected run command\\n' >&2
+      exit 64
+    fi
+    ;;
+  status)
+    test -f "${state}"
+    printf '{"id":"ssbx_test","slug":"%s","provider":"superserve","state":"running"}\\n' "$(cat "${state}")"
+    ;;
+  list)
+    if [[ -f "${state}" ]]; then
+      printf '[{"provider":"superserve","slug":"%s","state":"running"}]\\n' "$(cat "${state}")"
+    elif [[ "\${FAKE_CRABBOX_FAIL_EMPTY_LIST:-0}" == "1" ]]; then
+      printf 'inventory unavailable\\n' >&2
+      exit 1
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  stop)
+    if [[ "\${FAKE_CRABBOX_FAIL_STOP:-0}" == "1" ]]; then
+      printf 'transient stop failure\\n' >&2
+      exit 1
+    fi
+    rm -f "${state}"
+    ;;
+  *)
+    printf 'unexpected command %s\\n' "$1" >&2
+    exit 64
+    ;;
+esac
+`,
+	);
+	return { dir, calls, state, fakeCrabbox };
+}
+
+test("requires explicit live opt-in before mutation", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=set_CRABBOX_LIVE=1/);
+	assert.equal(fs.existsSync(fake.calls), false);
+});
+
+test("requires superserve provider filter before mutation", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "smolvm",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=set_CRABBOX_LIVE_PROVIDERS=superserve/);
+	assert.equal(fs.existsSync(fake.calls), false);
+});
+
+test("classifies missing key as environment blocked before mutation", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "",
+			SUPERSERVE_API_KEY: "",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=missing_superserve_api_key/);
+	assert.equal(fs.existsSync(fake.calls), false);
+});
+
+test("classifies doctor auth failure before creating a sandbox", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+			FAKE_CRABBOX_FAIL_DOCTOR: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=doctor_failed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	assert.doesNotMatch(fs.readFileSync(fake.calls, "utf8"), /^run --provider superserve /m);
+});
+
+test("runs retained reuse lifecycle and verifies cleanup", () => {
+	const fake = setupFakeCrabbox();
+	const secret = "ss_live_secret_value";
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: path.relative(repoRoot, fake.fakeCrabbox),
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: secret,
+			CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=live_superserve_smoke_passed/);
+	assert.match(result.stdout, /cleanup=confirmed provider=superserve slug=ss-live-/);
+	assert.doesNotMatch(result.stdout + result.stderr, new RegExp(secret));
+	assert.equal(fs.existsSync(fake.state), false);
+	const calls = fs.readFileSync(fake.calls, "utf8");
+	assert.match(calls, /^doctor --provider superserve --json$/m);
+	assert.match(calls, /^run --provider superserve --keep --slug ss-live-/m);
+	assert.match(calls, /^status --provider superserve --id ss-live-.* --wait --json$/m);
+	assert.match(calls, /^run --provider superserve --id ss-live-.* --no-sync -- /m);
+	assert.match(calls, /^stop --provider superserve ss-live-/m);
+});
+
+test("cleans up a lease left by a failed initial run", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+			CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_INITIAL: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stdout, /classification=diagnostic_only reason=initial_run_failed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	assert.match(fs.readFileSync(fake.calls, "utf8"), /^stop --provider superserve ss-live-/m);
+});
+
+test("preserves an auth blocker when no lease was created", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+			CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_BEFORE_CREATE: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	assert.match(result.stdout, /classification=environment_blocked reason=initial_run_failed/);
+	assert.equal(fs.existsSync(fake.state), false);
+	assert.doesNotMatch(fs.readFileSync(fake.calls, "utf8"), /^stop --provider superserve /m);
+});
+
+test("fails after three targeted cleanup attempts", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+			CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_INITIAL: "1",
+			FAKE_CRABBOX_FAIL_STOP: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.match(result.stderr, /cleanup=failed provider=superserve .* attempts=3/);
+	const stopCalls = fs
+		.readFileSync(fake.calls, "utf8")
+		.split("\n")
+		.filter((line) => line.startsWith("stop --provider superserve ss-live-"));
+	assert.equal(stopCalls.length, 3);
+});
+
+test("does not pass when post-stop inventory cannot be confirmed", () => {
+	const fake = setupFakeCrabbox();
+	const result = spawnSync("bash", ["scripts/live-superserve-smoke.sh"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			CRABBOX_BIN: fake.fakeCrabbox,
+			CRABBOX_LIVE: "1",
+			CRABBOX_LIVE_PROVIDERS: "superserve",
+			CRABBOX_SUPERSERVE_API_KEY: "ss_live_test",
+			CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+			FAKE_CRABBOX_FAIL_EMPTY_LIST: "1",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 1);
+	assert.doesNotMatch(result.stdout, /classification=live_superserve_smoke_passed/);
+	assert.match(result.stdout, /classification=diagnostic_only reason=lease_cleanup_unconfirmed/);
+	assert.match(result.stderr, /cleanup=failed provider=superserve/);
+});


### PR DESCRIPTION
Closes #286

## Summary
- Add Superserve as a Linux delegated-run provider for Crabbox.
- Implement Superserve config, provider registration, sandbox lifecycle, ownership metadata, cleanup, archive sync, delegated command execution, docs, and live-smoke coverage.
- Keep Superserve credentials secret-safe: API keys come from env/private config only, control-plane auth uses X-API-Key, data-plane auth uses X-Access-Token, and access tokens are not persisted in local claims.

## Verification
- `go test -race ./...`
- `go vet ./...`
- `npm ci --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node --test scripts/live-superserve-smoke.test.js`
- `node scripts/build-docs-site.mjs`
- `node scripts/check-docs-links.mjs`
- `node scripts/check-command-docs.mjs`
- Credentialed live smoke: `classification=live_superserve_smoke_passed` with cleanup confirmed.

## Notes
- This is a delegated-run provider, not an SSH lease provider.
- The final local branch is clean and pushed to `coygeek:feat/superserve-provider`.
- Execute-plans worker residue and root plan artifacts were removed after verified closeout.