### PR TITLE
fix: explain Tailscale tag ownership failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Fixed brokered Tailscale tag-ownership failures to return actionable exact-match and `tagOwners` guidance while preserving the raw API error.
 - Fixed managed Linux Tailscale bootstrap to deliver auth keys through stdin instead of exposing them in `tailscale up` process arguments.
 - Fixed trusted reverse-proxy identity deployments to support a secret-bound assertion when direct coordinator access cannot be network-isolated.
 - Fixed the portal and connected WebVNC desktops to default to the current system appearance by migrating away from legacy two-state browser theme preferences.

--- a/docs/features/tailscale.md
+++ b/docs/features/tailscale.md
@@ -139,6 +139,36 @@ CRABBOX_TAILSCALE_TAGS       default/allowed comma-separated tags (default tag:c
 CRABBOX_TAILSCALE_ENABLED    set 0 to force-disable, 1 to force-enable
 ```
 
+The OAuth client's tags and each requested lease tag must also satisfy Tailscale's
+ownership rules:
+
+- **Single tag:** give the OAuth client `tag:crabbox` and set
+  `CRABBOX_TAILSCALE_TAGS=tag:crabbox`. The tag sets match exactly.
+- **Multi-tag exact match:** an OAuth client with `tag:ci,tag:staging` can mint a key
+  requesting both tags together without extra ownership rules.
+- **Multi-tag subsets:** requesting only `tag:ci` from that two-tag client requires
+  `tag:ci` to own itself in `tagOwners`; do the same for every subset tag.
+- **Deployment-owner pattern:** preferably give the OAuth client one narrow owner tag,
+  such as `tag:crabbox-deployer`, and make that tag an owner of each workload tag that
+  Crabbox may request.
+
+Example deployment-owner policy:
+
+```json
+{
+  "tagOwners": {
+    "tag:crabbox-deployer": ["autogroup:admin"],
+    "tag:ci": ["tag:crabbox-deployer"],
+    "tag:staging": ["tag:crabbox-deployer"]
+  }
+}
+```
+
+Then assign only `tag:crabbox-deployer` to the OAuth client and set
+`CRABBOX_TAILSCALE_TAGS=tag:ci,tag:staging`. This keeps the client least-privilege
+without requiring it to carry every workload tag. Do not broaden the OAuth client to
+unrelated tags just to resolve an ownership error.
+
 Flow:
 
 1. The CLI sends the requested Tailscale settings (enabled, tags, hostname, optional
@@ -157,6 +187,10 @@ Flow:
 The auth key is never stored in lease records, provider labels, run logs, or local
 config. The short-lived key can still appear in user-data at the provider, so the
 Worker only mints one-off ephemeral keys — never long-lived reusable keys.
+
+If Tailscale rejects a requested subset or unowned tag, the coordinator returns
+`invalid_tailscale_tags` with exact-match/`tagOwners` guidance and preserves the raw
+Tailscale HTTP status and response body for diagnosis.
 
 ## SSH and VNC
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -250,8 +250,14 @@ CRABBOX_TAILSCALE_ENABLED=1
 CRABBOX_TAILSCALE_CLIENT_ID
 CRABBOX_TAILSCALE_CLIENT_SECRET
 CRABBOX_TAILSCALE_TAILNET=-              # or an explicit tailnet/org
-CRABBOX_TAILSCALE_TAGS=tag:crabbox      # must match the OAuth client's allowed tags
+CRABBOX_TAILSCALE_TAGS=tag:crabbox      # requested-tag allowlist/default
 ```
+
+For one tag, assign the same tag to the OAuth client. For multiple tags, either
+request the OAuth client's complete tag set or configure `tagOwners` so an OAuth
+client tag owns every subset tag Crabbox may request. Prefer one dedicated
+deployment-owner tag over broad OAuth permissions. Tailscale rejects unowned subset
+requests even when every tag is present in `CRABBOX_TAILSCALE_TAGS`.
 
 Verify end to end with `crabbox warmup --tailscale --network tailscale`. See
 [Tailscale](features/tailscale.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -251,6 +251,11 @@ tailscale ping <tailscale-fqdn-or-100.x-address>
 - Keep `CRABBOX_TAILSCALE_ENABLED` unset or `1`; set it to `0` only to disable
   brokered Tailscale intentionally.
 - Ensure requested tags are in the coordinator's `CRABBOX_TAILSCALE_TAGS` allowlist.
+- If `invalid_tailscale_tags` includes Tailscale's raw `requested tags ... are
+  invalid or not permitted` response, make the requested set exactly match the
+  OAuth client's tags or update `tagOwners` so an OAuth client tag owns every
+  requested tag. Multi-tag OAuth clients need explicit self-ownership for subset
+  requests; a dedicated deployment-owner tag is usually simpler and narrower.
 - Ensure the local client is joined to the same tailnet and that ACLs allow SSH
   to the tagged node.
 - For exit nodes, ensure the node is approved and that tailnet grants or ACLs

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -55,6 +55,7 @@ import {
   renderTailscaleHostname,
   tailscaleAllowed,
   tailscaleDefaultTags,
+  tailscaleTagOwnershipErrorMessage,
   validateTailscaleTags,
 } from "./tailscale";
 import type {
@@ -1774,6 +1775,13 @@ export class FleetCoordinator {
       const message = errorMessage(error);
       if (message.includes("tags not allowed") || message.includes("requires at least one")) {
         return json({ error: "invalid_tailscale_tags", message }, { status: 400 });
+      }
+      const tagOwnershipMessage = tailscaleTagOwnershipErrorMessage(error);
+      if (tagOwnershipMessage) {
+        return json(
+          { error: "invalid_tailscale_tags", message: tagOwnershipMessage },
+          { status: 400 },
+        );
       }
       return json({ error: "tailscale_unavailable", message }, { status: 502 });
     }

--- a/worker/src/tailscale.ts
+++ b/worker/src/tailscale.ts
@@ -6,6 +6,19 @@ export interface TailscaleKeyRequest {
   description: string;
 }
 
+type TailscaleAPIOperation = "oauth token" | "create auth key";
+
+class TailscaleAPIError extends Error {
+  constructor(
+    readonly operation: TailscaleAPIOperation,
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(`tailscale ${operation}: http ${status}: ${responseBody}`);
+    this.name = "TailscaleAPIError";
+  }
+}
+
 export function tailscaleAllowed(env: Env): boolean {
   if (env.CRABBOX_TAILSCALE_ENABLED === "0") {
     return false;
@@ -89,7 +102,7 @@ export async function createTailscaleAuthKey(
   );
   const text = await response.text();
   if (!response.ok) {
-    throw new Error(`tailscale create auth key: http ${response.status}: ${trimBody(text)}`);
+    throw tailscaleAPIError("create auth key", response.status, text);
   }
   const data = JSON.parse(text) as { key?: string };
   if (!data.key) {
@@ -115,13 +128,47 @@ async function tailscaleOAuthToken(
   });
   const text = await response.text();
   if (!response.ok) {
-    throw new Error(`tailscale oauth token: http ${response.status}: ${trimBody(text)}`);
+    throw tailscaleAPIError("oauth token", response.status, text);
   }
   const data = JSON.parse(text) as { access_token?: string };
   if (!data.access_token) {
     throw new Error("tailscale oauth token returned no access token");
   }
   return data.access_token;
+}
+
+export function tailscaleTagOwnershipErrorMessage(error: unknown): string | undefined {
+  if (!(error instanceof TailscaleAPIError) || !isTailscaleTagOwnershipError(error)) {
+    return undefined;
+  }
+  return [
+    "Tailscale rejected the requested tags.",
+    "The requested tag set must exactly match the OAuth client's tags, or every requested tag must be owned by one of the OAuth client tags in tagOwners.",
+    "For multi-tag allowlists, configure self-ownership for subset requests or use a dedicated deployment-owner tag.",
+    `Raw Tailscale error: ${error.message}`,
+  ].join(" ");
+}
+
+function tailscaleAPIError(
+  operation: TailscaleAPIOperation,
+  status: number,
+  responseBody: string,
+): TailscaleAPIError {
+  return new TailscaleAPIError(operation, status, trimBody(responseBody));
+}
+
+function isTailscaleTagOwnershipError(error: TailscaleAPIError): boolean {
+  if (error.status !== 400 && error.status !== 403) {
+    return false;
+  }
+  const body = error.responseBody.toLowerCase();
+  return (
+    (body.includes("requested tags") &&
+      (body.includes("invalid or not permitted") ||
+        body.includes("invalid or not allowed") ||
+        body.includes("not owned"))) ||
+    body.includes("tailnet-owned auth key must have tags set")
+  );
 }
 
 function normalizeTags(values: string[]): string[] {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3156,6 +3156,46 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
   });
 
+  it("translates brokered Tailscale tag ownership denials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: "requested tags [tag:ci] are invalid or not permitted" }, 400),
+        ),
+    );
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      {
+        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        CRABBOX_TAILSCALE_TAGS: "tag:crabbox,tag:ci",
+      },
+    );
+    const create = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "hetzner",
+          tailscale: true,
+          tailscaleTags: ["tag:ci"],
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+    expect(create.status).toBe(400);
+    const body = (await create.json()) as { error: string; message: string };
+    expect(body).toMatchObject({
+      error: "invalid_tailscale_tags",
+      message: expect.stringContaining("must exactly match the OAuth client's tags"),
+    });
+    expect(body.message).toContain("requested tags [tag:ci] are invalid or not permitted");
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
+  });
+
   it("reports brokered Tailscale disabled when OAuth secrets are absent", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, { hetzner: fakeProvider() });

--- a/worker/test/tailscale.test.ts
+++ b/worker/test/tailscale.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { renderTailscaleHostname } from "../src/tailscale";
+import {
+  createTailscaleAuthKey,
+  renderTailscaleHostname,
+  tailscaleTagOwnershipErrorMessage,
+} from "../src/tailscale";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("tailscale hostnames", () => {
   it("renders DNS labels from templates", () => {
@@ -18,5 +26,93 @@ describe("tailscale hostnames", () => {
     expect(renderTailscaleHostname("!!!", "cbx_abcdef123456", "", "aws")).toBe(
       "crabbox-cbx-abcdef123456",
     );
+  });
+});
+
+describe("tailscale tag ownership errors", () => {
+  it.each([
+    {
+      name: "OAuth token",
+      responses: [
+        new Response(
+          JSON.stringify({
+            message: "requested tags [tag:ci] are invalid or not permitted",
+          }),
+          { status: 400 },
+        ),
+      ],
+    },
+    {
+      name: "auth key",
+      responses: [
+        new Response(JSON.stringify({ access_token: "oauth-token" })),
+        new Response(
+          JSON.stringify({
+            message: "requested tags [tag:ci] are invalid or not permitted",
+          }),
+          { status: 400 },
+        ),
+      ],
+    },
+  ])("adds actionable guidance for $name tag denials", async ({ responses }) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift()!),
+    );
+
+    let caught: unknown;
+    try {
+      await createTailscaleAuthKey(
+        {
+          CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+          CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        },
+        {
+          hostname: "crabbox-ci",
+          tags: ["tag:ci"],
+          description: "test key",
+        },
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    const message = tailscaleTagOwnershipErrorMessage(caught);
+    expect(message).toContain("must exactly match the OAuth client's tags");
+    expect(message).toContain("dedicated deployment-owner tag");
+    expect(message).toContain("Raw Tailscale error: tailscale");
+    expect(message).toContain("requested tags [tag:ci] are invalid or not permitted");
+  });
+
+  it("does not classify unrelated OAuth failures as tag ownership errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ message: "API token invalid" }), { status: 401 }),
+        ),
+    );
+
+    let caught: unknown;
+    try {
+      await createTailscaleAuthKey(
+        {
+          CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+          CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+        },
+        {
+          hostname: "crabbox-ci",
+          tags: ["tag:ci"],
+          description: "test key",
+        },
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(tailscaleTagOwnershipErrorMessage(caught)).toBeUndefined();
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('http 401: {"message":"API token invalid"}');
   });
 });


### PR DESCRIPTION
## Summary

- classify Tailscale's known remote tag-ownership denial at both OAuth-token and auth-key endpoints
- return `invalid_tailscale_tags` with exact-match, self-ownership, and deployment-owner guidance while preserving the raw HTTP status/body
- keep unrelated OAuth failures, including HTTP 401 `API token invalid`, on the existing `tailscale_unavailable` path
- document single-tag, multi-tag exact-match, subset, and least-privilege deployment-owner configurations without adding a new environment variable

Closes https://github.com/openclaw/crabbox/issues/309

## Verification

- `npm test --prefix worker -- tailscale.test.ts fleet.test.ts` (177 tests)
- `npm test --prefix worker` (18 files, 418 tests)
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- `node scripts/check-docs-links.mjs`
- `scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean, confidence 0.96)

## Reproduction proof

The fleet regression requests `tag:ci`, which is inside the coordinator allowlist, then stubs Tailscale's documented/API-observed HTTP 400 response:

```text
requested tags [tag:ci] are invalid or not permitted
```

The response is now HTTP 400 `invalid_tailscale_tags`, includes actionable `tagOwners` guidance, and retains the raw Tailscale error. Separate unit coverage exercises the denial from both Tailscale endpoints and confirms an unrelated HTTP 401 remains unclassified.

### Live behavior proof

On June 13, 2026, a disposable Tailscale OAuth credential was created with auth-key write scope restricted to `tag:crabbox`. A local exact-head `FleetDurableObject` request then used the real Tailscale API while:

- the coordinator allowlist contained `tag:crabbox,tag:ci`;
- the brokered lease requested `tag:ci`;
- the disposable OAuth credential did not own `tag:ci`.

Redacted result:

```json
{"status":400,"error":"invalid_tailscale_tags","exactMatchGuidance":true,"rawTailscaleErrorPreserved":true,"upstreamDenialPreserved":true,"leaseStored":false}
```

The run stopped before provider provisioning, created no lease record or cloud resource, and the disposable OAuth credential was revoked immediately afterward.

Tailscale references:

- https://tailscale.com/docs/features/tags#apply-a-tag-from-another-tag
- https://tailscale.com/docs/features/oauth-clients#generating-long-lived-auth-keys
