### PR TITLE
feat(lambda): add Lambda Cloud provider

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -61,7 +61,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 63 providers (36 SSH lease, 25 delegated run, 2 service control).
+Current built-in surface: 64 providers (37 SSH lease, 25 delegated run, 2 service control).
 
 Access terms:
 
@@ -101,6 +101,7 @@ Access terms:
 | [incus](incus.md) | built-in; `ssh-lease` · self-hosted-virtualization | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Incus container or VM | `self-hosted`; GPU: optional | Crabbox; instance delete | Self-hosted Linux containers or VMs | Requires an accessible Incus environment |
 | [islo](islo.md) | built-in; `delegated-run` · delegated-sandbox | Provider-specific SSH; `provider-owned` · direct only; features: `ssh`, `url-bridge`, `run-session`, `tailscale`, `pause-resume`, `run-downloads` | `linux`; Islo sandbox | `provider-managed`; GPU: unknown | Islo; sandbox delete | Hosted delegated execution with keep, pause, and SSH helper | SSH feature is not Crabbox-managed sync/run |
 | [kubevirt](kubevirt.md) (`kubernetes-vm`) | built-in; `ssh-lease` · self-hosted-virtualization | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code` | `linux`; KubeVirt VirtualMachine | `self-hosted`; GPU: optional | Crabbox on Kubernetes; VirtualMachine delete | Kubernetes-hosted Linux VM | Needs KubeVirt, virtctl, and an SSH-ready template |
+| [lambda](lambda.md) | built-in; `ssh-lease` · gpu-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Lambda Cloud on-demand instance | `cloud`; GPU: yes | Crabbox; instance and key termination | Direct GPU-backed Linux workload over SSH | Direct-only; billing, quota, and capacity are account-owned |
 | [linode](linode.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Linode instance | `cloud`; GPU: optional | Crabbox; instance and key delete | Straightforward direct Linux VM | Direct-only; optional firewall must already exist |
 | [local-container](local-container.md) (`docker`, `container`, `local-docker`) | built-in; `ssh-lease` · local-runtime | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `cache-volume`, `workspace-checkpoint`, `workspace-fork` | `linux`; Docker-compatible container | `local`; GPU: optional | Crabbox; container delete | Fast local Linux test environment | Isolation follows the local container runtime |
 | [modal](modal.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `run-session` | `linux`; Modal Sandbox | `provider-managed`; GPU: optional | Modal; sandbox termination | Hosted Python or GPU-oriented delegated workloads | Provider owns execution; no normal SSH lease |

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -132,7 +132,7 @@ instance can still be reconciled.
 
 ## Ownership And Cleanup
 
-Crabbox encodes owned Lambda leases with namespaced tags such as:
+Crabbox encodes owned Lambda leases with flat Lambda tags such as:
 
 ```text
 crabbox=true
@@ -142,15 +142,17 @@ lease=cbx_abcdef123456
 slug=my-app
 target=linux
 expires_at=<unix-seconds>
+ttl_secs=<seconds>
 ```
 
 Release and cleanup require a complete ownership predicate: Crabbox marker,
 provider marker, lease id, slug, and Linux target. Lambda instances with
 partial, foreign, or malformed Crabbox-like tags are skipped or refused.
 
-Tag updates replace only Crabbox's namespaced tags and preserve unrelated
-operator tags already attached to the instance. Direct mode has no coordinator
-alarm. Use:
+Lambda has no safe tag-update path in this phase. Provider tags keep launch-time
+expiry metadata so provider-only orphan cleanup can eventually reclaim billable
+instances, while local Crabbox claims carry fresh touch and idle-timeout state.
+Direct mode has no coordinator alarm. Use:
 
 ```sh
 crabbox list --provider lambda --json

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -8,8 +8,8 @@ Read this when you are:
 
 Lambda is a Linux-only **SSH lease** provider for Lambda Cloud on-demand
 instances. Crabbox creates a Lambda instance, injects a per-lease SSH key and
-cloud-init user data, writes Crabbox ownership metadata as Lambda tags, waits
-for SSH/bootstrap readiness, and then uses the normal Crabbox SSH
+cloud-init user data, records Crabbox ownership metadata in the local lease
+claim, waits for SSH/bootstrap readiness, and then uses the normal Crabbox SSH
 sync/run/stop/cleanup path.
 
 Lambda is **direct-only** in this release. It does not run through the
@@ -115,13 +115,14 @@ classed doctor output rather than hidden behind generic errors.
 2. Ensure a Lambda SSH key exists for the lease.
 3. Launch one Lambda instance with `region`, `type`, `image` or `imageFamily`,
    cloud-init `user_data`, optional existing `firewallRuleset`, optional
-   existing filesystems, and Crabbox tags.
+   existing filesystems, and `quantity=1`.
 4. Wait for an instance id, public IP address, and Crabbox SSH bootstrap
    readiness.
 5. Claim the lease locally with Lambda instance and SSH-key metadata.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Terminate the Lambda instance and owned Lambda SSH key on `stop`; `cleanup`
-   deletes only resources with a complete Crabbox Lambda ownership tag set.
+   deletes resources backed by a complete local Crabbox Lambda claim, and can
+   also reclaim complete Crabbox-tagged Lambda instances.
 
 If SSH-key creation, instance launch, or post-launch readiness becomes
 indeterminate, Crabbox records a local recovery claim with enough metadata to
@@ -132,7 +133,7 @@ instance can still be reconciled.
 
 ## Ownership And Cleanup
 
-Crabbox encodes owned Lambda leases with flat Lambda tags such as:
+Crabbox encodes owned Lambda leases in local claims with flat labels such as:
 
 ```text
 crabbox=true
@@ -146,12 +147,14 @@ ttl_secs=<seconds>
 ```
 
 Release and cleanup require a complete ownership predicate: Crabbox marker,
-provider marker, lease id, slug, and Linux target. Lambda instances with
-partial, foreign, or malformed Crabbox-like tags are skipped or refused.
+provider marker, lease id, slug, and Linux target. Lambda instances backed only
+by partial, foreign, or malformed Crabbox-like metadata are skipped or refused.
 
-Lambda has no safe tag-update path in this phase. Provider tags keep launch-time
-expiry metadata so provider-only orphan cleanup can eventually reclaim billable
-instances, while local Crabbox claims carry fresh touch and idle-timeout state.
+Lambda has no safe tag-update path in this phase, and the launch path does not
+depend on provider-side tag persistence. Local Crabbox claims carry fresh touch
+and idle-timeout state. Complete Crabbox-tagged Lambda instances are still
+understood by `list`, `stop`, and `cleanup` for compatibility with manually
+seeded or future provider metadata.
 Direct mode has no coordinator alarm. Use:
 
 ```sh
@@ -209,7 +212,7 @@ classification=cleanup_failed
 
 External blockers such as missing credentials, inactive billing, quota, or
 capacity are reported as classified blocked outcomes. If cleanup fails, use the
-reported slug and Crabbox tags to inspect the instance with
+reported slug and local Crabbox claim to inspect the instance with
 `crabbox list --provider lambda --json` or the Lambda console. The smoke script
 redacts `LAMBDA_API_KEY`, user data, private key material, and Jupyter token/URL
 fields from diagnostic output.
@@ -220,7 +223,8 @@ fields from diagnostic output.
 - **Tailscale**: yes through the standard Linux cloud-init path when a direct
   Tailscale auth key is configured.
 - **Desktop / browser / code**: not advertised in this phase.
-- **Cleanup**: yes, tag-owned Lambda instances and owned Lambda SSH keys only.
+- **Cleanup**: yes, local-claim-owned or complete-tag-owned Lambda instances and
+  owned Lambda SSH keys only.
 - **Coordinator**: never; direct CLI only.
 
 ## Gotchas

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -126,10 +126,11 @@ classed doctor output rather than hidden behind generic errors.
 
 If SSH-key creation, instance launch, or post-launch readiness becomes
 indeterminate, Crabbox records a local recovery claim with enough metadata to
-retry `crabbox stop --provider lambda <lease-or-slug>`. Empty provider inventory
-is not treated as proof that creation failed while the outcome remains
-indeterminate: Crabbox retains the recovery claim so a late-created billable
-instance can still be reconciled.
+retry `crabbox stop --provider lambda <lease-or-slug>`. Ambiguous launches are
+reconciled by the per-lease Lambda SSH key name when the instance id response was
+lost. Empty provider inventory is not treated as proof that creation failed
+while the outcome remains indeterminate: Crabbox retains the recovery claim so a
+late-created billable instance can still be reconciled.
 
 ## Ownership And Cleanup
 

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -1,0 +1,242 @@
+# Lambda Provider
+
+Read this when you are:
+
+- choosing `provider: lambda`;
+- validating a direct Lambda Cloud GPU SSH lease;
+- changing `internal/providers/lambda` or the guarded live smoke.
+
+Lambda is a Linux-only **SSH lease** provider for Lambda Cloud on-demand
+instances. Crabbox creates a Lambda instance, injects a per-lease SSH key and
+cloud-init user data, writes Crabbox ownership metadata as Lambda tags, waits
+for SSH/bootstrap readiness, and then uses the normal Crabbox SSH
+sync/run/stop/cleanup path.
+
+Lambda is **direct-only** in this release. It does not run through the
+coordinator, so the local CLI must have a Lambda API key and direct cleanup
+remains the operator's responsibility. Lambda instances are billable while they
+are running; stopping a Crabbox lease terminates the instance rather than
+pausing it.
+
+## When To Use It
+
+Use Lambda when you need a direct Linux GPU instance and local Lambda credentials
+are acceptable. Prefer AWS, Azure, GCP, or Hetzner when you need a brokered team
+path, coordinator-side credentials, or cloud-specific cost accounting. Prefer a
+non-GPU direct provider such as DigitalOcean or Linode when a plain CPU Linux
+box is enough.
+
+## Commands
+
+```sh
+crabbox doctor --provider lambda
+crabbox warmup --provider lambda --class standard
+crabbox run --provider lambda --type gpu_1x_a10 -- go test ./...
+crabbox ssh --provider lambda --id my-app
+crabbox stop --provider lambda my-app
+crabbox cleanup --provider lambda --dry-run
+```
+
+`--id` accepts the canonical lease id (`cbx_...`), the friendly slug, or the
+Lambda instance id. `--type` is the exact Lambda instance type name; there is no
+separate Lambda size flag.
+
+## Configuration
+
+```yaml
+provider: lambda
+target: linux
+class: standard
+lambda:
+  region: us-west-1
+  type: gpu_1x_a10
+  imageFamily: lambda-stack-24-04
+  image: ""
+  firewallRuleset: ""
+  sshCIDRs: []
+  filesystemNames: []
+  filesystemMounts: []
+```
+
+Config keys under `lambda:`:
+
+| Key | Maps to | Default | Notes |
+| --- | --- | --- | --- |
+| `region` | `cfg.Lambda.Region` | `us-west-1` | Lambda region name. |
+| `type` | `cfg.Lambda.Type` | `gpu_1x_a10` | Lambda instance type name. |
+| `imageFamily` | `cfg.Lambda.ImageFamily` | `lambda-stack-24-04` | Lambda image family used when `image` is empty. |
+| `image` | `cfg.Lambda.Image` | empty | Exact Lambda image id. Mutually exclusive with `imageFamily`. |
+| `firewallRuleset` | `cfg.Lambda.FirewallRuleset` | empty | Optional existing Lambda firewall ruleset name. |
+| `sshCIDRs` | `cfg.Lambda.SSHCIDRs` | empty | Reserved for firewall-aware follow-up work; this phase does not create firewall rules. |
+| `filesystemNames` | `cfg.Lambda.FilesystemNames` | empty | Optional existing Lambda filesystem names to attach. |
+| `filesystemMounts` | `cfg.Lambda.FilesystemMounts` | empty | Optional existing Lambda filesystems with mount paths, e.g. `cache:/mnt/cache`. |
+
+The portable `--os ubuntu:24.04` selector maps to the default
+`lambda-stack-24-04` image family. Other explicit portable OS selectors are
+rejected unless `lambda.image`, `lambda.imageFamily`, `CRABBOX_LAMBDA_IMAGE`, or
+`CRABBOX_LAMBDA_IMAGE_FAMILY` provides an explicit Lambda image choice.
+
+Lambda leases default to SSH user `ubuntu` on port `22`. Explicit generic
+`ssh.user` and `ssh.port` values remain authoritative. The effective values
+appear in `crabbox config show --provider lambda`.
+
+Environment overrides:
+
+```text
+LAMBDA_API_KEY                         Lambda API key for direct mode
+CRABBOX_LAMBDA_REGION                  Override the region name
+CRABBOX_LAMBDA_TYPE                    Override the instance type name
+CRABBOX_LAMBDA_IMAGE                   Override with an exact image id
+CRABBOX_LAMBDA_IMAGE_FAMILY            Override with an image family
+CRABBOX_LAMBDA_FIREWALL_RULESET        Optional existing firewall ruleset name
+CRABBOX_LAMBDA_SSH_CIDRS               Comma-separated SSH CIDRs, reserved for follow-up
+CRABBOX_LAMBDA_FILESYSTEM_NAMES        Comma-separated existing filesystem names
+CRABBOX_LAMBDA_FILESYSTEM_MOUNTS       Comma-separated name[:mountPath] entries
+```
+
+Do not pass the Lambda API key as a command-line argument. Keep it in the
+environment or in a local secret manager.
+
+## Token Scope
+
+The provider uses Lambda account identity, regions, instance types, images,
+instances, SSH keys, optional filesystems, and optional firewall rulesets.
+Crabbox sends the API key only in the `Authorization: Bearer ...` header.
+
+`crabbox doctor --provider lambda` is non-mutating. It validates auth, region,
+capacity for the configured type, image or image family, optional filesystem
+references, optional firewall ruleset, and current inventory. Missing API keys,
+inactive accounts, invalid billing, quota, and capacity failures are reported as
+classed doctor output rather than hidden behind generic errors.
+
+## Lifecycle
+
+1. Generate a per-lease SSH key under the Crabbox testbox key directory.
+2. Ensure a Lambda SSH key exists for the lease.
+3. Launch one Lambda instance with `region`, `type`, `image` or `imageFamily`,
+   cloud-init `user_data`, optional existing `firewallRuleset`, optional
+   existing filesystems, and Crabbox tags.
+4. Wait for an instance id, public IP address, and Crabbox SSH bootstrap
+   readiness.
+5. Claim the lease locally with Lambda instance and SSH-key metadata.
+6. Run normal Crabbox sync/run/ssh workflows over SSH.
+7. Terminate the Lambda instance and owned Lambda SSH key on `stop`; `cleanup`
+   deletes only resources with a complete Crabbox Lambda ownership tag set.
+
+If SSH-key creation, instance launch, or post-launch readiness becomes
+indeterminate, Crabbox records a local recovery claim with enough metadata to
+retry `crabbox stop --provider lambda <lease-or-slug>`. Empty provider inventory
+is not treated as proof that creation failed while the outcome remains
+indeterminate: Crabbox retains the recovery claim so a late-created billable
+instance can still be reconciled.
+
+## Ownership And Cleanup
+
+Crabbox encodes owned Lambda leases with namespaced tags such as:
+
+```text
+crabbox=true
+created_by=crabbox
+provider=lambda
+lease=cbx_abcdef123456
+slug=my-app
+target=linux
+expires_at=<unix-seconds>
+```
+
+Release and cleanup require a complete ownership predicate: Crabbox marker,
+provider marker, lease id, slug, and Linux target. Lambda instances with
+partial, foreign, or malformed Crabbox-like tags are skipped or refused.
+
+Tag updates replace only Crabbox's namespaced tags and preserve unrelated
+operator tags already attached to the instance. Direct mode has no coordinator
+alarm. Use:
+
+```sh
+crabbox list --provider lambda --json
+crabbox cleanup --provider lambda --dry-run
+crabbox cleanup --provider lambda
+```
+
+## Firewall And Filesystem Scope
+
+Crabbox does not create or mutate Lambda firewall rulesets in this phase. If
+`lambda.firewallRuleset` or `CRABBOX_LAMBDA_FIREWALL_RULESET` is set, Crabbox
+validates that the named ruleset exists for the configured region and passes its
+name to the launch request. Operators own the ruleset policy, including SSH
+source restrictions. `lambda.sshCIDRs` and `CRABBOX_LAMBDA_SSH_CIDRS` are
+reserved for follow-up firewall work and do not create ingress rules.
+
+Crabbox can attach existing Lambda filesystems by name, optionally with mount
+paths. It validates configured filesystem names through `doctor` and passes the
+names to Lambda during launch. Crabbox does not create, delete, resize, or
+otherwise manage Lambda filesystems.
+
+## Guarded Live Smoke
+
+The repeatable live check is opt-in:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=lambda scripts/live-lambda-smoke.sh
+```
+
+The script builds `bin/crabbox`, reads `LAMBDA_API_KEY` from the environment,
+requires an empty Crabbox-owned Lambda inventory, creates a kept
+`gpu_1x_a10` instance by default, waits for ready status, runs `echo ok`,
+verifies `list --json`, stops the lease, runs dry-run cleanup, and verifies the
+Crabbox-owned inventory is empty afterward.
+
+Optional live-smoke overrides:
+
+```text
+CRABBOX_LIVE_LAMBDA_TYPE       Instance type for the smoke, default gpu_1x_a10
+CRABBOX_LIVE_LAMBDA_REGION     Region for the smoke, default us-west-1
+```
+
+Final classifications include:
+
+```text
+classification=live_lambda_smoke_passed
+classification=environment_blocked
+classification=billing_blocked
+classification=quota_blocked
+classification=capacity_blocked
+classification=validation_failed
+classification=cleanup_failed
+```
+
+External blockers such as missing credentials, inactive billing, quota, or
+capacity are reported as classified blocked outcomes. If cleanup fails, use the
+reported slug and Crabbox tags to inspect the instance with
+`crabbox list --provider lambda --json` or the Lambda console. The smoke script
+redacts `LAMBDA_API_KEY`, user data, private key material, and Jupyter token/URL
+fields from diagnostic output.
+
+## Capabilities
+
+- **SSH** and **Crabbox sync**: yes.
+- **Tailscale**: yes through the standard Linux cloud-init path when a direct
+  Tailscale auth key is configured.
+- **Desktop / browser / code**: not advertised in this phase.
+- **Cleanup**: yes, tag-owned Lambda instances and owned Lambda SSH keys only.
+- **Coordinator**: never; direct CLI only.
+
+## Gotchas
+
+- Lambda is direct-only. Coordinator secrets, team scheduling, and cost
+  accounting do not cover these instances.
+- Running Lambda instances are billable. Use short TTLs, dry-run cleanup, and
+  explicit live-smoke gates.
+- `--type` must be a valid Lambda instance type such as `gpu_1x_a10`.
+- `lambda.image` and `lambda.imageFamily` are mutually exclusive.
+- Crabbox can pass an existing firewall ruleset and existing filesystems during
+  launch, but it does not create or mutate those resources.
+- Phase 1 does not advertise Jupyter, desktop, VNC, browser, or code-server
+  surfaces even if a selected Lambda image includes provider-specific tooling.
+
+## Related Docs
+
+- [Provider reference](README.md)
+- [Provider backends](../provider-backends.md)
+- [Provider feature overview](../features/providers.md)
+- [Operations](../operations.md)

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -419,6 +419,20 @@
     "caveat": "Needs KubeVirt, virtctl, and an SSH-ready template",
     "docs": "kubevirt.md"
   },
