### PR TITLE
feat(coordinator): add outbound runtime adapter relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@
 - Added `provider: cloudflare-dynamic-workers` for authenticated Worker-runtime module execution through Cloudflare Dynamic Workers, including blocked-by-default egress, stable caching, durable run metadata, lifecycle commands, and isolated live smoke coverage. Thanks @coygeek.
 - Added `provider: vercel-sandbox` for delegated Linux microVM runs through the official Vercel Sandbox SDK, including archive sync, streamed output, retained-session resume, ownership-guarded lifecycle operations, and guarded live smoke coverage. Thanks @coygeek.
 - Added generic Job evidence fields plus bounded Islo single-file `--require-artifact` and `--download` support, with provider capability gating and secret-safe archive upload errors. Thanks @zozo123.
+- Added owner-scoped outbound runtime-adapter relays so registered workspaces can be created and deleted through a provider-neutral lifecycle API without exposing the provider control plane, including confirmed Delete actions in the portal.
 
 ### Fixed
 
+- Hardened runtime-adapter relays with end-to-end absolute deadlines, durable generation-scoped dispatch fences retained across ambiguous connector failures, atomic owner-only legacy cleanup, rejection of unfenced proxy deletes, per-owner in-flight quotas, post-cancellation accounting, response-delivery grace, connector-matched request validation, restart-safe TTL-first live-bridge revocation, retry-safe upstream rejection handling, generation-fenced confirmed-absence acknowledgments, and cleanup-fenced workspace bindings.
 - Fixed Cloudflare Dynamic Workers lifecycle reads, compatibility identity, bundle validation, and live-smoke credential isolation.
 - Fixed Windows local-container sync to avoid unusable WSL command shims, support Docker Desktop mount roots, and fall back to native rsync when WSL lacks native SSH tooling. Thanks @brokemac79.
 - Fixed brokered Tailscale cleanup to avoid privileged deletion from client-posted device IDs, preserve connectivity across normal reboots, and fail live preflight on application-level errors.
@@ -40,7 +42,6 @@
 - Added direct SSH login helpers for kept Islo sandboxes through the official Islo CLI proxy. Thanks @zozo123.
 - Added a portable Node.js and PostgreSQL coordinator runtime with durable pg-boss maintenance jobs, WebSocket bridges, trusted reverse-proxy identity support, container packaging, and the existing Cloudflare Worker/Durable Object runtime preserved as an adapter over the same fleet implementation.
 - Added refreshable coordinator bearer authentication through a shell-free JSON argv token command, including HTTP and reconnecting WebSocket bridges behind expiring upstream identity proxies.
-
 ### Fixed
 
 - Fixed pond ACL bootstrap to preserve Tailscale HuJSON comments, ordering, trailing commas, and unrelated policy sections while failing closed on ambiguous shapes. Thanks @coygeek.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ infrastructure.
 
 ### Coordinator deployment choices
 
-| Path | State and scheduling | Best fit |
-| --- | --- | --- |
-| **Cloudflare Workers** | Fleet Durable Object, alarms, scheduled Worker trigger | Managed edge deployment with minimal server operations and optional Cloudflare Access. |
+| Path                     | State and scheduling                                          | Best fit                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Cloudflare Workers**   | Fleet Durable Object, alarms, scheduled Worker trigger        | Managed edge deployment with minimal server operations and optional Cloudflare Access.                                       |
 | **Node.js + PostgreSQL** | PostgreSQL key/value state, pg-boss alarms and reconciliation | Initial runtime for containers, a VM, or Kubernetes with one replica; requires Node.js, PostgreSQL 13+, TLS, and WebSockets. |
-| **No coordinator** | Local claims and provider-owned state | Personal/direct providers where shared credentials, history, budgets, and central cleanup are unnecessary. |
+| **No coordinator**       | Local claims and provider-owned state                         | Personal/direct providers where shared credentials, history, budgets, and central cleanup are unnecessary.                   |
 
 Both coordinator runtimes expose the same API, GitHub login, portal, provider
 adapters, cost controls, cleanup behavior, and live bridges. State is not
@@ -178,26 +178,26 @@ hardware for macOS VM workflows.
 
 ### Delegated-run providers (sandbox/proof runners, no SSH lease)
 
-| Provider and aliases | Runs on | Notes |
-| --- | --- | --- |
-| [Cloudflare](docs/providers/cloudflare.md) — `cloudflare` (`cf`) | Linux | Cloudflare Containers via the Worker runtime. |
-| [Docker Sandbox](docs/providers/docker-sandbox.md) — `docker-sandbox` | Linux | Docker Sandboxes through the standalone `sbx` CLI. |
-| [E2B](docs/providers/e2b.md) — `e2b` | Linux | E2B Firecracker sandbox. |
-| [Freestyle](docs/providers/freestyle.md) — `freestyle` | Linux | Freestyle VMs through the Freestyle REST API. |
-| [Islo](docs/providers/islo.md) — `islo` | Linux | Islo sandbox. |
-| [Modal](docs/providers/modal.md) — `modal` | Linux | Modal Sandbox through the local Python client. |
-| [Microsoft Execution Containers](docs/providers/mxc.md) — `mxc` (`execution-container`) | Windows | Policy-driven local Windows process containment. |
-| [OpenComputer](docs/providers/opencomputer.md) — `opencomputer` (`oc`, `open-computer`) | Linux | OpenComputer Linux VMs through the OpenComputer REST API. |
-| [OpenSandbox](docs/providers/opensandbox.md) — `opensandbox` | Linux | OpenSandbox delegated containers through the OpenSandbox Go SDK. |
-| [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`) | Linux | Redeploy and stream an existing Railway service. |
-| [Anthropic Sandbox Runtime](docs/providers/anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux | Local one-shot sandboxing through Anthropic's `srt` CLI. |
-| [SmolVM](docs/providers/smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`) | Linux | Smol Machines microVM sandboxes via the smolfleet API. |
-| [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`) | Linux | Tensorlake Firecracker sandbox via the Tensorlake CLI. |
-| [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`) | Linux | Upstash Box through the Box REST API. |
-| [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions` | Linux | Azure Container Apps dynamic sessions. |
-| [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`) | Linux | Delegated Blacksmith CI Testbox lifecycle and execution. |
-| [W&B Sandboxes](docs/providers/wandb.md) — `wandb` (`weights-and-biases`) | Linux | Weights & Biases Sandboxes; reuses `wandb login` credentials. |
-| [Windows Sandbox](docs/providers/windows-sandbox.md) — `windows-sandbox` (`wsb`, `windows-sandbox-provider`) | Windows | Disposable Microsoft Windows Sandbox sessions through generated `.wsb` configs. |
+| Provider and aliases                                                                                           | Runs on      | Notes                                                                           |
+| -------------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------- |
+| [Cloudflare](docs/providers/cloudflare.md) — `cloudflare` (`cf`)                                               | Linux        | Cloudflare Containers via the Worker runtime.                                   |
+| [Docker Sandbox](docs/providers/docker-sandbox.md) — `docker-sandbox`                                          | Linux        | Docker Sandboxes through the standalone `sbx` CLI.                              |
+| [E2B](docs/providers/e2b.md) — `e2b`                                                                           | Linux        | E2B Firecracker sandbox.                                                        |
+| [Freestyle](docs/providers/freestyle.md) — `freestyle`                                                         | Linux        | Freestyle VMs through the Freestyle REST API.                                   |
+| [Islo](docs/providers/islo.md) — `islo`                                                                        | Linux        | Islo sandbox.                                                                   |
+| [Modal](docs/providers/modal.md) — `modal`                                                                     | Linux        | Modal Sandbox through the local Python client.                                  |
+| [Microsoft Execution Containers](docs/providers/mxc.md) — `mxc` (`execution-container`)                        | Windows      | Policy-driven local Windows process containment.                                |
+| [OpenComputer](docs/providers/opencomputer.md) — `opencomputer` (`oc`, `open-computer`)                        | Linux        | OpenComputer Linux VMs through the OpenComputer REST API.                       |
+| [OpenSandbox](docs/providers/opensandbox.md) — `opensandbox`                                                   | Linux        | OpenSandbox delegated containers through the OpenSandbox Go SDK.                |
+| [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`)                                        | Linux        | Redeploy and stream an existing Railway service.                                |
+| [Anthropic Sandbox Runtime](docs/providers/anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux | Local one-shot sandboxing through Anthropic's `srt` CLI.                        |
+| [SmolVM](docs/providers/smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`)                            | Linux        | Smol Machines microVM sandboxes via the smolfleet API.                          |
+| [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`)                             | Linux        | Tensorlake Firecracker sandbox via the Tensorlake CLI.                          |
+| [Upstash Box](docs/providers/upstash-box.md) — `upstash-box` (`upstash`, `box`, `upstashbox`)                  | Linux        | Upstash Box through the Box REST API.                                           |
+| [Azure Dynamic Sessions](docs/providers/azure-dynamic-sessions.md) — `azure-dynamic-sessions`                  | Linux        | Azure Container Apps dynamic sessions.                                          |
+| [Blacksmith Testbox](docs/providers/blacksmith-testbox.md) — `blacksmith-testbox` (`blacksmith`)               | Linux        | Delegated Blacksmith CI Testbox lifecycle and execution.                        |
+| [W&B Sandboxes](docs/providers/wandb.md) — `wandb` (`weights-and-biases`)                                      | Linux        | Weights & Biases Sandboxes; reuses `wandb login` credentials.                   |
+| [Windows Sandbox](docs/providers/windows-sandbox.md) — `windows-sandbox` (`wsb`, `windows-sandbox-provider`)   | Windows      | Disposable Microsoft Windows Sandbox sessions through generated `.wsb` configs. |
 
 See [Providers](docs/providers/README.md) for the full reference, capabilities,
 and authoring guide.
@@ -271,6 +271,7 @@ and authoring guide.
   verification, and service-token support keep normal use and operator
   automation separate. See [Auth and admin](docs/features/auth-admin.md) and
   [Security](docs/security.md).
+
 ## Machine classes
 
 `beast` is the default for providers that expose class-based managed capacity.
@@ -373,8 +374,9 @@ Set `broker.mode: registered` to keep provisioning and cleanup in any direct
 provider while registering lease metadata with the coordinator for inventory,
 sharing, and portal WebVNC. Kept desktop leases start the outbound WebVNC bridge
 automatically by default; set `broker.autoWebVNC: false` to opt out. The
-coordinator never receives provider credentials or deletes registered
-resources.
+coordinator never receives provider credentials or directly calls a registered
+provider. By default it removes only registration metadata; an explicitly
+bound outbound runtime adapter can perform a user-confirmed workspace delete.
 
 Forwarded environment is intentionally narrow: `NODE_OPTIONS` and `CI`. Do not
 pass secrets as command-line arguments. For live-secret smoke tests, use

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ language runtimes, dependencies, services, and secrets through its own setup,
 [Actions hydration](features/actions-hydration.md), devcontainer, Nix/mise/asdf
 config, or shell scripts.
 
-The architecture separates the *control plane* from *command execution*. The
+The architecture separates the _control plane_ from _command execution_. The
 broker serializes lease and provider state, while the CLI keeps SSH keys local
 and streams command I/O directly between the developer machine and the leased
 box. That keeps provider credentials out of the box, keeps user secrets out of
@@ -52,7 +52,7 @@ The CLI picks one of four modes per provider in `loadBackend`
 (`internal/cli/provider_backend.go`):
 
 - **Brokered (coordinator) mode** — chosen when the provider declares
-  `Coordinator: supported` *and* a broker URL is configured
+  `Coordinator: supported` _and_ a broker URL is configured
   (`CRABBOX_COORDINATOR` or `config set-broker`). The provider's SSH backend is
   wrapped in a `coordinatorLeaseBackend`: lease lifecycle goes through the
   coordinator over HTTPS, but the CLI still drives SSH, rsync, and command execution
@@ -65,9 +65,10 @@ The CLI picks one of four modes per provider in `loadBackend`
   `parallels`, `proxmox`, `daytona`, `runpod`, and so on) always runs here.
 - **Registered direct mode** — `broker.mode: registered` keeps the same direct
   SSH provider lifecycle but registers lease metadata and heartbeats with the
-  coordinator. It can list and share portal bridges, but cannot call the
-  provider, delete the resource, charge it to managed usage, or place it in a
-  ready pool.
+  coordinator. It can list and share portal bridges, but cannot directly call
+  the provider, charge the resource to managed usage, or place it in a ready
+  pool. By default release removes only metadata; an explicitly bound outbound
+  runtime adapter can perform a user-confirmed workspace delete.
 - **Delegated mode** — the provider implements a delegated-run backend (e.g.
   `e2b`, `modal`, `cloudflare`, `azure-dynamic-sessions`). The provider owns
   sync and execution end to end; the CLI calls `Warmup`/`Run` and never performs
@@ -164,10 +165,10 @@ One logical `FleetCoordinator` (`worker/src/fleet.ts`) owns:
 
 Runtime-specific persistence and scheduling stay behind `CoordinatorRuntime`:
 
-| Runtime | Durable state | Scheduling | WebSockets |
-| --- | --- | --- | --- |
-| Cloudflare | Durable Object storage | DO alarms plus scheduled Worker reconciliation | Hibernating WebSockets |
-| Node.js | PostgreSQL `crabbox` schema | pg-boss `crabbox_jobs` schema | In-process `ws`; reconnect after restart |
+| Runtime    | Durable state               | Scheduling                                     | WebSockets                               |
+| ---------- | --------------------------- | ---------------------------------------------- | ---------------------------------------- |
+| Cloudflare | Durable Object storage      | DO alarms plus scheduled Worker reconciliation | Hibernating WebSockets                   |
+| Node.js    | PostgreSQL `crabbox` schema | pg-boss `crabbox_jobs` schema                  | In-process `ws`; reconnect after restart |
 
 The Node runtime currently requires one service replica because lifecycle
 serialization and live bridge ownership are process-local. PostgreSQL and
@@ -285,7 +286,7 @@ Git, rsync, curl, jq, and a writable work root (default `/work/crabbox` on
 Linux, `C:\crabbox` on Windows, `/Users/<user>/crabbox` on macOS). Readiness is
 signaled by the `crabbox-ready` marker.
 
-Language runtimes, Docker, services, dependencies, and secrets are *project*
+Language runtimes, Docker, services, dependencies, and secrets are _project_
 setup, not base bootstrap. Use [Actions hydration](features/actions-hydration.md),
 devcontainers, Nix, mise/asdf, or repository scripts for that layer. Prefer
 provider snapshots/images once bootstrap is proven; cloud-init is fine for a
@@ -312,18 +313,18 @@ credential chain.
 
 ## Defaults
 
-| Setting | Default |
-| --- | --- |
-| Lease ID format | `cbx_<12 hex>` |
-| User token prefix | `cbxu_` |
-| TTL | 5400 s (capped at 86400 s) |
-| Idle timeout | 1800 s |
-| SSH port | 2222, fallback 22 |
-| Machine class | `beast` |
-| Work root | `/work/crabbox` (Linux) |
-| Run log | 64 KiB chunks, 8 MiB stored cap |
-| Cleanup retry | 5 min |
-| Bridge ticket TTL | 120 s |
+| Setting           | Default                         |
+| ----------------- | ------------------------------- |
+| Lease ID format   | `cbx_<12 hex>`                  |
+| User token prefix | `cbxu_`                         |
+| TTL               | 5400 s (capped at 86400 s)      |
+| Idle timeout      | 1800 s                          |
+| SSH port          | 2222, fallback 22               |
+| Machine class     | `beast`                         |
+| Work root         | `/work/crabbox` (Linux)         |
+| Run log           | 64 KiB chunks, 8 MiB stored cap |
+| Cleanup retry     | 5 min                           |
+| Bridge ticket TTL | 120 s                           |
 
 ## Failure Model
 
@@ -339,12 +340,12 @@ retry. Therefore:
 
 ## Source of Truth
 
-| Concern | Files |
-| --- | --- |
-| CLI command tree and flags | `internal/cli/cli_kong.go`, `internal/cli/app.go` |
-| Backend selection / modes | `internal/cli/provider_backend.go` |
-| Broker client | `internal/cli/coordinator.go`, `provider_coordinator.go` |
-| Run / sync / lease | `internal/cli/run.go`, `lease.go` |
-| Coordinator entry / auth | `worker/src/coordinator-entry.ts`, `worker/src/index.ts`, `worker/node/server.ts`, `worker/src/auth.ts` |
-| Fleet state / endpoints | `worker/src/fleet.ts`, `types.ts`, `config.ts`, `usage.ts` |
-| Runtime adapters | `worker/src/coordinator-runtime.ts`, `worker/node/node-runtime.ts`, `worker/node/postgres-storage.ts` |
+| Concern                    | Files                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| CLI command tree and flags | `internal/cli/cli_kong.go`, `internal/cli/app.go`                                                       |
+| Backend selection / modes  | `internal/cli/provider_backend.go`                                                                      |
+| Broker client              | `internal/cli/coordinator.go`, `provider_coordinator.go`                                                |
+| Run / sync / lease         | `internal/cli/run.go`, `lease.go`                                                                       |
+| Coordinator entry / auth   | `worker/src/coordinator-entry.ts`, `worker/src/index.ts`, `worker/node/server.ts`, `worker/src/auth.ts` |
+| Fleet state / endpoints    | `worker/src/fleet.ts`, `types.ts`, `config.ts`, `usage.ts`                                              |
+| Runtime adapters           | `worker/src/coordinator-runtime.ts`, `worker/node/node-runtime.ts`, `worker/node/postgres-storage.ts`   |

--- a/docs/commands/adapter.md
+++ b/docs/commands/adapter.md
@@ -50,12 +50,24 @@ Set `--id` to the same stable DNS-style ID used by
 [`crabbox adapter connect`](#outbound-connection) when the adapter is connected
 outbound to a coordinator. Child lifecycle commands then register both that
 adapter ID and the exact workspace ID with the coordinator. The portal can send
-Delete through the live relay and removes the registration only after the
-adapter confirms stable provider absence and completes matching local-state
-cleanup. Registration must return that exact adapter/workspace binding before
-the workspace can become ready; a failed or mismatched registration instead
-enters exact-identity provider cleanup. Without `--id`, registered leases retain
-the metadata-only removal behavior.
+Delete through the live relay. After the adapter proves stable provider absence,
+it sends an owner-scoped completion for that exact pending adapter/workspace
+registration generation before completing matching local-state cleanup. Each
+local claim persists a fresh registration ID; the coordinator retains it across
+refreshes and rejects stale completion retries after a later generation becomes
+active. If the coordinator record expires while the provider workspace remains
+live, the CLI rotates the persisted ID only after that explicit stale-generation
+rejection and retries registration. The old acknowledged ID remains durable
+beside the pending replacement until the replacement succeeds; confirmed-absence
+cleanup can safely try both after a crash or lost response. A workspace that
+never persisted a registration ID uses the legacy metadata-release cleanup path
+only after the coordinator confirms that its exact adapter/workspace binding
+also has no registration generation. Missing or malformed generation-aware
+claim state fails closed.
+Registration must return that exact adapter/workspace/registration
+binding before the workspace can become ready; a failed or mismatched
+registration instead enters exact-identity provider cleanup. Without `--id`,
+registered leases retain the metadata-only removal behavior.
 
 Validate a copied state file before an upgrade without locking, rewriting,
 reconciling, or running provider commands:
@@ -113,7 +125,8 @@ The relay accepts only typed JSON requests:
   "type": "request",
   "id": "request-1",
   "method": "DELETE",
-  "path": "/v1/workspaces/fleet-a-is-101"
+  "path": "/v1/workspaces/fleet-a-is-101",
+  "deadlineMs": 4102444800000
 }
 ```
 
@@ -126,11 +139,17 @@ Allowed operations are exactly:
 
 There is no arbitrary URL, shell, argv, environment, file, or provider-command
 surface. Request and response bodies are UTF-8 strings bounded to 64 KiB.
-Ordinary local requests time out after nine seconds. Desktop connection setup
+Only workspace creation accepts a non-empty request body. Ordinary local
+requests time out after nine seconds, and the coordinator allows five more
+seconds for response delivery. Every frame carries that absolute Unix
+millisecond deadline; the connector rejects expired frames before local
+dispatch and caps the local request context to the earlier of that deadline or
+its own timeout. Desktop connection setup
 gets the configured `--connection-timeout` plus 30 seconds of relay overhead,
-covering the adapter's matching setup budget without imposing a shorter relay
-deadline. Set it to the same value as `adapter serve --connection-timeout` when
-overriding the default. Responses contain only the request ID, HTTP status,
+and the connector negotiates that deadline plus five seconds of response grace
+with the coordinator. The setup value may not exceed 24 hours. Set it to the
+same value as `adapter serve --connection-timeout` when overriding the default.
+Responses contain only the request ID, HTTP status,
 optional content type, and exact bounded body:
 
 ```json
@@ -145,8 +164,12 @@ optional content type, and exact bounded body:
 
 The connector dispatches up to 64 ordinary requests concurrently and keeps a
 separate bounded lane for deletes, so a slow desktop setup cannot block its
-cancellation. WebSocket responses are serialized, and disconnecting the relay
-cancels every in-flight local request.
+cancellation. The coordinator also applies per-adapter, per-owner, and global
+in-flight limits; work already sent upstream remains counted after its caller
+disconnects until the response or deadline. A durable generation-scoped
+dispatch fence prevents confirmed absence from freeing and reusing a binding
+while an earlier delete can still reach the adapter. WebSocket responses are
+serialized, and disconnecting the relay cancels every in-flight local request.
 
 Flags:
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -27,8 +27,10 @@ cleanup remain in the direct adapter, while the CLI idempotently registers an
 owner-scoped lease record with the coordinator. This enables portal inventory,
 sharing, and outbound WebVNC for external, KubeVirt, static SSH, local, and other
 direct SSH providers without giving the coordinator provider credentials.
-Coordinator release and expiry remove only the registration; they never delete
-the provider resource. Registered records are excluded from provider access
+By default coordinator release and expiry remove only the registration. A
+registered lease can instead bind an outbound runtime adapter and workspace ID;
+the portal then confirms provider deletion through that adapter before removing
+the registration. Registered records remain excluded from provider access
 reconciliation, ready pools, image operations, orphan sweeps, and cost totals.
 
 The coordinator brokers the **control plane**, not the data plane. Lease
@@ -124,6 +126,10 @@ POST   /v1/artifacts/uploads
 GET    /v1/runners
 POST   /v1/runners/sync
 GET    /v1/usage
+POST   /v1/adapters/{adapter-id}/ticket
+GET    /v1/adapters/{adapter-id}
+GET    /v1/adapters/{adapter-id}/agent    (websocket; one-time ticket auth)
+*      /v1/adapters/{adapter-id}/proxy/v1/workspaces/...
 ```
 
 Registration accepts generic provider and SSH metadata. Repeating the same
@@ -131,6 +137,51 @@ owner/org/id/provider tuple refreshes it and reactivates an expired record.
 Changing provider, claiming another owner's ID, or replacing a managed record
 returns `409`. The CLI treats registration as best effort, but an authenticated
 WebVNC/share operation still requires the record to exist.
+
+Runtime adapters connect outbound to `/agent`, so their local lifecycle service
+does not need an inbound public route. The coordinator issues a short-lived,
+single-use ticket after normal owner authentication. The first ticket safely
+claims the adapter ID for that owner and organization; lease registration
+rejects unclaimed IDs and claims owned by another identity. The relay permits
+only the versioned workspace create, inspect, delete, and desktop-connection
+methods. Public proxy `DELETE` requests are rejected; destructive dispatch must
+go through a registered lease release so the coordinator can fence its immutable
+registration generation. Relay bodies are valid UTF-8 and bounded to 64 KiB. Lifecycle responses
+have a nine-second local deadline plus five seconds for relay delivery; desktop
+setup has a 150-second window. The absolute deadline travels with every frame,
+so work delayed in WebSocket buffers is rejected before local dispatch. Only
+workspace creation accepts a non-empty request body. Per-adapter, per-owner,
+and global in-flight limits isolate relay capacity. A lease reaching its TTL
+loses coordinator-mediated access immediately, including closure of existing
+WebVNC, code, and egress bridge sockets, while any pending external delete
+continues retrying as cleanup.
+The adapter/workspace binding remains reserved until that cleanup finishes.
+Generic and administrative lease release cannot clear a pending adapter delete;
+only an owner-scoped confirmed-absence completion for the exact adapter,
+workspace, and immutable registration generation can finalize it. The generation
+is refreshed whenever a terminal registration is reactivated, so a delayed
+completion from the previous workspace lifecycle cannot release the new one.
+Client claims retain an acknowledged generation and any pending replacement
+separately until registration succeeds, making both registration and later
+confirmed-absence cleanup recoverable across request loss or process failure.
+If that local generation state is missing, the CLI permits legacy release only
+through an atomic owner-scoped completion that requires the exact adapter and
+workspace binding to have no registration generation.
+Once a delete reaches the adapter, authentication failures and other generic
+upstream rejections remain retryable; only an explicit confirmed-absence result
+for the matching generation ends cleanup. Adapter `404` and terminal-looking
+relay responses alone never release the coordinator binding.
+Already-dispatched work remains charged to relay quotas if its caller
+disconnects. A durable dispatch fence also keeps that generation reserved until
+each selected delete succeeds or its absolute relay deadline expires; connector
+timeouts and transport failures cannot clear it early. Only the
+idempotency key and response content type cross the relay. Provider credentials
+and arbitrary callback URLs are never stored in lease records.
+
+The agent upgrade carries its single-use ticket only as an
+`Authorization: Bearer ...` header. Adapter-agent routes bypass end-user
+authentication at the coordinator, and tickets are not accepted in URLs or
+proxy-specific headers.
 
 Bridge ticket and websocket routes (WebVNC, code-server, egress) live under
 `/v1/leases/{id-or-slug}/{webvnc|code|egress}/...`; see

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -23,7 +23,7 @@ GET  /portal                                    lease / runner / host index
 GET  /portal/leases/{id-or-slug}                lease detail
 GET  /portal/leases/{id-or-slug}/share          share page
 POST /portal/leases/{id-or-slug}/share          add/remove user, set org, clear
-POST /portal/leases/{id-or-slug}/release        stop managed lease / remove registration
+POST /portal/leases/{id-or-slug}/release        stop, delete via adapter, or remove registration
 GET  /portal/leases/{id-or-slug}/vnc            WebVNC viewer page
 GET  /portal/leases/{id-or-slug}/code/...       code-server bridge (HTTP/WS proxy)
 GET  /portal/runs/{run-id}                       run detail
@@ -91,8 +91,10 @@ kinds:
   state pills, the lease class, icon-only access capabilities (SSH, VNC,
   code, browser), relative time cells, and a confirmed lifecycle action for
   sessions with manage access. The action stops and deletes the backing machine
-  for coordinator-managed leases; registered leases instead show **remove
-  registration** and warn that the external machine keeps running.
+  for coordinator-managed leases. Runtime-adapter-managed registrations show
+  **delete workspace** and permanently delete through that adapter; other
+  registered leases show **remove registration** and warn that the external
+  machine keeps running.
 - **External runners** — visibility-only rows for Blacksmith Testboxes synced
   from `crabbox list` output. They render as muted, disabled rows with status
   badges, inferred GitHub Actions run/workflow links, `stuck` markers for
@@ -129,9 +131,10 @@ The lease detail page shows:
   `crabbox run`, the WebVNC bridge, the code bridge, and (when egress is
   active) `crabbox egress status` / `crabbox egress stop`;
 - a viewport-fitted "recent runs" grid with state filters;
-- a stop button for coordinator-managed leases, or a metadata-only remove
-  registration button for client-managed leases, when the session can manage
-  the lease.
+- a stop button for coordinator-managed leases, a destructive delete-workspace
+  button for runtime-adapter-managed registrations, or a metadata-only remove
+  registration button for other client-managed leases, when the session can
+  manage the lease.
 
 Owners and users with `manage` access see a share control in the lease
 header. The share page (`/share`) adds or removes individual users, sets
@@ -139,6 +142,8 @@ org-wide access (`use`, `manage`, or off), or clears sharing entirely; it can
 also render embedded (`?embed=1`) inside the VNC viewer's share dialog. A
 `use` share can open visible lease pages and portal bridges; a `manage` share
 can also change sharing and use the matching stop or deregistration action.
+For adapter-managed registrations, that matching action deletes the external
+workspace rather than only removing coordinator metadata.
 
 `/portal/leases/{id-or-slug}/vnc` and `/portal/leases/{id-or-slug}/code/` are
 not ordinary pages. VNC opens a noVNC viewer that talks to the lease's desktop

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -50,12 +50,12 @@ CLIs and coordinators still interoperate.
 
 ## Ownership
 
-| Layer | Owns |
-|:------|:-----|
-| **CLI** | config + flags; per-lease SSH key; SSH readiness; Git seeding + rsync; sync fingerprints and sanity checks; remote command + streaming; the control WebSocket when available, with HTTP fallback; release |
-| **Broker** | request auth + identity; serialized lease state; provider credentials; machine create/delete; lease expiry; pool/status/inspect; run records, logs, events, telemetry; usage; spend caps |
-| **Provider** | raw compute: the per-provider adapter creates and deletes hosts (Hetzner servers, AWS EC2 instances, Azure VMs, GCP instances, and others) |
-| **Runner** | nothing durable on a brokered box: Linux is prepared with SSH, Git, rsync, and a work root; non-Linux targets get provider-specific bootstrap; static targets are existing SSH hosts; project runtimes come from repo-owned setup |
+| Layer        | Owns                                                                                                                                                                                                                              |
+| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CLI**      | config + flags; per-lease SSH key; SSH readiness; Git seeding + rsync; sync fingerprints and sanity checks; remote command + streaming; the control WebSocket when available, with HTTP fallback; release                         |
+| **Broker**   | request auth + identity; serialized lease state; provider credentials; machine create/delete; lease expiry; pool/status/inspect; run records, logs, events, telemetry; usage; spend caps                                          |
+| **Provider** | raw compute: the per-provider adapter creates and deletes hosts (Hetzner servers, AWS EC2 instances, Azure VMs, GCP instances, and others)                                                                                        |
+| **Runner**   | nothing durable on a brokered box: Linux is prepared with SSH, Git, rsync, and a work root; non-Linux targets get provider-specific bootstrap; static targets are existing SSH hosts; project runtimes come from repo-owned setup |
 
 ## What `crabbox run` does
 
@@ -141,8 +141,10 @@ the rest of the provider set).
 With `broker.mode: registered`, the provider path stays direct but the CLI
 mirrors owner-scoped lease metadata and heartbeats to the coordinator. That adds
 portal inventory, opt-in sharing, and outbound WebVNC without moving provider
-credentials or cleanup authority into the broker. Registered records do not
-count toward managed provider quotas, costs, images, pools, or maintenance.
+credentials or direct provider cleanup authority into the broker. Release
+removes only metadata by default; an explicitly bound outbound runtime adapter
+can perform a user-confirmed workspace delete. Registered records do not count
+toward managed provider quotas, costs, images, pools, or maintenance.
 
 Static SSH targets (`provider: ssh`) point at a preexisting machine and bypass
 the broker even when a broker URL exists in config. macOS and Windows WSL2

