### PR TITLE
fix(cloudflare): propagate stream write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed Cloudflare container runs to fail when streamed stdout or stderr cannot be written instead of silently reporting success after output loss.
 - Fixed Proxmox bridge readiness on PVE 8 by falling back to its compatible local-bridge and SDN-vnet inventory filter.
 
 ## 0.29.0 - 2026-06-12

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -592,6 +592,61 @@ func TestCloudflareClientExecStream(t *testing.T) {
 	}
 }
 
+func TestCloudflareClientExecStreamPropagatesWriterErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     string
+		stdout    io.Writer
+		stderr    io.Writer
+		want      string
+		writerErr string
+	}{
+		{
+			name:      "stdout",
+			event:     `{"type":"stdout","data":"hello"}`,
+			stdout:    cloudflareErrWriter("stdout closed"),
+			stderr:    io.Discard,
+			want:      "write cloudflare stdout",
+			writerErr: "stdout closed",
+		},
+		{
+			name:      "stderr",
+			event:     `{"type":"stderr","data":"warn"}`,
+			stdout:    io.Discard,
+			stderr:    cloudflareErrWriter("stderr closed"),
+			want:      "write cloudflare stderr",
+			writerErr: "stderr closed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = io.WriteString(w, tc.event+"\n")
+			}))
+			defer server.Close()
+
+			cfg := Config{}
+			cfg.Cloudflare.APIURL = server.URL
+			cfg.Cloudflare.Token = "test-token"
+			client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = client.execStream(context.Background(), "cbx_test", execStreamRequest{Command: "true"}, tc.stdout, tc.stderr)
+			if err == nil || !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), tc.writerErr) {
+				t.Fatalf("execStream error = %v, want %q and %q", err, tc.want, tc.writerErr)
+			}
+		})
+	}
+}
+
+type cloudflareErrWriter string
+
+func (w cloudflareErrWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("%s", string(w))
+}
+
 func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
 	execCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -217,7 +217,6 @@ func (c *cloudflareClient) execStream(ctx context.Context, sandboxID string, req
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 	exitCode := 0
-	completed := false
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
@@ -230,14 +229,17 @@ func (c *cloudflareClient) execStream(ctx context.Context, sandboxID string, req
 		switch event.Type {
 		case "stdout":
 			if stdout != nil {
-				_, _ = io.WriteString(stdout, event.Data)
+				if _, err := io.WriteString(stdout, event.Data); err != nil {
+					return exitCode, fmt.Errorf("write %s stdout: %w", providerName, err)
+				}
 			}
 		case "stderr":
 			if stderr != nil {
-				_, _ = io.WriteString(stderr, event.Data)
+				if _, err := io.WriteString(stderr, event.Data); err != nil {
+					return exitCode, fmt.Errorf("write %s stderr: %w", providerName, err)
+				}
 			}
 		case "complete":
-			completed = true
 			if event.ExitCode != nil {
 				exitCode = *event.ExitCode
 			}
@@ -255,10 +257,7 @@ func (c *cloudflareClient) execStream(ctx context.Context, sandboxID string, req
 	if err := scanner.Err(); err != nil {
 		return exitCode, err
 	}
-	if !completed {
-		return exitCode, fmt.Errorf("%s stream ended before completion", providerName)
-	}
-	return exitCode, nil
+	return exitCode, fmt.Errorf("%s stream ended before completion", providerName)
 }
 
 func (c *cloudflareClient) sandboxEndpoint(sandboxID, suffix string) string {


### PR DESCRIPTION
## Summary

- propagate Cloudflare container stdout/stderr writer failures instead of silently dropping streamed output
- preserve the existing incomplete-stream error while removing unreachable completion bookkeeping
- add regression coverage for both output streams
- document the user-visible fix in `CHANGELOG.md`

## Verification

- `go test -race ./internal/providers/cloudflare`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./internal/providers/cloudflare`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)

The first full-suite run hit the existing Apple VZ helper readiness timing test once. The isolated test then passed 5/5 and the complete `go test ./...` rerun passed.
