### PR TITLE
fix(codesandbox): harden live lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Fixed portable Node coordinator startup when the production bundle loads the external CommonJS `ssh2` dependency.
+- Fixed CodeSandbox ownership tags, one-shot SDK bridge shutdown, mount-safe root workspace replacement, runtime-only resume responses, and authenticated preview URLs, preventing lifecycle rejection, command hangs, archive-sync failures, and unusable private port links.
 - Hardened runtime-adapter relays with end-to-end absolute deadlines, durable generation-scoped dispatch fences retained across ambiguous connector failures, atomic owner-only legacy cleanup, rejection of unfenced proxy deletes, per-owner in-flight quotas, post-cancellation accounting, response-delivery grace, connector-matched request validation, restart-safe TTL-first live-bridge revocation, retry-safe upstream rejection handling, generation-fenced confirmed-absence acknowledgments, and cleanup-fenced workspace bindings.
 - Fixed Cloudflare Dynamic Workers lifecycle reads, compatibility identity, bundle validation, and live-smoke credential isolation.
 - Fixed Windows local-container sync to avoid unusable WSL command shims, support Docker Desktop mount roots, and fall back to native rsync when WSL lacks native SSH tooling. Thanks @brokemac79.

--- a/docs/providers/codesandbox.md
+++ b/docs/providers/codesandbox.md
@@ -110,8 +110,10 @@ Crabbox rejects broad paths such as `/` and `/project`.
    `git ls-files`-driven gzipped tar locally, uploads it through the SDK file
    bridge, and extracts it under `codeSandbox.workdir`. `--no-sync` skips the
    archive upload; `--sync-only` syncs and exits without running a command.
