### PR TITLE
fix: harden Tailscale cleanup lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed brokered Tailscale cleanup to avoid privileged deletion from client-posted device IDs, preserve connectivity across normal reboots, and fail live preflight on application-level errors.
 - Fixed Crabfleet workspaces to use any configured brokered provider and route the OpenClaw deployment through its canonical OAuth host and verified AWS backend with isolated, ephemeral key-only SSH access, stock-image cloud-init, and readiness-gated, pinned, Workers-compatible terminal attachment.
 
 ## 0.30.0 - 2026-06-13

--- a/docs/features/tailscale.md
+++ b/docs/features/tailscale.md
@@ -199,10 +199,10 @@ binaries, and record the client version. The built-in pinned defaults track the
 Islo Tailscale build so both bootstrap paths use the same binary version.
 
 On release, `crabbox stop` attempts a best-effort remote `tailscale logout` before
-provider cleanup when SSH is still reachable. Coordinator cleanup also attempts a
-best-effort Tailscale device delete when the lease record has a `deviceID`; missing
-device ids or Tailscale API failures are recorded in lease metadata without blocking
-provider deletion.
+provider cleanup when SSH is still reachable. Coordinator cleanup does not delete a
+device by an ID posted from the lease client; that metadata is diagnostic, not
+trusted authorization for a privileged tailnet operation. One-off nodes are
+ephemeral and age out in Tailscale if remote logout is unavailable.
 
 If Tailscale rejects a requested subset or unowned tag, the coordinator returns
 `invalid_tailscale_tags` with exact-match/`tagOwners` guidance and preserves the raw

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -240,11 +240,11 @@ minted Access JWT in `CRABBOX_ACCESS_TOKEN`.
 For brokered Tailscale reachability, the coordinator mints one ephemeral, pre-approved
 auth key per lease and injects it only into cloud-init. Lease records store only
 non-secret Tailscale metadata (hostname, FQDN, 100.x address, client version,
-device id, state, tags, and cleanup result).
+device id, state, and tags).
 
-Create a Tailscale OAuth client with the `auth_keys` scope, limited to the tags
-Crabbox may assign (typically `tag:crabbox`), and inject the credentials as
-coordinator secrets:
+Create a Tailscale OAuth client with only the `auth_keys` scope, limited to the
+tags Crabbox may assign (typically `tag:crabbox`), and inject the credentials as
+coordinator secrets. Crabbox does not require device-management scope:
 
 ```text
 CRABBOX_TAILSCALE_ENABLED=1

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1512,7 +1512,12 @@ func cloudInitTailscaleBootstrap(cfg Config) string {
 	loginServerFlag := `${TS_LOGIN_SERVER:+--login-server="$TS_LOGIN_SERVER"}`
 	tailscaleUpScript := `    ` + cloudInitTailscaleInstallBootstrap() + `
     systemctl enable --now tailscaled || service tailscaled start || true
-    ` + cloudInitTailscaleLogoutBootstrap() + `
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl disable crabbox-tailscale-logout.service >/dev/null 2>&1 || true
+      rm -f /etc/systemd/system/crabbox-tailscale-logout.service
+      systemctl daemon-reload || true
+    fi
+    rm -f /usr/local/bin/crabbox-tailscale-logout
     install -d -m 0750 -o ` + sshUserOwner + ` -g ` + sshUserGroup + ` /var/lib/crabbox
     set +x
     ` + loginServerExport + `TS_AUTHKEY=` + shellQuote(authKey) + `
