### PR TITLE
docs: add Slurm academic sandbox plan and adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules/
 *.test
 coverage.out
 /crabbox
+__pycache__/
+*.pyc
+.pytest_cache/
 .gomu_history.json
 mutation-report.*
 reports/mutation/

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,8 @@ Pick whichever matches your intent:
   [Architecture](architecture.md), [Orchestrator](orchestrator.md),
   [Broker auth and routing](features/broker-auth-routing.md),
   [Coordinator](features/coordinator.md),
-  [Bring your own infrastructure](features/bring-your-own-infrastructure.md).
+  [Bring your own infrastructure](features/bring-your-own-infrastructure.md),
+  [Slurm academic sandboxes](features/slurm-academic-sandboxes.md).
 - **Deploy the coordinator:** [Infrastructure](infrastructure.md),
   [Portable coordinator](features/portable-coordinator.md),
   [Operations](operations.md), [Security](security.md).
@@ -134,6 +135,7 @@ Pick whichever matches your intent:
   [Provider authoring](features/provider-authoring.md),
   [Provider backends](provider-backends.md),
   [Capacity fallback](features/capacity-fallback.md),
+  [Slurm academic sandboxes](features/slurm-academic-sandboxes.md),
   [Network](features/network.md), [Tailscale](features/tailscale.md).
   Per-provider: [AWS](providers/aws.md), [Azure](providers/azure.md),
   [Azure Dynamic Sessions](providers/azure-dynamic-sessions.md),

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -25,6 +25,7 @@ Read when:
   Durable Object and Node.js/PostgreSQL runtimes.
 - [Portable coordinator](portable-coordinator.md): deploy and operate the Node/PostgreSQL runtime on a conventional container platform.
 - [Bring your own infrastructure](bring-your-own-infrastructure.md): connect a private control plane through generic providers and optional registered mode.
+- [Slurm academic sandboxes](slurm-academic-sandboxes.md): offer Crabbox on campus Slurm clusters through a site-local external adapter before adding a built-in provider.
 - [Browser portal](portal.md): authenticated lease/run UI, detail pages, bridge routes, and runner visibility.
 - [Broker auth and routing](broker-auth-routing.md): GitHub login, shared bearer
   tokens, trusted proxy identity, optional Cloudflare Access, and public routes.
@@ -43,6 +44,7 @@ Read when:
 - [Authoring a provider](provider-authoring.md): step-by-step guide to writing a new provider.
 - [XCP-ng](../providers/xcp-ng.md): direct XCP-ng provider on dedicated x86_64 pool hardware. XCP-ng itself can host Linux, Windows, and BSD guests; Crabbox normal leases use Linux templates, with separate Windows x86_64/x64 ISO E2E coverage.
 - [Incus local E2E testbed](../providers/incus.md): local Apple Silicon runbook and smoke contract for the future `incus` adapter.
+- [Slurm academic sandboxes](slurm-academic-sandboxes.md): planning contract for academic Slurm allocations through `provider: external`.
 
 Provider deep-dives that live here in `features/`:
 

--- a/docs/features/bring-your-own-infrastructure.md
+++ b/docs/features/bring-your-own-infrastructure.md
@@ -126,7 +126,9 @@ Academic Slurm clusters usually fit this protocol path: the adapter submits an
 `sbatch` job, waits for the allocation to publish a host/port/key or proxy
 route, returns that as the external SSH target, and uses `scancel` on release.
 See [Slurm academic sandboxes](slurm-academic-sandboxes.md) for the full
-product and security contract.
+product and security contract, and
+[examples/slurm-external-provider](../../examples/slurm-external-provider/README.md)
+for a reference external adapter.
 
 ## Persisted routing
 
@@ -332,6 +334,7 @@ sweep cannot select a live registered direct resource.
 
 - [External Provider](../providers/external.md)
 - [Slurm academic sandboxes](slurm-academic-sandboxes.md)
+- [Reference Slurm external provider](../../examples/slurm-external-provider/README.md)
 - [KubeVirt Provider](../providers/kubevirt.md)
 - [Coordinator](coordinator.md)
 - [Portable Coordinator](portable-coordinator.md)

--- a/docs/features/bring-your-own-infrastructure.md
+++ b/docs/features/bring-your-own-infrastructure.md
@@ -21,6 +21,7 @@ provider runs are not recorded by the coordinator in registered mode.
 | --- | --- |
 | Deterministic CLI create/delete commands and SSH names | declarative `external.lifecycle` |
 | Arbitrary logic or structured provider metadata | external JSON protocol executable |
+| Slurm allocation that publishes an SSH endpoint from a scheduled job | external JSON protocol executable |
 | KubeVirt cluster | built-in `kubevirt` provider |
 | Existing SSH hosts | built-in `ssh` provider |
 | New reusable public provider | implement a normal provider adapter |
@@ -120,6 +121,12 @@ route, and readiness check.
 Keep the executable separately versioned when it is proprietary. Public
 Crabbox needs only the protocol contract documented in
 [External Provider](../providers/external.md).
+
+Academic Slurm clusters usually fit this protocol path: the adapter submits an
+`sbatch` job, waits for the allocation to publish a host/port/key or proxy
+route, returns that as the external SSH target, and uses `scancel` on release.
+See [Slurm academic sandboxes](slurm-academic-sandboxes.md) for the full
+product and security contract.
 
 ## Persisted routing
 
@@ -324,6 +331,7 @@ sweep cannot select a live registered direct resource.
 ## Related documentation
 
 - [External Provider](../providers/external.md)
+- [Slurm academic sandboxes](slurm-academic-sandboxes.md)
 - [KubeVirt Provider](../providers/kubevirt.md)
 - [Coordinator](coordinator.md)
 - [Portable Coordinator](portable-coordinator.md)

--- a/docs/features/slurm-academic-sandboxes.md
+++ b/docs/features/slurm-academic-sandboxes.md
@@ -8,6 +8,13 @@ Read this when:
   future built-in `provider: slurm`;
 - you need the product contract before writing a Slurm adapter.
 
+Slurm is different from Crabbox's cloud and sandbox providers. It does not hand
+out a new VM identity with a ready SSH contract; it schedules work onto an
+existing cluster allocation for a bounded wall-clock period. A Crabbox Slurm
+integration therefore needs an adapter layer that turns a scheduled allocation
+into the lease shape Crabbox expects: host, port, user, key or proxy, readiness
+check, status, and release.
+
 Crabbox does not currently ship a built-in Slurm provider. The first supported
 offer should be a site-local external provider adapter that submits a Slurm job,
 waits for a reachable SSH endpoint inside the allocation, and then lets Crabbox
@@ -75,6 +82,14 @@ not core provider code. The adapter owns Slurm-specific behavior:
 job may still sit pending before resources are allocated. Prefer `warmup` for
 interactive or agent workflows so queue time is paid before the first command.
 
+The repository includes a reference adapter and sample unprivileged `sshd`
+runner under
+[examples/slurm-external-provider](../../examples/slurm-external-provider/README.md).
+It is a starting point for campus pilots, not a universal production runner.
+Sites should replace the sample runner when policy requires a gateway,
+Open OnDemand-style connection script, Apptainer/Singularity wrapper,
+Pyxis/Enroot integration, or a managed SSH service.
+
 ## Configuration Sketch
 
 The concrete adapter name is site-owned. A generic repo or user config should
@@ -85,10 +100,13 @@ provider: external
 target: linux
 
 external:
-  command: slurm-cbx
+  command: python3
   args:
+    - /opt/crabbox-slurm/slurm-cbx.py
     - --state-dir
     - /home/example-user/.crabbox/slurm
+    - --runner-script
+    - /opt/crabbox-slurm/runner-unprivileged-sshd.sh
   capabilities:
     idempotentLeaseId: true
   config:
@@ -100,6 +118,9 @@ external:
     timeLimit: 02:00:00
     gres: gpu:1
     sshMode: proxy-through-login