-   Manifest, guardrail, archive, staging, atomic replacement, and cleanup
-   orchestration use Crabbox's provider-neutral delegated archive-sync core.
+   Manifest, guardrail, archive, staging, replacement, and cleanup orchestration
+   use Crabbox's provider-neutral delegated archive-sync core. The root
+   `/project/workspace` mount is replaced in place because CodeSandbox does not
+   permit renaming that mount; configured subdirectories retain atomic rename.
 3. Commands run through the SDK command client with `cwd` set to the configured
    workdir. Selected `--allow-env` and `--env-from-profile` values are sent to
    the local SDK bridge in the request body and staged through a temporary

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -28,6 +28,7 @@ type DelegatedArchiveSyncRequest struct {
 	CleanupContext      func(context.Context) (context.Context, context.CancelFunc)
 	Upload              func(context.Context, string, io.Reader) error
 	Exec                func(context.Context, string) error
+	Replace             func(context.Context, string, string) error
 }
 
 func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncRequest) ([]TimingPhase, time.Duration, error) {
@@ -152,7 +153,13 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	replaceDuration := time.Duration(0)
 	if stagingDir != "" {
 		replaceStart := now()
-		if err := replaceDelegatedArchiveWorkspace(syncCtx, req.Exec, stagingDir, req.Workdir, provider, stderr); err != nil {
+		replace := req.Replace
+		if replace == nil {
+			replace = func(ctx context.Context, stagingDir, workdir string) error {
+				return replaceDelegatedArchiveWorkspace(ctx, req.Exec, stagingDir, workdir, provider, stderr)
+			}
+		}
+		if err := replace(syncCtx, stagingDir, req.Workdir); err != nil {
 			return nil, 0, err
 		}
 		replaceDuration = now().Sub(replaceStart)

--- a/internal/cli/delegated_archive_sync_test.go
+++ b/internal/cli/delegated_archive_sync_test.go
@@ -100,6 +100,41 @@ func TestRunDelegatedArchiveSyncPreflightUsesFullArchive(t *testing.T) {
 	}
 }
 
+func TestRunDelegatedArchiveSyncSupportsProviderReplace(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	cfg := baseConfig()
+	cfg.Sync.Delete = true
+	var commands []string
+	var replacedStaging string
+	var replacedWorkdir string
+
+	_, _, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+		Config:  cfg,
+		Repo:    Repo{Root: root},
+		Workdir: "/workspace",
+		Suffix:  func() string { return "fixed" },
+		Upload:  func(context.Context, string, io.Reader) error { return nil },
+		Exec: func(_ context.Context, command string) error {
+			commands = append(commands, command)
+			return nil
+		},
+		Replace: func(_ context.Context, stagingDir, workdir string) error {
+			replacedStaging = stagingDir
+			replacedWorkdir = workdir
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacedStaging != "/.workspace.crabbox-sync-fixed" || replacedWorkdir != "/workspace" {
+		t.Fatalf("replace staging=%q workdir=%q", replacedStaging, replacedWorkdir)
+	}
+	if strings.Contains(strings.Join(commands, "\n"), "mv '/.workspace.crabbox-sync-fixed' '/workspace'") {
+		t.Fatalf("default replacement ran despite provider hook: %#v", commands)
+	}
+}
+
 func TestRunDelegatedArchiveSyncCleanupOutlivesCanceledParent(t *testing.T) {
 	root := newDelegatedArchiveSyncRepo(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -380,8 +380,8 @@ func (b *codeSandboxBackend) Resume(ctx context.Context, req ResumeRequest) erro
 	if err != nil {
 		return err
 	}
-	if err := validateCodeSandboxSandboxOwnership(claim, resumed); err != nil {
-		return err
+	if strings.TrimSpace(resumed.ID) != "" && strings.TrimSpace(resumed.ID) != sandboxID {
+		return exit(4, "codesandbox resumed sandbox %q does not match local claim %q", resumed.ID, claim.LeaseID)
 	}
 	fmt.Fprintf(b.rt.Stderr, "resumed lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil

--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -31,7 +31,7 @@ func TestWarmupCreatesSandboxClaim(t *testing.T) {
 	if len(fake.created) != 1 {
 		t.Fatalf("create calls=%d want 1", len(fake.created))
 	}
-	if got := fake.created[0].Tags; !contains(got, codeSandboxClaimTag) || !hasPrefix(got, codeSandboxScopeTagPrefix+"codesandbox/ownership:") {
+	if got := fake.created[0].Tags; !contains(got, codeSandboxClaimTag) || !hasPrefix(got, codeSandboxScopeTagPrefix) {
 		t.Fatalf("create tags=%v missing ownership tags", got)
 	}
 	leaseID := leasePrefix + fake.sandboxID
@@ -39,7 +39,7 @@ func TestWarmupCreatesSandboxClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read claim: %v", err)
 	}
-	if claim.Provider != providerName || claim.Slug != "codesandbox-blue" || claim.RepoRoot != "/repo" || !strings.HasPrefix(claim.ProviderScope, "codesandbox/ownership:") {
+	if claim.Provider != providerName || claim.Slug != "codesandbox-blue" || claim.RepoRoot != "/repo" || !strings.HasPrefix(claim.ProviderScope, codeSandboxClaimScopePrefix) {
 		t.Fatalf("claim=%#v", claim)
 	}
 	if !strings.Contains(stdout.String(), "leased "+leaseID) || !strings.Contains(stderr.String(), `"provider":"codesandbox"`) {
@@ -54,15 +54,29 @@ func TestResolveLeaseIDRequiresLocalClaimForRawIDs(t *testing.T) {
 	}
 }
 
+func TestCodeSandboxScopeTagUsesProviderAcceptedCharacters(t *testing.T) {
+	scope := codeSandboxClaimScopePrefix + strings.Repeat("a", 32)
+	tag := codeSandboxScopeTag(scope)
+	if tag != codeSandboxScopeTagPrefix+strings.Repeat("a", 32) {
+		t.Fatalf("tag=%q", tag)
+	}
+	if strings.ContainsAny(tag, ":/") {
+		t.Fatalf("tag=%q contains CodeSandbox-rejected punctuation", tag)
+	}
+	if got, ok := codeSandboxScopeFromTag(tag); !ok || got != scope {
+		t.Fatalf("round trip scope=%q ok=%v", got, ok)
+	}
+}
+
 func TestStopRejectsOwnershipMismatchBeforeDelete(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, "codesandbox/ownership:local", "", "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTagPrefix + "codesandbox/ownership:remote"}
+	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTag(codeSandboxClaimScopePrefix + "remote")}
 
 	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
@@ -123,10 +137,10 @@ func TestPauseRejectsOwnershipMismatchBeforeHibernate(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, "codesandbox/ownership:local", "", "/repo", time.Minute, false); err != nil {
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTagPrefix + "codesandbox/ownership:remote"}
+	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTag(codeSandboxClaimScopePrefix + "remote")}
 
 	err := backend.Pause(context.Background(), PauseRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
@@ -351,6 +365,32 @@ func TestRunSyncOnlyUploadsArchiveAndExtracts(t *testing.T) {
 	}
 }
 
+func TestRunSyncOnlyReplacesDefaultWorkspaceMountContents(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, "proof.txt"), []byte("proof\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoRoot)
+	fake := newFakeCodeSandboxAPI()
+	backend, _, _ := newFakeBackend(t, fake)
+
+	if _, err := backend.Run(context.Background(), RunRequest{
+		Repo:           Repo{Name: "my-app", Root: repoRoot},
+		SyncOnly:       true,
+		ForceSyncLarge: true,
+	}); err != nil {
+		t.Fatalf("Run sync-only err=%v", err)
+	}
+	if !fake.hasCommandContaining("rollback()") ||
+		!fake.hasCommandContaining("cp -a '/project/.workspace.crabbox-sync-") {
+		t.Fatalf("mount-safe replacement command missing: %#v", fake.commands)
+	}
+	if fake.hasCommandContaining("mv '/project/workspace'") {
+		t.Fatalf("attempted to rename CodeSandbox workspace mount: %#v", fake.commands)
+	}
+}
+
 func newFakeBackend(t *testing.T, api *fakeCodeSandboxAPI) (*codeSandboxBackend, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	cfg := newTestConfig()
@@ -392,7 +432,7 @@ type fakeCodeSandboxAPI struct {
 }
 
 func newFakeCodeSandboxAPI() *fakeCodeSandboxAPI {
-	scope := "codesandbox/ownership:local"
+	scope := codeSandboxClaimScopePrefix + "local"
 	return &fakeCodeSandboxAPI{
 		sandboxID: "sb-test01",
 		scope:     scope,
@@ -401,7 +441,7 @@ func newFakeCodeSandboxAPI() *fakeCodeSandboxAPI {
 			Title: "crabbox-my-app",
 			State: "running",
 			URL:   "https://sb-test01.csb.app",
-			Tags:  []string{codeSandboxClaimTag, codeSandboxScopeTagPrefix + scope},
+			Tags:  []string{codeSandboxClaimTag, codeSandboxScopeTag(scope)},
 		},
 	}
 }
@@ -414,8 +454,8 @@ func (f *fakeCodeSandboxAPI) CreateSandbox(_ context.Context, req CreateSandboxR
 	f.created = append(f.created, req)
 	f.sandbox.Tags = append([]string(nil), req.Tags...)
 	for _, tag := range req.Tags {
-		if strings.HasPrefix(tag, codeSandboxScopeTagPrefix) {
-			f.scope = strings.TrimPrefix(tag, codeSandboxScopeTagPrefix)
+		if scope, ok := codeSandboxScopeFromTag(tag); ok {
+			f.scope = scope
 		}
 	}
 	return f.sandbox, nil
@@ -439,7 +479,7 @@ func (f *fakeCodeSandboxAPI) HibernateSandbox(_ context.Context, id string) erro
 func (f *fakeCodeSandboxAPI) ResumeSandbox(_ context.Context, id string) (SandboxSummary, error) {
 	f.resumed = append(f.resumed, id)
 	f.sandbox.State = "running"
-	return f.sandbox, nil
+	return SandboxSummary{ID: id, State: "running"}, nil
 }
 
 func (f *fakeCodeSandboxAPI) RunCommand(ctx context.Context, _ string, req CommandRequest) (CommandResult, error) {

--- a/internal/providers/codesandbox/bridge.go
+++ b/internal/providers/codesandbox/bridge.go
@@ -364,7 +364,7 @@ for await (const chunk of process.stdin) chunks.push(chunk);
 const input = Buffer.concat(chunks).toString("utf8").trim();
 const req = input ? JSON.parse(input) : {};
 function emit(value) {
-  process.stdout.write(JSON.stringify(value));
+  process.stdout.write(JSON.stringify(value), () => process.exit(0));
 }
 function fail(code, message) {
   emit({ ok: false, error: { code, message: String(message || "") } });
@@ -527,7 +527,10 @@ async function writeFile(sandbox) {
 }
 function normalizePort(portInfo, fallbackPort, fallbackURL) {
   const port = Number((portInfo && (portInfo.port ?? portInfo.targetPort ?? portInfo.containerPort)) || fallbackPort || 0);
-  const host = String((portInfo && (portInfo.host ?? portInfo.url ?? portInfo.href)) || fallbackURL || "");
+  const rawHost = String(fallbackURL || (portInfo && (portInfo.host ?? portInfo.url ?? portInfo.href)) || "").trim();
+  const host = rawHost && !/^[a-z][a-z0-9+.-]*:\/\//i.test(rawHost)
+    ? (rawHost.startsWith("//") ? "https:" + rawHost : "https://" + rawHost)
+    : rawHost;
   return { port, host, url: host };
 }
 async function getHostURL(sdk, client, sandboxID, port) {

--- a/internal/providers/codesandbox/bridge_test.go
+++ b/internal/providers/codesandbox/bridge_test.go
@@ -167,7 +167,10 @@ func TestSDKBridgeScriptAwaitsAsyncPortListing(t *testing.T) {
 		t.Fatalf("bridge script must write files through the connected CodeSandbox client")
 	}
 	if strings.Contains(codeSandboxBridgeScript, "commands.run(command[0]") {
-		t.Fatalf("bridge script must use the documented commands.run(command string) SDK signature")
+		t.Fatalf("bridge script must use the documented command string SDK signatures")
+	}
+	if !strings.Contains(codeSandboxBridgeScript, "process.stdout.write(JSON.stringify(value), () => process.exit(0));") {
+		t.Fatalf("bridge script must exit after flushing its one-shot response")
 	}
 	if !strings.Contains(codeSandboxBridgeScript, "result = await commands.run(commandLine);") {
 		t.Fatalf("bridge script must pass one command string to CodeSandbox commands.run")
@@ -253,9 +256,17 @@ export class CodeSandbox {
               err.output = "EXPECTED_FAILURE_OUTPUT";
               throw err;
             }
-          }
+          },
+          ports: {
+            getAll: async () => [{ port: 3000, host: "sb_running-3000.csb.app" }],
+            waitForPort: async (port) => ({ port })
+          },
         })
       })
+    };
+    this.hosts = {
+      createToken: async (sandboxId) => ({ sandboxId, token: "preview-secret" }),
+      getUrl: (token, port) => "https://" + token.sandboxId + "-" + port + ".csb.app?preview_token=" + token.token
     };
   }
 }
@@ -299,6 +310,27 @@ export class CodeSandbox {
 	}
 	if command.Command.ExitCode != 7 || command.Command.Stdout != "EXPECTED_FAILURE_OUTPUT" {
 		t.Fatalf("command=%#v", command.Command)
+	}
+	ports, err := bridge.RoundTrip(context.Background(), "secret", BridgeRequest{
+		Operation: "list_ports",
+		SandboxID: "sb_running",
+	})
+	if err != nil {
+		t.Fatalf("list ports: %v", err)
+	}
+	if len(ports.Ports) != 1 || ports.Ports[0].Host != "https://sb_running-3000.csb.app" {
+		t.Fatalf("ports=%#v", ports.Ports)
+	}
+	port, err := bridge.RoundTrip(context.Background(), "secret", BridgeRequest{
+		Operation: "get_port_url",
+		SandboxID: "sb_running",
+		Port:      5173,
+	})
+	if err != nil {
+		t.Fatalf("get port URL: %v", err)
+	}
+	if port.Port.Host != "https://sb_running-5173.csb.app?preview_token=preview-secret" || port.Port.URL != port.Port.Host {
+		t.Fatalf("port=%#v", port.Port)
 	}
 }
 

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	codeSandboxCleanupTimeout = 30 * time.Second
-	codeSandboxExecTimeout    = 3600
-	codeSandboxNamePrefix     = "crabbox-"
-	codeSandboxClaimTag       = "crabbox"
-	codeSandboxScopeTagPrefix = "crabbox-scope:"
+	codeSandboxCleanupTimeout   = 30 * time.Second
+	codeSandboxExecTimeout      = 3600
+	codeSandboxNamePrefix       = "crabbox-"
+	codeSandboxClaimTag         = "crabbox"
+	codeSandboxClaimScopePrefix = "codesandbox/ownership:"
+	codeSandboxScopeTagPrefix   = "crabboxscope"
 )
 
 func (b *codeSandboxBackend) createSandbox(ctx context.Context, api codeSandboxAPI, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
@@ -27,7 +28,7 @@ func (b *codeSandboxBackend) createSandbox(ctx context.Context, api codeSandboxA
 	}
 	sb, err := api.CreateSandbox(ctx, CreateSandboxRequest{
 		Title:                  newSandboxTitle(repo),
-		Tags:                   []string{codeSandboxClaimTag, codeSandboxScopeTagPrefix + scope},
+		Tags:                   []string{codeSandboxClaimTag, codeSandboxScopeTag(scope)},
 		TemplateID:             strings.TrimSpace(b.cfg.CodeSandbox.TemplateID),
 		Privacy:                strings.TrimSpace(b.cfg.CodeSandbox.Privacy),
 		VMTier:                 strings.TrimSpace(b.cfg.CodeSandbox.VMTier),
@@ -122,7 +123,7 @@ func validateCodeSandboxClaimScope(claim LeaseClaim) error {
 	if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 		return exit(4, "codesandbox lease %q is not a CodeSandbox Crabbox claim", claim.LeaseID)
 	}
-	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), "codesandbox/ownership:") {
+	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), codeSandboxClaimScopePrefix) {
 		return exit(4, "codesandbox lease %q has an invalid ownership scope", claim.LeaseID)
 	}
 	return nil
@@ -134,8 +135,8 @@ func validateCodeSandboxSandboxOwnership(claim LeaseClaim, sb SandboxSummary) er
 	}
 	remoteScope := ""
 	for _, tag := range sb.Tags {
-		if strings.HasPrefix(tag, codeSandboxScopeTagPrefix) {
-			remoteScope = strings.TrimPrefix(tag, codeSandboxScopeTagPrefix)
+		if scope, ok := codeSandboxScopeFromTag(tag); ok {
+			remoteScope = scope
 			break
 		}
 	}
@@ -148,12 +149,27 @@ func validateCodeSandboxSandboxOwnership(claim LeaseClaim, sb SandboxSummary) er
 	return nil
 }
 
+func codeSandboxScopeTag(scope string) string {
+	return codeSandboxScopeTagPrefix + strings.TrimPrefix(scope, codeSandboxClaimScopePrefix)
+}
+
+func codeSandboxScopeFromTag(tag string) (string, bool) {
+	if !strings.HasPrefix(tag, codeSandboxScopeTagPrefix) {
+		return "", false
+	}
+	token := strings.TrimPrefix(tag, codeSandboxScopeTagPrefix)
+	if token == "" {
+		return "", false
+	}
+	return codeSandboxClaimScopePrefix + token, true
+}
+
 func newCodeSandboxClaimScope() (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
 		return "", exit(5, "generate codesandbox ownership token: %v", err)
 	}
-	return "codesandbox/ownership:" + hex.EncodeToString(token[:]), nil
+	return codeSandboxClaimScopePrefix + hex.EncodeToString(token[:]), nil
 }
 
 func newSandboxTitle(repo Repo) string {

--- a/internal/providers/codesandbox/sync.go
+++ b/internal/providers/codesandbox/sync.go
@@ -3,6 +3,7 @@ package codesandbox
 import (
 	"context"
 	"io"
+	"path"
 	"strings"
 	"time"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+	syncReq := core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
 		ForceSyncLarge:      req.ForceSyncLarge,
@@ -29,7 +30,13 @@ func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxA
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
-	})
+	}
+	if workdir == defaultWorkdir {
+		syncReq.Replace = func(replaceCtx context.Context, stagingDir, workdir string) error {
+			return b.execShell(replaceCtx, api, sandboxID, codeSandboxMountReplaceCommand(stagingDir, workdir))
+		}
+	}
+	return core.RunDelegatedArchiveSync(ctx, syncReq)
 }
 
 func (b *codeSandboxBackend) execShell(ctx context.Context, api codeSandboxAPI, sandboxID, command string) error {
@@ -41,9 +48,36 @@ func (b *codeSandboxBackend) execShell(ctx context.Context, api codeSandboxAPI, 
 		return err
 	}
 	if res.ExitCode != 0 {
-		return exit(res.ExitCode, "codesandbox exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+		detail := strings.TrimSpace(res.Stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(res.Stdout)
+		}
+		return exit(res.ExitCode, "codesandbox exec %q exited %d: %s", command, res.ExitCode, detail)
 	}
 	return nil
+}
+
+func codeSandboxMountReplaceCommand(stagingDir, workdir string) string {
+	backupDir := path.Join(workdir, path.Base(stagingDir)+".previous")
+	workdirGlob := shellQuote(workdir) + "/*"
+	backupGlob := shellQuote(backupDir) + "/*"
+	rollback := "rollback() { original_rc=$?; trap - EXIT HUP INT TERM; rollback_rc=0; " +
+		"for entry in " + workdirGlob + "; do " +
+		"if [ \"$entry\" != " + shellQuote(backupDir) + " ]; then rm -rf -- \"$entry\" || rollback_rc=$?; fi; done; " +
+		"if [ \"$rollback_rc\" -eq 0 ]; then for entry in " + backupGlob + "; do " +
+		"mv -- \"$entry\" " + shellQuote(workdir+"/") + " || { rollback_rc=$?; break; }; done; fi; " +
+		"if [ \"$rollback_rc\" -eq 0 ]; then rmdir " + shellQuote(backupDir) + " || rollback_rc=$?; fi; " +
+		"if [ \"$rollback_rc\" -ne 0 ]; then exit \"$rollback_rc\"; fi; exit \"$original_rc\"; }"
+	return "shopt -s dotglob nullglob; " + rollback +
+		"; mkdir -p " + shellQuote(workdir) +
+		" && rm -rf " + shellQuote(backupDir) +
+		" && mkdir -p " + shellQuote(backupDir) +
+		" && trap rollback EXIT HUP INT TERM" +
+		" && for entry in " + workdirGlob + "; do " +
+		"if [ \"$entry\" != " + shellQuote(backupDir) + " ]; then mv -- \"$entry\" " + shellQuote(backupDir+"/") + " || exit 1; fi; done" +
+		" && cp -a " + shellQuote(stagingDir+"/.") + " " + shellQuote(workdir+"/") +
+		" && trap - EXIT HUP INT TERM" +
+		" && rm -rf " + shellQuote(backupDir) + " " + shellQuote(stagingDir)
 }
 
 func (b *codeSandboxBackend) ensureWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID, workdir string) error {

--- a/internal/providers/codesandbox/sync_test.go
+++ b/internal/providers/codesandbox/sync_test.go
@@ -1,6 +1,10 @@
 package codesandbox
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -55,5 +59,64 @@ func TestSpecAllowsArchiveSyncOptionsButRejectsUnsupportedDelegatedOptions(t *te
 	}
 	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{FullResync: true}); err == nil {
 		t.Fatal("--full-resync should be rejected for delegated archive sync")
+	}
+}
+
+func TestCodeSandboxMountReplaceCommandReplacesContentsNotMount(t *testing.T) {
+	command := codeSandboxMountReplaceCommand("/project/.workspace.crabbox-sync-fixed", defaultWorkdir)
+	for _, want := range []string{
+		"rollback()",
+		"mv -- \"$entry\" '/project/workspace/.workspace.crabbox-sync-fixed.previous/'",
+		"cp -a '/project/.workspace.crabbox-sync-fixed/.' '/project/workspace/'",
+		"rm -rf '/project/workspace/.workspace.crabbox-sync-fixed.previous' '/project/.workspace.crabbox-sync-fixed'",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("command missing %q: %s", want, command)
+		}
+	}
+	if strings.Contains(command, "mv '/project/workspace'") {
+		t.Fatalf("command attempts to rename CodeSandbox mount: %s", command)
+	}
+}
+
+func TestCodeSandboxMountReplaceCommandRestoresWorkspaceAfterCopyFailure(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "workspace")
+	stagingDir := filepath.Join(root, ".workspace.crabbox-sync-missing")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldFile := filepath.Join(workdir, "old.txt")
+	if err := os.WriteFile(oldFile, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command("bash", "-lc", codeSandboxMountReplaceCommand(stagingDir, workdir))
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("replace unexpectedly succeeded: %s", output)
+	}
+	got, err := os.ReadFile(oldFile)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(got) != "old\n" {
+		t.Fatalf("restored file=%q", got)
+	}
+	matches, err := filepath.Glob(filepath.Join(workdir, "*.previous"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("rollback directories remain: %v", matches)
+	}
+}
+
+func TestCodeSandboxExecShellReportsCombinedSDKOutput(t *testing.T) {
+	fake := newFakeCodeSandboxAPI()
+	fake.commandResults = []CommandResult{{ExitCode: 1, Stdout: "mount is busy\n"}}
+	backend, _, _ := newFakeBackend(t, fake)
+	err := backend.execShell(context.Background(), fake, fake.sandboxID, "false")
+	if err == nil || !strings.Contains(err.Error(), "mount is busy") {
+		t.Fatalf("execShell err=%v", err)
 	}
 }

