### PR TITLE
feat: add portable Node coordinator runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Added
 
+- Added a portable Node.js and PostgreSQL coordinator runtime with durable pg-boss maintenance jobs, WebSocket bridges, trusted reverse-proxy identity support, container packaging, and the existing Cloudflare Worker/Durable Object runtime preserved as an adapter over the same fleet implementation.
 - Added repeatable `--local-container-volume host:container[:ro]` bind mounts for explicit local-container runs. Thanks @anagnorisis2peripeteia.
 - Added provider-neutral coordinator registration for direct SSH leases, with owner-scoped inventory and sharing, outbound WebVNC, automatic bridge daemons for kept desktops, and coordinator-safe metadata-only release and expiry.
 - Added provider-optional `crabbox pause` and `crabbox resume` lifecycle commands, with Islo sandbox pause/resume support that preserves local lease claims. Thanks @zozo123.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Added guarded SmolVM live E2E coverage for retained reuse, archive replacement, environment forwarding, command exit propagation, diagnostics, and targeted cleanup.
 - Added non-mutating Proxmox storage, bridge, pool, template, and cluster inventory readiness diagnostics plus guarded live lifecycle smoke coverage, with safer failed-create and cleanup claim handling. Thanks @coygeek.
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
+- Added a portable Node.js and PostgreSQL coordinator runtime with durable pg-boss maintenance jobs, WebSocket bridges, trusted reverse-proxy identity support, container packaging, and the existing Cloudflare Worker/Durable Object runtime preserved as an adapter over the same fleet implementation.
+- Added refreshable coordinator bearer authentication through a shell-free JSON argv token command, including HTTP and reconnecting WebSocket bridges behind expiring upstream identity proxies.
 
 ### Fixed
 
@@ -18,7 +20,6 @@
 
 ### Added
 
-- Added a portable Node.js and PostgreSQL coordinator runtime with durable pg-boss maintenance jobs, WebSocket bridges, trusted reverse-proxy identity support, container packaging, and the existing Cloudflare Worker/Durable Object runtime preserved as an adapter over the same fleet implementation.
 - Added repeatable `--local-container-volume host:container[:ro]` bind mounts for explicit local-container runs. Thanks @anagnorisis2peripeteia.
 - Added provider-neutral coordinator registration for direct SSH leases, with owner-scoped inventory and sharing, outbound WebVNC, automatic bridge daemons for kept desktops, and coordinator-safe metadata-only release and expiry.
 - Added provider-optional `crabbox pause` and `crabbox resume` lifecycle commands, with Islo sandbox pause/resume support that preserves local lease claims. Thanks @zozo123.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Laptop prerequisites: `git`, `ssh`, `ssh-keygen`, `rsync`, `curl`.
 ## Quick start
 
 Broker access is deployment-specific. Use a coordinator URL from your team, use
-direct-provider mode for a personal cloud account, or self-host the Worker
-broker with your own provider credentials and spend caps. See
+direct-provider mode for a personal cloud account, or self-host the broker on
+Cloudflare or Node.js/PostgreSQL with your own provider credentials and spend
+caps. See
 [Getting started](docs/getting-started.md#choosing-an-access-path) and
 [Infrastructure](docs/infrastructure.md#self-hosted-broker-minimum-setup) for the
 setup paths.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -425,6 +425,7 @@ This is the canonical environment-variable reference. The most common ones:
 ```text
 CRABBOX_COORDINATOR                broker URL (enables brokered mode for supported providers)
 CRABBOX_COORDINATOR_TOKEN          broker user/shared token
+CRABBOX_COORDINATOR_TOKEN_COMMAND  JSON argv array that prints a fresh bearer token
 CRABBOX_COORDINATOR_ADMIN_TOKEN    broker admin token
 CRABBOX_COORDINATOR_MODE           managed|registered
 CRABBOX_COORDINATOR_AUTO_WEBVNC    auto-start portal bridge for kept registered desktops

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -142,6 +142,19 @@ Worker sees the request. Configure either a service token or a pre-minted JWT:
 fallbacks.) These credentials satisfy Cloudflare Access only — the Worker still requires the
 Crabbox bearer or signed user token.
 
+For coordinators behind an upstream identity proxy that consumes the `Authorization` header,
+set `CRABBOX_COORDINATOR_TOKEN_COMMAND` to a JSON argv array. Crabbox executes it directly,
+without a shell, before each HTTP request and WebSocket reconnect. The command must print one
+bearer token line and takes precedence over `CRABBOX_COORDINATOR_TOKEN`. The proxy must inject a
+trusted identity header accepted by the coordinator after validating that token.
+
+```bash
+export CRABBOX_COORDINATOR_TOKEN_COMMAND='["identity-cli","token","--audience","coordinator"]'
+```
+
+Only set this in trusted machine-level configuration. Project config files cannot define token
+commands.
+
 Server-side, when `CRABBOX_ACCESS_TEAM_DOMAIN` and `CRABBOX_ACCESS_AUD` are configured, the
 Worker verifies the `Cf-Access-Jwt-Assertion` header against Cloudflare Access certs (RS256,
 matching `aud`, `iss`, and expiry) before trusting any Access identity. Without both

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -982,6 +982,8 @@ over both config files. The full list is in
 CRABBOX_CONFIG                  explicit config path (replaces file search)
 CRABBOX_COORDINATOR             broker URL
 CRABBOX_COORDINATOR_TOKEN       broker user token
+CRABBOX_COORDINATOR_TOKEN_COMMAND
+                               JSON argv array that prints a fresh broker bearer token
 CRABBOX_COORDINATOR_ADMIN_TOKEN broker admin token (also CRABBOX_ADMIN_TOKEN)
 CRABBOX_ACCESS_CLIENT_ID        Cloudflare Access service-token id
 CRABBOX_ACCESS_CLIENT_SECRET    Cloudflare Access service-token secret

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -8,10 +8,13 @@ Read this when you are:
 
 ## What the coordinator is
 
-The coordinator is the Cloudflare Worker (`worker/src/index.ts`) plus a single
-Fleet Durable Object (`worker/src/fleet.ts`). Together they are the broker: an
-authenticated control plane that owns provider credentials, lease state, run
-records, usage accounting, and the live access bridges.
+The coordinator is an authenticated control plane that owns provider
+credentials, lease state, run records, usage accounting, and live access
+bridges. `FleetCoordinator` (`worker/src/fleet.ts`) contains the shared behavior
+and runs through either:
+
+- the Cloudflare Worker and one Fleet Durable Object (`worker/src/index.ts`);
+- the Node.js service with PostgreSQL and pg-boss (`worker/node`).
 
 The default `broker.mode: managed` lets brokerable providers (`aws`, `azure`,
 `gcp`, and `hetzner`) transfer lifecycle operations to the coordinator. Every
@@ -29,14 +32,15 @@ the provider resource. Registered records are excluded from provider access
 reconciliation, ready pools, image operations, orphan sweeps, and cost totals.
 
 The coordinator brokers the **control plane**, not the data plane. Lease
-lifecycle, run recording, usage, and bridges flow through the Worker over HTTP.
-SSH readiness, rsync, command execution, and output streaming always happen
-directly from the CLI to the runner host and never traverse the Worker. See
+lifecycle, run recording, usage, and bridges flow through the coordinator over
+HTTP. SSH readiness, rsync, command execution, and output streaming always
+happen directly from the CLI to the runner host and never traverse the
+coordinator. See
 [Architecture](../architecture.md) for the full topology.
 
 ## Responsibilities
 
-The Fleet Durable Object holds all state in DO storage and owns:
+The fleet coordinator owns:
 
 - authentication of every broker request;
 - lease lifecycle: create, look up, heartbeat, release, expire, share;
@@ -48,12 +52,13 @@ The Fleet Durable Object holds all state in DO storage and owns:
 - live bridges (WebVNC, code-server, mediated egress) and the run-event control
   socket;
 - artifact-upload credentials and scoped upload URLs;
-- expiry and cleanup, driven by a DO alarm and a scheduled cron.
+- expiry and cleanup, driven by Durable Object alarms or durable pg-boss jobs
+  plus periodic reconciliation.
 
 ## Authentication
 
-Every request below the public health route requires a Bearer token, resolved in
-this order (`worker/src/auth.ts`):
+Every request below the public health route requires an authenticated identity,
+resolved in this order (`worker/src/auth.ts`):
 
 1. **Admin token** — matches `CRABBOX_ADMIN_TOKEN`. Grants admin scope.
 2. **Shared operator token** — matches `CRABBOX_SHARED_TOKEN`. Non-admin scope,
@@ -62,13 +67,16 @@ this order (`worker/src/auth.ts`):
    base64url payload, keyed by `CRABBOX_SESSION_SECRET` (falling back to
    `CRABBOX_SHARED_TOKEN`). Issued by GitHub OAuth login; default 30-day expiry.
    Carries `owner`, `org`, and GitHub `login`.
+4. **Trusted reverse-proxy identity** — opt-in through
+   `CRABBOX_TRUSTED_USER_HEADER`; intended only when an authenticated ingress
+   strips caller-supplied copies of that header.
 
 An optional Cloudflare Access JWT (`cf-access-jwt-assertion`, verified against
 `CRABBOX_ACCESS_TEAM_DOMAIN` and `CRABBOX_ACCESS_AUD`) supplies the verified
 owner email for admin and shared-token requests.
 
-After auth, the Worker strips inbound Access headers and injects a trusted
-context for the Durable Object: `x-crabbox-auth`, `x-crabbox-admin`,
+After auth, the coordinator strips inbound Access headers and injects a trusted
+context for the fleet implementation: `x-crabbox-auth`, `x-crabbox-admin`,
 `x-crabbox-owner`, `x-crabbox-org`, and `x-crabbox-github-login`. The portal
 converts a `crabbox_session` cookie into a Bearer token so browser sessions reuse
 the same auth path.
@@ -80,11 +88,11 @@ sub-routes.
 
 ## API surface
 
-The Worker (`worker/src/index.ts`) answers `GET /v1/health` and redirects `/` to
-`/portal` directly, routes auth, portal-login, and bridge websocket upgrades to
-the Durable Object unauthenticated, rejects `/v1/internal/*` externally, and
-otherwise authenticates and forwards to the Durable Object. The cron handler
-posts `/v1/internal/scheduled` to the DO to run maintenance.
+The shared entry router answers `GET /v1/health` and redirects `/` to `/portal`
+directly, routes auth, portal-login, and bridge websocket upgrades to the fleet
+unauthenticated, rejects `/v1/internal/*` externally, and otherwise
+authenticates and forwards to the fleet. Cloudflare cron or pg-boss
+reconciliation runs maintenance.
 
 Public and user-scoped routes:
 
@@ -244,6 +252,7 @@ bake/promote, Mac-host management, identity) are invoked through admin routes.
 
 - [Architecture](../architecture.md)
 - [Orchestrator](../orchestrator.md)
+- [Portable coordinator runtime proposal](../plan/portable-coordinator.md)
 - [CLI](../cli.md)
 - [Browser portal](portal.md)
 - [usage command](../commands/usage.md)

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -68,8 +68,9 @@ resolved in this order (`worker/src/auth.ts`):
    `CRABBOX_SHARED_TOKEN`). Issued by GitHub OAuth login; default 30-day expiry.
    Carries `owner`, `org`, and GitHub `login`.
 4. **Trusted reverse-proxy identity** — opt-in through
-   `CRABBOX_TRUSTED_USER_HEADER`; intended only when an authenticated ingress
-   strips caller-supplied copies of that header.
+   `CRABBOX_TRUSTED_USER_HEADER` on the Node runtime, accepted only from peers in
+   `CRABBOX_TRUSTED_PROXY_CIDRS`; the authenticated ingress must also strip
+   caller-supplied copies of that header.
 
 An optional Cloudflare Access JWT (`cf-access-jwt-assertion`, verified against
 `CRABBOX_ACCESS_TEAM_DOMAIN` and `CRABBOX_ACCESS_AUD`) supplies the verified

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,8 +1,8 @@
 # Infrastructure
 
 Read this when you stand up, audit, or operate a self-hosted Crabbox broker: the
-Cloudflare Worker coordinator, its secrets, the brokered providers (Hetzner, AWS,
-Azure, GCP), and the DNS/Access front door.
+Cloudflare or Node.js/PostgreSQL coordinator, its secrets, the brokered providers
+(Hetzner, AWS, Azure, GCP), and the network front door.
 
 Crabbox runs in three modes (see [How It Works](how-it-works.md)). A *broker* is
 only required for **brokered mode**, where lease lifecycle, cost limits, cleanup,
@@ -50,6 +50,70 @@ The Worker entry, routing, and Durable Object responsibilities are documented in
 [Architecture](architecture.md). The cron trigger in `worker/wrangler.jsonc`
 (`*/15 * * * *`) wakes the Durable Object every 15 minutes so scheduled cleanup
 runs even when no leases are active.
+
+## Node.js And PostgreSQL
+
+The portable runtime runs the same `FleetCoordinator` behavior as an ordinary
+Node.js service. PostgreSQL stores the existing coordinator key/value records;
+pg-boss stores exact alarms, retries, and the 15-minute reconciliation job.
+WebSocket bridges use the same tickets and protocol as Cloudflare.
+
+Requirements:
+
+- Node.js 22.12 or newer;
+- PostgreSQL;
+- one always-on service replica initially;
+- an ingress that supports WebSocket upgrades;
+- the same auth, provider, budget, and optional artifact environment variables
+  documented below.
+
+Build and run:
+
+```sh
+npm ci --prefix worker
+npm run check:node --prefix worker
+npm run build:node --prefix worker
+
+DATABASE_URL=postgresql://crabbox:password@db.example.com/crabbox \
+CRABBOX_SHARED_TOKEN=replace-me \
+CRABBOX_SHARED_OWNER=alice@example.com \
+CRABBOX_DEFAULT_ORG=example-org \
+CRABBOX_PUBLIC_URL=https://broker.example.com \
+npm run start:node --prefix worker
+```
+
+The service creates the `crabbox` and `crabbox_jobs` schemas on startup. Health
+and readiness routes:
+
+```text
+GET /v1/health
+GET /v1/ready
+```
+
+Build the container with `worker/` as the build context:
+
+```sh
+docker build -f worker/Dockerfile.node -t crabbox-coordinator:local worker
+```
+
+Long-lived WebSocket clients send periodic pings and must reconnect after
+service restarts or ingress drains. Run one replica until bridge ownership is
+externalized; PostgreSQL and pg-boss are ready for multiple service processes,
+but live bridge sockets remain process-local.
+
+### Trusted reverse-proxy identity
+
+An identity-aware ingress can authenticate browser and API requests without a
+second Crabbox login by forwarding the verified user in a header:
+
+```text
+CRABBOX_TRUSTED_USER_HEADER=X-Authenticated-User
+CRABBOX_TRUSTED_USER_ORG=example-org
+```
+
+Enable this only when Crabbox is unreachable except through that ingress and the
+ingress removes caller-supplied copies of the configured header. The forwarded
+identity receives non-admin scope; keep `CRABBOX_ADMIN_TOKEN` separate.
 
 ### GitHub browser login
 
@@ -347,6 +411,10 @@ expires_at=<unix-seconds>
 
 Use this when you want broker-owned provider credentials, coordinator cleanup,
 active-lease limits, monthly spend caps, and `crabbox usage`.
+
+The default deployment uses Cloudflare Workers and Durable Objects. For the
+container and PostgreSQL runtime, see
+[Portable Coordinator Runtime](plan/portable-coordinator.md).
 
 Cloudflare prerequisites:
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -90,6 +90,11 @@ GET /v1/health
 GET /v1/ready
 ```
 
+On `SIGTERM` or `SIGINT`, the service stops accepting requests and drains active
+HTTP, WebSocket, lifecycle, and provisioning operations before closing
+PostgreSQL. `CRABBOX_SHUTDOWN_TIMEOUT_MS` bounds that wait and defaults to two
+minutes.
+
 Build the container with `worker/` as the build context:
 
 ```sh

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -114,11 +114,15 @@ second Crabbox login by forwarding the verified user in a header:
 ```text
 CRABBOX_TRUSTED_USER_HEADER=X-Authenticated-User
 CRABBOX_TRUSTED_USER_ORG=example-org
+CRABBOX_TRUSTED_PROXY_CIDRS=10.0.0.0/8,fd00::/8
 ```
 
-Enable this only when Crabbox is unreachable except through that ingress and the
-ingress removes caller-supplied copies of the configured header. The forwarded
-identity receives non-admin scope; keep `CRABBOX_ADMIN_TOKEN` separate.
+The Node runtime accepts the identity only when the connection peer is within
+`CRABBOX_TRUSTED_PROXY_CIDRS`. Enable this only when the ingress removes
+caller-supplied copies of the configured identity header. The forwarded identity
+receives non-admin scope; keep `CRABBOX_ADMIN_TOKEN` separate. The Cloudflare
+Worker runtime does not expose a trusted socket peer, so use its verified Access
+JWT support instead.
 
 ### GitHub browser login
 
@@ -514,6 +518,8 @@ CRABBOX_GITHUB_ADMIN_OWNERS, CRABBOX_GITHUB_ADMIN_LOGINS (optional)
 CRABBOX_SESSION_SECRET
 CRABBOX_DEFAULT_ORG
 CRABBOX_ACCESS_TEAM_DOMAIN, CRABBOX_ACCESS_AUD   # Cloudflare Access route
+CRABBOX_TRUSTED_USER_HEADER, CRABBOX_TRUSTED_USER_ORG
+CRABBOX_TRUSTED_PROXY_CIDRS              # Node runtime peer allowlist
 CRABBOX_PUBLIC_URL                       # canonical coordinator URL for OAuth callback
 
 # Cost / limits

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -124,6 +124,11 @@ receives non-admin scope; keep `CRABBOX_ADMIN_TOKEN` separate. The Cloudflare
 Worker runtime does not expose a trusted socket peer, so use its verified Access
 JWT support instead.
 
+The same peer allowlist controls whether the Node runtime honors forwarded host,
+protocol, and client-IP headers. It walks the forwarded-for chain from the socket
+inward and uses the nearest address outside the trusted proxy ranges for dynamic
+provider ingress rules; direct callers always use the socket peer address.
+
 ### GitHub browser login
 
 Browser login uses a GitHub OAuth app owned by your deployment org. Configure the

--- a/docs/plan/portable-coordinator.md
+++ b/docs/plan/portable-coordinator.md
@@ -1,0 +1,239 @@
+# Portable Coordinator Runtime
+
+Status: Node/PostgreSQL and Cloudflare adapters implemented.
+
+Read when:
+
+- evaluating a coordinator deployment outside Cloudflare Workers;
+- separating coordinator behavior from Durable Object runtime primitives;
+- planning a container, Kubernetes, or managed-service deployment.
+
+Current behavior remains authoritative in
+[Coordinator](../features/coordinator.md), [Architecture](../architecture.md),
+and `worker/src/`. This document proposes a second runtime; it does not describe
+shipped behavior.
+
+## Decision
+
+Add a Node.js coordinator runtime backed by PostgreSQL. Keep the existing
+Cloudflare Worker and Durable Object deployment as an adapter over the same
+coordinator behavior.
+
+Use:
+
+- PostgreSQL for durable records and coordination;
+- [pg-boss](https://github.com/timgit/pg-boss) for delayed maintenance,
+  retries, and recurring reconciliation;
+- ordinary Node WebSockets for control, WebVNC, code, and egress bridges;
+- one service replica initially, with reconnectable WebSocket clients;
+- PostgreSQL advisory locks when multiple replicas become necessary.
+
+This is a smaller and more operationally conventional change than adopting an
+actor platform. Provider adapters already use portable TypeScript and `fetch`;
+the runtime-specific surface is concentrated in Durable Object storage, alarms,
+request routing, and WebSocket lifecycle.
+
+## Required Semantics
+
+The portable runtime must preserve:
+
+| Current primitive | Required behavior | Portable implementation |
+| --- | --- | --- |
+| Durable Object storage | durable key/value records and prefix scans | PostgreSQL JSONB key/value table |
+| One Fleet Durable Object | coordinated fleet mutations and cost reservations | one replica first; advisory lock for multi-replica |
+| Durable Object alarms | expiry, cleanup retry, orphan sweep | pg-boss delayed and recurring jobs |
+| Hibernating WebSockets | live bidirectional bridges | in-process WebSockets with ping, reconnect, and ticket replay |
+| Worker entrypoint | auth, OAuth, portal, API routing | Node HTTP server using the existing route handlers |
+| Worker secrets | provider and auth credentials | service secret injection |
+
+SSH, rsync, command execution, and output streaming remain direct between the
+CLI and runner. The portable coordinator changes only the control plane.
+
+## Runtime Boundary
+
+Runtime-dependent operations are now behind `CoordinatorRuntime`:
+
+```ts
+interface CoordinatorRuntime {
+  storage: CoordinatorStorage;
+  createWebSocketUpgrade(): CoordinatorWebSocketUpgrade;
+  getWebSockets(): Iterable<WebSocket>;
+  socketAttachment<T>(socket: WebSocket): T | undefined;
+  setSocketAttachment(socket: WebSocket, attachment: unknown): void;
+  acceptWebSocket(/* socket, attachment, tags, handlers */): void;
+  scheduleAlarm(time: number): Promise<void>;
+  clearAlarm(): Promise<void>;
+}
+```
+
+The first extraction should preserve the current key format (`lease:*`,
+`run:*`, ticket keys, image keys, and cleanup keys). A normalized relational
+schema can follow after both runtimes pass the same contract tests.
+
+The Cloudflare adapter wraps `DurableObjectStorage`, alarms, and hibernating
+WebSockets. The Node adapter wraps PostgreSQL, pg-boss, and a WebSocket server.
+
+## PostgreSQL Shape
+
+Start with one compatibility table:
+
+```sql
+create table coordinator_kv (
+  key text primary key,
+  value jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+create index coordinator_kv_updated_at_idx
+  on coordinator_kv (updated_at);
+```
+
+Use parameterized prefix queries. Keep pg-boss in its own schema. Do not place
+provider credentials in coordinator records.
+
+Initial deployment uses one process-level fleet mutex. Before enabling multiple
+replicas, replace it with a dedicated PostgreSQL connection holding a
+session-level advisory lock for each fleet mutation. Provider provisioning
+should then become a phased state transition:
+
+1. lock, validate limits, and persist a `provisioning` reservation;
+2. unlock and call the provider;
+3. lock and finalize the lease or record cleanup-required failure state.
+
+That avoids holding a database transaction across cloud API calls while keeping
+cost and capacity decisions atomic.
+
+## Maintenance
+
+Use a pg-boss `maintenance` job as the alarm equivalent:
+
+- schedule it for the earliest lease expiry, cleanup retry, or provider sweep;
+- let every lease mutation recompute the next due time;
+- use a recurring reconciliation job as a backstop after deploys or crashes;
+- make cleanup idempotent and retain the existing retry metadata;
+- acquire the fleet mutation lock before each maintenance pass.
+
+A process restart must not lose an expiry or cleanup request. Job delivery may
+repeat, so handlers must remain idempotent.
+
+## WebSockets
+
+WebSocket upgrade creation, attachment storage, socket enumeration, and
+lifecycle handlers are behind `CoordinatorRuntime`. The Cloudflare adapter
+retains hibernating sockets and the existing non-hibernating fallback.
+
+Portable deployments must assume that proxies and service rollouts can close
+long-lived connections:
+
+- ping at least every 30-60 seconds;
+- reconnect with bounded exponential backoff;
+- mint short-lived, one-use bridge tickets as today;
+- restore logical subscriptions after reconnect;
+- treat the in-memory socket registry as disposable state.
+
+Run one replica until bridge ownership is externalized. Multi-replica options,
+in preferred order:
+
+1. reconnect clients to the replica owning the bridge;
+2. use PostgreSQL only to discover the owning replica, then relay over an
+   internal service connection;
+3. add a binary-capable message bus when bridge volume justifies it.
+
+## Packaging
+
+Produce one OCI image containing:
+
+- the Node HTTP/WebSocket service;
+- database migrations;
+- health and readiness routes;
+- the existing portal assets;
+- no embedded credentials.
+
+Required deployment resources:
+
+- managed PostgreSQL;
+- secret injection for coordinator, OAuth, and provider credentials;
+- outbound access to provider APIs;
+- an ingress that supports WebSocket upgrades;
+- one always-on replica for the initial release.
+
+The portal should remain served by the coordinator initially. A static-site
+host can serve a later extracted frontend, but cannot replace the coordinator
+API, scheduler, durable state, or WebSocket bridges.
+
+## Alternatives
+
+### Rivet Actors
+
+[Rivet Actors](https://rivet.dev/docs/actors/) is the closest open-source
+semantic match: durable actors, state, timers, and WebSockets, with
+self-hosting on containers or Kubernetes.
+
+It is a useful spike target, but not the default:
+
+- it introduces a new runtime and control plane;
+- the current single global Fleet object becomes a large "god actor";
+- scaling well would require partitioning by lease, run, or bridge;
+- PostgreSQL is already sufficient for Crabbox's control-plane volume.
+
+Reconsider Rivet if Crabbox intentionally adopts per-lease actors or needs
+actor placement and hibernation across many replicas.
+
+### Restate, Temporal, or Dapr Actors
+
+These are strong durable-workflow or actor systems. They do not remove the need
+for a separate WebSocket service and would require a larger rewrite than the
+current coordinator needs. Reconsider one when lease lifecycle becomes a
+multi-service workflow with long-running compensation and audit requirements.
+
+### workerd
+
+[workerd](https://github.com/cloudflare/workerd) can self-host Worker APIs, but
+it is not by itself a production replacement for distributed Durable Object
+storage, alarms, and hibernating sockets. It helps API compatibility, not the
+coordinator's durable control-plane problem.
+
+## Implementation Phases
+
+### Phase 1: contracts
+
+- [x] Add storage, scheduler, socket, and upgrade interfaces.
+- [x] Wrap the current Durable Object implementation without changing behavior.
+- [x] Run the Worker tests through the Cloudflare adapter.
+
+### Phase 2: portable runtime
+
+- [x] Add PostgreSQL storage and migrations.
+- [x] Add Node HTTP and WebSocket entrypoints.
+- [x] Add pg-boss maintenance and reconciliation jobs.
+- [ ] Run the complete coordinator API suite against both runtimes.
+
+### Phase 3: deployment proof
+
+- Build the OCI image.
+- Deploy one replica with managed PostgreSQL.
+- Exercise auth, lease create/heartbeat/release, restart recovery, cleanup,
+  usage, portal, run recording, WebVNC, code, and egress.
+- Verify WebSocket reconnect during a rolling restart.
+
+### Phase 4: cutover
+
+- Add a Durable Object state export and PostgreSQL import tool.
+- Pause mutations during migration, import, validate counts and active leases,
+  then switch the coordinator URL.
+- Keep provider cleanup reconciliation enabled throughout rollback coverage.
+
+### Phase 5: scale only when required
+
+- Add advisory-lock mutation coordination.
+- Partition high-volume run logs or move them to object storage.
+- Externalize bridge routing before increasing replica count.
+
+## Acceptance Criteria
+
+- The same coordinator contract tests pass against Cloudflare and Node.
+- A service restart preserves leases, runs, tickets, and scheduled cleanup.
+- Expired resources are deleted after a restart without client traffic.
+- Cost and active-lease limits cannot be bypassed by concurrent creates.
+- WebSocket clients reconnect after proxy or replica termination.
+- Provider credentials never enter PostgreSQL, logs, images, or CLI output.

--- a/docs/plan/portable-coordinator.md
+++ b/docs/plan/portable-coordinator.md
@@ -56,6 +56,7 @@ Runtime-dependent operations are now behind `CoordinatorRuntime`:
 ```ts
 interface CoordinatorRuntime {
   storage: CoordinatorStorage;
+  runExclusive<T>(callback: () => Promise<T>): Promise<T>;
   createWebSocketUpgrade(): CoordinatorWebSocketUpgrade;
   getWebSockets(): Iterable<WebSocket>;
   socketAttachment<T>(socket: WebSocket): T | undefined;
@@ -65,6 +66,9 @@ interface CoordinatorRuntime {
   clearAlarm(): Promise<void>;
 }
 ```
+
+`runExclusive` serializes lifecycle state transitions, alarms, and control
+messages. Provider provisioning and bridge data traffic run outside that queue.
 
 The first extraction should preserve the current key format (`lease:*`,
 `run:*`, ticket keys, image keys, and cleanup keys). A normalized relational
@@ -81,6 +85,8 @@ Start with one compatibility table:
 create table coordinator_kv (
   key text primary key,
   value jsonb not null,
+  value_text text,
+  value_text_updated_at timestamptz,
   updated_at timestamptz not null default now()
 );
 
@@ -91,17 +97,21 @@ create index coordinator_kv_updated_at_idx
 Use parameterized prefix queries. Keep pg-boss in its own schema. Do not place
 provider credentials in coordinator records.
 
-Initial deployment uses one process-level fleet mutex. Before enabling multiple
-replicas, replace it with a dedicated PostgreSQL connection holding a
-session-level advisory lock for each fleet mutation. Provider provisioning
-should then become a phased state transition:
+The initial single-replica runtime serializes fleet lifecycle mutations with a
+process queue. Lease creation uses the same queue for reservation and
+finalization while provider provisioning runs outside it. A provider call
+therefore cannot stall heartbeats, releases, control messages, or proxied code
+traffic, while concurrent creates still make cost reservations in order. Before
+enabling multiple replicas, replace the process queue with PostgreSQL advisory
+locks for each fleet mutation. Provisioning is a phased state transition:
 
 1. lock, validate limits, and persist a `provisioning` reservation;
 2. unlock and call the provider;
 3. lock and finalize the lease or record cleanup-required failure state.
 
-That avoids holding a database transaction across cloud API calls while keeping
-cost and capacity decisions atomic.
+The lease record is persisted before the cloud API call and checked again before
+finalization, so concurrent release remains recoverable without holding a
+database transaction across provisioning.
 
 ## Maintenance
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -174,14 +174,16 @@ Provider docs:
 
 ## Worker API, Cost, And Operations
 
-- Worker auth and top-level routing: `worker/src/index.ts`, `worker/src/auth.ts`
+- Shared coordinator auth and top-level routing: `worker/src/coordinator-entry.ts`, `worker/src/index.ts`, `worker/src/auth.ts`
 - HTTP response/request helpers: `worker/src/http.ts`
 - GitHub OAuth login flow and user-token issuance: `worker/src/oauth.ts`
-- Fleet Durable Object routes and lease/run storage: `worker/src/fleet.ts`
+- Shared fleet routes and behavior: `worker/src/fleet.ts`
+- Cloudflare runtime adapter: `worker/src/coordinator-runtime.ts`
+- Node.js/PostgreSQL runtime, HTTP/WebSocket server, and durable jobs: `worker/node/node-runtime.ts`, `worker/node/postgres-storage.ts`, `worker/node/server.ts`
 - Browser portal lease detail, bridge status, and run log/event pages: `worker/src/portal.ts`, `worker/src/fleet.ts`
 - Usage aggregation, pricing fallback, owner/org limits, and cost guardrails: `worker/src/usage.ts`
 - Worker package scripts and dependencies: `worker/package.json`
-- Worker deployment config: `worker/wrangler.jsonc`, `worker/wrangler.cloudflare.jsonc`
+- Coordinator deployment config: `worker/wrangler.jsonc`, `worker/wrangler.cloudflare.jsonc`, `worker/Dockerfile.node`
 
 ## Cross-cutting Feature Docs
 

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -717,6 +717,7 @@ func configuredAdminCoordinator() (*CoordinatorClient, error) {
 		return nil, exit(2, "admin command requires broker.adminToken or CRABBOX_COORDINATOR_ADMIN_TOKEN")
 	}
 	cfg.CoordToken = cfg.CoordAdminToken
+	cfg.CoordTokenCommand = nil
 	coord, ok, err := newCoordinatorClient(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -278,6 +278,8 @@ Config:
 Environment:
   CRABBOX_COORDINATOR          Broker URL
   CRABBOX_COORDINATOR_TOKEN    Broker bearer token
+  CRABBOX_COORDINATOR_TOKEN_COMMAND
+                               JSON argv array that prints a fresh broker bearer token
   CRABBOX_COORDINATOR_ADMIN_TOKEN
                                Broker admin bearer token
   CRABBOX_ACCESS_CLIENT_ID     Cloudflare Access service token client ID

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -541,7 +541,7 @@ func (a App) publishArtifactDirectory(ctx context.Context, opts artifactPublishO
 			return nil, "", "", err
 		}
 		if opts.Storage == "auto" {
-			if useCoordinator && coord != nil && coord.Token != "" {
+			if useCoordinator && coord.hasConfiguredAuth() {
 				opts.Storage = "broker"
 			} else {
 				opts.Storage = "local"
@@ -633,7 +633,7 @@ func (a App) writeArtifactWebVNCStatus(ctx context.Context, cfg Config, target S
 		return "", false, nil
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
-	if err != nil || !useCoordinator || coord == nil || coord.Token == "" {
+	if err != nil || !useCoordinator || !coord.hasConfiguredAuth() {
 		return "", false, nil
 	}
 	status, err := coord.WebVNCStatus(ctx, leaseID)

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -186,7 +186,7 @@ func publishArtifactFiles(ctx context.Context, opts artifactPublishOptions, file
 }
 
 func publishArtifactFilesBroker(ctx context.Context, coord *CoordinatorClient, opts artifactPublishOptions, files []artifactFile) ([]artifactFile, error) {
-	if coord == nil || coord.Token == "" {
+	if !coord.hasConfiguredAuth() {
 		return nil, exit(2, "artifacts publish --storage broker requires a configured coordinator; run `crabbox login --url <broker-url>` or pass --storage local|s3|r2")
 	}
 	ensureArtifactPublishPrefix(&opts)

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -312,8 +312,9 @@ func TestCoordinatorClientForLoginAppliesURLBeforeRegisteredModeValidation(t *te
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("CRABBOX_CONFIG", configPath)
 	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", `["token-helper","--scope","example"]`)
 	t.Setenv("CRABBOX_PROVIDER", "")
-	if err := os.WriteFile(configPath, []byte("broker:\n  mode: registered\n"), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte("broker:\n  mode: registered\n  token: persisted\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.NotFoundHandler())
@@ -325,6 +326,12 @@ func TestCoordinatorClientForLoginAppliesURLBeforeRegisteredModeValidation(t *te
 	}
 	if client == nil || client.BaseURL != server.URL {
 		t.Fatalf("client=%#v", client)
+	}
+	if client.Token != "" {
+		t.Fatalf("login client retained stored token")
+	}
+	if got := strings.Join(client.TokenCommand, "\x00"); got != "token-helper\x00--scope\x00example" {
+		t.Fatalf("login token command=%q", client.TokenCommand)
 	}
 }
 

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -589,8 +589,10 @@ func applyNativeCheckpointForkConfig(cfg *Config, fs *flag.FlagSet, record check
 	if record.Native.Direct {
 		cfg.Coordinator = ""
 		cfg.CoordToken = ""
+		cfg.CoordTokenCommand = nil
 	} else if cfg.CoordAdminToken != "" {
 		cfg.CoordToken = cfg.CoordAdminToken
+		cfg.CoordTokenCommand = nil
 	}
 	if record.TargetOS != "" {
 		cfg.TargetOS = record.TargetOS

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -84,7 +84,7 @@ func (a App) webCode(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !useCoordinator || coord == nil || coord.Token == "" {
+	if !useCoordinator || !coord.hasConfiguredAuth() {
 		return exit(2, "code requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	server, target, leaseID, err := a.resolveNetworkLeaseTargetForRepoWithConfig(ctx, &cfg, *id, true, *reclaim)
@@ -242,9 +242,14 @@ func connectCodeBridge(ctx context.Context, coord *CoordinatorClient, leaseID, h
 		HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
 	})
 	if retryBridgeTicketInQuery(resp, err) {
-		ws, _, err = websocket.Dial(ctx, webCodeAgentURLWithTicket(coord.BaseURL, leaseID, ticket.Ticket), &websocket.DialOptions{
-			HTTPHeader: coord.webVNCAccessHeaders(),
-		})
+		headers, headerErr := coord.webVNCAccessHeaders(ctx)
+		if headerErr != nil {
+			err = headerErr
+		} else {
+			ws, _, err = websocket.Dial(ctx, webCodeAgentURLWithTicket(coord.BaseURL, leaseID, ticket.Ticket), &websocket.DialOptions{
+				HTTPHeader: headers,
+			})
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -44,6 +45,7 @@ type Config struct {
 	brokerProvider                string
 	BrokerAutoWebVNC              bool
 	CoordToken                    string
+	CoordTokenCommand             []string
 	CoordAdminToken               string
 	HostID                        string
 	Access                        AccessConfig
@@ -4686,6 +4688,21 @@ func applyEnv(cfg *Config) error {
 		cfg.BrokerAutoWebVNC = value
 	}
 	cfg.CoordToken = getenv("CRABBOX_COORDINATOR_TOKEN", cfg.CoordToken)
+	if raw := strings.TrimSpace(os.Getenv("CRABBOX_COORDINATOR_TOKEN_COMMAND")); raw != "" {
+		var command []string
+		if err := json.Unmarshal([]byte(raw), &command); err != nil {
+			return fmt.Errorf("CRABBOX_COORDINATOR_TOKEN_COMMAND must be a JSON argv array: %w", err)
+		}
+		if len(command) == 0 {
+			return errors.New("CRABBOX_COORDINATOR_TOKEN_COMMAND must contain an executable")
+		}
+		for _, arg := range command {
+			if strings.TrimSpace(arg) == "" || strings.ContainsAny(arg, "\r\n\x00") {
+				return errors.New("CRABBOX_COORDINATOR_TOKEN_COMMAND contains an invalid argv entry")
+			}
+		}
+		cfg.CoordTokenCommand = append([]string(nil), command...)
+	}
 	cfg.CoordAdminToken = getenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", getenv("CRABBOX_ADMIN_TOKEN", cfg.CoordAdminToken))
 	cfg.HostID = getenv("CRABBOX_HOST_ID", cfg.HostID)
 	cfg.Access.ClientID = getenv("CRABBOX_ACCESS_CLIENT_ID", getenv("CF_ACCESS_CLIENT_ID", cfg.Access.ClientID))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -67,7 +67,7 @@ func configShowView(cfg Config) map[string]any {
 		"coordinator":        cfg.Coordinator,
 		"brokerMode":         cfg.BrokerMode,
 		"brokerAutoWebVNC":   cfg.BrokerAutoWebVNC,
-		"brokerAuth":         tokenState(cfg.CoordToken),
+		"brokerAuth":         coordinatorTokenState(cfg),
 		"brokerAdminAuth":    tokenState(cfg.CoordAdminToken),
 		"accessAuth":         accessAuthState(cfg.Access),
 		"sshKey":             cfg.SSHKey,
@@ -360,7 +360,7 @@ func configShowView(cfg Config) map[string]any {
 func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "config=%s\n", userConfigPath())
 	fmt.Fprintf(w, "provider=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", cfg.Provider, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, cfg.ServerType, cfg.Profile)
-	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, tokenState(cfg.CoordToken), tokenState(cfg.CoordAdminToken))
+	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t auth=%s admin_auth=%s\n", blank(cfg.Coordinator, "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
 	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg)), len(syncIncludes(cfg)), cfg.Sync.Timeout)
@@ -639,6 +639,13 @@ func tokenState(token string) string {
 		return "missing"
 	}
 	return "configured"
+}
+
+func coordinatorTokenState(cfg Config) string {
+	if len(cfg.CoordTokenCommand) > 0 {
+		return "command"
+	}
+	return tokenState(cfg.CoordToken)
 }
 
 func accessAuthState(access AccessConfig) string {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -18,6 +18,7 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_COORDINATOR_MODE",
 		"CRABBOX_COORDINATOR_AUTO_WEBVNC",
 		"CRABBOX_COORDINATOR_TOKEN",
+		"CRABBOX_COORDINATOR_TOKEN_COMMAND",
 		"CRABBOX_COORDINATOR_ADMIN_TOKEN",
 		"CRABBOX_ADMIN_TOKEN",
 		"CRABBOX_HOST_ID",
@@ -285,6 +286,36 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_HOSTINGER_RELEASE_ACTION",
 	} {
 		t.Setenv(key, "")
+	}
+}
+
+func TestCoordinatorTokenCommandEnv(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", `["token-helper","--scope","example"]`)
+	cfg := baseConfig()
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(cfg.CoordTokenCommand, "\x00"); got != "token-helper\x00--scope\x00example" {
+		t.Fatalf("token command=%q", cfg.CoordTokenCommand)
+	}
+}
+
+func TestCoordinatorTokenCommandEnvRejectsInvalidArgv(t *testing.T) {
+	for name, value := range map[string]string{
+		"not-json":  "token-helper",
+		"empty":     `[]`,
+		"empty-arg": `["token-helper",""]`,
+		"newline":   `["token-helper","bad\narg"]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", value)
+			cfg := baseConfig()
+			if err := applyEnv(&cfg); err == nil {
+				t.Fatal("invalid token command was accepted")
+			}
+		})
 	}
 }
 

--- a/internal/cli/control_ws.go
+++ b/internal/cli/control_ws.go
@@ -44,14 +44,18 @@ func dialCoordinatorControl(ctx context.Context, coord *CoordinatorClient) (*coo
 		return nil, err
 	}
 	headers := http.Header{}
-	coord.addRequestHeaders(headers)
+	if err := coord.addRequestHeaders(ctx, headers); err != nil {
+		return nil, err
+	}
 	opts := &websocket.DialOptions{
 		HTTPHeader: headers,
 	}
 	if coord.Client != nil {
 		opts.HTTPClient = coord.Client
 	}
-	conn, resp, err := websocket.Dial(ctx, endpoint, opts)
+	dialCtx, cancel := context.WithTimeout(ctx, coordinatorControlDialTimeout)
+	defer cancel()
+	conn, resp, err := websocket.Dial(dialCtx, endpoint, opts)
 	if err != nil {
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()
@@ -112,9 +116,7 @@ func (c *coordinatorControlConn) read(ctx context.Context) (coordinatorControlMe
 }
 
 func followRunControlWebSocket(ctx context.Context, coord *CoordinatorClient, runID string, after int, poll time.Duration, stdout, stderr io.Writer) (int, bool, bool, error) {
-	dialCtx, cancel := context.WithTimeout(ctx, coordinatorControlDialTimeout)
-	control, err := dialCoordinatorControl(dialCtx, coord)
-	cancel()
+	control, err := dialCoordinatorControl(ctx, coord)
 	if err != nil {
 		if ctx.Err() != nil {
 			return after, false, false, ctx.Err()

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -18,13 +18,20 @@ import (
 )
 
 type CoordinatorClient struct {
-	BaseURL string
-	Token   string
-	Access  AccessConfig
-	Client  *http.Client
+	BaseURL      string
+	Token        string
+	TokenCommand []string
+	Access       AccessConfig
+	Client       *http.Client
+}
+
+func (c *CoordinatorClient) hasConfiguredAuth() bool {
+	return c != nil && (strings.TrimSpace(c.Token) != "" || len(c.TokenCommand) > 0)
 }
 
 const coordinatorHTTPTimeout = 30 * time.Minute
+const coordinatorTokenCommandTimeout = 15 * time.Second
+const maxCoordinatorTokenBytes = 16 * 1024
 
 type CoordinatorHTTPError struct {
 	Method     string
@@ -627,9 +634,10 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 	}
 	base.Path = strings.TrimRight(base.Path, "/")
 	return &CoordinatorClient{
-		BaseURL: strings.TrimRight(base.String(), "/"),
-		Token:   cfg.CoordToken,
-		Access:  cfg.Access,
+		BaseURL:      strings.TrimRight(base.String(), "/"),
+		Token:        cfg.CoordToken,
+		TokenCommand: append([]string(nil), cfg.CoordTokenCommand...),
+		Access:       cfg.Access,
 		Client: &http.Client{
 			Timeout: coordinatorHTTPTimeout,
 			Transport: &http.Transport{
@@ -1584,7 +1592,9 @@ func (c *CoordinatorClient) doHTTP(ctx context.Context, method, path string, dat
 	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	c.addRequestHeaders(req.Header)
+	if err := c.addRequestHeaders(ctx, req.Header); err != nil {
+		return err
+	}
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
@@ -1593,9 +1603,13 @@ func (c *CoordinatorClient) doHTTP(ctx context.Context, method, path string, dat
 	return decodeCoordinatorResponse(method, path, resp.StatusCode, resp.Body, out)
 }
 
-func (c *CoordinatorClient) addRequestHeaders(headers http.Header) {
-	if c.Token != "" {
-		headers.Set("Authorization", "Bearer "+c.Token)
+func (c *CoordinatorClient) addRequestHeaders(ctx context.Context, headers http.Header) error {
+	token, err := c.authorizationToken(ctx)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		headers.Set("Authorization", "Bearer "+token)
 	}
 	c.addAccessHeaders(headers)
 	if owner := localCoordinatorOwner(); owner != "" {
@@ -1604,10 +1618,61 @@ func (c *CoordinatorClient) addRequestHeaders(headers http.Header) {
 	if org := os.Getenv("CRABBOX_ORG"); org != "" {
 		headers.Set("X-Crabbox-Org", org)
 	}
+	return nil
+}
+
+func (c *CoordinatorClient) authorizationToken(ctx context.Context) (string, error) {
+	if len(c.TokenCommand) == 0 {
+		return c.Token, nil
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, coordinatorTokenCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(commandCtx, c.TokenCommand[0], c.TokenCommand[1:]...)
+	var output limitedCoordinatorTokenOutput
+	cmd.Stdout = &output
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		if errors.Is(commandCtx.Err(), context.DeadlineExceeded) {
+			return "", errors.New("coordinator token command timed out")
+		}
+		return "", fmt.Errorf("coordinator token command failed: %w", err)
+	}
+	if output.overflow {
+		return "", fmt.Errorf("coordinator token command output exceeds %d bytes", maxCoordinatorTokenBytes)
+	}
+	token := strings.TrimSuffix(output.String(), "\n")
+	token = strings.TrimSuffix(token, "\r")
+	if token == "" {
+		return "", errors.New("coordinator token command returned an empty token")
+	}
+	if strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n\x00") {
+		return "", errors.New("coordinator token command must return exactly one token line")
+	}
+	return token, nil
+}
+
+type limitedCoordinatorTokenOutput struct {
+	bytes.Buffer
+	overflow bool
+}
+
+func (w *limitedCoordinatorTokenOutput) Write(p []byte) (int, error) {
+	originalLength := len(p)
+	remaining := maxCoordinatorTokenBytes - w.Len()
+	if remaining <= 0 {
+		w.overflow = w.overflow || originalLength > 0
+		return originalLength, nil
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+		w.overflow = true
+	}
+	_, _ = w.Buffer.Write(p)
+	return originalLength, nil
 }
 
 func (c *CoordinatorClient) doCurl(ctx context.Context, method, path string, data []byte, hasBody bool, out any) error {
-	config, cleanup, err := c.curlConfig(method, path, data, hasBody)
+	config, cleanup, err := c.curlConfig(ctx, method, path, data, hasBody)
 	if err != nil {
 		return err
 	}
@@ -1632,7 +1697,7 @@ func (c *CoordinatorClient) doCurl(ctx context.Context, method, path string, dat
 	return decodeCoordinatorResponse(method, path, status, bytes.NewReader(body), out)
 }
 
-func (c *CoordinatorClient) curlConfig(method, path string, data []byte, hasBody bool) (string, func(), error) {
+func (c *CoordinatorClient) curlConfig(ctx context.Context, method, path string, data []byte, hasBody bool) (string, func(), error) {
 	var bodyPath string
 	cleanup := func() {}
 	if hasBody {
@@ -1667,8 +1732,13 @@ func (c *CoordinatorClient) curlConfig(method, path string, data []byte, hasBody
 		curlConfigValue(&cfg, "header", "Content-Type: application/json")
 		curlConfigValue(&cfg, "data-binary", "@"+bodyPath)
 	}
-	if c.Token != "" {
-		curlConfigValue(&cfg, "header", "Authorization: Bearer "+c.Token)
+	token, err := c.authorizationToken(ctx)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if token != "" {
+		curlConfigValue(&cfg, "header", "Authorization: Bearer "+token)
 	}
 	c.addCurlAccessHeaders(&cfg)
 	if owner := localCoordinatorOwner(); owner != "" {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -175,7 +176,7 @@ func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
 			Token:        "access-jwt",
 		},
 	}
-	config, cleanup, err := client.curlConfig("POST", "/v1/leases", []byte(`{"leaseID":"cbx"}`), true)
+	config, cleanup, err := client.curlConfig(context.Background(), "POST", "/v1/leases", []byte(`{"leaseID":"cbx"}`), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,6 +234,75 @@ func TestCoordinatorHTTPAddsAccessHeaders(t *testing.T) {
 	if err := client.Health(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCoordinatorTokenCommandRefreshesBearer(t *testing.T) {
+	t.Setenv("CRABBOX_TOKEN_HELPER", "1")
+	t.Setenv("CRABBOX_TOKEN_HELPER_VALUE", "first-token")
+	var authorizations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+	client := CoordinatorClient{
+		BaseURL: server.URL,
+		TokenCommand: []string{
+			os.Args[0],
+			"-test.run=^TestCoordinatorTokenCommandHelper$",
+		},
+		Client: server.Client(),
+	}
+
+	if err := client.Health(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_TOKEN_HELPER_VALUE", "second-token")
+	if err := client.Health(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(authorizations, []string{"Bearer first-token", "Bearer second-token"}) {
+		t.Fatalf("Authorization headers=%q", authorizations)
+	}
+}
+
+func TestCoordinatorConfiguredAuthRecognizesTokenCommand(t *testing.T) {
+	for name, client := range map[string]*CoordinatorClient{
+		"nil":           nil,
+		"empty":         {},
+		"static token":  {Token: "token"},
+		"token command": {TokenCommand: []string{"token-helper"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			want := name == "static token" || name == "token command"
+			if got := client.hasConfiguredAuth(); got != want {
+				t.Fatalf("hasConfiguredAuth()=%t want %t", got, want)
+			}
+		})
+	}
+}
+
+func TestCoordinatorTokenCommandRejectsMultipleLines(t *testing.T) {
+	t.Setenv("CRABBOX_TOKEN_HELPER", "1")
+	t.Setenv("CRABBOX_TOKEN_HELPER_VALUE", "first\nsecond")
+	client := CoordinatorClient{
+		TokenCommand: []string{os.Args[0], "-test.run=^TestCoordinatorTokenCommandHelper$"},
+	}
+	if _, err := client.authorizationToken(context.Background()); err == nil || !strings.Contains(err.Error(), "exactly one token line") {
+		t.Fatalf("error=%v, want one-line validation", err)
+	}
+}
+
+func TestCoordinatorTokenCommandHelper(t *testing.T) {
+	if os.Getenv("CRABBOX_TOKEN_HELPER") != "1" {
+		return
+	}
+	if delay, err := time.ParseDuration(os.Getenv("CRABBOX_TOKEN_HELPER_DELAY")); err == nil {
+		time.Sleep(delay)
+	}
+	_, _ = fmt.Fprintln(os.Stdout, os.Getenv("CRABBOX_TOKEN_HELPER_VALUE"))
+	os.Exit(0)
 }
 
 func TestCoordinatorAdminLeaseAudit(t *testing.T) {
@@ -695,6 +765,65 @@ func TestCoordinatorHeartbeatUsesControlWebSocket(t *testing.T) {
 	select {
 	case <-httpHeartbeats:
 		t.Fatal("heartbeat fell back to HTTP despite websocket success")
+	default:
+	}
+}
+
+func TestCoordinatorHeartbeatMintsTokenBeforeControlDialTimeout(t *testing.T) {
+	t.Setenv("CRABBOX_TOKEN_HELPER", "1")
+	t.Setenv("CRABBOX_TOKEN_HELPER_VALUE", "slow-token")
+	t.Setenv("CRABBOX_TOKEN_HELPER_DELAY", "1600ms")
+	controlHeartbeats := make(chan struct{}, 1)
+	httpHeartbeats := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
+			if got := r.Header.Get("Authorization"); got != "Bearer slow-token" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				t.Errorf("accept control websocket: %v", err)
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			if _, _, err := conn.Read(r.Context()); err != nil {
+				t.Errorf("read control heartbeat: %v", err)
+				return
+			}
+			controlHeartbeats <- struct{}{}
+			_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"heartbeat","leaseID":"cbx_123","ok":true}`))
+			<-r.Context().Done()
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_123/heartbeat":
+			httpHeartbeats <- struct{}{}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"aws","state":"active","expiresAt":"2026-05-01T00:30:00Z"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{
+		BaseURL: server.URL,
+		TokenCommand: []string{
+			os.Args[0],
+			"-test.run=^TestCoordinatorTokenCommandHelper$",
+		},
+		Client: server.Client(),
+	}
+	stop := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", 30*time.Minute, nil, nil, io.Discard)
+	defer stop()
+
+	select {
+	case <-controlHeartbeats:
+	case <-time.After(4 * time.Second):
+		t.Fatal("slow token mint prevented control websocket heartbeat")
+	}
+	select {
+	case <-httpHeartbeats:
+		t.Fatal("heartbeat fell back to HTTP after successful control websocket dial")
 	default:
 	}
 }

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -26,7 +26,7 @@ func (a App) desktopDoctor(ctx context.Context, args []string) error {
 		return nil
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
-	if err == nil && useCoordinator && coord != nil && coord.Token != "" {
+	if err == nil && useCoordinator && coord.hasConfiguredAuth() {
 		rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
 		status, err := coord.WebVNCStatus(ctx, leaseID)
 		if err != nil {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -294,6 +294,7 @@ func (a App) doctor(ctx context.Context, args []string) error {
 				if cfg.CoordAdminToken != "" {
 					adminCfg := cfg
 					adminCfg.CoordToken = cfg.CoordAdminToken
+					adminCfg.CoordTokenCommand = nil
 					adminCoord, _, err := newCoordinatorClient(adminCfg)
 					if err != nil {
 						return err

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -109,7 +109,7 @@ func (a App) egressHost(ctx context.Context, args []string) error {
 	if len(allow) == 0 {
 		return exit(2, "egress host requires --profile or --allow; refusing to start an open proxy")
 	}
-	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id)
+	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id, *ticket)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (a App) egressClient(ctx context.Context, args []string) error {
 	if err := validateEgressListen(*listen); err != nil {
 		return err
 	}
-	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id)
+	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id, *ticket)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !useCoordinator || coord == nil || coord.Token == "" {
+	if !useCoordinator || !coord.hasConfiguredAuth() {
 		return exit(2, "egress start requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false)
@@ -259,7 +259,7 @@ func (a App) egressStatus(ctx context.Context, args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox egress status --id <lease-id-or-slug>")
 	}
-	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id)
+	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id, "")
 	if err != nil {
 		return err
 	}
@@ -305,7 +305,7 @@ func (a App) egressStop(ctx context.Context, args []string) error {
 	return nil
 }
 
-func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinatorURL, id string) (*CoordinatorClient, string, error) {
+func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinatorURL, id, ticket string) (*CoordinatorClient, string, error) {
 	cfg, err := loadConfig()
 	if err != nil {
 		return nil, "", err
@@ -313,7 +313,6 @@ func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinato
 	cfg.Provider = provider
 	if strings.TrimSpace(coordinatorURL) != "" {
 		cfg.Coordinator = strings.TrimRight(strings.TrimSpace(coordinatorURL), "/")
-		cfg.CoordToken = firstNonBlank(cfg.CoordToken, "ticket-only")
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 	if err != nil {
@@ -322,10 +321,10 @@ func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinato
 	if !useCoordinator || coord == nil || coord.BaseURL == "" {
 		return nil, "", exit(2, "egress requires a configured coordinator")
 	}
-	if strings.TrimSpace(coordinatorURL) != "" && coord.Token == "ticket-only" {
+	if strings.TrimSpace(ticket) != "" {
 		return coord, id, nil
 	}
-	if coord.Token == "" {
+	if !coord.hasConfiguredAuth() {
 		return nil, "", exit(2, "egress requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	lease, err := coord.GetLease(ctx, id)
@@ -360,8 +359,12 @@ func connectEgressBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 	} else if strings.TrimSpace(sessionID) == "" {
 		sessionID = "egress_manual"
 	}
+	headers, err := coord.webVNCAccessHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
 	ws, _, err := websocket.Dial(ctx, egressAgentURL(coord.BaseURL, leaseID, role, ticket), &websocket.DialOptions{
-		HTTPHeader: coord.webVNCAccessHeaders(),
+		HTTPHeader: headers,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -83,6 +83,37 @@ func TestEgressStartCoordinatorOverrideUsesPublicRoute(t *testing.T) {
 	}
 }
 
+func TestExplicitEgressTicketDoesNotCreateFakeBearer(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CRABBOX_CONFIG", home+"/missing.yaml")
+
+	coord, leaseID, err := (App{}).egressCoordinatorAndLease(
+		context.Background(),
+		"aws",
+		"https://broker.example.com",
+		"cbx_abcdef123456",
+		"egress_ticket",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseID != "cbx_abcdef123456" {
+		t.Fatalf("leaseID=%q", leaseID)
+	}
+	if coord.hasConfiguredAuth() {
+		t.Fatal("explicit-ticket mode should not synthesize coordinator credentials")
+	}
+	headers, err := coord.webVNCAccessHeaders(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := headers.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization=%q, want empty", got)
+	}
+}
+
 func TestEgressClientBinaryRejectsNonLinuxTargets(t *testing.T) {
 	_, cleanup, err := egressClientBinaryForTarget(context.Background(), SSHTarget{TargetOS: targetWindows})
 	defer cleanup()

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -283,6 +283,7 @@ func (b *coordinatorLeaseBackend) listMachines(ctx context.Context) ([]Coordinat
 	}
 	cfg := b.cfg
 	cfg.CoordToken = cfg.CoordAdminToken
+	cfg.CoordTokenCommand = nil
 	coord, _, err := newCoordinatorClient(cfg)
 	if err != nil {
 		return nil, nil, err
@@ -300,7 +301,7 @@ func (b *coordinatorLeaseBackend) listMachines(ctx context.Context) ([]Coordinat
 }
 
 func (b *coordinatorLeaseBackend) listLeasesFallback(ctx context.Context, adminErr error) ([]CoordinatorLease, error) {
-	if b.cfg.CoordToken == "" {
+	if b.cfg.CoordToken == "" && len(b.cfg.CoordTokenCommand) == 0 {
 		return nil, adminErr
 	}
 	if adminErr != nil && isCoordinatorUnauthorized(adminErr) {
@@ -368,6 +369,7 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 func (b *coordinatorLeaseBackend) adminCoordinatorClient() (*CoordinatorClient, error) {
 	cfg := b.cfg
 	cfg.CoordToken = cfg.CoordAdminToken
+	cfg.CoordTokenCommand = nil
 	coord, _, err := newCoordinatorClient(cfg)
 	return coord, err
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2549,9 +2549,7 @@ func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, le
 				idleTimeoutOverride = updateIdleTimeout
 			}
 			if control == nil {
-				dialCtx, dialCancel := context.WithTimeout(callCtx, coordinatorControlDialTimeout)
-				control, _ = dialCoordinatorControl(dialCtx, coord)
-				dialCancel()
+				control, _ = dialCoordinatorControl(callCtx, coord)
 			}
 			if control != nil {
 				err = control.heartbeat(callCtx, leaseID, idleTimeoutOverride, telemetry)

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -105,7 +105,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !useCoordinator || coord == nil || coord.Token == "" {
+	if !useCoordinator || !coord.hasConfiguredAuth() {
 		return exit(2, "webvnc requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	server, target, leaseID, err := a.resolveNetworkLeaseTargetForRepo(ctx, cfg, *id, false, *reclaim)
@@ -392,7 +392,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		if useCoordinator && coord != nil && coord.Token != "" {
+		if useCoordinator && coord.hasConfiguredAuth() {
 			server, resolvedTarget, leaseID, err := a.resolveNetworkLeaseTargetForRepo(ctx, cfg, *id, false, *reclaim)
 			if err != nil {
 				return err
@@ -526,7 +526,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !useCoordinator || coord == nil || coord.Token == "" {
+	if !useCoordinator || !coord.hasConfiguredAuth() {
 		return exit(2, "webvnc status requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false)
@@ -648,7 +648,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !useCoordinator || coord == nil || coord.Token == "" {
+	if !useCoordinator || !coord.hasConfiguredAuth() {
 		return exit(2, "webvnc reset requires a configured coordinator login; run crabbox login --url <broker-url> first")
 	}
 	server, target, leaseID, err := a.resolveNetworkLeaseTarget(ctx, cfg, *id, false)
@@ -1175,9 +1175,14 @@ func connectWebVNCBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 		HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
 	})
 	if retryBridgeTicketInQuery(resp, err) {
-		ws, _, err = websocket.Dial(ctx, webVNCAgentURLWithTicketAndCapabilities(coord.BaseURL, leaseID, ticket.Ticket, capabilities), &websocket.DialOptions{
-			HTTPHeader: coord.webVNCAccessHeaders(),
-		})
+		headers, headerErr := coord.webVNCAccessHeaders(ctx)
+		if headerErr != nil {
+			err = headerErr
+		} else {
+			ws, _, err = websocket.Dial(ctx, webVNCAgentURLWithTicketAndCapabilities(coord.BaseURL, leaseID, ticket.Ticket, capabilities), &websocket.DialOptions{
+				HTTPHeader: headers,
+			})
+		}
 	}
 	if err != nil {
 		_ = tcp.Close()
@@ -1762,14 +1767,26 @@ func copyTCPToWebSocket(ctx context.Context, ws *websocket.Conn, tcp net.Conn) e
 	}
 }
 
-func (c *CoordinatorClient) webVNCAccessHeaders() http.Header {
+func (c *CoordinatorClient) webVNCEdgeHeaders() http.Header {
 	header := http.Header{}
 	c.addAccessHeaders(header)
 	return header
 }
 
+func (c *CoordinatorClient) webVNCAccessHeaders(ctx context.Context) (http.Header, error) {
+	header := c.webVNCEdgeHeaders()
+	token, err := c.authorizationToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+	return header, nil
+}
+
 func bridgeTicketHeaders(coord *CoordinatorClient, ticket string) http.Header {
-	headers := coord.webVNCAccessHeaders()
+	headers := coord.webVNCEdgeHeaders()
 	headers.Set("Authorization", "Bearer "+ticket)
 	return headers
 }
@@ -1782,7 +1799,7 @@ func retryBridgeTicketInQuery(resp *http.Response, err error) bool {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}
-	return resp.StatusCode == http.StatusUnauthorized
+	return resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden
 }
 
 func webVNCAgentURL(base, leaseID string) string {

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -419,8 +419,8 @@ func TestRetryBridgeTicketInQuery(t *testing.T) {
 	if !retryBridgeTicketInQuery(resp, errors.New("websocket rejected")) {
 		t.Fatal("expected unauthorized websocket response to retry with query ticket")
 	}
-	if retryBridgeTicketInQuery(&http.Response{StatusCode: http.StatusForbidden}, errors.New("forbidden")) {
-		t.Fatal("forbidden response should not retry with query ticket")
+	if !retryBridgeTicketInQuery(&http.Response{StatusCode: http.StatusForbidden}, errors.New("forbidden")) {
+		t.Fatal("expected upstream auth rejection to retry with query ticket")
 	}
 	if retryBridgeTicketInQuery(resp, nil) {
 		t.Fatal("successful dial should not retry with query ticket")

--- a/worker/.oxfmtrc.json
+++ b/worker/.oxfmtrc.json
@@ -3,7 +3,13 @@
   "arrowParens": "always",
   "bracketSpacing": true,
   "endOfLine": "lf",
-  "ignorePatterns": ["dist/**", "dist-cloudflare/**", "node_modules/**", "public/portal/assets/**"],
+  "ignorePatterns": [
+    "dist/**",
+    "dist-cloudflare/**",
+    "dist-node/**",
+    "node_modules/**",
+    "public/portal/assets/**"
+  ],
   "insertFinalNewline": true,
   "printWidth": 100,
   "semi": true,

--- a/worker/.oxlintrc.json
+++ b/worker/.oxlintrc.json
@@ -12,7 +12,13 @@
     "vitest": true,
     "worker": true
   },
-  "ignorePatterns": ["dist/**", "dist-cloudflare/**", "node_modules/**", "public/portal/assets/**"],
+  "ignorePatterns": [
+    "dist/**",
+    "dist-cloudflare/**",
+    "dist-node/**",
+    "node_modules/**",
+    "public/portal/assets/**"
+  ],
   "options": {
     "denyWarnings": true,
     "maxWarnings": 0,

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci
+COPY node ./node
+COPY public ./public
+COPY scripts ./scripts
+COPY src ./src
+COPY tsconfig.json tsconfig.node.json ./
+RUN npm run build:node && npm prune --omit=dev
+
+FROM node:22-bookworm-slim
+
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /app/dist-node ./dist-node
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/public ./public
+EXPOSE 8080
+CMD ["node", "dist-node/server.mjs"]

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -43,6 +43,9 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
   private readonly sockets = new Set<NodeWebSocket>();
   private readonly socketAlive = new WeakMap<NodeWebSocket, boolean>();
   private readonly socketOperationTails = new WeakMap<NodeWebSocket, Promise<void>>();
+  private readonly activeSocketOperations = new Set<Promise<unknown>>();
+  private socketClosures?: Promise<void>[];
+  private shuttingDown = false;
   private alarmHandler?: () => Promise<void>;
   private operationRunner = async <T>(callback: () => Promise<T>): Promise<T> => callback();
   private alarmRun: Promise<void> = Promise.resolve();
@@ -99,11 +102,26 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
     this.operationRunner = runner;
   }
 
-  async stop(): Promise<void> {
+  runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    return this.operationRunner(callback);
+  }
+
+  beginShutdown(): void {
+    this.shuttingDown = true;
     clearInterval(this.pingInterval);
-    for (const socket of this.sockets) {
-      socket.close(1012, "coordinator shutting down");
-    }
+  }
+
+  private closeSocketsForShutdown(): void {
+    if (this.socketClosures) return;
+    this.socketClosures = [...this.sockets].map((socket) => closeSocketForShutdown(socket));
+  }
+
+  async stop(): Promise<void> {
+    this.beginShutdown();
+    this.closeSocketsForShutdown();
+    await Promise.allSettled(this.socketClosures ?? []);
+    await this.drainSocketOperations();
+    await this.alarmRun;
     await this.boss.stop({ graceful: true, timeout: 10_000 });
     await this.storage.close();
   }
@@ -113,6 +131,9 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
   }
 
   createWebSocketUpgrade(): CoordinatorWebSocketUpgrade {
+    if (this.shuttingDown) {
+      throw new Error("coordinator is shutting down");
+    }
     const context = this.upgradeContext.getStore();
     if (!context || context.upgraded) {
       throw new Error("websocket upgrade context is unavailable");
@@ -244,7 +265,7 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
     // request that currently owns the lifecycle queue. Control frames mutate
     // lease state and stay serialized with HTTP requests and alarms.
     if (!isBridgeDataAttachment(attachment)) {
-      return this.operationRunner(operation);
+      return this.trackSocketOperation(this.operationRunner(operation));
     }
     const run = (this.socketOperationTails.get(socket) ?? Promise.resolve()).then(operation);
     this.socketOperationTails.set(
@@ -254,8 +275,57 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
         () => undefined,
       ),
     );
-    return run;
+    return this.trackSocketOperation(run);
   }
+
+  private trackSocketOperation<T>(operation: Promise<T>): Promise<T> {
+    this.activeSocketOperations.add(operation);
+    void operation.then(
+      () => this.activeSocketOperations.delete(operation),
+      () => this.activeSocketOperations.delete(operation),
+    );
+    return operation;
+  }
+
+  private async drainSocketOperations(): Promise<void> {
+    const active = [...this.activeSocketOperations];
+    if (active.length === 0) return;
+    await Promise.allSettled(active);
+    return this.drainSocketOperations();
+  }
+}
+
+function closeSocketForShutdown(socket: NodeWebSocket): Promise<void> {
+  if (socket.readyState === NodeWebSocket.CLOSED) {
+    return Promise.resolve();
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onClose: (() => void) | undefined;
+  const closed = new Promise<void>((resolve) => {
+    onClose = resolve;
+    socket.once("close", onClose);
+  });
+  const timedOut = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      try {
+        socket.terminate();
+      } finally {
+        resolve();
+      }
+    }, 2_000);
+    timer.unref();
+  });
+  try {
+    socket.close(1012, "coordinator shutting down");
+  } catch {
+    if (timer) clearTimeout(timer);
+    if (onClose) socket.off("close", onClose);
+    return Promise.resolve();
+  }
+  return Promise.race([closed, timedOut]).finally(() => {
+    if (timer) clearTimeout(timer);
+    if (onClose) socket.off("close", onClose);
+  });
 }
 
 function webSocketData(data: RawData, isBinary: boolean): string | ArrayBuffer {

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -1,0 +1,243 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+
+import { PgBoss } from "pg-boss";
+import { WebSocket as NodeWebSocket, WebSocketServer, type RawData } from "ws";
+
+import type {
+  CoordinatorRuntime,
+  CoordinatorSocketHandlers,
+  CoordinatorWebSocketUpgrade,
+} from "../src/coordinator-runtime";
+import { PostgresCoordinatorStorage } from "./postgres-storage";
+
+const alarmQueue = "coordinator-alarm";
+const reconcileQueue = "coordinator-reconcile";
+
+export interface NodeUpgradeContext {
+  request: IncomingMessage;
+  socket: Duplex;
+  head: Buffer;
+  upgraded: boolean;
+}
+
+export class NodeCoordinatorRuntime implements CoordinatorRuntime {
+  readonly storage: PostgresCoordinatorStorage;
+  private readonly boss: PgBoss;
+  private readonly webSocketServer = new WebSocketServer({
+    noServer: true,
+    perMessageDeflate: false,
+    maxPayload: 12 * 1024 * 1024,
+  });
+  private readonly upgradeContext = new AsyncLocalStorage<NodeUpgradeContext>();
+  private readonly attachments = new WeakMap<WebSocket, unknown>();
+  private readonly sockets = new Set<NodeWebSocket>();
+  private readonly socketAlive = new WeakMap<NodeWebSocket, boolean>();
+  private alarmHandler?: () => Promise<void>;
+  private operationRunner = async <T>(callback: () => Promise<T>): Promise<T> => callback();
+  private alarmRun: Promise<void> = Promise.resolve();
+  private readonly pingInterval: ReturnType<typeof setInterval>;
+
+  constructor(connectionString: string) {
+    this.storage = new PostgresCoordinatorStorage(connectionString);
+    this.boss = new PgBoss({
+      connectionString,
+      schema: "crabbox_jobs",
+      application_name: "crabbox-coordinator-jobs",
+    });
+    this.boss.on("error", (error) => {
+      console.error("coordinator job queue error", error);
+    });
+    this.pingInterval = setInterval(() => this.pingSockets(), 30_000);
+    this.pingInterval.unref();
+  }
+
+  async start(alarmHandler: () => Promise<void>): Promise<void> {
+    this.alarmHandler = alarmHandler;
+    await this.storage.initialize();
+    await this.boss.start();
+    await this.boss.createQueue(alarmQueue, {
+      // "short" permits one queued successor while the current alarm is active.
+      policy: "short",
+      retryLimit: 5,
+      retryDelay: 5,
+      retryBackoff: true,
+    });
+    await this.boss.createQueue(reconcileQueue, {
+      policy: "exclusive",
+      retryLimit: 5,
+      retryDelay: 5,
+      retryBackoff: true,
+    });
+    await this.boss.work(alarmQueue, { pollingIntervalSeconds: 1 }, async () => {
+      await this.runAlarm();
+    });
+    await this.boss.work(reconcileQueue, { pollingIntervalSeconds: 5 }, async () => {
+      await this.runAlarm();
+    });
+    await this.boss.schedule(reconcileQueue, "*/15 * * * *", null, {
+      tz: "UTC",
+      singletonKey: "reconcile",
+    });
+    await this.boss.send(reconcileQueue, null, {
+      singletonKey: "startup",
+      singletonSeconds: 60,
+    });
+  }
+
+  setOperationRunner(runner: <T>(callback: () => Promise<T>) => Promise<T>): void {
+    this.operationRunner = runner;
+  }
+
+  async stop(): Promise<void> {
+    clearInterval(this.pingInterval);
+    for (const socket of this.sockets) {
+      socket.close(1012, "coordinator shutting down");
+    }
+    await this.boss.stop({ graceful: true, timeout: 10_000 });
+    await this.storage.close();
+  }
+
+  runWithUpgrade<T>(context: NodeUpgradeContext, callback: () => Promise<T>): Promise<T> {
+    return this.upgradeContext.run(context, callback);
+  }
+
+  createWebSocketUpgrade(): CoordinatorWebSocketUpgrade {
+    const context = this.upgradeContext.getStore();
+    if (!context || context.upgraded) {
+      throw new Error("websocket upgrade context is unavailable");
+    }
+    let accepted: NodeWebSocket | undefined;
+    this.webSocketServer.handleUpgrade(context.request, context.socket, context.head, (socket) => {
+      accepted = socket;
+    });
+    if (!accepted) {
+      throw new Error("websocket upgrade did not produce a socket");
+    }
+    context.upgraded = true;
+    return {
+      socket: accepted as unknown as WebSocket,
+      response: new Response(null, {
+        status: 204,
+        headers: { "x-crabbox-websocket-upgraded": "1" },
+      }),
+    };
+  }
+
+  getWebSockets(): Iterable<WebSocket> {
+    return [...this.sockets] as unknown as WebSocket[];
+  }
+
+  socketAttachment<T>(socket: WebSocket): T | undefined {
+    return this.attachments.get(socket) as T | undefined;
+  }
+
+  setSocketAttachment(socket: WebSocket, attachment: unknown): void {
+    this.attachments.set(socket, attachment);
+  }
+
+  acceptWebSocket(
+    socket: WebSocket,
+    attachment: unknown,
+    _tags: string[],
+    handlers: CoordinatorSocketHandlers,
+  ): void {
+    const nodeSocket = socket as unknown as NodeWebSocket;
+    this.attachments.set(socket, attachment);
+    this.sockets.add(nodeSocket);
+    this.socketAlive.set(nodeSocket, true);
+    nodeSocket.on("pong", () => {
+      this.socketAlive.set(nodeSocket, true);
+    });
+    nodeSocket.on("message", (data, isBinary) => {
+      void Promise.resolve()
+        .then(() =>
+          this.operationRunner(async () => {
+            await handlers.message(webSocketData(data, isBinary));
+          }),
+        )
+        .catch((error) => {
+          this.failSocket(nodeSocket, "message", error);
+        });
+    });
+    nodeSocket.on("close", (code, reason) => {
+      this.sockets.delete(nodeSocket);
+      try {
+        handlers.close(code, reason.toString());
+      } catch (error) {
+        console.error("coordinator websocket close handler failed", error);
+      }
+    });
+    nodeSocket.on("error", () => {
+      try {
+        handlers.error();
+      } catch (error) {
+        console.error("coordinator websocket error handler failed", error);
+      }
+    });
+  }
+
+  async scheduleAlarm(time: number): Promise<void> {
+    await this.boss.deleteQueuedJobs(alarmQueue);
+    await this.boss.send(alarmQueue, null, {
+      startAfter: new Date(Math.max(Date.now(), time)),
+      singletonKey: "fleet",
+      retryLimit: 5,
+      retryDelay: 5,
+      retryBackoff: true,
+    });
+  }
+
+  async clearAlarm(): Promise<void> {
+    await this.boss.deleteQueuedJobs(alarmQueue);
+  }
+
+  private runAlarm(): Promise<void> {
+    const run = this.alarmRun.then(async () => {
+      if (!this.alarmHandler) {
+        throw new Error("coordinator alarm handler is unavailable");
+      }
+      return this.alarmHandler();
+    });
+    this.alarmRun = run.catch(() => undefined);
+    return run;
+  }
+
+  private pingSockets(): void {
+    for (const socket of this.sockets) {
+      if (this.socketAlive.get(socket) === false) {
+        socket.terminate();
+        continue;
+      }
+      this.socketAlive.set(socket, false);
+      socket.ping();
+    }
+  }
+
+  private failSocket(socket: NodeWebSocket, phase: string, error: unknown): void {
+    console.error(`coordinator websocket ${phase} handler failed`, error);
+    try {
+      socket.close(1011, "coordinator handler failed");
+    } catch (closeError) {
+      console.error("coordinator websocket close failed", closeError);
+      try {
+        socket.terminate();
+      } catch {
+        // The socket is already gone.
+      }
+    }
+  }
+}
+
+function webSocketData(data: RawData, isBinary: boolean): string | ArrayBuffer {
+  if (!isBinary) {
+    return data.toString();
+  }
+  const buffer = Array.isArray(data)
+    ? Buffer.concat(data)
+    : data instanceof ArrayBuffer
+      ? Buffer.from(data)
+      : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  return Uint8Array.from(buffer).buffer;
+}

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -14,6 +14,14 @@ import { PostgresCoordinatorStorage } from "./postgres-storage";
 
 const alarmQueue = "coordinator-alarm";
 const reconcileQueue = "coordinator-reconcile";
+const bridgeDataAttachmentKinds = new Set([
+  "webvnc-agent",
+  "webvnc-viewer",
+  "code-agent",
+  "code-viewer",
+  "egress-host",
+  "egress-client",
+]);
 
 export interface NodeUpgradeContext {
   request: IncomingMessage;
@@ -34,6 +42,7 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
   private readonly attachments = new WeakMap<WebSocket, unknown>();
   private readonly sockets = new Set<NodeWebSocket>();
   private readonly socketAlive = new WeakMap<NodeWebSocket, boolean>();
+  private readonly socketOperationTails = new WeakMap<NodeWebSocket, Promise<void>>();
   private alarmHandler?: () => Promise<void>;
   private operationRunner = async <T>(callback: () => Promise<T>): Promise<T> => callback();
   private alarmRun: Promise<void> = Promise.resolve();
@@ -151,30 +160,26 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
       this.socketAlive.set(nodeSocket, true);
     });
     nodeSocket.on("message", (data, isBinary) => {
-      void Promise.resolve()
-        .then(() =>
-          this.operationRunner(async () => {
-            await handlers.message(webSocketData(data, isBinary));
-          }),
-        )
-        .catch((error) => {
-          this.failSocket(nodeSocket, "message", error);
-        });
+      void this.runSocketOperation(nodeSocket, attachment, () =>
+        handlers.message(webSocketData(data, isBinary)),
+      ).catch((error) => {
+        this.failSocket(nodeSocket, "message", error);
+      });
     });
     nodeSocket.on("close", (code, reason) => {
       this.sockets.delete(nodeSocket);
-      try {
+      void this.runSocketOperation(nodeSocket, attachment, async () => {
         handlers.close(code, reason.toString());
-      } catch (error) {
+      }).catch((error) => {
         console.error("coordinator websocket close handler failed", error);
-      }
+      });
     });
     nodeSocket.on("error", () => {
-      try {
+      void this.runSocketOperation(nodeSocket, attachment, async () => {
         handlers.error();
-      } catch (error) {
+      }).catch((error) => {
         console.error("coordinator websocket error handler failed", error);
-      }
+      });
     });
   }
 
@@ -228,6 +233,29 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
       }
     }
   }
+
+  private runSocketOperation<T>(
+    socket: NodeWebSocket,
+    attachment: unknown,
+    callback: () => Promise<T> | T,
+  ): Promise<T> {
+    const operation = async () => callback();
+    // Data-plane frames and code-agent replies must be able to complete an HTTP
+    // request that currently owns the lifecycle queue. Control frames mutate
+    // lease state and stay serialized with HTTP requests and alarms.
+    if (!isBridgeDataAttachment(attachment)) {
+      return this.operationRunner(operation);
+    }
+    const run = (this.socketOperationTails.get(socket) ?? Promise.resolve()).then(operation);
+    this.socketOperationTails.set(
+      socket,
+      run.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return run;
+  }
 }
 
 function webSocketData(data: RawData, isBinary: boolean): string | ArrayBuffer {
@@ -240,4 +268,11 @@ function webSocketData(data: RawData, isBinary: boolean): string | ArrayBuffer {
       ? Buffer.from(data)
       : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
   return Uint8Array.from(buffer).buffer;
+}
+
+function isBridgeDataAttachment(attachment: unknown): boolean {
+  if (!attachment || typeof attachment !== "object" || !("kind" in attachment)) {
+    return false;
+  }
+  return bridgeDataAttachmentKinds.has(String(attachment.kind));
 }

--- a/worker/node/postgres-storage.ts
+++ b/worker/node/postgres-storage.ts
@@ -32,6 +32,11 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
       )
     `);
     await this.pool.query(`
+      alter table ${table}
+      add column if not exists value_text text,
+      add column if not exists value_text_updated_at timestamptz
+    `);
+    await this.pool.query(`
       create index if not exists coordinator_kv_updated_at_idx
       on ${table} (updated_at)
     `);
@@ -46,22 +51,38 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
   }
 
   async get<T>(key: string): Promise<T | undefined> {
-    const result = await this.pool.query<{ value: T }>(
-      `select value from ${table} where key = $1`,
+    const result = await this.pool.query<{ encoded_value: unknown }>(
+      `
+        select case
+          when value_text_updated_at = updated_at then value_text
+          else value::text
+        end as encoded_value
+        from ${table}
+        where key = $1
+      `,
       [key],
     );
-    return result.rows[0]?.value;
+    const row = result.rows[0];
+    return row ? decodeStoredValue<T>(row.encoded_value) : undefined;
   }
 
   async put<T>(key: string, value: T): Promise<void> {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) {
+      throw new TypeError("coordinator storage cannot persist undefined");
+    }
+    const jsonbEncoded = jsonbCompatibleEncoding(encoded);
     await this.pool.query(
       `
-        insert into ${table} (key, value)
-        values ($1, $2::jsonb)
+        insert into ${table} (key, value, value_text, value_text_updated_at)
+        values ($1, $2::jsonb, $3, now())
         on conflict (key) do update
-        set value = excluded.value, updated_at = now()
+        set value = excluded.value,
+            value_text = excluded.value_text,
+            value_text_updated_at = now(),
+            updated_at = now()
       `,
-      [key, JSON.stringify(value)],
+      [key, jsonbEncoded, encoded],
     );
   }
 
@@ -70,17 +91,42 @@ export class PostgresCoordinatorStorage implements CoordinatorStorage {
   }
 
   async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
-    const result = await this.pool.query<{ key: string; value: T }>(
+    const result = await this.pool.query<{ key: string; encoded_value: unknown }>(
       `
-        select key, value
+        select key,
+               case
+                 when value_text_updated_at = updated_at then value_text
+                 else value::text
+               end as encoded_value
         from ${table}
         where key like $1 escape '\\'
         order by key
       `,
       [`${escapeLike(prefix)}%`],
     );
-    return new Map(result.rows.map((row) => [row.key, row.value]));
+    return new Map(result.rows.map((row) => [row.key, decodeStoredValue<T>(row.encoded_value)]));
   }
+}
+
+function decodeStoredValue<T>(value: unknown): T {
+  return (typeof value === "string" ? JSON.parse(value) : value) as T;
+}
+
+function jsonbCompatibleEncoding(encoded: string): string {
+  if (!encoded.includes("\\u0000")) return encoded;
+  return JSON.stringify(replaceNulCharacters(JSON.parse(encoded)));
+}
+
+function replaceNulCharacters(value: unknown): unknown {
+  if (typeof value === "string") return value.replaceAll("\0", "\uFFFD");
+  if (Array.isArray(value)) return value.map(replaceNulCharacters);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key.replaceAll("\0", "\uFFFD"),
+      replaceNulCharacters(item),
+    ]),
+  );
 }
 
 function escapeLike(value: string): string {

--- a/worker/node/postgres-storage.ts
+++ b/worker/node/postgres-storage.ts
@@ -1,0 +1,93 @@
+import { Pool } from "pg";
+
+import type { CoordinatorStorage } from "../src/coordinator-runtime";
+
+const schema = "crabbox";
+const table = `${schema}.coordinator_kv`;
+
+export class PostgresCoordinatorStorage implements CoordinatorStorage {
+  readonly pool: Pool;
+
+  constructor(connectionString: string, pool?: Pool) {
+    this.pool =
+      pool ??
+      new Pool({
+        connectionString,
+        application_name: "crabbox-coordinator",
+        max: positiveInt(process.env["CRABBOX_DATABASE_POOL_SIZE"], 10),
+        connectionTimeoutMillis: positiveInt(
+          process.env["CRABBOX_DATABASE_CONNECT_TIMEOUT_MS"],
+          10_000,
+        ),
+      });
+  }
+
+  async initialize(): Promise<void> {
+    await this.pool.query(`create schema if not exists ${schema}`);
+    await this.pool.query(`
+      create table if not exists ${table} (
+        key text primary key,
+        value jsonb not null,
+        updated_at timestamptz not null default now()
+      )
+    `);
+    await this.pool.query(`
+      create index if not exists coordinator_kv_updated_at_idx
+      on ${table} (updated_at)
+    `);
+  }
+
+  async ready(): Promise<void> {
+    await this.pool.query("select 1");
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const result = await this.pool.query<{ value: T }>(
+      `select value from ${table} where key = $1`,
+      [key],
+    );
+    return result.rows[0]?.value;
+  }
+
+  async put<T>(key: string, value: T): Promise<void> {
+    await this.pool.query(
+      `
+        insert into ${table} (key, value)
+        values ($1, $2::jsonb)
+        on conflict (key) do update
+        set value = excluded.value, updated_at = now()
+      `,
+      [key, JSON.stringify(value)],
+    );
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.pool.query(`delete from ${table} where key = $1`, [key]);
+  }
+
+  async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
+    const result = await this.pool.query<{ key: string; value: T }>(
+      `
+        select key, value
+        from ${table}
+        where key like $1 escape '\\'
+        order by key
+      `,
+      [`${escapeLike(prefix)}%`],
+    );
+    return new Map(result.rows.map((row) => [row.key, row.value]));
+  }
+}
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, Server } from "node:http";
+import { BlockList, isIP } from "node:net";
 import type { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
 
@@ -82,6 +83,45 @@ export function shouldReadUnauthenticatedRequestBody(method: string | undefined)
 export function isReadinessRequestMethod(method: string | undefined): boolean {
   const normalized = (method || "GET").toUpperCase();
   return normalized === "GET" || normalized === "HEAD";
+}
+
+export function isTrustedProxySource(
+  address: string | undefined,
+  configuredCIDRs: string | undefined,
+): boolean {
+  const normalizedAddress = normalizeIPAddress(address);
+  const family = isIP(normalizedAddress);
+  if (family === 0 || !configuredCIDRs?.trim()) return false;
+
+  const blockList = new BlockList();
+  try {
+    for (const rawEntry of configuredCIDRs.split(",")) {
+      const entry = rawEntry.trim();
+      if (!entry) continue;
+      const separator = entry.lastIndexOf("/");
+      const subnet = normalizeIPAddress(separator === -1 ? entry : entry.slice(0, separator));
+      const subnetFamily = isIP(subnet);
+      if (subnetFamily === 0) return false;
+      const type = subnetFamily === 4 ? "ipv4" : "ipv6";
+      if (separator === -1) {
+        blockList.addAddress(subnet, type);
+        continue;
+      }
+      const prefix = Number(entry.slice(separator + 1));
+      const maxPrefix = subnetFamily === 4 ? 32 : 128;
+      if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) return false;
+      blockList.addSubnet(subnet, prefix, type);
+    }
+  } catch {
+    return false;
+  }
+  return blockList.check(normalizedAddress, family === 4 ? "ipv4" : "ipv6");
+}
+
+function normalizeIPAddress(address: string | undefined): string {
+  const value = address?.trim() ?? "";
+  const mappedIPv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);
+  return mappedIPv4?.[1] ?? value;
 }
 
 export async function readNodeRequestBody(

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -118,6 +118,26 @@ export function isTrustedProxySource(
   return blockList.check(normalizedAddress, family === 4 ? "ipv4" : "ipv6");
 }
 
+export function requestSourceIP(
+  peerAddress: string | undefined,
+  forwardedFor: string | undefined,
+  configuredCIDRs: string | undefined,
+): string | undefined {
+  const peer = normalizeIPAddress(peerAddress);
+  if (isIP(peer) === 0) return undefined;
+  if (!isTrustedProxySource(peer, configuredCIDRs)) return peer;
+
+  const chain = (forwardedFor ?? "")
+    .split(",")
+    .map((entry) => normalizeIPAddress(entry))
+    .filter((entry) => isIP(entry) !== 0);
+  for (let index = chain.length - 1; index >= 0; index -= 1) {
+    const candidate = chain[index];
+    if (candidate && !isTrustedProxySource(candidate, configuredCIDRs)) return candidate;
+  }
+  return peer;
+}
+
 function normalizeIPAddress(address: string | undefined): string {
   const value = address?.trim() ?? "";
   const mappedIPv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(value);

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -1,0 +1,158 @@
+import type { IncomingMessage, Server } from "node:http";
+import type { Writable } from "node:stream";
+import { finished } from "node:stream/promises";
+
+import { coordinatorRequestQueue, type CoordinatorRequestQueue } from "../src/coordinator-runtime";
+
+export const unauthenticatedRequestBodyBytes = 1024 * 1024;
+export const authenticatedRequestBodyBytes = 16 * 1024 * 1024;
+export const runFinishRequestBodyBytes = 64 * 1024 * 1024;
+
+const noop = () => {};
+
+export class RequestBodyTooLargeError extends Error {}
+
+export class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async run<T>(callback: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release = noop;
+    this.tail = new Promise<void>((resolvePromise) => {
+      release = resolvePromise;
+    });
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
+  }
+
+  async drain(): Promise<void> {
+    await this.tail;
+  }
+}
+
+export class AsyncOperationTracker {
+  private readonly active = new Set<Promise<unknown>>();
+
+  async run<T>(callback: () => Promise<T>): Promise<T> {
+    const operation = callback();
+    this.active.add(operation);
+    try {
+      return await operation;
+    } finally {
+      this.active.delete(operation);
+    }
+  }
+
+  async drain(): Promise<void> {
+    const active = [...this.active];
+    if (active.length === 0) return;
+    await Promise.allSettled(active);
+    return this.drain();
+  }
+}
+
+export type FleetRequestQueue = CoordinatorRequestQueue;
+
+export function requestBodyLimit(request: Request, authenticated: boolean): number {
+  if (!authenticated) return unauthenticatedRequestBodyBytes;
+  const url = new URL(request.url);
+  const path = url.pathname.split("/").filter(Boolean);
+  if (
+    request.method.toUpperCase() === "POST" &&
+    path.length === 4 &&
+    path[0] === "v1" &&
+    path[1] === "runs" &&
+    path[2] &&
+    path[3] === "finish"
+  ) {
+    return runFinishRequestBodyBytes;
+  }
+  return authenticatedRequestBodyBytes;
+}
+
+export function shouldReadUnauthenticatedRequestBody(method: string | undefined): boolean {
+  const normalized = (method || "GET").toUpperCase();
+  return normalized !== "GET" && normalized !== "HEAD";
+}
+
+export function isReadinessRequestMethod(method: string | undefined): boolean {
+  const normalized = (method || "GET").toUpperCase();
+  return normalized === "GET" || normalized === "HEAD";
+}
+
+export async function readNodeRequestBody(
+  request: IncomingMessage,
+  limit: number,
+): Promise<ArrayBuffer | undefined> {
+  const rawLength = request.headers["content-length"];
+  const declaredLength = Number(Array.isArray(rawLength) ? rawLength[0] : rawLength);
+  if (Number.isFinite(declaredLength) && declaredLength > limit) {
+    throw new RequestBodyTooLargeError();
+  }
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > limit) {
+      throw new RequestBodyTooLargeError();
+    }
+    chunks.push(buffer);
+  }
+  return chunks.length > 0 ? Uint8Array.from(Buffer.concat(chunks)).buffer : undefined;
+}
+
+export async function writeNodeResponseBody(stream: Writable, body: Buffer): Promise<void> {
+  const completion = finished(stream, { cleanup: true, readable: false });
+  stream.end(body);
+  await completion;
+}
+
+export function fleetRequestQueue(request: Request): FleetRequestQueue {
+  return coordinatorRequestQueue(request);
+}
+
+export function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function settlesWithin(
+  operation: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function drainAndStop(
+  activeRequests: Pick<AsyncOperationTracker, "drain">,
+  lifecycleMutex: Pick<AsyncMutex, "drain">,
+  stopRuntime: () => Promise<void>,
+  serverClosed: Promise<void>,
+): Promise<void> {
+  await Promise.all([activeRequests.drain(), lifecycleMutex.drain()]);
+  await stopRuntime();
+  await serverClosed;
+}

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -4,74 +4,123 @@ import { extname, resolve, sep } from "node:path";
 import type { Duplex } from "node:stream";
 import { fileURLToPath } from "node:url";
 
-import { routeCoordinatorRequest } from "../src/coordinator-entry";
+import { prepareCoordinatorRequest, routeCoordinatorRequest } from "../src/coordinator-entry";
 import { FleetCoordinator } from "../src/fleet";
 import type { Env } from "../src/types";
 import { NodeCoordinatorRuntime, type NodeUpgradeContext } from "./node-runtime";
-
-const noop = () => {};
-const maxRequestBodyBytes = 16 * 1024 * 1024;
-
-class RequestBodyTooLargeError extends Error {}
-
-class AsyncMutex {
-  private tail: Promise<void> = Promise.resolve();
-
-  async run<T>(callback: () => Promise<T>): Promise<T> {
-    const previous = this.tail;
-    let release = noop;
-    this.tail = new Promise<void>((resolvePromise) => {
-      release = resolvePromise;
-    });
-    await previous;
-    try {
-      return await callback();
-    } finally {
-      release();
-    }
-  }
-}
+import {
+  AsyncMutex,
+  AsyncOperationTracker,
+  RequestBodyTooLargeError,
+  closeServer,
+  drainAndStop,
+  fleetRequestQueue,
+  isReadinessRequestMethod,
+  readNodeRequestBody,
+  requestBodyLimit,
+  settlesWithin,
+  shouldReadUnauthenticatedRequestBody,
+  unauthenticatedRequestBodyBytes,
+  writeNodeResponseBody,
+} from "./server-support";
 
 const databaseURL = requiredEnv("DATABASE_URL");
 const port = positiveInt(process.env["PORT"], 8080);
+const shutdownTimeoutMs = positiveInt(process.env["CRABBOX_SHUTDOWN_TIMEOUT_MS"], 120_000);
 const env = process.env as unknown as Env;
 const runtime = new NodeCoordinatorRuntime(databaseURL);
 const coordinator = new FleetCoordinator(runtime, env);
 const lifecycleMutex = new AsyncMutex();
+const activeRequests = new AsyncOperationTracker();
 const publicDirectory = resolve(fileURLToPath(new URL("../public", import.meta.url)));
+let shutdownPromise: Promise<void> | undefined;
 
 runtime.setOperationRunner((callback) => lifecycleMutex.run(callback));
-await runtime.start(() => lifecycleMutex.run(() => coordinator.alarm()));
+await runtime.start(() => coordinator.alarm());
 
-const server = createServer(async (request, response) => {
+const server = createServer((request, response) => {
+  void activeRequests
+    .run(() => handleRequest(request, response))
+    .catch((error) => {
+      console.error("coordinator request handler failed", error);
+      response.destroy();
+    });
+});
+
+async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
   try {
-    const webRequest = await webRequestFromNode(request);
-    if (new URL(webRequest.url).pathname === "/v1/ready") {
-      await runtime.storage.ready();
-      await writeResponse(response, Response.json({ ok: true }));
+    const requestMetadata = webRequestFromNode(request);
+    if (new URL(requestMetadata.url).pathname === "/v1/ready") {
+      let result: Response;
+      if (isReadinessRequestMethod(requestMetadata.method)) {
+        await runtime.storage.ready();
+        result =
+          requestMetadata.method === "HEAD"
+            ? new Response(null, { status: 200 })
+            : Response.json({ ok: true });
+      } else {
+        result = Response.json(
+          { error: "method_not_allowed" },
+          { status: 405, headers: { allow: "GET, HEAD" } },
+        );
+      }
+      await writeResponse(response, result, true);
+      request.destroy();
       return;
     }
-    const asset = await staticAsset(webRequest);
+    const asset = await staticAsset(requestMetadata);
     if (asset) {
       await writeResponse(response, asset);
       return;
     }
-    const result = await routeCoordinatorRequest(webRequest, env, runFleetRequest);
+    const prepared = await prepareCoordinatorRequest(requestMetadata, env);
+    if ("response" in prepared) {
+      const readBody = shouldReadUnauthenticatedRequestBody(request.method);
+      if (readBody) {
+        await readNodeRequestBody(request, unauthenticatedRequestBodyBytes);
+      }
+      await writeResponse(response, prepared.response, !readBody);
+      if (!readBody) {
+        request.destroy();
+      }
+      return;
+    }
+    const webRequest = await requestWithNodeBody(
+      prepared.request,
+      request,
+      requestBodyLimit(prepared.request, prepared.authenticated),
+    );
+    const result = await runFleetRequest(webRequest);
     await writeResponse(response, result);
   } catch (error) {
     if (error instanceof RequestBodyTooLargeError) {
+      response.setHeader("connection", "close");
       await writeResponse(response, Response.json({ error: "request_too_large" }, { status: 413 }));
+      request.destroy();
       return;
     }
     console.error("coordinator request failed", error);
     await writeResponse(response, Response.json({ error: "internal_error" }, { status: 500 }));
   }
+}
+
+server.on("upgrade", (request, socket, head) => {
+  void activeRequests
+    .run(() => handleUpgrade(request, socket, head))
+    .catch((error) => {
+      console.error("coordinator websocket upgrade handler failed", error);
+      socket.destroy();
+    });
 });
 
-server.on("upgrade", async (request, socket, head) => {
+async function handleUpgrade(
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): Promise<void> {
   const context: NodeUpgradeContext = { request, socket, head, upgraded: false };
   try {
-    const webRequest = await webRequestFromNode(request);
+    const webRequest = webRequestFromNode(request);
     const response = await runtime.runWithUpgrade(context, () =>
       routeCoordinatorRequest(webRequest, env, runFleetRequest),
     );
@@ -87,30 +136,57 @@ server.on("upgrade", async (request, socket, head) => {
       );
     }
   }
-});
+}
 
 server.listen(port, () => {
   console.log(`crabbox coordinator listening on ${port}`);
 });
 
 process.on("SIGTERM", () => {
-  void shutdown();
+  void shutdown().catch(shutdownFailed);
 });
 process.on("SIGINT", () => {
-  void shutdown();
+  void shutdown().catch(shutdownFailed);
 });
 
 async function runFleetRequest(request: Request): Promise<Response> {
-  return lifecycleMutex.run(() => coordinator.fetch(request));
+  switch (fleetRequestQueue(request)) {
+    case "direct":
+      return coordinator.fetch(request);
+    case "lifecycle":
+      return lifecycleMutex.run(() => coordinator.fetch(request));
+  }
 }
 
 async function shutdown(): Promise<void> {
-  server.close();
-  await runtime.stop();
+  if (shutdownPromise) {
+    return shutdownPromise;
+  }
+  shutdownPromise = orderlyShutdown();
+  return shutdownPromise;
+}
+
+async function orderlyShutdown(): Promise<void> {
+  runtime.beginShutdown();
+  const serverClosed = closeServer(server);
+  server.closeIdleConnections?.();
+  const drained = await settlesWithin(
+    drainAndStop(activeRequests, lifecycleMutex, () => runtime.stop(), serverClosed),
+    shutdownTimeoutMs,
+  );
+  if (!drained) {
+    console.error(`coordinator shutdown exceeded ${shutdownTimeoutMs}ms`);
+    process.exit(1);
+  }
   process.exit(0);
 }
 
-async function webRequestFromNode(request: IncomingMessage): Promise<Request> {
+function shutdownFailed(error: unknown): void {
+  console.error("coordinator shutdown failed", error);
+  process.exit(1);
+}
+
+function webRequestFromNode(request: IncomingMessage): Request {
   const protocol = firstHeader(request.headers["x-forwarded-proto"]) || "http";
   const host =
     firstHeader(request.headers["x-forwarded-host"]) || request.headers.host || "localhost";
@@ -124,36 +200,35 @@ async function webRequestFromNode(request: IncomingMessage): Promise<Request> {
     }
   }
   const method = request.method || "GET";
-  const body = method === "GET" || method === "HEAD" ? undefined : await readRequestBody(request);
-  const init: RequestInit = { method, headers };
-  if (body !== undefined) {
-    init.body = body;
-  }
-  return new Request(url, init);
+  return new Request(url, { method, headers });
 }
 
-async function readRequestBody(request: IncomingMessage): Promise<ArrayBuffer | undefined> {
-  const chunks: Buffer[] = [];
-  let size = 0;
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    size += buffer.byteLength;
-    if (size > maxRequestBodyBytes) {
-      throw new RequestBodyTooLargeError();
-    }
-    chunks.push(buffer);
-  }
-  return chunks.length > 0 ? Uint8Array.from(Buffer.concat(chunks)).buffer : undefined;
+async function requestWithNodeBody(
+  request: Request,
+  nodeRequest: IncomingMessage,
+  limit: number,
+): Promise<Request> {
+  if (request.method === "GET" || request.method === "HEAD") return request;
+  const body = await readNodeRequestBody(nodeRequest, limit);
+  // oxlint-disable-next-line unicorn/no-invalid-fetch-options -- GET and HEAD return above.
+  return body === undefined ? request : new Request(request, { body });
 }
 
-async function writeResponse(response: ServerResponse, result: Response): Promise<void> {
+async function writeResponse(
+  response: ServerResponse,
+  result: Response,
+  closeConnection = false,
+): Promise<void> {
   response.statusCode = result.status;
   result.headers.forEach((value, name) => response.setHeader(name, value));
+  if (closeConnection) {
+    response.setHeader("connection", "close");
+  }
   const body = Buffer.from(await result.arrayBuffer());
   if (!response.hasHeader("content-length")) {
     response.setHeader("content-length", body.byteLength);
   }
-  response.end(body);
+  await writeNodeResponseBody(response, body);
 }
 
 async function writeUpgradeResponse(socket: Duplex, response: Response): Promise<void> {

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -18,6 +18,7 @@ import {
   isReadinessRequestMethod,
   isTrustedProxySource,
   readNodeRequestBody,
+  requestSourceIP,
   requestBodyLimit,
   settlesWithin,
   shouldReadUnauthenticatedRequestBody,
@@ -50,13 +51,9 @@ const server = createServer((request, response) => {
 
 async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
   try {
-    const requestMetadata = webRequestFromNode(request);
-    const authContext = {
-      trustedProxy: isTrustedProxySource(
-        request.socket.remoteAddress,
-        env.CRABBOX_TRUSTED_PROXY_CIDRS,
-      ),
-    };
+    const requestContext = nodeRequestContext(request);
+    const requestMetadata = webRequestFromNode(request, requestContext);
+    const authContext = { trustedProxy: requestContext.trustedProxy };
     if (new URL(requestMetadata.url).pathname === "/v1/ready") {
       let result: Response;
       if (isReadinessRequestMethod(requestMetadata.method)) {
@@ -127,13 +124,9 @@ async function handleUpgrade(
 ): Promise<void> {
   const context: NodeUpgradeContext = { request, socket, head, upgraded: false };
   try {
-    const webRequest = webRequestFromNode(request);
-    const authContext = {
-      trustedProxy: isTrustedProxySource(
-        request.socket.remoteAddress,
-        env.CRABBOX_TRUSTED_PROXY_CIDRS,
-      ),
-    };
+    const requestContext = nodeRequestContext(request);
+    const webRequest = webRequestFromNode(request, requestContext);
+    const authContext = { trustedProxy: requestContext.trustedProxy };
     const response = await runtime.runWithUpgrade(context, () =>
       routeCoordinatorRequest(webRequest, env, runFleetRequest, authContext),
     );
@@ -199,10 +192,32 @@ function shutdownFailed(error: unknown): void {
   process.exit(1);
 }
 
-function webRequestFromNode(request: IncomingMessage): Request {
-  const protocol = firstHeader(request.headers["x-forwarded-proto"]) || "http";
-  const host =
-    firstHeader(request.headers["x-forwarded-host"]) || request.headers.host || "localhost";
+interface NodeRequestContext {
+  sourceIP: string | undefined;
+  trustedProxy: boolean;
+}
+
+function nodeRequestContext(request: IncomingMessage): NodeRequestContext {
+  const configuredCIDRs = env.CRABBOX_TRUSTED_PROXY_CIDRS;
+  const peerAddress = request.socket.remoteAddress;
+  return {
+    sourceIP: requestSourceIP(
+      peerAddress,
+      joinedHeader(request.headers["x-forwarded-for"]),
+      configuredCIDRs,
+    ),
+    trustedProxy: isTrustedProxySource(peerAddress, configuredCIDRs),
+  };
+}
+
+function webRequestFromNode(request: IncomingMessage, context: NodeRequestContext): Request {
+  const protocol = context.trustedProxy
+    ? firstHeader(request.headers["x-forwarded-proto"]) || "http"
+    : "http";
+  const forwardedHost = context.trustedProxy
+    ? firstHeader(request.headers["x-forwarded-host"])
+    : "";
+  const host = forwardedHost || request.headers.host || "localhost";
   const url = `${protocol}://${host}${request.url || "/"}`;
   const headers = new Headers();
   for (const [name, value] of Object.entries(request.headers)) {
@@ -212,6 +227,8 @@ function webRequestFromNode(request: IncomingMessage): Request {
       headers.set(name, value);
     }
   }
+  headers.delete("cf-connecting-ip");
+  if (context.sourceIP) headers.set("cf-connecting-ip", context.sourceIP);
   const method = request.method || "GET";
   return new Request(url, { method, headers });
 }
@@ -299,6 +316,10 @@ function contentType(path: string): string {
 
 function firstHeader(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? "") : ((value ?? "").split(",")[0]?.trim() ?? "");
+}
+
+function joinedHeader(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value.join(",") : (value ?? "");
 }
 
 function requiredEnv(name: string): string {

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -1,0 +1,227 @@
+import { readFile } from "node:fs/promises";
+import { createServer, STATUS_CODES, type IncomingMessage, type ServerResponse } from "node:http";
+import { extname, resolve, sep } from "node:path";
+import type { Duplex } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+import { routeCoordinatorRequest } from "../src/coordinator-entry";
+import { FleetCoordinator } from "../src/fleet";
+import type { Env } from "../src/types";
+import { NodeCoordinatorRuntime, type NodeUpgradeContext } from "./node-runtime";
+
+const noop = () => {};
+const maxRequestBodyBytes = 16 * 1024 * 1024;
+
+class RequestBodyTooLargeError extends Error {}
+
+class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async run<T>(callback: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release = noop;
+    this.tail = new Promise<void>((resolvePromise) => {
+      release = resolvePromise;
+    });
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
+  }
+}
+
+const databaseURL = requiredEnv("DATABASE_URL");
+const port = positiveInt(process.env["PORT"], 8080);
+const env = process.env as unknown as Env;
+const runtime = new NodeCoordinatorRuntime(databaseURL);
+const coordinator = new FleetCoordinator(runtime, env);
+const mutationMutex = new AsyncMutex();
+const publicDirectory = resolve(fileURLToPath(new URL("../public", import.meta.url)));
+
+runtime.setOperationRunner((callback) => mutationMutex.run(callback));
+await runtime.start(() => mutationMutex.run(() => coordinator.alarm()));
+
+const server = createServer(async (request, response) => {
+  try {
+    const webRequest = await webRequestFromNode(request);
+    if (new URL(webRequest.url).pathname === "/v1/ready") {
+      await runtime.storage.ready();
+      await writeResponse(response, Response.json({ ok: true }));
+      return;
+    }
+    const asset = await staticAsset(webRequest);
+    if (asset) {
+      await writeResponse(response, asset);
+      return;
+    }
+    const result = await routeCoordinatorRequest(webRequest, env, runFleetRequest);
+    await writeResponse(response, result);
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      await writeResponse(response, Response.json({ error: "request_too_large" }, { status: 413 }));
+      return;
+    }
+    console.error("coordinator request failed", error);
+    await writeResponse(response, Response.json({ error: "internal_error" }, { status: 500 }));
+  }
+});
+
+server.on("upgrade", async (request, socket, head) => {
+  const context: NodeUpgradeContext = { request, socket, head, upgraded: false };
+  try {
+    const webRequest = await webRequestFromNode(request);
+    const response = await runtime.runWithUpgrade(context, () =>
+      routeCoordinatorRequest(webRequest, env, runFleetRequest),
+    );
+    if (!context.upgraded) {
+      await writeUpgradeResponse(socket, response);
+    }
+  } catch (error) {
+    console.error("coordinator websocket upgrade failed", error);
+    if (!context.upgraded) {
+      await writeUpgradeResponse(
+        socket,
+        Response.json({ error: "internal_error" }, { status: 500 }),
+      );
+    }
+  }
+});
+
+server.listen(port, () => {
+  console.log(`crabbox coordinator listening on ${port}`);
+});
+
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+process.on("SIGINT", () => {
+  void shutdown();
+});
+
+async function runFleetRequest(request: Request): Promise<Response> {
+  return mutationMutex.run(() => coordinator.fetch(request));
+}
+
+async function shutdown(): Promise<void> {
+  server.close();
+  await runtime.stop();
+  process.exit(0);
+}
+
+async function webRequestFromNode(request: IncomingMessage): Promise<Request> {
+  const protocol = firstHeader(request.headers["x-forwarded-proto"]) || "http";
+  const host =
+    firstHeader(request.headers["x-forwarded-host"]) || request.headers.host || "localhost";
+  const url = `${protocol}://${host}${request.url || "/"}`;
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(name, item);
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+  const method = request.method || "GET";
+  const body = method === "GET" || method === "HEAD" ? undefined : await readRequestBody(request);
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    init.body = body;
+  }
+  return new Request(url, init);
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<ArrayBuffer | undefined> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > maxRequestBodyBytes) {
+      throw new RequestBodyTooLargeError();
+    }
+    chunks.push(buffer);
+  }
+  return chunks.length > 0 ? Uint8Array.from(Buffer.concat(chunks)).buffer : undefined;
+}
+
+async function writeResponse(response: ServerResponse, result: Response): Promise<void> {
+  response.statusCode = result.status;
+  result.headers.forEach((value, name) => response.setHeader(name, value));
+  const body = Buffer.from(await result.arrayBuffer());
+  if (!response.hasHeader("content-length")) {
+    response.setHeader("content-length", body.byteLength);
+  }
+  response.end(body);
+}
+
+async function writeUpgradeResponse(socket: Duplex, response: Response): Promise<void> {
+  const body = Buffer.from(await response.arrayBuffer());
+  const headers = new Headers(response.headers);
+  headers.set("connection", "close");
+  headers.set("content-length", String(body.byteLength));
+  const statusText = STATUS_CODES[response.status] || "Error";
+  const lines = [`HTTP/1.1 ${response.status} ${statusText}`];
+  headers.forEach((value, name) => lines.push(`${name}: ${value}`));
+  socket.end(`${lines.join("\r\n")}\r\n\r\n${body.toString()}`);
+}
+
+async function staticAsset(request: Request): Promise<Response | undefined> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return undefined;
+  }
+  const pathname = decodeURIComponent(new URL(request.url).pathname);
+  if (!pathname.startsWith("/portal/assets/")) {
+    return undefined;
+  }
+  const path = resolve(publicDirectory, `.${pathname}`);
+  if (!path.startsWith(`${publicDirectory}${sep}`)) {
+    return Response.json({ error: "not_found" }, { status: 404 });
+  }
+  try {
+    const body = await readFile(path);
+    return new Response(request.method === "HEAD" ? null : body, {
+      headers: {
+        "cache-control": "public, max-age=3600",
+        "content-type": contentType(path),
+      },
+    });
+  } catch {
+    return Response.json({ error: "not_found" }, { status: 404 });
+  }
+}
+
+function contentType(path: string): string {
+  switch (extname(path)) {
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".svg":
+      return "image/svg+xml";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function firstHeader(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : ((value ?? "").split(",")[0]?.trim() ?? "");
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -37,11 +37,11 @@ const port = positiveInt(process.env["PORT"], 8080);
 const env = process.env as unknown as Env;
 const runtime = new NodeCoordinatorRuntime(databaseURL);
 const coordinator = new FleetCoordinator(runtime, env);
-const mutationMutex = new AsyncMutex();
+const lifecycleMutex = new AsyncMutex();
 const publicDirectory = resolve(fileURLToPath(new URL("../public", import.meta.url)));
 
-runtime.setOperationRunner((callback) => mutationMutex.run(callback));
-await runtime.start(() => mutationMutex.run(() => coordinator.alarm()));
+runtime.setOperationRunner((callback) => lifecycleMutex.run(callback));
+await runtime.start(() => lifecycleMutex.run(() => coordinator.alarm()));
 
 const server = createServer(async (request, response) => {
   try {
@@ -101,7 +101,7 @@ process.on("SIGINT", () => {
 });
 
 async function runFleetRequest(request: Request): Promise<Response> {
-  return mutationMutex.run(() => coordinator.fetch(request));
+  return lifecycleMutex.run(() => coordinator.fetch(request));
 }
 
 async function shutdown(): Promise<void> {

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -16,6 +16,7 @@ import {
   drainAndStop,
   fleetRequestQueue,
   isReadinessRequestMethod,
+  isTrustedProxySource,
   readNodeRequestBody,
   requestBodyLimit,
   settlesWithin,
@@ -50,6 +51,12 @@ const server = createServer((request, response) => {
 async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
   try {
     const requestMetadata = webRequestFromNode(request);
+    const authContext = {
+      trustedProxy: isTrustedProxySource(
+        request.socket.remoteAddress,
+        env.CRABBOX_TRUSTED_PROXY_CIDRS,
+      ),
+    };
     if (new URL(requestMetadata.url).pathname === "/v1/ready") {
       let result: Response;
       if (isReadinessRequestMethod(requestMetadata.method)) {
@@ -73,7 +80,7 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
       await writeResponse(response, asset);
       return;
     }
-    const prepared = await prepareCoordinatorRequest(requestMetadata, env);
+    const prepared = await prepareCoordinatorRequest(requestMetadata, env, authContext);
     if ("response" in prepared) {
       const readBody = shouldReadUnauthenticatedRequestBody(request.method);
       if (readBody) {
@@ -121,8 +128,14 @@ async function handleUpgrade(
   const context: NodeUpgradeContext = { request, socket, head, upgraded: false };
   try {
     const webRequest = webRequestFromNode(request);
+    const authContext = {
+      trustedProxy: isTrustedProxySource(
+        request.socket.remoteAddress,
+        env.CRABBOX_TRUSTED_PROXY_CIDRS,
+      ),
+    };
     const response = await runtime.runWithUpgrade(context, () =>
-      routeCoordinatorRequest(webRequest, env, runFleetRequest),
+      routeCoordinatorRequest(webRequest, env, runFleetRequest, authContext),
     );
     if (!context.upgraded) {
       await writeUpgradeResponse(socket, response);

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -11,11 +11,18 @@
         "@cloudflare/containers": "^0.3.5",
         "@novnc/novnc": "^1.7.0",
         "aws4fetch": "^1.0.20",
-        "fast-xml-parser": "^5.8.0"
+        "fast-xml-parser": "^5.8.0",
+        "pg": "^8.21.0",
+        "pg-boss": "^12.18.2",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260531.1",
+        "@types/node": "^22.19.19",
+        "@types/pg": "^8.20.0",
+        "@types/ws": "^8.18.1",
         "@typescript/native-preview": "^7.0.0-dev.20260527.2",
+        "esbuild": "^0.28.0",
         "oxfmt": "^0.52.0",
         "oxlint": "^1.67.0",
         "oxlint-tsgolint": "^0.23.0",
@@ -199,9 +206,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -216,9 +223,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -233,9 +240,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -250,9 +257,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -267,9 +274,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -284,9 +291,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -301,9 +308,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -318,9 +325,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -335,9 +342,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -352,9 +359,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -369,9 +376,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -386,9 +393,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -403,9 +410,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -420,9 +427,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -437,9 +444,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -454,9 +461,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -471,9 +478,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -488,9 +495,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -505,9 +512,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -522,9 +529,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -539,9 +546,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -556,9 +563,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -573,9 +580,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -590,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -607,9 +614,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -624,9 +631,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -2405,6 +2412,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript/native-preview": {
       "version": "7.0.0-dev.20260527.2",
       "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260527.2.tgz",
@@ -2713,6 +2752,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2741,9 +2792,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2754,32 +2805,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/estree-walker": {
@@ -3156,6 +3207,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3187,6 +3247,28 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -3204,6 +3286,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/non-error": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/non-error/-/non-error-0.1.0.tgz",
+      "integrity": "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/obug": {
@@ -3365,6 +3459,112 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-boss": {
+      "version": "12.18.2",
+      "resolved": "https://registry.npmjs.org/pg-boss/-/pg-boss-12.18.2.tgz",
+      "integrity": "sha512-06kXeWvVWY+BUNsOt2me1okg6NXx2DBnAQHTurA9jtrvbAO9qUOSE3/0ERERQDrokI+FREFM2Twha+JbrFT/8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^5.5.0",
+        "pg": "^8.20.0",
+        "serialize-error": "^13.0.1"
+      },
+      "bin": {
+        "pg-boss": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3412,6 +3612,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -3521,6 +3760,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-13.0.1.tgz",
+      "integrity": "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==",
+      "license": "MIT",
+      "dependencies": {
+        "non-error": "^0.1.0",
+        "type-fest": "^5.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -3583,6 +3838,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3620,6 +3884,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -3684,6 +3960,21 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -3707,6 +3998,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
@@ -3960,11 +4258,494 @@
         }
       }
     },
-    "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3995,6 +4776,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/youch": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,25 +6,36 @@
   "scripts": {
     "build": "wrangler deploy --dry-run --outdir dist",
     "build:cloudflare": "wrangler deploy --config wrangler.cloudflare.jsonc --dry-run --outdir dist-cloudflare",
+    "build:node": "node scripts/build-node.mjs",
     "check": "tsgo --noEmit",
+    "check:node": "tsgo --noEmit -p tsconfig.node.json",
     "deploy": "wrangler deploy",
     "deploy:cloudflare": "wrangler deploy --config wrangler.cloudflare.jsonc --containers-rollout=immediate",
     "prebuild": "node scripts/vendor-novnc.mjs",
+    "prebuild:node": "node scripts/vendor-novnc.mjs",
     "predeploy": "node scripts/vendor-novnc.mjs",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "lint": "oxlint --config .oxlintrc.json .",
+    "start:node": "node dist-node/server.mjs",
     "test": "vitest run"
   },
   "dependencies": {
     "@cloudflare/containers": "^0.3.5",
     "@novnc/novnc": "^1.7.0",
     "aws4fetch": "^1.0.20",
-    "fast-xml-parser": "^5.8.0"
+    "fast-xml-parser": "^5.8.0",
+    "pg": "^8.21.0",
+    "pg-boss": "^12.18.2",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260531.1",
+    "@types/node": "^22.19.19",
+    "@types/pg": "^8.20.0",
+    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260527.2",
+    "esbuild": "^0.28.0",
     "oxfmt": "^0.52.0",
     "oxlint": "^1.67.0",
     "oxlint-tsgolint": "^0.23.0",
@@ -33,6 +44,6 @@
     "wrangler": "^4.95.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   }
 }

--- a/worker/scripts/build-node.mjs
+++ b/worker/scripts/build-node.mjs
@@ -1,0 +1,12 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["node/server.ts"],
+  outfile: "dist-node/server.mjs",
+  bundle: true,
+  packages: "external",
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  sourcemap: true,
+});

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -9,7 +9,7 @@ const accessKeyCache = new Map<string, CryptoKey>();
 export interface AuthContext {
   authorized: boolean;
   admin: boolean;
-  auth: "bearer" | "github";
+  auth: "bearer" | "github" | "proxy";
   owner: string;
   org: string;
   login?: string;
@@ -39,19 +39,23 @@ export async function authenticateRequest(
     | "CRABBOX_ACCESS_AUD"
     | "CRABBOX_GITHUB_ADMIN_OWNERS"
     | "CRABBOX_GITHUB_ADMIN_LOGINS"
+    | "CRABBOX_TRUSTED_USER_HEADER"
+    | "CRABBOX_TRUSTED_USER_ORG"
   >,
 ): Promise<AuthContext | undefined> {
   const token = bearerToken(request);
-  if (!token) {
-    return undefined;
-  }
+  const trustedIdentity = trustedProxyIdentity(request, env);
   const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
   if (env.CRABBOX_ADMIN_TOKEN && token === env.CRABBOX_ADMIN_TOKEN) {
     return {
       authorized: true,
       admin: true,
       auth: "bearer",
-      owner: accessIdentity?.email ?? request.headers.get("x-crabbox-owner") ?? "unknown",
+      owner:
+        accessIdentity?.email ??
+        trustedIdentity?.owner ??
+        request.headers.get("x-crabbox-owner") ??
+        "unknown",
       org: request.headers.get("x-crabbox-org") ?? env.CRABBOX_DEFAULT_ORG ?? "unknown",
     };
   }
@@ -60,23 +64,29 @@ export async function authenticateRequest(
       authorized: true,
       admin: false,
       auth: "bearer",
-      owner: accessIdentity?.email ?? env.CRABBOX_SHARED_OWNER?.trim() ?? "unknown",
+      owner:
+        accessIdentity?.email ??
+        trustedIdentity?.owner ??
+        env.CRABBOX_SHARED_OWNER?.trim() ??
+        "unknown",
       org: env.CRABBOX_DEFAULT_ORG ?? "unknown",
     };
   }
-  const payload = await verifyUserToken(token, env).catch(() => undefined);
-  if (!payload) {
-    return undefined;
+  if (token) {
+    const payload = await verifyUserToken(token, env).catch(() => undefined);
+    if (payload) {
+      return {
+        authorized: true,
+        admin: githubUserIsAdmin(payload, env),
+        auth: "github",
+        owner: payload.owner,
+        org: payload.org,
+        login: payload.login,
+        tokenExpiresAt: new Date(payload.exp * 1000).toISOString(),
+      };
+    }
   }
-  return {
-    authorized: true,
-    admin: githubUserIsAdmin(payload, env),
-    auth: "github",
-    owner: payload.owner,
-    org: payload.org,
-    login: payload.login,
-    tokenExpiresAt: new Date(payload.exp * 1000).toISOString(),
-  };
+  return trustedIdentity;
 }
 
 function githubUserIsAdmin(
@@ -216,6 +226,37 @@ function sessionSecret(env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_
 interface AccessIdentity {
   email?: string;
   subject?: string;
+}
+
+function trustedProxyIdentity(
+  request: Request,
+  env: Pick<Env, "CRABBOX_TRUSTED_USER_HEADER" | "CRABBOX_TRUSTED_USER_ORG">,
+): AuthContext | undefined {
+  const header = env.CRABBOX_TRUSTED_USER_HEADER?.trim();
+  if (!header || !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(header)) {
+    return undefined;
+  }
+  const owner = request.headers.get(header)?.trim();
+  if (!owner || owner.length > 320 || hasControlCharacter(owner)) {
+    return undefined;
+  }
+  return {
+    authorized: true,
+    admin: false,
+    auth: "proxy",
+    owner,
+    org: env.CRABBOX_TRUSTED_USER_ORG?.trim() || "unknown",
+  };
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
 }
 
 interface AccessJwtPayload {

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -16,6 +16,10 @@ export interface AuthContext {
   tokenExpiresAt?: string;
 }
 
+export interface AuthRequestContext {
+  trustedProxy?: boolean;
+}
+
 interface UserTokenPayload {
   typ: "crabbox-user";
   owner: string;
@@ -42,9 +46,10 @@ export async function authenticateRequest(
     | "CRABBOX_TRUSTED_USER_HEADER"
     | "CRABBOX_TRUSTED_USER_ORG"
   >,
+  context: AuthRequestContext = {},
 ): Promise<AuthContext | undefined> {
   const token = bearerToken(request);
-  const trustedIdentity = trustedProxyIdentity(request, env);
+  const trustedIdentity = context.trustedProxy ? trustedProxyIdentity(request, env) : undefined;
   const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
   if (env.CRABBOX_ADMIN_TOKEN && token === env.CRABBOX_ADMIN_TOKEN) {
     return {

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -53,6 +53,7 @@ const awsMacHostQuotaSpecs: Record<string, { quotaCode: string; quotaName: strin
   },
 };
 const snapshotDeleteBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
+const securityGroupVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
 
 export interface AWSMacHost {
   id: string;
@@ -171,6 +172,7 @@ type DescribedSSHIngressRule = SSHIngressRule & { description: string };
 
 interface AWSIngressOptions {
   reconcile?: "authoritative" | "additive";
+  allowEmpty?: boolean;
 }
 
 const sshIngressRangeFamilies = [
@@ -1205,61 +1207,118 @@ export class EC2SpotClient {
       group = items(record(existing["securityGroupInfo"])["item"])[0];
       groupID = asString(record(group)["groupId"]);
       if (!groupID) {
-        const created = await this.ec2(
-          "CreateSecurityGroup",
-          createSecurityGroupParams(name, vpcID),
-        );
-        groupID = asString(record(created)["groupId"]);
+        try {
+          const created = await this.ec2(
+            "CreateSecurityGroup",
+            createSecurityGroupParams(name, vpcID),
+          );
+          groupID = asString(record(created)["groupId"]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.includes("InvalidGroup.Duplicate")) {
+            throw error;
+          }
+          group = await this.waitForSecurityGroup(name, vpcID, error);
+          groupID = asString(record(group)["groupId"]);
+        }
       }
     }
     if (!groupID) {
       throw new Error("aws security group id is empty");
     }
-    const cidrs = awsSSHCIDRs(config, this.env);
+    const cidrs = awsSSHCIDRs(config, this.env, options.allowEmpty);
     const ports = sshPorts(config);
-    if (options.reconcile !== "additive") {
-      await this.pruneStaleSSHIngress(groupID, group, ports, cidrs);
-    }
-    let compactedAfterRuleLimit = false;
-    for (const port of ports) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- cleanup is per port.
-      await this.revokeWorldTCP(groupID, port).catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("InvalidPermission.NotFound")) {
-          throw error;
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        if (options.reconcile !== "additive") {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- the whole ingress pass retries only on group propagation.
+          await this.pruneStaleSSHIngress(groupID, group, ports, cidrs);
         }
-      });
-      for (const cidr of cidrs) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- duplicate ingress handling is per CIDR.
-        await this.allowTCP(groupID, port, cidr).catch((error: unknown) => {
-          const message = error instanceof Error ? error.message : String(error);
-          if (message.includes("InvalidPermission.Duplicate")) {
-            return;
-          }
-          if (
-            options.reconcile !== "additive" &&
-            !compactedAfterRuleLimit &&
-            isAWSSecurityGroupRuleLimitError(message)
-          ) {
-            compactedAfterRuleLimit = true;
-            return this.compactSSHIngressForRuleLimit(groupID, ports, cidrs).then((compacted) => {
-              if (!compacted) {
-                throw error;
+        let compactedAfterRuleLimit = false;
+        for (const port of ports) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- cleanup is per port.
+          await this.revokeWorldTCP(groupID, port).catch((error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            if (!message.includes("InvalidPermission.NotFound")) {
+              throw error;
+            }
+          });
+          for (const cidr of cidrs) {
+            // oxlint-disable-next-line eslint/no-await-in-loop -- duplicate ingress handling is per CIDR.
+            await this.allowTCP(groupID, port, cidr).catch((error: unknown) => {
+              const message = error instanceof Error ? error.message : String(error);
+              if (message.includes("InvalidPermission.Duplicate")) {
+                return;
               }
-              return this.allowTCP(groupID, port, cidr).catch((retryError: unknown) => {
-                const retryMessage =
-                  retryError instanceof Error ? retryError.message : String(retryError);
-                if (!retryMessage.includes("InvalidPermission.Duplicate")) {
-                  throw retryError;
-                }
-              });
+              if (
+                options.reconcile !== "additive" &&
+                !compactedAfterRuleLimit &&
+                isAWSSecurityGroupRuleLimitError(message)
+              ) {
+                compactedAfterRuleLimit = true;
+                return this.compactSSHIngressForRuleLimit(groupID, ports, cidrs).then(
+                  (compacted) => {
+                    if (!compacted) {
+                      throw error;
+                    }
+                    return this.allowTCP(groupID, port, cidr).catch((retryError: unknown) => {
+                      const retryMessage =
+                        retryError instanceof Error ? retryError.message : String(retryError);
+                      if (!retryMessage.includes("InvalidPermission.Duplicate")) {
+                        throw retryError;
+                      }
+                    });
+                  },
+                );
+              }
+              throw error;
             });
           }
+        }
+        return groupID;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const delay = securityGroupVisibilityBackoffMs[attempt];
+        if (delay === undefined || !message.includes("InvalidGroup.NotFound")) {
           throw error;
-        });
+        }
+        // oxlint-disable-next-line eslint/no-await-in-loop -- EC2 group propagation is eventually consistent.
+        await sleep(delay);
+        group = undefined;
       }
     }
-    return groupID;
+  }
+
+  private async waitForSecurityGroup(
+    name: string,
+    vpcID: string,
+    duplicateError: unknown,
+  ): Promise<unknown> {
+    for (const delay of [0, ...securityGroupVisibilityBackoffMs]) {
+      if (delay > 0) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- EC2 group discovery is eventually consistent.
+        await sleep(delay);
+      }
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each lookup follows the bounded backoff.
+        const raced = await this.ec2("DescribeSecurityGroups", {
+          "Filter.1.Name": "group-name",
+          "Filter.1.Value.1": name,
+          "Filter.2.Name": "vpc-id",
+          "Filter.2.Value.1": vpcID,
+        });
+        const group = items(record(raced["securityGroupInfo"])["item"])[0];
+        if (asString(record(group)["groupId"])) {
+          return group;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("InvalidGroup.NotFound")) {
+          throw error;
+        }
+      }
+    }
+    throw duplicateError;
   }
 
   private async discoverMacHostID(
@@ -1624,10 +1683,10 @@ export class EC2SpotClient {
   }
 }
 
-function awsSSHCIDRs(config: LeaseConfig, env: Env): string[] {
+function awsSSHCIDRs(config: LeaseConfig, env: Env, allowEmpty = false): string[] {
   const configured = [...config.awsSSHCIDRs, ...(env.CRABBOX_AWS_SSH_CIDRS ?? "").split(",")];
   const cidrs = validatedCIDRs(configured, "CRABBOX_AWS_SSH_CIDRS");
-  if (cidrs.length === 0) {
+  if (cidrs.length === 0 && !allowEmpty) {
     throw new Error(
       "AWS SSH source CIDR is required; set CRABBOX_AWS_SSH_CIDRS or use Cloudflare request IP forwarding",
     );
@@ -1972,7 +2031,7 @@ function isCrabboxManagedSecurityGroup(group: unknown): boolean {
   );
 }
 
-function isAWSSecurityGroupRuleLimitError(message: string): boolean {
+export function isAWSSecurityGroupRuleLimitError(message: string): boolean {
   return message.includes("RulesPerSecurityGroupLimitExceeded");
 }
 

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -3,38 +3,58 @@ import { json } from "./http";
 import type { Env } from "./types";
 
 export type CoordinatorFetch = (request: Request) => Promise<Response>;
+export type PreparedCoordinatorRequest =
+  | { response: Response; authenticated: false }
+  | { request: Request; authenticated: boolean };
 
 export async function routeCoordinatorRequest(
   request: Request,
   env: Env,
   fleetFetch: CoordinatorFetch,
 ): Promise<Response> {
+  const prepared = await prepareCoordinatorRequest(request, env);
+  if ("response" in prepared) {
+    return prepared.response;
+  }
+  return fleetFetch(prepared.request);
+}
+
+export async function prepareCoordinatorRequest(
+  request: Request,
+  env: Env,
+): Promise<PreparedCoordinatorRequest> {
   const url = new URL(request.url);
   if (request.method === "GET" && url.pathname === "/v1/health") {
-    return json({ ok: true, service: "crabbox-coordinator" });
+    return { response: json({ ok: true, service: "crabbox-coordinator" }), authenticated: false };
   }
   if (request.method === "GET" && url.pathname === "/") {
-    return new Response(null, { status: 302, headers: { location: "/portal" } });
+    return {
+      response: new Response(null, { status: 302, headers: { location: "/portal" } }),
+      authenticated: false,
+    };
   }
   const canonicalPortal = canonicalPortalRedirect(request, env, url);
   if (canonicalPortal) {
-    return canonicalPortal;
+    return { response: canonicalPortal, authenticated: false };
   }
   if (url.pathname.startsWith("/v1/auth/")) {
-    return fleetFetch(request);
+    return { request, authenticated: false };
   }
   if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
-    return fleetFetch(request);
+    return { request, authenticated: false };
   }
   if (url.pathname.startsWith("/v1/internal/")) {
-    return json({ error: "not_found" }, { status: 404 });
+    return {
+      response: json({ error: "not_found" }, { status: 404 }),
+      authenticated: false,
+    };
   }
   if (
     isWebVNCAgentUpgrade(request, url) ||
     isCodeAgentUpgrade(request, url) ||
     isEgressAgentUpgrade(request, url)
   ) {
-    return fleetFetch(request);
+    return { request, authenticated: false };
   }
   const portal = url.pathname.startsWith("/portal");
   const authRequest = portal ? requestWithPortalCookie(request) : request;
@@ -43,14 +63,20 @@ export async function routeCoordinatorRequest(
     if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
       const login = new URL("/portal/login", url.origin);
       login.searchParams.set("returnTo", `${url.pathname}${url.search}`);
-      return new Response(null, {
-        status: 302,
-        headers: { location: login.pathname + login.search },
-      });
+      return {
+        response: new Response(null, {
+          status: 302,
+          headers: { location: login.pathname + login.search },
+        }),
+        authenticated: false,
+      };
     }
-    return json({ error: "unauthorized" }, { status: 401 });
+    return {
+      response: json({ error: "unauthorized" }, { status: 401 }),
+      authenticated: false,
+    };
   }
-  return fleetFetch(requestWithAuthContext(authRequest, auth));
+  return { request: requestWithAuthContext(authRequest, auth), authenticated: true };
 }
 
 function isWebVNCAgentUpgrade(request: Request, url: URL): boolean {

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,4 +1,4 @@
-import { authenticateRequest, requestWithAuthContext } from "./auth";
+import { authenticateRequest, requestWithAuthContext, type AuthRequestContext } from "./auth";
 import { json } from "./http";
 import type { Env } from "./types";
 
@@ -11,8 +11,9 @@ export async function routeCoordinatorRequest(
   request: Request,
   env: Env,
   fleetFetch: CoordinatorFetch,
+  authContext: AuthRequestContext = {},
 ): Promise<Response> {
-  const prepared = await prepareCoordinatorRequest(request, env);
+  const prepared = await prepareCoordinatorRequest(request, env, authContext);
   if ("response" in prepared) {
     return prepared.response;
   }
@@ -22,6 +23,7 @@ export async function routeCoordinatorRequest(
 export async function prepareCoordinatorRequest(
   request: Request,
   env: Env,
+  authContext: AuthRequestContext = {},
 ): Promise<PreparedCoordinatorRequest> {
   const url = new URL(request.url);
   if (request.method === "GET" && url.pathname === "/v1/health") {
@@ -58,7 +60,7 @@ export async function prepareCoordinatorRequest(
   }
   const portal = url.pathname.startsWith("/portal");
   const authRequest = portal ? requestWithPortalCookie(request) : request;
-  const auth = await authenticateRequest(authRequest, env);
+  const auth = await authenticateRequest(authRequest, env, authContext);
   if (!auth?.authorized) {
     if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
       const login = new URL("/portal/login", url.origin);

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,0 +1,123 @@
+import { authenticateRequest, requestWithAuthContext } from "./auth";
+import { json } from "./http";
+import type { Env } from "./types";
+
+export type CoordinatorFetch = (request: Request) => Promise<Response>;
+
+export async function routeCoordinatorRequest(
+  request: Request,
+  env: Env,
+  fleetFetch: CoordinatorFetch,
+): Promise<Response> {
+  const url = new URL(request.url);
+  if (request.method === "GET" && url.pathname === "/v1/health") {
+    return json({ ok: true, service: "crabbox-coordinator" });
+  }
+  if (request.method === "GET" && url.pathname === "/") {
+    return new Response(null, { status: 302, headers: { location: "/portal" } });
+  }
+  const canonicalPortal = canonicalPortalRedirect(request, env, url);
+  if (canonicalPortal) {
+    return canonicalPortal;
+  }
+  if (url.pathname.startsWith("/v1/auth/")) {
+    return fleetFetch(request);
+  }
+  if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
+    return fleetFetch(request);
+  }
+  if (url.pathname.startsWith("/v1/internal/")) {
+    return json({ error: "not_found" }, { status: 404 });
+  }
+  if (
+    isWebVNCAgentUpgrade(request, url) ||
+    isCodeAgentUpgrade(request, url) ||
+    isEgressAgentUpgrade(request, url)
+  ) {
+    return fleetFetch(request);
+  }
+  const portal = url.pathname.startsWith("/portal");
+  const authRequest = portal ? requestWithPortalCookie(request) : request;
+  const auth = await authenticateRequest(authRequest, env);
+  if (!auth?.authorized) {
+    if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
+      const login = new URL("/portal/login", url.origin);
+      login.searchParams.set("returnTo", `${url.pathname}${url.search}`);
+      return new Response(null, {
+        status: 302,
+        headers: { location: login.pathname + login.search },
+      });
+    }
+    return json({ error: "unauthorized" }, { status: 401 });
+  }
+  return fleetFetch(requestWithAuthContext(authRequest, auth));
+}
+
+function isWebVNCAgentUpgrade(request: Request, url: URL): boolean {
+  return (
+    request.method === "GET" &&
+    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+    /^\/v1\/leases\/[^/]+\/webvnc\/agent$/.test(url.pathname)
+  );
+}
+
+function isCodeAgentUpgrade(request: Request, url: URL): boolean {
+  return (
+    request.method === "GET" &&
+    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+    /^\/v1\/leases\/[^/]+\/code\/agent$/.test(url.pathname)
+  );
+}
+
+function isEgressAgentUpgrade(request: Request, url: URL): boolean {
+  return (
+    request.method === "GET" &&
+    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+    /^\/v1\/leases\/[^/]+\/egress\/(?:host|client)$/.test(url.pathname)
+  );
+}
+
+function canonicalPortalRedirect(request: Request, env: Env, url: URL): Response | undefined {
+  if (
+    request.method !== "GET" ||
+    request.headers.get("upgrade")?.toLowerCase() === "websocket" ||
+    !url.pathname.startsWith("/portal") ||
+    !env.CRABBOX_PUBLIC_URL
+  ) {
+    return undefined;
+  }
+  let publicURL: URL;
+  try {
+    publicURL = new URL(env.CRABBOX_PUBLIC_URL);
+  } catch {
+    return undefined;
+  }
+  if (url.origin === publicURL.origin) {
+    return undefined;
+  }
+  const location = new URL(`${url.pathname}${url.search}`, publicURL.origin);
+  return new Response(null, { status: 302, headers: { location: location.toString() } });
+}
+
+function requestWithPortalCookie(request: Request): Request {
+  if (request.headers.get("authorization")) {
+    return request;
+  }
+  const token = cookieValue(request.headers.get("cookie") ?? "", "crabbox_session");
+  if (!token) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${token}`);
+  return new Request(request, { headers });
+}
+
+function cookieValue(header: string, name: string): string {
+  for (const part of header.split(";")) {
+    const [rawKey, ...rawValue] = part.trim().split("=");
+    if (rawKey === name) {
+      return decodeURIComponent(rawValue.join("="));
+    }
+  }
+  return "";
+}

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -5,6 +5,83 @@ export interface CoordinatorStorage {
   list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
 }
 
+export type CoordinatorRequestQueue = "direct" | "lifecycle";
+
+export function coordinatorRequestQueue(request: Request): CoordinatorRequestQueue {
+  const url = new URL(request.url);
+  const path = url.pathname.split("/").filter(Boolean);
+  const method = request.method.toUpperCase();
+  if (method === "POST" && path.join("/") === "v1/leases") {
+    return "direct";
+  }
+  if (method === "POST" && path.join("/") === "v1/internal/scheduled") {
+    return "direct";
+  }
+  if (path[0] === "v1" && path[1] === "ready-pools") {
+    return "direct";
+  }
+  if (path[0] === "v1" && path[1] === "images") {
+    return "direct";
+  }
+  if (path.join("/") === "v1/pool") {
+    return "direct";
+  }
+  if (path[0] === "v1" && path[1] === "providers" && path[3] === "readiness") {
+    return "direct";
+  }
+  if (
+    path[0] === "v1" &&
+    path[1] === "leases" &&
+    path[2] &&
+    method === "POST" &&
+    (path[3] === "heartbeat" || path[3] === "release")
+  ) {
+    return "direct";
+  }
+  if (
+    path[0] === "v1" &&
+    path[1] === "admin" &&
+    (path[2] === "lease-audit" ||
+      path[2] === "aws-identity" ||
+      path[2] === "providers" ||
+      path[2] === "hosts" ||
+      path[2] === "mac-hosts" ||
+      path[2] === "aws-orphan-sweep" ||
+      path[2] === "azure-orphan-sweep" ||
+      (path[2] === "leases" && method === "POST"))
+  ) {
+    return "direct";
+  }
+  if (
+    method === "POST" &&
+    path[0] === "portal" &&
+    path[1] === "leases" &&
+    path[2] &&
+    path[3] === "release"
+  ) {
+    return "direct";
+  }
+  if (
+    path[0] === "portal" &&
+    ((method === "GET" && (path.length === 1 || path[1] === "admin" || path[1] === "hosts")) ||
+      (method === "POST" && path[1] === "hosts" && path[4] === "vnc"))
+  ) {
+    return "direct";
+  }
+  if (path[0] === "portal" && path[1] === "leases" && path[2] && path[3] === "code") {
+    return "direct";
+  }
+  return "lifecycle";
+}
+
+export async function bufferCoordinatorRequestBody(request: Request): Promise<Request> {
+  if (request.method === "GET" || request.method === "HEAD" || request.body === null) {
+    return request;
+  }
+  const body = await request.arrayBuffer();
+  return new Request(request, { body, method: request.method });
+}
+
 export interface CoordinatorSocketHandlers {
   message(data: string | ArrayBuffer | Blob): Promise<void> | void;
   close(code: number, reason: string): void;
@@ -18,6 +95,7 @@ export interface CoordinatorWebSocketUpgrade {
 
 export interface CoordinatorRuntime {
   readonly storage: CoordinatorStorage;
+  runExclusive<T>(callback: () => Promise<T>): Promise<T>;
   createWebSocketUpgrade(): CoordinatorWebSocketUpgrade;
   getWebSockets(): Iterable<WebSocket>;
   socketAttachment<T>(socket: WebSocket): T | undefined;
@@ -35,9 +113,24 @@ export interface CoordinatorRuntime {
 export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
   readonly storage: CoordinatorStorage;
   private readonly attachments = new WeakMap<WebSocket, unknown>();
+  private exclusiveTail = Promise.resolve();
 
   constructor(private readonly state: DurableObjectState) {
     this.storage = state.storage;
+  }
+
+  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    const predecessor = this.exclusiveTail;
+    let release!: () => void;
+    this.exclusiveTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
   }
 
   createWebSocketUpgrade(): CoordinatorWebSocketUpgrade {
@@ -75,7 +168,7 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
     }
     socket.accept();
     socket.addEventListener("message", (event) => {
-      void handlers.message(event.data);
+      void this.runSocketOperation(attachment, () => handlers.message(event.data));
     });
     socket.addEventListener("close", (event) => {
       handlers.close(event.code, event.reason);
@@ -92,4 +185,19 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
   clearAlarm(): Promise<void> {
     return this.state.storage.deleteAlarm();
   }
+
+  private runSocketOperation<T>(attachment: unknown, callback: () => Promise<T> | T): Promise<T> {
+    const operation = async () => callback();
+    if (socketAttachmentKind(attachment) === "control") {
+      return this.runExclusive(operation);
+    }
+    return operation();
+  }
+}
+
+function socketAttachmentKind(attachment: unknown): string | undefined {
+  if (!attachment || typeof attachment !== "object" || !("kind" in attachment)) {
+    return undefined;
+  }
+  return String(attachment.kind);
 }

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -1,0 +1,95 @@
+export interface CoordinatorStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<unknown>;
+  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>;
+}
+
+export interface CoordinatorSocketHandlers {
+  message(data: string | ArrayBuffer | Blob): Promise<void> | void;
+  close(code: number, reason: string): void;
+  error(): void;
+}
+
+export interface CoordinatorWebSocketUpgrade {
+  socket: WebSocket;
+  response: Response;
+}
+
+export interface CoordinatorRuntime {
+  readonly storage: CoordinatorStorage;
+  createWebSocketUpgrade(): CoordinatorWebSocketUpgrade;
+  getWebSockets(): Iterable<WebSocket>;
+  socketAttachment<T>(socket: WebSocket): T | undefined;
+  setSocketAttachment(socket: WebSocket, attachment: unknown): void;
+  acceptWebSocket(
+    socket: WebSocket,
+    attachment: unknown,
+    tags: string[],
+    handlers: CoordinatorSocketHandlers,
+  ): void;
+  scheduleAlarm(time: number): Promise<void>;
+  clearAlarm(): Promise<void>;
+}
+
+export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
+  readonly storage: CoordinatorStorage;
+  private readonly attachments = new WeakMap<WebSocket, unknown>();
+
+  constructor(private readonly state: DurableObjectState) {
+    this.storage = state.storage;
+  }
+
+  createWebSocketUpgrade(): CoordinatorWebSocketUpgrade {
+    const pair = new WebSocketPair();
+    return {
+      socket: pair[1],
+      response: new Response(null, { status: 101, webSocket: pair[0] }),
+    };
+  }
+
+  getWebSockets(): Iterable<WebSocket> {
+    return this.state.getWebSockets?.() ?? [];
+  }
+
+  socketAttachment<T>(socket: WebSocket): T | undefined {
+    return (this.attachments.get(socket) ?? socket.deserializeAttachment?.()) as T | undefined;
+  }
+
+  setSocketAttachment(socket: WebSocket, attachment: unknown): void {
+    this.attachments.set(socket, attachment);
+    socket.serializeAttachment?.(attachment);
+  }
+
+  acceptWebSocket(
+    socket: WebSocket,
+    attachment: unknown,
+    tags: string[],
+    handlers: CoordinatorSocketHandlers,
+  ): void {
+    this.attachments.set(socket, attachment);
+    if (typeof this.state.acceptWebSocket === "function") {
+      this.state.acceptWebSocket(socket, tags);
+      socket.serializeAttachment(attachment);
+      return;
+    }
+    socket.accept();
+    socket.addEventListener("message", (event) => {
+      void handlers.message(event.data);
+    });
+    socket.addEventListener("close", (event) => {
+      handlers.close(event.code, event.reason);
+    });
+    socket.addEventListener("error", () => {
+      handlers.error();
+    });
+  }
+
+  scheduleAlarm(time: number): Promise<void> {
+    return this.state.storage.setAlarm(time);
+  }
+
+  clearAlarm(): Promise<void> {
+    return this.state.storage.deleteAlarm();
+  }
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -7,6 +7,7 @@ import {
   awsRegionCandidates,
   isAWSInstanceCleanedAfterReadinessFailure,
   isRetryableAWSProvisioningError,
+  isAWSSecurityGroupRuleLimitError,
   type AWSMacHost,
 } from "./aws";
 import { AzureClient, azureRegionCandidates, type AzureDeferredCleanupRequest } from "./azure";
@@ -20,8 +21,9 @@ import {
 } from "./config";
 import {
   CloudflareCoordinatorRuntime,
+  bufferCoordinatorRequestBody,
+  coordinatorRequestQueue,
   type CoordinatorRuntime,
-  type CoordinatorStorage,
 } from "./coordinator-runtime";
 import { GCPClient } from "./gcp";
 import { HetznerClient } from "./hetzner";
@@ -103,6 +105,7 @@ const webVNCTicketTTLSeconds = 120;
 const codeTicketTTLSeconds = 120;
 const egressTicketTTLSeconds = 120;
 const leaseCleanupRetryDelayMs = 5 * 60 * 1000;
+const leaseCleanupClaimStaleMs = 30 * 60 * 1000;
 const awsOrphanSweepInitialDelayMs = 60 * 1000;
 const azureOrphanSweepInitialDelayMs = 60 * 1000;
 const defaultAWSOrphanSweepIntervalSeconds = 60 * 60;
@@ -119,6 +122,7 @@ const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureOrphanSweepRecordKey = "azure-orphan-sweep:last";
 const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
+const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
 
@@ -283,6 +287,29 @@ interface AzureDeferredCleanupRecord extends AzureDeferredCleanupRequest {
   lastError?: string;
 }
 
+interface AWSIngressReconcileTarget {
+  anchor: LeaseRecord;
+  attempts: number;
+  generation: string;
+  updatedAt: string;
+  retryAt: string;
+  lastError?: string;
+}
+
+interface AWSIngressReconcileRecord {
+  targets: AWSIngressReconcileTarget[];
+}
+
+interface LegacyAWSIngressReconcileRecord {
+  anchor: LeaseRecord;
+  attempts: number;
+  updatedAt: string;
+  retryAt: string;
+  lastError?: string;
+}
+
+type StoredAWSIngressReconcileRecord = AWSIngressReconcileRecord | LegacyAWSIngressReconcileRecord;
+
 interface CloudOrphanSweepCandidate {
   region: string;
   cloudID: string;
@@ -413,6 +440,9 @@ export class FleetCoordinator {
   private readonly egressSessions = new Map<string, EgressSessionStatus>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
+  private awsIngressBarrier: Promise<void> = Promise.resolve();
+  private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
+  private providerMaintenanceQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly state: CoordinatorRuntime,
@@ -888,6 +918,15 @@ export class FleetCoordinator {
       sendControl(socket, { type: "heartbeat", leaseID, ok: false, error: "not_found" });
       return;
     }
+    if (lease.cleanupStartedAt) {
+      sendControl(socket, {
+        type: "heartbeat",
+        leaseID: lease.id,
+        ok: false,
+        error: "cleanup_in_progress",
+      });
+      return;
+    }
     const heartbeat: { idleTimeoutSeconds?: number; telemetry?: Partial<LeaseTelemetry> } = {};
     if (input.idleTimeoutSeconds !== undefined) {
       heartbeat.idleTimeoutSeconds = input.idleTimeoutSeconds;
@@ -895,12 +934,12 @@ export class FleetCoordinator {
     if (input.telemetry !== undefined) {
       heartbeat.telemetry = input.telemetry;
     }
-    await this.applyLeaseHeartbeat(lease, heartbeat);
+    const updated = await this.applyLeaseHeartbeatState(lease, heartbeat);
     sendControl(socket, {
       type: "heartbeat",
       leaseID: lease.id,
       ok: true,
-      expiresAt: lease.expiresAt,
+      expiresAt: updated.expiresAt,
     });
   }
 
@@ -1001,23 +1040,20 @@ export class FleetCoordinator {
   }
 
   async alarm(): Promise<void> {
-    await this.runMaintenance();
+    await this.expireLeases();
+    await this.runAzureDeferredCleanups();
+    await this.runAWSOrphanSweepIfDue("alarm");
+    await this.runAzureOrphanSweepIfDue("alarm");
+    await this.reconcileAWSIngressIfIdle();
+    await this.state.runExclusive(() => this.scheduleAlarm());
   }
 
   private async scheduledMaintenance(request: Request): Promise<Response> {
     if (request.headers.get("x-crabbox-internal") !== "scheduled") {
       return json({ error: "unauthorized" }, { status: 401 });
     }
-    await this.runMaintenance();
+    await this.alarm();
     return json({ ok: true });
-  }
-
-  private async runMaintenance(): Promise<void> {
-    await this.expireLeases();
-    await this.runAzureDeferredCleanups();
-    await this.runAWSOrphanSweepIfDue("alarm");
-    await this.runAzureOrphanSweepIfDue("alarm");
-    await this.scheduleAlarm();
   }
 
   private async createLease(request: Request): Promise<Response> {
@@ -1062,19 +1098,6 @@ export class FleetCoordinator {
       );
     }
     const leaseID = validLeaseID(input.leaseID) ? input.leaseID : newLeaseID();
-    const leases = await this.leaseRecords();
-    const slug = allocateLeaseSlug(
-      normalizeLeaseSlug(input.slug ?? input.requestedSlug) || leaseSlugFromID(leaseID),
-      leaseID,
-      owner,
-      org,
-      leases,
-    );
-    const providerAccessLeases = await this.providerAccessRecords();
-    const tailscaleError = await this.prepareTailscaleConfig(config, input, leaseID, slug);
-    if (tailscaleError) {
-      return tailscaleError;
-    }
     const provider = this.provider(
       config.provider,
       providerRegionForConfig(config),
@@ -1090,132 +1113,273 @@ export class FleetCoordinator {
       config.ttlSeconds,
       providerHourlyUSD,
     );
-    const now = new Date();
-    const providerProject = providerProjectForConfig(config);
-    const providerRegion = ["aws", "azure", "gcp"].includes(config.provider)
-      ? providerRegionForConfig(config)
-      : undefined;
-    let record: LeaseRecord = {
-      id: leaseID,
-      slug,
-      provider: config.provider,
-      target: config.target,
-      os: config.os,
-      desktop: config.desktop,
-      desktopEnv: config.desktopEnv,
-      browser: config.browser,
-      code: config.code,
-      cloudID: "",
-      owner,
-      org,
-      profile: config.profile,
-      class: config.class,
-      serverType: config.serverType,
-      requestedServerType: config.serverType,
-      serverID: 0,
-      serverName: "",
-      providerKey: config.providerKey,
-      host: "",
-      sshUser: config.sshUser,
-      sshPort: config.sshPort,
-      sshFallbackPorts: config.sshFallbackPorts,
-      workRoot: config.workRoot,
-      keep: config.keep,
-      ttlSeconds: config.ttlSeconds,
-      idleTimeoutSeconds: config.idleTimeoutSeconds,
-      estimatedHourlyUSD: cost.hourlyUSD,
-      maxEstimatedUSD: cost.maxUSD,
-      state: "provisioning",
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-      lastTouchedAt: now.toISOString(),
-      expiresAt: leaseExpiresAt(
-        now,
-        now,
-        config.ttlSeconds,
-        config.idleTimeoutSeconds,
-      ).toISOString(),
-    };
-    if (providerProject) {
-      record.providerProject = providerProject;
-    }
-    if (providerRegion) {
-      record.region = providerRegion;
-    }
-    const requestedHostID = config.hostID || config.awsMacHostID;
-    if (requestedHostID) {
-      record.hostId = requestedHostID;
-    }
-    if (config.target === "windows") {
-      record.windowsMode = config.windowsMode;
-    }
-    if (config.pond) {
-      record.pond = config.pond;
-    }
-    if (config.exposedPorts.length > 0) {
-      record.exposedPorts = config.exposedPorts;
-    }
-    if (config.tailscale) {
-      record.tailscale = {
-        enabled: true,
-        hostname: config.tailscaleHostname,
-        tags: config.tailscaleTags,
-        state: "requested",
-      };
-      if (config.tailscaleExitNode) {
-        record.tailscale.exitNode = config.tailscaleExitNode;
-        record.tailscale.exitNodeAllowLanAccess = config.tailscaleExitNodeAllowLanAccess;
+    const reservation = await this.state.runExclusive(async () => {
+      const leases = await this.leaseRecords();
+      if (leases.some((lease) => lease.id === leaseID)) {
+        return json(
+          { error: "lease_id_conflict", message: "lease id already exists" },
+          { status: 409 },
+        );
       }
+      const slug = allocateLeaseSlug(
+        normalizeLeaseSlug(input.slug ?? input.requestedSlug) || leaseSlugFromID(leaseID),
+        leaseID,
+        owner,
+        org,
+        leases,
+      );
+      const providerAccessLeases = await this.providerAccessRecords();
+      const now = new Date();
+      const providerProject = providerProjectForConfig(config);
+      const providerRegion = ["aws", "azure", "gcp"].includes(config.provider)
+        ? providerRegionForConfig(config)
+        : undefined;
+      let record: LeaseRecord = {
+        id: leaseID,
+        slug,
+        provider: config.provider,
+        target: config.target,
+        os: config.os,
+        desktop: config.desktop,
+        desktopEnv: config.desktopEnv,
+        browser: config.browser,
+        code: config.code,
+        cloudID: "",
+        owner,
+        org,
+        profile: config.profile,
+        class: config.class,
+        serverType: config.serverType,
+        requestedServerType: config.serverType,
+        serverID: 0,
+        serverName: "",
+        providerKey: config.providerKey,
+        host: "",
+        sshUser: config.sshUser,
+        sshPort: config.sshPort,
+        sshFallbackPorts: config.sshFallbackPorts,
+        workRoot: config.workRoot,
+        keep: config.keep,
+        ttlSeconds: config.ttlSeconds,
+        idleTimeoutSeconds: config.idleTimeoutSeconds,
+        estimatedHourlyUSD: cost.hourlyUSD,
+        maxEstimatedUSD: cost.maxUSD,
+        state: "provisioning",
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+        lastTouchedAt: now.toISOString(),
+        expiresAt: leaseExpiresAt(
+          now,
+          now,
+          config.ttlSeconds,
+          config.idleTimeoutSeconds,
+        ).toISOString(),
+      };
+      if (providerProject) {
+        record.providerProject = providerProject;
+      }
+      if (providerRegion) {
+        record.region = providerRegion;
+      }
+      const requestedHostID = config.hostID || config.awsMacHostID;
+      if (requestedHostID) {
+        record.hostId = requestedHostID;
+      }
+      if (config.target === "windows") {
+        record.windowsMode = config.windowsMode;
+      }
+      if (config.pond) {
+        record.pond = config.pond;
+      }
+      if (config.exposedPorts.length > 0) {
+        record.exposedPorts = config.exposedPorts;
+      }
+      if (config.tailscale) {
+        record.tailscale = {
+          enabled: true,
+          state: "requested",
+        };
+      }
+      const limitError = enforceCostLimits(
+        mergeProviderAccessState(leases, providerAccessLeases),
+        record,
+        costLimits(this.env),
+        now,
+      );
+      if (limitError) {
+        return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
+      }
+      await this.putLease(record);
+      await this.scheduleAlarm();
+      return { record, slug };
+    });
+    if (reservation instanceof Response) {
+      return reservation;
     }
-    const limitError = enforceCostLimits(
-      [...leases, ...providerAccessLeases],
-      record,
-      costLimits(this.env),
-      now,
-    );
-    if (limitError) {
-      return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
+    let { record } = reservation;
+    const { slug } = reservation;
+    const tailscaleError = await this.prepareTailscaleConfig(config, input, leaseID, slug);
+    if (tailscaleError) {
+      await this.cancelLeaseReservation(record);
+      await this.removeReleasedLeaseReservation(record);
+      return tailscaleError;
     }
-    const accessContext = providerAccessContext(requestSourceCIDRs(request), [
-      ...leases,
-      ...providerAccessLeases,
-    ]);
-    const prepared = await provider.prepareLeaseCreate?.(config, record, accessContext);
-    if (prepared) {
-      config = prepared.config;
-      record = prepared.lease;
-    }
-    if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
-      await this.putProviderAccess(providerAccessReservation(record, now));
-    }
-    await this.putLease(record);
-    await this.scheduleAlarm();
-    const { server, serverType, market, attempts } = await provider
-      .createServerWithFallback(config, leaseID, slug, owner, prepared?.provisioning)
-      .catch(async (error: unknown) => {
+    record = withRequestedTailscaleMetadata(record, config);
+    let preparation:
+      | {
+          committed: false;
+          current: LeaseRecord | undefined;
+        }
+      | {
+          committed: true;
+          config: LeaseConfig;
+          prepared: ProviderLeaseCreatePreparation | undefined;
+          record: LeaseRecord;
+        };
+    try {
+      preparation = await this.state.runExclusive(async () => {
+        const latest = await this.getLease(record.id);
+        if (!latest || latest.state !== "provisioning") {
+          return { committed: false as const, current: latest };
+        }
+        const leases = await this.leaseRecords();
+        const providerAccessLeases = await this.providerAccessRecords();
+        const accessContext = providerAccessContext(
+          requestSourceCIDRs(request),
+          mergeProviderAccessState(leases, providerAccessLeases),
+        );
+        const prepared = await provider.prepareLeaseCreate?.(config, record, accessContext);
+        const preparedConfig = prepared?.config ?? config;
+        const preparedRecord = prepared?.lease ?? record;
+        const committedRecord = applyLeaseRecordChanges(latest, reservation.record, preparedRecord);
         if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
-          await this.deleteProviderAccess(record.id);
+          await this.putProviderAccess(providerAccessReservation(committedRecord, new Date()));
         }
-        const current = await this.getLease(record.id);
-        if (!current || current.state !== "provisioning") {
-          await this.scheduleAlarm();
-          throw error;
+        await this.putLease(committedRecord);
+        if (
+          committedRecord.provider === "aws" &&
+          prepared?.provisioning?.sshIngressReconcile === "additive"
+        ) {
+          await this.markAWSIngressReconcilePending(committedRecord);
         }
-        const failedAt = new Date().toISOString();
-        record = { ...current };
-        record.state = "failed";
-        record.updatedAt = failedAt;
-        record.endedAt = failedAt;
-        record.cleanupFailedAt = failedAt;
-        record.cleanupError = errorMessage(error);
-        await this.putLease(record);
         await this.scheduleAlarm();
-        throw error;
+        return {
+          committed: true as const,
+          config: preparedConfig,
+          prepared,
+          record: committedRecord,
+        };
       });
+    } catch (error) {
+      await this.cancelLeaseReservation(record);
+      await this.removeReleasedLeaseReservation(record);
+      throw error;
+    }
+    if (!preparation.committed) {
+      const current = await this.removeReleasedLeaseReservation(record);
+      return json(
+        {
+          error: "lease_state_changed",
+          message: "lease changed state while provider preparation was in progress",
+          lease: current,
+        },
+        { status: 409 },
+      );
+    }
+    config = preparation.config;
+    const { prepared } = preparation;
+    record = preparation.record;
+    let lastProvisioningTarget: ProviderProvisioningTarget | undefined;
+    const provisioning = prepared?.provisioning
+      ? {
+          ...prepared.provisioning,
+          onTargetAttempt: async (target: ProviderProvisioningTarget) => {
+            lastProvisioningTarget = { ...target };
+            await prepared.provisioning?.onTargetAttempt?.(target);
+            const region = target.region;
+            if (record.provider !== "aws" || !region) {
+              return;
+            }
+            await this.state.runExclusive(async () => {
+              const current = (await this.getLease(record.id)) ?? record;
+              await this.markAWSIngressReconcilePending({ ...current, region });
+              await this.scheduleAlarm();
+            });
+          },
+        }
+      : undefined;
+    const provision = () =>
+      provider.createServerWithFallback(config, leaseID, slug, owner, provisioning);
+    const provisioned =
+      config.provider !== "aws"
+        ? provision()
+        : prepared?.provisioning?.sshIngressReconcile === "additive"
+          ? this.withAWSIngressAdditiveOperation(provision).catch(async (error: unknown) => {
+              if (!isAWSSecurityGroupRuleLimitError(errorMessage(error))) {
+                throw error;
+              }
+              return await this.withAWSIngressOperationLock(async () => {
+                const recovery = await this.state.runExclusive(async () => {
+                  const current = await this.getLease(record.id);
+                  if (!current || current.state !== "provisioning") {
+                    return undefined;
+                  }
+                  const leases = await this.leaseRecords();
+                  const providerAccessLeases = await this.providerAccessRecords();
+                  const recoveryRegion = lastProvisioningTarget?.region;
+                  const recoveryLease = recoveryRegion
+                    ? { ...current, region: recoveryRegion }
+                    : current;
+                  return {
+                    current: structuredClone(recoveryLease),
+                    accessState: structuredClone(
+                      replaceProviderAccessState(
+                        mergeProviderAccessState(leases, providerAccessLeases),
+                        recoveryLease,
+                      ),
+                    ),
+                  };
+                });
+                if (!recovery) {
+                  throw error;
+                }
+                await provider.reconcileLeaseAccess?.(
+                  recovery.current,
+                  providerAccessContext([], recovery.accessState),
+                );
+                return await provision();
+              });
+            })
+          : this.withAWSIngressOperationLock(provision);
+    const { server, serverType, market, attempts } = await provisioned.catch(
+      async (error: unknown) => {
+        await this.state.runExclusive(async () => {
+          if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
+            await this.deleteProviderAccess(record.id);
+          }
+          const current = await this.getLease(record.id);
+          if (!current || current.state !== "provisioning") {
+            await this.markAWSIngressReconcilePending(record);
+            await this.scheduleAlarm();
+            return;
+          }
+          const failedAt = new Date().toISOString();
+          record = { ...current };
+          record.state = "failed";
+          record.updatedAt = failedAt;
+          record.endedAt = failedAt;
+          record.cleanupFailedAt = failedAt;
+          record.cleanupError = errorMessage(error);
+          await this.putLease(record);
+          await this.markAWSIngressReconcilePending(record);
+          await this.scheduleAlarm();
+        });
+        throw error;
+      },
+    );
     let current = await this.getLease(record.id);
     if (!current || current.state !== "provisioning") {
       return this.abortProvisionedLeaseAfterStateChange(
-        current,
         record,
         config,
         server,
@@ -1223,7 +1387,8 @@ export class FleetCoordinator {
         Boolean(prepared?.provisioning?.publishAccessBeforeProvisioning),
       );
     }
-    record = { ...current };
+    const finalizationBase = structuredClone(current);
+    record = structuredClone(current);
     record.state = "active";
     record.cloudID = server.cloudID;
     record.serverType = serverType;
@@ -1256,10 +1421,22 @@ export class FleetCoordinator {
     );
     record.estimatedHourlyUSD = finalCost.hourlyUSD;
     record.maxEstimatedUSD = finalCost.maxUSD;
-    current = await this.getLease(record.id);
-    if (!current || current.state !== "provisioning") {
+    const finalization = await this.state.runExclusive(async () => {
+      const latest = await this.getLease(record.id);
+      if (!latest || latest.state !== "provisioning") {
+        return { committed: false as const, current: latest };
+      }
+      const committedRecord = applyLeaseRecordChanges(latest, finalizationBase, record);
+      await this.putLease(committedRecord);
+      if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
+        await this.deleteProviderAccess(committedRecord.id);
+      }
+      await this.markAWSIngressReconcilePending(committedRecord);
+      await this.scheduleAlarm();
+      return { committed: true as const, record: committedRecord };
+    });
+    if (!finalization.committed) {
       return this.abortProvisionedLeaseAfterStateChange(
-        current,
         record,
         config,
         server,
@@ -1267,12 +1444,7 @@ export class FleetCoordinator {
         Boolean(prepared?.provisioning?.publishAccessBeforeProvisioning),
       );
     }
-    record = { ...current, ...record };
-    await this.putLease(record);
-    if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
-      await this.deleteProviderAccess(record.id);
-    }
-    await this.scheduleAlarm();
+    record = finalization.record;
     return json({ lease: record }, { status: 201 });
   }
 
@@ -1286,23 +1458,7 @@ export class FleetCoordinator {
       return lease ? json({ lease }) : notFound();
     }
     if (method === "POST" && action === "heartbeat") {
-      const admin = isAdminRequest(request);
-      const lease = await this.resolveLease(leaseID, request, admin);
-      if (!lease) {
-        return notFound();
-      }
-      if (!this.leaseManageableByRequest(lease, request, admin)) {
-        return json(
-          { error: "forbidden", message: "lease manage access required" },
-          { status: 403 },
-        );
-      }
-      const body = await optionalJson<{
-        idleTimeoutSeconds?: number;
-        telemetry?: Partial<LeaseTelemetry>;
-      }>(request);
-      const updatedLease = await this.applyLeaseHeartbeat(lease, body, request);
-      return json({ lease: updatedLease });
+      return this.heartbeatLease(request, leaseID);
     }
     if (method === "POST" && action === "tailscale") {
       const admin = isAdminRequest(request);
@@ -1453,13 +1609,96 @@ export class FleetCoordinator {
     return json({ lease: record }, { status: existing ? 200 : 201 });
   }
 
-  private async applyLeaseHeartbeat(
+  private async heartbeatLease(request: Request, leaseID: string): Promise<Response> {
+    const input = await optionalJson<{
+      idleTimeoutSeconds?: number;
+      telemetry?: Partial<LeaseTelemetry>;
+    }>(request);
+    const requestCIDRs = requestSourceCIDRs(request);
+    const committed = await this.state.runExclusive(async () => {
+      const admin = isAdminRequest(request);
+      const lease = await this.resolveLease(leaseID, request, admin);
+      if (!lease) {
+        return notFound();
+      }
+      if (!this.leaseManageableByRequest(lease, request, admin)) {
+        return json(
+          { error: "forbidden", message: "lease manage access required" },
+          { status: 403 },
+        );
+      }
+      if (lease.cleanupStartedAt) {
+        return json(
+          { error: "cleanup_in_progress", message: "lease cleanup has already started" },
+          { status: 409 },
+        );
+      }
+      return structuredClone(await this.applyLeaseHeartbeatState(lease, input));
+    });
+    if (committed instanceof Response) {
+      return committed;
+    }
+    const managedProvider = managedLeaseProvider(committed);
+    if (requestCIDRs.length === 0 || !managedProvider) {
+      return json({ lease: committed });
+    }
+
+    const refresh = async (): Promise<LeaseRecord> => {
+      const snapshot = await this.state.runExclusive(async () => {
+        const latest = await this.getLease(committed.id);
+        if (!latest || latest.state !== "active" || latest.cleanupStartedAt) {
+          return undefined;
+        }
+        const leases = await this.leaseRecords();
+        const providerAccessLeases = await this.providerAccessRecords();
+        return {
+          lease: structuredClone(latest),
+          context: providerAccessContext(
+            requestCIDRs,
+            replaceProviderAccessState(
+              mergeProviderAccessState(leases, providerAccessLeases),
+              latest,
+            ),
+          ),
+        };
+      });
+      if (!snapshot) {
+        return (await this.getLease(committed.id)) ?? committed;
+      }
+      const provider = this.provider(
+        managedProvider,
+        snapshot.lease.region,
+        snapshot.lease.providerProject,
+      );
+      const refreshed = await provider.refreshLeaseAccess?.(snapshot.lease, snapshot.context);
+      if (!refreshed) {
+        return snapshot.lease;
+      }
+      return await this.state.runExclusive(async () => {
+        const latest = await this.getLease(committed.id);
+        if (!latest || latest.state !== "active" || latest.cleanupStartedAt) {
+          return latest ?? snapshot.lease;
+        }
+        const merged = applyLeaseRecordChanges(latest, snapshot.lease, refreshed);
+        await this.putLease(merged);
+        if (managedProvider === "aws") {
+          await this.markAWSIngressReconcilePending(merged);
+        }
+        await this.scheduleAlarm();
+        return merged;
+      });
+    };
+    const lease =
+      managedProvider === "aws" ? await this.withAWSIngressOperationLock(refresh) : await refresh();
+    return json({ lease });
+  }
+
+  private async applyLeaseHeartbeatState(
     lease: LeaseRecord,
     input: {
       idleTimeoutSeconds?: number;
       telemetry?: Partial<LeaseTelemetry>;
     },
-    request?: Request,
   ): Promise<LeaseRecord> {
     const now = new Date();
     const requestedIdleTimeoutSeconds = input.idleTimeoutSeconds;
@@ -1479,20 +1718,6 @@ export class FleetCoordinator {
     lease.lastTouchedAt = now.toISOString();
     lease.expiresAt = recomputeLeaseExpiresAt(lease, now).toISOString();
     clearLeaseCleanupMetadata(lease);
-    const requestCIDRs = request ? requestSourceCIDRs(request) : [];
-    const managedProvider = managedLeaseProvider(lease);
-    if (requestCIDRs.length > 0 && managedProvider) {
-      const provider = this.provider(managedProvider, lease.region, lease.providerProject);
-      const leases = await this.leaseRecords();
-      const accessContext = providerAccessContext(
-        requestCIDRs,
-        replaceProviderAccessState([...leases, ...(await this.providerAccessRecords())], lease),
-      );
-      const updatedLease = await provider.refreshLeaseAccess?.(lease, accessContext);
-      if (updatedLease) {
-        lease = updatedLease;
-      }
-    }
     await this.putLease(lease);
     await this.scheduleAlarm();
     return lease;
@@ -1565,7 +1790,32 @@ export class FleetCoordinator {
     }
     const body = await optionalJson<{ delete?: boolean }>(request);
     const shouldDelete = body.delete ?? !lease.keep;
-    return json({ lease: await this.releaseResolvedLease(lease, { deleteServer: shouldDelete }) });
+    if (lease.cleanupStartedAt) {
+      if (!shouldDelete) {
+        return json(
+          {
+            error: "cleanup_in_progress",
+            message: "lease cleanup has already started",
+            lease,
+          },
+          { status: 409 },
+        );
+      }
+      await this.scheduleAlarm();
+      return json({ lease });
+    }
+    const released = await this.releaseResolvedLease(lease, { deleteServer: shouldDelete });
+    if (released.cleanupStartedAt && !shouldDelete) {
+      return json(
+        {
+          error: "cleanup_in_progress",
+          message: "lease cleanup has already started",
+          lease: released,
+        },
+        { status: 409 },
+      );
+    }
+    return json({ lease: released });
   }
 
   private async shareLeaseRoute(request: Request, leaseID: string): Promise<Response> {
@@ -2134,18 +2384,31 @@ export class FleetCoordinator {
         409,
       );
     }
-    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
-      return portalError("WebVNC unavailable", "Lease manage access is required.", 403);
-    }
-    if (lease.target !== "macos") {
-      return portalError("WebVNC unavailable", "Only macOS host leases can be enabled here.", 409);
-    }
-    lease.desktop = true;
-    lease.updatedAt = new Date().toISOString();
-    await this.putLease(lease);
-    return new Response(null, {
-      status: 303,
-      headers: { location: `/portal/leases/${encodeURIComponent(lease.id)}/vnc` },
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (!current || current.state !== "active" || leaseHostID(current) !== hostID) {
+        return portalError(
+          "WebVNC unavailable",
+          "No active Crabbox lease is attached to that dedicated host. Start a host-pinned desktop lease from the CLI, then open WebVNC for the new lease.",
+          409,
+        );
+      }
+      if (!this.leaseManageableByRequest(current, request, isAdminRequest(request))) {
+        return portalError("WebVNC unavailable", "Lease manage access is required.", 403);
+      }
+      if (current.target !== "macos") {
+        return portalError(
+          "WebVNC unavailable",
+          "Only macOS host leases can be enabled here.",
+          409,
+        );
+      }
+      const updated = { ...current, desktop: true, updatedAt: new Date().toISOString() };
+      await this.putLease(updated);
+      return new Response(null, {
+        status: 303,
+        headers: { location: `/portal/leases/${encodeURIComponent(updated.id)}/vnc` },
+      });
     });
   }
 
@@ -3473,33 +3736,31 @@ export class FleetCoordinator {
   }
 
   private async readyPoolStatus(key: string, request: Request): Promise<ReadyPoolEntry[]> {
-    const entries = (await this.visibleReadyPoolEntries(request)).filter(
-      (entry) => entry.key === key,
+    return await this.withReadyPoolBorrowLock(() =>
+      this.state.runExclusive(() => this.readyPoolStatusSnapshot(request, key)),
     );
-    await this.markStaleReadyPoolEntries(
-      entries,
-      new Map((await this.leaseRecords()).map((lease) => [lease.id, lease])),
-      Date.now(),
-    );
-    return (await this.visibleReadyPoolEntries(request)).filter((entry) => entry.key === key);
   }
 
   private async allReadyPoolStatus(request: Request): Promise<ReadyPoolEntry[]> {
-    const entries = await this.visibleReadyPoolEntries(request);
-    await this.markStaleReadyPoolEntries(
-      entries,
-      new Map((await this.leaseRecords()).map((lease) => [lease.id, lease])),
-      Date.now(),
+    return await this.withReadyPoolBorrowLock(() =>
+      this.state.runExclusive(() => this.readyPoolStatusSnapshot(request)),
     );
-    return await this.visibleReadyPoolEntries(request);
   }
 
-  private async visibleReadyPoolEntries(request: Request): Promise<ReadyPoolEntry[]> {
+  private async readyPoolStatusSnapshot(request: Request, key?: string): Promise<ReadyPoolEntry[]> {
     const entries = await this.readyPoolEntries();
     const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
-    return entries
-      .filter((entry) =>
+    const visible = entries.filter(
+      (entry) =>
+        (!key || entry.key === key) &&
         this.readyPoolEntryVisibleToRequest(entry, request, leases.get(entry.leaseID)),
+    );
+    await this.markStaleReadyPoolEntries(visible, leases, Date.now());
+    return (await this.readyPoolEntries())
+      .filter(
+        (entry) =>
+          (!key || entry.key === key) &&
+          this.readyPoolEntryVisibleToRequest(entry, request, leases.get(entry.leaseID)),
       )
       .map((entry) => redactReadyPoolEntry(entry))
       .toSorted((a, b) => a.key.localeCompare(b.key) || a.leaseID.localeCompare(b.leaseID));
@@ -3584,74 +3845,62 @@ export class FleetCoordinator {
   private async borrowReadyPoolLease(request: Request, key: string): Promise<Response> {
     const input = await readJson<ReadyPoolBorrowRequest>(request);
     return await this.withReadyPoolBorrowLock(async () => {
-      const entries = (await this.readyPoolStatus(key, request)).filter((entry) =>
-        readyPoolEntryMatches(entry, input),
-      );
-      const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
-      const nowMs = Date.now();
-      const candidates: Array<{ entry: ReadyPoolEntry; lease: LeaseRecord }> = [];
-      let blockedByManageAccess = false;
-      for (const entry of entries) {
-        const lease = leases.get(entry.leaseID);
-        if (
-          lease &&
-          entry.state === "ready" &&
-          lease.state === "active" &&
-          Date.parse(lease.expiresAt) > nowMs
-        ) {
-          if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
-            blockedByManageAccess = true;
-            continue;
+      return await this.state.runExclusive(async () => {
+        const entries = (await this.readyPoolStatusSnapshot(request, key)).filter((entry) =>
+          readyPoolEntryMatches(entry, input),
+        );
+        const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
+        const nowMs = Date.now();
+        const candidates: Array<{ entry: ReadyPoolEntry; lease: LeaseRecord }> = [];
+        let blockedByManageAccess = false;
+        for (const entry of entries) {
+          const lease = leases.get(entry.leaseID);
+          if (
+            lease &&
+            entry.state === "ready" &&
+            lease.state === "active" &&
+            Date.parse(lease.expiresAt) > nowMs
+          ) {
+            if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+              blockedByManageAccess = true;
+              continue;
+            }
+            candidates.push({ entry, lease });
           }
-          candidates.push({ entry, lease });
         }
-      }
-      const ready = candidates.toSorted(
-        (a, b) =>
-          Date.parse(a.entry.lastReadyAt ?? a.entry.createdAt) -
-          Date.parse(b.entry.lastReadyAt ?? b.entry.createdAt),
-      );
-      if (ready.length === 0) {
-        await this.markStaleReadyPoolEntries(entries, leases, nowMs);
-        if (blockedByManageAccess) {
+        const ready = candidates.toSorted(
+          (a, b) =>
+            Date.parse(a.entry.lastReadyAt ?? a.entry.createdAt) -
+            Date.parse(b.entry.lastReadyAt ?? b.entry.createdAt),
+        );
+        const first = ready[0];
+        if (!first) {
+          if (blockedByManageAccess) {
+            return json(
+              { error: "forbidden", message: "lease manage access required" },
+              { status: 403 },
+            );
+          }
           return json(
-            { error: "forbidden", message: "lease manage access required" },
-            { status: 403 },
+            { error: "no_ready_lease", message: "no matching ready lease in pool" },
+            { status: 409 },
           );
         }
-        return json(
-          { error: "no_ready_lease", message: "no matching ready lease in pool" },
-          { status: 409 },
-        );
-      }
-      const first = ready[0];
-      if (!first) {
-        await this.markStaleReadyPoolEntries(entries, leases, nowMs);
-        if (blockedByManageAccess) {
-          return json(
-            { error: "forbidden", message: "lease manage access required" },
-            { status: 403 },
-          );
-        }
-        return json(
-          { error: "no_ready_lease", message: "no matching ready lease in pool" },
-          { status: 409 },
-        );
-      }
-      const { entry, lease } = first;
-      const now = new Date().toISOString();
-      const borrowed: ReadyPoolEntry = {
-        ...entry,
-        state: "busy",
-        borrowedBy: requestOwner(request),
-        borrowedAt: now,
-        borrowToken: crypto.randomUUID(),
-        lastUsedAt: now,
-        updatedAt: now,
-        expiresAt: lease.expiresAt,
-      };
-      await this.putReadyPoolEntry(borrowed);
-      return json({ entry: borrowed, lease });
+        const { entry, lease } = first;
+        const now = new Date().toISOString();
+        const borrowed: ReadyPoolEntry = {
+          ...entry,
+          state: "busy",
+          borrowedBy: requestOwner(request),
+          borrowedAt: now,
+          borrowToken: crypto.randomUUID(),
+          lastUsedAt: now,
+          updatedAt: now,
+          expiresAt: lease.expiresAt,
+        };
+        await this.putReadyPoolEntry(borrowed);
+        return json({ entry: borrowed, lease });
+      });
     });
   }
 
@@ -4060,8 +4309,8 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
-    const sweep = await this.runAWSOrphanSweep("admin", config);
-    await this.scheduleAlarm();
+    const sweep = await this.runAWSOrphanSweepIfDue("admin", config);
+    await this.state.runExclusive(() => this.scheduleAlarm());
     return json({ config, sweep });
   }
 
@@ -4083,8 +4332,8 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
-    const sweep = await this.runAzureOrphanSweep("admin", config);
-    await this.scheduleAlarm();
+    const sweep = await this.runAzureOrphanSweepIfDue("admin", config);
+    await this.state.runExclusive(() => this.scheduleAlarm());
     return json({ config, sweep });
   }
 
@@ -4761,24 +5010,36 @@ export class FleetCoordinator {
   }
 
   private async expireLeases(): Promise<void> {
-    const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
-    const now = Date.now();
-    const expired = [...leases.values()].filter((lease) => leaseNeedsCleanup(lease, now));
-    await Promise.all(
-      expired.map(async (lease) => {
+    const claims = await this.state.runExclusive(async () => {
+      const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+      const now = Date.now();
+      const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
+      for (const stored of leases.values()) {
+        if (!leaseNeedsCleanup(stored, now)) {
+          continue;
+        }
+        const lease = structuredClone(stored);
+        const claimExpiresAt = cleanupClaimDeadline(lease);
+        if (lease.cleanupStartedAt && claimExpiresAt > now) {
+          continue;
+        }
         const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
         if (Number.isFinite(retryAt) && retryAt > now) {
-          return;
+          continue;
         }
-        const nowISO = new Date().toISOString();
+        const nowDate = new Date();
+        const nowISO = nowDate.toISOString();
         if (isRegisteredLease(lease)) {
           lease.state = "expired";
           lease.updatedAt = nowISO;
           lease.endedAt = nowISO;
           delete lease.releaseDeletesServer;
           clearLeaseCleanupMetadata(lease);
+          delete lease.cleanupStartedAt;
+          delete lease.cleanupClaimExpiresAt;
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each lease claim is committed while the state lock is held.
           await this.putLease(lease);
-          return;
+          continue;
         }
         if (lease.state === "provisioning" && !lease.cloudID) {
           lease.state = "failed";
@@ -4786,29 +5047,69 @@ export class FleetCoordinator {
           lease.endedAt = nowISO;
           lease.cleanupFailedAt = nowISO;
           lease.cleanupError = "lease expired before provider returned a cloud resource";
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each lease claim is committed while the state lock is held.
           await this.putLease(lease);
-          return;
+          continue;
         }
-        try {
-          await this.deleteLeaseServer(lease);
-        } catch (error) {
-          lease.cleanupAttempts = (lease.cleanupAttempts ?? 0) + 1;
-          lease.cleanupError = errorMessage(error);
-          lease.cleanupFailedAt = nowISO;
-          lease.cleanupRetryAt = new Date(now + leaseCleanupRetryDelayMs).toISOString();
-          lease.updatedAt = nowISO;
-          await this.putLease(lease);
-          console.warn(
-            `lease cleanup failed lease=${lease.id} provider=${lease.provider} cloud=${lease.cloudID}: ${lease.cleanupError}`,
-          );
-          return;
-        }
-        lease.state = leaseIsLive(lease) ? "expired" : lease.state;
+        lease.cleanupStartedAt = nowISO;
+        lease.cleanupClaimExpiresAt = new Date(
+          nowDate.getTime() + leaseCleanupClaimStaleMs,
+        ).toISOString();
         lease.updatedAt = nowISO;
-        lease.endedAt = nowISO;
-        delete lease.releaseDeletesServer;
-        clearLeaseCleanupMetadata(lease);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each cleanup claim must be durable before provider I/O starts.
         await this.putLease(lease);
+        claimed.push({ claim: nowISO, lease });
+      }
+      return claimed;
+    });
+    await Promise.all(
+      claims.map(async ({ claim, lease }) => {
+        const cleanup = async () => {
+          let failure: string | undefined;
+          try {
+            await this.deleteLeaseServer(lease);
+          } catch (error) {
+            failure = errorMessage(error);
+          }
+          await this.state.runExclusive(async () => {
+            const current = await this.getLease(lease.id);
+            if (!current || current.cleanupStartedAt !== claim) {
+              return;
+            }
+            const nowDate = new Date();
+            const nowISO = nowDate.toISOString();
+            if (failure) {
+              current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
+              delete current.cleanupStartedAt;
+              delete current.cleanupClaimExpiresAt;
+              current.cleanupError = failure;
+              current.cleanupFailedAt = nowISO;
+              current.cleanupRetryAt = new Date(
+                nowDate.getTime() + leaseCleanupRetryDelayMs,
+              ).toISOString();
+              current.updatedAt = nowISO;
+              await this.putLease(current);
+              console.warn(
+                `lease cleanup failed lease=${current.id} provider=${current.provider} cloud=${current.cloudID}: ${failure}`,
+              );
+              return;
+            }
+            current.state = leaseIsLive(current) ? "expired" : current.state;
+            current.updatedAt = nowISO;
+            current.endedAt = nowISO;
+            delete current.releaseDeletesServer;
+            clearLeaseCleanupMetadata(current);
+            delete current.cleanupStartedAt;
+            delete current.cleanupClaimExpiresAt;
+            await this.putLease(current);
+            await this.markAWSIngressReconcilePending(current);
+          });
+        };
+        if (managedLeaseProvider(lease) === "aws") {
+          await this.withAWSIngressOperationLock(cleanup);
+        } else {
+          await cleanup();
+        }
       }),
     );
   }
@@ -4832,11 +5133,188 @@ export class FleetCoordinator {
     if (azureCleanupAlarm !== undefined) {
       alarmTimes.push(azureCleanupAlarm);
     }
+    const awsIngressAlarm = await this.nextAWSIngressReconcileAlarmTime();
+    if (awsIngressAlarm !== undefined) {
+      alarmTimes.push(awsIngressAlarm);
+    }
     if (alarmTimes.length === 0) {
       await this.state.clearAlarm();
       return;
     }
     await this.state.scheduleAlarm(Math.min(...alarmTimes));
+  }
+
+  private async nextAWSIngressReconcileAlarmTime(): Promise<number | undefined> {
+    const record = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
+      awsIngressReconcileRecordKey,
+    );
+    const retryTimes = awsIngressReconcileTargets(record)
+      .map((target) => Date.parse(target.retryAt))
+      .filter((time) => Number.isFinite(time));
+    return retryTimes.length > 0 ? Math.max(Date.now() + 1000, Math.min(...retryTimes)) : undefined;
+  }
+
+  private async markAWSIngressReconcilePending(anchor: LeaseRecord): Promise<void> {
+    if (!leaseHasPublishedAWSAccess(anchor) || isRegisteredLease(anchor)) {
+      return;
+    }
+    const current = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
+      awsIngressReconcileRecordKey,
+    );
+    const targets = awsIngressReconcileTargets(current);
+    const key = awsIngressReconcileTargetKey(anchor);
+    const previous = targets.find((target) => awsIngressReconcileTargetKey(target.anchor) === key);
+    const now = new Date().toISOString();
+    await this.state.storage.put<AWSIngressReconcileRecord>(awsIngressReconcileRecordKey, {
+      targets: [
+        ...targets.filter((target) => awsIngressReconcileTargetKey(target.anchor) !== key),
+        {
+          anchor: structuredClone(anchor),
+          attempts: previous?.attempts ?? 0,
+          generation: crypto.randomUUID(),
+          updatedAt: now,
+          retryAt: now,
+          ...(previous?.lastError ? { lastError: previous.lastError } : {}),
+        },
+      ],
+    });
+  }
+
+  private async reconcileAWSIngressIfIdle(): Promise<void> {
+    const work = await this.state.runExclusive(async () => {
+      const stored = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
+        awsIngressReconcileRecordKey,
+      );
+      const targets = awsIngressReconcileTargets(stored);
+      if (targets.length === 0) {
+        if (stored) {
+          await this.state.storage.delete(awsIngressReconcileRecordKey);
+        }
+        return undefined;
+      }
+      const now = Date.now();
+      const due = targets.filter((target) => {
+        const retryAt = Date.parse(target.retryAt);
+        return !Number.isFinite(retryAt) || retryAt <= now;
+      });
+      if (due.length === 0) {
+        return undefined;
+      }
+      const leases = await this.leaseRecords();
+      const providerAccessLeases = await this.providerAccessRecords();
+      const accessState = mergeProviderAccessState(leases, providerAccessLeases);
+      if (
+        accessState.some(
+          (lease) =>
+            lease.provider === "aws" && !isRegisteredLease(lease) && lease.state === "provisioning",
+        )
+      ) {
+        const retryAt = new Date(now + 10_000).toISOString();
+        await this.state.storage.put<AWSIngressReconcileRecord>(awsIngressReconcileRecordKey, {
+          targets: targets.map((target) =>
+            due.includes(target) ? { ...target, retryAt } : target,
+          ),
+        });
+        return undefined;
+      }
+      return structuredClone(due);
+    });
+    if (!work) {
+      return;
+    }
+    for (const target of work) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- one fence protects all shared AWS ingress mutations.
+      await this.withAWSIngressOperationLock(async () => {
+        const fresh = await this.state.runExclusive(async () => {
+          const stored = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
+            awsIngressReconcileRecordKey,
+          );
+          const targets = awsIngressReconcileTargets(stored);
+          const key = awsIngressReconcileTargetKey(target.anchor);
+          const current = targets.find(
+            (candidate) =>
+              awsIngressReconcileTargetKey(candidate.anchor) === key &&
+              candidate.generation === target.generation,
+          );
+          if (!current) {
+            return undefined;
+          }
+          const leases = await this.leaseRecords();
+          const providerAccessLeases = await this.providerAccessRecords();
+          const accessState = mergeProviderAccessState(leases, providerAccessLeases);
+          if (
+            accessState.some(
+              (lease) =>
+                lease.provider === "aws" &&
+                !isRegisteredLease(lease) &&
+                lease.state === "provisioning",
+            )
+          ) {
+            current.retryAt = new Date(Date.now() + 10_000).toISOString();
+            await this.state.storage.put<AWSIngressReconcileRecord>(awsIngressReconcileRecordKey, {
+              targets,
+            });
+            return undefined;
+          }
+          return {
+            accessState: structuredClone(accessState),
+            target: structuredClone(current),
+          };
+        });
+        if (!fresh) {
+          return;
+        }
+        const key = awsIngressReconcileTargetKey(fresh.target.anchor);
+        let failure: string | undefined;
+        if (fresh.target.anchor.provider === "aws" && !isRegisteredLease(fresh.target.anchor)) {
+          const provider = this.provider("aws", fresh.target.anchor.region);
+          try {
+            await provider.reconcileLeaseAccess?.(
+              fresh.target.anchor,
+              providerAccessContext([], fresh.accessState),
+            );
+          } catch (error) {
+            failure = errorMessage(error);
+            console.warn(
+              `AWS SSH ingress reconciliation failed lease=${fresh.target.anchor.id} region=${fresh.target.anchor.region ?? ""}: ${failure}`,
+            );
+          }
+        }
+        await this.state.runExclusive(async () => {
+          const stored = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
+            awsIngressReconcileRecordKey,
+          );
+          const targets = awsIngressReconcileTargets(stored);
+          const index = targets.findIndex(
+            (candidate) =>
+              awsIngressReconcileTargetKey(candidate.anchor) === key &&
+              candidate.generation === fresh.target.generation,
+          );
+          if (index < 0) {
+            return;
+          }
+          if (failure) {
+            const now = new Date();
+            targets[index] = {
+              ...targets[index]!,
+              attempts: targets[index]!.attempts + 1,
+              updatedAt: now.toISOString(),
+              retryAt: new Date(now.getTime() + leaseCleanupRetryDelayMs).toISOString(),
+              lastError: failure,
+            };
+          } else {
+            targets.splice(index, 1);
+          }
+          if (targets.length === 0) {
+            await this.state.storage.delete(awsIngressReconcileRecordKey);
+          } else {
+            await this.state.storage.put<AWSIngressReconcileRecord>(awsIngressReconcileRecordKey, {
+              targets,
+            });
+          }
+        });
+      });
+    }
   }
 
   private async nextAzureDeferredCleanupAlarmTime(): Promise<number | undefined> {
@@ -4853,9 +5331,11 @@ export class FleetCoordinator {
   }
 
   private async runAzureDeferredCleanups(): Promise<void> {
-    const records = await this.state.storage.list<AzureDeferredCleanupRecord>({
-      prefix: azureDeferredCleanupPrefix,
-    });
+    const records = await this.state.runExclusive(() =>
+      this.state.storage.list<AzureDeferredCleanupRecord>({
+        prefix: azureDeferredCleanupPrefix,
+      }),
+    );
     const now = Date.now();
     await Promise.all(
       [...records.entries()].map(async ([key, record]) => {
@@ -4866,20 +5346,31 @@ export class FleetCoordinator {
         try {
           await new AzureClient(this.env, { location: record.location }).deleteServer(record.name);
         } catch (error) {
-          const nextRecord: AzureDeferredCleanupRecord = {
-            ...record,
-            attempts: record.attempts + 1,
-            updatedAt: new Date().toISOString(),
-            retryAt: new Date(now + leaseCleanupRetryDelayMs).toISOString(),
-            lastError: errorMessage(error),
-          };
-          await this.state.storage.put(key, nextRecord);
-          console.warn(
-            `azure deferred cleanup failed name=${record.name} location=${record.location}: ${nextRecord.lastError}`,
-          );
+          await this.state.runExclusive(async () => {
+            const current = await this.state.storage.get<AzureDeferredCleanupRecord>(key);
+            if (!current || current.updatedAt !== record.updatedAt) {
+              return;
+            }
+            const nextRecord: AzureDeferredCleanupRecord = {
+              ...current,
+              attempts: current.attempts + 1,
+              updatedAt: new Date().toISOString(),
+              retryAt: new Date(now + leaseCleanupRetryDelayMs).toISOString(),
+              lastError: errorMessage(error),
+            };
+            await this.state.storage.put(key, nextRecord);
+            console.warn(
+              `azure deferred cleanup failed name=${record.name} location=${record.location}: ${nextRecord.lastError}`,
+            );
+          });
           return;
         }
-        await this.state.storage.delete(key);
+        await this.state.runExclusive(async () => {
+          const current = await this.state.storage.get<AzureDeferredCleanupRecord>(key);
+          if (current?.updatedAt === record.updatedAt) {
+            await this.state.storage.delete(key);
+          }
+        });
       }),
     );
   }
@@ -4904,21 +5395,28 @@ export class FleetCoordinator {
     return Math.max(now + 1000, lastFinishedAt + config.intervalSeconds * 1000);
   }
 
-  private async runAWSOrphanSweepIfDue(trigger: "alarm" | "admin"): Promise<void> {
-    const config = this.awsOrphanSweepConfig();
-    if (!config.enabled) {
-      return;
-    }
-    const lastRun = await this.state.storage.get<AWSOrphanSweepRecord>(awsOrphanSweepRecordKey);
-    const lastFinishedAt = Date.parse(lastRun?.finishedAt ?? "");
-    if (
-      trigger !== "admin" &&
-      Number.isFinite(lastFinishedAt) &&
-      Date.now() < lastFinishedAt + config.intervalSeconds * 1000
-    ) {
-      return;
-    }
-    await this.runAWSOrphanSweep(trigger, config);
+  private async runAWSOrphanSweepIfDue(
+    trigger: "alarm" | "admin",
+    requestedConfig?: AWSOrphanSweepConfig,
+  ): Promise<AWSOrphanSweepRecord | undefined> {
+    return this.withProviderMaintenanceLock(async () => {
+      const config = requestedConfig ?? this.awsOrphanSweepConfig();
+      if (!config.enabled) {
+        return undefined;
+      }
+      const lastRun = await this.state.runExclusive(() =>
+        this.state.storage.get<AWSOrphanSweepRecord>(awsOrphanSweepRecordKey),
+      );
+      const lastFinishedAt = Date.parse(lastRun?.finishedAt ?? "");
+      if (
+        trigger !== "admin" &&
+        Number.isFinite(lastFinishedAt) &&
+        Date.now() < lastFinishedAt + config.intervalSeconds * 1000
+      ) {
+        return undefined;
+      }
+      return await this.runAWSOrphanSweep(trigger, config);
+    });
   }
 
   private async runAWSOrphanSweep(
@@ -4926,9 +5424,15 @@ export class FleetCoordinator {
     config = this.awsOrphanSweepConfig(),
   ): Promise<AWSOrphanSweepRecord> {
     const startedAt = new Date().toISOString();
-    const leases = [...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values()];
+    const leases = await this.state.runExclusive(async () => [
+      ...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values(),
+    ]);
+    const now = Date.now();
     const activeAWSLeases = leases.filter(
-      (lease) => lease.provider === "aws" && !isRegisteredLease(lease) && leaseIsLive(lease),
+      (lease) =>
+        lease.provider === "aws" &&
+        !isRegisteredLease(lease) &&
+        leaseOwnsCloudResourceDuringSweep(lease, now),
     );
     const activeLeases = new Map(activeAWSLeases.map((lease) => [lease.id, lease]));
     const activeCloudIDs = new Set(activeAWSLeases.map((lease) => lease.cloudID).filter(Boolean));
@@ -5025,8 +5529,10 @@ export class FleetCoordinator {
       errors,
       nextRunAt: new Date(Date.parse(finishedAt) + config.intervalSeconds * 1000).toISOString(),
     };
-    await this.state.storage.put(awsOrphanSweepRecordKey, record);
-    await this.state.storage.delete(awsOrphanSweepFirstAlarmKey);
+    await this.state.runExclusive(async () => {
+      await this.state.storage.put(awsOrphanSweepRecordKey, record);
+      await this.state.storage.delete(awsOrphanSweepFirstAlarmKey);
+    });
     if (candidates.length > 0 || macHostCandidates.length > 0 || errors.length > 0) {
       console.warn(
         `aws orphan sweep mode=${record.mode} scanned=${record.scanned} candidates=${candidates.length} terminated=${record.terminated} mac_hosts=${macHostCandidates.length} mac_hosts_released=${record.macHostsReleased ?? 0} errors=${errors.length}`,
@@ -5082,21 +5588,28 @@ export class FleetCoordinator {
     return Math.max(now + 1000, lastFinishedAt + config.intervalSeconds * 1000);
   }
 
-  private async runAzureOrphanSweepIfDue(trigger: "alarm" | "admin"): Promise<void> {
-    const config = this.azureOrphanSweepConfig();
-    if (!config.enabled) {
-      return;
-    }
-    const lastRun = await this.state.storage.get<AzureOrphanSweepRecord>(azureOrphanSweepRecordKey);
-    const lastFinishedAt = Date.parse(lastRun?.finishedAt ?? "");
-    if (
-      trigger !== "admin" &&
-      Number.isFinite(lastFinishedAt) &&
-      Date.now() < lastFinishedAt + config.intervalSeconds * 1000
-    ) {
-      return;
-    }
-    await this.runAzureOrphanSweep(trigger, config);
+  private async runAzureOrphanSweepIfDue(
+    trigger: "alarm" | "admin",
+    requestedConfig?: AzureOrphanSweepConfig,
+  ): Promise<AzureOrphanSweepRecord | undefined> {
+    return this.withProviderMaintenanceLock(async () => {
+      const config = requestedConfig ?? this.azureOrphanSweepConfig();
+      if (!config.enabled) {
+        return undefined;
+      }
+      const lastRun = await this.state.runExclusive(() =>
+        this.state.storage.get<AzureOrphanSweepRecord>(azureOrphanSweepRecordKey),
+      );
+      const lastFinishedAt = Date.parse(lastRun?.finishedAt ?? "");
+      if (
+        trigger !== "admin" &&
+        Number.isFinite(lastFinishedAt) &&
+        Date.now() < lastFinishedAt + config.intervalSeconds * 1000
+      ) {
+        return undefined;
+      }
+      return await this.runAzureOrphanSweep(trigger, config);
+    });
   }
 
   private async runAzureOrphanSweep(
@@ -5104,9 +5617,15 @@ export class FleetCoordinator {
     config = this.azureOrphanSweepConfig(),
   ): Promise<AzureOrphanSweepRecord> {
     const startedAt = new Date().toISOString();
-    const leases = [...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values()];
+    const leases = await this.state.runExclusive(async () => [
+      ...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values(),
+    ]);
+    const now = Date.now();
     const liveAzureLeases = leases.filter(
-      (lease) => lease.provider === "azure" && !isRegisteredLease(lease) && leaseIsLive(lease),
+      (lease) =>
+        lease.provider === "azure" &&
+        !isRegisteredLease(lease) &&
+        leaseOwnsCloudResourceDuringSweep(lease, now),
     );
     const liveLeases = new Map(liveAzureLeases.map((lease) => [lease.id, lease]));
     const liveCloudIDs = new Set(liveAzureLeases.map((lease) => lease.cloudID).filter(Boolean));
@@ -5173,8 +5692,10 @@ export class FleetCoordinator {
       errors,
       nextRunAt: new Date(Date.parse(finishedAt) + config.intervalSeconds * 1000).toISOString(),
     };
-    await this.state.storage.put(azureOrphanSweepRecordKey, record);
-    await this.state.storage.delete(azureOrphanSweepFirstAlarmKey);
+    await this.state.runExclusive(async () => {
+      await this.state.storage.put(azureOrphanSweepRecordKey, record);
+      await this.state.storage.delete(azureOrphanSweepFirstAlarmKey);
+    });
     if (candidates.length > 0 || errors.length > 0) {
       console.warn(
         `azure orphan sweep mode=${record.mode} scanned=${record.scanned} candidates=${candidates.length} terminated=${record.terminated} errors=${errors.length}`,
@@ -5287,7 +5808,7 @@ export class FleetCoordinator {
     const active: LeaseRecord[] = [];
     const staleKeys: string[] = [];
     for (const [key, record] of records) {
-      if (record.state === "active" && Date.parse(record.expiresAt) > now) {
+      if (leaseIsLive(record) && Date.parse(record.expiresAt) > now) {
         active.push(record);
         continue;
       }
@@ -5324,6 +5845,61 @@ export class FleetCoordinator {
       release = resolve;
     });
     this.readyPoolBorrowQueue = previous.then(() => next);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async withAWSIngressOperationLock<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.awsIngressBarrier.catch(() => {});
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.awsIngressBarrier = previous.then(() => gate);
+    await previous;
+    await Promise.all(this.awsIngressAdditiveOperations);
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async withAWSIngressAdditiveOperation<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    let active!: Promise<void>;
+    for (;;) {
+      const barrier = this.awsIngressBarrier;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- retry only when an authoritative fence arrived first.
+      await barrier.catch(() => {});
+      if (barrier !== this.awsIngressBarrier) {
+        continue;
+      }
+      active = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      this.awsIngressAdditiveOperations.add(active);
+      break;
+    }
+    try {
+      return await operation();
+    } finally {
+      this.awsIngressAdditiveOperations.delete(active);
+      release();
+    }
+  }
+
+  private async withProviderMaintenanceLock<T>(operation: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.providerMaintenanceQueue.catch(() => {});
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.providerMaintenanceQueue = previous.then(() => next);
     await previous;
     try {
       return await operation();
@@ -5440,6 +6016,44 @@ export class FleetCoordinator {
     await this.state.storage.put(leaseKey(lease.id), lease);
   }
 
+  private async cancelLeaseReservation(reservation: LeaseRecord): Promise<void> {
+    await this.state.runExclusive(async () => {
+      const current = await this.getLease(reservation.id);
+      if (
+        !current ||
+        current.state !== "provisioning" ||
+        current.createdAt !== reservation.createdAt
+      ) {
+        return;
+      }
+      await this.deleteProviderAccess(reservation.id);
+      await this.state.storage.delete(leaseKey(reservation.id));
+      await this.scheduleAlarm();
+    });
+  }
+
+  private async removeReleasedLeaseReservation(
+    reservation: LeaseRecord,
+  ): Promise<LeaseRecord | undefined> {
+    const current = await this.state.runExclusive(async () => {
+      const latest = await this.getLease(reservation.id);
+      if (
+        !latest ||
+        latest.state !== "released" ||
+        latest.cloudID ||
+        latest.createdAt !== reservation.createdAt
+      ) {
+        return latest;
+      }
+      await this.deleteProviderAccess(reservation.id);
+      await this.state.storage.delete(leaseKey(reservation.id));
+      await this.markAWSIngressReconcilePending(reservation);
+      await this.scheduleAlarm();
+      return undefined;
+    });
+    return current;
+  }
+
   private async putProviderAccess(lease: LeaseRecord): Promise<void> {
     await this.state.storage.put(providerAccessKey(lease.id), lease);
   }
@@ -5526,8 +6140,7 @@ export class FleetCoordinator {
     if (provider === "azure") {
       return new AzureProvider(
         this.env,
-        this.state.storage,
-        (time) => this.state.scheduleAlarm(time),
+        (request) => recordAzureDeferredCleanup(this.state, () => this.scheduleAlarm(), request),
         region,
       );
     }
@@ -5546,56 +6159,146 @@ export class FleetCoordinator {
   }
 
   private async abortProvisionedLeaseAfterStateChange(
-    current: LeaseRecord | undefined,
     record: LeaseRecord,
     config: LeaseConfig,
     server: ProviderMachine,
     serverType: string,
     deletePublishedAccess: boolean,
   ): Promise<Response> {
-    if (deletePublishedAccess) {
-      await this.deleteProviderAccess(record.id);
-    }
-    const cleanupLease = provisionedLeaseRecord(current ?? record, config, server, serverType);
-    if (current?.state === "released" && current.releaseDeletesServer === false) {
-      cleanupLease.state = "released";
-      cleanupLease.keep = true;
-      clearLeaseCleanupMetadata(cleanupLease);
+    const preparation = await this.state.runExclusive(async () => {
+      if (deletePublishedAccess) {
+        await this.deleteProviderAccess(record.id);
+      }
+      const latest = await this.getLease(record.id);
+      const previous = latest ? structuredClone(latest) : undefined;
+      const cleanupLease = provisionedLeaseRecord(latest ?? record, config, server, serverType);
+      if (latest?.state === "released" && latest.releaseDeletesServer === false) {
+        cleanupLease.state = "released";
+        cleanupLease.keep = true;
+        clearLeaseCleanupMetadata(cleanupLease);
+        delete cleanupLease.cleanupStartedAt;
+        delete cleanupLease.cleanupClaimExpiresAt;
+        await this.putLease(cleanupLease);
+        await this.markAWSIngressReconcilePending(cleanupLease);
+        await this.scheduleAlarm();
+        return { keep: true as const, lease: cleanupLease };
+      }
+      const cleanupStarted = new Date();
+      const cleanupStartedAt = cleanupStarted.toISOString();
+      cleanupLease.state = latest?.state ?? cleanupLease.state;
+      cleanupLease.cleanupStartedAt = cleanupStartedAt;
+      cleanupLease.cleanupClaimExpiresAt = new Date(
+        cleanupStarted.getTime() + leaseCleanupClaimStaleMs,
+      ).toISOString();
+      delete cleanupLease.cleanupRetryAt;
+      cleanupLease.updatedAt = cleanupStartedAt;
+      if (cleanupLease.state === "released") {
+        cleanupLease.releaseDeletesServer = true;
+      }
       await this.putLease(cleanupLease);
+      await this.markAWSIngressReconcilePending(cleanupLease);
       await this.scheduleAlarm();
+      return {
+        keep: false as const,
+        lease: cleanupLease,
+        cleanupStartedAt,
+        claimed: structuredClone(cleanupLease),
+        previous,
+      };
+    });
+    if (preparation.keep) {
       return json(
         {
           error: "lease_state_changed",
           message: "lease changed state while provider provisioning was in progress",
-          lease: cleanupLease,
+          lease: preparation.lease,
         },
         { status: 409 },
       );
     }
     try {
-      await this.deleteLeaseServer(cleanupLease);
+      await this.deleteLeaseServer(preparation.lease);
     } catch (error) {
-      const failedAt = new Date().toISOString();
-      cleanupLease.state = current?.state ?? "active";
-      if (cleanupLease.state === "released") {
-        cleanupLease.releaseDeletesServer = true;
+      const failure = await this.state.runExclusive(async () => {
+        const latest = await this.getLease(record.id);
+        const cleanupLease = provisionedLeaseRecord(
+          latest ?? preparation.lease,
+          config,
+          server,
+          serverType,
+        );
+        if (latest?.state === "released" && latest.releaseDeletesServer === false) {
+          cleanupLease.state = "released";
+          cleanupLease.keep = true;
+          clearLeaseCleanupMetadata(cleanupLease);
+          delete cleanupLease.cleanupStartedAt;
+          delete cleanupLease.cleanupClaimExpiresAt;
+          await this.putLease(cleanupLease);
+          await this.markAWSIngressReconcilePending(cleanupLease);
+          await this.scheduleAlarm();
+          return { suppressed: true as const, lease: cleanupLease };
+        }
+        if (latest?.cleanupStartedAt !== preparation.cleanupStartedAt) {
+          return { suppressed: true as const, lease: latest ?? cleanupLease };
+        }
+        const failedAt = new Date().toISOString();
+        cleanupLease.state = latest?.state ?? "active";
+        if (cleanupLease.state === "released") {
+          cleanupLease.releaseDeletesServer = true;
+        }
+        cleanupLease.cleanupAttempts = (cleanupLease.cleanupAttempts ?? 0) + 1;
+        delete cleanupLease.cleanupStartedAt;
+        delete cleanupLease.cleanupClaimExpiresAt;
+        cleanupLease.cleanupFailedAt = failedAt;
+        cleanupLease.cleanupError = errorMessage(error);
+        cleanupLease.cleanupRetryAt = new Date(Date.now() + leaseCleanupRetryDelayMs).toISOString();
+        cleanupLease.expiresAt = failedAt;
+        cleanupLease.updatedAt = failedAt;
+        await this.putLease(cleanupLease);
+        await this.markAWSIngressReconcilePending(cleanupLease);
+        await this.scheduleAlarm();
+        return { suppressed: false as const, lease: cleanupLease };
+      });
+      if (failure.suppressed) {
+        return json(
+          {
+            error: "lease_state_changed",
+            message: "lease changed state while provider provisioning was in progress",
+            lease: failure.lease,
+          },
+          { status: 409 },
+        );
       }
-      cleanupLease.cleanupAttempts = (cleanupLease.cleanupAttempts ?? 0) + 1;
-      cleanupLease.cleanupFailedAt = failedAt;
-      cleanupLease.cleanupError = errorMessage(error);
-      cleanupLease.cleanupRetryAt = new Date(Date.now() + leaseCleanupRetryDelayMs).toISOString();
-      cleanupLease.expiresAt = failedAt;
-      cleanupLease.updatedAt = failedAt;
-      await this.putLease(cleanupLease);
-      await this.scheduleAlarm();
       throw error;
     }
-    await this.scheduleAlarm();
+    const latest = await this.state.runExclusive(async () => {
+      const current = await this.getLease(record.id);
+      if (current?.cleanupStartedAt === preparation.cleanupStartedAt) {
+        if (preparation.previous) {
+          const completed = applyLeaseRecordChanges(
+            current,
+            preparation.claimed,
+            preparation.previous,
+          );
+          clearLeaseCleanupMetadata(completed);
+          delete completed.cleanupStartedAt;
+          delete completed.cleanupClaimExpiresAt;
+          delete completed.releaseDeletesServer;
+          completed.updatedAt = new Date().toISOString();
+          await this.putLease(completed);
+        } else {
+          await this.state.storage.delete(leaseKey(record.id));
+        }
+      }
+      await this.markAWSIngressReconcilePending(preparation.lease);
+      await this.scheduleAlarm();
+      return this.getLease(record.id);
+    });
     return json(
       {
         error: "lease_state_changed",
         message: "lease changed state while provider provisioning was in progress",
-        lease: current,
+        lease: latest,
       },
       { status: 409 },
     );
@@ -5605,45 +6308,126 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     options: { deleteServer: boolean; keep?: boolean },
   ): Promise<LeaseRecord> {
+    const release = () => this.releaseResolvedLeaseOperation(lease, options);
+    return managedLeaseProvider(lease) === "aws" &&
+      (lease.state === "active" || Boolean(lease.cloudID))
+      ? this.withAWSIngressOperationLock(release)
+      : release();
+  }
+
+  private async releaseResolvedLeaseOperation(
+    lease: LeaseRecord,
+    options: { deleteServer: boolean; keep?: boolean },
+  ): Promise<LeaseRecord> {
     this.clearEgressLease(lease.id);
-    const deleteServer = options.deleteServer && !isRegisteredLease(lease);
-    if (
-      deleteServer &&
-      lease.cloudID &&
-      (leaseIsLive(lease) || lease.releaseDeletesServer !== undefined || lease.cleanupError)
-    ) {
-      await this.deleteLeaseServer(lease);
+    const preparation = await this.state.runExclusive(async () => {
+      const current = (await this.getLease(lease.id)) ?? structuredClone(lease);
+      if (current.cleanupStartedAt) {
+        return { cleanup: false as const, lease: current };
+      }
+      const deleteServer = options.deleteServer && !isRegisteredLease(current);
+      const shouldDelete = Boolean(
+        deleteServer &&
+        current.cloudID &&
+        (leaseIsLive(current) ||
+          current.releaseDeletesServer !== undefined ||
+          current.cleanupError),
+      );
+      if (!shouldDelete) {
+        const released = finalizedReleasedLease(current, deleteServer, options.keep);
+        await this.putLease(released);
+        await this.markAWSIngressReconcilePending(released);
+        await this.scheduleAlarm();
+        return { cleanup: false as const, lease: released };
+      }
+      const now = new Date();
+      const claimed = finalizedReleasedLease(current, true, options.keep);
+      claimed.cleanupStartedAt = now.toISOString();
+      claimed.cleanupClaimExpiresAt = new Date(
+        now.getTime() + leaseCleanupClaimStaleMs,
+      ).toISOString();
+      claimed.releaseDeletesServer = true;
+      await this.putLease(claimed);
+      await this.markAWSIngressReconcilePending(claimed);
+      await this.scheduleAlarm();
+      return {
+        cleanup: true as const,
+        claim: claimed.cleanupStartedAt,
+        lease: structuredClone(claimed),
+      };
+    });
+    if (!preparation.cleanup) {
+      return preparation.lease;
     }
-    const wasUnprovisionedRelease =
-      !lease.cloudID && (lease.state === "provisioning" || lease.state === "released");
-    const now = new Date().toISOString();
-    lease.state = "released";
-    lease.updatedAt = now;
-    lease.releasedAt = now;
-    lease.endedAt = now;
-    if (wasUnprovisionedRelease) {
-      lease.releaseDeletesServer = deleteServer;
-    } else if (lease.releaseDeletesServer === false && !deleteServer) {
-      lease.releaseDeletesServer = false;
-    } else {
-      delete lease.releaseDeletesServer;
+    try {
+      await this.deleteLeaseServer(preparation.lease);
+    } catch (error) {
+      await this.state.runExclusive(async () => {
+        const current = await this.getLease(preparation.lease.id);
+        if (!current || current.cleanupStartedAt !== preparation.claim) {
+          return;
+        }
+        const failedAt = new Date();
+        current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
+        delete current.cleanupStartedAt;
+        delete current.cleanupClaimExpiresAt;
+        current.cleanupError = errorMessage(error);
+        current.cleanupFailedAt = failedAt.toISOString();
+        current.cleanupRetryAt = new Date(
+          failedAt.getTime() + leaseCleanupRetryDelayMs,
+        ).toISOString();
+        current.updatedAt = failedAt.toISOString();
+        current.releaseDeletesServer = true;
+        await this.putLease(current);
+        await this.scheduleAlarm();
+      });
+      throw error;
     }
-    clearLeaseCleanupMetadata(lease);
-    if (options.keep !== undefined) {
-      lease.keep = options.keep;
-    }
-    await this.putLease(lease);
-    return lease;
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(preparation.lease.id);
+      if (!current || current.cleanupStartedAt !== preparation.claim) {
+        return current ?? preparation.lease;
+      }
+      const released = finalizedReleasedLease(current, true, options.keep);
+      await this.putLease(released);
+      await this.markAWSIngressReconcilePending(released);
+      await this.scheduleAlarm();
+      return released;
+    });
   }
 }
 
 export class FleetDurableObject extends FleetCoordinator implements DurableObject {
+  private readonly runtime: CloudflareCoordinatorRuntime;
+
   constructor(
     state: DurableObjectState,
     env: Env,
     testProviders: Partial<Record<Provider, CloudProvider>> = {},
   ) {
-    super(new CloudflareCoordinatorRuntime(state), env, testProviders);
+    const runtime = new CloudflareCoordinatorRuntime(state);
+    super(runtime, env, testProviders);
+    this.runtime = runtime;
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    if (coordinatorRequestQueue(request) === "direct") {
+      return super.fetch(request);
+    }
+    const bufferedRequest = await bufferCoordinatorRequestBody(request);
+    return this.runtime.runExclusive(() => super.fetch(bufferedRequest));
+  }
+
+  override alarm(): Promise<void> {
+    return super.alarm();
+  }
+
+  override webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const attachment = this.runtime.socketAttachment<{ kind?: string }>(socket);
+    if (attachment?.kind !== "control") {
+      return super.webSocketMessage(socket, message);
+    }
+    return this.runtime.runExclusive(() => super.webSocketMessage(socket, message));
   }
 }
 
@@ -6199,12 +6983,20 @@ function validCodeTicket(value: string | undefined): value is string {
 }
 
 export function bridgeTicketFromRequest(request: Request): string {
+  const queryTicket = new URL(request.url).searchParams.get("ticket") ?? "";
+  if (
+    validWebVNCTicket(queryTicket) ||
+    validCodeTicket(queryTicket) ||
+    validEgressTicket(queryTicket)
+  ) {
+    return queryTicket;
+  }
   const auth = request.headers.get("authorization")?.trim() ?? "";
   const match = /^Bearer\s+(.+)$/i.exec(auth);
   if (match?.[1]) {
     return match[1].trim();
   }
-  return new URL(request.url).searchParams.get("ticket") ?? "";
+  return queryTicket;
 }
 
 function validEgressTicket(value: string | undefined): value is string {
@@ -6329,6 +7121,29 @@ function allowProviderImageDelete(): Promise<undefined> {
 
 function azureDeferredCleanupKey(location: string, name: string): string {
   return `${azureDeferredCleanupPrefix}${location}:${name}`;
+}
+
+export function recordAzureDeferredCleanup(
+  state: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  scheduleAlarm: () => Promise<void>,
+  request: AzureDeferredCleanupRequest,
+): Promise<void> {
+  return state.runExclusive(async () => {
+    const key = azureDeferredCleanupKey(request.location, request.name);
+    const current = await state.storage.get<AzureDeferredCleanupRecord>(key);
+    const now = new Date().toISOString();
+    const record: AzureDeferredCleanupRecord = {
+      ...request,
+      attempts: current?.attempts ?? 0,
+      updatedAt: now,
+      retryAt: now,
+    };
+    if (current?.lastError) {
+      record.lastError = current.lastError;
+    }
+    await state.storage.put(key, record);
+    await scheduleAlarm();
+  });
 }
 
 function validCrabboxProviderKey(value: string | undefined): value is string {
@@ -6923,6 +7738,17 @@ function replaceProviderAccessState(leases: LeaseRecord[], lease: LeaseRecord): 
   return next;
 }
 
+function mergeProviderAccessState(
+  leases: LeaseRecord[],
+  providerAccessLeases: LeaseRecord[],
+): LeaseRecord[] {
+  const merged = new Map(leases.map((lease) => [lease.id, lease]));
+  for (const lease of providerAccessLeases) {
+    merged.set(lease.id, lease);
+  }
+  return [...merged.values()];
+}
+
 function finiteNumber(value: number | undefined): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
@@ -7470,7 +8296,50 @@ function leaseNeedsCleanup(lease: LeaseRecord, now: number): boolean {
   if (leaseIsLive(lease) && Date.parse(lease.expiresAt) <= now) {
     return true;
   }
-  return Boolean(!leaseIsLive(lease) && lease.cloudID && lease.cleanupError);
+  return Boolean(
+    !leaseIsLive(lease) && lease.cloudID && (lease.cleanupError || lease.cleanupStartedAt),
+  );
+}
+
+function applyLeaseRecordChanges(
+  latest: LeaseRecord,
+  baseline: LeaseRecord,
+  updated: LeaseRecord,
+): LeaseRecord {
+  const merged = structuredClone(latest) as unknown as Record<string, unknown>;
+  const before = baseline as unknown as Record<string, unknown>;
+  const after = updated as unknown as Record<string, unknown>;
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    const beforeHasKey = Object.hasOwn(before, key);
+    const afterHasKey = Object.hasOwn(after, key);
+    if (
+      beforeHasKey === afterHasKey &&
+      JSON.stringify(before[key]) === JSON.stringify(after[key])
+    ) {
+      continue;
+    }
+    if (afterHasKey) {
+      merged[key] = structuredClone(after[key]);
+    } else {
+      delete merged[key];
+    }
+  }
+  return merged as unknown as LeaseRecord;
+}
+
+function withRequestedTailscaleMetadata(lease: LeaseRecord, config: LeaseConfig): LeaseRecord {
+  if (!config.tailscale) return lease;
+  const tailscale: TailscaleMetadata = {
+    enabled: true,
+    hostname: config.tailscaleHostname,
+    tags: config.tailscaleTags,
+    state: "requested",
+  };
+  if (config.tailscaleExitNode) {
+    tailscale.exitNode = config.tailscaleExitNode;
+    tailscale.exitNodeAllowLanAccess = config.tailscaleExitNodeAllowLanAccess;
+  }
+  return { ...lease, tailscale };
 }
 
 function provisionedLeaseRecord(
@@ -7496,6 +8365,10 @@ function provisionedLeaseRecord(
 
 function nextLeaseAlarmTime(lease: LeaseRecord): number {
   const now = Date.now();
+  const claimDeadline = cleanupClaimDeadline(lease);
+  if (lease.cleanupStartedAt && Number.isFinite(claimDeadline)) {
+    return claimDeadline;
+  }
   const expiresAt = Date.parse(lease.expiresAt);
   const cleanupRetryAt = Date.parse(lease.cleanupRetryAt ?? "");
   if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt > now) {
@@ -7507,11 +8380,49 @@ function nextLeaseAlarmTime(lease: LeaseRecord): number {
   return expiresAt;
 }
 
+function cleanupClaimDeadline(lease: LeaseRecord): number {
+  const explicit = Date.parse(lease.cleanupClaimExpiresAt ?? "");
+  if (Number.isFinite(explicit)) {
+    return explicit;
+  }
+  const startedAt = Date.parse(lease.cleanupStartedAt ?? "");
+  return Number.isFinite(startedAt) ? startedAt + leaseCleanupClaimStaleMs : Number.NaN;
+}
+
 function clearLeaseCleanupMetadata(lease: LeaseRecord): void {
   delete lease.cleanupAttempts;
   delete lease.cleanupError;
   delete lease.cleanupFailedAt;
   delete lease.cleanupRetryAt;
+}
+
+function finalizedReleasedLease(
+  current: LeaseRecord,
+  deleteServer: boolean,
+  keep?: boolean,
+): LeaseRecord {
+  const lease = structuredClone(current);
+  const wasUnprovisionedRelease =
+    !lease.cloudID && (lease.state === "provisioning" || lease.state === "released");
+  const now = new Date().toISOString();
+  lease.state = "released";
+  lease.updatedAt = now;
+  lease.releasedAt = now;
+  lease.endedAt = now;
+  if (wasUnprovisionedRelease) {
+    lease.releaseDeletesServer = deleteServer;
+  } else if (!deleteServer && !isRegisteredLease(lease) && lease.cloudID) {
+    lease.releaseDeletesServer = false;
+  } else {
+    delete lease.releaseDeletesServer;
+  }
+  clearLeaseCleanupMetadata(lease);
+  delete lease.cleanupStartedAt;
+  delete lease.cleanupClaimExpiresAt;
+  if (keep !== undefined) {
+    lease.keep = keep;
+  }
+  return lease;
 }
 
 function normalizeShareUser(value: string | undefined): string {
@@ -7707,12 +8618,85 @@ function withLeaseSSHSourceCIDRs(
   };
 }
 
+function leaseOwnsAWSSSHAccess(lease: LeaseRecord): boolean {
+  return (
+    lease.provider === "aws" &&
+    !isRegisteredLease(lease) &&
+    (leaseIsLive(lease) || lease.releaseDeletesServer === false)
+  );
+}
+
+function leaseHasPublishedAWSAccess(lease: LeaseRecord): boolean {
+  return Boolean(
+    lease.provider === "aws" &&
+    (lease.cloudID ||
+      lease.network?.sshSourceCIDRsComplete !== undefined ||
+      (lease.network?.sshSourceCIDRs?.length ?? 0) > 0 ||
+      lease.network?.awsSecurityGroupID ||
+      lease.network?.awsSubnetID),
+  );
+}
+
+function awsIngressReconcileTargetKey(lease: LeaseRecord): string {
+  return [
+    lease.region ?? "",
+    lease.network?.awsSecurityGroupID ?? "",
+    lease.network?.awsSubnetID ?? "",
+    lease.sshPort,
+    ...(lease.sshFallbackPorts ?? []).toSorted(),
+  ].join("\u0000");
+}
+
+function awsIngressAccessTargetKey(
+  lease: LeaseRecord,
+  region: string,
+  ports: string[],
+  env: Env,
+): string {
+  const securityGroupID =
+    lease.network?.awsSecurityGroupID || env.CRABBOX_AWS_SECURITY_GROUP_ID || "";
+  const subnetID = lease.network?.awsSubnetID || env.CRABBOX_AWS_SUBNET_ID || "";
+  const group = securityGroupID ? `sg:${securityGroupID}` : `auto:${subnetID}`;
+  return [region, group, ...ports.toSorted()].join("\u0000");
+}
+
+function awsIngressGroupMetadataUnknown(lease: LeaseRecord, env: Env): boolean {
+  return !lease.network?.awsSecurityGroupID && !env.CRABBOX_AWS_SECURITY_GROUP_ID;
+}
+
+function awsIngressPortScopeKey(region: string, port: string): string {
+  return [region, port].join("\u0000");
+}
+
+function awsLeaseSSHPorts(lease: LeaseRecord): string[] {
+  return uniqueNonEmpty([lease.sshPort, ...(lease.sshFallbackPorts ?? [])]);
+}
+
+function awsIngressReconcileTargets(
+  record: StoredAWSIngressReconcileRecord | undefined,
+): AWSIngressReconcileTarget[] {
+  if (!record) {
+    return [];
+  }
+  if ("targets" in record) {
+    return record.targets.map((target) => structuredClone(target));
+  }
+  return [
+    {
+      anchor: structuredClone(record.anchor),
+      attempts: record.attempts,
+      generation: `legacy:${record.updatedAt}:${awsIngressReconcileTargetKey(record.anchor)}`,
+      updatedAt: record.updatedAt,
+      retryAt: record.retryAt,
+      ...(record.lastError ? { lastError: record.lastError } : {}),
+    },
+  ];
+}
+
 function activeAWSSSHSourceCIDRs(leases: LeaseRecord[], cidrs: string[]): string[] {
   return uniqueNonEmpty([
     ...leases.flatMap((lease) =>
-      lease.provider === "aws" && !isRegisteredLease(lease) && leaseIsLive(lease)
-        ? (lease.network?.sshSourceCIDRs ?? [])
-        : [],
+      leaseOwnsAWSSSHAccess(lease) ? (lease.network?.sshSourceCIDRs ?? []) : [],
     ),
     ...cidrs,
   ]);
@@ -7721,9 +8705,7 @@ function activeAWSSSHSourceCIDRs(leases: LeaseRecord[], cidrs: string[]): string
 function hasUnknownActiveAWSSSHSource(leases: LeaseRecord[]): boolean {
   return leases.some(
     (lease) =>
-      lease.provider === "aws" &&
-      !isRegisteredLease(lease) &&
-      leaseIsLive(lease) &&
+      leaseOwnsAWSSSHAccess(lease) &&
       (lease.network?.sshSourceCIDRs?.length ?? 0) === 0 &&
       !lease.network?.sshSourceCIDRsComplete,
   );
@@ -7756,7 +8738,11 @@ function cloudOrphanSweepCandidate(
   }
   const leaseID = (labels["lease"] ?? "").trim();
   const activeLease = leaseID ? activeLeases.get(leaseID) : undefined;
-  if (activeLease?.cloudID === machine.cloudID) {
+  if (
+    activeLease?.state === "provisioning" ||
+    activeLease?.cloudID === cloudID ||
+    (activeLease?.releaseDeletesServer === false && !activeLease.cloudID)
+  ) {
     return undefined;
   }
   const now = Date.now();
@@ -7809,6 +8795,16 @@ function cloudOrphanSweepCandidate(
     candidate.activeCloudID = activeLease.cloudID;
   }
   return candidate;
+}
+
+function leaseOwnsCloudResourceDuringSweep(lease: LeaseRecord, now: number): boolean {
+  if (leaseIsLive(lease)) {
+    return true;
+  }
+  if (lease.state === "released" && lease.releaseDeletesServer === false) {
+    return true;
+  }
+  return Boolean(lease.cleanupStartedAt && cleanupClaimDeadline(lease) > now);
 }
 
 function awsMacHostSweepCandidate(
@@ -7874,6 +8870,7 @@ interface CloudProvider {
     lease: LeaseRecord,
     context: ProviderAccessContext,
   ): Promise<LeaseRecord | void>;
+  reconcileLeaseAccess?(lease: LeaseRecord, context: ProviderAccessContext): Promise<void>;
   createServerWithFallback(
     config: ReturnType<typeof leaseConfig>,
     leaseID: string,
@@ -7968,6 +8965,11 @@ interface ProviderLeaseCreateFinalization {
 interface ProviderProvisioningContext {
   sshIngressReconcile?: "authoritative" | "additive";
   publishAccessBeforeProvisioning?: boolean;
+  onTargetAttempt?: (target: ProviderProvisioningTarget) => Promise<void>;
+}
+
+interface ProviderProvisioningTarget {
+  region?: string;
 }
 
 class HetznerProvider implements CloudProvider {
@@ -8056,35 +9058,16 @@ class AzureProvider implements CloudProvider {
 
   constructor(
     private readonly env: Env,
-    private readonly storage?: CoordinatorStorage,
-    private readonly scheduleAlarm?: (time: number) => Promise<void>,
+    private readonly deferredCleanup?: (request: AzureDeferredCleanupRequest) => Promise<void>,
     private readonly location?: string,
   ) {}
 
   private get client(): AzureClient {
     this.clientValue ??= new AzureClient(this.env, {
       ...(this.location ? { location: this.location } : {}),
-      deferredCleanup: (request) => this.recordDeferredCleanup(request),
+      ...(this.deferredCleanup ? { deferredCleanup: this.deferredCleanup } : {}),
     });
     return this.clientValue;
-  }
-
-  private async recordDeferredCleanup(request: AzureDeferredCleanupRequest): Promise<void> {
-    if (!this.storage) return;
-    const key = azureDeferredCleanupKey(request.location, request.name);
-    const current = await this.storage.get<AzureDeferredCleanupRecord>(key);
-    const now = new Date().toISOString();
-    const record: AzureDeferredCleanupRecord = {
-      ...request,
-      attempts: current?.attempts ?? 0,
-      updatedAt: now,
-      retryAt: now,
-    };
-    if (current?.lastError) {
-      record.lastError = current.lastError;
-    }
-    await this.storage.put(key, record);
-    await this.scheduleAlarm?.(Date.now() + 1000);
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {
@@ -8309,7 +9292,7 @@ class GCPProvider implements CloudProvider {
   }
 }
 
-class AWSProvider implements CloudProvider {
+export class AWSProvider implements CloudProvider {
   private clientValue?: EC2SpotClient;
   private readonly region: string;
 
@@ -8358,22 +9341,45 @@ class AWSProvider implements CloudProvider {
   ): Promise<ProviderLeaseCreatePreparation> {
     const sourceCIDRs = awsLeaseSSHSourceCIDRs(config, context);
     const globalCIDRs = awsGlobalSSHSourceCIDRs(this.env);
-    const nextLease = withLeaseSSHSourceCIDRs(
+    const nextLeaseWithSources = withLeaseSSHSourceCIDRs(
       lease,
       sourceCIDRs,
       sourceCIDRs.length > 0 || globalCIDRs.length > 0,
     );
+    const nextLease: LeaseRecord = {
+      ...nextLeaseWithSources,
+      network: {
+        ...nextLeaseWithSources.network,
+        ...(config.awsSGID ? { awsSecurityGroupID: config.awsSGID } : {}),
+        ...(config.awsSubnetID ? { awsSubnetID: config.awsSubnetID } : {}),
+      },
+    };
     const activeLeases = replaceProviderAccessState(context.activeLeases, nextLease);
+    const targetKey = awsIngressAccessTargetKey(
+      nextLease,
+      nextLease.region || config.awsRegion,
+      awsLeaseSSHPorts(nextLease),
+      this.env,
+    );
+    const targetLeases = activeLeases.filter(
+      (candidate) =>
+        leaseOwnsAWSSSHAccess(candidate) &&
+        awsIngressAccessTargetKey(
+          candidate,
+          candidate.region || this.region,
+          awsLeaseSSHPorts(candidate),
+          this.env,
+        ) === targetKey,
+    );
     return {
       config: {
         ...config,
-        awsSSHCIDRs: activeAWSSSHSourceCIDRs(activeLeases, [...sourceCIDRs, ...globalCIDRs]),
+        awsSSHCIDRs: activeAWSSSHSourceCIDRs(targetLeases, [...sourceCIDRs, ...globalCIDRs]),
       },
       lease: nextLease,
       provisioning: {
-        sshIngressReconcile: hasUnknownActiveAWSSSHSource(activeLeases)
-          ? "additive"
-          : "authoritative",
+        // Creates overlap outside the coordinator queue. Only serialized refreshes may prune.
+        sshIngressReconcile: "additive",
         publishAccessBeforeProvisioning: true,
       },
     };
@@ -8387,42 +9393,91 @@ class AWSProvider implements CloudProvider {
       return;
     }
     const sourceCIDRs = context.requestSourceCIDRs;
-    if (sourceCIDRs.length === 0) {
-      return;
-    }
-    const nextLease = withLeaseSSHSourceCIDRs(lease, sourceCIDRs, true);
+    const nextLease =
+      sourceCIDRs.length > 0 ? withLeaseSSHSourceCIDRs(lease, sourceCIDRs, true) : lease;
     const activeLeases = replaceProviderAccessState(context.activeLeases, nextLease);
-    const cidrs = activeAWSSSHSourceCIDRs(activeLeases, sourceCIDRs);
-    if (cidrs.length === 0) {
-      return nextLease;
-    }
     try {
-      const config = leaseConfig({
-        provider: "aws",
-        target: lease.target,
-        windowsMode: lease.windowsMode ?? "normal",
-        class: lease.class,
-        serverType: lease.serverType,
-        awsSSHCIDRs: cidrs,
-        capacity: { market: lease.market === "spot" ? "spot" : "on-demand" },
-        providerKey: lease.providerKey,
-        sshUser: lease.sshUser,
-        sshPort: lease.sshPort,
-        sshFallbackPorts: lease.sshFallbackPorts ?? [],
-        sshPublicKey: "ssh-ed25519 heartbeat-refresh",
-        workRoot: lease.workRoot,
-        ...(lease.hostId || lease.hostID ? { hostId: lease.hostId || lease.hostID } : {}),
-        ...(lease.region ? { awsRegion: lease.region } : {}),
-      });
-      const region = config.awsRegion || this.region;
-      const client = region === this.region ? this.client : new EC2SpotClient(this.env, region);
-      await client.refreshSSHIngress(config, {
-        reconcile: hasUnknownActiveAWSSSHSource(activeLeases) ? "additive" : "authoritative",
-      });
+      await this.reconcileLeaseAccess(nextLease, { ...context, activeLeases });
     } catch (error) {
       console.warn(`refresh AWS SSH ingress failed for ${lease.id}: ${errorMessage(error)}`);
     }
     return nextLease;
+  }
+
+  async reconcileLeaseAccess(lease: LeaseRecord, context: ProviderAccessContext): Promise<void> {
+    const globalCIDRs = awsGlobalSSHSourceCIDRs(this.env);
+    const accessLeases = context.activeLeases.filter(leaseOwnsAWSSSHAccess);
+    const targets = new Map<string, { lease: LeaseRecord; port: string; region: string }>();
+    const targetScopes = new Map<string, { identities: Set<string>; hasUnknownGroup: boolean }>();
+    for (const candidate of [lease, ...accessLeases]) {
+      const region = candidate.region || this.region;
+      for (const port of awsLeaseSSHPorts(candidate)) {
+        const key = awsIngressAccessTargetKey(candidate, region, [port], this.env);
+        if (!targets.has(key)) {
+          targets.set(key, { lease: candidate, port, region });
+        }
+        const scopeKey = awsIngressPortScopeKey(region, port);
+        const scope = targetScopes.get(scopeKey) ?? {
+          identities: new Set<string>(),
+          hasUnknownGroup: false,
+        };
+        scope.identities.add(key);
+        scope.hasUnknownGroup ||= awsIngressGroupMetadataUnknown(candidate, this.env);
+        targetScopes.set(scopeKey, scope);
+      }
+    }
+    const ambiguousTargetScopes = new Set(
+      [...targetScopes]
+        .filter(([, scope]) => scope.hasUnknownGroup && scope.identities.size > 1)
+        .map(([scopeKey]) => scopeKey),
+    );
+    for (const [targetKey, target] of targets) {
+      const targetLease = target.lease;
+      const targetLeases = accessLeases.filter((candidate) => {
+        const region = candidate.region || this.region;
+        return (
+          awsLeaseSSHPorts(candidate).includes(target.port) &&
+          awsIngressAccessTargetKey(candidate, region, [target.port], this.env) === targetKey
+        );
+      });
+      const cidrs = activeAWSSSHSourceCIDRs(targetLeases, globalCIDRs);
+      const reconcile =
+        ambiguousTargetScopes.has(awsIngressPortScopeKey(target.region, target.port)) ||
+        hasUnknownActiveAWSSSHSource(targetLeases)
+          ? "additive"
+          : "authoritative";
+      const config = leaseConfig({
+        provider: "aws",
+        target: targetLease.target,
+        windowsMode: targetLease.windowsMode ?? "normal",
+        class: targetLease.class,
+        serverType: targetLease.serverType,
+        awsSSHCIDRs: cidrs,
+        ...(targetLease.network?.awsSecurityGroupID
+          ? { awsSGID: targetLease.network.awsSecurityGroupID }
+          : {}),
+        ...(targetLease.network?.awsSubnetID
+          ? { awsSubnetID: targetLease.network.awsSubnetID }
+          : {}),
+        capacity: { market: targetLease.market === "spot" ? "spot" : "on-demand" },
+        providerKey: targetLease.providerKey,
+        sshUser: targetLease.sshUser,
+        sshPort: target.port,
+        sshFallbackPorts: [],
+        sshPublicKey: "ssh-ed25519 ingress-reconcile",
+        workRoot: targetLease.workRoot,
+        ...(targetLease.hostId || targetLease.hostID
+          ? { hostId: targetLease.hostId || targetLease.hostID }
+          : {}),
+      });
+      const { region } = target;
+      const client = region === this.region ? this.client : new EC2SpotClient(this.env, region);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each regional shared group is distinct.
+      await client.refreshSSHIngress(
+        { ...config, awsRegion: region },
+        { reconcile, allowEmpty: true },
+      );
+    }
   }
 
   async createServerWithFallback(
@@ -8447,6 +9502,9 @@ class AWSProvider implements CloudProvider {
     for (const region of regions) {
       const client = region === this.region ? this.client : new EC2SpotClient(this.env, region);
       try {
+        // Record only regions whose provisioning path is about to mutate provider state.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- region fallback is intentionally ordered.
+        await provisioning?.onTargetAttempt?.({ region });
         // oxlint-disable-next-line eslint/no-await-in-loop -- region fallback must preserve ordered capacity preference.
         const { server, serverType, market, attempts } = await client.createServerWithFallback(
           { ...config, awsRegion: region },

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -18,6 +18,11 @@ import {
   type LeaseConfig,
   type LeaseConfigDefaults,
 } from "./config";
+import {
+  CloudflareCoordinatorRuntime,
+  type CoordinatorRuntime,
+  type CoordinatorStorage,
+} from "./coordinator-runtime";
 import { GCPClient } from "./gcp";
 import { HetznerClient } from "./hetzner";
 import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
@@ -392,7 +397,7 @@ interface WebVNCViewerSession {
   connectedAt: string;
 }
 
-export class FleetDurableObject implements DurableObject {
+export class FleetCoordinator {
   private readonly webVNCAgents = new Map<string, Map<string, WebSocket>>();
   private readonly webVNCAgentCapabilities = new Map<string, Map<string, Set<string>>>();
   private readonly webVNCViewers = new Map<string, Map<string, WebVNCViewerSession>>();
@@ -410,7 +415,7 @@ export class FleetDurableObject implements DurableObject {
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
 
   constructor(
-    private readonly state: DurableObjectState,
+    private readonly state: CoordinatorRuntime,
     private readonly env: Env,
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
   ) {
@@ -630,7 +635,7 @@ export class FleetDurableObject implements DurableObject {
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    const attachment = bridgeAttachment(socket);
+    const attachment = this.bridgeAttachment(socket);
     if (!attachment) {
       return;
     }
@@ -646,11 +651,8 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private restoreBridgeWebSockets(): void {
-    if (typeof this.state.getWebSockets !== "function") {
-      return;
-    }
     for (const socket of this.state.getWebSockets()) {
-      const attachment = bridgeAttachment(socket);
+      const attachment = this.bridgeAttachment(socket);
       if (!attachment || socket.readyState !== WebSocket.OPEN) {
         continue;
       }
@@ -659,21 +661,19 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private acceptBridgeWebSocket(socket: WebSocket, attachment: BridgeAttachment): void {
-    if (typeof this.state.acceptWebSocket === "function") {
-      this.state.acceptWebSocket(socket, bridgeTags(attachment));
-      socket.serializeAttachment(attachment);
-    } else {
-      socket.accept();
-      socket.addEventListener("message", (event) => {
-        void this.handleBridgeMessage(socket, attachment, event.data);
-      });
-      socket.addEventListener("close", (event) => {
-        this.handleBridgeClose(socket, event.code, event.reason);
-      });
-      socket.addEventListener("error", () => {
+    this.state.acceptWebSocket(socket, attachment, bridgeTags(attachment), {
+      message: (data) => this.handleBridgeMessage(socket, attachment, data),
+      close: (code, reason) => {
+        this.handleBridgeClose(socket, code, reason);
+      },
+      error: () => {
         this.handleBridgeClose(socket, 1011, "bridge socket error");
-      });
-    }
+      },
+    });
+  }
+
+  private bridgeAttachment(socket: WebSocket): BridgeAttachment | undefined {
+    return bridgeAttachment(this.state.socketAttachment(socket));
   }
 
   private trackBridgeSocket(socket: WebSocket, attachment: BridgeAttachment): void {
@@ -779,9 +779,8 @@ export class FleetDurableObject implements DurableObject {
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json({ error: "websocket_required" }, { status: 426 });
     }
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const server = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const server = upgrade.socket;
     const attachment: BridgeAttachment = {
       kind: "control",
       clientID: crypto.randomUUID(),
@@ -797,7 +796,7 @@ export class FleetDurableObject implements DurableObject {
       protocol: 1,
       clientID: attachment.clientID,
     });
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private async handleControlMessage(
@@ -906,9 +905,7 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private serializeBridgeAttachment(socket: WebSocket, attachment: BridgeAttachment): void {
-    if (typeof socket.serializeAttachment === "function") {
-      socket.serializeAttachment(attachment);
-    }
+    this.state.setSocketAttachment(socket, attachment);
   }
 
   private async handleBridgeMessage(
@@ -972,7 +969,7 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private handleBridgeClose(socket: WebSocket, code: number, reason: string): void {
-    const attachment = bridgeAttachment(socket);
+    const attachment = this.bridgeAttachment(socket);
     if (!attachment) {
       return;
     }
@@ -2367,9 +2364,8 @@ export class FleetDurableObject implements DurableObject {
     if (error) {
       return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
     }
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const agent = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const agent = upgrade.socket;
 
     const agentID = newWebVNCSessionID("agent");
     const capabilities = webVNCAgentCapabilities(request);
@@ -2381,7 +2377,7 @@ export class FleetDurableObject implements DurableObject {
       id: agentID,
       capabilities,
     });
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private async createEgressTicket(request: Request, identifier: string): Promise<Response> {
@@ -2470,9 +2466,8 @@ export class FleetDurableObject implements DurableObject {
     if (lease.state !== "active") {
       return json({ error: "egress_unavailable", message: "lease is not active" }, { status: 409 });
     }
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const agent = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const agent = upgrade.socket;
     const attachment: BridgeAttachment = {
       kind: role === "host" ? "egress-host" : "egress-client",
       leaseID: lease.id,
@@ -2495,7 +2490,7 @@ export class FleetDurableObject implements DurableObject {
       this.egressClients.set(key, agent);
     }
     this.acceptBridgeWebSocket(agent, attachment);
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private async egressStatus(request: Request, identifier: string): Promise<Response> {
@@ -2808,15 +2803,14 @@ export class FleetDurableObject implements DurableObject {
     if (error) {
       return json({ error: "code_unavailable", message: error }, { status: 409 });
     }
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const agent = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const agent = upgrade.socket;
 
     closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
     this.clearCodeLease(lease.id);
     this.codeAgents.set(lease.id, agent);
     this.acceptBridgeWebSocket(agent, { kind: "code-agent", leaseID: lease.id });
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private async codePortalProxy(
@@ -2906,9 +2900,8 @@ export class FleetDurableObject implements DurableObject {
   }
 
   private codeViewerWebSocket(request: Request, lease: LeaseRecord, agent: WebSocket): Response {
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const viewer = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const viewer = upgrade.socket;
     const id = crypto.randomUUID();
     this.codeViewers.set(id, viewer);
     this.acceptBridgeWebSocket(viewer, { kind: "code-viewer", leaseID: lease.id, id });
@@ -2920,7 +2913,7 @@ export class FleetDurableObject implements DurableObject {
       headers: codeForwardHeaders(request.headers),
     };
     agent.send(JSON.stringify(open));
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private sendCodeWebSocketData(agent: WebSocket, message: CodeWebSocketData): void {
@@ -3185,9 +3178,8 @@ export class FleetDurableObject implements DurableObject {
       ? requestedViewerID
       : newWebVNCSessionID("viewer");
 
-    const pair = new WebSocketPair();
-    const client = pair[0];
-    const viewer = pair[1];
+    const upgrade = this.state.createWebSocketUpgrade();
+    const viewer = upgrade.socket;
     const owner = requestOwner(request);
     const label = webVNCViewerLabel(owner);
 
@@ -3213,7 +3205,7 @@ export class FleetDurableObject implements DurableObject {
       label,
     });
     flushPendingWebVNC(this.pendingWebVNCToViewer, webVNCBufferKey(lease.id, agent.id), viewer);
-    return new Response(null, { status: 101, webSocket: client });
+    return upgrade.response;
   }
 
   private clearWebVNCAgent(leaseID: string, agentID: string, socket: WebSocket): void {
@@ -4841,10 +4833,10 @@ export class FleetDurableObject implements DurableObject {
       alarmTimes.push(azureCleanupAlarm);
     }
     if (alarmTimes.length === 0) {
-      await this.state.storage.deleteAlarm();
+      await this.state.clearAlarm();
       return;
     }
-    await this.state.storage.setAlarm(Math.min(...alarmTimes));
+    await this.state.scheduleAlarm(Math.min(...alarmTimes));
   }
 
   private async nextAzureDeferredCleanupAlarmTime(): Promise<number | undefined> {
@@ -5500,7 +5492,7 @@ export class FleetDurableObject implements DurableObject {
       if (socket.readyState !== WebSocket.OPEN) {
         continue;
       }
-      const attachment = bridgeAttachment(socket);
+      const attachment = this.bridgeAttachment(socket);
       if (!attachment || attachment.kind !== "control") {
         continue;
       }
@@ -5532,7 +5524,12 @@ export class FleetDurableObject implements DurableObject {
       );
     }
     if (provider === "azure") {
-      return new AzureProvider(this.env, this.state.storage, region);
+      return new AzureProvider(
+        this.env,
+        this.state.storage,
+        (time) => this.state.scheduleAlarm(time),
+        region,
+      );
     }
     if (provider === "gcp") {
       return new GCPProvider(this.env, region, project);
@@ -5637,6 +5634,16 @@ export class FleetDurableObject implements DurableObject {
     }
     await this.putLease(lease);
     return lease;
+  }
+}
+
+export class FleetDurableObject extends FleetCoordinator implements DurableObject {
+  constructor(
+    state: DurableObjectState,
+    env: Env,
+    testProviders: Partial<Record<Provider, CloudProvider>> = {},
+  ) {
+    super(new CloudflareCoordinatorRuntime(state), env, testProviders);
   }
 }
 
@@ -6668,8 +6675,8 @@ export function codeResponseHeaders(values: Record<string, string>): Headers {
   return headers;
 }
 
-function bridgeAttachment(socket: WebSocket): BridgeAttachment | undefined {
-  const attachment = socket.deserializeAttachment?.() as BridgeAttachment | undefined;
+function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
+  const attachment = value as BridgeAttachment | undefined;
   if (!attachment || typeof attachment !== "object") {
     return undefined;
   }
@@ -8049,7 +8056,8 @@ class AzureProvider implements CloudProvider {
 
   constructor(
     private readonly env: Env,
-    private readonly storage?: DurableObjectStorage,
+    private readonly storage?: CoordinatorStorage,
+    private readonly scheduleAlarm?: (time: number) => Promise<void>,
     private readonly location?: string,
   ) {}
 
@@ -8076,7 +8084,7 @@ class AzureProvider implements CloudProvider {
       record.lastError = current.lastError;
     }
     await this.storage.put(key, record);
-    await this.storage.setAlarm(Date.now() + 1000);
+    await this.scheduleAlarm?.(Date.now() + 1000);
   }
 
   listCrabboxServers(): Promise<ProviderMachine[]> {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -13,6 +13,7 @@ const computeBaseURL = "https://compute.googleapis.com/compute/v1";
 const tokenURL = "https://oauth2.googleapis.com/token";
 const defaultImage = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64";
 const firewallName = "crabbox-ssh";
+const firewallVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
 
 interface TokenCache {
   token: string;
@@ -471,8 +472,58 @@ export class GCPClient {
       await this.waitGlobalOperation(op);
       return;
     }
-    const op = await this.gcp<GCPOperation>("POST", "/global/firewalls", firewall);
-    await this.waitGlobalOperation(op);
+    try {
+      const op = await this.gcp<GCPOperation>("POST", "/global/firewalls", firewall);
+      await this.waitGlobalOperation(op);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.toLowerCase().includes("http 409")) {
+        throw error;
+      }
+      await this.reconcileRacedFirewall(name, firewall, error);
+    }
+  }
+
+  private async reconcileRacedFirewall(
+    name: string,
+    firewall: Record<string, unknown>,
+    conflictError: unknown,
+  ): Promise<void> {
+    for (const delay of [0, ...firewallVisibilityBackoffMs]) {
+      if (delay > 0) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- firewall insertion is eventually consistent.
+        await sleep(delay);
+      }
+      let raced: { description?: string } | undefined;
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each lookup follows bounded propagation backoff.
+        raced = await this.gcp<{ description?: string }>("GET", `/global/firewalls/${name}`);
+      } catch (error) {
+        if (isNotFound(error)) {
+          continue;
+        }
+        throw error;
+      }
+      if (!raced.description?.includes("Crabbox-managed")) {
+        throw new Error(`gcp firewall ${name} exists but is not Crabbox-managed`, {
+          cause: conflictError,
+        });
+      }
+      try {
+        // A completed update proves the raced insert is visible and the desired policy is effective.
+        // oxlint-disable-next-line eslint/no-await-in-loop -- a conflicting insert may still be finishing.
+        const op = await this.gcp<GCPOperation>("PUT", `/global/firewalls/${name}`, firewall);
+        // oxlint-disable-next-line eslint/no-await-in-loop -- the raced policy must finish before this caller proceeds.
+        await this.waitGlobalOperation(op);
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message.toLowerCase() : String(error);
+        if (!message.includes("http 409") && !message.includes("http 404")) {
+          throw error;
+        }
+      }
+    }
+    throw conflictError;
   }
 
   private async gcp<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,58 +1,16 @@
-import { authenticateRequest, requestWithAuthContext } from "./auth";
+import { authenticateRequest } from "./auth";
+import { routeCoordinatorRequest } from "./coordinator-entry";
 import { FleetDurableObject } from "./fleet";
-import { json } from "./http";
 import type { Env } from "./types";
 
 export { FleetDurableObject };
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
-    if (request.method === "GET" && url.pathname === "/v1/health") {
-      return json({ ok: true, service: "crabbox-coordinator" });
-    }
-    if (request.method === "GET" && url.pathname === "/") {
-      return new Response(null, { status: 302, headers: { location: "/portal" } });
-    }
-    const canonicalPortal = canonicalPortalRedirect(request, env, url);
-    if (canonicalPortal) {
-      return canonicalPortal;
-    }
-    if (url.pathname.startsWith("/v1/auth/")) {
+    return routeCoordinatorRequest(request, env, async (fleetRequest) => {
       const id = env.FLEET.idFromName("default");
-      return env.FLEET.get(id).fetch(request);
-    }
-    if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
-      const id = env.FLEET.idFromName("default");
-      return env.FLEET.get(id).fetch(request);
-    }
-    if (url.pathname.startsWith("/v1/internal/")) {
-      return json({ error: "not_found" }, { status: 404 });
-    }
-    if (
-      isWebVNCAgentUpgrade(request, url) ||
-      isCodeAgentUpgrade(request, url) ||
-      isEgressAgentUpgrade(request, url)
-    ) {
-      const id = env.FLEET.idFromName("default");
-      return env.FLEET.get(id).fetch(request);
-    }
-    const portal = url.pathname.startsWith("/portal");
-    const authRequest = portal ? requestWithPortalCookie(request) : request;
-    const auth = await authenticateRequest(authRequest, env);
-    if (!auth?.authorized) {
-      if (portal && request.method === "GET" && request.headers.get("upgrade") !== "websocket") {
-        const login = new URL("/portal/login", url.origin);
-        login.searchParams.set("returnTo", `${url.pathname}${url.search}`);
-        return new Response(null, {
-          status: 302,
-          headers: { location: login.pathname + login.search },
-        });
-      }
-      return json({ error: "unauthorized" }, { status: 401 });
-    }
-    const id = env.FLEET.idFromName("default");
-    return env.FLEET.get(id).fetch(requestWithAuthContext(authRequest, auth));
+      return env.FLEET.get(id).fetch(fleetRequest);
+    });
   },
 
   async scheduled(
@@ -84,73 +42,4 @@ export async function isAuthorized(
   >,
 ): Promise<boolean> {
   return Boolean((await authenticateRequest(request, env))?.authorized);
-}
-
-function isWebVNCAgentUpgrade(request: Request, url: URL): boolean {
-  return (
-    request.method === "GET" &&
-    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
-    /^\/v1\/leases\/[^/]+\/webvnc\/agent$/.test(url.pathname)
-  );
-}
-
-function isCodeAgentUpgrade(request: Request, url: URL): boolean {
-  return (
-    request.method === "GET" &&
-    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
-    /^\/v1\/leases\/[^/]+\/code\/agent$/.test(url.pathname)
-  );
-}
-
-function isEgressAgentUpgrade(request: Request, url: URL): boolean {
-  return (
-    request.method === "GET" &&
-    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
-    /^\/v1\/leases\/[^/]+\/egress\/(?:host|client)$/.test(url.pathname)
-  );
-}
-
-function canonicalPortalRedirect(request: Request, env: Env, url: URL): Response | undefined {
-  if (
-    request.method !== "GET" ||
-    request.headers.get("upgrade")?.toLowerCase() === "websocket" ||
-    !url.pathname.startsWith("/portal") ||
-    !env.CRABBOX_PUBLIC_URL
-  ) {
-    return undefined;
-  }
-  let publicURL: URL;
-  try {
-    publicURL = new URL(env.CRABBOX_PUBLIC_URL);
-  } catch {
-    return undefined;
-  }
-  if (url.origin === publicURL.origin) {
-    return undefined;
-  }
-  const location = new URL(`${url.pathname}${url.search}`, publicURL.origin);
-  return new Response(null, { status: 302, headers: { location: location.toString() } });
-}
-
-function requestWithPortalCookie(request: Request): Request {
-  if (request.headers.get("authorization")) {
-    return request;
-  }
-  const token = cookieValue(request.headers.get("cookie") ?? "", "crabbox_session");
-  if (!token) {
-    return request;
-  }
-  const headers = new Headers(request.headers);
-  headers.set("authorization", `Bearer ${token}`);
-  return new Request(request, { headers });
-}
-
-function cookieValue(header: string, name: string): string {
-  for (const part of header.split(";")) {
-    const [rawKey, ...rawValue] = part.trim().split("=");
-    if (rawKey === name) {
-      return decodeURIComponent(rawValue.join("="));
-    }
-  }
-  return "";
 }

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -1,4 +1,5 @@
 import { issueUserToken, sha256Hex, userTokenExpiresAt } from "./auth";
+import type { CoordinatorStorage } from "./coordinator-runtime";
 import { errorMessage, json, readJson } from "./http";
 import type { Env, Provider } from "./types";
 import { requestOrg } from "./usage";
@@ -56,7 +57,7 @@ interface AllowedGitHubTeam {
 export async function githubAuthRoute(
   request: Request,
   action: string | undefined,
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   env: Env,
 ): Promise<Response> {
   const method = request.method.toUpperCase();
@@ -74,7 +75,7 @@ export async function githubAuthRoute(
 
 export async function githubPortalLogin(
   request: Request,
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   env: Env,
 ): Promise<Response> {
   const clientID = env.CRABBOX_GITHUB_CLIENT_ID;
@@ -109,7 +110,7 @@ export function githubPortalLogout(): Response {
 
 async function githubAuthStart(
   request: Request,
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   env: Env,
 ): Promise<Response> {
   const clientID = env.CRABBOX_GITHUB_CLIENT_ID;
@@ -166,7 +167,7 @@ function newPendingOAuth(
 }
 
 async function storePendingOAuth(
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   pending: OAuthPending,
 ): Promise<void> {
   await storage.put(oauthKey(pending.id), pending);
@@ -189,7 +190,7 @@ function githubAuthorizeURLFor(
 
 async function githubAuthCallback(
   request: Request,
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   env: Env,
 ): Promise<Response> {
   const url = new URL(request.url);
@@ -260,7 +261,7 @@ async function githubAuthCallback(
   }
 }
 
-async function githubAuthPoll(request: Request, storage: DurableObjectStorage): Promise<Response> {
+async function githubAuthPoll(request: Request, storage: CoordinatorStorage): Promise<Response> {
   const input = await readJson<{ loginID?: string; pollSecret?: string }>(request);
   if (!input.loginID || !input.pollSecret) {
     return json({ error: "invalid_poll" }, { status: 400 });
@@ -508,14 +509,14 @@ function githubHeaders(accessToken: string): Record<string, string> {
 class GitHubAuthorizationError extends Error {}
 
 async function deletePendingOAuth(
-  storage: DurableObjectStorage,
+  storage: CoordinatorStorage,
   pending: OAuthPending,
 ): Promise<void> {
   await storage.delete(oauthKey(pending.id));
   await storage.delete(oauthStateKey(pending.state));
 }
 
-async function cleanupExpiredPendingOAuth(storage: DurableObjectStorage): Promise<number> {
+async function cleanupExpiredPendingOAuth(storage: CoordinatorStorage): Promise<number> {
   const entries = await storage.list<OAuthPending>({ prefix: "oauth:" });
   let active = 0;
   const now = Date.now();

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -330,6 +330,8 @@ export interface LeaseRecord {
   cleanupError?: string;
   cleanupFailedAt?: string;
   cleanupRetryAt?: string;
+  cleanupStartedAt?: string;
+  cleanupClaimExpiresAt?: string;
   releaseDeletesServer?: boolean;
   releasedAt?: string;
   endedAt?: string;
@@ -403,6 +405,8 @@ export interface ReadyPoolReturnRequest {
 export interface LeaseNetworkState {
   sshSourceCIDRs?: string[];
   sshSourceCIDRsComplete?: boolean;
+  awsSecurityGroupID?: string;
+  awsSubnetID?: string;
 }
 
 export type LeaseShareRole = "use" | "manage";

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -72,6 +72,7 @@ export interface Env {
   CRABBOX_ACCESS_AUD?: string;
   CRABBOX_TRUSTED_USER_HEADER?: string;
   CRABBOX_TRUSTED_USER_ORG?: string;
+  CRABBOX_TRUSTED_PROXY_CIDRS?: string;
   CRABBOX_COST_RATES_JSON?: string;
   CRABBOX_EUR_TO_USD?: string;
   CRABBOX_MAX_ACTIVE_LEASES?: string;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -70,6 +70,8 @@ export interface Env {
   CRABBOX_DEFAULT_ORG?: string;
   CRABBOX_ACCESS_TEAM_DOMAIN?: string;
   CRABBOX_ACCESS_AUD?: string;
+  CRABBOX_TRUSTED_USER_HEADER?: string;
+  CRABBOX_TRUSTED_USER_ORG?: string;
   CRABBOX_COST_RATES_JSON?: string;
   CRABBOX_EUR_TO_USD?: string;
   CRABBOX_MAX_ACTIVE_LEASES?: string;

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -54,6 +54,126 @@ describe("aws provider", () => {
     expect(params).not.toHaveProperty("Description");
   });
 
+  it("recovers when another create wins the shared security group race", async () => {
+    let describeSecurityGroups = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeVpcs") {
+          return ec2XMLResponse(
+            "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+          );
+        }
+        if (action === "DescribeSecurityGroups") {
+          describeSecurityGroups += 1;
+          return ec2XMLResponse(
+            describeSecurityGroups === 1
+              ? "<DescribeSecurityGroupsResponse><securityGroupInfo /></DescribeSecurityGroupsResponse>"
+              : "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-raced</groupId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+          );
+        }
+        if (action === "CreateSecurityGroup") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidGroup.Duplicate</Code><Message>already exists</Message></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (action === "RevokeSecurityGroupIngress") {
+          return ec2XMLResponse("<RevokeSecurityGroupIngressResponse />");
+        }
+        if (action === "AuthorizeSecurityGroupIngress") {
+          return ec2XMLResponse("<AuthorizeSecurityGroupIngressResponse />");
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+
+    await client.refreshSSHIngress(
+      leaseConfig({
+        provider: "aws",
+        awsSSHCIDRs: ["198.51.100.77/32"],
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      { reconcile: "additive" },
+    );
+
+    expect(describeSecurityGroups).toBe(2);
+  });
+
+  it("retries raced security group discovery and initial ingress propagation", async () => {
+    let describeSecurityGroups = 0;
+    let authorizeIngress = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeVpcs") {
+          return ec2XMLResponse(
+            "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+          );
+        }
+        if (action === "DescribeSecurityGroups") {
+          describeSecurityGroups += 1;
+          return ec2XMLResponse(
+            describeSecurityGroups < 3
+              ? "<DescribeSecurityGroupsResponse><securityGroupInfo /></DescribeSecurityGroupsResponse>"
+              : "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-raced</groupId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+          );
+        }
+        if (action === "CreateSecurityGroup") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidGroup.Duplicate</Code><Message>already exists</Message></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (action === "RevokeSecurityGroupIngress") {
+          return ec2XMLResponse("<RevokeSecurityGroupIngressResponse />");
+        }
+        if (action === "AuthorizeSecurityGroupIngress") {
+          authorizeIngress += 1;
+          return authorizeIngress === 1
+            ? ec2XMLResponse(
+                "<Response><Errors><Error><Code>InvalidGroup.NotFound</Code><Message>not visible</Message></Error></Errors></Response>",
+                400,
+              )
+            : ec2XMLResponse("<AuthorizeSecurityGroupIngressResponse />");
+        }
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+          500,
+        );
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      "eu-west-1",
+    );
+
+    await client.refreshSSHIngress(
+      leaseConfig({
+        provider: "aws",
+        awsSSHCIDRs: ["198.51.100.77/32"],
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      { reconcile: "additive" },
+    );
+
+    expect(describeSecurityGroups).toBe(3);
+    expect(authorizeIngress).toBe(3);
+  });
+
   it("extracts only Crabbox-owned SSH ingress rules from AWS security groups", () => {
     expect(
       crabboxSSHIngressRules(

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   CloudflareCoordinatorRuntime,
+  coordinatorRequestQueue,
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
   type CoordinatorStorage,
@@ -38,6 +39,10 @@ class MemoryRuntime implements CoordinatorRuntime {
   alarmTime?: number;
   private readonly attachments = new WeakMap<WebSocket, unknown>();
 
+  runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    return callback();
+  }
+
   createWebSocketUpgrade(): never {
     throw new Error("websocket upgrade not configured");
   }
@@ -73,6 +78,23 @@ class MemoryRuntime implements CoordinatorRuntime {
 }
 
 describe("coordinator runtimes", () => {
+  it("keeps provider-backed portal requests outside the lifecycle queue", () => {
+    for (const [method, path] of [
+      ["GET", "/portal"],
+      ["GET", "/portal/admin/health"],
+      ["GET", "/portal/hosts/aws/h-123"],
+      ["POST", "/portal/hosts/aws/h-123/vnc"],
+      ["POST", "/portal/leases/example/release"],
+    ]) {
+      expect(
+        coordinatorRequestQueue(new Request(`https://coordinator.test${path}`, { method })),
+      ).toBe("direct");
+    }
+    expect(coordinatorRequestQueue(new Request("https://coordinator.test/portal/login"))).toBe(
+      "lifecycle",
+    );
+  });
+
   it("runs the fleet coordinator without a Durable Object", async () => {
     const coordinator = new FleetCoordinator(new MemoryRuntime(), {
       CRABBOX_DEFAULT_ORG: "example-org",
@@ -113,5 +135,65 @@ describe("coordinator runtimes", () => {
     expect(runtime.socketAttachment(socket)).toBe(attachment);
     expect(storage.setAlarm).toHaveBeenCalledWith(1234);
     expect(storage.deleteAlarm).toHaveBeenCalledOnce();
+  });
+
+  it("serializes Cloudflare coordinator state transitions", async () => {
+    const state = {
+      storage: {},
+    } as unknown as DurableObjectState;
+    const runtime = new CloudflareCoordinatorRuntime(state);
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = runtime.runExclusive(async () => {
+      order.push("first:start");
+      await firstBlocked;
+      order.push("first:end");
+    });
+    const second = runtime.runExclusive(async () => {
+      order.push("second");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+  });
+
+  it("serializes fallback control socket messages with state transitions", async () => {
+    const state = {
+      storage: {},
+    } as unknown as DurableObjectState;
+    const runtime = new CloudflareCoordinatorRuntime(state);
+    const listeners = new Map<string, EventListener>();
+    const socket = {
+      accept: vi.fn<() => void>(),
+      addEventListener: vi.fn<(type: string, listener: EventListener) => void>((type, listener) => {
+        listeners.set(type, listener);
+      }),
+    } as unknown as WebSocket;
+    const message = vi.fn<() => Promise<void>>(async () => {});
+    let releaseTransition!: () => void;
+    const transitionBlocked = new Promise<void>((resolve) => {
+      releaseTransition = resolve;
+    });
+    const transition = runtime.runExclusive(async () => transitionBlocked);
+    runtime.acceptWebSocket(socket, { kind: "control" }, [], {
+      message,
+      close: () => {},
+      error: () => {},
+    });
+
+    listeners.get("message")?.({ data: "{}" } as MessageEvent);
+    await Promise.resolve();
+    expect(message).not.toHaveBeenCalled();
+
+    releaseTransition();
+    await transition;
+    await vi.waitFor(() => expect(message).toHaveBeenCalledOnce());
   });
 });

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CloudflareCoordinatorRuntime,
+  type CoordinatorRuntime,
+  type CoordinatorSocketHandlers,
+  type CoordinatorStorage,
+} from "../src/coordinator-runtime";
+import { FleetCoordinator } from "../src/fleet";
+import type { Env } from "../src/types";
+
+class MemoryStorage implements CoordinatorStorage {
+  private readonly values = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async put<T>(key: string, value: T): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+
+  async list<T>({ prefix = "" }: { prefix?: string } = {}): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key, value as T]),
+    );
+  }
+}
+
+class MemoryRuntime implements CoordinatorRuntime {
+  readonly storage = new MemoryStorage();
+  alarmTime?: number;
+  private readonly attachments = new WeakMap<WebSocket, unknown>();
+
+  createWebSocketUpgrade(): never {
+    throw new Error("websocket upgrade not configured");
+  }
+
+  getWebSockets(): Iterable<WebSocket> {
+    return [];
+  }
+
+  socketAttachment<T>(socket: WebSocket): T | undefined {
+    return this.attachments.get(socket) as T | undefined;
+  }
+
+  setSocketAttachment(socket: WebSocket, attachment: unknown): void {
+    this.attachments.set(socket, attachment);
+  }
+
+  acceptWebSocket(
+    socket: WebSocket,
+    attachment: unknown,
+    _tags: string[],
+    _handlers: CoordinatorSocketHandlers,
+  ): void {
+    this.attachments.set(socket, attachment);
+  }
+
+  async scheduleAlarm(time: number): Promise<void> {
+    this.alarmTime = time;
+  }
+
+  async clearAlarm(): Promise<void> {
+    this.alarmTime = undefined;
+  }
+}
+
+describe("coordinator runtimes", () => {
+  it("runs the fleet coordinator without a Durable Object", async () => {
+    const coordinator = new FleetCoordinator(new MemoryRuntime(), {
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env);
+
+    const response = await coordinator.fetch(new Request("https://coordinator.test/v1/health"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, fleet: "default" });
+  });
+
+  it("maps Cloudflare alarms and hibernating socket attachments", async () => {
+    const storage = {
+      setAlarm: vi.fn<(time: number) => Promise<void>>(async () => {}),
+      deleteAlarm: vi.fn<() => Promise<void>>(async () => {}),
+    };
+    const acceptWebSocket = vi.fn<(socket: WebSocket, tags?: string[]) => void>();
+    const state = {
+      storage,
+      acceptWebSocket,
+      getWebSockets: () => [],
+    } as unknown as DurableObjectState;
+    const runtime = new CloudflareCoordinatorRuntime(state);
+    const serializeAttachment = vi.fn<(value: unknown) => void>();
+    const socket = { serializeAttachment } as unknown as WebSocket;
+    const attachment = { kind: "control", clientID: "client-1" };
+
+    runtime.acceptWebSocket(socket, attachment, ["control:client-1"], {
+      message: () => {},
+      close: () => {},
+      error: () => {},
+    });
+    await runtime.scheduleAlarm(1234);
+    await runtime.clearAlarm();
+
+    expect(acceptWebSocket).toHaveBeenCalledWith(socket, ["control:client-1"]);
+    expect(serializeAttachment).toHaveBeenCalledWith(attachment);
+    expect(runtime.socketAttachment(socket)).toBe(attachment);
+    expect(storage.setAlarm).toHaveBeenCalledWith(1234);
+    expect(storage.deleteAlarm).toHaveBeenCalledOnce();
+  });
+});

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -2,8 +2,10 @@ import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { awsPromotedAMIConfigKey, type LeaseConfig } from "../src/config";
+import { EC2SpotClient } from "../src/aws";
+import { awsPromotedAMIConfigKey, leaseConfig, type LeaseConfig } from "../src/config";
 import {
+  AWSProvider,
   FleetDurableObject,
   bridgeTicketFromRequest,
   codeForwardHeaders,
@@ -11,6 +13,7 @@ import {
   flushPendingWebVNC,
   forwardOrBufferWebVNC,
   resetWebVNCBridge,
+  recordAzureDeferredCleanup,
   shouldActivateEgressSession,
   type WebVNCBuffer,
 } from "../src/fleet";
@@ -23,6 +26,7 @@ import type {
   ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
+  ReadyPoolEntry,
   RunRecord,
 } from "../src/types";
 
@@ -74,6 +78,15 @@ class MemoryStorage {
 
   alarm(): number | undefined {
     return this.alarmTime;
+  }
+}
+
+class HookedMemoryStorage extends MemoryStorage {
+  beforePut?: (key: string, value: unknown) => Promise<void>;
+
+  override async put<T>(key: string, value: T): Promise<void> {
+    await this.beforePut?.(key, value);
+    await super.put(key, value);
   }
 }
 
@@ -316,6 +329,89 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBeUndefined();
   });
 
+  it("keeps heartbeats flowing while expiry cleanup runs and reconciles AWS ingress", async () => {
+    const storage = new MemoryStorage();
+    const deleteStarted = deferred<void>();
+    const finishDelete = deferred<void>();
+    const reconciliations: string[][] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        undefined,
+        {
+          provider: "aws",
+          onReconcileLeaseAccess(_lease, context) {
+            reconciliations.push(
+              context.activeLeases
+                .filter((candidate) => candidate.provider === "aws" && candidate.state === "active")
+                .map((candidate) => candidate.id)
+                .toSorted(),
+            );
+          },
+        },
+        async () => {
+          deleteStarted.resolve();
+          await finishDelete.promise;
+        },
+      ),
+    });
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        provider: "aws",
+        cloudID: "i-expired",
+        region: "eu-west-1",
+        network: {
+          awsSecurityGroupID: "sg-shared",
+          sshSourceCIDRs: ["198.51.100.10/32"],
+          sshSourceCIDRsComplete: true,
+        },
+        expiresAt: new Date(Date.now() - 1_000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        provider: "aws",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "i-active",
+        region: "eu-west-1",
+        network: {
+          awsSecurityGroupID: "sg-shared",
+          sshSourceCIDRs: ["198.51.100.20/32"],
+          sshSourceCIDRsComplete: true,
+        },
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+
+    const alarm = fleet.alarm();
+    await deleteStarted.promise;
+    const heartbeatCompleted = await Promise.race([
+      fleet
+        .fetch(
+          request("POST", "/v1/leases/cbx_000000000002/heartbeat", {
+            headers: {
+              "x-crabbox-owner": "alice@example.com",
+              "x-crabbox-org": "example-org",
+            },
+            body: { idleTimeoutSeconds: 300 },
+          }),
+        )
+        .then((response) => response.status === 200),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    expect(heartbeatCompleted).toBe(true);
+
+    finishDelete.resolve();
+    await alarm;
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000001")?.state).toBe("expired");
+    expect(reconciliations).toEqual([["cbx_000000000002"]]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+  });
+
   it("keeps provider cleanup failures active even when the cloud instance is already gone", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {
@@ -515,6 +611,58 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBe(firstAlarm);
   });
 
+  it("serializes Azure deferred cleanup persistence with alarm reconciliation", async () => {
+    const storage = new MemoryStorage();
+    let tail = Promise.resolve();
+    const state = {
+      storage,
+      async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+        const predecessor = tail;
+        const successor = deferred<void>();
+        tail = successor.promise;
+        await predecessor;
+        try {
+          return await callback();
+        } finally {
+          successor.resolve();
+        }
+      },
+    };
+    const staleRead = deferred<void>();
+    const staleBlocked = deferred<void>();
+    const staleSchedule = state.runExclusive(async () => {
+      expect((await storage.list({ prefix: "azure-cleanup:" })).size).toBe(0);
+      staleRead.resolve();
+      await staleBlocked.promise;
+      await storage.setAlarm(Date.now() + 60_000);
+    });
+    await staleRead.promise;
+
+    const deferredCleanup = recordAzureDeferredCleanup(
+      state,
+      async () => {
+        const records = await storage.list<{ retryAt: string }>({ prefix: "azure-cleanup:" });
+        const retryAt = Date.parse([...records.values()][0]?.retryAt ?? "");
+        await storage.setAlarm(Math.max(Date.now() + 1000, retryAt));
+      },
+      {
+        name: "crabbox-deferred",
+        location: "eastus",
+        resourceGroup: "crabbox-leases",
+        createdAt: new Date().toISOString(),
+      },
+    );
+    staleBlocked.resolve();
+    await Promise.all([staleSchedule, deferredCleanup]);
+
+    expect(storage.value("azure-cleanup:eastus:crabbox-deferred")).toMatchObject({
+      attempts: 0,
+      location: "eastus",
+      name: "crabbox-deferred",
+    });
+    expect(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1500);
+  });
+
   it("bootstraps AWS orphan sweep maintenance from the Worker cron route", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(
@@ -660,10 +808,46 @@ describe("fleet lease identity and idle", () => {
       testLease({
         id: "cbx_000000000777",
         provider: "azure",
-        cloudID: "vm-provisioning",
+        cloudID: "",
         region: "eastus",
         state: "provisioning",
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000778",
+      testLease({
+        id: "cbx_000000000778",
+        provider: "azure",
+        cloudID: "vm-cleaning",
+        region: "eastus",
+        state: "released",
+        cleanupStartedAt: new Date().toISOString(),
+        cleanupClaimExpiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000779",
+      testLease({
+        id: "cbx_000000000779",
+        provider: "azure",
+        cloudID: "",
+        region: "eastus",
+        state: "released",
+        keep: true,
+        releaseDeletesServer: false,
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000780",
+      testLease({
+        id: "cbx_000000000780",
+        provider: "azure",
+        cloudID: "vm-retained",
+        region: "eastus",
+        state: "released",
+        keep: true,
+        releaseDeletesServer: false,
       }),
     );
     const fleet = testFleet(
@@ -705,6 +889,39 @@ describe("fleet lease identity and idle", () => {
                 labels: {
                   crabbox: "true",
                   lease: "cbx_000000000777",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                provider: "azure",
+                cloudID: "vm-cleaning",
+                name: "vm-cleaning",
+                labels: {
+                  crabbox: "true",
+                  lease: "cbx_000000000778",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                provider: "azure",
+                cloudID: "vm-retaining",
+                name: "vm-retaining",
+                labels: {
+                  crabbox: "true",
+                  lease: "cbx_000000000779",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                provider: "azure",
+                cloudID: "vm-retained",
+                name: "vm-retained",
+                labels: {
+                  crabbox: "true",
+                  lease: "cbx_000000000780",
                   created_at: oldSeconds,
                   expires_at: oldSeconds,
                 },
@@ -1184,6 +1401,79 @@ describe("fleet lease identity and idle", () => {
     expect(cleanReturn.status).toBe(200);
   });
 
+  it("does not let a stale ready-pool status write overwrite a newer registration", async () => {
+    const storage = new HookedMemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000001";
+    const key = "example";
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: "2026-05-01T00:00:00.000Z",
+      }),
+    );
+    storage.seed<ReadyPoolEntry>(`ready-pool:${key}:${leaseID}`, {
+      key,
+      leaseID,
+      state: "ready",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-05-01T00:00:00.000Z",
+    });
+    const stalePutStarted = deferred<void>();
+    const finishStalePut = deferred<void>();
+    let blocked = false;
+    storage.beforePut = async (storageKey, value) => {
+      if (
+        !blocked &&
+        storageKey === `ready-pool:${key}:${leaseID}` &&
+        (value as ReadyPoolEntry).state === "stale"
+      ) {
+        blocked = true;
+        stalePutStarted.resolve();
+        await finishStalePut.promise;
+      }
+    };
+
+    const status = fleet.fetch(request("GET", `/v1/ready-pools/${key}`, { headers }));
+    await stalePutStarted.promise;
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const register = fleet.fetch(
+      request("POST", `/v1/ready-pools/${key}/register`, {
+        headers,
+        body: { leaseID },
+      }),
+    );
+    expect(
+      await Promise.race([
+        register.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 25)),
+      ]),
+    ).toBe(false);
+
+    finishStalePut.resolve();
+    expect((await status).status).toBe(200);
+    expect((await register).status).toBe(200);
+    expect(storage.value<ReadyPoolEntry>(`ready-pool:${key}:${leaseID}`)?.state).toBe("ready");
+  });
+
   it("requires manage access to borrow and drain ready-pool leases", async () => {
     const storage = new MemoryStorage();
     let deleted = "";
@@ -1578,8 +1868,8 @@ describe("fleet lease identity and idle", () => {
     const create = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
         body: {
           leaseID: "cbx_abcdef123456",
@@ -1617,8 +1907,8 @@ describe("fleet lease identity and idle", () => {
     const update = await fleet.fetch(
       request("POST", "/v1/leases/blue-lobster/tailscale", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
         body: {
           enabled: true,
@@ -1636,6 +1926,283 @@ describe("fleet lease identity and idle", () => {
     expect(updated.lease.tailscale?.ipv4).toBe("100.64.0.10");
     expect(updated.lease.tailscale?.exitNode).toBe("mac-studio.tailnet.ts.net");
     expect(updated.lease.tailscale?.state).toBe("ready");
+  });
+
+  it("does not hold the state transition lock while minting a Tailscale key", async () => {
+    const storage = new MemoryStorage();
+    const accessSnapshots = new Map<string, LeaseRecord[]>();
+    let oauthStarted!: () => void;
+    let finishOAuth!: () => void;
+    let providerCreateStarted!: () => void;
+    let finishProviderCreate!: () => void;
+    const oauthStartedPromise = new Promise<void>((resolve) => {
+      oauthStarted = resolve;
+    });
+    const finishOAuthPromise = new Promise<void>((resolve) => {
+      finishOAuth = resolve;
+    });
+    const providerCreateStartedPromise = new Promise<void>((resolve) => {
+      providerCreateStarted = resolve;
+    });
+    const finishProviderCreatePromise = new Promise<void>((resolve) => {
+      finishProviderCreate = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+          oauthStarted();
+          await finishOAuthPromise;
+          return jsonResponse({ access_token: "oauth-token" });
+        }
+        if (url === "https://api.tailscale.com/api/v2/tailnet/-/keys") {
+          return jsonResponse({ key: "tskey-oneoff" });
+        }
+        return jsonResponse({ message: `unexpected ${url}` }, 500);
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(
+          async () => {
+            providerCreateStarted();
+            await finishProviderCreatePromise;
+          },
+          {
+            provider: "aws",
+            onPrepareLeaseCreate(config, lease, context) {
+              accessSnapshots.set(lease.id, structuredClone(context.activeLeases));
+              return {
+                config,
+                lease: {
+                  ...lease,
+                  network: { sshSourceCIDRs: context.requestSourceCIDRs },
+                },
+                provisioning: {
+                  sshIngressReconcile: "authoritative",
+                  publishAccessBeforeProvisioning: true,
+                },
+              };
+            },
+          },
+        ),
+      },
+      {
+        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        CRABBOX_TAILSCALE_TAGS: "tag:ci",
+      },
+    );
+    const firstCreate = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "cf-connecting-ip": "198.51.100.10" },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          tailscale: true,
+          tailscaleTags: ["tag:ci"],
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await oauthStartedPromise;
+    const secondCreate = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "cf-connecting-ip": "198.51.100.11" },
+        body: {
+          leaseID: "cbx_abcdef123457",
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+    const secondReachedProvider = await Promise.race([
+      providerCreateStartedPromise.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    expect(secondReachedProvider).toBe(true);
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", "/v1/leases/cbx_abcdef123457/release", {
+            body: { delete: false },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+
+    finishOAuth();
+    await vi.waitFor(() => expect(accessSnapshots.has("cbx_abcdef123456")).toBe(true));
+    expect(
+      accessSnapshots.get("cbx_abcdef123456")?.find((lease) => lease.id === "cbx_abcdef123457"),
+    ).toMatchObject({
+      state: "provisioning",
+      network: { sshSourceCIDRs: ["198.51.100.11/32"] },
+    });
+    finishProviderCreate();
+    expect((await firstCreate).status).toBe(201);
+    expect((await secondCreate).status).toBe(409);
+  });
+
+  it("removes a retained release canceled before provider preparation", async () => {
+    const storage = new MemoryStorage();
+    let oauthStarted!: () => void;
+    let finishOAuth!: () => void;
+    let providerCalled = false;
+    const oauthStartedPromise = new Promise<void>((resolve) => {
+      oauthStarted = resolve;
+    });
+    const finishOAuthPromise = new Promise<void>((resolve) => {
+      finishOAuth = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+          oauthStarted();
+          await finishOAuthPromise;
+          return jsonResponse({ access_token: "oauth-token" });
+        }
+        if (url === "https://api.tailscale.com/api/v2/tailnet/-/keys") {
+          return jsonResponse({ key: "tskey-oneoff" });
+        }
+        return jsonResponse({ message: `unexpected ${url}` }, 500);
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(
+          () => {
+            providerCalled = true;
+          },
+          {
+            provider: "aws",
+            onPrepareLeaseCreate(config, lease) {
+              providerCalled = true;
+              return { config, lease };
+            },
+          },
+        ),
+      },
+      {
+        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        CRABBOX_TAILSCALE_TAGS: "tag:ci",
+      },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          tailscale: true,
+          tailscaleTags: ["tag:ci"],
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await oauthStartedPromise;
+    const release = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(release.status).toBe(200);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "released",
+      releaseDeletesServer: false,
+    });
+
+    finishOAuth();
+    expect((await createPromise).status).toBe(409);
+    expect(providerCalled).toBe(false);
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
+    expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
+  });
+
+  it("removes a retained release when Tailscale preparation fails", async () => {
+    const storage = new MemoryStorage();
+    let oauthStarted!: () => void;
+    let finishOAuth!: () => void;
+    let providerCalled = false;
+    const oauthStartedPromise = new Promise<void>((resolve) => {
+      oauthStarted = resolve;
+    });
+    const finishOAuthPromise = new Promise<void>((resolve) => {
+      finishOAuth = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+          oauthStarted();
+          await finishOAuthPromise;
+          return jsonResponse({ message: "oauth unavailable" }, 503);
+        }
+        return jsonResponse({ message: `unexpected ${url}` }, 500);
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(() => {
+          providerCalled = true;
+        }),
+      },
+      {
+        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        CRABBOX_TAILSCALE_TAGS: "tag:ci",
+      },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          tailscale: true,
+          tailscaleTags: ["tag:ci"],
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await oauthStartedPromise;
+    const release = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(release.status).toBe(200);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "released",
+      releaseDeletesServer: false,
+    });
+
+    finishOAuth();
+    expect((await createPromise).status).toBe(502);
+    expect(providerCalled).toBe(false);
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
+    expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
   });
 
   it("persists brokered leases as provisioning before provider create returns", async () => {
@@ -1681,6 +2248,73 @@ describe("fleet lease identity and idle", () => {
       cloudID: "vm-cbx-abcdef123456",
     });
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.state).toBe("active");
+  });
+
+  it("rejects a concurrent create with the same lease ID", async () => {
+    const storage = new MemoryStorage();
+    let createStarted!: () => void;
+    let finishCreate!: () => void;
+    const createStartedPromise = new Promise<void>((resolve) => {
+      createStarted = resolve;
+    });
+    const finishCreatePromise = new Promise<void>((resolve) => {
+      finishCreate = resolve;
+    });
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        async () => {
+          createStarted();
+          await finishCreatePromise;
+        },
+        { provider: "azure", cloudID: "vm-cbx-abcdef123456", region: "eastus" },
+      ),
+    });
+    const firstCreate = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await createStartedPromise;
+    const conflictingCreate = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "bob@example.com",
+          "x-crabbox-org": "other-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "westus3",
+          sshPublicKey: "ssh-ed25519 other",
+        },
+      }),
+    );
+    expect(conflictingCreate.status).toBe(409);
+    await expect(conflictingCreate.json()).resolves.toMatchObject({ error: "lease_id_conflict" });
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      owner: "alice@example.com",
+      org: "example-org",
+      state: "provisioning",
+    });
+
+    finishCreate();
+    const firstResult = await firstCreate;
+    expect(firstResult.status).toBe(201);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      owner: "alice@example.com",
+      org: "example-org",
+      state: "active",
+    });
   });
 
   it("marks provisioning leases failed when provider create fails", async () => {
@@ -1825,6 +2459,114 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("rejects a no-delete release after provisioning cleanup has started", async () => {
+    const storage = new MemoryStorage();
+    let createStarted!: () => void;
+    let finishCreate!: () => void;
+    let deleteStarted!: () => void;
+    let finishDelete!: () => void;
+    const createStartedPromise = new Promise<void>((resolve) => {
+      createStarted = resolve;
+    });
+    const finishCreatePromise = new Promise<void>((resolve) => {
+      finishCreate = resolve;
+    });
+    const deleteStartedPromise = new Promise<void>((resolve) => {
+      deleteStarted = resolve;
+    });
+    const finishDeletePromise = new Promise<void>((resolve) => {
+      finishDelete = resolve;
+    });
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(
+        async () => {
+          createStarted();
+          await finishCreatePromise;
+        },
+        { provider: "azure", cloudID: "vm-cbx-abcdef123456", region: "eastus" },
+        async () => {
+          deleteStarted();
+          await finishDeletePromise;
+          throw new Error("azure delete throttled");
+        },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          ttlSeconds: 1200,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await createStartedPromise;
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", "/v1/leases/cbx_abcdef123456/release", {
+            headers,
+            body: { delete: true },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+    finishCreate();
+    await deleteStartedPromise;
+
+    const noDelete = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(noDelete.status).toBe(409);
+    await expect(noDelete.json()).resolves.toMatchObject({ error: "cleanup_in_progress" });
+    const claimed = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    expect(claimed).toMatchObject({
+      state: "released",
+      cloudID: "vm-cbx-abcdef123456",
+      releaseDeletesServer: true,
+      cleanupStartedAt: expect.any(String),
+      cleanupClaimExpiresAt: expect.any(String),
+    });
+    expect(
+      Date.parse(claimed?.cleanupClaimExpiresAt ?? "") -
+        Date.parse(claimed?.cleanupStartedAt ?? ""),
+    ).toBe(30 * 60 * 1000);
+    expect(storage.alarm()).toBe(Date.parse(claimed?.cleanupClaimExpiresAt ?? ""));
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/heartbeat", {
+        headers,
+        body: { idleTimeoutSeconds: 300 },
+      }),
+    );
+    expect(heartbeat.status).toBe(409);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.cleanupStartedAt).toBe(
+      claimed?.cleanupStartedAt,
+    );
+
+    finishDelete();
+    expect((await createPromise).status).toBe(500);
+    const released = storage.value<LeaseRecord>("lease:cbx_abcdef123456");
+    expect(released?.state).toBe("released");
+    expect(released?.cleanupStartedAt).toBeUndefined();
+    expect(released?.cleanupClaimExpiresAt).toBeUndefined();
+    expect(released).toMatchObject({
+      releaseDeletesServer: true,
+      cleanupError: "azure delete throttled",
+      cleanupRetryAt: expect.any(String),
+    });
+  });
+
   it("does not reactivate a provisioning lease released while create finalization is pending", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
@@ -1892,6 +2634,152 @@ describe("fleet lease identity and idle", () => {
       provider: "azure",
       state: "released",
       cloudID: "",
+    });
+  });
+
+  it("preserves heartbeat updates while create finalization is pending", async () => {
+    const storage = new MemoryStorage();
+    let finalizationStarted!: () => void;
+    let finishFinalization!: () => void;
+    const finalizationStartedPromise = new Promise<void>((resolve) => {
+      finalizationStarted = resolve;
+    });
+    const finishFinalizationPromise = new Promise<void>((resolve) => {
+      finishFinalization = resolve;
+    });
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        cloudID: "vm-cbx-abcdef123456",
+        region: "eastus",
+        onFinalizeLeaseCreate: async (config, lease) => {
+          finalizationStarted();
+          await finishFinalizationPromise;
+          return { config, lease };
+        },
+      }),
+    });
+
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          ttlSeconds: 1200,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await finalizationStartedPromise;
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/heartbeat", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { idleTimeoutSeconds: 300 },
+      }),
+    );
+    expect(heartbeat.status).toBe(200);
+    const heartbeatLease = ((await heartbeat.json()) as { lease: LeaseRecord }).lease;
+
+    finishFinalization();
+    const create = await createPromise;
+    expect(create.status).toBe(201);
+    const createdLease = ((await create.json()) as { lease: LeaseRecord }).lease;
+    expect(createdLease).toMatchObject({
+      id: "cbx_abcdef123456",
+      state: "active",
+      cloudID: "vm-cbx-abcdef123456",
+      idleTimeoutSeconds: 300,
+      lastTouchedAt: heartbeatLease.lastTouchedAt,
+      expiresAt: heartbeatLease.expiresAt,
+    });
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toEqual(createdLease);
+  });
+
+  it("buffers Cloudflare heartbeat bodies before serializing state transitions", async () => {
+    const storage = new MemoryStorage();
+    let finalizationStarted!: () => void;
+    let finishFinalization!: () => void;
+    let bodyReadStarted!: () => void;
+    let finishBody!: () => void;
+    const finalizationStartedPromise = new Promise<void>((resolve) => {
+      finalizationStarted = resolve;
+    });
+    const finishFinalizationPromise = new Promise<void>((resolve) => {
+      finishFinalization = resolve;
+    });
+    const bodyReadStartedPromise = new Promise<void>((resolve) => {
+      bodyReadStarted = resolve;
+    });
+    const finishBodyPromise = new Promise<void>((resolve) => {
+      finishBody = resolve;
+    });
+    const fleet = testFleet(storage, {
+      azure: fakeProvider(undefined, {
+        provider: "azure",
+        cloudID: "vm-cbx-abcdef123456",
+        region: "eastus",
+        onFinalizeLeaseCreate: async (config, lease) => {
+          finalizationStarted();
+          await finishFinalizationPromise;
+          return { config, lease };
+        },
+      }),
+    });
+    const headers = {
+      "content-type": "application/json",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "azure",
+          azureLocation: "eastus",
+          ttlSeconds: 1200,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await finalizationStartedPromise;
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        bodyReadStarted();
+        await finishBodyPromise;
+        controller.enqueue(new TextEncoder().encode('{"idleTimeoutSeconds":300}'));
+        controller.close();
+      },
+    });
+    const heartbeatPromise = fleet.fetch(
+      new Request("https://coordinator.test/v1/leases/cbx_abcdef123456/heartbeat", {
+        method: "POST",
+        headers,
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+    await bodyReadStartedPromise;
+    finishFinalization();
+    expect((await createPromise).status).toBe(201);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.state).toBe("active");
+
+    finishBody();
+    expect((await heartbeatPromise).status).toBe(200);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+      state: "active",
+      cloudID: "vm-cbx-abcdef123456",
+      idleTimeoutSeconds: 300,
     });
   });
 
@@ -2213,8 +3101,9 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("rejects brokered Tailscale tags outside the coordinator allowlist", async () => {
+    const storage = new MemoryStorage();
     const fleet = testFleet(
-      new MemoryStorage(),
+      storage,
       { hetzner: fakeProvider() },
       {
         CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
@@ -2238,15 +3127,17 @@ describe("fleet lease identity and idle", () => {
       error: "invalid_tailscale_tags",
       message: "tailscale tags not allowed: tag:prod",
     });
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
   });
 
   it("reports brokered Tailscale disabled when OAuth secrets are absent", async () => {
-    const fleet = testFleet(new MemoryStorage(), { hetzner: fakeProvider() });
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, { hetzner: fakeProvider() });
     const create = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
         body: {
           leaseID: "cbx_abcdef123456",
@@ -2261,6 +3152,7 @@ describe("fleet lease identity and idle", () => {
       error: "tailscale_disabled",
       message: "Tailscale is disabled for this coordinator",
     });
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
   });
 
   it("passes the Cloudflare request source IP as AWS SSH ingress CIDR", async () => {
@@ -2297,6 +3189,813 @@ describe("fleet lease identity and idle", () => {
     );
     expect(create.status).toBe(201);
     expect(awsCIDRs).toEqual(["203.0.113.7/32"]);
+  });
+
+  it("uses additive AWS ingress reconciliation while creates can overlap", async () => {
+    const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
+    const config = leaseConfig({
+      provider: "aws",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      state: "provisioning",
+      network: { sshSourceCIDRs: ["203.0.113.7/32"] },
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const active = testLease({
+      id: "cbx_000000000001",
+      provider: "aws",
+      network: { sshSourceCIDRs: ["198.51.100.44/32"] },
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const prepared = await provider.prepareLeaseCreate(config, lease, {
+      requestSourceCIDRs: ["203.0.113.7/32"],
+      activeLeases: [active],
+    });
+
+    expect(prepared.config.awsSSHCIDRs).toEqual(["198.51.100.44/32", "203.0.113.7/32"]);
+    expect(prepared.provisioning).toMatchObject({
+      sshIngressReconcile: "additive",
+      publishAccessBeforeProvisioning: true,
+    });
+  });
+
+  it("reports each AWS fallback region before provisioning mutates it", async () => {
+    const attempts: string[] = [];
+    const targets: string[] = [];
+    const machine: ProviderMachine = {
+      provider: "aws",
+      id: 123,
+      cloudID: "i-123",
+      name: "crabbox-test",
+      status: "running",
+      serverType: "c7a.8xlarge",
+      host: "192.0.2.10",
+      labels: {},
+    };
+    const create = vi
+      .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+      .mockImplementation(async (candidateConfig) => {
+        attempts.push(candidateConfig.awsRegion);
+        if (candidateConfig.awsRegion === "eu-west-1") {
+          throw new Error("capacity unavailable");
+        }
+        return { server: machine, serverType: machine.serverType };
+      });
+    const wait = vi.spyOn(EC2SpotClient.prototype, "waitForServerIP").mockResolvedValue(machine);
+    try {
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      const config = {
+        ...leaseConfig({ provider: "aws", sshPublicKey: "ssh-ed25519 test" }),
+        capacityRegions: ["us-east-1"],
+      };
+
+      const result = await provider.createServerWithFallback(
+        config,
+        "cbx_abcdef123456",
+        "test",
+        "alice@example.com",
+        {
+          onTargetAttempt: async (target) => {
+            targets.push(target.region ?? "");
+          },
+        },
+      );
+
+      expect(attempts).toEqual(["eu-west-1", "us-east-1"]);
+      expect(targets).toEqual(attempts);
+      expect(result.server.region).toBe("us-east-1");
+    } finally {
+      create.mockRestore();
+      wait.mockRestore();
+    }
+  });
+
+  it("keeps retained unknown AWS access additive and ignores unrelated regions", async () => {
+    const requests: Array<{ action: string; cidr: string; groupID: string; hostname: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const fetchRequest = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await fetchRequest.clone().text());
+        const action = params.get("Action") ?? "";
+        const groupID = params.get("GroupId") ?? params.get("GroupId.1") ?? "";
+        requests.push({
+          action,
+          cidr:
+            params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+            params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6") ??
+            "",
+          groupID,
+          hostname: new URL(fetchRequest.url).hostname,
+        });
+        if (action === "DescribeSecurityGroups") {
+          return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse>
+  <securityGroupInfo>
+    <item>
+      <groupId>${groupID}</groupId>
+      <ipPermissions>
+        <item>
+          <ipProtocol>tcp</ipProtocol>
+          <fromPort>22</fromPort>
+          <toPort>22</toPort>
+          <ipRanges>
+            <item>
+              <cidrIp>203.0.113.10/32</cidrIp>
+              <description>Crabbox SSH</description>
+            </item>
+          </ipRanges>
+        </item>
+      </ipPermissions>
+    </item>
+  </securityGroupInfo>
+</DescribeSecurityGroupsResponse>`);
+        }
+        return new Response(`<Response />`);
+      }),
+    );
+    const provider = new AWSProvider(
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    const anchor = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      state: "released",
+      region: "eu-west-1",
+      network: { awsSecurityGroupID: "sg-west" },
+    });
+    const retained = testLease({
+      id: "cbx_abcdef123457",
+      provider: "aws",
+      state: "released",
+      region: "eu-west-1",
+      releaseDeletesServer: false,
+      network: { awsSecurityGroupID: "sg-west" },
+    });
+    const activeEast = testLease({
+      id: "cbx_abcdef123460",
+      provider: "aws",
+      state: "active",
+      region: "us-east-1",
+      network: {
+        awsSecurityGroupID: "sg-east",
+        sshSourceCIDRs: ["198.51.100.20/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+    const unrelated = testLease({
+      id: "cbx_abcdef123458",
+      provider: "azure",
+      state: "active",
+      region: "eastus",
+    });
+    const historical = testLease({
+      id: "cbx_abcdef123459",
+      provider: "aws",
+      state: "released",
+      region: "us-invalid-1",
+    });
+
+    await provider.reconcileLeaseAccess(anchor, {
+      requestSourceCIDRs: [],
+      activeLeases: [retained, activeEast, unrelated, historical],
+    });
+
+    expect(new Set(requests.map((entry) => `${entry.hostname}:${entry.groupID}`))).toEqual(
+      new Set(["ec2.eu-west-1.amazonaws.com:sg-west", "ec2.us-east-1.amazonaws.com:sg-east"]),
+    );
+    expect(
+      requests.filter(
+        (entry) =>
+          entry.action === "RevokeSecurityGroupIngress" &&
+          entry.groupID === "sg-west" &&
+          entry.cidr === "203.0.113.10/32",
+      ),
+    ).toEqual([]);
+    expect(
+      requests.some(
+        (entry) =>
+          entry.action === "AuthorizeSecurityGroupIngress" &&
+          entry.groupID === "sg-west" &&
+          entry.cidr === "198.51.100.20/32",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps reconciliation additive when legacy metadata may resolve to an explicit AWS group", async () => {
+    const revokedCIDRs: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const fetchRequest = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await fetchRequest.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeVpcs") {
+          return new Response(
+            "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+          );
+        }
+        if (action === "DescribeSecurityGroups") {
+          return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+        }
+        if (action === "RevokeSecurityGroupIngress") {
+          revokedCIDRs.push(params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "");
+        }
+        return new Response("<Response />");
+      }),
+    );
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    const anchor = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      state: "released",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: { awsSecurityGroupID: "sg-shared" },
+    });
+    const legacy = testLease({
+      id: "cbx_abcdef123457",
+      provider: "aws",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: {
+        sshSourceCIDRs: ["198.51.100.10/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+    const explicit = testLease({
+      id: "cbx_abcdef123458",
+      provider: "aws",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: {
+        awsSecurityGroupID: "sg-shared",
+        sshSourceCIDRs: ["198.51.100.20/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+
+    await provider.reconcileLeaseAccess(anchor, {
+      requestSourceCIDRs: [],
+      activeLeases: [legacy, explicit],
+    });
+
+    expect(revokedCIDRs.filter((cidr) => cidr !== "0.0.0.0/0")).toEqual([]);
+  });
+
+  it("prunes stale CIDRs from a single auto-managed AWS group", async () => {
+    const revokedCIDRs: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const fetchRequest = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await fetchRequest.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeVpcs") {
+          return new Response(
+            "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+          );
+        }
+        if (action === "DescribeSecurityGroups") {
+          return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-auto</groupId><groupName>crabbox-runners</groupName><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+        }
+        if (action === "RevokeSecurityGroupIngress") {
+          revokedCIDRs.push(params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "");
+        }
+        return new Response("<Response />");
+      }),
+    );
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    const anchor = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      state: "released",
+      region: "eu-west-1",
+      sshPort: "22",
+    });
+    const active = testLease({
+      id: "cbx_abcdef123457",
+      provider: "aws",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: {
+        sshSourceCIDRs: ["198.51.100.20/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+
+    await provider.reconcileLeaseAccess(anchor, {
+      requestSourceCIDRs: [],
+      activeLeases: [active],
+    });
+
+    expect(revokedCIDRs).toContain("198.51.100.10/32");
+    expect(revokedCIDRs).not.toContain("198.51.100.20/32");
+  });
+
+  it("reconciles distinct SSH port sets that share an AWS security group", async () => {
+    const authorizedRules: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const fetchRequest = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await fetchRequest.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "DescribeSecurityGroups") {
+          return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+        }
+        if (action === "AuthorizeSecurityGroupIngress") {
+          authorizedRules.push(
+            `${params.get("IpPermissions.1.FromPort")}:${
+              params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+              params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6")
+            }`,
+          );
+        }
+        return new Response("<Response />");
+      }),
+    );
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    const anchor = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      state: "released",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: { awsSecurityGroupID: "sg-shared" },
+    });
+    const active22 = testLease({
+      id: "cbx_abcdef123457",
+      provider: "aws",
+      region: "eu-west-1",
+      sshPort: "22",
+      network: {
+        awsSecurityGroupID: "sg-shared",
+        sshSourceCIDRs: ["198.51.100.20/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+    const active2222 = testLease({
+      id: "cbx_abcdef123458",
+      provider: "aws",
+      region: "eu-west-1",
+      sshPort: "2222",
+      network: {
+        awsSecurityGroupID: "sg-shared",
+        sshSourceCIDRs: ["198.51.100.21/32"],
+        sshSourceCIDRsComplete: true,
+      },
+    });
+
+    await provider.reconcileLeaseAccess(anchor, {
+      requestSourceCIDRs: [],
+      activeLeases: [active22, active2222],
+    });
+
+    expect(new Set(authorizedRules)).toEqual(
+      new Set(["22:198.51.100.20/32", "22:198.51.100.21/32", "2222:198.51.100.21/32"]),
+    );
+  });
+
+  it("reconciles AWS ingress after the final overlapping create drains", async () => {
+    const storage = new MemoryStorage();
+    const started = [deferred<void>(), deferred<void>()];
+    const finish = [deferred<void>(), deferred<void>()];
+    let createIndex = 0;
+    const reconciliations: string[][] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        async () => {
+          const index = createIndex++;
+          started[index]?.resolve();
+          await finish[index]?.promise;
+        },
+        {
+          provider: "aws",
+          region: "eu-west-1",
+          onPrepareLeaseCreate(config, lease, context) {
+            return {
+              config,
+              lease: {
+                ...lease,
+                network: { ...lease.network, sshSourceCIDRs: context.requestSourceCIDRs },
+              },
+              provisioning: {
+                sshIngressReconcile: "additive",
+                publishAccessBeforeProvisioning: true,
+              },
+            };
+          },
+          onReconcileLeaseAccess(_lease, context) {
+            reconciliations.push(
+              context.activeLeases
+                .filter((active) => active.provider === "aws" && active.state === "active")
+                .map((active) => active.id)
+                .toSorted(),
+            );
+          },
+        },
+      ),
+    });
+    const create = (leaseID: string, sourceIP: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: { "cf-connecting-ip": sourceIP },
+          body: { leaseID, provider: "aws", sshPublicKey: "ssh-ed25519 test" },
+        }),
+      );
+
+    const first = create("cbx_abcdef123456", "198.51.100.10");
+    await started[0]?.promise;
+    const second = create("cbx_abcdef123457", "198.51.100.11");
+    await started[1]?.promise;
+    finish[0]?.resolve();
+    expect((await first).status).toBe(201);
+    expect(reconciliations).toEqual([]);
+
+    finish[1]?.resolve();
+    expect((await second).status).toBe(201);
+    expect(reconciliations).toEqual([]);
+
+    await fleet.alarm();
+    expect(reconciliations).toEqual([["cbx_abcdef123456", "cbx_abcdef123457"]]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+  });
+
+  it("recovers additive AWS creates from security-group rule limits", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const reconciliations: Array<{ cidrs: string[]; region: string; stateRegions: string[] }> = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          creates += 1;
+          if (creates === 1) {
+            throw new Error("RulesPerSecurityGroupLimitExceeded: security group rule quota");
+          }
+        },
+        {
+          provider: "aws",
+          region: "us-east-1",
+          onPrepareLeaseCreate(config, lease, context) {
+            return {
+              config,
+              lease: {
+                ...lease,
+                network: {
+                  ...lease.network,
+                  sshSourceCIDRs: context.requestSourceCIDRs,
+                  sshSourceCIDRsComplete: true,
+                },
+              },
+              provisioning: {
+                sshIngressReconcile: "additive",
+                publishAccessBeforeProvisioning: true,
+              },
+            };
+          },
+          async onCreateProvisioning(provisioning) {
+            await provisioning?.onTargetAttempt?.({ region: "us-east-1" });
+          },
+          onReconcileLeaseAccess(lease, context) {
+            reconciliations.push({
+              cidrs: context.activeLeases.flatMap(
+                (candidate) => candidate.network?.sshSourceCIDRs ?? [],
+              ),
+              region: lease.region ?? "",
+              stateRegions: context.activeLeases.map((candidate) => candidate.region ?? ""),
+            });
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "cf-connecting-ip": "198.51.100.10" },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          awsRegion: "eu-west-1",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(creates).toBe(2);
+    expect(reconciliations).toEqual([
+      {
+        cidrs: ["198.51.100.10/32"],
+        region: "us-east-1",
+        stateRegions: ["us-east-1"],
+      },
+    ]);
+  });
+
+  it("preserves distinct pending AWS ingress targets until each reconciles", async () => {
+    const storage = new MemoryStorage();
+    const reconciled: string[] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        (config) => {
+          if (config.awsRegion === "eu-west-1") {
+            throw new Error("first region failed");
+          }
+        },
+        {
+          provider: "aws",
+          region: "us-east-1",
+          onPrepareLeaseCreate(config, lease, context) {
+            return {
+              config,
+              lease: {
+                ...lease,
+                network: {
+                  ...lease.network,
+                  awsSecurityGroupID: config.awsSGID,
+                  sshSourceCIDRs: context.requestSourceCIDRs,
+                },
+              },
+              provisioning: {
+                sshIngressReconcile: "additive",
+                publishAccessBeforeProvisioning: true,
+              },
+            };
+          },
+          onReconcileLeaseAccess(lease) {
+            reconciled.push(`${lease.region}:${lease.network?.awsSecurityGroupID}`);
+          },
+        },
+      ),
+    });
+    const create = (leaseID: string, awsRegion: string, awsSGID: string) =>
+      fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: { "cf-connecting-ip": "198.51.100.10" },
+          body: {
+            leaseID,
+            provider: "aws",
+            awsRegion,
+            awsSGID,
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+
+    expect((await create("cbx_abcdef123456", "eu-west-1", "sg-west")).status).toBe(500);
+    expect((await create("cbx_abcdef123457", "us-east-1", "sg-east")).status).toBe(201);
+    expect(
+      storage.value<{ targets: Array<{ anchor: LeaseRecord }> }>("aws-ingress-reconcile:pending")
+        ?.targets,
+    ).toHaveLength(2);
+
+    await fleet.alarm();
+
+    expect(reconciled.toSorted()).toEqual(["eu-west-1:sg-west", "us-east-1:sg-east"]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+  });
+
+  it("retains every attempted AWS region for cleanup when provisioning fails", async () => {
+    const storage = new MemoryStorage();
+    const reconciled: string[] = [];
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onPrepareLeaseCreate(config, lease, context) {
+          return {
+            config,
+            lease: {
+              ...lease,
+              network: {
+                ...lease.network,
+                awsSecurityGroupID: config.awsSGID,
+                sshSourceCIDRs: context.requestSourceCIDRs,
+                sshSourceCIDRsComplete: true,
+              },
+            },
+            provisioning: {
+              sshIngressReconcile: "additive",
+              publishAccessBeforeProvisioning: true,
+            },
+          };
+        },
+        async onCreateProvisioning(provisioning) {
+          await provisioning?.onTargetAttempt?.({ region: "eu-west-1" });
+          await provisioning?.onTargetAttempt?.({ region: "us-east-1" });
+          throw new Error("capacity unavailable");
+        },
+        onReconcileLeaseAccess(lease) {
+          reconciled.push(lease.region ?? "");
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { "cf-connecting-ip": "198.51.100.10" },
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          awsRegion: "eu-west-1",
+          awsSGID: "sg-shared",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(
+      storage
+        .value<{ targets: Array<{ anchor: LeaseRecord }> }>("aws-ingress-reconcile:pending")
+        ?.targets.map((target) => target.anchor.region)
+        .toSorted(),
+    ).toEqual(["eu-west-1", "us-east-1"]);
+
+    await fleet.alarm();
+    expect(reconciled.toSorted()).toEqual(["eu-west-1", "us-east-1"]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+  });
+
+  it("fences a release behind AWS ingress reconciliation and preserves the newer work", async () => {
+    const storage = new MemoryStorage();
+    const reconcileStarted = deferred<void>();
+    const finishReconcile = deferred<void>();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onPrepareLeaseCreate(config, lease, context) {
+          return {
+            config,
+            lease: {
+              ...lease,
+              network: { ...lease.network, sshSourceCIDRs: context.requestSourceCIDRs },
+            },
+            provisioning: {
+              sshIngressReconcile: "additive",
+              publishAccessBeforeProvisioning: true,
+            },
+          };
+        },
+        async onReconcileLeaseAccess() {
+          reconcileStarted.resolve();
+          await finishReconcile.promise;
+        },
+      }),
+    });
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", "/v1/leases", {
+            headers: { "cf-connecting-ip": "198.51.100.10" },
+            body: {
+              leaseID: "cbx_abcdef123456",
+              provider: "aws",
+              sshPublicKey: "ssh-ed25519 test",
+            },
+          }),
+        )
+      ).status,
+    ).toBe(201);
+
+    const alarm = fleet.alarm();
+    await reconcileStarted.promise;
+    const release = fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        body: { delete: false },
+      }),
+    );
+    const releaseCompleted = await Promise.race([
+      release.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    expect(releaseCompleted).toBe(false);
+    finishReconcile.resolve();
+    expect((await release).status).toBe(200);
+    await alarm;
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeDefined();
+
+    await fleet.alarm();
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+  });
+
+  it("applies a heartbeat after an older AWS ingress reconciliation snapshot", async () => {
+    const storage = new MemoryStorage();
+    const reconcileStarted = deferred<void>();
+    const finishReconcile = deferred<void>();
+    const operations: string[] = [];
+    let reconciliationCount = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, {
+        provider: "aws",
+        onPrepareLeaseCreate(config, lease, context) {
+          return {
+            config,
+            lease: {
+              ...lease,
+              network: { ...lease.network, sshSourceCIDRs: context.requestSourceCIDRs },
+            },
+            provisioning: {
+              sshIngressReconcile: "additive",
+              publishAccessBeforeProvisioning: true,
+            },
+          };
+        },
+        onRefreshLeaseAccess(lease, context) {
+          operations.push(`refresh:${context.requestSourceCIDRs.join(",")}`);
+          return {
+            ...lease,
+            network: { ...lease.network, sshSourceCIDRs: context.requestSourceCIDRs },
+          };
+        },
+        async onReconcileLeaseAccess(_lease, context) {
+          reconciliationCount += 1;
+          operations.push(
+            `reconcile:${context.activeLeases
+              .flatMap((candidate) => candidate.network?.sshSourceCIDRs ?? [])
+              .join(",")}`,
+          );
+          if (reconciliationCount === 1) {
+            reconcileStarted.resolve();
+            await finishReconcile.promise;
+          }
+        },
+      }),
+    });
+    expect(
+      (
+        await fleet.fetch(
+          request("POST", "/v1/leases", {
+            headers: {
+              "cf-connecting-ip": "198.51.100.10",
+              "x-crabbox-owner": "alice@example.com",
+              "x-crabbox-org": "example-org",
+            },
+            body: {
+              leaseID: "cbx_abcdef123456",
+              provider: "aws",
+              sshPublicKey: "ssh-ed25519 test",
+            },
+          }),
+        )
+      ).status,
+    ).toBe(201);
+
+    const alarm = fleet.alarm();
+    await reconcileStarted.promise;
+    const heartbeat = fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/heartbeat", {
+        headers: {
+          "cf-connecting-ip": "198.51.100.20",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { idleTimeoutSeconds: 300 },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(operations).toEqual(["reconcile:198.51.100.10/32"]);
+
+    finishReconcile.resolve();
+    expect((await heartbeat).status).toBe(200);
+    await alarm;
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeDefined();
+
+    await fleet.alarm();
+    expect(operations).toEqual([
+      "reconcile:198.51.100.10/32",
+      "refresh:198.51.100.20/32",
+      "reconcile:198.51.100.20/32",
+    ]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
   });
 
   it("preserves active AWS lease SSH ingress CIDRs while creating another lease", async () => {
@@ -2370,6 +4069,51 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.network?.sshSourceCIDRs).toEqual([
       "203.0.113.7/32",
     ]);
+  });
+
+  it("starts provider access TTL when the snapshot is published", async () => {
+    vi.useFakeTimers();
+    try {
+      const storage = new MemoryStorage();
+      const reservedAt = new Date("2026-06-01T12:00:00.000Z");
+      const publishedAt = new Date("2026-06-01T12:10:00.000Z");
+      let publishedExpiry = "";
+      vi.setSystemTime(reservedAt);
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(
+          () => {
+            publishedExpiry =
+              storage.value<LeaseRecord>("provider-access:cbx_abcdef123456")?.expiresAt ?? "";
+          },
+          {
+            provider: "aws",
+            onPrepareLeaseCreate(config, lease) {
+              vi.setSystemTime(publishedAt);
+              return {
+                config,
+                lease,
+                provisioning: { publishAccessBeforeProvisioning: true },
+              };
+            },
+          },
+        ),
+      });
+
+      const create = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider: "aws",
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+
+      expect(create.status).toBe(201);
+      expect(Date.parse(publishedExpiry)).toBe(publishedAt.getTime() + 15 * 60 * 1000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("lets providers choose additive access reconciliation for unknown active lease state", async () => {
@@ -4036,19 +5780,26 @@ describe("fleet lease identity and idle", () => {
     expect(runtime.timers).toEqual([]);
   });
 
-  it("accepts bridge tickets in authorization before falling back to query strings", () => {
+  it("prefers valid query bridge tickets over unrelated bearer authorization", () => {
+    const queryTicket = `code_${"a".repeat(32)}`;
     expect(
       bridgeTicketFromRequest(
-        request("GET", "/v1/leases/blue-lobster/code/agent?ticket=code_query", {
-          headers: { authorization: "Bearer code_header" },
+        request("GET", `/v1/leases/blue-lobster/code/agent?ticket=${queryTicket}`, {
+          headers: { authorization: "Bearer edge-identity-token" },
         }),
       ),
-    ).toBe("code_header");
+    ).toBe(queryTicket);
+  });
+
+  it("uses bearer bridge tickets when the query value is absent or invalid", () => {
+    const headerTicket = `code_${"b".repeat(32)}`;
     expect(
       bridgeTicketFromRequest(
-        request("GET", "/v1/leases/blue-lobster/code/agent?ticket=code_query"),
+        request("GET", "/v1/leases/blue-lobster/code/agent?ticket=invalid", {
+          headers: { authorization: `Bearer ${headerTicket}` },
+        }),
       ),
-    ).toBe("code_query");
+    ).toBe(headerTicket);
   });
 
   it("uses a VS Code-compatible CSP for code proxy responses", () => {
@@ -8071,6 +9822,14 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 function ec2XMLResponse(body: string, status = 200): Response {
   return new Response(body, { status, headers: { "content-type": "application/xml" } });
 }
@@ -8147,10 +9906,15 @@ function fakeProvider(
       lease: LeaseRecord,
       context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
     ) => LeaseRecord | undefined;
+    onReconcileLeaseAccess?: (
+      lease: LeaseRecord,
+      context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
+    ) => Promise<void> | void;
     onCreateProvisioning?: (provisioning?: {
       sshIngressReconcile?: "authoritative" | "additive";
       publishAccessBeforeProvisioning?: boolean;
-    }) => void;
+      onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+    }) => Promise<void> | void;
     onPrepareLeaseConfig?: (
       config: LeaseConfig,
       storage: MemoryStorage | undefined,
@@ -8259,6 +10023,12 @@ function fakeProvider(
     ) {
       return result.onRefreshLeaseAccess?.(lease, context);
     },
+    async reconcileLeaseAccess(
+      lease: LeaseRecord,
+      context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
+    ) {
+      await result.onReconcileLeaseAccess?.(lease, context);
+    },
     async createServerWithFallback(
       config: LeaseConfig,
       _leaseID: string,
@@ -8267,9 +10037,10 @@ function fakeProvider(
       provisioning?: {
         sshIngressReconcile?: "authoritative" | "additive";
         publishAccessBeforeProvisioning?: boolean;
+        onTargetAttempt?: (target: { region?: string }) => Promise<void>;
       },
     ) {
-      result.onCreateProvisioning?.(provisioning);
+      await result.onCreateProvisioning?.(provisioning);
       await onCreate?.(config);
       return {
         server: {

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { leaseConfig } from "../src/config";
 import {
@@ -10,6 +10,10 @@ import {
   operationDone,
 } from "../src/gcp";
 import type { Env, ProviderMachine } from "../src/types";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("gcp provider", () => {
   const env: Env = {
@@ -37,6 +41,97 @@ describe("gcp provider", () => {
     expect(() => new GCPClient({ ...env, CRABBOX_GCP_SSH_CIDRS: "::::/128" })).toThrow(
       "CRABBOX_GCP_SSH_CIDRS entries must be valid",
     );
+  });
+
+  it("recovers when another create wins the shared firewall race", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const calls: string[] = [];
+    let firewallReads = 0;
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${url.pathname}`);
+      if (url.pathname.includes("/global/firewalls/") && method === "GET") {
+        firewallReads += 1;
+        return firewallReads === 1
+          ? new Response("not found", { status: 404 })
+          : Response.json({ description: "Crabbox-managed SSH ingress" });
+      }
+      if (url.pathname.endsWith("/global/firewalls") && method === "POST") {
+        return new Response("already exists", { status: 409 });
+      }
+      return Response.json({});
+    };
+
+    await (
+      client as unknown as { ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void> }
+    ).ensureFirewall(
+      leaseConfig({
+        provider: "gcp",
+        gcpSSHCIDRs: ["198.51.100.77/32"],
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    );
+
+    expect(calls.filter((call) => call.startsWith("GET "))).toHaveLength(2);
+    expect(calls.filter((call) => call.startsWith("POST "))).toHaveLength(1);
+    expect(calls.filter((call) => call.startsWith("PUT "))).toHaveLength(1);
+  });
+
+  it("waits for a raced firewall insert before reconciling policy", async () => {
+    vi.useFakeTimers();
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    let firewallReads = 0;
+    let firewallUpdates = 0;
+    let operationWaits = 0;
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      if (url.pathname.includes("/global/firewalls/") && method === "GET") {
+        firewallReads += 1;
+        return firewallReads < 3
+          ? new Response("not found", { status: 404 })
+          : Response.json({ description: "Crabbox-managed SSH ingress" });
+      }
+      if (url.pathname.endsWith("/global/firewalls") && method === "POST") {
+        return new Response("already exists", { status: 409 });
+      }
+      if (url.pathname.includes("/global/firewalls/") && method === "PUT") {
+        firewallUpdates += 1;
+        return firewallUpdates === 1
+          ? new Response("operation in progress", { status: 409 })
+          : Response.json({ name: "op-raced", status: "PENDING" });
+      }
+      if (url.pathname.endsWith("/global/operations/op-raced/wait") && method === "POST") {
+        operationWaits += 1;
+        return Response.json({ name: "op-raced", status: "DONE" });
+      }
+      return Response.json({});
+    };
+
+    const ensure = (
+      client as unknown as { ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void> }
+    ).ensureFirewall(
+      leaseConfig({
+        provider: "gcp",
+        gcpSSHCIDRs: ["198.51.100.77/32"],
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+    );
+    await vi.runAllTimersAsync();
+    await ensure;
+
+    expect(firewallReads).toBe(4);
+    expect(firewallUpdates).toBe(2);
+    expect(operationWaits).toBe(1);
   });
 
   it("lists Crabbox machines across aggregated GCP zones", async () => {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -25,16 +25,20 @@ describe("coordinator auth", () => {
     await expect(isAuthorized(allowed, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(true);
   });
 
-  it("accepts an explicitly trusted reverse-proxy identity header", async () => {
+  it("accepts a reverse-proxy identity only from a trusted proxy source", async () => {
     const request = new Request("https://example.test/v1/whoami", {
       headers: { "x-authenticated-user": "alice@example.com" },
     });
 
     await expect(
-      authenticateRequest(request, {
-        CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
-        CRABBOX_TRUSTED_USER_ORG: "example-org",
-      }),
+      authenticateRequest(
+        request,
+        {
+          CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
+          CRABBOX_TRUSTED_USER_ORG: "example-org",
+        },
+        { trustedProxy: true },
+      ),
     ).resolves.toEqual({
       authorized: true,
       admin: false,
@@ -42,6 +46,12 @@ describe("coordinator auth", () => {
       owner: "alice@example.com",
       org: "example-org",
     });
+    await expect(
+      authenticateRequest(request, {
+        CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
+        CRABBOX_TRUSTED_USER_ORG: "example-org",
+      }),
+    ).resolves.toBeUndefined();
     await expect(authenticateRequest(request, {})).resolves.toBeUndefined();
   });
 

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -25,6 +25,26 @@ describe("coordinator auth", () => {
     await expect(isAuthorized(allowed, { CRABBOX_SHARED_TOKEN: "secret" })).resolves.toBe(true);
   });
 
+  it("accepts an explicitly trusted reverse-proxy identity header", async () => {
+    const request = new Request("https://example.test/v1/whoami", {
+      headers: { "x-authenticated-user": "alice@example.com" },
+    });
+
+    await expect(
+      authenticateRequest(request, {
+        CRABBOX_TRUSTED_USER_HEADER: "X-Authenticated-User",
+        CRABBOX_TRUSTED_USER_ORG: "example-org",
+      }),
+    ).resolves.toEqual({
+      authorized: true,
+      admin: false,
+      auth: "proxy",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    await expect(authenticateRequest(request, {})).resolves.toBeUndefined();
+  });
+
   it("keeps shared bearer token non-admin and ignores caller-supplied identity headers", async () => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -2,6 +2,16 @@ import { EventEmitter } from "node:events";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type OperationRunner = <T>(callback: () => Promise<T>) => Promise<T>;
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 const mocks = vi.hoisted(() => {
   const boss = {
     on: vi.fn<(...args: unknown[]) => unknown>(),
@@ -75,5 +85,86 @@ describe("NodeCoordinatorRuntime", () => {
       expect.any(Error),
     );
     errorLog.mockRestore();
+  });
+
+  it("lets code-agent replies bypass the lifecycle queue", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const socket = Object.assign(new EventEmitter(), {
+      close: vi.fn<(code?: number, reason?: string) => void>(),
+      terminate: vi.fn<() => void>(),
+    });
+    const operationRunner = vi.fn<OperationRunner>(
+      async <T>(_callback: () => Promise<T>): Promise<T> => await new Promise<T>(() => {}),
+    );
+    const message = vi.fn<() => Promise<void>>(async () => {});
+    runtime.setOperationRunner(operationRunner);
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "code-agent" }, [], {
+      message,
+      close: vi.fn<(code: number, reason: string) => void>(),
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("{}"), false);
+
+    await vi.waitFor(() => {
+      expect(message).toHaveBeenCalledOnce();
+    });
+    expect(operationRunner).not.toHaveBeenCalled();
+  });
+
+  it("serializes control messages with lifecycle operations", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const socket = Object.assign(new EventEmitter(), {
+      close: vi.fn<(code?: number, reason?: string) => void>(),
+      terminate: vi.fn<() => void>(),
+    });
+    const operationRunner = vi.fn<OperationRunner>(
+      async <T>(callback: () => Promise<T>): Promise<T> => callback(),
+    );
+    const message = vi.fn<() => Promise<void>>(async () => {});
+    runtime.setOperationRunner(operationRunner);
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "control" }, [], {
+      message,
+      close: vi.fn<(code: number, reason: string) => void>(),
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("{}"), false);
+
+    await vi.waitFor(() => {
+      expect(message).toHaveBeenCalledOnce();
+    });
+    expect(operationRunner).toHaveBeenCalledOnce();
+  });
+
+  it("keeps data-plane close callbacks behind earlier messages", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const socket = Object.assign(new EventEmitter(), {
+      close: vi.fn<(code?: number, reason?: string) => void>(),
+      terminate: vi.fn<() => void>(),
+    });
+    const order: string[] = [];
+    const messageDone = deferred<void>();
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "code-agent" }, [], {
+      message: async () => {
+        order.push("message");
+        await messageDone.promise;
+      },
+      close: () => {
+        order.push("close");
+      },
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("{}"), false);
+    socket.emit("close", 1000, Buffer.from("done"));
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(["message"]);
+    });
+    messageDone.resolve();
+    await vi.waitFor(() => {
+      expect(order).toEqual(["message", "close"]);
+    });
   });
 });

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -167,4 +167,49 @@ describe("NodeCoordinatorRuntime", () => {
       expect(order).toEqual(["message", "close"]);
     });
   });
+
+  it("drains socket operations before stopping jobs and closing storage", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const messageDone = deferred<void>();
+    const socket = new EventEmitter();
+    const close = vi.fn<() => void>(() => {
+      queueMicrotask(() => socket.emit("close", 1000, Buffer.from("shutdown")));
+    });
+    Object.assign(socket, {
+      close,
+      terminate: vi.fn<() => void>(),
+      readyState: 1,
+    });
+    const message = vi.fn<() => Promise<void>>(async () => {
+      await messageDone.promise;
+      await runtime.scheduleAlarm(Date.now() + 60_000);
+    });
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "code-agent" }, [], {
+      message,
+      close: vi.fn<(code: number, reason: string) => void>(),
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("{}"), false);
+    await vi.waitFor(() => expect(message).toHaveBeenCalledOnce());
+
+    runtime.beginShutdown();
+    expect(close).not.toHaveBeenCalled();
+    const stopped = runtime.stop();
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(mocks.boss.stop).not.toHaveBeenCalled();
+    expect(mocks.storage.close).not.toHaveBeenCalled();
+    messageDone.resolve();
+    await stopped;
+
+    expect(mocks.boss.send).toHaveBeenCalledWith(
+      "coordinator-alarm",
+      null,
+      expect.objectContaining({ singletonKey: "fleet" }),
+    );
+    expect(mocks.boss.send.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      mocks.boss.stop.mock.invocationCallOrder.at(-1) ?? 0,
+    );
+    expect(mocks.storage.close).toHaveBeenCalledOnce();
+  });
 });

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from "node:events";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const boss = {
+    on: vi.fn<(...args: unknown[]) => unknown>(),
+    start: vi.fn<() => Promise<void>>(async () => {}),
+    stop: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+    createQueue: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+    work: vi.fn<(...args: unknown[]) => Promise<string>>(async () => "worker-id"),
+    schedule: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+    send: vi.fn<(...args: unknown[]) => Promise<string>>(async () => "job-id"),
+    deleteQueuedJobs: vi.fn<(...args: unknown[]) => Promise<void>>(async () => {}),
+  };
+  const storage = {
+    initialize: vi.fn<() => Promise<void>>(async () => {}),
+    close: vi.fn<() => Promise<void>>(async () => {}),
+  };
+  return { boss, storage };
+});
+
+vi.mock("pg-boss", () => ({
+  PgBoss: function PgBoss() {
+    return mocks.boss;
+  },
+}));
+
+vi.mock("../node/postgres-storage", () => ({
+  PostgresCoordinatorStorage: function PostgresCoordinatorStorage() {
+    return mocks.storage;
+  },
+}));
+
+import { NodeCoordinatorRuntime } from "../node/node-runtime";
+
+describe("NodeCoordinatorRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows an active alarm to enqueue one successor", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+
+    await runtime.start(async () => {});
+
+    expect(mocks.boss.createQueue).toHaveBeenCalledWith(
+      "coordinator-alarm",
+      expect.objectContaining({ policy: "short" }),
+    );
+  });
+
+  it("contains WebSocket message handler failures to the offending socket", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const socket = Object.assign(new EventEmitter(), {
+      close: vi.fn<(code?: number, reason?: string) => void>(),
+      terminate: vi.fn<() => void>(),
+    });
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, {}, [], {
+      message: async () => {
+        throw new Error("invalid peer frame");
+      },
+      close: vi.fn<(code: number, reason: string) => void>(),
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("bad"), false);
+
+    await vi.waitFor(() => {
+      expect(socket.close).toHaveBeenCalledWith(1011, "coordinator handler failed");
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      "coordinator websocket message handler failed",
+      expect.any(Error),
+    );
+    errorLog.mockRestore();
+  });
+});

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -1,0 +1,62 @@
+import type { Pool, QueryResult, QueryResultRow } from "pg";
+import { describe, expect, it, vi } from "vitest";
+
+import { PostgresCoordinatorStorage } from "../node/postgres-storage";
+
+describe("PostgresCoordinatorStorage", () => {
+  it("initializes its schema and compatibility table", async () => {
+    const pool = fakePool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await storage.initialize();
+
+    expect(pool.query).toHaveBeenCalledTimes(3);
+    expect(pool.query.mock.calls.map(([sql]) => String(sql))).toEqual([
+      expect.stringContaining("create schema if not exists crabbox"),
+      expect.stringContaining("create table if not exists crabbox.coordinator_kv"),
+      expect.stringContaining("create index if not exists coordinator_kv_updated_at_idx"),
+    ]);
+  });
+
+  it("stores JSON values with an upsert", async () => {
+    const pool = fakePool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await storage.put("lease:1", { state: "active" });
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("on conflict (key) do update"),
+      ["lease:1", '{"state":"active"}'],
+    );
+  });
+
+  it("escapes LIKE metacharacters in prefix scans", async () => {
+    const pool = fakePool([{ key: "run:100%_x", value: { id: "100" } }]);
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    const records = await storage.list<{ id: string }>({ prefix: "run:100%_x" });
+
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining("where key like $1"), [
+      "run:100\\%\\_x%",
+    ]);
+    expect(records).toEqual(new Map([["run:100%_x", { id: "100" }]]));
+  });
+});
+
+function fakePool(rows: QueryResultRow[] = []) {
+  const query = vi.fn<(text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(
+    async () => queryResult(rows),
+  );
+  const end = vi.fn<() => Promise<void>>(async () => undefined);
+  return { query, end } as unknown as Pool & { query: typeof query };
+}
+
+function queryResult<T extends QueryResultRow>(rows: T[]): QueryResult<T> {
+  return {
+    command: "",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows,
+  };
+}

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -10,10 +10,11 @@ describe("PostgresCoordinatorStorage", () => {
 
     await storage.initialize();
 
-    expect(pool.query).toHaveBeenCalledTimes(3);
+    expect(pool.query).toHaveBeenCalledTimes(4);
     expect(pool.query.mock.calls.map(([sql]) => String(sql))).toEqual([
       expect.stringContaining("create schema if not exists crabbox"),
       expect.stringContaining("create table if not exists crabbox.coordinator_kv"),
+      expect.stringContaining("add column if not exists value_text text"),
       expect.stringContaining("create index if not exists coordinator_kv_updated_at_idx"),
     ]);
   });
@@ -26,12 +27,40 @@ describe("PostgresCoordinatorStorage", () => {
 
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining("on conflict (key) do update"),
-      ["lease:1", '{"state":"active"}'],
+      ["lease:1", '{"state":"active"}', '{"state":"active"}'],
     );
   });
 
+  it("round-trips NUL-containing strings through the text representation", async () => {
+    const pool = fakePool([{ encoded_value: '"before\\u0000after"' }]);
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await storage.put("runlog:1", "before\0after");
+    const value = await storage.get<string>("runlog:1");
+
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining("$2::jsonb"), [
+      "runlog:1",
+      '"before�after"',
+      '"before\\u0000after"',
+    ]);
+    expect(value).toBe("before\0after");
+  });
+
+  it("sanitizes NUL-containing object keys in the JSONB compatibility value", async () => {
+    const pool = fakePool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+
+    await storage.put("runlog:1", { "before\0after": "value" });
+
+    expect(pool.query).toHaveBeenCalledWith(expect.stringContaining("$2::jsonb"), [
+      "runlog:1",
+      '{"before�after":"value"}',
+      '{"before\\u0000after":"value"}',
+    ]);
+  });
+
   it("escapes LIKE metacharacters in prefix scans", async () => {
-    const pool = fakePool([{ key: "run:100%_x", value: { id: "100" } }]);
+    const pool = fakePool([{ key: "run:100%_x", encoded_value: '{"id":"100"}' }]);
     const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
 
     const records = await storage.list<{ id: string }>({ prefix: "run:100%_x" });

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -1,0 +1,199 @@
+import type { IncomingMessage } from "node:http";
+import { Writable } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AsyncMutex,
+  AsyncOperationTracker,
+  RequestBodyTooLargeError,
+  drainAndStop,
+  authenticatedRequestBodyBytes,
+  fleetRequestQueue,
+  isReadinessRequestMethod,
+  readNodeRequestBody,
+  requestBodyLimit,
+  runFinishRequestBodyBytes,
+  settlesWithin,
+  shouldReadUnauthenticatedRequestBody,
+  unauthenticatedRequestBodyBytes,
+  writeNodeResponseBody,
+} from "../node/server-support";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("Node server support", () => {
+  it("keeps provider I/O, maintenance, and code proxy traffic off the lifecycle queue", () => {
+    expect(
+      fleetRequestQueue(new Request("https://coordinator.test/v1/leases", { method: "POST" })),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(
+        new Request("https://coordinator.test/v1/internal/scheduled", { method: "POST" }),
+      ),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(
+        new Request("https://coordinator.test/portal/leases/cbx_1/code/assets/app.js"),
+      ),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(
+        new Request("https://coordinator.test/v1/leases/cbx_1/heartbeat", { method: "POST" }),
+      ),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(
+        new Request("https://coordinator.test/v1/leases/cbx_1/release", { method: "POST" }),
+      ),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(new Request("https://coordinator.test/v1/images", { method: "POST" })),
+    ).toBe("direct");
+    expect(
+      fleetRequestQueue(
+        new Request("https://coordinator.test/v1/admin/aws-orphan-sweep", { method: "POST" }),
+      ),
+    ).toBe("direct");
+  });
+
+  it("waits for queued and active work to drain", async () => {
+    const mutex = new AsyncMutex();
+    const tracker = new AsyncOperationTracker();
+    const done = deferred<void>();
+    const operation = tracker.run(() => mutex.run(() => done.promise));
+    let drained = false;
+    const drain = (async () => {
+      await Promise.all([tracker.drain(), mutex.drain()]);
+      drained = true;
+    })();
+
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    done.resolve();
+    await operation;
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  it("allows the worst-case encoded retained run log", () => {
+    const retainedLogBytes = 8 * 1024 * 1024;
+    const fallbackPreviewBytes = 64 * 1024;
+    const worstCaseJSONBytes = (retainedLogBytes + fallbackPreviewBytes) * 6 + 4096;
+    const request = new Request("https://coordinator.test/v1/runs/run_1/finish", {
+      method: "POST",
+    });
+    expect(requestBodyLimit(request, true)).toBe(runFinishRequestBodyBytes);
+    expect(
+      requestBodyLimit(
+        new Request("https://coordinator.test//v1/runs/run_1//finish/", { method: "POST" }),
+        true,
+      ),
+    ).toBe(runFinishRequestBodyBytes);
+    expect(runFinishRequestBodyBytes).toBeGreaterThan(worstCaseJSONBytes);
+  });
+
+  it("keeps unauthenticated and ordinary authenticated body limits smaller", () => {
+    const request = new Request("https://coordinator.test/v1/runs/run_1/finish", {
+      method: "POST",
+    });
+    expect(requestBodyLimit(request, false)).toBe(unauthenticatedRequestBodyBytes);
+    expect(
+      requestBodyLimit(new Request("https://coordinator.test/v1/leases", { method: "POST" }), true),
+    ).toBe(authenticatedRequestBodyBytes);
+  });
+
+  it("caps bodies drained before authentication completes", async () => {
+    const request = {
+      headers: {},
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.alloc(unauthenticatedRequestBodyBytes);
+        yield Buffer.from("overflow");
+      },
+    } as unknown as IncomingMessage;
+
+    await expect(
+      readNodeRequestBody(request, unauthenticatedRequestBodyBytes),
+    ).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+  });
+
+  it("does not wait for unauthenticated GET or HEAD bodies", () => {
+    expect(shouldReadUnauthenticatedRequestBody("GET")).toBe(false);
+    expect(shouldReadUnauthenticatedRequestBody("HEAD")).toBe(false);
+    expect(shouldReadUnauthenticatedRequestBody("get")).toBe(false);
+    expect(shouldReadUnauthenticatedRequestBody("POST")).toBe(true);
+  });
+
+  it("only serves readiness over GET or HEAD", () => {
+    expect(isReadinessRequestMethod("GET")).toBe(true);
+    expect(isReadinessRequestMethod("HEAD")).toBe(true);
+    expect(isReadinessRequestMethod("POST")).toBe(false);
+  });
+
+  it("rejects declared oversized bodies without reading their stream", async () => {
+    const iterator = vi.fn<() => AsyncIterator<unknown>>();
+    const request = {
+      headers: { "content-length": String(unauthenticatedRequestBodyBytes + 1) },
+      [Symbol.asyncIterator]: iterator,
+    } as unknown as IncomingMessage;
+
+    await expect(
+      readNodeRequestBody(request, unauthenticatedRequestBodyBytes),
+    ).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+    expect(iterator).not.toHaveBeenCalled();
+  });
+
+  it("settles response writes when the client disconnects", async () => {
+    const response = new Writable({
+      write() {
+        this.destroy();
+      },
+    });
+
+    await expect(writeNodeResponseBody(response, Buffer.from("payload"))).rejects.toThrow(
+      "Premature close",
+    );
+  });
+
+  it("bounds shutdown waits", async () => {
+    expect(await settlesWithin(Promise.resolve(), 100)).toBe(true);
+    expect(await settlesWithin(new Promise(() => {}), 1)).toBe(false);
+  });
+
+  it("drains HTTP work before stopping sockets and awaiting server closure", async () => {
+    const order: string[] = [];
+    let finishRequests!: () => void;
+    let finishServerClose!: () => void;
+    const requestsDrained = new Promise<void>((resolve) => {
+      finishRequests = resolve;
+    });
+    const serverClosed = new Promise<void>((resolve) => {
+      finishServerClose = resolve;
+    });
+    const shutdown = drainAndStop(
+      { drain: async () => requestsDrained },
+      { drain: async () => {} },
+      async () => {
+        order.push("sockets:closed");
+      },
+      serverClosed.then(() => {
+        order.push("server:closed");
+        return undefined;
+      }),
+    );
+
+    await Promise.resolve();
+    expect(order).toEqual([]);
+    finishRequests();
+    await vi.waitFor(() => expect(order).toEqual(["sockets:closed"]));
+    finishServerClose();
+    await shutdown;
+    expect(order).toEqual(["sockets:closed", "server:closed"]);
+  });
+});

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -14,6 +14,7 @@ import {
   isTrustedProxySource,
   readNodeRequestBody,
   requestBodyLimit,
+  requestSourceIP,
   runFinishRequestBodyBytes,
   settlesWithin,
   shouldReadUnauthenticatedRequestBody,
@@ -145,6 +146,15 @@ describe("Node server support", () => {
     expect(isTrustedProxySource("192.0.2.10", ranges)).toBe(false);
     expect(isTrustedProxySource("10.4.5.6", undefined)).toBe(false);
     expect(isTrustedProxySource("10.4.5.6", "invalid,10.0.0.0/8")).toBe(false);
+  });
+
+  it("derives caller IPs from sockets and trusted proxy chains", () => {
+    const ranges = "10.0.0.0/8,fd00::/8";
+    expect(requestSourceIP("198.51.100.8", "203.0.113.9", ranges)).toBe("198.51.100.8");
+    expect(requestSourceIP("10.0.0.2", "192.0.2.9, 198.51.100.8", ranges)).toBe("198.51.100.8");
+    expect(requestSourceIP("10.0.0.2", "198.51.100.8, 10.0.0.3", ranges)).toBe("198.51.100.8");
+    expect(requestSourceIP("::ffff:198.51.100.8", undefined, ranges)).toBe("198.51.100.8");
+    expect(requestSourceIP(undefined, "198.51.100.8", ranges)).toBeUndefined();
   });
 
   it("rejects declared oversized bodies without reading their stream", async () => {

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -11,6 +11,7 @@ import {
   authenticatedRequestBodyBytes,
   fleetRequestQueue,
   isReadinessRequestMethod,
+  isTrustedProxySource,
   readNodeRequestBody,
   requestBodyLimit,
   runFinishRequestBodyBytes,
@@ -134,6 +135,16 @@ describe("Node server support", () => {
     expect(isReadinessRequestMethod("GET")).toBe(true);
     expect(isReadinessRequestMethod("HEAD")).toBe(true);
     expect(isReadinessRequestMethod("POST")).toBe(false);
+  });
+
+  it("trusts reverse-proxy identities only from configured peer networks", () => {
+    const ranges = "127.0.0.1,10.0.0.0/8,2001:db8::/32";
+    expect(isTrustedProxySource("127.0.0.1", ranges)).toBe(true);
+    expect(isTrustedProxySource("::ffff:10.4.5.6", ranges)).toBe(true);
+    expect(isTrustedProxySource("2001:db8::42", ranges)).toBe(true);
+    expect(isTrustedProxySource("192.0.2.10", ranges)).toBe(false);
+    expect(isTrustedProxySource("10.4.5.6", undefined)).toBe(false);
+    expect(isTrustedProxySource("10.4.5.6", "invalid,10.0.0.0/8")).toBe(false);
   });
 
   it("rejects declared oversized bodies without reading their stream", async () => {

--- a/worker/tsconfig.node.json
+++ b/worker/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@cloudflare/workers-types"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "node/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add a portable Node.js/PostgreSQL coordinator runtime alongside the existing Cloudflare Worker adapter
- share coordinator routing, authentication, lifecycle, bridge, and provider reconciliation behavior across both runtimes
- add refreshable shell-free token-command authentication for identity-aware coordinator deployments
- harden request limits, shutdown ordering, maintenance jobs, forwarded identity, proxy address handling, and provider cleanup
- document container deployment, PostgreSQL requirements, trusted proxy configuration, and the single-replica bridge constraint

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` (411 tests)
- `npm run build:node --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- branch-wide autoreview: no findings

## Configuration

The Node runtime requires `DATABASE_URL`. Identity-aware reverse proxies may set `CRABBOX_TRUSTED_USER_HEADER`, `CRABBOX_TRUSTED_USER_ORG`, and `CRABBOX_TRUSTED_PROXY_CIDRS`; forwarded identity, host, protocol, and caller-address headers are honored only from configured proxy peers. Existing provider and coordinator secrets remain environment-managed and are not persisted by Crabbox.
