### PR TITLE
fix: keep Tailscale auth keys off argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Fixed managed Linux Tailscale bootstrap to deliver auth keys through stdin instead of exposing them in `tailscale up` process arguments.
 - Fixed trusted reverse-proxy identity deployments to support a secret-bound assertion when direct coordinator access cannot be network-isolated.
 - Fixed the portal and connected WebVNC desktops to default to the current system appearance by migrating away from legacy two-state browser theme preferences.
 - Fixed Cloudflare container runs to fail when streamed stdout or stderr cannot be written instead of silently reporting success after output loss.

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -127,7 +127,8 @@ tailscale_exit_node_allow_lan_access=true|false
 
 Brokered leases receive a one-shot auth key minted by the Worker via Tailscale
 OAuth. Direct-provider leases use a key read from the environment variable named
-by `--tailscale-auth-key-env`. The auth key is never stored on the runner.
+by `--tailscale-auth-key-env`. Bootstrap pipes the key to `tailscale up` through
+stdin, so it is neither placed in process arguments nor stored on the runner.
 
 When the metadata says the lease is on the tailnet but the client cannot reach
 it, the usual causes are:

--- a/docs/features/runner-bootstrap.md
+++ b/docs/features/runner-bootstrap.md
@@ -103,8 +103,9 @@ metadata under `/var/lib/crabbox` (such as `tailscale-ipv4`, `tailscale-hostname
 and exit-node details), and extends `crabbox-ready` with a bounded check that a
 `100.x` address has appeared.
 
-The auth key is not persisted after `tailscale up`. Brokered leases receive a
-one-off key minted by the coordinator; direct-provider leases read it from
+The auth key is piped to `tailscale up` through stdin and is not persisted or
+placed in process arguments. Brokered leases receive a one-off key minted by
+the coordinator; direct-provider leases read it from
 `CRABBOX_TAILSCALE_AUTH_KEY`. Set `TS_CONTROL_URL` on the operator shell to
 register the box against a self-hosted control plane (Headscale and similar)
 instead of the default Tailscale control plane.

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1482,7 +1482,7 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
 	sshUserChown := shellQuote(sshUser + ":" + sshUser)
 	tags := strings.Join(cfg.Tailscale.Tags, ",")
 	tailscaleUpArgs := []string{
-		"--auth-key=\"$TS_AUTHKEY\"",
+		"--auth-key=file:/dev/stdin",
 		"--hostname=" + shellQuote(hostname),
 		"--advertise-tags=" + shellQuote(tags),
 	}
@@ -1512,7 +1512,7 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
     install -d -m 0750 -o ` + sshUserOwner + ` -g ` + sshUserGroup + ` /var/lib/crabbox
     set +x
     ` + loginServerExport + `TS_AUTHKEY=` + shellQuote(authKey) + `
-    tailscale up ` + strings.Join(tailscaleUpArgs, " ") + " " + loginServerFlag + `
+    printf '%s' "$TS_AUTHKEY" | tailscale up ` + strings.Join(tailscaleUpArgs, " ") + " " + loginServerFlag + `
     unset TS_AUTHKEY
     set -x
     ts_ip=""

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -374,7 +374,7 @@ func TestCloudInitTailscaleProfile(t *testing.T) {
 	for _, want := range []string{
 		"https://tailscale.com/install.sh",
 		"install -d -m 0750 -o 'runner' -g 'runner' /var/lib/crabbox",
-		"tailscale up --auth-key=\"$TS_AUTHKEY\" --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",
+		"printf '%s' \"$TS_AUTHKEY\" | tailscale up --auth-key=file:/dev/stdin --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",
 		"printf '%s\\n' 'crabbox-blue-lobster' > /var/lib/crabbox/tailscale-hostname",
 		"printf '%s\\n' 'mac-studio.tailnet.ts.net' > /var/lib/crabbox/tailscale-exit-node",
 		"printf '%s\\n' 'true' > /var/lib/crabbox/tailscale-exit-node-allow-lan-access",
@@ -385,6 +385,9 @@ func TestCloudInitTailscaleProfile(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("cloudInit(tailscale) missing %q", want)
 		}
+	}
+	if strings.Contains(got, `--auth-key="$TS_AUTHKEY"`) {
+		t.Fatal("cloudInit(tailscale) must not expose the auth key through process argv")
 	}
 	if strings.Contains(cloudInit(baseConfig(), "ssh-ed25519 test"), "tailscale up") {
 		t.Fatal("cloudInit should not install Tailscale by default")
@@ -430,7 +433,7 @@ func TestCloudInitTailscaleDefaultsAndMissingAuthKey(t *testing.T) {
 	got := cloudInit(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
 		"install -d -m 0750 -o 'crabbox' -g 'crabbox' /var/lib/crabbox",
-		"tailscale up --auth-key=\"$TS_AUTHKEY\" --hostname='crabbox-lease'",
+		"printf '%s' \"$TS_AUTHKEY\" | tailscale up --auth-key=file:/dev/stdin --hostname='crabbox-lease'",
 		"printf '%s\\n' 'crabbox-lease' > /var/lib/crabbox/tailscale-hostname",
 	} {
 		if !strings.Contains(got, want) {

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -1423,7 +1423,7 @@ function tailscaleBootstrap(config: LeaseConfig): string {
   }
   const sshUser = config.sshUser.trim() || "crabbox";
   const upArgs = [
-    `--auth-key="$TS_AUTHKEY"`,
+    "--auth-key=file:/dev/stdin",
     `--hostname=${shellQuote(config.tailscaleHostname)}`,
     `--advertise-tags=${shellQuote(config.tailscaleTags.join(","))}`,
   ];
@@ -1438,7 +1438,7 @@ function tailscaleBootstrap(config: LeaseConfig): string {
     install -d -m 0750 -o ${shellQuote(sshUser)} -g ${shellQuote(sshUser)} /var/lib/crabbox
     set +x
     TS_AUTHKEY=${shellQuote(config.tailscaleAuthKey)}
-    tailscale up ${upArgs.join(" ")}
+    printf '%s' "$TS_AUTHKEY" | tailscale up ${upArgs.join(" ")}
     unset TS_AUTHKEY
     set -x
     ts_ip=""

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -367,8 +367,9 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("https://tailscale.com/install.sh");
     expect(got).toContain("install -d -m 0750 -o 'runner' -g 'runner' /var/lib/crabbox");
     expect(got).toContain(
-      "tailscale up --auth-key=\"$TS_AUTHKEY\" --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",
+      "printf '%s' \"$TS_AUTHKEY\" | tailscale up --auth-key=file:/dev/stdin --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",
     );
+    expect(got).not.toContain('--auth-key="$TS_AUTHKEY"');
     expect(got).toContain(
       "printf '%s\\n' 'crabbox-blue-lobster' > /var/lib/crabbox/tailscale-hostname",
     );


### PR DESCRIPTION
## Summary

- pipe Tailscale auth keys to `tailscale up --auth-key=file:/dev/stdin` in both Go and Worker bootstrap generators
- preserve hostname, tag, exit-node, LAN-access, and direct-provider login-server arguments
- add regression coverage and document stdin delivery

Closes https://github.com/openclaw/crabbox/issues/306

## Verification

- `go test ./internal/cli -run 'TestCloudInitTailscale'`
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `scripts/check-docs.sh`
- provider matrix check
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, confidence 0.98)

## Live proof

Built and exercised commit `465ed7176627e075bf0ea3e89b50ee54f14a3024` on direct Azure lease `cbx_62666e988d03` (`Standard_D2s_v7`). A one-use ephemeral Tailscale auth key was forwarded as a redacted environment value and consumed by:

```sh
printf '%s' "$CRABBOX_TAILSCALE_AUTH_KEY" | sudo tailscale up --auth-key=file:/dev/stdin --hostname=tailscale-argv-306-live
```

The lease reported `TAILSCALE_STDIN_AUTH_LIVE_OK ip=100.68.248.16`; the local Mac received three `tailscale ping` pongs from that node via DERP. The auth key was invalidated after its single use, and the VM, NIC, public IP, and OS disk were deleted.

A production brokered attempt reached the coordinator but stopped before bootstrap because its current Tailscale OAuth credential returned HTTP 401 `API token invalid`. Worker bootstrap generation is covered by the Worker regression test; no brokered-bootstrap success is claimed from that credential state.