+    loginHost: login.cluster.example.edu
+    acquireTimeoutSeconds: 3600
+    runnerWorkRoot: /scratch/example-lab/crabbox
   workRoot: /scratch/example-lab/crabbox
 ```
 
@@ -113,13 +134,13 @@ The adapter should return the resolved endpoint as protocol JSON:
     "slug": "bright-coral",
     "name": "crabbox-bright-coral-012345",
     "cloudId": "slurm/job/123456",
-    "serverType": "slurm:batch cpu=16 mem=64G time=02:00:00 gres=gpu:1",
+    "serverType": "slurm partition=batch account=example-lab cpus=16 mem=64G timeLimit=02:00:00 gres=gpu:1",
     "ssh": {
-      "user": "crabbox",
-      "host": "login.cluster.example.edu",
-      "port": "22",
-      "key": "/home/example-user/.crabbox/slurm/cbx_0123456789ab/id_ed25519",
-      "proxyCommand": "ssh -W node123.cluster.example.edu:39022 login.cluster.example.edu",
+      "user": "alice",
+      "host": "node123.cluster.example.edu",
+      "port": "39022",
+      "key": "/home/example-user/.crabbox/slurm/jobs/cbx_0123456789ab/id_ed25519",
+      "proxyCommand": "ssh -W %h:%p login.cluster.example.edu",
       "readyCheck": "command -v bash && command -v python3 && command -v git && command -v rsync && command -v tar"
     }
   }
@@ -197,6 +218,14 @@ Also verify failure cleanup:
 - temporary keys and endpoint files disappear after `stop`;
 - registered mode outage does not block `scancel`.
 
+For the checked-in reference adapter, run the local syntax checks before a
+cluster smoke:
+
+```sh
+python3 -m py_compile examples/slurm-external-provider/slurm-cbx.py
+bash -n examples/slurm-external-provider/runner-unprivileged-sshd.sh
+```
+
 ## Future Built-In Provider Criteria
 
 Do not add `provider: slurm` until the external shape has survived real site
@@ -223,3 +252,4 @@ normal Crabbox key instead of creating their own key pair.
 - [Slurm REST quick start](https://slurm.schedmd.com/rest_quickstart.html)
 - [JupyterHub BatchSpawner](https://github.com/jupyterhub/batchspawner)
 - [Open OnDemand example campus documentation](https://www.chpc.utah.edu/documentation/software/ondemand.php)
+- [Reference Slurm external provider example](../../examples/slurm-external-provider/README.md)

--- a/docs/features/slurm-academic-sandboxes.md
+++ b/docs/features/slurm-academic-sandboxes.md
@@ -1,0 +1,225 @@
+# Slurm Academic Sandboxes
+
+Read this when:
+
+- an academic, lab, or research group wants Crabbox on an existing Slurm
+  cluster;
+- you are deciding whether to use `provider: ssh`, `provider: external`, or a
+  future built-in `provider: slurm`;
+- you need the product contract before writing a Slurm adapter.
+
+Crabbox does not currently ship a built-in Slurm provider. The first supported
+offer should be a site-local external provider adapter that submits a Slurm job,
+waits for a reachable SSH endpoint inside the allocation, and then lets Crabbox
+use the normal SSH sync/run path. That gives campuses a practical path without
+putting cluster-specific scheduler, account, security, or filesystem policy in
+Crabbox core.
+
+## Product Offer
+
+Position the feature as "Crabbox for academic clusters":
+
+- researchers and agents run `crabbox warmup` or `crabbox run` against existing
+  institutional capacity instead of public cloud;
+- the site keeps Slurm accounts, partitions, QOS, GPU policy, fair-share, and
+  filesystem layout in its own adapter or config;
+- Crabbox keeps its normal value: git-aware sync, command streaming, Actions
+  hydration on Linux SSH leases, result collection, logs, artifacts, SSH access,
+  and optional registered coordinator visibility;
+- no Slurm controller, login node, or `slurmrestd` endpoint has to become
+  internet-facing.
+
+This is not a replacement for Open OnDemand, JupyterHub, or batch workflows.
+Those tools are still the right interface for interactive notebooks, desktops,
+teaching portals, and long scientific jobs. Crabbox is the CLI/agent proof
+runner for software tests, repros, smoke runs, and short-lived development
+tasks that benefit from the same cluster resources.
+
+## Recommended Path
+
+Use the least-specific integration that satisfies the workflow:
+
+| Need | Crabbox path |
+| --- | --- |
+| Run on a fixed login, lab, or bastion host | `provider: ssh` |
+| Allocate compute through Slurm and then SSH into the allocation | `provider: external` with a Slurm adapter |
+| Share inventory, WebVNC bridges, and run history without giving the broker Slurm credentials | external provider plus registered coordinator mode |
+| Reusable public Slurm support after multiple sites converge on one contract | future built-in `provider: slurm` |
+
+Avoid running heavy tests directly on a Slurm login node through static SSH.
+Login nodes are usually shared control-plane machines. The useful Crabbox shape
+is "submit through the login node, run inside a scheduled allocation."
+
+## External Adapter Shape
+
+The first adapter should implement the versioned external provider protocol,
+not core provider code. The adapter owns Slurm-specific behavior:
+
+1. `doctor` verifies `sbatch`, `squeue`, `scancel`, cluster auth, the configured
+   account/partition/QOS, and the chosen SSH/proxy mode without creating a job.
+2. `acquire` submits an `sbatch --parsable` job with a Crabbox-owned job name,
+   resource limits, and a site-owned runner script.
+3. The batch script starts an SSH-reachable runner inside the allocation. Common
+   variants are a per-job `sshd` on an allocated node, an SSH proxy through the
+   submit host, or a site-managed gateway command.
+4. The adapter polls `squeue` or `sacct` and a private state file until the job
+   publishes host, port, user, key/proxy, and readiness metadata.
+5. The adapter returns a normal external provider lease with `cloudId` set to
+   the Slurm job identity.
+6. Crabbox waits for SSH, claims the lease, rsyncs the repo, runs commands, and
+   collects results through the ordinary SSH lease path.
+7. `release` uses `scancel` and removes adapter state, temporary keys, and
+   per-job routing files.
+
+`sbatch` submits work and returns after the controller accepts the script; the
+job may still sit pending before resources are allocated. Prefer `warmup` for
+interactive or agent workflows so queue time is paid before the first command.
+
+## Configuration Sketch
+
+The concrete adapter name is site-owned. A generic repo or user config should
+look like this:
+
+```yaml
+provider: external
+target: linux
+
+external:
+  command: slurm-cbx
+  args:
+    - --state-dir
+    - /home/example-user/.crabbox/slurm
+  capabilities:
+    idempotentLeaseId: true
+  config:
+    account: example-lab
+    partition: batch
+    qos: normal
+    cpus: 16
+    mem: 64G
+    timeLimit: 02:00:00
+    gres: gpu:1
+    sshMode: proxy-through-login
+  workRoot: /scratch/example-lab/crabbox
+```
+
+The adapter should return the resolved endpoint as protocol JSON:
+
+```json
+{
+  "protocolVersion": 1,
+  "lease": {
+    "leaseId": "cbx_0123456789ab",
+    "slug": "bright-coral",
+    "name": "crabbox-bright-coral-012345",
+    "cloudId": "slurm/job/123456",
+    "serverType": "slurm:batch cpu=16 mem=64G time=02:00:00 gres=gpu:1",
+    "ssh": {
+      "user": "crabbox",
+      "host": "login.cluster.example.edu",
+      "port": "22",
+      "key": "/home/example-user/.crabbox/slurm/cbx_0123456789ab/id_ed25519",
+      "proxyCommand": "ssh -W node123.cluster.example.edu:39022 login.cluster.example.edu",
+      "readyCheck": "command -v bash && command -v python3 && command -v git && command -v rsync && command -v tar"
+    }
+  }
+}
+```
+
+The external protocol currently does not pass Crabbox's generated public key to
+the adapter. A Slurm adapter should therefore either generate a per-job SSH key
+itself and return the mode-`0600` private key path, or use a site-managed SSH
+proxy/auth contract. Do not print private key contents in protocol JSON.
+
+## Runner Script Contract
+
+Keep the batch script small and site-owned. It should:
+
+- request only the resources configured for the lease profile;
+- create a per-job work root on approved storage, usually scratch or project
+  storage rather than a shared source checkout;
+- start from a site-approved environment, module set, Apptainer/Singularity
+  image, Pyxis/Enroot container, or bare host image;
+- ensure `bash`, `python3`, `git`, `rsync`, `tar`, and OpenSSH server/client
+  pieces needed by the selected SSH mode are available;
+- publish one private endpoint state file once SSH is reachable;
+- clean temporary keys, sockets, and state on normal exit, `scancel`, and job
+  timeout where Slurm epilog/trap policy permits.
+
+Container support should stay site-configured. Slurm itself exposes container
+options in `srun`, and many HPC sites use Apptainer/Singularity or Pyxis/Enroot
+policies. Crabbox should not choose a default container runtime for all
+clusters.
+
+## Security Boundaries
+
+Slurm is usually inside a trusted campus network. Keep it that way:
+
+- do not expose `slurmrestd` directly to the public internet; if a site uses it,
+  put it behind site TLS, SSO, monitoring, and network controls;
+- keep cluster credentials in SSH agents, Kerberos/OIDC helpers, module
+  environments, or the adapter's credential store, not repo YAML;
+- keep adapter state and returned key files under a private directory with
+  mode `0700` directories and mode `0600` key/routing files;
+- prefer a login-node `ProxyCommand`, site gateway, or tailnet path when compute
+  nodes cannot accept inbound SSH from developer machines;
+- scope cleanup by Crabbox lease ID and Slurm job ID so one user cannot cancel
+  unrelated jobs by reusing a slug;
+- make time limits and idle timeouts shorter than the Slurm wall clock limit so
+  Crabbox has a chance to collect results before the scheduler kills the job.
+
+Registered coordinator mode is optional and provider-neutral. Use it when the
+site wants portal inventory, sharing, history, or outbound WebVNC bridges, but
+the coordinator still must not receive Slurm credentials.
+
+## Acceptance Contract
+
+Before treating a site adapter as production-ready, prove this sequence from a
+normal user account:
+
+```sh
+crabbox doctor --provider external
+crabbox warmup --provider external --slug slurm-smoke --keep --ttl 2h --idle-timeout 30m
+crabbox inspect --provider external --id slurm-smoke --json
+crabbox run --provider external --id slurm-smoke --preflight -- hostname
+crabbox actions hydrate --provider external --id slurm-smoke
+crabbox stop --provider external slurm-smoke
+```
+
+Also verify failure cleanup:
+
+- an invalid partition or account fails before creating a job, or cancels the
+  failed job during rollback;
+- a queued job can be stopped before it starts running;
+- a job whose SSH endpoint never appears is cancelled unless `--keep` was
+  requested;
+- `list` and `status` show the Slurm job ID and scheduler state;
+- temporary keys and endpoint files disappear after `stop`;
+- registered mode outage does not block `scancel`.
+
+## Future Built-In Provider Criteria
+
+Do not add `provider: slurm` until the external shape has survived real site
+use. A built-in adapter is justified when:
+
+- at least two Slurm sites can use the same public configuration model;
+- the SSH endpoint pattern is stable enough to document without assuming one
+  campus network;
+- cleanup and status can be implemented without dangerous scheduler queries;
+- the provider can expose honest feature flags, probably `ssh`,
+  `crabbox-sync`, and `cleanup` for Linux only;
+- tests can cover request rendering, status parsing, release safety, and
+  idempotent acquisition without a live cluster.
+
+Potential core follow-up: add an optional external protocol field containing
+the Crabbox-generated SSH public key. That would let adapters authorize the
+normal Crabbox key instead of creating their own key pair.
+
+## References
+
+- [Slurm `sbatch`](https://slurm.schedmd.com/sbatch.html)
+- [Slurm `srun` container options](https://slurm.schedmd.com/srun.html)
+- [Slurm REST API security guidance](https://slurm.schedmd.com/rest.html)
+- [Slurm REST quick start](https://slurm.schedmd.com/rest_quickstart.html)
+- [JupyterHub BatchSpawner](https://github.com/jupyterhub/batchspawner)
+- [Open OnDemand example campus documentation](https://www.chpc.utah.edu/documentation/software/ondemand.php)

--- a/docs/features/slurm-academic-sandboxes.md
+++ b/docs/features/slurm-academic-sandboxes.md
@@ -224,6 +224,7 @@ cluster smoke:
 ```sh
 python3 -m py_compile examples/slurm-external-provider/slurm-cbx.py
 bash -n examples/slurm-external-provider/runner-unprivileged-sshd.sh
+python3 -m pytest examples/slurm-external-provider/ -q
 ```
 
 ## Future Built-In Provider Criteria

--- a/docs/features/slurm-academic-sandboxes.md
+++ b/docs/features/slurm-academic-sandboxes.md
@@ -62,8 +62,10 @@ is "submit through the login node, run inside a scheduled allocation."
 The first adapter should implement the versioned external provider protocol,
 not core provider code. The adapter owns Slurm-specific behavior:
 
-1. `doctor` verifies `sbatch`, `squeue`, `scancel`, cluster auth, the configured
-   account/partition/QOS, and the chosen SSH/proxy mode without creating a job.
+1. `doctor` verifies required Slurm commands, basic scheduler visibility,
+   adapter state paths, runner paths, and the chosen SSH/proxy mode without
+   creating a job. Site policy such as account, partition, and QOS acceptance is
+   proven by `acquire`/`warmup` or by site-specific non-submitting checks.
 2. `acquire` submits an `sbatch --parsable` job with a Crabbox-owned job name,
    resource limits, and a site-owned runner script.
 3. The batch script starts an SSH-reachable runner inside the allocation. Common
@@ -207,10 +209,11 @@ crabbox actions hydrate --provider external --id slurm-smoke
 crabbox stop --provider external slurm-smoke
 ```
 
-Also verify failure cleanup:
+Also verify scheduler policy and failure cleanup:
 
-- an invalid partition or account fails before creating a job, or cancels the
-  failed job during rollback;
+- a valid account, partition, and QOS can acquire a job and reach SSH readiness;
+- an invalid partition or account fails during acquire before creating a job, or
+  cancels the failed job during rollback;
 - a queued job can be stopped before it starts running;
 - a job whose SSH endpoint never appears is cancelled unless `--keep` was
   requested;

--- a/docs/features/slurm-academic-sandboxes.md
+++ b/docs/features/slurm-academic-sandboxes.md
@@ -62,10 +62,11 @@ is "submit through the login node, run inside a scheduled allocation."
 The first adapter should implement the versioned external provider protocol,
 not core provider code. The adapter owns Slurm-specific behavior:
 
-1. `doctor` verifies required Slurm commands, basic scheduler visibility,
-   adapter state paths, runner paths, and the chosen SSH/proxy mode without
-   creating a job. Site policy such as account, partition, and QOS acceptance is
-   proven by `acquire`/`warmup` or by site-specific non-submitting checks.
+1. `doctor` verifies required Slurm command binaries, adapter state paths,
+   runner paths, and the chosen SSH/proxy mode without creating a job or querying
+   scheduler policy. Slurm controller reachability and site policy such as
+   account, partition, and QOS acceptance are proven by `acquire`/`warmup` or by
+   site-specific non-submitting checks.
 2. `acquire` submits an `sbatch --parsable` job with a Crabbox-owned job name,
    resource limits, and a site-owned runner script.
 3. The batch script starts an SSH-reachable runner inside the allocation. Common

