### PR TITLE
fix: harden Cloudflare Dynamic Workers lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,10 @@ jobs:
         run: npm run build
         working-directory: worker
 
+      - name: Build Cloudflare Dynamic Workers
+        run: npm run build:cloudflare-dynamic-workers
+        working-directory: worker
+
       - name: Build Node runtime
         run: npm run build:node
         working-directory: worker

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -639,6 +639,8 @@ type CloudflareConfig struct {
 	Workdir string
 }
 
+const DefaultCloudflareDynamicWorkersCompatibilityDate = "2026-06-12"
+
 type CloudflareDynamicWorkersConfig struct {
 	LoaderURL                      string
 	Token                          string
@@ -2053,10 +2055,11 @@ func baseConfig() Config {
 			Workdir: "/workspace/crabbox",
 		},
 		CloudflareDynamicWorkers: CloudflareDynamicWorkersConfig{
-			CacheMode:   "stable",
-			Egress:      "blocked",
-			TimeoutSecs: 60,
-			Metadata:    map[string]string{},
+			CompatibilityDate: DefaultCloudflareDynamicWorkersCompatibilityDate,
+			CacheMode:         "stable",
+			Egress:            "blocked",
+			TimeoutSecs:       60,
+			Metadata:          map[string]string{},
 		},
 		Proxmox: ProxmoxConfig{
 			User:      "crabbox",

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -513,7 +513,7 @@ func (b *backend) buildRunRequest(req RunRequest, leaseID, workerID, cacheMode s
 		RetainMetadata:     req.Keep || cacheMode == "explicit",
 		RetainOnFailure:    req.KeepOnFailure,
 		Module:             moduleSource{Name: workerModuleName(req.Script), Source: string(req.Script.Data)},
-		CompatibilityDate:  strings.TrimSpace(cfg.CompatibilityDate),
+		CompatibilityDate:  effectiveCompatibilityDate(cfg.CompatibilityDate),
 		CompatibilityFlags: append([]string(nil), cfg.CompatibilityFlags...),
 		Egress:             normalizeEgress(cfg.Egress),
 		Limits:             limits{CPUMs: cfg.CPUMs, Subrequests: cfg.Subrequests},
@@ -629,7 +629,7 @@ func stableRunID(moduleName string, source []byte, cfg CloudflareDynamicWorkersC
 	_, _ = h.Write([]byte{0})
 	_, _ = h.Write(source)
 	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(strings.TrimSpace(cfg.CompatibilityDate)))
+	_, _ = h.Write([]byte(effectiveCompatibilityDate(cfg.CompatibilityDate)))
 	_, _ = h.Write([]byte{0})
 	flags := append([]string(nil), cfg.CompatibilityFlags...)
 	sort.Strings(flags)
@@ -653,6 +653,10 @@ func stableRunID(moduleName string, source []byte, cfg CloudflareDynamicWorkersC
 
 func normalizeCacheMode(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func effectiveCompatibilityDate(value string) string {
+	return blank(strings.TrimSpace(value), defaultCompatibilityDate)
 }
 
 func normalizeEgress(value string) string {

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -193,6 +193,19 @@ func TestDefaultHTTPClientHonorsConfiguredRunTimeout(t *testing.T) {
 	}
 }
 
+func TestDefaultHTTPClientDisablesTimeoutWhenRunTimeoutIsDisabled(t *testing.T) {
+	cfg := testConfig("http://127.0.0.1:1")
+	cfg.CloudflareDynamicWorkers.TimeoutSecs = 0
+	client := defaultHTTPClient(cfg)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport=%T", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != 0 {
+		t.Fatalf("response header timeout=%s, want disabled", transport.ResponseHeaderTimeout)
+	}
+}
+
 func TestClientTimeoutCoversResponseBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -351,6 +364,67 @@ func TestClientRejectsInvalidStatusIdentityAndState(t *testing.T) {
 				t.Fatalf("status error=%v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestClientRetriesTransientStatusReads(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			http.Error(w, "error code: 1104", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(runStatus{ID: "run_expected", Status: "succeeded"})
+	}))
+	defer server.Close()
+	client := &client{
+		baseURL:             server.URL,
+		token:               "test-token",
+		http:                server.Client(),
+		responseBodyTimeout: time.Second,
+		readRetryDelays:     []time.Duration{0, 0},
+	}
+
+	status, err := client.Status(context.Background(), "run_expected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 || status.Status != "succeeded" {
+		t.Fatalf("calls=%d status=%#v", calls, status)
+	}
+}
+
+func TestClientRetryDoesNotDrainStalledErrorBody(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("error code: "))
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+			return
+		}
+		_ = json.NewEncoder(w).Encode(runStatus{ID: "run_expected", Status: "succeeded"})
+	}))
+	defer server.Close()
+	client := &client{
+		baseURL:             server.URL,
+		token:               "test-token",
+		http:                server.Client(),
+		responseBodyTimeout: time.Second,
+		readRetryDelays:     []time.Duration{0},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	status, err := client.Status(ctx, "run_expected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || status.Status != "succeeded" {
+		t.Fatalf("calls=%d status=%#v", calls, status)
 	}
 }
 
