### PR TITLE
fix(coordinator): load ssh2 in Node bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Fixed portable Node coordinator startup when the production bundle loads the external CommonJS `ssh2` dependency.
 - Hardened runtime-adapter relays with end-to-end absolute deadlines, durable generation-scoped dispatch fences retained across ambiguous connector failures, atomic owner-only legacy cleanup, rejection of unfenced proxy deletes, per-owner in-flight quotas, post-cancellation accounting, response-delivery grace, connector-matched request validation, restart-safe TTL-first live-bridge revocation, retry-safe upstream rejection handling, generation-fenced confirmed-absence acknowledgments, and cleanup-fenced workspace bindings.
 - Fixed Cloudflare Dynamic Workers lifecycle reads, compatibility identity, bundle validation, and live-smoke credential isolation.
 - Fixed Windows local-container sync to avoid unusable WSL command shims, support Docker Desktop mount roots, and fall back to native rsync when WSL lacks native SSH tooling. Thanks @brokemac79.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1,4 +1,6 @@
-import { Client as SSHClient, type ClientChannel, utils as sshUtils } from "ssh2";
+import ssh2, { type Client as SSHClient, type ClientChannel } from "ssh2";
+
+const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
 import { isAdminRequest, sha256Hex } from "./auth";
@@ -2678,7 +2680,7 @@ export class FleetCoordinator {
       connect: while (Date.now() < readyDeadline) {
         for (const port of terminalPorts) {
           if (closed) break connect;
-          const candidate = new SSHClient();
+          const candidate = new SSHClientConstructor();
           connectingClient = candidate;
           try {
             // oxlint-disable-next-line eslint/no-await-in-loop -- SSH readiness retries are sequential.

--- a/worker/src/ssh2.d.ts
+++ b/worker/src/ssh2.d.ts
@@ -57,4 +57,10 @@ declare module "ssh2" {
       options?: { comment?: string },
     ): { private: string; public: string };
   };
+
+  const ssh2: {
+    Client: typeof Client;
+    utils: typeof utils;
+  };
+  export default ssh2;
 }

--- a/worker/test/node-build.test.ts
+++ b/worker/test/node-build.test.ts
@@ -1,0 +1,56 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("Node production bundle", () => {
+  it("loads external CommonJS dependencies before validating configuration", async () => {
+    const workerDirectory = fileURLToPath(new URL("..", import.meta.url));
+    const outputRoot = join(workerDirectory, "dist-node");
+    await mkdir(outputRoot, { recursive: true });
+    const outputDirectory = await mkdtemp(join(outputRoot, "test-"));
+    const outfile = join(outputDirectory, "server.mjs");
+
+    try {
+      await build({
+        absWorkingDir: workerDirectory,
+        entryPoints: ["node/server.ts"],
+        outfile,
+        bundle: true,
+        packages: "external",
+        platform: "node",
+        format: "esm",
+        target: "node22",
+      });
+
+      const result = await runNode(outfile);
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("DATABASE_URL is required");
+      expect(result.stderr).not.toContain("Named export");
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function runNode(entrypoint: string): Promise<{
+  code: number | null;
+  stderr: string;
+}> {
+  const env = { ...process.env };
+  delete env.DATABASE_URL;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [entrypoint], { env });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stderr }));
+  });
+}


### PR DESCRIPTION
## Summary

- load the CommonJS `ssh2` package through its default export in the externalized Node ESM bundle
- preserve typed client and key-generation access through the local declaration
- add a production-bundle startup regression test that verifies module linking reaches configuration validation

## Testing

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm run check:node`
- `npm test` (598 tests)
- `npm run build:node`
- startup smoke reaches the expected `DATABASE_URL is required` configuration error
- structured autoreview: clean after fixing its accepted cross-platform path finding
