### PR TITLE
Add Namespace Compute Instance provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ from the CLI.
 | [KubeVirt](docs/providers/kubevirt.md) — `kubevirt` (`kubernetes-vm`) | Linux · direct | Generic KubeVirt VMs through `kubectl`, `virtctl`, and control-plane SSH forwarding. |
 | [External](docs/providers/external.md) — `external` (`exec-provider`) | Linux · direct | Configured executable implementing the Crabbox provider protocol. |
 | [Namespace Devbox](docs/providers/namespace-devbox.md) — `namespace-devbox` (`namespace`, `namespace-devboxes`) | Linux · direct | Namespace.so Devboxes over SSH. |
+| [Namespace Instance](docs/providers/namespace-instance.md) — `namespace-instance` (`namespace-compute`) | Linux · direct | Namespace Compute Instances over SSH through `nsc`. |
 | [Semaphore](docs/providers/semaphore.md) — `semaphore` (`sem`) | Linux · direct | A Semaphore CI job leased as a testbox. |
 | [Sprites](docs/providers/sprites.md) — `sprites` | Linux · direct | Sprites microVMs through `sprite proxy`. |
 | [Tenki](docs/providers/tenki.md) — `tenki` | Linux · direct | Tenki sandbox VMs through `tenki sandbox ssh-proxy`. |
@@ -469,6 +470,7 @@ scripts/check-docs.sh
 
 # Optional live smoke, when broker/provider credentials are available
 CRABBOX_LIVE=1 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-instance CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 ```
 
 CI runs the full gate (gofmt, vet, race tests, all Go modules, coverage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -557,6 +557,7 @@ CRABBOX_BLACKSMITH_*               Blacksmith Testbox
 CRABBOX_KUBEVIRT_*                 KubeVirt
 CRABBOX_EXTERNAL_*                 External executable provider
 CRABBOX_NAMESPACE_*                Namespace Devbox
+CRABBOX_NAMESPACE_INSTANCE_*       Namespace Compute Instances
 CRABBOX_SEMAPHORE_* / SEMAPHORE_*  Semaphore
 CRABBOX_E2B_API_KEY / E2B_*        E2B
 CRABBOX_MODAL_* / MODAL_*          Modal

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -50,6 +50,8 @@ Provider deep-dives that live here in `features/`:
 - [Blacksmith Testbox](blacksmith-testbox.md): delegated Testbox runner behavior.
 - [Namespace Devbox](namespace-devbox.md): Namespace Devbox SSH leases with Crabbox sync/run.
 - [Namespace Devbox setup](namespace-devbox-setup.md): CLI install, browser authentication, and live checks.
+- [Namespace Instance](namespace-instance.md): Namespace Compute Instance SSH leases through `nsc`.
+- [Namespace Instance setup](namespace-instance-setup.md): `nsc` install, auth, doctor, and opt-in live smoke checks.
 - [Semaphore](semaphore.md): Semaphore CI job leases with Crabbox SSH sync/run.
 - [Sprites](sprites.md): Sprites microVM SSH leases through `sprite proxy`.
 - [Daytona](daytona.md): Daytona SDK/toolbox sandbox leases with optional short-lived SSH access.

--- a/docs/features/namespace-instance-setup.md
+++ b/docs/features/namespace-instance-setup.md
@@ -1,0 +1,120 @@
+# Namespace Instance Setup
+
+Read when:
+
+- installing and authenticating the Namespace `nsc` CLI for Crabbox;
+- preparing a machine so `provider: namespace-instance` works non-interactively;
+- running the opt-in live smoke for Namespace Compute Instances.
+
+Crabbox does not talk to Namespace with a stored API token. It shells out to the
+upstream `nsc` CLI and lets that CLI own login, account selection, endpoint,
+keychain, inventory, create, describe, extend, and destroy. Crabbox then uses
+the SSH target returned by `nsc` for normal SSH and rsync.
+
+For provider selection, config keys, and the lifecycle boundary, see
+[Namespace Instance](namespace-instance.md).
+
+## Install and Authenticate
+
+Install the upstream Namespace CLI and log in:
+
+```sh
+nsc login
+nsc auth check-login
+```
+
+For automation hosts, complete the login handoff using the flow printed by
+`nsc login`. Do not paste login codes, auth tokens, or workspace/account details
+into Crabbox config, scripts, docs, or issue comments.
+
+Optional Namespace CLI routing can be configured through Crabbox when needed:
+
+```yaml
+provider: namespace-instance
+namespaceInstance:
+  endpoint: https://api.namespace.example
+  keychain: crabbox
+  region: us-west
+```
+
+Those values become `nsc --endpoint`, `nsc --keychain`, and `nsc --region`
+arguments. Leave them unset for the CLI defaults.
+
+## Read-Only Check
+
+Before creating an instance, verify local readiness:
+
+```sh
+nsc auth check-login
+nsc list -o json
+crabbox doctor --provider namespace-instance
+```
+
+`crabbox doctor` checks the same non-mutating prerequisites and reports whether
+`nsc`, auth, and inventory access are ready.
+
+## Live Smoke
+
+The live smoke creates and destroys a real Namespace Compute Instance. It is
+disabled unless all opt-in variables are explicit:
+
+```sh
+go build -trimpath -o bin/crabbox ./cmd/crabbox
+CRABBOX_LIVE=1 \
+CRABBOX_BIN=bin/crabbox \
+CRABBOX_LIVE_PROVIDERS=namespace-instance \
+CRABBOX_LIVE_REPO=/path/to/my-app \
+scripts/live-smoke.sh
+```
+
+The smoke runs:
+
+```text
+doctor -> warmup -> status --wait -> run --no-sync -> list --json -> stop
+```
+
+It also registers a cleanup trap after `warmup` returns a lease, so a later
+failure still attempts `crabbox stop --provider namespace-instance`.
+
+Useful smoke overrides:
+
+```text
+CRABBOX_LIVE_NAMESPACE_INSTANCE_SLUG
+CRABBOX_LIVE_NAMESPACE_INSTANCE_TTL
+CRABBOX_LIVE_NAMESPACE_INSTANCE_IDLE_TIMEOUT
+CRABBOX_LIVE_NAMESPACE_INSTANCE_DURATION
+CRABBOX_LIVE_NAMESPACE_INSTANCE_MACHINE_TYPE
+CRABBOX_LIVE_NAMESPACE_INSTANCE_WAIT_TIMEOUT
+```
+
+## How Crabbox Drives `nsc`
+
+- **Doctor** — `nsc --help`, `nsc auth check-login`, and `nsc list -o json`.
+- **Create** — `nsc create` with machine type, duration, purpose, SSH public key,
+  cidfile, JSON output path, optional ephemeral mode, optional unique tag,
+  optional volumes, and Crabbox labels.
+- **Describe/list** — `nsc describe <id> -o json` and `nsc list -o json --all`.
+- **Extend** — `nsc extend <id> --ensure_minimum <duration>` when a retained
+  lease needs a longer minimum lifetime.
+- **Release** — `nsc destroy <id> --force`.
+
+## Troubleshooting
+
+- `namespace-instance smoke requires CRABBOX_LIVE_REPO` means the destructive
+  smoke was not explicitly pointed at a checkout. Set the variable to a local
+  repo path.
+- `namespace-instance smoke requires the authenticated Namespace nsc CLI on PATH`
+  means `nsc` was not found. Install it and make sure the same shell can run
+  `nsc auth check-login`.
+- `namespace-instance smoke requires an authenticated nsc CLI` means the CLI is
+  present but not logged in. Run `nsc login`, then retry `nsc auth check-login`.
+- `plan_gap: nsc JSON did not expose a normal SSH target` means the current
+  `nsc` response did not include enough SSH host/user/port information for the
+  direct SSH path. Do not guess a target; capture redacted CLI behavior and add
+  an API-backed SSH resolution path before enabling that environment.
+
+Related docs:
+
+- [Namespace Instance](namespace-instance.md)
+- [Provider: Namespace Instance](../providers/namespace-instance.md)
+- [Namespace Devbox setup](namespace-devbox-setup.md)

--- a/docs/features/namespace-instance.md
+++ b/docs/features/namespace-instance.md
@@ -1,0 +1,101 @@
+# Namespace Instance
+
+Read this when you are:
+
+- choosing `provider: namespace-instance`;
+- comparing Namespace Compute Instances with Namespace Devboxes;
+- debugging the `nsc` lifecycle behind Crabbox sync and run.
+
+`provider: namespace-instance` creates or reuses Namespace Compute Instances and
+exposes them to Crabbox as Linux SSH leases. Namespace owns account auth and the
+instance lifecycle through `nsc`; Crabbox owns local slugs, repo claims, dirty
+checkout sync, command execution, status/list normalization, and cleanup policy.
+
+The provider is Linux-only, direct from the CLI, and never brokered through the
+coordinator.
+
+## Namespace Provider Choice
+
+Use the canonical provider names when switching between Namespace products:
+
+| Provider | CLI Crabbox shells out to | Aliases | Best fit |
+| --- | --- | --- | --- |
+| `namespace-devbox` | `devbox` | `namespace`, `namespace-devboxes` | Namespace Devbox images and Devbox pause/resume semantics. |
+| `namespace-instance` | `nsc` | `namespace-compute` | Short-lived Compute Instances managed by `nsc`. |
+
+The short `namespace` alias intentionally remains attached to
+`namespace-devbox` for compatibility.
+
+## Setup
+
+Install and authenticate `nsc`:
+
+```sh
+nsc login
+nsc auth check-login
+crabbox doctor --provider namespace-instance
+```
+
+Select the provider in config:
+
+```yaml
+provider: namespace-instance
+namespaceInstance:
+  machineType: linux-small
+  duration: 15m
+  workRoot: /work/crabbox
+```
+
+Crabbox does not read or store Namespace credentials. It invokes `nsc` for
+auth-sensitive work and keeps provider tokens out of argv and Crabbox config.
+
+## Commands
+
+```sh
+crabbox warmup --provider namespace-instance --slug smoke
+crabbox status --provider namespace-instance --id smoke --wait
+crabbox run --provider namespace-instance --id smoke -- pnpm test
+crabbox list --provider namespace-instance
+crabbox stop --provider namespace-instance smoke
+```
+
+Use `--namespace-instance-duration 30m` or command `--ttl 30m` to request a
+short-lived instance duration. Use `--namespace-instance-machine-type` when you
+need a specific Namespace machine type.
+
+## Provider Boundary
+
+Namespace Instance is an **SSH-lease** provider, not a delegated-run provider:
+
+- Namespace `nsc` creates, lists, describes, extends, and destroys the instance.
+- Crabbox connects over SSH, syncs the checkout with rsync, runs commands, and
+  records local lease metadata.
+- Cleanup filters `nsc` inventory to Crabbox-owned `namespace-instance` labels
+  before destroying stale instances.
+
+The provider declares the `ssh`, `crabbox-sync`, and `cleanup` features.
+
+## Configuration
+
+Set these under `namespaceInstance`, override per invocation with the matching
+`--namespace-instance-*` flag, or use the matching
+`CRABBOX_NAMESPACE_INSTANCE_*` environment variable. Flag wins over env, which
+wins over config file, which wins over the built-in default.
+
+| Config key | Flag | Env var | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `machineType` | `--namespace-instance-machine-type` | `CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE` | `linux-small` via class map | Exact Namespace machine type. |
+| `duration` | `--namespace-instance-duration` | `CRABBOX_NAMESPACE_INSTANCE_DURATION` | lease `--ttl` when set | Positive Go-style duration, such as `15m` or `2h`. |
+| `ephemeral` | `--namespace-instance-ephemeral` | `CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL` | `true` | Requests ephemeral Namespace instances. |
+| `region` | `--namespace-instance-region` | `CRABBOX_NAMESPACE_INSTANCE_REGION` | _(none)_ | Optional `nsc --region` value. |
+| `endpoint` | `--namespace-instance-endpoint` | `CRABBOX_NAMESPACE_INSTANCE_ENDPOINT` | _(none)_ | Optional `nsc --endpoint` value. |
+| `keychain` | `--namespace-instance-keychain` | `CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN` | _(none)_ | Optional `nsc --keychain` value. |
+| `workRoot` | `--namespace-instance-work-root` | `CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT` | `/work/crabbox` | Remote sync root; must be a dedicated absolute subdirectory. |
+| `volume` / `volumes` | `--namespace-instance-volume` | `CRABBOX_NAMESPACE_INSTANCE_VOLUME` | _(none)_ | Comma-separated flag/env or YAML list of `nsc --volume` specs. |
+
+Related docs:
+
+- [Provider: Namespace Instance](../providers/namespace-instance.md)
+- [Namespace Instance setup](namespace-instance-setup.md)
+- [Namespace Devbox](namespace-devbox.md)
+- [Providers](providers.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,6 +54,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=e2b               CRABBOX_LIVE_REPO=/path/
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=modal             CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=daytona           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-devbox  CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-instance CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=semaphore         CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=sprites           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
@@ -70,7 +71,11 @@ Per-provider smoke prerequisites:
 - **Modal** — an authenticated Modal Python client (`python3 -m modal setup` or Modal token env vars).
 - **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`, and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.
 - **Daytona** — `CRABBOX_DAYTONA_SNAPSHOT`, `DAYTONA_SNAPSHOT`, or `daytona.snapshot`.
-- **Namespace** — the authenticated `devbox` CLI on `PATH`.
+- **Namespace Devbox** — the authenticated `devbox` CLI on `PATH`; the
+  `namespace` alias still selects this provider.
+- **Namespace Instance** — the authenticated `nsc` CLI on `PATH`, plus an
+  explicit `CRABBOX_LIVE_REPO`; this smoke creates and destroys a Compute
+  Instance and runs only when `CRABBOX_LIVE_PROVIDERS=namespace-instance`.
 - **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token in the environment.
 - **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -60,7 +60,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 49 providers (29 SSH lease, 19 delegated run, 1 service control).
+Current built-in surface: 50 providers (30 SSH lease, 19 delegated run, 1 service control).
 
 Access terms:
 
