### PR TITLE
feat: add workspace runtime adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added an idempotent workspace adapter over coordinator leases, with durable owner-scoped lifecycle mapping and truthful capability negotiation for external control planes.
 - Added a generated provider decision matrix with checked metadata for execution model, access, substrate, GPU fit, lifecycle, cleanup, and provider caveats; docs validation now fails on provider drift. Thanks @coygeek.
 - Added confirmed lifecycle actions to portal lease rows, with provider shutdown for coordinator-managed boxes and explicitly metadata-only deregistration for client-managed boxes.
 - Added `provider: superserve` for delegated Linux sandbox runs through the Superserve control and data planes, including archive sync, retained leases, ownership-guarded lifecycle operations, and credentialed live smoke coverage. Thanks @coygeek.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -237,7 +237,8 @@ CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE optional; set 1 to release stale pending EC2 
 
 Workspace leases currently use their hard TTL for provider expiry because the
 adapter does not yet receive a trustworthy activity signal. Workspace TTLs must
-be at least 1,200 seconds so the crash-recovery claim expires before hard TTL.
+be at least 1,800 seconds so a durable claim and ambiguity-recovery window both
+fit before hard TTL.
 
 ### Artifact backend
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -198,6 +198,9 @@ CRABBOX_HOST_ID                    optional; pins a brokered host such as an EC2
 CRABBOX_AWS_MAC_HOST_ID            optional legacy AWS alias for CRABBOX_HOST_ID
 CRABBOX_SHARED_OWNER              optional fixed owner identity for shared-token automation
 CRABBOX_ADMIN_TOKEN               required for admin routes and image promotion
+CRABBOX_WORKSPACE_SSH_PUBLIC_KEY  required for /v1/workspaces lease provisioning
+CRABBOX_WORKSPACE_PROVIDER        optional workspace provider; currently hetzner only
+CRABBOX_WORKSPACE_CLASS           optional workspace machine class; default standard
 CRABBOX_GITHUB_CLIENT_ID          required for browser login
 CRABBOX_GITHUB_CLIENT_SECRET      required for browser login
 CRABBOX_SESSION_SECRET            required for browser login
@@ -231,6 +234,9 @@ CRABBOX_AWS_ORPHAN_SWEEP_INTERVAL_SECONDS optional; default 3600
 CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS    optional; default 900
 CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE optional; set 1 to release stale pending EC2 Mac hosts during orphan sweep
 ```
+
+Workspace leases currently use their hard TTL for provider expiry because the
+adapter does not yet receive a trustworthy activity signal.
 
 ### Artifact backend
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -236,7 +236,8 @@ CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE optional; set 1 to release stale pending EC2 
 ```
 
 Workspace leases currently use their hard TTL for provider expiry because the
-adapter does not yet receive a trustworthy activity signal.
+adapter does not yet receive a trustworthy activity signal. Workspace TTLs must
+be at least 1,200 seconds so the crash-recovery claim expires before hard TTL.
 
 ### Artifact backend
 

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -17,6 +17,9 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (method === "POST" && path.join("/") === "v1/leases") {
     return "direct";
   }