+  "lambda": {
+    "status": "built-in",
+    "category": "gpu-cloud",
+    "substrate": "Lambda Cloud on-demand instance",
+    "location": "cloud",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "yes",
+    "lifecycle": "Crabbox",
+    "cleanup": "instance and key termination",
+    "bestFit": "Direct GPU-backed Linux workload over SSH",
+    "caveat": "Direct-only; billing, quota, and capacity are account-owned",
+    "docs": "lambda.md"
+  },
   "linode": {
     "status": "built-in",
     "category": "direct-cloud",

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -88,9 +88,9 @@ SSH-lease providers:
 - Canonical Multipass local Ubuntu VM: `internal/providers/multipass`
 - Cirrus Labs tart local macOS VM: `internal/providers/tart`
 - Microsoft Hyper-V local Windows VM: `internal/providers/hyperv`
-- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites:
+- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites, Lambda:
   `internal/providers/daytona`, `internal/providers/morph`, `internal/providers/exedev`, `internal/providers/kubevirt`, `internal/providers/external`, `internal/providers/tenki`, `internal/providers/namespace`,
-  `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`
+  `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`, `internal/providers/lambda`
 
 Delegated-run providers (no SSH lease):
 
@@ -146,7 +146,7 @@ Actions hydration or repo scripts.
 Provider docs:
 
 - Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
-- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/blaxel.md` for delegated Blaxel sandbox execution, `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/vultr.md` for the direct Vultr provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, `docs/providers/superserve.md` for delegated Superserve execution and live proof, and `docs/providers/cloudflare-sandbox.md` for Cloudflare Sandbox bridge-backed delegated Linux execution
+- Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/blaxel.md` for delegated Blaxel sandbox execution, `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/vultr.md` for the direct Vultr provider, `docs/providers/lambda.md` for the direct Lambda GPU SSH lease provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, `docs/providers/superserve.md` for delegated Superserve execution and live proof, and `docs/providers/cloudflare-sandbox.md` for Cloudflare Sandbox bridge-backed delegated Linux execution
 - Provider selection, landscape, live-smoke, and backend authoring guide: `docs/features/provider-selection.md`, `docs/features/provider-landscape.md`, `docs/features/provider-live-smoke.md`, `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -6658,6 +6658,7 @@ func applyEnv(cfg *Config) error {
 	if imageFamily := os.Getenv("CRABBOX_LAMBDA_IMAGE_FAMILY"); imageFamily != "" {
 		cfg.Lambda.ImageFamily = imageFamily
 		cfg.lambdaImageFamilyExplicit = true
+		cfg.Lambda.Image = ""
 	}
 	cfg.Lambda.FirewallRuleset = getenv("CRABBOX_LAMBDA_FIREWALL_RULESET", cfg.Lambda.FirewallRuleset)
 	if cidrs := os.Getenv("CRABBOX_LAMBDA_SSH_CIDRS"); cidrs != "" {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -107,6 +107,10 @@ type Config struct {
 	Linode                        LinodeConfig
 	linodeImageExplicit           bool
 	linodeTypeExplicit            bool
+	Lambda                        LambdaConfig
+	lambdaImageExplicit           bool
+	lambdaImageFamilyExplicit     bool
+	lambdaTypeExplicit            bool
 	Nebius                        NebiusConfig
 	OVH                           OVHConfig
 	ovhImageExplicit              bool
@@ -271,6 +275,22 @@ type LinodeConfig struct {
 	Type       string
 	FirewallID string
 	SSHCIDRs   []string
+}
+
+type LambdaConfig struct {
+	Region           string
+	Type             string
+	Image            string
+	ImageFamily      string
+	FirewallRuleset  string
+	SSHCIDRs         []string
+	FilesystemNames  []string
+	FilesystemMounts []LambdaFilesystemMount
+}
+
+type LambdaFilesystemMount struct {
+	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
+	MountPath string `yaml:"mountPath,omitempty" json:"mountPath,omitempty"`
 }
 
 // NebiusConfig is intentionally non-secret. Authentication stays in the
@@ -1532,6 +1552,49 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "lambda" {
+		if cfg.Lambda.Region == "" {
+			cfg.Lambda.Region = "us-west-1"
+		}
+		if cfg.Lambda.Type == "" {
+			cfg.Lambda.Type = "gpu_1x_a10"
+		}
+		if cfg.osImageExplicit && !cfg.lambdaImageExplicit && !cfg.lambdaImageFamilyExplicit {
+			if cfg.OSImage == "ubuntu:24.04" {
+				cfg.Lambda.ImageFamily = "lambda-stack-24-04"
+			} else {
+				cfg.Lambda.ImageFamily = ""
+			}
+		} else if cfg.Lambda.Image == "" && cfg.Lambda.ImageFamily == "" {
+			cfg.Lambda.ImageFamily = "lambda-stack-24-04"
+		}
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+		} else {
+			cfg.WorkRoot = defaultPOSIXWorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else {
+			cfg.SSHUser = "ubuntu"
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = "22"
+		}
+		cfg.SSHFallbackPorts = nil
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "nebius" {
 		if cfg.Nebius.CLI == "" {
 			cfg.Nebius.CLI = "nebius"
@@ -2247,6 +2310,11 @@ func baseConfig() Config {
 			Image:  linodeImage,
 			Type:   "g6-standard-1",
 		},
+		Lambda: LambdaConfig{
+			Region:      "us-west-1",
+			Type:        "gpu_1x_a10",
+			ImageFamily: "lambda-stack-24-04",
+		},
 		OVH: OVHConfig{
 			Endpoint: "https://api.us.ovhcloud.com/1.0",
 			Image:    "Ubuntu 24.04",
@@ -2638,6 +2706,7 @@ type fileConfig struct {
 	DigitalOcean             *fileDigitalOceanConfig             `yaml:"digitalocean,omitempty"`
 	Vultr                    *fileVultrConfig                    `yaml:"vultr,omitempty"`
 	Linode                   *fileLinodeConfig                   `yaml:"linode,omitempty"`
+	Lambda                   *fileLambdaConfig                   `yaml:"lambda,omitempty"`
 	Nebius                   *fileNebiusConfig                   `yaml:"nebius,omitempty"`
 	OVH                      *fileOVHConfig                      `yaml:"ovh,omitempty"`
 	Scaleway                 *fileScalewayConfig                 `yaml:"scaleway,omitempty"`
@@ -2765,6 +2834,17 @@ type fileLinodeConfig struct {
 	Type       string   `yaml:"type,omitempty"`
 	FirewallID string   `yaml:"firewall,omitempty"`
 	SSHCIDRs   []string `yaml:"sshCIDRs,omitempty"`
+}
+
+type fileLambdaConfig struct {
+	Region           string                  `yaml:"region,omitempty"`
+	Type             string                  `yaml:"type,omitempty"`
+	Image            string                  `yaml:"image,omitempty"`
+	ImageFamily      string                  `yaml:"imageFamily,omitempty"`
+	FirewallRuleset  string                  `yaml:"firewallRuleset,omitempty"`
+	SSHCIDRs         []string                `yaml:"sshCIDRs,omitempty"`
+	FilesystemNames  []string                `yaml:"filesystemNames,omitempty"`
+	FilesystemMounts []LambdaFilesystemMount `yaml:"filesystemMounts,omitempty"`
 }
 
 type fileNebiusConfig struct {
@@ -4152,6 +4232,42 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if len(file.Linode.SSHCIDRs) > 0 {
 			cfg.Linode.SSHCIDRs = file.Linode.SSHCIDRs
+		}
+	}
+	if file.Lambda != nil {
+		lambdaImageSet := false
+		lambdaImageFamilySet := false
+		if file.Lambda.Region != "" {
+			cfg.Lambda.Region = file.Lambda.Region
+		}
+		if file.Lambda.Type != "" {
+			cfg.Lambda.Type = file.Lambda.Type
+			cfg.lambdaTypeExplicit = true
+		}
+		if file.Lambda.Image != "" {
+			cfg.Lambda.Image = file.Lambda.Image
+			cfg.lambdaImageExplicit = true
+			lambdaImageSet = true
+		}
+		if file.Lambda.ImageFamily != "" {
+			cfg.Lambda.ImageFamily = file.Lambda.ImageFamily
+			cfg.lambdaImageFamilyExplicit = true
+			lambdaImageFamilySet = true
+		}
+		if lambdaImageSet && !lambdaImageFamilySet {
+			cfg.Lambda.ImageFamily = ""
+		}
+		if file.Lambda.FirewallRuleset != "" {
+			cfg.Lambda.FirewallRuleset = file.Lambda.FirewallRuleset
+		}
+		if len(file.Lambda.SSHCIDRs) > 0 {
+			cfg.Lambda.SSHCIDRs = file.Lambda.SSHCIDRs
+		}
+		if len(file.Lambda.FilesystemNames) > 0 {
+			cfg.Lambda.FilesystemNames = file.Lambda.FilesystemNames
+		}
+		if len(file.Lambda.FilesystemMounts) > 0 {
+			cfg.Lambda.FilesystemMounts = file.Lambda.FilesystemMounts
 		}
 	}
 	if file.Nebius != nil {
@@ -6529,6 +6645,30 @@ func applyEnv(cfg *Config) error {
 	if cidrs := os.Getenv("CRABBOX_LINODE_SSH_CIDRS"); cidrs != "" {
 		cfg.Linode.SSHCIDRs = splitCommaList(cidrs)
 	}
+	cfg.Lambda.Region = getenv("CRABBOX_LAMBDA_REGION", cfg.Lambda.Region)
+	if lambdaType := os.Getenv("CRABBOX_LAMBDA_TYPE"); lambdaType != "" {
+		cfg.Lambda.Type = lambdaType
+		cfg.lambdaTypeExplicit = true
+	}
+	if image := os.Getenv("CRABBOX_LAMBDA_IMAGE"); image != "" {
+		cfg.Lambda.Image = image
+		cfg.lambdaImageExplicit = true
+		cfg.Lambda.ImageFamily = ""
+	}
+	if imageFamily := os.Getenv("CRABBOX_LAMBDA_IMAGE_FAMILY"); imageFamily != "" {
+		cfg.Lambda.ImageFamily = imageFamily
+		cfg.lambdaImageFamilyExplicit = true
+	}
+	cfg.Lambda.FirewallRuleset = getenv("CRABBOX_LAMBDA_FIREWALL_RULESET", cfg.Lambda.FirewallRuleset)
+	if cidrs := os.Getenv("CRABBOX_LAMBDA_SSH_CIDRS"); cidrs != "" {
+		cfg.Lambda.SSHCIDRs = splitCommaList(cidrs)
+	}
+	if names := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_NAMES"); names != "" {
+		cfg.Lambda.FilesystemNames = splitCommaList(names)
+	}
+	if mounts := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_MOUNTS"); mounts != "" {
+		cfg.Lambda.FilesystemMounts = parseLambdaFilesystemMounts(mounts)
+	}
 	cfg.Nebius.CLI = getenv("CRABBOX_NEBIUS_CLI", cfg.Nebius.CLI)
 	cfg.Nebius.Profile = getenv("CRABBOX_NEBIUS_PROFILE", cfg.Nebius.Profile)
 	cfg.Nebius.ParentID = getenv("CRABBOX_NEBIUS_PARENT_ID", cfg.Nebius.ParentID)
@@ -8095,6 +8235,20 @@ func getenvList(name string) ([]string, bool) {
 func splitCommaList(value string) []string {
 	parts := strings.Split(value, ",")
 	return normalizeList(parts)
+}
+
+func parseLambdaFilesystemMounts(value string) []LambdaFilesystemMount {
+	parts := splitCommaList(value)
+	out := make([]LambdaFilesystemMount, 0, len(parts))
+	for _, part := range parts {
+		name, mountPath, ok := strings.Cut(part, ":")
+		if !ok {
+			out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(part)})
+			continue
+		}
+		out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(name), MountPath: strings.TrimSpace(mountPath)})
+	}
+	return out
 }
 
 func normalizeList(values []string) []string {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -71,6 +71,16 @@ func effectiveConfigForShow(cfg Config) Config {
 		}
 		cfg.SSHFallbackPorts = nil
 	}
+	if cfg.Provider == "lambda" {
+		base := baseConfig()
+		if !IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == base.SSHUser) {
+			cfg.SSHUser = "ubuntu"
+		}
+		if !IsSSHPortExplicit(&cfg) && (cfg.SSHPort == "" || cfg.SSHPort == base.SSHPort) {
+			cfg.SSHPort = "22"
+		}
+		cfg.SSHFallbackPorts = nil
+	}
 	if cfg.Provider == "scaleway" {
 		base := baseConfig()
 		if !IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == base.SSHUser) {
@@ -184,6 +194,17 @@ func configShowView(cfg Config) map[string]any {
 			"type":     cfg.Linode.Type,
 			"firewall": cfg.Linode.FirewallID,
 			"sshCIDRs": cfg.Linode.SSHCIDRs,
+		},
+		"lambda": map[string]any{
+			"region":           cfg.Lambda.Region,
+			"type":             cfg.Lambda.Type,
+			"image":            cfg.Lambda.Image,
+			"imageFamily":      cfg.Lambda.ImageFamily,
+			"firewallRuleset":  cfg.Lambda.FirewallRuleset,
+			"sshCIDRs":         cfg.Lambda.SSHCIDRs,
+			"filesystemNames":  cfg.Lambda.FilesystemNames,
+			"filesystemMounts": cfg.Lambda.FilesystemMounts,
+			"auth":             lambdaAuthState(),
 		},
 		"nvidiaBrev": map[string]any{
 			"cli":           cfg.NvidiaBrev.CLI,
@@ -589,6 +610,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "digitalocean region=%s image=%s vpc=%s ssh_cidrs=%s\n", cfg.DigitalOcean.Region, cfg.DigitalOcean.Image, blank(cfg.DigitalOcean.VPCUUID, "-"), blank(strings.Join(cfg.DigitalOcean.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "vultr region=%s os=%s image=%s snapshot=%s firewall_group=%s vpc_ids=%s ssh_cidrs=%s user_scheme=%s\n", cfg.Vultr.Region, blank(cfg.Vultr.OS, "-"), blank(cfg.Vultr.Image, "-"), blank(cfg.Vultr.Snapshot, "-"), blank(cfg.Vultr.FirewallGroup, "-"), blank(strings.Join(cfg.Vultr.VPCIDs, ","), "-"), blank(strings.Join(cfg.Vultr.SSHCIDRs, ","), "-"), blank(cfg.Vultr.UserScheme, "-"))
 	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
+	fmt.Fprintf(w, "lambda region=%s type=%s image=%s image_family=%s firewall_ruleset=%s ssh_cidrs=%s filesystems=%s mounts=%d auth=%s\n", cfg.Lambda.Region, cfg.Lambda.Type, blank(cfg.Lambda.Image, "-"), blank(cfg.Lambda.ImageFamily, "-"), blank(cfg.Lambda.FirewallRuleset, "-"), blank(strings.Join(cfg.Lambda.SSHCIDRs, ","), "-"), blank(strings.Join(cfg.Lambda.FilesystemNames, ","), "-"), len(cfg.Lambda.FilesystemMounts), lambdaAuthState())
 	fmt.Fprintf(w, "nvidia_brev cli=%s org=%s type=%s gpu_name=%s provider=%s mode=%s launchable=%s startup_script=%s release_action=%s target=%s user=%s work_root=%s auth=cli\n", blank(cfg.NvidiaBrev.CLI, "-"), blank(cfg.NvidiaBrev.Org, "-"), blank(cfg.NvidiaBrev.Type, "-"), blank(cfg.NvidiaBrev.GPUName, "-"), blank(cfg.NvidiaBrev.Provider, "-"), blank(cfg.NvidiaBrev.Mode, "-"), blank(cfg.NvidiaBrev.Launchable, "-"), blank(cfg.NvidiaBrev.StartupScript, "-"), blank(cfg.NvidiaBrev.ReleaseAction, "-"), blank(cfg.NvidiaBrev.Target, "-"), blank(cfg.NvidiaBrev.User, "-"), blank(cfg.NvidiaBrev.WorkRoot, "-"))
 	fmt.Fprintf(w, "nebius cli=%s profile=%s parent_id=%s subnet_id=%s platform=%s preset=%s image_family=%s disk_type=%s disk_size_gib=%d user=%s public_ip=%s security_group_ids=%s service_account_id=%s recovery_policy=%s auth=cli\n", blank(cfg.Nebius.CLI, "-"), blank(cfg.Nebius.Profile, "-"), blank(cfg.Nebius.ParentID, "-"), blank(cfg.Nebius.SubnetID, "-"), blank(cfg.Nebius.Platform, "-"), blank(cfg.Nebius.Preset, "-"), blank(cfg.Nebius.ImageFamily, "-"), blank(cfg.Nebius.DiskType, "-"), cfg.Nebius.DiskSizeGiB, blank(cfg.Nebius.User, "-"), blank(cfg.Nebius.PublicIP, "-"), blank(strings.Join(cfg.Nebius.SecurityGroupIDs, ","), "-"), blank(cfg.Nebius.ServiceAccountID, "-"), blank(cfg.Nebius.RecoveryPolicy, "-"))
 	fmt.Fprintf(w, "hostinger api_url=%s item_id=%s payment_method_id=%s template_id=%s data_center_id=%s hostname_prefix=%s user=%s work_root=%s allow_purchase=%t release_action=%s auth=%s\n", blank(cfg.Hostinger.APIURL, "-"), blank(cfg.Hostinger.ItemID, "-"), blank(cfg.Hostinger.PaymentMethodID, "-"), blank(cfg.Hostinger.TemplateID, "-"), blank(cfg.Hostinger.DataCenterID, "-"), blank(cfg.Hostinger.HostnamePrefix, "-"), blank(cfg.Hostinger.User, "-"), blank(cfg.Hostinger.WorkRoot, "-"), cfg.Hostinger.AllowPurchase, blank(cfg.Hostinger.ReleaseAction, "-"), tokenState(cfg.Hostinger.APIToken))
@@ -626,6 +648,13 @@ func redactedConfigURL(value string) string {
 		out = strings.TrimPrefix(out, "https://")
 	}
 	return out
+}
+
+func lambdaAuthState() string {
+	if strings.TrimSpace(os.Getenv("LAMBDA_API_KEY")) != "" {
+		return "env"
+	}
+	return "missing"
 }
 
 func redactedConfigURLWithoutQuery(value string) string {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -956,6 +956,78 @@ func TestConfigShowIncludesHostingerWithoutSecret(t *testing.T) {
 	}
 }
 
+func TestConfigShowIncludesLambdaWithoutSecret(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("LAMBDA_API_KEY", "lambda-secret-token")
+	if err := os.WriteFile(configPath, []byte(`provider: lambda
+lambda:
+  region: us-east-1
+  type: gpu_1x_h100_sxm5
+  imageFamily: lambda-stack-24-04
+  firewallRuleset: crabbox
+  sshCIDRs: [203.0.113.0/24]
+  filesystemNames: [cache]
+  filesystemMounts:
+    - name: cache
+      mountPath: /mnt/cache
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "lambda region=us-east-1 type=gpu_1x_h100_sxm5 image=- image_family=lambda-stack-24-04 firewall_ruleset=crabbox ssh_cidrs=203.0.113.0/24 filesystems=cache mounts=1 auth=env") {
+		t.Fatalf("config show missing lambda summary: %q", text)
+	}
+	if !strings.Contains(text, "ssh=ubuntu@<host>:22 fallback_ports=-") {
+		t.Fatalf("config show missing effective lambda ssh defaults: %q", text)
+	}
+	if strings.Contains(text, "lambda-secret-token") || strings.Contains(text, "LAMBDA_API_KEY") {
+		t.Fatalf("config show text leaked lambda credential: %q", text)
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), "lambda-secret-token") || strings.Contains(stdout.String(), "LAMBDA_API_KEY") {
+		t.Fatalf("config show json leaked lambda credential: %q", stdout.String())
+	}
+	var got struct {
+		SSHUser          string   `json:"sshUser"`
+		SSHPort          string   `json:"sshPort"`
+		SSHFallbackPorts []string `json:"sshFallbackPorts"`
+		Lambda           struct {
+			Region           string                  `json:"region"`
+			Type             string                  `json:"type"`
+			ImageFamily      string                  `json:"imageFamily"`
+			FirewallRuleset  string                  `json:"firewallRuleset"`
+			SSHCIDRs         []string                `json:"sshCIDRs"`
+			FilesystemNames  []string                `json:"filesystemNames"`
+			FilesystemMounts []LambdaFilesystemMount `json:"filesystemMounts"`
+			Auth             string                  `json:"auth"`
+		} `json:"lambda"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Lambda.Region != "us-east-1" || got.Lambda.Type != "gpu_1x_h100_sxm5" || got.Lambda.ImageFamily != "lambda-stack-24-04" || got.Lambda.FirewallRuleset != "crabbox" || got.Lambda.Auth != "env" {
+		t.Fatalf("unexpected lambda json: %#v", got.Lambda)
+	}
+	if got.SSHUser != "ubuntu" || got.SSHPort != "22" || len(got.SSHFallbackPorts) != 0 {
+		t.Fatalf("unexpected lambda ssh json: %#v", got)
+	}
+}
+
 func TestConfigShowIncludesNvidiaBrevWithoutSecretSurface(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1907,6 +1907,27 @@ func TestLambdaProviderConfigDefaultsAndEnv(t *testing.T) {
 	}
 }
 
+func TestLambdaImageFamilyEnvClearsFileImage(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "lambda"
+	if err := applyFileConfig(&cfg, fileConfig{Lambda: &fileLambdaConfig{
+		Image: "img-file",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_LAMBDA_IMAGE_FAMILY", "lambda-stack-24-04")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lambda.Image != "" || cfg.Lambda.ImageFamily != "lambda-stack-24-04" {
+		t.Fatalf("image family env did not clear file image: %#v", cfg.Lambda)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatalf("applyProviderConfigDefaults err=%v", err)
+	}
+}
+
 func TestNebiusConfigFileEnvAndDefaults(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -74,6 +74,15 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_LINODE_TYPE",
 		"CRABBOX_LINODE_FIREWALL",
 		"CRABBOX_LINODE_SSH_CIDRS",
+		"CRABBOX_LAMBDA_REGION",
+		"CRABBOX_LAMBDA_TYPE",
+		"CRABBOX_LAMBDA_IMAGE",
+		"CRABBOX_LAMBDA_IMAGE_FAMILY",
+		"CRABBOX_LAMBDA_FIREWALL_RULESET",
+		"CRABBOX_LAMBDA_SSH_CIDRS",
+		"CRABBOX_LAMBDA_FILESYSTEM_NAMES",
+		"CRABBOX_LAMBDA_FILESYSTEM_MOUNTS",
+		"LAMBDA_API_KEY",
 		"CRABBOX_NEBIUS_CLI",
 		"CRABBOX_NEBIUS_PROFILE",
 		"CRABBOX_NEBIUS_PARENT_ID",
@@ -1837,6 +1846,63 @@ func TestLinodeConfigFileAndEnv(t *testing.T) {
 		t.Fatalf("linode defaults leaked into generic fields: cfg=%#v", cfg)
 	}
 	if got := serverTypeForConfig(cfg); got != "g6-nanode-1" {
+		t.Fatalf("serverTypeForConfig=%q", got)
+	}
+}
+
+func TestLambdaProviderConfigDefaultsAndEnv(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "lambda"
+	if err := applyFileConfig(&cfg, fileConfig{Lambda: &fileLambdaConfig{
+		Region:          "us-east-1",
+		Type:            "gpu_1x_h100_sxm5",
+		ImageFamily:     "lambda-stack-24-04",
+		FirewallRuleset: "crabbox",
+		SSHCIDRs:        []string{"203.0.113.0/24"},
+		FilesystemNames: []string{"cache"},
+		FilesystemMounts: []LambdaFilesystemMount{{
+			Name:      "dataset",
+			MountPath: "/mnt/dataset",
+		}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Lambda.Region != "us-east-1" || cfg.Location == "us-east-1" || cfg.Lambda.Type != "gpu_1x_h100_sxm5" || cfg.Lambda.ImageFamily != "lambda-stack-24-04" || cfg.Lambda.FirewallRuleset != "crabbox" {
+		t.Fatalf("file lambda config not applied: cfg=%#v lambda=%#v", cfg, cfg.Lambda)
+	}
+	if strings.Join(cfg.Lambda.SSHCIDRs, ",") != "203.0.113.0/24" || strings.Join(cfg.Lambda.FilesystemNames, ",") != "cache" || len(cfg.Lambda.FilesystemMounts) != 1 {
+		t.Fatalf("file lambda lists not applied: %#v", cfg.Lambda)
+	}
+
+	t.Setenv("CRABBOX_LAMBDA_REGION", "us-south-1")
+	t.Setenv("CRABBOX_LAMBDA_TYPE", "gpu_1x_a10")
+	t.Setenv("CRABBOX_LAMBDA_IMAGE", "img-123")
+	t.Setenv("CRABBOX_LAMBDA_IMAGE_FAMILY", "")
+	t.Setenv("CRABBOX_LAMBDA_FIREWALL_RULESET", "agents")
+	t.Setenv("CRABBOX_LAMBDA_SSH_CIDRS", "198.51.100.0/24,2001:db8::/64")
+	t.Setenv("CRABBOX_LAMBDA_FILESYSTEM_NAMES", "cache,models")
+	t.Setenv("CRABBOX_LAMBDA_FILESYSTEM_MOUNTS", "cache:/mnt/cache,models:/mnt/models")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatalf("applyEnv err=%v", err)
+	}
+	if cfg.Lambda.Region != "us-south-1" || cfg.Location == "us-south-1" || cfg.Lambda.Type != "gpu_1x_a10" || cfg.Lambda.Image != "img-123" || cfg.Lambda.ImageFamily != "" || cfg.Image == "img-123" || cfg.Lambda.FirewallRuleset != "agents" {
+		t.Fatalf("env lambda config not applied: cfg=%#v lambda=%#v", cfg, cfg.Lambda)
+	}
+	if strings.Join(cfg.Lambda.SSHCIDRs, ",") != "198.51.100.0/24,2001:db8::/64" || strings.Join(cfg.Lambda.FilesystemNames, ",") != "cache,models" || len(cfg.Lambda.FilesystemMounts) != 2 {
+		t.Fatalf("env lambda lists not applied: %#v", cfg.Lambda)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatalf("applyProviderConfigDefaults err=%v", err)
+	}
+	base := baseConfig()
+	if cfg.Location != base.Location || cfg.Image != base.Image {
+		t.Fatalf("lambda defaults leaked into generic fields: cfg=%#v", cfg)
+	}
+	if cfg.SSHUser != "ubuntu" || cfg.SSHPort != "22" || len(cfg.SSHFallbackPorts) != 0 {
+		t.Fatalf("lambda ssh defaults not applied: user=%q port=%q fallback=%v", cfg.SSHUser, cfg.SSHPort, cfg.SSHFallbackPorts)
+	}
+	if got := serverTypeForConfig(cfg); got != "gpu_1x_a10" {
 		t.Fatalf("serverTypeForConfig=%q", got)
 	}
 }

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -33,6 +33,7 @@ var benchmarkProviderCategories = map[string]string{
 	"incus":                      "self-hosted-virtualization",
 	"islo":                       "delegated-sandbox",
 	"kubevirt":                   "self-hosted-virtualization",
+	"lambda":                     "gpu-cloud",
 	"linode":                     "direct-cloud",
 	"local-container":            "local-runtime",
 	"modal":                      "delegated-sandbox",

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -15,6 +15,7 @@ func init() {
 	RegisterProvider(testDigitalOceanProvider{})
 	RegisterProvider(testVultrProvider{})
 	RegisterProvider(testLinodeProvider{})
+	RegisterProvider(testLambdaProvider{})
 	RegisterProvider(testNebiusProvider{})
 	RegisterProvider(testScalewayProvider{})
 	RegisterProvider(testAWSProvider{})
@@ -407,6 +408,38 @@ func (testLinodeProvider) ServerTypeForConfig(cfg Config) string {
 }
 func (testLinodeProvider) ServerTypeForClass(string) string { return "g6-standard-1" }
 func (p testLinodeProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testLambdaProvider struct{}
+
+func (testLambdaProvider) Name() string      { return "lambda" }
+func (testLambdaProvider) Aliases() []string { return nil }
+func (testLambdaProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "lambda",
+		Family:      "lambda",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testLambdaProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (testLambdaProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (testLambdaProvider) ServerTypeForConfig(cfg Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.Lambda.Type != "" {
+		return cfg.Lambda.Type
+	}
+	return "gpu_1x_a10"
+}
+func (testLambdaProvider) ServerTypeForClass(string) string { return "gpu_1x_a10" }
+func (p testLambdaProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/incus"
 	_ "github.com/openclaw/crabbox/internal/providers/islo"
 	_ "github.com/openclaw/crabbox/internal/providers/kubevirt"
+	_ "github.com/openclaw/crabbox/internal/providers/lambda"
 	_ "github.com/openclaw/crabbox/internal/providers/linode"
 	_ "github.com/openclaw/crabbox/internal/providers/localcontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/modal"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -1122,6 +1122,7 @@ func allBuiltInProviderNames() []string {
 		"incus",
 		"islo",
 		"kubevirt",
+		"lambda",
 		"linode",
 		"local-container",
 		"modal",

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -77,6 +77,28 @@ func TestNvidiaBrevRegistersCanonicalAndAliases(t *testing.T) {
 	}
 }
 
+func TestLambdaRegistersAsBuiltInProvider(t *testing.T) {
+	provider, err := core.ProviderFor("lambda")
+	if err != nil {
+		t.Fatalf("ProviderFor(lambda): %v", err)
+	}
+	if provider.Name() != "lambda" {
+		t.Fatalf("ProviderFor(lambda).Name=%q", provider.Name())
+	}
+	spec := provider.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever || len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("lambda spec=%#v", spec)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("lambda features=%v missing %s", spec.Features, feature)
+		}
+	}
+	if _, ok := provider.(core.DoctorProvider); !ok {
+		t.Fatal("lambda does not expose doctor")
+	}
+}
+
 func TestNebiusRegistersWithoutAliases(t *testing.T) {
 	provider, err := core.ProviderFor("nebius")
 	if err != nil {

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -1,0 +1,718 @@
+package lambda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type lambdaAPI interface {
+	ListInstances(context.Context) ([]Instance, error)
+	GetInstance(context.Context, string) (Instance, error)
+	LaunchInstance(context.Context, LaunchInstanceRequest) (LaunchInstanceResponse, error)
+	TerminateInstances(context.Context, []string) error
+	ListSSHKeys(context.Context) ([]SSHKey, error)
+	AddSSHKey(context.Context, AddSSHKeyRequest) (SSHKey, error)
+	DeleteSSHKey(context.Context, string) error
+	ListRegions(context.Context) ([]Region, error)
+	ListInstanceTypes(context.Context) ([]InstanceType, error)
+	ListImages(context.Context) ([]Image, error)
+	ListFilesystems(context.Context) ([]Filesystem, error)
+	ListFirewallRulesets(context.Context) ([]FirewallRuleset, error)
+}
+
+type ambiguousLambdaCreateError struct {
+	err error
+}
+
+func (e *ambiguousLambdaCreateError) Error() string {
+	return fmt.Sprintf("lambda instance creation remains indeterminate; preserving SSH credentials for recovery: %v", e.err)
+}
+
+func (e *ambiguousLambdaCreateError) Unwrap() error { return e.err }
+
+type lambdaSSHKeyIdentity struct {
+	ID      string
+	Name    string
+	Created bool
+}
+
+func (b *backend) initDirect() {
+	b.cfg.Provider = providerName
+	if b.cfg.TargetOS == "" {
+		b.cfg.TargetOS = core.TargetLinux
+	}
+	if b.cfg.SSHUser == "" {
+		b.cfg.SSHUser = defaultUser
+	}
+	if b.cfg.SSHPort == "" {
+		b.cfg.SSHPort = defaultPort
+	}
+	if b.cfg.ServerType == "" {
+		b.cfg.ServerType = typeForConfig(b.cfg)
+	}
+	if b.cfg.Lambda.Region == "" {
+		b.cfg.Lambda.Region = defaultRegion
+	}
+	if b.cfg.Lambda.Type == "" {
+		b.cfg.Lambda.Type = defaultType
+	}
+	if b.cfg.Lambda.Image == "" && b.cfg.Lambda.ImageFamily == "" {
+		b.cfg.Lambda.ImageFamily = defaultImageFamily
+	}
+	b.DirectSSHBackend = shared.DirectSSHBackend{
+		SpecValue:       b.spec,
+		Cfg:             b.cfg,
+		RT:              b.rt,
+		Delete:          b.deleteServer,
+		StoredLeaseKeys: true,
+	}
+	if b.waitSSH == nil {
+		b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+			return core.WaitForSSHReady(ctx, target, b.rt.Stderr, phase, timeout)
+		}
+	}
+}
+
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	b.initDirect()
+	return shared.AcquireAttemptsRetry(b.rt, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
+}
+
+func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
+	if err := validateConfig(b.cfg); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if b.cfg.TargetOS != "" && b.cfg.TargetOS != core.TargetLinux {
+		return core.LeaseTarget{}, core.Exit(2, "provider=lambda only supports target=linux")
+	}
+	if b.cfg.Tailscale.Enabled && b.cfg.Tailscale.AuthKey == "" {
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", b.cfg.Tailscale.AuthKeyEnv)
+	}
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := ownedServers(instances, b.cfg)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(b.cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	cfg := b.cfg
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	if cfg.SSHUser == "" {
+		cfg.SSHUser = defaultUser
+	}
+	if cfg.SSHPort == "" {
+		cfg.SSHPort = defaultPort
+	}
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = providerKeyForLease(leaseID)
+	cfg.ServerType = typeForConfig(cfg)
+	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	now := b.now()
+	var (
+		key        lambdaSSHKeyIdentity
+		instanceID string
+		committed  bool
+	)
+	defer func() {
+		if err == nil || committed {
+			return
+		}
+		var ambiguous *ambiguousLambdaCreateError
+		if errors.As(err, &ambiguous) {
+			return
+		}
+		if instanceID == "" && !key.Created {
+			core.RemoveStoredTestboxKey(leaseID)
+			return
+		}
+		_ = b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, key, instanceID, "rollback-cleanup", req.Keep, now)
+		cleanupErr := rollbackLambdaAcquire(client, instanceID, key)
+		if cleanupErr != nil {
+			err = fmt.Errorf("%v; lambda cleanup failed: %w", err, cleanupErr)
+			return
+		}
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
+	}()
+	key, err = b.ensureSSHKey(ctx, client, cfg.ProviderKey, publicKey)
+	if err != nil {
+		if !key.Created {
+			return core.LeaseTarget{}, err
+		}
+		if claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, key, "", "ambiguous-key-create", req.Keep, now); claimErr != nil {
+			return core.LeaseTarget{}, errors.Join(&ambiguousLambdaCreateError{err: err}, fmt.Errorf("persist lambda SSH-key recovery: %w", claimErr))
+		}
+		return core.LeaseTarget{}, &ambiguousLambdaCreateError{err: err}
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=lambda lease=%s slug=%s type=%s region=%s image=%s image_family=%s keep=%v\n", leaseID, slug, cfg.ServerType, regionForConfig(cfg), imageForConfig(cfg), imageFamilyForConfig(cfg), req.Keep)
+	launchReq := b.launchRequest(cfg, leaseID, slug, publicKey, key, req.Keep, now)
+	launch, err := client.LaunchInstance(ctx, launchReq)
+	if err != nil {
+		if !isAmbiguousLambdaMutationError(err) {
+			return core.LeaseTarget{}, err
+		}
+		if claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, key, "", "ambiguous-create", req.Keep, now); claimErr != nil {
+			return core.LeaseTarget{}, errors.Join(&ambiguousLambdaCreateError{err: err}, fmt.Errorf("persist lambda launch recovery: %w", claimErr))
+		}
+		return core.LeaseTarget{}, &ambiguousLambdaCreateError{err: err}
+	}
+	if len(launch.InstanceIDs) != 1 || strings.TrimSpace(launch.InstanceIDs[0]) == "" {
+		err = core.Exit(5, "lambda launch returned %d instance ids; want exactly one", len(launch.InstanceIDs))
+		return core.LeaseTarget{}, err
+	}
+	instanceID = strings.TrimSpace(launch.InstanceIDs[0])
+	instance, err := b.waitForInstanceReady(ctx, client, instanceID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := serverFromInstance(instance, cfg)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := b.waitSSH(ctx, &ssh, "lambda bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server.Labels = lambdaLabelsWithKey(leaseTags(cfg, leaseID, slug, "ready", req.Keep, now), key)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	committed = true
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s lambda=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *backend) launchRequest(cfg core.Config, leaseID, slug, publicKey string, key lambdaSSHKeyIdentity, keep bool, now time.Time) LaunchInstanceRequest {
+	tags := lambdaProviderLaunchTags(leaseTags(cfg, leaseID, slug, "provisioning", keep, now), key)
+	req := LaunchInstanceRequest{
+		RegionName:       regionForConfig(cfg),
+		InstanceTypeName: typeForConfig(cfg),
+		Quantity:         1,
+		SSHKeyNames:      []string{key.Name},
+		Name:             lambdaInstanceName(leaseID, slug),
+		UserData:         lambdaUserData(cfg, publicKey),
+		Tags:             tags,
+	}
+	if image := imageForConfig(cfg); image != "" {
+		req.ImageID = image
+	} else {
+		req.ImageFamily = imageFamilyForConfig(cfg)
+	}
+	if ruleset := strings.TrimSpace(cfg.Lambda.FirewallRuleset); ruleset != "" {
+		req.FirewallRulesetName = ruleset
+	}
+	req.FileSystemNames = append([]string(nil), cfg.Lambda.FilesystemNames...)
+	for _, mount := range cfg.Lambda.FilesystemMounts {
+		if strings.TrimSpace(mount.Name) == "" {
+			continue
+		}
+		req.FileSystemMounts = append(req.FileSystemMounts, FilesystemMountRequest{Name: strings.TrimSpace(mount.Name), MountPath: strings.TrimSpace(mount.MountPath)})
+	}
+	return req
+}
+
+func lambdaLabelsWithKey(labels map[string]string, key lambdaSSHKeyIdentity) map[string]string {
+	labels[lambdaKeyIDLabel] = key.ID
+	labels[lambdaKeyNameLabel] = key.Name
+	labels[lambdaKeyOwnedLabel] = fmt.Sprint(key.Created)
+	return labels
+}
+
+func lambdaProviderLaunchTags(labels map[string]string, key lambdaSSHKeyIdentity) map[string]string {
+	labels = lambdaLabelsWithKey(labels, key)
+	// Lambda has no safe tag-update method in the Plan 01 foundation. Keep
+	// provider-only inventory identifiable but non-expiring; local claims carry
+	// the mutable cleanup clock after acquire/touch.
+	for _, field := range []string{"expires_at", "last_touched_at", "idle_timeout", "idle_timeout_secs", "ttl_secs"} {
+		delete(labels, field)
+	}
+	return labels
+}
+
+func (b *backend) ensureSSHKey(ctx context.Context, client lambdaAPI, name, publicKey string) (lambdaSSHKeyIdentity, error) {
+	keys, err := client.ListSSHKeys(ctx)
+	if err != nil {
+		return lambdaSSHKeyIdentity{}, err
+	}
+	for _, key := range keys {
+		if key.Name != name {
+			continue
+		}
+		if strings.TrimSpace(key.PublicKey) != strings.TrimSpace(publicKey) {
+			return lambdaSSHKeyIdentity{}, core.Exit(2, "lambda SSH key %q already exists with different public key", name)
+		}
+		return lambdaSSHKeyIdentity{ID: key.ID, Name: key.Name, Created: false}, nil
+	}
+	key, err := client.AddSSHKey(ctx, AddSSHKeyRequest{Name: name, PublicKey: publicKey})
+	if err != nil {
+		return lambdaSSHKeyIdentity{Name: name, Created: isAmbiguousLambdaMutationError(err)}, err
+	}
+	return lambdaSSHKeyIdentity{ID: key.ID, Name: firstNonBlank(key.Name, name), Created: true}, nil
+}
+
+func (b *backend) waitForInstanceReady(ctx context.Context, client lambdaAPI, id string) (Instance, error) {
+	deadline := b.now().Add(5 * time.Minute)
+	for {
+		item, err := client.GetInstance(ctx, id)
+		if err != nil {
+			return Instance{}, err
+		}
+		if strings.EqualFold(item.Status, "active") && strings.TrimSpace(item.IP) != "" {
+			return item, nil
+		}
+		if isTerminalInstanceStatus(item.Status) {
+			return Instance{}, core.Exit(5, "lambda instance %s reached terminal status %s", id, item.Status)
+		}
+		if b.now().After(deadline) {
+			return Instance{}, core.Exit(5, "timed out waiting for Lambda instance %s to become active with public IP", id)
+		}
+		timer := time.NewTimer(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return Instance{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	b.initDirect()
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers := ownedServers(instances, b.cfg)
+	byID := map[string]Instance{}
+	for _, item := range instances {
+		if isOwnedInstance(item) {
+			byID[item.ID] = item
+		}
+	}
+	if claim, ok, claimErr := core.ResolveLeaseClaimForProvider(req.ID, providerName); claimErr != nil {
+		return core.LeaseTarget{}, claimErr
+	} else if ok && claim.CloudID != "" {
+		if item, found := byID[claim.CloudID]; found {
+			return b.targetFromInstance(item, req)
+		}
+	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err == nil && leaseID != "" {
+		return b.targetFromInstance(byID[server.CloudID], req)
+	}
+	if item, ok := byID[req.ID]; ok {
+		return b.targetFromInstance(item, req)
+	}
+	if req.ReleaseOnly {
+		return b.releaseTargetFromClaim(req.ID)
+	}
+	return core.LeaseTarget{}, core.Exit(4, "lease/lambda instance not found: %s", req.ID)
+}
+
+func (b *backend) releaseTargetFromClaim(id string) (core.LeaseTarget, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(id, providerName)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if !ok {
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	if !ok || claim.LeaseID == "" {
+		return core.LeaseTarget{}, core.Exit(4, "lease/lambda instance not found: %s", id)
+	}
+	if err := validateLambdaLabels(claim.Labels); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] != "rollback-cleanup" {
+		return core.LeaseTarget{}, core.Exit(4, "lambda recovery is still pending for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+	}
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
+	server.PublicNet.IPv4.IP = claim.SSHHost
+	server.ServerType.Name = claim.Labels["server_type"]
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+}
+
+func (b *backend) targetFromInstance(item Instance, req core.ResolveRequest) (core.LeaseTarget, error) {
+	if err := validateLambdaLabels(item.Tags); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server, err := mergeLocalClaimLabels(serverFromInstance(item, b.cfg))
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := server.Labels["lease"]
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	ssh := core.SSHTargetFromConfig(b.cfg, server.PublicNet.IPv4.IP)
+	core.UseStoredTestboxKey(&ssh, leaseID)
+	if req.Repo.Root != "" {
+		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, server.Labels["slug"], b.cfg, server, ssh, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
+	b.initDirect()
+	servers, err := b.listOwnedServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.LeaseView, 0, len(servers))
+	for _, server := range servers {
+		out = append(out, server)
+	}
+	return out, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	b.initDirect()
+	return b.deleteServer(ctx, b.cfg, req.Lease.Server)
+}
+
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s lambda=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	b.initDirect()
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
+	if err != nil {
+		return err
+	}
+	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	_ = ctx
+	b.initDirect()
+	server := req.Lease.Server
+	if err := validateLambdaLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
+	cfg := b.cfg
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+	}
+	labels := core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, b.now())
+	labels[lambdaTouchLocalLabel] = "true"
+	server.Labels = labels
+	if claim, ok, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID); err == nil && ok {
+		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, claim, labels); err != nil {
+			return core.Server{}, err
+		}
+	}
+	return server, nil
+}
+
+func (b *backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseTarget, meta core.TailscaleMetadata) (core.Server, error) {
+	_ = ctx
+	b.initDirect()
+	server := lease.Server
+	if err := validateLambdaLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
+	labels := make(map[string]string, len(server.Labels)+8)
+	for key, value := range server.Labels {
+		labels[key] = value
+	}
+	applyTailscaleMetadata(labels, meta)
+	labels[lambdaTouchLocalLabel] = "true"
+	server.Labels = labels
+	if claim, ok, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err == nil && ok {
+		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels); err != nil {
+			return core.Server{}, err
+		}
+	}
+	return server, nil
+}
+
+func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
+	if err := validateLambdaLabels(server.Labels); err != nil {
+		return err
+	}
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return err
+	}
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
+	if err != nil {
+		return fmt.Errorf("read lambda cleanup claim: %w", err)
+	}
+	if claimExists {
+		if claim.Provider != providerName {
+			return core.Exit(2, "lease=%s is claimed by provider=%s; refusing lambda cleanup", claim.LeaseID, claim.Provider)
+		}
+		if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
+			return core.Exit(2, "refusing to release Lambda instance %s from stale local claim", server.CloudID)
+		}
+	}
+	instanceID := firstNonBlank(server.CloudID, claim.CloudID)
+	if server.CloudID == "" {
+		server.CloudID = instanceID
+	}
+	liveFound := false
+	if instanceID != "" {
+		live, getErr := client.GetInstance(ctx, instanceID)
+		if getErr == nil {
+			liveFound = true
+			if err := validateLiveInstance(live, server); err != nil {
+				return err
+			}
+			server = serverFromInstance(live, b.cfg)
+		} else if !isLambdaNotFound(getErr) {
+			return getErr
+		}
+	}
+	if liveFound {
+		if err := client.TerminateInstances(ctx, []string{instanceID}); err != nil {
+			return err
+		}
+	}
+	keyID := firstNonBlank(server.Labels[lambdaKeyIDLabel], claim.Labels[lambdaKeyIDLabel])
+	keyOwned := firstNonBlank(server.Labels[lambdaKeyOwnedLabel], claim.Labels[lambdaKeyOwnedLabel]) == "true"
+	if keyOwned && keyID != "" {
+		if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isLambdaNotFound(err) {
+			return err
+		}
+	}
+	if claimExists {
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			return fmt.Errorf("finalize lambda cleanup claim: %w", err)
+		}
+	}
+	core.RemoveStoredTestboxKey(server.Labels["lease"])
+	return nil
+}
+
+func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot string, key lambdaSSHKeyIdentity, cloudID, recovery string, keep bool, now time.Time) error {
+	labels := leaseTags(cfg, leaseID, slug, "provisioning", keep, now)
+	labels[lambdaRecoveryKeyLabel] = recovery
+	labels[lambdaKeyIDLabel] = key.ID
+	labels[lambdaKeyNameLabel] = firstNonBlank(key.Name, cfg.ProviderKey)
+	labels[lambdaKeyOwnedLabel] = fmt.Sprint(key.Created)
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("resolve lambda recovery working directory: %w", err)
+		}
+	}
+	server := core.Server{Provider: providerName, Name: lambdaInstanceName(leaseID, slug), CloudID: cloudID, Labels: labels}
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
+}
+
+func ownedServers(instances []Instance, cfg core.Config) []core.Server {
+	out := make([]core.Server, 0, len(instances))
+	for _, item := range instances {
+		if isOwnedInstance(item) {
+			out = append(out, serverFromInstance(item, cfg))
+		}
+	}
+	return out
+}
+
+func (b *backend) listOwnedServers(ctx context.Context) ([]core.Server, error) {
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return nil, err
+	}
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]core.Server, 0, len(instances))
+	for _, item := range instances {
+		if !isOwnedInstance(item) {
+			continue
+		}
+		server := serverFromInstance(item, b.cfg)
+		server, err = mergeLocalClaimLabels(server)
+		if err != nil {
+			return nil, err
+		}
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func mergeLocalClaimLabels(server core.Server) (core.Server, error) {
+	leaseID := server.Labels["lease"]
+	if leaseID == "" {
+		return server, nil
+	}
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.Server{}, fmt.Errorf("read lambda lease claim: %w", err)
+	}
+	if !ok || claim.Provider != providerName {
+		return server, nil
+	}
+	if claim.CloudID != "" && claim.CloudID != server.CloudID {
+		return core.Server{}, core.Exit(2, "refusing to list Lambda instance %s from stale local claim", server.CloudID)
+	}
+	if err := validateLambdaLabels(claim.Labels); err != nil {
+		return core.Server{}, err
+	}
+	labels := make(map[string]string, len(claim.Labels))
+	for key, value := range claim.Labels {
+		labels[key] = value
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func serverFromInstance(item Instance, cfg core.Config) core.Server {
+	labels := normalizeLambdaLabels(item.Tags)
+	server := core.Server{
+		CloudID:  item.ID,
+		Provider: providerName,
+		Name:     firstNonBlank(item.Name, item.Hostname, item.ID),
+		Status:   normalizeInstanceStatus(item.Status),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = strings.TrimSpace(item.IP)
+	server.ServerType.Name = firstNonBlank(item.Type, cfg.ServerType, typeForConfig(cfg))
+	return server
+}
+
+func validateLiveInstance(item Instance, expected core.Server) error {
+	labels := normalizeLambdaLabels(item.Tags)
+	if err := validateLambdaLabels(labels); err != nil {
+		return err
+	}
+	expectedProviderKey := expected.Labels["provider_key"]
+	if expectedProviderKey == "" && expected.Labels["lease"] != "" {
+		expectedProviderKey = providerKeyForLease(expected.Labels["lease"])
+	}
+	if item.ID != expected.CloudID ||
+		labels["lease"] != expected.Labels["lease"] ||
+		labels["slug"] != expected.Labels["slug"] ||
+		labels["provider_key"] != expectedProviderKey {
+		return core.Exit(2, "refusing to operate on changed Lambda instance %s", expected.CloudID)
+	}
+	return nil
+}
+
+func rollbackLambdaAcquire(client lambdaAPI, instanceID string, key lambdaSSHKeyIdentity) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var errs []error
+	if instanceID != "" {
+		if err := client.TerminateInstances(ctx, []string{instanceID}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if key.Created && key.ID != "" {
+		if err := client.DeleteSSHKey(ctx, key.ID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func normalizeInstanceStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "active":
+		return "ready"
+	case "booting":
+		return "starting"
+	case "terminating":
+		return "stopping"
+	case "terminated":
+		return "deleted"
+	case "preempted":
+		return "preempted"
+	case "unhealthy":
+		return "unhealthy"
+	default:
+		if strings.TrimSpace(status) == "" {
+			return "unknown"
+		}
+		return strings.ToLower(strings.TrimSpace(status))
+	}
+}
+
+func isTerminalInstanceStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "terminated", "terminating", "preempted", "unhealthy":
+		return true
+	default:
+		return false
+	}
+}
+
+func isLambdaNotFound(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.Status == 404
+}
+
+func isAmbiguousLambdaMutationError(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return true
+	}
+	return apiErr.Status >= 500 || apiErr.Status == 408 || apiErr.Status == 429
+}
+
+func lambdaInstanceName(leaseID, slug string) string {
+	name := strings.ToLower(core.LeaseProviderName(leaseID, slug))
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 63 {
+		out = strings.Trim(out[:63], "-")
+	}
+	if out == "" || out[0] == '-' {
+		return "crabbox-" + strings.TrimPrefix(strings.ReplaceAll(leaseID, "_", "-"), "-")
+	}
+	return out
+}
+
+func providerKeyForLease(leaseID string) string {
+	key := core.ProviderKeyForLease(leaseID)
+	if len(key) > 64 {
+		key = key[:64]
+	}
+	return strings.TrimRight(key, "-")
+}
+
+func (b *backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
+}

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -197,12 +197,18 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		return core.LeaseTarget{}, err
 	}
 	server.Labels = lambdaLabelsWithKey(leaseTags(cfg, leaseID, slug, "ready", req.Keep, now), key)
+	target = core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(target); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		return core.LeaseTarget{}, err
 	}
 	committed = true
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s lambda=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
-	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+	return target, nil
 }
 
 func (b *backend) launchRequest(cfg core.Config, leaseID, slug, publicKey string, key lambdaSSHKeyIdentity, keep bool, now time.Time) LaunchInstanceRequest {

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -106,7 +106,10 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	servers := ownedServers(instances, b.cfg)
+	servers, err := b.ownedServersFromInstances(instances)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
 	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
 		return core.LeaseTarget{}, err
@@ -203,15 +206,12 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 }
 
 func (b *backend) launchRequest(cfg core.Config, leaseID, slug, publicKey string, key lambdaSSHKeyIdentity, keep bool, now time.Time) LaunchInstanceRequest {
-	tags := lambdaProviderLaunchTags(leaseTags(cfg, leaseID, slug, "provisioning", keep, now), key)
 	req := LaunchInstanceRequest{
 		RegionName:       regionForConfig(cfg),
 		InstanceTypeName: typeForConfig(cfg),
 		Quantity:         1,
 		SSHKeyNames:      []string{key.Name},
-		Name:             lambdaInstanceName(leaseID, slug),
 		UserData:         lambdaUserData(cfg, publicKey),
-		Tags:             tags,
 	}
 	if image := imageForConfig(cfg); image != "" {
 		req.ImageID = image
@@ -240,9 +240,9 @@ func lambdaLabelsWithKey(labels map[string]string, key lambdaSSHKeyIdentity) map
 
 func lambdaProviderLaunchTags(labels map[string]string, key lambdaSSHKeyIdentity) map[string]string {
 	labels = lambdaLabelsWithKey(labels, key)
-	// Lambda has no safe tag-update method in the Plan 01 foundation. Provider
-	// tags keep the launch-time expiry so provider-only orphan cleanup can
-	// eventually reclaim billable instances; local claims carry fresh touch data.
+	// Keep launch-time expiry for complete provider-tagged instances that are
+	// manually seeded, legacy-created, or supported by a future tag API. Local
+	// claims carry fresh touch data for the current launch path.
 	for _, field := range []string{"last_touched_at", "idle_timeout", "idle_timeout_secs"} {
 		delete(labels, field)
 	}
@@ -306,26 +306,44 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	servers := ownedServers(instances, b.cfg)
+	servers, err := b.ownedServersFromInstances(instances)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
 	byID := map[string]Instance{}
 	for _, item := range instances {
-		if isOwnedInstance(item) {
-			byID[item.ID] = item
-		}
+		byID[item.ID] = item
 	}
 	if claim, ok, claimErr := core.ResolveLeaseClaimForProvider(req.ID, providerName); claimErr != nil {
 		return core.LeaseTarget{}, claimErr
 	} else if ok && claim.CloudID != "" {
 		if item, found := byID[claim.CloudID]; found {
-			return b.targetFromInstance(item, req)
+			if isOwnedInstance(item) {
+				return b.targetFromInstance(item, req)
+			}
+			return b.targetFromClaimedInstance(item, claim.Labels, req)
 		}
 	}
 	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
 	if err == nil && leaseID != "" {
-		return b.targetFromInstance(byID[server.CloudID], req)
+		item, found := byID[server.CloudID]
+		if !found {
+			return core.LeaseTarget{}, core.Exit(4, "lease/lambda instance not found: %s", req.ID)
+		}
+		if isOwnedInstance(item) {
+			return b.targetFromInstance(item, req)
+		}
+		return b.targetFromClaimedInstance(item, server.Labels, req)
 	}
 	if item, ok := byID[req.ID]; ok {
-		return b.targetFromInstance(item, req)
+		if isOwnedInstance(item) {
+			return b.targetFromInstance(item, req)
+		}
+		if server, claimed, claimErr := claimedServerFromInstance(item, b.cfg); claimErr != nil {
+			return core.LeaseTarget{}, claimErr
+		} else if claimed {
+			return b.targetFromClaimedInstance(item, server.Labels, req)
+		}
 	}
 	if req.ReleaseOnly {
 		return b.releaseTargetFromClaim(req.ID)
@@ -350,7 +368,7 @@ func (b *backend) releaseTargetFromClaim(id string) (core.LeaseTarget, error) {
 	if err := validateLambdaLabels(claim.Labels); err != nil {
 		return core.LeaseTarget{}, err
 	}
-	if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] != "rollback-cleanup" {
+	if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] != "rollback-cleanup" && claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-key-create" {
 		return core.LeaseTarget{}, core.Exit(4, "lambda recovery is still pending for lease=%s; credentials and recovery claim retained", claim.LeaseID)
 	}
 	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
@@ -367,6 +385,26 @@ func (b *backend) targetFromInstance(item Instance, req core.ResolveRequest) (co
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	leaseID := server.Labels["lease"]
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	ssh := core.SSHTargetFromConfig(b.cfg, server.PublicNet.IPv4.IP)
+	core.UseStoredTestboxKey(&ssh, leaseID)
+	if req.Repo.Root != "" {
+		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, server.Labels["slug"], b.cfg, server, ssh, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *backend) targetFromClaimedInstance(item Instance, labels map[string]string, req core.ResolveRequest) (core.LeaseTarget, error) {
+	if err := validateLambdaLabels(labels); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	server := serverFromInstance(item, b.cfg)
+	server.Labels = cloneLambdaLabels(labels)
 	leaseID := server.Labels["lease"]
 	if req.ReleaseOnly {
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
@@ -488,7 +526,9 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 			if err := validateLiveInstance(live, server); err != nil {
 				return err
 			}
-			server = serverFromInstance(live, b.cfg)
+			liveServer := serverFromInstance(live, b.cfg)
+			liveServer.Labels = cloneLambdaLabels(server.Labels)
+			server = liveServer
 		} else if !isLambdaNotFound(getErr) {
 			return getErr
 		}
@@ -499,7 +539,17 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 		}
 	}
 	keyID := firstNonBlank(server.Labels[lambdaKeyIDLabel], claim.Labels[lambdaKeyIDLabel])
+	keyName := firstNonBlank(server.Labels[lambdaKeyNameLabel], claim.Labels[lambdaKeyNameLabel])
 	keyOwned := firstNonBlank(server.Labels[lambdaKeyOwnedLabel], claim.Labels[lambdaKeyOwnedLabel]) == "true"
+	if keyOwned && keyID == "" && keyName != "" {
+		resolvedID, found, err := resolveSSHKeyIDByName(ctx, client, keyName)
+		if err != nil {
+			return err
+		}
+		if found {
+			keyID = resolvedID
+		}
+	}
 	if keyOwned && keyID != "" {
 		if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isLambdaNotFound(err) {
 			return err
@@ -531,14 +581,17 @@ func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, re
 	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
 }
 
-func ownedServers(instances []Instance, cfg core.Config) []core.Server {
-	out := make([]core.Server, 0, len(instances))
-	for _, item := range instances {
-		if isOwnedInstance(item) {
-			out = append(out, serverFromInstance(item, cfg))
+func resolveSSHKeyIDByName(ctx context.Context, client lambdaAPI, name string) (string, bool, error) {
+	keys, err := client.ListSSHKeys(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	for _, key := range keys {
+		if key.Name == name && key.ID != "" {
+			return key.ID, true, nil
 		}
 	}
-	return out
+	return "", false, nil
 }
 
 func (b *backend) listOwnedServers(ctx context.Context) ([]core.Server, error) {
@@ -550,19 +603,50 @@ func (b *backend) listOwnedServers(ctx context.Context) ([]core.Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	return b.ownedServersFromInstances(instances)
+}
+
+func (b *backend) ownedServersFromInstances(instances []Instance) ([]core.Server, error) {
 	servers := make([]core.Server, 0, len(instances))
 	for _, item := range instances {
-		if !isOwnedInstance(item) {
+		if isOwnedInstance(item) {
+			server := serverFromInstance(item, b.cfg)
+			var err error
+			server, err = mergeLocalClaimLabels(server)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, server)
 			continue
 		}
-		server := serverFromInstance(item, b.cfg)
-		server, err = mergeLocalClaimLabels(server)
+		server, claimed, err := claimedServerFromInstance(item, b.cfg)
 		if err != nil {
 			return nil, err
 		}
-		servers = append(servers, server)
+		if claimed {
+			servers = append(servers, server)
+		}
 	}
 	return servers, nil
+}
+
+func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, bool, error) {
+	if strings.TrimSpace(item.ID) == "" {
+		return core.Server{}, false, nil
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProviderCloudID(item.ID, providerName)
+	if err != nil {
+		return core.Server{}, false, err
+	}
+	if !ok || claim.Provider != providerName || claim.CloudID != item.ID {
+		return core.Server{}, false, nil
+	}
+	if err := validateLambdaLabels(claim.Labels); err != nil {
+		return core.Server{}, false, err
+	}
+	server := serverFromInstance(item, cfg)
+	server.Labels = cloneLambdaLabels(claim.Labels)
+	return server, true, nil
 }
 
 func mergeLocalClaimLabels(server core.Server) (core.Server, error) {
@@ -583,11 +667,7 @@ func mergeLocalClaimLabels(server core.Server) (core.Server, error) {
 	if err := validateLambdaLabels(claim.Labels); err != nil {
 		return core.Server{}, err
 	}
-	labels := make(map[string]string, len(claim.Labels))
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
-	server.Labels = labels
+	server.Labels = cloneLambdaLabels(claim.Labels)
 	return server, nil
 }
 
@@ -608,6 +688,11 @@ func serverFromInstance(item Instance, cfg core.Config) core.Server {
 func validateLiveInstance(item Instance, expected core.Server) error {
 	labels := normalizeLambdaLabels(item.Tags)
 	if err := validateLambdaLabels(labels); err != nil {
+		if item.ID == expected.CloudID {
+			if claimErr := validateLambdaLabels(expected.Labels); claimErr == nil {
+				return nil
+			}
+		}
 		return err
 	}
 	expectedProviderKey := expected.Labels["provider_key"]
@@ -621,6 +706,14 @@ func validateLiveInstance(item Instance, expected core.Server) error {
 		return core.Exit(2, "refusing to operate on changed Lambda instance %s", expected.CloudID)
 	}
 	return nil
+}
+
+func cloneLambdaLabels(labels map[string]string) map[string]string {
+	out := make(map[string]string, len(labels))
+	for key, value := range labels {
+		out[key] = value
+	}
+	return out
 }
 
 func rollbackLambdaAcquire(client lambdaAPI, instanceID string, key lambdaSSHKeyIdentity) error {

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -240,10 +240,10 @@ func lambdaLabelsWithKey(labels map[string]string, key lambdaSSHKeyIdentity) map
 
 func lambdaProviderLaunchTags(labels map[string]string, key lambdaSSHKeyIdentity) map[string]string {
 	labels = lambdaLabelsWithKey(labels, key)
-	// Lambda has no safe tag-update method in the Plan 01 foundation. Keep
-	// provider-only inventory identifiable but non-expiring; local claims carry
-	// the mutable cleanup clock after acquire/touch.
-	for _, field := range []string{"expires_at", "last_touched_at", "idle_timeout", "idle_timeout_secs", "ttl_secs"} {
+	// Lambda has no safe tag-update method in the Plan 01 foundation. Provider
+	// tags keep the launch-time expiry so provider-only orphan cleanup can
+	// eventually reclaim billable instances; local claims carry fresh touch data.
+	for _, field := range []string{"last_touched_at", "idle_timeout", "idle_timeout_secs"} {
 		delete(labels, field)
 	}
 	return labels

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -638,7 +638,16 @@ func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, boo
 	if err != nil {
 		return core.Server{}, false, err
 	}
-	if !ok || claim.Provider != providerName || claim.CloudID != item.ID {
+	if !ok {
+		claim, ok, err = ambiguousLaunchClaimForInstance(item)
+		if err != nil {
+			return core.Server{}, false, err
+		}
+	}
+	if !ok || claim.Provider != providerName {
+		return core.Server{}, false, nil
+	}
+	if claim.CloudID != "" && claim.CloudID != item.ID {
 		return core.Server{}, false, nil
 	}
 	if err := validateLambdaLabels(claim.Labels); err != nil {
@@ -647,6 +656,43 @@ func claimedServerFromInstance(item Instance, cfg core.Config) (core.Server, boo
 	server := serverFromInstance(item, cfg)
 	server.Labels = cloneLambdaLabels(claim.Labels)
 	return server, true, nil
+}
+
+func ambiguousLaunchClaimForInstance(item Instance) (core.LeaseClaim, bool, error) {
+	keyNames := make(map[string]struct{}, len(item.SSHKeyNames))
+	for _, keyName := range item.SSHKeyNames {
+		keyName = strings.TrimSpace(keyName)
+		if keyName != "" {
+			keyNames[keyName] = struct{}{}
+		}
+	}
+	if len(keyNames) == 0 {
+		return core.LeaseClaim{}, false, nil
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return core.LeaseClaim{}, false, err
+	}
+	var matched core.LeaseClaim
+	found := false
+	for _, claim := range claims {
+		if claim.Provider != providerName || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+			continue
+		}
+		keyName := strings.TrimSpace(claim.Labels[lambdaKeyNameLabel])
+		if keyName == "" {
+			continue
+		}
+		if _, ok := keyNames[keyName]; !ok {
+			continue
+		}
+		if found {
+			return core.LeaseClaim{}, false, core.Exit(2, "multiple Lambda recovery claims match instance %s by SSH key", item.ID)
+		}
+		matched = claim
+		found = true
+	}
+	return matched, found, nil
 }
 
 func mergeLocalClaimLabels(server core.Server) (core.Server, error) {

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -223,6 +223,35 @@ func TestAcquirePreservesExplicitSSHUserAndPort(t *testing.T) {
 	}
 }
 
+func TestAcquireRollsBackWhenOnAcquiredFails(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	var observed core.LeaseTarget
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "callback-fail",
+		OnAcquired: func(acquired core.LeaseTarget) error {
+			observed = acquired
+			return errors.New("controller unavailable")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "controller unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+	if observed.Server.CloudID != "i-100" || observed.SSH.Host != "203.0.113.25" || observed.LeaseID == "" {
+		t.Fatalf("observed=%#v", observed)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-100" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-700" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("callback-fail", providerName); claimErr != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, claimErr)
+	}
+}
+
 func TestAcquireReusesMatchingSSHKeyAndReleaseDoesNotDeleteIt(t *testing.T) {
 	api := &fakeLambdaAPI{sshKeys: []SSHKey{{ID: "key-existing", Name: "placeholder", PublicKey: "will be replaced"}}}
 	b := newTestBackend(t, api)

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -202,8 +202,11 @@ func TestAcquireCreatesKeyLaunchesPollsAndClaimsLease(t *testing.T) {
 		req.Tags[lambdaKeyIDLabel] != "key-700" || req.Tags[lambdaKeyNameLabel] != api.addKeyRequests[0].Name || req.Tags[lambdaKeyOwnedLabel] != "true" {
 		t.Fatalf("tags=%v", req.Tags)
 	}
-	if req.Tags["expires_at"] != "" || req.Tags["last_touched_at"] != "" || req.Tags["ttl_secs"] != "" {
-		t.Fatalf("provider launch tags should not carry stale cleanup timing: %v", req.Tags)
+	if req.Tags["expires_at"] == "" || req.Tags["ttl_secs"] == "" {
+		t.Fatalf("provider launch tags should carry orphan cleanup timing: %v", req.Tags)
+	}
+	if req.Tags["last_touched_at"] != "" || req.Tags["idle_timeout_secs"] != "" {
+		t.Fatalf("provider launch tags should not carry mutable touch timing: %v", req.Tags)
 	}
 	claim, ok, err := core.ResolveLeaseClaimForProvider("my-app", providerName)
 	if err != nil || !ok || claim.CloudID != "i-100" || claim.Labels[lambdaKeyOwnedLabel] != "true" || claim.Labels[lambdaKeyIDLabel] != "key-700" {
@@ -445,6 +448,22 @@ func TestCleanupDryRunDoesNotMutate(t *testing.T) {
 	}
 	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
 		t.Fatalf("mutated during dry run: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestCleanupDeletesProviderOnlyExpiredLambdaInstance(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	old := time.Now().Add(-48 * time.Hour)
+	labels := lambdaProviderLaunchTags(leaseTags(cfg, "cbx_abcdef123456", "old", "provisioning", false, old), lambdaSSHKeyIdentity{ID: "key-old", Name: "crabbox-cbx-old", Created: true})
+	api := &fakeLambdaAPI{instances: []Instance{{ID: "i-old", Name: "old", Status: "active", IP: "203.0.113.50", Type: defaultType, Tags: labels}}}
+	if err := newTestBackend(t, api).Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || len(api.terminatedIDs[0]) != 1 || api.terminatedIDs[0][0] != "i-old" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
 	}
 }
 

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -1,0 +1,595 @@
+package lambda
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeLambdaAPI struct {
+	instances       []Instance
+	sshKeys         []SSHKey
+	listKeyErr      error
+	addKeyErr       error
+	launchErr       error
+	terminateErr    error
+	deleteKeyErr    error
+	launchRequests  []LaunchInstanceRequest
+	addKeyRequests  []AddSSHKeyRequest
+	terminatedIDs   [][]string
+	deletedKeyIDs    []string
+	nextKeyID        int
+	nextInstanceID   int
+	listInstancesHit int
+}
+
+func (f *fakeLambdaAPI) ListInstances(context.Context) ([]Instance, error) {
+	f.listInstancesHit++
+	return append([]Instance(nil), f.instances...), nil
+}
+
+func (f *fakeLambdaAPI) GetInstance(_ context.Context, id string) (Instance, error) {
+	for _, item := range f.instances {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return Instance{}, &APIError{Status: 404}
+}
+
+func (f *fakeLambdaAPI) LaunchInstance(_ context.Context, req LaunchInstanceRequest) (LaunchInstanceResponse, error) {
+	f.launchRequests = append(f.launchRequests, req)
+	if f.launchErr != nil {
+		return LaunchInstanceResponse{}, f.launchErr
+	}
+	if f.nextInstanceID == 0 {
+		f.nextInstanceID = 100
+	}
+	id := "i-" + string(rune('0'+f.nextInstanceID%10))
+	if f.nextInstanceID >= 100 {
+		id = "i-100"
+	}
+	item := Instance{
+		ID:          id,
+		Name:        req.Name,
+		Status:      "active",
+		Region:      Region{Name: req.RegionName},
+		Type:        req.InstanceTypeName,
+		IP:          "203.0.113.25",
+		SSHKeyNames: append([]string(nil), req.SSHKeyNames...),
+		Tags:        req.Tags,
+	}
+	f.instances = append(f.instances, item)
+	f.nextInstanceID++
+	return LaunchInstanceResponse{InstanceIDs: []string{id}}, nil
+}
+
+func (f *fakeLambdaAPI) TerminateInstances(_ context.Context, ids []string) error {
+	f.terminatedIDs = append(f.terminatedIDs, append([]string(nil), ids...))
+	if f.terminateErr != nil {
+		return f.terminateErr
+	}
+	return nil
+}
+
+func (f *fakeLambdaAPI) ListSSHKeys(context.Context) ([]SSHKey, error) {
+	if f.listKeyErr != nil {
+		return nil, f.listKeyErr
+	}
+	return append([]SSHKey(nil), f.sshKeys...), nil
+}
+
+func (f *fakeLambdaAPI) AddSSHKey(_ context.Context, req AddSSHKeyRequest) (SSHKey, error) {
+	f.addKeyRequests = append(f.addKeyRequests, req)
+	if f.addKeyErr != nil {
+		return SSHKey{Name: req.Name}, f.addKeyErr
+	}
+	if f.nextKeyID == 0 {
+		f.nextKeyID = 700
+	}
+	key := SSHKey{ID: "key-700", Name: req.Name, PublicKey: req.PublicKey}
+	f.sshKeys = append(f.sshKeys, key)
+	f.nextKeyID++
+	return key, nil
+}
+
+func (f *fakeLambdaAPI) DeleteSSHKey(_ context.Context, id string) error {
+	f.deletedKeyIDs = append(f.deletedKeyIDs, id)
+	return f.deleteKeyErr
+}
+
+func (f *fakeLambdaAPI) ListRegions(context.Context) ([]Region, error) {
+	return []Region{{Name: defaultRegion}}, nil
+}
+
+func (f *fakeLambdaAPI) ListInstanceTypes(context.Context) ([]InstanceType, error) {
+	return []InstanceType{{Name: defaultType, RegionsWithCapacityAvailable: []string{defaultRegion}}}, nil
+}
+
+func (f *fakeLambdaAPI) ListImages(context.Context) ([]Image, error) {
+	return []Image{{Family: defaultImageFamily, Region: defaultRegion}}, nil
+}
+
+func (f *fakeLambdaAPI) ListFilesystems(context.Context) ([]Filesystem, error) { return nil, nil }
+
+func (f *fakeLambdaAPI) ListFirewallRulesets(context.Context) ([]FirewallRuleset, error) {
+	return nil, nil
+}
+
+func newTestBackend(t *testing.T, api *fakeLambdaAPI) *backend {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.SSHUser = defaultUser
+	cfg.SSHPort = defaultPort
+	cfg.WorkRoot = "/work/crabbox"
+	cfg.ServerType = defaultType
+	cfg.Lambda.Region = defaultRegion
+	cfg.Lambda.Type = defaultType
+	cfg.Lambda.ImageFamily = defaultImageFamily
+	b := &backend{spec: Provider{}.Spec(), cfg: cfg, rt: core.Runtime{Stderr: io.Discard}}
+	b.clientFactory = func(core.Runtime) (lambdaAPI, error) { return api, nil }
+	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
+	return b
+}
+
+func TestListShowsOnlyCompleteOwnedLambdaInstances(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	owned := Instance{ID: "i-owned", Name: "owned", Status: "active", IP: "203.0.113.10", Type: defaultType, Tags: leaseTags(cfg, "cbx_abcdef123456", "owned", "ready", false, time.Now())}
+	api := &fakeLambdaAPI{instances: []Instance{
+		owned,
+		{ID: "i-foreign", Name: "foreign", Tags: map[string]string{"crabbox": "true", "provider": "other"}},
+		{ID: "i-partial", Name: "partial", Tags: map[string]string{"crabbox": "true", "provider": providerName}},
+	}}
+	views, err := newTestBackend(t, api).List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].CloudID != "i-owned" || views[0].Status != "ready" {
+		t.Fatalf("views=%#v", views)
+	}
+}
+
+func TestAcquireCreatesKeyLaunchesPollsAndClaimsLease(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	b.cfg.Lambda.FirewallRuleset = "default"
+	b.cfg.Lambda.FilesystemNames = []string{"cache"}
+	b.cfg.Lambda.FilesystemMounts = []core.LambdaFilesystemMount{{Name: "cache", MountPath: "/mnt/cache"}}
+	b.cfg.Tailscale.Enabled = true
+	b.cfg.Tailscale.AuthKey = "tskey-auth-test"
+	b.cfg.Tailscale.HostnameTemplate = "{{slug}}-{{lease}}"
+	b.cfg.Tailscale.Tags = []string{"tag:ci", "tag:crabbox"}
+
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "my-app", Keep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID == "" || lease.Server.CloudID != "i-100" || lease.SSH.Host != "203.0.113.25" || lease.SSH.User != defaultUser || lease.SSH.Port != defaultPort {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if len(api.addKeyRequests) != 1 || !strings.HasPrefix(api.addKeyRequests[0].Name, "crabbox-cbx-") {
+		t.Fatalf("addKeyRequests=%#v", api.addKeyRequests)
+	}
+	if len(api.launchRequests) != 1 {
+		t.Fatalf("launchRequests=%#v", api.launchRequests)
+	}
+	req := api.launchRequests[0]
+	if req.RegionName != defaultRegion || req.InstanceTypeName != defaultType || req.Quantity != 1 || len(req.SSHKeyNames) != 1 || req.SSHKeyNames[0] != api.addKeyRequests[0].Name {
+		t.Fatalf("launch request=%#v", req)
+	}
+	if req.ImageFamily != defaultImageFamily || req.ImageID != "" || req.UserData == "" || strings.Contains(req.UserData, "base64") {
+		t.Fatalf("launch image/user_data shape=%#v", req)
+	}
+	if req.FirewallRulesetName != "default" || len(req.FileSystemNames) != 1 || len(req.FileSystemMounts) != 1 {
+		t.Fatalf("launch optional resources=%#v", req)
+	}
+	if req.Tags["provider"] != providerName || req.Tags["lease"] != lease.LeaseID || req.Tags["slug"] != "my-app" || req.Tags["tailscale"] != "true" ||
+		req.Tags[lambdaKeyIDLabel] != "key-700" || req.Tags[lambdaKeyNameLabel] != api.addKeyRequests[0].Name || req.Tags[lambdaKeyOwnedLabel] != "true" {
+		t.Fatalf("tags=%v", req.Tags)
+	}
+	if req.Tags["expires_at"] != "" || req.Tags["last_touched_at"] != "" || req.Tags["ttl_secs"] != "" {
+		t.Fatalf("provider launch tags should not carry stale cleanup timing: %v", req.Tags)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("my-app", providerName)
+	if err != nil || !ok || claim.CloudID != "i-100" || claim.Labels[lambdaKeyOwnedLabel] != "true" || claim.Labels[lambdaKeyIDLabel] != "key-700" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	if claim.Labels["expires_at"] == "" || claim.Labels["last_touched_at"] == "" || claim.Labels["state"] != "ready" {
+		t.Fatalf("local claim should carry ready cleanup timing: %v", claim.Labels)
+	}
+}
+
+func TestAcquirePreservesExplicitSSHUserAndPort(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	b.cfg.SSHUser = "alice"
+	b.cfg.SSHPort = "2222"
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "custom-ssh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.User != "alice" || lease.SSH.Port != "2222" {
+		t.Fatalf("ssh target=%#v", lease.SSH)
+	}
+	if len(api.launchRequests) != 1 || !strings.Contains(api.launchRequests[0].UserData, `Port 2222`) || !strings.Contains(api.launchRequests[0].UserData, `name: "alice"`) {
+		t.Fatalf("user_data did not preserve explicit SSH settings: %q", api.launchRequests[0].UserData)
+	}
+}
+
+func TestAcquireReusesMatchingSSHKeyAndReleaseDoesNotDeleteIt(t *testing.T) {
+	api := &fakeLambdaAPI{sshKeys: []SSHKey{{ID: "key-existing", Name: "placeholder", PublicKey: "will be replaced"}}}
+	b := newTestBackend(t, api)
+	var capturedPublicKey string
+	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(b.cfg, "cbx_abcdef123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = keyPath
+	capturedPublicKey = publicKey
+	api.sshKeys = []SSHKey{{ID: "key-existing", Name: providerKeyForLease("cbx_abcdef123456"), PublicKey: capturedPublicKey}}
+
+	leaseID := "cbx_abcdef123456"
+	slug := "reuse"
+	labels := leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now())
+	labels[lambdaKeyIDLabel] = "key-existing"
+	labels[lambdaKeyNameLabel] = providerKeyForLease(leaseID)
+	labels[lambdaKeyOwnedLabel] = "false"
+	server := core.Server{Provider: providerName, CloudID: "i-existing", Name: "existing", Labels: labels}
+	api.instances = []Instance{{ID: "i-existing", Name: "existing", Status: "active", IP: "203.0.113.40", Type: defaultType, Tags: labels}}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-existing" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+}
+
+func TestAcquireRejectsMismatchedDuplicateSSHKey(t *testing.T) {
+	api := &fakeLambdaAPI{sshKeys: []SSHKey{{ID: "key-existing", Name: providerKeyForLease("cbx_any"), PublicKey: "ssh-ed25519 other"}}}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_any"
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(b.cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = keyPath
+	api.sshKeys[0].Name = providerKeyForLease(leaseID)
+	_, err = b.ensureSSHKey(context.Background(), api, providerKeyForLease(leaseID), "ssh-ed25519 expected")
+	if err == nil || !strings.Contains(err.Error(), "different public key") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestAcquireDoesNotPersistRecoveryClaimForPreCreateKeyError(t *testing.T) {
+	api := &fakeLambdaAPI{listKeyErr: errors.New("list keys denied")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "key-list-fail"})
+	if err == nil || !strings.Contains(err.Error(), "list keys denied") {
+		t.Fatalf("err=%v", err)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("key-list-fail", providerName); claimErr != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, claimErr)
+	}
+}
+
+func TestAcquireDoesNotPersistRecoveryClaimForDefiniteKeyCreateAPIError(t *testing.T) {
+	api := &fakeLambdaAPI{addKeyErr: &APIError{Status: 400, Code: "global/invalid-parameters", Message: "bad key"}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "key-api-fail"})
+	if err == nil || !strings.Contains(err.Error(), "invalid-parameters") {
+		t.Fatalf("err=%v", err)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("key-api-fail", providerName); claimErr != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, claimErr)
+	}
+}
+
+func TestAcquireRollsBackKeyForDefiniteLaunchAPIError(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: &APIError{Status: 400, Code: "global/invalid-parameters", Message: "bad launch"}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "launch-api-fail"})
+	if err == nil || !strings.Contains(err.Error(), "invalid-parameters") {
+		t.Fatalf("err=%v", err)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("launch-api-fail", providerName); claimErr != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, claimErr)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-700" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+}
+
+func TestAcquirePreservesRecoveryForAmbiguousKeyCreateAPIError(t *testing.T) {
+	api := &fakeLambdaAPI{addKeyErr: &APIError{Status: 500, Code: "provider/upstream", Message: "server error"}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "key-api-ambiguous"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("key-api-ambiguous", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-key-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+}
+
+func TestAcquirePreservesRecoveryForAmbiguousLaunchAPIError(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: &APIError{Status: 500, Code: "provider/upstream", Message: "server error"}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "launch-api-ambiguous"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("launch-api-ambiguous", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+}
+
+func TestReleaseTerminatesThenDeletesOwnedKeyAndLocalArtifacts(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := lease.SSH.Key
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-100" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-700" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("release", providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored key still exists: %v", err)
+	}
+}
+
+func TestReleaseMissingInstanceStillDeletesOwnedKeyAndClaim(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123457"
+	slug := "missing-instance"
+	labels := leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now())
+	labels[lambdaKeyIDLabel] = "key-missing"
+	labels[lambdaKeyNameLabel] = providerKeyForLease(leaseID)
+	labels[lambdaKeyOwnedLabel] = "true"
+	server := core.Server{Provider: providerName, CloudID: "i-missing", Name: "missing", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	target, err := b.releaseTargetFromClaim(slug)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 0 {
+		t.Fatalf("terminated missing instance=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-missing" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseFromClaimOnlyCloudIDTerminatesSafely(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	slug := "claim-only"
+	labels := leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now())
+	labels[lambdaKeyIDLabel] = "key-claim"
+	labels[lambdaKeyNameLabel] = providerKeyForLease(leaseID)
+	labels[lambdaKeyOwnedLabel] = "true"
+	api.instances = []Instance{{ID: "i-claim", Name: "claim", Status: "active", IP: "203.0.113.60", Type: defaultType, Tags: labels}}
+	server := core.Server{Provider: providerName, CloudID: "i-claim", Name: "claim", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	target, err := b.releaseTargetFromClaim(slug)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.Server.CloudID = ""
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-claim" || len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-claim" {
+		t.Fatalf("terminated=%v deletedKeyIDs=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestCleanupDryRunDoesNotMutate(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	cfg.ServerType = defaultType
+	old := time.Now().Add(-48 * time.Hour)
+	labels := leaseTags(cfg, "cbx_abcdef123456", "old", "ready", false, old)
+	labels["last_touched_at"] = core.LeaseLabelTime(old)
+	labels["expires_at"] = core.LeaseLabelTime(old.Add(time.Minute))
+	api := &fakeLambdaAPI{instances: []Instance{{ID: "i-old", Name: "old", Status: "active", IP: "203.0.113.50", Type: defaultType, Tags: labels}}}
+	if err := newTestBackend(t, api).Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("mutated during dry run: terminated=%v keys=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+}
+
+func TestCleanupUsesFreshLocalClaimLabelsWhenTouchIsLocalOnly(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123456"
+	slug := "fresh-claim"
+	old := time.Now().Add(-48 * time.Hour)
+	staleLabels := leaseTags(b.cfg, leaseID, slug, "ready", false, old)
+	staleLabels["last_touched_at"] = core.LeaseLabelTime(old)
+	staleLabels["expires_at"] = core.LeaseLabelTime(old.Add(time.Minute))
+	api.instances = []Instance{{ID: "i-fresh", Name: "fresh", Status: "active", IP: "203.0.113.70", Type: defaultType, Tags: staleLabels}}
+	freshLabels := leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now())
+	server := core.Server{Provider: providerName, CloudID: "i-fresh", Name: "fresh", Labels: freshLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), b.cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 0 {
+		t.Fatalf("cleanup used stale provider tags: terminated=%v", api.terminatedIDs)
+	}
+}
+
+func TestResolvePreservesFreshLocalClaimLabels(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123458"
+	slug := "resolve-fresh"
+	key := lambdaSSHKeyIdentity{ID: "key-resolve", Name: providerKeyForLease(leaseID), Created: true}
+	providerTags := lambdaProviderLaunchTags(leaseTags(b.cfg, leaseID, slug, "provisioning", false, time.Now()), key)
+	api.instances = []Instance{{ID: "i-resolve", Name: "resolve", Status: "active", IP: "203.0.113.80", Type: defaultType, Tags: providerTags}}
+	claimLabels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now()), key)
+	server := core.Server{Provider: providerName, CloudID: "i-resolve", Name: "resolve", Labels: claimLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), b.cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Server.Labels["state"] != "ready" || target.Server.Labels["expires_at"] == "" {
+		t.Fatalf("resolved labels=%v", target.Server.Labels)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName)
+	if err != nil || !ok || claim.Labels["state"] != "ready" || claim.Labels["expires_at"] == "" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestAmbiguousLaunchPreservesRecoveryClaimAndStoredKey(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	keyPath, pathErr := core.TestboxKeyPath(claim.LeaseID)
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		t.Fatalf("stored recovery key missing: %v", statErr)
+	}
+}
+
+func TestFailedRollbackRecoveryClaimKeepsInstanceIDForRetry(t *testing.T) {
+	api := &fakeLambdaAPI{terminateErr: errors.New("terminate unavailable")}
+	b := newTestBackend(t, api)
+	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error {
+		return errors.New("ssh never became ready")
+	}
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "retry-cleanup"})
+	if err == nil || !strings.Contains(err.Error(), "terminate unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("retry-cleanup", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "i-100" || claim.Labels[lambdaRecoveryKeyLabel] != "rollback-cleanup" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.terminateErr = nil
+	target, err := b.releaseTargetFromClaim("retry-cleanup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) < 2 || api.terminatedIDs[len(api.terminatedIDs)-1][0] != "i-100" {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+}
+
+func TestTouchAndTailscaleMetadataAreLocalOnly(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "touch"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	touched, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running", IdleTimeout: 20 * time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if touched.Labels["state"] != "running" || touched.Labels[lambdaTouchLocalLabel] != "true" {
+		t.Fatalf("touched labels=%v", touched.Labels)
+	}
+	updated, err := b.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{LeaseID: lease.LeaseID, Server: touched}, core.TailscaleMetadata{
+		Enabled:  true,
+		Hostname: "touch",
+		FQDN:     "touch.example.ts.net",
+		IPv4:     "100.64.1.10",
+		Tags:     []string{"tag:ci", "tag:crabbox"},
+		State:    "ready",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Labels["tailscale_ipv4"] != "100.64.1.10" || updated.Labels["tailscale_tags"] != "tag:ci,tag:crabbox" || updated.Labels[lambdaTouchLocalLabel] != "true" {
+		t.Fatalf("updated labels=%v", updated.Labels)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("touch", providerName)
+	if err != nil || !ok || claim.Labels["tailscale_fqdn"] != "touch.example.ts.net" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestReleaseRemovesStoredKeyDirectory(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "keydir"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Dir(lease.SSH.Key)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("key dir still exists: %v", err)
+	}
+}

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -58,13 +58,12 @@ func (f *fakeLambdaAPI) LaunchInstance(_ context.Context, req LaunchInstanceRequ
 	}
 	item := Instance{
 		ID:          id,
-		Name:        req.Name,
+		Name:        id,
 		Status:      "active",
 		Region:      Region{Name: req.RegionName},
 		Type:        req.InstanceTypeName,
 		IP:          "203.0.113.25",
 		SSHKeyNames: append([]string(nil), req.SSHKeyNames...),
-		Tags:        req.Tags,
 	}
 	f.instances = append(f.instances, item)
 	f.nextInstanceID++
@@ -197,16 +196,6 @@ func TestAcquireCreatesKeyLaunchesPollsAndClaimsLease(t *testing.T) {
 	}
 	if req.FirewallRulesetName != "default" || len(req.FileSystemNames) != 1 || len(req.FileSystemMounts) != 1 {
 		t.Fatalf("launch optional resources=%#v", req)
-	}
-	if req.Tags["provider"] != providerName || req.Tags["lease"] != lease.LeaseID || req.Tags["slug"] != "my-app" || req.Tags["tailscale"] != "true" ||
-		req.Tags[lambdaKeyIDLabel] != "key-700" || req.Tags[lambdaKeyNameLabel] != api.addKeyRequests[0].Name || req.Tags[lambdaKeyOwnedLabel] != "true" {
-		t.Fatalf("tags=%v", req.Tags)
-	}
-	if req.Tags["expires_at"] == "" || req.Tags["ttl_secs"] == "" {
-		t.Fatalf("provider launch tags should carry orphan cleanup timing: %v", req.Tags)
-	}
-	if req.Tags["last_touched_at"] != "" || req.Tags["idle_timeout_secs"] != "" {
-		t.Fatalf("provider launch tags should not carry mutable touch timing: %v", req.Tags)
 	}
 	claim, ok, err := core.ResolveLeaseClaimForProvider("my-app", providerName)
 	if err != nil || !ok || claim.CloudID != "i-100" || claim.Labels[lambdaKeyOwnedLabel] != "true" || claim.Labels[lambdaKeyIDLabel] != "key-700" {
@@ -406,6 +395,46 @@ func TestReleaseMissingInstanceStillDeletesOwnedKeyAndClaim(t *testing.T) {
 	}
 }
 
+func TestListResolveAndReleaseUseLocalClaimForUntaggedLambdaInstance(t *testing.T) {
+	api := &fakeLambdaAPI{}
+	b := newTestBackend(t, api)
+	leaseID := "cbx_abcdef123459"
+	slug := "untagged"
+	labels := lambdaLabelsWithKey(leaseTags(b.cfg, leaseID, slug, "ready", false, time.Now()), lambdaSSHKeyIdentity{ID: "key-untagged", Name: providerKeyForLease(leaseID), Created: true})
+	api.instances = []Instance{{ID: "i-untagged", Name: "untagged", Status: "active", IP: "203.0.113.61", Type: defaultType}}
+	server := core.Server{Provider: providerName, CloudID: "i-untagged", Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	views, err := b.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].CloudID != "i-untagged" || views[0].Labels["lease"] != leaseID {
+		t.Fatalf("views=%#v", views)
+	}
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Server.CloudID != "i-untagged" || target.SSH.Host != "203.0.113.61" || target.Server.Labels["slug"] != slug {
+		t.Fatalf("target=%#v", target)
+	}
+	releaseTarget, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "i-untagged", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: releaseTarget}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-untagged" || len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-untagged" {
+		t.Fatalf("terminated=%v deletedKeyIDs=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
 func TestReleaseFromClaimOnlyCloudIDTerminatesSafely(t *testing.T) {
 	api := &fakeLambdaAPI{}
 	b := newTestBackend(t, api)
@@ -560,6 +589,37 @@ func TestFailedRollbackRecoveryClaimKeepsInstanceIDForRetry(t *testing.T) {
 	}
 	if len(api.terminatedIDs) < 2 || api.terminatedIDs[len(api.terminatedIDs)-1][0] != "i-100" {
 		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+}
+
+func TestAmbiguousKeyCreateRecoveryDeletesOwnedKeyByName(t *testing.T) {
+	api := &fakeLambdaAPI{addKeyErr: &APIError{Status: 500, Code: "provider/upstream", Message: "server error"}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "key-api-ambiguous"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("key-api-ambiguous", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-key-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.addKeyErr = nil
+	api.sshKeys = append(api.sshKeys, SSHKey{ID: "key-late", Name: claim.Labels[lambdaKeyNameLabel]})
+	target, err := b.releaseTargetFromClaim("key-api-ambiguous")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 0 {
+		t.Fatalf("terminated=%v", api.terminatedIDs)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-late" {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("key-api-ambiguous", providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 type fakeLambdaAPI struct {
-	instances       []Instance
-	sshKeys         []SSHKey
-	listKeyErr      error
-	addKeyErr       error
-	launchErr       error
-	terminateErr    error
-	deleteKeyErr    error
-	launchRequests  []LaunchInstanceRequest
-	addKeyRequests  []AddSSHKeyRequest
-	terminatedIDs   [][]string
+	instances        []Instance
+	sshKeys          []SSHKey
+	listKeyErr       error
+	addKeyErr        error
+	launchErr        error
+	terminateErr     error
+	deleteKeyErr     error
+	launchRequests   []LaunchInstanceRequest
+	addKeyRequests   []AddSSHKeyRequest
+	terminatedIDs    [][]string
 	deletedKeyIDs    []string
 	nextKeyID        int
 	nextInstanceID   int

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -565,6 +565,44 @@ func TestAmbiguousLaunchPreservesRecoveryClaimAndStoredKey(t *testing.T) {
 	}
 }
 
+func TestAmbiguousLaunchRecoveryFindsInstanceBySSHKeyName(t *testing.T) {
+	api := &fakeLambdaAPI{launchErr: errors.New("transport closed")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous-keyed"})
+	if err == nil || !strings.Contains(err.Error(), "indeterminate") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("ambiguous-keyed", providerName)
+	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+	api.launchErr = nil
+	api.instances = append(api.instances, Instance{
+		ID:          "i-late",
+		Name:        "late",
+		Status:      "active",
+		IP:          "203.0.113.90",
+		Type:        defaultType,
+		SSHKeyNames: []string{claim.Labels[lambdaKeyNameLabel]},
+	})
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous-keyed", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Server.CloudID != "i-late" || target.Server.Labels[lambdaRecoveryKeyLabel] != "ambiguous-create" {
+		t.Fatalf("target=%#v", target)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminatedIDs) != 1 || api.terminatedIDs[0][0] != "i-late" || len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != "key-700" {
+		t.Fatalf("terminated=%v deletedKeyIDs=%v", api.terminatedIDs, api.deletedKeyIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("ambiguous-keyed", providerName); err != nil || ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+}
+
 func TestFailedRollbackRecoveryClaimKeepsInstanceIDForRetry(t *testing.T) {
 	api := &fakeLambdaAPI{terminateErr: errors.New("terminate unavailable")}
 	b := newTestBackend(t, api)

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -1,0 +1,210 @@
+package lambda
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Client struct {
+	token   string
+	client  *http.Client
+	baseURL string
+}
+
+type APIError struct {
+	Operation  string
+	Status     int
+	Code       string
+	Message    string
+	Suggestion string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.Code != "" || e.Message != "" {
+		return fmt.Sprintf("lambda %s: http %d: code=%s message=%s", e.Operation, e.Status, e.Code, e.Message)
+	}
+	return fmt.Sprintf("lambda %s: http %d: %s", e.Operation, e.Status, e.Body)
+}
+
+func newClient(rt core.Runtime) (*Client, error) {
+	token, err := requireToken()
+	if err != nil {
+		return nil, err
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &Client{token: token, client: httpClient, baseURL: defaultAPIBaseURL}, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+		reader = &buf
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(resp.Body)
+	operation := method + " " + path
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.decodeAPIError(operation, resp.StatusCode, data, readErr)
+	}
+	if readErr != nil {
+		return fmt.Errorf("lambda %s response body: %w", operation, readErr)
+	}
+	if out == nil || len(data) == 0 {
+		return nil
+	}
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("lambda %s decode: %w", operation, err)
+	}
+	if len(envelope.Data) == 0 {
+		return fmt.Errorf("lambda %s decode: missing data envelope", operation)
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("lambda %s decode data: %w", operation, err)
+	}
+	return nil
+}
+
+func (c *Client) decodeAPIError(operation string, status int, data []byte, readErr error) error {
+	body := strings.TrimSpace(string(data))
+	var envelope apiErrorEnvelope
+	if err := json.Unmarshal(data, &envelope); err == nil && (envelope.Error.Code != "" || envelope.Error.Message != "") {
+		apiErr := &APIError{
+			Operation:  operation,
+			Status:     status,
+			Code:       envelope.Error.Code,
+			Message:    c.redact(envelope.Error.Message),
+			Suggestion: c.redact(envelope.Error.Suggestion),
+			Body:       c.redact(body),
+		}
+		if readErr != nil {
+			apiErr.Body = strings.TrimSpace(apiErr.Body + "; response body read failed: " + readErr.Error())
+		}
+		return apiErr
+	}
+	if len(body) > 400 {
+		body = body[:400]
+	}
+	body = c.redact(body)
+	if readErr != nil {
+		if body != "" {
+			body += "; "
+		}
+		body += "response body read failed: " + readErr.Error()
+	}
+	return &APIError{Operation: operation, Status: status, Body: body}
+}
+
+func (c *Client) redact(value string) string {
+	out := value
+	if c.token != "" {
+		out = strings.ReplaceAll(out, c.token, "<redacted>")
+	}
+	for _, field := range []string{"token", "api_key", "user_data", "private_key", "privateKey", "jupyter_token", "jupyterToken", "jupyter_url", "jupyterUrl"} {
+		out = redactJSONishField(out, field)
+		out = redactInlineField(out, field)
+	}
+	out = redactPrivateKeyBlock(out)
+	out = redactJupyterURLs(out)
+	return out
+}
+
+func redactJSONishField(body, field string) string {
+	pattern := regexp.MustCompile(`("` + regexp.QuoteMeta(field) + `"\s*:\s*")[^"]*(")`)
+	return pattern.ReplaceAllString(body, `${1}<redacted>${2}`)
+}
+
+func redactInlineField(body, field string) string {
+	pattern := regexp.MustCompile(`(?i)(` + regexp.QuoteMeta(field) + `\s*[=: ]\s*)[^",\s]+`)
+	return pattern.ReplaceAllString(body, `${1}<redacted>`)
+}
+
+func redactPrivateKeyBlock(body string) string {
+	pattern := regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----`)
+	return pattern.ReplaceAllString(body, "<redacted>")
+}
+
+func redactJupyterURLs(body string) string {
+	pattern := regexp.MustCompile(`https?://[^\s"']*(?i:token=)[^\s"']+`)
+	return pattern.ReplaceAllString(body, "<redacted>")
+}
+
+func (c *Client) ListInstanceTypes(ctx context.Context) ([]InstanceType, error) {
+	var out []InstanceType
+	err := c.do(ctx, http.MethodGet, "/instance-types", nil, &out)
+	return out, err
+}
+
+func (c *Client) ListRegions(ctx context.Context) ([]Region, error) {
+	var out []Region
+	err := c.do(ctx, http.MethodGet, "/regions", nil, &out)
+	return out, err
+}
+
+func (c *Client) ListImages(ctx context.Context) ([]Image, error) {
+	var out []Image
+	err := c.do(ctx, http.MethodGet, "/images", nil, &out)
+	return out, err
+}
+
+func (c *Client) ListInstances(ctx context.Context) ([]Instance, error) {
+	var out []Instance
+	err := c.do(ctx, http.MethodGet, "/instances", nil, &out)
+	return out, err
+}
+
+func (c *Client) GetInstance(ctx context.Context, id string) (Instance, error) {
+	var out Instance
+	err := c.do(ctx, http.MethodGet, "/instances/"+id, nil, &out)
+	return out, err
+}
+
+func (c *Client) ListSSHKeys(ctx context.Context) ([]SSHKey, error) {
+	var out []SSHKey
+	err := c.do(ctx, http.MethodGet, "/ssh-keys", nil, &out)
+	return out, err
+}
+
+func (c *Client) ListFilesystems(ctx context.Context) ([]Filesystem, error) {
+	var out []Filesystem
+	err := c.do(ctx, http.MethodGet, "/file-systems", nil, &out)
+	return out, err
+}
+
+func (c *Client) ListFirewallRulesets(ctx context.Context) ([]FirewallRuleset, error) {
+	var out []FirewallRuleset
+	err := c.do(ctx, http.MethodGet, "/firewall-rulesets", nil, &out)
+	return out, err
+}

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -133,6 +133,7 @@ func (c *Client) redact(value string) string {
 	if c.token != "" {
 		out = strings.ReplaceAll(out, c.token, "<redacted>")
 	}
+	out = redactInlineUserData(out)
 	for _, field := range []string{"token", "api_key", "user_data", "private_key", "privateKey", "jupyter_token", "jupyterToken", "jupyter_url", "jupyterUrl"} {
 		out = redactJSONishField(out, field)
 		out = redactInlineField(out, field)
@@ -149,6 +150,11 @@ func redactJSONishField(body, field string) string {
 
 func redactInlineField(body, field string) string {
 	pattern := regexp.MustCompile(`(?i)(` + regexp.QuoteMeta(field) + `\s*[=: ]\s*)[^",\s]+`)
+	return pattern.ReplaceAllString(body, `${1}<redacted>`)
+}
+
+func redactInlineUserData(body string) string {
+	pattern := regexp.MustCompile(`(?is)(\buser_data\s*[=:]\s*)(?:"(?:\\.|[^"])*"|[\s\S]*)`)
 	return pattern.ReplaceAllString(body, `${1}<redacted>`)
 }
 

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -191,10 +191,30 @@ func (c *Client) GetInstance(ctx context.Context, id string) (Instance, error) {
 	return out, err
 }
 
+func (c *Client) LaunchInstance(ctx context.Context, req LaunchInstanceRequest) (LaunchInstanceResponse, error) {
+	var out LaunchInstanceResponse
+	err := c.do(ctx, http.MethodPost, "/instance-operations/launch", req, &out)
+	return out, err
+}
+
+func (c *Client) TerminateInstances(ctx context.Context, ids []string) error {
+	return c.do(ctx, http.MethodPost, "/instance-operations/terminate", TerminateInstanceRequest{InstanceIDs: ids}, nil)
+}
+
 func (c *Client) ListSSHKeys(ctx context.Context) ([]SSHKey, error) {
 	var out []SSHKey
 	err := c.do(ctx, http.MethodGet, "/ssh-keys", nil, &out)
 	return out, err
+}
+
+func (c *Client) AddSSHKey(ctx context.Context, req AddSSHKeyRequest) (SSHKey, error) {
+	var out SSHKey
+	err := c.do(ctx, http.MethodPost, "/ssh-keys", req, &out)
+	return out, err
+}
+
+func (c *Client) DeleteSSHKey(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/ssh-keys/"+id, nil, nil)
 }
 
 func (c *Client) ListFilesystems(ctx context.Context) ([]Filesystem, error) {

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -162,9 +163,49 @@ func redactJupyterURLs(body string) string {
 }
 
 func (c *Client) ListInstanceTypes(ctx context.Context) ([]InstanceType, error) {
-	var out []InstanceType
-	err := c.do(ctx, http.MethodGet, "/instance-types", nil, &out)
-	return out, err
+	var raw json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/instance-types", nil, &raw); err != nil {
+		return nil, err
+	}
+	return decodeInstanceTypes(raw)
+}
+
+func decodeInstanceTypes(raw json.RawMessage) ([]InstanceType, error) {
+	var list []InstanceType
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return list, nil
+	}
+
+	var keyed map[string]struct {
+		InstanceType                 InstanceType `json:"instance_type"`
+		Name                         string       `json:"name,omitempty"`
+		Description                  string       `json:"description,omitempty"`
+		RegionsWithCapacityAvailable []string     `json:"regions_with_capacity_available,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &keyed); err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(keyed))
+	for key := range keyed {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]InstanceType, 0, len(keys))
+	for _, key := range keys {
+		item := keyed[key]
+		instanceType := item.InstanceType
+		if instanceType.Name == "" {
+			instanceType.Name = firstNonBlank(item.Name, key)
+		}
+		if instanceType.Description == "" {
+			instanceType.Description = item.Description
+		}
+		if len(instanceType.RegionsWithCapacityAvailable) == 0 {
+			instanceType.RegionsWithCapacityAvailable = item.RegionsWithCapacityAvailable
+		}
+		out = append(out, instanceType)
+	}
+	return out, nil
 }
 
 func (c *Client) ListRegions(ctx context.Context) ([]Region, error) {

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -41,6 +41,30 @@ func TestClientUsesBearerAndDataEnvelope(t *testing.T) {
 	}
 }
 
+func TestClientListInstanceTypesAcceptsMapEnvelope(t *testing.T) {
+	t.Setenv(tokenEnv, "lambda-secret-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/instance-types" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"data":{"gpu_1x_a10":{"instance_type":{"name":"gpu_1x_a10","description":"A10"},"regions_with_capacity_available":["us-west-1"]}}}`))
+	}))
+	defer server.Close()
+
+	client, err := newClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL + "/api/v1"
+	types, err := client.ListInstanceTypes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 || types[0].Name != "gpu_1x_a10" || types[0].Description != "A10" || len(types[0].RegionsWithCapacityAvailable) != 1 || types[0].RegionsWithCapacityAvailable[0] != "us-west-1" {
+		t.Fatalf("types=%#v", types)
+	}
+}
+
 func TestClientPreservesErrorCodeAndRedactsSecrets(t *testing.T) {
 	t.Setenv(tokenEnv, "lambda-secret-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -102,7 +102,6 @@ func TestLaunchRequestShape(t *testing.T) {
 		SSHKeyNames:         []string{"crabbox-cbx_123"},
 		ImageFamily:         "lambda-stack-24-04",
 		UserData:            "cloud-config",
-		Tags:                map[string]string{"Crabbox": "true"},
 		FirewallRulesetName: "crabbox",
 		FileSystemNames:     []string{"cache"},
 		FileSystemMounts:    []FilesystemMountRequest{{Name: "cache", MountPath: "/mnt/cache"}},
@@ -114,6 +113,15 @@ func TestLaunchRequestShape(t *testing.T) {
 	for _, key := range []string{"region_name", "instance_type_name", "quantity", "ssh_key_names", "image_family", "user_data", "firewall_ruleset_name", "file_system_names", "file_system_mounts"} {
 		if !strings.Contains(string(data), `"`+key+`"`) {
 			t.Fatalf("request missing %s: %s", key, data)
+		}
+	}
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"name", "tags"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("request should not include unsupported %s: %s", key, data)
 		}
 	}
 }

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -69,7 +69,7 @@ func TestClientPreservesErrorCodeAndRedactsSecrets(t *testing.T) {
 	t.Setenv(tokenEnv, "lambda-secret-token")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":{"code":"global/invalid-api-key","message":"token lambda-secret-token user_data=boot private_key=-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY----- jupyter_url=https://example.test/?token=abc","suggestion":"replace api_key=lambda-secret-token"}}`))
+		_, _ = w.Write([]byte(`{"error":{"code":"global/invalid-api-key","message":"token lambda-secret-token user_data=#cloud-config\nruncmd:\n- export TS_AUTHKEY=tskey-secret\nprivate_key=-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----\njupyter_url=https://example.test/?token=abc","suggestion":"replace api_key=lambda-secret-token"}}`))
 	}))
 	defer server.Close()
 