@@ -1583,34 +1588,6 @@ func cloudInitTailscaleInstallBootstrap() string {
       printf '%s\n' 'WantedBy=multi-user.target'
     } >/etc/systemd/system/tailscaled.service
     systemctl daemon-reload || true`
-}
-
-func cloudInitTailscaleLogoutBootstrap() string {
-	return `{
-      printf '%s\n' '#!/usr/bin/env sh'
-      printf '%s\n' 'if command -v tailscale >/dev/null 2>&1; then'
-      printf '%s\n' '  tailscale logout >/dev/null 2>&1 || true'
-      printf '%s\n' 'fi'
-    } >/usr/local/bin/crabbox-tailscale-logout
-    chmod 0755 /usr/local/bin/crabbox-tailscale-logout
-    if command -v systemctl >/dev/null 2>&1; then
-      {
-        printf '%s\n' '[Unit]'
-        printf '%s\n' 'Description=Crabbox Tailscale logout on shutdown'
-        printf '%s\n' 'DefaultDependencies=no'
-        printf '%s\n' 'Before=shutdown.target reboot.target halt.target'
-        printf '%s\n' ''
-        printf '%s\n' '[Service]'
-        printf '%s\n' 'Type=oneshot'
-        printf '%s\n' 'ExecStart=/usr/local/bin/crabbox-tailscale-logout'
-        printf '%s\n' 'TimeoutStartSec=20'
-        printf '%s\n' ''
-        printf '%s\n' '[Install]'
-        printf '%s\n' 'WantedBy=halt.target reboot.target shutdown.target'
-      } >/etc/systemd/system/crabbox-tailscale-logout.service
-      systemctl daemon-reload || true
-      systemctl enable crabbox-tailscale-logout.service || true
-    fi`
 }
 
 // cloudInitPondHostsBootstrap installs /usr/local/bin/crabbox-pond-hosts and a

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -373,7 +373,6 @@ func TestCloudInitTailscaleProfile(t *testing.T) {
 	got := cloudInit(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
 		"https://tailscale.com/install.sh",
-		"/usr/local/bin/crabbox-tailscale-logout",
 		"install -d -m 0750 -o 'runner' -g 'runner' /var/lib/crabbox",
 		"printf '%s' \"$TS_AUTHKEY\" | tailscale up --auth-key=file:/dev/stdin --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",
 		"printf '%s\\n' 'crabbox-blue-lobster' > /var/lib/crabbox/tailscale-hostname",
@@ -391,6 +390,12 @@ func TestCloudInitTailscaleProfile(t *testing.T) {
 	}
 	if strings.Contains(got, `--auth-key="$TS_AUTHKEY"`) {
 		t.Fatal("cloudInit(tailscale) must not expose the auth key through process argv")
+	}
+	if !strings.Contains(got, "systemctl disable crabbox-tailscale-logout.service") {
+		t.Fatal("cloudInit(tailscale) must remove the legacy reboot logout unit")
+	}
+	if strings.Contains(got, "tailscale logout") || strings.Contains(got, "WantedBy=halt.target reboot.target shutdown.target") {
+		t.Fatal("cloudInit(tailscale) must not install a normal-reboot logout hook")
 	}
 	if strings.Contains(cloudInit(baseConfig(), "ssh-ed25519 test"), "tailscale up") {
 		t.Fatal("cloudInit should not install Tailscale by default")

--- a/internal/cli/network.go
+++ b/internal/cli/network.go
@@ -37,8 +37,6 @@ type TailscaleMetadata struct {
 	Error                  string   `json:"error,omitempty"`
 	Version                string   `json:"version,omitempty"`
 	DeviceID               string   `json:"deviceID,omitempty"`
-	CleanupState           string   `json:"cleanupState,omitempty"`
-	CleanupError           string   `json:"cleanupError,omitempty"`
 	ExitNode               string   `json:"exitNode,omitempty"`
 	ExitNodeAllowLANAccess bool     `json:"exitNodeAllowLanAccess,omitempty"`
 }
@@ -295,8 +293,6 @@ func serverTailscaleMetadata(server Server) TailscaleMetadata {
 		Error:                  labels["tailscale_error"],
 		Version:                labels["tailscale_version"],
 		DeviceID:               labels["tailscale_device_id"],
-		CleanupState:           labels["tailscale_cleanup_state"],
-		CleanupError:           labels["tailscale_cleanup_error"],
 		ExitNode:               labels["tailscale_exit_node"],
 		ExitNodeAllowLANAccess: labelBool(labels["tailscale_exit_node_allow_lan_access"]),
 	}
@@ -336,12 +332,6 @@ func applyTailscaleMetadataToServer(server *Server, meta TailscaleMetadata) {
 	}
 	if meta.DeviceID != "" {
 		server.Labels["tailscale_device_id"] = meta.DeviceID
-	}
-	if meta.CleanupState != "" {
-		server.Labels["tailscale_cleanup_state"] = meta.CleanupState
-	}
-	if meta.CleanupError != "" {
-		server.Labels["tailscale_cleanup_error"] = meta.CleanupError
 	}
 	if meta.ExitNode != "" {
 		server.Labels["tailscale_exit_node"] = meta.ExitNode

--- a/scripts/live-tailscale-smoke.sh
+++ b/scripts/live-tailscale-smoke.sh
@@ -103,12 +103,16 @@ if [[ "$http_code" != "200" ]]; then
   exit 1
 fi
 
+status="$(jq -r '.tailscale.status // "unknown"' "$tmp_body")"
 if [[ "$json" == "1" ]]; then
   jq -c . "$tmp_body"
 else
-  status="$(jq -r '.tailscale.status // "unknown"' "$tmp_body")"
   enabled="$(jq -r '.tailscale.enabled // false' "$tmp_body")"
   tags="$(jq -r '(.tailscale.tags // []) | join(",")' "$tmp_body")"
   install_mode="$(jq -r '.tailscale.install.mode // "unknown"' "$tmp_body")"
   echo "tailscale status=$status enabled=$enabled tags=${tags:-none} install=$install_mode"
+fi
+if [[ "$status" != "ok" ]]; then
+  echo "tailscale preflight failed status=$status" >&2
+  exit 1
 fi

--- a/scripts/live-tailscale-smoke.test.js
+++ b/scripts/live-tailscale-smoke.test.js
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 test("live tailscale smoke supports help", () => {
@@ -24,4 +27,39 @@ test("live tailscale smoke emits disabled json without live credentials", () => 
 	const body = JSON.parse(result.stdout);
 	assert.equal(body.tailscale.status, "disabled");
 	assert.equal(body.tailscale.enabled, false);
+});
+
+test("live tailscale smoke fails on application-level preflight errors", () => {
+	const dir = mkdtempSync(join(tmpdir(), "crabbox-tailscale-smoke-"));
+	const curl = join(dir, "curl");
+	writeFileSync(
+		curl,
+		`#!/usr/bin/env bash
+set -euo pipefail
+cfg="$2"
+output="$(ruby -rjson -e 'line = File.readlines(ARGV[0]).find { |item| item.start_with?("output = ") }; print JSON.parse(line.split("=", 2)[1].strip)' "$cfg")"
+printf '{"tailscale":{"status":"missing_oauth_credentials","enabled":true}}\\n' >"$output"
+printf '200'
+`,
+	);
+	chmodSync(curl, 0o755);
+
+	try {
+		const result = spawnSync("bash", ["scripts/live-tailscale-smoke.sh", "--json"], {
+			env: {
+				...process.env,
+				PATH: `${dir}:${process.env.PATH}`,
+				CRABBOX_LIVE: "1",
+				CRABBOX_COORDINATOR: "https://broker.example.com",
+				CRABBOX_ADMIN_TOKEN: "test-token",
+			},
+			encoding: "utf8",
+		});
+
+		assert.equal(result.status, 1, result.stderr || result.stdout);
+		assert.match(result.stdout, /"status":"missing_oauth_credentials"/);
+		assert.match(result.stderr, /preflight failed status=missing_oauth_credentials/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 });

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -1494,34 +1494,6 @@ function tailscaleInstallBootstrap(config: LeaseConfig): string {
     systemctl daemon-reload || true`;
 }
 