--- a/examples/slurm-external-provider/README.md
+++ b/examples/slurm-external-provider/README.md
@@ -1,0 +1,169 @@
+# Slurm External Provider Example
+
+This directory contains a reference `provider: external` adapter for campus
+Slurm clusters. It is intentionally site-adaptable example code, not a built-in
+Crabbox provider.
+
+The adapter turns a Slurm allocation into a normal Crabbox SSH lease:
+
+1. `slurm-cbx.py` receives the Crabbox external provider JSON request.
+2. `acquire` submits a Slurm batch job with `sbatch --parsable`.
+3. The batch job runs `runner-unprivileged-sshd.sh`, which starts a per-job SSH
+   endpoint and writes `endpoint.json` to a shared state directory.
+4. The adapter waits for that endpoint, then returns a normal external-provider
+   lease with host, port, user, key, and optional proxy metadata.
+5. Crabbox uses its standard SSH path for sync, run, Actions hydration, logs,
+   artifacts, and `stop`.
+6. `release` cancels the Slurm job with `scancel` and removes local state.
+
+Most production sites should fork this adapter. Common site-specific changes
+include replacing the sample unprivileged `sshd` runner with an approved gateway
+command, container wrapper, Open OnDemand-style connect script, Apptainer image,
+or Pyxis/Enroot launch policy.
+
+## Crabbox Configuration
+
+Use an absolute path to the adapter and runner:
+
+```yaml
+provider: external
+target: linux
+
+external:
+  command: python3
+  args:
+    - /opt/crabbox-slurm/slurm-cbx.py
+    - --state-dir
+    - /home/alice/.crabbox/slurm
+    - --runner-script
+    - /opt/crabbox-slurm/runner-unprivileged-sshd.sh
+  capabilities:
+    idempotentLeaseId: true
+  config:
+    account: example-lab
+    partition: batch
+    qos: normal
+    cpus: 16
+    mem: 64G
+    timeLimit: 02:00:00
+    gres: gpu:1
+    sshMode: proxy-through-login
+    loginHost: login.cluster.example.edu
+    acquireTimeoutSeconds: 3600
+    runnerWorkRoot: /scratch/example-lab/crabbox
+  workRoot: /scratch/example-lab/crabbox
+```
+
+Then run:
+
+```sh
+crabbox doctor --provider external
+crabbox warmup --provider external --slug slurm-smoke --keep --ttl 2h --idle-timeout 30m
+crabbox run --provider external --id slurm-smoke --preflight -- hostname
+crabbox stop --provider external slurm-smoke
+```
+
+Use `warmup` for interactive or agent workflows. Slurm may accept the job
+quickly while the allocation remains queued; the adapter waits until the
+allocation publishes SSH before returning the lease to Crabbox.
+
+## Adapter Config Keys
+
+All keys below live under `external.config`.
+
+| Key | Meaning |
+| --- | --- |
+| `account` | Slurm account passed as `--account`. |
+| `partition` | Slurm partition passed as `--partition`. |
+| `qos` | Slurm QOS passed as `--qos`. |
+| `cpus` | CPU count passed as `--cpus-per-task`. |
+| `mem` | Memory request passed as `--mem`. |
+| `timeLimit` | Wall clock limit passed as `--time`. |
+| `gres` | Generic resources, for example `gpu:1`, passed as `--gres`. |
+| `nodes` | Node count passed as `--nodes`. |
+| `constraint` | Node constraint passed as `--constraint`. |
+| `reservation` | Reservation passed as `--reservation`. |
+| `extraSbatchArgs` | Additional non-secret Slurm arguments as a string array. |
+| `sshMode` | `direct` or `proxy-through-login`. |
+| `loginHost` | Login or bastion host used when `sshMode=proxy-through-login`. |
+| `loginUser` | Optional login host username for the proxy command. |
+| `proxyCommand` | Optional explicit SSH `ProxyCommand` template. |
+| `sshUser` | SSH user for the compute endpoint; defaults to the Slurm job user. |
+| `sshPrivateKey` | Existing private key path; omit to generate a per-lease key. |
+| `readyCheck` | Crabbox SSH readiness check. |
+| `acquireTimeoutSeconds` | Seconds to wait for scheduler allocation and endpoint publication. |
+| `runnerWorkRoot` | Work root the sample batch runner creates; keep it aligned with `external.workRoot`. |
+
+`extraSbatchArgs` must not contain secrets. Slurm arguments are visible in
+process and scheduler metadata on many clusters.
+
+`proxyCommand` supports these template variables:
+
+```text
+{host} {port} {loginHost} {loginUser} {leaseId} {slug} {name} {jobId}
+```
+
+If `sshMode=proxy-through-login` and no explicit `proxyCommand` is configured,
+the adapter returns:
+
+```text
+ssh -W %h:%p <loginHost>
+```
+
+or `ssh -W %h:%p <loginUser>@<loginHost>` when `loginUser` is set.
+
+## Shared State
+
+`--state-dir` must be visible to both the submit host and the compute job when
+using the sample runner, because the job writes `endpoint.json` there. Home,
+project, or scratch filesystems usually work. A site-owned gateway can replace
+this with a different publication mechanism as long as `slurm-cbx.py` can read
+the resulting endpoint.
+
+The adapter creates:
+
+```text
+<state-dir>/jobs/<lease-id>/state.json
+<state-dir>/jobs/<lease-id>/id_ed25519
+<state-dir>/jobs/<lease-id>/id_ed25519.pub
+<state-dir>/jobs/<lease-id>/endpoint.json
+<state-dir>/jobs/<lease-id>/slurm-<job-id>.out
+```
+
+Private directories and key files are created with restrictive modes. The
+adapter removes the job directory on successful `release`.
+
+## Endpoint Contract
+
+The runner publishes this JSON:
+
+```json
+{
+  "host": "node123.cluster.example.edu",
+  "port": "39022",
+  "user": "alice",
+  "readyCheck": "command -v bash && command -v python3 && command -v git && command -v rsync && command -v tar"
+}
+```
+
+The adapter combines that endpoint with the generated or configured SSH key and
+optional proxy settings before returning the Crabbox external-provider lease.
+
+## Security Notes
+
+- Do not expose `slurmrestd` or Slurm controller services to Crabbox clients.
+- Keep Slurm credentials in the user's normal cluster login mechanism, Kerberos
+  ticket, SSH agent, or site credential helper.
+- Keep `--state-dir` private to the user or project service account.
+- Use a per-job SSH key when possible and remove it on `release`.
+- Validate that `scancel` only targets the persisted Slurm job for the exact
+  Crabbox lease ID.
+- Replace the sample `runner-unprivileged-sshd.sh` if unprivileged `sshd` is not
+  allowed by site policy.
+
+## Local Syntax Checks
+
+```sh
+python3 -m py_compile examples/slurm-external-provider/slurm-cbx.py
+bash -n examples/slurm-external-provider/runner-unprivileged-sshd.sh
+```

