### PR TITLE
[codex] fix Windows rsync fallback for local containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed Windows local-container sync to avoid unusable WSL command shims, support Docker Desktop mount roots, and fall back to native rsync when WSL lacks native SSH tooling. Thanks @brokemac79.
 - Fixed brokered Tailscale cleanup to avoid privileged deletion from client-posted device IDs, preserve connectivity across normal reboots, and fail live preflight on application-level errors.
 - Fixed Crabfleet workspaces to use any configured brokered provider and route the OpenClaw deployment through its canonical OAuth host and verified AWS backend with isolated, ephemeral key-only SSH access, stock-image cloud-init, and readiness-gated, pinned, Workers-compatible terminal attachment.
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -40,11 +40,6 @@ type SSHTarget struct {
 	ProxyCommand           string
 }
 
-var windowsWSLMountRootCache struct {
-	once  sync.Once
-	value string
-}
-
 func isLocalMacTarget(target SSHTarget) bool {
 	if runtime.GOOS != "darwin" || target.TargetOS != targetMacOS {
 		return false
@@ -783,9 +778,10 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		wslExe, err = exec.LookPath("wsl")
 	}
 	// Fall back to native rsync when WSL is absent or lacks native tools.
-	if err != nil || !windowsWSLHasNativeRsyncSSH(wslExe) {
+	if err != nil || !windowsWSLHasNativeRsyncSSH(ctx, wslExe) {
 		return windowsNativeRsyncCommand(ctx, args)
 	}
+	mountRoot := windowsWSLMountRoot(ctx, wslExe)
 
 	// Prepare WSL key: copy with correct permissions.
 	wslKey := ""
@@ -795,7 +791,7 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
 		knownHostsPath = knownHostsFile(target)
 		if keyData, err := os.ReadFile(windowsHostPath(target.Key)); err == nil {
-			cpCmd := exec.Command(wslExe, "sh", "-lc",
+			cpCmd := exec.CommandContext(ctx, wslExe, "sh", "-lc",
 				fmt.Sprintf("umask 077; cat > %s && chmod 600 %s",
 					shellQuote(wslKey),
 					shellQuote(wslKey)))
@@ -810,7 +806,7 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		}
 		if knownHostsData, err := os.ReadFile(windowsHostPath(knownHostsPath)); err == nil {
 			wslKnownHosts = wslKey + "-known_hosts"
-			cpKnownHostsCmd := exec.Command(wslExe, "sh", "-lc",
+			cpKnownHostsCmd := exec.CommandContext(ctx, wslExe, "sh", "-lc",
 				fmt.Sprintf("cat > %s && chmod 600 %s",
 					shellQuote(wslKnownHosts),
 					shellQuote(wslKnownHosts)))
@@ -826,15 +822,15 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 	// the -e "ssh ..." arg which embeds key and known_hosts paths).
 	wslArgs := make([]string, len(args))
 	for i, arg := range args {
-		converted := windowsToWSLPath(arg)
+		converted := windowsToWSLPathWithRoot(arg, mountRoot)
 		// Replace key path with WSL temp copy inside -e string
 		if wslKey != "" && target.Key != "" {
-			keyWSL := windowsToWSLMountPath(target.Key)
+			keyWSL := windowsToWSLMountPathWithRoot(target.Key, mountRoot)
 			converted = strings.ReplaceAll(converted, keyWSL, wslKey)
 		}
 		// Replace known_hosts path
 		if knownHostsPath != "" && wslKnownHosts != "" {
-			khWSL := windowsToWSLMountPath(knownHostsPath)
+			khWSL := windowsToWSLMountPathWithRoot(knownHostsPath, mountRoot)
 			converted = strings.ReplaceAll(converted, khWSL, wslKnownHosts)
 		}
 		wslArgs[i] = converted
@@ -857,11 +853,11 @@ func windowsHostPath(path string) string {
 	return path
 }
 
-func windowsWSLHasNativeRsyncSSH(wslExe string) bool {
+func windowsWSLHasNativeRsyncSSH(ctx context.Context, wslExe string) bool {
 	if strings.TrimSpace(wslExe) == "" {
 		return false
 	}
-	out, err := exec.Command(wslExe, "sh", "-lc", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"").Output()
+	out, err := exec.CommandContext(ctx, wslExe, "sh", "-lc", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"").Output()
 	return err == nil && windowsWSLNativeToolPaths(string(out))
 }
 
@@ -903,11 +899,6 @@ func windowsWSLMountedDrivePath(path string) bool {
 	return len(rest) >= 1 && rest[0] >= 'a' && rest[0] <= 'z' && (len(rest) == 1 || rest[1] == '/')
 }
 
-// windowsToWSLMountPath converts a single Windows path to WSL /mnt/ form.
-func windowsToWSLMountPath(path string) string {
-	return windowsToWSLMountPathWithRoot(path, windowsWSLMountRoot())
-}
-
 func windowsToWSLMountPathWithRoot(path, mountRoot string) string {
 	path = strings.ReplaceAll(path, `\`, "/")
 	if len(path) >= 2 && path[1] == ':' {
@@ -924,7 +915,7 @@ func windowsToWSLMountPathWithRoot(path, mountRoot string) string {
 // WSL mount paths. Handles both C:\... and /c/... formats embedded in
 // larger strings (like the -e "ssh -i C:\path\key ..." argument).
 func windowsToWSLPath(s string) string {
-	return windowsToWSLPathWithRoot(s, windowsWSLMountRoot())
+	return windowsToWSLPathWithRoot(s, "/mnt")
 }
 
 func windowsToWSLPathWithRoot(s, mountRoot string) string {
@@ -958,20 +949,17 @@ func windowsToWSLPathWithRoot(s, mountRoot string) string {
 	return s
 }
 
-func windowsWSLMountRoot() string {
+func windowsWSLMountRoot(ctx context.Context, wslExe string) string {
 	if runtime.GOOS != "windows" {
 		return "/mnt"
 	}
-	windowsWSLMountRootCache.once.Do(func() {
-		windowsWSLMountRootCache.value = "/mnt"
-		out, err := exec.Command("wsl", "sh", "-lc", "if [ -d /mnt/host/c ]; then printf /mnt/host; else printf /mnt; fi").Output()
-		if err == nil {
-			if value := strings.TrimSpace(string(out)); value != "" {
-				windowsWSLMountRootCache.value = value
-			}
+	out, err := exec.CommandContext(ctx, wslExe, "sh", "-lc", "if [ -d /mnt/host/c ]; then printf /mnt/host; else printf /mnt; fi").Output()
+	if err == nil {
+		if value := strings.TrimSpace(string(out)); value != "" {
+			return value
 		}
-	})
-	return windowsWSLMountRootCache.value
+	}
+	return "/mnt"
 }
 
 func shellQuote(s string) string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -790,10 +790,11 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 	// Prepare WSL key: copy with correct permissions.
 	wslKey := ""
 	knownHostsPath := ""
+	wslKnownHosts := ""
 	if target.Key != "" {
 		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
-		knownHostsPath = filepath.Join(filepath.Dir(target.Key), "known_hosts")
-		if keyData, err := os.ReadFile(target.Key); err == nil {
+		knownHostsPath = knownHostsFile(target)
+		if keyData, err := os.ReadFile(windowsHostPath(target.Key)); err == nil {
 			cpCmd := exec.Command(wslExe, "sh", "-lc",
 				fmt.Sprintf("umask 077; cat > %s && chmod 600 %s",
 					shellQuote(wslKey),
@@ -801,19 +802,22 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 			cpCmd.Stdin = bytes.NewReader(keyData)
 			if err := cpCmd.Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: copy SSH key into WSL for rsync failed: %v\n", err)
+				return windowsNativeRsyncCommand(ctx, args)
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "warning: read SSH key for WSL rsync failed: %s: %v\n", target.Key, err)
+			return windowsNativeRsyncCommand(ctx, args)
 		}
-		if knownHostsData, err := os.ReadFile(knownHostsPath); err == nil {
-			wslKH := wslKey + "-known_hosts"
+		if knownHostsData, err := os.ReadFile(windowsHostPath(knownHostsPath)); err == nil {
+			wslKnownHosts = wslKey + "-known_hosts"
 			cpKnownHostsCmd := exec.Command(wslExe, "sh", "-lc",
 				fmt.Sprintf("cat > %s && chmod 600 %s",
-					shellQuote(wslKH),
-					shellQuote(wslKH)))
+					shellQuote(wslKnownHosts),
+					shellQuote(wslKnownHosts)))
 			cpKnownHostsCmd.Stdin = bytes.NewReader(knownHostsData)
 			if err := cpKnownHostsCmd.Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: copy known_hosts into WSL for rsync failed: %v\n", err)
+				wslKnownHosts = ""
 			}
 		}
 	}
@@ -829,10 +833,9 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 			converted = strings.ReplaceAll(converted, keyWSL, wslKey)
 		}
 		// Replace known_hosts path
-		if knownHostsPath != "" {
+		if knownHostsPath != "" && wslKnownHosts != "" {
 			khWSL := windowsToWSLMountPath(knownHostsPath)
-			wslKH := wslKey + "-known_hosts"
-			converted = strings.ReplaceAll(converted, khWSL, wslKH)
+			converted = strings.ReplaceAll(converted, khWSL, wslKnownHosts)
 		}
 		wslArgs[i] = converted
 	}
@@ -843,6 +846,15 @@ func windowsNativeRsyncCommand(ctx context.Context, args []string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "rsync", args...)
 	cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
 	return cmd
+}
+
+func windowsHostPath(path string) string {
+	path = strings.ReplaceAll(path, `\`, "/")
+	if len(path) >= 3 && path[0] == '/' && path[2] == '/' &&
+		(path[1] >= 'a' && path[1] <= 'z' || path[1] >= 'A' && path[1] <= 'Z') {
+		return string(path[1]) + ":" + path[2:]
+	}
+	return path
 }
 
 func windowsWSLHasNativeRsyncSSH(wslExe string) bool {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -876,13 +876,19 @@ func windowsWSLNativeToolPath(path string) bool {
 	if strings.HasSuffix(path, ".exe") {
 		return false
 	}
-	if path == "/mnt/c" || strings.HasPrefix(path, "/mnt/c/") {
-		return false
-	}
-	if path == "/mnt/host/c" || strings.HasPrefix(path, "/mnt/host/c/") {
+	if windowsWSLMountedDrivePath(path) {
 		return false
 	}
 	return true
+}
+
+func windowsWSLMountedDrivePath(path string) bool {
+	rest, ok := strings.CutPrefix(path, "/mnt/")
+	if !ok {
+		return false
+	}
+	rest = strings.TrimPrefix(rest, "host/")
+	return len(rest) >= 1 && rest[0] >= 'a' && rest[0] <= 'z' && (len(rest) == 1 || rest[1] == '/')
 }
 
 // windowsToWSLMountPath converts a single Windows path to WSL /mnt/ form.

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -40,6 +40,11 @@ type SSHTarget struct {
 	ProxyCommand           string
 }
 
+var windowsWSLMountRootCache struct {
+	once  sync.Once
+	value string
+}
+
 func isLocalMacTarget(target SSHTarget) bool {
 	if runtime.GOOS != "darwin" || target.TargetOS != targetMacOS {
 		return false
@@ -773,11 +778,13 @@ func rsyncLocalPathForGOOS(goos, path string) string {
 // into WSL /tmp with correct permissions, and paths within args are
 // converted to WSL mount paths.
 func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *exec.Cmd {
-	if _, err := exec.LookPath("wsl"); err != nil {
-		// No WSL — fall back to native rsync with MSYS2 workarounds.
-		cmd := exec.CommandContext(ctx, "rsync", args...)
-		cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
-		return cmd
+	wslExe, err := exec.LookPath("wsl.exe")
+	if err != nil {
+		wslExe, err = exec.LookPath("wsl")
+	}
+	// Fall back to native rsync when WSL is absent or lacks native tools.
+	if err != nil || !windowsWSLHasNativeRsyncSSH(wslExe) {
+		return windowsNativeRsyncCommand(ctx, args)
 	}
 
 	// Prepare WSL key: copy with correct permissions.
@@ -786,12 +793,29 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 	if target.Key != "" {
 		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
 		knownHostsPath = filepath.Join(filepath.Dir(target.Key), "known_hosts")
-		cpCmd := exec.Command("wsl", "bash", "-c",
-			fmt.Sprintf("mkdir -p /tmp && cp %s %s 2>/dev/null; chmod 600 %s 2>/dev/null",
-				shellQuote(windowsToWSLMountPath(target.Key)),
-				shellQuote(wslKey),
-				shellQuote(wslKey)))
-		_ = cpCmd.Run()
+		if keyData, err := os.ReadFile(target.Key); err == nil {
+			cpCmd := exec.Command(wslExe, "sh", "-lc",
+				fmt.Sprintf("umask 077; cat > %s && chmod 600 %s",
+					shellQuote(wslKey),
+					shellQuote(wslKey)))
+			cpCmd.Stdin = bytes.NewReader(keyData)
+			if err := cpCmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: copy SSH key into WSL for rsync failed: %v\n", err)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: read SSH key for WSL rsync failed: %s: %v\n", target.Key, err)
+		}
+		if knownHostsData, err := os.ReadFile(knownHostsPath); err == nil {
+			wslKH := wslKey + "-known_hosts"
+			cpKnownHostsCmd := exec.Command(wslExe, "sh", "-lc",
+				fmt.Sprintf("cat > %s && chmod 600 %s",
+					shellQuote(wslKH),
+					shellQuote(wslKH)))
+			cpKnownHostsCmd.Stdin = bytes.NewReader(knownHostsData)
+			if err := cpKnownHostsCmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: copy known_hosts into WSL for rsync failed: %v\n", err)
+			}
+		}
 	}
 
 	// Convert all args: replace Windows paths inside strings (including
@@ -812,18 +836,68 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		}
 		wslArgs[i] = converted
 	}
-	return exec.CommandContext(ctx, "wsl", append([]string{"rsync"}, wslArgs...)...)
+	return exec.CommandContext(ctx, wslExe, append([]string{"rsync"}, wslArgs...)...)
+}
+
+func windowsNativeRsyncCommand(ctx context.Context, args []string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "rsync", args...)
+	cmd.Env = append(os.Environ(), "MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning")
+	return cmd
+}
+
+func windowsWSLHasNativeRsyncSSH(wslExe string) bool {
+	if strings.TrimSpace(wslExe) == "" {
+		return false
+	}
+	out, err := exec.Command(wslExe, "sh", "-lc", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"").Output()
+	return err == nil && windowsWSLNativeToolPaths(string(out))
+}
+
+func windowsWSLNativeToolPaths(output string) bool {
+	paths := 0
+	for _, line := range strings.Split(output, "\n") {
+		path := strings.TrimSpace(line)
+		if path == "" {
+			continue
+		}
+		paths++
+		if !windowsWSLNativeToolPath(path) {
+			return false
+		}
+	}
+	return paths >= 2
+}
+
+func windowsWSLNativeToolPath(path string) bool {
+	path = strings.ToLower(strings.TrimSpace(path))
+	if path == "" {
+		return false
+	}
+	if strings.HasSuffix(path, ".exe") {
+		return false
+	}
+	if path == "/mnt/c" || strings.HasPrefix(path, "/mnt/c/") {
+		return false
+	}
+	if path == "/mnt/host/c" || strings.HasPrefix(path, "/mnt/host/c/") {
+		return false
+	}
+	return true
 }
 
 // windowsToWSLMountPath converts a single Windows path to WSL /mnt/ form.
 func windowsToWSLMountPath(path string) string {
+	return windowsToWSLMountPathWithRoot(path, windowsWSLMountRoot())
+}
+
+func windowsToWSLMountPathWithRoot(path, mountRoot string) string {
 	path = strings.ReplaceAll(path, `\`, "/")
 	if len(path) >= 2 && path[1] == ':' {
 		drive := strings.ToLower(string(path[0]))
-		return "/mnt/" + drive + path[2:]
+		return strings.TrimRight(mountRoot, "/") + "/" + drive + path[2:]
 	}
 	if len(path) >= 3 && path[0] == '/' && path[2] == '/' && path[1] >= 'a' && path[1] <= 'z' {
-		return "/mnt" + path
+		return strings.TrimRight(mountRoot, "/") + path
 	}
 	return path
 }
@@ -832,32 +906,54 @@ func windowsToWSLMountPath(path string) string {
 // WSL mount paths. Handles both C:\... and /c/... formats embedded in
 // larger strings (like the -e "ssh -i C:\path\key ..." argument).
 func windowsToWSLPath(s string) string {
+	return windowsToWSLPathWithRoot(s, windowsWSLMountRoot())
+}
+
+func windowsToWSLPathWithRoot(s, mountRoot string) string {
+	mountRoot = strings.TrimRight(mountRoot, "/")
 	s = strings.ReplaceAll(s, `\`, "/")
-	// Replace drive-letter paths: C:/... -> /mnt/c/...
+	// Replace drive-letter paths: C:/... -> /mnt/c/... or /mnt/host/c/...
 	for i := 0; i < len(s)-2; i++ {
 		c := s[i]
 		if (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') && s[i+1] == ':' && s[i+2] == '/' {
 			// Only replace if at start of string or preceded by a non-path char
 			if i == 0 || s[i-1] == ' ' || s[i-1] == '\'' || s[i-1] == '"' || s[i-1] == '=' {
 				drive := strings.ToLower(string(c))
-				s = s[:i] + "/mnt/" + drive + s[i+2:]
-				i += 4 // skip past /mnt/X
+				replacement := mountRoot + "/" + drive + s[i+2:]
+				s = s[:i] + replacement
+				i += len(mountRoot) + 2 // skip past /mnt[/host]/X
 			}
 		}
 	}
-	// Also handle /c/... -> /mnt/c/... (from rsyncLocalPath conversion)
+	// Also handle /c/... -> /mnt/c/... or /mnt/host/c/... (from rsyncLocalPath conversion)
 	for i := 0; i < len(s)-2; i++ {
 		if s[i] == '/' && s[i+1] >= 'a' && s[i+1] <= 'z' && s[i+2] == '/' {
 			if i == 0 || s[i-1] == ' ' || s[i-1] == '\'' || s[i-1] == '"' || s[i-1] == '=' {
 				// Avoid converting remote paths like crabbox@host:/work
 				if i == 0 || s[i-1] != ':' {
-					s = s[:i] + "/mnt" + s[i:]
-					i += 4
+					s = s[:i] + mountRoot + s[i:]
+					i += len(mountRoot)
 				}
 			}
 		}
 	}
 	return s
+}
+
+func windowsWSLMountRoot() string {
+	if runtime.GOOS != "windows" {
+		return "/mnt"
+	}
+	windowsWSLMountRootCache.once.Do(func() {
+		windowsWSLMountRootCache.value = "/mnt"
+		out, err := exec.Command("wsl", "sh", "-lc", "if [ -d /mnt/host/c ]; then printf /mnt/host; else printf /mnt; fi").Output()
+		if err == nil {
+			if value := strings.TrimSpace(string(out)); value != "" {
+				windowsWSLMountRootCache.value = value
+			}
+		}
+	})
+	return windowsWSLMountRootCache.value
 }
 
 func shellQuote(s string) string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -791,7 +791,7 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
 		knownHostsPath = knownHostsFile(target)
 		if keyData, err := os.ReadFile(windowsHostPath(target.Key)); err == nil {
-			cpCmd := exec.CommandContext(ctx, wslExe, "sh", "-lc",
+			cpCmd := exec.CommandContext(ctx, wslExe, "sh", "-c",
 				fmt.Sprintf("umask 077; cat > %s && chmod 600 %s",
 					shellQuote(wslKey),
 					shellQuote(wslKey)))
@@ -806,7 +806,7 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 		}
 		if knownHostsData, err := os.ReadFile(windowsHostPath(knownHostsPath)); err == nil {
 			wslKnownHosts = wslKey + "-known_hosts"
-			cpKnownHostsCmd := exec.CommandContext(ctx, wslExe, "sh", "-lc",
+			cpKnownHostsCmd := exec.CommandContext(ctx, wslExe, "sh", "-c",
 				fmt.Sprintf("cat > %s && chmod 600 %s",
 					shellQuote(wslKnownHosts),
 					shellQuote(wslKnownHosts)))
@@ -857,7 +857,7 @@ func windowsWSLHasNativeRsyncSSH(ctx context.Context, wslExe string) bool {
 	if strings.TrimSpace(wslExe) == "" {
 		return false
 	}
-	out, err := exec.CommandContext(ctx, wslExe, "sh", "-lc", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"").Output()
+	out, err := exec.CommandContext(ctx, wslExe, "sh", "-c", "rsync_path=$(command -v rsync) || exit 1; ssh_path=$(command -v ssh) || exit 1; printf '%s\\n%s\\n' \"$rsync_path\" \"$ssh_path\"").Output()
 	return err == nil && windowsWSLNativeToolPaths(string(out))
 }
 
@@ -953,7 +953,7 @@ func windowsWSLMountRoot(ctx context.Context, wslExe string) string {
 	if runtime.GOOS != "windows" {
 		return "/mnt"
 	}
-	out, err := exec.CommandContext(ctx, wslExe, "sh", "-lc", "if [ -d /mnt/host/c ]; then printf /mnt/host; else printf /mnt; fi").Output()
+	out, err := exec.CommandContext(ctx, wslExe, "sh", "-c", "if [ -d /mnt/host/c ]; then printf /mnt/host; else printf /mnt; fi").Output()
 	if err == nil {
 		if value := strings.TrimSpace(string(out)); value != "" {
 			return value

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -872,6 +872,65 @@ func TestRsyncLocalPathPassesThroughNonWindowsPath(t *testing.T) {
 	}
 }
 
+func TestWindowsToWSLMountPathSupportsHostMountRoot(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		`C:\Users\marti\.ssh\id_ed25519`: "/mnt/host/c/Users/marti/.ssh/id_ed25519",
+		"C:/oc-work/my-app":              "/mnt/host/c/oc-work/my-app",
+		"/c/msys64/usr/bin/rsync.exe":    "/mnt/host/c/msys64/usr/bin/rsync.exe",
+	}
+	for in, want := range tests {
+		got := windowsToWSLMountPathWithRoot(in, "/mnt/host")
+		if got != want {
+			t.Fatalf("windowsToWSLMountPathWithRoot(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWindowsWSLNativeToolPathsRejectsWindowsShims(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		paths string
+		want  bool
+	}{
+		{
+			name:  "native paths",
+			paths: "/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  true,
+		},
+		{
+			name:  "missing ssh",
+			paths: "/usr/bin/rsync\n",
+			want:  false,
+		},
+		{
+			name:  "exe shim",
+			paths: "/usr/bin/rsync.exe\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
+			name:  "mnt c shim",
+			paths: "/mnt/c/msys64/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
+			name:  "mnt host c shim",
+			paths: "/mnt/host/c/msys64/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := windowsWSLNativeToolPaths(tc.paths); got != tc.want {
+				t.Fatalf("windowsWSLNativeToolPaths(%q) = %v, want %v", tc.paths, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeRsyncOptionsNoTimesForcesChecksum(t *testing.T) {
 	t.Parallel()
 	got := normalizeRsyncOptions(rsyncOptions{NoTimes: true})
@@ -902,6 +961,18 @@ func TestWindowsToWSLPath(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("windowsToWSLPath(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestWindowsToWSLPathSupportsHostMountRoot(t *testing.T) {
+	t.Parallel()
+	in := `ssh -i C:\Users\marti\AppData\Local\Temp\cbx\id_ed25519 -o UserKnownHostsFile=/c/tmp/known_hosts`
+	got := windowsToWSLPathWithRoot(in, "/mnt/host")
+	if !strings.Contains(got, "/mnt/host/c/Users/marti/AppData/Local/Temp/cbx/id_ed25519") {
+		t.Fatalf("converted path missing host-root key path: %q", got)
+	}
+	if !strings.Contains(got, "UserKnownHostsFile=/mnt/host/c/tmp/known_hosts") {
+		t.Fatalf("converted path missing host-root known_hosts path: %q", got)
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -887,6 +887,20 @@ func TestWindowsToWSLMountPathSupportsHostMountRoot(t *testing.T) {
 	}
 }
 
+func TestWindowsHostPathConvertsMSYSDrivePath(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		`C:\Users\marti\.ssh\id_ed25519`: "C:/Users/marti/.ssh/id_ed25519",
+		"/c/Users/marti/.ssh/id_ed25519": "c:/Users/marti/.ssh/id_ed25519",
+		"/work/repo":                     "/work/repo",
+	}
+	for in, want := range tests {
+		if got := windowsHostPath(in); got != want {
+			t.Fatalf("windowsHostPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestWindowsWSLNativeToolPathsRejectsWindowsShims(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -915,8 +915,18 @@ func TestWindowsWSLNativeToolPathsRejectsWindowsShims(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "mnt other drive shim",
+			paths: "/mnt/d/tools/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
 			name:  "mnt host c shim",
 			paths: "/mnt/host/c/msys64/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
+			name:  "mnt host other drive shim",
+			paths: "/mnt/host/e/tools/rsync\n/usr/bin/ssh\n",
 			want:  false,
 		},
 	}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -872,6 +872,65 @@ func TestRsyncLocalPathPassesThroughNonWindowsPath(t *testing.T) {
 	}
 }
 
+func TestWindowsToWSLMountPathSupportsHostMountRoot(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		`C:\Users\alice\.ssh\id_ed25519`: "/mnt/host/c/Users/alice/.ssh/id_ed25519",
+		"C:/oc-work/my-app":              "/mnt/host/c/oc-work/my-app",
+		"/c/msys64/usr/bin/rsync.exe":    "/mnt/host/c/msys64/usr/bin/rsync.exe",
+	}
+	for in, want := range tests {
+		got := windowsToWSLMountPathWithRoot(in, "/mnt/host")
+		if got != want {
+			t.Fatalf("windowsToWSLMountPathWithRoot(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWindowsWSLNativeToolPathsRejectsWindowsShims(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		paths string
+		want  bool
+	}{
+		{
+			name:  "native paths",
+			paths: "/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  true,
+		},
+		{
+			name:  "missing ssh",
+			paths: "/usr/bin/rsync\n",
+			want:  false,
+		},
+		{
+			name:  "exe shim",
+			paths: "/usr/bin/rsync.exe\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
+			name:  "mnt c shim",
+			paths: "/mnt/c/msys64/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+		{
+			name:  "mnt host c shim",
+			paths: "/mnt/host/c/msys64/usr/bin/rsync\n/usr/bin/ssh\n",
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := windowsWSLNativeToolPaths(tc.paths); got != tc.want {
+				t.Fatalf("windowsWSLNativeToolPaths(%q) = %v, want %v", tc.paths, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeRsyncOptionsNoTimesForcesChecksum(t *testing.T) {
 	t.Parallel()
 	got := normalizeRsyncOptions(rsyncOptions{NoTimes: true})
@@ -902,6 +961,18 @@ func TestWindowsToWSLPath(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("windowsToWSLPath(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestWindowsToWSLPathSupportsHostMountRoot(t *testing.T) {
+	t.Parallel()
+	in := `ssh -i C:\Users\alice\AppData\Local\Temp\cbx\id_ed25519 -o UserKnownHostsFile=/c/tmp/known_hosts`
+	got := windowsToWSLPathWithRoot(in, "/mnt/host")
+	if !strings.Contains(got, "/mnt/host/c/Users/alice/AppData/Local/Temp/cbx/id_ed25519") {
+		t.Fatalf("converted path missing host-root key path: %q", got)
+	}
+	if !strings.Contains(got, "UserKnownHostsFile=/mnt/host/c/tmp/known_hosts") {
+		t.Fatalf("converted path missing host-root known_hosts path: %q", got)
 	}
 }
 


### PR DESCRIPTION
﻿## What changed

- Only use WSL rsync on Windows when the selected WSL distro has native `rsync` and `ssh` available.
- Reject WSL probe results that resolve to Windows interop shims, including `.exe`, `/mnt/c`, and `/mnt/host/c` command paths.
- Fall back to native MSYS2/Cygwin rsync with the existing path-conversion safeguards when WSL is present but unsuitable.
- Copy the SSH key and known_hosts data into WSL through stdin instead of relying on WSL mount-path access to the Windows key path.
- Add `/mnt/host`-aware Windows-to-WSL path conversion coverage and focused shim-rejection coverage.

## Why

On Windows hosts where the default WSL distro is `docker-desktop`, `wsl.exe` can exist while the distro lacks native `rsync` and `ssh`. Crabbox then tried `wsl rsync`, which could fall through to Windows PATH shims while still using WSL `/tmp` key paths. That caused synced local-container runs to fail because the SSH identity path was not accessible from the process that actually ran rsync.

## Validation

- `docker run --rm -v "C:\oc-work\crabbox-pr-windows-rsync:/src" -w /src golang:1.26 sh -lc "/usr/local/go/bin/go test ./internal/cli -run 'Test(RsyncLocalPath|WindowsToWSL|WindowsWSL|NormalizeRsyncOptions)' && /usr/local/go/bin/go test ./internal/cli -run 'TestWindows'"`
- Built `crabbox.exe` from this branch as `0.30.1-dev`.
- Synced local-container smoke passed from Windows with `provider=local-container`, lease `cbx_e28706413742`, sync enabled, and `rsync` phase completing in 1.522s:
  `crabbox run --provider local-container --no-hydrate --timing-json --label windows-rsync-pr-smoke-rankup --shell -- "printf 'sync-ok\n'; test -f go.mod; uname -a"`

## Note

A broader `go test ./internal/cli` run from the Windows-mounted Docker volume previously failed in unrelated checkpoint/pond ACL golden tests with newline/golden-output differences; the focused rsync/path and Windows tests above pass.