-function tailscaleLogoutBootstrap(): string {
-  return `{
-      printf '%s\\n' '#!/usr/bin/env sh'
-      printf '%s\\n' 'if command -v tailscale >/dev/null 2>&1; then'
-      printf '%s\\n' '  tailscale logout >/dev/null 2>&1 || true'
-      printf '%s\\n' 'fi'
-    } >/usr/local/bin/crabbox-tailscale-logout
-    chmod 0755 /usr/local/bin/crabbox-tailscale-logout
-    if command -v systemctl >/dev/null 2>&1; then
-      {
-        printf '%s\\n' '[Unit]'
-        printf '%s\\n' 'Description=Crabbox Tailscale logout on shutdown'
-        printf '%s\\n' 'DefaultDependencies=no'
-        printf '%s\\n' 'Before=shutdown.target reboot.target halt.target'
-        printf '%s\\n' ''
-        printf '%s\\n' '[Service]'
-        printf '%s\\n' 'Type=oneshot'
-        printf '%s\\n' 'ExecStart=/usr/local/bin/crabbox-tailscale-logout'
-        printf '%s\\n' 'TimeoutStartSec=20'
-        printf '%s\\n' ''
-        printf '%s\\n' '[Install]'
-        printf '%s\\n' 'WantedBy=halt.target reboot.target shutdown.target'
-      } >/etc/systemd/system/crabbox-tailscale-logout.service
-      systemctl daemon-reload || true
-      systemctl enable crabbox-tailscale-logout.service || true
-    fi`;
-}
-
 function tailscaleBootstrap(config: LeaseConfig): string {
   if (!config.tailscaleAuthKey) {
     return `    echo "tailscale requested but no auth key was injected" >&2
@@ -1541,7 +1513,12 @@ function tailscaleBootstrap(config: LeaseConfig): string {
   }
   return `    ${tailscaleInstallBootstrap(config)}
     systemctl enable --now tailscaled || service tailscaled start || true
-    ${tailscaleLogoutBootstrap()}
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl disable crabbox-tailscale-logout.service >/dev/null 2>&1 || true
+      rm -f /etc/systemd/system/crabbox-tailscale-logout.service
+      systemctl daemon-reload || true
+    fi
+    rm -f /usr/local/bin/crabbox-tailscale-logout
     install -d -m 0750 -o ${shellQuote(sshUser)} -g ${shellQuote(sshUser)} /var/lib/crabbox
     set +x
     TS_AUTHKEY=${shellQuote(config.tailscaleAuthKey)}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -62,7 +62,6 @@ import {
 import { leaseSlugFromID, normalizeLeaseSlug, slugWithCollisionSuffix } from "./slug";
 import {
   createTailscaleAuthKey,
-  deleteTailscaleDevice,
   renderTailscaleHostname,
   tailscaleAllowed,
   tailscaleDefaultTags,
@@ -6588,7 +6587,6 @@ export class FleetCoordinator {
         const cleanup = async () => {
           let failure: string | undefined;
           try {
-            await this.cleanupLeaseTailscaleDevice(lease, claim);
             await this.deleteLeaseServer(lease);
           } catch (error) {
             failure = errorMessage(error);
@@ -7714,51 +7712,6 @@ export class FleetCoordinator {
     await this.provider(provider, lease.region, lease.providerProject).releaseLease(lease);
   }
 
-  private async cleanupLeaseTailscaleDevice(lease: LeaseRecord, claim: string): Promise<void> {
-    const metadata = lease.tailscale;
-    if (!metadata?.enabled) {
-      return;
-    }
-    const deviceID = metadata.deviceID?.trim();
-    if (!deviceID) {
-      await this.recordTailscaleCleanupResult(lease.id, claim, "missing_device_id");
-      return;
-    }
-    try {
-      await deleteTailscaleDevice(this.env, deviceID);
-      await this.recordTailscaleCleanupResult(lease.id, claim, "api_delete_succeeded");
-    } catch (error) {
-      await this.recordTailscaleCleanupResult(
-        lease.id,
-        claim,
-        "api_delete_failed",
-        errorMessage(error),
-      );
-    }
-  }
-
-  private async recordTailscaleCleanupResult(
-    leaseID: string,
-    claim: string,
-    cleanupState: NonNullable<TailscaleMetadata["cleanupState"]>,
-    cleanupError?: string,
-  ): Promise<void> {
-    await this.state.runExclusive(async () => {
-      const current = await this.getLease(leaseID);
-      if (!current || current.cleanupStartedAt !== claim || !current.tailscale?.enabled) {
-        return;
-      }
-      current.tailscale = { ...current.tailscale, cleanupState };
-      if (cleanupError) {
-        current.tailscale.cleanupError = cleanupError;
-      } else {
-        delete current.tailscale.cleanupError;
-      }
-      current.updatedAt = new Date().toISOString();
-      await this.putLease(current);
-    });
-  }
-
   private async abortProvisionedLeaseAfterStateChange(
     record: LeaseRecord,
     config: LeaseConfig,
@@ -7818,7 +7771,6 @@ export class FleetCoordinator {
       );
     }
     try {
-      await this.cleanupLeaseTailscaleDevice(preparation.lease, preparation.cleanupStartedAt);
       await this.deleteLeaseServer(preparation.lease);
     } catch (error) {
       const failure = await this.state.runExclusive(async () => {
@@ -7995,7 +7947,6 @@ export class FleetCoordinator {
       return preparation.lease;
     }
     try {
-      await this.cleanupLeaseTailscaleDevice(preparation.lease, preparation.claim);
       await this.deleteLeaseServer(preparation.lease);
     } catch (error) {
       await this.state.runExclusive(async () => {
@@ -9528,7 +9479,6 @@ function mergeTailscaleMetadata(
   const error = nonSecretString(input.error) || current?.error;
   const version = nonSecretString(input.version) || current?.version;
   const deviceID = nonSecretString(input.deviceID) || current?.deviceID;
-  const cleanupError = nonSecretString(input.cleanupError) || current?.cleanupError;
   const exitNode = nonSecretString(input.exitNode) || current?.exitNode;
   if (hostname) {
     merged.hostname = hostname;
@@ -9548,18 +9498,6 @@ function mergeTailscaleMetadata(
   if (deviceID) {
     merged.deviceID = deviceID;
   }
-  if (
-    input.cleanupState === "missing_device_id" ||
-    input.cleanupState === "api_delete_succeeded" ||
-    input.cleanupState === "api_delete_failed"
-  ) {
-    merged.cleanupState = input.cleanupState;
-  } else if (current?.cleanupState) {
-    merged.cleanupState = current.cleanupState;
-  }
-  if (cleanupError) {
-    merged.cleanupError = cleanupError;
-  }
   if (exitNode) {
     merged.exitNode = exitNode;
     merged.exitNodeAllowLanAccess =
@@ -9567,9 +9505,6 @@ function mergeTailscaleMetadata(
   }
   if (merged.state !== "failed") {
     delete merged.error;
-  }
-  if (merged.cleanupState !== "api_delete_failed") {
-    delete merged.cleanupError;
   }
   return merged;
 }

--- a/worker/src/tailscale.ts
+++ b/worker/src/tailscale.ts
@@ -41,7 +41,7 @@ export interface TailscalePreflightResult {
   message?: string;
 }
 
-type TailscaleAPIOperation = "oauth token" | "create auth key" | "delete device";
+type TailscaleAPIOperation = "oauth token" | "create auth key";
 
 class TailscaleAPIError extends Error {
   constructor(
@@ -160,30 +160,6 @@ export async function createTailscaleAuthKey(
     throw new Error("tailscale create auth key returned no key");
   }
   return data.key;
-}
-
-export async function deleteTailscaleDevice(env: Env, deviceID: string): Promise<void> {
-  const trimmed = deviceID.trim();
-  if (!trimmed) {
-    throw new Error("tailscale device id is empty");
-  }
-  const clientID = env.CRABBOX_TAILSCALE_CLIENT_ID;
-  const clientSecret = env.CRABBOX_TAILSCALE_CLIENT_SECRET;
-  if (!clientID || !clientSecret) {
-    throw new Error("tailscale OAuth secrets are not configured");
-  }
-  const token = await tailscaleOAuthToken(clientID, clientSecret, { scope: "devices" });
-  const response = await fetch(
-    `https://api.tailscale.com/api/v2/device/${encodeURIComponent(trimmed)}`,
-    {
-      method: "DELETE",
-      headers: { authorization: `Bearer ${token}` },
-    },
-  );
-  const text = await response.text();
-  if (!response.ok && response.status !== 404) {
-    throw tailscaleAPIError("delete device", response.status, text);
-  }
 }
 
 export async function tailscalePreflight(env: Env): Promise<TailscalePreflightResult> {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -444,8 +444,6 @@ export interface TailscaleMetadata {
   error?: string;
   version?: string;
   deviceID?: string;
-  cleanupState?: "missing_device_id" | "api_delete_succeeded" | "api_delete_failed";
-  cleanupError?: string;
   exitNode?: string;
   exitNodeAllowLanAccess?: boolean;
 }

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -396,7 +396,9 @@ describe("cloud-init bootstrap", () => {
       tailscaleExitNodeAllowLanAccess: true,
     });
     expect(got).toContain("https://tailscale.com/install.sh");
-    expect(got).toContain("/usr/local/bin/crabbox-tailscale-logout");
+    expect(got).toContain("systemctl disable crabbox-tailscale-logout.service");
+    expect(got).not.toContain("tailscale logout");
+    expect(got).not.toContain("WantedBy=halt.target reboot.target shutdown.target");
     expect(got).toContain("install -d -m 0750 -o 'runner' -g 'runner' /var/lib/crabbox");
     expect(got).toContain(
       "printf '%s' \"$TS_AUTHKEY\" | tailscale up --auth-key=file:/dev/stdin --hostname='crabbox-blue-lobster' --advertise-tags='tag:crabbox' --exit-node='mac-studio.tailnet.ts.net' --exit-node-allow-lan-access",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4535,21 +4535,13 @@ describe("fleet lease identity and idle", () => {
     expect(text).not.toContain("tskey-preflight-secret");
   });
 
-  it("cleans up recorded Tailscale devices before provider release", async () => {
+  it("does not trust client-posted Tailscale device IDs for privileged cleanup", async () => {
     const storage = new MemoryStorage();
     const cleanupOrder: string[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = String(input);
-        if (url === "https://api.tailscale.com/api/v2/oauth/token") {
-          return jsonResponse({ access_token: "oauth-token" });
-        }
-        if (url === "https://api.tailscale.com/api/v2/device/node-123") {
-          cleanupOrder.push(`tailscale:${init?.method ?? "GET"}`);
-          return new Response("");
-        }
-        return jsonResponse({ message: `unexpected ${url}` }, 500);
+      vi.fn(async (input: RequestInfo | URL) => {
+        throw new Error(`unexpected Tailscale API request: ${String(input)}`);
       }),
     );
     storage.seed(
@@ -4578,10 +4570,7 @@ describe("fleet lease identity and idle", () => {
           cleanupOrder.push(`provider:${id}`);
         }),
       },
-      {
-        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
-        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
-      },
+      {},
     );
 
     const response = await fleet.fetch(
@@ -4591,9 +4580,10 @@ describe("fleet lease identity and idle", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(cleanupOrder).toEqual(["tailscale:DELETE", "provider:4242"]);
+    expect(cleanupOrder).toEqual(["provider:4242"]);
     const stored = storage.value<LeaseRecord>("lease:cbx_tailscale_cleanup");
-    expect(stored?.tailscale?.cleanupState).toBe("api_delete_succeeded");
+    expect(stored?.tailscale?.deviceID).toBe("node-123");
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("does not hold the state transition lock while minting a Tailscale key", async () => {

--- a/worker/test/tailscale.test.ts
+++ b/worker/test/tailscale.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createTailscaleAuthKey,
-  deleteTailscaleDevice,
   renderTailscaleHostname,
   tailscaleInstallConfig,
   tailscalePreflight,
@@ -182,39 +181,6 @@ describe("tailscale preflight", () => {
       mode: "pinned",
       version: "1.99.1",
       sha256: { amd64: "amd", arm64: "arm" },
-    });
-  });
-});
-
-describe("tailscale device cleanup", () => {
-  it("uses OAuth device scope and deletes the recorded node", async () => {
-    const calls: Array<{ url: string; body?: string; method?: string }> = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        calls.push({ url: String(input), body: String(init?.body ?? ""), method: init?.method });
-        if (String(input) === "https://api.tailscale.com/api/v2/oauth/token") {
-          return new Response(JSON.stringify({ access_token: "oauth-token" }));
-        }
-        if (String(input) === "https://api.tailscale.com/api/v2/device/node-123") {
-          return new Response("");
-        }
-        return new Response(JSON.stringify({ message: "unexpected" }), { status: 500 });
-      }),
-    );
-
-    await deleteTailscaleDevice(
-      {
-        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
-        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
-      },
-      "node-123",
-    );
-
-    expect(calls[0].body).toContain("scope=devices");
-    expect(calls[1]).toMatchObject({
-      url: "https://api.tailscale.com/api/v2/device/node-123",
-      method: "DELETE",
     });
   });
 });


### PR DESCRIPTION
## Summary

- remove coordinator-side Tailscale device deletion because the device ID is posted by the lease client and cannot safely authorize a privileged tailnet operation
- stop installing logout-on-reboot hooks and remove the legacy unit/helper from reused images
- make the live preflight script fail when the coordinator returns an application-level error
- retain diagnostic device metadata, explicit CLI best-effort logout, and ephemeral Tailscale node expiry

Follow-up to https://github.com/openclaw/crabbox/issues/309.

## Security

The coordinator now requires only the documented `auth_keys` OAuth scope. It no longer requests device-management authority or trusts client-posted device IDs for deletion.

## Verification

- `go test ./internal/cli -run 'TestCloudInitTailscale' -count=1`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `node --test scripts/live-tailscale-smoke.test.js`
- `node scripts/check-docs-links.mjs`
- `node scripts/build-docs-site.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`

The final autoreview completed clean with no accepted or actionable findings. Live Tailscale OAuth credentials were not available locally; the removed device API path therefore has no remaining credentialed live operation to exercise.