@@ -1322,15 +1396,28 @@ func TestWorkerModuleNameUsesJavaScriptForStdin(t *testing.T) {
 
 func TestStableRunIDIncludesForwardedEnv(t *testing.T) {
 	cfg := testConfig("http://127.0.0.1:1").CloudflareDynamicWorkers
+	cfg.CompatibilityDate = ""
 	source := []byte("export default { fetch() { return new Response('ok') } }\n")
 	first := stableRunID("worker.mjs", source, cfg, map[string]string{"TOKEN": "alpha", "FEATURE": "on"})
 	reordered := stableRunID("worker.mjs", source, cfg, map[string]string{"FEATURE": "on", "TOKEN": "alpha"})
 	second := stableRunID("worker.mjs", source, cfg, map[string]string{"TOKEN": "beta", "FEATURE": "on"})
 	empty := stableRunID("worker.mjs", source, cfg, nil)
 	renamed := stableRunID("index.js", source, cfg, map[string]string{"TOKEN": "alpha", "FEATURE": "on"})
+	explicitDefault := cfg
+	explicitDefault.CompatibilityDate = defaultCompatibilityDate
+	defaultDate := stableRunID("worker.mjs", source, explicitDefault, map[string]string{"TOKEN": "alpha", "FEATURE": "on"})
+	changedDate := cfg
+	changedDate.CompatibilityDate = "2026-06-13"
+	differentDate := stableRunID("worker.mjs", source, changedDate, map[string]string{"TOKEN": "alpha", "FEATURE": "on"})
 
 	if first != reordered {
 		t.Fatalf("stable id should be independent of env map iteration order: %q != %q", first, reordered)
+	}
+	if first != defaultDate {
+		t.Fatalf("empty and explicit default compatibility dates should match: %q != %q", first, defaultDate)
+	}
+	if first == differentDate {
+		t.Fatal("stable id should change when the compatibility date changes")
 	}
 	if first == second {
 		t.Fatal("stable id should change when forwarded env values change")
@@ -1340,6 +1427,20 @@ func TestStableRunIDIncludesForwardedEnv(t *testing.T) {
 	}
 	if first == renamed {
 		t.Fatal("stable id should change when the main module name changes")
+	}
+}
+
+func TestBuildRunRequestSendsEffectiveCompatibilityDate(t *testing.T) {
+	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
+	backend.cfg.CloudflareDynamicWorkers.CompatibilityDate = ""
+	req := backend.buildRunRequest(
+		RunRequest{Script: &RunScriptSpec{Source: "stdin", Data: []byte("export default {}")}},
+		"run_1",
+		"worker_1",
+		"stable",
+	)
+	if req.CompatibilityDate != defaultCompatibilityDate {
+		t.Fatalf("compatibility date=%q, want %q", req.CompatibilityDate, defaultCompatibilityDate)
 	}
 }
 

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -26,6 +26,7 @@ type client struct {
 	token               string
 	http                *http.Client
 	responseBodyTimeout time.Duration
+	readRetryDelays     []time.Duration
 }
 
 type readinessResponse struct {
@@ -121,6 +122,13 @@ const (
 	responseHeaderTimeoutOverhead = 5 * time.Second
 )
 
+var defaultReadRetryDelays = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	time.Second,
+	2 * time.Second,
+}
+
 var newLoaderAPI = func(cfg Config, rt Runtime) (loaderAPI, error) {
 	baseURL, err := loaderURL(cfg)
 	if err != nil {
@@ -140,6 +148,7 @@ var newLoaderAPI = func(cfg Config, rt Runtime) (loaderAPI, error) {
 		token:               token,
 		http:                httpClient,
 		responseBodyTimeout: responseHeaderTimeout(cfg),
+		readRetryDelays:     append([]time.Duration(nil), defaultReadRetryDelays...),
 	}, nil
 }
 
@@ -298,7 +307,7 @@ func noRedirectHTTPClient(httpClient *http.Client) *http.Client {
 func responseHeaderTimeout(cfg Config) time.Duration {
 	runTimeout := time.Duration(cfg.CloudflareDynamicWorkers.TimeoutSecs) * time.Second
 	if runTimeout <= 0 {
-		return defaultResponseHeaderTimeout
+		return 0
 	}
 	timeout := runTimeout + responseHeaderTimeoutOverhead
 	if timeout < defaultResponseHeaderTimeout {
@@ -528,34 +537,63 @@ func (c *client) DeleteAcknowledgedComplete(ctx context.Context, id string) erro
 }
 
 func (c *client) doJSON(ctx context.Context, method, endpoint string, input any, output any) error {
-	var body io.Reader
-	if input != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(input); err != nil {
+	for attempt := 0; ; attempt++ {
+		var body io.Reader
+		if input != nil {
+			var buf bytes.Buffer
+			if err := json.NewEncoder(&buf).Encode(input); err != nil {
+				return err
+			}
+			body = &buf
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, body)
+		if err != nil {
 			return err
 		}
-		body = &buf
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		if input != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return err
+		}
+		if method == http.MethodGet && retryableReadStatus(resp.StatusCode) && attempt < len(c.readRetryDelays) {
+			_ = resp.Body.Close()
+			if err := waitForRetry(ctx, c.readRetryDelays[attempt]); err != nil {
+				return err
+			}
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return c.responseError(ctx, resp)
+		}
+		if output == nil {
+			return nil
+		}
+		return c.decodeJSONResponse(ctx, resp.Body, output)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, body)
-	if err != nil {
-		return err
+}
+
+func retryableReadStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	if input != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.responseError(ctx, resp)
-	}
-	if output == nil {
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
 		return nil
 	}
-	return c.decodeJSONResponse(ctx, resp.Body, output)
 }
 
 func (c *client) responseError(ctx context.Context, resp *http.Response) error {
@@ -595,6 +633,9 @@ func (c *client) readResponseBody(ctx context.Context, body io.ReadCloser, limit
 }
 
 func (c *client) withResponseBodyDeadline(ctx context.Context, body io.ReadCloser, read func() error) error {
+	if c.responseBodyTimeout <= 0 {
+		return read()
+	}
 	bodyCtx, cancel := context.WithTimeout(ctx, c.responseBodyTimeout)
 	defer cancel()
 	stopClose := context.AfterFunc(bodyCtx, func() {

--- a/internal/providers/cloudflaredynamicworkers/core.go
+++ b/internal/providers/cloudflaredynamicworkers/core.go
@@ -34,8 +34,9 @@ type ExitError = core.ExitError
 type timingReport = core.TimingReport
 
 const (
-	providerName = "cloudflare-dynamic-workers"
-	targetWorker = core.TargetWorkerRuntime
+	providerName             = "cloudflare-dynamic-workers"
+	targetWorker             = core.TargetWorkerRuntime
+	defaultCompatibilityDate = core.DefaultCloudflareDynamicWorkersCompatibilityDate
 )
 
 func exit(code int, format string, args ...any) core.ExitError {

--- a/scripts/deploy-cloudflare-dynamic-workers-smoke.sh
+++ b/scripts/deploy-cloudflare-dynamic-workers-smoke.sh
@@ -200,13 +200,23 @@ local_checks() {
   if [[ "$SKIP_LOCAL_CHECKS" == "1" ]]; then
     return 0
   fi
-  run_logged npm ci --prefix "$ROOT/worker" || return $?
-  run_logged npm run format:check --prefix "$ROOT/worker" || return $?
-  run_logged npm run lint --prefix "$ROOT/worker" || return $?
-  run_logged npm run check --prefix "$ROOT/worker" || return $?
-  run_logged npm test --prefix "$ROOT/worker" -- cloudflare-dynamic-worker-runner || return $?
-  run_logged npm test --prefix "$ROOT/worker" -- cloudflare-container-runner || return $?
-  run_logged npm run build:cloudflare-dynamic-workers --prefix "$ROOT/worker" || return $?
+  local clean_env=(
+    env
+    -u CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN
+    -u CLOUDFLARE_API_TOKEN
+    -u CLOUDFLARE_API_KEY
+    -u CLOUDFLARE_EMAIL
+    -u CF_API_TOKEN
+    -u CF_API_KEY
+    -u CF_API_EMAIL
+  )
+  run_logged "${clean_env[@]}" npm ci --prefix "$ROOT/worker" || return $?
+  run_logged "${clean_env[@]}" npm run format:check --prefix "$ROOT/worker" || return $?
+  run_logged "${clean_env[@]}" npm run lint --prefix "$ROOT/worker" || return $?
+  run_logged "${clean_env[@]}" npm run check --prefix "$ROOT/worker" || return $?
+  run_logged "${clean_env[@]}" npm test --prefix "$ROOT/worker" -- cloudflare-dynamic-worker-runner || return $?
+  run_logged "${clean_env[@]}" npm test --prefix "$ROOT/worker" -- cloudflare-container-runner || return $?
+  run_logged "${clean_env[@]}" npm run build:cloudflare-dynamic-workers --prefix "$ROOT/worker" || return $?
 }
 
 deploy_runner() {
@@ -215,7 +225,7 @@ deploy_runner() {
   fi
   deployed_worker="crabbox-cfdw-smoke-$(date -u +%Y%m%d%H%M%S)-$RANDOM"
   local deploy_config_base
-  deploy_config_base="$(mktemp "$ROOT/worker/.wrangler-cfdw-smoke-XXXXXX")"
+  deploy_config_base="$(mktemp "${TMPDIR:-/tmp}/wrangler-cfdw-smoke-XXXXXX")"
   deploy_config="${deploy_config_base}.json"
   mv "$deploy_config_base" "$deploy_config"
   local secrets_file
@@ -226,10 +236,10 @@ deploy_runner() {
   smoke_tmp_files+=("$deploy_config" "$secrets_file")
   cat >"$deploy_config" <<EOF
 {
-  "\$schema": "./node_modules/wrangler/config-schema.json",
   "name": "$deployed_worker",
-  "main": "src/cloudflare-dynamic-worker-runner.ts",
+  "main": "$ROOT/worker/src/cloudflare-dynamic-worker-runner.ts",
   "compatibility_date": "2026-06-12",
+  "compatibility_flags": ["global_fetch_strictly_public"],
   "workers_dev": true,
   "preview_urls": false,
   "worker_loaders": [{ "binding": "LOADER" }],

--- a/scripts/deploy-cloudflare-dynamic-workers-smoke.test.js
+++ b/scripts/deploy-cloudflare-dynamic-workers-smoke.test.js
@@ -60,7 +60,21 @@ test("dynamic workers smoke classifies deploy quota failures", () => {
   const npxCalls = path.join(dir, "npx-calls.jsonl");
 
   writeExecutable(fakeCrabbox, "#!/usr/bin/env bash\nexit 0\n");
-  writeExecutable(path.join(bin, "npm"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    path.join(bin, "npm"),
+    `#!/usr/bin/env node
+const credentialNames = [
+  "CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN",
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_API_KEY",
+  "CLOUDFLARE_EMAIL",
+  "CF_API_TOKEN",
+  "CF_API_KEY",
+  "CF_API_EMAIL",
+];
+if (credentialNames.some((name) => process.env[name])) process.exit(42);
+`,
+  );
   writeExecutable(
     path.join(bin, "npx"),
     `#!/usr/bin/env node
@@ -267,6 +281,7 @@ test("dynamic workers smoke deletes its Worker before the KV namespace", () => {
     path.join(bin, "npx"),
     `#!/usr/bin/env node
 const fs = require("node:fs");
+const path = require("node:path");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.CRABBOX_FAKE_NPX_CALLS, JSON.stringify(args) + "\\n");
 if (args[0] === "wrangler" && args[1] === "kv" && args[2] === "namespace" && args[3] === "create") {
@@ -290,6 +305,8 @@ if (args[0] === "wrangler" && args[1] === "deploy") {
     (binding) => binding.name === "RUN_COORDINATOR",
   );
   if (coordinator?.class_name !== "DynamicWorkerRunCoordinator") process.exit(4);
+  if (!config.compatibility_flags?.includes("global_fetch_strictly_public")) process.exit(7);
+  if (!path.isAbsolute(config.main)) process.exit(8);
   if (
     !config.migrations?.some((migration) =>
       migration.new_sqlite_classes?.includes("DynamicWorkerRunCoordinator"),
@@ -328,8 +345,9 @@ process.exit(0);
     CRABBOX_FAKE_NPX_CALLS: npxCalls,
     CRABBOX_LIVE: "1",
     CRABBOX_LIVE_PROVIDERS: "cloudflare-dynamic-workers",
-    CRABBOX_CFDW_SKIP_LOCAL_CHECKS: "1",
     CLOUDFLARE_ACCOUNT_ID: "account",
+    CLOUDFLARE_API_TOKEN: "deploy-secret",
+    CF_API_KEY: "legacy-secret",
     CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN: runnerToken,
   });
 

--- a/worker/test/cloudflare-dynamic-worker-runner.test.ts
+++ b/worker/test/cloudflare-dynamic-worker-runner.test.ts
@@ -3556,6 +3556,7 @@ describe("Cloudflare Dynamic Workers runner", () => {
     );
 
     expect(config).toContain('"main": "src/cloudflare-dynamic-worker-runner.ts"');
+    expect(config).toContain('"compatibility_flags": ["global_fetch_strictly_public"]');
     expect(config).toContain('"worker_loaders"');
     expect(config).toContain('"binding": "LOADER"');
     expect(config).toContain('"kv_namespaces"');

--- a/worker/wrangler.cloudflare-dynamic-workers.jsonc
+++ b/worker/wrangler.cloudflare-dynamic-workers.jsonc
@@ -3,6 +3,7 @@
   "name": "crabbox-cloudflare-dynamic-workers-runner",
   "main": "src/cloudflare-dynamic-worker-runner.ts",
   "compatibility_date": "2026-06-12",
+  "compatibility_flags": ["global_fetch_strictly_public"],
   "workers_dev": true,
   "preview_urls": false,
   "worker_loaders": [


### PR DESCRIPTION
## Summary

- follow up the landed Cloudflare Dynamic Workers provider from https://github.com/openclaw/crabbox/pull/287
- make claim deletion race-safe and stabilize transient Cloudflare lifecycle reads
- pin compatibility identity, require the Worker-to-Worker fetch compatibility flag, and validate the Dynamic Workers bundle in CI
- keep live smoke configuration outside the checkout and scrub Cloudflare credentials from dependency checks

## Verification

- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (566 tests)
- `npm run build --prefix worker`
- `npm run build:cloudflare-dynamic-workers --prefix worker`
- `npm run build:node --prefix worker`
- `node --test scripts/*.test.js` (201 tests)
- `scripts/check-docs.sh`
- `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=cloudflare-dynamic-workers CRABBOX_CFDW_SKIP_LOCAL_CHECKS=1 scripts/deploy-cloudflare-dynamic-workers-smoke.sh`
  - deployed an ephemeral loader and KV namespace
  - observed `CRABBOX_CFDW_OK`
  - observed `CRABBOX_CFDW_EGRESS_BLOCKED`
  - status, refreshed list, stop, and cleanup passed
  - final classification: `live_cloudflare_dynamic_workers_smoke_passed`
  - teardown confirmed the Worker no longer exists and the KV namespace is absent
- autoreview: clean, no accepted or actionable findings
