### PR TITLE
feat: improve portal lease controls and theming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added a generated provider decision matrix with checked metadata for execution model, access, substrate, GPU fit, lifecycle, cleanup, and provider caveats; docs validation now fails on provider drift. Thanks @coygeek.
+- Added confirmed lifecycle actions to portal lease rows, with provider shutdown for coordinator-managed boxes and explicitly metadata-only deregistration for client-managed boxes.
 - Added `provider: superserve` for delegated Linux sandbox runs through the Superserve control and data planes, including archive sync, retained leases, ownership-guarded lifecycle operations, and credentialed live smoke coverage. Thanks @coygeek.
 - Added `provider: linode` for direct Linux SSH leases with per-lease keys, account-bound cleanup, preserved operator tags, interface-aware existing firewalls, and guarded live smoke coverage. Thanks @coygeek.
 - Added `provider: windows-sandbox` for disposable native Windows runs through Microsoft Windows Sandbox, including mapped workspace sync, streamed output, timeout and cancellation cleanup, and keep-on-failure inspection. Thanks @zozo123.
@@ -17,6 +18,7 @@
 
 ### Fixed
 
+- Fixed the portal and connected WebVNC desktops to default to the current system appearance by migrating away from legacy two-state browser theme preferences.
 - Fixed Cloudflare container runs to fail when streamed stdout or stderr cannot be written instead of silently reporting success after output loss.
 - Fixed Proxmox bridge readiness on PVE 8 by falling back to its compatible local-bridge and SDN-vnet inventory filter.
 

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -119,6 +119,9 @@ desktop in the support matrix.
 For kept registered desktop leases, `broker.autoWebVNC: true` starts the bridge
 daemon automatically. The daemon heartbeats the registration while connected;
 `crabbox stop` stops it and removes the registration after provider cleanup.
+The portal defaults to the viewer's system appearance and sends the resolved
+light or dark theme through that bridge on connect and whenever the operating
+system appearance changes.
 
 ### Collaborative WebVNC
 

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -23,7 +23,7 @@ GET  /portal                                    lease / runner / host index
 GET  /portal/leases/{id-or-slug}                lease detail
 GET  /portal/leases/{id-or-slug}/share          share page
 POST /portal/leases/{id-or-slug}/share          add/remove user, set org, clear
-POST /portal/leases/{id-or-slug}/release        stop the lease
+POST /portal/leases/{id-or-slug}/release        stop managed lease / remove registration
 GET  /portal/leases/{id-or-slug}/vnc            WebVNC viewer page
 GET  /portal/leases/{id-or-slug}/code/...       code-server bridge (HTTP/WS proxy)
 GET  /portal/runs/{run-id}                       run detail
@@ -41,6 +41,13 @@ browser calls directly: `/vnc/viewer` (the noVNC WebSocket), `/vnc/status`,
 `/vnc/control` (take control), and `/vnc/theme` (sync the desktop theme).
 Static assets, including the noVNC client at `/portal/assets/novnc/rfb.js`,
 are served from the coordinator's bundled assets.
+
+The portal defaults to the browser's system color scheme and tracks later
+system appearance changes. Explicit light, dark, or system choices use the
+`crabbox-theme-source` browser storage key; the distinct key intentionally
+resets preferences written by the older two-state switch. WebVNC sends the
+resolved light or dark appearance to connected desktops, including registered
+direct Linux leases.
 
 A `GET /` redirects to `/portal` (while `GET /v1/health` returns a JSON
 health payload). When
@@ -80,9 +87,12 @@ Access JWT email can become the portal owner.
 The index renders a searchable, paginated, sortable grid that mixes three row
 kinds:
 
-- **Leases** — Crabbox-managed boxes with compact provider/target badges,
+- **Leases** — managed or registered boxes with compact provider/target badges,
   state pills, the lease class, icon-only access capabilities (SSH, VNC,
-  code, browser), and relative time cells.
+  code, browser), relative time cells, and a confirmed lifecycle action for
+  sessions with manage access. The action stops and deletes the backing machine
+  for coordinator-managed leases; registered leases instead show **remove
+  registration** and warn that the external machine keeps running.
 - **External runners** — visibility-only rows for Blacksmith Testboxes synced
   from `crabbox list` output. They render as muted, disabled rows with status
   badges, inferred GitHub Actions run/workflow links, `stuck` markers for