+  if (path[0] === "v1" && path[1] === "workspaces") {
+    return "direct";
+  }
   if (method === "POST" && path.join("/") === "v1/internal/scheduled") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1,5 +1,5 @@
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
-import { isAdminRequest } from "./auth";
+import { isAdminRequest, sha256Hex } from "./auth";
 import {
   EC2SpotClient,
   awsLaunchCandidates,
@@ -26,7 +26,11 @@ import {
   type CoordinatorRuntime,
 } from "./coordinator-runtime";
 import { GCPClient } from "./gcp";
-import { HetznerClient } from "./hetzner";
+import {
+  HetznerClient,
+  hetznerProvisioningFailureMayHaveResource,
+  hetznerProvisioningFailureRetryable,
+} from "./hetzner";
 import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
 import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth";
 import { defaultOSImage, normalizeOSImage } from "./os-image";
@@ -129,6 +133,13 @@ const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
 const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
 const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
+const workspaceReconcileIntervalMs = 10_000;
+const workspaceReconcileMaxIntervalMs = 5 * 60_000;
+const workspaceProvisionClaimMs = 20 * 60_000;
+const workspaceProvisionRecoveryGraceMs = 15 * 60_000;
+const workspaceProviderKeyPrefix = "crabbox-workspace-";
+const workspaceMaxRecordsPerOwner = 100;
+const workspaceTerminalRetentionMs = 24 * 60 * 60_000;
 
 interface WebVNCTicketRecord {
   ticket: string;
@@ -170,6 +181,38 @@ interface EgressSessionStatus {
   allow: string[];
   createdAt: string;
   updatedAt: string;
+}
+
+interface WorkspaceCreateRequest {
+  id?: string;
+  runtime?: string;
+  profile?: string;
+  ttlSeconds?: number;
+  idleTimeoutSeconds?: number;
+  capabilities?: {
+    desktop?: boolean;
+  };
+}
+
+interface WorkspaceRecord {
+  id: string;
+  leaseID: string;
+  owner: string;
+  org: string;
+  profile: string;
+  provider: Provider;
+  class: string;
+  desktop: boolean;
+  ttlSeconds: number;
+  idleTimeoutSeconds: number;
+  createdAt: string;
+  updatedAt: string;
+  provisionClaim?: string;
+  provisionClaimExpiresAt?: string;
+  reconcileAfter?: string;
+  recoveryMisses?: number;
+  releaseRequestedAt?: string;
+  error?: string;
 }
 
 interface CodeProxyRequest {
@@ -572,6 +615,12 @@ export class FleetCoordinator {
       if (method === "POST" && parts.join("/") === "v1/leases") {
         return await this.createLease(request);
       }
+      if (method === "POST" && parts.join("/") === "v1/workspaces") {
+        return await this.createWorkspace(request);
+      }
+      if (parts[0] === "v1" && parts[1] === "workspaces" && parts[2]) {
+        return await this.workspaceRoute(request, parts[2], parts[3], parts[4]);
+      }
       if (
         parts[0] === "v1" &&
         parts[1] === "leases" &&
@@ -925,6 +974,15 @@ export class FleetCoordinator {
       sendControl(socket, { type: "heartbeat", leaseID, ok: false, error: "not_found" });
       return;
     }
+    if (lease.workspaceID) {
+      sendControl(socket, {
+        type: "heartbeat",
+        leaseID: lease.id,
+        ok: false,
+        error: "workspace_managed_lease",
+      });
+      return;
+    }
     if (lease.cleanupStartedAt) {
       sendControl(socket, {
         type: "heartbeat",
@@ -1048,6 +1106,8 @@ export class FleetCoordinator {
 
   async alarm(): Promise<void> {
     await this.expireLeases();
+    await this.provisionPendingWorkspace();
+    await this.pruneTerminalWorkspaces();
     await this.runAzureDeferredCleanups();
     await this.runAWSOrphanSweepIfDue("alarm");
     await this.runAzureOrphanSweepIfDue("alarm");
@@ -1063,7 +1123,11 @@ export class FleetCoordinator {
     return json({ ok: true });
   }
 
-  private async createLease(request: Request): Promise<Response> {
+  private async createLease(
+    request: Request,
+    reservationGuard?: () => Promise<Response | undefined>,
+    workspaceID?: string,
+  ): Promise<Response> {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const input = await readJson<LeaseRequest>(request);
@@ -1074,6 +1138,19 @@ export class FleetCoordinator {
     if (azureWindowsARM64Image) defaults.azureWindowsARM64Image = azureWindowsARM64Image;
     if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
     let config = leaseConfig(input, defaults);
+    if (
+      !workspaceID &&
+      config.provider === "hetzner" &&
+      config.providerKey.startsWith(workspaceProviderKeyPrefix)
+    ) {
+      return json(
+        {
+          error: "reserved_provider_key",
+          message: `${workspaceProviderKeyPrefix}* is reserved for workspace provisioning`,
+        },
+        { status: 400 },
+      );
+    }
     if (!isAdminRequest(request) && hasNativeLeaseSource(config)) {
       return json(
         {
@@ -1121,6 +1198,13 @@ export class FleetCoordinator {
       providerHourlyUSD,
     );
     const reservation = await this.state.runExclusive(async () => {
+      const blocked = await reservationGuard?.();
+      if (blocked) {
+        return blocked;
+      }
+      if (!workspaceID && (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))) {
+        return workspaceManagedLeaseResponse();
+      }
       const leases = await this.leaseRecords();
       if (leases.some((lease) => lease.id === leaseID)) {
         return json(
@@ -1144,6 +1228,7 @@ export class FleetCoordinator {
       let record: LeaseRecord = {
         id: leaseID,
         slug,
+        ...(workspaceID ? { workspaceID } : {}),
         provider: config.provider,
         target: config.target,
         os: config.os,
@@ -1315,6 +1400,44 @@ export class FleetCoordinator {
           },
         }
       : undefined;
+    const provisioningStart = await this.state.runExclusive(async () => {
+      const current = await this.getLease(record.id);
+      if (!current || current.state !== "provisioning") {
+        return { started: false as const, current };
+      }
+      if (current.workspaceID) {
+        const workspace = await this.state.storage.get<WorkspaceRecord>(
+          workspaceKey(current.owner, current.org, current.workspaceID),
+        );
+        if (workspace?.releaseRequestedAt && workspaceOwnsLease(workspace, current)) {
+          if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
+            await this.deleteProviderAccess(current.id);
+          }
+          return { started: false as const, current, workspace };
+        }
+      }
+      current.provisioningRequestStartedAt = new Date().toISOString();
+      current.updatedAt = current.provisioningRequestStartedAt;
+      await this.putLease(current);
+      return { started: true as const, current };
+    });
+    if (!provisioningStart.started) {
+      if (provisioningStart.workspace) {
+        await this.finalizeAbsentWorkspaceLease(
+          provisioningStart.workspace,
+          provisioningStart.current,
+        );
+      }
+      return json(
+        {
+          error: "lease_state_changed",
+          message: "lease changed state before provider provisioning began",
+          lease: provisioningStart.current,
+        },
+        { status: 409 },
+      );
+    }
+    record = provisioningStart.current;
     const provision = () =>
       provider.createServerWithFallback(config, leaseID, slug, owner, provisioning);
     const provisioned =
@@ -1377,6 +1500,15 @@ export class FleetCoordinator {
           record.endedAt = failedAt;
           record.cleanupFailedAt = failedAt;
           record.cleanupError = errorMessage(error);
+          record.provisioningResourceMayExist =
+            config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
+          record.provisioningFailureRetryable =
+            config.provider === "hetzner" && hetznerProvisioningFailureRetryable(error);
+          if (record.provisioningResourceMayExist || record.provisioningFailureRetryable) {
+            delete record.failureError;
+          } else {
+            record.failureError = record.cleanupError;
+          }
           await this.putLease(record);
           await this.markAWSIngressReconcilePending(record);
           await this.scheduleAlarm();
@@ -1397,6 +1529,7 @@ export class FleetCoordinator {
     const finalizationBase = structuredClone(current);
     record = structuredClone(current);
     record.state = "active";
+    delete record.provisioningRequestStartedAt;
     record.cloudID = server.cloudID;
     record.serverType = serverType;
     if (server.hostID) {
@@ -1453,6 +1586,827 @@ export class FleetCoordinator {
     }
     record = finalization.record;
     return json({ lease: record }, { status: 201 });
+  }
+
+  private async createWorkspace(request: Request): Promise<Response> {
+    const input = workspaceCreateInput(await readJson<unknown>(request).catch(() => undefined));
+    if (!input) {
+      return json(
+        { error: "invalid_workspace_request", message: "workspace request has invalid fields" },
+        { status: 400 },
+      );
+    }
+    const id = validWorkspaceID(input.id) ? input.id : undefined;
+    if (!id) {
+      return json({ error: "invalid_workspace_id" }, { status: 400 });
+    }
+    if (input.runtime && input.runtime !== "crabbox") {
+      return json(
+        { error: "unsupported_runtime", message: "workspace runtime must be crabbox" },
+        { status: 400 },
+      );
+    }
+    const idempotencyKey = request.headers.get("idempotency-key");
+    if (idempotencyKey && idempotencyKey !== id) {
+      return json({ error: "idempotency_key_mismatch" }, { status: 400 });
+    }
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    const profile = workspaceProfile(input.profile);
+    if (!profile) {
+      return json(
+        { error: "invalid_profile", message: "workspace profile is too long" },
+        { status: 400 },
+      );
+    }
+    const ttlSeconds = workspaceSeconds(input.ttlSeconds, 14_400);
+    const idleTimeoutSeconds = workspaceSeconds(input.idleTimeoutSeconds, 1_800);
+    if (ttlSeconds === undefined || idleTimeoutSeconds === undefined) {
+      return json(
+        { error: "invalid_duration", message: "workspace durations must be whole seconds" },
+        { status: 400 },
+      );
+    }
+    const desktop = false;
+    const key = workspaceKey(owner, org, id);
+    const existingResponse = await this.state.runExclusive(async () => {
+      const existing = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!existing) {
+        return undefined;
+      }
+      await this.state.storage.put(workspaceLeaseReservationKey(existing.leaseID), true);
+      const conflict = workspaceConflictResponse(
+        existing,
+        profile,
+        desktop,
+        ttlSeconds,
+        idleTimeoutSeconds,
+      );
+      if (conflict) return conflict;
+      const lease = await this.getLease(existing.leaseID);
+      if (workspaceNextReconcileAt(existing, lease) !== undefined) {
+        await this.scheduleAlarm();
+      }
+      return json(workspaceResponse(existing, lease), {
+        status: workspaceHTTPStatus(existing, lease),
+      });
+    });
+    if (existingResponse) {
+      return existingResponse;
+    }
+    if (!this.env.CRABBOX_WORKSPACE_SSH_PUBLIC_KEY?.trim()) {
+      return json(
+        {
+          error: "workspace_not_configured",
+          message: "CRABBOX_WORKSPACE_SSH_PUBLIC_KEY is required",
+        },
+        { status: 424 },
+      );
+    }
+    let provider: Provider;
+    try {
+      provider = workspaceProvider(this.env.CRABBOX_WORKSPACE_PROVIDER);
+    } catch (error) {
+      return json(
+        { error: "workspace_not_configured", message: errorMessage(error) },
+        { status: 424 },
+      );
+    }
+    const machineClass = workspaceClass(this.env.CRABBOX_WORKSPACE_CLASS);
+    const reservation = await this.state.runExclusive(async () => {
+      const current = await this.state.storage.get<WorkspaceRecord>(key);
+      if (current) {
+        await this.state.storage.put(workspaceLeaseReservationKey(current.leaseID), true);
+        const conflict = workspaceConflictResponse(
+          current,
+          profile,
+          desktop,
+          ttlSeconds,
+          idleTimeoutSeconds,
+        );
+        return conflict
+          ? { response: conflict }
+          : { record: current, lease: await this.getLease(current.leaseID) };
+      }
+      const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
+      const ownerWorkspaceCount = [...workspaces.values()].filter(
+        (candidate) => candidate.owner === owner && candidate.org === org,
+      ).length;
+      if (ownerWorkspaceCount >= workspaceMaxRecordsPerOwner) {
+        return {
+          response: json(
+            {
+              error: "workspace_limit_exceeded",
+              message: `workspace record limit exceeded: ${ownerWorkspaceCount}/${workspaceMaxRecordsPerOwner}`,
+            },
+            { status: 429 },
+          ),
+        };
+      }
+      const leaseID = await this.allocateWorkspaceLeaseID();
+      const nowISO = new Date().toISOString();
+      const record: WorkspaceRecord = {
+        id,
+        leaseID,
+        owner,
+        org,
+        profile,
+        provider,
+        class: machineClass,
+        desktop,
+        ttlSeconds,
+        idleTimeoutSeconds,
+        createdAt: nowISO,
+        updatedAt: nowISO,
+      };
+      await this.state.storage.put(key, record);
+      await this.state.storage.put(workspaceLeaseReservationKey(record.leaseID), true);
+      return { record, lease: undefined };
+    });
+    if ("response" in reservation) {
+      return reservation.response;
+    }
+    if (!reservation.lease && !reservation.record.releaseRequestedAt && !reservation.record.error) {
+      await this.state.runExclusive(() => this.scheduleAlarm());
+    }
+    return json(workspaceResponse(reservation.record, reservation.lease), {
+      status: workspaceHTTPStatus(reservation.record, reservation.lease),
+    });
+  }
+
+  private async allocateWorkspaceLeaseID(): Promise<string> {
+    const leaseID = newLeaseID();
+    if (
+      (await this.getLease(leaseID)) ||
+      (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))
+    ) {
+      return await this.allocateWorkspaceLeaseID();
+    }
+    return leaseID;
+  }
+
+  private async provisionPendingWorkspace(): Promise<void> {
+    const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
+    const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+    const leasesByID = new Map([...leases.values()].map((lease) => [lease.id, lease]));
+    const now = Date.now();
+    const candidates = [...workspaces.values()]
+      .filter((record) => {
+        const dueAt = workspaceNextReconcileAt(record, leasesByID.get(record.leaseID), now);
+        return dueAt !== undefined && dueAt <= now;
+      })
+      .slice(0, 3);
+    await Promise.all(
+      candidates.map((workspace) =>
+        this.reconcileWorkspace(workspace, leasesByID.get(workspace.leaseID)),
+      ),
+    );
+  }
+
+  private async pruneTerminalWorkspaces(): Promise<void> {
+    const cutoff = Date.now() - workspaceTerminalRetentionMs;
+    const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
+    const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+    const leasesByID = new Map([...leases.values()].map((lease) => [lease.id, lease]));
+    const stale = [...workspaces.entries()].filter(([, workspace]) => {
+      const lease = leasesByID.get(workspace.leaseID);
+      const terminalAt = workspaceTerminalTimestamp(workspace, lease);
+      return terminalAt !== undefined && terminalAt <= cutoff;
+    });
+    if (stale.length === 0) {
+      return;
+    }
+    await this.state.runExclusive(async () => {
+      await Promise.all(
+        stale.map(async ([key, workspace]) => {
+          const current = await this.state.storage.get<WorkspaceRecord>(key);
+          if (!current || current.leaseID !== workspace.leaseID) {
+            return;
+          }
+          const lease = await this.getLease(current.leaseID);
+          const terminalAt = workspaceTerminalTimestamp(current, lease);
+          if (terminalAt === undefined || terminalAt > cutoff) {
+            return;
+          }
+          await Promise.all([
+            this.state.storage.delete(key),
+            this.state.storage.delete(workspaceLeaseReservationKey(current.leaseID)),
+          ]);
+        }),
+      );
+    });
+  }
+
+  private async reconcileWorkspace(
+    workspace: WorkspaceRecord,
+    initialLease?: LeaseRecord,
+  ): Promise<void> {
+    let lease = initialLease;
+    if (lease && !workspaceOwnsLease(workspace, lease)) {
+      await this.recordWorkspaceError(
+        workspace,
+        "workspace lease reservation conflicts with another lifecycle",
+      );
+      return;
+    }
+    if (!lease && workspaceProvisionDeadline(workspace) <= Date.now()) {
+      if (!workspace.releaseRequestedAt) {
+        await this.recordWorkspaceError(workspace, "workspace provisioning deadline expired");
+      }
+      return;
+    }
+    const claimExpiresAt = Date.parse(workspace.provisionClaimExpiresAt ?? "");
+    if (
+      lease?.state === "provisioning" &&
+      !lease.cloudID &&
+      !lease.provisioningRequestStartedAt &&
+      (!Number.isFinite(claimExpiresAt) || claimExpiresAt <= Date.now())
+    ) {
+      if (workspace.releaseRequestedAt) {
+        await this.finalizeAbsentWorkspaceLease(workspace, lease);
+      } else {
+        await this.retryWorkspaceProvisioning(workspace, lease);
+      }
+      return;
+    }
+    if (lease?.state === "failed" && lease.provisioningResourceMayExist === false) {
+      if (workspace.releaseRequestedAt) {
+        await this.finalizeAbsentWorkspaceLease(workspace, lease);
+      } else if (lease.provisioningFailureRetryable) {
+        await this.retryWorkspaceProvisioning(workspace, lease);
+      } else {
+        await this.recordWorkspaceError(
+          workspace,
+          lease.failureError || lease.cleanupError || "workspace provisioning failed",
+        );
+      }
+      return;
+    }
+    if (
+      lease?.state === "provisioning" ||
+      lease?.state === "failed" ||
+      (lease?.state === "released" && lease.releaseDeletesServer === true && !lease.cloudID)
+    ) {
+      lease = await this.recoverWorkspaceProvisioning(workspace, lease);
+    }
+    if (workspace.releaseRequestedAt) {
+      if (
+        !lease ||
+        lease.state === "expired" ||
+        (lease.state === "released" &&
+          !lease.cleanupStartedAt &&
+          !lease.cleanupError &&
+          lease.releaseDeletesServer === undefined)
+      ) {
+        return;
+      }
+      if (lease.state === "provisioning" && !lease.cloudID) {
+        return;
+      }
+      try {
+        await this.releaseWorkspaceLease(workspace);
+      } catch {
+        // Lease cleanup state carries the provider error and remains retryable.
+      }
+      return;
+    }
+    if (lease?.state === "failed") {
+      const currentWorkspace = await this.state.storage.get<WorkspaceRecord>(
+        workspaceKey(workspace.owner, workspace.org, workspace.id),
+      );
+      if (!lease.failureError && currentWorkspace?.reconcileAfter && !currentWorkspace.error) {
+        return;
+      }
+      await this.recordWorkspaceError(
+        workspace,
+        lease.failureError || lease.cleanupError || "workspace provisioning failed",
+      );
+      return;
+    }
+    if (lease) {
+      return;
+    }
+    const sshPublicKey = this.env.CRABBOX_WORKSPACE_SSH_PUBLIC_KEY?.trim();
+    if (!sshPublicKey) {
+      await this.recordWorkspaceError(workspace, "CRABBOX_WORKSPACE_SSH_PUBLIC_KEY is required");
+      return;
+    }
+    let createResponse: Response;
+    const provisionClaim = crypto.randomUUID();
+    try {
+      createResponse = await this.createLease(
+        await workspaceLeaseRequest(workspace, sshPublicKey),
+        async () => {
+          const current = await this.state.storage.get<WorkspaceRecord>(
+            workspaceKey(workspace.owner, workspace.org, workspace.id),
+          );
+          if (
+            !current ||
+            current.leaseID !== workspace.leaseID ||
+            current.releaseRequestedAt ||
+            current.error
+          ) {
+            return json(
+              {
+                error: "workspace_state_changed",
+                message: "workspace changed before lease reservation",
+              },
+              { status: 409 },
+            );
+          }
+          const activeClaimExpiresAt = Date.parse(current.provisionClaimExpiresAt ?? "");
+          if (
+            current.provisionClaim &&
+            Number.isFinite(activeClaimExpiresAt) &&
+            activeClaimExpiresAt > Date.now()
+          ) {
+            return json(
+              {
+                error: "workspace_provisioning_claimed",
+                message: "workspace provisioning is already in progress",
+              },
+              { status: 409 },
+            );
+          }
+          const now = new Date();
+          current.provisionClaim = provisionClaim;
+          current.provisionClaimExpiresAt = new Date(
+            now.getTime() + workspaceProvisionClaimMs,
+          ).toISOString();
+          current.updatedAt = now.toISOString();
+          delete current.reconcileAfter;
+          await this.state.storage.put(
+            workspaceKey(workspace.owner, workspace.org, workspace.id),
+            current,
+          );
+          return undefined;
+        },
+        workspace.id,
+      );
+    } catch (error) {
+      const persistedLease = await this.getLease(workspace.leaseID);
+      if (persistedLease && workspaceOwnsLease(workspace, persistedLease)) {
+        await this.deferWorkspaceReconciliation(workspace, true);
+      } else {
+        await this.recordWorkspaceError(workspace, errorMessage(error));
+      }
+      return;
+    }
+    if (!createResponse.ok) {
+      const current = await this.state.storage.get<WorkspaceRecord>(
+        workspaceKey(workspace.owner, workspace.org, workspace.id),
+      );
+      if (current?.releaseRequestedAt) {
+        await this.completeWorkspaceCreate(current, provisionClaim);
+        return;
+      }
+      const persistedLease = await this.getLease(workspace.leaseID);
+      if (!persistedLease || !workspaceOwnsLease(workspace, persistedLease)) {
+        if (await workspaceAdmissionRetryable(createResponse)) {
+          await this.deferWorkspaceReconciliation(workspace, true);
+          return;
+        }
+        await this.recordWorkspaceError(
+          workspace,
+          await workspaceResponseError(
+            createResponse,
+            `lease create HTTP ${createResponse.status}`,
+          ),
+        );
+        return;
+      }
+    }
+    await this.completeWorkspaceCreate(workspace, provisionClaim);
+    const current = await this.state.storage.get<WorkspaceRecord>(
+      workspaceKey(workspace.owner, workspace.org, workspace.id),
+    );
+    if (current?.leaseID === workspace.leaseID && current.releaseRequestedAt) {
+      try {
+        await this.releaseWorkspaceLease(current);
+      } catch {
+        // Lease cleanup state carries the provider error and remains retryable.
+      }
+    }
+  }
+
+  private async recoverWorkspaceProvisioning(
+    workspace: WorkspaceRecord,
+    lease: LeaseRecord,
+  ): Promise<LeaseRecord> {
+    const providerResourceDefinitelyAbsent =
+      lease.state === "failed" && lease.provisioningResourceMayExist === false;
+    const claimExpiresAt = Date.parse(workspace.provisionClaimExpiresAt ?? "");
+    const now = Date.now();
+    const recoveryDeadline = workspaceProvisionRecoveryDeadline(workspace, lease);
+    if (Number.isFinite(claimExpiresAt) && claimExpiresAt > now) {
+      return lease;
+    }
+    const provider = this.provider(workspace.provider, lease.region, lease.providerProject);
+    let server: ProviderMachine | undefined;
+    try {
+      if (lease.cloudID && provider.getServer) {
+        server = await provider.getServer(lease.cloudID);
+      } else if (provider.findServerByLease) {
+        server = await provider.findServerByLease(lease.id);
+      } else {
+        server = (await provider.listCrabboxServers()).find(
+          (machine) => machine.labels?.["lease"] === lease.id,
+        );
+      }
+    } catch (error) {
+      if (!providerResourceNotFound(error)) {
+        await this.recordWorkspaceRecoveryMiss(workspace, Number.POSITIVE_INFINITY);
+        return lease;
+      }
+    }
+    if (server) {
+      const recovered = await this.state.runExclusive(async () => {
+        const current = await this.getLease(lease.id);
+        if (
+          !current ||
+          (current.state !== "provisioning" &&
+            current.state !== "failed" &&
+            !(current.state === "released" && current.releaseDeletesServer === true))
+        ) {
+          return current ?? lease;
+        }
+        const recoveredAt = new Date().toISOString();
+        current.cloudID = server.cloudID || String(server.id);
+        current.serverID = server.id;
+        current.serverName = server.name;
+        current.serverType = server.serverType;
+        if (server.host.trim()) {
+          current.state = "active";
+          current.host = server.host;
+        } else {
+          current.state = "provisioning";
+        }
+        if (server.region) {
+          current.region = server.region;
+        }
+        if (server.hostID) {
+          current.hostId = server.hostID;
+        }
+        current.updatedAt = recoveredAt;
+        current.lastTouchedAt = recoveredAt;
+        delete current.failureError;
+        delete current.provisioningResourceMayExist;
+        delete current.provisioningFailureRetryable;
+        delete current.provisioningRequestStartedAt;
+        delete current.endedAt;
+        delete current.releasedAt;
+        clearLeaseCleanupMetadata(current);
+        await this.putLease(current);
+        await this.scheduleAlarm();
+        return current;
+      });
+      if (recovered.state === "active") {
+        await this.completeWorkspaceCreate(workspace, workspace.provisionClaim);
+      } else {
+        await this.deferWorkspaceReconciliation(workspace);
+      }
+      return recovered;
+    }
+    if (!providerResourceDefinitelyAbsent && recoveryDeadline > now) {
+      await this.recordWorkspaceRecoveryMiss(workspace, recoveryDeadline);
+      return lease;
+    }
+    const retryableLease = await this.state.runExclusive(async () => {
+      const currentWorkspace = await this.state.storage.get<WorkspaceRecord>(
+        workspaceKey(workspace.owner, workspace.org, workspace.id),
+      );
+      const current = await this.getLease(lease.id);
+      if (
+        !currentWorkspace ||
+        currentWorkspace.leaseID !== workspace.leaseID ||
+        currentWorkspace.releaseRequestedAt ||
+        !current ||
+        !workspaceOwnsLease(currentWorkspace, current) ||
+        !(
+          current.state === "provisioning" ||
+          (current.state === "failed" && current.provisioningFailureRetryable)
+        )
+      ) {
+        return undefined;
+      }
+      current.state = "failed";
+      current.provisioningResourceMayExist = false;
+      current.provisioningFailureRetryable = true;
+      delete current.provisioningRequestStartedAt;
+      current.updatedAt = new Date().toISOString();
+      await this.putLease(current);
+      return current;
+    });
+    if (retryableLease) {
+      await this.retryWorkspaceProvisioning(workspace, retryableLease);
+      return retryableLease;
+    }
+    return await this.finalizeAbsentWorkspaceLease(workspace, lease);
+  }
+
+  private async workspaceRoute(
+    request: Request,
+    workspaceID: string,
+    action?: string,
+    connection?: string,
+  ): Promise<Response> {
+    if (!validWorkspaceID(workspaceID)) {
+      return notFound();
+    }
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    const key = workspaceKey(owner, org, workspaceID);
+    const method = request.method.toUpperCase();
+    if (method === "GET" && action === undefined) {
+      return await this.state.runExclusive(async () => {
+        const record = await this.state.storage.get<WorkspaceRecord>(key);
+        if (!record) {
+          return notFound();
+        }
+        const lease = await this.getLease(record.leaseID);
+        return json(workspaceResponse(record, lease));
+      });
+    }
+    if (method === "POST" && action === "connections" && connection === "desktop") {
+      const record = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!record) {
+        return notFound();
+      }
+      return json(
+        {
+          error: "desktop_unavailable",
+          message: "workspace desktop handoff is not configured",
+        },
+        { status: 409 },
+      );
+    }
+    if (method === "DELETE" && action === undefined) {
+      const release = await this.state.runExclusive(async () => {
+        const record = await this.state.storage.get<WorkspaceRecord>(key);
+        if (!record) {
+          return { response: notFound() };
+        }
+        const lease = await this.getLease(record.leaseID);
+        if (!record.releaseRequestedAt) {
+          record.releaseRequestedAt = new Date().toISOString();
+          record.updatedAt = record.releaseRequestedAt;
+          delete record.reconcileAfter;
+          await this.state.storage.put(key, record);
+        }
+        await this.scheduleAlarm();
+        return {
+          record,
+          lease,
+          release:
+            Boolean(lease) &&
+            !(
+              !lease?.cloudID &&
+              (lease?.state === "provisioning" ||
+                lease?.state === "failed" ||
+                (lease?.state === "released" && lease.releaseDeletesServer === true))
+            ) &&
+            lease?.state !== "expired" &&
+            (lease?.state !== "released" || lease.releaseDeletesServer !== undefined),
+        };
+      });
+      if ("response" in release) {
+        return release.response;
+      }
+      if (release.release) {
+        try {
+          await this.releaseWorkspaceLease(release.record);
+        } catch {
+          // Lease cleanup state carries the provider error and remains retryable.
+        }
+      }
+      const record = (await this.state.storage.get<WorkspaceRecord>(key)) ?? release.record;
+      const lease = await this.getLease(record.leaseID);
+      return json(workspaceResponse(record, lease));
+    }
+    return json({ error: "not_found" }, { status: 404 });
+  }
+
+  private async recordWorkspaceError(workspace: WorkspaceRecord, message: string): Promise<void> {
+    const key = workspaceKey(workspace.owner, workspace.org, workspace.id);
+    await this.state.runExclusive(async () => {
+      const current = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!current || current.leaseID !== workspace.leaseID) {
+        return;
+      }
+      current.error = message.slice(0, 500);
+      delete current.provisionClaim;
+      delete current.provisionClaimExpiresAt;
+      delete current.reconcileAfter;
+      delete current.recoveryMisses;
+      current.updatedAt = new Date().toISOString();
+      await this.state.storage.put(key, current);
+    });
+  }
+
+  private async completeWorkspaceCreate(
+    workspace: WorkspaceRecord,
+    expectedClaim: string | undefined,
+  ): Promise<void> {
+    const key = workspaceKey(workspace.owner, workspace.org, workspace.id);
+    await this.state.runExclusive(async () => {
+      const current = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!current || current.leaseID !== workspace.leaseID) {
+        return;
+      }
+      if (expectedClaim && current.provisionClaim !== expectedClaim) {
+        return;
+      }
+      delete current.error;
+      delete current.provisionClaim;
+      delete current.provisionClaimExpiresAt;
+      delete current.reconcileAfter;
+      delete current.recoveryMisses;
+      current.updatedAt = new Date().toISOString();
+      await this.state.storage.put(key, current);
+    });
+  }
+
+  private async deferWorkspaceReconciliation(
+    workspace: WorkspaceRecord,
+    releaseProvisionClaim = false,
+  ): Promise<void> {
+    const key = workspaceKey(workspace.owner, workspace.org, workspace.id);
+    await this.state.runExclusive(async () => {
+      const current = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!current || current.leaseID !== workspace.leaseID) {
+        return;
+      }
+      const now = new Date();
+      if (releaseProvisionClaim) {
+        delete current.provisionClaim;
+        delete current.provisionClaimExpiresAt;
+      }
+      current.reconcileAfter = new Date(now.getTime() + workspaceReconcileIntervalMs).toISOString();
+      current.updatedAt = now.toISOString();
+      await this.state.storage.put(key, current);
+    });
+  }
+
+  private async recordWorkspaceRecoveryMiss(
+    workspace: WorkspaceRecord,
+    provisioningDeadline: number,
+  ): Promise<void> {
+    const key = workspaceKey(workspace.owner, workspace.org, workspace.id);
+    await this.state.runExclusive(async () => {
+      const current = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!current || current.leaseID !== workspace.leaseID) {
+        return;
+      }
+      const now = new Date();
+      current.recoveryMisses = (current.recoveryMisses ?? 0) + 1;
+      const delay = Math.min(
+        workspaceReconcileIntervalMs * 2 ** Math.min(current.recoveryMisses - 1, 5),
+        workspaceReconcileMaxIntervalMs,
+      );
+      const retryAt = Number.isFinite(provisioningDeadline)
+        ? Math.min(now.getTime() + delay, provisioningDeadline)
+        : now.getTime() + delay;
+      current.reconcileAfter = new Date(retryAt).toISOString();
+      current.updatedAt = now.toISOString();
+      await this.state.storage.put(key, current);
+    });
+  }
+
+  private async retryWorkspaceProvisioning(
+    workspace: WorkspaceRecord,
+    lease: LeaseRecord,
+  ): Promise<void> {
+    const key = workspaceKey(workspace.owner, workspace.org, workspace.id);
+    await this.state.runExclusive(async () => {
+      const currentWorkspace = await this.state.storage.get<WorkspaceRecord>(key);
+      const currentLease = await this.getLease(lease.id);
+      if (
+        !currentWorkspace ||
+        currentWorkspace.leaseID !== workspace.leaseID ||
+        currentWorkspace.releaseRequestedAt ||
+        !currentLease ||
+        !workspaceOwnsLease(currentWorkspace, currentLease) ||
+        !(
+          (currentLease.state === "provisioning" && !currentLease.provisioningRequestStartedAt) ||
+          (currentLease.state === "failed" &&
+            currentLease.provisioningResourceMayExist === false &&
+            currentLease.provisioningFailureRetryable)
+        )
+      ) {
+        return;
+      }
+      const now = new Date();
+      if (workspaceProvisionDeadline(currentWorkspace) <= now.getTime()) {
+        const message = "workspace provisioning deadline expired";
+        currentLease.state = "failed";
+        currentLease.failureError = message;
+        currentLease.provisioningFailureRetryable = false;
+        currentLease.updatedAt = now.toISOString();
+        currentLease.endedAt = currentLease.updatedAt;
+        currentWorkspace.error = message;
+        currentWorkspace.updatedAt = now.toISOString();
+        delete currentWorkspace.reconcileAfter;
+        delete currentWorkspace.provisionClaim;
+        delete currentWorkspace.provisionClaimExpiresAt;
+        await Promise.all([
+          this.putLease(currentLease),
+          this.state.storage.put(key, currentWorkspace),
+        ]);
+        await this.scheduleAlarm();
+        return;
+      }
+      await this.state.storage.delete(leaseKey(currentLease.id));
+      currentWorkspace.recoveryMisses = (currentWorkspace.recoveryMisses ?? 0) + 1;
+      const delay = Math.min(
+        workspaceReconcileIntervalMs * 2 ** Math.min(currentWorkspace.recoveryMisses - 1, 5),
+        workspaceReconcileMaxIntervalMs,
+      );
+      currentWorkspace.reconcileAfter = new Date(now.getTime() + delay).toISOString();
+      currentWorkspace.updatedAt = now.toISOString();
+      delete currentWorkspace.error;
+      delete currentWorkspace.provisionClaim;
+      delete currentWorkspace.provisionClaimExpiresAt;
+      await this.state.storage.put(key, currentWorkspace);
+      await this.scheduleAlarm();
+    });
+  }
+
+  private async finalizeAbsentWorkspaceLease(
+    workspace: WorkspaceRecord,
+    lease: LeaseRecord,
+  ): Promise<LeaseRecord> {
+    const message = "provider resource not found after interrupted workspace provisioning";
+    const failed = await this.state.runExclusive(async () => {
+      const currentWorkspace = await this.state.storage.get<WorkspaceRecord>(
+        workspaceKey(workspace.owner, workspace.org, workspace.id),
+      );
+      const current = await this.getLease(lease.id);
+      if (
+        !current ||
+        (current.state !== "provisioning" &&
+          current.state !== "failed" &&
+          !(current.state === "released" && current.releaseDeletesServer === true))
+      ) {
+        return current ?? lease;
+      }
+      const failedAt = new Date().toISOString();
+      const releaseRequested = Boolean(currentWorkspace?.releaseRequestedAt);
+      current.state = releaseRequested ? "released" : "failed";
+      current.updatedAt = failedAt;
+      current.endedAt = failedAt;
+      current.cloudID = "";
+      current.serverID = 0;
+      current.serverName = "";
+      current.host = "";
+      current.provisioningResourceMayExist = false;
+      current.provisioningFailureRetryable = false;
+      delete current.provisioningRequestStartedAt;
+      if (releaseRequested) {
+        current.releasedAt = failedAt;
+        delete current.releaseDeletesServer;
+        delete current.failureError;
+      } else {
+        current.failureError = message;
+      }
+      clearLeaseCleanupMetadata(current);
+      await this.putLease(current);
+      return current;
+    });
+    if (failed.state === "released") {
+      await this.clearWorkspaceReleaseError(failed);
+    } else {
+      await this.recordWorkspaceError(workspace, message);
+    }
+    return failed;
+  }
+
+  private async clearWorkspaceReleaseError(lease: LeaseRecord): Promise<void> {
+    if (!lease.workspaceID) {
+      return;
+    }
+    const key = workspaceKey(lease.owner, lease.org, lease.workspaceID);
+    const workspace = await this.state.storage.get<WorkspaceRecord>(key);
+    if (
+      !workspace ||
+      !workspaceOwnsLease(workspace, lease) ||
+      !workspace.releaseRequestedAt ||
+      !workspace.error
+    ) {
+      return;
+    }
+    delete workspace.error;
+    workspace.updatedAt = new Date().toISOString();
+    await this.state.storage.put(key, workspace);
+  }
+
+  private async releaseWorkspaceLease(
+    workspace: WorkspaceRecord,
+  ): Promise<LeaseRecord | undefined> {
+    const lease = await this.getLease(workspace.leaseID);
+    if (!lease || !workspaceOwnsLease(workspace, lease)) {
+      return lease;
+    }
+    return await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
   }
 
   private async leaseRoute(request: Request, leaseID: string, action?: string): Promise<Response> {
@@ -1514,6 +2468,9 @@ export class FleetCoordinator {
       return json({ error: "host_required" }, { status: 400 });
     }
 
+    if (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) {
+      return workspaceManagedLeaseResponse();
+    }
     const existing = await this.getLease(leaseID);
     if (
       existing &&
@@ -1633,6 +2590,9 @@ export class FleetCoordinator {
           { error: "forbidden", message: "lease manage access required" },
           { status: 403 },
         );
+      }
+      if (lease.workspaceID) {
+        return workspaceManagedLeaseResponse();
       }
       if (lease.cleanupStartedAt) {
         return json(
@@ -1805,6 +2765,9 @@ export class FleetCoordinator {
     }
     if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
+    }
+    if (lease.workspaceID) {
+      return workspaceManagedLeaseResponse();
     }
     const body = await optionalJson<{ delete?: boolean }>(request);
     const shouldDelete = body.delete ?? !lease.keep;
@@ -5046,9 +6009,21 @@ export class FleetCoordinator {
   private async expireLeases(): Promise<void> {
     const claims = await this.state.runExclusive(async () => {
       const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+      const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
+      const workspacesByLeaseID = new Map(
+        [...workspaces.values()].map((workspace) => [workspace.leaseID, workspace]),
+      );
       const now = Date.now();
       const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
       for (const stored of leases.values()) {
+        const workspace = workspacesByLeaseID.get(stored.id);
+        if (
+          workspace &&
+          workspaceOwnsLease(workspace, stored) &&
+          workspaceProvisioningNeedsRecovery(workspace, stored, now)
+        ) {
+          continue;
+        }
         if (!leaseNeedsCleanup(stored, now)) {
           continue;
         }
@@ -5137,6 +6112,7 @@ export class FleetCoordinator {
             delete current.cleanupStartedAt;
             delete current.cleanupClaimExpiresAt;
             await this.putLease(current);
+            await this.clearWorkspaceReleaseError(current);
             await this.markAWSIngressReconcilePending(current);
           });
         };
@@ -5151,11 +6127,44 @@ export class FleetCoordinator {
 
   private async scheduleAlarm(): Promise<void> {
     const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+    const workspaces = await this.state.storage.list<WorkspaceRecord>({ prefix: "workspace:" });
     const now = Date.now();
+    const workspacesByLeaseID = new Map(
+      [...workspaces.values()].map((workspace) => [workspace.leaseID, workspace]),
+    );
     const alarmTimes = [...leases.values()]
-      .filter((lease) => leaseIsLive(lease) || leaseNeedsCleanup(lease, now))
+      .filter((lease) => {
+        const workspace = workspacesByLeaseID.get(lease.id);
+        return (
+          !(
+            workspace &&
+            workspaceOwnsLease(workspace, lease) &&
+            workspaceProvisioningNeedsRecovery(workspace, lease, now)
+          ) &&
+          (leaseIsLive(lease) || leaseNeedsCleanup(lease, now))
+        );
+      })
       .map((lease) => nextLeaseAlarmTime(lease))
       .filter((time) => Number.isFinite(time));
+    const leasesByID = new Map([...leases.values()].map((lease) => [lease.id, lease]));
+    const workspaceAlarm = [...workspaces.values()]
+      .map((workspace) =>
+        workspaceNextReconcileAt(workspace, leasesByID.get(workspace.leaseID), now),
+      )
+      .filter((time): time is number => time !== undefined)
+      .toSorted((left, right) => left - right)[0];
+    if (workspaceAlarm !== undefined) {
+      alarmTimes.push(Math.max(now + 1, workspaceAlarm));
+    }
+    const workspaceRetentionAlarm = [...workspaces.values()]
+      .map((workspace) => workspaceTerminalTimestamp(workspace, leasesByID.get(workspace.leaseID)))
+      .filter((time): time is number => time !== undefined)
+      .map((time) => time + workspaceTerminalRetentionMs)
+      .filter((time) => time > now)
+      .toSorted((left, right) => left - right)[0];
+    if (workspaceRetentionAlarm !== undefined) {
+      alarmTimes.push(workspaceRetentionAlarm);
+    }
     const orphanSweepAlarm = await this.nextAWSOrphanSweepAlarmTime();
     if (orphanSweepAlarm !== undefined) {
       alarmTimes.push(orphanSweepAlarm);
@@ -6389,11 +7398,42 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     options: { deleteServer: boolean; keep?: boolean },
   ): Promise<LeaseRecord> {
-    const release = () => this.releaseResolvedLeaseOperation(lease, options);
-    return managedLeaseProvider(lease) === "aws" &&
-      (lease.state === "active" || Boolean(lease.cloudID))
+    await this.markWorkspaceReleaseRequested(lease);
+    const current = (await this.getLease(lease.id)) ?? lease;
+    if (
+      current.workspaceID &&
+      !current.cloudID &&
+      (current.state === "provisioning" ||
+        current.state === "failed" ||
+        (current.state === "released" && current.releaseDeletesServer === true))
+    ) {
+      await this.state.runExclusive(() => this.scheduleAlarm());
+      return current;
+    }
+    const release = () => this.releaseResolvedLeaseOperation(current, options);
+    return managedLeaseProvider(current) === "aws" &&
+      (current.state === "active" || Boolean(current.cloudID))
       ? this.withAWSIngressOperationLock(release)
       : release();
+  }
+
+  private async markWorkspaceReleaseRequested(lease: LeaseRecord): Promise<void> {
+    const workspaceID = lease.workspaceID;
+    if (!workspaceID) {
+      return;
+    }
+    await this.state.runExclusive(async () => {
+      const key = workspaceKey(lease.owner, lease.org, workspaceID);
+      const workspace = await this.state.storage.get<WorkspaceRecord>(key);
+      if (!workspace || !workspaceOwnsLease(workspace, lease)) {
+        throw new Error("workspace lease reservation conflicts with another lifecycle");
+      }
+      if (!workspace.releaseRequestedAt) {
+        workspace.releaseRequestedAt = new Date().toISOString();
+        workspace.updatedAt = workspace.releaseRequestedAt;
+        await this.state.storage.put(key, workspace);
+      }
+    });
   }
 
   private async releaseResolvedLeaseOperation(
@@ -6417,6 +7457,7 @@ export class FleetCoordinator {
       if (!shouldDelete) {
         const released = finalizedReleasedLease(current, deleteServer, options.keep);
         await this.putLease(released);
+        await this.clearWorkspaceReleaseError(released);
         await this.markAWSIngressReconcilePending(released);
         await this.scheduleAlarm();
         return { cleanup: false as const, lease: released };
@@ -6472,6 +7513,7 @@ export class FleetCoordinator {
       }
       const released = finalizedReleasedLease(current, true, options.keep);
       await this.putLease(released);
+      await this.clearWorkspaceReleaseError(released);
       await this.markAWSIngressReconcilePending(released);
       await this.scheduleAlarm();
       return released;
@@ -6590,6 +7632,14 @@ function portalReturnLocation(request: Request): string {
 
 function leaseKey(leaseID: string): string {
   return `lease:${leaseID}`;
+}
+
+function workspaceLeaseReservationKey(leaseID: string): string {
+  return `workspace-lease:${leaseID}`;
+}
+
+function workspaceKey(owner: string, org: string, workspaceID: string): string {
+  return `workspace:${encodeURIComponent(org)}:${encodeURIComponent(owner)}:${workspaceID}`;
 }
 
 function providerAccessPrefix(): string {
@@ -6957,6 +8007,358 @@ function newLeaseID(): string {
   return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
+function validWorkspaceID(value: string | undefined): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 63 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value)
+  );
+}
+
+function workspaceManagedLeaseResponse(): Response {
+  return json(
+    {
+      error: "workspace_managed_lease",
+      message: "workspace leases must be managed through the workspace lifecycle",
+    },
+    { status: 409 },
+  );
+}
+
+function workspaceCreateInput(value: unknown): WorkspaceCreateRequest | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const input = value as Record<string, unknown>;
+  if (input["id"] !== undefined && typeof input["id"] !== "string") return undefined;
+  if (input["runtime"] !== undefined && typeof input["runtime"] !== "string") return undefined;
+  if (input["profile"] !== undefined && typeof input["profile"] !== "string") return undefined;
+  if (input["ttlSeconds"] !== undefined && typeof input["ttlSeconds"] !== "number")
+    return undefined;
+  if (
+    input["idleTimeoutSeconds"] !== undefined &&
+    typeof input["idleTimeoutSeconds"] !== "number"
+  ) {
+    return undefined;
+  }
+  const capabilities = input["capabilities"];
+  if (
+    capabilities !== undefined &&
+    (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities))
+  ) {
+    return undefined;
+  }
+  const desktop = (capabilities as Record<string, unknown> | undefined)?.["desktop"];
+  if (desktop !== undefined && typeof desktop !== "boolean") return undefined;
+  return input as WorkspaceCreateRequest;
+}
+
+function workspaceProvider(value: string | undefined): Provider {
+  const provider = value?.trim() || "hetzner";
+  if (provider !== "hetzner") {
+    throw new Error(`unsupported workspace provider: ${provider}`);
+  }
+  return provider;
+}
+
+function workspaceProfile(value: string | undefined): string | undefined {
+  const profile = value?.trim() || "default";
+  return profile.length <= 120 ? profile : undefined;
+}
+
+function workspaceClass(configured: string | undefined): string {
+  const machineClass = configured?.trim() || "standard";
+  return ["standard", "fast", "large", "beast"].includes(machineClass) ? machineClass : "standard";
+}
+
+function workspaceSeconds(value: number | undefined, fallback: number): number | undefined {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1) return undefined;
+  return Math.min(value, 86_400);
+}
+
+async function workspaceAdmissionRetryable(response: Response): Promise<boolean> {
+  if (response.status === 429) {
+    const body = (await response
+      .clone()
+      .json()
+      .catch(() => undefined)) as { error?: unknown } | undefined;
+    return body?.error !== "cost_limit_exceeded";
+  }
+  return response.status === 424 || response.status >= 500;
+}
+
+async function workspaceLeaseRequest(
+  workspace: WorkspaceRecord,
+  sshPublicKey: string,
+): Promise<Request> {
+  const remainingMs = workspaceProvisionDeadline(workspace) - Date.now();
+  if (remainingMs <= 0) {
+    throw new Error("workspace provisioning deadline expired");
+  }
+  const remainingSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
+  const providerKey = `${workspaceProviderKeyPrefix}${(await sha256Hex(sshPublicKey.trim())).slice(0, 12)}`;
+  return new Request("https://crabbox.invalid/v1/leases", {
+    method: "POST",
+    headers: workspaceRecordHeaders(workspace),
+    body: JSON.stringify({
+      leaseID: workspace.leaseID,
+      slug: workspace.id,
+      provider: workspace.provider,
+      profile: workspace.profile,
+      class: workspace.class,
+      providerKey,
+      desktop: workspace.desktop,
+      ttlSeconds: remainingSeconds,
+      // The adapter has no activity channel yet, so idle expiry would terminate active workspaces.
+      idleTimeoutSeconds: remainingSeconds,
+      keep: false,
+      sshPublicKey,
+    } satisfies LeaseRequest),
+  });
+}
+
+function workspaceRecordHeaders(workspace: WorkspaceRecord): Headers {
+  return new Headers({
+    "content-type": "application/json",
+    "x-crabbox-owner": workspace.owner,
+    "x-crabbox-org": workspace.org,
+  });
+}
+
+function workspaceHTTPStatus(workspace: WorkspaceRecord, lease?: LeaseRecord): number {
+  return workspaceStatus(workspace, lease) === "provisioning" ? 202 : 200;
+}
+
+function workspaceConflictResponse(
+  workspace: WorkspaceRecord,
+  profile: string,
+  desktop: boolean,
+  ttlSeconds: number,
+  idleTimeoutSeconds: number,
+): Response | undefined {
+  if (
+    workspace.profile === profile &&
+    workspace.desktop === desktop &&
+    workspace.ttlSeconds === ttlSeconds &&
+    workspace.idleTimeoutSeconds === idleTimeoutSeconds
+  ) {
+    return undefined;
+  }
+  return json(
+    {
+      error: "workspace_id_conflict",
+      message: "workspace id already exists with different settings",
+    },
+    { status: 409 },
+  );
+}
+
+function workspaceProvisionDeadline(workspace: WorkspaceRecord): number {
+  return Date.parse(workspace.createdAt) + workspace.ttlSeconds * 1000;
+}
+
+function workspaceProvisionRecoveryDeadline(
+  workspace: WorkspaceRecord,
+  lease?: LeaseRecord,
+): number {
+  const requestStartedAt = Date.parse(lease?.provisioningRequestStartedAt ?? "");
+  return Number.isFinite(requestStartedAt)
+    ? requestStartedAt + workspaceProvisionRecoveryGraceMs
+    : workspaceProvisionDeadline(workspace) + workspaceProvisionRecoveryGraceMs;
+}
+
+function workspaceProvisioningNeedsRecovery(
+  workspace: WorkspaceRecord,
+  lease: LeaseRecord,
+  now = Date.now(),
+): boolean {
+  if (lease.cloudID) {
+    return false;
+  }
+  if (
+    lease.state !== "provisioning" &&
+    lease.state !== "failed" &&
+    !(lease.state === "released" && lease.releaseDeletesServer === true)
+  ) {
+    return false;
+  }
+  const deadline =
+    lease.state === "provisioning" || lease.provisioningResourceMayExist === true
+      ? workspaceProvisionRecoveryDeadline(workspace, lease)
+      : workspaceProvisionDeadline(workspace);
+  return now < deadline;
+}
+
+function workspaceNextReconcileAt(
+  workspace: WorkspaceRecord,
+  lease?: LeaseRecord,
+  now = Date.now(),
+): number | undefined {
+  if (lease && !workspaceOwnsLease(workspace, lease)) return workspace.error ? undefined : now;
+  const claimExpiresAt = Date.parse(workspace.provisionClaimExpiresAt ?? "");
+  const deferredUntil = Date.parse(workspace.reconcileAfter ?? "");
+  const provisioningDeadline =
+    lease?.state === "provisioning" || lease?.provisioningResourceMayExist === true
+      ? workspaceProvisionRecoveryDeadline(workspace, lease)
+      : workspaceProvisionDeadline(workspace);
+  if (Number.isFinite(deferredUntil) && deferredUntil > now) {
+    return provisioningDeadline > now
+      ? Math.min(deferredUntil, provisioningDeadline)
+      : deferredUntil;
+  }
+  if (!lease && Number.isFinite(claimExpiresAt) && claimExpiresAt > now) {
+    return claimExpiresAt;
+  }
+  if (
+    lease?.state === "provisioning" ||
+    lease?.state === "failed" ||
+    (lease?.state === "released" && lease.releaseDeletesServer === true && !lease.cloudID)
+  ) {
+    if (Number.isFinite(claimExpiresAt) && claimExpiresAt > now) {
+      return claimExpiresAt;
+    }
+  }
+  if (workspace.releaseRequestedAt) {
+    if (!lease || lease.state === "expired") return undefined;
+    if (lease.cleanupStartedAt) {
+      const claimDeadline = cleanupClaimDeadline(lease);
+      return Number.isFinite(claimDeadline) ? claimDeadline : now + workspaceReconcileIntervalMs;
+    }
+    const retryAt = Date.parse(lease.cleanupRetryAt ?? "");
+    if (Number.isFinite(retryAt) && retryAt > now) return retryAt;
+    if (lease.state === "provisioning") return now;
+    if (
+      lease.state === "released" &&
+      !lease.cleanupError &&
+      lease.releaseDeletesServer === undefined
+    ) {
+      return undefined;
+    }
+    return now;
+  }
+  if (workspace.error) return undefined;
+  if (!lease || lease.state === "failed") return now;
+  if (lease.state === "provisioning") return now;
+  return undefined;
+}
+
+function workspaceStatus(
+  workspace: WorkspaceRecord,
+  lease?: LeaseRecord,
+): "provisioning" | "ready" | "stopping" | "stopped" | "expired" | "failed" {
+  if (lease && !workspaceOwnsLease(workspace, lease)) return "failed";
+  if (workspace.releaseRequestedAt) {
+    if (!lease) return "stopped";
+    if (
+      lease?.state === "released" &&
+      !lease.cleanupStartedAt &&
+      !lease.cleanupError &&
+      lease.releaseDeletesServer === undefined
+    ) {
+      return "stopped";
+    }
+    if (lease?.state === "expired") return "expired";
+    return "stopping";
+  }
+  if (workspace.error && !lease) return "failed";
+  switch (lease?.state) {
+    case "active": {
+      if (Date.parse(lease.expiresAt) <= Date.now()) return "expired";
+      if (lease.cleanupStartedAt || lease.cleanupError) return "failed";
+      return "ready";
+    }
+    case "released":
+      return "stopped";
+    case "expired":
+      return "expired";
+    case "failed":
+      return workspace.error || lease.failureError ? "failed" : "provisioning";
+    default:
+      return "provisioning";
+  }
+}
+
+function workspaceTerminalTimestamp(
+  workspace: WorkspaceRecord,
+  lease?: LeaseRecord,
+): number | undefined {
+  const terminal =
+    (!lease && Boolean(workspace.releaseRequestedAt || workspace.error)) ||
+    lease?.state === "expired" ||
+    (lease?.state === "released" &&
+      !lease.cleanupStartedAt &&
+      !lease.cleanupError &&
+      lease.releaseDeletesServer === undefined) ||
+    (lease?.state === "failed" &&
+      Boolean(workspace.error) &&
+      lease.provisioningResourceMayExist !== true);
+  if (!terminal) {
+    return undefined;
+  }
+  const timestamps = [workspace.updatedAt, lease?.endedAt, lease?.releasedAt, lease?.updatedAt]
+    .map((value) => Date.parse(value ?? ""))
+    .filter(Number.isFinite);
+  return timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+}
+
+function workspaceOwnsLease(workspace: WorkspaceRecord, lease: LeaseRecord): boolean {
+  return (
+    lease.workspaceID === workspace.id &&
+    lease.id === workspace.leaseID &&
+    lease.owner === workspace.owner &&
+    lease.org === workspace.org
+  );
+}
+
+function workspaceResponse(
+  workspace: WorkspaceRecord,
+  lease?: LeaseRecord,
+): Record<string, unknown> {
+  const status = workspaceStatus(workspace, lease);
+  return {
+    id: workspace.id,
+    workspaceId: workspace.id,
+    providerResourceId: workspace.leaseID,
+    status,
+    profile: workspace.profile,
+    capabilities: {
+      terminal: false,
+      takeover: false,
+      vnc: false,
+      desktop: false,
+      logs: false,
+      artifacts: false,
+    },
+    ...(lease?.expiresAt ? { expiresAt: lease.expiresAt } : {}),
+    message:
+      workspace.error ??
+      (lease && !workspaceOwnsLease(workspace, lease)
+        ? "workspace lease reservation conflicts with another lifecycle"
+        : undefined) ??
+      lease?.failureError ??
+      (lease?.state === "failed" ? "workspace provisioning recovery pending" : undefined) ??
+      lease?.cleanupError ??
+      (status === "ready"
+        ? "workspace ready"
+        : status === "failed"
+          ? "workspace provisioning failed"
+          : `workspace ${status}`),
+  };
+}
+
+async function workspaceResponseError(response: Response, fallback: string): Promise<string> {
+  const body = (await response.json().catch(() => undefined)) as
+    | { message?: unknown; error?: unknown }
+    | undefined;
+  for (const value of [body?.message, body?.error]) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return fallback;
+}
+
 function newRunID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
@@ -7121,6 +8523,11 @@ function isProviderImageNotFound(error: unknown): boolean {
     message.includes("aws snapshot not found") ||
     message.includes("http 404")
   );
+}
+
+function providerResourceNotFound(error: unknown): boolean {
+  const message = errorMessage(error);
+  return message.includes("http 404") || isCloudNotFoundError(message);
 }
 
 function checkpointStrategy(value: string | undefined): "image" | "disk-snapshot" | undefined {
@@ -8966,6 +10373,7 @@ function parseProviderLabelTime(value: string | undefined): number {
 
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
+  findServerByLease?(leaseID: string): Promise<ProviderMachine | undefined>;
   getServer?(id: string): Promise<ProviderMachine>;
   prepareLeaseConfig?(
     config: ReturnType<typeof leaseConfig>,
@@ -9081,7 +10489,7 @@ interface ProviderProvisioningTarget {
   region?: string;
 }
 
-class HetznerProvider implements CloudProvider {
+export class HetznerProvider implements CloudProvider {
   private clientValue?: HetznerClient;
 
   constructor(private readonly env: Env) {}
@@ -9094,6 +10502,11 @@ class HetznerProvider implements CloudProvider {
   async listCrabboxServers(): Promise<ProviderMachine[]> {
     const servers = await this.client.listCrabboxServers();
     return servers.map((server) => this.client.toMachine(server));
+  }
+
+  async findServerByLease(leaseID: string): Promise<ProviderMachine | undefined> {
+    const server = await this.client.findServerByLease(leaseID);
+    return server ? this.client.toMachine(server) : undefined;
   }
 
   async createServerWithFallback(
@@ -9121,8 +10534,17 @@ class HetznerProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
-    await this.deleteServer(String(lease.serverID));
-    if (validCrabboxProviderKey(lease.providerKey)) {
+    try {
+      await this.deleteServer(String(lease.serverID));
+    } catch (error) {
+      if (!providerResourceNotFound(error)) {
+        throw error;
+      }
+    }
+    if (
+      !lease.providerKey.startsWith(workspaceProviderKeyPrefix) &&
+      validCrabboxProviderKey(lease.providerKey)
+    ) {
       await this.deleteSSHKey(lease.providerKey);
     }
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -31,6 +31,7 @@ import {
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
   sshPublicKeyIdentity,
+  workspaceProviderKeyPrefix,
 } from "./hetzner";
 import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
 import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth";
@@ -140,7 +141,6 @@ const workspaceProvisionClaimMs = 15 * 60_000;
 const workspaceProvisionRecoveryGraceMs = 15 * 60_000;
 const workspaceMinimumTTLSeconds =
   (workspaceProvisionClaimMs + workspaceProvisionRecoveryGraceMs) / 1000;
-const workspaceProviderKeyPrefix = "crabbox-workspace-";
 const workspaceMaxRecordsPerOwner = 100;
 const workspaceTerminalRetentionMs = 24 * 60 * 60_000;
 
@@ -1802,6 +1802,11 @@ export class FleetCoordinator {
           const terminalAt = workspaceTerminalTimestamp(current, lease);
           if (terminalAt === undefined || terminalAt > cutoff) {
             return;
+          }
+          if (lease && workspaceOwnsLease(current, lease)) {
+            const detachedLease = structuredClone(lease);
+            delete detachedLease.workspaceID;
+            await this.putLease(detachedLease);
           }
           await Promise.all([
             this.state.storage.delete(key),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1422,17 +1422,20 @@ export class FleetCoordinator {
       return { started: true as const, current };
     });
     if (!provisioningStart.started) {
+      let current = provisioningStart.current;
       if (provisioningStart.workspace) {
-        await this.finalizeAbsentWorkspaceLease(
+        current = await this.finalizeAbsentWorkspaceLease(
           provisioningStart.workspace,
           provisioningStart.current,
         );
+      } else {
+        current = await this.removeReleasedLeaseReservation(record);
       }
       return json(
         {
           error: "lease_state_changed",
           message: "lease changed state before provider provisioning began",
-          lease: provisioningStart.current,
+          lease: current,
         },
         { status: 409 },
       );

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1943,9 +1943,10 @@ export class FleetCoordinator {
             );
           }
           const now = new Date();
+          const hardDeadline = workspaceProvisionDeadline(current);
           current.provisionClaim = provisionClaim;
           current.provisionClaimExpiresAt = new Date(
-            now.getTime() + workspaceProvisionClaimMs,
+            Math.min(now.getTime() + workspaceProvisionClaimMs, hardDeadline),
           ).toISOString();
           current.updatedAt = now.toISOString();
           delete current.reconcileAfter;
@@ -8135,8 +8136,8 @@ async function workspaceLeaseRequest(
   sshPublicKey: string,
 ): Promise<Request> {
   const remainingMs = workspaceProvisionDeadline(workspace) - Date.now();
-  if (remainingMs <= 0) {
-    throw new Error("workspace provisioning deadline expired");
+  if (remainingMs < workspaceProvisionRecoveryGraceMs) {
+    throw new Error("workspace provisioning recovery window no longer fits before hard TTL");
   }
   const remainingSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
   const providerKey = `${workspaceProviderKeyPrefix}${(
@@ -8207,9 +8208,13 @@ function workspaceProvisionRecoveryDeadline(
   lease?: LeaseRecord,
 ): number {
   const requestStartedAt = Date.parse(lease?.provisioningRequestStartedAt ?? "");
-  return Number.isFinite(requestStartedAt)
-    ? requestStartedAt + workspaceProvisionRecoveryGraceMs
-    : workspaceProvisionDeadline(workspace) + workspaceProvisionRecoveryGraceMs;
+  const hardDeadline = workspaceProvisionDeadline(workspace);
+  return Math.min(
+    hardDeadline,
+    Number.isFinite(requestStartedAt)
+      ? requestStartedAt + workspaceProvisionRecoveryGraceMs
+      : hardDeadline,
+  );
 }
 
 function workspaceProvisioningNeedsRecovery(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -30,6 +30,7 @@ import {
   HetznerClient,
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
+  sshPublicKeyIdentity,
 } from "./hetzner";
 import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
 import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth";
@@ -2038,7 +2039,7 @@ export class FleetCoordinator {
         current.serverID = server.id;
         current.serverName = server.name;
         current.serverType = server.serverType;
-        if (server.host.trim()) {
+        if (server.status === "running" && server.host.trim()) {
           current.state = "active";
           current.host = server.host;
         } else {
@@ -8100,7 +8101,9 @@ async function workspaceLeaseRequest(
     throw new Error("workspace provisioning deadline expired");
   }
   const remainingSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
-  const providerKey = `${workspaceProviderKeyPrefix}${(await sha256Hex(sshPublicKey.trim())).slice(0, 12)}`;
+  const providerKey = `${workspaceProviderKeyPrefix}${(
+    await sha256Hex(sshPublicKeyIdentity(sshPublicKey))
+  ).slice(0, 12)}`;
   return new Request("https://crabbox.invalid/v1/leases", {
     method: "POST",
     headers: workspaceRecordHeaders(workspace),

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -138,7 +138,8 @@ const workspaceReconcileIntervalMs = 10_000;
 const workspaceReconcileMaxIntervalMs = 5 * 60_000;
 const workspaceProvisionClaimMs = 15 * 60_000;
 const workspaceProvisionRecoveryGraceMs = 15 * 60_000;
-const workspaceMinimumTTLSeconds = 20 * 60;
+const workspaceMinimumTTLSeconds =
+  (workspaceProvisionClaimMs + workspaceProvisionRecoveryGraceMs) / 1000;
 const workspaceProviderKeyPrefix = "crabbox-workspace-";
 const workspaceMaxRecordsPerOwner = 100;
 const workspaceTerminalRetentionMs = 24 * 60 * 60_000;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -136,8 +136,9 @@ const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
 const workspaceReconcileIntervalMs = 10_000;
 const workspaceReconcileMaxIntervalMs = 5 * 60_000;
-const workspaceProvisionClaimMs = 20 * 60_000;
+const workspaceProvisionClaimMs = 15 * 60_000;
 const workspaceProvisionRecoveryGraceMs = 15 * 60_000;
+const workspaceMinimumTTLSeconds = 20 * 60;
 const workspaceProviderKeyPrefix = "crabbox-workspace-";
 const workspaceMaxRecordsPerOwner = 100;
 const workspaceTerminalRetentionMs = 24 * 60 * 60_000;
@@ -1631,6 +1632,15 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    if (ttlSeconds < workspaceMinimumTTLSeconds) {
+      return json(
+        {
+          error: "invalid_duration",
+          message: `workspace ttlSeconds must be at least ${workspaceMinimumTTLSeconds}`,
+        },
+        { status: 400 },
+      );
+    }
     const desktop = false;
     const key = workspaceKey(owner, org, id);
     const existingResponse = await this.state.runExclusive(async () => {
@@ -2024,6 +2034,32 @@ export class FleetCoordinator {
       }
     }
     if (server) {
+      const recoveryConfig = leaseConfig({
+        provider: workspace.provider,
+        target: lease.target,
+        profile: lease.profile,
+        class: lease.class,
+        serverType: server.serverType,
+        providerKey: lease.providerKey,
+        desktop: lease.desktop ?? false,
+        browser: lease.browser ?? false,
+        code: lease.code ?? false,
+        ttlSeconds: lease.ttlSeconds,
+        idleTimeoutSeconds: lease.idleTimeoutSeconds ?? lease.ttlSeconds,
+        keep: lease.keep,
+        sshPublicKey:
+          this.env.CRABBOX_WORKSPACE_SSH_PUBLIC_KEY?.trim() || readinessDummySSHPublicKey,
+      });
+      const providerHourlyUSD = await provider
+        .hourlyPriceUSD(server.serverType, recoveryConfig)
+        .catch(() => undefined);
+      const recoveredCost = leaseCost(
+        this.env,
+        workspace.provider,
+        server.serverType,
+        lease.ttlSeconds,
+        providerHourlyUSD,
+      );
       const recovered = await this.state.runExclusive(async () => {
         const current = await this.getLease(lease.id);
         if (
@@ -2039,6 +2075,8 @@ export class FleetCoordinator {
         current.serverID = server.id;
         current.serverName = server.name;
         current.serverType = server.serverType;
+        current.estimatedHourlyUSD = recoveredCost.hourlyUSD;
+        current.maxEstimatedUSD = recoveredCost.maxUSD;
         if (server.status === "running" && server.host.trim()) {
           current.state = "active";
           current.host = server.host;

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -37,6 +37,8 @@ interface HetznerServerTypePrice {
   };
 }
 
+export const workspaceProviderKeyPrefix = "crabbox-workspace-";
+
 export class HetznerProvisioningError extends Error {
   constructor(
     message: string,
@@ -210,12 +212,12 @@ export class HetznerClient {
     return (await this.request<HetznerServerResponse>("GET", `/servers/${id}`)).server;
   }
 
-  async waitForServerIP(id: number): Promise<HetznerServer> {
+  async waitForServerIP(id: number, requireRunning = false): Promise<HetznerServer> {
     const deadline = Date.now() + 60_000;
     while (Date.now() < deadline) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- polling must wait between Hetzner API reads.
       const server = await this.getServer(id);
-      if (server.status === "running" && server.public_net.ipv4.ip) {
+      if (server.public_net.ipv4.ip && (!requireRunning || server.status === "running")) {
         return server;
       }
       // oxlint-disable-next-line eslint/no-await-in-loop -- this delay is the polling interval.
@@ -275,11 +277,15 @@ export class HetznerClient {
         transientHetznerError(message) || isRetryableProvisioningError(message),
       );
     }
-    if (response.server.status === "running" && response.server.public_net.ipv4.ip) {
+    const requireRunning = config.providerKey.startsWith(workspaceProviderKeyPrefix);
+    if (
+      response.server.public_net.ipv4.ip &&
+      (!requireRunning || response.server.status === "running")
+    ) {
       return response.server;
     }
     try {
-      return await this.waitForServerIP(response.server.id);
+      return await this.waitForServerIP(response.server.id, requireRunning);
     } catch (error) {
       throw new HetznerProvisioningError(errorText(error), true, true);
     }

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -287,7 +287,7 @@ export class HetznerClient {
 
   private async listSSHKeys(): Promise<HetznerSSHKey[]> {
     const keys: HetznerSSHKey[] = [];
-    const perPage = 100;
+    const perPage = 50;
     for (let page = 1; page <= 100; page += 1) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- Hetzner SSH key pagination is sequential.
       const response = await this.request<HetznerListSSHKeysResponse>(

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -91,25 +91,22 @@ export class HetznerClient {
   }
 
   async ensureSSHKey(name: string, publicKey: string): Promise<HetznerSSHKey> {
+    const identity = sshPublicKeyIdentity(publicKey);
     const byName = await this.request<HetznerListSSHKeysResponse>(
       "GET",
       `/ssh_keys?${new URLSearchParams({ name })}`,
     );
     for (const key of byName.ssh_keys) {
       if (key.name === name) {
-        if (key.public_key.trim() !== publicKey.trim()) {
+        if (sshPublicKeyIdentity(key.public_key) !== identity) {
           throw new Error(`hetzner ssh key ${name} exists with different public key`);
         }
         return key;
       }
     }
 
-    const all = await this.request<HetznerListSSHKeysResponse>(
-      "GET",
-      `/ssh_keys?${new URLSearchParams({ per_page: "100" })}`,
-    );
-    for (const key of all.ssh_keys) {
-      if (key.public_key.trim() === publicKey.trim()) {
+    for (const key of await this.listSSHKeys()) {
+      if (sshPublicKeyIdentity(key.public_key) === identity) {
         return key;
       }
     }
@@ -128,12 +125,10 @@ export class HetznerClient {
       if (!String(error).includes("uniqueness_error")) {
         throw error;
       }
-      const raced = await this.request<HetznerListSSHKeysResponse>(
-        "GET",
-        `/ssh_keys?${new URLSearchParams({ name })}`,
+      const key = (await this.listSSHKeys()).find(
+        (entry) => sshPublicKeyIdentity(entry.public_key) === identity,
       );
-      const key = raced.ssh_keys.find((entry) => entry.name === name);
-      if (key?.public_key.trim() === publicKey.trim()) {
+      if (key) {
         return key;
       }
       throw error;
@@ -220,7 +215,7 @@ export class HetznerClient {
     while (Date.now() < deadline) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- polling must wait between Hetzner API reads.
       const server = await this.getServer(id);
-      if (server.public_net.ipv4.ip) {
+      if (server.status === "running" && server.public_net.ipv4.ip) {
         return server;
       }
       // oxlint-disable-next-line eslint/no-await-in-loop -- this delay is the polling interval.
@@ -280,7 +275,7 @@ export class HetznerClient {
         transientHetznerError(message) || isRetryableProvisioningError(message),
       );
     }
-    if (response.server.public_net.ipv4.ip) {
+    if (response.server.status === "running" && response.server.public_net.ipv4.ip) {
       return response.server;
     }
     try {
@@ -288,6 +283,23 @@ export class HetznerClient {
     } catch (error) {
       throw new HetznerProvisioningError(errorText(error), true, true);
     }
+  }
+
+  private async listSSHKeys(): Promise<HetznerSSHKey[]> {
+    const keys: HetznerSSHKey[] = [];
+    const perPage = 100;
+    for (let page = 1; page <= 100; page += 1) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- Hetzner SSH key pagination is sequential.
+      const response = await this.request<HetznerListSSHKeysResponse>(
+        "GET",
+        `/ssh_keys?${new URLSearchParams({ page: String(page), per_page: String(perPage) })}`,
+      );
+      keys.push(...response.ssh_keys);
+      if (response.ssh_keys.length < perPage) {
+        break;
+      }
+    }
+    return keys;
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -312,6 +324,11 @@ export class HetznerClient {
     }
     return (await response.json()) as T;
   }
+}
+
+export function sshPublicKeyIdentity(publicKey: string): string {
+  const [type, encoded] = publicKey.trim().split(/\s+/, 3);
+  return type && encoded ? `${type} ${encoded}` : publicKey.trim();
 }
 
 export function isRetryableProvisioningError(message: string): boolean {

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -37,6 +37,31 @@ interface HetznerServerTypePrice {
   };
 }
 
+export class HetznerProvisioningError extends Error {
+  constructor(
+    message: string,
+    readonly resourceMayExist: boolean,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "HetznerProvisioningError";
+  }
+}
+
+export function hetznerProvisioningFailureMayHaveResource(error: unknown): boolean {
+  return (
+    (error instanceof HetznerProvisioningError && error.resourceMayExist) ||
+    errorText(error).includes("timed out waiting for server IP")
+  );
+}
+
+export function hetznerProvisioningFailureRetryable(error: unknown): boolean {
+  return (
+    (error instanceof HetznerProvisioningError && error.retryable) ||
+    errorText(error).includes("timed out waiting for server IP")
+  );
+}
+
 export class HetznerClient {
   private readonly token: string;
 
@@ -54,6 +79,15 @@ export class HetznerClient {
     });
     const response = await this.request<HetznerListServersResponse>("GET", `/servers?${query}`);
     return response.servers;
+  }
+
+  async findServerByLease(leaseID: string): Promise<HetznerServer | undefined> {
+    const query = new URLSearchParams({
+      label_selector: `crabbox=true,lease=${leaseID}`,
+      per_page: "1",
+    });
+    const response = await this.request<HetznerListServersResponse>("GET", `/servers?${query}`);
+    return response.servers[0];
   }
 
   async ensureSSHKey(name: string, publicKey: string): Promise<HetznerSSHKey> {
@@ -80,15 +114,30 @@ export class HetznerClient {
       }
     }
 
-    const created = await this.request<HetznerSSHKeyResponse>("POST", "/ssh_keys", {
-      name,
-      public_key: publicKey,
-      labels: {
-        crabbox: "true",
-        created_by: "crabbox",
-      },
-    });
-    return created.ssh_key;
+    try {
+      const created = await this.request<HetznerSSHKeyResponse>("POST", "/ssh_keys", {
+        name,
+        public_key: publicKey,
+        labels: {
+          crabbox: "true",
+          created_by: "crabbox",
+        },
+      });
+      return created.ssh_key;
+    } catch (error) {
+      if (!String(error).includes("uniqueness_error")) {
+        throw error;
+      }
+      const raced = await this.request<HetznerListSSHKeysResponse>(
+        "GET",
+        `/ssh_keys?${new URLSearchParams({ name })}`,
+      );
+      const key = raced.ssh_keys.find((entry) => entry.name === name);
+      if (key?.public_key.trim() === publicKey.trim()) {
+        return key;
+      }
+      throw error;
+    }
   }
 
   async deleteSSHKey(name: string): Promise<void> {
@@ -124,13 +173,21 @@ export class HetznerClient {
     slug: string,
     owner: string,
   ): Promise<{ server: HetznerServer; serverType: string }> {
-    const key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
+    let key: HetznerSSHKey;
+    try {
+      key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
+    } catch (error) {
+      const message = errorText(error);
+      throw new HetznerProvisioningError(message, false, transientHetznerError(message));
+    }
     const resolvedConfig = { ...config, providerKey: key.name };
     const candidates = prependUnique(
       resolvedConfig.serverType,
       serverTypeCandidatesForClass(resolvedConfig.class),
     );
     const failures: string[] = [];
+    let resourceMayExist = false;
+    let retryable = false;
     for (const serverType of candidates) {
       try {
         // oxlint-disable-next-line eslint/no-await-in-loop -- server-type fallback must stay sequential.
@@ -142,14 +199,16 @@ export class HetznerClient {
         );
         return { server, serverType };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorText(error);
         failures.push(`${serverType}: ${message}`);
-        if (!isRetryableProvisioningError(message)) {
+        resourceMayExist = hetznerProvisioningFailureMayHaveResource(error);
+        retryable = hetznerProvisioningFailureRetryable(error);
+        if (resourceMayExist || !isRetryableProvisioningError(message)) {
           break;
         }
       }
     }
-    throw new Error(failures.join("; "));
+    throw new HetznerProvisioningError(failures.join("; "), resourceMayExist, retryable);
   }
 
   async getServer(id: number): Promise<HetznerServer> {
@@ -196,23 +255,39 @@ export class HetznerClient {
     const now = new Date();
     const name = leaseProviderName(leaseID, slug);
     const labels = leaseProviderLabels(config, leaseID, slug, owner, "hetzner", now);
-    const response = await this.request<HetznerServerResponse>("POST", "/servers", {
-      name,
-      server_type: config.serverType,
-      image: config.image,
-      location: config.location,
-      labels,
-      ssh_keys: [config.providerKey],
-      user_data: cloudInit(config),
-      start_after_create: true,
-      public_net: {
-        enable_ipv4: true,
-        enable_ipv6: false,
-      },
-    });
-    return response.server.public_net.ipv4.ip
-      ? response.server
-      : await this.waitForServerIP(response.server.id);
+    let response: HetznerServerResponse;
+    try {
+      response = await this.request<HetznerServerResponse>("POST", "/servers", {
+        name,
+        server_type: config.serverType,
+        image: config.image,
+        location: config.location,
+        labels,
+        ssh_keys: [config.providerKey],
+        user_data: cloudInit(config),
+        start_after_create: true,
+        public_net: {
+          enable_ipv4: true,
+          enable_ipv6: false,
+        },
+      });
+    } catch (error) {
+      const message = errorText(error);
+      const status = /hetzner POST \/servers: http (\d{3})/.exec(message)?.[1];
+      throw new HetznerProvisioningError(
+        message,
+        status === undefined || Number.parseInt(status, 10) >= 500,
+        transientHetznerError(message) || isRetryableProvisioningError(message),
+      );
+    }
+    if (response.server.public_net.ipv4.ip) {
+      return response.server;
+    }
+    try {
+      return await this.waitForServerIP(response.server.id);
+    } catch (error) {
+      throw new HetznerProvisioningError(errorText(error), true, true);
+    }
   }
 
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -273,4 +348,20 @@ async function safeBody(response: Response): Promise<string> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function transientHetznerError(message: string): boolean {
+  if (message.includes("exists with different public key")) {
+    return false;
+  }
+  const status = /hetzner \w+ [^:]+: http (\d{3})/.exec(message)?.[1];
+  return (
+    status === undefined ||
+    Number.parseInt(status, 10) === 429 ||
+    Number.parseInt(status, 10) >= 500
+  );
 }

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -170,6 +170,7 @@ export class HetznerClient {
     slug: string,
     owner: string,
   ): Promise<{ server: HetznerServer; serverType: string }> {
+    const requireRunning = config.providerKey.startsWith(workspaceProviderKeyPrefix);
     let key: HetznerSSHKey;
     try {
       key = await this.ensureSSHKey(config.providerKey, config.sshPublicKey);
@@ -193,6 +194,7 @@ export class HetznerClient {
           leaseID,
           slug,
           owner,
+          requireRunning,
         );
         return { server, serverType };
       } catch (error) {
@@ -248,6 +250,7 @@ export class HetznerClient {
     leaseID: string,
     slug: string,
     owner: string,
+    requireRunning: boolean,
   ): Promise<HetznerServer> {
     const now = new Date();
     const name = leaseProviderName(leaseID, slug);
@@ -277,7 +280,6 @@ export class HetznerClient {
         transientHetznerError(message) || isRetryableProvisioningError(message),
       );
     }
-    const requireRunning = config.providerKey.startsWith(workspaceProviderKeyPrefix);
     if (
       response.server.public_net.ipv4.ip &&
       (!requireRunning || response.server.status === "running")

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -67,6 +67,9 @@ export interface Env {
   CRABBOX_GITHUB_ADMIN_OWNERS?: string;
   CRABBOX_GITHUB_ADMIN_LOGINS?: string;
   CRABBOX_PUBLIC_URL?: string;
+  CRABBOX_WORKSPACE_PROVIDER?: string;
+  CRABBOX_WORKSPACE_CLASS?: string;
+  CRABBOX_WORKSPACE_SSH_PUBLIC_KEY?: string;
   CRABBOX_DEFAULT_ORG?: string;
   CRABBOX_ACCESS_TEAM_DOMAIN?: string;
   CRABBOX_ACCESS_AUD?: string;
@@ -284,6 +287,7 @@ export interface RunTelemetrySummary {
 export interface LeaseRecord {
   id: string;
   slug?: string;
+  workspaceID?: string;
   provider: string;
   lifecycle?: LeaseLifecycle;
   target: TargetOS;
@@ -338,6 +342,10 @@ export interface LeaseRecord {
   cleanupRetryAt?: string;
   cleanupStartedAt?: string;
   cleanupClaimExpiresAt?: string;
+  failureError?: string;
+  provisioningResourceMayExist?: boolean;
+  provisioningFailureRetryable?: boolean;
+  provisioningRequestStartedAt?: string;
   releaseDeletesServer?: boolean;
   releasedAt?: string;
   endedAt?: string;

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -101,6 +101,9 @@ describe("coordinator runtimes", () => {
       ["GET", "/portal/hosts/aws/h-123"],
       ["POST", "/portal/hosts/aws/h-123/vnc"],
       ["POST", "/portal/leases/example/release"],
+      ["POST", "/v1/workspaces"],
+      ["GET", "/v1/workspaces/fleet-is-101"],
+      ["DELETE", "/v1/workspaces/fleet-is-101"],
     ]) {
       expect(
         coordinatorRequestQueue(new Request(`https://coordinator.test${path}`, { method })),

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1035,6 +1035,51 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBe(Date.parse(String(workspace["reconcileAfter"])));
   });
 
+  it("refuses late workspace provisioning that cannot recover before hard TTL", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const createdAt = new Date(Date.now() - 6 * 60_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-130", {
+      id: "fleet-is-130",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(0);
+    const failed = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-130", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(failed.json()).resolves.toMatchObject({
+      status: "failed",
+      message: "workspace provisioning recovery window no longer fits before hard TTL",
+    });
+  });
+
   it("rejects a conflicting non-workspace lease using the reserved workspace lease ID", async () => {
     const storage = new MemoryStorage();
     let providerReleases = 0;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4093,6 +4093,64 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
   });
 
+  it("removes a release canceled after provider preparation", async () => {
+    const storage = new MemoryStorage();
+    const prepareStarted = deferred<void>();
+    const finishPrepare = deferred<void>();
+    let providerCalled = false;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(
+        () => {
+          providerCalled = true;
+        },
+        {
+          provider: "aws",
+          async onPrepareLeaseCreate(config, lease) {
+            prepareStarted.resolve();
+            await finishPrepare.promise;
+            return {
+              config,
+              lease,
+              provisioning: {
+                sshIngressReconcile: "authoritative",
+                publishAccessBeforeProvisioning: true,
+              },
+            };
+          },
+        },
+      ),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const createPromise = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: "cbx_abcdef123456",
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    await prepareStarted.promise;
+    const releasePromise = fleet.fetch(
+      request("POST", "/v1/leases/cbx_abcdef123456/release", {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    finishPrepare.resolve();
+
+    expect((await releasePromise).status).toBe(200);
+    expect((await createPromise).status).toBe(409);
+    expect(providerCalled).toBe(false);
+    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
+    expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
+  });
+
   it("removes a retained release when Tailscale preparation fails", async () => {
     const storage = new MemoryStorage();
     let oauthStarted!: () => void;
@@ -11933,6 +11991,17 @@ function fakeProvider(
             publishAccessBeforeProvisioning?: boolean;
           };
         }
+      | Promise<
+          | {
+              config: LeaseConfig;
+              lease: LeaseRecord;
+              provisioning?: {
+                sshIngressReconcile?: "authoritative" | "additive";
+                publishAccessBeforeProvisioning?: boolean;
+              };
+            }
+          | undefined
+        >
       | undefined;
     onRefreshLeaseAccess?: (
       lease: LeaseRecord,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -361,6 +361,23 @@ describe("fleet lease identity and idle", () => {
       profile,
       capabilities: { terminal: false, desktop: false, vnc: false },
     });
+    const shortTTL = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "fleet-too-short",
+          runtime: "crabbox",
+          ttlSeconds: 1199,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+    expect(shortTTL.status).toBe(400);
+    await expect(shortTTL.json()).resolves.toMatchObject({
+      error: "invalid_duration",
+      message: "workspace ttlSeconds must be at least 1200",
+    });
     await fleet.alarm();
     expect(createdClass).toBe("standard");
     expect(createdProviderKey).toBe(
@@ -1934,7 +1951,7 @@ describe("fleet lease identity and idle", () => {
             cloudID: "655",
             name: "crabbox-fleet-is-129",
             status: "initializing",
-            serverType: "cpx62",
+            serverType: "cx53",
             host: "192.0.2.129",
             labels: { lease: leaseID },
           },
@@ -1969,6 +1986,8 @@ describe("fleet lease identity and idle", () => {
         serverName: "",
         host: "",
         keep: false,
+        ttlSeconds: 3600,
+        idleTimeoutSeconds: 3600,
         state: "provisioning",
         provisioningRequestStartedAt: old,
         createdAt: old,
@@ -1992,6 +2011,9 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
       cloudID: "655",
       state: "provisioning",
+      serverType: "cx53",
+      estimatedHourlyUSD: 0.1,
+      maxEstimatedUSD: 0.1,
     });
   });
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -223,6 +223,30 @@ describe("fleet lease identity and idle", () => {
     expect((error as HetznerProvisioningError).retryable).toBe(false);
   });
 
+  it("recovers Hetzner SSH key uniqueness races by key identity", async () => {
+    const existing = {
+      id: 42,
+      name: "legacy-workspace-key",
+      fingerprint: "fingerprint",
+      public_key: "ssh-ed25519 workspace-test old-comment",
+    };
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ error: { code: "uniqueness_error" } }, 409),
+      jsonResponse({ ssh_keys: [existing] }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      client.ensureSSHKey("crabbox-workspace-new", "ssh-ed25519 workspace-test new-comment"),
+    ).resolves.toEqual(existing);
+  });
+
   it("treats an already-absent Hetzner server as successful cleanup", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1867,6 +1891,79 @@ describe("fleet lease identity and idle", () => {
       status: "expired",
     });
     expect(providerReleases).toBe(1);
+  });
+
+  it("does not report a recovered initializing server as ready when it already has an IP", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {
+        servers: [
+          {
+            provider: "hetzner",
+            id: 655,
+            cloudID: "655",
+            name: "crabbox-fleet-is-129",
+            status: "initializing",
+            serverType: "cpx62",
+            host: "192.0.2.129",
+            labels: { lease: leaseID },
+          },
+        ],
+      }),
+    });
+    const old = new Date(Date.now() - 20 * 60_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-129", {
+      id: "fleet-is-129",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 3600,
+      idleTimeoutSeconds: 360,
+      createdAt: old,
+      updatedAt: old,
+    });
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "fleet-is-129",
+        workspaceID: "fleet-is-129",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        keep: false,
+        state: "provisioning",
+        provisioningRequestStartedAt: old,
+        createdAt: old,
+        updatedAt: old,
+        lastTouchedAt: old,
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    const pending = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-129", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(pending.json()).resolves.toMatchObject({ status: "provisioning" });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      cloudID: "655",
+      state: "provisioning",
+    });
   });
 
   it("expires interrupted workspace recovery through normal lease cleanup", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -7,6 +7,7 @@ import { awsPromotedAMIConfigKey, leaseConfig, type LeaseConfig } from "../src/c
 import {
   AWSProvider,
   FleetDurableObject,
+  HetznerProvider,
   bridgeTicketFromRequest,
   codeForwardHeaders,
   codeResponseHeaders,
@@ -17,6 +18,7 @@ import {
   shouldActivateEgressSession,
   type WebVNCBuffer,
 } from "../src/fleet";
+import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { portalCode } from "../src/portal";
 import type {
   Env,
@@ -125,6 +127,1843 @@ class FakeWebSocket {
 }
 
 describe("fleet lease identity and idle", () => {
+  it("keeps transient Hetzner create failures recoverable", async () => {
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({
+        ssh_key: {
+          id: 1,
+          name: "crabbox-workspace-test",
+          public_key: "ssh-ed25519 workspace-test",
+        },
+      }),
+      jsonResponse({ error: { code: "server_error" } }, 503),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-workspace-test",
+      sshPublicKey: "ssh-ed25519 workspace-test",
+    });
+
+    const error = await client
+      .createServerWithFallback(config, "cbx_abcdef123456", "fleet-is-100", "alice@example.com")
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HetznerProvisioningError);
+    expect((error as HetznerProvisioningError).resourceMayExist).toBe(true);
+  });
+
+  it("uses the terminating Hetzner fallback error to decide retryability", async () => {
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({
+        ssh_key: {
+          id: 1,
+          name: "crabbox-workspace-test",
+          public_key: "ssh-ed25519 workspace-test",
+        },
+      }),
+      jsonResponse({ error: { code: "server_type_not_available" } }, 400),
+      jsonResponse({ error: { code: "invalid_input" } }, 400),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-workspace-test",
+      sshPublicKey: "ssh-ed25519 workspace-test",
+    });
+
+    const error = await client
+      .createServerWithFallback(config, "cbx_abcdef123456", "fleet-is-100", "alice@example.com")
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HetznerProvisioningError);
+    expect((error as HetznerProvisioningError).retryable).toBe(false);
+  });
+
+  it("treats a conflicting shared Hetzner SSH key as terminal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          ssh_keys: [
+            {
+              id: 1,
+              name: "crabbox-workspace-test",
+              public_key: "ssh-ed25519 different-key",
+            },
+          ],
+        }),
+      ),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-workspace-test",
+      sshPublicKey: "ssh-ed25519 workspace-test",
+    });
+
+    const error = await client
+      .createServerWithFallback(config, "cbx_abcdef123456", "fleet-is-100", "alice@example.com")
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(HetznerProvisioningError);
+    expect((error as HetznerProvisioningError).resourceMayExist).toBe(false);
+    expect((error as HetznerProvisioningError).retryable).toBe(false);
+  });
+
+  it("treats an already-absent Hetzner server as successful cleanup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: { code: "not_found" } }, 404)),
+    );
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const lease = testLease({
+      provider: "hetzner",
+      serverID: 123,
+      providerKey: "crabbox-workspace-deadbeef0000",
+    });
+
+    await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
+  });
+
+  it("reserves the shared workspace provider key from ordinary leases", async () => {
+    const fleet = testFleet(undefined, { hetzner: fakeProvider() });
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {
+          provider: "hetzner",
+          providerKey: "crabbox-workspace-deadbeef0000",
+          sshPublicKey: "ssh-ed25519 ordinary-test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "reserved_provider_key" });
+  });
+
+  it("adapts workspaces onto owner-scoped lease lifecycle", async () => {
+    const storage = new MemoryStorage();
+    let createdClass = "";
+    let createdProviderKey = "";
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          (config) => {
+            createdClass = config.class;
+            createdProviderKey = config.providerKey;
+          },
+          {},
+          async () => {
+            providerReleases += 1;
+          },
+        ),
+      },
+      {
+        CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test",
+      },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const profile = "profile-".padEnd(100, "x");
+    const body = {
+      id: "fleet-is-101",
+      runtime: "crabbox",
+      profile,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: true },
+    };
+    const create = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers: { ...headers, "idempotency-key": body.id },
+        body,
+      }),
+    );
+    expect(create.status).toBe(202);
+    const created = (await create.json()) as { providerResourceId: string };
+    expect(created.providerResourceId).toMatch(/^cbx_[a-f0-9]{12}$/);
+    expect(created).toMatchObject({
+      status: "provisioning",
+      profile,
+      capabilities: { terminal: false, desktop: false, vnc: false },
+    });
+    await fleet.alarm();
+    expect(createdClass).toBe("standard");
+    expect(createdProviderKey).toBe(
+      `crabbox-workspace-${(await sha256HexForTest("ssh-ed25519 workspace-test")).slice(0, 12)}`,
+    );
+    const ready = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(ready.json()).resolves.toMatchObject({
+      providerResourceId: created.providerResourceId,
+      status: "ready",
+    });
+
+    const leaseKey = `lease:${created.providerResourceId}`;
+    const activeLease = storage.value<LeaseRecord>(leaseKey)!;
+    expect(activeLease.idleTimeoutSeconds).toBe(body.ttlSeconds);
+    const staleTouch = new Date(Date.now() - 60_000).toISOString();
+    activeLease.lastTouchedAt = staleTouch;
+    activeLease.updatedAt = staleTouch;
+    storage.seed(leaseKey, activeLease);
+    const inspect = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(inspect.json()).resolves.toMatchObject({
+      id: body.id,
+      providerResourceId: created.providerResourceId,
+      status: "ready",
+    });
+    expect(storage.value<LeaseRecord>(leaseKey)?.lastTouchedAt).toBe(staleTouch);
+
+    const desktop = await fleet.fetch(
+      request("POST", `/v1/workspaces/${body.id}/connections/desktop`, { headers }),
+    );
+    expect(desktop.status).toBe(409);
+    await expect(desktop.json()).resolves.toEqual({
+      error: "desktop_unavailable",
+      message: "workspace desktop handoff is not configured",
+    });
+    const missingDesktop = await fleet.fetch(
+      request("POST", "/v1/workspaces/missing-workspace/connections/desktop", { headers }),
+    );
+    expect(missingDesktop.status).toBe(404);
+    const otherOwnerDesktop = await fleet.fetch(
+      request("POST", `/v1/workspaces/${body.id}/connections/desktop`, {
+        headers: {
+          "x-crabbox-owner": "bob@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(otherOwnerDesktop.status).toBe(404);
+
+    const duplicate = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    await expect(duplicate.json()).resolves.toMatchObject({
+      providerResourceId: created.providerResourceId,
+      status: "ready",
+    });
+
+    const otherOwner = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers: {
+          "x-crabbox-owner": "bob@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body,
+      }),
+    );
+    const other = (await otherOwner.json()) as { providerResourceId: string };
+    expect(other.providerResourceId).not.toBe(created.providerResourceId);
+
+    const released = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(released.json()).resolves.toMatchObject({ status: "stopped" });
+    expect(providerReleases).toBe(1);
+  });
+
+  it("rejects malformed workspace request bodies", async () => {
+    const fleet = testFleet();
+    const headers = {
+      "content-type": "application/json",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    await Promise.all(
+      [null, [], { id: 42 }, { id: "fleet-invalid", profile: 42 }].map(async (body) => {
+        const response = await fleet.fetch(
+          new Request("https://coordinator.test/v1/workspaces", {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+          }),
+        );
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: "invalid_workspace_request",
+        });
+      }),
+    );
+    const invalidJSON = await fleet.fetch(
+      new Request("https://coordinator.test/v1/workspaces", {
+        method: "POST",
+        headers,
+        body: "{",
+      }),
+    );
+    expect(invalidJSON.status).toBe(400);
+    await expect(invalidJSON.json()).resolves.toMatchObject({
+      error: "invalid_workspace_request",
+    });
+  });
+
+  it("keeps delete pending until concurrent workspace provisioning settles", async () => {
+    const storage = new MemoryStorage();
+    const started = deferred<void>();
+    const unblock = deferred<void>();
+    let providerCreates = 0;
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          async () => {
+            providerCreates += 1;
+            started.resolve();
+            await unblock.promise;
+          },
+          {},
+          async () => {
+            providerReleases += 1;
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-102",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const creating = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    expect(creating.status).toBe(202);
+    const provisioning = fleet.alarm();
+    await started.promise;
+
+    const duplicate = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    expect(duplicate.status).toBe(202);
+    const pending = (await duplicate.json()) as { providerResourceId: string };
+    expect(pending).toMatchObject({ status: "provisioning" });
+
+    const deleting = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(deleting.json()).resolves.toMatchObject({ status: "stopping" });
+
+    unblock.resolve();
+    await provisioning;
+    const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({
+      providerResourceId: pending.providerResourceId,
+      status: "stopped",
+    });
+    expect(providerCreates).toBe(1);
+    expect(providerReleases).toBe(1);
+  });
+
+  it("blocks provisioning when delete wins before lease reservation", async () => {
+    const storage = new MemoryStorage();
+    const preparing = deferred<void>();
+    const unblock = deferred<void>();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          () => {
+            providerCreates += 1;
+          },
+          {
+            onPrepareLeaseConfig: async (config) => {
+              preparing.resolve();
+              await unblock.promise;
+              return config;
+            },
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-105",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const provisioning = fleet.alarm();
+    await preparing.promise;
+
+    const deleted = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(deleted.json()).resolves.toMatchObject({ status: "stopped" });
+
+    unblock.resolve();
+    await provisioning;
+    expect(providerCreates).toBe(0);
+    expect((await storage.list({ prefix: "lease:" })).size).toBe(0);
+    const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+  });
+
+  it("provisions a persisted workspace reservation from the durable alarm", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const now = new Date().toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-103", {
+      id: "fleet-is-103",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const resumed = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "fleet-is-103",
+          runtime: "crabbox",
+          ttlSeconds: 1200,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+    await expect(resumed.json()).resolves.toMatchObject({
+      providerResourceId: "cbx_abcdef123456",
+      status: "provisioning",
+    });
+    await fleet.alarm();
+    const ready = await fleet.fetch(request("GET", "/v1/workspaces/fleet-is-103", { headers }));
+    await expect(ready.json()).resolves.toMatchObject({
+      providerResourceId: "cbx_abcdef123456",
+      status: "ready",
+    });
+    expect(providerCreates).toBe(1);
+  });
+
+  it("waits for an unexpired provisioning claim when no lease was written", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-121", {
+      id: "fleet-is-121",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      provisionClaim: "claim-121",
+      provisionClaimExpiresAt: claimExpiresAt,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(0);
+    expect(storage.alarm()).toBe(Date.parse(claimExpiresAt));
+  });
+
+  it("retries a persisted lease when the provider request never started", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const now = new Date().toISOString();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-123";
+    storage.seed(workspaceKey, {
+      id: "fleet-is-123",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      provisionClaim: "expired-claim",
+      provisionClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: "fleet-is-123",
+        workspaceID: "fleet-is-123",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        keep: false,
+        state: "provisioning",
+        createdAt: now,
+        updatedAt: now,
+        lastTouchedAt: now,
+        expiresAt: new Date(Date.now() + 1200_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+    expect(providerCreates).toBe(0);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toBeUndefined();
+
+    const workspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+    storage.seed(workspaceKey, {
+      ...workspace,
+      reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(1);
+    const ready = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-123", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(ready.json()).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it("backs off provider recovery errors after the ambiguity deadline", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {
+        onList: () => {
+          providerLookups += 1;
+          throw new Error("provider unavailable");
+        },
+      }),
+    });
+    const old = new Date(Date.now() - 20 * 60_000).toISOString();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-124";
+    storage.seed(workspaceKey, {
+      id: "fleet-is-124",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1,
+      idleTimeoutSeconds: 1,
+      createdAt: old,
+      updatedAt: old,
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: "fleet-is-124",
+        workspaceID: "fleet-is-124",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        keep: false,
+        state: "failed",
+        provisioningResourceMayExist: true,
+        provisioningRequestStartedAt: old,
+        createdAt: old,
+        updatedAt: old,
+        lastTouchedAt: old,
+        expiresAt: new Date(Date.now() - 1_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(1);
+    expect(storage.alarm()).toBeGreaterThan(Date.now() + 5_000);
+  });
+
+  it.each([
+    { id: "fleet-is-127", state: "failed" as const, retryable: true },
+    { id: "fleet-is-128", state: "provisioning" as const, retryable: undefined },
+  ])("retries $state provisioning after confirmed provider absence", async (testCase) => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const old = new Date(Date.now() - 20 * 60_000).toISOString();
+    const workspaceKey = `workspace:example-org:alice%40example.com:${testCase.id}`;
+    storage.seed(workspaceKey, {
+      id: testCase.id,
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 3600,
+      idleTimeoutSeconds: 360,
+      createdAt: old,
+      updatedAt: old,
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: testCase.id,
+        workspaceID: testCase.id,
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        keep: false,
+        state: testCase.state,
+        provisioningResourceMayExist: true,
+        provisioningFailureRetryable: testCase.retryable,
+        provisioningRequestStartedAt: old,
+        createdAt: old,
+        updatedAt: old,
+        lastTouchedAt: old,
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(0);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toBeUndefined();
+    const workspace = storage.value<WorkspaceRecord>(workspaceKey)!;
+    expect(Date.parse(workspace.reconcileAfter ?? "")).toBeGreaterThan(Date.now());
+
+    storage.seed(workspaceKey, {
+      ...workspace,
+      reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(1);
+    const ready = await fleet.fetch(
+      request("GET", `/v1/workspaces/${testCase.id}`, {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(ready.json()).resolves.toMatchObject({ status: "ready" });
+  });
+
+  it("does not recover an expired lease while its provider request claim is active", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {
+        onList: () => {
+          providerLookups += 1;
+        },
+      }),
+    });
+    const now = new Date().toISOString();
+    const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-125", {
+      id: "fleet-is-125",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1,
+      idleTimeoutSeconds: 1,
+      provisionClaim: "claim-125",
+      provisionClaimExpiresAt: claimExpiresAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: "fleet-is-125",
+        workspaceID: "fleet-is-125",
+        owner: "alice@example.com",
+        org: "example-org",
+        cloudID: "",
+        serverID: 0,
+        serverName: "",
+        host: "",
+        keep: false,
+        state: "provisioning",
+        provisioningRequestStartedAt: now,
+        createdAt: now,
+        updatedAt: now,
+        lastTouchedAt: now,
+        expiresAt: new Date(Date.now() - 1_000).toISOString(),
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerLookups).toBe(0);
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.state).toBe("provisioning");
+    expect(storage.alarm()).toBe(Date.parse(claimExpiresAt));
+  });
+
+  it("does not start provider provisioning after workspace release wins", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-126";
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          async () => {
+            providerCreates += 1;
+          },
+          {
+            onPrepareLeaseCreate: () => {
+              const workspace = storage.value<WorkspaceRecord>(workspaceKey)!;
+              const releasedAt = new Date().toISOString();
+              storage.seed(workspaceKey, {
+                ...workspace,
+                releaseRequestedAt: releasedAt,
+                updatedAt: releasedAt,
+              });
+              return undefined;
+            },
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "fleet-is-126",
+          runtime: "crabbox",
+          ttlSeconds: 1200,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+
+    await fleet.alarm();
+
+    expect(providerCreates).toBe(0);
+    const stopped = await fleet.fetch(request("GET", "/v1/workspaces/fleet-is-126", { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+  });
+
+  it("retries transient workspace admission failures without poisoning the workspace ID", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      {},
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-116",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+
+    await fleet.alarm();
+
+    const pending = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(pending.json()).resolves.toMatchObject({ status: "provisioning" });
+    const workspace = storage.value<Record<string, unknown>>(
+      "workspace:example-org:alice%40example.com:fleet-is-116",
+    )!;
+    expect(workspace["error"]).toBeUndefined();
+    expect(Date.parse(String(workspace["reconcileAfter"]))).toBeGreaterThan(Date.now());
+    expect(storage.alarm()).toBe(Date.parse(String(workspace["reconcileAfter"])));
+  });
+
+  it("rejects a conflicting non-workspace lease using the reserved workspace lease ID", async () => {
+    const storage = new MemoryStorage();
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(undefined, {}, async () => {
+          providerReleases += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-110",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const created = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const pending = (await created.json()) as { providerResourceId: string };
+    const now = new Date().toISOString();
+    storage.seed(`lease:${pending.providerResourceId}`, {
+      id: pending.providerResourceId,
+      slug: body.id,
+      provider: "hetzner",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "999",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "cpx62",
+      requestedServerType: "cpx62",
+      serverID: 999,
+      serverName: "unrelated",
+      providerKey: "unrelated",
+      host: "192.0.2.110",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "provisioning",
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      expiresAt: new Date(Date.now() - 1_000).toISOString(),
+    } as LeaseRecord);
+
+    await fleet.alarm();
+
+    const failed = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(failed.json()).resolves.toMatchObject({
+      status: "failed",
+      message: "workspace lease reservation conflicts with another lifecycle",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${pending.providerResourceId}`)?.state).toBe(
+      "expired",
+    );
+    expect(providerReleases).toBe(1);
+  });
+
+  it("reserves workspace lease IDs before asynchronous provisioning starts", async () => {
+    const fleet = testFleet(
+      undefined,
+      { hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const created = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "fleet-is-120",
+          runtime: "crabbox",
+          ttlSeconds: 1200,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+    const pending = (await created.json()) as { providerResourceId: string };
+
+    const genericCreate = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: {
+          leaseID: pending.providerResourceId,
+          provider: "hetzner",
+          providerKey: "ordinary-key",
+          sshPublicKey: "ssh-ed25519 ordinary-test",
+        },
+      }),
+    );
+    expect(genericCreate.status).toBe(409);
+    await expect(genericCreate.json()).resolves.toMatchObject({
+      error: "workspace_managed_lease",
+    });
+
+    const registration = await fleet.fetch(
+      request("PUT", `/v1/leases/${pending.providerResourceId}/registration`, {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "host.example.test",
+          ttlSeconds: 1200,
+          idleTimeoutSeconds: 360,
+        },
+      }),
+    );
+    expect(registration.status).toBe(409);
+    await expect(registration.json()).resolves.toMatchObject({
+      error: "workspace_managed_lease",
+    });
+  });
+
+  it("does not advertise an expired active workspace as ready during cleanup", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-111",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const created = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const pending = (await created.json()) as { providerResourceId: string };
+    await fleet.alarm();
+    const leaseKey = `lease:${pending.providerResourceId}`;
+    const lease = storage.value<LeaseRecord>(leaseKey)!;
+    lease.expiresAt = new Date(Date.now() - 1_000).toISOString();
+    lease.cleanupStartedAt = new Date().toISOString();
+    storage.seed(leaseKey, lease);
+
+    const expired = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+
+    await expect(expired.json()).resolves.toMatchObject({ status: "expired" });
+  });
+
+  it("recovers and releases an interrupted provider resource after release intent persisted", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          undefined,
+          {
+            servers: [
+              {
+                provider: "hetzner",
+                id: 321,
+                cloudID: "321",
+                name: "crabbox-fleet-is-106",
+                status: "running",
+                serverType: "cpx62",
+                host: "192.0.2.106",
+                labels: { lease: leaseID },
+              },
+            ],
+          },
+          async () => {
+            providerReleases += 1;
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const now = new Date().toISOString();
+    const expiresAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-106", {
+      id: "fleet-is-106",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      createdAt: now,
+      updatedAt: now,
+      releaseRequestedAt: now,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      id: leaseID,
+      slug: "fleet-is-106",
+      workspaceID: "fleet-is-106",
+      provider: "hetzner",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "cpx62",
+      requestedServerType: "cpx62",
+      serverID: 0,
+      serverName: "",
+      providerKey: "workspace-test",
+      host: "",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "released",
+      releaseDeletesServer: true,
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      expiresAt,
+    } as LeaseRecord);
+
+    await fleet.alarm();
+    expect(providerReleases).toBe(1);
+    const stopped = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-106", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(stopped.json()).resolves.toMatchObject({
+      providerResourceId: leaseID,
+      status: "stopped",
+    });
+  });
+
+  it("keeps failed workspace cleanup retryable until provider deletion succeeds", async () => {
+    const storage = new MemoryStorage();
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(undefined, {}, async () => {
+          providerReleases += 1;
+          if (providerReleases === 1) {
+            throw new Error("provider cleanup throttled");
+          }
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-104",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    await fleet.alarm();
+
+    const pending = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(pending.json()).resolves.toMatchObject({
+      status: "stopping",
+      message: "provider cleanup throttled",
+    });
+    const nextBody = { ...body, id: "fleet-is-107" };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body: nextBody }));
+    await fleet.alarm();
+    const nextReady = await fleet.fetch(
+      request("GET", `/v1/workspaces/${nextBody.id}`, { headers }),
+    );
+    await expect(nextReady.json()).resolves.toMatchObject({ status: "ready" });
+    expect(providerReleases).toBe(1);
+
+    const stopped = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({
+      status: "stopped",
+      message: "workspace stopped",
+    });
+    expect(providerReleases).toBe(2);
+  });
+
+  it("keeps deletion pending while recovering a provider resource after provisioning failure", async () => {
+    const storage = new MemoryStorage();
+    let leaseID = "";
+    let providerReleases = 0;
+    let providerLookups = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          async () => {
+            throw new Error("timed out waiting for server IP");
+          },
+          {
+            onList: () => {
+              providerLookups += 1;
+              return providerLookups === 1
+                ? []
+                : [
+                    {
+                      provider: "hetzner",
+                      id: 777,
+                      cloudID: "777",
+                      name: "crabbox-fleet-is-112",
+                      status: "running",
+                      serverType: "cpx62",
+                      host: "192.0.2.112",
+                      labels: { lease: leaseID },
+                    },
+                  ];
+            },
+          },
+          async () => {
+            providerReleases += 1;
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-112",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const created = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const pending = (await created.json()) as { providerResourceId: string };
+    leaseID = pending.providerResourceId;
+
+    await fleet.alarm();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-112";
+    const recovering = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(recovering.json()).resolves.toMatchObject({
+      status: "provisioning",
+      message: "workspace provisioning recovery pending",
+    });
+    const workspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+    expect(storage.alarm()).toBe(Date.parse(String(workspace["reconcileAfter"])));
+    expect(storage.alarm()).toBeGreaterThan(Date.now());
+    const deleting = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(deleting.json()).resolves.toMatchObject({ status: "stopping" });
+    expect(providerReleases).toBe(0);
+    const deletingWorkspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+    storage.seed(workspaceKey, {
+      ...deletingWorkspace,
+      reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+    const retrying = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(retrying.json()).resolves.toMatchObject({ status: "stopping" });
+    const retryingWorkspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+    expect(retryingWorkspace["error"]).toBeUndefined();
+    storage.seed(workspaceKey, {
+      ...retryingWorkspace,
+      reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({
+      providerResourceId: pending.providerResourceId,
+      status: "stopped",
+    });
+    expect(providerReleases).toBe(1);
+  });
+
+  it("fails deterministic workspace provisioning errors without waiting for the lease TTL", async () => {
+    const storage = new MemoryStorage();
+    let providerLookups = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(
+          async () => {
+            throw new Error("hetzner POST /servers: http 400: invalid_input");
+          },
+          {
+            onList: () => {
+              providerLookups += 1;
+              return [];
+            },
+          },
+        ),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-117",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+
+    await fleet.alarm();
+
+    const failed = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(failed.json()).resolves.toMatchObject({
+      status: "failed",
+      message: "hetzner POST /servers: http 400: invalid_input",
+    });
+    const lease = [...(await storage.list<LeaseRecord>({ prefix: "lease:" })).values()][0];
+    expect(lease?.provisioningResourceMayExist).toBe(false);
+
+    const stopping = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopping.json()).resolves.toMatchObject({ status: "stopping" });
+    await fleet.alarm();
+    const stopped = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+    expect(providerLookups).toBe(0);
+  });
+
+  it("retries transient workspace provisioning failures when no resource can exist", async () => {
+    const storage = new MemoryStorage();
+    let providerCreates = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(async () => {
+          providerCreates += 1;
+          if (providerCreates === 1) {
+            throw new HetznerProvisioningError(
+              "hetzner POST /servers: http 429: rate_limit_exceeded",
+              false,
+              true,
+            );
+          }
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-119",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-119";
+
+    await fleet.alarm();
+    const recovering = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(recovering.json()).resolves.toMatchObject({ status: "provisioning" });
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const workspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+      storage.seed(workspaceKey, {
+        ...workspace,
+        reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+      });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- retry phases depend on persisted state.
+      await fleet.alarm();
+    }
+
+    const ready = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(ready.json()).resolves.toMatchObject({ status: "ready" });
+    expect(providerCreates).toBe(2);
+  });
+
+  it("does not retry workspace cost-limit failures", async () => {
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      {
+        CRABBOX_MAX_ACTIVE_LEASES: "1",
+        CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test",
+      },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-118",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+
+    await fleet.alarm();
+
+    const failed = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(failed.json()).resolves.toMatchObject({
+      status: "failed",
+      message: expect.stringContaining("active lease limit exceeded"),
+    });
+    const workspace = storage.value<Record<string, unknown>>(
+      "workspace:example-org:alice%40example.com:fleet-is-118",
+    );
+    expect(workspace?.["reconcileAfter"]).toBeUndefined();
+  });
+
+  it("bounds workspace records per owner and prunes old terminal reservations", async () => {
+    const storage = new MemoryStorage();
+    const old = new Date(Date.now() - 25 * 60 * 60_000).toISOString();
+    for (let index = 0; index < 100; index += 1) {
+      const id = `fleet-cap-${index}`;
+      const leaseID = `cbx_${index.toString(16).padStart(12, "0")}`;
+      storage.seed(`workspace:example-org:alice%40example.com:${id}`, {
+        id,
+        leaseID,
+        owner: "alice@example.com",
+        org: "example-org",
+        profile: "default",
+        provider: "hetzner",
+        class: "standard",
+        desktop: false,
+        ttlSeconds: 1200,
+        idleTimeoutSeconds: 360,
+        createdAt: old,
+        updatedAt: old,
+        releaseRequestedAt: old,
+      });
+      storage.seed(`workspace-lease:${leaseID}`, true);
+    }
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider() },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const limited = await fleet.fetch(
+      request("POST", "/v1/workspaces", {
+        headers,
+        body: {
+          id: "fleet-over-limit",
+          runtime: "crabbox",
+          ttlSeconds: 1200,
+          idleTimeoutSeconds: 360,
+          capabilities: { desktop: false },
+        },
+      }),
+    );
+    expect(limited.status).toBe(429);
+    await expect(limited.json()).resolves.toMatchObject({
+      error: "workspace_limit_exceeded",
+    });
+
+    await fleet.alarm();
+
+    expect((await storage.list({ prefix: "workspace:" })).size).toBe(0);
+    expect((await storage.list({ prefix: "workspace-lease:" })).size).toBe(0);
+  });
+
+  it("schedules terminal workspace retention cleanup", async () => {
+    const storage = new MemoryStorage();
+    const terminalAt = new Date().toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-122", {
+      id: "fleet-is-122",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      createdAt: terminalAt,
+      updatedAt: terminalAt,
+      releaseRequestedAt: terminalAt,
+    });
+    const fleet = testFleet(storage);
+
+    await fleet.alarm();
+
+    expect(storage.alarm()).toBe(Date.parse(terminalAt) + 24 * 60 * 60_000);
+  });
+
+  it("keeps workspace-owned leases behind workspace deletion and cleans retained resources", async () => {
+    const storage = new MemoryStorage();
+    let providerReleases = 0;
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(undefined, {}, async () => {
+          providerReleases += 1;
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-113",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const created = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const pending = (await created.json()) as { providerResourceId: string };
+    await fleet.alarm();
+
+    const leaseKey = `lease:${pending.providerResourceId}`;
+    const lastTouchedAt = storage.value<LeaseRecord>(leaseKey)?.lastTouchedAt;
+    const genericHeartbeat = await fleet.fetch(
+      request("POST", `/v1/leases/${pending.providerResourceId}/heartbeat`, {
+        headers,
+        body: { idleTimeoutSeconds: 3_600 },
+      }),
+    );
+    expect(genericHeartbeat.status).toBe(409);
+    await expect(genericHeartbeat.json()).resolves.toMatchObject({
+      error: "workspace_managed_lease",
+    });
+    expect(storage.value<LeaseRecord>(leaseKey)?.lastTouchedAt).toBe(lastTouchedAt);
+
+    const genericRelease = await fleet.fetch(
+      request("POST", `/v1/leases/${pending.providerResourceId}/release`, {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(genericRelease.status).toBe(409);
+    await expect(genericRelease.json()).resolves.toMatchObject({
+      error: "workspace_managed_lease",
+    });
+
+    const retained = storage.value<LeaseRecord>(leaseKey)!;
+    retained.state = "released";
+    retained.releaseDeletesServer = false;
+    storage.seed(leaseKey, retained);
+
+    const stopped = await fleet.fetch(request("DELETE", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopped.json()).resolves.toMatchObject({ status: "stopped" });
+    expect(providerReleases).toBe(1);
+  });
+
+  it("routes portal release of a workspace lease through workspace cleanup state", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(
+      storage,
+      {
+        hetzner: fakeProvider(undefined, {}, async () => {
+          throw new Error("provider cleanup throttled");
+        }),
+      },
+      { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const body = {
+      id: "fleet-is-115",
+      runtime: "crabbox",
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      capabilities: { desktop: false },
+    };
+    const created = await fleet.fetch(request("POST", "/v1/workspaces", { headers, body }));
+    const pending = (await created.json()) as { providerResourceId: string };
+    await fleet.alarm();
+
+    const release = await fleet.fetch(
+      request("POST", `/portal/leases/${pending.providerResourceId}/release`, { headers }),
+    );
+    expect(release.status).toBe(500);
+
+    const stopping = await fleet.fetch(request("GET", `/v1/workspaces/${body.id}`, { headers }));
+    await expect(stopping.json()).resolves.toMatchObject({
+      status: "stopping",
+      message: "provider cleanup throttled",
+    });
+  });
+
+  it("schedules claimed workspace provisioning from the claim deadline", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_abcdef123456";
+    const now = new Date().toISOString();
+    const claimExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    const expiresAt = new Date(Date.now() + 5_000).toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-108", {
+      id: "fleet-is-108",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1,
+      idleTimeoutSeconds: 1,
+      provisionClaim: "claim-108",
+      provisionClaimExpiresAt: claimExpiresAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      id: leaseID,
+      slug: "fleet-is-108",
+      workspaceID: "fleet-is-108",
+      provider: "hetzner",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "cpx62",
+      requestedServerType: "cpx62",
+      serverID: 0,
+      serverName: "",
+      providerKey: "workspace-test",
+      host: "",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1,
+      idleTimeoutSeconds: 1,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "provisioning",
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      expiresAt,
+    } as LeaseRecord);
+
+    await fleet.alarm();
+
+    expect(storage.alarm()).toBe(Date.parse(claimExpiresAt));
+  });
+
+  it("expires an interrupted workspace resource after identity is recovered without an IP", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    let providerReleases = 0;
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(
+        undefined,
+        {
+          servers: [
+            {
+              provider: "hetzner",
+              id: 654,
+              cloudID: "654",
+              name: "crabbox-fleet-is-109",
+              status: "initializing",
+              serverType: "cpx62",
+              host: "",
+              labels: { lease: leaseID },
+            },
+          ],
+        },
+        async () => {
+          providerReleases += 1;
+        },
+      ),
+    });
+    const now = new Date().toISOString();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-109";
+    storage.seed(workspaceKey, {
+      id: "fleet-is-109",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      provisionClaim: "expired-claim",
+      provisionClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      id: leaseID,
+      slug: "fleet-is-109",
+      workspaceID: "fleet-is-109",
+      provider: "hetzner",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "cpx62",
+      requestedServerType: "cpx62",
+      serverID: 0,
+      serverName: "",
+      providerKey: "workspace-test",
+      host: "",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "provisioning",
+      provisioningRequestStartedAt: now,
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      endedAt: now,
+      releasedAt: now,
+      expiresAt: new Date(Date.now() + 360_000).toISOString(),
+    } as LeaseRecord);
+
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      cloudID: "654",
+      serverID: 654,
+      state: "provisioning",
+      host: "",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.endedAt).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releasedAt).toBeUndefined();
+
+    const recovered = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    recovered.expiresAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed(`lease:${leaseID}`, recovered);
+    await fleet.alarm();
+
+    const expired = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-109", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(expired.json()).resolves.toMatchObject({
+      providerResourceId: leaseID,
+      status: "expired",
+    });
+    expect(providerReleases).toBe(1);
+  });
+
+  it("expires interrupted workspace recovery through normal lease cleanup", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, undefined, async () => {
+        throw new Error("hetzner GET /servers/654: http 404: not found");
+      }),
+    });
+    const now = new Date().toISOString();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-114";
+    storage.seed(workspaceKey, {
+      id: "fleet-is-114",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      id: leaseID,
+      slug: "fleet-is-114",
+      workspaceID: "fleet-is-114",
+      provider: "hetzner",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "654",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "cpx62",
+      requestedServerType: "cpx62",
+      serverID: 654,
+      serverName: "crabbox-fleet-is-114",
+      providerKey: "workspace-test",
+      host: "",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1200,
+      idleTimeoutSeconds: 360,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "provisioning",
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      expiresAt: new Date(Date.now() + 360_000).toISOString(),
+    } as LeaseRecord);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each retry depends on persisted recovery state.
+      await fleet.alarm();
+      const workspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+      storage.seed(workspaceKey, {
+        ...workspace,
+        reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+      });
+    }
+
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.failureError).toBeUndefined();
+    const expiredLease = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expiredLease.expiresAt = new Date(Date.now() - 1_000).toISOString();
+    storage.seed(`lease:${leaseID}`, expiredLease);
+    const workspace = storage.value<Record<string, unknown>>(workspaceKey)!;
+    storage.seed(workspaceKey, {
+      ...workspace,
+      createdAt: new Date(Date.now() - 40 * 60_000).toISOString(),
+      reconcileAfter: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("expired");
+    const expired = await fleet.fetch(
+      request("GET", "/v1/workspaces/fleet-is-114", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(expired.json()).resolves.toMatchObject({ status: "expired" });
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.failureError).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupError).toBeUndefined();
+  });
+
   it("registers client-owned leases without granting the coordinator provider lifecycle", async () => {
     const storage = new MemoryStorage();
     let providerReleases = 0;
@@ -294,7 +2133,6 @@ describe("fleet lease identity and idle", () => {
         expiresAt: "2026-05-01T00:00:01.000Z",
       }),
     );
-
     await fleet.alarm();
 
     const lease = storage.value<LeaseRecord>("lease:cbx_000000000001");
@@ -8696,6 +10534,17 @@ describe("fleet run history", () => {
       }),
     );
     storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        slug: "fleet-is-201",
+        workspaceID: "fleet-is-201",
+        owner: "peter@example.com",
+        org: "openclaw",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
       "run:run_000000000001",
       testRun({
         id: "run_000000000001",
@@ -8759,6 +10608,21 @@ describe("fleet run history", () => {
       ok: true,
     });
     expect(storage.value<LeaseRecord>("lease:cbx_000000000001")?.idleTimeoutSeconds).toBe(900);
+
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "heartbeat",
+        leaseID: "cbx_000000000002",
+        idleTimeoutSeconds: 900,
+      }),
+    );
+    expect(socket.sentJSON()[3]).toMatchObject({
+      type: "heartbeat",
+      leaseID: "cbx_000000000002",
+      ok: false,
+      error: "workspace_managed_lease",
+    });
   });
 
   it("records finished runs and serves logs", async () => {
@@ -10113,6 +11977,10 @@ function fakeProvider(
         return await result.onList();
       }
       return result.servers ?? [];
+    },
+    async findServerByLease(leaseID: string) {
+      const servers = result.onList ? await result.onList() : (result.servers ?? []);
+      return servers.find((server) => server.labels?.["lease"] === leaseID);
     },
     async getServer(id: string) {
       if (onGet) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -247,6 +247,35 @@ describe("fleet lease identity and idle", () => {
     ).resolves.toEqual(existing);
   });
 
+  it("finds an existing Hetzner SSH key by identity on a later page", async () => {
+    const existing = {
+      id: 99,
+      name: "older-workspace-key",
+      fingerprint: "fingerprint",
+      public_key: "ssh-ed25519 workspace-test old-comment",
+    };
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: index + 1,
+      name: `unrelated-${index}`,
+      fingerprint: `fingerprint-${index}`,
+      public_key: `ssh-ed25519 unrelated-${index}`,
+    }));
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: firstPage }),
+      jsonResponse({ ssh_keys: [existing] }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+
+    await expect(
+      client.ensureSSHKey("crabbox-workspace-new", "ssh-ed25519 workspace-test new-comment"),
+    ).resolves.toEqual(existing);
+  });
+
   it("treats an already-absent Hetzner server as successful cleanup", async () => {
     vi.stubGlobal(
       "fetch",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -343,7 +343,7 @@ describe("fleet lease identity and idle", () => {
       id: "fleet-is-101",
       runtime: "crabbox",
       profile,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: true },
     };
@@ -367,7 +367,7 @@ describe("fleet lease identity and idle", () => {
         body: {
           id: "fleet-too-short",
           runtime: "crabbox",
-          ttlSeconds: 1199,
+          ttlSeconds: 1799,
           idleTimeoutSeconds: 360,
           capabilities: { desktop: false },
         },
@@ -376,7 +376,7 @@ describe("fleet lease identity and idle", () => {
     expect(shortTTL.status).toBe(400);
     await expect(shortTTL.json()).resolves.toMatchObject({
       error: "invalid_duration",
-      message: "workspace ttlSeconds must be at least 1200",
+      message: "workspace ttlSeconds must be at least 1800",
     });
     await fleet.alarm();
     expect(createdClass).toBe("standard");
@@ -515,7 +515,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-102",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -573,7 +573,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-105",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -618,7 +618,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       createdAt: now,
       updatedAt: now,
@@ -630,7 +630,7 @@ describe("fleet lease identity and idle", () => {
         body: {
           id: "fleet-is-103",
           runtime: "crabbox",
-          ttlSeconds: 1200,
+          ttlSeconds: 1800,
           idleTimeoutSeconds: 360,
           capabilities: { desktop: false },
         },
@@ -671,7 +671,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       provisionClaim: "claim-121",
       provisionClaimExpiresAt: claimExpiresAt,
@@ -708,7 +708,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       provisionClaim: "expired-claim",
       provisionClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
@@ -989,7 +989,7 @@ describe("fleet lease identity and idle", () => {
         body: {
           id: "fleet-is-126",
           runtime: "crabbox",
-          ttlSeconds: 1200,
+          ttlSeconds: 1800,
           idleTimeoutSeconds: 360,
           capabilities: { desktop: false },
         },
@@ -1017,7 +1017,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-116",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1047,7 +1047,7 @@ describe("fleet lease identity and idle", () => {
       },
       { CRABBOX_WORKSPACE_SSH_PUBLIC_KEY: "ssh-ed25519 workspace-test" },
     );
-    const createdAt = new Date(Date.now() - 6 * 60_000).toISOString();
+    const createdAt = new Date(Date.now() - 16 * 60_000).toISOString();
     storage.seed("workspace:example-org:alice%40example.com:fleet-is-130", {
       id: "fleet-is-130",
       leaseID: "cbx_abcdef123456",
@@ -1057,7 +1057,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       createdAt,
       updatedAt: createdAt,
@@ -1099,7 +1099,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-110",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1129,7 +1129,7 @@ describe("fleet lease identity and idle", () => {
       sshPort: "22",
       workRoot: "/workspaces/crabbox",
       keep: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       estimatedHourlyUSD: 0,
       maxEstimatedUSD: 0,
@@ -1169,7 +1169,7 @@ describe("fleet lease identity and idle", () => {
         body: {
           id: "fleet-is-120",
           runtime: "crabbox",
-          ttlSeconds: 1200,
+          ttlSeconds: 1800,
           idleTimeoutSeconds: 360,
           capabilities: { desktop: false },
         },
@@ -1200,7 +1200,7 @@ describe("fleet lease identity and idle", () => {
           provider: "external",
           target: "linux",
           host: "host.example.test",
-          ttlSeconds: 1200,
+          ttlSeconds: 1800,
           idleTimeoutSeconds: 360,
         },
       }),
@@ -1225,7 +1225,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-111",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1284,7 +1284,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       createdAt: now,
       updatedAt: now,
@@ -1314,7 +1314,7 @@ describe("fleet lease identity and idle", () => {
       sshPort: "22",
       workRoot: "/workspaces/crabbox",
       keep: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       estimatedHourlyUSD: 0,
       maxEstimatedUSD: 0,
@@ -1364,7 +1364,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-104",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1438,7 +1438,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-112",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1510,7 +1510,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-117",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1560,7 +1560,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-119",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1610,7 +1610,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-118",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1644,7 +1644,7 @@ describe("fleet lease identity and idle", () => {
         provider: "hetzner",
         class: "standard",
         desktop: false,
-        ttlSeconds: 1200,
+        ttlSeconds: 1800,
         idleTimeoutSeconds: 360,
         createdAt: old,
         updatedAt: old,
@@ -1667,7 +1667,7 @@ describe("fleet lease identity and idle", () => {
         body: {
           id: "fleet-over-limit",
           runtime: "crabbox",
-          ttlSeconds: 1200,
+          ttlSeconds: 1800,
           idleTimeoutSeconds: 360,
           capabilities: { desktop: false },
         },
@@ -1696,7 +1696,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       createdAt: terminalAt,
       updatedAt: terminalAt,
@@ -1728,7 +1728,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-113",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1789,7 +1789,7 @@ describe("fleet lease identity and idle", () => {
     const body = {
       id: "fleet-is-115",
       runtime: "crabbox",
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       capabilities: { desktop: false },
     };
@@ -1909,7 +1909,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       provisionClaim: "expired-claim",
       provisionClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
@@ -1940,7 +1940,7 @@ describe("fleet lease identity and idle", () => {
       sshPort: "22",
       workRoot: "/workspaces/crabbox",
       keep: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       estimatedHourlyUSD: 0,
       maxEstimatedUSD: 0,
@@ -2081,7 +2081,7 @@ describe("fleet lease identity and idle", () => {
       provider: "hetzner",
       class: "standard",
       desktop: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       createdAt: now,
       updatedAt: now,
@@ -2110,7 +2110,7 @@ describe("fleet lease identity and idle", () => {
       sshPort: "22",
       workRoot: "/workspaces/crabbox",
       keep: false,
-      ttlSeconds: 1200,
+      ttlSeconds: 1800,
       idleTimeoutSeconds: 360,
       estimatedHourlyUSD: 0,
       maxEstimatedUSD: 0,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -316,6 +316,51 @@ describe("fleet lease identity and idle", () => {
     ).resolves.toEqual(existing);
   });
 
+  it("preserves workspace readiness when its SSH key is reused under another name", async () => {
+    const existingKey = {
+      id: 42,
+      name: "legacy-key",
+      fingerprint: "fingerprint",
+      public_key: "ssh-ed25519 workspace-test",
+    };
+    const initializingServer = {
+      id: 123,
+      name: "crabbox-workspace",
+      status: "initializing",
+      server_type: { name: "cpx62" },
+      public_net: { ipv4: { ip: "192.0.2.123" } },
+      labels: {},
+    };
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [existingKey] }),
+      jsonResponse({ server: initializingServer }),
+      jsonResponse({
+        server: {
+          ...initializingServer,
+          status: "running",
+        },
+      }),
+    ];
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () => responses.shift() ?? jsonResponse({}, 500),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "crabbox-workspace-deadbeef0000",
+      sshPublicKey: "ssh-ed25519 workspace-test",
+    });
+
+    await expect(
+      client.createServerWithFallback(config, "cbx_abcdef123456", "workspace", "alice@example.com"),
+    ).resolves.toMatchObject({
+      server: { id: 123, status: "running" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
   it("treats an already-absent Hetzner server as successful cleanup", async () => {
     vi.stubGlobal(
       "fetch",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -159,6 +159,46 @@ describe("fleet lease identity and idle", () => {
     expect((error as HetznerProvisioningError).resourceMayExist).toBe(true);
   });
 
+  it("keeps ordinary Hetzner leases IP-ready while the server is still initializing", async () => {
+    const responses = [
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({ ssh_keys: [] }),
+      jsonResponse({
+        ssh_key: {
+          id: 1,
+          name: "ordinary-key",
+          public_key: "ssh-ed25519 ordinary-test",
+        },
+      }),
+      jsonResponse({
+        server: {
+          id: 123,
+          name: "crabbox-ordinary",
+          status: "initializing",
+          server_type: { name: "cpx62" },
+          public_net: { ipv4: { ip: "192.0.2.123" } },
+          labels: {},
+        },
+      }),
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
+    );
+    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+    const config = leaseConfig({
+      provider: "hetzner",
+      providerKey: "ordinary-key",
+      sshPublicKey: "ssh-ed25519 ordinary-test",
+    });
+
+    await expect(
+      client.createServerWithFallback(config, "cbx_abcdef123456", "ordinary", "alice@example.com"),
+    ).resolves.toMatchObject({
+      server: { id: 123, status: "initializing" },
+    });
+  });
+
   it("uses the terminating Hetzner fallback error to decide retryability", async () => {
     const responses = [
       jsonResponse({ ssh_keys: [] }),
@@ -1707,6 +1747,49 @@ describe("fleet lease identity and idle", () => {
     await fleet.alarm();
 
     expect(storage.alarm()).toBe(Date.parse(terminalAt) + 24 * 60 * 60_000);
+  });
+
+  it("detaches a retained lease when its terminal workspace record is pruned", async () => {
+    const storage = new MemoryStorage();
+    const terminalAt = new Date(Date.now() - 25 * 60 * 60_000).toISOString();
+    const workspaceKey = "workspace:example-org:alice%40example.com:fleet-is-131";
+    storage.seed(workspaceKey, {
+      id: "fleet-is-131",
+      leaseID: "cbx_abcdef123456",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "hetzner",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1800,
+      idleTimeoutSeconds: 360,
+      createdAt: terminalAt,
+      updatedAt: terminalAt,
+      error: "workspace provisioning failed",
+    });
+    storage.seed(
+      "lease:cbx_abcdef123456",
+      testLease({
+        id: "cbx_abcdef123456",
+        slug: "fleet-is-131",
+        workspaceID: "fleet-is-131",
+        owner: "alice@example.com",
+        org: "example-org",
+        state: "failed",
+        failureError: "workspace provisioning failed",
+        provisioningResourceMayExist: false,
+        createdAt: terminalAt,
+        updatedAt: terminalAt,
+        endedAt: terminalAt,
+      }),
+    );
+    const fleet = testFleet(storage);
+
+    await fleet.alarm();
+
+    expect(storage.value(workspaceKey)).toBeUndefined();
+    expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.workspaceID).toBeUndefined();
   });
 
   it("keeps workspace-owned leases behind workspace deletion and cleans retained resources", async () => {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -14,6 +14,8 @@
   "vars": {
     "CRABBOX_DEFAULT_ORG": "openclaw",
     "CRABBOX_GITHUB_ALLOWED_ORG": "openclaw",
+    "CRABBOX_WORKSPACE_PROVIDER": "hetzner",
+    "CRABBOX_WORKSPACE_CLASS": "standard",
     "CRABBOX_USER_TOKEN_TTL_SECONDS": "15552000",
     "CRABBOX_AWS_REGION": "eu-west-1",
     "CRABBOX_CAPACITY_REGIONS": "eu-west-1,eu-west-2,eu-central-1,us-east-1,us-west-2",
@@ -50,6 +52,8 @@
     "vars": {
       "CRABBOX_DEFAULT_ORG": "openclaw",
       "CRABBOX_GITHUB_ALLOWED_ORG": "openclaw",
+      "CRABBOX_WORKSPACE_PROVIDER": "hetzner",
+      "CRABBOX_WORKSPACE_CLASS": "standard",
       "CRABBOX_USER_TOKEN_TTL_SECONDS": "15552000",
       "CRABBOX_AWS_REGION": "eu-west-1",
       "CRABBOX_CAPACITY_REGIONS": "eu-west-1,eu-west-2,eu-central-1,us-east-1,us-west-2",


### PR DESCRIPTION
## Summary

- add owner-scoped `/v1/workspaces` lifecycle routes backed by coordinator leases
- provision OpenClaw workspaces on Hetzner with stable shared SSH-key identity
- recover ambiguous creates, enforce hard TTLs, and preserve truthful cleanup/readiness state
- protect workspace-owned leases from generic lifecycle mutation

## Verification

- `cd worker && npm run check`
- `cd worker && npm run lint`
- `cd worker && npm run format:check`
- `cd worker && npm test` (468 tests)
- `cd worker && npm run build`
- `cd worker && npm run build:node`
- `autoreview --mode branch --base origin/main` (clean)