--- a/scripts/live-codesandbox-smoke-classify.test.js
+++ b/scripts/live-codesandbox-smoke-classify.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
 const { classify } = require("./live-codesandbox-smoke.test.js");
@@ -19,4 +21,21 @@ test("CodeSandbox smoke treats explicit environment blockers as non-diagnostic",
 test("CodeSandbox smoke does not hide SDK contract failures", () => {
   assert.equal(classify("codesandbox bridge sdk_error: vmTier was not a VMTier object"), "diagnostic_only");
   assert.equal(classify("codesandbox bridge sdk_error: commands.run is not a function"), "diagnostic_only");
+  assert.equal(classify("diagnostic_only: preview failed: HTTP 401 Unauthorized"), "diagnostic_only");
+});
+
+test("CodeSandbox smoke classifies early command failures without masking them", () => {
+  const script = path.join(__dirname, "live-codesandbox-smoke.test.js");
+  const result = spawnSync(process.execPath, [script], {
+    env: {
+      ...process.env,
+      CRABBOX_BIN: process.execPath,
+      CRABBOX_CODESANDBOX_API_KEY: "test-token",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /classification=diagnostic_only/);
+  assert.doesNotMatch(result.stderr, /ReferenceError/);
 });

--- a/scripts/live-codesandbox-smoke.test.js
+++ b/scripts/live-codesandbox-smoke.test.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { spawnSync } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -16,11 +16,7 @@ const smokeEnv = {
 };
 let cleanupArmed = false;
 
-if (require.main === module) {
-  main();
-}
-
-function main() {
+async function main() {
   if (!token.trim()) {
     emit("environment_blocked", "reason=missing_CRABBOX_CODESANDBOX_API_KEY_or_CSB_API_KEY");
     cleanup();
@@ -44,20 +40,15 @@ function main() {
     requireOutput(sync, "CODESANDBOX_SMOKE_SYNC_OK", "sync proof command");
     run("pause", ["pause", "--provider", "codesandbox", slug], { cwd: smokeRepo });
     run("resume", ["resume", "--provider", "codesandbox", slug], { cwd: smokeRepo });
-    run("start preview server", [
-      "run",
-      "--provider",
-      "codesandbox",
-      "--id",
-      slug,
-      "--no-sync",
-      "--",
-      "/bin/sh",
-      "-lc",
-      "nohup node -e 'require(\"http\").createServer((_,res)=>res.end(\"CODESANDBOX_SMOKE_PORT_OK\")).listen(3000,\"0.0.0.0\"); setInterval(()=>{}, 1000)' >/tmp/crabbox-codesandbox-port.log 2>&1 &",
-    ], { cwd: smokeRepo });
-    const ports = run("ports", ["ports", "--provider", "codesandbox", "--id", slug, "--publish", "3000", "--json"], { cwd: smokeRepo });
-    requirePortURL(ports.stdout);
+    const preview = startPreviewServer();
+    try {
+      await waitForPreviewStart(preview);
+      const ports = run("ports", ["ports", "--provider", "codesandbox", "--id", slug, "--publish", "3000", "--json"], { cwd: smokeRepo });
+      const previewURL = requirePortURL(ports.stdout);
+      await requirePreviewResponse(previewURL);
+    } finally {
+      await stopPreviewServer(preview);
+    }
     stopAndVerifyEmpty();
     emit("live_codesandbox_smoke_passed");
   } catch (error) {
@@ -139,6 +130,100 @@ function runLocal(label, args, cwd) {
   }
 }
 
+function startPreviewServer() {
+  const child = spawn(
+    bin,
+    [
+      "run",
+      "--provider",
+      "codesandbox",
+      "--id",
+      slug,
+      "--no-sync",
+      "--",
+      "/bin/sh",
+      "-lc",
+      "exec node -e 'require(\"http\").createServer((_,res)=>res.end(\"CODESANDBOX_SMOKE_PORT_OK\")).listen(3000,\"0.0.0.0\")'",
+    ],
+    {
+      cwd: smokeRepo,
+      env: smokeEnv,
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const preview = { child, stdout: "", stderr: "", spawnError: null };
+  child.stdout.on("data", (chunk) => {
+    preview.stdout = appendOutput(preview.stdout, chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    preview.stderr = appendOutput(preview.stderr, chunk);
+  });
+  child.on("error", (error) => {
+    preview.spawnError = error;
+  });
+  return preview;
+}
+
+async function waitForPreviewStart(preview) {
+  await delay(5000);
+  if (preview.spawnError) {
+    throw new Error(`start preview server failed: ${preview.spawnError.message}`);
+  }
+  if (preview.child.exitCode !== null || preview.child.signalCode !== null) {
+    throw new SmokeError("start preview server exited early", previewResult(preview));
+  }
+}
+
+async function stopPreviewServer(preview) {
+  if (!preview || preview.child.exitCode !== null || preview.child.signalCode !== null) return;
+  signalChild(preview.child, "SIGTERM");
+  await waitForExit(preview.child, 5000);
+  if (preview.child.exitCode === null && preview.child.signalCode === null) {
+    signalChild(preview.child, "SIGKILL");
+    await waitForExit(preview.child, 5000);
+  }
+}
+
+function signalChild(child, signal) {
+  try {
+    if (process.platform === "win32") {
+      child.kill(signal);
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function delay(timeoutMs) {
+  return new Promise((resolve) => setTimeout(resolve, timeoutMs));
+}
+
+function appendOutput(current, chunk) {
+  return `${current}${chunk}`.slice(-1024 * 1024);
+}
+
+function previewResult(preview) {
+  return {
+    status: preview.child.exitCode,
+    stdout: preview.stdout,
+    stderr: preview.stderr || (preview.child.signalCode ? `signal=${preview.child.signalCode}` : ""),
+  };
+}
+
 function stopAndVerifyEmpty() {
   run("stop", ["stop", "--provider", "codesandbox", slug], { cwd: smokeRepo });
   cleanupArmed = false;
@@ -182,6 +267,23 @@ function requirePortURL(stdout) {
   if (item.port !== 3000 || !/^https:\/\/.+\.csb\.app/.test(host)) {
     throw new Error(`diagnostic_only: ports output did not include a CodeSandbox URL for port 3000: ${JSON.stringify(payload)}`);
   }
+  return host;
+}
+
+async function requirePreviewResponse(url) {
+  let lastError;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      const body = await response.text();
+      if (response.ok && body.includes("CODESANDBOX_SMOKE_PORT_OK")) return;
+      lastError = new Error(`HTTP ${response.status}: ${body.slice(0, 200)}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(2000);
+  }
+  throw new Error(`diagnostic_only: CodeSandbox preview request failed: ${lastError?.message || "unknown error"}`);
 }
 
 function jsonContainsSlug(text, want) {
@@ -204,6 +306,9 @@ function hasSlug(value, want) {
 
 function classify(message) {
   const lower = message.toLowerCase();
+  if (lower.includes("diagnostic_only:")) {
+    return "diagnostic_only";
+  }
   if (lower.includes("quota") || lower.includes("rate limit") || lower.includes("too many requests") || lower.includes("429") || lower.includes("capacity")) {
     return "environment_blocked";
   }
@@ -243,3 +348,7 @@ class SmokeError extends Error {
 }
 
 module.exports = { classify };
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

- make CodeSandbox ownership tags conform to the provider's accepted tag format
- terminate one-shot SDK bridge processes after flushing JSON responses
- validate ownership before resume while accepting runtime-only resume responses
- replace the root workspace mount with rollback-safe child moves instead of renaming the mount
- return authenticated HTTPS preview URLs and strengthen the live smoke through an HTTP content check
- add shared delegated-sync coverage and CodeSandbox regression tests

## Root cause

The initial provider implementation assumed CodeSandbox preserved punctuation-heavy ownership tags, returned metadata tags from `resume()`, allowed its root workspace mount to be renamed, and returned directly usable port hosts. Live testing showed each assumption was false. The SDK bridge also kept its WebSocket event loop alive after writing a complete one-shot response.

## Verification

- `go test ./...`
- `go test -race ./internal/cli ./internal/providers/codesandbox`
- `go vet ./...`
- `node --test scripts/live-codesandbox-smoke-classify.test.js`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
- real CodeSandbox lifecycle: doctor, warmup, status, successful command, expected nonzero command, archive sync, pause, resume, authenticated port URL, HTTPS sentinel response, stop, and zero remaining smoke sandboxes

The broader `go test -race ./...` run was also attempted. It passed the affected packages but hit the pre-existing timing threshold in `TestRunpodAcquireRollbackCannotBlockForever`; the normal full suite and affected race suites are green.

## Credentials

No credentials are stored in the repository or passed on command lines. Live validation injected the CodeSandbox token from the local secret store.