@@ -119,14 +129,16 @@ The lease detail page shows:
   `crabbox run`, the WebVNC bridge, the code bridge, and (when egress is
   active) `crabbox egress status` / `crabbox egress stop`;
 - a viewport-fitted "recent runs" grid with state filters;
-- a stop button when the session can manage the lease.
+- a stop button for coordinator-managed leases, or a metadata-only remove
+  registration button for client-managed leases, when the session can manage
+  the lease.
 
 Owners and users with `manage` access see a share control in the lease
 header. The share page (`/share`) adds or removes individual users, sets
 org-wide access (`use`, `manage`, or off), or clears sharing entirely; it can
 also render embedded (`?embed=1`) inside the VNC viewer's share dialog. A
 `use` share can open visible lease pages and portal bridges; a `manage` share
-can also change sharing and stop the lease.
+can also change sharing and use the matching stop or deregistration action.
 
 `/portal/leases/{id-or-slug}/vnc` and `/portal/leases/{id-or-slug}/code/` are
 not ordinary pages. VNC opens a noVNC viewer that talks to the lease's desktop

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1956,7 +1956,19 @@ export class FleetCoordinator {
         this.visibleExternalRunners(request),
         this.portalMacHosts(),
       ]);
-      return portalHome(leases, runners, request, this.attachPortalMacHostLeases(macHosts, leases));
+      const admin = isAdminRequest(request);
+      const manageableLeaseIDs = new Set(
+        leases
+          .filter((lease) => this.leaseManageableByRequest(lease, request, admin))
+          .map((lease) => lease.id),
+      );
+      return portalHome(
+        leases,
+        runners,
+        request,
+        this.attachPortalMacHostLeases(macHosts, leases),
+        manageableLeaseIDs,
+      );
     }
     if (method === "GET" && parts[1] === "admin") {
       if (!isAdminRequest(request)) {

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -11,6 +11,7 @@ const novncModuleURL = "/portal/assets/novnc/rfb.js";
 const copyIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>`;
 const lockIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>`;
 const ejectIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 17h14"/><path d="m12 5 7 9H5z"/></svg>`;
+const powerIcon = `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v9"/><path d="M6.3 5.7a8 8 0 1 0 11.4 0"/></svg>`;
 const serverIcon = `<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="3" width="14" height="18" rx="2"/><path d="M8 8h8M8 12h8M8 16h4"/></svg>`;
 const dedicatedHostIcon = `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16"/><path d="M7 7V4h10v3"/><rect x="5" y="7" width="14" height="13" rx="2"/><path d="M9 11h6M9 15h3"/></svg>`;
 const vncIcon = `<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="13" rx="2"/><path d="M8 21h8M12 17v4"/></svg>`;
@@ -119,6 +120,7 @@ export function portalHome(
   runners: ExternalRunnerRecord[],
   request: Request,
   macHosts: PortalMacHostRecord[] = [],
+  manageableLeaseIDs: ReadonlySet<string> = new Set(),
 ): Response {
   const sortedLeases = leases.toSorted((a, b) => leaseSortTime(b).localeCompare(leaseSortTime(a)));
   const active = sortedLeases.filter((lease) => lease.state === "active");
@@ -160,7 +162,12 @@ export function portalHome(
     .toSorted((a, b) => b.sort.localeCompare(a.sort))
     .map((row) =>
       row.kind === "lease"
-        ? leaseRow(row.lease, { admin, owner, org })
+        ? leaseRow(row.lease, {
+            admin,
+            owner,
+            org,
+            canManage: manageableLeaseIDs.has(row.lease.id),
+          })
         : row.kind === "runner"
           ? externalRunnerLeaseRow(row.runner, { admin, owner, org })
           : macHostRow(row.host, { admin, owner, org }),
@@ -405,6 +412,7 @@ function adminLeaseRow(
     lease.state === "active" || lease.state === "provisioning" || lease.state === "failed";
   const releaseLabel =
     lease.lifecycle === "registered" ? "Remove registration" : "Emergency release";
+  const releaseConfirmation = leaseReleaseConfirmation(lease);
   return `<tr data-filter-tags="${escapeHTML([stateGroup, lease.state, lease.provider, lease.owner, lease.org, lease.target, lease.serverType].join(" "))}">
     <td><a class="lease-link" href="/portal/leases/${encodeURIComponent(lease.id)}"><strong>${escapeHTML(lease.slug || lease.id)}</strong><small>${escapeHTML(lease.id)}</small></a></td>
     <td><span class="pill" data-state="${escapeHTML(lease.state)}">${escapeHTML(lease.state)}</span></td>
@@ -413,7 +421,7 @@ function adminLeaseRow(
     <td>${targetBadge(lease.target)}</td>
     <td>${escapeHTML(`${lease.class} / ${lease.serverType}`)}</td>
     ${timeCell(lease.state === "active" || lease.state === "provisioning" ? lease.expiresAt : lease.updatedAt)}
-    <td>${canEject ? `<form class="admin-eject-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=${encodeURIComponent(returnPath)}"><button class="admin-eject" type="submit" title="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}" aria-label="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}">${ejectIcon}</button></form>` : ""}</td>
+    <td>${canEject ? `<form class="admin-eject-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=${encodeURIComponent(returnPath)}" data-confirm="${escapeHTML(releaseConfirmation)}"><button class="admin-eject" type="submit" title="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}" aria-label="${releaseLabel} ${escapeHTML(lease.slug || lease.id)}">${ejectIcon}</button></form>` : ""}</td>
   </tr>`;
 }
 
@@ -557,7 +565,7 @@ export function portalLeaseDetail(
           ${leaseTelemetryTimeline(lease.telemetry, lease.telemetryHistory)}
           ${
             active && options.canManage
-              ? `<form method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release" class="stop-form">
+              ? `<form method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release" class="stop-form" data-confirm="${escapeHTML(leaseReleaseConfirmation(lease))}">
                   <button class="button ${registered ? "secondary" : "danger"}" type="submit">${registered ? "remove registration" : "stop lease"}</button>
                 </form>`
               : ""
@@ -1922,7 +1930,7 @@ function shellArg(value: string): string {
 
 function leaseRow(
   lease: LeaseRecord,
-  context: { admin: boolean; owner: string; org: string },
+  context: { admin: boolean; owner: string; org: string; canManage: boolean },
 ): string {
   const label = lease.slug || lease.id;
   const detailPath = `/portal/leases/${encodeURIComponent(lease.id)}`;
@@ -1952,8 +1960,28 @@ function leaseRow(
     <td>${escapeHTML(lease.class)}</td>
     <td>${accessCell(lease, detailPath)}</td>
     ${timeCell(timeLabel)}
-    <td></td>
+    <td>${active && context.canManage ? leaseReleaseAction(lease) : ""}</td>
   </tr>`;
+}
+
+function leaseReleaseAction(lease: LeaseRecord): string {
+  const registered = lease.lifecycle === "registered";
+  const label = lease.slug || lease.id;
+  const actionLabel = registered ? `Remove ${label} registration` : `Stop ${label}`;
+  return `<form class="lease-release-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=%2Fportal" data-confirm="${escapeHTML(leaseReleaseConfirmation(lease))}">
+    <button class="access-icon lease-release" data-release-kind="${registered ? "registered" : "managed"}" type="submit" title="${escapeHTML(actionLabel)}" aria-label="${escapeHTML(actionLabel)}">${registered ? ejectIcon : powerIcon}</button>
+  </form>`;
+}
+
+function leaseReleaseConfirmation(lease: {
+  id: string;
+  slug?: string;
+  lifecycle?: LeaseRecord["lifecycle"];
+}): string {
+  const label = lease.slug || lease.id;
+  return lease.lifecycle === "registered"
+    ? `Remove ${label} from Crabbox? The external machine will keep running. Use crabbox stop locally to shut it down.`
+    : `Stop ${label}? This deletes the backing machine.`;
 }
 
 function portalRowFilterGroupTags(groups: Record<string, string | string[] | undefined>): string {
@@ -2873,7 +2901,7 @@ function html(
   <meta name="color-scheme" content="dark light">
   <meta name="theme-color" content="#0b0d0f">
   <title>${escapeHTML(title)}</title>
-  <script nonce="${pageNonce}">(function(){var s;try{s=localStorage.getItem('crabbox-theme')}catch(e){}var m=(s==='light'||s==='dark')?s:'system';var d=window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.themeSource=m;document.documentElement.dataset.theme=m==='system'?(d?'dark':'light'):m})();</script>
+  <script nonce="${pageNonce}">(function(){var s;try{s=localStorage.getItem('crabbox-theme-source')}catch(e){}var m=(s==='light'||s==='dark'||s==='system')?s:'system';var d=window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.dataset.themeSource=m;document.documentElement.dataset.theme=m==='system'?(d?'dark':'light'):m})();</script>
   <style>
     :root {
       color-scheme: dark;
@@ -3080,6 +3108,11 @@ function html(
     .access-icon[data-access="vscode"] { color:#d8b4fe; }
     .access-icon[data-access="vnc"] { color:#38bdf8; }
     .access-icon:hover { border-color:var(--hover-line); background:var(--hover); }
+    .lease-release-form { display:flex; justify-content:flex-end; }
+    .lease-release { color:var(--muted); cursor:pointer; }
+    .lease-release[data-release-kind="managed"] { color:var(--bad); }
+    .lease-release:hover,.lease-release:focus-visible { border-color:color-mix(in srgb, var(--bad) 45%, var(--line)); background:color-mix(in srgb, var(--bad) 12%, transparent); }
+    .lease-release:disabled { opacity:0.5; cursor:wait; }
     .table-panel { min-height:0; display:grid; grid-template-rows:auto auto minmax(0,1fr) auto; overflow:hidden; }
     .command-panel,.log-panel { min-height:0; overflow:hidden; }
     .run-shell .table-panel { max-height:55dvh; }
@@ -3125,7 +3158,7 @@ function html(
     .lease-table th:nth-child(5) { width:82px; }
     .lease-table th:nth-child(6) { width:118px; }
     .lease-table th:nth-child(7) { width:148px; }
-    .lease-table th:nth-child(8) { width:24px; }
+    .lease-table th:nth-child(8),.lease-table td:nth-child(8) { width:40px; padding-left:4px; padding-right:4px; text-align:right; }
     .run-table th:nth-child(2) { width:104px; }
     .run-table th:nth-child(3) { width:112px; }
     .run-table th:nth-child(4) { width:92px; }
@@ -3282,10 +3315,10 @@ function portalEnhancementsScript(): string {
   const themeRoot = document.documentElement;
   const systemDark = window.matchMedia && matchMedia("(prefers-color-scheme: dark)");
   function storedTheme() {
-    try { return localStorage.getItem("crabbox-theme"); } catch (_) { return null; }
+    try { return localStorage.getItem("crabbox-theme-source"); } catch (_) { return null; }
   }
   function themeSource(value) {
-    return value === "light" || value === "dark" ? value : "system";
+    return value === "light" || value === "dark" || value === "system" ? value : "system";
   }
   function resolvedTheme(source) {
     return source === "system" ? (systemDark && systemDark.matches ? "dark" : "light") : source;
@@ -3311,7 +3344,7 @@ function portalEnhancementsScript(): string {
       const current = themeSource(themeRoot.dataset.themeSource);
       const next = current === "system" ? "dark" : current === "dark" ? "light" : "system";
       applyTheme(next);
-      try { localStorage.setItem("crabbox-theme", next); } catch (_) {}
+      try { localStorage.setItem("crabbox-theme-source", next); } catch (_) {}
     });
   });
   if (systemDark) {
@@ -3322,6 +3355,19 @@ function portalEnhancementsScript(): string {
     if (systemDark.addEventListener) systemDark.addEventListener("change", onSystemChange);
     else if (systemDark.addListener) systemDark.addListener(onSystemChange);
   }
+  document.querySelectorAll("form[data-confirm]").forEach((form) => {
+    form.addEventListener("submit", (event) => {
+      const message = form.dataset.confirm || "";
+      if (message && !window.confirm(message)) {
+        event.preventDefault();
+        return;
+      }
+      if (event.submitter) {
+        event.submitter.disabled = true;
+        event.submitter.setAttribute("aria-busy", "true");
+      }
+    });
+  });
   function copyText(text, source) {
     const finish = () => {
       source.dataset.state = "ok";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -182,6 +182,15 @@ describe("fleet lease identity and idle", () => {
     expect(portalHTML).toContain("client managed");
     expect(portalHTML).toContain("remove registration");
 
+    const portalIndex = await fleet.fetch(request("GET", "/portal", { headers: ownerHeaders }));
+    expect(portalIndex.status).toBe(200);
+    const portalIndexHTML = await portalIndex.text();
+    expect(portalIndexHTML).toContain('data-release-kind="registered"');
+    expect(portalIndexHTML).toContain('title="Remove test-box registration"');
+    expect(portalIndexHTML).toContain(
+      "The external machine will keep running. Use crabbox stop locally to shut it down.",
+    );
+
     const poolRegistration = await fleet.fetch(
       request("POST", "/v1/ready-pools/example/register", {
         headers: ownerHeaders,
@@ -211,15 +220,16 @@ describe("fleet lease identity and idle", () => {
     expect(friend.status).toBe(200);
 
     const released = await fleet.fetch(
-      request("POST", "/v1/leases/test-box/release", {
+      request("POST", "/portal/leases/test-box/release?return=/portal", {
         headers: ownerHeaders,
-        body: { delete: true },
       }),
     );
-    expect(released.status).toBe(200);
+    expect(released.status).toBe(303);
+    expect(released.headers.get("location")).toBe("/portal");
     expect(providerReleases).toBe(0);
-    await expect(released.json()).resolves.toMatchObject({
-      lease: { lifecycle: "registered", state: "released" },
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000099")).toMatchObject({
+      lifecycle: "registered",
+      state: "released",
     });
   });
 
@@ -1644,6 +1654,14 @@ describe("fleet lease identity and idle", () => {
     );
     expect(friendRelease.status).toBe(403);
 
+    const friendUsePortal = await fleet.fetch(
+      request("GET", "/portal", { headers: friendHeaders }),
+    );
+    expect(friendUsePortal.status).toBe(200);
+    expect(await friendUsePortal.text()).not.toContain(
+      'action="/portal/leases/cbx_000000000001/release?return=%2Fportal"',
+    );
+
     const orgShared = await fleet.fetch(
       request("PUT", "/v1/leases/blue-lobster/share", {
         headers: ownerHeaders,
@@ -1654,6 +1672,14 @@ describe("fleet lease identity and idle", () => {
     await expect(orgShared.json()).resolves.toMatchObject({
       share: { users: { "friend@example.com": "use" }, org: "manage" },
     });
+
+    const friendManagePortal = await fleet.fetch(
+      request("GET", "/portal", { headers: friendHeaders }),
+    );
+    expect(friendManagePortal.status).toBe(200);
+    expect(await friendManagePortal.text()).toContain(
+      'action="/portal/leases/cbx_000000000001/release?return=%2Fportal"',
+    );
 
     const friendSharePage = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/share", { headers: friendHeaders }),
@@ -4981,6 +5007,11 @@ describe("fleet lease identity and idle", () => {
     expect(body).toContain('title="server"');
     expect(body).toContain('data-access="vscode"');
     expect(body).toContain('data-access="vnc"');
+    expect(body).toContain('data-release-kind="managed"');
+    expect(body).toContain('title="Stop blue-lobster"');
+    expect(body).toContain("This deletes the backing machine.");
+    expect(body).toContain('action="/portal/leases/cbx_000000000001/release?return=%2Fportal"');
+    expect(body).not.toContain('action="/portal/leases/cbx_000000000003/release?return=%2Fportal"');
     expect(body).toContain("data-sort=");
     expect(body).toContain("<time datetime=");
     expect(body).not.toContain("windows / normal");

--- a/worker/test/portal-theme.test.ts
+++ b/worker/test/portal-theme.test.ts
@@ -9,10 +9,15 @@ describe("portal theme", () => {
 
     expect(body).toContain("data-theme-source");
     expect(body).toContain("prefers-color-scheme: dark");
-    expect(body).toContain("crabbox-theme");
+    expect(body).toContain("crabbox-theme-source");
+    expect(body).not.toContain("getItem('crabbox-theme')");
+    expect(body).not.toContain('getItem("crabbox-theme")');
+    expect(body).toContain('value === "system"');
     expect(body).toContain('const next = current === "system" ? "dark"');
     expect(body).toContain('Theme: " + source');
     expect(body).toContain("crabbox-theme-change");
+    expect(body).toContain('querySelectorAll("form[data-confirm]")');
+    expect(body).toContain("window.confirm(message)");
   });
 
   it("renders an explicit admin summary when the portal is admin scoped", async () => {


### PR DESCRIPTION
## Summary

- default the portal to the browser's system appearance and follow later system changes, while preserving explicit light, dark, and system choices under a new preference key
- add permission-aware lifecycle controls to active lease rows
- stop and delete coordinator-managed machines; label externally registered leases as registration removal and warn that their machine keeps running

## Testing

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (412 tests)
- `npm run build --prefix worker`
- `autoreview --mode local` (clean)