@@ -101,6 +101,7 @@ Access terms:
 | [multipass](multipass.md) (`mp`, `canonical-multipass`) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `cache-volume` | `linux`; Canonical Multipass VM | `local`; GPU: no | Crabbox; VM delete and purge | Portable local Ubuntu VM | Ubuntu-only first implementation |
 | [mxc](mxc.md) (`execution-container`) | built-in; `delegated-run` · local-sandbox | No SSH; `provider-owned` · direct only; features: none | `windows/normal`; Microsoft Execution Container | `local`; GPU: no | Windows runtime; container termination | Local isolated Windows command execution | Windows host and execution-container support required |
 | [namespace-devbox](namespace-devbox.md) (`namespace`, `namespace-devboxes`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Devbox | `provider-managed`; GPU: unknown | Namespace devbox CLI; stop by default; optional delete | Fast managed development box over SSH | Uses the devbox product, not Namespace Compute instances |
+| [namespace-instance](namespace-instance.md) (`namespace-compute`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Compute Instance | `provider-managed`; GPU: unknown | Namespace nsc CLI; Crabbox labels and nsc destroy | Namespace Compute Instance over normal Crabbox SSH | Requires nsc JSON SSH metadata; namespace alias remains Devbox |
 | [opencomputer](opencomputer.md) (`oc`, `open-computer`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; OpenComputer Linux VM | `provider-managed`; GPU: unknown | OpenComputer; VM delete | Hosted delegated Linux VM execution | REST execution contract, not an SSH lease |
 | [opensandbox](opensandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; OpenSandbox sandbox | `provider-managed`; GPU: unknown | OpenSandbox; sandbox delete | Hosted delegated sandbox through an open SDK | Requires compatible OpenSandbox control and exec endpoints |
 | [parallels](parallels.md) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code`, `workspace-checkpoint`, `workspace-fork`, `workspace-restore`, `provider-snapshot` | `linux`, `macos`, `windows/normal`, `windows/wsl2`; Parallels linked-clone VM | `local`; GPU: no | Crabbox; clone delete | Local macOS, Linux, or Windows VM with snapshots | Requires prepared Parallels source VMs and SSH |

--- a/docs/providers/namespace-instance.md
+++ b/docs/providers/namespace-instance.md
@@ -1,0 +1,179 @@
+# Namespace Instance Provider
+
+Read this when you:
+
+- choose `provider: namespace-instance`;
+- configure Namespace Compute Instance machine type, duration, region, endpoint,
+  keychain, volumes, or work root;
+- compare Namespace Compute Instances with Namespace Devboxes.
+
+Namespace Instance is a direct **SSH-lease** provider for Namespace Compute
+Instances. Crabbox shells out to the Namespace `nsc` CLI for auth, inventory,
+create, describe, extend, and destroy, then uses the normal Crabbox SSH sync/run
+path once the instance exposes SSH.
+
+The provider runs direct from the CLI and is never brokered through the Crabbox
+coordinator. Targets Linux only.
+
+## Namespace Devbox Boundary
+
+Crabbox has two Namespace-backed providers:
+
+- `namespace-devbox` uses the Namespace `devbox` CLI and keeps the `namespace`
+  and `namespace-devboxes` aliases.
+- `namespace-instance` uses the Namespace `nsc` CLI for Compute Instances. Its
+  alias is `namespace-compute`.
+
+Use `namespace-devbox` when you want Devbox images and Devbox lifecycle
+semantics. Use `namespace-instance` when you want short-lived Compute Instances
+with `nsc`-managed instance lifecycle.
+
+## Prerequisites
+
+Install `nsc` and authenticate before using Crabbox:
+
+```sh
+nsc login
+nsc auth check-login
+```
+
+Crabbox does not store Namespace credentials and does not accept Namespace API
+tokens on the command line. It relies on the auth state that `nsc` resolves on
+the operator machine.
+
+Run a read-only readiness check before creating an instance:
+
+```sh
+crabbox doctor --provider namespace-instance
+```
+
+`doctor` verifies that `nsc` is available, `nsc auth check-login` succeeds, and
+`nsc list -o json` can read inventory.
+
+## Commands
+
+```sh
+crabbox warmup --provider namespace-instance --slug smoke --namespace-instance-machine-type linux-small
+crabbox status --provider namespace-instance --id smoke --wait
+crabbox run --provider namespace-instance --id smoke --no-sync -- echo crabbox-ok
+crabbox list --provider namespace-instance
+crabbox stop --provider namespace-instance smoke
+crabbox cleanup --provider namespace-instance --dry-run
+```
+
+Lease-acting commands accept the Crabbox lease ID, the friendly slug, or the
+Namespace instance ID for Crabbox-managed instances.
+
+## Configuration
+
+```yaml
+provider: namespace-instance
+target: linux
+namespaceInstance:
+  machineType: linux-small
+  duration: 15m
+  ephemeral: true
+  region: ""
+  endpoint: ""
+  keychain: ""
+  workRoot: /work/crabbox
+  volume:
+    - cache:/cache
+```
+
+Defaults baked into Crabbox: `ephemeral: true` and `workRoot: /work/crabbox`.
+When `duration` is unset and the command has a `--ttl`, Crabbox uses the lease
+TTL as the requested Namespace duration. When `machineType` is unset, each
+Crabbox class currently maps to `linux-small`.
+
+Provider flags:
+
+```text
+--namespace-instance-machine-type
+--namespace-instance-duration
+--namespace-instance-ephemeral
+--namespace-instance-region
+--namespace-instance-endpoint
+--namespace-instance-keychain
+--namespace-instance-work-root
+--namespace-instance-volume
+```
+
+Environment overrides:
+
+```text
+CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE
+CRABBOX_NAMESPACE_INSTANCE_DURATION
+CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL
+CRABBOX_NAMESPACE_INSTANCE_REGION
+CRABBOX_NAMESPACE_INSTANCE_ENDPOINT
+CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN
+CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT
+CRABBOX_NAMESPACE_INSTANCE_VOLUME
+```
+
+## Lifecycle
+
+1. `doctor` checks the local `nsc` CLI, auth, and inventory access without
+   creating resources.
+2. `warmup` creates a Crabbox lease ID and slug, creates or reuses the per-lease
+   SSH key, and calls `nsc create` with Crabbox labels, machine type, duration,
+   SSH public key, optional region/endpoint/keychain, and optional volumes.
+3. Crabbox reads the returned instance JSON, describes the instance when needed,
+   resolves the SSH target, waits for SSH readiness, and records a local lease
+   claim.
+4. `run`, `ssh`, `sync`, `status`, and `list` use the normal SSH-lease
+   contract and Crabbox-managed labels.
+5. `stop` calls `nsc destroy --force` for the claimed instance and removes the
+   local claim. Already-gone instances are treated as a successful cleanup path.
+6. `cleanup` lists `nsc` inventory, filters to Crabbox-owned
+   `namespace-instance` labels, and destroys expired or stale instances. Use
+   `--dry-run` to preview.
+
+## Capabilities
+
+- **SSH**: yes.
+- **Crabbox sync**: yes — standard rsync over SSH.
+- **Cleanup**: yes — destroys stale Crabbox-owned Namespace Compute Instances.
+- **Actions hydration**: yes — same Linux SSH contract as other SSH-lease
+  providers.
+- **Desktop / browser / code**: not surfaced for this provider.
+- **Coordinator (broker)**: never; always direct from the CLI.
+
+## Live Smoke
+
+The repository live smoke is opt-in and destructive because it creates and
+destroys a real Namespace Compute Instance. Run it only from an authenticated
+operator machine:
+
+```sh
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=namespace-instance \
+CRABBOX_LIVE_REPO=/path/to/my-app \
+scripts/live-smoke.sh
+```
+
+The smoke requires `nsc`, `jq`, `rg`, `CRABBOX_LIVE=1`, explicit
+`CRABBOX_LIVE_PROVIDERS=namespace-instance`, and an explicit
+`CRABBOX_LIVE_REPO`. It runs `doctor`, `warmup`, `status`, `run`, `list`, and
+`stop`, and it attempts `stop` from a cleanup trap after a lease has been
+created.
+
+## Gotchas
+
+- The `namespace` alias belongs to `namespace-devbox`, not
+  `namespace-instance`.
+- `nsc` auth is external to Crabbox. If `nsc auth check-login` fails, fix the
+  local CLI login before debugging Crabbox.
+- Keep `workRoot` under a dedicated absolute subdirectory. Broad roots such as
+  `/`, `/home`, or `/tmp` are rejected.
+- Phase one depends on the SSH target fields returned by `nsc` JSON. If an
+  account or instance shape does not expose host, user, and port, Crabbox fails
+  closed rather than guessing an API-backed SSH path.
+
+## Related docs
+
+- [Feature: Namespace Instance](../features/namespace-instance.md)
+- [Namespace Instance setup](../features/namespace-instance-setup.md)
+- [Provider: Namespace Devbox](namespace-devbox.md)
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -433,6 +433,20 @@
     "caveat": "Uses the devbox product, not Namespace Compute instances",
     "docs": "namespace-devbox.md"
   },
+  "namespace-instance": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Namespace Compute Instance",
+    "location": "provider-managed",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "unknown",
+    "lifecycle": "Namespace nsc CLI",
+    "cleanup": "Crabbox labels and nsc destroy",
+    "bestFit": "Namespace Compute Instance over normal Crabbox SSH",
+    "caveat": "Requires nsc JSON SSH metadata; namespace alias remains Devbox",
+    "docs": "namespace-instance.md"
+  },
   "opencomputer": {
     "status": "built-in",
     "category": "delegated-sandbox",

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -84,8 +84,8 @@ SSH-lease providers:
 - Canonical Multipass local Ubuntu VM: `internal/providers/multipass`
 - Cirrus Labs tart local macOS VM: `internal/providers/tart`
 - Microsoft Hyper-V local Windows VM: `internal/providers/hyperv`
-- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites, Railway:
-  `internal/providers/daytona`, `internal/providers/morph`, `internal/providers/exedev`, `internal/providers/kubevirt`, `internal/providers/external`, `internal/providers/tenki`, `internal/providers/namespace`,
+- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace Devbox, Namespace Instance, RunPod, Semaphore, Sprites, Railway:
+  `internal/providers/daytona`, `internal/providers/morph`, `internal/providers/exedev`, `internal/providers/kubevirt`, `internal/providers/external`, `internal/providers/tenki`, `internal/providers/namespace`, `internal/providers/namespaceinstance`,
   `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`,
   `internal/providers/railway`
 
@@ -133,7 +133,7 @@ Actions hydration or repo scripts.
 
 Provider docs:
 
-- Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
+- Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/namespace-instance.md`, `docs/features/namespace-instance-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
 - Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/incus.md` for the separate local live validation contract, and `docs/providers/superserve.md` for delegated Superserve execution and live proof
 - Provider/backend authoring guide: `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1275,6 +1276,9 @@ func applyProviderConfigDefaults(cfg *Config) error {
 			cfg.ServerType = serverTypeForConfig(*cfg)
 		}
 		normalizeTargetConfig(cfg)
+		if err := validateNamespaceInstanceWorkRoot(cfg.NamespaceInstance.WorkRoot); err != nil {
+			return err
+		}
 		return validateTargetConfig(*cfg)
 	}
 	if cfg.Provider == "hyperv" {
@@ -5868,6 +5872,19 @@ func serverTypeForConfig(cfg Config) string {
 		return parallelsServerTypeForConfig(cfg)
 	}
 	return serverTypeForClass(cfg.Class)
+}
+
+func validateNamespaceInstanceWorkRoot(workRoot string) error {
+	clean := path.Clean(strings.TrimSpace(workRoot))
+	if clean == "." || !path.IsAbs(clean) {
+		return exit(2, "namespaceInstance.workRoot %q must resolve to an absolute path", workRoot)
+	}
+	switch clean {
+	case "/", "/tmp", "/var", "/work", "/home":
+		return exit(2, "namespaceInstance.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+	default:
+		return nil
+	}
 }
 
 func serverTypeForProviderClass(provider, class string) string {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1074,11 +1074,13 @@ func loadConfigWithOverrides(coordinator, provider string) (Config, error) {
 	cfg := baseConfig()
 	for _, path := range configPaths() {
 		freestyleAPIURL := cfg.Freestyle.APIURL
+		namespaceInstanceEndpoint := cfg.NamespaceInstance.Endpoint
 		if err := applyConfigFile(&cfg, path); err != nil {
 			return Config{}, err
 		}
 		if !trustedProviderEndpointConfigPath(path) {
 			cfg.Freestyle.APIURL = freestyleAPIURL
+			cfg.NamespaceInstance.Endpoint = namespaceInstanceEndpoint
 		}
 	}
 	if err := applyEnv(&cfg); err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -128,6 +128,7 @@ type Config struct {
 	deleteOnReleaseExplicit       map[string]bool
 	External                      ExternalConfig
 	Namespace                     NamespaceConfig
+	NamespaceInstance             NamespaceInstanceConfig
 	Morph                         MorphConfig
 	Daytona                       DaytonaConfig
 	E2B                           E2BConfig
@@ -327,6 +328,17 @@ type NamespaceConfig struct {
 	AutoStopIdleTimeout time.Duration
 	WorkRoot            string
 	DeleteOnRelease     bool
+}
+
+type NamespaceInstanceConfig struct {
+	MachineType string
+	Duration    time.Duration
+	Ephemeral   bool
+	Region      string
+	Endpoint    string
+	Keychain    string
+	WorkRoot    string
+	Volumes     []string
 }
 
 type MorphConfig struct {
@@ -1226,6 +1238,45 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "namespace-instance" {
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+			if cfg.NamespaceInstance.WorkRoot == "" || cfg.NamespaceInstance.WorkRoot == baseConfig().NamespaceInstance.WorkRoot {
+				cfg.NamespaceInstance.WorkRoot = cfg.explicitWorkRoot
+			}
+		} else if cfg.NamespaceInstance.WorkRoot != "" {
+			cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+		} else {
+			cfg.NamespaceInstance.WorkRoot = "/work/crabbox"
+			cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else if cfg.SSHUser == "" {
+			cfg.SSHUser = baseConfig().SSHUser
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = "22"
+		}
+		if cfg.NamespaceInstance.Duration == 0 && cfg.TTL > 0 {
+			cfg.NamespaceInstance.Duration = cfg.TTL
+		}
+		if cfg.ServerType == "" || !cfg.ServerTypeExplicit {
+			cfg.ServerType = serverTypeForConfig(*cfg)
+		}
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "hyperv" {
 		if !IsTargetExplicit(cfg) {
 			cfg.TargetOS = targetWindows
@@ -1717,6 +1768,10 @@ func baseConfig() Config {
 			WorkRoot:            "/workspaces/crabbox",
 			AutoStopIdleTimeout: 30 * time.Minute,
 		},
+		NamespaceInstance: NamespaceInstanceConfig{
+			Ephemeral: true,
+			WorkRoot:  "/work/crabbox",
+		},
 		Morph: MorphConfig{
 			APIURL:         "https://cloud.morph.so",
 			SSHGatewayHost: "ssh.cloud.morph.so",
@@ -1978,6 +2033,7 @@ type fileConfig struct {
 	KubeVirt             *fileKubeVirtConfig                `yaml:"kubevirt,omitempty"`
 	External             *fileExternalConfig                `yaml:"external,omitempty"`
 	Namespace            *fileNamespaceConfig               `yaml:"namespace,omitempty"`
+	NamespaceInstance    *fileNamespaceInstanceConfig       `yaml:"namespaceInstance,omitempty"`
 	Morph                *fileMorphConfig                   `yaml:"morph,omitempty"`
 	Daytona              *fileDaytonaConfig                 `yaml:"daytona,omitempty"`
 	E2B                  *fileE2BConfig                     `yaml:"e2b,omitempty"`
@@ -2297,6 +2353,45 @@ type fileNamespaceConfig struct {
 	AutoStopIdleTimeout string `yaml:"autoStopIdleTimeout,omitempty"`
 	WorkRoot            string `yaml:"workRoot,omitempty"`
 	DeleteOnRelease     *bool  `yaml:"deleteOnRelease,omitempty"`
+}
+
+type fileNamespaceInstanceConfig struct {
+	MachineType string   `yaml:"machineType,omitempty"`
+	Duration    string   `yaml:"duration,omitempty"`
+	Ephemeral   *bool    `yaml:"ephemeral,omitempty"`
+	Region      string   `yaml:"region,omitempty"`
+	Endpoint    string   `yaml:"endpoint,omitempty"`
+	Keychain    string   `yaml:"keychain,omitempty"`
+	WorkRoot    string   `yaml:"workRoot,omitempty"`
+	Volume      []string `yaml:"volume,omitempty"`
+}
+
+func (cfg *fileNamespaceInstanceConfig) UnmarshalYAML(node *yaml.Node) error {
+	var raw struct {
+		MachineType string   `yaml:"machineType,omitempty"`
+		Duration    string   `yaml:"duration,omitempty"`
+		Ephemeral   *bool    `yaml:"ephemeral,omitempty"`
+		Region      string   `yaml:"region,omitempty"`
+		Endpoint    string   `yaml:"endpoint,omitempty"`
+		Keychain    string   `yaml:"keychain,omitempty"`
+		WorkRoot    string   `yaml:"workRoot,omitempty"`
+		Volume      []string `yaml:"volume,omitempty"`
+		Volumes     []string `yaml:"volumes,omitempty"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	*cfg = fileNamespaceInstanceConfig{
+		MachineType: raw.MachineType,
+		Duration:    raw.Duration,
+		Ephemeral:   raw.Ephemeral,
+		Region:      raw.Region,
+		Endpoint:    raw.Endpoint,
+		Keychain:    raw.Keychain,
+		WorkRoot:    raw.WorkRoot,
+		Volume:      append(append([]string(nil), raw.Volume...), raw.Volumes...),
+	}
+	return nil
 }
 
 type fileMorphConfig struct {
@@ -3656,6 +3751,36 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			MarkDeleteOnReleaseExplicit(cfg, "namespace-devbox")
 		}
 	}
+	if file.NamespaceInstance != nil {
+		if file.NamespaceInstance.MachineType != "" {
+			cfg.NamespaceInstance.MachineType = file.NamespaceInstance.MachineType
+		}
+		if file.NamespaceInstance.Duration != "" {
+			parsed, err := time.ParseDuration(file.NamespaceInstance.Duration)
+			if err != nil || parsed <= 0 {
+				return exit(2, "namespaceInstance.duration must be a positive duration")
+			}
+			cfg.NamespaceInstance.Duration = parsed
+		}
+		if file.NamespaceInstance.Ephemeral != nil {
+			cfg.NamespaceInstance.Ephemeral = *file.NamespaceInstance.Ephemeral
+		}
+		if file.NamespaceInstance.Region != "" {
+			cfg.NamespaceInstance.Region = file.NamespaceInstance.Region
+		}
+		if file.NamespaceInstance.Endpoint != "" {
+			cfg.NamespaceInstance.Endpoint = file.NamespaceInstance.Endpoint
+		}
+		if file.NamespaceInstance.Keychain != "" {
+			cfg.NamespaceInstance.Keychain = file.NamespaceInstance.Keychain
+		}
+		if file.NamespaceInstance.WorkRoot != "" {
+			cfg.NamespaceInstance.WorkRoot = file.NamespaceInstance.WorkRoot
+		}
+		if len(file.NamespaceInstance.Volume) > 0 {
+			cfg.NamespaceInstance.Volumes = append([]string(nil), file.NamespaceInstance.Volume...)
+		}
+	}
 	if file.Morph != nil {
 		if file.Morph.APIKey != "" {
 			cfg.Morph.APIKey = file.Morph.APIKey
@@ -5001,6 +5126,24 @@ func applyEnv(cfg *Config) error {
 	cfg.Linode.FirewallID = getenv("CRABBOX_LINODE_FIREWALL", cfg.Linode.FirewallID)
 	if cidrs := os.Getenv("CRABBOX_LINODE_SSH_CIDRS"); cidrs != "" {
 		cfg.Linode.SSHCIDRs = splitCommaList(cidrs)
+	}
+	cfg.NamespaceInstance.MachineType = getenv("CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE", cfg.NamespaceInstance.MachineType)
+	if duration := os.Getenv("CRABBOX_NAMESPACE_INSTANCE_DURATION"); duration != "" {
+		parsed, err := time.ParseDuration(duration)
+		if err != nil || parsed <= 0 {
+			return exit(2, "CRABBOX_NAMESPACE_INSTANCE_DURATION must be a positive duration")
+		}
+		cfg.NamespaceInstance.Duration = parsed
+	}
+	if value, ok := getenvBool("CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL"); ok {
+		cfg.NamespaceInstance.Ephemeral = value
+	}
+	cfg.NamespaceInstance.Region = getenv("CRABBOX_NAMESPACE_INSTANCE_REGION", cfg.NamespaceInstance.Region)
+	cfg.NamespaceInstance.Endpoint = getenv("CRABBOX_NAMESPACE_INSTANCE_ENDPOINT", cfg.NamespaceInstance.Endpoint)
+	cfg.NamespaceInstance.Keychain = getenv("CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN", cfg.NamespaceInstance.Keychain)
+	cfg.NamespaceInstance.WorkRoot = getenv("CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT", cfg.NamespaceInstance.WorkRoot)
+	if raw := os.Getenv("CRABBOX_NAMESPACE_INSTANCE_VOLUME"); strings.TrimSpace(raw) != "" {
+		cfg.NamespaceInstance.Volumes = splitCommaList(raw)
 	}
 	cfg.Proxmox.APIURL = getenv("CRABBOX_PROXMOX_API_URL", cfg.Proxmox.APIURL)
 	cfg.Proxmox.TokenID = getenv("CRABBOX_PROXMOX_TOKEN_ID", cfg.Proxmox.TokenID)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"io"
 	"os"
 	"path/filepath"
@@ -64,6 +65,14 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_LINODE_TYPE",
 		"CRABBOX_LINODE_FIREWALL",
 		"CRABBOX_LINODE_SSH_CIDRS",
+		"CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE",
+		"CRABBOX_NAMESPACE_INSTANCE_DURATION",
+		"CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL",
+		"CRABBOX_NAMESPACE_INSTANCE_REGION",
+		"CRABBOX_NAMESPACE_INSTANCE_ENDPOINT",
+		"CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN",
+		"CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT",
+		"CRABBOX_NAMESPACE_INSTANCE_VOLUME",
 		"CRABBOX_DAYTONA_API_KEY",
 		"DAYTONA_API_KEY",
 		"CRABBOX_DAYTONA_JWT_TOKEN",
@@ -4170,6 +4179,103 @@ func TestNamespaceDevboxSizeForConfig(t *testing.T) {
 				t.Fatalf("size=%q want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestNamespaceInstanceConfigFileAndDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_PROVIDER", "")
+	data := []byte(`
+provider: namespace-instance
+ttl: 75m
+namespaceInstance:
+  machineType: linux-large
+  duration: 2h
+  ephemeral: false
+  region: us-west
+  endpoint: https://namespace.example.test
+  keychain: test-keychain
+  workRoot: /work/crabbox-file
+  volume:
+    - cache:/cache
+    - tmp:/tmp/cache
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "namespace-instance" || cfg.TargetOS != targetLinux || cfg.WorkRoot != "/work/crabbox-file" {
+		t.Fatalf("provider defaults not applied: provider=%q target=%q workRoot=%q", cfg.Provider, cfg.TargetOS, cfg.WorkRoot)
+	}
+	if cfg.NamespaceInstance.MachineType != "linux-large" || cfg.ServerType != "linux-large" || cfg.NamespaceInstance.Duration != 2*time.Hour || cfg.NamespaceInstance.Ephemeral || cfg.NamespaceInstance.Region != "us-west" || cfg.NamespaceInstance.Endpoint != "https://namespace.example.test" || cfg.NamespaceInstance.Keychain != "test-keychain" || cfg.NamespaceInstance.WorkRoot != "/work/crabbox-file" {
+		t.Fatalf("namespaceInstance config not loaded: %#v serverType=%q", cfg.NamespaceInstance, cfg.ServerType)
+	}
+	if len(cfg.NamespaceInstance.Volumes) != 2 || cfg.NamespaceInstance.Volumes[1] != "tmp:/tmp/cache" {
+		t.Fatalf("volumes=%#v", cfg.NamespaceInstance.Volumes)
+	}
+}
+
+func TestNamespaceInstanceConfigEnvAndFlags(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_PROVIDER", "namespace-instance")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_MACHINE_TYPE", "linux-env")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_DURATION", "3h")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_EPHEMERAL", "false")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_REGION", "eu-env")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_ENDPOINT", "https://namespace-env.example.test")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_KEYCHAIN", "env-keychain")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT", "/work/crabbox-env")
+	t.Setenv("CRABBOX_NAMESPACE_INSTANCE_VOLUME", "cache:/cache,go:/go")
+	if err := os.WriteFile(configPath, []byte("provider: namespace-instance\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NamespaceInstance.MachineType != "linux-env" || cfg.NamespaceInstance.Duration != 3*time.Hour || cfg.NamespaceInstance.Ephemeral || cfg.NamespaceInstance.Region != "eu-env" || cfg.NamespaceInstance.Endpoint != "https://namespace-env.example.test" || cfg.NamespaceInstance.Keychain != "env-keychain" || cfg.NamespaceInstance.WorkRoot != "/work/crabbox-env" || cfg.WorkRoot != "/work/crabbox-env" {
+		t.Fatalf("namespaceInstance env not loaded: %#v", cfg.NamespaceInstance)
+	}
+	if len(cfg.NamespaceInstance.Volumes) != 2 || cfg.NamespaceInstance.Volumes[0] != "cache:/cache" {
+		t.Fatalf("env volumes=%#v", cfg.NamespaceInstance.Volumes)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := registerProviderFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--namespace-instance-machine-type", "linux-flag",
+		"--namespace-instance-duration", "4h",
+		"--namespace-instance-ephemeral=true",
+		"--namespace-instance-region", "flag-region",
+		"--namespace-instance-endpoint", "https://namespace-flag.example.test",
+		"--namespace-instance-keychain", "flag-keychain",
+		"--namespace-instance-work-root", "/work/crabbox-flag",
+		"--namespace-instance-volume", "flag:/flag",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NamespaceInstance.MachineType != "linux-flag" || cfg.ServerType != "linux-flag" || cfg.NamespaceInstance.Duration != 4*time.Hour || !cfg.NamespaceInstance.Ephemeral || cfg.NamespaceInstance.Region != "flag-region" || cfg.NamespaceInstance.Endpoint != "https://namespace-flag.example.test" || cfg.NamespaceInstance.Keychain != "flag-keychain" || cfg.NamespaceInstance.WorkRoot != "/work/crabbox-flag" || cfg.WorkRoot != "/work/crabbox-flag" {
+		t.Fatalf("namespaceInstance flags not applied: %#v serverType=%q", cfg.NamespaceInstance, cfg.ServerType)
+	}
+	if len(cfg.NamespaceInstance.Volumes) != 1 || cfg.NamespaceInstance.Volumes[0] != "flag:/flag" {
+		t.Fatalf("flag volumes=%#v", cfg.NamespaceInstance.Volumes)
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4279,6 +4279,43 @@ func TestNamespaceInstanceConfigEnvAndFlags(t *testing.T) {
 	}
 }
 
+func TestNamespaceInstanceRejectsUnsafeWorkRootFromConfigAndEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		env  string
+	}{
+		{
+			name: "config-file",
+			body: "provider: namespace-instance\nnamespaceInstance:\n  workRoot: /work\n",
+		},
+		{
+			name: "environment",
+			body: "provider: namespace-instance\n",
+			env:  "/tmp",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			home := t.TempDir()
+			configPath := filepath.Join(home, "config.yaml")
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			if tc.env != "" {
+				t.Setenv("CRABBOX_NAMESPACE_INSTANCE_WORK_ROOT", tc.env)
+			}
+			if err := os.WriteFile(configPath, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := loadConfig()
+			if err == nil || !strings.Contains(err.Error(), "namespaceInstance.workRoot") || !strings.Contains(err.Error(), "too broad") {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
 func TestConfigServerTypeHelperBranches(t *testing.T) {
 	if got := incusServerTypeForConfig(Config{}); got != "container" {
 		t.Fatalf("incus default=%q", got)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4316,6 +4316,49 @@ func TestNamespaceInstanceRejectsUnsafeWorkRootFromConfigAndEnv(t *testing.T) {
 	}
 }
 
+func TestRepoConfigCannotOverrideNamespaceInstanceEndpoint(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+	userPath := userConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte("provider: namespace-instance\nnamespaceInstance:\n  endpoint: https://trusted.example.test\n  keychain: trusted-keychain\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(".crabbox.yaml", []byte("namespaceInstance:\n  endpoint: https://attacker.example.test\n  machineType: linux-repo\n  workRoot: /work/crabbox-repo\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NamespaceInstance.Endpoint != "https://trusted.example.test" {
+		t.Fatalf("NamespaceInstance.Endpoint=%q, want trusted user endpoint", cfg.NamespaceInstance.Endpoint)
+	}
+	if cfg.NamespaceInstance.Keychain != "trusted-keychain" || cfg.NamespaceInstance.MachineType != "linux-repo" || cfg.NamespaceInstance.WorkRoot != "/work/crabbox-repo" {
+		t.Fatalf("unexpected merged namespaceInstance config: %#v", cfg.NamespaceInstance)
+	}
+}
+
 func TestConfigServerTypeHelperBranches(t *testing.T) {
 	if got := incusServerTypeForConfig(Config{}); got != "container" {
 		t.Fatalf("incus default=%q", got)

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -27,6 +27,7 @@ func init() {
 	RegisterProvider(testRunPodProvider{})
 	RegisterProvider(testBlacksmithProvider{})
 	RegisterProvider(testNamespaceProvider{})
+	RegisterProvider(testNamespaceInstanceProvider{})
 	RegisterProvider(testMorphProvider{})
 	RegisterProvider(testDaytonaProvider{})
 	RegisterProvider(testIsloProvider{})
@@ -957,6 +958,92 @@ type testNamespaceFlagValues struct {
 	Image    *string
 	Size     *string
 	WorkRoot *string
+}
+
+type testNamespaceInstanceProvider struct{}
+
+func (testNamespaceInstanceProvider) Name() string { return "namespace-instance" }
+func (testNamespaceInstanceProvider) Aliases() []string {
+	return []string{"namespace-compute"}
+}
+func (testNamespaceInstanceProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "namespace-instance",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testNamespaceInstanceProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+	return testNamespaceInstanceFlagValues{
+		MachineType: fs.String("namespace-instance-machine-type", defaults.NamespaceInstance.MachineType, ""),
+		Duration:    fs.String("namespace-instance-duration", defaults.NamespaceInstance.Duration.String(), ""),
+		Ephemeral:   fs.Bool("namespace-instance-ephemeral", defaults.NamespaceInstance.Ephemeral, ""),
+		Region:      fs.String("namespace-instance-region", defaults.NamespaceInstance.Region, ""),
+		Endpoint:    fs.String("namespace-instance-endpoint", defaults.NamespaceInstance.Endpoint, ""),
+		Keychain:    fs.String("namespace-instance-keychain", defaults.NamespaceInstance.Keychain, ""),
+		WorkRoot:    fs.String("namespace-instance-work-root", defaults.NamespaceInstance.WorkRoot, ""),
+		Volume:      fs.String("namespace-instance-volume", strings.Join(defaults.NamespaceInstance.Volumes, ","), ""),
+	}
+}
+func (testNamespaceInstanceProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(testNamespaceInstanceFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "namespace-instance-machine-type") {
+		cfg.NamespaceInstance.MachineType = *v.MachineType
+		cfg.ServerType = *v.MachineType
+		cfg.ServerTypeExplicit = true
+	}
+	if flagWasSet(fs, "namespace-instance-duration") {
+		applyLeaseDuration(&cfg.NamespaceInstance.Duration, *v.Duration)
+	}
+	if flagWasSet(fs, "namespace-instance-ephemeral") {
+		cfg.NamespaceInstance.Ephemeral = *v.Ephemeral
+	}
+	if flagWasSet(fs, "namespace-instance-region") {
+		cfg.NamespaceInstance.Region = *v.Region
+	}
+	if flagWasSet(fs, "namespace-instance-endpoint") {
+		cfg.NamespaceInstance.Endpoint = *v.Endpoint
+	}
+	if flagWasSet(fs, "namespace-instance-keychain") {
+		cfg.NamespaceInstance.Keychain = *v.Keychain
+	}
+	if flagWasSet(fs, "namespace-instance-work-root") {
+		cfg.NamespaceInstance.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if flagWasSet(fs, "namespace-instance-volume") {
+		cfg.NamespaceInstance.Volumes = splitCommaList(*v.Volume)
+	}
+	return nil
+}
+func (p testNamespaceInstanceProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+func (testNamespaceInstanceProvider) ServerTypeForConfig(cfg Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if strings.TrimSpace(cfg.NamespaceInstance.MachineType) != "" {
+		return strings.TrimSpace(cfg.NamespaceInstance.MachineType)
+	}
+	return "linux-small"
+}
+func (testNamespaceInstanceProvider) ServerTypeForClass(string) string { return "linux-small" }
+
+type testNamespaceInstanceFlagValues struct {
+	MachineType *string
+	Duration    *string
+	Ephemeral   *bool
+	Region      *string
+	Endpoint    *string
+	Keychain    *string
+	WorkRoot    *string
+	Volume      *string
 }
 
 type testMorphProvider struct{}

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/multipass"
 	_ "github.com/openclaw/crabbox/internal/providers/mxc"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
+	_ "github.com/openclaw/crabbox/internal/providers/namespaceinstance"
 	_ "github.com/openclaw/crabbox/internal/providers/opencomputer"
 	_ "github.com/openclaw/crabbox/internal/providers/opensandbox"
 	_ "github.com/openclaw/crabbox/internal/providers/parallels"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -108,6 +108,25 @@ func TestIncusRegistersAsBuiltInProvider(t *testing.T) {
 	}
 }
 
+func TestNamespaceInstanceRegistersWithoutAliasCollision(t *testing.T) {
+	for _, name := range []string{"namespace-instance", "namespace-compute"} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", name, err)
+		}
+		if provider.Name() != "namespace-instance" {
+			t.Fatalf("ProviderFor(%q).Name=%q want namespace-instance", name, provider.Name())
+		}
+	}
+	provider, err := core.ProviderFor("namespace")
+	if err != nil {
+		t.Fatalf("ProviderFor(namespace): %v", err)
+	}
+	if provider.Name() != "namespace-devbox" {
+		t.Fatalf("namespace alias now resolves to %q; namespace-instance must not steal it", provider.Name())
+	}
+}
+
 func TestAppleVZRegistersAsBuiltInProvider(t *testing.T) {
 	for _, name := range []string{"apple-vz", "applevz"} {
 		provider, err := core.ProviderFor(name)
@@ -148,6 +167,7 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 		"multipass",
 		"mxc",
 		"namespace-devbox",
+		"namespace-instance",
 		"opencomputer",
 		"opensandbox",
 		"parallels",

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -115,6 +115,29 @@ func TestAcquireMissingSSHMetadataReturnsPlanGapAndDestroysCreatedInstance(t *te
 	}
 }
 
+func TestAcquireDestroysCIDFileInstanceWhenCreateReturnsError(t *testing.T) {
+	oldNewLeaseID := newLeaseID
+	oldEnsureKey := ensureTestboxKeyForConfig
+	defer func() {
+		newLeaseID = oldNewLeaseID
+		ensureTestboxKeyForConfig = oldEnsureKey
+	}()
+	newLeaseID = func() string { return "cbx_test003" }
+	ensureTestboxKeyForConfig = func(Config, string) (string, string, error) {
+		return "/tmp/crabbox-test-key", "ssh-ed25519 synthetic", nil
+	}
+	runner := &createErrorArtifactRunner{createID: "inst-created-before-error"}
+	var stderr bytes.Buffer
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{MachineType: "linux-small", WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &stderr})
+	_, err := b.Acquire(context.Background(), AcquireRequest{})
+	if err == nil || !strings.Contains(err.Error(), "nsc create failed") {
+		t.Fatalf("err=%v", err)
+	}
+	if !strings.Contains(joinCalls(runner.calls), "destroy inst-created-before-error --force") {
+		t.Fatalf("create-error rollback destroy not called:\n%s", joinCalls(runner.calls))
+	}
+}
+
 func TestResolveUsesClaimAndDoesNotRequireSSHForStatusOnly(t *testing.T) {
 	oldResolve := resolveLeaseClaimForProvider
 	oldResolveCloud := resolveLeaseClaimForProviderCloudID

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -212,6 +212,35 @@ func TestCleanupDryRunSkipsForeignAndDoesNotDestroy(t *testing.T) {
 	}
 }
 
+func TestCleanupRequiresRawOwnershipLabelsBeforeDestroy(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{
+		{Stdout: `[
+			{"id":"owned","status":"failed","labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_owned","slug":"owned","state":"failed"}},
+			{"id":"lease-only","status":"failed","labels":{"lease":"cbx_manual","slug":"manual","state":"failed"}},
+			{"id":"missing-provider","status":"failed","labels":{"crabbox":"true","lease":"cbx_missing_provider","slug":"missing-provider","state":"failed"}},
+			{"id":"missing-lease","status":"failed","labels":{"crabbox":"true","provider":"namespace-instance","slug":"missing-lease","state":"failed"}}
+		]`},
+		{},
+	}}
+	var stderr bytes.Buffer
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &stderr})
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	calls := joinCalls(runner.calls)
+	if !strings.Contains(calls, "destroy owned --force") {
+		t.Fatalf("owned instance not destroyed:\n%s", calls)
+	}
+	for _, id := range []string{"lease-only", "missing-provider", "missing-lease"} {
+		if strings.Contains(calls, "destroy "+id+" --force") || strings.Contains(stderr.String(), "delete server id="+id) {
+			t.Fatalf("foreign/partial instance %q was eligible for cleanup:\ncalls=%s\nstderr=%s", id, calls, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "skip server id="+id) {
+			t.Fatalf("foreign/partial instance %q was not reported as skipped:\n%s", id, stderr.String())
+		}
+	}
+}
+
 func TestTouchExtendsInstanceAndPreservesLabels(t *testing.T) {
 	runner := &recordingRunner{results: []LocalCommandResult{{}}}
 	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{Duration: time.Hour, WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -1,0 +1,239 @@
+package namespaceinstance
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestAcquireCreatesInstanceWaitsForSSHTargetAndClaims(t *testing.T) {
+	oldNewLeaseID := newLeaseID
+	oldEnsureKey := ensureTestboxKeyForConfig
+	oldWait := waitForSSHReady
+	oldClaim := claimLeaseTargetForConfig
+	defer func() {
+		newLeaseID = oldNewLeaseID
+		ensureTestboxKeyForConfig = oldEnsureKey
+		waitForSSHReady = oldWait
+		claimLeaseTargetForConfig = oldClaim
+	}()
+	newLeaseID = func() string { return "cbx_test001" }
+	ensureTestboxKeyForConfig = func(Config, string) (string, string, error) {
+		return "/tmp/crabbox-test-key", "ssh-ed25519 synthetic", nil
+	}
+	waitCalled := false
+	waitForSSHReady = func(_ context.Context, target *SSHTarget, _ io.Writer, phase string, _ time.Duration) error {
+		waitCalled = true
+		if phase != "bootstrap" || target.Host != "203.0.113.10" || target.Key != "/tmp/crabbox-test-key" {
+			t.Fatalf("wait target=%#v phase=%q", target, phase)
+		}
+		return nil
+	}
+	var claimed struct {
+		leaseID string
+		slug    string
+		server  Server
+		target  SSHTarget
+	}
+	claimLeaseTargetForConfig = func(leaseID, slug string, _ Config, server Server, target SSHTarget, _ time.Duration) error {
+		claimed.leaseID = leaseID
+		claimed.slug = slug
+		claimed.server = server
+		claimed.target = target
+		return nil
+	}
+	runner := &recordingRunner{results: []LocalCommandResult{
+		{Stdout: `[]`},
+		{Stdout: `{"id":"inst-synthetic","status":"running","ssh":{"host":"203.0.113.10","user":"root","port":22},"labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_test001","slug":"blue"}}`},
+		{Stdout: `{"id":"inst-synthetic","status":"running","ssh":{"host":"203.0.113.10","user":"root","port":22}}`},
+	}}
+	var stderr bytes.Buffer
+	b := newBackend(Provider{}.Spec(), core.Config{
+		Provider: providerName,
+		TTL:      2 * time.Hour,
+		NamespaceInstance: core.NamespaceInstanceConfig{
+			MachineType: "linux-small",
+			Duration:    90 * time.Minute,
+			Ephemeral:   true,
+			Region:      "us-test",
+			WorkRoot:    defaultWorkRoot,
+		},
+	}, core.Runtime{Exec: runner, Stderr: &stderr})
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Keep: true, RequestedSlug: "blue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_test001" || lease.Server.CloudID != "inst-synthetic" || lease.SSH.Host != "203.0.113.10" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if !waitCalled || claimed.leaseID != "cbx_test001" || claimed.slug != "blue" || claimed.server.Labels["state"] != "ready" || claimed.target.Host != "203.0.113.10" {
+		t.Fatalf("wait=%v claimed=%#v", waitCalled, claimed)
+	}
+	joined := joinCalls(runner.calls)
+	for _, want := range []string{"list -o json --all", "create", "--machine_type linux-small", "--duration 1h30m0s", "--ephemeral", "--ssh_key /tmp/crabbox-test-key.pub", "--unique_tag crabbox-cbx-test001", "describe inst-synthetic -o json"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("calls missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestAcquireMissingSSHMetadataReturnsPlanGapAndDestroysCreatedInstance(t *testing.T) {
+	oldNewLeaseID := newLeaseID
+	oldEnsureKey := ensureTestboxKeyForConfig
+	oldWait := waitForSSHReady
+	defer func() {
+		newLeaseID = oldNewLeaseID
+		ensureTestboxKeyForConfig = oldEnsureKey
+		waitForSSHReady = oldWait
+	}()
+	newLeaseID = func() string { return "cbx_test002" }
+	ensureTestboxKeyForConfig = func(Config, string) (string, string, error) {
+		return "/tmp/crabbox-test-key", "ssh-ed25519 synthetic", nil
+	}
+	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+		t.Fatal("wait should not be called without SSH metadata")
+		return nil
+	}
+	runner := &recordingRunner{results: []LocalCommandResult{
+		{Stdout: `[]`},
+		{Stdout: `{"id":"inst-no-ssh","labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_test002","slug":"no-ssh"}}`},
+		{Stdout: `{"id":"inst-no-ssh"}`},
+		{},
+	}}
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{MachineType: "linux-small", WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})
+	_, err := b.Acquire(context.Background(), AcquireRequest{})
+	if err == nil || !strings.Contains(err.Error(), "plan_gap") {
+		t.Fatalf("err=%v", err)
+	}
+	if !strings.Contains(joinCalls(runner.calls), "destroy inst-no-ssh --force") {
+		t.Fatalf("rollback destroy not called:\n%s", joinCalls(runner.calls))
+	}
+}
+
+func TestResolveUsesClaimAndDoesNotRequireSSHForStatusOnly(t *testing.T) {
+	oldResolve := resolveLeaseClaimForProvider
+	oldResolveCloud := resolveLeaseClaimForProviderCloudID
+	defer func() {
+		resolveLeaseClaimForProvider = oldResolve
+		resolveLeaseClaimForProviderCloudID = oldResolveCloud
+	}()
+	resolveLeaseClaimForProvider = func(identifier, provider string) (LeaseClaim, bool, error) {
+		if identifier != "blue" || provider != providerName {
+			return LeaseClaim{}, false, nil
+		}
+		return LeaseClaim{
+			LeaseID:  "cbx_claim",
+			Slug:     "blue",
+			Provider: providerName,
+			CloudID:  "inst-claim",
+			SSHHost:  "203.0.113.20",
+			SSHPort:  2202,
+			Labels:   map[string]string{"crabbox": "true", "provider": providerName, "lease": "cbx_claim", "slug": "blue", "state": "ready"},
+		}, true, nil
+	}
+	resolveLeaseClaimForProviderCloudID = func(string, string) (LeaseClaim, bool, error) {
+		return LeaseClaim{}, false, nil
+	}
+	runner := &recordingRunner{results: []LocalCommandResult{{Stdout: `{"id":"inst-claim","status":"running","labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_claim","slug":"blue"}}`}}}
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "blue", StatusOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_claim" || lease.Server.CloudID != "inst-claim" || lease.SSH.Host != "203.0.113.20" || lease.SSH.Port != "2202" {
+		t.Fatalf("lease=%#v", lease)
+	}
+}
+
+func TestListFiltersNonCrabboxInstancesByDefault(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{{Stdout: `[
+		{"id":"owned","labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_owned","slug":"owned"}},
+		{"id":"foreign","labels":{"project":"manual"}}
+	]`}}}
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})
+	leases, err := b.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 || leases[0].CloudID != "owned" {
+		t.Fatalf("leases=%#v", leases)
+	}
+}
+
+func TestReleaseDestroysClaimedInstanceAndRemovesLocalState(t *testing.T) {
+	oldResolve := resolveLeaseClaimForProvider
+	oldRemoveClaim := removeLeaseClaim
+	oldRemoveKey := removeStoredTestboxKey
+	defer func() {
+		resolveLeaseClaimForProvider = oldResolve
+		removeLeaseClaim = oldRemoveClaim
+		removeStoredTestboxKey = oldRemoveKey
+	}()
+	resolveLeaseClaimForProvider = func(identifier, provider string) (LeaseClaim, bool, error) {
+		if identifier != "cbx_release" || provider != providerName {
+			return LeaseClaim{}, false, nil
+		}
+		return LeaseClaim{LeaseID: "cbx_release", Provider: providerName, CloudID: "inst-release"}, true, nil
+	}
+	var removedClaim, removedKey string
+	removeLeaseClaim = func(leaseID string) { removedClaim = leaseID }
+	removeStoredTestboxKey = func(leaseID string) { removedKey = leaseID }
+	runner := &recordingRunner{results: []LocalCommandResult{{}}}
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})
+	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_release", Server: Server{CloudID: "inst-release"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(joinCalls(runner.calls), "destroy inst-release --force") || removedClaim != "cbx_release" || removedKey != "cbx_release" {
+		t.Fatalf("calls=%s removedClaim=%q removedKey=%q", joinCalls(runner.calls), removedClaim, removedKey)
+	}
+}
+
+func TestCleanupDryRunSkipsForeignAndDoesNotDestroy(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{{Stdout: `[
+		{"id":"owned","status":"failed","labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_owned","slug":"owned","state":"failed"}},
+		{"id":"foreign","status":"failed","labels":{"crabbox":"true","provider":"namespace-devbox","lease":"cbx_foreign","state":"failed"}}
+	]`}}}
+	var stderr bytes.Buffer
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &stderr})
+	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(joinCalls(runner.calls), "destroy") {
+		t.Fatalf("dry-run destroyed: %s", joinCalls(runner.calls))
+	}
+	if !strings.Contains(stderr.String(), "delete server id=owned") || strings.Contains(stderr.String(), "delete server id=foreign") {
+		t.Fatalf("stderr=%s", stderr.String())
+	}
+}
+
+func TestTouchExtendsInstanceAndPreservesLabels(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{{}}}
+	b := newBackend(Provider{}.Spec(), core.Config{Provider: providerName, NamespaceInstance: core.NamespaceInstanceConfig{Duration: time.Hour, WorkRoot: defaultWorkRoot}}, core.Runtime{Exec: runner, Stderr: &bytes.Buffer{}})
+	server, err := b.Touch(context.Background(), TouchRequest{
+		Lease: LeaseTarget{Server: Server{CloudID: "inst-touch", Labels: map[string]string{"crabbox": "true", "provider": providerName, "lease": "cbx_touch", "slug": "touch", "custom": "keep"}}},
+		State: "ready",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.Labels["custom"] != "keep" || server.Labels["state"] != "ready" {
+		t.Fatalf("labels=%#v", server.Labels)
+	}
+	if !strings.Contains(joinCalls(runner.calls), "extend inst-touch --ensure_minimum 1h0m0s") {
+		t.Fatalf("calls=%s", joinCalls(runner.calls))
+	}
+}
+
+func joinCalls(calls []LocalCommandRequest) string {
+	var lines []string
+	for _, call := range calls {
+		lines = append(lines, call.Name+" "+strings.Join(call.Args, " "))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/providers/namespaceinstance/client.go
+++ b/internal/providers/namespaceinstance/client.go
@@ -1,0 +1,121 @@
+package namespaceinstance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type nscClient struct {
+	path   string
+	cfg    NamespaceInstanceConfig
+	runner CommandRunner
+}
+
+func newNSCClient(cfg Config, rt Runtime) (*nscClient, error) {
+	if rt.Exec == nil {
+		return nil, exit(2, "provider=%s requires a local command runner for nsc", providerName)
+	}
+	return &nscClient{path: "nsc", cfg: cfg.NamespaceInstance, runner: rt.Exec}, nil
+}
+
+func (c *nscClient) CheckReadiness(ctx context.Context) (string, error) {
+	if _, err := c.run(ctx, "--help"); err != nil {
+		return "", fmt.Errorf("nsc CLI unavailable: %w", err)
+	}
+	if _, err := c.run(ctx, "auth", "check-login"); err != nil {
+		return "", fmt.Errorf("nsc auth check-login failed: %w", err)
+	}
+	result, err := c.run(ctx, "list", "-o", "json")
+	if err != nil {
+		return "", fmt.Errorf("nsc list readiness check failed: %w", err)
+	}
+	count, err := parseNSCListCount(result.Stdout)
+	if err != nil {
+		return "", fmt.Errorf("decode nsc list readiness output: %w", err)
+	}
+	return strconv.Itoa(count), nil
+}
+
+func (c *nscClient) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithTimeout(ctx, commandTimeout())
+		defer cancel()
+	}
+	argv := c.globalArgs()
+	argv = append(argv, args...)
+	result, err := c.runner.Run(ctx, LocalCommandRequest{Name: c.path, Args: argv})
+	if err != nil {
+		return result, exit(commandExitCode(result), "nsc %s failed", safeCommand(args))
+	}
+	return result, nil
+}
+
+func (c *nscClient) globalArgs() []string {
+	var args []string
+	if value := strings.TrimSpace(c.cfg.Endpoint); value != "" {
+		args = append(args, "--endpoint", value)
+	}
+	if value := strings.TrimSpace(c.cfg.Keychain); value != "" {
+		args = append(args, "--keychain", value)
+	}
+	if value := strings.TrimSpace(c.cfg.Region); value != "" {
+		args = append(args, "--region", value)
+	}
+	return args
+}
+
+func parseNSCListCount(out string) (int, error) {
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return 0, nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal([]byte(out), &items); err == nil {
+		return len(items), nil
+	}
+	var wrapped struct {
+		Instances []json.RawMessage `json:"instances"`
+		Items     []json.RawMessage `json:"items"`
+		Results   []json.RawMessage `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(out), &wrapped); err != nil {
+		return 0, err
+	}
+	switch {
+	case wrapped.Instances != nil:
+		return len(wrapped.Instances), nil
+	case wrapped.Items != nil:
+		return len(wrapped.Items), nil
+	case wrapped.Results != nil:
+		return len(wrapped.Results), nil
+	default:
+		return 0, nil
+	}
+}
+
+func commandExitCode(result LocalCommandResult) int {
+	if result.ExitCode != 0 {
+		return result.ExitCode
+	}
+	return 1
+}
+
+func safeCommand(args []string) string {
+	if len(args) == 0 {
+		return "command"
+	}
+	switch args[0] {
+	case "--help":
+		return "--help"
+	case "auth":
+		return "auth check-login"
+	case "list":
+		return "list"
+	default:
+		return "command"
+	}
+}