--- a/internal/cli/adapter_connect.go
+++ b/internal/cli/adapter_connect.go
@@ -23,6 +23,7 @@ const (
 	adapterRelayRequestTimeout        = 9 * time.Second
 	adapterRelayHandshakeTimeout      = 10 * time.Second
 	adapterRelayDefaultConnectionTime = 2 * time.Minute
+	adapterRelayMaxConnectionTime     = 24 * time.Hour
 	adapterRelayConnectionOverhead    = 30 * time.Second
 	adapterRelayWriteTimeout          = 5 * time.Second
 	adapterRelayMinBackoff            = 250 * time.Millisecond
@@ -38,12 +39,13 @@ type coordinatorAdapterTicket struct {
 }
 
 type adapterRelayRequest struct {
-	Type    string            `json:"type"`
-	ID      string            `json:"id"`
-	Method  string            `json:"method"`
-	Path    string            `json:"path"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    *string           `json:"body,omitempty"`
+	Type       string            `json:"type"`
+	ID         string            `json:"id"`
+	Method     string            `json:"method"`
+	Path       string            `json:"path"`
+	DeadlineMS int64             `json:"deadlineMs"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Body       *string           `json:"body,omitempty"`
 }
 
 type adapterRelayResponse struct {
@@ -87,6 +89,9 @@ func (a App) adapterConnect(ctx context.Context, args []string) error {
 	}
 	if *connectionTimeout <= 0 {
 		return exit(2, "--connection-timeout must be greater than zero")
+	}
+	if *connectionTimeout > adapterRelayMaxConnectionTime {
+		return exit(2, "--connection-timeout must not exceed %s", adapterRelayMaxConnectionTime)
 	}
 	desktopRequestTimeout := *connectionTimeout + adapterRelayConnectionOverhead
 	if desktopRequestTimeout <= *connectionTimeout {
@@ -197,7 +202,11 @@ func connectAdapterRelay(
 ) error {
 	dialCtx, cancelDial := context.WithTimeout(ctx, adapterRelayHandshakeTimeout)
 	defer cancelDial()
-	ticket, err := coord.CreateAdapterTicket(dialCtx, adapterID)
+	coordinatorDesktopTimeout := desktopRequestTimeout + adapterRelayWriteTimeout
+	if coordinatorDesktopTimeout <= desktopRequestTimeout {
+		return errors.New("adapter relay desktop timeout is too large")
+	}
+	ticket, err := coord.CreateAdapterTicket(dialCtx, adapterID, coordinatorDesktopTimeout)
 	if err != nil {
 		return fmt.Errorf("create adapter ticket: %w", err)
 	}
@@ -234,9 +243,11 @@ func connectAdapterRelay(
 	return relay.serve(ctx)
 }
 
-func (c *CoordinatorClient) CreateAdapterTicket(ctx context.Context, adapterID string) (coordinatorAdapterTicket, error) {
+func (c *CoordinatorClient) CreateAdapterTicket(ctx context.Context, adapterID string, desktopTimeout time.Duration) (coordinatorAdapterTicket, error) {
 	var result coordinatorAdapterTicket
-	err := c.do(ctx, http.MethodPost, "/v1/adapters/"+url.PathEscape(adapterID)+"/ticket", map[string]any{}, &result)
+	err := c.do(ctx, http.MethodPost, "/v1/adapters/"+url.PathEscape(adapterID)+"/ticket", map[string]any{
+		"desktopTimeoutMs": desktopTimeout.Milliseconds(),
+	}, &result)
 	return result, err
 }
 
@@ -339,12 +350,18 @@ func (r *adapterRelay) handle(ctx context.Context, request adapterRelayRequest) 
 	if err := validateAdapterRelayRequest(request); err != nil {
 		return adapterRelayErrorResponse(request.ID, http.StatusBadRequest, "invalid_request", err.Error())
 	}
+	deadline := time.UnixMilli(request.DeadlineMS)
+	if !deadline.After(time.Now()) {
+		return adapterRelayErrorResponse(request.ID, http.StatusGatewayTimeout, "adapter_timeout", "adapter relay request expired before local dispatch")
+	}
 	body := []byte(nil)
 	if request.Body != nil {
 		body = []byte(*request.Body)
 	}
-	requestCtx, cancel := context.WithTimeout(ctx, adapterRelayTimeoutForRequest(request, r.desktopTimeout))
-	defer cancel()
+	deadlineCtx, cancelDeadline := context.WithDeadline(ctx, deadline)
+	defer cancelDeadline()
+	requestCtx, cancelTimeout := context.WithTimeout(deadlineCtx, adapterRelayTimeoutForRequest(request, r.desktopTimeout))
+	defer cancelTimeout()
 	localPath, ok := adapterRelayCanonicalPath(request.Method, request.Path)
 	if !ok {
 		return adapterRelayErrorResponse(request.ID, http.StatusBadRequest, "invalid_request", "method and path are outside the crabfleet/v1 adapter surface")
@@ -371,6 +388,9 @@ func (r *adapterRelay) handle(ctx context.Context, request adapterRelayRequest) 
 	localRequest.Header.Set("Accept", "application/json")
 	if request.Method == http.MethodPost && request.Path == "/v1/workspaces" && localRequest.Header.Get("Content-Type") == "" {
 		localRequest.Header.Set("Content-Type", "application/json")
+	}
+	if requestCtx.Err() != nil {
+		return adapterRelayErrorResponse(request.ID, http.StatusGatewayTimeout, "adapter_timeout", "adapter relay request expired before local dispatch")
 	}
 
 	localResponse, err := r.client.Do(localRequest)
@@ -413,6 +433,9 @@ func validateAdapterRelayRequest(request adapterRelayRequest) error {
 	}
 	if !validAdapterRelayRequestID(request.ID) {
 		return errors.New("id must be 1 to 128 printable characters")
+	}
+	if request.DeadlineMS <= 0 {
+		return errors.New("deadlineMs must be a positive Unix millisecond timestamp")
 	}
 	if request.Method != strings.ToUpper(request.Method) || !adapterRelayRouteAllowed(request.Method, request.Path) {
 		return errors.New("method and path are outside the crabfleet/v1 adapter surface")

--- a/internal/cli/adapter_connect_test.go
+++ b/internal/cli/adapter_connect_test.go
@@ -15,6 +15,8 @@ import (
 	"nhooyr.io/websocket"
 )
 
+const adapterRelayTestDeadlineMS int64 = 4_102_444_800_000
+
 func TestAdapterRelayForwardsOnlyAllowedLocalRequestData(t *testing.T) {
 	body := " {\n  \"id\": \"fleet-a-is-101\"\n}\n"
 	var gotMethod, gotPath, gotBody, gotAuthorization, gotIdempotency, gotCookie, gotAccess string
@@ -39,10 +41,11 @@ func TestAdapterRelayForwardsOnlyAllowedLocalRequestData(t *testing.T) {
 		client:         local.Client(),
 	}
 	response := relay.handle(context.Background(), adapterRelayRequest{
-		Type:   "request",
-		ID:     "req-1",
-		Method: http.MethodPost,
-		Path:   "/v1/workspaces",
+		Type:       "request",
+		ID:         "req-1",
+		Method:     http.MethodPost,
+		Path:       "/v1/workspaces",
+		DeadlineMS: adapterRelayTestDeadlineMS,
 		Headers: map[string]string{
 			"Authorization":           "Bearer remote-secret",
 			"Cookie":                  "session=remote-secret",
@@ -111,31 +114,88 @@ func TestAdapterRelayRejectsBodiesAndResponsesOver64KiB(t *testing.T) {
 
 	tooLarge := strings.Repeat("x", adapterRelayMaxBodyBytes+1)
 	response := relay.handle(context.Background(), adapterRelayRequest{
-		Type: "request", ID: "req-large", Method: http.MethodPost, Path: "/v1/workspaces", Body: &tooLarge,
+		Type: "request", ID: "req-large", Method: http.MethodPost, Path: "/v1/workspaces", DeadlineMS: adapterRelayTestDeadlineMS, Body: &tooLarge,
 	})
 	if response.Status != http.StatusBadRequest || calls.Load() != 0 || !strings.Contains(response.Body, "body exceeds 64 KiB") {
 		t.Fatalf("oversized request response=%#v calls=%d", response, calls.Load())
 	}
 
 	response = relay.handle(context.Background(), adapterRelayRequest{
-		Type: "request", ID: "req-response-large", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101",
+		Type: "request", ID: "req-response-large", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: adapterRelayTestDeadlineMS,
 	})
 	if response.Status != http.StatusBadGateway || calls.Load() != 1 || !strings.Contains(response.Body, "response exceeds 64 KiB") {
 		t.Fatalf("oversized local response=%#v calls=%d", response, calls.Load())
 	}
 }
 
+func TestAdapterRelayRejectsExpiredRequestBeforeLocalDispatch(t *testing.T) {
+	var calls atomic.Int32
+	local := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer local.Close()
+	relay := adapterRelay{
+		localBaseURL:   local.URL,
+		loadLocalToken: func() (string, error) { return "local-secret", nil },
+		client:         local.Client(),
+	}
+	request := adapterRelayRequest{
+		Type: "request", ID: "request-expired", Method: http.MethodPost, Path: "/v1/workspaces", DeadlineMS: time.Now().Add(-time.Second).UnixMilli(),
+	}
+	response := relay.handle(context.Background(), request)
+	if response.Status != http.StatusGatewayTimeout || calls.Load() != 0 || !strings.Contains(response.Body, "adapter_timeout") {
+		t.Fatalf("expired response=%#v calls=%d", response, calls.Load())
+	}
+	request.ID = "request-missing-deadline"
+	request.DeadlineMS = 0
+	if err := validateAdapterRelayRequest(request); err == nil || !strings.Contains(err.Error(), "deadlineMs") {
+		t.Fatalf("missing deadline validation error=%v", err)
+	}
+}
+
+func TestAdapterRelayUsesEarlierCoordinatorDeadlineForLocalRequest(t *testing.T) {
+	deadlineMS := time.Now().Add(2 * time.Second).UnixMilli()
+	var gotDeadline time.Time
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		var ok bool
+		gotDeadline, ok = request.Context().Deadline()
+		if !ok {
+			t.Fatal("local adapter request has no deadline")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Request:    request,
+		}, nil
+	})}
+	relay := adapterRelay{
+		localBaseURL:   "http://adapter.local",
+		loadLocalToken: func() (string, error) { return "local-secret", nil },
+		client:         client,
+	}
+	response := relay.handle(context.Background(), adapterRelayRequest{
+		Type: "request", ID: "request-deadline", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: deadlineMS,
+	})
+	if response.Status != http.StatusOK {
+		t.Fatalf("response=%#v", response)
+	}
+	if gotDeadline.UnixMilli() != deadlineMS {
+		t.Fatalf("local deadline=%s want Unix ms %d", gotDeadline, deadlineMS)
+	}
+}
+
 func TestAdapterRelayRejectsRemoteBodyOnDelete(t *testing.T) {
 	body := `{}`
 	err := validateAdapterRelayRequest(adapterRelayRequest{
-		Type: "request", ID: "req-delete", Method: http.MethodDelete, Path: "/v1/workspaces/fleet-a-is-101", Body: &body,
+		Type: "request", ID: "req-delete", Method: http.MethodDelete, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: adapterRelayTestDeadlineMS, Body: &body,
 	})
 	if err == nil || !strings.Contains(err.Error(), "body is not allowed") {
 		t.Fatalf("delete body validation error=%v", err)
 	}
 	empty := ""
 	if err := validateAdapterRelayRequest(adapterRelayRequest{
-		Type: "request", ID: "req-delete-empty", Method: http.MethodDelete, Path: "/v1/workspaces/fleet-a-is-101", Body: &empty,
+		Type: "request", ID: "req-delete-empty", Method: http.MethodDelete, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: adapterRelayTestDeadlineMS, Body: &empty,
 	}); err != nil {
 		t.Fatalf("explicit empty delete body rejected: %v", err)
 	}
@@ -154,7 +214,7 @@ func TestAdapterRelayReloadsLocalTokenForEveryRequest(t *testing.T) {
 		loadLocalToken: func() (string, error) { return token, nil },
 		client:         local.Client(),
 	}
-	request := adapterRelayRequest{Type: "request", ID: "request-1", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101"}
+	request := adapterRelayRequest{Type: "request", ID: "request-1", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: adapterRelayTestDeadlineMS}
 	if response := relay.handle(context.Background(), request); response.Status != http.StatusOK {
 		t.Fatalf("first response=%#v", response)
 	}
@@ -181,7 +241,7 @@ func TestAdapterRelayDoesNotCallLocalServiceWhenTokenReloadFails(t *testing.T) {
 		client:         local.Client(),
 	}
 	response := relay.handle(context.Background(), adapterRelayRequest{
-		Type: "request", ID: "request-1", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101",
+		Type: "request", ID: "request-1", Method: http.MethodGet, Path: "/v1/workspaces/fleet-a-is-101", DeadlineMS: adapterRelayTestDeadlineMS,
 	})
 	if response.Status != http.StatusBadGateway || calls.Load() != 0 || !strings.Contains(response.Body, "adapter_auth_unavailable") {
 		t.Fatalf("response=%#v calls=%d", response, calls.Load())
@@ -252,8 +312,8 @@ func TestAdapterRelayServesDeleteWhileDesktopRequestIsInFlight(t *testing.T) {
 			}
 			defer release()
 			requests := []string{
-				`{"type":"request","id":"desktop","method":"POST","path":"/v1/workspaces/fleet-a-is-101/connections/desktop"}`,
-				`{"type":"request","id":"delete","method":"DELETE","path":"/v1/workspaces/fleet-a-is-101"}`,
+				`{"type":"request","id":"desktop","method":"POST","path":"/v1/workspaces/fleet-a-is-101/connections/desktop","deadlineMs":4102444800000}`,
+				`{"type":"request","id":"delete","method":"DELETE","path":"/v1/workspaces/fleet-a-is-101","deadlineMs":4102444800000}`,
 			}
 			if err := conn.Write(r.Context(), websocket.MessageText, []byte(requests[0])); err != nil {
 				serverErr <- err
@@ -346,6 +406,14 @@ func TestConnectAdapterRelayUsesTicketHeaderAndRelaysResponse(t *testing.T) {
 			if r.Header.Get("CF-Access-Client-Id") != "access-client" || r.Header.Get("CF-Access-Client-Secret") != "access-secret" || r.Header.Get("cf-access-token") != "access-token" {
 				t.Errorf("ticket request missing Access credentials: %#v", r.Header)
 			}
+			var ticketRequest struct {
+				DesktopTimeoutMS int64 `json:"desktopTimeoutMs"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&ticketRequest); err != nil {
+				t.Errorf("decode ticket request: %v", err)
+			} else if ticketRequest.DesktopTimeoutMS != 155_000 {
+				t.Errorf("ticket desktop timeout=%d want=155000", ticketRequest.DesktopTimeoutMS)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"ticket":"adapter-ticket","adapterID":"mac-lab"}`)
 		case "/v1/adapters/mac-lab/agent":
@@ -364,7 +432,7 @@ func TestConnectAdapterRelayUsesTicketHeaderAndRelaysResponse(t *testing.T) {
 				return
 			}
 			defer conn.Close(websocket.StatusNormalClosure, "test complete")
-			request := `{"type":"request","id":"request-1","method":"GET","path":"/v1/workspaces/fleet-a-is-101","headers":{"authorization":"Bearer remote-token"}}`
+			request := `{"type":"request","id":"request-1","method":"GET","path":"/v1/workspaces/fleet-a-is-101","deadlineMs":4102444800000,"headers":{"authorization":"Bearer remote-token"}}`
 			if err := conn.Write(r.Context(), websocket.MessageText, []byte(request)); err != nil {
 				t.Errorf("write adapter request: %v", err)
 				return

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -16,34 +16,36 @@ import (
 )
 
 type leaseClaim struct {
-	LeaseID            string            `json:"leaseID"`
-	Slug               string            `json:"slug,omitempty"`
-	Provider           string            `json:"provider,omitempty"`
-	CloudID            string            `json:"cloudID,omitempty"`
-	ProviderScope      string            `json:"providerScope,omitempty"`
-	StaticHost         string            `json:"staticHost,omitempty"`
-	StaticUser         string            `json:"staticUser,omitempty"`
-	StaticPort         string            `json:"staticPort,omitempty"`
-	StaticWorkRoot     string            `json:"staticWorkRoot,omitempty"`
-	TargetOS           string            `json:"targetOS,omitempty"`
-	WindowsMode        string            `json:"windowsMode,omitempty"`
-	Pond               string            `json:"pond,omitempty"`
-	RepoRoot           string            `json:"repoRoot"`
-	ClaimedAt          string            `json:"claimedAt"`
-	LastUsedAt         string            `json:"lastUsedAt"`
-	IdleTimeoutSeconds int               `json:"idleTimeoutSeconds,omitempty"`
-	TailscaleIPv4      string            `json:"tailscaleIPv4,omitempty"`
-	TailscaleFQDN      string            `json:"tailscaleFQDN,omitempty"`
-	TailscaleHostname  string            `json:"tailscaleHostname,omitempty"`
-	TailscaleTags      []string          `json:"tailscaleTags,omitempty"`
-	TailscaleLoginURL  string            `json:"tailscaleLoginURL,omitempty"`
-	TailscaleExitNode  string            `json:"tailscaleExitNode,omitempty"`
-	TailscaleExitLAN   bool              `json:"tailscaleExitLAN,omitempty"`
-	SSHHost            string            `json:"sshHost,omitempty"`
-	SSHPort            int               `json:"sshPort,omitempty"`
-	BridgeURL          string            `json:"bridgeURL,omitempty"`
-	CacheVolumes       []string          `json:"cacheVolumes,omitempty"`
-	Labels             map[string]string `json:"labels,omitempty"`
+	LeaseID                             string            `json:"leaseID"`
+	Slug                                string            `json:"slug,omitempty"`
+	Provider                            string            `json:"provider,omitempty"`
+	CloudID                             string            `json:"cloudID,omitempty"`
+	ProviderScope                       string            `json:"providerScope,omitempty"`
+	StaticHost                          string            `json:"staticHost,omitempty"`
+	StaticUser                          string            `json:"staticUser,omitempty"`
+	StaticPort                          string            `json:"staticPort,omitempty"`
+	StaticWorkRoot                      string            `json:"staticWorkRoot,omitempty"`
+	TargetOS                            string            `json:"targetOS,omitempty"`
+	WindowsMode                         string            `json:"windowsMode,omitempty"`
+	Pond                                string            `json:"pond,omitempty"`
+	RepoRoot                            string            `json:"repoRoot"`
+	ClaimedAt                           string            `json:"claimedAt"`
+	LastUsedAt                          string            `json:"lastUsedAt"`
+	IdleTimeoutSeconds                  int               `json:"idleTimeoutSeconds,omitempty"`
+	TailscaleIPv4                       string            `json:"tailscaleIPv4,omitempty"`
+	TailscaleFQDN                       string            `json:"tailscaleFQDN,omitempty"`
+	TailscaleHostname                   string            `json:"tailscaleHostname,omitempty"`
+	TailscaleTags                       []string          `json:"tailscaleTags,omitempty"`
+	TailscaleLoginURL                   string            `json:"tailscaleLoginURL,omitempty"`
+	TailscaleExitNode                   string            `json:"tailscaleExitNode,omitempty"`
+	TailscaleExitLAN                    bool              `json:"tailscaleExitLAN,omitempty"`
+	SSHHost                             string            `json:"sshHost,omitempty"`
+	SSHPort                             int               `json:"sshPort,omitempty"`
+	BridgeURL                           string            `json:"bridgeURL,omitempty"`
+	RuntimeAdapterRegistrationID        string            `json:"runtimeAdapterRegistrationID,omitempty"`
+	RuntimeAdapterPendingRegistrationID string            `json:"runtimeAdapterPendingRegistrationID,omitempty"`
+	CacheVolumes                        []string          `json:"cacheVolumes,omitempty"`
+	Labels                              map[string]string `json:"labels,omitempty"`
 }
 
 var claimMutationMutexes sync.Map

--- a/internal/cli/controller_service.go
+++ b/internal/cli/controller_service.go
@@ -601,7 +601,7 @@ func (s *controllerService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		s.getWorkspace(w, id)
 	case http.MethodDelete:
-		s.deleteWorkspace(w, id)
+		s.deleteWorkspace(w, r.Context(), id)
 	default:
 		writeControllerMethodNotAllowed(w, http.MethodGet, http.MethodDelete)
 	}
@@ -1007,9 +1007,15 @@ func (s *controllerService) getWorkspace(w http.ResponseWriter, id string) {
 	writeControllerJSON(w, http.StatusOK, controllerResponse(record))
 }
 
-func (s *controllerService) deleteWorkspace(w http.ResponseWriter, id string) {
+func (s *controllerService) deleteWorkspace(w http.ResponseWriter, requestCtx context.Context, id string) {
 	s.sideEffectGate.Lock()
 	s.mu.Lock()
+	if requestCtx.Err() != nil {
+		s.mu.Unlock()
+		s.sideEffectGate.Unlock()
+		writeControllerError(w, http.StatusRequestTimeout, "request_canceled", "workspace delete request was canceled before dispatch")
+		return
+	}
 	record, ok := s.state.Workspaces[id]
 	if !ok {
 		s.mu.Unlock()

--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -463,6 +463,58 @@ func TestControllerWorkspaceLifecycleAndIdempotency(t *testing.T) {
 	}
 }
 
+func TestControllerCanceledDeleteDoesNotCrossSideEffectGate(t *testing.T) {
+	runner := newFakeControllerWorkspaceRunner()
+	service, cancelService := testControllerService(t, runner, 1)
+	defer cancelService()
+	created := controllerHTTP(service, http.MethodPost, "/v1/workspaces", "test-token", controllerWorkspaceRequest{
+		ID: "canceled-delete-box",
+	})
+	if created.Code != http.StatusAccepted {
+		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
+	}
+	want := waitControllerWorkspaceStatus(t, service, "canceled-delete-box", "ready")
+	waitControllerWorkspaceInactive(t, service, "canceled-delete-box")
+
+	service.sideEffectGate.Lock()
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	request := httptest.NewRequest(
+		http.MethodDelete,
+		"/v1/workspaces/canceled-delete-box",
+		nil,
+	).WithContext(requestCtx)
+	request.Header.Set("Authorization", "Bearer test-token")
+	response := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		service.ServeHTTP(response, request)
+		close(done)
+	}()
+	select {
+	case <-done:
+		service.sideEffectGate.Unlock()
+		t.Fatal("delete crossed the held side-effect gate")
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancelRequest()
+	service.sideEffectGate.Unlock()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled delete did not return")
+	}
+	if response.Code != http.StatusRequestTimeout || !strings.Contains(response.Body.String(), `"code":"request_canceled"`) {
+		t.Fatalf("delete status=%d body=%s", response.Code, response.Body.String())
+	}
+	if got, ok := service.workspace("canceled-delete-box"); !ok || got != want {
+		t.Fatalf("workspace changed after canceled delete: got=%#v exists=%t want=%#v", got, ok, want)
+	}
+	_, stops, _ := runner.counts()
+	if stops != 0 {
+		t.Fatalf("canceled delete dispatched %d provider stops", stops)
+	}
+}
+
 func TestControllerResponseCapabilitiesDoNotInferTerminalFromDesktop(t *testing.T) {
 	response := controllerResponse(controllerWorkspaceRecord{
 		Request: controllerWorkspaceRequest{

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -48,80 +48,82 @@ func (e CoordinatorHTTPError) Error() string {
 }
 
 type CoordinatorLease struct {
-	ID                   string                `json:"id"`
-	Slug                 string                `json:"slug,omitempty"`
-	Provider             string                `json:"provider"`
-	Lifecycle            string                `json:"lifecycle,omitempty"`
-	RuntimeAdapterID     string                `json:"runtimeAdapterID,omitempty"`
-	RuntimeWorkspaceID   string                `json:"runtimeAdapterWorkspaceID,omitempty"`
-	TargetOS             string                `json:"target,omitempty"`
-	WindowsMode          string                `json:"windowsMode,omitempty"`
-	Desktop              bool                  `json:"desktop,omitempty"`
-	DesktopEnv           string                `json:"desktopEnv,omitempty"`
-	Browser              bool                  `json:"browser,omitempty"`
-	Code                 bool                  `json:"code,omitempty"`
-	Tailscale            *TailscaleMetadata    `json:"tailscale,omitempty"`
-	Region               string                `json:"region,omitempty"`
-	Owner                string                `json:"owner"`
-	Org                  string                `json:"org"`
-	Share                *CoordinatorShare     `json:"share,omitempty"`
-	Profile              string                `json:"profile"`
-	Class                string                `json:"class"`
-	Pond                 string                `json:"pond,omitempty"`
-	ExposedPorts         []string              `json:"exposedPorts,omitempty"`
-	ServerType           string                `json:"serverType"`
-	RequestedServerType  string                `json:"requestedServerType,omitempty"`
-	HostID               string                `json:"hostId,omitempty"`
-	HostIDCompat         string                `json:"hostID,omitempty"`
-	Market               string                `json:"market,omitempty"`
-	ProvisioningAttempts []ProvisioningAttempt `json:"provisioningAttempts,omitempty"`
-	CapacityHints        []CapacityHint        `json:"capacityHints,omitempty"`
-	ServerID             int64                 `json:"serverID"`
-	CloudID              string                `json:"cloudID"`
-	ServerName           string                `json:"serverName"`
-	Host                 string                `json:"host"`
-	SSHUser              string                `json:"sshUser"`
-	SSHPort              string                `json:"sshPort"`
-	SSHFallbackPorts     []string              `json:"sshFallbackPorts,omitempty"`
-	WorkRoot             string                `json:"workRoot"`
-	Keep                 bool                  `json:"keep"`
-	State                string                `json:"state"`
-	TTLSeconds           int                   `json:"ttlSeconds,omitempty"`
-	IdleTimeoutSeconds   int                   `json:"idleTimeoutSeconds,omitempty"`
-	CreatedAt            string                `json:"createdAt,omitempty"`
-	UpdatedAt            string                `json:"updatedAt,omitempty"`
-	LastTouchedAt        string                `json:"lastTouchedAt,omitempty"`
-	ExpiresAt            string                `json:"expiresAt"`
-	Telemetry            *LeaseTelemetry       `json:"telemetry,omitempty"`
-	TelemetryHistory     []*LeaseTelemetry     `json:"telemetryHistory,omitempty"`
+	ID                    string                `json:"id"`
+	Slug                  string                `json:"slug,omitempty"`
+	Provider              string                `json:"provider"`
+	Lifecycle             string                `json:"lifecycle,omitempty"`
+	RuntimeAdapterID      string                `json:"runtimeAdapterID,omitempty"`
+	RuntimeWorkspaceID    string                `json:"runtimeAdapterWorkspaceID,omitempty"`
+	RuntimeRegistrationID string                `json:"runtimeAdapterRegistrationID,omitempty"`
+	TargetOS              string                `json:"target,omitempty"`
+	WindowsMode           string                `json:"windowsMode,omitempty"`
+	Desktop               bool                  `json:"desktop,omitempty"`
+	DesktopEnv            string                `json:"desktopEnv,omitempty"`
+	Browser               bool                  `json:"browser,omitempty"`
+	Code                  bool                  `json:"code,omitempty"`
+	Tailscale             *TailscaleMetadata    `json:"tailscale,omitempty"`
+	Region                string                `json:"region,omitempty"`
+	Owner                 string                `json:"owner"`
+	Org                   string                `json:"org"`
+	Share                 *CoordinatorShare     `json:"share,omitempty"`
+	Profile               string                `json:"profile"`
+	Class                 string                `json:"class"`
+	Pond                  string                `json:"pond,omitempty"`
+	ExposedPorts          []string              `json:"exposedPorts,omitempty"`
+	ServerType            string                `json:"serverType"`
+	RequestedServerType   string                `json:"requestedServerType,omitempty"`
+	HostID                string                `json:"hostId,omitempty"`
+	HostIDCompat          string                `json:"hostID,omitempty"`
+	Market                string                `json:"market,omitempty"`
+	ProvisioningAttempts  []ProvisioningAttempt `json:"provisioningAttempts,omitempty"`
+	CapacityHints         []CapacityHint        `json:"capacityHints,omitempty"`
+	ServerID              int64                 `json:"serverID"`
+	CloudID               string                `json:"cloudID"`
+	ServerName            string                `json:"serverName"`
+	Host                  string                `json:"host"`
+	SSHUser               string                `json:"sshUser"`
+	SSHPort               string                `json:"sshPort"`
+	SSHFallbackPorts      []string              `json:"sshFallbackPorts,omitempty"`
+	WorkRoot              string                `json:"workRoot"`
+	Keep                  bool                  `json:"keep"`
+	State                 string                `json:"state"`
+	TTLSeconds            int                   `json:"ttlSeconds,omitempty"`
+	IdleTimeoutSeconds    int                   `json:"idleTimeoutSeconds,omitempty"`
+	CreatedAt             string                `json:"createdAt,omitempty"`
+	UpdatedAt             string                `json:"updatedAt,omitempty"`
+	LastTouchedAt         string                `json:"lastTouchedAt,omitempty"`
+	ExpiresAt             string                `json:"expiresAt"`
+	Telemetry             *LeaseTelemetry       `json:"telemetry,omitempty"`
+	TelemetryHistory      []*LeaseTelemetry     `json:"telemetryHistory,omitempty"`
 }
 
 type CoordinatorLeaseRegistration struct {
-	Slug               string   `json:"slug,omitempty"`
-	Provider           string   `json:"provider"`
-	TargetOS           string   `json:"target"`
-	WindowsMode        string   `json:"windowsMode,omitempty"`
-	Desktop            bool     `json:"desktop,omitempty"`
-	DesktopEnv         string   `json:"desktopEnv,omitempty"`
-	Browser            bool     `json:"browser,omitempty"`
-	Code               bool     `json:"code,omitempty"`
-	CloudID            string   `json:"cloudID,omitempty"`
-	ServerID           int64    `json:"serverID,omitempty"`
-	ServerName         string   `json:"serverName,omitempty"`
-	ServerType         string   `json:"serverType,omitempty"`
-	Host               string   `json:"host"`
-	SSHUser            string   `json:"sshUser,omitempty"`
-	SSHPort            string   `json:"sshPort,omitempty"`
-	SSHFallbackPorts   []string `json:"sshFallbackPorts,omitempty"`
-	WorkRoot           string   `json:"workRoot,omitempty"`
-	Profile            string   `json:"profile,omitempty"`
-	Class              string   `json:"class,omitempty"`
-	Pond               string   `json:"pond,omitempty"`
-	ExposedPorts       []string `json:"exposedPorts,omitempty"`
-	TTLSeconds         int      `json:"ttlSeconds,omitempty"`
-	IdleTimeoutSeconds int      `json:"idleTimeoutSeconds,omitempty"`
-	RuntimeAdapterID   string   `json:"runtimeAdapterID,omitempty"`
-	RuntimeWorkspaceID string   `json:"runtimeAdapterWorkspaceID,omitempty"`
+	Slug                  string   `json:"slug,omitempty"`
+	Provider              string   `json:"provider"`
+	TargetOS              string   `json:"target"`
+	WindowsMode           string   `json:"windowsMode,omitempty"`
+	Desktop               bool     `json:"desktop,omitempty"`
+	DesktopEnv            string   `json:"desktopEnv,omitempty"`
+	Browser               bool     `json:"browser,omitempty"`
+	Code                  bool     `json:"code,omitempty"`
+	CloudID               string   `json:"cloudID,omitempty"`
+	ServerID              int64    `json:"serverID,omitempty"`
+	ServerName            string   `json:"serverName,omitempty"`
+	ServerType            string   `json:"serverType,omitempty"`
+	Host                  string   `json:"host"`
+	SSHUser               string   `json:"sshUser,omitempty"`
+	SSHPort               string   `json:"sshPort,omitempty"`
+	SSHFallbackPorts      []string `json:"sshFallbackPorts,omitempty"`
+	WorkRoot              string   `json:"workRoot,omitempty"`
+	Profile               string   `json:"profile,omitempty"`
+	Class                 string   `json:"class,omitempty"`
+	Pond                  string   `json:"pond,omitempty"`
+	ExposedPorts          []string `json:"exposedPorts,omitempty"`
+	TTLSeconds            int      `json:"ttlSeconds,omitempty"`
+	IdleTimeoutSeconds    int      `json:"idleTimeoutSeconds,omitempty"`
+	RuntimeAdapterID      string   `json:"runtimeAdapterID,omitempty"`
+	RuntimeWorkspaceID    string   `json:"runtimeAdapterWorkspaceID,omitempty"`
+	RuntimeRegistrationID string   `json:"runtimeAdapterRegistrationID,omitempty"`
 }
 
 type CoordinatorShareRole string
@@ -863,6 +865,35 @@ func (c *CoordinatorClient) ReleaseLease(ctx context.Context, id string, deleteS
 		Lease CoordinatorLease `json:"lease"`
 	}
 	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{"delete": deleteServer}, &res)
+	return res.Lease, err
+}
+
+func (c *CoordinatorClient) CompleteRuntimeAdapterDelete(ctx context.Context, id, adapterID, workspaceID, registrationID string) (CoordinatorLease, error) {
+	var res struct {
+		Lease CoordinatorLease `json:"lease"`
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{
+		"runtimeAdapterDeleteCompletion": map[string]string{
+			"adapterID":      adapterID,
+			"workspaceID":    workspaceID,
+			"registrationID": registrationID,
+			"status":         "absent",
+		},
+	}, &res)
+	return res.Lease, err
+}
+
+func (c *CoordinatorClient) CompleteLegacyRuntimeAdapterDelete(ctx context.Context, id, adapterID, workspaceID string) (CoordinatorLease, error) {
+	var res struct {
+		Lease CoordinatorLease `json:"lease"`
+	}
+	err := c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/release", map[string]any{
+		"runtimeAdapterLegacyDeleteCompletion": map[string]string{
+			"adapterID":   adapterID,
+			"workspaceID": workspaceID,
+			"status":      "absent",
+		},
+	}, &res)
 	return res.Lease, err
 }
 

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -136,12 +138,33 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 		IdleTimeoutSeconds: int(cfg.IdleTimeout.Seconds()),
 	}
 	if adapterMode {
+		registrationID, err := ensureRuntimeAdapterRegistrationID(lease.LeaseID)
+		if err != nil {
+			a.coordinatorRegistrationWarning(lease.LeaseID, err)
+			return err
+		}
 		registration.RuntimeAdapterID = adapterID
 		registration.RuntimeWorkspaceID = workspaceID
+		registration.RuntimeRegistrationID = registrationID
 	}
-	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
-	defer cancel()
-	registered, err := coord.RegisterLease(callCtx, lease.LeaseID, registration)
+	register := func() (CoordinatorLease, error) {
+		callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
+		defer cancel()
+		return coord.RegisterLease(callCtx, lease.LeaseID, registration)
+	}
+	registered, err := register()
+	if adapterMode && runtimeAdapterRegistrationReplay(err) {
+		registrationID, rotateErr := stageRuntimeAdapterRegistrationReplacement(
+			lease.LeaseID,
+			registration.RuntimeRegistrationID,
+		)
+		if rotateErr != nil {
+			a.coordinatorRegistrationWarning(lease.LeaseID, rotateErr)
+			return rotateErr
+		}
+		registration.RuntimeRegistrationID = registrationID
+		registered, err = register()
+	}
 	if err != nil {
 		a.coordinatorRegistrationWarning(lease.LeaseID, err)
 		if adapterMode {
@@ -149,16 +172,29 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 		}
 		return nil
 	}
-	if adapterMode && (registered.RuntimeAdapterID != adapterID || registered.RuntimeWorkspaceID != workspaceID) {
+	if adapterMode && (registered.RuntimeAdapterID != adapterID ||
+		registered.RuntimeWorkspaceID != workspaceID ||
+		registered.RuntimeRegistrationID != registration.RuntimeRegistrationID) {
 		err := fmt.Errorf(
-			"coordinator returned adapter binding %q/%q, expected %q/%q",
+			"coordinator returned adapter binding %q/%q/%q, expected %q/%q/%q",
 			registered.RuntimeAdapterID,
 			registered.RuntimeWorkspaceID,
+			registered.RuntimeRegistrationID,
 			adapterID,
 			workspaceID,
+			registration.RuntimeRegistrationID,
 		)
 		a.coordinatorRegistrationWarning(lease.LeaseID, err)
 		return err
+	}
+	if adapterMode {
+		if err := acknowledgeRuntimeAdapterRegistrationID(
+			lease.LeaseID,
+			registration.RuntimeRegistrationID,
+		); err != nil {
+			a.coordinatorRegistrationWarning(lease.LeaseID, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -210,6 +246,139 @@ func adapterRuntimeRegistrationBinding() (adapterID, workspaceID string, require
 	return adapterID, workspaceID, true, nil
 }
 
+func ensureRuntimeAdapterRegistrationID(leaseID string) (string, error) {
+	var registrationID string
+	err := mutateLeaseClaimGuarded(
+		leaseID,
+		func(claim leaseClaim, exists bool) error {
+			if !exists || claim.LeaseID != leaseID {
+				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
+			}
+			return nil
+		},
+		func(claim *leaseClaim) error {
+			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+			if pending != "" {
+				if !validControllerWorkspaceID(pending) {
+					return fmt.Errorf("adapter coordinator registration has an invalid pending registration id")
+				}
+				registrationID = pending
+				return nil
+			}
+			registrationID = current
+			if current == "" {
+				generated, err := randomHex(16)
+				if err != nil {
+					return fmt.Errorf("generate runtime adapter registration id: %w", err)
+				}
+				registrationID = generated
+				claim.RuntimeAdapterRegistrationID = generated
+			}
+			if !validControllerWorkspaceID(registrationID) {
+				return fmt.Errorf("adapter coordinator registration has an invalid registration id")
+			}
+			return nil
+		},
+	)
+	return registrationID, err
+}
+
+func stageRuntimeAdapterRegistrationReplacement(leaseID, rejectedID string) (string, error) {
+	var registrationID string
+	err := mutateLeaseClaimGuarded(
+		leaseID,
+		func(claim leaseClaim, exists bool) error {
+			if !exists || claim.LeaseID != leaseID {
+				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
+			}
+			return nil
+		},
+		func(claim *leaseClaim) error {
+			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+			if pending != "" && !validControllerWorkspaceID(pending) {
+				return fmt.Errorf("adapter coordinator registration has an invalid pending registration id")
+			}
+			if pending != "" && pending != rejectedID {
+				registrationID = pending
+				return nil
+			}
+			if pending == rejectedID {
+				claim.RuntimeAdapterRegistrationID = rejectedID
+				claim.RuntimeAdapterPendingRegistrationID = ""
+				current = rejectedID
+			}
+			if current != rejectedID {
+				if !validControllerWorkspaceID(current) {
+					return fmt.Errorf("adapter coordinator registration changed while rotating its generation")
+				}
+				registrationID = current
+				return nil
+			}
+			generated, err := randomHex(16)
+			if err != nil {
+				return fmt.Errorf("rotate runtime adapter registration id: %w", err)
+			}
+			registrationID = generated
+			claim.RuntimeAdapterPendingRegistrationID = generated
+			return nil
+		},
+	)
+	return registrationID, err
+}
+
+func acknowledgeRuntimeAdapterRegistrationID(leaseID, registrationID string) error {
+	return mutateLeaseClaimGuarded(
+		leaseID,
+		func(claim leaseClaim, exists bool) error {
+			if !exists || claim.LeaseID != leaseID {
+				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
+			}
+			return nil
+		},
+		func(claim *leaseClaim) error {
+			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+			switch {
+			case pending == registrationID:
+				claim.RuntimeAdapterRegistrationID = registrationID
+				claim.RuntimeAdapterPendingRegistrationID = ""
+			case current == registrationID:
+				// Another registration attempt may already have staged the next
+				// generation. Do not discard that independent pending transition.
+			case registrationID == "":
+				return fmt.Errorf("coordinator acknowledged an empty runtime adapter registration id")
+			default:
+				return fmt.Errorf("runtime adapter registration changed before acknowledgment")
+			}
+			return nil
+		},
+	)
+}
+
+func runtimeAdapterRegistrationReplay(err error) bool {
+	return coordinatorResponseErrorCode(err, 409) == "runtime_adapter_registration_replayed"
+}
+
+func runtimeAdapterDeleteCompletionMismatch(err error) bool {
+	return coordinatorResponseErrorCode(err, 409) == "runtime_adapter_delete_completion_mismatch"
+}
+
+func coordinatorResponseErrorCode(err error, status int) string {
+	var httpErr CoordinatorHTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != status {
+		return ""
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(httpErr.Message), &body) != nil {
+		return ""
+	}
+	return body.Error
+}
+
 func (a App) coordinatorRegistrationWarning(leaseID string, err error) {
 	if a.Stderr == nil {
 		return
@@ -246,10 +415,91 @@ func (a App) releaseRegisteredCoordinatorLeaseBestEffort(ctx context.Context, cf
 }
 
 func (a App) releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(ctx context.Context, cfg Config, leaseID string) error {
-	err := a.releaseRegisteredCoordinatorLease(ctx, cfg, leaseID, false)
+	adapterID, workspaceID, adapterMode, err := adapterRuntimeRegistrationBinding()
+	if err != nil {
+		return err
+	}
+	if adapterMode {
+		return a.completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx, cfg, leaseID, adapterID, workspaceID)
+	}
+	claim, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return err
+	}
+	if exists && (strings.TrimSpace(claim.RuntimeAdapterRegistrationID) != "" ||
+		strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID) != "") {
+		return fmt.Errorf("runtime adapter delete completion requires adapter binding for persisted registration id")
+	}
+	err = a.releaseRegisteredCoordinatorLease(ctx, cfg, leaseID, false)
 	if isCoordinatorNotFound(err) {
 		// Stable provider absence is already proven. A missing coordinator row is
 		// the desired terminal state and makes this cleanup retry idempotent.
+		return nil
+	}
+	return err
+}
+
+func (a App) completeRuntimeAdapterDeleteAfterConfirmedAbsence(ctx context.Context, cfg Config, leaseID, adapterID, workspaceID string) error {
+	if !shouldRegisterCoordinatorLease(cfg) || strings.TrimSpace(leaseID) == "" {
+		return nil
+	}
+	coord, configured, err := newCoordinatorClient(cfg)
+	if err != nil || !configured || coord == nil {
+		if err == nil {
+			err = fmt.Errorf("coordinator is not configured")
+		}
+		return err
+	}
+	claim, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return err
+	}
+	registrationIDs := uniqueNonBlankStrings(
+		claim.RuntimeAdapterPendingRegistrationID,
+		claim.RuntimeAdapterRegistrationID,
+	)
+	if !exists || claim.LeaseID != leaseID || len(registrationIDs) == 0 {
+		return completeLegacyRuntimeAdapterDeleteAfterConfirmedAbsence(
+			ctx,
+			coord,
+			leaseID,
+			adapterID,
+			workspaceID,
+		)
+	}
+	for _, registrationID := range registrationIDs {
+		if !validControllerWorkspaceID(registrationID) {
+			return fmt.Errorf("runtime adapter delete completion has an invalid persisted registration id")
+		}
+		callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
+		_, err := coord.CompleteRuntimeAdapterDelete(callCtx, leaseID, adapterID, workspaceID, registrationID)
+		cancel()
+		if err == nil || isCoordinatorNotFound(err) {
+			return nil
+		}
+		if runtimeAdapterDeleteCompletionMismatch(err) {
+			continue
+		}
+		return err
+	}
+	return completeLegacyRuntimeAdapterDeleteAfterConfirmedAbsence(
+		ctx,
+		coord,
+		leaseID,
+		adapterID,
+		workspaceID,
+	)
+}
+
+func completeLegacyRuntimeAdapterDeleteAfterConfirmedAbsence(
+	ctx context.Context,
+	coord *CoordinatorClient,
+	leaseID, adapterID, workspaceID string,
+) error {
+	callCtx, cancel := context.WithTimeout(ctx, coordinatorRegistrationTimeout)
+	defer cancel()
+	_, err := coord.CompleteLegacyRuntimeAdapterDelete(callCtx, leaseID, adapterID, workspaceID)
+	if isCoordinatorNotFound(err) {
 		return nil
 	}
 	return err

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -763,6 +764,7 @@ func TestResolvedLeaseClaimUpdatesRejectActiveStateChange(t *testing.T) {
 }
 
 func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
 	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
 	var got CoordinatorLeaseRegistration
@@ -771,7 +773,11 @@ func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
 			t.Fatal(err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"external","lifecycle":"registered","state":"active","runtimeAdapterID":"mac-lab","runtimeAdapterWorkspaceID":"fleet-a-is-123"}}`))
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": map[string]any{
+			"id": "cbx_123", "provider": "external", "lifecycle": "registered", "state": "active",
+			"runtimeAdapterID": "mac-lab", "runtimeAdapterWorkspaceID": "fleet-a-is-123",
+			"runtimeAdapterRegistrationID": got.RuntimeRegistrationID,
+		}})
 	}))
 	defer server.Close()
 
@@ -798,12 +804,117 @@ func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
 		SSH: SSHTarget{Host: "192.0.2.10", User: "runner", Port: "22", TargetOS: targetLinux},
 	}
 	lease.Server.ServerType.Name = "cpu16"
+	if err := claimLeaseTargetForRepoConfig(
+		lease.LeaseID, "my-box", cfg, lease.Server, lease.SSH, "/workspace", cfg.IdleTimeout, true,
+	); err != nil {
+		t.Fatal(err)
+	}
 	app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, lease)
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
-	if got.Provider != "external" || got.CloudID != "external-box-123" || got.Host != "192.0.2.10" || got.WorkRoot != "/workspace" || !got.Desktop || got.DesktopEnv != "gnome" || len(got.ExposedPorts) != 2 || got.TTLSeconds != 7200 || got.IdleTimeoutSeconds != 1800 || got.RuntimeAdapterID != "mac-lab" || got.RuntimeWorkspaceID != "fleet-a-is-123" {
+	if got.Provider != "external" || got.CloudID != "external-box-123" || got.Host != "192.0.2.10" || got.WorkRoot != "/workspace" || !got.Desktop || got.DesktopEnv != "gnome" || len(got.ExposedPorts) != 2 || got.TTLSeconds != 7200 || got.IdleTimeoutSeconds != 1800 || got.RuntimeAdapterID != "mac-lab" || got.RuntimeWorkspaceID != "fleet-a-is-123" || got.RuntimeRegistrationID == "" {
 		t.Fatalf("registration=%#v", got)
+	}
+	claim, err := readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.RuntimeAdapterRegistrationID != got.RuntimeRegistrationID {
+		t.Fatalf("claim registration id=%q request=%q", claim.RuntimeAdapterRegistrationID, got.RuntimeRegistrationID)
+	}
+}
+
+func TestAdapterRegistrationRotatesRejectedTerminalGeneration(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	var registrationIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got CoordinatorLeaseRegistration
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		registrationIDs = append(registrationIDs, got.RuntimeRegistrationID)
+		w.Header().Set("Content-Type", "application/json")
+		if len(registrationIDs) == 1 {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"runtime_adapter_registration_replayed"}`))
+			return
+		}
+		if len(registrationIDs) == 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"temporarily_unavailable"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": map[string]any{
+			"id": "cbx_123", "provider": "external", "lifecycle": "registered", "state": "active",
+			"runtimeAdapterID": "mac-lab", "runtimeAdapterWorkspaceID": "fleet-a-is-123",
+			"runtimeAdapterRegistrationID": got.RuntimeRegistrationID,
+		}})
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "token"
+	cfg.BrokerMode = BrokerModeRegistered
+	cfg.IdleTimeout = time.Hour
+	lease := LeaseTarget{
+		LeaseID: "cbx_123",
+		Server:  Server{Provider: "external", CloudID: "external-box-123"},
+		SSH:     SSHTarget{Host: "192.0.2.10", Port: "22", TargetOS: targetLinux},
+	}
+	if err := claimLeaseTargetForRepoConfig(
+		lease.LeaseID, "adapter-box", cfg, lease.Server, lease.SSH, "/repo", cfg.IdleTimeout, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutateLeaseClaim(lease.LeaseID, func(claim *leaseClaim) error {
+		claim.RuntimeAdapterRegistrationID = "registration-generation-old"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	app := App{Stderr: &stderr}
+	if err := app.registerCoordinatorLeaseBestEffort(
+		context.Background(), cfg, lease,
+	); err == nil {
+		t.Fatal("replacement registration unexpectedly succeeded through a transport failure")
+	}
+	claim, err := readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registrationIDs) != 2 ||
+		registrationIDs[0] != "registration-generation-old" ||
+		registrationIDs[1] == "" ||
+		registrationIDs[1] == registrationIDs[0] {
+		t.Fatalf("registration ids=%q", registrationIDs)
+	}
+	if claim.RuntimeAdapterRegistrationID != registrationIDs[0] ||
+		claim.RuntimeAdapterPendingRegistrationID != registrationIDs[1] {
+		t.Fatalf("failed replacement claim=%#v requests=%q", claim, registrationIDs)
+	}
+	stderr.Reset()
+	if err := app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, lease); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if len(registrationIDs) != 3 || registrationIDs[2] != registrationIDs[1] {
+		t.Fatalf("retried registration ids=%q", registrationIDs)
+	}
+	claim, err = readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.RuntimeAdapterRegistrationID != registrationIDs[1] ||
+		claim.RuntimeAdapterPendingRegistrationID != "" {
+		t.Fatalf("claim registration id=%q requests=%q", claim.RuntimeAdapterRegistrationID, registrationIDs)
 	}
 }
 
@@ -918,13 +1029,25 @@ func TestReleaseRegisteredCoordinatorLeaseNeverRequestsProviderDeletion(t *testi
 }
 
 func TestControllerManagedCoordinatorDeregistrationWaitsForConfirmedAbsence(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
 	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
 	requests := 0
+	var completion struct {
+		RuntimeAdapterDeleteCompletion struct {
+			AdapterID      string `json:"adapterID"`
+			WorkspaceID    string `json:"workspaceID"`
+			RegistrationID string `json:"registrationID"`
+			Status         string `json:"status"`
+		} `json:"runtimeAdapterDeleteCompletion"`
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/release" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&completion); err != nil {
+			t.Fatal(err)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","provider":"external","lifecycle":"registered","state":"released"}}`))
@@ -933,6 +1056,19 @@ func TestControllerManagedCoordinatorDeregistrationWaitsForConfirmedAbsence(t *t
 
 	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
 	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_123", "adapter-box", cfg,
+		Server{Provider: "external", CloudID: "adapter-box"},
+		SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutateLeaseClaim("cbx_123", func(claim *leaseClaim) error {
+		claim.RuntimeAdapterRegistrationID = "registration-generation-123"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 	app.releaseRegisteredCoordinatorLeaseBestEffort(context.Background(), cfg, "cbx_123")
 	if requests != 0 {
 		t.Fatalf("controller-owned provider stop deregistered coordinator early: requests=%d", requests)
@@ -943,9 +1079,388 @@ func TestControllerManagedCoordinatorDeregistrationWaitsForConfirmedAbsence(t *t
 	if requests != 1 {
 		t.Fatalf("confirmed absence deregistration requests=%d", requests)
 	}
+	if completion.RuntimeAdapterDeleteCompletion.AdapterID != "mac-lab" ||
+		completion.RuntimeAdapterDeleteCompletion.WorkspaceID != "fleet-a-is-123" ||
+		completion.RuntimeAdapterDeleteCompletion.RegistrationID != "registration-generation-123" ||
+		completion.RuntimeAdapterDeleteCompletion.Status != "absent" {
+		t.Fatalf("confirmed absence completion=%#v", completion.RuntimeAdapterDeleteCompletion)
+	}
+}
+
+func TestConfirmedAbsenceFallsBackFromPendingToAcknowledgedGeneration(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	var registrationIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var completion struct {
+			RuntimeAdapterDeleteCompletion struct {
+				RegistrationID string `json:"registrationID"`
+			} `json:"runtimeAdapterDeleteCompletion"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&completion); err != nil {
+			t.Fatal(err)
+		}
+		registrationIDs = append(registrationIDs, completion.RuntimeAdapterDeleteCompletion.RegistrationID)
+		w.Header().Set("Content-Type", "application/json")
+		if len(registrationIDs) == 1 {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"runtime_adapter_delete_completion_mismatch"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","state":"released"}}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_123", "adapter-box", cfg,
+		Server{Provider: "external", CloudID: "adapter-box"},
+		SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutateLeaseClaim("cbx_123", func(claim *leaseClaim) error {
+		claim.RuntimeAdapterRegistrationID = "registration-generation-current"
+		claim.RuntimeAdapterPendingRegistrationID = "registration-generation-pending"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	if err := app.releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(context.Background(), cfg, "cbx_123"); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(registrationIDs, []string{
+		"registration-generation-pending",
+		"registration-generation-current",
+	}) {
+		t.Fatalf("completion registration ids=%q", registrationIDs)
+	}
+}
+
+func TestConfirmedAbsenceFallsBackToVerifiedLegacyReleaseAfterGenerationMismatches(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	var requests []string
+	var registrationIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_123/release":
+			var body struct {
+				RuntimeAdapterDeleteCompletion *struct {
+					RegistrationID string `json:"registrationID"`
+				} `json:"runtimeAdapterDeleteCompletion"`
+				RuntimeAdapterLegacyDeleteCompletion *struct {
+					AdapterID   string `json:"adapterID"`
+					WorkspaceID string `json:"workspaceID"`
+					Status      string `json:"status"`
+				} `json:"runtimeAdapterLegacyDeleteCompletion"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.RuntimeAdapterDeleteCompletion != nil {
+				requests = append(requests, "complete")
+				registrationIDs = append(registrationIDs, body.RuntimeAdapterDeleteCompletion.RegistrationID)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"error":"runtime_adapter_delete_completion_mismatch"}`))
+				return
+			}
+			if body.RuntimeAdapterLegacyDeleteCompletion == nil {
+				t.Fatal("missing atomic legacy runtime adapter completion")
+			}
+			requests = append(requests, "legacy-complete")
+			if completion := body.RuntimeAdapterLegacyDeleteCompletion; completion.AdapterID != "mac-lab" ||
+				completion.WorkspaceID != "fleet-a-is-123" || completion.Status != "absent" {
+				t.Fatalf("legacy completion=%#v", completion)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","state":"released"}}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_123", "adapter-box", cfg,
+		Server{Provider: "external", CloudID: "adapter-box"},
+		SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutateLeaseClaim("cbx_123", func(claim *leaseClaim) error {
+		claim.RuntimeAdapterRegistrationID = "registration-generation-current"
+		claim.RuntimeAdapterPendingRegistrationID = "registration-generation-pending"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	if err := app.releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(context.Background(), cfg, "cbx_123"); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(registrationIDs, []string{
+		"registration-generation-pending",
+		"registration-generation-current",
+	}) {
+		t.Fatalf("completion registration ids=%q", registrationIDs)
+	}
+	if !reflect.DeepEqual(requests, []string{"complete", "complete", "legacy-complete"}) {
+		t.Fatalf("requests=%q", requests)
+	}
+}
+
+func TestConfirmedAbsenceGenerationMismatchRejectsGenerationAwareLegacyFallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	completionRequests := 0
+	legacyCompletionRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_123/release":
+			var body struct {
+				RuntimeAdapterDeleteCompletion       json.RawMessage `json:"runtimeAdapterDeleteCompletion"`
+				RuntimeAdapterLegacyDeleteCompletion *struct {
+					AdapterID   string `json:"adapterID"`
+					WorkspaceID string `json:"workspaceID"`
+					Status      string `json:"status"`
+				} `json:"runtimeAdapterLegacyDeleteCompletion"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			if len(body.RuntimeAdapterDeleteCompletion) != 0 {
+				completionRequests++
+				_, _ = w.Write([]byte(`{"error":"runtime_adapter_delete_completion_mismatch"}`))
+				return
+			}
+			if completion := body.RuntimeAdapterLegacyDeleteCompletion; completion == nil ||
+				completion.AdapterID != "mac-lab" || completion.WorkspaceID != "fleet-a-is-123" ||
+				completion.Status != "absent" {
+				t.Fatalf("legacy completion=%#v", completion)
+			}
+			legacyCompletionRequests++
+			_, _ = w.Write([]byte(`{"error":"runtime_adapter_delete_completion_mismatch"}`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_123", "adapter-box", cfg,
+		Server{Provider: "external", CloudID: "adapter-box"},
+		SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := mutateLeaseClaim("cbx_123", func(claim *leaseClaim) error {
+		claim.RuntimeAdapterRegistrationID = "registration-generation-old"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := (App{}).releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(
+		context.Background(),
+		cfg,
+		"cbx_123",
+	)
+	if err == nil || !strings.Contains(err.Error(), "runtime_adapter_delete_completion_mismatch") {
+		t.Fatalf("generation-aware cleanup error=%v", err)
+	}
+	if completionRequests != 1 || legacyCompletionRequests != 1 {
+		t.Fatalf("completion=%d legacy completion=%d", completionRequests, legacyCompletionRequests)
+	}
+}
+
+func TestControllerManagedCoordinatorDeregistrationWithoutGenerationUsesLegacyRelease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	requests := 0
+	var completion struct {
+		AdapterID   string `json:"adapterID"`
+		WorkspaceID string `json:"workspaceID"`
+		Status      string `json:"status"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/release" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			RuntimeAdapterLegacyDeleteCompletion json.RawMessage `json:"runtimeAdapterLegacyDeleteCompletion"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(body.RuntimeAdapterLegacyDeleteCompletion, &completion); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_123","state":"released"}}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	if err := claimLeaseTargetForRepoConfig(
+		"cbx_123", "adapter-box", cfg,
+		Server{Provider: "external", CloudID: "adapter-box"},
+		SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	if err := app.releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(context.Background(), cfg, "cbx_123"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 || completion.AdapterID != "mac-lab" || completion.WorkspaceID != "fleet-a-is-123" ||
+		completion.Status != "absent" {
+		t.Fatalf("requests=%d completion=%#v", requests, completion)
+	}
+}
+
+func TestExpiredLegacyPendingDeleteUsesAtomicCoordinatorFinalizer(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	pending := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_expired/release" {
+			t.Fatalf("expired pending cleanup used non-atomic request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			RuntimeAdapterLegacyDeleteCompletion *struct {
+				AdapterID   string `json:"adapterID"`
+				WorkspaceID string `json:"workspaceID"`
+				Status      string `json:"status"`
+			} `json:"runtimeAdapterLegacyDeleteCompletion"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if completion := body.RuntimeAdapterLegacyDeleteCompletion; completion == nil ||
+			completion.AdapterID != "mac-lab" || completion.WorkspaceID != "fleet-a-is-123" ||
+			completion.Status != "absent" {
+			t.Fatalf("legacy completion=%#v", completion)
+		}
+		pending = false
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lease":{"id":"cbx_expired","state":"released"}}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	if err := (App{}).releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(
+		context.Background(),
+		cfg,
+		"cbx_expired",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if pending {
+		t.Fatal("expired legacy pending cleanup was treated as already complete")
+	}
+}
+
+func TestControllerManagedCoordinatorDeregistrationWithoutClaimRejectsGenerationAwareRelease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	completionRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/release" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		completionRequests++
+		var body struct {
+			RuntimeAdapterLegacyDeleteCompletion json.RawMessage `json:"runtimeAdapterLegacyDeleteCompletion"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if len(body.RuntimeAdapterLegacyDeleteCompletion) == 0 {
+			t.Fatal("missing atomic legacy runtime adapter completion")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"runtime_adapter_delete_completion_mismatch"}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+	err := (App{}).releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(
+		context.Background(),
+		cfg,
+		"cbx_123",
+	)
+	if err == nil || !strings.Contains(err.Error(), "runtime_adapter_delete_completion_mismatch") {
+		t.Fatalf("generation-aware cleanup error=%v", err)
+	}
+	if completionRequests != 1 {
+		t.Fatalf("generation-aware atomic completion requests=%d", completionRequests)
+	}
+}
+
+func TestConfirmedAbsenceWithoutAdapterBindingRejectsPersistedGeneration(t *testing.T) {
+	for _, field := range []string{"current", "pending"} {
+		t.Run(field, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("CRABBOX_ADAPTER_ID", "")
+			t.Setenv(controllerWorkspaceIDEnv, "")
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				t.Fatalf("generation-aware cleanup made unexpected request %s %s", r.Method, r.URL.Path)
+			}))
+			defer server.Close()
+
+			cfg := Config{Coordinator: server.URL, CoordToken: "token", BrokerMode: BrokerModeRegistered}
+			if err := claimLeaseTargetForRepoConfig(
+				"cbx_123", "adapter-box", cfg,
+				Server{Provider: "external", CloudID: "adapter-box"},
+				SSHTarget{Host: "192.0.2.10", Port: "22"}, "/repo", time.Hour, true,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if err := mutateLeaseClaim("cbx_123", func(claim *leaseClaim) error {
+				if field == "current" {
+					claim.RuntimeAdapterRegistrationID = "registration-generation-current"
+				} else {
+					claim.RuntimeAdapterPendingRegistrationID = "registration-generation-pending"
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			err := (App{}).releaseRegisteredCoordinatorLeaseAfterConfirmedAbsence(
+				context.Background(),
+				cfg,
+				"cbx_123",
+			)
+			if err == nil || !strings.Contains(err.Error(), "requires adapter binding") {
+				t.Fatalf("generation-aware cleanup error=%v", err)
+			}
+			if requests != 0 {
+				t.Fatalf("generation-aware cleanup requests=%d", requests)
+			}
+		})
+	}
 }
 
 func TestConfirmedAbsenceCoordinatorDeregistrationTreatsMissingAsClean(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_123/release" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -23,6 +23,7 @@ const bridgeDataAttachmentKinds = new Set([
   "egress-host",
   "egress-client",
   "workspace-terminal",
+  "runtime-adapter-agent",
 ]);
 
 export interface NodeUpgradeContext {
@@ -108,6 +109,7 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
   beginShutdown(): void {
     this.shuttingDown = true;
     clearInterval(this.pingInterval);
+    this.closeSocketsForShutdown();
   }
 
   private closeSocketsForShutdown(): void {
@@ -117,7 +119,6 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
 
   async stop(): Promise<void> {
     this.beginShutdown();
-    this.closeSocketsForShutdown();
     await Promise.allSettled(this.socketClosures ?? []);
     await this.drainSocketOperations();
     await this.alarmRun;

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -1,9 +1,10 @@
-import type { IncomingMessage, Server } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
 import { BlockList, isIP } from "node:net";
 import type { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
 
 import { coordinatorRequestQueue, type CoordinatorRequestQueue } from "../src/coordinator-runtime";
+import { runtimeAdapterRelayBodyLimit } from "../src/runtime-adapter-relay";
 
 export const unauthenticatedRequestBodyBytes = 1024 * 1024;
 export const authenticatedRequestBodyBytes = 16 * 1024 * 1024;
@@ -12,6 +13,29 @@ export const runFinishRequestBodyBytes = 64 * 1024 * 1024;
 const noop = () => {};
 
 export class RequestBodyTooLargeError extends Error {}
+
+export function nodeRequestAbortSignal(
+  request: IncomingMessage,
+  response: ServerResponse,
+): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController();
+  const abortRequest = () => controller.abort();
+  const abortResponse = () => {
+    if (!response.writableFinished) controller.abort();
+  };
+  request.once("aborted", abortRequest);
+  response.once("close", abortResponse);
+  if (request.aborted || (response.destroyed && !response.writableFinished)) {
+    controller.abort();
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      request.off("aborted", abortRequest);
+      response.off("close", abortResponse);
+    },
+  };
+}
 
 export class AsyncMutex {
   private tail: Promise<void> = Promise.resolve();
@@ -62,6 +86,15 @@ export function requestBodyLimit(request: Request, authenticated: boolean): numb
   if (!authenticated) return unauthenticatedRequestBodyBytes;
   const url = new URL(request.url);
   const path = url.pathname.split("/").filter(Boolean);
+  if (
+    path.length >= 5 &&
+    path[0] === "v1" &&
+    path[1] === "adapters" &&
+    path[2] &&
+    path[3] === "proxy"
+  ) {
+    return runtimeAdapterRelayBodyLimit;
+  }
   if (
     request.method.toUpperCase() === "POST" &&
     path.length === 4 &&

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -17,6 +17,7 @@ import {
   fleetRequestQueue,
   isReadinessRequestMethod,
   isTrustedProxySource,
+  nodeRequestAbortSignal,
   readNodeRequestBody,
   requestSourceIP,
   requestBodyLimit,
@@ -50,9 +51,10 @@ const server = createServer((request, response) => {
 });
 
 async function handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const cancellation = nodeRequestAbortSignal(request, response);
   try {
     const requestContext = nodeRequestContext(request);
-    const requestMetadata = webRequestFromNode(request, requestContext);
+    const requestMetadata = webRequestFromNode(request, requestContext, cancellation.signal);
     const authContext = { trustedProxy: requestContext.trustedProxy };
     if (new URL(requestMetadata.url).pathname === "/v1/ready") {
       let result: Response;
@@ -105,6 +107,8 @@ async function handleRequest(request: IncomingMessage, response: ServerResponse)
     }
     console.error("coordinator request failed", error);
     await writeResponse(response, Response.json({ error: "internal_error" }, { status: 500 }));
+  } finally {
+    cancellation.dispose();
   }
 }
 
@@ -210,7 +214,11 @@ function nodeRequestContext(request: IncomingMessage): NodeRequestContext {
   };
 }
 
-function webRequestFromNode(request: IncomingMessage, context: NodeRequestContext): Request {
+function webRequestFromNode(
+  request: IncomingMessage,
+  context: NodeRequestContext,
+  signal?: AbortSignal,
+): Request {
   const protocol = context.trustedProxy
     ? firstHeader(request.headers["x-forwarded-proto"]) || "http"
     : "http";
@@ -230,7 +238,7 @@ function webRequestFromNode(request: IncomingMessage, context: NodeRequestContex
   headers.delete("cf-connecting-ip");
   if (context.sourceIP) headers.set("cf-connecting-ip", context.sourceIP);
   const method = request.method || "GET";
-  return new Request(url, { method, headers });
+  return new Request(url, { method, headers, ...(signal ? { signal } : {}) });
 }
 
 async function requestWithNodeBody(

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -59,7 +59,8 @@ export async function prepareCoordinatorRequest(
   if (
     isWebVNCAgentUpgrade(request, url) ||
     isCodeAgentUpgrade(request, url) ||
-    isEgressAgentUpgrade(request, url)
+    isEgressAgentUpgrade(request, url) ||
+    isRuntimeAdapterAgentUpgrade(request, url)
   ) {
     return { request: requestWithoutProxySecret(request), authenticated: false };
   }
@@ -107,6 +108,14 @@ function isEgressAgentUpgrade(request: Request, url: URL): boolean {
     request.method === "GET" &&
     request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
     /^\/v1\/leases\/[^/]+\/egress\/(?:host|client)$/.test(url.pathname)
+  );
+}
+
+function isRuntimeAdapterAgentUpgrade(request: Request, url: URL): boolean {
+  return (
+    request.method === "GET" &&
+    request.headers.get("upgrade")?.toLowerCase() === "websocket" &&
+    /^\/v1\/adapters\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\/agent$/.test(url.pathname)
   );
 }
 

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -29,6 +29,13 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (path[0] === "v1" && path[1] === "images") {
     return "direct";
   }
+  if (
+    path[0] === "v1" &&
+    path[1] === "adapters" &&
+    ((method === "GET" && path.length === 3) || path[3] === "proxy")
+  ) {
+    return "direct";
+  }
   if (path.join("/") === "v1/pool") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -59,6 +59,22 @@ import {
   type PortalMacHostRecord,
   webVNCBridgeCommand,
 } from "./portal";
+import {
+  readRuntimeAdapterRelayBody,
+  runtimeAdapterProxyPath,
+  runtimeAdapterRelayBodyAllowed,
+  runtimeAdapterRelayContentType,
+  runtimeAdapterRelayFrameLimit,
+  runtimeAdapterRelayHeaders,
+  runtimeAdapterRelayMethodAllowed,
+  runtimeAdapterRelayTimeoutForPath,
+  runtimeAdapterRelayTimeoutMs,
+  validRuntimeAdapterID,
+  validRuntimeAdapterDesktopRelayTimeout,
+  validRuntimeAdapterRelayResponse,
+  type RuntimeAdapterRelayRequest,
+  type RuntimeAdapterRelayResponse,
+} from "./runtime-adapter-relay";
 import { leaseSlugFromID, normalizeLeaseSlug, slugWithCollisionSuffix } from "./slug";
 import {
   createTailscaleAuthKey,
@@ -117,6 +133,19 @@ const maxExternalRunnerSyncItems = 200;
 const webVNCTicketTTLSeconds = 120;
 const codeTicketTTLSeconds = 120;
 const egressTicketTTLSeconds = 120;
+const runtimeAdapterTicketTTLSeconds = 120;
+const runtimeAdapterDeleteRetryBaseMs = 5_000;
+const runtimeAdapterDeleteRetryMaxMs = 60_000;
+const runtimeAdapterDeleteDispatchGraceMs = 1_000;
+const runtimeAdapterDeleteInitialRetryMs =
+  runtimeAdapterRelayTimeoutMs + runtimeAdapterDeleteDispatchGraceMs;
+const runtimeAdapterMaxPendingPerAdapter = 16;
+const runtimeAdapterMaxPendingPerOwner = 32;
+const runtimeAdapterMaxPendingGlobal = 128;
+const runtimeAdapterReservedDeletesPerAdapter = 4;
+const runtimeAdapterReservedDeletesPerOwner = 8;
+const runtimeAdapterReservedDeletesGlobal = 16;
+const runtimeAdapterMaxBufferedBytes = runtimeAdapterRelayFrameLimit * 2;
 const leaseCleanupRetryDelayMs = 5 * 60 * 1000;
 const leaseCleanupClaimStaleMs = 30 * 60 * 1000;
 const awsOrphanSweepInitialDelayMs = 60 * 1000;
@@ -131,6 +160,7 @@ const maxCodeRequestBytes = 10 * 1024 * 1024;
 const maxCodeWebSocketFrameChunkBytes = 15 * 1024;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const fatalTextDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
 const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
 const azureOrphanSweepRecordKey = "azure-orphan-sweep:last";
@@ -173,6 +203,87 @@ interface CodeTicketRecord {
   org: string;
   createdAt: string;
   expiresAt: string;
+}
+
+interface RuntimeAdapterTicketRecord {
+  ticket: string;
+  adapterID: string;
+  owner: string;
+  org: string;
+  createdAt: string;
+  expiresAt: string;
+  desktopTimeoutMs?: number;
+}
+
+interface RuntimeAdapterIdentityRecord {
+  adapterID: string;
+  owner: string;
+  org: string;
+  createdAt: string;
+}
+
+interface RuntimeAdapterPendingRequest {
+  adapterID: string;
+  owner: string;
+  org: string;
+  dispatched: boolean;
+  clientSettled: boolean;
+  resolve: (result: RuntimeAdapterRelayResult) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  signal: AbortSignal;
+  abortHandler: () => void;
+}
+
+interface RuntimeAdapterRelayResult {
+  origin: "relay" | "upstream";
+  response: RuntimeAdapterRelayResponse;
+}
+
+interface RuntimeAdapterProxyResult {
+  origin: "relay" | "upstream";
+  dispatched: boolean;
+  response: Response;
+}
+
+interface RuntimeAdapterProxyScope {
+  owner: string;
+  org: string;
+}
+
+interface RuntimeAdapterDeleteClaim {
+  requestedAt: string;
+  claimID: string;
+  created: boolean;
+}
+
+interface RuntimeAdapterDeleteVersion {
+  requestedAt: string;
+  claimID?: string;
+}
+
+interface RuntimeAdapterDeleteDispatch {
+  lease: LeaseRecord;
+  version: RuntimeAdapterDeleteVersion;
+  deadlineMs: number;
+  fenceUntil: string;
+}
+
+type RuntimeAdapterDeleteFinalization =
+  | { status: "completed"; lease: LeaseRecord }
+  | { status: "in-flight"; retryAt: string }
+  | { status: "mismatch" };
+
+interface RuntimeAdapterDeleteCompletion {
+  adapterID: string;
+  workspaceID: string;
+  registrationID: string;
+  status: "absent";
+}
+
+interface RuntimeAdapterLegacyDeleteCompletion {
+  adapterID: string;
+  workspaceID: string;
+  status: "absent";
 }
 
 type EgressRole = "host" | "client";
@@ -257,6 +368,7 @@ interface CodeProxyResponse {
 }
 
 interface CodePendingRequest {
+  leaseID: string;
   resolve: (response: CodeProxyResponse) => void;
   timeout: ReturnType<typeof setTimeout>;
   response?: CodeProxyResponse;
@@ -305,6 +417,7 @@ interface CodeWebSocketClose {
 }
 
 interface CodePendingWebSocketFrame {
+  leaseID: string;
   id: string;
   frame: "text" | "binary";
   chunks: string[];
@@ -460,6 +573,13 @@ type BridgeAttachment =
   | { kind: "egress-host"; leaseID: string; sessionID: string }
   | { kind: "egress-client"; leaseID: string; sessionID: string }
   | {
+      kind: "runtime-adapter-agent";
+      adapterID: string;
+      owner: string;
+      org: string;
+      desktopTimeoutMs?: number;
+    }
+  | {
       kind: "control";
       clientID: string;
       owner: string;
@@ -508,8 +628,12 @@ export class FleetCoordinator {
   private readonly egressHosts = new Map<string, WebSocket>();
   private readonly egressClients = new Map<string, WebSocket>();
   private readonly egressSessions = new Map<string, EgressSessionStatus>();
+  private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
+  private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
+  private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
+  private readonly bridgeRestoreReady: Promise<boolean>;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private awsIngressBarrier: Promise<void> = Promise.resolve();
   private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
@@ -521,6 +645,13 @@ export class FleetCoordinator {
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
   ) {
     this.restoreBridgeWebSockets();
+    this.bridgeRestoreReady = this.revokeInactiveRestoredBridgeSockets().then(
+      () => true,
+      (error) => {
+        console.warn("could not reconcile restored lease bridges", errorMessage(error));
+        return false;
+      },
+    );
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -654,6 +785,20 @@ export class FleetCoordinator {
       if (parts[0] === "v1" && parts[1] === "workspaces" && parts[2]) {
         return await this.workspaceRoute(request, parts[2], parts[3], parts[4]);
       }
+      if (parts[0] === "v1" && parts[1] === "adapters" && parts[2]) {
+        if (parts[3] === "ticket" && parts.length === 4) {
+          return await this.createRuntimeAdapterTicket(request, parts[2]);
+        }
+        if (parts[3] === "agent" && parts.length === 4) {
+          return await this.runtimeAdapterAgent(request, parts[2]);
+        }
+        if (parts[3] === "proxy") {
+          return await this.runtimeAdapterProxy(request, parts[2], parts.slice(4));
+        }
+        if (method === "GET" && parts.length === 3) {
+          return await this.runtimeAdapterStatus(request, parts[2]);
+        }
+      }
       if (
         parts[0] === "v1" &&
         parts[1] === "leases" &&
@@ -779,6 +924,28 @@ export class FleetCoordinator {
     }
   }
 
+  private async revokeInactiveRestoredBridgeSockets(): Promise<void> {
+    const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+    const now = Date.now();
+    const revoked = new Map<string, string>();
+    for (const socket of this.state.getWebSockets()) {
+      const attachment = this.bridgeAttachment(socket);
+      if (!attachment || !("leaseID" in attachment)) {
+        continue;
+      }
+      const lease = leases.get(leaseKey(attachment.leaseID));
+      if (!lease || !leaseIsLive(lease) || Date.parse(lease.expiresAt) <= now) {
+        revoked.set(
+          attachment.leaseID,
+          lease && leaseIsLive(lease) ? "lease expired" : "lease ended",
+        );
+      }
+    }
+    for (const [leaseID, reason] of revoked) {
+      this.closeLeaseBridges(leaseID, 1008, reason);
+    }
+  }
+
   private acceptBridgeWebSocket(socket: WebSocket, attachment: BridgeAttachment): void {
     this.state.acceptWebSocket(socket, attachment, bridgeTags(attachment), {
       message: (data) => this.handleBridgeMessage(socket, attachment, data),
@@ -823,6 +990,14 @@ export class FleetCoordinator {
       case "egress-client":
         this.egressClients.set(egressSocketKey(attachment.leaseID, attachment.sessionID), socket);
         this.trackEgressSession(attachment);
+        break;
+      case "runtime-adapter-agent":
+        closeSocket(
+          this.runtimeAdapterAgents.get(attachment.adapterID),
+          1012,
+          "replaced by a newer runtime adapter agent",
+        );
+        this.runtimeAdapterAgents.set(attachment.adapterID, socket);
         break;
       case "control":
         this.controlSockets.set(attachment.clientID, socket);
@@ -1050,6 +1225,10 @@ export class FleetCoordinator {
     attachment: BridgeAttachment,
     message: string | ArrayBuffer | Blob,
   ): Promise<void> {
+    if (!(await this.bridgeRestoreReady)) {
+      closeSocket(socket, 1011, "lease state unavailable");
+      return;
+    }
     switch (attachment.kind) {
       case "webvnc-agent":
         await forwardOrBufferWebVNC(
@@ -1098,6 +1277,9 @@ export class FleetCoordinator {
           this.egressHosts.get(egressSocketKey(attachment.leaseID, attachment.sessionID)),
         );
         break;
+      case "runtime-adapter-agent":
+        await this.handleRuntimeAdapterAgentMessage(attachment.adapterID, socket, message);
+        break;
       case "control":
         await this.handleControlMessage(socket, attachment, message);
         break;
@@ -1129,6 +1311,9 @@ export class FleetCoordinator {
       case "egress-client":
         this.clearEgressClient(attachment.leaseID, attachment.sessionID, socket);
         break;
+      case "runtime-adapter-agent":
+        this.clearRuntimeAdapterAgent(attachment.adapterID, socket);
+        break;
       case "control":
         if (this.controlSockets.get(attachment.clientID) === socket) {
           this.controlSockets.delete(attachment.clientID);
@@ -1139,6 +1324,7 @@ export class FleetCoordinator {
 
   async alarm(): Promise<void> {
     await this.expireLeases();
+    await this.reconcileRuntimeAdapterDeletes();
     await this.provisionPendingWorkspace();
     await this.pruneTerminalWorkspaces();
     await this.runAzureDeferredCleanups();
@@ -2978,6 +3164,26 @@ export class FleetCoordinator {
     if (!host) {
       return json({ error: "host_required" }, { status: 400 });
     }
+    const runtimeAdapterID = input.runtimeAdapterID;
+    const runtimeAdapterWorkspaceID = input.runtimeAdapterWorkspaceID;
+    const runtimeAdapterRegistrationID = input.runtimeAdapterRegistrationID;
+    if (
+      (runtimeAdapterID !== undefined ||
+        runtimeAdapterWorkspaceID !== undefined ||
+        runtimeAdapterRegistrationID !== undefined) &&
+      (!validRuntimeAdapterID(runtimeAdapterID) ||
+        !validRuntimeAdapterID(runtimeAdapterWorkspaceID) ||
+        !validRuntimeAdapterID(runtimeAdapterRegistrationID))
+    ) {
+      return json(
+        {
+          error: "invalid_runtime_adapter_binding",
+          message:
+            "runtime adapter id, workspace id, and registration id must all be valid DNS-style identifiers",
+        },
+        { status: 400 },
+      );
+    }
 
     if (await this.state.storage.get(workspaceLeaseReservationKey(leaseID))) {
       return workspaceManagedLeaseResponse();
@@ -2998,8 +3204,118 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
+    if (existing?.runtimeAdapterDeleteRequestedAt) {
+      return json(
+        {
+          error: "runtime_adapter_delete_pending",
+          message: "registered lease cannot be refreshed while its workspace deletion is pending",
+        },
+        { status: 409 },
+      );
+    }
+    if (
+      existing &&
+      leaseIsLive(existing) &&
+      existing.runtimeAdapterID &&
+      runtimeAdapterID &&
+      (existing.runtimeAdapterID !== runtimeAdapterID ||
+        existing.runtimeAdapterWorkspaceID !== runtimeAdapterWorkspaceID ||
+        (existing.runtimeAdapterRegistrationID !== undefined &&
+          existing.runtimeAdapterRegistrationID !== runtimeAdapterRegistrationID))
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_conflict",
+          message: "registered lease runtime adapter binding cannot change",
+        },
+        { status: 409 },
+      );
+    }
+    const inheritRuntimeAdapterBinding =
+      existing !== undefined && leaseIsLive(existing) && runtimeAdapterID === undefined;
+    const effectiveRuntimeAdapterID =
+      runtimeAdapterID ?? (inheritRuntimeAdapterBinding ? existing.runtimeAdapterID : undefined);
+    const effectiveRuntimeAdapterWorkspaceID =
+      runtimeAdapterWorkspaceID ??
+      (inheritRuntimeAdapterBinding ? existing.runtimeAdapterWorkspaceID : undefined);
+    const effectiveRuntimeAdapterRegistrationID =
+      runtimeAdapterRegistrationID ??
+      (inheritRuntimeAdapterBinding ? existing.runtimeAdapterRegistrationID : undefined);
+    if (
+      effectiveRuntimeAdapterID &&
+      effectiveRuntimeAdapterWorkspaceID &&
+      !validRuntimeAdapterID(effectiveRuntimeAdapterRegistrationID)
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_registration_required",
+          message: "runtime adapter registrations require an immutable registration id",
+        },
+        { status: 409 },
+      );
+    }
+    if (
+      existing &&
+      effectiveRuntimeAdapterRegistrationID &&
+      existing.runtimeAdapterRegistrationID === effectiveRuntimeAdapterRegistrationID &&
+      (!leaseIsLive(existing) || !existing.runtimeAdapterID)
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_registration_replayed",
+          message: "a new runtime adapter registration requires a new registration id",
+        },
+        { status: 409 },
+      );
+    }
+    if (effectiveRuntimeAdapterID && effectiveRuntimeAdapterWorkspaceID) {
+      const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(
+        runtimeAdapterIdentityKey(effectiveRuntimeAdapterID),
+      );
+      if (!identity) {
+        return json(
+          {
+            error: "runtime_adapter_unclaimed",
+            message: "runtime adapter id must be claimed before it can be bound to a lease",
+          },
+          { status: 409 },
+        );
+      }
+      if (
+        identity.adapterID !== effectiveRuntimeAdapterID ||
+        identity.owner !== owner ||
+        identity.org !== org
+      ) {
+        return json(
+          {
+            error: "runtime_adapter_conflict",
+            message: "runtime adapter id belongs to another owner or organization",
+          },
+          { status: 409 },
+        );
+      }
+    }
 
     const leases = await this.leaseRecords();
+    if (
+      effectiveRuntimeAdapterID &&
+      effectiveRuntimeAdapterWorkspaceID &&
+      leases.some(
+        (lease) =>
+          lease.id !== leaseID &&
+          (leaseIsLive(lease) || Boolean(lease.runtimeAdapterDeleteRequestedAt)) &&
+          lease.runtimeAdapterID === effectiveRuntimeAdapterID &&
+          lease.runtimeAdapterWorkspaceID === effectiveRuntimeAdapterWorkspaceID,
+      )
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_workspace_conflict",
+          message: "runtime adapter workspace is already bound to a live lease or pending deletion",
+        },
+        { status: 409 },
+      );
+    }
     const now = new Date();
     const nowISO = now.toISOString();
     const ttlSeconds = clampLeaseSeconds(input.ttlSeconds, 86_400);
@@ -3019,6 +3335,13 @@ export class FleetCoordinator {
       slug,
       provider,
       lifecycle: "registered",
+      ...(effectiveRuntimeAdapterID && effectiveRuntimeAdapterWorkspaceID
+        ? {
+            runtimeAdapterID: effectiveRuntimeAdapterID,
+            runtimeAdapterWorkspaceID: effectiveRuntimeAdapterWorkspaceID,
+            runtimeAdapterRegistrationID: effectiveRuntimeAdapterRegistrationID!,
+          }
+        : {}),
       target,
       ...(target === "windows"
         ? { windowsMode: input.windowsMode === "wsl2" ? "wsl2" : "normal" }
@@ -3079,6 +3402,13 @@ export class FleetCoordinator {
     delete record.releasedAt;
     delete record.releaseDeletesServer;
     clearLeaseCleanupMetadata(record);
+    if (!effectiveRuntimeAdapterID || !effectiveRuntimeAdapterWorkspaceID) {
+      delete record.runtimeAdapterID;
+      delete record.runtimeAdapterWorkspaceID;
+    }
+    if (!existing || !leaseIsLive(existing)) {
+      clearRuntimeAdapterDeleteMetadata(record);
+    }
     await this.putLease(record);
     await this.scheduleAlarm();
     return json({ lease: record }, { status: existing ? 200 : 201 });
@@ -3280,7 +3610,71 @@ export class FleetCoordinator {
     if (lease.workspaceID) {
       return workspaceManagedLeaseResponse();
     }
-    const body = await optionalJson<{ delete?: boolean }>(request);
+    const body = await optionalJson<{
+      delete?: boolean;
+      runtimeAdapterDeleteCompletion?: unknown;
+      runtimeAdapterLegacyDeleteCompletion?: unknown;
+    }>(request);
+    const runtimeAdapterCompletion = runtimeAdapterDeleteCompletion(
+      body.runtimeAdapterDeleteCompletion,
+    );
+    const runtimeAdapterLegacyCompletion = runtimeAdapterLegacyDeleteCompletion(
+      body.runtimeAdapterLegacyDeleteCompletion,
+    );
+    if (
+      body.runtimeAdapterDeleteCompletion !== undefined &&
+      runtimeAdapterCompletion === undefined
+    ) {
+      return json(
+        {
+          error: "invalid_runtime_adapter_delete_completion",
+          message:
+            "runtime adapter delete completion must identify an absent adapter workspace registration",
+        },
+        { status: 400 },
+      );
+    }
+    if (
+      body.runtimeAdapterLegacyDeleteCompletion !== undefined &&
+      runtimeAdapterLegacyCompletion === undefined
+    ) {
+      return json(
+        {
+          error: "invalid_runtime_adapter_legacy_delete_completion",
+          message:
+            "legacy runtime adapter delete completion must identify an absent adapter workspace binding",
+        },
+        { status: 400 },
+      );
+    }
+    if (runtimeAdapterCompletion && runtimeAdapterLegacyCompletion) {
+      return json(
+        {
+          error: "invalid_runtime_adapter_delete_completion",
+          message: "runtime adapter delete completion must select exactly one generation mode",
+        },
+        { status: 400 },
+      );
+    }
+    if (runtimeAdapterCompletion) {
+      return await this.completeRuntimeAdapterDelete(
+        request,
+        lease,
+        runtimeAdapterCompletion,
+        admin,
+      );
+    }
+    if (runtimeAdapterLegacyCompletion) {
+      return await this.completeLegacyRuntimeAdapterDelete(
+        request,
+        lease,
+        runtimeAdapterLegacyCompletion,
+        admin,
+      );
+    }
+    if (lease.runtimeAdapterDeleteRequestedAt) {
+      return runtimeAdapterDeletePendingResponse(lease);
+    }
     const shouldDelete = body.delete ?? !lease.keep;
     if (lease.cleanupStartedAt) {
       if (!shouldDelete) {
@@ -3297,6 +3691,9 @@ export class FleetCoordinator {
       return json({ lease });
     }
     const released = await this.releaseResolvedLease(lease, { deleteServer: shouldDelete });
+    if (released.runtimeAdapterDeleteRequestedAt) {
+      return runtimeAdapterDeletePendingResponse(released);
+    }
     if (released.cleanupStartedAt && !shouldDelete) {
       return json(
         {
@@ -3308,6 +3705,110 @@ export class FleetCoordinator {
       );
     }
     return json({ lease: released });
+  }
+
+  private async completeRuntimeAdapterDelete(
+    request: Request,
+    lease: LeaseRecord,
+    completion: RuntimeAdapterDeleteCompletion,
+    admin: boolean,
+  ): Promise<Response> {
+    if (
+      !isRegisteredLease(lease) ||
+      lease.runtimeAdapterID !== completion.adapterID ||
+      lease.runtimeAdapterWorkspaceID !== completion.workspaceID ||
+      lease.runtimeAdapterRegistrationID !== completion.registrationID
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_delete_completion_mismatch",
+          message:
+            "runtime adapter delete completion does not match the registered lease generation",
+        },
+        { status: 409 },
+      );
+    }
+    if (
+      !admin &&
+      (lease.owner !== requestOwner(request) || lease.org !== requestOrg(request, this.env))
+    ) {
+      return json(
+        {
+          error: "forbidden",
+          message: "runtime adapter delete completion requires the lease owner",
+        },
+        { status: 403 },
+      );
+    }
+    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+      const result = await this.finalizeRuntimeAdapterDeleteCompletion(lease, completion);
+      if (result.status === "in-flight") {
+        return runtimeAdapterDeleteInFlightResponse(result.retryAt);
+      }
+      if (result.status === "mismatch") {
+        return json(
+          {
+            error: "lease_state_changed",
+            message: "lease changed while completing its runtime adapter delete",
+            lease: await this.getLease(lease.id),
+          },
+          { status: 409 },
+        );
+      }
+      return json({ lease: result.lease });
+    });
+  }
+
+  private async completeLegacyRuntimeAdapterDelete(
+    request: Request,
+    lease: LeaseRecord,
+    completion: RuntimeAdapterLegacyDeleteCompletion,
+    admin: boolean,
+  ): Promise<Response> {
+    if (
+      !isRegisteredLease(lease) ||
+      lease.runtimeAdapterID !== completion.adapterID ||
+      lease.runtimeAdapterWorkspaceID !== completion.workspaceID ||
+      lease.runtimeAdapterRegistrationID
+    ) {
+      return json(
+        {
+          error: "runtime_adapter_delete_completion_mismatch",
+          message:
+            "legacy runtime adapter delete completion does not match a generation-less registered binding",
+        },
+        { status: 409 },
+      );
+    }
+    if (
+      !admin &&
+      (lease.owner !== requestOwner(request) || lease.org !== requestOrg(request, this.env))
+    ) {
+      return json(
+        {
+          error: "forbidden",
+          message: "legacy runtime adapter delete completion requires the lease owner",
+        },
+        { status: 403 },
+      );
+    }
+    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+      const result = await this.finalizeLegacyRuntimeAdapterDelete(lease, completion);
+      if (result.status === "in-flight") {
+        return runtimeAdapterDeleteInFlightResponse(result.retryAt);
+      }
+      if (result.status === "mismatch") {
+        return json(
+          {
+            error: "lease_state_changed",
+            message: "lease changed while completing its legacy runtime adapter delete",
+            lease: await this.getLease(lease.id),
+          },
+          { status: 409 },
+        );
+      }
+      return json({ lease: result.lease });
+    });
   }
 
   private async shareLeaseRoute(request: Request, leaseID: string): Promise<Response> {
@@ -3756,6 +4257,10 @@ export class FleetCoordinator {
         ...(lease.slug ? { slug: lease.slug } : {}),
         provider: lease.provider,
         lifecycle: lease.lifecycle,
+        ...(lease.runtimeAdapterID ? { runtimeAdapterID: lease.runtimeAdapterID } : {}),
+        ...(lease.runtimeAdapterWorkspaceID
+          ? { runtimeAdapterWorkspaceID: lease.runtimeAdapterWorkspaceID }
+          : {}),
         state: lease.state,
         target: lease.target || "linux",
         owner: lease.owner,
@@ -3979,10 +4484,374 @@ export class FleetCoordinator {
     if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
       return portalError("Stop unavailable", "Lease manage access is required.", 403);
     }
+    if (isRegisteredLease(lease) && lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID) {
+      const adapterID = lease.runtimeAdapterID;
+      const workspaceID = lease.runtimeAdapterWorkspaceID;
+      return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+        const current = await this.state.runExclusive(() => this.getLease(lease.id));
+        if (!current || !leaseIsLive(current)) {
+          return portalError("Delete unavailable", "That lease is no longer active.", 409);
+        }
+        if (!this.leaseManageableByRequest(current, request, isAdminRequest(request))) {
+          return portalError("Delete unavailable", "Lease manage access is required.", 403);
+        }
+        if (
+          current.runtimeAdapterID !== adapterID ||
+          current.runtimeAdapterWorkspaceID !== workspaceID ||
+          current.runtimeAdapterRegistrationID !== lease.runtimeAdapterRegistrationID
+        ) {
+          return portalError("Delete unavailable", "The runtime adapter binding changed.", 409);
+        }
+        const deleteClaim = await this.markRuntimeAdapterDeletePending(
+          current,
+          runtimeAdapterDeleteInitialRetryMs,
+        );
+        if (!deleteClaim) {
+          return portalError("Delete unavailable", "That lease is no longer active.", 409);
+        }
+        const dispatch = await this.beginRuntimeAdapterDeleteDispatch(current, deleteClaim);
+        if (!dispatch) {
+          return portalError(
+            "Delete unavailable",
+            "Another delete for this workspace is still settling. Try again shortly.",
+            503,
+          );
+        }
+        const proxyResult = await (async () => {
+          let result: RuntimeAdapterProxyResult | undefined;
+          try {
+            result = await this.runtimeAdapterProxyResult(
+              new Request(request.url, { method: "DELETE", headers: request.headers }),
+              adapterID,
+              ["v1", "workspaces", workspaceID],
+              { owner: current.owner, org: current.org },
+              dispatch.deadlineMs,
+            );
+            return result;
+          } finally {
+            await this.finishRuntimeAdapterDeleteDispatch(
+              dispatch,
+              result !== undefined && (await runtimeAdapterDeleteDispatchSafeToClear(result)),
+            );
+          }
+        })();
+        const response = proxyResult.response;
+        let body:
+          | { id?: unknown; status?: unknown; message?: unknown; error?: unknown }
+          | undefined;
+        if (response.status !== 204) {
+          body = (await response
+            .clone()
+            .json()
+            .catch(() => undefined)) as
+            | { status?: unknown; message?: unknown; error?: unknown }
+            | undefined;
+        }
+        if (!response.ok) {
+          const relayRetryable =
+            proxyResult.origin === "relay" &&
+            ["runtime_adapter_busy", "runtime_adapter_backpressure"].includes(
+              runtimeAdapterErrorCode(body) ?? "",
+            );
+          if (deleteClaim.created && !proxyResult.dispatched && !relayRetryable) {
+            await this.clearRuntimeAdapterDeletePending(current, deleteClaim);
+          }
+          const unavailable =
+            response.status === 429 || response.status === 503 || response.status === 504;
+          return portalError(
+            unavailable ? "Delete unavailable" : "Delete failed",
+            unavailable
+              ? "The runtime adapter is offline or did not respond. Try again after its lifecycle agent reconnects."
+              : "The runtime adapter rejected the delete request. The workspace is still registered.",
+            unavailable ? 503 : 502,
+          );
+        }
+        if (
+          response.ok &&
+          response.status !== 204 &&
+          (body?.id !== workspaceID ||
+            !["stopping", "stopped", "expired"].includes(String(body?.status)))
+        ) {
+          return portalError(
+            "Delete failed",
+            "The runtime adapter returned an invalid workspace confirmation. The workspace is still registered.",
+            502,
+          );
+        }
+        const applied = await this.scheduleRuntimeAdapterDeleteRetry(
+          current,
+          deleteClaim,
+          runtimeAdapterDeleteRetryBaseMs,
+        );
+        if (!applied) {
+          const latest = await this.getLease(lease.id);
+          if (
+            latest &&
+            !leaseIsLive(latest) &&
+            !latest.runtimeAdapterDeleteRequestedAt &&
+            latest.runtimeAdapterID === adapterID &&
+            latest.runtimeAdapterWorkspaceID === workspaceID &&
+            latest.runtimeAdapterRegistrationID === lease.runtimeAdapterRegistrationID
+          ) {
+            return new Response(null, {
+              status: 303,
+              headers: { location: portalReturnLocation(request) },
+            });
+          }
+          return portalError(
+            "Delete unavailable",
+            "The lease changed while the runtime adapter was deleting its workspace.",
+            409,
+          );
+        }
+        return new Response(null, {
+          status: 303,
+          headers: { location: portalReturnLocation(request) },
+        });
+      });
+    }
     await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
     return new Response(null, {
       status: 303,
       headers: { location: portalReturnLocation(request) },
+    });
+  }
+
+  private async serializeRuntimeAdapterDelete<T>(
+    leaseID: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.runtimeAdapterDeleteQueues.get(leaseID) ?? Promise.resolve();
+    let release!: () => void;
+    const turn = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => turn);
+    this.runtimeAdapterDeleteQueues.set(leaseID, tail);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.runtimeAdapterDeleteQueues.get(leaseID) === tail) {
+        this.runtimeAdapterDeleteQueues.delete(leaseID);
+      }
+    }
+  }
+
+  private async markRuntimeAdapterDeletePending(
+    lease: LeaseRecord,
+    retryDelay: number,
+  ): Promise<RuntimeAdapterDeleteClaim | undefined> {
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (
+        !current ||
+        !leaseIsLive(current) ||
+        !isRegisteredLease(current) ||
+        current.runtimeAdapterID !== lease.runtimeAdapterID ||
+        current.runtimeAdapterWorkspaceID !== lease.runtimeAdapterWorkspaceID ||
+        current.runtimeAdapterRegistrationID !== lease.runtimeAdapterRegistrationID
+      ) {
+        return undefined;
+      }
+      const now = new Date();
+      const created = !current.runtimeAdapterDeleteRequestedAt;
+      const claimID = crypto.randomUUID();
+      current.runtimeAdapterDeleteRequestedAt ??= now.toISOString();
+      current.runtimeAdapterDeleteClaimID = claimID;
+      current.runtimeAdapterDeleteRetryAt = new Date(now.getTime() + retryDelay).toISOString();
+      if (created) {
+        current.runtimeAdapterDeleteAttempts = 0;
+        delete current.runtimeAdapterDeleteError;
+      }
+      current.updatedAt = now.toISOString();
+      await this.putLease(current);
+      await this.scheduleAlarm();
+      return { requestedAt: current.runtimeAdapterDeleteRequestedAt, claimID, created };
+    });
+  }
+
+  private async beginRuntimeAdapterDeleteDispatch(
+    lease: LeaseRecord,
+    version: RuntimeAdapterDeleteVersion,
+  ): Promise<RuntimeAdapterDeleteDispatch | undefined> {
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (!current || !runtimeAdapterDeleteVersionMatches(current, lease, version)) {
+        return undefined;
+      }
+      const now = Date.now();
+      const existingFence = Date.parse(current.runtimeAdapterDeleteDispatchUntil ?? "");
+      if (Number.isFinite(existingFence) && existingFence > now) {
+        return undefined;
+      }
+      const deadlineMs = now + runtimeAdapterRelayTimeoutMs;
+      const fenceUntil = new Date(deadlineMs + runtimeAdapterDeleteDispatchGraceMs).toISOString();
+      current.runtimeAdapterDeleteDispatchUntil = fenceUntil;
+      const retryAt = Date.parse(current.runtimeAdapterDeleteRetryAt ?? "");
+      if (!Number.isFinite(retryAt) || retryAt < Date.parse(fenceUntil)) {
+        current.runtimeAdapterDeleteRetryAt = fenceUntil;
+      }
+      current.updatedAt = new Date(now).toISOString();
+      await this.putLease(current);
+      await this.scheduleAlarm();
+      return {
+        lease: structuredClone(current),
+        version,
+        deadlineMs,
+        fenceUntil,
+      };
+    });
+  }
+
+  private async finishRuntimeAdapterDeleteDispatch(
+    dispatch: RuntimeAdapterDeleteDispatch,
+    safeToClear: boolean,
+  ): Promise<void> {
+    if (!safeToClear) {
+      return;
+    }
+    await this.state.runExclusive(async () => {
+      const current = await this.getLease(dispatch.lease.id);
+      if (
+        !current ||
+        current.runtimeAdapterDeleteDispatchUntil !== dispatch.fenceUntil ||
+        !runtimeAdapterDeleteVersionMatches(current, dispatch.lease, dispatch.version)
+      ) {
+        return;
+      }
+      delete current.runtimeAdapterDeleteDispatchUntil;
+      current.updatedAt = new Date().toISOString();
+      await this.putLease(current);
+      await this.scheduleAlarm();
+    });
+  }
+
+  private async clearRuntimeAdapterDeletePending(
+    lease: LeaseRecord,
+    claim: RuntimeAdapterDeleteVersion,
+  ): Promise<void> {
+    await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (!current || !runtimeAdapterDeleteVersionMatches(current, lease, claim)) {
+        return;
+      }
+      clearRuntimeAdapterDeleteMetadata(current);
+      current.updatedAt = new Date().toISOString();
+      await this.putLease(current);
+      await this.scheduleAlarm();
+    });
+  }
+
+  private async finalizeRuntimeAdapterDeleteCompletion(
+    lease: LeaseRecord,
+    completion: RuntimeAdapterDeleteCompletion,
+  ): Promise<RuntimeAdapterDeleteFinalization> {
+    const result = await this.state.runExclusive(
+      async (): Promise<RuntimeAdapterDeleteFinalization> => {
+        const current = await this.getLease(lease.id);
+        if (
+          !current ||
+          !isRegisteredLease(current) ||
+          current.owner !== lease.owner ||
+          current.org !== lease.org ||
+          current.runtimeAdapterID !== completion.adapterID ||
+          current.runtimeAdapterWorkspaceID !== completion.workspaceID ||
+          current.runtimeAdapterRegistrationID !== completion.registrationID
+        ) {
+          return { status: "mismatch" };
+        }
+        const dispatchUntil = Date.parse(current.runtimeAdapterDeleteDispatchUntil ?? "");
+        if (Number.isFinite(dispatchUntil) && dispatchUntil > Date.now()) {
+          return {
+            status: "in-flight",
+            retryAt: current.runtimeAdapterDeleteDispatchUntil!,
+          };
+        }
+        if (!leaseIsLive(current) && !current.runtimeAdapterDeleteRequestedAt) {
+          return { status: "completed", lease: current };
+        }
+        const finalized = current.runtimeAdapterDeleteRequestedAt
+          ? finalizedRuntimeAdapterDeleteLease(current)
+          : finalizedReleasedLease(current, false);
+        await this.putLease(finalized);
+        await this.clearWorkspaceReleaseError(finalized);
+        await this.markAWSIngressReconcilePending(finalized);
+        await this.scheduleAlarm();
+        return { status: "completed", lease: finalized };
+      },
+    );
+    if (result.status === "completed") {
+      this.closeLeaseBridges(lease.id, 1008, "lease ended");
+    }
+    return result;
+  }
+
+  private async finalizeLegacyRuntimeAdapterDelete(
+    lease: LeaseRecord,
+    completion: RuntimeAdapterLegacyDeleteCompletion,
+  ): Promise<RuntimeAdapterDeleteFinalization> {
+    const result = await this.state.runExclusive(
+      async (): Promise<RuntimeAdapterDeleteFinalization> => {
+        const current = await this.getLease(lease.id);
+        if (
+          !current ||
+          !isRegisteredLease(current) ||
+          current.runtimeAdapterRegistrationID ||
+          current.owner !== lease.owner ||
+          current.org !== lease.org ||
+          current.runtimeAdapterID !== completion.adapterID ||
+          current.runtimeAdapterWorkspaceID !== completion.workspaceID
+        ) {
+          return { status: "mismatch" };
+        }
+        const dispatchUntil = Date.parse(current.runtimeAdapterDeleteDispatchUntil ?? "");
+        if (Number.isFinite(dispatchUntil) && dispatchUntil > Date.now()) {
+          return {
+            status: "in-flight",
+            retryAt: current.runtimeAdapterDeleteDispatchUntil!,
+          };
+        }
+        if (!leaseIsLive(current) && !current.runtimeAdapterDeleteRequestedAt) {
+          return { status: "completed", lease: current };
+        }
+        const finalized = current.runtimeAdapterDeleteRequestedAt
+          ? finalizedRuntimeAdapterDeleteLease(current)
+          : finalizedReleasedLease(current, false);
+        await this.putLease(finalized);
+        await this.clearWorkspaceReleaseError(finalized);
+        await this.markAWSIngressReconcilePending(finalized);
+        await this.scheduleAlarm();
+        return { status: "completed", lease: finalized };
+      },
+    );
+    if (result.status === "completed") {
+      this.closeLeaseBridges(lease.id, 1008, "lease ended");
+    }
+    return result;
+  }
+
+  private async scheduleRuntimeAdapterDeleteRetry(
+    lease: LeaseRecord,
+    claim: RuntimeAdapterDeleteVersion,
+    retryDelay: number,
+  ): Promise<boolean> {
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      if (!current || !runtimeAdapterDeleteVersionMatches(current, lease, claim)) {
+        return false;
+      }
+      const now = new Date();
+      const dispatchUntil = Date.parse(current.runtimeAdapterDeleteDispatchUntil ?? "");
+      current.runtimeAdapterDeleteRetryAt = new Date(
+        Math.max(now.getTime() + retryDelay, Number.isFinite(dispatchUntil) ? dispatchUntil : 0),
+      ).toISOString();
+      delete current.runtimeAdapterDeleteError;
+      current.updatedAt = now.toISOString();
+      await this.putLease(current);
+      await this.scheduleAlarm();
+      return true;
     });
   }
 
@@ -4280,6 +5149,678 @@ export class FleetCoordinator {
       createdAt: session?.createdAt ?? "",
       updatedAt: session?.updatedAt ?? "",
     });
+  }
+
+  private async reconcileRuntimeAdapterDeletes(): Promise<void> {
+    const pending = await this.state.runExclusive(async () => {
+      const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
+      const now = Date.now();
+      return [...leases.values()]
+        .filter(
+          (lease) =>
+            (leaseIsLive(lease) || lease.state === "expired") &&
+            isRegisteredLease(lease) &&
+            Boolean(lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID) &&
+            Boolean(lease.runtimeAdapterDeleteRequestedAt) &&
+            (!Number.isFinite(Date.parse(lease.runtimeAdapterDeleteRetryAt ?? "")) ||
+              Date.parse(lease.runtimeAdapterDeleteRetryAt ?? "") <= now) &&
+            (!Number.isFinite(Date.parse(lease.runtimeAdapterDeleteDispatchUntil ?? "")) ||
+              Date.parse(lease.runtimeAdapterDeleteDispatchUntil ?? "") <= now),
+        )
+        .map((lease) => structuredClone(lease));
+    });
+    await Promise.all(pending.map((lease) => this.reconcileRuntimeAdapterDelete(lease)));
+  }
+
+  private async reconcileRuntimeAdapterDelete(lease: LeaseRecord): Promise<void> {
+    await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+      const requestedAt = lease.runtimeAdapterDeleteRequestedAt;
+      const adapterID = lease.runtimeAdapterID;
+      const workspaceID = lease.runtimeAdapterWorkspaceID;
+      if (!requestedAt || !adapterID || !workspaceID) {
+        return;
+      }
+      const version: RuntimeAdapterDeleteVersion = {
+        requestedAt,
+        ...(lease.runtimeAdapterDeleteClaimID === undefined
+          ? {}
+          : { claimID: lease.runtimeAdapterDeleteClaimID }),
+      };
+      const current = await this.state.runExclusive(async () => {
+        const latest = await this.getLease(lease.id);
+        if (!latest || !runtimeAdapterDeleteVersionMatches(latest, lease, version)) {
+          return undefined;
+        }
+        const now = Date.now();
+        const retryAt = Date.parse(latest.runtimeAdapterDeleteRetryAt ?? "");
+        const dispatchUntil = Date.parse(latest.runtimeAdapterDeleteDispatchUntil ?? "");
+        if (
+          (Number.isFinite(retryAt) && retryAt > now) ||
+          (Number.isFinite(dispatchUntil) && dispatchUntil > now)
+        ) {
+          return undefined;
+        }
+        return structuredClone(latest);
+      });
+      if (!current) {
+        return;
+      }
+      const dispatch = await this.beginRuntimeAdapterDeleteDispatch(current, version);
+      if (!dispatch) {
+        return;
+      }
+      const proxyResult = await (async () => {
+        let result: RuntimeAdapterProxyResult | undefined;
+        try {
+          result = await this.runtimeAdapterProxyResult(
+            new Request("https://coordinator.invalid/runtime-adapter-delete", {
+              method: "DELETE",
+            }),
+            adapterID,
+            ["v1", "workspaces", workspaceID],
+            { owner: dispatch.lease.owner, org: dispatch.lease.org },
+            dispatch.deadlineMs,
+          );
+          return result;
+        } finally {
+          await this.finishRuntimeAdapterDeleteDispatch(
+            dispatch,
+            result !== undefined && (await runtimeAdapterDeleteDispatchSafeToClear(result)),
+          );
+        }
+      })();
+      const response = proxyResult.response;
+      let body: { id?: unknown; status?: unknown; message?: unknown; error?: unknown } | undefined;
+      if (response.status !== 204) {
+        body = (await response
+          .clone()
+          .json()
+          .catch(() => undefined)) as
+          | { id?: unknown; status?: unknown; message?: unknown; error?: unknown }
+          | undefined;
+      }
+      const acknowledged =
+        proxyResult.origin === "upstream" &&
+        (response.status === 204 ||
+          (response.ok &&
+            body?.id === workspaceID &&
+            ["stopping", "stopped", "expired"].includes(String(body.status))));
+      await this.state.runExclusive(async () => {
+        const latest = await this.getLease(lease.id);
+        if (!latest || !runtimeAdapterDeleteVersionMatches(latest, dispatch.lease, version)) {
+          return;
+        }
+        const attempts = (latest.runtimeAdapterDeleteAttempts ?? 0) + 1;
+        const retryDelay = Math.min(
+          runtimeAdapterDeleteRetryMaxMs,
+          runtimeAdapterDeleteRetryBaseMs * 2 ** Math.min(attempts - 1, 4),
+        );
+        const dispatchUntil = Date.parse(latest.runtimeAdapterDeleteDispatchUntil ?? "");
+        latest.runtimeAdapterDeleteAttempts = attempts;
+        latest.runtimeAdapterDeleteRetryAt = new Date(
+          Math.max(Date.now() + retryDelay, Number.isFinite(dispatchUntil) ? dispatchUntil : 0),
+        ).toISOString();
+        if (acknowledged) {
+          delete latest.runtimeAdapterDeleteError;
+        } else {
+          latest.runtimeAdapterDeleteError =
+            response.status === 503 || response.status === 504
+              ? "runtime_adapter_unavailable"
+              : response.ok
+                ? "runtime_adapter_invalid_response"
+                : `runtime_adapter_http_${response.status}`;
+        }
+        latest.updatedAt = new Date().toISOString();
+        await this.putLease(latest);
+      });
+    });
+  }
+
+  private async createRuntimeAdapterTicket(request: Request, adapterID: string): Promise<Response> {
+    if (request.method.toUpperCase() !== "POST") {
+      return notFound();
+    }
+    if (!validRuntimeAdapterID(adapterID)) {
+      return json({ error: "invalid_adapter_id" }, { status: 400 });
+    }
+    let rawInput: unknown;
+    try {
+      rawInput = await optionalJson<unknown>(request);
+    } catch {
+      return json({ error: "invalid_adapter_ticket_request" }, { status: 400 });
+    }
+    if (!rawInput || typeof rawInput !== "object" || Array.isArray(rawInput)) {
+      return json({ error: "invalid_adapter_ticket_request" }, { status: 400 });
+    }
+    const input = rawInput as { desktopTimeoutMs?: unknown };
+    if (
+      input.desktopTimeoutMs !== undefined &&
+      !validRuntimeAdapterDesktopRelayTimeout(input.desktopTimeoutMs)
+    ) {
+      return json(
+        {
+          error: "invalid_desktop_timeout",
+          message: "desktop timeout is outside the supported relay range",
+        },
+        { status: 400 },
+      );
+    }
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    const identityKey = runtimeAdapterIdentityKey(adapterID);
+    const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(identityKey);
+    if (
+      identity &&
+      (identity.adapterID !== adapterID || identity.owner !== owner || identity.org !== org)
+    ) {
+      return json(
+        {
+          error: "adapter_id_conflict",
+          message: "runtime adapter id belongs to another owner or organization",
+        },
+        { status: 409 },
+      );
+    }
+    await this.cleanupExpiredRuntimeAdapterTickets();
+    const now = new Date();
+    if (!identity) {
+      await this.state.storage.put<RuntimeAdapterIdentityRecord>(identityKey, {
+        adapterID,
+        owner,
+        org,
+        createdAt: now.toISOString(),
+      });
+    }
+    const ticket: RuntimeAdapterTicketRecord = {
+      ticket: newRuntimeAdapterTicket(),
+      adapterID,
+      owner,
+      org,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + runtimeAdapterTicketTTLSeconds * 1000).toISOString(),
+      ...(input.desktopTimeoutMs === undefined ? {} : { desktopTimeoutMs: input.desktopTimeoutMs }),
+    };
+    await this.state.storage.put(runtimeAdapterTicketKey(ticket.ticket), ticket);
+    return json({
+      ticket: ticket.ticket,
+      adapterID: ticket.adapterID,
+      expiresAt: ticket.expiresAt,
+    });
+  }
+
+  private async runtimeAdapterAgent(request: Request, adapterID: string): Promise<Response> {
+    if (request.method.toUpperCase() !== "GET") {
+      return notFound();
+    }
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return json(
+        { error: "upgrade_required", message: "runtime adapter agent requires websocket upgrade" },
+        { status: 426 },
+      );
+    }
+    const ticket = await this.consumeRuntimeAdapterTicket(request);
+    if (!ticket || ticket.adapterID !== adapterID) {
+      return json(
+        { error: "adapter_ticket_required", message: "valid runtime adapter ticket required" },
+        { status: 401 },
+      );
+    }
+    const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(
+      runtimeAdapterIdentityKey(adapterID),
+    );
+    if (
+      !identity ||
+      identity.adapterID !== adapterID ||
+      identity.owner !== ticket.owner ||
+      identity.org !== ticket.org
+    ) {
+      return json(
+        {
+          error: "adapter_identity_mismatch",
+          message: "runtime adapter ticket no longer matches the claimed adapter identity",
+        },
+        { status: 401 },
+      );
+    }
+    const upgrade = this.state.createWebSocketUpgrade({
+      maxPayload: runtimeAdapterRelayFrameLimit,
+    });
+    const agent = upgrade.socket;
+    const previous = this.runtimeAdapterAgents.get(adapterID);
+    if (previous) {
+      this.clearRuntimeAdapterAgent(adapterID, previous);
+      closeSocket(previous, 1012, "replaced by a newer runtime adapter agent");
+    }
+    this.runtimeAdapterAgents.set(adapterID, agent);
+    this.acceptBridgeWebSocket(agent, {
+      kind: "runtime-adapter-agent",
+      adapterID,
+      owner: ticket.owner,
+      org: ticket.org,
+      ...(ticket.desktopTimeoutMs === undefined
+        ? {}
+        : { desktopTimeoutMs: ticket.desktopTimeoutMs }),
+    });
+    return upgrade.response;
+  }
+
+  private async runtimeAdapterStatus(request: Request, adapterID: string): Promise<Response> {
+    if (!validRuntimeAdapterID(adapterID)) {
+      return notFound();
+    }
+    const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(
+      runtimeAdapterIdentityKey(adapterID),
+    );
+    const agent = this.runtimeAdapterAgents.get(adapterID);
+    const attachment = agent ? this.bridgeAttachment(agent) : undefined;
+    if (
+      !identity ||
+      identity.adapterID !== adapterID ||
+      !agent ||
+      agent.readyState !== WebSocket.OPEN ||
+      attachment?.kind !== "runtime-adapter-agent" ||
+      attachment.owner !== identity.owner ||
+      attachment.org !== identity.org ||
+      (!isAdminRequest(request) &&
+        (identity.owner !== requestOwner(request) ||
+          identity.org !== requestOrg(request, this.env)))
+    ) {
+      return json({ adapterID, connected: false });
+    }
+    return json({ adapterID, connected: true });
+  }
+
+  private async runtimeAdapterProxy(
+    request: Request,
+    adapterID: string,
+    proxyParts: string[],
+  ): Promise<Response> {
+    const path = runtimeAdapterProxyPath(proxyParts);
+    const method = request.method.toUpperCase();
+    if (path && method === "DELETE" && runtimeAdapterRelayMethodAllowed(method, path)) {
+      return json(
+        {
+          error: "runtime_adapter_delete_requires_lease",
+          message:
+            "runtime adapter workspace deletes must use a registered lease release so the lifecycle generation can be fenced",
+        },
+        { status: 409 },
+      );
+    }
+    return (await this.runtimeAdapterProxyResult(request, adapterID, proxyParts)).response;
+  }
+
+  private async runtimeAdapterProxyResult(
+    request: Request,
+    adapterID: string,
+    proxyParts: string[],
+    scope?: RuntimeAdapterProxyScope,
+    relayDeadlineMs?: number,
+  ): Promise<RuntimeAdapterProxyResult> {
+    if (!validRuntimeAdapterID(adapterID)) {
+      return { origin: "relay", dispatched: false, response: notFound() };
+    }
+    const path = runtimeAdapterProxyPath(proxyParts);
+    const method = request.method.toUpperCase();
+    if (!path || !runtimeAdapterRelayMethodAllowed(method, path)) {
+      return { origin: "relay", dispatched: false, response: notFound() };
+    }
+    let relayHeaders: Record<string, string> | undefined;
+    try {
+      relayHeaders = runtimeAdapterRelayHeaders(request);
+    } catch (error) {
+      if (error instanceof RangeError) {
+        return {
+          origin: "relay",
+          dispatched: false,
+          response: json(
+            { error: "idempotency_key_too_long", message: error.message },
+            { status: 431 },
+          ),
+        };
+      }
+      throw error;
+    }
+    const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(
+      runtimeAdapterIdentityKey(adapterID),
+    );
+    if (!identity || identity.adapterID !== adapterID) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_unclaimed",
+            message: "runtime adapter id has not been claimed",
+          },
+          { status: 409 },
+        ),
+      };
+    }
+    const identityMismatch = scope
+      ? identity.owner !== scope.owner || identity.org !== scope.org
+      : identity.owner !== requestOwner(request) || identity.org !== requestOrg(request, this.env);
+    if (identityMismatch && (scope !== undefined || !isAdminRequest(request))) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_forbidden",
+            message: "runtime adapter belongs to another owner or organization",
+          },
+          { status: 403 },
+        ),
+      };
+    }
+    let body: string | undefined;
+    try {
+      body = await readRuntimeAdapterRelayBody(request);
+    } catch (error) {
+      if (error instanceof RangeError) {
+        return {
+          origin: "relay",
+          dispatched: false,
+          response: json({ error: "request_too_large", message: error.message }, { status: 413 }),
+        };
+      }
+      if (error instanceof TypeError) {
+        return {
+          origin: "relay",
+          dispatched: false,
+          response: json(
+            { error: "invalid_request_body", message: "runtime adapter body must be valid UTF-8" },
+            { status: 400 },
+          ),
+        };
+      }
+      throw error;
+    }
+    if (!runtimeAdapterRelayBodyAllowed(method, path, body)) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "invalid_request_body",
+            message: "runtime adapter request body is allowed only for workspace creation",
+          },
+          { status: 400 },
+        ),
+      };
+    }
+    const agent = this.runtimeAdapterAgents.get(adapterID);
+    const attachment = agent ? this.bridgeAttachment(agent) : undefined;
+    if (
+      !agent ||
+      agent.readyState !== WebSocket.OPEN ||
+      attachment?.kind !== "runtime-adapter-agent"
+    ) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          { error: "runtime_adapter_unavailable", message: "runtime adapter is not connected" },
+          { status: 503 },
+        ),
+      };
+    }
+    if (attachment.owner !== identity.owner || attachment.org !== identity.org) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_identity_mismatch",
+            message: "connected runtime adapter does not match its claimed identity",
+          },
+          { status: 503 },
+        ),
+      };
+    }
+    if (this.runtimeAdapterRelayAtCapacity(adapterID, identity, method)) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_busy",
+            message: "runtime adapter relay has too many in-flight requests",
+          },
+          { status: 429, headers: { "retry-after": "1" } },
+        ),
+      };
+    }
+    const bufferedAmount = (agent as WebSocket & { readonly bufferedAmount?: number })
+      .bufferedAmount;
+    if (typeof bufferedAmount === "number" && bufferedAmount > runtimeAdapterMaxBufferedBytes) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_backpressure",
+            message: "runtime adapter relay transport is congested",
+          },
+          { status: 503, headers: { "retry-after": "1" } },
+        ),
+      };
+    }
+    const relayTimeoutMs = runtimeAdapterRelayTimeoutForPath(path, attachment.desktopTimeoutMs);
+    const maximumDeadlineMs = Date.now() + relayTimeoutMs;
+    const deadlineMs =
+      relayDeadlineMs === undefined
+        ? maximumDeadlineMs
+        : Math.min(relayDeadlineMs, maximumDeadlineMs);
+    if (!Number.isSafeInteger(deadlineMs) || deadlineMs <= Date.now()) {
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          {
+            error: "runtime_adapter_timeout",
+            message: "runtime adapter request expired before dispatch",
+          },
+          { status: 504 },
+        ),
+      };
+    }
+    const id = crypto.randomUUID();
+    const relayRequest: RuntimeAdapterRelayRequest = {
+      type: "request",
+      id,
+      method: method as RuntimeAdapterRelayRequest["method"],
+      path,
+      deadlineMs,
+      ...(relayHeaders ? { headers: relayHeaders } : {}),
+      ...(body === undefined ? {} : { body }),
+    };
+    let relayResult: RuntimeAdapterRelayResult;
+    try {
+      relayResult = await new Promise<RuntimeAdapterRelayResult>((resolve) => {
+        const timeout = setTimeout(
+          () => {
+            this.settleRuntimeAdapterPending(id, {
+              origin: "relay",
+              response: runtimeAdapterRelayError(
+                id,
+                504,
+                "runtime_adapter_timeout",
+                "runtime adapter did not respond in time",
+              ),
+            });
+          },
+          Math.max(0, deadlineMs - Date.now()),
+        );
+        const abortHandler = () => {
+          this.cancelRuntimeAdapterPending(id);
+        };
+        const pending: RuntimeAdapterPendingRequest = {
+          adapterID,
+          owner: identity.owner,
+          org: identity.org,
+          dispatched: false,
+          clientSettled: false,
+          resolve,
+          timeout,
+          signal: request.signal,
+          abortHandler,
+        };
+        this.runtimeAdapterPending.set(id, pending);
+        request.signal.addEventListener("abort", abortHandler, { once: true });
+        if (request.signal.aborted) {
+          abortHandler();
+        } else {
+          pending.dispatched = true;
+          agent.send(JSON.stringify(relayRequest));
+        }
+      });
+    } catch {
+      this.takeRuntimeAdapterPending(id);
+      return {
+        origin: "relay",
+        dispatched: false,
+        response: json(
+          { error: "runtime_adapter_unavailable", message: "runtime adapter disconnected" },
+          { status: 503 },
+        ),
+      };
+    }
+    const response = relayResult.response;
+    const headers = new Headers({ "cache-control": "no-store" });
+    const contentType = runtimeAdapterRelayContentType(response.headers);
+    headers.set(
+      "content-type",
+      contentType?.toLowerCase().startsWith("application/json")
+        ? "application/json; charset=utf-8"
+        : "text/plain; charset=utf-8",
+    );
+    const responseBody = [204, 205, 304].includes(response.status) ? null : (response.body ?? null);
+    return {
+      origin: relayResult.origin,
+      dispatched: true,
+      response: new Response(responseBody, {
+        status: response.status,
+        headers,
+      }),
+    };
+  }
+
+  private async handleRuntimeAdapterAgentMessage(
+    adapterID: string,
+    socket: WebSocket,
+    rawData: unknown,
+  ): Promise<void> {
+    const messageBytes = runtimeAdapterRelayMessageBytes(rawData);
+    if (messageBytes === undefined || messageBytes > runtimeAdapterRelayFrameLimit) {
+      closeSocket(socket, 1009, "runtime adapter response too large");
+      return;
+    }
+    let input: unknown;
+    try {
+      const raw = await normalizeWebVNCData(rawData);
+      const text = typeof raw === "string" ? raw : fatalTextDecoder.decode(raw);
+      input = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const id =
+      input && typeof input === "object" && !Array.isArray(input)
+        ? (input as { id?: unknown }).id
+        : undefined;
+    if (typeof id !== "string") {
+      return;
+    }
+    const pending = this.runtimeAdapterPending.get(id);
+    if (!pending || pending.adapterID !== adapterID) {
+      return;
+    }
+    if (!validRuntimeAdapterRelayResponse(input, id)) {
+      return;
+    }
+    this.settleRuntimeAdapterPending(id, { origin: "upstream", response: input });
+  }
+
+  private runtimeAdapterRelayAtCapacity(
+    adapterID: string,
+    identity: RuntimeAdapterIdentityRecord,
+    method: string,
+  ): boolean {
+    const isDelete = method === "DELETE";
+    const globalLimit =
+      runtimeAdapterMaxPendingGlobal + (isDelete ? runtimeAdapterReservedDeletesGlobal : 0);
+    if (this.runtimeAdapterPending.size >= globalLimit) {
+      return true;
+    }
+    let adapterPending = 0;
+    let ownerPending = 0;
+    for (const pending of this.runtimeAdapterPending.values()) {
+      if (pending.adapterID === adapterID) adapterPending += 1;
+      if (pending.owner === identity.owner) ownerPending += 1;
+    }
+    const adapterLimit =
+      runtimeAdapterMaxPendingPerAdapter + (isDelete ? runtimeAdapterReservedDeletesPerAdapter : 0);
+    const ownerLimit =
+      runtimeAdapterMaxPendingPerOwner + (isDelete ? runtimeAdapterReservedDeletesPerOwner : 0);
+    return adapterPending >= adapterLimit || ownerPending >= ownerLimit;
+  }
+
+  private takeRuntimeAdapterPending(id: string): RuntimeAdapterPendingRequest | undefined {
+    const pending = this.runtimeAdapterPending.get(id);
+    if (!pending) return undefined;
+    this.runtimeAdapterPending.delete(id);
+    clearTimeout(pending.timeout);
+    pending.signal.removeEventListener("abort", pending.abortHandler);
+    return pending;
+  }
+
+  private settleRuntimeAdapterPending(id: string, result: RuntimeAdapterRelayResult): boolean {
+    const pending = this.takeRuntimeAdapterPending(id);
+    if (!pending) return false;
+    if (!pending.clientSettled) {
+      pending.resolve(result);
+    }
+    return true;
+  }
+
+  private cancelRuntimeAdapterPending(id: string): void {
+    const pending = this.runtimeAdapterPending.get(id);
+    if (!pending || pending.clientSettled) return;
+    const result: RuntimeAdapterRelayResult = {
+      origin: "relay",
+      response: runtimeAdapterRelayError(
+        id,
+        499,
+        "client_closed_request",
+        "runtime adapter request was cancelled",
+      ),
+    };
+    if (!pending.dispatched) {
+      this.settleRuntimeAdapterPending(id, result);
+      return;
+    }
+    pending.clientSettled = true;
+    pending.signal.removeEventListener("abort", pending.abortHandler);
+    pending.resolve(result);
+  }
+
+  private clearRuntimeAdapterAgent(adapterID: string, socket: WebSocket): void {
+    if (this.runtimeAdapterAgents.get(adapterID) !== socket) {
+      return;
+    }
+    this.runtimeAdapterAgents.delete(adapterID);
+    for (const [id, pending] of this.runtimeAdapterPending) {
+      if (pending.adapterID !== adapterID) continue;
+      this.settleRuntimeAdapterPending(id, {
+        origin: "relay",
+        response: runtimeAdapterRelayError(
+          id,
+          503,
+          "runtime_adapter_unavailable",
+          "runtime adapter disconnected",
+        ),
+      });
+    }
   }
 
   private async createWebVNCTicket(request: Request, identifier: string): Promise<Response> {
@@ -4651,7 +6192,7 @@ export class FleetCoordinator {
         this.pendingCodeRequests.delete(id);
         resolve({ type: "http", id, status: 504, error: "code bridge timed out" });
       }, 30_000);
-      this.pendingCodeRequests.set(id, { resolve, timeout, chunks: [] });
+      this.pendingCodeRequests.set(id, { leaseID: lease.id, resolve, timeout, chunks: [] });
       agent.send(JSON.stringify(message));
     });
     if (response.error) {
@@ -4783,6 +6324,7 @@ export class FleetCoordinator {
     if (message.type === "ws_start" && message.id) {
       const start = message as CodeWebSocketFrameStart;
       this.pendingCodeFrames.set(start.chunkID, {
+        leaseID,
         id: start.id,
         frame: start.frame ?? "binary",
         chunks: [],
@@ -4850,17 +6392,28 @@ export class FleetCoordinator {
     }
   }
 
-  private clearCodeLease(_leaseID: string): void {
+  private clearCodeLease(leaseID: string, code = 1011, reason = "code bridge disconnected"): void {
     for (const [id, viewer] of this.codeViewers) {
+      const attachment = this.bridgeAttachment(viewer);
+      if (attachment?.kind !== "code-viewer" || attachment.leaseID !== leaseID) {
+        continue;
+      }
       this.codeViewers.delete(id);
-      closeSocket(viewer, 1011, "code bridge disconnected");
+      closeSocket(viewer, code, reason);
     }
     for (const [id, pending] of this.pendingCodeRequests) {
+      if (pending.leaseID !== leaseID) {
+        continue;
+      }
       clearTimeout(pending.timeout);
       this.pendingCodeRequests.delete(id);
-      pending.resolve({ type: "http", id, status: 502, error: "code bridge disconnected" });
+      pending.resolve({ type: "http", id, status: 502, error: reason });
     }
-    this.pendingCodeFrames.clear();
+    for (const [chunkID, pending] of this.pendingCodeFrames) {
+      if (pending.leaseID === leaseID) {
+        this.pendingCodeFrames.delete(chunkID);
+      }
+    }
   }
 
   private clearEgressHost(leaseID: string, sessionID: string, socket: WebSocket): void {
@@ -4883,20 +6436,37 @@ export class FleetCoordinator {
     this.egressHosts.delete(key);
   }
 
-  private clearEgressLease(leaseID: string): void {
+  private clearEgressLease(leaseID: string, code = 1011, reason = "lease ended"): void {
     for (const [key, socket] of this.egressHosts) {
       if (egressSocketLeaseID(key) === leaseID) {
-        closeSocket(socket, 1011, "lease ended");
+        closeSocket(socket, code, reason);
         this.egressHosts.delete(key);
       }
     }
     for (const [key, socket] of this.egressClients) {
       if (egressSocketLeaseID(key) === leaseID) {
-        closeSocket(socket, 1011, "lease ended");
+        closeSocket(socket, code, reason);
         this.egressClients.delete(key);
       }
     }
     this.egressSessions.delete(leaseID);
+  }
+
+  private closeLeaseBridges(leaseID: string, code: number, reason: string): void {
+    const webVNCAgents = this.webVNCAgents.get(leaseID);
+    for (const [agentID, socket] of webVNCAgents ?? []) {
+      closeSocket(socket, code, reason);
+      this.pendingWebVNCToViewer.delete(webVNCBufferKey(leaseID, agentID));
+    }
+    this.webVNCAgents.delete(leaseID);
+    this.webVNCAgentCapabilities.delete(leaseID);
+    this.closeWebVNCViewers(leaseID, code, reason);
+
+    const codeAgent = this.codeAgents.get(leaseID);
+    this.codeAgents.delete(leaseID);
+    closeSocket(codeAgent, code, reason);
+    this.clearCodeLease(leaseID, code, reason);
+    this.clearEgressLease(leaseID, code, reason);
   }
 
   private clearEgressSessionSockets(
@@ -5100,6 +6670,37 @@ export class FleetCoordinator {
     }
     this.webVNCViewers.delete(leaseID);
     this.webVNCControllers.delete(leaseID);
+  }
+
+  private async consumeRuntimeAdapterTicket(
+    request: Request,
+  ): Promise<RuntimeAdapterTicketRecord | undefined> {
+    const value = runtimeAdapterTicketFromRequest(request);
+    if (!validRuntimeAdapterTicket(value)) {
+      return undefined;
+    }
+    const key = runtimeAdapterTicketKey(value);
+    const ticket = await this.state.storage.get<RuntimeAdapterTicketRecord>(key);
+    if (!ticket || ticket.ticket !== value) {
+      return undefined;
+    }
+    await this.state.storage.delete(key);
+    if (Date.parse(ticket.expiresAt) <= Date.now()) {
+      return undefined;
+    }
+    return ticket;
+  }
+
+  private async cleanupExpiredRuntimeAdapterTickets(): Promise<void> {
+    const tickets = await this.state.storage.list<RuntimeAdapterTicketRecord>({
+      prefix: runtimeAdapterTicketPrefix(),
+    });
+    const now = Date.now();
+    await Promise.all(
+      [...tickets.entries()]
+        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
+        .map(([key]) => this.state.storage.delete(key)),
+    );
   }
 
   private async consumeWebVNCTicket(request: Request): Promise<WebVNCTicketRecord | undefined> {
@@ -5997,9 +7598,13 @@ export class FleetCoordinator {
     if (!lease) {
       return notFound();
     }
-    return json({
-      lease: await this.releaseResolvedLease(lease, { deleteServer: true, keep: false }),
-    });
+    if (lease.runtimeAdapterDeleteRequestedAt) {
+      return runtimeAdapterDeletePendingResponse(lease);
+    }
+    const released = await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
+    return released.runtimeAdapterDeleteRequestedAt
+      ? runtimeAdapterDeletePendingResponse(released)
+      : json({ lease: released });
   }
 
   private filterLeases(leases: LeaseRecord[], request: Request): LeaseRecord[] {
@@ -6527,6 +8132,9 @@ export class FleetCoordinator {
       const now = Date.now();
       const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
       for (const stored of leases.values()) {
+        if (!leaseIsLive(stored)) {
+          this.closeLeaseBridges(stored.id, 1008, "lease ended");
+        }
         const workspace = workspacesByLeaseID.get(stored.id);
         if (
           workspace &&
@@ -6555,10 +8163,14 @@ export class FleetCoordinator {
           lease.endedAt = nowISO;
           delete lease.releaseDeletesServer;
           clearLeaseCleanupMetadata(lease);
+          if (!lease.runtimeAdapterDeleteRequestedAt) {
+            clearRuntimeAdapterDeleteMetadata(lease);
+          }
           delete lease.cleanupStartedAt;
           delete lease.cleanupClaimExpiresAt;
           // oxlint-disable-next-line eslint/no-await-in-loop -- each lease claim is committed while the state lock is held.
           await this.putLease(lease);
+          this.closeLeaseBridges(lease.id, 1008, "lease expired");
           continue;
         }
         if (lease.state === "provisioning" && !lease.cloudID) {
@@ -6651,7 +8263,9 @@ export class FleetCoordinator {
             workspaceOwnsLease(workspace, lease) &&
             workspaceProvisioningNeedsRecovery(workspace, lease, now)
           ) &&
-          (leaseIsLive(lease) || leaseNeedsCleanup(lease, now))
+          (leaseIsLive(lease) ||
+            Boolean(lease.runtimeAdapterDeleteRequestedAt) ||
+            leaseNeedsCleanup(lease, now))
         );
       })
       .map((lease) => nextLeaseAlarmTime(lease))
@@ -7862,8 +9476,11 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     options: { deleteServer: boolean; keep?: boolean },
   ): Promise<LeaseRecord> {
-    await this.markWorkspaceReleaseRequested(lease);
     const current = (await this.getLease(lease.id)) ?? lease;
+    if (current.runtimeAdapterDeleteRequestedAt) {
+      return current;
+    }
+    await this.markWorkspaceReleaseRequested(current);
     if (
       current.workspaceID &&
       !current.cloudID &&
@@ -7905,11 +9522,13 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     options: { deleteServer: boolean; keep?: boolean },
   ): Promise<LeaseRecord> {
-    this.clearEgressLease(lease.id);
     const preparation = await this.state.runExclusive(async () => {
       const current = (await this.getLease(lease.id)) ?? structuredClone(lease);
+      if (current.runtimeAdapterDeleteRequestedAt) {
+        return { cleanup: false as const, blocked: true as const, lease: current };
+      }
       if (current.cleanupStartedAt) {
-        return { cleanup: false as const, lease: current };
+        return { cleanup: false as const, blocked: false as const, lease: current };
       }
       const deleteServer = options.deleteServer && !isRegisteredLease(current);
       const shouldDelete = Boolean(
@@ -7925,7 +9544,7 @@ export class FleetCoordinator {
         await this.clearWorkspaceReleaseError(released);
         await this.markAWSIngressReconcilePending(released);
         await this.scheduleAlarm();
-        return { cleanup: false as const, lease: released };
+        return { cleanup: false as const, blocked: false as const, lease: released };
       }
       const now = new Date();
       const claimed = finalizedReleasedLease(current, true, options.keep);
@@ -7939,10 +9558,15 @@ export class FleetCoordinator {
       await this.scheduleAlarm();
       return {
         cleanup: true as const,
+        blocked: false as const,
         claim: claimed.cleanupStartedAt,
         lease: structuredClone(claimed),
       };
     });
+    if (preparation.blocked) {
+      return preparation.lease;
+    }
+    this.closeLeaseBridges(lease.id, 1008, "lease ended");
     if (!preparation.cleanup) {
       return preparation.lease;
     }
@@ -8465,6 +10089,111 @@ function egressTicketKey(ticket: string): string {
   return `${egressTicketPrefix()}${ticket}`;
 }
 
+function runtimeAdapterTicketPrefix(): string {
+  return "runtime-adapter-ticket:";
+}
+
+function runtimeAdapterTicketKey(ticket: string): string {
+  return `${runtimeAdapterTicketPrefix()}${ticket}`;
+}
+
+function runtimeAdapterIdentityKey(adapterID: string): string {
+  return `runtime-adapter-identity:${adapterID}`;
+}
+
+function runtimeAdapterRelayError(
+  id: string,
+  status: number,
+  error: string,
+  message: string,
+): RuntimeAdapterRelayResponse {
+  return {
+    type: "response",
+    id,
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ error, message }),
+  };
+}
+
+function runtimeAdapterErrorCode(body: unknown): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+  const error = (body as { error?: unknown }).error;
+  if (typeof error === "string") {
+    return error;
+  }
+  if (!error || typeof error !== "object" || Array.isArray(error)) {
+    return undefined;
+  }
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+async function runtimeAdapterDeleteDispatchSafeToClear(
+  result: RuntimeAdapterProxyResult,
+): Promise<boolean> {
+  if (!result.dispatched) {
+    return true;
+  }
+  if (result.origin !== "upstream") {
+    return false;
+  }
+  if (result.response.ok) {
+    return true;
+  }
+  const body = await result.response
+    .clone()
+    .json()
+    .catch(() => undefined);
+  return !["adapter_timeout", "adapter_unavailable"].includes(runtimeAdapterErrorCode(body) ?? "");
+}
+
+function runtimeAdapterDeleteCompletion(
+  value: unknown,
+): RuntimeAdapterDeleteCompletion | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const completion = value as Partial<RuntimeAdapterDeleteCompletion>;
+  if (
+    completion.status !== "absent" ||
+    !validRuntimeAdapterID(completion.adapterID) ||
+    !validRuntimeAdapterID(completion.workspaceID) ||
+    !validRuntimeAdapterID(completion.registrationID)
+  ) {
+    return undefined;
+  }
+  return {
+    adapterID: completion.adapterID,
+    workspaceID: completion.workspaceID,
+    registrationID: completion.registrationID,
+    status: completion.status,
+  };
+}
+
+function runtimeAdapterLegacyDeleteCompletion(
+  value: unknown,
+): RuntimeAdapterLegacyDeleteCompletion | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const completion = value as Partial<RuntimeAdapterLegacyDeleteCompletion>;
+  if (
+    completion.status !== "absent" ||
+    !validRuntimeAdapterID(completion.adapterID) ||
+    !validRuntimeAdapterID(completion.workspaceID)
+  ) {
+    return undefined;
+  }
+  return {
+    adapterID: completion.adapterID,
+    workspaceID: completion.workspaceID,
+    status: completion.status,
+  };
+}
+
 function newLeaseID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
@@ -8486,6 +10215,32 @@ function workspaceManagedLeaseResponse(): Response {
       message: "workspace leases must be managed through the workspace lifecycle",
     },
     { status: 409 },
+  );
+}
+
+function runtimeAdapterDeletePendingResponse(lease: LeaseRecord): Response {
+  return json(
+    {
+      error: "runtime_adapter_delete_pending",
+      message: "lease release is blocked while its runtime adapter delete is pending",
+      lease,
+    },
+    { status: 409 },
+  );
+}
+
+function runtimeAdapterDeleteInFlightResponse(retryAt: string): Response {
+  const retryAtMs = Date.parse(retryAt);
+  const retryAfter = Number.isFinite(retryAtMs)
+    ? Math.max(1, Math.ceil((retryAtMs - Date.now()) / 1000))
+    : 1;
+  return json(
+    {
+      error: "runtime_adapter_delete_in_flight",
+      message: "a generation-scoped runtime adapter delete is still settling",
+      retryAt,
+    },
+    { status: 409, headers: { "retry-after": String(retryAfter) } },
   );
 }
 
@@ -9122,6 +10877,12 @@ function newEgressTicket(): string {
   return `egress_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
+function newRuntimeAdapterTicket(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return `adapter_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
 function newEgressSessionID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
@@ -9154,6 +10915,17 @@ function validRegisteredLeaseID(value: string | undefined): value is string {
 
 function validWebVNCTicket(value: string | undefined): value is string {
   return typeof value === "string" && /^wvnc_[a-f0-9]{32}$/.test(value);
+}
+
+function validRuntimeAdapterTicket(value: string | undefined): value is string {
+  return typeof value === "string" && /^adapter_[a-f0-9]{32}$/.test(value);
+}
+
+function runtimeAdapterTicketFromRequest(request: Request): string {
+  // Adapter-agent upgrades bypass user auth; keep the single-use ticket out of URLs and dedicated proxy headers.
+  const authorization = request.headers.get("authorization") ?? "";
+  const [scheme, token] = authorization.split(/\s+/, 2);
+  return scheme?.toLowerCase() === "bearer" ? (token ?? "") : "";
 }
 
 function validWebVNCSessionID(value: string | undefined): value is string {
@@ -9756,6 +11528,14 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
       return typeof attachment.leaseID === "string" && typeof attachment.sessionID === "string"
         ? attachment
         : undefined;
+    case "runtime-adapter-agent":
+      return validRuntimeAdapterID(attachment.adapterID) &&
+        typeof attachment.owner === "string" &&
+        typeof attachment.org === "string" &&
+        (attachment.desktopTimeoutMs === undefined ||
+          validRuntimeAdapterDesktopRelayTimeout(attachment.desktopTimeoutMs))
+        ? attachment
+        : undefined;
     case "control":
       return typeof attachment.clientID === "string" &&
         typeof attachment.owner === "string" &&
@@ -9782,6 +11562,9 @@ function bridgeTags(attachment: BridgeAttachment): string[] {
   }
   if (attachment.kind === "webvnc-agent" || attachment.kind === "webvnc-viewer") {
     return [`lease:${attachment.leaseID}`, `webvnc:${attachment.id}`, attachment.kind];
+  }
+  if (attachment.kind === "runtime-adapter-agent") {
+    return [`adapter:${attachment.adapterID}`, attachment.kind];
   }
   return [`lease:${attachment.leaseID}`, attachment.kind];
 }
@@ -9911,6 +11694,21 @@ async function normalizeWebVNCData(data: unknown): Promise<string | ArrayBuffer>
     return await data.arrayBuffer();
   }
   return String(data);
+}
+
+function runtimeAdapterRelayMessageBytes(data: unknown): number | undefined {
+  if (typeof data === "string") {
+    return data.length > runtimeAdapterRelayFrameLimit
+      ? data.length
+      : textEncoder.encode(data).byteLength;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (data instanceof Blob) {
+    return data.size;
+  }
+  return undefined;
 }
 
 function webVNCDataBytes(data: string | ArrayBuffer): number {
@@ -10628,11 +12426,29 @@ function provisionedLeaseRecord(
 
 function nextLeaseAlarmTime(lease: LeaseRecord): number {
   const now = Date.now();
+  const expiresAt = Date.parse(lease.expiresAt);
+  const runtimeAdapterDeleteRetryAt = Date.parse(lease.runtimeAdapterDeleteRetryAt ?? "");
+  const runtimeAdapterDeleteDispatchUntil = Date.parse(
+    lease.runtimeAdapterDeleteDispatchUntil ?? "",
+  );
+  if (lease.runtimeAdapterDeleteRequestedAt) {
+    let deleteAlarm = Number.isFinite(runtimeAdapterDeleteRetryAt)
+      ? Math.max(now + 1000, runtimeAdapterDeleteRetryAt)
+      : now + 1000;
+    if (
+      Number.isFinite(runtimeAdapterDeleteDispatchUntil) &&
+      runtimeAdapterDeleteDispatchUntil > now
+    ) {
+      deleteAlarm = Math.max(deleteAlarm, runtimeAdapterDeleteDispatchUntil);
+    }
+    return leaseIsLive(lease) && Number.isFinite(expiresAt)
+      ? Math.min(expiresAt, deleteAlarm)
+      : deleteAlarm;
+  }
   const claimDeadline = cleanupClaimDeadline(lease);
   if (lease.cleanupStartedAt && Number.isFinite(claimDeadline)) {
     return claimDeadline;
   }
-  const expiresAt = Date.parse(lease.expiresAt);
   const cleanupRetryAt = Date.parse(lease.cleanupRetryAt ?? "");
   if (Number.isFinite(cleanupRetryAt) && cleanupRetryAt > now) {
     if (Number.isFinite(expiresAt) && expiresAt <= now) {
@@ -10659,6 +12475,41 @@ function clearLeaseCleanupMetadata(lease: LeaseRecord): void {
   delete lease.cleanupRetryAt;
 }
 
+function clearRuntimeAdapterDeleteMetadata(lease: LeaseRecord): void {
+  delete lease.runtimeAdapterDeleteRequestedAt;
+  delete lease.runtimeAdapterDeleteClaimID;
+  delete lease.runtimeAdapterDeleteRetryAt;
+  delete lease.runtimeAdapterDeleteDispatchUntil;
+  delete lease.runtimeAdapterDeleteAttempts;
+  delete lease.runtimeAdapterDeleteError;
+}
+
+function runtimeAdapterDeleteVersionMatches(
+  current: LeaseRecord,
+  anchor: LeaseRecord,
+  claim: RuntimeAdapterDeleteVersion,
+): boolean {
+  return (
+    (leaseIsLive(current) || current.state === "expired") &&
+    isRegisteredLease(current) &&
+    current.runtimeAdapterDeleteRequestedAt === claim.requestedAt &&
+    current.runtimeAdapterDeleteClaimID === claim.claimID &&
+    current.runtimeAdapterID === anchor.runtimeAdapterID &&
+    current.runtimeAdapterWorkspaceID === anchor.runtimeAdapterWorkspaceID &&
+    current.runtimeAdapterRegistrationID === anchor.runtimeAdapterRegistrationID
+  );
+}
+
+function finalizedRuntimeAdapterDeleteLease(current: LeaseRecord): LeaseRecord {
+  if (current.state !== "expired") {
+    return finalizedReleasedLease(current, false, true);
+  }
+  const lease = structuredClone(current);
+  lease.updatedAt = new Date().toISOString();
+  clearRuntimeAdapterDeleteMetadata(lease);
+  return lease;
+}
+
 function finalizedReleasedLease(
   current: LeaseRecord,
   deleteServer: boolean,
@@ -10680,6 +12531,7 @@ function finalizedReleasedLease(
     delete lease.releaseDeletesServer;
   }
   clearLeaseCleanupMetadata(lease);
+  clearRuntimeAdapterDeleteMetadata(lease);
   delete lease.cleanupStartedAt;
   delete lease.cleanupClaimExpiresAt;
   if (keep !== undefined) {

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -85,6 +85,8 @@ export interface PortalAdminLeaseSummary {
   slug?: string;
   provider: string;
   lifecycle?: LeaseRecord["lifecycle"];
+  runtimeAdapterID?: string;
+  runtimeAdapterWorkspaceID?: string;
   state: LeaseRecord["state"];
   target: string;
   owner: string;
@@ -411,7 +413,11 @@ function adminLeaseRow(
   const canEject =
     lease.state === "active" || lease.state === "provisioning" || lease.state === "failed";
   const releaseLabel =
-    lease.lifecycle === "registered" ? "Remove registration" : "Emergency release";
+    lease.lifecycle === "registered" && lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID
+      ? "Delete workspace"
+      : lease.lifecycle === "registered"
+        ? "Remove registration"
+        : "Emergency release";
   const releaseConfirmation = leaseReleaseConfirmation(lease);
   return `<tr data-filter-tags="${escapeHTML([stateGroup, lease.state, lease.provider, lease.owner, lease.org, lease.target, lease.serverType].join(" "))}">
     <td><a class="lease-link" href="/portal/leases/${encodeURIComponent(lease.id)}"><strong>${escapeHTML(lease.slug || lease.id)}</strong><small>${escapeHTML(lease.id)}</small></a></td>
@@ -553,7 +559,7 @@ export function portalLeaseDetail(
           </div>
           <dl class="meta-grid">
             ${metaHTMLRow("provider", providerBadge(lease.provider))}
-            ${metaRow("lifecycle", registered ? "client managed" : "coordinator managed")}
+            ${metaRow("lifecycle", registered ? (lease.runtimeAdapterID ? "runtime adapter managed" : "client managed") : "coordinator managed")}
             ${metaHTMLRow("target", targetBadge(target, lease.windowsMode))}
             ${metaRow("class", lease.class)}
             ${metaRow("host", lease.host || "pending")}
@@ -566,7 +572,7 @@ export function portalLeaseDetail(
           ${
             active && options.canManage
               ? `<form method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release" class="stop-form" data-confirm="${escapeHTML(leaseReleaseConfirmation(lease))}">
-                  <button class="button ${registered ? "secondary" : "danger"}" type="submit">${registered ? "remove registration" : "stop lease"}</button>
+                  <button class="button ${registered && !lease.runtimeAdapterID ? "secondary" : "danger"}" type="submit">${registered ? (lease.runtimeAdapterID ? "delete workspace" : "remove registration") : "stop lease"}</button>
                 </form>`
               : ""
           }
@@ -1966,10 +1972,15 @@ function leaseRow(
 
 function leaseReleaseAction(lease: LeaseRecord): string {
   const registered = lease.lifecycle === "registered";
+  const adapterManaged = Boolean(lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID);
   const label = lease.slug || lease.id;
-  const actionLabel = registered ? `Remove ${label} registration` : `Stop ${label}`;
+  const actionLabel = registered
+    ? adapterManaged
+      ? `Delete ${label} workspace`
+      : `Remove ${label} registration`
+    : `Stop ${label}`;
   return `<form class="lease-release-form" method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release?return=%2Fportal" data-confirm="${escapeHTML(leaseReleaseConfirmation(lease))}">
-    <button class="access-icon lease-release" data-release-kind="${registered ? "registered" : "managed"}" type="submit" title="${escapeHTML(actionLabel)}" aria-label="${escapeHTML(actionLabel)}">${registered ? ejectIcon : powerIcon}</button>
+    <button class="access-icon lease-release" data-release-kind="${registered ? (adapterManaged ? "adapter" : "registered") : "managed"}" type="submit" title="${escapeHTML(actionLabel)}" aria-label="${escapeHTML(actionLabel)}">${registered && !adapterManaged ? ejectIcon : powerIcon}</button>
   </form>`;
 }
 
@@ -1977,11 +1988,16 @@ function leaseReleaseConfirmation(lease: {
   id: string;
   slug?: string;
   lifecycle?: LeaseRecord["lifecycle"];
+  runtimeAdapterID?: string;
+  runtimeAdapterWorkspaceID?: string;
 }): string {
   const label = lease.slug || lease.id;
-  return lease.lifecycle === "registered"
-    ? `Remove ${label} from Crabbox? The external machine will keep running. Use crabbox stop locally to shut it down.`
-    : `Stop ${label}? This deletes the backing machine.`;
+  if (lease.lifecycle !== "registered") {
+    return `Stop ${label}? This deletes the backing machine.`;
+  }
+  return lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID
+    ? `Delete ${label}? This permanently deletes the external workspace through its runtime adapter.`
+    : `Remove ${label} from Crabbox? The external machine will keep running. Use crabbox stop locally to shut it down.`;
 }
 
 function portalRowFilterGroupTags(groups: Record<string, string | string[] | undefined>): string {
@@ -3110,7 +3126,7 @@ function html(
     .access-icon:hover { border-color:var(--hover-line); background:var(--hover); }
     .lease-release-form { display:flex; justify-content:flex-end; }
     .lease-release { color:var(--muted); cursor:pointer; }
-    .lease-release[data-release-kind="managed"] { color:var(--bad); }
+    .lease-release[data-release-kind="managed"], .lease-release[data-release-kind="adapter"] { color:var(--bad); }
     .lease-release:hover,.lease-release:focus-visible { border-color:color-mix(in srgb, var(--bad) 45%, var(--line)); background:color-mix(in srgb, var(--bad) 12%, transparent); }
     .lease-release:disabled { opacity:0.5; cursor:wait; }
     .table-panel { min-height:0; display:grid; grid-template-rows:auto auto minmax(0,1fr) auto; overflow:hidden; }

--- a/worker/src/runtime-adapter-relay.ts
+++ b/worker/src/runtime-adapter-relay.ts
@@ -1,0 +1,170 @@
+const runtimeAdapterIDPattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export const runtimeAdapterRelayBodyLimit = 64 * 1024;
+// Covers a maximally JSON-escaped body plus the bounded response envelope.
+export const runtimeAdapterRelayFrameLimit = 512 * 1024;
+// The connector allows ordinary local calls 9s, then needs up to 5s to write
+// the response back over the relay WebSocket.
+export const runtimeAdapterRelayTimeoutMs = 14_000;
+export const runtimeAdapterDesktopRelayTimeoutMs = 150_000;
+export const runtimeAdapterDesktopRelayMaxTimeoutMs = 24 * 60 * 60 * 1_000 + 35_000;
+
+export type RuntimeAdapterRelayRequest = {
+  type: "request";
+  id: string;
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+  /** Absolute Unix epoch deadline. The connector must not start expired work. */
+  deadlineMs: number;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+export type RuntimeAdapterRelayResponse = {
+  type: "response";
+  id: string;
+  status: number;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+export function validRuntimeAdapterID(value: unknown): value is string {
+  return typeof value === "string" && runtimeAdapterIDPattern.test(value);
+}
+
+export function runtimeAdapterProxyPath(parts: string[]): string | undefined {
+  if (parts[0] !== "v1" || parts[1] !== "workspaces") {
+    return undefined;
+  }
+  if (parts.length === 2) {
+    return "/v1/workspaces";
+  }
+  if (!validRuntimeAdapterID(parts[2])) {
+    return undefined;
+  }
+  if (parts.length === 3) {
+    return `/v1/workspaces/${parts[2]}`;
+  }
+  if (parts.length === 5 && parts[3] === "connections" && parts[4] === "desktop") {
+    return `/v1/workspaces/${parts[2]}/connections/desktop`;
+  }
+  return undefined;
+}
+
+export function runtimeAdapterRelayMethodAllowed(method: string, path: string): boolean {
+  if (path === "/v1/workspaces") {
+    return method === "POST";
+  }
+  if (path.endsWith("/connections/desktop")) {
+    return method === "POST";
+  }
+  return method === "GET" || method === "DELETE";
+}
+
+export function runtimeAdapterRelayBodyAllowed(
+  method: string,
+  path: string,
+  body: string | undefined,
+): boolean {
+  return body === undefined || body === "" || (method === "POST" && path === "/v1/workspaces");
+}
+
+export function validRuntimeAdapterDesktopRelayTimeout(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= runtimeAdapterRelayTimeoutMs &&
+    value <= runtimeAdapterDesktopRelayMaxTimeoutMs
+  );
+}
+
+export function runtimeAdapterRelayTimeoutForPath(path: string, desktopTimeoutMs?: number): number {
+  if (!path.endsWith("/connections/desktop")) return runtimeAdapterRelayTimeoutMs;
+  return validRuntimeAdapterDesktopRelayTimeout(desktopTimeoutMs)
+    ? desktopTimeoutMs
+    : runtimeAdapterDesktopRelayTimeoutMs;
+}
+
+export function runtimeAdapterRelayHeaders(request: Request): Record<string, string> | undefined {
+  const idempotencyKey = request.headers.get("idempotency-key")?.trim();
+  if (!idempotencyKey) return undefined;
+  if (idempotencyKey.length > 128) {
+    throw new RangeError("runtime adapter idempotency key is too long");
+  }
+  return { "idempotency-key": idempotencyKey };
+}
+
+export function runtimeAdapterRelayContentType(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  return Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === "content-type")?.[1];
+}
+
+export async function readRuntimeAdapterRelayBody(request: Request): Promise<string | undefined> {
+  if (!request.body) {
+    return undefined;
+  }
+  const declared = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > runtimeAdapterRelayBodyLimit) {
+    throw new RangeError("runtime adapter request body is too large");
+  }
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop -- a bounded stream must be consumed in order.
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > runtimeAdapterRelayBodyLimit) {
+      void reader.cancel();
+      throw new RangeError("runtime adapter request body is too large");
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(body);
+  } catch {
+    throw new TypeError("runtime adapter request body must be valid UTF-8");
+  }
+}
+
+export function validRuntimeAdapterRelayResponse(
+  value: unknown,
+  expectedID: string,
+): value is RuntimeAdapterRelayResponse {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const response = value as Partial<RuntimeAdapterRelayResponse>;
+  const headers = response.headers;
+  if (
+    headers !== undefined &&
+    (!headers ||
+      typeof headers !== "object" ||
+      Array.isArray(headers) ||
+      Object.entries(headers).some(
+        ([key, header]) =>
+          key.toLowerCase() !== "content-type" ||
+          typeof header !== "string" ||
+          /[\r\n]/.test(header) ||
+          new TextEncoder().encode(header).byteLength > 256,
+      ))
+  ) {
+    return false;
+  }
+  return Boolean(
+    response.type === "response" &&
+    response.id === expectedID &&
+    Number.isInteger(response.status) &&
+    (response.status ?? 0) >= 200 &&
+    (response.status ?? 0) <= 599 &&
+    (response.body === undefined ||
+      (typeof response.body === "string" &&
+        new TextEncoder().encode(response.body).byteLength <= runtimeAdapterRelayBodyLimit)),
+  );
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -206,6 +206,9 @@ export interface LeaseRegistrationRequest {
   exposedPorts?: string[];
   ttlSeconds?: number;
   idleTimeoutSeconds?: number;
+  runtimeAdapterID?: string;
+  runtimeAdapterWorkspaceID?: string;
+  runtimeAdapterRegistrationID?: string;
 }
 
 export const coordinatorProviderRegistry = [
@@ -291,6 +294,15 @@ export interface LeaseRecord {
   workspaceID?: string;
   provider: string;
   lifecycle?: LeaseLifecycle;
+  runtimeAdapterID?: string;
+  runtimeAdapterWorkspaceID?: string;
+  runtimeAdapterRegistrationID?: string;
+  runtimeAdapterDeleteRequestedAt?: string;
+  runtimeAdapterDeleteClaimID?: string;
+  runtimeAdapterDeleteRetryAt?: string;
+  runtimeAdapterDeleteDispatchUntil?: string;
+  runtimeAdapterDeleteAttempts?: number;
+  runtimeAdapterDeleteError?: string;
   target: TargetOS;
   os?: string;
   windowsMode?: WindowsMode;

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -6,9 +6,11 @@ import {
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
   type CoordinatorStorage,
+  type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
 import { githubAuthRoute } from "../src/oauth";
+import { runtimeAdapterRelayFrameLimit } from "../src/runtime-adapter-relay";
 import type { Env } from "../src/types";
 
 afterEach(() => {
@@ -43,6 +45,9 @@ class MemoryRuntime implements CoordinatorRuntime {
   readonly storage = new MemoryStorage();
   readonly ephemeralWebSocketMaxPayloadBytes = 1024 * 1024;
   alarmTime?: number;
+  upgradeOptions?: CoordinatorWebSocketUpgradeOptions;
+  acceptedTags?: string[];
+  acceptedAttachment?: unknown;
   private readonly attachments = new WeakMap<WebSocket, unknown>();
   private exclusiveTail: Promise<void> = Promise.resolve();
 
@@ -60,8 +65,20 @@ class MemoryRuntime implements CoordinatorRuntime {
     }
   }
 
-  createWebSocketUpgrade(): never {
-    throw new Error("websocket upgrade not configured");
+  createWebSocketUpgrade(options?: CoordinatorWebSocketUpgradeOptions): {
+    socket: WebSocket;
+    response: Response;
+  } {
+    this.upgradeOptions = options;
+    return {
+      socket: {
+        readyState: WebSocket.OPEN,
+        send: () => undefined,
+        close: () => undefined,
+        serializeAttachment: () => undefined,
+      } as unknown as WebSocket,
+      response: new Response(null),
+    };
   }
 
   getWebSockets(): Iterable<WebSocket> {
@@ -79,10 +96,12 @@ class MemoryRuntime implements CoordinatorRuntime {
   acceptWebSocket(
     socket: WebSocket,
     attachment: unknown,
-    _tags: string[],
+    tags: string[],
     _handlers: CoordinatorSocketHandlers,
   ): void {
     this.attachments.set(socket, attachment);
+    this.acceptedTags = tags;
+    this.acceptedAttachment = attachment;
   }
 
   acceptEphemeralWebSocket(_socket: WebSocket, _handlers: CoordinatorSocketHandlers): void {}
@@ -97,6 +116,40 @@ class MemoryRuntime implements CoordinatorRuntime {
 }
 
 describe("coordinator runtimes", () => {
+  it("applies the protocol frame limit to runtime adapter upgrades", async () => {
+    const runtime = new MemoryRuntime();
+    const coordinator = new FleetCoordinator(runtime, {
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const ticketResponse = await coordinator.fetch(
+      new Request("https://coordinator.test/v1/adapters/example-adapter/ticket", {
+        method: "POST",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ desktopTimeoutMs: 180_000 }),
+      }),
+    );
+    const { ticket } = (await ticketResponse.json()) as { ticket: string };
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/v1/adapters/example-adapter/agent", {
+        headers: {
+          ...headers,
+          upgrade: "websocket",
+          authorization: `Bearer ${ticket}`,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runtime.upgradeOptions).toEqual({ maxPayload: runtimeAdapterRelayFrameLimit });
+    expect(runtime.acceptedTags).toEqual(["adapter:example-adapter", "runtime-adapter-agent"]);
+    expect(runtime.acceptedAttachment).toMatchObject({ desktopTimeoutMs: 180_000 });
+  });
+
   it("keeps provider-backed portal requests outside the lifecycle queue", () => {
     for (const [method, path] of [
       ["GET", "/portal"],
@@ -107,6 +160,8 @@ describe("coordinator runtimes", () => {
       ["POST", "/v1/workspaces"],
       ["GET", "/v1/workspaces/fleet-is-101"],
       ["DELETE", "/v1/workspaces/fleet-is-101"],
+      ["GET", "/v1/adapters/applied-alice"],
+      ["POST", "/v1/adapters/applied-alice/proxy/v1/workspaces"],
     ]) {
       expect(
         coordinatorRequestQueue(new Request(`https://coordinator.test${path}`, { method })),
@@ -123,6 +178,13 @@ describe("coordinator runtimes", () => {
     expect(
       coordinatorRequestQueue(
         new Request("https://coordinator.test/v1/auth/github/start", { method: "POST" }),
+      ),
+    ).toBe("lifecycle");
+    expect(
+      coordinatorRequestQueue(
+        new Request("https://coordinator.test/v1/adapters/applied-alice/ticket", {
+          method: "POST",
+        }),
       ),
     ).toBe("lifecycle");
   });

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -28,6 +28,11 @@ import {
 } from "../src/fleet";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { portalCode } from "../src/portal";
+import {
+  runtimeAdapterDesktopRelayTimeoutMs,
+  runtimeAdapterRelayFrameLimit,
+  runtimeAdapterRelayTimeoutMs,
+} from "../src/runtime-adapter-relay";
 import type {
   Env,
   ExternalRunnerRecord,
@@ -102,8 +107,12 @@ class HookedMemoryStorage extends MemoryStorage {
 
 class FakeWebSocket {
   readyState = WebSocket.OPEN;
+  bufferedAmount = 0;
+  closeCode?: number;
+  closeReason?: string;
   private attachment: unknown;
   private readonly sent: string[] = [];
+  onSend?: (data: string) => void;
 
   constructor(attachment?: unknown) {
     this.attachment = attachment;
@@ -111,9 +120,12 @@ class FakeWebSocket {
 
   send(data: string): void {
     this.sent.push(data);
+    this.onSend?.(data);
   }
 
-  close(): void {
+  close(code?: number, reason?: string): void {
+    this.closeCode = code;
+    this.closeReason = reason;
     this.readyState = WebSocket.CLOSED;
   }
 
@@ -133,6 +145,2180 @@ class FakeWebSocket {
     return this.sent.map((value) => JSON.parse(value) as unknown);
   }
 }
+
+describe("runtime adapter relay", () => {
+  it("issues owner-scoped tickets and proxies only typed lifecycle requests", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const invalidTicket = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/ticket", { headers, body: null }),
+    );
+    expect(invalidTicket.status).toBe(400);
+    await expect(invalidTicket.json()).resolves.toMatchObject({
+      error: "invalid_adapter_ticket_request",
+    });
+    expect(storage.value("runtime-adapter-identity:example-adapter")).toBeUndefined();
+    const ticket = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/ticket", { headers, body: {} }),
+    );
+    expect(ticket.status).toBe(200);
+    await expect(ticket.json()).resolves.toMatchObject({
+      adapterID: "example-adapter",
+      ticket: expect.stringMatching(/^adapter_[a-f0-9]{32}$/),
+    });
+    const conflictingTicket = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/ticket", {
+        headers: {
+          "x-crabbox-owner": "mallory@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: {},
+      }),
+    );
+    expect(conflictingTicket.status).toBe(409);
+    await expect(conflictingTicket.json()).resolves.toMatchObject({
+      error: "adapter_id_conflict",
+    });
+
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as {
+        id: string;
+        method: string;
+        path: string;
+        body?: string;
+      };
+      expect(message).toMatchObject({
+        method: "POST",
+        path: "/v1/workspaces",
+        body: JSON.stringify({ id: "example-workspace-1" }),
+      });
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-1", status: "provisioning" }),
+        }),
+      );
+    };
+
+    const status = await fleet.fetch(request("GET", "/v1/adapters/example-adapter", { headers }));
+    await expect(status.json()).resolves.toEqual({ adapterID: "example-adapter", connected: true });
+
+    const proxied = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/proxy/v1/workspaces", {
+        headers: { ...headers, "idempotency-key": "example-workspace-1" },
+        body: { id: "example-workspace-1" },
+      }),
+    );
+    expect(proxied.status).toBe(202);
+    expect(proxied.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    await expect(proxied.json()).resolves.toEqual({
+      id: "example-workspace-1",
+      status: "provisioning",
+    });
+
+    const sendsBeforeInvalidDesktopBody = socket.sentJSON().length;
+    const invalidDesktopBody = await fleet.fetch(
+      request(
+        "POST",
+        "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1/connections/desktop",
+        { headers, body: {} },
+      ),
+    );
+    expect(invalidDesktopBody.status).toBe(400);
+    await expect(invalidDesktopBody.json()).resolves.toMatchObject({
+      error: "invalid_request_body",
+    });
+    expect(socket.sentJSON()).toHaveLength(sendsBeforeInvalidDesktopBody);
+
+    const wrongOwner = await fleet.fetch(
+      request("GET", "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1", {
+        headers: { "x-crabbox-owner": "mallory@example.com", "x-crabbox-org": "example-org" },
+      }),
+    );
+    expect(wrongOwner.status).toBe(403);
+    await expect(wrongOwner.json()).resolves.toMatchObject({
+      error: "runtime_adapter_forbidden",
+    });
+    const forbiddenPath = await fleet.fetch(
+      request(
+        "POST",
+        "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1/shell",
+        {
+          headers,
+          body: { command: "id" },
+        },
+      ),
+    );
+    expect(forbiddenPath.status).toBe(404);
+
+    const sendsBeforeInvalidKey = socket.sentJSON().length;
+    const invalidKey = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/proxy/v1/workspaces", {
+        headers: { ...headers, "idempotency-key": "x".repeat(129) },
+        body: { id: "example-workspace-2" },
+      }),
+    );
+    expect(invalidKey.status).toBe(431);
+    await expect(invalidKey.json()).resolves.toMatchObject({
+      error: "idempotency_key_too_long",
+    });
+    expect(socket.sentJSON()).toHaveLength(sendsBeforeInvalidKey);
+  });
+
+  it("rejects oversized adapter frames before parsing unknown fields", async () => {
+    const fleet = testFleet();
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const message = JSON.stringify({
+      type: "response",
+      id: "unknown-request",
+      padding: "x".repeat(runtimeAdapterRelayFrameLimit),
+    });
+
+    await fleet.webSocketMessage(socket as unknown as WebSocket, message);
+
+    expect(socket.closeCode).toBe(1009);
+    expect(socket.closeReason).toBe("runtime adapter response too large");
+  });
+
+  it("bounds pending relay work, applies backpressure, and removes aborted requests", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+      runtimeAdapterPending: Map<string, unknown>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const proxyPath = "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1";
+    const pendingRequests = Array.from({ length: 16 }, () =>
+      fleet.fetch(request("GET", proxyPath, { headers })),
+    );
+    await vi.waitFor(() => expect(socket.sentJSON()).toHaveLength(16));
+
+    const limited = await fleet.fetch(request("GET", proxyPath, { headers }));
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).toBe("1");
+    await expect(limited.json()).resolves.toMatchObject({ error: "runtime_adapter_busy" });
+
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string; method: string };
+      if (message.method !== "DELETE") return;
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-1", status: "stopped" }),
+        }),
+      );
+    };
+    const successfulDeleteLease = testLease({
+      id: "cbx_000000000080",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-1",
+      runtimeAdapterRegistrationID: "registration-generation-80",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${successfulDeleteLease.id}`, successfulDeleteLease);
+    const reservedDelete = await fleet.fetch(
+      request("POST", `/portal/leases/${successfulDeleteLease.id}/release`, { headers }),
+    );
+    expect(reservedDelete.status).toBe(303);
+
+    const unfencedDelete = await fleet.fetch(request("DELETE", proxyPath, { headers }));
+    expect(unfencedDelete.status).toBe(409);
+
+    socket.onSend = undefined;
+    const pendingDeletes = Array.from({ length: 4 }, (_, index) => {
+      const suffix = 81 + index;
+      const pendingLease = testLease({
+        id: `cbx_0000000000${suffix}`,
+        provider: "external",
+        lifecycle: "registered",
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: `example-workspace-${suffix}`,
+        runtimeAdapterRegistrationID: `registration-generation-${suffix}`,
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: true,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      });
+      storage.seed(`lease:${pendingLease.id}`, pendingLease);
+      return fleet.fetch(request("POST", `/portal/leases/${pendingLease.id}/release`, { headers }));
+    });
+    await vi.waitFor(() => expect(socket.sentJSON()).toHaveLength(21));
+    const lease = testLease({
+      id: "cbx_000000000085",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-85",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const deferredDelete = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(deferredDelete.status).toBe(503);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+
+    fleet.webSocketClose(socket as unknown as WebSocket, 1006, "gone", false);
+    await expect(Promise.all(pendingRequests)).resolves.toHaveLength(16);
+    await expect(Promise.all(pendingDeletes)).resolves.toHaveLength(4);
+    expect(relayState.runtimeAdapterPending.size).toBe(0);
+
+    const congestedSocket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    congestedSocket.bufferedAmount = 2 * 1024 * 1024;
+    relayState.runtimeAdapterAgents.set("example-adapter", congestedSocket as unknown as WebSocket);
+    const congested = await fleet.fetch(request("GET", proxyPath, { headers }));
+    expect(congested.status).toBe(503);
+    expect(congested.headers.get("retry-after")).toBe("1");
+    await expect(congested.json()).resolves.toMatchObject({
+      error: "runtime_adapter_backpressure",
+    });
+    expect(congestedSocket.sentJSON()).toHaveLength(0);
+
+    const abortSocket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    relayState.runtimeAdapterAgents.set("example-adapter", abortSocket as unknown as WebSocket);
+    const abortController = new AbortController();
+    const abortedRequest = fleet.fetch(
+      new Request(`https://crabbox.test${proxyPath}`, {
+        headers,
+        signal: abortController.signal,
+      }),
+    );
+    await vi.waitFor(() => expect(abortSocket.sentJSON()).toHaveLength(1));
+    expect(relayState.runtimeAdapterPending.size).toBe(1);
+    abortController.abort();
+
+    expect((await abortedRequest).status).toBe(499);
+    expect(relayState.runtimeAdapterPending.size).toBe(1);
+    const abortedRelayMessage = abortSocket.sentJSON()[0] as { id: string };
+    await fleet.webSocketMessage(
+      abortSocket as unknown as WebSocket,
+      JSON.stringify({
+        type: "response",
+        id: abortedRelayMessage.id,
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "example-workspace-1", status: "running" }),
+      }),
+    );
+    expect(relayState.runtimeAdapterPending.size).toBe(0);
+  });
+
+  it("isolates ordinary relay capacity by owner while preserving delete capacity", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const aliceHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const bobHeaders = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    const connect = (adapterID: string, owner: string): FakeWebSocket => {
+      storage.seed(`runtime-adapter-identity:${adapterID}`, {
+        adapterID,
+        owner,
+        org: "example-org",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      const socket = new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID,
+        owner,
+        org: "example-org",
+      });
+      relayState.runtimeAdapterAgents.set(adapterID, socket as unknown as WebSocket);
+      return socket;
+    };
+    const firstAlice = connect("alice-adapter-1", "alice@example.com");
+    const secondAlice = connect("alice-adapter-2", "alice@example.com");
+    const thirdAlice = connect("alice-adapter-3", "alice@example.com");
+    const bob = connect("bob-adapter", "bob@example.com");
+    const proxySuffix = "/proxy/v1/workspaces/example-workspace";
+    const alicePending = [
+      ...Array.from({ length: 16 }, () =>
+        fleet.fetch(
+          request("GET", `/v1/adapters/alice-adapter-1${proxySuffix}`, {
+            headers: aliceHeaders,
+          }),
+        ),
+      ),
+      ...Array.from({ length: 16 }, () =>
+        fleet.fetch(
+          request("GET", `/v1/adapters/alice-adapter-2${proxySuffix}`, {
+            headers: aliceHeaders,
+          }),
+        ),
+      ),
+    ];
+    await vi.waitFor(() => expect(firstAlice.sentJSON()).toHaveLength(16));
+    await vi.waitFor(() => expect(secondAlice.sentJSON()).toHaveLength(16));
+
+    const ownerLimited = await fleet.fetch(
+      request("GET", `/v1/adapters/alice-adapter-3${proxySuffix}`, { headers: aliceHeaders }),
+    );
+    expect(ownerLimited.status).toBe(429);
+    expect(thirdAlice.sentJSON()).toHaveLength(0);
+
+    thirdAlice.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        thirdAlice as unknown as WebSocket,
+        JSON.stringify({ type: "response", id: message.id, status: 204 }),
+      );
+    };
+    const deleteLease = testLease({
+      id: "cbx_000000000072",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "alice-adapter-3",
+      runtimeAdapterWorkspaceID: "example-workspace",
+      runtimeAdapterRegistrationID: "registration-generation-72",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed(`lease:${deleteLease.id}`, deleteLease);
+    const reservedDelete = await fleet.fetch(
+      request("POST", `/portal/leases/${deleteLease.id}/release`, {
+        headers: aliceHeaders,
+      }),
+    );
+    expect(reservedDelete.status).toBe(303);
+
+    const unfencedDelete = await fleet.fetch(
+      request("DELETE", `/v1/adapters/alice-adapter-3${proxySuffix}`, {
+        headers: aliceHeaders,
+      }),
+    );
+    expect(unfencedDelete.status).toBe(409);
+    await expect(unfencedDelete.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_requires_lease",
+    });
+    expect(thirdAlice.sentJSON()).toHaveLength(1);
+
+    bob.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        bob as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace", status: "running" }),
+        }),
+      );
+    };
+    const otherOwner = await fleet.fetch(
+      request("GET", `/v1/adapters/bob-adapter${proxySuffix}`, { headers: bobHeaders }),
+    );
+    expect(otherOwner.status).toBe(200);
+
+    fleet.webSocketClose(firstAlice as unknown as WebSocket, 1006, "gone", false);
+    fleet.webSocketClose(secondAlice as unknown as WebSocket, 1006, "gone", false);
+    await expect(Promise.all(alicePending)).resolves.toHaveLength(32);
+  });
+
+  it("routes portal Delete through the bound adapter and keeps deregistration as fallback", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000099",
+      slug: "example-box",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-99",
+      runtimeAdapterRegistrationID: "registration-generation-99",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    let workspaceStatus = "stopping";
+    const initialResponse = deferred<void>();
+    let holdInitialResponse = true;
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string; method: string; path: string };
+      expect(message).toMatchObject({
+        method: "DELETE",
+        path: "/v1/workspaces/example-workspace-99",
+      });
+      const respond = () =>
+        fleet.webSocketMessage(
+          socket as unknown as WebSocket,
+          JSON.stringify({
+            type: "response",
+            id: message.id,
+            status:
+              workspaceStatus === "stopping"
+                ? 202
+                : workspaceStatus === "rejected"
+                  ? 403
+                  : workspaceStatus === "rate-limited"
+                    ? 429
+                    : 200,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              id: "example-workspace-99",
+              status: workspaceStatus,
+            }),
+          }),
+        );
+      if (holdInitialResponse) {
+        holdInitialResponse = false;
+        void initialResponse.promise.then(respond);
+      } else {
+        void respond();
+      }
+    };
+
+    const page = await fleet.fetch(request("GET", "/portal", { headers }));
+    const pageHTML = await page.text();
+    expect(pageHTML).toContain('data-release-kind="adapter"');
+    expect(pageHTML).toContain('title="Delete example-box workspace"');
+    expect(pageHTML).toContain("permanently deletes the external workspace");
+
+    const requestedPromise = fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    await vi.waitFor(() => expect(socket.sentJSON()).toHaveLength(1));
+    const inFlight = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(inFlight).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    initialResponse.resolve();
+    const requested = await requestedPromise;
+    expect(requested.status).toBe(303);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+    });
+
+    workspaceStatus = "failed";
+    const failed = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(failed.status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("active");
+
+    workspaceStatus = "rejected";
+    const manuallyRejected = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(manuallyRejected.status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+    });
+
+    workspaceStatus = "stopping";
+    const manuallyRearmed = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(manuallyRearmed.status).toBe(303);
+
+    const rateLimitedPending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(rateLimitedPending).toBeDefined();
+    if (rateLimitedPending) {
+      rateLimitedPending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, rateLimitedPending);
+    }
+    workspaceStatus = "rate-limited";
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+    });
+
+    const rejectedPending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(rejectedPending).toBeDefined();
+    if (rejectedPending) {
+      rejectedPending.expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      rejectedPending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, rejectedPending);
+    }
+    workspaceStatus = "rejected";
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+      runtimeAdapterDeleteError: "runtime_adapter_http_403",
+    });
+
+    workspaceStatus = "stopping";
+    const rearmed = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(rearmed.status).toBe(303);
+
+    const pending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(pending).toBeDefined();
+    if (pending) {
+      pending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, pending);
+    }
+    workspaceStatus = "signed-url-secret";
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteError: "runtime_adapter_invalid_response",
+    });
+
+    workspaceStatus = "stopped";
+    const retry = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(retry).toBeDefined();
+    if (retry) {
+      retry.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, retry);
+    }
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteDispatchUntil,
+    ).toBeUndefined();
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({ state: "released" });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+  });
+
+  it("accepts only an owner-scoped exact confirmed-absence completion", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const managerHeaders = {
+      "x-crabbox-owner": "manager@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    const lease = testLease({
+      id: "cbx_000000000078",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-78",
+      runtimeAdapterRegistrationID: "registration-generation-78",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteClaimID: "delete-claim",
+      runtimeAdapterDeleteRetryAt: new Date(Date.now() + 60_000).toISOString(),
+      owner: "alice@example.com",
+      org: "example-org",
+      share: { users: { "manager@example.com": "manage" } },
+      keep: true,
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const completion = {
+      adapterID: "example-adapter",
+      workspaceID: "example-workspace-78",
+      registrationID: "registration-generation-78",
+      status: "absent",
+    };
+
+    const generationMissing = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: {
+          runtimeAdapterDeleteCompletion: {
+            adapterID: completion.adapterID,
+            workspaceID: completion.workspaceID,
+            status: completion.status,
+          },
+        },
+      }),
+    );
+    expect(generationMissing.status).toBe(400);
+
+    const manager = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: managerHeaders,
+        body: { runtimeAdapterDeleteCompletion: completion },
+      }),
+    );
+    expect(manager.status).toBe(403);
+
+    const mismatch = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: {
+          runtimeAdapterDeleteCompletion: {
+            ...completion,
+            workspaceID: "example-workspace-other",
+          },
+        },
+      }),
+    );
+    expect(mismatch.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteClaimID: "delete-claim",
+    });
+
+    const completed = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { runtimeAdapterDeleteCompletion: completion },
+      }),
+    );
+    expect(completed.status).toBe(200);
+    await expect(completed.json()).resolves.toMatchObject({ lease: { state: "released" } });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+
+    const repeated = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { runtimeAdapterDeleteCompletion: completion },
+      }),
+    );
+    expect(repeated.status).toBe(200);
+    await expect(repeated.json()).resolves.toMatchObject({ lease: { state: "released" } });
+
+    const unboundReactivation = await fleet.fetch(
+      request("PUT", `/v1/leases/${lease.id}/registration`, {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "replacement.example.test",
+        },
+      }),
+    );
+    expect(unboundReactivation.status).toBe(200);
+    await expect(unboundReactivation.json()).resolves.toMatchObject({
+      lease: {
+        state: "active",
+        runtimeAdapterRegistrationID: "registration-generation-78",
+      },
+    });
+
+    const replayedRegistration = await fleet.fetch(
+      request("PUT", `/v1/leases/${lease.id}/registration`, {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "replacement.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-78",
+          runtimeAdapterRegistrationID: "registration-generation-78",
+        },
+      }),
+    );
+    expect(replayedRegistration.status).toBe(409);
+    await expect(replayedRegistration.json()).resolves.toMatchObject({
+      error: "runtime_adapter_registration_replayed",
+    });
+
+    const reactivated = await fleet.fetch(
+      request("PUT", `/v1/leases/${lease.id}/registration`, {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "replacement.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-78",
+          runtimeAdapterRegistrationID: "registration-generation-78-next",
+        },
+      }),
+    );
+    expect(reactivated.status).toBe(200);
+    await expect(reactivated.json()).resolves.toMatchObject({
+      lease: {
+        state: "active",
+        runtimeAdapterRegistrationID: "registration-generation-78-next",
+      },
+    });
+
+    const delayedCompletion = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { runtimeAdapterDeleteCompletion: completion },
+      }),
+    );
+    expect(delayedCompletion.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterRegistrationID: "registration-generation-78-next",
+    });
+
+    const autonomouslyStopped = testLease({
+      id: "cbx_000000000077",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-77",
+      runtimeAdapterRegistrationID: "registration-generation-77",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed(`lease:${autonomouslyStopped.id}`, autonomouslyStopped);
+    const autonomousCompletion = await fleet.fetch(
+      request("POST", `/v1/leases/${autonomouslyStopped.id}/release`, {
+        headers,
+        body: {
+          runtimeAdapterDeleteCompletion: {
+            adapterID: "example-adapter",
+            workspaceID: "example-workspace-77",
+            registrationID: "registration-generation-77",
+            status: "absent",
+          },
+        },
+      }),
+    );
+    expect(autonomousCompletion.status).toBe(200);
+    await expect(autonomousCompletion.json()).resolves.toMatchObject({
+      lease: { state: "released" },
+    });
+
+    const legacyPending = testLease({
+      id: "cbx_000000000076",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-76",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      owner: "alice@example.com",
+      org: "example-org",
+      share: { users: { "manager@example.com": "manage" } },
+      keep: true,
+    });
+    storage.seed(`lease:${legacyPending.id}`, legacyPending);
+    const legacyCompletionBody = {
+      runtimeAdapterLegacyDeleteCompletion: {
+        adapterID: "example-adapter",
+        workspaceID: "example-workspace-76",
+        status: "absent",
+      },
+    };
+    const legacyManagerCompletion = await fleet.fetch(
+      request("POST", `/v1/leases/${legacyPending.id}/release`, {
+        headers: managerHeaders,
+        body: legacyCompletionBody,
+      }),
+    );
+    expect(legacyManagerCompletion.status).toBe(403);
+    expect(storage.value<LeaseRecord>(`lease:${legacyPending.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+    });
+    const genericLegacyRelease = await fleet.fetch(
+      request("POST", `/v1/leases/${legacyPending.id}/release`, {
+        headers,
+        body: { delete: false },
+      }),
+    );
+    expect(genericLegacyRelease.status).toBe(409);
+    await expect(genericLegacyRelease.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_pending",
+    });
+    const legacyCompletion = await fleet.fetch(
+      request("POST", `/v1/leases/${legacyPending.id}/release`, {
+        headers,
+        body: legacyCompletionBody,
+      }),
+    );
+    expect(legacyCompletion.status).toBe(200);
+    await expect(legacyCompletion.json()).resolves.toMatchObject({
+      lease: { state: "released" },
+    });
+
+    const expiredLegacyPending = testLease({
+      id: "cbx_000000000074",
+      provider: "external",
+      lifecycle: "registered",
+      state: "expired",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-74",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed(`lease:${expiredLegacyPending.id}`, expiredLegacyPending);
+    const expiredLegacyCompletion = await fleet.fetch(
+      request("POST", `/v1/leases/${expiredLegacyPending.id}/release`, {
+        headers,
+        body: {
+          runtimeAdapterLegacyDeleteCompletion: {
+            adapterID: "example-adapter",
+            workspaceID: "example-workspace-74",
+            status: "absent",
+          },
+        },
+      }),
+    );
+    expect(expiredLegacyCompletion.status).toBe(200);
+    await expect(expiredLegacyCompletion.json()).resolves.toMatchObject({
+      lease: { state: "expired" },
+    });
+    expect(
+      storage.value<LeaseRecord>(`lease:${expiredLegacyPending.id}`)
+        ?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+  });
+
+  it("keeps completion fenced until a generation-scoped delete dispatch expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const lease = testLease({
+        id: "cbx_000000000075",
+        provider: "external",
+        lifecycle: "registered",
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: "example-workspace-75",
+        runtimeAdapterRegistrationID: "registration-generation-75",
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: true,
+      });
+      storage.seed("runtime-adapter-identity:example-adapter", {
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const socket = new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      });
+      const relayState = fleet as unknown as {
+        runtimeAdapterAgents: Map<string, WebSocket>;
+      };
+      relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+      const sent = deferred<void>();
+      socket.onSend = () => sent.resolve();
+
+      const deletion = fleet.fetch(
+        request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+      );
+      await sent.promise;
+      let completionSettled = false;
+      const completion = fleet
+        .fetch(
+          request("POST", `/v1/leases/${lease.id}/release`, {
+            headers,
+            body: {
+              runtimeAdapterDeleteCompletion: {
+                adapterID: "example-adapter",
+                workspaceID: "example-workspace-75",
+                registrationID: "registration-generation-75",
+                status: "absent",
+              },
+            },
+          }),
+        )
+        .then((response) => {
+          completionSettled = true;
+          return response;
+        });
+      await Promise.resolve();
+      expect(completionSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(runtimeAdapterRelayTimeoutMs);
+      expect((await deletion).status).toBe(503);
+      const fenced = await completion;
+      expect(fenced.status).toBe(409);
+      expect(fenced.headers.get("retry-after")).toBe("1");
+      await expect(fenced.json()).resolves.toMatchObject({
+        error: "runtime_adapter_delete_in_flight",
+      });
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+        state: "active",
+        runtimeAdapterDeleteDispatchUntil: expect.any(String),
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const retried = await fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/release`, {
+          headers,
+          body: {
+            runtimeAdapterDeleteCompletion: {
+              adapterID: "example-adapter",
+              workspaceID: "example-workspace-75",
+              registrationID: "registration-generation-75",
+              status: "absent",
+            },
+          },
+        }),
+      );
+      expect(retried.status).toBe(200);
+      await expect(retried.json()).resolves.toMatchObject({ lease: { state: "released" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the delete fence after an ambiguous connector timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const lease = testLease({
+        id: "cbx_000000000073",
+        provider: "external",
+        lifecycle: "registered",
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: "example-workspace-73",
+        runtimeAdapterRegistrationID: "registration-generation-73",
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: true,
+      });
+      storage.seed("runtime-adapter-identity:example-adapter", {
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const socket = new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      });
+      const relayState = fleet as unknown as {
+        runtimeAdapterAgents: Map<string, WebSocket>;
+      };
+      relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+      socket.onSend = (data) => {
+        const message = JSON.parse(data) as { id: string };
+        void fleet.webSocketMessage(
+          socket as unknown as WebSocket,
+          JSON.stringify({
+            type: "response",
+            id: message.id,
+            status: 504,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              error: { code: "adapter_timeout", message: "local adapter request timed out" },
+            }),
+          }),
+        );
+      };
+
+      const deletion = await fleet.fetch(
+        request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+      );
+      expect(deletion.status).toBe(503);
+      const fenced = await confirmRuntimeAdapterAbsence(fleet, lease, headers);
+      expect(fenced.status).toBe(409);
+      await expect(fenced.json()).resolves.toMatchObject({
+        error: "runtime_adapter_delete_in_flight",
+      });
+
+      await vi.advanceTimersByTimeAsync(runtimeAdapterRelayTimeoutMs + 2_000);
+      const completed = await confirmRuntimeAdapterAbsence(fleet, lease, headers);
+      expect(completed.status).toBe(200);
+      await expect(completed.json()).resolves.toMatchObject({ lease: { state: "released" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps delete intent after a post-send adapter disconnect and retries to confirmation", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000089",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-89",
+      runtimeAdapterRegistrationID: "registration-generation-89",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    const offline = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(offline.status).toBe(503);
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const sent = deferred<void>();
+    socket.onSend = () => sent.resolve();
+
+    const deletePromise = fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    await sent.promise;
+    fleet.webSocketClose(socket as unknown as WebSocket, 1006, "gone", false);
+
+    expect((await deletePromise).status).toBe(503);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteClaimID: expect.any(String),
+    });
+
+    const retrySocket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    retrySocket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        retrySocket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-89", status: "stopped" }),
+        }),
+      );
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", retrySocket as unknown as WebSocket);
+    const pending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(pending).toBeDefined();
+    if (pending) {
+      pending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      pending.runtimeAdapterDeleteDispatchUntil = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, pending);
+    }
+
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteDispatchUntil,
+    ).toBeUndefined();
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({ state: "released" });
+  });
+
+  it("revokes expired leases while retaining adapter delete retries", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const expiresAt = new Date(Date.now() + 5_000).toISOString();
+    const lease = testLease({
+      id: "cbx_000000000084",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-84",
+      runtimeAdapterRegistrationID: "registration-generation-84",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteClaimID: "delete-claim",
+      runtimeAdapterDeleteRetryAt: new Date(Date.now() + 60_000).toISOString(),
+      owner: "alice@example.com",
+      org: "example-org",
+      desktop: true,
+      keep: true,
+      expiresAt,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("active");
+    expect(storage.alarm()).toBe(Date.parse(expiresAt));
+    const expiring = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(expiring).toBeDefined();
+    if (expiring) {
+      expiring.expiresAt = new Date(Date.now() - 1_000).toISOString();
+      storage.seed(`lease:${lease.id}`, expiring);
+    }
+    const webVNCAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_expiry",
+      capabilities: new Set<string>(),
+    });
+    const webVNCViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_expiry",
+      agentID: "agent_expiry",
+      owner: "alice@example.com",
+      label: "alice",
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const codeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code-viewer-expiry",
+    });
+    const egressHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID: lease.id,
+      sessionID: "egress-expiry",
+    });
+    const egressClient = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID: lease.id,
+      sessionID: "egress-expiry",
+    });
+    const relayState = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<
+        string,
+        Map<
+          string,
+          {
+            id: string;
+            agentID: string;
+            socket: WebSocket;
+            owner: string;
+            label: string;
+            connectedAt: string;
+          }
+        >
+      >;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+      egressHosts: Map<string, WebSocket>;
+      egressClients: Map<string, WebSocket>;
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.webVNCAgents.set(
+      lease.id,
+      new Map([["agent_expiry", webVNCAgent as unknown as WebSocket]]),
+    );
+    relayState.webVNCViewers.set(
+      lease.id,
+      new Map([
+        [
+          "viewer_expiry",
+          {
+            id: "viewer_expiry",
+            agentID: "agent_expiry",
+            socket: webVNCViewer as unknown as WebSocket,
+            owner: "alice@example.com",
+            label: "alice",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    relayState.codeAgents.set(lease.id, codeAgent as unknown as WebSocket);
+    relayState.codeViewers.set("code-viewer-expiry", codeViewer as unknown as WebSocket);
+    const egressKey = `${lease.id}\0egress-expiry`;
+    relayState.egressHosts.set(egressKey, egressHost as unknown as WebSocket);
+    relayState.egressClients.set(egressKey, egressClient as unknown as WebSocket);
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "expired",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteClaimID: "delete-claim",
+    });
+    for (const socket of [
+      webVNCAgent,
+      webVNCViewer,
+      codeAgent,
+      codeViewer,
+      egressHost,
+      egressClient,
+    ]) {
+      expect(socket.closeCode).toBe(1008);
+      expect(socket.closeReason).toBe("lease expired");
+    }
+    const revokedTicket = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/webvnc/ticket`, { headers, body: {} }),
+    );
+    expect(revokedTicket.status).toBe(409);
+    const pendingRefresh = await fleet.fetch(
+      request("PUT", `/v1/leases/${lease.id}/registration`, {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "replacement.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-84",
+          runtimeAdapterRegistrationID: "registration-generation-84",
+        },
+      }),
+    );
+    expect(pendingRefresh.status).toBe(409);
+    await expect(pendingRefresh.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_pending",
+    });
+    const pendingRebind = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000083/registration", {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "rebound.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-84",
+          runtimeAdapterRegistrationID: "registration-generation-84-rebound",
+        },
+      }),
+    );
+    expect(pendingRebind.status).toBe(409);
+    await expect(pendingRebind.json()).resolves.toMatchObject({
+      error: "runtime_adapter_workspace_conflict",
+    });
+
+    const authFailure = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    relayState.runtimeAdapterAgents.set("example-adapter", authFailure as unknown as WebSocket);
+    authFailure.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        authFailure as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 401,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ error: { code: "unauthorized" } }),
+        }),
+      );
+    };
+    const authPending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(authPending).toBeDefined();
+    if (authPending) {
+      authPending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, authPending);
+    }
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "expired",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteError: "runtime_adapter_http_401",
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+    });
+
+    const pending = storage.value<LeaseRecord>(`lease:${lease.id}`);
+    expect(pending).toBeDefined();
+    if (pending) {
+      pending.runtimeAdapterDeleteRetryAt = new Date(0).toISOString();
+      storage.seed(`lease:${lease.id}`, pending);
+    }
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-84", status: "stopped" }),
+        }),
+      );
+    };
+
+    await fleet.alarm();
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "expired",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+    });
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({ state: "expired" });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+  });
+
+  it("expires leases before waiting for a due adapter delete retry", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = testLease({
+      id: "cbx_000000000082",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-82",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteClaimID: "delete-claim",
+      runtimeAdapterDeleteRetryAt: new Date(0).toISOString(),
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const sent = deferred<void>();
+    socket.onSend = () => sent.resolve();
+
+    const alarm = fleet.alarm();
+    await sent.promise;
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("expired");
+    fleet.webSocketClose(socket as unknown as WebSocket, 1006, "gone", false);
+    await alarm;
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "expired",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+    });
+  });
+
+  it("revokes restored bridge sockets from durable terminal lease state", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000071",
+      provider: "external",
+      lifecycle: "registered",
+      state: "expired",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID: lease.id,
+      sessionID: "restored-expired-session",
+    });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => [socket as unknown as WebSocket],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    await vi.waitFor(() => expect(socket.closeCode).toBe(1008));
+    expect(socket.closeReason).toBe("lease ended");
+  });
+
+  it("keeps a dispatched portal delete binding fenced until completion", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000087",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-87",
+      runtimeAdapterRegistrationID: "registration-generation-87",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const sent = deferred<{ id: string }>();
+    socket.onSend = (data) => sent.resolve(JSON.parse(data) as { id: string });
+
+    const deleting = fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    const message = await sent.promise;
+    const racedRelease = await (
+      fleet as unknown as {
+        releaseResolvedLeaseOperation: (
+          lease: LeaseRecord,
+          options: { deleteServer: boolean; keep?: boolean },
+        ) => Promise<LeaseRecord>;
+      }
+    ).releaseResolvedLeaseOperation(lease, { deleteServer: false });
+    expect(racedRelease).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    const released = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, { headers }),
+    );
+    expect(released.status).toBe(409);
+    await expect(released.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_pending",
+    });
+    const registered = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000081/registration", {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "replacement.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-87",
+          runtimeAdapterRegistrationID: "registration-generation-87-replacement",
+        },
+      }),
+    );
+    expect(registered.status).toBe(409);
+    await expect(registered.json()).resolves.toMatchObject({
+      error: "runtime_adapter_workspace_conflict",
+    });
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "response",
+        id: message.id,
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "example-workspace-87", status: "stopped" }),
+      }),
+    );
+
+    expect((await deleting).status).toBe(303);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({ state: "released" });
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+  });
+
+  it("keeps a reconciling delete binding fenced until completion", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000086",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-86",
+      runtimeAdapterRegistrationID: "registration-generation-86",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+      runtimeAdapterDeleteClaimID: "old-delete-claim",
+      runtimeAdapterDeleteRetryAt: new Date(0).toISOString(),
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const sent = deferred<{ id: string }>();
+    socket.onSend = (data) => sent.resolve(JSON.parse(data) as { id: string });
+
+    const reconciling = fleet.alarm();
+    const message = await sent.promise;
+    const released = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, { headers }),
+    );
+    expect(released.status).toBe(409);
+    await expect(released.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_pending",
+    });
+    const registered = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000080/registration", {
+        headers,
+        body: {
+          provider: "external",
+          target: "linux",
+          host: "reconciled-replacement.example.test",
+          runtimeAdapterID: "example-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-86",
+          runtimeAdapterRegistrationID: "registration-generation-86-replacement",
+        },
+      }),
+    );
+    expect(registered.status).toBe(409);
+    await expect(registered.json()).resolves.toMatchObject({
+      error: "runtime_adapter_workspace_conflict",
+    });
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "response",
+        id: message.id,
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "example-workspace-86", status: "stopped" }),
+      }),
+    );
+    await reconciling;
+
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "expired",
+      runtimeAdapterDeleteRequestedAt: "2026-06-13T00:00:00.000Z",
+    });
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(
+      storage.value<LeaseRecord>(`lease:${lease.id}`)?.runtimeAdapterDeleteRequestedAt,
+    ).toBeUndefined();
+  });
+
+  it("serializes concurrent upstream rejections without abandoning delete intent", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000088",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-88",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    const sent = [deferred<void>(), deferred<void>()];
+    const messages: { id: string }[] = [];
+    socket.onSend = (data) => {
+      messages.push(JSON.parse(data) as { id: string });
+      sent[messages.length - 1]?.resolve();
+    };
+
+    const firstDelete = fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    await sent[0].promise;
+    const secondDelete = fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    await Promise.resolve();
+    expect(messages).toHaveLength(1);
+
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "response",
+        id: messages[0]?.id,
+        status: 404,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ error: { code: "not_found" } }),
+      }),
+    );
+    expect((await firstDelete).status).toBe(502);
+    await sent[1].promise;
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({
+        type: "response",
+        id: messages[1]?.id,
+        status: 404,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ error: { code: "not_found" } }),
+      }),
+    );
+
+    expect((await secondDelete).status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+      runtimeAdapterDeleteRetryAt: expect.any(String),
+    });
+  });
+
+  it("keeps the registration when the relay rejects local adapter ownership", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = testLease({
+      id: "cbx_000000000098",
+      slug: "legacy-misbound-box",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "other-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-98",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:other-adapter", {
+      adapterID: "other-adapter",
+      owner: "mallory@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const response = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("active");
+  });
+
+  it("keeps adapter 404s pending until an exact generation confirms absence", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000097",
+      slug: "already-gone-box",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-97",
+      runtimeAdapterRegistrationID: "registration-generation-97",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    let errorCode = "not_found";
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: { code: errorCode, message: "not found" } }),
+        }),
+      );
+    };
+
+    const genericMissing = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(genericMissing.status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+
+    errorCode = "workspace_not_found";
+    const confirmedMissing = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(confirmedMissing.status).toBe(502);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, headers)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("released");
+
+    const sendsBeforeStaleRequest = socket.sentJSON().length;
+    const staleRequest = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers }),
+    );
+    expect(staleRequest.status).toBe(409);
+    expect(socket.sentJSON()).toHaveLength(sendsBeforeStaleRequest);
+  });
+
+  it("lets manage-share users delete through the lease owner's adapter", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const managerHeaders = {
+      "x-crabbox-owner": "manager@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000096",
+      slug: "shared-adapter-box",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-96",
+      runtimeAdapterRegistrationID: "registration-generation-96",
+      owner: "alice@example.com",
+      org: "example-org",
+      share: { users: { "manager@example.com": "manage" } },
+      keep: true,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-96", status: "stopped" }),
+        }),
+      );
+    };
+
+    const response = await fleet.fetch(
+      request("POST", `/portal/leases/${lease.id}/release`, { headers: managerHeaders }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+      state: "active",
+      runtimeAdapterDeleteRequestedAt: expect.any(String),
+    });
+    expect((await confirmRuntimeAdapterAbsence(fleet, lease, ownerHeaders)).status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("released");
+  });
+
+  it("returns JSON for relay-generated timeout and disconnect responses", async () => {
+    vi.useFakeTimers();
+    try {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      storage.seed("runtime-adapter-identity:example-adapter", {
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      const relayState = fleet as unknown as {
+        runtimeAdapterAgents: Map<string, WebSocket>;
+      };
+      const timeoutSocket = new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      });
+      const sent = deferred<void>();
+      let timedOutRequestID = "";
+      timeoutSocket.onSend = (data) => {
+        const message = JSON.parse(data) as { id: string; deadlineMs: number };
+        timedOutRequestID = message.id;
+        expect(message.deadlineMs).toBe(Date.now() + runtimeAdapterRelayTimeoutMs);
+        sent.resolve();
+      };
+      relayState.runtimeAdapterAgents.set("example-adapter", timeoutSocket as unknown as WebSocket);
+      let timedOutSettled = false;
+      const timedOutPromise = fleet
+        .fetch(
+          request("GET", "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1", {
+            headers,
+          }),
+        )
+        .then((response) => {
+          timedOutSettled = true;
+          return response;
+        });
+      await sent.promise;
+      const malformedText = JSON.stringify({
+        type: "response",
+        id: timedOutRequestID,
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: "~",
+      });
+      const malformedBytes = new TextEncoder().encode(malformedText);
+      malformedBytes[malformedText.indexOf('"body":"~"') + 8] = 0xff;
+      await fleet.webSocketMessage(timeoutSocket as unknown as WebSocket, malformedBytes.buffer);
+      expect(timedOutSettled).toBe(false);
+      await vi.advanceTimersByTimeAsync(runtimeAdapterRelayTimeoutMs);
+      const timedOut = await timedOutPromise;
+      expect(timedOut.status).toBe(504);
+      expect(timedOut.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      await expect(timedOut.json()).resolves.toMatchObject({ error: "runtime_adapter_timeout" });
+
+      const desktopSent = deferred<void>();
+      timeoutSocket.onSend = (data) => {
+        const message = JSON.parse(data) as { deadlineMs: number };
+        expect(message.deadlineMs).toBe(Date.now() + runtimeAdapterDesktopRelayTimeoutMs);
+        desktopSent.resolve();
+      };
+      let desktopSettled = false;
+      const desktopTimedOutPromise = fleet
+        .fetch(
+          request(
+            "POST",
+            "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1/connections/desktop",
+            { headers },
+          ),
+        )
+        .then((response) => {
+          desktopSettled = true;
+          return response;
+        });
+      await desktopSent.promise;
+      await vi.advanceTimersByTimeAsync(runtimeAdapterRelayTimeoutMs);
+      expect(desktopSettled).toBe(false);
+      await vi.advanceTimersByTimeAsync(
+        runtimeAdapterDesktopRelayTimeoutMs - runtimeAdapterRelayTimeoutMs,
+      );
+      const desktopTimedOut = await desktopTimedOutPromise;
+      expect(desktopTimedOut.status).toBe(504);
+      await expect(desktopTimedOut.json()).resolves.toMatchObject({
+        error: "runtime_adapter_timeout",
+      });
+
+      const disconnectedSocket = new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      });
+      relayState.runtimeAdapterAgents.set(
+        "example-adapter",
+        disconnectedSocket as unknown as WebSocket,
+      );
+      disconnectedSocket.onSend = () => {
+        fleet.webSocketClose(disconnectedSocket as unknown as WebSocket, 1006, "gone", false);
+      };
+      const disconnected = await fleet.fetch(
+        request("GET", "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-1", {
+          headers,
+        }),
+      );
+      expect(disconnected.status).toBe(503);
+      expect(disconnected.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      await expect(disconnected.json()).resolves.toMatchObject({
+        error: "runtime_adapter_unavailable",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends a streamed request only to the adapter connected after body consumption", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "content-type": "application/json",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    const oldSocket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    oldSocket.onSend = () => {
+      throw new Error("stale runtime adapter received request");
+    };
+    const newSocket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    newSocket.onSend = (data) => {
+      const message = JSON.parse(data) as { id: string };
+      void fleet.webSocketMessage(
+        newSocket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 202,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-1", status: "provisioning" }),
+        }),
+      );
+    };
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", oldSocket as unknown as WebSocket);
+    const bodyReadStarted = deferred<void>();
+    const finishBody = deferred<void>();
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        bodyReadStarted.resolve();
+        await finishBody.promise;
+        controller.enqueue(new TextEncoder().encode('{"id":"example-workspace-1"}'));
+        controller.close();
+      },
+    });
+    const proxiedPromise = fleet.fetch(
+      new Request("https://crabbox.test/v1/adapters/example-adapter/proxy/v1/workspaces", {
+        method: "POST",
+        headers,
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+
+    await bodyReadStarted.promise;
+    fleet.webSocketClose(oldSocket as unknown as WebSocket, 1012, "replaced", false);
+    oldSocket.close();
+    relayState.runtimeAdapterAgents.set("example-adapter", newSocket as unknown as WebSocket);
+    finishBody.resolve();
+    const proxied = await proxiedPromise;
+
+    expect(proxied.status).toBe(202);
+    expect(oldSocket.sentJSON()).toEqual([]);
+    expect(newSocket.sentJSON()).toHaveLength(1);
+    await expect(proxied.json()).resolves.toEqual({
+      id: "example-workspace-1",
+      status: "provisioning",
+    });
+  });
+});
 
 describe("fleet lease identity and idle", () => {
   it("keeps transient Hetzner create failures recoverable", async () => {
@@ -2821,6 +5007,128 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(response.status).toBe(409);
+  });
+
+  it("persists an immutable runtime adapter binding on registered leases", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const path = "/v1/leases/cbx_000000000096/registration";
+    const body = {
+      provider: "external",
+      target: "linux",
+      host: "host.example.test",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-96",
+      runtimeAdapterRegistrationID: "registration-generation-96",
+    };
+
+    const unclaimed = await fleet.fetch(request("PUT", path, { headers, body }));
+    expect(unclaimed.status).toBe(409);
+    await expect(unclaimed.json()).resolves.toMatchObject({ error: "runtime_adapter_unclaimed" });
+
+    const claimed = await fleet.fetch(
+      request("POST", "/v1/adapters/example-adapter/ticket", { headers, body: {} }),
+    );
+    expect(claimed.status).toBe(200);
+
+    const created = await fleet.fetch(request("PUT", path, { headers, body }));
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({
+      lease: {
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: "example-workspace-96",
+        runtimeAdapterRegistrationID: "registration-generation-96",
+      },
+    });
+
+    const duplicateBinding = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000094/registration", { headers, body }),
+    );
+    expect(duplicateBinding.status).toBe(409);
+    await expect(duplicateBinding.json()).resolves.toMatchObject({
+      error: "runtime_adapter_workspace_conflict",
+    });
+
+    const refreshed = await fleet.fetch(
+      request("PUT", path, {
+        headers,
+        body: { provider: "external", target: "linux", host: "host.example.test" },
+      }),
+    );
+    expect(refreshed.status).toBe(200);
+    await expect(refreshed.json()).resolves.toMatchObject({
+      lease: {
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: "example-workspace-96",
+      },
+    });
+
+    const changed = await fleet.fetch(
+      request("PUT", path, {
+        headers,
+        body: { ...body, runtimeAdapterWorkspaceID: "example-workspace-other" },
+      }),
+    );
+    expect(changed.status).toBe(409);
+    await expect(changed.json()).resolves.toMatchObject({ error: "runtime_adapter_conflict" });
+
+    const otherHeaders = {
+      "x-crabbox-owner": "mallory@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const otherClaim = await fleet.fetch(
+      request("POST", "/v1/adapters/other-adapter/ticket", {
+        headers: otherHeaders,
+        body: {},
+      }),
+    );
+    expect(otherClaim.status).toBe(200);
+    const wrongOwner = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000095/registration", {
+        headers,
+        body: {
+          ...body,
+          runtimeAdapterID: "other-adapter",
+          runtimeAdapterWorkspaceID: "example-workspace-95",
+        },
+      }),
+    );
+    expect(wrongOwner.status).toBe(409);
+    await expect(wrongOwner.json()).resolves.toMatchObject({ error: "runtime_adapter_conflict" });
+
+    const released = await fleet.fetch(
+      request("POST", "/v1/leases/cbx_000000000096/release", { headers }),
+    );
+    expect(released.status).toBe(200);
+    const rebound = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_000000000094/registration", {
+        headers,
+        body: {
+          ...body,
+          runtimeAdapterRegistrationID: "registration-generation-94",
+        },
+      }),
+    );
+    expect(rebound.status).toBe(201);
+    const ordinary = await fleet.fetch(
+      request("PUT", path, {
+        headers,
+        body: { provider: "external", target: "linux", host: "ordinary.example.test" },
+      }),
+    );
+    expect(ordinary.status).toBe(200);
+    const ordinaryBody = (await ordinary.json()) as { lease: LeaseRecord };
+    expect(ordinaryBody.lease.runtimeAdapterID).toBeUndefined();
+    expect(ordinaryBody.lease.runtimeAdapterWorkspaceID).toBeUndefined();
+    const ordinaryRelease = await fleet.fetch(
+      request("POST", "/portal/leases/cbx_000000000096/release", { headers }),
+    );
+    expect(ordinaryRelease.status).toBe(303);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000094")?.state).toBe("active");
   });
 
   it("keeps expired leases active when provider cleanup fails and retries later", async () => {
@@ -13684,6 +15992,33 @@ function request(
     },
     body: init.body === undefined ? undefined : JSON.stringify(init.body),
   });
+}
+
+function confirmRuntimeAdapterAbsence(
+  fleet: FleetDurableObject,
+  lease: LeaseRecord,
+  headers: Record<string, string>,
+): Promise<Response> {
+  if (
+    !lease.runtimeAdapterID ||
+    !lease.runtimeAdapterWorkspaceID ||
+    !lease.runtimeAdapterRegistrationID
+  ) {
+    throw new Error("runtime adapter completion test requires an exact registration generation");
+  }
+  return fleet.fetch(
+    request("POST", `/v1/leases/${lease.id}/release`, {
+      headers,
+      body: {
+        runtimeAdapterDeleteCompletion: {
+          adapterID: lease.runtimeAdapterID,
+          workspaceID: lease.runtimeAdapterWorkspaceID,
+          registrationID: lease.runtimeAdapterRegistrationID,
+          status: "absent",
+        },
+      },
+    }),
+  );
 }
 
 async function sha256HexForTest(value: string): Promise<string> {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -113,6 +113,13 @@ describe("coordinator auth", () => {
       new Request("https://example.test/v1/leases/lease-1/webvnc/agent", {
         headers: { upgrade: "websocket", "x-crabbox-proxy-secret": "proxy-secret" },
       }),
+      new Request("https://example.test/v1/adapters/example-adapter/agent", {
+        headers: {
+          upgrade: "websocket",
+          authorization: "Bearer adapter_ticket",
+          "x-crabbox-proxy-secret": "proxy-secret",
+        },
+      }),
     ];
 
     const routedRequests = await Promise.all(
@@ -126,6 +133,7 @@ describe("coordinator auth", () => {
     );
 
     expect(routedRequests.map((request) => request.headers.get("x-crabbox-proxy-secret"))).toEqual([
+      null,
       null,
       null,
       null,

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -185,6 +185,31 @@ describe("NodeCoordinatorRuntime", () => {
     expect(operationRunner).not.toHaveBeenCalled();
   });
 
+  it("lets runtime-adapter replies bypass the lifecycle queue", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const socket = Object.assign(new EventEmitter(), {
+      close: vi.fn<(code?: number, reason?: string) => void>(),
+      terminate: vi.fn<() => void>(),
+    });
+    const operationRunner = vi.fn<OperationRunner>(
+      async <T>(_callback: () => Promise<T>): Promise<T> => await new Promise<T>(() => {}),
+    );
+    const message = vi.fn<() => Promise<void>>(async () => {});
+    runtime.setOperationRunner(operationRunner);
+
+    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "runtime-adapter-agent" }, [], {
+      message,
+      close: vi.fn<(code: number, reason: string) => void>(),
+      error: vi.fn<() => void>(),
+    });
+    socket.emit("message", Buffer.from("{}"), false);
+
+    await vi.waitFor(() => {
+      expect(message).toHaveBeenCalledOnce();
+    });
+    expect(operationRunner).not.toHaveBeenCalled();
+  });
+
   it("serializes control messages with lifecycle operations", async () => {
     const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
     const socket = Object.assign(new EventEmitter(), {
@@ -267,9 +292,8 @@ describe("NodeCoordinatorRuntime", () => {
     await vi.waitFor(() => expect(message).toHaveBeenCalledOnce());
 
     runtime.beginShutdown();
-    expect(close).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
     const stopped = runtime.stop();
-    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
     expect(mocks.boss.stop).not.toHaveBeenCalled();
     expect(mocks.storage.close).not.toHaveBeenCalled();
     messageDone.resolve();

--- a/worker/test/runtime-adapter-relay.test.ts
+++ b/worker/test/runtime-adapter-relay.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readRuntimeAdapterRelayBody,
+  runtimeAdapterProxyPath,
+  runtimeAdapterRelayBodyAllowed,
+  runtimeAdapterRelayBodyLimit,
+  runtimeAdapterRelayContentType,
+  runtimeAdapterDesktopRelayTimeoutMs,
+  runtimeAdapterRelayFrameLimit,
+  runtimeAdapterRelayHeaders,
+  runtimeAdapterRelayMethodAllowed,
+  runtimeAdapterRelayTimeoutForPath,
+  runtimeAdapterRelayTimeoutMs,
+  validRuntimeAdapterID,
+  validRuntimeAdapterRelayResponse,
+} from "../src/runtime-adapter-relay";
+
+describe("runtime adapter relay", () => {
+  it("bounds a fully escaped response envelope", () => {
+    expect(runtimeAdapterRelayFrameLimit).toBeGreaterThan(runtimeAdapterRelayBodyLimit * 6);
+  });
+
+  it("accepts only stable DNS-style adapter and workspace IDs", () => {
+    expect(validRuntimeAdapterID("example-adapter")).toBe(true);
+    expect(validRuntimeAdapterID("a".repeat(63))).toBe(true);
+    expect(validRuntimeAdapterID("Example-Adapter")).toBe(false);
+    expect(validRuntimeAdapterID("a".repeat(64))).toBe(false);
+    expect(validRuntimeAdapterID("../workspace")).toBe(false);
+  });
+
+  it("allows only the versioned lifecycle routes and methods", () => {
+    expect(runtimeAdapterProxyPath(["v1", "workspaces"])).toBe("/v1/workspaces");
+    expect(runtimeAdapterProxyPath(["v1", "workspaces", "example-workspace"])).toBe(
+      "/v1/workspaces/example-workspace",
+    );
+    expect(
+      runtimeAdapterProxyPath(["v1", "workspaces", "example-workspace", "connections", "desktop"]),
+    ).toBe("/v1/workspaces/example-workspace/connections/desktop");
+    expect(
+      runtimeAdapterProxyPath(["v1", "workspaces", "example-workspace", "shell"]),
+    ).toBeUndefined();
+    expect(runtimeAdapterProxyPath(["v1", "workspaces", ".."])).toBeUndefined();
+
+    expect(runtimeAdapterRelayMethodAllowed("POST", "/v1/workspaces")).toBe(true);
+    expect(runtimeAdapterRelayMethodAllowed("DELETE", "/v1/workspaces")).toBe(false);
+    expect(runtimeAdapterRelayMethodAllowed("GET", "/v1/workspaces/example-workspace")).toBe(true);
+    expect(runtimeAdapterRelayMethodAllowed("DELETE", "/v1/workspaces/example-workspace")).toBe(
+      true,
+    );
+    expect(
+      runtimeAdapterRelayMethodAllowed(
+        "POST",
+        "/v1/workspaces/example-workspace/connections/desktop",
+      ),
+    ).toBe(true);
+    expect(runtimeAdapterRelayBodyAllowed("POST", "/v1/workspaces", "{}")).toBe(true);
+    expect(
+      runtimeAdapterRelayBodyAllowed(
+        "POST",
+        "/v1/workspaces/example-workspace/connections/desktop",
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      runtimeAdapterRelayBodyAllowed(
+        "POST",
+        "/v1/workspaces/example-workspace/connections/desktop",
+        "{}",
+      ),
+    ).toBe(false);
+    expect(runtimeAdapterRelayTimeoutForPath("/v1/workspaces/example-workspace")).toBe(
+      runtimeAdapterRelayTimeoutMs,
+    );
+    expect(
+      runtimeAdapterRelayTimeoutForPath("/v1/workspaces/example-workspace/connections/desktop"),
+    ).toBe(runtimeAdapterDesktopRelayTimeoutMs);
+    expect(
+      runtimeAdapterRelayTimeoutForPath(
+        "/v1/workspaces/example-workspace/connections/desktop",
+        11 * 60 * 1_000,
+      ),
+    ).toBe(11 * 60 * 1_000);
+  });
+
+  it("forwards only a bounded idempotency key", () => {
+    expect(
+      runtimeAdapterRelayHeaders(
+        new Request("https://example.test", {
+          headers: { "idempotency-key": "example-workspace", authorization: "Bearer secret" },
+        }),
+      ),
+    ).toEqual({ "idempotency-key": "example-workspace" });
+    expect(() =>
+      runtimeAdapterRelayHeaders(
+        new Request("https://example.test", {
+          headers: { "idempotency-key": "x".repeat(129) },
+        }),
+      ),
+    ).toThrow("runtime adapter idempotency key is too long");
+  });
+
+  it("reads response content type case-insensitively", () => {
+    expect(runtimeAdapterRelayContentType({ "Content-Type": "application/json" })).toBe(
+      "application/json",
+    );
+    expect(runtimeAdapterRelayContentType({ "content-TYPE": "text/plain" })).toBe("text/plain");
+    expect(runtimeAdapterRelayContentType(undefined)).toBeUndefined();
+  });
+
+  it("bounds streamed request and response bodies", async () => {
+    await expect(
+      readRuntimeAdapterRelayBody(
+        new Request("https://example.test", { method: "POST", body: '{"id":"example-workspace"}' }),
+      ),
+    ).resolves.toBe('{"id":"example-workspace"}');
+    await expect(
+      readRuntimeAdapterRelayBody(
+        new Request("https://example.test", {
+          method: "POST",
+          body: "x".repeat(runtimeAdapterRelayBodyLimit + 1),
+        }),
+      ),
+    ).rejects.toThrow("too large");
+    await expect(
+      readRuntimeAdapterRelayBody(
+        new Request("https://example.test", {
+          method: "POST",
+          body: new Uint8Array([0xc3, 0x28]),
+        }),
+      ),
+    ).rejects.toThrow("must be valid UTF-8");
+
+    expect(
+      validRuntimeAdapterRelayResponse(
+        { type: "response", id: "request-1", status: 202, body: '{"status":"stopping"}' },
+        "request-1",
+      ),
+    ).toBe(true);
+    expect(
+      validRuntimeAdapterRelayResponse(
+        { type: "response", id: "request-1", status: 200, body: "x".repeat(65_537) },
+        "request-1",
+      ),
+    ).toBe(false);
+    expect(
+      validRuntimeAdapterRelayResponse(
+        {
+          type: "response",
+          id: "request-1",
+          status: 200,
+          headers: { authorization: "secret" },
+        },
+        "request-1",
+      ),
+    ).toBe(false);
+  });
+});

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -1,4 +1,5 @@
-import type { IncomingMessage } from "node:http";
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { Writable } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
@@ -12,6 +13,7 @@ import {
   fleetRequestQueue,
   isReadinessRequestMethod,
   isTrustedProxySource,
+  nodeRequestAbortSignal,
   readNodeRequestBody,
   requestBodyLimit,
   requestSourceIP,
@@ -21,6 +23,7 @@ import {
   unauthenticatedRequestBodyBytes,
   writeNodeResponseBody,
 } from "../node/server-support";
+import { runtimeAdapterRelayBodyLimit } from "../src/runtime-adapter-relay";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
@@ -31,6 +34,39 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 }
 
 describe("Node server support", () => {
+  it("aborts Fetch work when the Node client disconnects", () => {
+    const request = Object.assign(new EventEmitter(), { aborted: false });
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      writableFinished: false,
+    });
+    const cancellation = nodeRequestAbortSignal(
+      request as unknown as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+
+    expect(cancellation.signal.aborted).toBe(false);
+    response.emit("close");
+    expect(cancellation.signal.aborted).toBe(true);
+    cancellation.dispose();
+  });
+
+  it("does not treat a completed Node response as client cancellation", () => {
+    const request = Object.assign(new EventEmitter(), { aborted: false });
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: false,
+      writableFinished: true,
+    });
+    const cancellation = nodeRequestAbortSignal(
+      request as unknown as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+
+    response.emit("close");
+    expect(cancellation.signal.aborted).toBe(false);
+    cancellation.dispose();
+  });
+
   it("keeps provider I/O, maintenance, and code proxy traffic off the lifecycle queue", () => {
     expect(
       fleetRequestQueue(new Request("https://coordinator.test/v1/leases", { method: "POST" })),
@@ -109,6 +145,14 @@ describe("Node server support", () => {
     expect(
       requestBodyLimit(new Request("https://coordinator.test/v1/leases", { method: "POST" }), true),
     ).toBe(authenticatedRequestBodyBytes);
+    expect(
+      requestBodyLimit(
+        new Request("https://coordinator.test/v1/adapters/example-adapter/proxy/v1/workspaces", {
+          method: "POST",
+        }),
+        true,
+      ),
+    ).toBe(runtimeAdapterRelayBodyLimit);
   });
 
   it("caps bodies drained before authentication completes", async () => {


### PR DESCRIPTION
## Summary

- add owner-scoped, ticket-authenticated outbound runtime-adapter sessions so the coordinator can create, inspect, delete, and open desktops without storing provider credentials or requiring an inbound adapter port
- bind registered leases to an exact adapter, workspace, and generation; persist and reconcile destructive Delete intent across retries, disconnects, timeouts, restarts, expiry, and re-registration
- add confirmed portal Delete actions, bounded relay bodies/backpressure/fairness, absolute request deadlines, Node shutdown cancellation, and terminal bridge revocation
- add atomic legacy cleanup and fail-closed generation handling so delayed or ambiguous responses cannot delete a rebound workspace

## Security and lifecycle properties

- one-time tickets are owner-scoped and carried only in the Authorization header
- relay paths are allowlisted to the versioned workspace lifecycle API
- bodies, pending work, owner concurrency, timeouts, and buffered WebSocket frames are bounded
- destructive completion is fenced by durable per-generation dispatch state; ambiguous outcomes retain retry intent
- provider credentials and arbitrary callback URLs never enter coordinator lease records

## Verification

- Worker tests: 597/597
- `npm run check`, `check:node`, `lint`, and `format:check`
- focused Go lifecycle tests
- `go vet ./...`
- `go test -race ./... -count=1`
- structured autoreview: zero findings, patch correct
