### PR TITLE
Add Namespace Compute instance provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ from the CLI.
 | [KubeVirt](docs/providers/kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct | Generic KubeVirt VMs through `kubectl`, `virtctl`, and control-plane SSH forwarding. |
 | [External](docs/providers/external.md) — `external` (`exec-provider`) | Linux · direct | Configured executable implementing the Crabbox provider protocol. |
 | [Namespace Devbox](docs/providers/namespace-devbox.md) — `namespace-devbox` (`namespace`, `namespace-devboxes`) | Linux · direct | Namespace.so Devboxes over SSH. |
+| [Namespace Compute Instance](docs/providers/namespace-instance.md) — `namespace-instance` (`namespace-compute`, `nsc`) | Linux · direct | Namespace Compute instances through the `nsc` CLI. |
 | [Semaphore](docs/providers/semaphore.md) — `semaphore` (`sem`) | Linux · direct | A Semaphore CI job leased as a testbox. |
 | [Sprites](docs/providers/sprites.md) — `sprites` | Linux · direct | Sprites microVMs through `sprite proxy`. |
 | [Tenki](docs/providers/tenki.md) — `tenki` | Linux · direct | Tenki sandbox VMs through `tenki sandbox ssh-proxy`. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,7 @@ Pick whichever matches your intent:
   [Blacksmith Testbox](providers/blacksmith-testbox.md),
   [KubeVirt](providers/kubevirt.md), [External](providers/external.md),
   [Namespace Devbox](providers/namespace-devbox.md),
+  [Namespace Compute Instance](providers/namespace-instance.md),
   [Semaphore](providers/semaphore.md), [Sprites](providers/sprites.md),
   [Tenki](providers/tenki.md),
   [Daytona](providers/daytona.md), [Islo](providers/islo.md),

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -60,7 +60,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 49 providers (29 SSH lease, 19 delegated run, 1 service control).
+Current built-in surface: 50 providers (30 SSH lease, 19 delegated run, 1 service control).
 
 Access terms:
 
@@ -101,6 +101,7 @@ Access terms:
 | [multipass](multipass.md) (`mp`, `canonical-multipass`) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `cache-volume` | `linux`; Canonical Multipass VM | `local`; GPU: no | Crabbox; VM delete and purge | Portable local Ubuntu VM | Ubuntu-only first implementation |
 | [mxc](mxc.md) (`execution-container`) | built-in; `delegated-run` · local-sandbox | No SSH; `provider-owned` · direct only; features: none | `windows/normal`; Microsoft Execution Container | `local`; GPU: no | Windows runtime; container termination | Local isolated Windows command execution | Windows host and execution-container support required |
 | [namespace-devbox](namespace-devbox.md) (`namespace`, `namespace-devboxes`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Devbox | `provider-managed`; GPU: unknown | Namespace devbox CLI; stop by default; optional delete | Fast managed development box over SSH | Uses the devbox product, not Namespace Compute instances |
+| [namespace-instance](namespace-instance.md) (`namespace-compute`, `nsc`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Compute instance | `provider-managed`; GPU: unknown | nsc CLI; instance destroy | Short-lived Namespace Compute Linux VM over SSH | Requires the nsc CLI and Namespace Compute access |
 | [opencomputer](opencomputer.md) (`oc`, `open-computer`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; OpenComputer Linux VM | `provider-managed`; GPU: unknown | OpenComputer; VM delete | Hosted delegated Linux VM execution | REST execution contract, not an SSH lease |
 | [opensandbox](opensandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; OpenSandbox sandbox | `provider-managed`; GPU: unknown | OpenSandbox; sandbox delete | Hosted delegated sandbox through an open SDK | Requires compatible OpenSandbox control and exec endpoints |
 | [parallels](parallels.md) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code`, `workspace-checkpoint`, `workspace-fork`, `workspace-restore`, `provider-snapshot` | `linux`, `macos`, `windows/normal`, `windows/wsl2`; Parallels linked-clone VM | `local`; GPU: no | Crabbox; clone delete | Local macOS, Linux, or Windows VM with snapshots | Requires prepared Parallels source VMs and SSH |

--- a/docs/providers/namespace-instance.md
+++ b/docs/providers/namespace-instance.md
@@ -1,0 +1,150 @@
+# Namespace Compute Instance Provider
+
+Read this when you:
+
+- choose `provider: namespace-instance`;
+- configure the Namespace Compute machine type, duration, region, endpoint, or
+  volumes;
+- change `internal/providers/namespaceinstance`.
+
+Namespace Compute Instance is an **SSH-lease** provider. Crabbox shells out to
+the Namespace `nsc` CLI to create, inspect, extend, list, and destroy Compute
+instances, then uses Crabbox's normal SSH sync/run path on the leased Linux
+box.
+
+The provider runs **direct from the CLI**. It never goes through the broker
+coordinator and supports Linux targets only.
+
+## When to use
+
+Use Namespace Compute Instance when you want a fresh Namespace Compute VM with a
+short lease, Crabbox-owned labels, and the standard Crabbox SSH data plane. Use
+Namespace Devbox (`provider: namespace-devbox`) when you specifically need the
+Namespace Devbox product and its Devbox lifecycle.
+
+## Prerequisites
+
+Install the Namespace `nsc` CLI and authenticate before using Crabbox:
+
+```sh
+nsc auth login
+```
+
+Crabbox does not store Namespace credentials. It passes the configured endpoint,
+keychain, region, volumes, duration, and machine type to `nsc`.
+
+## Commands
+
+```sh
+crabbox warmup --provider namespace-instance --namespace-instance-machine-type 4x8
+crabbox run --provider namespace-instance --id swift-crab -- pnpm test
+crabbox ssh --provider namespace-instance --id swift-crab
+crabbox status --provider namespace-instance --id swift-crab
+crabbox stop --provider namespace-instance swift-crab
+```
+
+Aliases for the provider name: `namespace-compute`, `nsc`.
+
+## Configuration
+
+```yaml
+provider: namespace-instance
+target: linux
+namespaceInstance:
+  machineType: 4x8
+  duration: 30m
+  ephemeral: true
+  region: ""
+  endpoint: ""
+  keychain: ""
+  volumes: []
+  workRoot: /workspaces/crabbox
+```
+
+Defaults baked into Crabbox: `duration: 30m`, `ephemeral: true`,
+`workRoot: /workspaces/crabbox`. `machineType`, `region`, `endpoint`,
+`keychain`, and `volumes` are unset by default. When `machineType` is unset,
+Crabbox derives it from `--class`.
+
+Provider flags:
+
+```text
+--namespace-instance-machine-type
+--namespace-instance-duration
+--namespace-instance-ephemeral
+--namespace-instance-region
+--namespace-instance-endpoint
+--namespace-instance-keychain
+--namespace-instance-volume
+--namespace-instance-work-root
+```
+
+Environment overrides:
+
+```text
+CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE
+CRABBOX_NAMESPACE_INSTANCE_DURATION
+CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL
+CRABBOX_NAMESPACE_INSTANCE_REGION
+CRABBOX_NAMESPACE_INSTANCE_ENDPOINT
+CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN
+CRABBOX_NAMESPACE_INSTANCE_VOLUMES
+CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT
+```
+
+## Lifecycle
+
+1. Crabbox creates a per-lease SSH key and runs `nsc create` with Crabbox
+   ownership labels and the configured machine options.
+2. It reads the instance JSON from `nsc`, waits for SSH readiness, and records a
+   local Crabbox lease claim.
+3. `crabbox run`, `crabbox ssh`, and `crabbox pond connect` use the normal SSH
+   executor and sync path against the instance.
+4. `crabbox stop` runs `nsc destroy --force` and removes the local lease claim
+   and generated key.
+5. `crabbox cleanup --provider namespace-instance` lists Crabbox-owned
+   instances and destroys expired leases.
+
+## Capabilities
+
+- **SSH**: yes.
+- **Crabbox sync**: yes — standard rsync over SSH.
+- **Cleanup**: yes — stale Crabbox-owned instances are destroyed through `nsc`.
+- **Actions hydration**: yes — same Linux SSH contract as other SSH-lease
+  providers.
+- **Desktop / browser / code**: not surfaced for this provider.
+- **Coordinator (broker)**: never; always direct from the CLI.
+
+## Machine type mapping
+
+`--namespace-instance-machine-type` accepts any `nsc create --machine_type`
+value and always wins over the class mapping. When it is unset, Crabbox maps
+`--class` as follows:
+
+| Class      | Machine type |
+| ---------- | ------------ |
+| `standard` | `4x8`        |
+| `fast`     | `4x8`        |
+| `large`    | `8x16`       |
+| `beast`    | `16x32`      |
+
+An empty class resolves to `4x8`. Other class values pass through as the
+machine type.
+
+## Gotchas
+
+- Run `nsc auth login` first. Crabbox does not store Namespace credentials.
+- `namespace-instance` does not replace `namespace-devbox`; the bare
+  `namespace` alias remains reserved for Namespace Devboxes.
+- `--namespace-instance-volume` accepts comma-separated volume specs and passes
+  each value through to `nsc --volume`.
+- `--tailscale` is rejected because Namespace Compute instances expose SSH
+  directly in this adapter.
+- `namespaceInstance.workRoot` must be an absolute path under a dedicated
+  subdirectory; broad roots such as `/`, `/home`, `/tmp`, or `/workspaces` are
+  rejected.
+
+## Related docs
+
+- [Namespace Devbox provider](namespace-devbox.md)
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -433,6 +433,20 @@
     "caveat": "Uses the devbox product, not Namespace Compute instances",
     "docs": "namespace-devbox.md"
   },
+  "namespace-instance": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Namespace Compute instance",
+    "location": "provider-managed",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "unknown",
+    "lifecycle": "nsc CLI",
+    "cleanup": "instance destroy",
+    "bestFit": "Short-lived Namespace Compute Linux VM over SSH",
+    "caveat": "Requires the nsc CLI and Namespace Compute access",
+    "docs": "namespace-instance.md"
+  },
   "opencomputer": {
     "status": "built-in",
     "category": "delegated-sandbox",

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -128,6 +128,7 @@ type Config struct {
 	deleteOnReleaseExplicit       map[string]bool
 	External                      ExternalConfig
 	Namespace                     NamespaceConfig
+	NamespaceInstance             NamespaceInstanceConfig
 	Morph                         MorphConfig
 	Daytona                       DaytonaConfig
 	E2B                           E2BConfig
@@ -327,6 +328,17 @@ type NamespaceConfig struct {
 	AutoStopIdleTimeout time.Duration
 	WorkRoot            string
 	DeleteOnRelease     bool
+}
+
+type NamespaceInstanceConfig struct {
+	MachineType string
+	Duration    time.Duration
+	Ephemeral   bool
+	Region      string
+	Endpoint    string
+	Keychain    string
+	Volumes     []string
+	WorkRoot    string
 }
 
 type MorphConfig struct {
@@ -1717,6 +1729,11 @@ func baseConfig() Config {
 			WorkRoot:            "/workspaces/crabbox",
 			AutoStopIdleTimeout: 30 * time.Minute,
 		},
+		NamespaceInstance: NamespaceInstanceConfig{
+			Duration:  30 * time.Minute,
+			Ephemeral: true,
+			WorkRoot:  "/workspaces/crabbox",
+		},
 		Morph: MorphConfig{
 			APIURL:         "https://cloud.morph.so",
 			SSHGatewayHost: "ssh.cloud.morph.so",
@@ -1978,6 +1995,7 @@ type fileConfig struct {
 	KubeVirt             *fileKubeVirtConfig                `yaml:"kubevirt,omitempty"`
 	External             *fileExternalConfig                `yaml:"external,omitempty"`
 	Namespace            *fileNamespaceConfig               `yaml:"namespace,omitempty"`
+	NamespaceInstance    *fileNamespaceInstanceConfig       `yaml:"namespaceInstance,omitempty"`
 	Morph                *fileMorphConfig                   `yaml:"morph,omitempty"`
 	Daytona              *fileDaytonaConfig                 `yaml:"daytona,omitempty"`
 	E2B                  *fileE2BConfig                     `yaml:"e2b,omitempty"`
@@ -2297,6 +2315,17 @@ type fileNamespaceConfig struct {
 	AutoStopIdleTimeout string `yaml:"autoStopIdleTimeout,omitempty"`
 	WorkRoot            string `yaml:"workRoot,omitempty"`
 	DeleteOnRelease     *bool  `yaml:"deleteOnRelease,omitempty"`
+}
+
+type fileNamespaceInstanceConfig struct {
+	MachineType string   `yaml:"machineType,omitempty"`
+	Duration    string   `yaml:"duration,omitempty"`
+	Ephemeral   *bool    `yaml:"ephemeral,omitempty"`
+	Region      string   `yaml:"region,omitempty"`
+	Endpoint    string   `yaml:"endpoint,omitempty"`
+	Keychain    string   `yaml:"keychain,omitempty"`
+	Volumes     []string `yaml:"volumes,omitempty"`
+	WorkRoot    string   `yaml:"workRoot,omitempty"`
 }
 
 type fileMorphConfig struct {
@@ -3654,6 +3683,30 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Namespace.DeleteOnRelease != nil {
 			cfg.Namespace.DeleteOnRelease = *file.Namespace.DeleteOnRelease
 			MarkDeleteOnReleaseExplicit(cfg, "namespace-devbox")
+		}
+	}
+	if file.NamespaceInstance != nil {
+		if file.NamespaceInstance.MachineType != "" {
+			cfg.NamespaceInstance.MachineType = file.NamespaceInstance.MachineType
+		}
+		applyLeaseDuration(&cfg.NamespaceInstance.Duration, file.NamespaceInstance.Duration)
+		if file.NamespaceInstance.Ephemeral != nil {
+			cfg.NamespaceInstance.Ephemeral = *file.NamespaceInstance.Ephemeral
+		}
+		if file.NamespaceInstance.Region != "" {
+			cfg.NamespaceInstance.Region = file.NamespaceInstance.Region
+		}
+		if file.NamespaceInstance.Endpoint != "" {
+			cfg.NamespaceInstance.Endpoint = file.NamespaceInstance.Endpoint
+		}
+		if file.NamespaceInstance.Keychain != "" {
+			cfg.NamespaceInstance.Keychain = file.NamespaceInstance.Keychain
+		}
+		if len(file.NamespaceInstance.Volumes) > 0 {
+			cfg.NamespaceInstance.Volumes = append([]string(nil), file.NamespaceInstance.Volumes...)
+		}
+		if file.NamespaceInstance.WorkRoot != "" {
+			cfg.NamespaceInstance.WorkRoot = file.NamespaceInstance.WorkRoot
 		}
 	}
 	if file.Morph != nil {
@@ -5156,6 +5209,20 @@ func applyEnv(cfg *Config) error {
 		cfg.Namespace.DeleteOnRelease = value
 		MarkDeleteOnReleaseExplicit(cfg, "namespace-devbox")
 	}
+	cfg.NamespaceInstance.MachineType = getenv("CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE", cfg.NamespaceInstance.MachineType)
+	if duration := os.Getenv("CRABBOX_NAMESPACE_INSTANCE_DURATION"); duration != "" {
+		applyLeaseDuration(&cfg.NamespaceInstance.Duration, duration)
+	}
+	if value, ok := getenvBool("CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL"); ok {
+		cfg.NamespaceInstance.Ephemeral = value
+	}
+	cfg.NamespaceInstance.Region = getenv("CRABBOX_NAMESPACE_INSTANCE_REGION", cfg.NamespaceInstance.Region)
+	cfg.NamespaceInstance.Endpoint = getenv("CRABBOX_NAMESPACE_INSTANCE_ENDPOINT", cfg.NamespaceInstance.Endpoint)
+	cfg.NamespaceInstance.Keychain = getenv("CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN", cfg.NamespaceInstance.Keychain)
+	if volumes := os.Getenv("CRABBOX_NAMESPACE_INSTANCE_VOLUMES"); volumes != "" {
+		cfg.NamespaceInstance.Volumes = splitCSV(volumes)
+	}
+	cfg.NamespaceInstance.WorkRoot = getenv("CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT", cfg.NamespaceInstance.WorkRoot)
 	cfg.Morph.APIKey = getenv("CRABBOX_MORPH_API_KEY", getenv("MORPH_API_KEY", cfg.Morph.APIKey))
 	cfg.Morph.APIURL = getenv("CRABBOX_MORPH_API_URL", cfg.Morph.APIURL)
 	cfg.Morph.Snapshot = getenv("CRABBOX_MORPH_SNAPSHOT", cfg.Morph.Snapshot)

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/multipass"
 	_ "github.com/openclaw/crabbox/internal/providers/mxc"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
+	_ "github.com/openclaw/crabbox/internal/providers/namespaceinstance"
 	_ "github.com/openclaw/crabbox/internal/providers/opencomputer"
 	_ "github.com/openclaw/crabbox/internal/providers/opensandbox"
 	_ "github.com/openclaw/crabbox/internal/providers/parallels"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -98,6 +98,32 @@ func TestAnthropicSandboxRuntimeRegistersCanonicalAndAlias(t *testing.T) {
 	}
 }
 
+func TestNamespaceInstanceRegistersWithoutStealingDevboxAlias(t *testing.T) {
+	for _, name := range []string{"namespace-instance", "namespace-compute", "nsc"} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", name, err)
+		}
+		if provider.Name() != "namespace-instance" {
+			t.Fatalf("ProviderFor(%q).Name=%q", name, provider.Name())
+		}
+	}
+	provider, err := core.ProviderFor("namespace")
+	if err != nil {
+		t.Fatalf("ProviderFor(namespace): %v", err)
+	}
+	if provider.Name() != "namespace-devbox" {
+		t.Fatalf("namespace alias now resolves to %q; namespace-instance must not steal it", provider.Name())
+	}
+	spec := mustProvider(t, "namespace-instance").Spec()
+	if spec.Family != "namespace" || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("namespace-instance spec=%#v", spec)
+	}
+	if !spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("namespace-instance features=%v", spec.Features)
+	}
+}
+
 func TestIncusRegistersAsBuiltInProvider(t *testing.T) {
 	provider, err := core.ProviderFor("incus")
 	if err != nil {
@@ -148,6 +174,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"multipass",
 		"mxc",
 		"namespace-devbox",
+		"namespace-instance",
 		"opencomputer",
 		"opensandbox",
 		"parallels",

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -1,0 +1,605 @@
+package namespaceinstance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const providerName = "namespace-instance"
+
+type Backend struct {
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
+}
+
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	if strings.TrimSpace(cfg.NamespaceInstance.WorkRoot) != "" {
+		cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+	}
+	return &Backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *Backend) Spec() core.ProviderSpec { return b.spec }
+
+func (b *Backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	leaseID := core.NewLeaseID()
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	name := core.LeaseProviderName(leaseID, slug)
+	keyPath, _, err := core.EnsureTestboxKey(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	cfg := b.configForRun()
+	machineType := namespaceInstanceMachineTypeForConfig(cfg)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s machine_type=%s duration=%s keep=%v\n", providerName, leaseID, slug, name, machineType, cfg.NamespaceInstance.Duration, req.Keep)
+
+	instance, err := b.createInstance(ctx, cfg, name, leaseID, slug, keyPath+".pub", req.Keep)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if strings.TrimSpace(instance.ID) == "" {
+		if instance.ID = strings.TrimSpace(instance.Name); instance.ID == "" {
+			return core.LeaseTarget{}, core.Exit(5, "namespace instance create response missing id")
+		}
+	}
+	lease, err := b.prepareLease(ctx, cfg, instance, leaseID, slug, keyPath, req.Keep)
+	if err != nil {
+		if !req.Keep {
+			err = b.cleanupFailedAcquire(instance.ID, err)
+		}
+		return core.LeaseTarget{}, err
+	}
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !req.Keep {
+			err = b.cleanupFailedAcquire(instance.ID, err)
+		}
+		return core.LeaseTarget{}, err
+	}
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		if !req.Keep {
+			core.RemoveLeaseClaim(leaseID)
+			err = b.cleanupFailedAcquire(instance.ID, err)
+		}
+		return core.LeaseTarget{}, err
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, instance.ID)
+	return lease, nil
+}
+
+func (b *Backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	claim, claimOK, err := core.ResolveLeaseClaim(req.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if claimOK && claim.Provider != "" && claim.Provider != providerName {
+		return core.LeaseTarget{}, core.Exit(4, "%q is claimed by provider %s", req.ID, claim.Provider)
+	}
+	id := strings.TrimSpace(req.ID)
+	leaseID := id
+	slug := core.NormalizeLeaseSlug(id)
+	if claimOK {
+		id = firstNonBlank(claim.CloudID, claim.Labels["name"], claim.LeaseID)
+		leaseID = claim.LeaseID
+		slug = firstNonBlank(claim.Slug, core.NewLeaseSlug(leaseID))
+	}
+	if id == "" {
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s requires --id <instance-id-or-slug>", providerName)
+	}
+	instance, err := b.describeInstance(ctx, id)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if leaseID == "" {
+		leaseID = firstNonBlank(instance.Labels["lease"], namespaceInstanceLeaseIDFromName(instance.Name), namespaceInstanceLeaseIDFromName(instance.ID))
+	}
+	if slug == "" {
+		slug = firstNonBlank(instance.Labels["slug"], core.NormalizeLeaseSlug(instance.Name), core.NewLeaseSlug(leaseID))
+	}
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: namespaceInstanceServer(instance, leaseID, slug, b.configForRun(), true), LeaseID: leaseID}, nil
+	}
+	keyPath, _, err := core.EnsureTestboxKey(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	lease, err := b.prepareLease(ctx, b.configForRun(), instance, leaseID, slug, keyPath, true)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if req.Repo.Root != "" {
+		if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *Backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cfg := b.configForRun()
+	var out []core.LeaseView
+	for _, instance := range instances {
+		if !req.All && !namespaceInstanceOwned(instance) {
+			continue
+		}
+		leaseID := firstNonBlank(instance.Labels["lease"], namespaceInstanceLeaseIDFromName(firstNonBlank(instance.Name, instance.ID)))
+		slug := firstNonBlank(instance.Labels["slug"], core.NormalizeLeaseSlug(firstNonBlank(instance.Name, instance.ID)))
+		out = append(out, namespaceInstanceServer(instance, leaseID, slug, cfg, true))
+	}
+	return out, nil
+}
+
+func (b *Backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	if _, err := b.commandOutput(ctx, b.withCommonArgs([]string{"auth", "check-login"}, b.configForRun())); err != nil {
+		return core.DoctorResult{}, core.Exit(1, "namespace nsc auth check failed: %v", err)
+	}
+	instances, err := b.listInstances(ctx)
+	if err != nil {
+		return core.DoctorResult{}, core.Exit(1, "namespace nsc list failed: %v", err)
+	}
+	return core.InventoryDoctorResult(providerName, len(instances)), nil
+}
+
+func (b *Backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	id := firstNonBlank(req.Lease.Server.CloudID, req.Lease.Server.Name)
+	if id == "" {
+		if claim, ok, err := core.ResolveLeaseClaim(req.Lease.LeaseID); err != nil {
+			return err
+		} else if ok {
+			id = firstNonBlank(claim.CloudID, claim.Labels["name"], claim.LeaseID)
+		}
+	}
+	if id == "" {
+		return core.Exit(2, "provider=%s release requires an instance id", providerName)
+	}
+	if err := b.destroyInstance(ctx, id); err != nil {
+		return err
+	}
+	core.RemoveLeaseClaim(req.Lease.LeaseID)
+	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
+	return nil
+}
+
+func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("destroyed namespace instance lease=%s instance=%s", lease.LeaseID, lease.Server.CloudID)
+}
+
+func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	id := firstNonBlank(server.CloudID, server.Name)
+	duration := b.configForRun().NamespaceInstance.Duration
+	if id != "" && duration > 0 {
+		if err := b.extendInstance(ctx, id, duration); err != nil {
+			return core.Server{}, err
+		}
+	}
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	return server, nil
+}
+
+func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	views, err := b.List(ctx, core.ListRequest{All: false})
+	if err != nil {
+		return err
+	}
+	servers := make([]core.Server, 0, len(views))
+	for _, view := range views {
+		servers = append(servers, view)
+	}
+	helper := shared.DirectSSHBackend{
+		SpecValue: b.spec,
+		Cfg:       b.configForRun(),
+		RT:        b.rt,
+		Delete: func(ctx context.Context, _ core.Config, server core.Server) error {
+			return b.destroyInstance(ctx, firstNonBlank(server.CloudID, server.Name))
+		},
+	}
+	return helper.CleanupServers(ctx, req, servers)
+}
+
+func (b *Backend) configForRun() core.Config {
+	cfg := b.cfg
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = namespaceInstanceMachineTypeForConfig(cfg)
+	cfg.Network = core.NetworkPublic
+	cfg.SSHPort = firstNonBlank(cfg.SSHPort, "22")
+	cfg.SSHFallbackPorts = nil
+	if strings.TrimSpace(cfg.NamespaceInstance.WorkRoot) != "" {
+		cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+	}
+	if cfg.NamespaceInstance.Duration <= 0 {
+		cfg.NamespaceInstance.Duration = 30 * time.Minute
+	}
+	return cfg
+}
+
+func (b *Backend) createInstance(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKeyPath string, keep bool) (namespaceInstance, error) {
+	args := []string{
+		"create",
+		"--machine_type", namespaceInstanceMachineTypeForConfig(cfg),
+		"--duration", durationArg(cfg.NamespaceInstance.Duration),
+		"--ssh_key", publicKeyPath,
+		"--unique_tag", name,
+		"--label", "crabbox=true",
+		"--label", "provider=" + providerName,
+		"--label", "lease=" + leaseID,
+		"--label", "slug=" + slug,
+		"--label", fmt.Sprintf("keep=%t", keep),
+		"-o", "json",
+	}
+	if cfg.NamespaceInstance.Ephemeral {
+		args = append(args, "--ephemeral")
+	}
+	args = b.withCommonArgs(args, cfg)
+	for _, volume := range cfg.NamespaceInstance.Volumes {
+		args = append(args, "--volume", volume)
+	}
+	out, err := b.commandOutput(ctx, args)
+	if err != nil {
+		return namespaceInstance{}, err
+	}
+	return parseNamespaceInstanceObject(out)
+}
+
+func (b *Backend) describeInstance(ctx context.Context, id string) (namespaceInstance, error) {
+	out, err := b.commandOutput(ctx, b.withCommonArgs([]string{"describe", id, "-o", "json"}, b.configForRun()))
+	if err != nil {
+		return namespaceInstance{}, err
+	}
+	return parseNamespaceInstanceObject(out)
+}
+
+func (b *Backend) listInstances(ctx context.Context) ([]namespaceInstance, error) {
+	out, err := b.commandOutput(ctx, b.withCommonArgs([]string{"list", "-o", "json"}, b.configForRun()))
+	if err != nil {
+		return nil, err
+	}
+	return parseNamespaceInstanceList(out)
+}
+
+func (b *Backend) destroyInstance(ctx context.Context, id string) error {
+	result, err := b.runCommand(ctx, b.withCommonArgs([]string{"destroy", id, "--force"}, b.configForRun()), b.rt.Stdout, b.rt.Stderr)
+	if err == nil {
+		return nil
+	}
+	if isNamespaceNotFound(result.Stdout + "\n" + result.Stderr + "\n" + err.Error()) {
+		return nil
+	}
+	return core.Exit(result.ExitCode, "namespace instance destroy %s failed: %v", id, err)
+}
+
+func (b *Backend) extendInstance(ctx context.Context, id string, duration time.Duration) error {
+	result, err := b.runCommand(ctx, b.withCommonArgs([]string{"extend", id, "--ensure_minimum", durationArg(duration)}, b.configForRun()), b.rt.Stdout, b.rt.Stderr)
+	if err != nil {
+		return core.Exit(result.ExitCode, "namespace instance extend %s failed: %v", id, err)
+	}
+	return nil
+}
+
+func (b *Backend) prepareLease(ctx context.Context, cfg core.Config, instance namespaceInstance, leaseID, slug, keyPath string, keep bool) (core.LeaseTarget, error) {
+	target, err := namespaceInstanceSSHTarget(instance, keyPath, cfg)
+	if err != nil {
+		refreshed, describeErr := b.describeInstance(ctx, instance.ID)
+		if describeErr != nil {
+			return core.LeaseTarget{}, err
+		}
+		instance = mergeNamespaceInstance(instance, refreshed)
+		target, err = namespaceInstanceSSHTarget(instance, keyPath, cfg)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	target.TargetOS = core.TargetLinux
+	target.NetworkKind = core.NetworkPublic
+	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"
+	server := namespaceInstanceServer(instance, leaseID, slug, cfg, keep)
+	server.PublicNet.IPv4.IP = target.Host
+	if err := namespaceInstanceWaitForSSH(ctx, &target, b.rt.Stderr, "namespace instance ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server.Status = "ready"
+	server.Labels["state"] = "ready"
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *Backend) withCommonArgs(args []string, cfg core.Config) []string {
+	if strings.TrimSpace(cfg.NamespaceInstance.Region) != "" {
+		args = append(args, "--region", strings.TrimSpace(cfg.NamespaceInstance.Region))
+	}
+	if strings.TrimSpace(cfg.NamespaceInstance.Endpoint) != "" {
+		args = append(args, "--endpoint", strings.TrimSpace(cfg.NamespaceInstance.Endpoint))
+	}
+	if strings.TrimSpace(cfg.NamespaceInstance.Keychain) != "" {
+		args = append(args, "--keychain", strings.TrimSpace(cfg.NamespaceInstance.Keychain))
+	}
+	return args
+}
+
+func (b *Backend) commandOutput(ctx context.Context, args []string) (string, error) {
+	result, err := b.runCommand(ctx, args, nil, nil)
+	if err != nil {
+		return "", core.Exit(result.ExitCode, "namespace nsc failed: %v: %s", err, strings.TrimSpace(result.Stdout+result.Stderr))
+	}
+	if result.Stderr != "" && b.rt.Stderr != nil {
+		_, _ = io.WriteString(b.rt.Stderr, result.Stderr)
+	}
+	return result.Stdout, nil
+}
+
+func (b *Backend) runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: "nsc", Args: args, Stdout: stdout, Stderr: stderr})
+}
+
+func (b *Backend) cleanupFailedAcquire(id string, cause error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	if err := b.destroyInstance(ctx, id); err != nil {
+		return fmt.Errorf("%w; namespace cleanup failed for instance %s: %v", cause, id, err)
+	}
+	return cause
+}
+
+type namespaceInstance struct {
+	ID          string
+	Name        string
+	Status      string
+	MachineType string
+	Labels      map[string]string
+	SSH         namespaceSSH
+	CreatedAt   string
+	Deadline    string
+}
+
+type namespaceSSH struct {
+	User string
+	Host string
+	Port string
+}
+
+func namespaceInstanceSSHTarget(instance namespaceInstance, keyPath string, cfg core.Config) (core.SSHTarget, error) {
+	host := firstNonBlank(instance.SSH.Host)
+	port := firstNonBlank(instance.SSH.Port, cfg.SSHPort, "22")
+	user := firstNonBlank(instance.SSH.User, cfg.SSHUser, "root")
+	if host == "" {
+		return core.SSHTarget{}, core.Exit(5, "namespace instance %s missing SSH host", firstNonBlank(instance.ID, instance.Name))
+	}
+	return core.SSHTarget{User: user, Host: host, Port: port, Key: keyPath}, nil
+}
+
+func namespaceInstanceServer(instance namespaceInstance, leaseID, slug string, cfg core.Config, keep bool) core.Server {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	for key, value := range instance.Labels {
+		if strings.TrimSpace(value) != "" {
+			labels[key] = value
+		}
+	}
+	labels["provider"] = providerName
+	labels["lease"] = leaseID
+	labels["slug"] = slug
+	labels["name"] = firstNonBlank(instance.Name, instance.ID)
+	labels["state"] = firstNonBlank(instance.Status, "unknown")
+	server := core.Server{
+		CloudID:  firstNonBlank(instance.ID, instance.Name),
+		Provider: providerName,
+		Name:     firstNonBlank(instance.Name, instance.ID),
+		Status:   labels["state"],
+		Labels:   labels,
+	}
+	server.ServerType.Name = firstNonBlank(instance.MachineType, namespaceInstanceMachineTypeForConfig(cfg))
+	return server
+}
+
+func parseNamespaceInstanceObject(output string) (namespaceInstance, error) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(extractJSONValue(output)), &raw); err != nil {
+		return namespaceInstance{}, core.Exit(5, "namespace nsc returned invalid JSON: %v", err)
+	}
+	for _, key := range []string{"instance", "data"} {
+		if nested, ok := raw[key].(map[string]any); ok {
+			raw = nested
+			break
+		}
+	}
+	return namespaceInstanceFromMap(raw), nil
+}
+
+func parseNamespaceInstanceList(output string) ([]namespaceInstance, error) {
+	value := extractJSONValue(output)
+	var raws []map[string]any
+	if err := json.Unmarshal([]byte(value), &raws); err != nil {
+		var wrapped map[string][]map[string]any
+		if err2 := json.Unmarshal([]byte(value), &wrapped); err2 != nil {
+			if strings.TrimSpace(output) == "" || strings.Contains(strings.ToLower(output), "no instance") {
+				return nil, nil
+			}
+			return nil, core.Exit(5, "namespace nsc list returned invalid JSON: %v", err)
+		}
+		for _, key := range []string{"instances", "items", "data"} {
+			if wrapped[key] != nil {
+				raws = wrapped[key]
+				break
+			}
+		}
+	}
+	out := make([]namespaceInstance, 0, len(raws))
+	for _, raw := range raws {
+		out = append(out, namespaceInstanceFromMap(raw))
+	}
+	return out, nil
+}
+
+func namespaceInstanceFromMap(raw map[string]any) namespaceInstance {
+	labels := labelsFromAny(firstValue(raw, "labels", "metadata"))
+	sshMap := mapFromAny(firstValue(raw, "ssh", "ssh_config", "sshConfig"))
+	instance := namespaceInstance{
+		ID:          stringValue(firstValue(raw, "id", "instance_id", "instanceId", "cid")),
+		Name:        stringValue(firstValue(raw, "name", "display_name", "displayName")),
+		Status:      stringValue(firstValue(raw, "status", "state")),
+		MachineType: stringValue(firstValue(raw, "machine_type", "machineType", "shape")),
+		Labels:      labels,
+		CreatedAt:   stringValue(firstValue(raw, "created_at", "createdAt")),
+		Deadline:    stringValue(firstValue(raw, "deadline", "expires_at", "expiresAt")),
+		SSH: namespaceSSH{
+			User: stringValue(firstValue(raw, "ssh_user", "sshUser", "username")),
+			Host: stringValue(firstValue(raw, "ssh_host", "sshHost", "endpoint", "public_ip", "publicIp")),
+			Port: stringValue(firstValue(raw, "ssh_port", "sshPort", "port")),
+		},
+	}
+	if instance.SSH.User == "" {
+		instance.SSH.User = stringValue(firstValue(sshMap, "user", "username"))
+	}
+	if instance.SSH.Host == "" {
+		instance.SSH.Host = stringValue(firstValue(sshMap, "host", "hostname", "endpoint"))
+	}
+	if instance.SSH.Port == "" {
+		instance.SSH.Port = stringValue(firstValue(sshMap, "port"))
+	}
+	if instance.ID == "" {
+		instance.ID = stringValue(firstValue(labels, "lease", "name"))
+	}
+	return instance
+}
+
+func mergeNamespaceInstance(base, next namespaceInstance) namespaceInstance {
+	if base.ID == "" {
+		base.ID = next.ID
+	}
+	if base.Name == "" {
+		base.Name = next.Name
+	}
+	if base.Status == "" {
+		base.Status = next.Status
+	}
+	if base.MachineType == "" {
+		base.MachineType = next.MachineType
+	}
+	if base.SSH.Host == "" {
+		base.SSH = next.SSH
+	}
+	if len(base.Labels) == 0 {
+		base.Labels = next.Labels
+	}
+	return base
+}
+
+func namespaceInstanceOwned(instance namespaceInstance) bool {
+	return instance.Labels["crabbox"] == "true" || instance.Labels["provider"] == providerName || strings.HasPrefix(instance.Name, "crabbox-")
+}
+
+func namespaceInstanceLeaseIDFromName(name string) string {
+	slug := core.NormalizeLeaseSlug(name)
+	if strings.HasPrefix(slug, "cbx-") {
+		return strings.Replace(slug, "cbx-", "cbx_", 1)
+	}
+	if slug == "" {
+		slug = "namespace-instance"
+	}
+	return "nsi_" + slug
+}
+
+func extractJSONValue(output string) string {
+	trimmed := strings.TrimSpace(output)
+	arrayStart := strings.Index(trimmed, "[")
+	objectStart := strings.Index(trimmed, "{")
+	switch {
+	case objectStart >= 0 && (arrayStart < 0 || objectStart < arrayStart):
+		return trimmed[objectStart:]
+	case arrayStart >= 0:
+		return trimmed[arrayStart:]
+	}
+	return trimmed
+}
+
+func labelsFromAny(value any) map[string]string {
+	out := map[string]string{}
+	for key, value := range mapFromAny(value) {
+		if s := stringValue(value); s != "" {
+			out[key] = s
+		}
+	}
+	return out
+}
+
+func mapFromAny(value any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	if typed, ok := value.(map[string]string); ok {
+		out := make(map[string]any, len(typed))
+		for key, value := range typed {
+			out[key] = value
+		}
+		return out
+	}
+	return nil
+}
+
+func firstValue[V any](values map[string]V, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return v.String()
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	default:
+		return ""
+	}
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func durationArg(duration time.Duration) string {
+	if duration <= 0 {
+		duration = 30 * time.Minute
+	}
+	return duration.Truncate(time.Second).String()
+}
+
+func isNamespaceNotFound(value string) bool {
+	value = strings.ToLower(value)
+	return strings.Contains(value, "not found") || strings.Contains(value, "no such instance") || strings.Contains(value, "not_exist")
+}
+
+var namespaceInstanceWaitForSSH = core.WaitForSSHReady

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -1,0 +1,222 @@
+package namespaceinstance
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecKeepsNamespaceAliasForDevbox(t *testing.T) {
+	provider := Provider{}
+	if provider.Name() != providerName {
+		t.Fatalf("provider name=%q", provider.Name())
+	}
+	if strings.Join(provider.Aliases(), ",") != "namespace-compute,nsc" {
+		t.Fatalf("aliases=%v", provider.Aliases())
+	}
+	spec := provider.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureSSH) || !spec.Features.Has(core.FeatureCrabboxSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("features=%v", spec.Features)
+	}
+}
+
+func TestAcquireBuildsNSCCreateAndReturnsSSHTarget(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	runner := &queuedRunner{results: []runnerResult{{
+		stdout: `{"id":"inst-1","name":"crabbox-test","status":"running","machine_type":"8x16","ssh":{"user":"crabbox","host":"203.0.113.10","port":2222},"labels":{"provider":"namespace-instance","lease":"cbx_test","slug":"test"}}`,
+	}}}
+	var stderr bytes.Buffer
+	restoreWait := stubWait()
+	defer restoreWait()
+
+	cfg := core.Config{
+		Provider:    providerName,
+		TargetOS:    core.TargetLinux,
+		SSHUser:     "crabbox",
+		Class:       "large",
+		WorkRoot:    "/workspace/default",
+		IdleTimeout: time.Hour,
+		NamespaceInstance: core.NamespaceInstanceConfig{
+			Duration:  15 * time.Minute,
+			Ephemeral: true,
+			Region:    "us-west-1",
+			Endpoint:  "https://compute.namespace.example",
+			Keychain:  "test-keychain",
+			Volumes:   []string{"cache:/var/cache"},
+			WorkRoot:  "/workspaces/crabbox",
+		},
+	}
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: &stderr, Exec: runner}).(*Backend)
+
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "test"})
+	if err != nil {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	if lease.Server.CloudID != "inst-1" || lease.SSH.Host != "203.0.113.10" || lease.SSH.User != "crabbox" || lease.SSH.Port != "2222" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].Name != "nsc" {
+		t.Fatalf("calls=%#v", runner.calls)
+	}
+	args := strings.Join(runner.calls[0].Args, "\x00")
+	for _, want := range []string{
+		"create",
+		"--machine_type\x008x16",
+		"--duration\x0015m0s",
+		"--ephemeral",
+		"--ssh_key",
+		"--unique_tag",
+		"--label\x00provider=namespace-instance",
+		"--label\x00slug=test",
+		"--region\x00us-west-1",
+		"--endpoint\x00https://compute.namespace.example",
+		"--keychain\x00test-keychain",
+		"--volume\x00cache:/var/cache",
+		"-o\x00json",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("create args missing %q: %q", want, args)
+		}
+	}
+}
+
+func TestListFiltersCrabboxOwnedInstances(t *testing.T) {
+	runner := &queuedRunner{results: []runnerResult{{
+		stdout: `[
+{"id":"owned","name":"crabbox-owned","state":"running","machineType":"4x8","ssh_host":"203.0.113.10","labels":{"provider":"namespace-instance","lease":"cbx_owned","slug":"owned"}},
+{"id":"other","name":"user-instance","state":"running","machineType":"4x8","labels":{"owner":"someone"}}
+]`,
+	}}}
+	backend := NewBackend(Provider{}.Spec(), core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*Backend)
+
+	views, err := backend.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatalf("List err=%v", err)
+	}
+	if len(views) != 1 || views[0].CloudID != "owned" || views[0].Labels["slug"] != "owned" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestDestroyTreatsMissingInstanceAsReleased(t *testing.T) {
+	runner := &queuedRunner{results: []runnerResult{{
+		stderr: "instance not found",
+		err:    errors.New("exit status 1"),
+		code:   1,
+	}}}
+	backend := NewBackend(Provider{}.Spec(), core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*Backend)
+
+	if err := backend.destroyInstance(context.Background(), "missing"); err != nil {
+		t.Fatalf("destroyInstance err=%v", err)
+	}
+	if len(runner.calls) != 1 || strings.Join(runner.calls[0].Args, " ") != "destroy missing --force" {
+		t.Fatalf("calls=%#v", runner.calls)
+	}
+}
+
+func TestLifecycleCommandsUseConfiguredNSCContext(t *testing.T) {
+	runner := &queuedRunner{results: []runnerResult{
+		{stdout: `{"id":"inst-1","name":"crabbox-test"}`},
+		{stdout: `[]`},
+		{},
+		{},
+		{stdout: `{}`},
+		{stdout: `[]`},
+	}}
+	cfg := core.Config{NamespaceInstance: core.NamespaceInstanceConfig{
+		Region:   "us-east-1",
+		Endpoint: "https://compute.namespace.example",
+		Keychain: "ci-keychain",
+		Duration: time.Minute,
+		WorkRoot: "/workspaces/crabbox",
+	}}
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*Backend)
+
+	if _, err := backend.describeInstance(context.Background(), "inst-1"); err != nil {
+		t.Fatalf("describe err=%v", err)
+	}
+	if _, err := backend.listInstances(context.Background()); err != nil {
+		t.Fatalf("list err=%v", err)
+	}
+	if err := backend.destroyInstance(context.Background(), "inst-1"); err != nil {
+		t.Fatalf("destroy err=%v", err)
+	}
+	if err := backend.extendInstance(context.Background(), "inst-1", time.Minute); err != nil {
+		t.Fatalf("extend err=%v", err)
+	}
+	if _, err := backend.Doctor(context.Background(), core.DoctorRequest{}); err != nil {
+		t.Fatalf("doctor err=%v", err)
+	}
+
+	for _, call := range runner.calls {
+		args := strings.Join(call.Args, "\x00")
+		for _, want := range []string{
+			"--region\x00us-east-1",
+			"--endpoint\x00https://compute.namespace.example",
+			"--keychain\x00ci-keychain",
+		} {
+			if !strings.Contains(args, want) {
+				t.Fatalf("%s args missing %q: %q", call.Args[0], want, args)
+			}
+		}
+	}
+}
+
+func TestProviderRejectsUnsafeWorkRoot(t *testing.T) {
+	for _, workRoot := range []string{"/", "/workspaces", "/tmp", "relative"} {
+		cfg := core.Config{NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: workRoot}}
+		if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err == nil {
+			t.Fatalf("expected %q to be rejected", workRoot)
+		}
+	}
+	cfg := core.Config{NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: "/workspaces/crabbox"}}
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
+		t.Fatalf("expected safe workRoot, got %v", err)
+	}
+}
+
+type runnerResult struct {
+	stdout string
+	stderr string
+	err    error
+	code   int
+}
+
+type queuedRunner struct {
+	calls   []core.LocalCommandRequest
+	results []runnerResult
+}
+
+func (r *queuedRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	if len(r.results) == 0 {
+		return core.LocalCommandResult{}, nil
+	}
+	result := r.results[0]
+	r.results = r.results[1:]
+	code := result.code
+	if code == 0 && result.err != nil {
+		code = 1
+	}
+	return core.LocalCommandResult{Stdout: result.stdout, Stderr: result.stderr, ExitCode: code}, result.err
+}
+
+func stubWait() func() {
+	previous := namespaceInstanceWaitForSSH
+	namespaceInstanceWaitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		return nil
+	}
+	return func() { namespaceInstanceWaitForSSH = previous }
+}

--- a/internal/providers/namespaceinstance/flags.go
+++ b/internal/providers/namespaceinstance/flags.go
@@ -1,0 +1,125 @@
+package namespaceinstance
+
+import (
+	"flag"
+	"path"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	MachineType *string
+	Duration    *string
+	Ephemeral   *bool
+	Region      *string
+	Endpoint    *string
+	Keychain    *string
+	Volumes     *string
+	WorkRoot    *string
+}
+
+func RegisterProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		MachineType: fs.String("namespace-instance-machine-type", defaults.NamespaceInstance.MachineType, "Namespace Compute machine type"),
+		Duration:    fs.String("namespace-instance-duration", defaults.NamespaceInstance.Duration.String(), "Namespace Compute lease duration"),
+		Ephemeral:   fs.Bool("namespace-instance-ephemeral", defaults.NamespaceInstance.Ephemeral, "create an ephemeral Namespace Compute instance"),
+		Region:      fs.String("namespace-instance-region", defaults.NamespaceInstance.Region, "Namespace Compute region"),
+		Endpoint:    fs.String("namespace-instance-endpoint", defaults.NamespaceInstance.Endpoint, "Namespace Compute API endpoint for nsc"),
+		Keychain:    fs.String("namespace-instance-keychain", defaults.NamespaceInstance.Keychain, "Namespace keychain for nsc"),
+		Volumes:     fs.String("namespace-instance-volume", strings.Join(defaults.NamespaceInstance.Volumes, ","), "Namespace Compute volume spec (comma-separated; passed through to nsc --volume)"),
+		WorkRoot:    fs.String("namespace-instance-work-root", defaults.NamespaceInstance.WorkRoot, "remote Crabbox work root on Namespace Compute instances"),
+	}
+}
+
+func ApplyProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "namespace-instance-machine-type") {
+		cfg.NamespaceInstance.MachineType = *v.MachineType
+	}
+	if core.FlagWasSet(fs, "namespace-instance-duration") {
+		duration, err := time.ParseDuration(*v.Duration)
+		if err != nil || duration <= 0 {
+			return core.Exit(2, "invalid --namespace-instance-duration %q", *v.Duration)
+		}
+		cfg.NamespaceInstance.Duration = duration
+	}
+	if core.FlagWasSet(fs, "namespace-instance-ephemeral") {
+		cfg.NamespaceInstance.Ephemeral = *v.Ephemeral
+	}
+	if core.FlagWasSet(fs, "namespace-instance-region") {
+		cfg.NamespaceInstance.Region = *v.Region
+	}
+	if core.FlagWasSet(fs, "namespace-instance-endpoint") {
+		cfg.NamespaceInstance.Endpoint = *v.Endpoint
+	}
+	if core.FlagWasSet(fs, "namespace-instance-keychain") {
+		cfg.NamespaceInstance.Keychain = *v.Keychain
+	}
+	if core.FlagWasSet(fs, "namespace-instance-volume") {
+		cfg.NamespaceInstance.Volumes = splitCSV(*v.Volumes)
+	}
+	if core.FlagWasSet(fs, "namespace-instance-work-root") {
+		cfg.NamespaceInstance.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	return validateNamespaceInstanceConfig(*cfg)
+}
+
+func splitCSV(value string) []string {
+	var out []string
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func namespaceInstanceMachineTypeForConfig(cfg core.Config) string {
+	if strings.TrimSpace(cfg.NamespaceInstance.MachineType) != "" {
+		return strings.TrimSpace(cfg.NamespaceInstance.MachineType)
+	}
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	return namespaceInstanceMachineTypeForClass(cfg.Class)
+}
+
+func namespaceInstanceMachineTypeForClass(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "", "standard", "fast":
+		return "4x8"
+	case "large":
+		return "8x16"
+	case "beast":
+		return "16x32"
+	default:
+		return strings.TrimSpace(class)
+	}
+}
+
+func validateNamespaceInstanceConfig(cfg core.Config) error {
+	return cleanNamespaceInstanceWorkRoot(namespaceInstanceWorkRoot(cfg))
+}
+
+func namespaceInstanceWorkRoot(cfg core.Config) string {
+	return core.Blank(strings.TrimSpace(cfg.NamespaceInstance.WorkRoot), "/workspaces/crabbox")
+}
+
+func cleanNamespaceInstanceWorkRoot(workRoot string) error {
+	clean := path.Clean(strings.TrimSpace(workRoot))
+	if clean == "" || !strings.HasPrefix(clean, "/") {
+		return core.Exit(2, "namespaceInstance.workRoot %q must resolve to an absolute path", workRoot)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspaces":
+		return core.Exit(2, "namespaceInstance.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return nil
+}

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -1,0 +1,71 @@
+package namespaceinstance
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+
+func (Provider) Aliases() []string {
+	return []string{"namespace-compute", "nsc"}
+}
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "namespace",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) ServerTypeForConfig(cfg core.Config) string {
+	return namespaceInstanceMachineTypeForConfig(cfg)
+}
+
+func (p Provider) ServerTypeForClass(class string) string {
+	return namespaceInstanceMachineTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; Namespace Compute instances expose SSH directly", providerName)
+	}
+	if err := validateNamespaceInstanceConfig(cfg); err != nil {
+		return nil, err
+	}
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "namespace-instance doctor backend unavailable")
+	}
+	return doctor, nil
+}


### PR DESCRIPTION
Fixes #296.

## Summary
- add a namespace-instance SSH lease provider backed by the nsc CLI
- wire provider config, flags, aliases, lifecycle operations, listing, doctor, cleanup, and registration
- pass configured Namespace region, endpoint, and keychain through create, auth, describe, list, destroy, and extend
- validate namespaceInstance.workRoot against the documented dedicated-directory safety rules
- document the provider and regenerate the provider matrix

## Validation
- go test ./internal/providers/namespaceinstance ./internal/providers/all ./internal/cli ./cmd/crabbox
- go vet ./internal/providers/namespaceinstance ./internal/providers/all ./internal/cli ./cmd/crabbox
- scripts/check-docs.sh
- go test ./...

## Review follow-up
- Addressed ClawSweeper review finding: configured nsc context is now reused for lifecycle and doctor commands, with fake-runner regression coverage.
- Addressed ClawSweeper review finding: namespace-instance work roots are validated on flag application and provider configuration, with regression coverage.