### PR TITLE
docs: record Cloudflare lifecycle hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed Cloudflare Dynamic Workers lifecycle reads, compatibility identity, bundle validation, and live-smoke credential isolation.
 - Fixed Windows local-container sync to avoid unusable WSL command shims, support Docker Desktop mount roots, and fall back to native rsync when WSL lacks native SSH tooling. Thanks @brokemac79.
 - Fixed brokered Tailscale cleanup to avoid privileged deletion from client-posted device IDs, preserve connectivity across normal reboots, and fail live preflight on application-level errors.
 - Fixed Crabfleet workspaces to use any configured brokered provider and route the OpenClaw deployment through its canonical OAuth host and verified AWS backend with isolated, ephemeral key-only SSH access, stock-image cloud-init, and readiness-gated, pinned, Workers-compatible terminal attachment.


### PR DESCRIPTION
## Summary

- record the user-visible Cloudflare Dynamic Workers lifecycle hardening landed in https://github.com/openclaw/crabbox/pull/331

## Verification

- `git diff --check`
- focused Cloudflare Dynamic Workers Go tests
- Dynamic Workers bundle dry-run build
- all nine Dynamic Workers smoke-harness tests