--- a/examples/slurm-external-provider/README.md
+++ b/examples/slurm-external-provider/README.md
@@ -167,3 +167,14 @@ optional proxy settings before returning the Crabbox external-provider lease.
 python3 -m py_compile examples/slurm-external-provider/slurm-cbx.py
 bash -n examples/slurm-external-provider/runner-unprivileged-sshd.sh
 ```
+
+## Tests
+
+`test_slurm_cbx.py` covers the adapter without a real cluster by faking
+`sbatch`, `squeue`, `sacct`, and `scancel`. It exercises `doctor`, the
+acquire/resolve/release happy path, idempotent re-acquire, lease-id parsing,
+endpoint-timeout cancellation, `list` filtering, and `cleanup`:
+
+```sh
+python3 -m pytest examples/slurm-external-provider/ -q
+```

--- a/examples/slurm-external-provider/runner-unprivileged-sshd.sh
+++ b/examples/slurm-external-provider/runner-unprivileged-sshd.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CBX_LEASE_ID:?missing CBX_LEASE_ID}"
+: "${CBX_STATE_DIR:?missing CBX_STATE_DIR}"
+: "${CBX_WORK_ROOT:?missing CBX_WORK_ROOT}"
+: "${CBX_SSH_PUBLIC_KEY_FILE:?missing CBX_SSH_PUBLIC_KEY_FILE}"
+
+job_dir="${CBX_STATE_DIR}/jobs/${CBX_LEASE_ID}"
+sshd_dir="${job_dir}/sshd"
+work_dir="${CBX_WORK_ROOT}/${CBX_LEASE_ID}"
+endpoint_file="${job_dir}/endpoint.json"
+endpoint_tmp="${endpoint_file}.tmp"
+authorized_keys="${sshd_dir}/authorized_keys"
+host_key="${sshd_dir}/ssh_host_ed25519_key"
+config_file="${sshd_dir}/sshd_config"
+pid_file="${sshd_dir}/sshd.pid"
+log_file="${job_dir}/sshd.log"
+
+mkdir -p "${sshd_dir}" "${work_dir}"
+chmod 700 "${job_dir}" "${sshd_dir}" || true
+
+cp "${CBX_SSH_PUBLIC_KEY_FILE}" "${authorized_keys}"
+chmod 600 "${authorized_keys}" || true
+
+if [ ! -f "${host_key}" ]; then
+  ssh-keygen -q -t ed25519 -N "" -f "${host_key}" -C "crabbox-${CBX_LEASE_ID}-host"
+fi
+chmod 600 "${host_key}" || true
+
+if [ -n "${CBX_SSH_PORT:-}" ]; then
+  port="${CBX_SSH_PORT}"
+else
+  port="$(python3 - <<'PY'
+import random
+import socket
+
+for _ in range(200):
+    candidate = random.randint(39000, 49999)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("", candidate))
+        except OSError:
+            continue
+    print(candidate)
+    break
+else:
+    raise SystemExit("could not find a free high port")
+PY
+)"
+fi
+
+sshd_path="${CBX_SSHD:-}"
+if [ -z "${sshd_path}" ]; then
+  sshd_path="$(command -v sshd || true)"
+fi
+if [ -z "${sshd_path}" ]; then
+  echo "sshd not found; install OpenSSH server or replace this runner" >&2
+  exit 127
+fi
+
+cat >"${config_file}" <<EOF
+Port ${port}
+ListenAddress 0.0.0.0
+HostKey ${host_key}
+PidFile ${pid_file}
+AuthorizedKeysFile ${authorized_keys}
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+UsePAM no
+PermitRootLogin no
+AllowTcpForwarding yes
+X11Forwarding no
+PermitTunnel no
+PermitUserEnvironment no
+StrictModes no
+LogLevel VERBOSE
+Subsystem sftp internal-sftp
+EOF
+
+host="$(hostname -f 2>/dev/null || hostname)"
+user="${CBX_SSH_USER:-${USER:-}}"
+ready_check="${CBX_READY_CHECK:-command -v bash && command -v python3 && command -v git && command -v rsync && command -v tar}"
+
+python3 - "${endpoint_tmp}" "${endpoint_file}" "${host}" "${port}" "${user}" "${ready_check}" <<'PY'
+import json
+import os
+import sys
+
+tmp, final, host, port, user, ready_check = sys.argv[1:7]
+payload = {
+    "host": host,
+    "port": port,
+    "user": user,
+    "readyCheck": ready_check,
+}
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, separators=(",", ":"))
+    handle.write("\n")
+os.replace(tmp, final)
+PY
+
+cleanup() {
+  rm -f "${endpoint_file}" "${endpoint_tmp}" "${pid_file}"
+}
+trap cleanup EXIT INT TERM
+
+echo "crabbox Slurm SSH endpoint ready host=${host} port=${port} user=${user}" >&2
+exec "${sshd_path}" -D -e -f "${config_file}" >>"${log_file}" 2>&1

--- a/examples/slurm-external-provider/slurm-cbx.py
+++ b/examples/slurm-external-provider/slurm-cbx.py
@@ -185,17 +185,22 @@ class SlurmCrabboxAdapter:
         if not env["CBX_WORK_ROOT"]:
             env["CBX_WORK_ROOT"] = str(Path("~/crabbox-slurm-work").expanduser())
 
-        result = run(command, env=env)
-        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-        raw_job_id = lines[-1] if lines else ""
-        if not raw_job_id:
-            raise AdapterError("sbatch returned no job id")
-        # ``sbatch --parsable`` prints "<jobid>" or "<jobid>;<cluster>". Keep the
-        # bare numeric job id for squeue/sacct/scancel but persist the raw value
-        # for display and cloud-id purposes.
-        job_id = raw_job_id.split(";", 1)[0].strip()
-        if not job_id:
-            raise AdapterError(f"sbatch returned an unparsable job id: {raw_job_id!r}")
+        try:
+            result = run(command, env=env)
+            lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            raw_job_id = lines[-1] if lines else ""
+            if not raw_job_id:
+                raise AdapterError("sbatch returned no job id")
+            # ``sbatch --parsable`` prints "<jobid>" or "<jobid>;<cluster>". Keep the
+            # bare numeric job id for squeue/sacct/scancel but persist the raw value
+            # for display and cloud-id purposes.
+            job_id = raw_job_id.split(";", 1)[0].strip()
+            if not job_id:
+                raise AdapterError(f"sbatch returned an unparsable job id: {raw_job_id!r}")
+        except Exception:
+            if not request.get("keep"):
+                self.remove_job_dir(lease_id)
+            raise
         state.update(
             {
                 "jobId": job_id,

--- a/examples/slurm-external-provider/slurm-cbx.py
+++ b/examples/slurm-external-provider/slurm-cbx.py
@@ -123,6 +123,7 @@ class SlurmCrabboxAdapter:
         missing = [name for name in ("sbatch", "squeue", "scancel") if shutil.which(name) is None]
         if missing:
             raise AdapterError(f"missing Slurm command(s): {', '.join(missing)}")
+        validate_ssh_config(config)
         runner = self.runner(config)
         if not runner.exists():
             raise AdapterError(f"runner script does not exist: {runner}")
@@ -133,6 +134,7 @@ class SlurmCrabboxAdapter:
         }
 
     def acquire(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        validate_ssh_config(config)
         desired = request.get("desired") or {}
         lease_id = required_string(desired, "leaseId")
         slug = required_string(desired, "slug")
@@ -424,36 +426,52 @@ class SlurmCrabboxAdapter:
             state["schedulerState"] = status
             if status in TERMINAL_STATES:
                 state["status"] = status.lower()
+            elif status == "MISSING":
+                state["status"] = "missing"
             elif status == "RUNNING" and str(state.get("status")) != "ready":
                 state["status"] = "running"
             elif status == "PENDING":
                 state["status"] = "pending"
         else:
-            state["status"] = "missing"
+            state["status"] = "unknown"
+            state["schedulerStateUnknownAt"] = now()
         state["updatedAt"] = now()
         self.save_state(str(state["leaseId"]), state)
         return state
 
     def query_job_state(self, job_id: str) -> str:
+        return self.query_job_state_observation(job_id)["state"]
+
+    def query_job_state_observation(self, job_id: str) -> Dict[str, str]:
         result = subprocess.run(
             ["squeue", "-h", "-j", job_id, "-o", "%T"],
             text=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             check=False,
         )
+        if result.returncode != 0:
+            return {
+                "state": "",
+                "detail": result.stderr.strip() or result.stdout.strip() or f"squeue exit {result.returncode}",
+            }
         for line in result.stdout.splitlines():
             value = line.strip().upper()
             if value:
-                return value
+                return {"state": value, "detail": ""}
         if shutil.which("sacct"):
             result = subprocess.run(
                 ["sacct", "-n", "-j", job_id, "--format", "State", "--parsable2"],
                 text=True,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 check=False,
             )
+            if result.returncode != 0:
+                return {
+                    "state": "",
+                    "detail": result.stderr.strip() or result.stdout.strip() or f"sacct exit {result.returncode}",
+                }
             for line in result.stdout.splitlines():
                 # ``State`` can be e.g. "CANCELLED by 1000"; keep only the leading
                 # token. Empty lines (sacct sometimes prints blank step rows) are
@@ -461,8 +479,9 @@ class SlurmCrabboxAdapter:
                 field = line.split("|", 1)[0].strip()
                 tokens = field.split()
                 if tokens:
-                    return tokens[0].upper()
-        return ""
+                    return {"state": tokens[0].upper(), "detail": ""}
+            return {"state": "MISSING", "detail": "squeue and sacct returned no job rows"}
+        return {"state": "", "detail": "squeue returned no rows and sacct is unavailable"}
 
     def cancel_job(self, job_id: str) -> None:
         if not job_id:
@@ -476,10 +495,14 @@ class SlurmCrabboxAdapter:
         )
         if result.returncode == 0:
             return
-        status = self.query_job_state(job_id)
-        if status and status not in TERMINAL_STATES:
+        observation = self.query_job_state_observation(job_id)
+        status = observation["state"]
+        if status and status not in TERMINAL_STATES and status != "MISSING":
             detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
             raise AdapterError(f"scancel {job_id} failed while job is still {status}: {detail}")
+        if not status:
+            detail = result.stderr.strip() or result.stdout.strip() or observation["detail"] or f"exit {result.returncode}"
+            raise AdapterError(f"scancel {job_id} failed and scheduler state is unknown: {detail}")
 
     def ensure_ssh_key(self, job_dir: Path, lease_id: str, config: Dict[str, Any]) -> Path:
         configured = config_string(config, "sshPrivateKey", "")
@@ -630,6 +653,14 @@ def config_string(config: Dict[str, Any], key: str, default: str) -> str:
     if value in (None, ""):
         return default
     return str(value)
+
+
+def validate_ssh_config(config: Dict[str, Any]) -> None:
+    mode = config_string(config, "sshMode", "direct")
+    if mode not in ("direct", "proxy-through-login"):
+        raise AdapterError(f"unsupported sshMode: {mode}")
+    if mode == "proxy-through-login" and not config_string(config, "loginHost", ""):
+        raise AdapterError("sshMode=proxy-through-login requires loginHost")
 
 
 def scheduler_state(state: Dict[str, Any]) -> str:

--- a/examples/slurm-external-provider/slurm-cbx.py
+++ b/examples/slurm-external-provider/slurm-cbx.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""Reference Crabbox external-provider adapter for Slurm.
+
+This adapter is intentionally conservative example code. It owns Slurm job
+submission and cancellation, then returns a normal SSH endpoint to Crabbox once
+the scheduled allocation has started a site runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+PROTOCOL_VERSION = 1
+DEFAULT_READY_CHECK = (
+    "command -v bash && command -v python3 && command -v git && "
+    "command -v rsync && command -v tar"
+)
+TERMINAL_STATES = {
+    "BOOT_FAIL",
+    "CANCELLED",
+    "COMPLETED",
+    "DEADLINE",
+    "FAILED",
+    "NODE_FAIL",
+    "OUT_OF_MEMORY",
+    "PREEMPTED",
+    "REVOKED",
+    "SPECIAL_EXIT",
+    "TIMEOUT",
+}
+
+
+class AdapterError(Exception):
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Crabbox external provider for Slurm")
+    parser.add_argument("--state-dir", default="~/.crabbox/slurm")
+    parser.add_argument("--runner-script", default="")
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    args = parser.parse_args()
+
+    try:
+        request = json.load(sys.stdin)
+        adapter = SlurmCrabboxAdapter(args)
+        response = adapter.handle(request)
+        json.dump(response, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 0
+    except AdapterError as exc:
+        print(str(exc), file=sys.stderr)
+        json.dump({"error": str(exc)}, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive boundary for protocol callers.
+        print(f"unexpected adapter failure: {exc}", file=sys.stderr)
+        json.dump({"error": f"unexpected adapter failure: {exc}"}, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 1
+
+
+class SlurmCrabboxAdapter:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.state_dir = Path(args.state_dir).expanduser().resolve()
+        self.runner_script = Path(args.runner_script).expanduser().resolve() if args.runner_script else None
+        self.poll_interval = args.poll_interval
+
+    def handle(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        operation = str(request.get("operation") or "")
+        config = request.get("config") or {}
+        if not isinstance(config, dict):
+            raise AdapterError("request config must be an object")
+
+        if operation == "doctor":
+            return self.doctor(config)
+        if operation == "acquire":
+            return {"protocolVersion": PROTOCOL_VERSION, "lease": self.acquire(request, config)}
+        if operation == "resolve":
+            return {"protocolVersion": PROTOCOL_VERSION, "lease": self.resolve(request, config)}
+        if operation == "list":
+            return {"protocolVersion": PROTOCOL_VERSION, "leases": self.list_leases(request, config)}
+        if operation == "release":
+            self.release(request, config)
+            return {"protocolVersion": PROTOCOL_VERSION, "message": "released Slurm lease"}
+        if operation == "touch":
+            return {"protocolVersion": PROTOCOL_VERSION, "lease": self.touch(request, config)}
+        if operation == "cleanup":
+            return self.cleanup(request, config)
+        raise AdapterError(f"unsupported operation: {operation}")
+
+    def doctor(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        missing = [name for name in ("sbatch", "squeue", "scancel") if shutil.which(name) is None]
+        if missing:
+            raise AdapterError(f"missing Slurm command(s): {', '.join(missing)}")
+        runner = self.runner(config)
+        if not runner.exists():
+            raise AdapterError(f"runner script does not exist: {runner}")
+        self.ensure_private_dir(self.state_dir)
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "message": f"Slurm external provider ready; state={self.state_dir} runner={runner}",
+        }
+
+    def acquire(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        desired = request.get("desired") or {}
+        lease_id = required_string(desired, "leaseId")
+        slug = required_string(desired, "slug")
+        name = required_string(desired, "name")
+        job_dir = self.job_dir(lease_id)
+        self.ensure_private_dir(job_dir)
+
+        existing = self.load_state(lease_id)
+        if existing and existing.get("jobId"):
+            return self.wait_for_endpoint(existing, config, keep=bool(request.get("keep")))
+
+        key_path = self.ensure_ssh_key(job_dir, lease_id, config)
+        public_key_path = Path(str(key_path) + ".pub")
+        endpoint_path = job_dir / "endpoint.json"
+        runner = self.runner(config)
+        if not runner.exists():
+            raise AdapterError(f"runner script does not exist: {runner}")
+
+        state = {
+            "leaseId": lease_id,
+            "slug": slug,
+            "name": name,
+            "status": "submitting",
+            "createdAt": now(),
+            "updatedAt": now(),
+            "keyPath": str(key_path),
+            "publicKeyPath": str(public_key_path),
+            "endpointPath": str(endpoint_path),
+            "runnerScript": str(runner),
+            "config": public_config(config),
+        }
+        self.save_state(lease_id, state)
+
+        command = self.sbatch_command(config, name, job_dir, runner)
+        env = os.environ.copy()
+        env.update(
+            {
+                "CBX_LEASE_ID": lease_id,
+                "CBX_SLUG": slug,
+                "CBX_NAME": name,
+                "CBX_STATE_DIR": str(self.state_dir),
+                "CBX_WORK_ROOT": str(config_string(config, "runnerWorkRoot", "")),
+                "CBX_SSH_PUBLIC_KEY_FILE": str(public_key_path),
+                "CBX_SSH_USER": config_string(config, "sshUser", ""),
+                "CBX_READY_CHECK": config_string(config, "readyCheck", DEFAULT_READY_CHECK),
+            }
+        )
+        if not env["CBX_WORK_ROOT"]:
+            env["CBX_WORK_ROOT"] = str(Path("~/crabbox-slurm-work").expanduser())
+
+        result = run(command, env=env)
+        raw_job_id = result.stdout.strip().splitlines()[-1].strip()
+        if not raw_job_id:
+            raise AdapterError("sbatch returned no job id")
+        job_id = raw_job_id.split(";", 1)[0]
+        state.update(
+            {
+                "jobId": job_id,
+                "rawJobId": raw_job_id,
+                "cloudId": f"slurm/job/{raw_job_id}",
+                "status": "pending",
+                "updatedAt": now(),
+            }
+        )
+        self.save_state(lease_id, state)
+
+        try:
+            return self.wait_for_endpoint(state, config, keep=bool(request.get("keep")))
+        except Exception:
+            if not request.get("keep"):
+                self.cancel_job(job_id)
+                self.remove_job_dir(lease_id)
+            raise
+
+    def resolve(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        state = self.find_state(request)
+        if not state:
+            raise AdapterError(f"could not resolve Slurm lease {request.get('id')!r}")
+        self.validate_expected(request, state)
+        if request.get("releaseOnly"):
+            return self.lease_from_state(state, config, require_endpoint=False)
+        return self.wait_for_endpoint(state, config, keep=True)
+
+    def list_leases(self, request: Dict[str, Any], config: Dict[str, Any]) -> List[Dict[str, Any]]:
+        include_all = bool(request.get("all"))
+        leases: List[Dict[str, Any]] = []
+        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
+            state = read_json(state_path)
+            refreshed = self.refresh_state(state)
+            if not include_all and str(refreshed.get("status") or "").lower() in {"released", "missing"}:
+                continue
+            if not include_all and scheduler_state(refreshed) in TERMINAL_STATES:
+                continue
+            leases.append(self.lease_from_state(refreshed, config, require_endpoint=False))
+        return leases
+
+    def release(self, request: Dict[str, Any], config: Dict[str, Any]) -> None:
+        state = self.find_state(request)
+        if not state:
+            return
+        self.validate_expected(request, state)
+        job_id = str(state.get("jobId") or "")
+        if job_id:
+            self.cancel_job(job_id)
+        self.remove_job_dir(str(state.get("leaseId")))
+
+    def touch(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        state = self.find_state(request)
+        if not state:
+            raise AdapterError("touch could not resolve lease")
+        state = self.refresh_state(state)
+        state["updatedAt"] = now()
+        self.save_state(str(state["leaseId"]), state)
+        return self.lease_from_state(state, config, require_endpoint=False)
+
+    def cleanup(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+        dry_run = bool(request.get("dryRun"))
+        removed: List[str] = []
+        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
+            state = self.refresh_state(read_json(state_path))
+            lease_id = str(state.get("leaseId") or state_path.parent.name)
+            if scheduler_state(state) in TERMINAL_STATES or str(state.get("status")) == "missing":
+                removed.append(lease_id)
+                if not dry_run:
+                    self.remove_job_dir(lease_id)
+        action = "would remove" if dry_run else "removed"
+        return {"protocolVersion": PROTOCOL_VERSION, "message": f"{action} {len(removed)} Slurm lease state directories"}
+
+    def wait_for_endpoint(self, state: Dict[str, Any], config: Dict[str, Any], keep: bool) -> Dict[str, Any]:
+        timeout = int(config.get("acquireTimeoutSeconds") or 1800)
+        deadline = time.time() + timeout
+        lease_id = str(state["leaseId"])
+        endpoint_path = Path(str(state["endpointPath"]))
+        while time.time() < deadline:
+            if endpoint_path.exists():
+                endpoint = read_json(endpoint_path)
+                state["endpoint"] = endpoint
+                state["status"] = "ready"
+                state["updatedAt"] = now()
+                self.save_state(lease_id, state)
+                return self.lease_from_state(state, config, require_endpoint=True)
+            state = self.refresh_state(state)
+            current = scheduler_state(state)
+            if current in TERMINAL_STATES:
+                raise AdapterError(f"Slurm job {state.get('jobId')} ended before publishing SSH endpoint: {current}")
+            time.sleep(self.poll_interval)
+        if not keep:
+            self.cancel_job(str(state.get("jobId") or ""))
+        raise AdapterError(f"timed out waiting for Slurm job {state.get('jobId')} to publish SSH endpoint")
+
+    def lease_from_state(self, state: Dict[str, Any], config: Dict[str, Any], require_endpoint: bool) -> Dict[str, Any]:
+        endpoint = state.get("endpoint")
+        endpoint_path = Path(str(state.get("endpointPath") or ""))
+        if endpoint is None and endpoint_path.exists():
+            endpoint = read_json(endpoint_path)
+            state["endpoint"] = endpoint
+        if require_endpoint and not isinstance(endpoint, dict):
+            raise AdapterError(f"Slurm lease {state.get('leaseId')} has no endpoint")
+        if not isinstance(endpoint, dict):
+            endpoint = {}
+
+        host = str(endpoint.get("host") or "")
+        port = str(endpoint.get("port") or "22")
+        user = str(endpoint.get("user") or config_string(config, "sshUser", "") or os.environ.get("USER") or "")
+        key = str(endpoint.get("key") or config_string(config, "sshPrivateKey", "") or state.get("keyPath") or "")
+        ready_check = str(endpoint.get("readyCheck") or config_string(config, "readyCheck", DEFAULT_READY_CHECK))
+        ssh: Dict[str, Any] = {}
+        if host and user:
+            ssh = {
+                "user": user,
+                "host": host,
+                "port": port,
+                "key": key,
+                "readyCheck": ready_check,
+            }
+            proxy = self.proxy_command(config, state, host, port, user, endpoint)
+            if proxy:
+                ssh["proxyCommand"] = proxy
+                ssh["sshConfigProxy"] = True
+
+        labels = {
+            "slug": str(state["slug"]),
+            "state": str(state.get("status") or "pending"),
+            "slurmJobId": str(state.get("rawJobId") or state.get("jobId") or ""),
+        }
+        return {
+            "leaseId": str(state["leaseId"]),
+            "slug": str(state["slug"]),
+            "name": str(state["name"]),
+            "cloudId": str(state.get("cloudId") or f"slurm/job/{state.get('rawJobId') or state.get('jobId')}"),
+            "status": str(state.get("status") or "pending"),
+            "serverType": self.server_type(state, config),
+            "labels": labels,
+            "ssh": ssh,
+        }
+
+    def proxy_command(
+        self,
+        config: Dict[str, Any],
+        state: Dict[str, Any],
+        host: str,
+        port: str,
+        user: str,
+        endpoint: Dict[str, Any],
+    ) -> str:
+        explicit = str(endpoint.get("proxyCommand") or config_string(config, "proxyCommand", ""))
+        login_host = str(endpoint.get("loginHost") or config_string(config, "loginHost", ""))
+        login_user = str(endpoint.get("loginUser") or config_string(config, "loginUser", ""))
+        if explicit:
+            return render_template(
+                explicit,
+                state,
+                host=host,
+                port=port,
+                user=user,
+                login_host=login_host,
+                login_user=login_user,
+            )
+        if config_string(config, "sshMode", "direct") == "proxy-through-login":
+            if not login_host:
+                raise AdapterError("sshMode=proxy-through-login requires loginHost")
+            login = f"{login_user}@{login_host}" if login_user else login_host
+            return f"ssh -W %h:%p {login}"
+        return ""
+
+    def sbatch_command(self, config: Dict[str, Any], name: str, job_dir: Path, runner: Path) -> List[str]:
+        command = ["sbatch", "--parsable", "--job-name", name, "--output", str(job_dir / "slurm-%j.out")]
+        mapping = [
+            ("account", "--account"),
+            ("partition", "--partition"),
+            ("qos", "--qos"),
+            ("cpus", "--cpus-per-task"),
+            ("mem", "--mem"),
+            ("timeLimit", "--time"),
+            ("gres", "--gres"),
+            ("nodes", "--nodes"),
+            ("constraint", "--constraint"),
+            ("reservation", "--reservation"),
+        ]
+        for key, flag in mapping:
+            value = config.get(key)
+            if value not in (None, ""):
+                command.extend([flag, str(value)])
+        extra = config.get("extraSbatchArgs") or []
+        if not isinstance(extra, list) or not all(isinstance(item, str) and item for item in extra):
+            raise AdapterError("extraSbatchArgs must be a string array")
+        command.extend(extra)
+        command.extend(["--export", "ALL,CBX_LEASE_ID,CBX_SLUG,CBX_NAME,CBX_STATE_DIR,CBX_WORK_ROOT,CBX_SSH_PUBLIC_KEY_FILE,CBX_SSH_USER,CBX_READY_CHECK"])
+        command.append(str(runner))
+        return command
+
+    def refresh_state(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        job_id = str(state.get("jobId") or "")
+        if not job_id:
+            return state
+        status = self.query_job_state(job_id)
+        if status:
+            state["schedulerState"] = status
+            if status in TERMINAL_STATES:
+                state["status"] = status.lower()
+            elif status == "RUNNING" and str(state.get("status")) != "ready":
+                state["status"] = "running"
+            elif status == "PENDING":
+                state["status"] = "pending"
+        else:
+            state["status"] = "missing"
+        state["updatedAt"] = now()
+        self.save_state(str(state["leaseId"]), state)
+        return state
+
+    def query_job_state(self, job_id: str) -> str:
+        result = subprocess.run(
+            ["squeue", "-h", "-j", job_id, "-o", "%T"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        for line in result.stdout.splitlines():
+            value = line.strip().upper()
+            if value:
+                return value
+        if shutil.which("sacct"):
+            result = subprocess.run(
+                ["sacct", "-n", "-j", job_id, "--format", "State", "--parsable2"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            for line in result.stdout.splitlines():
+                value = line.split("|", 1)[0].strip().split()[0].upper()
+                if value:
+                    return value
+        return ""
+
+    def cancel_job(self, job_id: str) -> None:
+        if not job_id:
+            return
+        result = subprocess.run(
+            ["scancel", job_id],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        status = self.query_job_state(job_id)
+        if status and status not in TERMINAL_STATES:
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+            raise AdapterError(f"scancel {job_id} failed while job is still {status}: {detail}")
+
+    def ensure_ssh_key(self, job_dir: Path, lease_id: str, config: Dict[str, Any]) -> Path:
+        configured = config_string(config, "sshPrivateKey", "")
+        if configured:
+            path = Path(configured).expanduser().resolve()
+            if not path.exists():
+                raise AdapterError(f"configured sshPrivateKey does not exist: {path}")
+            if not Path(str(path) + ".pub").exists():
+                raise AdapterError(f"configured sshPrivateKey public key does not exist: {path}.pub")
+            return path
+        key_path = job_dir / "id_ed25519"
+        if not key_path.exists():
+            run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key_path), "-C", f"crabbox-{lease_id}"])
+            key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        return key_path
+
+    def runner(self, config: Dict[str, Any]) -> Path:
+        configured = config_string(config, "runnerScript", "")
+        if configured:
+            return Path(configured).expanduser().resolve()
+        if self.runner_script:
+            return self.runner_script
+        return Path(__file__).with_name("runner-unprivileged-sshd.sh")
+
+    def find_state(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        lease = request.get("lease") or {}
+        identifiers = [
+            request.get("id"),
+            lease.get("leaseId") if isinstance(lease, dict) else None,
+            lease.get("slug") if isinstance(lease, dict) else None,
+            lease.get("name") if isinstance(lease, dict) else None,
+            lease.get("cloudId") if isinstance(lease, dict) else None,
+        ]
+        expected = request.get("expected") or {}
+        if isinstance(expected, dict):
+            identifiers.extend([expected.get("leaseId"), expected.get("attemptLeaseId"), expected.get("slug"), expected.get("cloudId")])
+        wanted = {str(value) for value in identifiers if value}
+        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
+            state = read_json(state_path)
+            values = {
+                str(state.get("leaseId") or ""),
+                str(state.get("slug") or ""),
+                str(state.get("name") or ""),
+                str(state.get("cloudId") or ""),
+                f"slurm/job/{state.get('rawJobId') or state.get('jobId')}",
+                str(state.get("jobId") or ""),
+                str(state.get("rawJobId") or ""),
+            }
+            if wanted & values:
+                return state
+        return None
+
+    def validate_expected(self, request: Dict[str, Any], state: Dict[str, Any]) -> None:
+        expected = request.get("expected") or {}
+        if not isinstance(expected, dict) or not expected:
+            return
+        checks = {
+            "leaseId": str(state.get("leaseId") or ""),
+            "attemptLeaseId": str(state.get("leaseId") or ""),
+            "slug": str(state.get("slug") or ""),
+            "cloudId": str(state.get("cloudId") or ""),
+        }
+        for key, actual in checks.items():
+            want = str(expected.get(key) or "")
+            if want and want != actual:
+                raise AdapterError(f"expected {key}={want} does not match Slurm lease {actual}")
+
+    def server_type(self, state: Dict[str, Any], config: Dict[str, Any]) -> str:
+        parts = ["slurm"]
+        for key in ("partition", "account", "qos", "cpus", "mem", "timeLimit", "gres"):
+            value = config.get(key)
+            if value not in (None, ""):
+                parts.append(f"{key}={value}")
+        scheduler = state.get("schedulerState")
+        if scheduler:
+            parts.append(f"state={scheduler}")
+        return " ".join(parts)
+
+    def ensure_private_dir(self, path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        try:
+            path.chmod(stat.S_IRWXU)
+        except OSError:
+            pass
+        jobs = self.state_dir / "jobs"
+        jobs.mkdir(parents=True, exist_ok=True)
+        try:
+            jobs.chmod(stat.S_IRWXU)
+        except OSError:
+            pass
+
+    def job_dir(self, lease_id: str) -> Path:
+        return self.state_dir / "jobs" / lease_id
+
+    def state_path(self, lease_id: str) -> Path:
+        return self.job_dir(lease_id) / "state.json"
+
+    def load_state(self, lease_id: str) -> Optional[Dict[str, Any]]:
+        path = self.state_path(lease_id)
+        if not path.exists():
+            return None
+        return read_json(path)
+
+    def save_state(self, lease_id: str, state: Dict[str, Any]) -> None:
+        job_dir = self.job_dir(lease_id)
+        self.ensure_private_dir(job_dir)
+        path = self.state_path(lease_id)
+        tmp = path.with_suffix(".json.tmp")
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp, path)
+
+    def remove_job_dir(self, lease_id: str) -> None:
+        job_dir = self.job_dir(lease_id)
+        if job_dir.exists():
+            shutil.rmtree(job_dir)
+
+
+def run(command: List[str], env: Optional[Dict[str, str]] = None) -> subprocess.CompletedProcess:
+    result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, check=False)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        detail = stderr or stdout or f"exit {result.returncode}"
+        raise AdapterError(f"command failed: {' '.join(command)}: {detail}")
+    return result
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise AdapterError(f"expected JSON object in {path}")
+    return value
+
+
+def required_string(data: Dict[str, Any], key: str) -> str:
+    value = str(data.get(key) or "").strip()
+    if not value:
+        raise AdapterError(f"missing required desired.{key}")
+    return value
+
+
+def config_string(config: Dict[str, Any], key: str, default: str) -> str:
+    value = config.get(key)
+    if value in (None, ""):
+        return default
+    return str(value)
+
+
+def scheduler_state(state: Dict[str, Any]) -> str:
+    return str(state.get("schedulerState") or "").upper()
+
+
+def public_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    redacted: Dict[str, Any] = {}
+    for key, value in config.items():
+        lower = key.lower()
+        if "token" in lower or "secret" in lower or "password" in lower:
+            redacted[key] = "<redacted>"
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def render_template(
+    template: str,
+    state: Dict[str, Any],
+    *,
+    host: str,
+    port: str,
+    user: str,
+    login_host: str,
+    login_user: str,
+) -> str:
+    values = {
+        "host": host,
+        "port": port,
+        "user": user,
+        "loginHost": login_host,
+        "loginUser": login_user,
+        "leaseId": str(state.get("leaseId") or ""),
+        "slug": str(state.get("slug") or ""),
+        "name": str(state.get("name") or ""),
+        "jobId": str(state.get("rawJobId") or state.get("jobId") or ""),
+    }
+    result = template
+    for key, value in values.items():
+        result = result.replace("{" + key + "}", value)
+    return result
+
+
+def now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/slurm-external-provider/slurm-cbx.py
+++ b/examples/slurm-external-provider/slurm-cbx.py
@@ -44,11 +44,32 @@ class AdapterError(Exception):
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Crabbox external provider for Slurm")
-    parser.add_argument("--state-dir", default="~/.crabbox/slurm")
-    parser.add_argument("--runner-script", default="")
-    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser = argparse.ArgumentParser(
+        description="Crabbox external provider for Slurm. Reads a protocol "
+        "request as JSON on stdin and writes a protocol response as JSON on "
+        "stdout.",
+    )
+    parser.add_argument(
+        "--state-dir",
+        default="~/.crabbox/slurm",
+        help="Private directory for per-lease job state, keys, and endpoints "
+        "(must be visible to both submit host and compute job).",
+    )
+    parser.add_argument(
+        "--runner-script",
+        default="",
+        help="Default batch runner script used when external.config.runnerScript "
+        "is not set; defaults to the bundled runner-unprivileged-sshd.sh.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="Seconds between squeue/sacct polls while waiting for an endpoint.",
+    )
     args = parser.parse_args()
+    if args.poll_interval < 0:
+        parser.error("--poll-interval must not be negative")
 
     try:
         request = json.load(sys.stdin)
@@ -163,10 +184,16 @@ class SlurmCrabboxAdapter:
             env["CBX_WORK_ROOT"] = str(Path("~/crabbox-slurm-work").expanduser())
 
         result = run(command, env=env)
-        raw_job_id = result.stdout.strip().splitlines()[-1].strip()
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        raw_job_id = lines[-1] if lines else ""
         if not raw_job_id:
             raise AdapterError("sbatch returned no job id")
-        job_id = raw_job_id.split(";", 1)[0]
+        # ``sbatch --parsable`` prints "<jobid>" or "<jobid>;<cluster>". Keep the
+        # bare numeric job id for squeue/sacct/scancel but persist the raw value
+        # for display and cloud-id purposes.
+        job_id = raw_job_id.split(";", 1)[0].strip()
+        if not job_id:
+            raise AdapterError(f"sbatch returned an unparsable job id: {raw_job_id!r}")
         state.update(
             {
                 "jobId": job_id,
@@ -195,11 +222,27 @@ class SlurmCrabboxAdapter:
             return self.lease_from_state(state, config, require_endpoint=False)
         return self.wait_for_endpoint(state, config, keep=True)
 
+    def iter_states(self):
+        """Yield persisted lease states, skipping unreadable/corrupt files.
+
+        ``list`` and ``cleanup`` must not abort because a single state.json was
+        truncated by a crash mid-write or left behind by an older adapter.
+        """
+        jobs = self.state_dir / "jobs"
+        for state_path in sorted(jobs.glob("*/state.json")):
+            try:
+                state = read_json(state_path)
+            except (AdapterError, OSError, json.JSONDecodeError):
+                print(f"skipping unreadable Slurm state file: {state_path}", file=sys.stderr)
+                continue
+            if not state.get("leaseId"):
+                state["leaseId"] = state_path.parent.name
+            yield state
+
     def list_leases(self, request: Dict[str, Any], config: Dict[str, Any]) -> List[Dict[str, Any]]:
         include_all = bool(request.get("all"))
         leases: List[Dict[str, Any]] = []
-        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
-            state = read_json(state_path)
+        for state in self.iter_states():
             refreshed = self.refresh_state(state)
             if not include_all and str(refreshed.get("status") or "").lower() in {"released", "missing"}:
                 continue
@@ -230,9 +273,11 @@ class SlurmCrabboxAdapter:
     def cleanup(self, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
         dry_run = bool(request.get("dryRun"))
         removed: List[str] = []
-        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
-            state = self.refresh_state(read_json(state_path))
-            lease_id = str(state.get("leaseId") or state_path.parent.name)
+        for state in self.iter_states():
+            state = self.refresh_state(state)
+            lease_id = str(state.get("leaseId") or "")
+            if not lease_id:
+                continue
             if scheduler_state(state) in TERMINAL_STATES or str(state.get("status")) == "missing":
                 removed.append(lease_id)
                 if not dry_run:
@@ -292,11 +337,18 @@ class SlurmCrabboxAdapter:
                 ssh["proxyCommand"] = proxy
                 ssh["sshConfigProxy"] = True
 
+        # ``slug``, ``name``, ``lease``, ``externalResourceName`` and
+        # ``externalResourceNameFromEnv`` are reserved routing labels in the
+        # Crabbox external-provider protocol. Returning any of them makes the
+        # broker reject the lease (most visibly when ``idempotentLeaseId`` is
+        # enabled), so the adapter must keep its own labels namespaced.
         labels = {
-            "slug": str(state["slug"]),
             "state": str(state.get("status") or "pending"),
             "slurmJobId": str(state.get("rawJobId") or state.get("jobId") or ""),
         }
+        scheduler = state.get("schedulerState")
+        if scheduler:
+            labels["slurmState"] = str(scheduler)
         return {
             "leaseId": str(state["leaseId"]),
             "slug": str(state["slug"]),
@@ -403,9 +455,13 @@ class SlurmCrabboxAdapter:
                 check=False,
             )
             for line in result.stdout.splitlines():
-                value = line.split("|", 1)[0].strip().split()[0].upper()
-                if value:
-                    return value
+                # ``State`` can be e.g. "CANCELLED by 1000"; keep only the leading
+                # token. Empty lines (sacct sometimes prints blank step rows) are
+                # skipped without indexing into an empty split.
+                field = line.split("|", 1)[0].strip()
+                tokens = field.split()
+                if tokens:
+                    return tokens[0].upper()
         return ""
 
     def cancel_job(self, job_id: str) -> None:
@@ -461,8 +517,9 @@ class SlurmCrabboxAdapter:
         if isinstance(expected, dict):
             identifiers.extend([expected.get("leaseId"), expected.get("attemptLeaseId"), expected.get("slug"), expected.get("cloudId")])
         wanted = {str(value) for value in identifiers if value}
-        for state_path in sorted((self.state_dir / "jobs").glob("*/state.json")):
-            state = read_json(state_path)
+        if not wanted:
+            return None
+        for state in self.iter_states():
             values = {
                 str(state.get("leaseId") or ""),
                 str(state.get("slug") or ""),

--- a/examples/slurm-external-provider/slurm-cbx.py
+++ b/examples/slurm-external-provider/slurm-cbx.py
@@ -140,18 +140,20 @@ class SlurmCrabboxAdapter:
         slug = required_string(desired, "slug")
         name = required_string(desired, "name")
         job_dir = self.job_dir(lease_id)
-        self.ensure_private_dir(job_dir)
 
         existing = self.load_state(lease_id)
         if existing and existing.get("jobId"):
             return self.wait_for_endpoint(existing, config, keep=bool(request.get("keep")))
 
-        key_path = self.ensure_ssh_key(job_dir, lease_id, config)
-        public_key_path = Path(str(key_path) + ".pub")
-        endpoint_path = job_dir / "endpoint.json"
         runner = self.runner(config)
         if not runner.exists():
             raise AdapterError(f"runner script does not exist: {runner}")
+        command = self.sbatch_command(config, name, job_dir, runner)
+
+        self.ensure_private_dir(job_dir)
+        key_path = self.ensure_ssh_key(job_dir, lease_id, config)
+        public_key_path = Path(str(key_path) + ".pub")
+        endpoint_path = job_dir / "endpoint.json"
 
         state = {
             "leaseId": lease_id,
@@ -168,7 +170,6 @@ class SlurmCrabboxAdapter:
         }
         self.save_state(lease_id, state)
 
-        command = self.sbatch_command(config, name, job_dir, runner)
         env = os.environ.copy()
         env.update(
             {

--- a/examples/slurm-external-provider/test_slurm_cbx.py
+++ b/examples/slurm-external-provider/test_slurm_cbx.py
@@ -80,6 +80,7 @@ class FakeSlurm:
         self.sacct_returncode = 0
         self.sacct_available = True
         self.scancel_returncode = 0
+        self.sbatch_error = ""
         self.cancelled: List[str] = []
         self._module = module
         monkeypatch.setattr(module, "run", self._run)
@@ -91,6 +92,8 @@ class FakeSlurm:
         self.calls.append(list(command))
         prog = command[0]
         if prog == "sbatch":
+            if self.sbatch_error:
+                raise self._module.AdapterError(self.sbatch_error)
             return types.SimpleNamespace(stdout=f"{self.job_id};cluster\n", stderr="", returncode=0)
         if prog == "ssh-keygen":
             # Emulate ssh-keygen by writing private + public key files.
@@ -277,6 +280,33 @@ def test_acquire_cancels_when_endpoint_never_appears(
     # Rollback cancelled the job and removed the state directory.
     assert fake_slurm.cancelled == ["123456"]
     assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_acquire_removes_state_when_sbatch_rejects_before_job_id(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    fake_slurm.sbatch_error = "sbatch: invalid partition"
+
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(acquire_request())
+
+    assert "invalid partition" in str(excinfo.value)
+    assert fake_slurm.cancelled == []
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_acquire_keeps_state_when_sbatch_rejects_and_keep_set(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    fake_slurm.sbatch_error = "sbatch: account rejected"
+
+    with pytest.raises(slurm_cbx.AdapterError):
+        adapter.handle(acquire_request(keep=True))
+
+    state = adapter.load_state(LEASE_ID)
+    assert state is not None
+    assert "jobId" not in state
+    assert adapter.job_dir(LEASE_ID).exists()
 
 
 def test_acquire_keeps_job_on_failure_when_keep_set(

--- a/examples/slurm-external-provider/test_slurm_cbx.py
+++ b/examples/slurm-external-provider/test_slurm_cbx.py
@@ -1,0 +1,451 @@
+"""Tests for the reference Slurm external-provider adapter.
+
+These tests exercise the adapter without a real Slurm cluster by faking the
+``sbatch``/``squeue``/``sacct``/``scancel``/``ssh-keygen`` subprocess calls and by
+substituting the per-job endpoint publication that the batch runner would
+normally perform inside an allocation.
+
+Run with::
+
+    python3 -m pytest examples/slurm-external-provider/ -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+MODULE_PATH = Path(__file__).with_name("slurm-cbx.py")
+
+
+def _load_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("slurm_cbx", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+slurm_cbx = _load_module()
+
+
+# A canonical Crabbox lease id and the broker-generated identity that the
+# external-provider protocol sends in ``desired``.
+LEASE_ID = "cbx_0123456789ab"
+SLUG = "slurm-smoke"
+NAME = "crabbox-slurm-smoke-0a1b2c3d"
+
+
+def make_args(state_dir: Path, runner: Path) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        state_dir=str(state_dir),
+        runner_script=str(runner),
+        poll_interval=0.0,
+    )
+
+
+@pytest.fixture()
+def runner_script(tmp_path: Path) -> Path:
+    runner = tmp_path / "runner.sh"
+    runner.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    runner.chmod(0o755)
+    return runner
+
+
+@pytest.fixture()
+def adapter(tmp_path: Path, runner_script: Path) -> slurm_cbx.SlurmCrabboxAdapter:
+    state_dir = tmp_path / "state"
+    return slurm_cbx.SlurmCrabboxAdapter(make_args(state_dir, runner_script))
+
+
+class FakeSlurm:
+    """Records subprocess invocations and drives job-state transitions.
+
+    The fake stands in for both the module-level ``run`` helper (used for
+    sbatch/ssh-keygen, which must succeed or raise) and ``subprocess.run`` (used
+    for squeue/sacct/scancel, which are tolerant of non-zero exits).
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, module: types.ModuleType) -> None:
+        self.calls: List[List[str]] = []
+        self.job_id = "123456"
+        self.squeue_states: List[str] = ["PENDING", "RUNNING"]
+        self.sacct_state = "COMPLETED"
+        self.scancel_returncode = 0
+        self.cancelled: List[str] = []
+        self._module = module
+        monkeypatch.setattr(module, "run", self._run)
+        monkeypatch.setattr(module.subprocess, "run", self._subprocess_run)
+        monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    # ``run`` raises on failure, matching the real helper.
+    def _run(self, command: List[str], env: Dict[str, str] | None = None):
+        self.calls.append(list(command))
+        prog = command[0]
+        if prog == "sbatch":
+            return types.SimpleNamespace(stdout=f"{self.job_id};cluster\n", stderr="", returncode=0)
+        if prog == "ssh-keygen":
+            # Emulate ssh-keygen by writing private + public key files.
+            out_index = command.index("-f") + 1
+            key_path = Path(command[out_index])
+            key_path.write_text("PRIVATE KEY\n", encoding="utf-8")
+            Path(str(key_path) + ".pub").write_text("ssh-ed25519 AAAA crabbox\n", encoding="utf-8")
+            return types.SimpleNamespace(stdout="", stderr="", returncode=0)
+        raise AssertionError(f"unexpected run() command: {command}")
+
+    def _subprocess_run(self, command: List[str], **_: Any):
+        self.calls.append(list(command))
+        prog = command[0]
+        if prog == "squeue":
+            state = self.squeue_states.pop(0) if self.squeue_states else ""
+            return types.SimpleNamespace(stdout=(state + "\n") if state else "", stderr="", returncode=0)
+        if prog == "sacct":
+            return types.SimpleNamespace(stdout=f"{self.sacct_state}\n", stderr="", returncode=0)
+        if prog == "scancel":
+            self.cancelled.append(command[-1])
+            return types.SimpleNamespace(stdout="", stderr="", returncode=self.scancel_returncode)
+        raise AssertionError(f"unexpected subprocess.run command: {command}")
+
+    def names(self) -> List[str]:
+        return [call[0] for call in self.calls]
+
+
+@pytest.fixture()
+def fake_slurm(monkeypatch: pytest.MonkeyPatch) -> FakeSlurm:
+    return FakeSlurm(monkeypatch, slurm_cbx)
+
+
+def _publish_endpoint(adapter: slurm_cbx.SlurmCrabboxAdapter, lease_id: str) -> None:
+    """Simulate the batch runner writing endpoint.json inside the allocation."""
+    endpoint_path = adapter.job_dir(lease_id) / "endpoint.json"
+    endpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    endpoint_path.write_text(
+        json.dumps(
+            {
+                "host": "node123.cluster.example.edu",
+                "port": "39022",
+                "user": "alice",
+                "readyCheck": "command -v bash",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def acquire_request(**overrides: Any) -> Dict[str, Any]:
+    request = {
+        "operation": "acquire",
+        "desired": {"leaseId": LEASE_ID, "slug": SLUG, "name": NAME},
+        "config": {},
+    }
+    request.update(overrides)
+    return request
+
+
+def test_doctor_reports_ready(adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm) -> None:
+    response = adapter.handle({"operation": "doctor", "config": {}})
+    assert response["protocolVersion"] == slurm_cbx.PROTOCOL_VERSION
+    assert "ready" in response["message"]
+    # doctor must not submit a job.
+    assert "sbatch" not in fake_slurm.names()
+
+
+def test_doctor_missing_commands(adapter: slurm_cbx.SlurmCrabboxAdapter, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slurm_cbx.shutil, "which", lambda name: None)
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle({"operation": "doctor", "config": {}})
+    assert "missing Slurm command" in str(excinfo.value)
+
+
+def test_acquire_resolve_release_happy_path(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    # The runner publishes the endpoint immediately for the test.
+    _publish_endpoint(adapter, LEASE_ID)
+
+    response = adapter.handle(acquire_request())
+    lease = response["lease"]
+
+    assert response["protocolVersion"] == slurm_cbx.PROTOCOL_VERSION
+    assert lease["leaseId"] == LEASE_ID
+    assert lease["slug"] == SLUG
+    assert lease["name"] == NAME
+    assert lease["cloudId"] == "slurm/job/123456;cluster"
+    assert lease["status"] == "ready"
+    ssh = lease["ssh"]
+    assert ssh["host"] == "node123.cluster.example.edu"
+    assert ssh["port"] == "39022"
+    assert ssh["user"] == "alice"
+    # The generated per-job private key path is returned, never key contents.
+    assert ssh["key"].endswith("id_ed25519")
+    assert "PRIVATE" not in ssh["key"]
+
+    # Reserved routing labels must not leak into the lease labels.
+    for reserved in ("slug", "name", "lease", "externalResourceName", "externalResourceNameFromEnv"):
+        assert reserved not in lease["labels"]
+    assert lease["labels"]["slurmJobId"] == "123456;cluster"
+    assert "sbatch" in fake_slurm.names()
+
+    # resolve returns the same lease without resubmitting.
+    fake_slurm.squeue_states = ["RUNNING"]
+    resolve = adapter.handle(
+        {
+            "operation": "resolve",
+            "id": LEASE_ID,
+            "expected": {"leaseId": LEASE_ID, "slug": SLUG},
+            "config": {},
+        }
+    )
+    assert resolve["lease"]["leaseId"] == LEASE_ID
+    assert resolve["lease"]["ssh"]["host"] == "node123.cluster.example.edu"
+
+    # release cancels the persisted job and removes the job directory.
+    release = adapter.handle(
+        {
+            "operation": "release",
+            "id": LEASE_ID,
+            "expected": {"leaseId": LEASE_ID, "slug": SLUG},
+            "config": {},
+        }
+    )
+    assert release["message"] == "released Slurm lease"
+    assert fake_slurm.cancelled == ["123456"]
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_acquire_is_idempotent(adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    first = adapter.handle(acquire_request())
+    submissions = fake_slurm.names().count("sbatch")
+    assert submissions == 1
+
+    fake_slurm.squeue_states = ["RUNNING"]
+    second = adapter.handle(acquire_request())
+    # A second acquire with the same lease id must not submit another job.
+    assert fake_slurm.names().count("sbatch") == 1
+    assert second["lease"]["cloudId"] == first["lease"]["cloudId"]
+
+
+def test_lease_id_parsing_handles_parsable_cluster_suffix(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    fake_slurm.job_id = "987654"
+    _publish_endpoint(adapter, LEASE_ID)
+    response = adapter.handle(acquire_request())
+    state = adapter.load_state(LEASE_ID)
+    assert state is not None
+    # Numeric job id used for squeue/scancel; raw id retained for display.
+    assert state["jobId"] == "987654"
+    assert state["rawJobId"] == "987654;cluster"
+    assert response["lease"]["labels"]["slurmJobId"] == "987654;cluster"
+
+
+def test_acquire_cancels_when_endpoint_never_appears(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    # No endpoint is published, and the scheduler reports a terminal state.
+    fake_slurm.squeue_states = ["PENDING", "FAILED"]
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(acquire_request(config={"acquireTimeoutSeconds": 60}))
+    assert "ended before publishing SSH endpoint" in str(excinfo.value)
+    # Rollback cancelled the job and removed the state directory.
+    assert fake_slurm.cancelled == ["123456"]
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_acquire_keeps_job_on_failure_when_keep_set(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    fake_slurm.squeue_states = ["FAILED"]
+    with pytest.raises(slurm_cbx.AdapterError):
+        adapter.handle(acquire_request(keep=True, config={"acquireTimeoutSeconds": 60}))
+    # keep=True must not cancel or delete the state on failure.
+    assert fake_slurm.cancelled == []
+    assert adapter.job_dir(LEASE_ID).exists()
+
+
+def test_list_filters_terminal_and_omits_reserved_labels(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    # Active job: squeue reports RUNNING -> stays in the default list.
+    fake_slurm.squeue_states = ["RUNNING"]
+    leases = adapter.handle({"operation": "list", "config": {}})["leases"]
+    assert len(leases) == 1
+    lease = leases[0]
+    assert lease["leaseId"] == LEASE_ID
+    for reserved in ("slug", "name", "lease", "externalResourceName", "externalResourceNameFromEnv"):
+        assert reserved not in lease["labels"]
+
+    # Terminal job: squeue empty, sacct COMPLETED -> filtered unless all=True.
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_state = "COMPLETED"
+    default_list = adapter.handle({"operation": "list", "config": {}})["leases"]
+    assert default_list == []
+
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_state = "COMPLETED"
+    all_list = adapter.handle({"operation": "list", "all": True, "config": {}})["leases"]
+    assert len(all_list) == 1
+
+
+def test_cleanup_removes_terminal_state(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_state = "COMPLETED"
+    dry = adapter.handle({"operation": "cleanup", "dryRun": True, "config": {}})
+    assert "would remove 1" in dry["message"]
+    assert adapter.job_dir(LEASE_ID).exists()
+
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_state = "COMPLETED"
+    wet = adapter.handle({"operation": "cleanup", "config": {}})
+    assert "removed 1" in wet["message"]
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_list_skips_corrupt_state_file(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    # A second job dir with a truncated state.json must not break list/cleanup.
+    bad_dir = adapter.state_dir / "jobs" / "cbx_badbadbadba"
+    bad_dir.mkdir(parents=True, exist_ok=True)
+    (bad_dir / "state.json").write_text("{not json", encoding="utf-8")
+
+    fake_slurm.squeue_states = ["RUNNING"]
+    leases = adapter.handle({"operation": "list", "config": {}})["leases"]
+    assert [lease["leaseId"] for lease in leases] == [LEASE_ID]
+
+
+def test_release_unknown_lease_is_noop(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    response = adapter.handle({"operation": "release", "id": "cbx_ffffffffffff", "config": {}})
+    assert response["message"] == "released Slurm lease"
+    assert fake_slurm.cancelled == []
+
+
+def test_validate_expected_mismatch_rejected(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(
+            {
+                "operation": "resolve",
+                "id": LEASE_ID,
+                "expected": {"leaseId": LEASE_ID, "slug": "different-slug"},
+                "config": {},
+            }
+        )
+    assert "does not match" in str(excinfo.value)
+
+
+def test_proxy_through_login(adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    config = {"sshMode": "proxy-through-login", "loginHost": "login.cluster.example.edu"}
+    response = adapter.handle(acquire_request(config=config))
+    ssh = response["lease"]["ssh"]
+    assert ssh["proxyCommand"] == "ssh -W %h:%p login.cluster.example.edu"
+    assert ssh["sshConfigProxy"] is True
+
+
+def test_proxy_through_login_requires_login_host(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(acquire_request(config={"sshMode": "proxy-through-login"}))
+    assert "requires loginHost" in str(excinfo.value)
+
+
+def test_sbatch_command_builds_resource_flags(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, runner_script: Path
+) -> None:
+    config = {
+        "account": "lab",
+        "partition": "batch",
+        "cpus": 16,
+        "mem": "64G",
+        "timeLimit": "02:00:00",
+        "gres": "gpu:1",
+        "extraSbatchArgs": ["--exclusive"],
+    }
+    job_dir = adapter.job_dir(LEASE_ID)
+    command = adapter.sbatch_command(config, NAME, job_dir, runner_script)
+    assert command[0] == "sbatch"
+    assert "--parsable" in command
+    assert command[command.index("--account") + 1] == "lab"
+    assert command[command.index("--cpus-per-task") + 1] == "16"
+    assert command[command.index("--gres") + 1] == "gpu:1"
+    assert "--exclusive" in command
+    assert command[-1] == str(runner_script)
+
+
+def test_sbatch_rejects_non_string_extra_args(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, runner_script: Path
+) -> None:
+    job_dir = adapter.job_dir(LEASE_ID)
+    with pytest.raises(slurm_cbx.AdapterError):
+        adapter.sbatch_command({"extraSbatchArgs": [123]}, NAME, job_dir, runner_script)
+
+
+def test_query_job_state_parses_sacct_qualifier(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # squeue empty, sacct reports "CANCELLED by 1000" -> first token only.
+    def fake_run(command, **_):
+        if command[0] == "squeue":
+            return types.SimpleNamespace(stdout="\n", stderr="", returncode=0)
+        return types.SimpleNamespace(stdout="CANCELLED by 1000\n\n", stderr="", returncode=0)
+
+    monkeypatch.setattr(slurm_cbx.subprocess, "run", fake_run)
+    monkeypatch.setattr(slurm_cbx.shutil, "which", lambda name: f"/usr/bin/{name}")
+    assert adapter.query_job_state("123456") == "CANCELLED"
+
+
+def test_public_config_redacts_secrets() -> None:
+    redacted = slurm_cbx.public_config({"account": "lab", "apiToken": "shh", "myPassword": "pw"})
+    assert redacted["account"] == "lab"
+    assert redacted["apiToken"] == "<redacted>"
+    assert redacted["myPassword"] == "<redacted>"
+
+
+def test_main_doctor_via_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, runner_script: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import io
+    import sys
+
+    monkeypatch.setattr(slurm_cbx.shutil, "which", lambda name: f"/usr/bin/{name}")
+    state_dir = tmp_path / "state"
+    argv = [
+        "slurm-cbx.py",
+        "--state-dir",
+        str(state_dir),
+        "--runner-script",
+        str(runner_script),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({"operation": "doctor", "config": {}})))
+    exit_code = slurm_cbx.main()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["protocolVersion"] == slurm_cbx.PROTOCOL_VERSION
+    assert "ready" in payload["message"]

--- a/examples/slurm-external-provider/test_slurm_cbx.py
+++ b/examples/slurm-external-provider/test_slurm_cbx.py
@@ -75,13 +75,16 @@ class FakeSlurm:
         self.calls: List[List[str]] = []
         self.job_id = "123456"
         self.squeue_states: List[str] = ["PENDING", "RUNNING"]
+        self.squeue_returncode = 0
         self.sacct_state = "COMPLETED"
+        self.sacct_returncode = 0
+        self.sacct_available = True
         self.scancel_returncode = 0
         self.cancelled: List[str] = []
         self._module = module
         monkeypatch.setattr(module, "run", self._run)
         monkeypatch.setattr(module.subprocess, "run", self._subprocess_run)
-        monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(module.shutil, "which", self._which)
 
     # ``run`` raises on failure, matching the real helper.
     def _run(self, command: List[str], env: Dict[str, str] | None = None):
@@ -102,9 +105,13 @@ class FakeSlurm:
         self.calls.append(list(command))
         prog = command[0]
         if prog == "squeue":
+            if self.squeue_returncode != 0:
+                return types.SimpleNamespace(stdout="", stderr="squeue unavailable", returncode=self.squeue_returncode)
             state = self.squeue_states.pop(0) if self.squeue_states else ""
             return types.SimpleNamespace(stdout=(state + "\n") if state else "", stderr="", returncode=0)
         if prog == "sacct":
+            if self.sacct_returncode != 0:
+                return types.SimpleNamespace(stdout="", stderr="sacct unavailable", returncode=self.sacct_returncode)
             return types.SimpleNamespace(stdout=f"{self.sacct_state}\n", stderr="", returncode=0)
         if prog == "scancel":
             self.cancelled.append(command[-1])
@@ -113,6 +120,11 @@ class FakeSlurm:
 
     def names(self) -> List[str]:
         return [call[0] for call in self.calls]
+
+    def _which(self, name: str) -> str | None:
+        if name == "sacct" and not self.sacct_available:
+            return None
+        return f"/usr/bin/{name}"
 
 
 @pytest.fixture()
@@ -160,6 +172,15 @@ def test_doctor_missing_commands(adapter: slurm_cbx.SlurmCrabboxAdapter, monkeyp
     with pytest.raises(slurm_cbx.AdapterError) as excinfo:
         adapter.handle({"operation": "doctor", "config": {}})
     assert "missing Slurm command" in str(excinfo.value)
+
+
+def test_doctor_validates_proxy_config_before_submit(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle({"operation": "doctor", "config": {"sshMode": "proxy-through-login"}})
+    assert "requires loginHost" in str(excinfo.value)
+    assert "sbatch" not in fake_slurm.names()
 
 
 def test_acquire_resolve_release_happy_path(
@@ -313,6 +334,55 @@ def test_cleanup_removes_terminal_state(
     wet = adapter.handle({"operation": "cleanup", "config": {}})
     assert "removed 1" in wet["message"]
     assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_refresh_state_preserves_unknown_scheduler_state(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_returncode = 1
+    state = adapter.refresh_state(adapter.load_state(LEASE_ID))
+
+    assert state["status"] == "unknown"
+    assert "schedulerStateUnknownAt" in state
+    assert adapter.job_dir(LEASE_ID).exists()
+
+    cleanup = adapter.handle({"operation": "cleanup", "config": {}})
+    assert "removed 0" in cleanup["message"]
+    assert adapter.job_dir(LEASE_ID).exists()
+
+
+def test_release_keeps_state_after_ambiguous_scancel_failure(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    fake_slurm.scancel_returncode = 1
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_returncode = 1
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle({"operation": "release", "id": LEASE_ID, "config": {}})
+
+    assert "scheduler state is unknown" in str(excinfo.value)
+    assert adapter.job_dir(LEASE_ID).exists()
+
+
+def test_release_removes_state_when_scancel_fails_but_absence_is_proven(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    _publish_endpoint(adapter, LEASE_ID)
+    adapter.handle(acquire_request())
+
+    fake_slurm.scancel_returncode = 1
+    fake_slurm.squeue_states = []
+    fake_slurm.sacct_state = ""
+    adapter.handle({"operation": "release", "id": LEASE_ID, "config": {}})
+
+    assert adapter.job_dir(LEASE_ID).exists() is False
 
 
 def test_list_skips_corrupt_state_file(

--- a/examples/slurm-external-provider/test_slurm_cbx.py
+++ b/examples/slurm-external-provider/test_slurm_cbx.py
@@ -295,6 +295,30 @@ def test_acquire_removes_state_when_sbatch_rejects_before_job_id(
     assert not adapter.job_dir(LEASE_ID).exists()
 
 
+def test_acquire_missing_runner_leaves_no_state(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm, tmp_path: Path
+) -> None:
+    missing_runner = tmp_path / "missing-runner.sh"
+
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(acquire_request(config={"runnerScript": str(missing_runner)}))
+
+    assert "runner script does not exist" in str(excinfo.value)
+    assert "sbatch" not in fake_slurm.names()
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
+def test_acquire_invalid_sbatch_args_leave_no_state(
+    adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
+) -> None:
+    with pytest.raises(slurm_cbx.AdapterError) as excinfo:
+        adapter.handle(acquire_request(config={"extraSbatchArgs": [123]}))
+
+    assert "extraSbatchArgs must be a string array" in str(excinfo.value)
+    assert "sbatch" not in fake_slurm.names()
+    assert not adapter.job_dir(LEASE_ID).exists()
+
+
 def test_acquire_keeps_state_when_sbatch_rejects_and_keep_set(
     adapter: slurm_cbx.SlurmCrabboxAdapter, fake_slurm: FakeSlurm
 ) -> None:


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/325

## Summary

Adds a campus Slurm external-provider reference path without putting cluster-specific scheduler, account, filesystem, gateway, or security policy in Crabbox core.

- Documents the recommended Slurm shape as `provider: external`.
- Adds `examples/slurm-external-provider/slurm-cbx.py`, a conservative adapter for `doctor`, `acquire`, `resolve`, `list`, `release`, `touch`, and `cleanup`.
- Adds `runner-unprivileged-sshd.sh` as a sample allocation-side SSH endpoint publisher.
- Adds fake-Slurm pytest coverage for acquire/resolve/release, idempotency, timeout rollback, pre-submit validation failures, immediate `sbatch` rejection rollback, unknown scheduler state, failed cancellation, list filtering, and cleanup.
- Fixes immediate `sbatch` submission failures so non-keep acquires remove the per-lease local state/key directory before any job ID exists.
- Moves runner and `sbatch_command` validation before any per-lease state directory/key side effects.

## Verification

Local validation on current head `4b5d513a5cdd5281c98deb6913769cfac363c88a`:

```text
python3 -m py_compile examples/slurm-external-provider/slurm-cbx.py examples/slurm-external-provider/test_slurm_cbx.py
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest examples/slurm-external-provider -q
node scripts/check-command-docs.mjs
node scripts/check-docs-links.mjs
bash -n examples/slurm-external-provider/runner-unprivileged-sshd.sh
git diff --check
```

Result: 27 fake-Slurm pytest tests passed.

Public CI is green on current head: https://github.com/openclaw/crabbox/actions/runs/28102200108

## Representative Protocol Proof

Representative external-provider proof was rerun on current head `4b5d513a5cdd5281c98deb6913769cfac363c88a` against the actual adapter with fake `sbatch`/`squeue`/`sacct`/`scancel` binaries on PATH, no real campus credentials required:

```text
PATH=<fake-slurm-bin>:$PATH \
  examples/slurm-external-provider/slurm-cbx.py \
  --state-dir <tmp>/state \
  --runner-script <tmp>/runner.sh \
  --poll-interval 0
```

Proof summary:

```text
doctor -> protocolVersion=1, Slurm external provider ready
acquire -> lease cbx_slurmproof01, cloudId slurm/job/123456;cluster, status ready, SSH host node123.cluster.example.edu:39022
list -> one ready lease with slurmState RUNNING
release -> released Slurm lease, fake scheduler called scancel 123456
list after release -> []
```

Full redacted output is posted here: https://github.com/openclaw/crabbox/pull/345#issuecomment-4789938479

## Merge Caveat

This is representative proof, not live campus Slurm proof. Do not merge unless maintainers accept representative proof as sufficient for this P3 external-adapter docs/example contract; live campus proof remains stronger.