--- a/internal/providers/namespaceinstance/client.go
+++ b/internal/providers/namespaceinstance/client.go
@@ -76,11 +76,27 @@ func (c *nscClient) CreateInstance(ctx context.Context, req createInstanceReques
 			args = append(args, "--label", key+"="+value)
 		}
 	}
-	result, err := c.run(ctx, args...)
-	if err != nil {
-		return namespaceInstance{}, err
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithTimeout(ctx, createCommandTimeout())
+		defer cancel()
 	}
-	instance, parseErr := parseNSCInstance(result.Stdout)
+	result, err := c.run(ctx, args...)
+	instance, parseErr := parseNSCCreateResult(result.Stdout, jsonPath, cidPath)
+	if err != nil {
+		return instance, err
+	}
+	if instance.ID == "" {
+		if parseErr != nil {
+			return namespaceInstance{}, fmt.Errorf("decode nsc create output: %w", parseErr)
+		}
+		return namespaceInstance{}, exit(2, "nsc create did not return an instance id")
+	}
+	return instance, nil
+}
+
+func parseNSCCreateResult(stdout, jsonPath, cidPath string) (namespaceInstance, error) {
+	instance, parseErr := parseNSCInstance(stdout)
 	if parseErr != nil || instance.ID == "" {
 		if data, readErr := os.ReadFile(jsonPath); readErr == nil {
 			instance, parseErr = parseNSCInstance(string(data))
@@ -91,13 +107,7 @@ func (c *nscClient) CreateInstance(ctx context.Context, req createInstanceReques
 			instance.ID = strings.TrimSpace(string(data))
 		}
 	}
-	if instance.ID == "" {
-		if parseErr != nil {
-			return namespaceInstance{}, fmt.Errorf("decode nsc create output: %w", parseErr)
-		}
-		return namespaceInstance{}, exit(2, "nsc create did not return an instance id")
-	}
-	return instance, nil
+	return instance, parseErr
 }
 
 func (c *nscClient) DescribeInstance(ctx context.Context, id string) (namespaceInstance, error) {

--- a/internal/providers/namespaceinstance/client.go
+++ b/internal/providers/namespaceinstance/client.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type nscClient struct {
@@ -39,6 +42,131 @@ func (c *nscClient) CheckReadiness(ctx context.Context) (string, error) {
 	return strconv.Itoa(count), nil
 }
 
+func (c *nscClient) CreateInstance(ctx context.Context, req createInstanceRequest) (namespaceInstance, error) {
+	dir, err := os.MkdirTemp("", "crabbox-nsc-create-*")
+	if err != nil {
+		return namespaceInstance{}, exit(2, "create nsc temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	jsonPath := filepath.Join(dir, "instance.json")
+	cidPath := filepath.Join(dir, "instance.cid")
+	args := []string{
+		"create",
+		"--machine_type", req.MachineType,
+		"--duration", req.Duration.String(),
+		"--purpose", "Crabbox disposable SSH lease",
+		"--ssh_key", req.PublicKeyPath,
+		"--cidfile", cidPath,
+		"--output_json_to", jsonPath,
+		"-o", "json",
+	}
+	if req.Ephemeral {
+		args = append(args, "--ephemeral")
+	}
+	if req.UniqueTag != "" {
+		args = append(args, "--unique_tag", req.UniqueTag)
+	}
+	for _, volume := range req.Volumes {
+		if strings.TrimSpace(volume) != "" {
+			args = append(args, "--volume", strings.TrimSpace(volume))
+		}
+	}
+	for key, value := range req.Labels {
+		if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+			args = append(args, "--label", key+"="+value)
+		}
+	}
+	result, err := c.run(ctx, args...)
+	if err != nil {
+		return namespaceInstance{}, err
+	}
+	instance, parseErr := parseNSCInstance(result.Stdout)
+	if parseErr != nil || instance.ID == "" {
+		if data, readErr := os.ReadFile(jsonPath); readErr == nil {
+			instance, parseErr = parseNSCInstance(string(data))
+		}
+	}
+	if instance.ID == "" {
+		if data, readErr := os.ReadFile(cidPath); readErr == nil {
+			instance.ID = strings.TrimSpace(string(data))
+		}
+	}
+	if instance.ID == "" {
+		if parseErr != nil {
+			return namespaceInstance{}, fmt.Errorf("decode nsc create output: %w", parseErr)
+		}
+		return namespaceInstance{}, exit(2, "nsc create did not return an instance id")
+	}
+	return instance, nil
+}
+
+func (c *nscClient) DescribeInstance(ctx context.Context, id string) (namespaceInstance, error) {
+	result, err := c.run(ctx, "describe", strings.TrimSpace(id), "-o", "json")
+	if err != nil {
+		if nscNotFoundError(err) {
+			return namespaceInstance{}, err
+		}
+		return namespaceInstance{}, err
+	}
+	instance, err := parseNSCInstance(result.Stdout)
+	if err != nil {
+		return namespaceInstance{}, fmt.Errorf("decode nsc describe output: %w", err)
+	}
+	if instance.ID == "" {
+		instance.ID = strings.TrimSpace(id)
+	}
+	return instance, nil
+}
+
+func (c *nscClient) ListInstances(ctx context.Context, all bool) ([]namespaceInstance, error) {
+	args := []string{"list", "-o", "json"}
+	if all {
+		args = append(args, "--all")
+	}
+	result, err := c.run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return parseNSCInstances(result.Stdout)
+}
+
+func (c *nscClient) DestroyInstance(ctx context.Context, id string) error {
+	_, err := c.run(ctx, "destroy", strings.TrimSpace(id), "--force")
+	if err != nil && nscNotFoundError(err) {
+		return err
+	}
+	return err
+}
+
+func (c *nscClient) ExtendInstance(ctx context.Context, id string, minimum time.Duration) error {
+	if minimum <= 0 {
+		return nil
+	}
+	_, err := c.run(ctx, "extend", strings.TrimSpace(id), "--ensure_minimum", minimum.String())
+	return err
+}
+
+func (c *nscClient) ResolveSSH(instance namespaceInstance, cfg Config, keyPath string) (SSHTarget, error) {
+	target := sshTargetFromConfig(cfg, instance.SSHHost)
+	target.Key = keyPath
+	if instance.SSHUser != "" {
+		target.User = instance.SSHUser
+	}
+	if instance.SSHPort != "" {
+		target.Port = instance.SSHPort
+	}
+	if target.User == "" {
+		target.User = "root"
+	}
+	if target.Port == "" {
+		target.Port = "22"
+	}
+	if strings.TrimSpace(target.Host) == "" || strings.TrimSpace(target.User) == "" || strings.TrimSpace(target.Port) == "" || strings.TrimSpace(target.Key) == "" {
+		return SSHTarget{}, exit(2, "plan_gap: nsc JSON did not expose a normal SSH target for namespace-instance; implement API-backed GetSSHConfig before enabling run/sync")
+	}
+	return target, nil
+}
+
 func (c *nscClient) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -49,6 +177,9 @@ func (c *nscClient) run(ctx context.Context, args ...string) (LocalCommandResult
 	argv = append(argv, args...)
 	result, err := c.runner.Run(ctx, LocalCommandRequest{Name: c.path, Args: argv})
 	if err != nil {
+		if len(args) > 0 && (args[0] == "destroy" || args[0] == "describe") && commandOutputLooksNotFound(result) {
+			return result, exit(4, "nsc %s target not found", args[0])
+		}
 		return result, exit(commandExitCode(result), "nsc %s failed", safeCommand(args))
 	}
 	return result, nil
@@ -115,7 +246,212 @@ func safeCommand(args []string) string {
 		return "auth check-login"
 	case "list":
 		return "list"
+	case "create":
+		return "create"
+	case "describe":
+		return "describe"
+	case "destroy":
+		return "destroy"
+	case "extend":
+		return "extend"
 	default:
 		return "command"
 	}
+}
+
+type createInstanceRequest struct {
+	MachineType   string
+	Duration      time.Duration
+	Ephemeral     bool
+	PublicKeyPath string
+	UniqueTag     string
+	Labels        map[string]string
+	Volumes       []string
+}
+
+type namespaceInstance struct {
+	ID          string
+	Name        string
+	Status      string
+	MachineType string
+	Region      string
+	Labels      map[string]string
+	Deadline    string
+	SSHHost     string
+	SSHUser     string
+	SSHPort     string
+}
+
+func parseNSCInstances(out string) ([]namespaceInstance, error) {
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return nil, nil
+	}
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal([]byte(out), &rawItems); err != nil {
+		var wrapped map[string]json.RawMessage
+		if wrapErr := json.Unmarshal([]byte(out), &wrapped); wrapErr != nil {
+			instance, instErr := parseNSCInstance(out)
+			if instErr != nil {
+				return nil, err
+			}
+			if instance.ID == "" {
+				return nil, nil
+			}
+			return []namespaceInstance{instance}, nil
+		}
+		for _, key := range []string{"instances", "items", "results"} {
+			if raw := wrapped[key]; len(raw) > 0 {
+				if arrErr := json.Unmarshal(raw, &rawItems); arrErr != nil {
+					return nil, arrErr
+				}
+				break
+			}
+		}
+	}
+	outItems := make([]namespaceInstance, 0, len(rawItems))
+	for _, raw := range rawItems {
+		instance, err := parseNSCInstance(string(raw))
+		if err != nil {
+			return nil, err
+		}
+		if instance.ID != "" {
+			outItems = append(outItems, instance)
+		}
+	}
+	return outItems, nil
+}
+
+func parseNSCInstance(out string) (namespaceInstance, error) {
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return namespaceInstance{}, nil
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(out), &root); err != nil {
+		if looksLikeInstanceID(out) {
+			return namespaceInstance{ID: out}, nil
+		}
+		return namespaceInstance{}, err
+	}
+	if nested := firstMap(root, "instance", "environment", "metadata", "result"); nested != nil {
+		for k, v := range root {
+			if _, ok := nested[k]; !ok {
+				nested[k] = v
+			}
+		}
+		root = nested
+	}
+	labels := stringMap(firstAny(root, "labels", "label"))
+	sshMap := firstMap(root, "ssh", "sshConfig", "ssh_config", "sshTarget", "ssh_target")
+	host := firstString(root, "sshHost", "ssh_host", "host", "hostname", "ip", "address", "endpoint")
+	user := firstString(root, "sshUser", "ssh_user", "user", "username", "login")
+	port := firstString(root, "sshPort", "ssh_port", "port")
+	if sshMap != nil {
+		host = firstNonEmpty(host, firstString(sshMap, "host", "hostname", "ip", "address", "endpoint"))
+		user = firstNonEmpty(user, firstString(sshMap, "user", "username", "login"))
+		port = firstNonEmpty(port, firstString(sshMap, "port", "sshPort", "ssh_port"))
+	}
+	return namespaceInstance{
+		ID:          firstString(root, "id", "instanceId", "instance_id", "cid", "name"),
+		Name:        firstString(root, "name", "purpose", "displayName", "display_name"),
+		Status:      firstString(root, "status", "state", "phase"),
+		MachineType: firstString(root, "machineType", "machine_type", "shape", "type"),
+		Region:      firstString(root, "region", "location"),
+		Labels:      labels,
+		Deadline:    firstString(root, "deadline", "expiresAt", "expires_at", "expiration", "ttl"),
+		SSHHost:     host,
+		SSHUser:     user,
+		SSHPort:     port,
+	}, nil
+}
+
+func looksLikeInstanceID(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && !strings.ContainsAny(value, " \t\r\n{}[]")
+}
+
+func firstAny(m map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstMap(m map[string]any, keys ...string) map[string]any {
+	for _, key := range keys {
+		if value, ok := m[key].(map[string]any); ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstString(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := m[key]
+		if !ok {
+			continue
+		}
+		switch v := value.(type) {
+		case string:
+			if strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v)
+			}
+		case float64:
+			if v == float64(int64(v)) {
+				return strconv.FormatInt(int64(v), 10)
+			}
+			return strconv.FormatFloat(v, 'f', -1, 64)
+		case json.Number:
+			return v.String()
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func stringMap(value any) map[string]string {
+	out := map[string]string{}
+	switch typed := value.(type) {
+	case map[string]any:
+		for k, v := range typed {
+			if key := strings.TrimSpace(k); key != "" {
+				out[key] = fmt.Sprint(v)
+			}
+		}
+	case map[string]string:
+		for k, v := range typed {
+			if key := strings.TrimSpace(k); key != "" {
+				out[key] = strings.TrimSpace(v)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func nscNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "404")
+}
+
+func commandOutputLooksNotFound(result LocalCommandResult) bool {
+	msg := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "404")
 }

--- a/internal/providers/namespaceinstance/client_test.go
+++ b/internal/providers/namespaceinstance/client_test.go
@@ -1,0 +1,130 @@
+package namespaceinstance
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	results []LocalCommandResult
+	errs    []error
+	calls   []LocalCommandRequest
+}
+
+func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	idx := len(r.calls) - 1
+	var result LocalCommandResult
+	if idx < len(r.results) {
+		result = r.results[idx]
+	}
+	var err error
+	if idx < len(r.errs) {
+		err = r.errs[idx]
+	}
+	return result, err
+}
+
+func TestCheckReadinessUsesNonMutatingNSCCommands(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{
+		{},
+		{},
+		{Stdout: `[{"name":"one"},{"name":"two"}]`},
+	}}
+	client, err := newNSCClient(core.Config{NamespaceInstance: core.NamespaceInstanceConfig{
+		Endpoint: "https://namespace.example.test",
+		Keychain: "test-keychain",
+		Region:   "us-west",
+	}}, core.Runtime{Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := client.CheckReadiness(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != "2" {
+		t.Fatalf("count=%q", count)
+	}
+	got := make([][]string, 0, len(runner.calls))
+	for _, call := range runner.calls {
+		if call.Name != "nsc" {
+			t.Fatalf("Name=%q", call.Name)
+		}
+		got = append(got, call.Args)
+		joined := strings.Join(call.Args, " ")
+		for _, mutating := range []string{"create", "destroy", "extend"} {
+			if strings.Contains(joined, mutating) {
+				t.Fatalf("doctor used mutating command %q in %v", mutating, call.Args)
+			}
+		}
+	}
+	want := [][]string{
+		{"--endpoint", "https://namespace.example.test", "--keychain", "test-keychain", "--region", "us-west", "--help"},
+		{"--endpoint", "https://namespace.example.test", "--keychain", "test-keychain", "--region", "us-west", "auth", "check-login"},
+		{"--endpoint", "https://namespace.example.test", "--keychain", "test-keychain", "--region", "us-west", "list", "-o", "json"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("calls=%#v want %#v", got, want)
+	}
+}
+
+func TestCheckReadinessRedactsCommandFailureOutput(t *testing.T) {
+	secret := "workspace-123 instance-456 login-code"
+	runner := &recordingRunner{
+		results: []LocalCommandResult{{}, {ExitCode: 1, Stderr: secret}},
+		errs:    []error{nil, errors.New(secret)},
+	}
+	client, err := newNSCClient(core.Config{}, core.Runtime{Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.CheckReadiness(context.Background())
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked command output: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auth check-login") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestParseNSCListCountShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "empty", in: "", want: 0},
+		{name: "null", in: "null", want: 0},
+		{name: "array", in: `[{},{}]`, want: 2},
+		{name: "instances", in: `{"instances":[{},{}]}`, want: 2},
+		{name: "items", in: `{"items":[{}]}`, want: 1},
+		{name: "results", in: `{"results":[{},{},{}]}`, want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNSCListCount(tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("count=%d want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewClientRequiresRunner(t *testing.T) {
+	_, err := newNSCClient(core.Config{}, core.Runtime{})
+	if err == nil || !strings.Contains(err.Error(), "requires a local command runner") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/providers/namespaceinstance/client_test.go
+++ b/internal/providers/namespaceinstance/client_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,6 +15,81 @@ type recordingRunner struct {
 	results []LocalCommandResult
 	errs    []error
 	calls   []LocalCommandRequest
+}
+
+func TestCreateInstanceBuildsFakeableNSCCommandAndParsesSSH(t *testing.T) {
+	runner := &recordingRunner{results: []LocalCommandResult{
+		{Stdout: `{"id":"inst-synthetic","status":"running","ssh":{"host":"203.0.113.10","user":"root","port":2222},"labels":{"crabbox":"true","provider":"namespace-instance","lease":"cbx_test"}}`},
+	}}
+	client, err := newNSCClient(core.Config{NamespaceInstance: core.NamespaceInstanceConfig{
+		Endpoint: "https://namespace.example.test",
+		Region:   "us-test",
+		Keychain: "kc",
+	}}, core.Runtime{Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	instance, err := client.CreateInstance(context.Background(), createInstanceRequest{
+		MachineType:   "linux-small",
+		Duration:      2 * time.Hour,
+		Ephemeral:     true,
+		PublicKeyPath: "/tmp/key.pub",
+		UniqueTag:     "crabbox-cbx-test",
+		Labels:        map[string]string{"crabbox": "true", "provider": "namespace-instance", "lease": "cbx_test"},
+		Volumes:       []string{"cache:tag:/cache:10Gi"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instance.ID != "inst-synthetic" || instance.SSHHost != "203.0.113.10" || instance.SSHUser != "root" || instance.SSHPort != "2222" {
+		t.Fatalf("instance=%#v", instance)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls=%d", len(runner.calls))
+	}
+	args := runner.calls[0].Args
+	for _, want := range []string{"--endpoint", "https://namespace.example.test", "--region", "us-test", "--keychain", "kc", "create", "--machine_type", "linux-small", "--duration", "2h0m0s", "--ephemeral", "--ssh_key", "/tmp/key.pub", "--unique_tag", "crabbox-cbx-test", "--volume", "cache:tag:/cache:10Gi", "-o", "json"} {
+		if !containsArg(args, want) {
+			t.Fatalf("args missing %q: %#v", want, args)
+		}
+	}
+	if !containsArg(args, "--label") || !containsArg(args, "provider=namespace-instance") {
+		t.Fatalf("label args missing: %#v", args)
+	}
+}
+
+func TestResolveSSHRequiresNormalTarget(t *testing.T) {
+	client := &nscClient{}
+	_, err := client.ResolveSSH(namespaceInstance{ID: "inst-synthetic"}, core.Config{}, "/tmp/key")
+	if err == nil || !strings.Contains(err.Error(), "plan_gap") {
+		t.Fatalf("err=%v", err)
+	}
+	target, err := client.ResolveSSH(namespaceInstance{ID: "inst-synthetic", SSHHost: "203.0.113.10", SSHUser: "ubuntu", SSHPort: "2202"}, core.Config{}, "/tmp/key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Host != "203.0.113.10" || target.User != "ubuntu" || target.Port != "2202" || target.Key != "/tmp/key" {
+		t.Fatalf("target=%#v", target)
+	}
+}
+
+func TestParseNSCInstancesFiltersWrappedShapes(t *testing.T) {
+	instances, err := parseNSCInstances(`{"instances":[{"instance_id":"inst-one","ssh_host":"203.0.113.10"},{"id":"inst-two","ssh":{"endpoint":"198.51.100.20","username":"root","port":22}}]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(instances) != 2 || instances[0].ID != "inst-one" || instances[0].SSHHost != "203.0.113.10" || instances[1].SSHHost != "198.51.100.20" {
+		t.Fatalf("instances=%#v", instances)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {

--- a/internal/providers/namespaceinstance/client_test.go
+++ b/internal/providers/namespaceinstance/client_test.go
@@ -3,6 +3,7 @@ package namespaceinstance
 import (
 	"context"
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -15,6 +16,12 @@ type recordingRunner struct {
 	results []LocalCommandResult
 	errs    []error
 	calls   []LocalCommandRequest
+}
+
+type createErrorArtifactRunner struct {
+	createID          string
+	calls             []LocalCommandRequest
+	sawCreateDeadline bool
 }
 
 func TestCreateInstanceBuildsFakeableNSCCommandAndParsesSSH(t *testing.T) {
@@ -58,6 +65,28 @@ func TestCreateInstanceBuildsFakeableNSCCommandAndParsesSSH(t *testing.T) {
 	}
 }
 
+func TestCreateInstanceReturnsCIDFileIDOnCommandError(t *testing.T) {
+	runner := &createErrorArtifactRunner{createID: "inst-created"}
+	client, err := newNSCClient(core.Config{}, core.Runtime{Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	instance, err := client.CreateInstance(context.Background(), createInstanceRequest{
+		MachineType:   "linux-small",
+		Duration:      time.Hour,
+		PublicKeyPath: "/tmp/key.pub",
+	})
+	if err == nil {
+		t.Fatal("expected create error")
+	}
+	if instance.ID != "inst-created" {
+		t.Fatalf("instance=%#v", instance)
+	}
+	if !runner.sawCreateDeadline {
+		t.Fatal("create did not receive an extended command deadline")
+	}
+}
+
 func TestResolveSSHRequiresNormalTarget(t *testing.T) {
 	client := &nscClient{}
 	_, err := client.ResolveSSH(namespaceInstance{ID: "inst-synthetic"}, core.Config{}, "/tmp/key")
@@ -92,6 +121,15 @@ func containsArg(args []string, want string) bool {
 	return false
 }
 
+func argAfter(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	idx := len(r.calls) - 1
@@ -104,6 +142,22 @@ func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (Local
 		err = r.errs[idx]
 	}
 	return result, err
+}
+
+func (r *createErrorArtifactRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	if !containsArg(req.Args, "create") {
+		return LocalCommandResult{Stdout: "[]"}, nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) > 15*time.Minute {
+		r.sawCreateDeadline = true
+	}
+	if path := argAfter(req.Args, "--cidfile"); path != "" {
+		if err := os.WriteFile(path, []byte(r.createID+"\n"), 0o600); err != nil {
+			return LocalCommandResult{ExitCode: 1}, err
+		}
+	}
+	return LocalCommandResult{ExitCode: 124}, errors.New("nsc create timed out after allocating instance")
 }
 
 func TestCheckReadinessUsesNonMutatingNSCCommands(t *testing.T) {

--- a/internal/providers/namespaceinstance/core.go
+++ b/internal/providers/namespaceinstance/core.go
@@ -58,6 +58,10 @@ func commandTimeout() time.Duration {
 	return 30 * time.Second
 }
 
+func createCommandTimeout() time.Duration {
+	return 20 * time.Minute
+}
+
 var newLeaseID = core.NewLeaseID
 var allocateDirectLeaseSlug = core.AllocateDirectLeaseSlug
 var ensureTestboxKeyForConfig = core.EnsureTestboxKeyForConfig

--- a/internal/providers/namespaceinstance/core.go
+++ b/internal/providers/namespaceinstance/core.go
@@ -3,6 +3,7 @@ package namespaceinstance
 import (
 	"context"
 	"flag"
+	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -27,6 +28,9 @@ type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type LeaseTarget = core.LeaseTarget
 type Server = core.Server
+type SSHTarget = core.SSHTarget
+type CleanupRequest = core.CleanupRequest
+type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName       = "namespace-instance"
@@ -52,4 +56,28 @@ var contextWithTimeout = context.WithTimeout
 
 func commandTimeout() time.Duration {
 	return 30 * time.Second
+}
+
+var newLeaseID = core.NewLeaseID
+var allocateDirectLeaseSlug = core.AllocateDirectLeaseSlug
+var ensureTestboxKeyForConfig = core.EnsureTestboxKeyForConfig
+var providerKeyForLease = core.ProviderKeyForLease
+var sshTargetFromConfig = core.SSHTargetFromConfig
+var waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSH(ctx, target, stderr)
+}
+var bootstrapWaitTimeout = core.BootstrapWaitTimeout
+var claimLeaseTargetForConfig = core.ClaimLeaseTargetForConfig
+var resolveLeaseClaimForProvider = core.ResolveLeaseClaimForProvider
+var resolveLeaseClaimForProviderCloudID = core.ResolveLeaseClaimForProviderCloudID
+var listLeaseClaims = core.ListLeaseClaims
+var removeLeaseClaim = core.RemoveLeaseClaim
+var removeStoredTestboxKey = core.RemoveStoredTestboxKey
+var useStoredTestboxKey = core.UseStoredTestboxKey
+var directLeaseLabels = core.DirectLeaseLabels
+var touchDirectLeaseLabels = core.TouchDirectLeaseLabels
+var shouldCleanupServer = core.ShouldCleanupServer
+
+func leaseLabelTime(t time.Time) string {
+	return core.LeaseLabelTime(t)
 }

--- a/internal/providers/namespaceinstance/core.go
+++ b/internal/providers/namespaceinstance/core.go
@@ -1,0 +1,55 @@
+package namespaceinstance
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type NamespaceInstanceConfig = core.NamespaceInstanceConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type CommandRunner = core.CommandRunner
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type DoctorCheck = core.DoctorCheck
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+
+const (
+	providerName       = "namespace-instance"
+	providerAlias      = "namespace-compute"
+	defaultMachineType = "linux-small"
+	defaultWorkRoot    = "/work/crabbox"
+	targetLinux        = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func normalizeLeaseSlug(value string) string {
+	return core.NormalizeLeaseSlug(value)
+}
+
+var contextWithTimeout = context.WithTimeout
+
+func commandTimeout() time.Duration {
+	return 30 * time.Second
+}

--- a/internal/providers/namespaceinstance/flags.go
+++ b/internal/providers/namespaceinstance/flags.go
@@ -1,0 +1,163 @@
+package namespaceinstance
+
+import (
+	"flag"
+	"path"
+	"strings"
+	"time"
+)
+
+type flagValues struct {
+	MachineType *string
+	Duration    *string
+	Ephemeral   *bool
+	Region      *string
+	Endpoint    *string
+	Keychain    *string
+	WorkRoot    *string
+	Volume      *string
+}
+
+func RegisterNamespaceInstanceProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return flagValues{
+		MachineType: fs.String("namespace-instance-machine-type", defaults.NamespaceInstance.MachineType, "Namespace Instance machine type"),
+		Duration:    fs.String("namespace-instance-duration", durationString(defaults.NamespaceInstance.Duration), "Namespace Instance duration"),
+		Ephemeral:   fs.Bool("namespace-instance-ephemeral", defaults.NamespaceInstance.Ephemeral, "request ephemeral Namespace Instances"),
+		Region:      fs.String("namespace-instance-region", defaults.NamespaceInstance.Region, "Namespace Instance region"),
+		Endpoint:    fs.String("namespace-instance-endpoint", defaults.NamespaceInstance.Endpoint, "Namespace nsc API endpoint"),
+		Keychain:    fs.String("namespace-instance-keychain", defaults.NamespaceInstance.Keychain, "Namespace nsc keychain name"),
+		WorkRoot:    fs.String("namespace-instance-work-root", defaults.NamespaceInstance.WorkRoot, "remote Crabbox work root on Namespace Instances"),
+		Volume:      fs.String("namespace-instance-volume", strings.Join(defaults.NamespaceInstance.Volumes, ","), "comma-separated Namespace Instance volume specs"),
+	}
+}
+
+func ApplyNamespaceInstanceProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "namespace-instance-machine-type") {
+		cfg.NamespaceInstance.MachineType = strings.TrimSpace(*v.MachineType)
+		cfg.ServerType = cfg.NamespaceInstance.MachineType
+		cfg.ServerTypeExplicit = true
+	}
+	if flagWasSet(fs, "namespace-instance-duration") {
+		duration, err := parsePositiveDuration(*v.Duration, "namespace-instance duration")
+		if err != nil {
+			return err
+		}
+		cfg.NamespaceInstance.Duration = duration
+	}
+	if flagWasSet(fs, "namespace-instance-ephemeral") {
+		cfg.NamespaceInstance.Ephemeral = *v.Ephemeral
+	}
+	if flagWasSet(fs, "namespace-instance-region") {
+		cfg.NamespaceInstance.Region = strings.TrimSpace(*v.Region)
+	}
+	if flagWasSet(fs, "namespace-instance-endpoint") {
+		cfg.NamespaceInstance.Endpoint = strings.TrimSpace(*v.Endpoint)
+	}
+	if flagWasSet(fs, "namespace-instance-keychain") {
+		cfg.NamespaceInstance.Keychain = strings.TrimSpace(*v.Keychain)
+	}
+	if flagWasSet(fs, "namespace-instance-work-root") {
+		cfg.NamespaceInstance.WorkRoot = strings.TrimSpace(*v.WorkRoot)
+		cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+	}
+	if flagWasSet(fs, "namespace-instance-volume") {
+		cfg.NamespaceInstance.Volumes = splitVolumeList(*v.Volume)
+	}
+	applyNamespaceInstanceDefaults(cfg)
+	return validateNamespaceInstanceConfig(*cfg)
+}
+
+func applyNamespaceInstanceDefaults(cfg *Config) {
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetLinux
+	}
+	if cfg.NamespaceInstance.WorkRoot == "" {
+		cfg.NamespaceInstance.WorkRoot = defaultWorkRoot
+	}
+	cfg.WorkRoot = cfg.NamespaceInstance.WorkRoot
+	if cfg.NamespaceInstance.Duration == 0 && cfg.TTL > 0 {
+		cfg.NamespaceInstance.Duration = cfg.TTL
+	}
+	if cfg.ServerType == "" || !cfg.ServerTypeExplicit {
+		cfg.ServerType = namespaceInstanceServerTypeForConfig(*cfg)
+	}
+}
+
+func validateNamespaceInstanceConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.TargetOS) != "" && strings.TrimSpace(cfg.TargetOS) != targetLinux {
+		return exit(2, "provider=%s supports target=linux only, got target=%s", providerName, cfg.TargetOS)
+	}
+	if cfg.NamespaceInstance.Duration < 0 {
+		return exit(2, "namespace-instance duration must be positive")
+	}
+	if err := validateWorkRoot(cfg.NamespaceInstance.WorkRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func namespaceInstanceServerTypeForConfig(cfg Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if value := strings.TrimSpace(cfg.NamespaceInstance.MachineType); value != "" {
+		return value
+	}
+	return namespaceInstanceServerTypeForClass(cfg.Class)
+}
+
+func namespaceInstanceServerTypeForClass(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "", "standard", "fast", "large", "beast":
+		return defaultMachineType
+	default:
+		return defaultMachineType
+	}
+}
+
+func parsePositiveDuration(value, field string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, exit(2, "%s must be a positive duration", field)
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil || parsed <= 0 {
+		return 0, exit(2, "%s must be a positive duration", field)
+	}
+	return parsed, nil
+}
+
+func durationString(value time.Duration) string {
+	if value == 0 {
+		return ""
+	}
+	return value.String()
+}
+
+func splitVolumeList(value string) []string {
+	var out []string
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func validateWorkRoot(workRoot string) error {
+	clean := path.Clean(strings.TrimSpace(workRoot))
+	if clean == "" || !strings.HasPrefix(clean, "/") {
+		return exit(2, "namespaceInstance.workRoot %q must resolve to an absolute path", workRoot)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/work", "/workspace", "/workspaces":
+		return exit(2, "namespaceInstance.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+	}
+	return nil
+}

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -1,0 +1,107 @@
+package namespaceinstance
+
+import (
+	"context"
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string { return providerName }
+func (Provider) Aliases() []string {
+	return []string{providerAlias}
+}
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "namespace",
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterNamespaceInstanceProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyNamespaceInstanceProviderFlags(cfg, fs, values)
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	return namespaceInstanceServerTypeForConfig(cfg)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	return namespaceInstanceServerTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) *backend {
+	applyNamespaceInstanceDefaults(&cfg)
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	count, err := client.CheckReadiness(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return DoctorResult{
+		Provider: providerName,
+		Status:   "ok",
+		Message:  "nsc=ready auth=ready list=ready mutation=false",
+		Checks: []DoctorCheck{
+			{Status: "ok", Check: "nsc", Message: "nsc=ready", Details: map[string]string{"mutation": "false"}},
+			{Status: "ok", Check: "auth", Message: "auth=ready", Details: map[string]string{"mutation": "false"}},
+			{Status: "ok", Check: "inventory", Message: "list=ready", Details: map[string]string{"leases": count, "mutation": "false"}},
+		},
+	}, nil
+}
+
+func (b *backend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, exit(2, "provider=%s acquire is deferred to the namespace-instance lifecycle plan", providerName)
+}
+
+func (b *backend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+	return LeaseTarget{LeaseID: req.ID}, exit(2, "provider=%s resolve is deferred to the namespace-instance lifecycle plan", providerName)
+}
+
+func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, exit(2, "provider=%s list is deferred to the namespace-instance lifecycle plan", providerName)
+}
+
+func (b *backend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
+	return exit(2, "provider=%s release is deferred to the namespace-instance lifecycle plan", providerName)
+}
+
+func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	return req.Lease.Server, nil
+}

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -339,20 +339,22 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 }
 
 func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options, All: true})
-	if err != nil {
-		return err
-	}
 	client, err := newNSCClient(b.cfg, b.rt)
 	if err != nil {
 		return err
 	}
+	instances, err := client.ListInstances(ctx, true)
+	if err != nil {
+		return err
+	}
 	now := b.now()
-	for _, server := range servers {
-		if !isOwnedServer(server) {
-			fmt.Fprintf(b.rt.Stderr, "skip server id=%s name=%s reason=not crabbox namespace-instance\n", server.DisplayID(), server.Name)
+	for _, instance := range instances {
+		if !isOwnedInstance(instance) {
+			name := firstNonEmpty(instance.Name, instance.ID)
+			fmt.Fprintf(b.rt.Stderr, "skip server id=%s name=%s reason=not crabbox namespace-instance\n", instance.ID, name)
 			continue
 		}
+		server := serverFromInstance(instance, b.cfg)
 		shouldDelete, reason := shouldCleanupServer(server, now)
 		if !shouldDelete {
 			fmt.Fprintf(b.rt.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -124,6 +124,13 @@ func (b *backend) acquire(ctx context.Context, req AcquireRequest) (lease LeaseT
 		Volumes:       cfg.NamespaceInstance.Volumes,
 	})
 	if err != nil {
+		if strings.TrimSpace(instance.ID) != "" {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			if cleanupErr := client.DestroyInstance(cleanupCtx, instance.ID); cleanupErr != nil && !nscNotFoundError(cleanupErr) {
+				fmt.Fprintf(b.rt.Stderr, "warning: cleanup namespace-instance lease=%s after create failure: %v\n", leaseID, cleanupErr)
+			}
+		}
 		return LeaseTarget{}, err
 	}
 	createdID := instance.ID

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -3,6 +3,9 @@ package namespaceinstance
 import (
 	"context"
 	"flag"
+	"fmt"
+	"strings"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -86,22 +89,446 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	}, nil
 }
 
-func (b *backend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
-	return LeaseTarget{}, exit(2, "provider=%s acquire is deferred to the namespace-instance lifecycle plan", providerName)
+func (b *backend) acquire(ctx context.Context, req AcquireRequest) (lease LeaseTarget, err error) {
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cfg := b.cfg
+	leaseID := newLeaseID()
+	instances, err := client.ListInstances(ctx, true)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := serversFromInstances(instances)
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	keyPath, _, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = providerKeyForLease(leaseID)
+	now := b.now()
+	labels := namespaceLabels(cfg, leaseID, slug, req.Keep, now)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s type=%s keep=%v\n", providerName, leaseID, slug, namespaceInstanceServerTypeForConfig(cfg), req.Keep)
+	instance, err := client.CreateInstance(ctx, createInstanceRequest{
+		MachineType:   namespaceInstanceServerTypeForConfig(cfg),
+		Duration:      namespaceDuration(cfg),
+		Ephemeral:     cfg.NamespaceInstance.Ephemeral,
+		PublicKeyPath: keyPath + ".pub",
+		UniqueTag:     providerKeyForLease(leaseID),
+		Labels:        labels,
+		Volumes:       cfg.NamespaceInstance.Volumes,
+	})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	createdID := instance.ID
+	rollback := true
+	defer func() {
+		if !rollback || strings.TrimSpace(createdID) == "" {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if cleanupErr := client.DestroyInstance(cleanupCtx, createdID); cleanupErr != nil && !nscNotFoundError(cleanupErr) {
+			fmt.Fprintf(b.rt.Stderr, "warning: cleanup namespace-instance lease=%s after acquire failure: %v\n", leaseID, cleanupErr)
+		}
+	}()
+	described, err := client.DescribeInstance(ctx, createdID)
+	if err == nil && described.ID != "" {
+		instance = mergeInstance(instance, described)
+	}
+	instance.Labels = mergeLabels(labels, instance.Labels)
+	server := serverFromInstance(instance, cfg)
+	target, err := client.ResolveSSH(instance, cfg, keyPath)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+		return LeaseTarget{}, err
+	}
+	server.Labels["state"] = "ready"
+	if err := claimLeaseTargetForConfig(leaseID, slug, cfg, server, target, req.Options.IdleTimeout); err != nil {
+		return LeaseTarget{}, err
+	}
+	rollback = false
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *backend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
-	return LeaseTarget{LeaseID: req.ID}, exit(2, "provider=%s resolve is deferred to the namespace-instance lifecycle plan", providerName)
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	return b.acquire(ctx, req)
 }
 
-func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) {
-	return nil, exit(2, "provider=%s list is deferred to the namespace-instance lifecycle plan", providerName)
+func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if claim, ok, err := resolveLeaseClaimForProvider(req.ID, providerName); err != nil {
+		return LeaseTarget{}, err
+	} else if ok {
+		return b.resolveClaim(ctx, client, claim, req)
+	}
+	if claim, ok, err := resolveLeaseClaimForProviderCloudID(req.ID, providerName); err != nil {
+		return LeaseTarget{}, err
+	} else if ok {
+		return b.resolveClaim(ctx, client, claim, req)
+	}
+	instance, err := client.DescribeInstance(ctx, req.ID)
+	if err == nil && instance.ID != "" {
+		if !isOwnedInstance(instance) {
+			return LeaseTarget{}, exit(4, "lease/server not found: %s (instance is not Crabbox-managed)", req.ID)
+		}
+		return b.leaseFromInstance(ctx, client, instance, LeaseClaim{}, req)
+	}
+	instances, listErr := client.ListInstances(ctx, true)
+	if listErr != nil {
+		return LeaseTarget{}, listErr
+	}
+	var matches []namespaceInstance
+	for _, instance := range instances {
+		if !isOwnedInstance(instance) {
+			continue
+		}
+		if instanceMatches(instance, req.ID) {
+			matches = append(matches, instance)
+		}
+	}
+	if len(matches) > 1 {
+		return LeaseTarget{}, exit(2, "ambiguous namespace-instance lease/server alias: %s", req.ID)
+	}
+	if len(matches) == 1 {
+		return b.leaseFromInstance(ctx, client, matches[0], LeaseClaim{}, req)
+	}
+	if err != nil && !nscNotFoundError(err) {
+		return LeaseTarget{}, err
+	}
+	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
 }
 
-func (b *backend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
-	return exit(2, "provider=%s release is deferred to the namespace-instance lifecycle plan", providerName)
+func (b *backend) resolveClaim(ctx context.Context, client *nscClient, claim LeaseClaim, req ResolveRequest) (LeaseTarget, error) {
+	instance := instanceFromClaim(claim)
+	if claim.CloudID != "" {
+		described, err := client.DescribeInstance(ctx, claim.CloudID)
+		if err == nil && described.ID != "" {
+			instance = mergeInstance(instance, described)
+		} else if err != nil && !nscNotFoundError(err) {
+			return LeaseTarget{}, err
+		}
+	}
+	if instance.ID == "" {
+		instance.ID = claim.CloudID
+	}
+	if instance.ID == "" {
+		return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	}
+	return b.leaseFromInstance(ctx, client, instance, claim, req)
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
-	return req.Lease.Server, nil
+func (b *backend) leaseFromInstance(ctx context.Context, client *nscClient, instance namespaceInstance, claim LeaseClaim, req ResolveRequest) (LeaseTarget, error) {
+	server := serverFromInstance(instance, b.cfg)
+	leaseID := firstNonEmpty(instance.Labels["lease"], claim.LeaseID)
+	if leaseID == "" {
+		leaseID = req.ID
+	}
+	target := sshTargetFromConfig(b.cfg, firstNonEmpty(instance.SSHHost, claim.SSHHost))
+	target.Key = b.cfg.SSHKey
+	if leaseID != "" {
+		useStoredTestboxKey(&target, leaseID)
+	}
+	if instance.SSHUser != "" {
+		target.User = instance.SSHUser
+	}
+	if instance.SSHPort != "" {
+		target.Port = instance.SSHPort
+	} else if claim.SSHPort > 0 {
+		target.Port = fmt.Sprint(claim.SSHPort)
+	}
+	if target.User == "" {
+		target.User = "root"
+	}
+	if target.Port == "" {
+		target.Port = "22"
+	}
+	if !req.ReleaseOnly && !req.StatusOnly {
+		resolved, err := client.ResolveSSH(instance, b.cfg, target.Key)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		target = resolved
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	instances, err := client.ListInstances(ctx, req.All)
+	if err != nil {
+		return nil, err
+	}
+	var out []LeaseView
+	for _, instance := range instances {
+		if !req.All && !isOwnedInstance(instance) {
+			continue
+		}
+		out = append(out, serverFromInstance(instance, b.cfg))
+	}
+	return out, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	leaseID := req.Lease.LeaseID
+	if leaseID == "" {
+		leaseID = req.Lease.Server.Labels["lease"]
+	}
+	claim, claimed, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		return err
+	}
+	instanceID := firstNonEmpty(req.Lease.Server.CloudID, claim.CloudID)
+	if instanceID == "" {
+		return exit(2, "namespace-instance release requires a claimed instance id")
+	}
+	if !claimed && !isOwnedServer(req.Lease.Server) {
+		return exit(2, "refusing to release unclaimed namespace-instance server: %s", req.Lease.Server.DisplayID())
+	}
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	if err := client.DestroyInstance(ctx, instanceID); err != nil && !nscNotFoundError(err) {
+		return err
+	}
+	if leaseID != "" {
+		removeLeaseClaim(leaseID)
+		removeStoredTestboxKey(leaseID)
+	}
+	return nil
+}
+
+func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	labels := touchDirectLeaseLabels(server.Labels, b.cfg, req.State, b.now())
+	server.Labels = labels
+	if strings.TrimSpace(server.CloudID) == "" {
+		return server, exit(2, "namespace-instance touch requires an instance id")
+	}
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return server, err
+	}
+	duration := req.IdleTimeout
+	if duration <= 0 {
+		duration = namespaceDuration(b.cfg)
+	}
+	if err := client.ExtendInstance(ctx, server.CloudID, duration); err != nil {
+		return server, err
+	}
+	return server, nil
+}
+
+func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	servers, err := b.List(ctx, ListRequest{Options: req.Options, All: true})
+	if err != nil {
+		return err
+	}
+	client, err := newNSCClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	now := b.now()
+	for _, server := range servers {
+		if !isOwnedServer(server) {
+			fmt.Fprintf(b.rt.Stderr, "skip server id=%s name=%s reason=not crabbox namespace-instance\n", server.DisplayID(), server.Name)
+			continue
+		}
+		shouldDelete, reason := shouldCleanupServer(server, now)
+		if !shouldDelete {
+			fmt.Fprintf(b.rt.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stderr, "delete server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
+		if !req.DryRun {
+			if err := client.DestroyInstance(ctx, server.CloudID); err != nil && !nscNotFoundError(err) {
+				return err
+			}
+			if leaseID := server.Labels["lease"]; leaseID != "" {
+				removeLeaseClaim(leaseID)
+				removeStoredTestboxKey(leaseID)
+			}
+		}
+	}
+	return nil
+}
+
+func (b *backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func namespaceDuration(cfg Config) time.Duration {
+	if cfg.NamespaceInstance.Duration > 0 {
+		return cfg.NamespaceInstance.Duration
+	}
+	if cfg.TTL > 0 {
+		return cfg.TTL
+	}
+	return time.Hour
+}
+
+func namespaceLabels(cfg Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["provider"] = providerName
+	labels["state"] = "provisioning"
+	labels["slug"] = slug
+	labels["machine_type"] = namespaceInstanceServerTypeForConfig(cfg)
+	if cfg.NamespaceInstance.Region != "" {
+		labels["namespace_region"] = cfg.NamespaceInstance.Region
+	}
+	if cfg.NamespaceInstance.Endpoint != "" {
+		labels["namespace_endpoint"] = cfg.NamespaceInstance.Endpoint
+	}
+	return labels
+}
+
+func serverFromInstance(instance namespaceInstance, cfg Config) Server {
+	labels := mergeLabels(instance.Labels, map[string]string{})
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if labels["provider"] == "" {
+		labels["provider"] = providerName
+	}
+	if labels["crabbox"] == "" && labels["lease"] != "" {
+		labels["crabbox"] = "true"
+	}
+	if instance.Region != "" {
+		labels["namespace_region"] = instance.Region
+	}
+	status := normalizeInstanceStatus(instance.Status)
+	if status != "" && labels["state"] == "" {
+		labels["state"] = status
+	}
+	server := Server{
+		CloudID:  instance.ID,
+		Provider: providerName,
+		Name:     firstNonEmpty(instance.Name, labels["slug"], instance.ID),
+		Status:   status,
+		Labels:   labels,
+	}
+	server.ServerType.Name = firstNonEmpty(instance.MachineType, namespaceInstanceServerTypeForConfig(cfg))
+	server.PublicNet.IPv4.IP = instance.SSHHost
+	return server
+}
+
+func serversFromInstances(instances []namespaceInstance) []Server {
+	servers := make([]Server, 0, len(instances))
+	for _, instance := range instances {
+		servers = append(servers, serverFromInstance(instance, Config{}))
+	}
+	return servers
+}
+
+func instanceFromClaim(claim LeaseClaim) namespaceInstance {
+	labels := mergeLabels(claim.Labels, map[string]string{})
+	return namespaceInstance{
+		ID:      claim.CloudID,
+		Name:    firstNonEmpty(labels["slug"], claim.Slug, claim.CloudID),
+		Status:  labels["state"],
+		Labels:  labels,
+		SSHHost: claim.SSHHost,
+		SSHPort: fmt.Sprint(claim.SSHPort),
+	}
+}
+
+func mergeInstance(base, overlay namespaceInstance) namespaceInstance {
+	if overlay.ID != "" {
+		base.ID = overlay.ID
+	}
+	if overlay.Name != "" {
+		base.Name = overlay.Name
+	}
+	if overlay.Status != "" {
+		base.Status = overlay.Status
+	}
+	if overlay.MachineType != "" {
+		base.MachineType = overlay.MachineType
+	}
+	if overlay.Region != "" {
+		base.Region = overlay.Region
+	}
+	if overlay.Deadline != "" {
+		base.Deadline = overlay.Deadline
+	}
+	if overlay.SSHHost != "" {
+		base.SSHHost = overlay.SSHHost
+	}
+	if overlay.SSHUser != "" {
+		base.SSHUser = overlay.SSHUser
+	}
+	if overlay.SSHPort != "" {
+		base.SSHPort = overlay.SSHPort
+	}
+	base.Labels = mergeLabels(base.Labels, overlay.Labels)
+	return base
+}
+
+func mergeLabels(primary, secondary map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range primary {
+		if strings.TrimSpace(k) != "" {
+			out[k] = v
+		}
+	}
+	for k, v := range secondary {
+		if strings.TrimSpace(k) != "" && strings.TrimSpace(v) != "" {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isOwnedInstance(instance namespaceInstance) bool {
+	return instance.Labels != nil && instance.Labels["crabbox"] == "true" && instance.Labels["provider"] == providerName && instance.Labels["lease"] != ""
+}
+
+func isOwnedServer(server Server) bool {
+	return server.Labels != nil && server.Labels["crabbox"] == "true" && server.Labels["provider"] == providerName && server.Labels["lease"] != ""
+}
+
+func instanceMatches(instance namespaceInstance, id string) bool {
+	id = strings.TrimSpace(id)
+	slug := normalizeLeaseSlug(id)
+	return id != "" && (instance.ID == id || instance.Labels["lease"] == id || normalizeLeaseSlug(instance.Labels["slug"]) == slug || normalizeLeaseSlug(instance.Name) == slug)
+}
+
+func normalizeInstanceStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "ready", "running", "active":
+		return "ready"
+	case "pending", "creating", "provisioning", "starting":
+		return "provisioning"
+	case "deleted", "destroyed", "stopped":
+		return "released"
+	case "failed", "error":
+		return "failed"
+	default:
+		return strings.ToLower(strings.TrimSpace(status))
+	}
 }

--- a/internal/providers/namespaceinstance/provider_test.go
+++ b/internal/providers/namespaceinstance/provider_test.go
@@ -1,0 +1,127 @@
+package namespaceinstance
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndAliases(t *testing.T) {
+	provider := Provider{}
+	if provider.Name() != providerName {
+		t.Fatalf("Name=%q", provider.Name())
+	}
+	if aliases := provider.Aliases(); len(aliases) != 1 || aliases[0] != providerAlias {
+		t.Fatalf("Aliases=%v", aliases)
+	}
+	spec := provider.Spec()
+	if spec.Name != providerName || spec.Family != "namespace" || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("spec missing feature %s: %#v", feature, spec.Features)
+		}
+	}
+}
+
+func TestProviderForResolvesCanonicalAndComputeAlias(t *testing.T) {
+	for _, name := range []string{providerName, providerAlias} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", name, err)
+		}
+		if provider.Name() != providerName {
+			t.Fatalf("ProviderFor(%q).Name=%q", name, provider.Name())
+		}
+	}
+}
+
+func TestServerTypeMapping(t *testing.T) {
+	provider := Provider{}
+	if got := provider.ServerTypeForClass("standard"); got != defaultMachineType {
+		t.Fatalf("ServerTypeForClass=%q", got)
+	}
+	if got := provider.ServerTypeForConfig(core.Config{ServerType: "ns/custom", ServerTypeExplicit: true}); got != "ns/custom" {
+		t.Fatalf("explicit ServerTypeForConfig=%q", got)
+	}
+	if got := provider.ServerTypeForConfig(core.Config{NamespaceInstance: core.NamespaceInstanceConfig{MachineType: "linux-large"}}); got != "linux-large" {
+		t.Fatalf("machine type ServerTypeForConfig=%q", got)
+	}
+	if got := provider.ServerTypeForConfig(core.Config{ServerType: "cpx51"}); got != defaultMachineType {
+		t.Fatalf("implicit cross-provider ServerTypeForConfig=%q", got)
+	}
+}
+
+func TestApplyFlagsSetsNamespaceInstanceConfig(t *testing.T) {
+	defaults := core.Config{NamespaceInstance: core.NamespaceInstanceConfig{Ephemeral: true, WorkRoot: defaultWorkRoot}}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := Provider{}.RegisterFlags(fs, defaults)
+	if fs.Lookup("namespace-instance-token") != nil {
+		t.Fatal("namespace-instance token must not be registered as an argv flag")
+	}
+	args := []string{
+		"--namespace-instance-machine-type", "linux-large",
+		"--namespace-instance-duration", "2h",
+		"--namespace-instance-ephemeral=false",
+		"--namespace-instance-region", "us-west",
+		"--namespace-instance-endpoint", "https://namespace.example.test",
+		"--namespace-instance-keychain", "test-keychain",
+		"--namespace-instance-work-root", "/work/crabbox-test",
+		"--namespace-instance-volume", "cache:/cache,tmp:/tmp/cache",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.Config{TTL: 90 * time.Minute}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NamespaceInstance.MachineType != "linux-large" || cfg.ServerType != "linux-large" || !cfg.ServerTypeExplicit {
+		t.Fatalf("machine/server type not applied: cfg=%#v", cfg.NamespaceInstance)
+	}
+	if cfg.NamespaceInstance.Duration != 2*time.Hour || cfg.NamespaceInstance.Ephemeral || cfg.NamespaceInstance.Region != "us-west" || cfg.NamespaceInstance.Endpoint != "https://namespace.example.test" || cfg.NamespaceInstance.Keychain != "test-keychain" || cfg.NamespaceInstance.WorkRoot != "/work/crabbox-test" || cfg.WorkRoot != "/work/crabbox-test" {
+		t.Fatalf("flags not applied: %#v", cfg.NamespaceInstance)
+	}
+	if len(cfg.NamespaceInstance.Volumes) != 2 || cfg.NamespaceInstance.Volumes[1] != "tmp:/tmp/cache" {
+		t.Fatalf("volumes=%#v", cfg.NamespaceInstance.Volumes)
+	}
+}
+
+func TestValidateRejectsUnsupportedTargetAndBroadWorkRoot(t *testing.T) {
+	cfg := core.Config{TargetOS: core.TargetWindows, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: defaultWorkRoot}}
+	err := validateNamespaceInstanceConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "target=windows") {
+		t.Fatalf("target err=%v", err)
+	}
+	cfg = core.Config{TargetOS: core.TargetLinux, NamespaceInstance: core.NamespaceInstanceConfig{WorkRoot: "/work"}}
+	err = validateNamespaceInstanceConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "too broad") {
+		t.Fatalf("work root err=%v", err)
+	}
+}
+
+func TestConfigureReturnsDoctorAndSSHLeaseScaffold(t *testing.T) {
+	gotBackend, err := Provider{}.Configure(core.Config{}, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := gotBackend.(core.SSHLeaseBackend); !ok {
+		t.Fatalf("backend=%T, want SSHLeaseBackend scaffold", gotBackend)
+	}
+	doctor, err := Provider{}.ConfigureDoctor(core.Config{}, core.Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := doctor.(*backend); !ok {
+		t.Fatalf("doctor=%T", doctor)
+	}
+}

--- a/scripts/live-namespace-instance-smoke.test.js
+++ b/scripts/live-namespace-instance-smoke.test.js
@@ -58,7 +58,7 @@ esac
 `;
 }
 
-function lifecycleCrabboxBody({ failAfterWarmup = false } = {}) {
+function lifecycleCrabboxBody({ doctorFailure = false, failAfterWarmup = false } = {}) {
   return `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
@@ -68,6 +68,7 @@ case "$1" in
     ;;
   doctor)
     [[ "$*" == "doctor --provider namespace-instance" ]] || exit 97
+    ${doctorFailure ? "printf 'nsc auth check-login failed\\n' >&2\n    exit 2" : ""}
     printf 'ok provider=namespace-instance\\n'
     ;;
   warmup)
@@ -179,16 +180,10 @@ test("namespace-instance live smoke requires nsc on PATH", () => {
   assert.equal(fs.existsSync(crabboxLog), false);
 });
 
-test("namespace-instance live smoke classifies missing nsc auth", () => {
+test("namespace-instance live smoke uses routed doctor readiness", () => {
   const harness = makeTempHarness(
-    "namespace-instance-auth",
-    lifecycleCrabboxBody(),
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >>"\${NSC_FAKE_LOG:?}"
-printf 'not logged in\\n' >&2
-exit 7
-`,
+    "namespace-instance-doctor-readiness",
+    lifecycleCrabboxBody({ doctorFailure: true }),
   );
   const result = runLiveSmoke(harness, {
     CRABBOX_LIVE: "1",
@@ -197,9 +192,9 @@ exit 7
   });
 
   assert.equal(result.status, 2, result.stdout + result.stderr);
-  assert.match(result.stderr, /requires an authenticated nsc CLI/);
-  assert.equal(fs.existsSync(harness.crabboxLog), false);
-  assert.match(fs.readFileSync(harness.nscLog, "utf8"), /^auth check-login$/m);
+  assert.match(result.stderr, /nsc auth check-login failed/);
+  assert.match(fs.readFileSync(harness.crabboxLog, "utf8"), /^doctor --provider namespace-instance$/m);
+  assert.equal(fs.existsSync(harness.nscLog), false);
 });
 
 test("namespace-instance live smoke dispatches the lifecycle sequence", () => {
@@ -220,7 +215,7 @@ test("namespace-instance live smoke dispatches the lifecycle sequence", () => {
   assert.match(calls, /^run --provider namespace-instance --id namespace-instance-smoke-test --no-sync -- echo crabbox-namespace-instance-ok$/m);
   assert.match(calls, /^list --provider namespace-instance --json$/m);
   assert.match(calls, /^stop --provider namespace-instance namespace-instance-smoke-test$/m);
-  assert.match(fs.readFileSync(harness.nscLog, "utf8"), /^auth check-login$/m);
+  assert.equal(fs.existsSync(harness.nscLog), false);
 });
 
 test("namespace-instance live smoke cleanup trap stops created lease", () => {

--- a/scripts/live-namespace-instance-smoke.test.js
+++ b/scripts/live-namespace-instance-smoke.test.js
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function makeTempHarness(name, crabboxBody, nscBody = defaultNSCBody()) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `crabbox-live-${name}-`));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const fakeNSC = path.join(bin, "nsc");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  const nscLog = path.join(dir, "nsc.log");
+  fs.mkdirSync(bin);
+  writeExecutable(fakeCrabbox, crabboxBody);
+  writeExecutable(fakeNSC, nscBody);
+  return { bin, crabboxLog, dir, fakeCrabbox, fakeNSC, nscLog };
+}
+
+function runLiveSmoke(harness, env = {}) {
+  return spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${harness.bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: harness.fakeCrabbox,
+      CRABBOX_CONFIG: path.join(harness.dir, "missing-crabbox.yaml"),
+      CRABBOX_FAKE_LOG: harness.crabboxLog,
+      CRABBOX_LIVE_COORDINATOR: "0",
+      NSC_FAKE_LOG: harness.nscLog,
+      ...env,
+    },
+    encoding: "utf8",
+  });
+}
+
+function defaultNSCBody() {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${NSC_FAKE_LOG:?}"
+case "$*" in
+  "auth check-login")
+    printf 'logged in\\n'
+    ;;
+  *)
+    printf 'unexpected nsc args: %s\\n' "$*" >&2
+    exit 98
+    ;;
+esac
+`;
+}
+
+function lifecycleCrabboxBody({ failAfterWarmup = false } = {}) {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+case "$1" in
+  config)
+    exit 0
+    ;;
+  doctor)
+    [[ "$*" == "doctor --provider namespace-instance" ]] || exit 97
+    printf 'ok provider=namespace-instance\\n'
+    ;;
+  warmup)
+    printf 'provisioning provider=namespace-instance lease=cbx_123456789abc slug=namespace-instance-smoke-test type=linux-small keep=false\\n'
+    printf 'provisioned lease=cbx_123456789abc slug=namespace-instance-smoke-test state=ready\\n'
+    ;;
+  status)
+    ${failAfterWarmup ? "printf 'status failed after create\\n' >&2\n    exit 42" : "printf 'lease=cbx_123456789abc slug=namespace-instance-smoke-test provider=namespace-instance state=ready ready=true\\n'"}
+    ;;
+  run)
+    printf 'crabbox-namespace-instance-ok\\n'
+    ;;
+  list)
+    printf '[{"id":"cbx_123456789abc","slug":"namespace-instance-smoke-test","provider":"namespace-instance","state":"ready"}]\\n'
+    ;;
+  stop)
+    printf 'stopped %s\\n' "\${*: -1}"
+    ;;
+  admin)
+    printf '[]\\n'
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`;
+}
+
+test("default live smoke does not run namespace-instance", () => {
+  const harness = makeTempHarness("namespace-instance-default", lifecycleCrabboxBody());
+  const env = { ...process.env };
+  delete env.CRABBOX_LIVE_PROVIDERS;
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      PATH: `${harness.bin}${path.delimiter}${env.PATH ?? ""}`,
+      CRABBOX_BIN: harness.fakeCrabbox,
+      CRABBOX_CONFIG: path.join(harness.dir, "missing-crabbox.yaml"),
+      CRABBOX_FAKE_LOG: harness.crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_REPO: repoRoot,
+      NSC_FAKE_LOG: harness.nscLog,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 99, result.stdout + result.stderr);
+  const calls = fs.readFileSync(harness.crabboxLog, "utf8");
+  assert.match(calls, /^warmup --provider aws/m);
+  assert.doesNotMatch(calls, /--provider namespace-instance/);
+  assert.doesNotMatch(calls, /^doctor --provider namespace-instance$/m);
+});
+
+test("namespace-instance live smoke requires CRABBOX_LIVE", () => {
+  const harness = makeTempHarness("namespace-instance-no-live", lifecycleCrabboxBody());
+  const result = runLiveSmoke(harness, {
+    CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+    CRABBOX_LIVE_REPO: repoRoot,
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /set CRABBOX_LIVE=1/);
+  assert.equal(fs.existsSync(harness.crabboxLog), false);
+});
+
+test("namespace-instance live smoke requires explicit repo path", () => {
+  const harness = makeTempHarness("namespace-instance-no-repo", lifecycleCrabboxBody());
+  const result = runLiveSmoke(harness, {
+    CRABBOX_LIVE: "1",
+    CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /requires CRABBOX_LIVE_REPO/);
+  assert.equal(fs.existsSync(harness.crabboxLog), false);
+});
+
+test("namespace-instance live smoke requires nsc on PATH", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-namespace-instance-missing-nsc-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  fs.mkdirSync(bin);
+  writeExecutable(fakeCrabbox, lifecycleCrabboxBody());
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\ncat >/dev/null\n");
+  writeExecutable(path.join(bin, "rg"), "#!/usr/bin/env bash\nexit 0\n");
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      PATH: `${bin}${path.delimiter}/bin${path.delimiter}/usr/bin`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /requires the authenticated Namespace nsc CLI/);
+  assert.equal(fs.existsSync(crabboxLog), false);
+});
+
+test("namespace-instance live smoke classifies missing nsc auth", () => {
+  const harness = makeTempHarness(
+    "namespace-instance-auth",
+    lifecycleCrabboxBody(),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${NSC_FAKE_LOG:?}"
+printf 'not logged in\\n' >&2
+exit 7
+`,
+  );
+  const result = runLiveSmoke(harness, {
+    CRABBOX_LIVE: "1",
+    CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+    CRABBOX_LIVE_REPO: repoRoot,
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /requires an authenticated nsc CLI/);
+  assert.equal(fs.existsSync(harness.crabboxLog), false);
+  assert.match(fs.readFileSync(harness.nscLog, "utf8"), /^auth check-login$/m);
+});
+
+test("namespace-instance live smoke dispatches the lifecycle sequence", () => {
+  const harness = makeTempHarness("namespace-instance-lifecycle", lifecycleCrabboxBody());
+  const result = runLiveSmoke(harness, {
+    CRABBOX_LIVE: "1",
+    CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+    CRABBOX_LIVE_REPO: repoRoot,
+    CRABBOX_LIVE_NAMESPACE_INSTANCE_SLUG: "namespace-instance-smoke-test",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /crabbox-namespace-instance-ok/);
+  const calls = fs.readFileSync(harness.crabboxLog, "utf8");
+  assert.match(calls, /^doctor --provider namespace-instance$/m);
+  assert.match(calls, /^warmup --provider namespace-instance --slug namespace-instance-smoke-test --ttl 15m --idle-timeout 5m --namespace-instance-duration 15m --namespace-instance-machine-type linux-small --timing-json$/m);
+  assert.match(calls, /^status --provider namespace-instance --id namespace-instance-smoke-test --wait --wait-timeout 5m$/m);
+  assert.match(calls, /^run --provider namespace-instance --id namespace-instance-smoke-test --no-sync -- echo crabbox-namespace-instance-ok$/m);
+  assert.match(calls, /^list --provider namespace-instance --json$/m);
+  assert.match(calls, /^stop --provider namespace-instance namespace-instance-smoke-test$/m);
+  assert.match(fs.readFileSync(harness.nscLog, "utf8"), /^auth check-login$/m);
+});
+
+test("namespace-instance live smoke cleanup trap stops created lease", () => {
+  const harness = makeTempHarness("namespace-instance-cleanup", lifecycleCrabboxBody({ failAfterWarmup: true }));
+  const result = runLiveSmoke(harness, {
+    CRABBOX_LIVE: "1",
+    CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+    CRABBOX_LIVE_REPO: repoRoot,
+    CRABBOX_LIVE_NAMESPACE_INSTANCE_SLUG: "namespace-instance-smoke-test",
+  });
+
+  assert.equal(result.status, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /status failed after create/);
+  const calls = fs.readFileSync(harness.crabboxLog, "utf8");
+  assert.match(calls, /^warmup --provider namespace-instance/m);
+  assert.match(calls, /^status --provider namespace-instance --id namespace-instance-smoke-test --wait --wait-timeout 5m$/m);
+  assert.match(calls, /^stop --provider namespace-instance namespace-instance-smoke-test$/m);
+});

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -385,10 +385,6 @@ namespace_instance_smoke() {
     echo "namespace-instance smoke requires the authenticated Namespace nsc CLI on PATH" >&2
     return 2
   fi
-  if ! nsc auth check-login >/dev/null 2>&1; then
-    echo "namespace-instance smoke requires an authenticated nsc CLI; run nsc login" >&2
-    return 2
-  fi
 
   local lease=""
   local slug=""

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -373,6 +373,77 @@ namespace_smoke() {
   run_in_repo "$cb" list --provider namespace-devbox --json | jq 'map({id:.id,slug:.slug,provider:.provider,state:.state})'
 }
 
+namespace_instance_smoke() {
+  need_tool jq
+  need_tool rg
+
+  if [[ -z "${CRABBOX_LIVE_REPO:-}" ]]; then
+    echo "namespace-instance smoke requires CRABBOX_LIVE_REPO to be set explicitly" >&2
+    return 2
+  fi
+  if ! command -v nsc >/dev/null 2>&1; then
+    echo "namespace-instance smoke requires the authenticated Namespace nsc CLI on PATH" >&2
+    return 2
+  fi
+  if ! nsc auth check-login >/dev/null 2>&1; then
+    echo "namespace-instance smoke requires an authenticated nsc CLI; run nsc login" >&2
+    return 2
+  fi
+
+  local lease=""
+  local slug=""
+  cleanup() {
+    trap - RETURN ERR
+    if [[ -n "$lease" ]]; then
+      stop_provider_lease namespace-instance "$lease" "$slug"
+      lease=""
+      slug=""
+    fi
+  }
+  trap cleanup RETURN ERR
+
+  run_in_repo "$cb" doctor --provider namespace-instance
+
+  local smoke_slug="${CRABBOX_LIVE_NAMESPACE_INSTANCE_SLUG:-namespace-instance-smoke-$$}"
+  local ttl="${CRABBOX_LIVE_NAMESPACE_INSTANCE_TTL:-15m}"
+  local idle="${CRABBOX_LIVE_NAMESPACE_INSTANCE_IDLE_TIMEOUT:-5m}"
+  local duration="${CRABBOX_LIVE_NAMESPACE_INSTANCE_DURATION:-$ttl}"
+  local machine_type="${CRABBOX_LIVE_NAMESPACE_INSTANCE_MACHINE_TYPE:-linux-small}"
+  local out
+  capture_run out run_in_repo "$cb" warmup \
+    --provider namespace-instance \
+    --slug "$smoke_slug" \
+    --ttl "$ttl" \
+    --idle-timeout "$idle" \
+    --namespace-instance-duration "$duration" \
+    --namespace-instance-machine-type "$machine_type" \
+    --timing-json
+  printf '%s\n' "$out"
+  lease="$(printf '%s\n' "$out" | extract_lease)"
+  slug="$(printf '%s\n' "$out" | extract_slug)"
+  test -n "$lease"
+  test -n "$slug"
+
+  local step_status=0
+  run_in_repo "$cb" status --provider namespace-instance --id "$slug" --wait --wait-timeout "${CRABBOX_LIVE_NAMESPACE_INSTANCE_WAIT_TIMEOUT:-5m}" || step_status=$?
+  if [[ "$step_status" -ne 0 ]]; then
+    cleanup
+    return "$step_status"
+  fi
+  run_in_repo "$cb" run --provider namespace-instance --id "$slug" --no-sync -- echo crabbox-namespace-instance-ok || step_status=$?
+  if [[ "$step_status" -ne 0 ]]; then
+    cleanup
+    return "$step_status"
+  fi
+  run_in_repo "$cb" list --provider namespace-instance --json | jq 'map({id:(.id // .CloudID),slug:(.slug // .labels.slug),provider:(.provider // .Provider // .labels.provider),state:(.state // .labels.state // .status)})' || step_status=$?
+  if [[ "$step_status" -ne 0 ]]; then
+    cleanup
+    return "$step_status"
+  fi
+  stop_provider_lease namespace-instance "$lease" "$slug"
+  lease=""
+}
+
 semaphore_smoke() {
   need_tool jq
   need_tool rg
@@ -912,6 +983,10 @@ fi
 
 if has_provider namespace-devbox || has_provider namespace; then
   namespace_smoke
+fi
+
+if has_provider namespace-instance || has_provider namespace-compute; then
+  namespace_instance_smoke
 fi
 
 if has_provider semaphore; then


### PR DESCRIPTION
Closes #296

## Summary

- Add a new built-in `namespace-instance` provider, with `namespace-compute` as its alias, without changing the existing `namespace-devbox` provider or the `namespace` alias.
- Implement Namespace Compute Instance lifecycle support through `nsc`: doctor/readiness checks, create/list/describe/destroy/extend, acquire/resolve/list/release/touch/cleanup, local lease claims, and per-lease SSH keys.
- Add docs, provider matrix metadata, command docs, setup guidance, and an opt-in Namespace Instance live-smoke harness.
- Harden review findings around cleanup ownership, create-error rollback, configured work-root validation, routed smoke readiness, and repo-local endpoint trust boundaries.

## Verification

- `gofmt -w $(git ls-files '*.go')`
- `go test ./internal/providers/namespaceinstance ./internal/providers/all ./internal/cli ./cmd/crabbox`
- `go test -race ./internal/providers/namespaceinstance ./internal/providers/all ./internal/cli`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `bin/crabbox providers --json`
- `bin/crabbox doctor --provider namespace-instance --json`
- `node --test scripts/live-smoke.test.js`
- `node --test scripts/live-namespace-instance-smoke.test.js`
- `node scripts/check-docs-links.mjs`
- `node scripts/check-command-docs.mjs`
- `node scripts/check-provider-matrix.mjs`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- `~/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Notes

- The live Namespace lifecycle smoke remains opt-in through `CRABBOX_LIVE=1` and `CRABBOX_LIVE_PROVIDERS=namespace-instance`.
- The non-mutating local doctor check passed with `nsc` available and authenticated, and reported zero active Namespace Instance leases.