@@ -87,7 +87,7 @@ func TestClientPreservesErrorCodeAndRedactsSecrets(t *testing.T) {
 		t.Fatalf("Code=%q", apiErr.Code)
 	}
 	combined := apiErr.Error() + apiErr.Body + apiErr.Suggestion
-	for _, secret := range []string{"lambda-secret-token", "boot", "BEGIN PRIVATE KEY", "token=abc"} {
+	for _, secret := range []string{"lambda-secret-token", "cloud-config", "TS_AUTHKEY", "tskey-secret", "BEGIN PRIVATE KEY", "token=abc"} {
 		if strings.Contains(combined, secret) {
 			t.Fatalf("error leaked %q: %s", secret, combined)
 		}

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -1,0 +1,94 @@
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClientUsesBearerAndDataEnvelope(t *testing.T) {
+	t.Setenv(tokenEnv, "lambda-secret-token")
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/api/v1/regions" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"name":"us-west-1"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := newClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL + "/api/v1"
+	regions, err := client.ListRegions(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer lambda-secret-token" {
+		t.Fatalf("Authorization=%q", gotAuth)
+	}
+	if len(regions) != 1 || regions[0].Name != "us-west-1" {
+		t.Fatalf("regions=%#v", regions)
+	}
+}
+
+func TestClientPreservesErrorCodeAndRedactsSecrets(t *testing.T) {
+	t.Setenv(tokenEnv, "lambda-secret-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"global/invalid-api-key","message":"token lambda-secret-token user_data=boot private_key=-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY----- jupyter_url=https://example.test/?token=abc","suggestion":"replace api_key=lambda-secret-token"}}`))
+	}))
+	defer server.Close()
+
+	client, err := newClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	err = client.do(context.Background(), http.MethodGet, "/regions", nil, &[]Region{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err=%T %v", err, err)
+	}
+	if apiErr.Code != "global/invalid-api-key" {
+		t.Fatalf("Code=%q", apiErr.Code)
+	}
+	combined := apiErr.Error() + apiErr.Body + apiErr.Suggestion
+	for _, secret := range []string{"lambda-secret-token", "boot", "BEGIN PRIVATE KEY", "token=abc"} {
+		if strings.Contains(combined, secret) {
+			t.Fatalf("error leaked %q: %s", secret, combined)
+		}
+	}
+}
+
+func TestLaunchRequestShape(t *testing.T) {
+	req := LaunchInstanceRequest{
+		RegionName:          "us-west-1",
+		InstanceTypeName:    "gpu_1x_a10",
+		SSHKeyNames:         []string{"crabbox-cbx_123"},
+		ImageFamily:         "lambda-stack-24-04",
+		UserData:            "cloud-config",
+		Tags:                map[string]string{"Crabbox": "true"},
+		FirewallRulesetName: "crabbox",
+		FileSystemNames:     []string{"cache"},
+		FileSystemMounts:    []FilesystemMountRequest{{Name: "cache", MountPath: "/mnt/cache"}},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"region_name", "instance_type_name", "ssh_key_names", "image_family", "user_data", "firewall_ruleset_name", "file_system_names", "file_system_mounts"} {
+		if !strings.Contains(string(data), `"`+key+`"`) {
+			t.Fatalf("request missing %s: %s", key, data)
+		}
+	}
+}

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -74,6 +74,7 @@ func TestLaunchRequestShape(t *testing.T) {
 	req := LaunchInstanceRequest{
 		RegionName:          "us-west-1",
 		InstanceTypeName:    "gpu_1x_a10",
+		Quantity:            1,
 		SSHKeyNames:         []string{"crabbox-cbx_123"},
 		ImageFamily:         "lambda-stack-24-04",
 		UserData:            "cloud-config",
@@ -86,7 +87,7 @@ func TestLaunchRequestShape(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"region_name", "instance_type_name", "ssh_key_names", "image_family", "user_data", "firewall_ruleset_name", "file_system_names", "file_system_mounts"} {
+	for _, key := range []string{"region_name", "instance_type_name", "quantity", "ssh_key_names", "image_family", "user_data", "firewall_ruleset_name", "file_system_names", "file_system_mounts"} {
 		if !strings.Contains(string(data), `"`+key+`"`) {
 			t.Fatalf("request missing %s: %s", key, data)
 		}

--- a/internal/providers/lambda/cloudinit.go
+++ b/internal/providers/lambda/cloudinit.go
@@ -1,0 +1,7 @@
+package lambda
+
+import core "github.com/openclaw/crabbox/internal/cli"
+
+func lambdaUserData(cfg core.Config, publicKey string) string {
+	return core.CloudInitUserData(cfg, publicKey)
+}

--- a/internal/providers/lambda/config.go
+++ b/internal/providers/lambda/config.go
@@ -1,0 +1,87 @@
+package lambda
+
+import (
+	"os"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	providerName       = "lambda"
+	defaultAPIBaseURL  = "https://cloud.lambda.ai/api/v1"
+	defaultRegion      = "us-west-1"
+	defaultType        = "gpu_1x_a10"
+	defaultImageFamily = "lambda-stack-24-04"
+	defaultUser        = "ubuntu"
+	defaultPort        = "22"
+	tokenEnv           = "LAMBDA_API_KEY"
+)
+
+func tokenFromEnv() string {
+	return strings.TrimSpace(os.Getenv(tokenEnv))
+}
+
+func requireToken() (string, error) {
+	token := tokenFromEnv()
+	if token == "" {
+		return "", core.Exit(3, "%s is required", tokenEnv)
+	}
+	return token, nil
+}
+
+func regionForConfig(cfg core.Config) string {
+	return firstNonBlank(cfg.Lambda.Region, defaultRegion)
+}
+
+func typeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	return firstNonBlank(cfg.Lambda.Type, defaultType)
+}
+
+func imageFamilyForConfig(cfg core.Config) string {
+	if strings.TrimSpace(cfg.Lambda.Image) != "" {
+		return ""
+	}
+	return firstNonBlank(cfg.Lambda.ImageFamily, defaultImageFamily)
+}
+
+func imageForConfig(cfg core.Config) string {
+	return strings.TrimSpace(cfg.Lambda.Image)
+}
+
+func serverTypeForClass(class string) string {
+	switch strings.ToLower(strings.TrimSpace(class)) {
+	case "standard", "fast", "large", "beast":
+		return defaultType
+	default:
+		return defaultType
+	}
+}
+
+func validateConfig(cfg core.Config) error {
+	if strings.TrimSpace(regionForConfig(cfg)) == "" {
+		return core.Exit(2, "lambda region is required")
+	}
+	if strings.TrimSpace(typeForConfig(cfg)) == "" {
+		return core.Exit(2, "lambda type is required")
+	}
+	if core.OSImageWasExplicit(cfg) && strings.TrimSpace(cfg.Lambda.Image) == "" && strings.TrimSpace(cfg.Lambda.ImageFamily) == "" {
+		return core.Exit(2, "provider=lambda does not support os %q; set lambda.image, lambda.imageFamily, CRABBOX_LAMBDA_IMAGE, or CRABBOX_LAMBDA_IMAGE_FAMILY", cfg.OSImage)
+	}
+	if strings.TrimSpace(cfg.Lambda.Image) != "" && strings.TrimSpace(cfg.Lambda.ImageFamily) != "" {
+		return core.Exit(2, "lambda image and imageFamily are mutually exclusive")
+	}
+	return nil
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/providers/lambda/doctor.go
+++ b/internal/providers/lambda/doctor.go
@@ -1,0 +1,241 @@
+package lambda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type doctorClient interface {
+	ListRegions(context.Context) ([]Region, error)
+	ListInstanceTypes(context.Context) ([]InstanceType, error)
+	ListImages(context.Context) ([]Image, error)
+	ListInstances(context.Context) ([]Instance, error)
+	ListFilesystems(context.Context) ([]Filesystem, error)
+	ListFirewallRulesets(context.Context) ([]FirewallRuleset, error)
+}
+
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	if tokenFromEnv() == "" {
+		return core.DoctorResult{
+			Provider: providerName,
+			Checks: []core.DoctorCheck{{
+				Status:  "failed",
+				Check:   "auth",
+				Message: "provider=lambda class=missing_token hint=set LAMBDA_API_KEY mutation=false",
+				Details: map[string]string{"provider": providerName, "class": "missing_token", "auth": "missing", "mutation": "false"},
+			}},
+		}, nil
+	}
+	client, err := b.clientFactory(b.rt)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	return lambdaDoctor(ctx, b.cfg, client)
+}
+
+func lambdaDoctor(ctx context.Context, cfg core.Config, client doctorClient) (core.DoctorResult, error) {
+	checks := []core.DoctorCheck{}
+	add := func(status, check, class, message string, details map[string]string) {
+		if details == nil {
+			details = map[string]string{}
+		}
+		details["provider"] = providerName
+		details["class"] = class
+		details["mutation"] = "false"
+		checks = append(checks, core.DoctorCheck{Status: status, Check: check, Message: message, Details: details})
+	}
+
+	regions, err := client.ListRegions(ctx)
+	if err != nil {
+		add("failed", "auth", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	add("ok", "auth", "ready", "provider=lambda auth=ready mutation=false", map[string]string{"auth": "ready"})
+
+	region := regionForConfig(cfg)
+	if !hasRegion(regions, region) {
+		add("failed", "region", "missing_region", fmt.Sprintf("provider=lambda region=%s class=missing_region mutation=false", region), map[string]string{"region": region})
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	add("ok", "region", "ready", fmt.Sprintf("provider=lambda region=%s mutation=false", region), map[string]string{"region": region})
+
+	types, err := client.ListInstanceTypes(ctx)
+	if err != nil {
+		add("failed", "capacity", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	instanceType := typeForConfig(cfg)
+	typeItem, ok := findType(types, instanceType)
+	if !ok {
+		add("failed", "type", "missing_type", fmt.Sprintf("provider=lambda type=%s class=missing_type mutation=false", instanceType), map[string]string{"type": instanceType})
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	if !typeHasCapacity(typeItem, region) {
+		add("failed", "capacity", "insufficient_capacity", fmt.Sprintf("provider=lambda region=%s type=%s class=insufficient_capacity mutation=false", region, instanceType), map[string]string{"region": region, "type": instanceType})
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	add("ok", "capacity", "ready", fmt.Sprintf("provider=lambda region=%s type=%s mutation=false", region, instanceType), map[string]string{"region": region, "type": instanceType})
+
+	if imageForConfig(cfg) != "" || imageFamilyForConfig(cfg) != "" {
+		images, err := client.ListImages(ctx)
+		if err != nil {
+			add("failed", "image", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+			return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+		}
+		if !hasImage(images, imageForConfig(cfg), imageFamilyForConfig(cfg), region) {
+			add("failed", "image", "missing_image", fmt.Sprintf("provider=lambda image=%s image_family=%s class=missing_image mutation=false", imageForConfig(cfg), imageFamilyForConfig(cfg)), map[string]string{"image": imageForConfig(cfg), "image_family": imageFamilyForConfig(cfg)})
+			return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+		}
+		add("ok", "image", "ready", fmt.Sprintf("provider=lambda image=%s image_family=%s mutation=false", imageForConfig(cfg), imageFamilyForConfig(cfg)), map[string]string{"image": imageForConfig(cfg), "image_family": imageFamilyForConfig(cfg)})
+	}
+
+	if len(cfg.Lambda.FilesystemNames) > 0 || len(cfg.Lambda.FilesystemMounts) > 0 {
+		filesystems, err := client.ListFilesystems(ctx)
+		if err != nil {
+			add("failed", "filesystem", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+			return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+		}
+		for _, name := range requestedFilesystemNames(cfg) {
+			if !hasFilesystem(filesystems, name, region) {
+				add("failed", "filesystem", "missing_filesystem", fmt.Sprintf("provider=lambda filesystem=%s region=%s class=missing_filesystem mutation=false", name, region), map[string]string{"filesystem": name, "region": region})
+				return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+			}
+		}
+		add("ok", "filesystem", "ready", fmt.Sprintf("provider=lambda filesystems=%d mutation=false", len(requestedFilesystemNames(cfg))), map[string]string{"filesystems": fmt.Sprintf("%d", len(requestedFilesystemNames(cfg)))})
+	}
+
+	if strings.TrimSpace(cfg.Lambda.FirewallRuleset) != "" {
+		rulesets, err := client.ListFirewallRulesets(ctx)
+		if err != nil {
+			add("failed", "firewall", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+			return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+		}
+		if !hasFirewallRuleset(rulesets, cfg.Lambda.FirewallRuleset, region) {
+			add("failed", "firewall", "missing_firewall", fmt.Sprintf("provider=lambda firewall_ruleset=%s region=%s class=missing_firewall mutation=false", cfg.Lambda.FirewallRuleset, region), map[string]string{"firewall_ruleset": cfg.Lambda.FirewallRuleset, "region": region})
+			return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+		}
+		add("ok", "firewall", "ready", fmt.Sprintf("provider=lambda firewall_ruleset=%s mutation=false", cfg.Lambda.FirewallRuleset), map[string]string{"firewall_ruleset": cfg.Lambda.FirewallRuleset})
+	}
+
+	instances, err := client.ListInstances(ctx)
+	if err != nil {
+		add("failed", "inventory", classifyError(err), fmt.Sprintf("provider=lambda class=%s mutation=false %v", classifyError(err), err), nil)
+		return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+	}
+	add("ok", "inventory", "ready", fmt.Sprintf("provider=lambda inventory=ready api=list mutation=false leases=%d", len(instances)), map[string]string{"leases": fmt.Sprintf("%d", len(instances))})
+	return core.DoctorResult{Provider: providerName, Checks: checks}, nil
+}
+
+func classifyError(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Code {
+		case "global/invalid-api-key":
+			return "invalid_auth"
+		case "global/account-inactive":
+			return "account_inactive"
+		case "global/invalid-address":
+			return "invalid_billing"
+		case "global/quota-exceeded":
+			return "quota"
+		case "instance-operations/launch/insufficient-capacity":
+			return "capacity"
+		case "instance-operations/launch/file-system-in-wrong-region":
+			return "filesystem_region"
+		case "global/object-does-not-exist":
+			return "missing_resource"
+		case "global/invalid-parameters":
+			return "invalid_config"
+		default:
+			if strings.HasPrefix(apiErr.Code, "provider/") {
+				return "provider"
+			}
+		}
+	}
+	return "provider"
+}
+
+func hasRegion(regions []Region, name string) bool {
+	for _, region := range regions {
+		if region.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func findType(types []InstanceType, name string) (InstanceType, bool) {
+	for _, item := range types {
+		if item.Name == name {
+			return item, true
+		}
+	}
+	return InstanceType{}, false
+}
+
+func typeHasCapacity(item InstanceType, region string) bool {
+	for _, available := range item.RegionsWithCapacityAvailable {
+		if available == region {
+			return true
+		}
+	}
+	return false
+}
+
+func hasImage(images []Image, id, family, region string) bool {
+	for _, image := range images {
+		if id != "" && image.ID != id {
+			continue
+		}
+		if family != "" && image.Family != family {
+			continue
+		}
+		if image.Region != "" && image.Region != region {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func requestedFilesystemNames(cfg core.Config) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, name := range cfg.Lambda.FilesystemNames {
+		name = strings.TrimSpace(name)
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, mount := range cfg.Lambda.FilesystemMounts {
+		name := strings.TrimSpace(mount.Name)
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func hasFilesystem(filesystems []Filesystem, name, region string) bool {
+	for _, fs := range filesystems {
+		if fs.Name == name && (fs.Region.Name == "" || fs.Region.Name == region) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFirewallRuleset(rulesets []FirewallRuleset, name, region string) bool {
+	for _, ruleset := range rulesets {
+		if ruleset.Name == name && (ruleset.Region.Name == "" || ruleset.Region.Name == region) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/lambda/doctor_test.go
+++ b/internal/providers/lambda/doctor_test.go
@@ -1,0 +1,145 @@
+package lambda
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeDoctorClient struct {
+	regions     []Region
+	types       []InstanceType
+	images      []Image
+	instances   []Instance
+	filesystems []Filesystem
+	firewalls   []FirewallRuleset
+	err         error
+	calls       []string
+}
+
+func (f *fakeDoctorClient) ListRegions(context.Context) ([]Region, error) {
+	f.calls = append(f.calls, "regions")
+	return f.regions, f.err
+}
+func (f *fakeDoctorClient) ListInstanceTypes(context.Context) ([]InstanceType, error) {
+	f.calls = append(f.calls, "types")
+	return f.types, f.err
+}
+func (f *fakeDoctorClient) ListImages(context.Context) ([]Image, error) {
+	f.calls = append(f.calls, "images")
+	return f.images, f.err
+}
+func (f *fakeDoctorClient) ListInstances(context.Context) ([]Instance, error) {
+	f.calls = append(f.calls, "instances")
+	return f.instances, f.err
+}
+func (f *fakeDoctorClient) ListFilesystems(context.Context) ([]Filesystem, error) {
+	f.calls = append(f.calls, "filesystems")
+	return f.filesystems, f.err
+}
+func (f *fakeDoctorClient) ListFirewallRulesets(context.Context) ([]FirewallRuleset, error) {
+	f.calls = append(f.calls, "firewalls")
+	return f.firewalls, f.err
+}
+
+func TestDoctorMissingTokenDoesNotCallHTTP(t *testing.T) {
+	t.Setenv(tokenEnv, "")
+	called := false
+	b := &backend{
+		spec: Provider{}.Spec(),
+		cfg:  core.Config{Provider: providerName},
+		clientFactory: func(core.Runtime) (*Client, error) {
+			called = true
+			return nil, errors.New("should not be called")
+		},
+	}
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("clientFactory called without token")
+	}
+	if len(result.Checks) != 1 || result.Checks[0].Details["class"] != "missing_token" {
+		t.Fatalf("checks=%#v", result.Checks)
+	}
+}
+
+func TestDoctorSuccessIsReadOnly(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Lambda.Region = "us-west-1"
+	cfg.Lambda.Type = "gpu_1x_a10"
+	cfg.Lambda.ImageFamily = "lambda-stack-24-04"
+	cfg.Lambda.FirewallRuleset = "crabbox"
+	cfg.Lambda.FilesystemNames = []string{"cache"}
+	client := &fakeDoctorClient{
+		regions:     []Region{{Name: "us-west-1"}},
+		types:       []InstanceType{{Name: "gpu_1x_a10", RegionsWithCapacityAvailable: []string{"us-west-1"}}},
+		images:      []Image{{Family: "lambda-stack-24-04", Region: "us-west-1"}},
+		filesystems: []Filesystem{{Name: "cache", Region: Region{Name: "us-west-1"}}},
+		firewalls:   []FirewallRuleset{{Name: "crabbox", Region: Region{Name: "us-west-1"}}},
+		instances:   []Instance{{ID: "i-1"}},
+	}
+	result, err := lambdaDoctor(context.Background(), cfg, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Checks) == 0 {
+		t.Fatal("no checks")
+	}
+	if strings.Join(client.calls, ",") != "regions,types,images,filesystems,firewalls,instances" {
+		t.Fatalf("calls=%v", client.calls)
+	}
+	for _, check := range result.Checks {
+		if check.Details["mutation"] != "false" {
+			t.Fatalf("mutating check: %#v", check)
+		}
+		if check.Status == "failed" {
+			t.Fatalf("unexpected failed check: %#v", check)
+		}
+	}
+}
+
+func TestDoctorClassifiesAPIErrorCodes(t *testing.T) {
+	tests := map[string]string{
+		"global/invalid-api-key":                                 "invalid_auth",
+		"global/account-inactive":                                "account_inactive",
+		"global/invalid-address":                                 "invalid_billing",
+		"global/quota-exceeded":                                  "quota",
+		"instance-operations/launch/insufficient-capacity":       "capacity",
+		"instance-operations/launch/file-system-in-wrong-region": "filesystem_region",
+		"global/object-does-not-exist":                           "missing_resource",
+		"global/invalid-parameters":                              "invalid_config",
+		"provider/upstream":                                      "provider",
+	}
+	for code, want := range tests {
+		err := &APIError{Code: code}
+		if got := classifyError(err); got != want {
+			t.Fatalf("classifyError(%q)=%q want %q", code, got, want)
+		}
+	}
+}
+
+func TestDoctorDetectsCapacityGap(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Lambda.Region = "us-west-1"
+	cfg.Lambda.Type = "gpu_1x_a10"
+	cfg.Lambda.ImageFamily = ""
+	client := &fakeDoctorClient{
+		regions: []Region{{Name: "us-west-1"}},
+		types:   []InstanceType{{Name: "gpu_1x_a10", RegionsWithCapacityAvailable: []string{"us-east-1"}}},
+	}
+	result, err := lambdaDoctor(context.Background(), cfg, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	last := result.Checks[len(result.Checks)-1]
+	if last.Check != "capacity" || last.Details["class"] != "insufficient_capacity" {
+		t.Fatalf("last=%#v", last)
+	}
+}

--- a/internal/providers/lambda/doctor_test.go
+++ b/internal/providers/lambda/doctor_test.go
@@ -51,7 +51,7 @@ func TestDoctorMissingTokenDoesNotCallHTTP(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  core.Config{Provider: providerName},
-		clientFactory: func(core.Runtime) (*Client, error) {
+		clientFactory: func(core.Runtime) (lambdaAPI, error) {
 			called = true
 			return nil, errors.New("should not be called")
 		},

--- a/internal/providers/lambda/provider.go
+++ b/internal/providers/lambda/provider.go
@@ -1,0 +1,60 @@
+package lambda
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
+func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
+	return nil
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	return validateConfig(cfg)
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	return typeForConfig(cfg)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	return serverTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newClient}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newClient}, nil
+}
+
+type backend struct {
+	spec          core.ProviderSpec
+	cfg           core.Config
+	rt            core.Runtime
+	clientFactory func(core.Runtime) (*Client, error)
+}
+
+func (b *backend) Spec() core.ProviderSpec { return b.spec }

--- a/internal/providers/lambda/provider.go
+++ b/internal/providers/lambda/provider.go
@@ -1,9 +1,12 @@
 package lambda
 
 import (
+	"context"
 	"flag"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -43,18 +46,24 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
-	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newClient}, nil
+	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newLambdaAPIClient}, nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newClient}, nil
+	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newLambdaAPIClient}, nil
 }
 
 type backend struct {
+	shared.DirectSSHBackend
 	spec          core.ProviderSpec
 	cfg           core.Config
 	rt            core.Runtime
-	clientFactory func(core.Runtime) (*Client, error)
+	clientFactory func(core.Runtime) (lambdaAPI, error)
+	waitSSH       func(context.Context, *core.SSHTarget, string, time.Duration) error
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
+
+func newLambdaAPIClient(rt core.Runtime) (lambdaAPI, error) {
+	return newClient(rt)
+}

--- a/internal/providers/lambda/provider_test.go
+++ b/internal/providers/lambda/provider_test.go
@@ -1,0 +1,38 @@
+package lambda
+
+import (
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndDefaults(t *testing.T) {
+	spec := (Provider{}).Spec()
+	if spec.Name != providerName || spec.Family != providerName || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	if got := (Provider{}).ServerTypeForConfig(cfg); got != defaultType {
+		t.Fatalf("ServerTypeForConfig=%q want %q", got, defaultType)
+	}
+}
+
+func TestValidateConfigRejectsAmbiguousImage(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.Lambda.Image = "img-123"
+	cfg.Lambda.ImageFamily = "lambda-stack-24-04"
+	if err := (Provider{}).ValidateConfig(cfg); err == nil {
+		t.Fatal("ValidateConfig succeeded for image plus imageFamily")
+	}
+}

--- a/internal/providers/lambda/tags.go
+++ b/internal/providers/lambda/tags.go
@@ -1,0 +1,93 @@
+package lambda
+
+import (
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	lambdaKeyIDLabel       = "lambda_ssh_key_id"
+	lambdaKeyNameLabel     = "lambda_ssh_key_name"
+	lambdaKeyOwnedLabel    = "lambda_ssh_key_owned"
+	lambdaTouchLocalLabel  = "lambda_touch_local_only"
+	lambdaRecoveryKeyLabel = "recovery"
+)
+
+func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) map[string]string {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
+	}
+	return labels
+}
+
+func isOwnedInstance(item Instance) bool {
+	return validateLambdaLabels(item.Tags) == nil
+}
+
+func validateLambdaLabels(labels map[string]string) error {
+	if labels == nil ||
+		labels["crabbox"] != "true" ||
+		labels["created_by"] != "crabbox" ||
+		labels["provider"] != providerName ||
+		labels["lease"] == "" ||
+		labels["slug"] == "" ||
+		labels["target"] != core.TargetLinux {
+		return core.Exit(2, "refusing to operate on non-Crabbox Lambda instance")
+	}
+	return nil
+}
+
+func normalizeLambdaLabels(labels map[string]string) map[string]string {
+	out := make(map[string]string, len(labels))
+	for key, value := range labels {
+		out[strings.ToLower(strings.TrimSpace(key))] = strings.TrimSpace(value)
+	}
+	if out["provider_key"] == "" && out["lease"] != "" {
+		out["provider_key"] = providerKeyForLease(out["lease"])
+	}
+	return out
+}
+
+func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
+	if !meta.Enabled {
+		delete(labels, "tailscale_state")
+		delete(labels, "tailscale_hostname")
+		delete(labels, "tailscale_tags")
+		delete(labels, "tailscale_ipv4")
+		delete(labels, "tailscale_fqdn")
+		delete(labels, "tailscale_error")
+		delete(labels, "tailscale_exit_node")
+		delete(labels, "tailscale_exit_node_allow_lan_access")
+		return
+	}
+	labels["tailscale"] = "true"
+	if meta.State != "" {
+		labels["tailscale_state"] = meta.State
+	}
+	if meta.Hostname != "" {
+		labels["tailscale_hostname"] = meta.Hostname
+	}
+	if len(meta.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
+	}
+	if meta.IPv4 != "" {
+		labels["tailscale_ipv4"] = meta.IPv4
+	}
+	if meta.FQDN != "" {
+		labels["tailscale_fqdn"] = meta.FQDN
+	}
+	if meta.Error != "" {
+		labels["tailscale_error"] = meta.Error
+	}
+	if meta.ExitNode != "" {
+		labels["tailscale_exit_node"] = meta.ExitNode
+		labels["tailscale_exit_node_allow_lan_access"] = "false"
+		if meta.ExitNodeAllowLANAccess {
+			labels["tailscale_exit_node_allow_lan_access"] = "true"
+		}
+	}
+}

--- a/internal/providers/lambda/types.go
+++ b/internal/providers/lambda/types.go
@@ -29,14 +29,15 @@ type Image struct {
 }
 
 type Instance struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name,omitempty"`
-	Status      string   `json:"status,omitempty"`
-	Region      Region   `json:"region,omitempty"`
-	Type        string   `json:"instance_type_name,omitempty"`
-	Hostname    string   `json:"hostname,omitempty"`
-	IP          string   `json:"ip,omitempty"`
-	SSHKeyNames []string `json:"ssh_key_names,omitempty"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name,omitempty"`
+	Status      string            `json:"status,omitempty"`
+	Region      Region            `json:"region,omitempty"`
+	Type        string            `json:"instance_type_name,omitempty"`
+	Hostname    string            `json:"hostname,omitempty"`
+	IP          string            `json:"ip,omitempty"`
+	SSHKeyNames []string          `json:"ssh_key_names,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
 }
 
 type SSHKey struct {
@@ -60,6 +61,7 @@ type FirewallRuleset struct {
 type LaunchInstanceRequest struct {
 	RegionName          string                   `json:"region_name"`
 	InstanceTypeName    string                   `json:"instance_type_name"`
+	Quantity            int                      `json:"quantity"`
 	SSHKeyNames         []string                 `json:"ssh_key_names"`
 	Name                string                   `json:"name,omitempty"`
 	ImageID             string                   `json:"image_id,omitempty"`
@@ -69,6 +71,10 @@ type LaunchInstanceRequest struct {
 	FirewallRulesetName string                   `json:"firewall_ruleset_name,omitempty"`
 	FileSystemNames     []string                 `json:"file_system_names,omitempty"`
 	FileSystemMounts    []FilesystemMountRequest `json:"file_system_mounts,omitempty"`
+}
+
+type LaunchInstanceResponse struct {
+	InstanceIDs []string `json:"instance_ids"`
 }
 
 type FilesystemMountRequest struct {

--- a/internal/providers/lambda/types.go
+++ b/internal/providers/lambda/types.go
@@ -63,11 +63,9 @@ type LaunchInstanceRequest struct {
 	InstanceTypeName    string                   `json:"instance_type_name"`
 	Quantity            int                      `json:"quantity"`
 	SSHKeyNames         []string                 `json:"ssh_key_names"`
-	Name                string                   `json:"name,omitempty"`
 	ImageID             string                   `json:"image_id,omitempty"`
 	ImageFamily         string                   `json:"image_family,omitempty"`
 	UserData            string                   `json:"user_data,omitempty"`
-	Tags                map[string]string        `json:"tags,omitempty"`
 	FirewallRulesetName string                   `json:"firewall_ruleset_name,omitempty"`
 	FileSystemNames     []string                 `json:"file_system_names,omitempty"`
 	FileSystemMounts    []FilesystemMountRequest `json:"file_system_mounts,omitempty"`

--- a/internal/providers/lambda/types.go
+++ b/internal/providers/lambda/types.go
@@ -1,0 +1,94 @@
+package lambda
+
+type apiErrorEnvelope struct {
+	Error apiErrorBody `json:"error"`
+}
+
+type apiErrorBody struct {
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+type Region struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type InstanceType struct {
+	Name                         string   `json:"name"`
+	Description                  string   `json:"description,omitempty"`
+	RegionsWithCapacityAvailable []string `json:"regions_with_capacity_available,omitempty"`
+}
+
+type Image struct {
+	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
+	Family string `json:"family,omitempty"`
+	Region string `json:"region,omitempty"`
+}
+
+type Instance struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Status      string   `json:"status,omitempty"`
+	Region      Region   `json:"region,omitempty"`
+	Type        string   `json:"instance_type_name,omitempty"`
+	Hostname    string   `json:"hostname,omitempty"`
+	IP          string   `json:"ip,omitempty"`
+	SSHKeyNames []string `json:"ssh_key_names,omitempty"`
+}
+
+type SSHKey struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key,omitempty"`
+}
+
+type Filesystem struct {
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name"`
+	Region Region `json:"region,omitempty"`
+}
+
+type FirewallRuleset struct {
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name"`
+	Region Region `json:"region,omitempty"`
+}
+
+type LaunchInstanceRequest struct {
+	RegionName          string                   `json:"region_name"`
+	InstanceTypeName    string                   `json:"instance_type_name"`
+	SSHKeyNames         []string                 `json:"ssh_key_names"`
+	Name                string                   `json:"name,omitempty"`
+	ImageID             string                   `json:"image_id,omitempty"`
+	ImageFamily         string                   `json:"image_family,omitempty"`
+	UserData            string                   `json:"user_data,omitempty"`
+	Tags                map[string]string        `json:"tags,omitempty"`
+	FirewallRulesetName string                   `json:"firewall_ruleset_name,omitempty"`
+	FileSystemNames     []string                 `json:"file_system_names,omitempty"`
+	FileSystemMounts    []FilesystemMountRequest `json:"file_system_mounts,omitempty"`
+}
+
+type FilesystemMountRequest struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mount_path,omitempty"`
+}
+
+type TerminateInstanceRequest struct {
+	InstanceIDs []string `json:"instance_ids"`
+}
+
+type AddSSHKeyRequest struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+type DeleteSSHKeyRequest struct {
+	ID string `json:"id"`
+}
+
+type UpdateInstanceNameRequest struct {
+	Name string `json:"name"`
+}

--- a/scripts/live-lambda-smoke.sh
+++ b/scripts/live-lambda-smoke.sh
@@ -238,6 +238,11 @@ print(json.dumps(sorted(keys, key=lambda key: (key["name"], str(key["id"]))), se
 '
 }
 
+is_lambda_not_found_output() {
+  local output="$1"
+  [[ "$output" == *"lease/lambda not found:"* || "$output" == *"lease/lambda instance not found:"* ]]
+}
+
 local_testbox_key_snapshot() {
   local roots=(
     "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
@@ -278,7 +283,7 @@ cleanup() {
       fi
       local lower_cleanup_output
       lower_cleanup_output="$(printf '%s' "$cleanup_output" | tr '[:upper:]' '[:lower:]')"
-      if [ "$cleanup_status" -ne 4 ] || [[ "$lower_cleanup_output" != *"lease/lambda not found:"* ]]; then
+      if [ "$cleanup_status" -ne 4 ] || ! is_lambda_not_found_output "$lower_cleanup_output"; then
         if [ "$attempt" -lt "$cleanup_attempts" ]; then
           sleep "$cleanup_poll_seconds"
         fi

--- a/scripts/live-lambda-smoke.sh
+++ b/scripts/live-lambda-smoke.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-lambda}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ "$item" == "lambda" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+redact_output() {
+  LAMBDA_SMOKE_REDACT_TOKEN="${LAMBDA_API_KEY:-}" python3 -c '
+import os
+import re
+import sys
+
+body = sys.stdin.read()
+token = os.environ.get("LAMBDA_SMOKE_REDACT_TOKEN", "")
+if token:
+    body = body.replace(token, "<redacted>")
+for field in ("token", "api_key", "user_data", "private_key", "privateKey", "jupyter_token", "jupyterToken", "jupyter_url", "jupyterUrl"):
+    body = re.sub(rf"(\"{re.escape(field)}\"\s*:\s*\")[^\"]*(\")", rf"\1<redacted>\2", body, flags=re.IGNORECASE)
+    body = re.sub(rf"({re.escape(field)}\s*[=: ]\s*)[^\",\s]+", rf"\1<redacted>", body, flags=re.IGNORECASE)
+body = re.sub(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----", "<redacted>", body)
+body = re.sub(r"""https?://[^\s"]*token=[^\s"]+""", "<redacted>", body, flags=re.IGNORECASE)
+sys.stdout.write(body)
+'
+}
+
+classify_known_external_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification=""
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *billing* || "$lower" == *"invalid-address"* || "$lower" == *"invalid billing"* || "$lower" == *"account-inactive"* || "$lower" == *"account inactive"* || "$lower" == *"inactive account"* ]]; then
+    classification="billing_blocked"
+  elif [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *"account limit"* ]]; then
+    classification="quota_blocked"
+  elif [[ "$lower" == *capacity* || "$lower" == *"insufficient-capacity"* || "$lower" == *"insufficient capacity"* ]]; then
+    classification="capacity_blocked"
+  elif [[ "$lower" == *"invalid-api-key"* || "$lower" == *unauthorized* || "$lower" == *forbidden* || "$lower" == *"permission denied"* || "$lower" == *"missing_token"* ]]; then
+    classification="environment_blocked"
+  else
+    return 1
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" | redact_output >&2
+  return 0
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" | redact_output >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    if classify_known_external_blocker "$command" "$status" "$output"; then
+      exit 0
+    fi
+    classify_validation_failure "$command" "$status" "$output"
+    exit "$status"
+  fi
+  CAPTURED_OUTPUT="$(printf '%s\n' "$output" | redact_output)"
+}
+
+run_capture_validation() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$output"
+    exit "$status"
+  fi
+  CAPTURED_OUTPUT="$(printf '%s\n' "$output" | redact_output)"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels") or value.get("tags")
+        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox.slug") == slug):
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("Lambda Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+raw_lambda_has_slug() {
+  CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+import urllib.request
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+token = os.environ["LAMBDA_API_KEY"]
+url = "https://cloud.lambda.ai/api/v1/instances"
+
+try:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    data = payload.get("data", payload)
+    for item in data if isinstance(data, list) else []:
+        tags = item.get("tags") or {}
+        name = str(item.get("name", ""))
+        if tags.get("crabbox.slug") == slug or tags.get("slug") == slug or name == f"crabbox-{slug}":
+            sys.exit(0)
+except Exception:
+    sys.exit(2)
+
+sys.exit(1)
+'
+}
+
+raw_lambda_managed_key_snapshot() {
+  python3 -c '
+import json
+import os
+import sys
+import urllib.request
+
+token = os.environ["LAMBDA_API_KEY"]
+url = "https://cloud.lambda.ai/api/v1/ssh-keys"
+keys = []
+
+try:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    data = payload.get("data", payload)
+    for key in data if isinstance(data, list) else []:
+        name = str(key.get("name", ""))
+        if name.startswith("crabbox-cbx-"):
+            keys.append({
+                "id": key.get("id"),
+                "name": name,
+                "public_key": key.get("public_key"),
+            })
+except Exception:
+    sys.exit(2)
+
+print(json.dumps(sorted(keys, key=lambda key: (key["name"], str(key["id"]))), separators=(",", ":")))
+'
+}
+
+local_testbox_key_snapshot() {
+  local roots=(
+    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
+    "$HOME/Library/Application Support/crabbox/testboxes"
+  )
+  local root
+  for root in "${roots[@]}"; do
+    if [ -d "$root" ]; then
+      find "$root" -type f -print
+    fi
+  done | sort -u
+}
+
+cleanup_armed=0
+slug="lambda-smoke-$(date +%Y%m%d%H%M%S)-$$"
+config_file=""
+initial_managed_key_snapshot=""
+initial_local_key_snapshot=""
+lambda_type="${CRABBOX_LIVE_LAMBDA_TYPE:-gpu_1x_a10}"
+lambda_region="${CRABBOX_LIVE_LAMBDA_REGION:-us-west-1}"
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    local cleanup_output=""
+    local cleanup_status=1
+    local attempt
+    local cleanup_attempts=65
+    local cleanup_poll_seconds=2
+    for ((attempt = 1; attempt <= cleanup_attempts; attempt++)); do
+      set +e
+      cleanup_output="$(bin/crabbox stop --provider lambda "$slug" 2>&1)"
+      cleanup_status=$?
+      set -e
+      if [ "$cleanup_status" -eq 0 ]; then
+        cleanup_armed=0
+        break
+      fi
+      local lower_cleanup_output
+      lower_cleanup_output="$(printf '%s' "$cleanup_output" | tr '[:upper:]' '[:lower:]')"
+      if [ "$cleanup_status" -ne 4 ] || [[ "$lower_cleanup_output" != *"lease/lambda not found:"* ]]; then
+        if [ "$attempt" -lt "$cleanup_attempts" ]; then
+          sleep "$cleanup_poll_seconds"
+        fi
+        continue
+      fi
+      local slug_status=2
+      set +e
+      raw_lambda_has_slug >/dev/null 2>&1
+      slug_status=$?
+      set -e
+      if [ "$slug_status" -eq 1 ]; then
+        local current_managed_key_snapshot=""
+        local key_snapshot_status=1
+        set +e
+        current_managed_key_snapshot="$(raw_lambda_managed_key_snapshot 2>/dev/null)"
+        key_snapshot_status=$?
+        set -e
+        local current_local_key_snapshot
+        current_local_key_snapshot="$(local_testbox_key_snapshot)"
+        if [ "$key_snapshot_status" -eq 0 ] &&
+          [ "$current_managed_key_snapshot" = "$initial_managed_key_snapshot" ] &&
+          [ "$current_local_key_snapshot" = "$initial_local_key_snapshot" ]; then
+          cleanup_status=0
+          cleanup_armed=0
+          break
+        fi
+      fi
+      if [ "$attempt" -lt "$cleanup_attempts" ]; then
+        sleep "$cleanup_poll_seconds"
+      fi
+    done
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider lambda $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" | redact_output >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  if [ -n "$config_file" ]; then
+    rm -f "$config_file"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=lambda_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+if [[ -z "${LAMBDA_API_KEY:-}" ]]; then
+  printf 'classification=environment_blocked reason=LAMBDA_API_KEY_missing\n'
+  exit 0
+fi
+
+mkdir -p bin
+go build -trimpath -o bin/crabbox ./cmd/crabbox
+
+config_file="$(mktemp)"
+cat >"$config_file" <<YAML
+provider: lambda
+target: linux
+lambda:
+  region: $lambda_region
+  imageFamily: lambda-stack-24-04
+  type: $lambda_type
+YAML
+
+export CRABBOX_CONFIG="$config_file"
+export CRABBOX_COORDINATOR=
+export LAMBDA_API_KEY
+
+run_capture "bin/crabbox doctor --provider lambda" bin/crabbox doctor --provider lambda
+doctor_output="$CAPTURED_OUTPUT"
+printf '%s\n' "$doctor_output"
+run_capture "bin/crabbox list --provider lambda --json" bin/crabbox list --provider lambda --json
+initial_list_output="$CAPTURED_OUTPUT"
+validate_list_json_empty "bin/crabbox list --provider lambda --json" "$initial_list_output"
+run_capture "lambda managed SSH key snapshot" raw_lambda_managed_key_snapshot
+initial_managed_key_snapshot="$CAPTURED_OUTPUT"
+initial_local_key_snapshot="$(local_testbox_key_snapshot)"
+cleanup_armed=1
+run_capture "bin/crabbox warmup --provider lambda --slug $slug --keep --type $lambda_type --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider lambda --slug "$slug" --keep --type "$lambda_type" --ttl 20m --idle-timeout 5m
+run_capture_validation "bin/crabbox status --provider lambda --id $slug --wait --wait-timeout 600s" bin/crabbox status --provider lambda --id "$slug" --wait --wait-timeout 600s
+run_capture_validation "bin/crabbox run --provider lambda --id $slug --no-sync -- echo ok" bin/crabbox run --provider lambda --id "$slug" --no-sync -- echo ok
+run_capture_validation "bin/crabbox list --provider lambda --json" bin/crabbox list --provider lambda --json
+list_output="$CAPTURED_OUTPUT"
+printf '%s\n' "$list_output"
+validate_list_json_contains_slug "bin/crabbox list --provider lambda --json" "$list_output"
+run_capture_validation "bin/crabbox stop --provider lambda $slug" bin/crabbox stop --provider lambda "$slug"
+run_capture_validation "bin/crabbox cleanup --provider lambda --dry-run" bin/crabbox cleanup --provider lambda --dry-run
+cleanup_output="$CAPTURED_OUTPUT"
+run_capture_validation "bin/crabbox list --provider lambda --json" bin/crabbox list --provider lambda --json
+post_list_output="$CAPTURED_OUTPUT"
+validate_list_json_empty "bin/crabbox list --provider lambda --json" "$post_list_output"
+cleanup_armed=0
+printf '%s\n' "$cleanup_output"
+printf '%s\n' "$post_list_output"
+printf 'classification=live_lambda_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-lambda-smoke.test.js
+++ b/scripts/live-lambda-smoke.test.js
@@ -330,7 +330,7 @@ case "$1" in
     printf 'attempt\\n' >>"${stopAttempts}"
     attempts="$(wc -l <"${stopAttempts}" | tr -d ' ')"
     if [[ "$attempts" -lt 4 ]]; then
-      printf 'lease/lambda not found: %s\\n' "$4" >&2
+      printf 'lease/lambda instance not found: %s\\n' "$4" >&2
       exit 4
     fi
     ;;
@@ -476,7 +476,7 @@ case "$1" in
     exit 37
     ;;
   stop)
-    printf 'lease/lambda not found: %s\\n' "$4" >&2
+    printf 'lease/lambda instance not found: %s\\n' "$4" >&2
     exit 4
     ;;
   *)

--- a/scripts/live-lambda-smoke.test.js
+++ b/scripts/live-lambda-smoke.test.js
@@ -1,0 +1,588 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function writeRawInventoryPythonStub(binDir, rawStatus) {
+  const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(python, "python3 is required for smoke tests");
+  writeExecutable(
+    path.join(binDir, "python3"),
+    `#!/usr/bin/env bash
+if [[ "$*" == *"urllib.request"* && "$*" == *"/ssh-keys"* ]]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [[ "$*" == *"urllib.request"* ]]; then
+  exit ${rawStatus}
+fi
+exec ${JSON.stringify(python)} "$@"
+`,
+  );
+}
+
+function prepareSmokeRepo(dir) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, "live-lambda-smoke.sh");
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, "scripts", "live-lambda-smoke.sh"), smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}
+
+test("live lambda smoke skips unless opted in", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-skip-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: { ...process.env, CRABBOX_LIVE: "", LAMBDA_API_KEY: "" },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_LIVE_not_enabled/);
+});
+
+test("live lambda smoke skips unless provider filter selects lambda", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-filter-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "aws,digitalocean",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=lambda_not_selected/);
+});
+
+test("live lambda smoke requires token before building", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-token-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=LAMBDA_API_KEY_missing/);
+});
+
+test("live lambda smoke runs guarded lifecycle and redacts token", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${LAMBDA_API_KEY:-}" != "test-secret-token" ]]; then
+  printf 'missing token\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 runtime=unchecked default_type=gpu_1x_a10 region=us-west-1 image_family=lambda-stack-24-04 api_key=test-secret-token jupyter_url=https://example.test/?token=abc\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip instance id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_lambda_smoke_passed/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-secret-token|token=abc/);
+
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider lambda");
+  assert.equal(seen[1], "list --provider lambda --json");
+  assert.match(seen[2], /^warmup --provider lambda --slug lambda-smoke-\d{14}-\d+ --keep --type gpu_1x_a10 --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider lambda --id lambda-smoke-\d{14}-\d+ --wait --wait-timeout 600s$/);
+  assert.match(seen[4], /^run --provider lambda --id lambda-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider lambda --json");
+  assert.match(seen[6], /^stop --provider lambda lambda-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "cleanup --provider lambda --dry-run");
+  assert.equal(seen[8], "list --provider lambda --json");
+});
+
+test("live lambda smoke attempts cleanup after partial failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopped = path.join(dir, "stopped.log");
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "$1" == "doctor" ]]; then
+  printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "list" ]]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'instance-operations/launch/insufficient-capacity after partial create\\n' >&2
+  exit 37
+fi
+if [[ "$1" == "stop" ]]; then
+  printf '%s\\n' "$4" >>"${stopped}"
+  exit 0
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=capacity_blocked/);
+  assert.match(result.stderr, /insufficient-capacity after partial create/);
+  assert.match(fs.readFileSync(stopped, "utf8"), /^lambda-smoke-\d{14}-\d+\n$/);
+  assert.doesNotMatch(fs.readFileSync(calls, "utf8"), /^cleanup /m);
+});
+
+test("live lambda smoke treats post-create lifecycle failure as validation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-status-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopped = path.join(dir, "stopped.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status never became ready\\n' >&2
+    exit 42
+    ;;
+  stop)
+    printf '%s\\n' "$4" >>"${stopped}"
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /status never became ready/);
+  assert.match(fs.readFileSync(stopped, "utf8"), /^lambda-smoke-\d{14}-\d+\n$/);
+});
+
+test("live lambda smoke retries cleanup through ambiguous-create recovery", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-recovery-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopAttempts = path.join(dir, "stop-attempts.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 0);
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf 'transport closed during launch\\n' >&2
+    exit 37
+    ;;
+  stop)
+    printf 'attempt\\n' >>"${stopAttempts}"
+    attempts="$(wc -l <"${stopAttempts}" | tr -d ' ')"
+    if [[ "$attempts" -lt 4 ]]; then
+      printf 'lease/lambda not found: %s\\n' "$4" >&2
+      exit 4
+    fi
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.equal(fs.readFileSync(stopAttempts, "utf8"), "attempt\nattempt\nattempt\nattempt\n");
+  assert.doesNotMatch(result.stderr, /classification=cleanup_failed/);
+});
+
+test("live lambda smoke keeps cleanup armed until final inventory is empty", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-post-list-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  const stopAttempts = path.join(dir, "stop-attempts.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  writeRawInventoryPythonStub(binDir, 1);
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" ]]; then
+      printf '[]\\n'
+    elif [[ -f "${slugFile}.post-list-seen" ]]; then
+      printf '[]\\n'
+    elif [[ -f "${slugFile}.stopped" ]]; then
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+      touch "${slugFile}.post-list-seen"
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf 'attempt\\n' >>"${stopAttempts}"
+    touch "${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'cleanup dry run\\n'
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.equal(fs.readFileSync(stopAttempts, "utf8"), "attempt\nattempt\n");
+});
+
+test("live lambda smoke fails ambiguous cleanup when managed keys remain", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-key-leak-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const keySnapshots = path.join(dir, "key-snapshots.log");
+  fs.mkdirSync(binDir, { recursive: true });
+  const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(python, "python3 is required for smoke tests");
+  writeExecutable(
+    path.join(binDir, "python3"),
+    `#!/usr/bin/env bash
+if [[ "$*" == *"urllib.request"* && "$*" == *"/ssh-keys"* ]]; then
+  printf 'snapshot\\n' >>${JSON.stringify(keySnapshots)}
+  count="$(wc -l <${JSON.stringify(keySnapshots)} | tr -d ' ')"
+  if [[ "$count" -eq 1 ]]; then
+    printf '[]\\n'
+  else
+    printf '[{"id":"key-leaked","name":"crabbox-cbx-leaked","public_key":"ssh-ed25519 AAAA"}]\\n'
+  fi
+  exit 0
+fi
+if [[ "$*" == *"urllib.request"* ]]; then
+  exit 1
+fi
+exec ${JSON.stringify(python)} "$@"
+`,
+  );
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf 'transport closed during launch\\n' >&2
+    exit 37
+    ;;
+  stop)
+    printf 'lease/lambda not found: %s\\n' "$4" >&2
+    exit 4
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=cleanup_failed/);
+  assert.equal(fs.readFileSync(keySnapshots, "utf8").split("\n").filter(Boolean).length, 66);
+});
+
+test("live lambda smoke refuses a non-empty inventory before mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-nonempty-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[{"labels":{"slug":"existing"}}]\\n'
+    ;;
+  *)
+    printf 'mutation must not run\\n' >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "lambda",
+      LAMBDA_API_KEY: "test-secret-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /inventory is not empty/);
+  assert.deepEqual(fs.readFileSync(calls, "utf8").trim().split("\n"), [
+    "doctor --provider lambda",
+    "list --provider lambda --json",
+  ]);
+});
+
+test("live lambda smoke classifies billing and quota blockers", () => {
+  for (const [name, stderr, classification] of [
+    ["billing", "global/account-inactive invalid billing", "billing_blocked"],
+    ["quota", "global/quota-exceeded account limit", "quota_blocked"],
+  ]) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `crabbox-live-lambda-${name}-`));
+    const binDir = path.join(dir, "bin");
+    const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+    fs.mkdirSync(binDir, { recursive: true });
+    writeGoStub(
+      binDir,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "doctor" ]]; then
+  printf '%s\\n' ${JSON.stringify(stderr)} >&2
+  exit 12
+fi
+exit 99
+`,
+    );
+    const result = spawnSync("bash", [smokeScript], {
+      cwd: tempRoot,
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        CRABBOX_LIVE: "1",
+        CRABBOX_LIVE_PROVIDERS: "lambda",
+        LAMBDA_API_KEY: "test-secret-token",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stderr, new RegExp(`classification=${classification}`));
+  }
+});


### PR DESCRIPTION
Closes #336

## Summary

Adds a built-in `lambda` provider for Lambda Cloud On-Demand GPU instances.

This implements a direct Linux SSH lease provider with Lambda API auth, provider defaults/config/env overrides, non-mutating doctor checks, instance launch/resolve/list/stop/cleanup behavior, local claim-backed recovery, Tailscale cloud-init support, provider docs, generated provider metadata, and a guarded live smoke script.

## Notes

- Direct-only provider; no coordinator-side Lambda credentials.
- Live Lambda mutation remains opt-in behind `CRABBOX_LIVE=1`, `CRABBOX_LIVE_PROVIDERS=lambda`, and `LAMBDA_API_KEY`.
- No live Lambda resources were created during local verification because the live gates were not enabled.
- Lambda ownership uses local Crabbox claims as the primary durable metadata source. Complete provider-side metadata is still understood for compatibility.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm test --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `node scripts/check-docs-links.mjs`
- `bash scripts/check-docs.sh`
- `bash -n scripts/live-lambda-smoke.sh`
- `node --test scripts/live-lambda-smoke.test.js`
- `scripts/live-lambda-smoke.sh` -> `classification=environment_blocked reason=CRABBOX_LIVE_not_enabled`
- `~/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean
