### PR TITLE
fix: keep OAuth callbacks off lifecycle queue

### DIFF
--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -11,6 +11,9 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   const url = new URL(request.url);
   const path = url.pathname.split("/").filter(Boolean);
   const method = request.method.toUpperCase();
+  if (method === "GET" && path.join("/") === "v1/auth/github/callback") {
+    return "direct";
+  }
   if (method === "POST" && path.join("/") === "v1/leases") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -467,7 +467,7 @@ export class FleetCoordinator {
         return await this.scheduledMaintenance(request);
       }
       if (parts[0] === "v1" && parts[1] === "auth" && parts[2] === "github") {
-        return await githubAuthRoute(request, parts[3], this.state.storage, this.env);
+        return await githubAuthRoute(request, parts[3], this.state, this.env);
       }
       if (method === "GET" && parts.join("/") === "portal/login") {
         return await githubPortalLogin(request, this.state.storage, this.env);

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -1,5 +1,5 @@
 import { issueUserToken, sha256Hex, userTokenExpiresAt } from "./auth";
-import type { CoordinatorStorage } from "./coordinator-runtime";
+import type { CoordinatorRuntime, CoordinatorStorage } from "./coordinator-runtime";
 import { errorMessage, json, readJson } from "./http";
 import type { Env, Provider } from "./types";
 import { requestOrg } from "./usage";
@@ -28,6 +28,7 @@ interface OAuthPending {
   org?: string;
   login?: string;
   error?: string;
+  callbackClaim?: string;
 }
 
 interface GitHubUser {
@@ -57,18 +58,18 @@ interface AllowedGitHubTeam {
 export async function githubAuthRoute(
   request: Request,
   action: string | undefined,
-  storage: CoordinatorStorage,
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
   env: Env,
 ): Promise<Response> {
   const method = request.method.toUpperCase();
   if (method === "POST" && action === "start") {
-    return await githubAuthStart(request, storage, env);
+    return await githubAuthStart(request, runtime.storage, env);
   }
   if (method === "GET" && action === "callback") {
-    return await githubAuthCallback(request, storage, env);
+    return await githubAuthCallback(request, runtime, env);
   }
   if (method === "POST" && action === "poll") {
-    return await githubAuthPoll(request, storage);
+    return await githubAuthPoll(request, runtime.storage);
   }
   return json({ error: "not_found" }, { status: 404 });
 }
@@ -190,25 +191,22 @@ function githubAuthorizeURLFor(
 
 async function githubAuthCallback(
   request: Request,
-  storage: CoordinatorStorage,
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
   env: Env,
 ): Promise<Response> {
   const url = new URL(request.url);
   const code = url.searchParams.get("code") ?? "";
   const state = url.searchParams.get("state") ?? "";
   const error = url.searchParams.get("error") ?? "";
-  const id = state ? await storage.get<string>(oauthStateKey(state)) : undefined;
-  const pending = id ? await storage.get<OAuthPending>(oauthKey(id)) : undefined;
-  if (!pending || pending.state !== state || Date.parse(pending.expiresAt) <= Date.now()) {
-    return html(
-      "Crabbox login expired",
-      "The login request expired. Run crabbox login --url <broker-url> again.",
-      400,
-    );
+  const claimed = await claimPendingOAuth(runtime, state);
+  if ("response" in claimed) {
+    return claimed.response;
   }
+  const { pending, claim } = claimed;
   if (error || !code) {
-    pending.error = error || "missing_code";
-    await storage.put(oauthKey(pending.id), pending);
+    await finishPendingOAuth(runtime, pending.id, claim, {
+      error: error || "missing_code",
+    });
     return html("Crabbox login failed", "GitHub did not authorize the login.", 400);
   }
   try {
@@ -232,19 +230,27 @@ async function githubAuthCallback(
     if (identity.name) {
       tokenInput.name = identity.name;
     }
-    pending.token = await issueUserToken(env, tokenInput);
-    const tokenExpiry = userTokenExpiresAt(pending.token);
-    if (tokenExpiry) {
-      pending.tokenExpiresAt = tokenExpiry;
+    const token = await issueUserToken(env, tokenInput);
+    const completion: Pick<OAuthPending, "token" | "owner" | "org" | "login"> & {
+      tokenExpiresAt?: string;
+    } = {
+      token,
+      owner: identity.owner,
+      org,
+      login: identity.login,
+    };
+    const tokenExpiresAt = userTokenExpiresAt(token);
+    if (tokenExpiresAt) {
+      completion.tokenExpiresAt = tokenExpiresAt;
     }
-    pending.owner = identity.owner;
-    pending.org = org;
-    pending.login = identity.login;
-    await storage.put(oauthKey(pending.id), pending);
-    if (pending.mode === "portal") {
-      await deletePendingOAuth(storage, pending);
-      return redirect(pending.returnTo || "/portal", 302, {
-        "set-cookie": portalSessionCookie(pending.token, ttlSeconds),
+    const completed = await finishPendingOAuth(runtime, pending.id, claim, completion);
+    if (!completed) {
+      return expiredOAuthResponse();
+    }
+    if (completed.mode === "portal") {
+      await runtime.runExclusive(() => deletePendingOAuth(runtime.storage, completed));
+      return redirect(completed.returnTo || "/portal", 302, {
+        "set-cookie": portalSessionCookie(token, ttlSeconds),
       });
     }
     return html(
@@ -252,13 +258,75 @@ async function githubAuthCallback(
       "GitHub authorized Crabbox. You can close this tab and return to the terminal.",
     );
   } catch (err) {
-    pending.error = errorMessage(err);
-    await storage.put(oauthKey(pending.id), pending);
+    await finishPendingOAuth(runtime, pending.id, claim, { error: errorMessage(err) });
     if (err instanceof GitHubAuthorizationError) {
       return html("Crabbox login denied", err.message, 403);
     }
     return html("Crabbox login failed", "The coordinator could not finish GitHub login.", 500);
   }
+}
+
+async function claimPendingOAuth(
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  state: string,
+): Promise<
+  | { pending: OAuthPending; claim: string }
+  | {
+      response: Response;
+    }
+> {
+  return runtime.runExclusive(async () => {
+    const id = state ? await runtime.storage.get<string>(oauthStateKey(state)) : undefined;
+    const pending = id ? await runtime.storage.get<OAuthPending>(oauthKey(id)) : undefined;
+    if (!pending || pending.state !== state || Date.parse(pending.expiresAt) <= Date.now()) {
+      return { response: expiredOAuthResponse() };
+    }
+    if (pending.callbackClaim || pending.error || pending.token) {
+      return {
+        response: html(
+          "Crabbox login already used",
+          "This GitHub login callback is already being processed or completed.",
+          409,
+        ),
+      };
+    }
+    const claim = randomID("callback");
+    pending.callbackClaim = claim;
+    await runtime.storage.put(oauthKey(pending.id), pending);
+    return { pending: structuredClone(pending), claim };
+  });
+}
+
+async function finishPendingOAuth(
+  runtime: Pick<CoordinatorRuntime, "storage" | "runExclusive">,
+  id: string,
+  claim: string,
+  result: Partial<
+    Pick<OAuthPending, "token" | "tokenExpiresAt" | "owner" | "org" | "login" | "error">
+  >,
+): Promise<OAuthPending | undefined> {
+  return runtime.runExclusive(async () => {
+    const pending = await runtime.storage.get<OAuthPending>(oauthKey(id));
+    if (
+      !pending ||
+      pending.callbackClaim !== claim ||
+      Date.parse(pending.expiresAt) <= Date.now()
+    ) {
+      return undefined;
+    }
+    Object.assign(pending, result);
+    delete pending.callbackClaim;
+    await runtime.storage.put(oauthKey(pending.id), pending);
+    return structuredClone(pending);
+  });
+}
+
+function expiredOAuthResponse(): Response {
+  return html(
+    "Crabbox login expired",
+    "The login request expired. Run crabbox login --url <broker-url> again.",
+    400,
+  );
 }
 
 async function githubAuthPoll(request: Request, storage: CoordinatorStorage): Promise<Response> {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   CloudflareCoordinatorRuntime,
@@ -8,7 +8,12 @@ import {
   type CoordinatorStorage,
 } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
+import { githubAuthRoute } from "../src/oauth";
 import type { Env } from "../src/types";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 class MemoryStorage implements CoordinatorStorage {
   private readonly values = new Map<string, unknown>();
@@ -38,9 +43,20 @@ class MemoryRuntime implements CoordinatorRuntime {
   readonly storage = new MemoryStorage();
   alarmTime?: number;
   private readonly attachments = new WeakMap<WebSocket, unknown>();
+  private exclusiveTail: Promise<void> = Promise.resolve();
 
-  runExclusive<T>(callback: () => Promise<T>): Promise<T> {
-    return callback();
+  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    const predecessor = this.exclusiveTail;
+    let release!: () => void;
+    this.exclusiveTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await predecessor;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
   }
 
   createWebSocketUpgrade(): never {
@@ -93,6 +109,90 @@ describe("coordinator runtimes", () => {
     expect(coordinatorRequestQueue(new Request("https://coordinator.test/portal/login"))).toBe(
       "lifecycle",
     );
+    expect(
+      coordinatorRequestQueue(
+        new Request("https://coordinator.test/v1/auth/github/callback?code=x&state=y"),
+      ),
+    ).toBe("direct");
+    expect(
+      coordinatorRequestQueue(
+        new Request("https://coordinator.test/v1/auth/github/start", { method: "POST" }),
+      ),
+    ).toBe("lifecycle");
+  });
+
+  it("does not hold the lifecycle queue across GitHub OAuth requests", async () => {
+    const runtime = new MemoryRuntime();
+    const env = {
+      CRABBOX_DEFAULT_ORG: "example-org",
+      CRABBOX_GITHUB_CLIENT_ID: "github-client",
+      CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+      CRABBOX_SHARED_TOKEN: "shared",
+    } as Env;
+    const start = await runtime.runExclusive(() =>
+      githubAuthRoute(
+        new Request("https://coordinator.test/v1/auth/github/start", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ pollSecretHash: "0".repeat(64) }),
+        }),
+        "start",
+        runtime,
+        env,
+      ),
+    );
+    const startBody = (await start.json()) as { url: string };
+    const state = new URL(startBody.url).searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    let releaseTokenExchange!: () => void;
+    const tokenExchangeBlocked = new Promise<void>((resolve) => {
+      releaseTokenExchange = resolve;
+    });
+    let signalTokenExchange!: () => void;
+    const tokenExchangeStarted = new Promise<void>((resolve) => {
+      signalTokenExchange = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url === "https://github.com/login/oauth/access_token") {
+          signalTokenExchange();
+          await tokenExchangeBlocked;
+          return Response.json({ access_token: "github-access-token" });
+        }
+        if (url === "https://api.github.com/user") {
+          return Response.json({ login: "friend", email: "friend@example.com" });
+        }
+        if (url === "https://api.github.com/user/emails") {
+          return Response.json([]);
+        }
+        if (url === "https://api.github.com/user/memberships/orgs/example-org") {
+          return Response.json({
+            state: "active",
+            organization: { login: "example-org" },
+          });
+        }
+        throw new Error(`unexpected GitHub URL: ${url}`);
+      }),
+    );
+
+    const callbackRequest = new Request(
+      `https://coordinator.test/v1/auth/github/callback?code=ok&state=${state}`,
+    );
+    const callback = githubAuthRoute(callbackRequest, "callback", runtime, env);
+    await tokenExchangeStarted;
+
+    await expect(runtime.runExclusive(async () => "lifecycle-completed")).resolves.toBe(
+      "lifecycle-completed",
+    );
+    const duplicate = await githubAuthRoute(callbackRequest, "callback", runtime, env);
+    expect(duplicate.status).toBe(409);
+
+    releaseTokenExchange();
+    await expect(callback).resolves.toMatchObject({ status: 200 });
   });
 
   it("runs the fleet coordinator without a Durable Object", async () => {


### PR DESCRIPTION
## Summary

- keep GitHub OAuth callback network requests outside the coordinator lifecycle queue
- serialize only the callback claim and completion storage transitions
- reject duplicate callback replay while the original callback is processing or completed

Follow-up to https://github.com/openclaw/crabbox/pull/292 after autoreview identified an unauthenticated lifecycle queue-stall path.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` (412 tests)
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- focused OAuth/fleet regression suite (177 tests)
- autoreview rerun: no accepted/actionable findings
- live PostgreSQL Node coordinator persistence and authenticated WebSocket proof after the fix
