### PR TITLE
docs: add Station profiles security roadmap

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -84,6 +84,7 @@ Provider deep-dives that live here in `features/`:
 
 - [Sync](sync.md): Git file-list manifests, rsync, fingerprints, excludes, guardrails, and sanity checks.
 - [Jobs](jobs.md): named repo-local warmup, hydrate, run, and cleanup workflows.
+- [Station profiles](station-profiles.md): planned supervised workload records, agent profile, and model-access security gates.
 - [Actions hydration](actions-hydration.md): let GitHub Actions prepare a runner, then sync local work into that workspace.
 - [Capsules](capsules.md): local-first replay manifests for GitHub Actions failures.
 - [Checkpoints](checkpoints.md): save, restore, and fork reusable remote workspaces.

--- a/docs/features/station-profiles.md
+++ b/docs/features/station-profiles.md
@@ -1,9 +1,16 @@
 # Station Profiles Roadmap
 
-Station profiles are a planned lifecycle primitive for supervised long-running
-workloads. They are not implemented in the current CLI: there is no
-`crabbox station` command, `stationProfile` config key, or `modelAccess`
-credential path yet.
+Station profiles are a lifecycle primitive for supervised long-running
+workloads.
+
+**Status:** an initial, disabled-by-default primitive now exists in
+`internal/station`. It provides the `StationProfile` config struct with parsing
+and validation, the agent-profile boundary type, feature-gated phase
+enforcement (every phase returns a clear "not yet enabled" error until turned
+on), and the security gating that keeps `modelAccess` a separate, audited field
+that is never sourced from `env.allow`. There is still no `crabbox station`
+command, no top-level `stationProfile` config wiring, and no live `modelAccess`
+credential delivery; those land in later, separately reviewed phases.
 
 This page records the product and security boundary for
 [issue #193](https://github.com/openclaw/crabbox/issues/193) so future PRs can

--- a/docs/features/station-profiles.md
+++ b/docs/features/station-profiles.md
@@ -79,6 +79,7 @@ station:
   profiles:
     agent:
       enabled: true
+      agent: true
       command: scripts/agent-loop.sh
       ttl: 10h
       idleTimeout: 45m

--- a/docs/features/station-profiles.md
+++ b/docs/features/station-profiles.md
@@ -1,0 +1,130 @@
+# Station Profiles Roadmap
+
+Station profiles are a planned lifecycle primitive for supervised long-running
+workloads. They are not implemented in the current CLI: there is no
+`crabbox station` command, `stationProfile` config key, or `modelAccess`
+credential path yet.
+
+This page records the product and security boundary for
+[issue #193](https://github.com/openclaw/crabbox/issues/193) so future PRs can
+ship the feature in reviewable pieces.
+
+## Terms
+
+**Station** is the proposed user-facing primitive: a durable supervised workload
+record bound to a warm lease. A station is still a Crabbox box; the difference
+is that Crabbox records one long-running workload lifecycle instead of only a
+single `run` invocation.
+
+**stationProfile** is the proposed config selector for named station policies,
+for example `default` or `agent`.
+
+**Agent Station** is shorthand for a station using `stationProfile: agent`.
+The agent loop is repo-owned code. Crabbox supervises and records it, but does
+not own the prompt loop, planning strategy, model choice, or test
+interpretation.
+
+**modelAccess** is the proposed explicit credential-delivery policy for
+model/tool access. It must be separate from ordinary `env.allow` forwarding.
+
+Use **reasoning access** only in explanatory copy. It means the repo-owned
+workload may run a reasoning loop because a user granted scoped model/tool
+access. Crabbox must not expose, judge, store, or reconstruct model reasoning.
+
+## Phase Gates
+
+Ship Station in phases, with separate review for each phase:
+
+1. Generic Station, no model credentials.
+2. `agent` station profile, still no model credentials by default.
+3. `modelAccess`, only after Station behavior and evidence are stable.
+
+Phase 1 should target SSH-backed lease providers first. Delegated-run providers
+should wait until they expose an explicit station-capable contract.
+
+## Phase 1 Contract
+
+A Station is not just `warmup && run --keep` under a new name. The minimum
+contract is:
+
+- one durable station id;
+- one or more attempts;
+- one lease id per attempt;
+- one supervisor boot id, pid/start time, command hash, and workdir per
+  attempt;
+- explicit TTL and idle timeout;
+- separate lease heartbeat and station heartbeat;
+- station-centered status, logs, stop reason, and terminal state;
+- idempotent stop that preserves the original terminal reason;
+- evidence written on stop, failure, TTL expiry, idle expiry, or lost
+  supervisor.
+
+Station status should keep `state`, `desiredState`, `attempt`,
+`lastObservedAt`, and `stopReason` separate. It should distinguish lease state,
+supervisor liveness, command state, and cleanup/revocation state.
+
+## Agent Profile
+
+The first `agent` profile should remain repo-owned and conservative:
+
+```yaml
+station:
+  profiles:
+    agent:
+      enabled: true
+      command: scripts/agent-loop.sh
+      ttl: 10h
+      idleTimeout: 45m
+      restartPolicy: never
+```
+
+`restartPolicy` should default to `never`. Agent loops are not safely replayable
+by default, so retries are a later product decision.
+
+## modelAccess Security Gates
+
+`modelAccess` must not ship until all of these are true:
+
+- No Crabbox broker, coordinator, cloud provider, or admin credential enters the
+  station unless explicitly part of the workload policy.
+- Only workload-scoped model/tool credentials enter the station.
+- Credentials expire at or before station TTL.
+- Credentials are scoped, where possible, to repo/org/user, station id, attempt
+  id, gateway, command hash, allowed models/tools, and budget.
+- Credentials are never written to logs, timing JSON, events, compliance
+  reports, artifacts, screenshots, terminal captures, failure bundles, or
+  process arguments.
+- Evidence records receipts, not secrets: profile, gateway, budget, token
+  expiry, redaction policy version, issuer, and revocation reason.
+- Egress defaults to deny and only allows named approved egress profiles.
+- Stop, TTL expiry, idle expiry, budget exhaustion, or compliance failure
+  revokes credentials before lease teardown.
+- Model/tool credentials do not use ordinary repo `env.allow`; they use a
+  separate audited delivery path.
+
+Do not return stopped `modelAccess` stations to warm pools in v1. Treat them as
+dirty by default because they hosted credentialed long-running work.
+
+## Evidence
+
+Station evidence should extend run evidence instead of inventing an unrelated
+format. Minimum fields:
+
+- station id, attempt id, lease id, and run id if one exists;
+- start and stop timestamps;
+- repo SHA, branch, and dirty summary;
+- command and shell/argv mode;
+- station profile;
+- supervisor boot id, pid, start time, and exit status;
+- TTL, idle timeout, stop reason, and final state;
+- log/event retention limits;
+- model access policy and credential receipt metadata, if enabled;
+- revocation timestamp and reason, if model access was enabled.
+
+## Non-goals
+
+Station should not add an agent memory database, vector index, semantic judge,
+scenario state machine, or model reasoning store to Crabbox core.
+
+Crabbox owns lifecycle, synchronization, supervision, cleanup, credential policy,
+logs, artifacts, and evidence. The repo-owned workload owns the brain.

--- a/docs/security.md
+++ b/docs/security.md
@@ -169,6 +169,9 @@ Handling rules:
 - The CLI forwards environment variables only by allowlist. The default allow
   list is `CI` and `NODE_OPTIONS`; extend it with repo-local `env.allow` config
   (or a profile's `env.allow`).
+- Future `modelAccess` credentials for Station profiles must not use ordinary
+  repo `env.allow`; they need a separate scoped, auditable, revocable delivery
+  path. See [Station profiles](features/station-profiles.md).
 - Never pass a secret value as a command-line flag.
 - Never log environment values; redact secret-looking strings in diagnostics.
 - Treat delegated-run providers as part of the runtime trust boundary: when you

--- a/internal/station/config.go
+++ b/internal/station/config.go
@@ -1,0 +1,204 @@
+package station
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the parsed `station` config block. Profiles are keyed by name.
+type Config struct {
+	Profiles map[string]StationProfile
+}
+
+// fileConfig mirrors the on-disk YAML shape:
+//
+//	station:
+//	  profiles:
+//	    agent:
+//	      enabled: true
+//	      command: scripts/agent-loop.sh
+//	      ttl: 10h
+//	      idleTimeout: 45m
+//	      restartPolicy: never
+type fileConfig struct {
+	Profiles map[string]fileStationProfile `yaml:"profiles,omitempty"`
+}
+
+type fileStationProfile struct {
+	Enabled       bool             `yaml:"enabled,omitempty"`
+	Agent         bool             `yaml:"agent,omitempty"`
+	Command       string           `yaml:"command,omitempty"`
+	TTL           string           `yaml:"ttl,omitempty"`
+	IdleTimeout   string           `yaml:"idleTimeout,omitempty"`
+	RestartPolicy string           `yaml:"restartPolicy,omitempty"`
+	ModelAccess   *fileModelAccess `yaml:"modelAccess,omitempty"`
+	// Allow is intentionally absent: model/tool credentials must not flow
+	// through env.allow, and station profiles do not carry an env.allow list.
+}
+
+type fileModelAccess struct {
+	Enabled       bool     `yaml:"enabled,omitempty"`
+	Gateway       string   `yaml:"gateway,omitempty"`
+	AllowedModels []string `yaml:"allowedModels,omitempty"`
+	AllowedTools  []string `yaml:"allowedTools,omitempty"`
+	EgressProfile string   `yaml:"egressProfile,omitempty"`
+	BudgetUSD     float64  `yaml:"budgetUSD,omitempty"`
+}
+
+// Parse decodes a `station` config block from YAML and validates it. The input
+// is the YAML value of the `station` key (not the whole config document).
+//
+// Parsing never enables anything: a profile is disabled unless it explicitly
+// sets enabled: true, and modelAccess stays inert regardless of declaration.
+func Parse(data []byte) (Config, error) {
+	var file fileConfig
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return Config{}, fmt.Errorf("station: %w", err)
+	}
+	cfg := Config{Profiles: map[string]StationProfile{}}
+	for _, name := range sortedKeys(file.Profiles) {
+		profile, err := convertProfile(name, file.Profiles[name])
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Profiles[name] = profile
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func convertProfile(name string, in fileStationProfile) (StationProfile, error) {
+	profile := StationProfile{
+		Name:          name,
+		Enabled:       in.Enabled,
+		Agent:         in.Agent,
+		Command:       strings.TrimSpace(in.Command),
+		RestartPolicy: RestartNever,
+	}
+	if rp := strings.TrimSpace(in.RestartPolicy); rp != "" {
+		profile.RestartPolicy = RestartPolicy(rp)
+	}
+	if ttl := strings.TrimSpace(in.TTL); ttl != "" {
+		parsed, err := time.ParseDuration(ttl)
+		if err != nil {
+			return StationProfile{}, fmt.Errorf("station profile %q ttl: %w", name, err)
+		}
+		profile.TTL = parsed
+	}
+	if idle := strings.TrimSpace(in.IdleTimeout); idle != "" {
+		parsed, err := time.ParseDuration(idle)
+		if err != nil {
+			return StationProfile{}, fmt.Errorf("station profile %q idleTimeout: %w", name, err)
+		}
+		profile.IdleTimeout = parsed
+	}
+	if in.ModelAccess != nil {
+		profile.ModelAccess = ModelAccessPolicy{
+			Enabled:       in.ModelAccess.Enabled,
+			Gateway:       strings.TrimSpace(in.ModelAccess.Gateway),
+			AllowedModels: trimAll(in.ModelAccess.AllowedModels),
+			AllowedTools:  trimAll(in.ModelAccess.AllowedTools),
+			EgressProfile: strings.TrimSpace(in.ModelAccess.EgressProfile),
+			BudgetUSD:     in.ModelAccess.BudgetUSD,
+		}
+	}
+	return profile, nil
+}
+
+// Validate checks every profile for structural errors. It does not enable any
+// phase; that remains the job of Gate.
+func (c Config) Validate() error {
+	for _, name := range sortedKeys(c.Profiles) {
+		if err := c.Profiles[name].Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Validate checks a single profile for structural errors.
+func (p StationProfile) Validate() error {
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("station profile name must not be empty")
+	}
+	switch p.RestartPolicy {
+	case RestartNever:
+	case RestartOnFailure:
+		// Restarts are a later product decision; reject them for now so a
+		// profile cannot silently rely on unimplemented replay behavior.
+		return fmt.Errorf("station profile %q restartPolicy %q is not yet supported; only %q is allowed", p.Name, p.RestartPolicy, RestartNever)
+	default:
+		return fmt.Errorf("station profile %q has unknown restartPolicy %q", p.Name, p.RestartPolicy)
+	}
+	if p.TTL < 0 {
+		return fmt.Errorf("station profile %q ttl must not be negative", p.Name)
+	}
+	if p.IdleTimeout < 0 {
+		return fmt.Errorf("station profile %q idleTimeout must not be negative", p.Name)
+	}
+	if p.IdleTimeout > 0 && p.TTL > 0 && p.IdleTimeout > p.TTL {
+		return fmt.Errorf("station profile %q idleTimeout must not exceed ttl", p.Name)
+	}
+	if p.Enabled && p.Command == "" {
+		return fmt.Errorf("station profile %q is enabled but has no command", p.Name)
+	}
+	return p.ModelAccess.validate(p.Name)
+}
+
+func (m ModelAccessPolicy) validate(profileName string) error {
+	if m.IsZero() {
+		return nil
+	}
+	// Enforce the structural pieces of the roadmap's modelAccess security gates
+	// at parse time. The runtime gate (Gate) still refuses to deliver
+	// credentials until the modelAccess phase is enabled.
+	if !m.Enabled {
+		return fmt.Errorf("station profile %q modelAccess is configured but not enabled; set enabled: true or remove it", profileName)
+	}
+	if m.Gateway == "" {
+		return fmt.Errorf("station profile %q modelAccess requires a gateway", profileName)
+	}
+	if len(m.AllowedModels) == 0 && len(m.AllowedTools) == 0 {
+		return fmt.Errorf("station profile %q modelAccess must allow at least one model or tool", profileName)
+	}
+	if m.EgressProfile == "" {
+		// Egress defaults to deny; an empty egress profile would mean no egress
+		// at all, which is never a valid model-access configuration.
+		return fmt.Errorf("station profile %q modelAccess requires a named egressProfile (egress defaults to deny)", profileName)
+	}
+	if m.BudgetUSD <= 0 {
+		return fmt.Errorf("station profile %q modelAccess requires a positive budgetUSD", profileName)
+	}
+	return nil
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func trimAll(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/station/gate.go
+++ b/internal/station/gate.go
@@ -1,0 +1,130 @@
+package station
+
+import "fmt"
+
+// Gate is the feature gate for the Station primitive. Its zero value is the
+// safe default: every phase is disabled, so no station lifecycle, no agent
+// loop supervision, and no model-access credential delivery can run.
+//
+// Phases are enabled independently and only by an explicit opt-in, mirroring
+// the cautious skeleton style used elsewhere in the codebase. A future PR will
+// flip these as each phase ships and is reviewed.
+type Gate struct {
+	enabled map[Phase]bool
+}
+
+// DefaultGate returns the disabled-by-default gate. Nothing is enabled.
+func DefaultGate() Gate {
+	return Gate{}
+}
+
+// WithPhase returns a copy of the gate with the given phase enabled. It is the
+// single explicit opt-in seam; callers must not mutate the gate any other way.
+func (g Gate) WithPhase(p Phase) Gate {
+	enabled := make(map[Phase]bool, len(g.enabled)+1)
+	for k, v := range g.enabled {
+		enabled[k] = v
+	}
+	enabled[p] = true
+	return Gate{enabled: enabled}
+}
+
+// Enabled reports whether a phase is turned on.
+func (g Gate) Enabled(p Phase) bool {
+	return g.enabled[p]
+}
+
+// notEnabledError is returned when a phase is exercised while disabled. It is a
+// distinct type so callers can detect the gate condition.
+type notEnabledError struct {
+	phase Phase
+}
+
+func (e notEnabledError) Error() string {
+	return fmt.Sprintf("station %s phase is not yet enabled", e.phase)
+}
+
+// IsNotEnabled reports whether err is a phase-gate "not yet enabled" error.
+func IsNotEnabled(err error) bool {
+	_, ok := err.(notEnabledError)
+	return ok
+}
+
+// EnsurePhase returns a clear "not yet enabled" error unless the phase is on.
+// It is the enforcement stub future lifecycle code calls before doing work.
+func (g Gate) EnsurePhase(p Phase) error {
+	if !g.Enabled(p) {
+		return notEnabledError{phase: p}
+	}
+	return nil
+}
+
+// AgentProfile is the agent-profile boundary type. It wraps a StationProfile
+// that has been admitted as an agent station and records what Crabbox owns
+// versus what the repo-owned workload owns. Construct it only through
+// NewAgentProfile so the boundary checks always run.
+type AgentProfile struct {
+	profile StationProfile
+}
+
+// Profile returns the underlying station profile.
+func (a AgentProfile) Profile() StationProfile {
+	return a.profile
+}
+
+// Command returns the repo-owned workload entrypoint. Crabbox supervises and
+// records this command; it does not own the prompt loop or model choice.
+func (a AgentProfile) Command() string {
+	return a.profile.Command
+}
+
+// NewAgentProfile admits a profile as an agent station, enforcing the phase
+// gate and the agent-profile boundary. It returns a "not yet enabled" error
+// while the agent-profile phase is off, mirroring the roadmap's staged rollout.
+func NewAgentProfile(g Gate, p StationProfile) (AgentProfile, error) {
+	if err := g.EnsurePhase(PhaseAgentProfile); err != nil {
+		return AgentProfile{}, err
+	}
+	if err := p.Validate(); err != nil {
+		return AgentProfile{}, err
+	}
+	if !p.Agent {
+		return AgentProfile{}, fmt.Errorf("station profile %q is not an agent profile", p.Name)
+	}
+	if !p.Enabled {
+		return AgentProfile{}, fmt.Errorf("station profile %q is not enabled", p.Name)
+	}
+	if p.Command == "" {
+		return AgentProfile{}, fmt.Errorf("station profile %q has no command", p.Name)
+	}
+	return AgentProfile{profile: p}, nil
+}
+
+// AuthorizeModelAccess is the credential-delivery gate. It refuses unless the
+// modelAccess phase is enabled, and it always refuses to source credentials
+// from env.allow forwarding. No secret is produced here; this is the seam a
+// future phase replaces with the audited delivery path.
+//
+// envAllow is passed in only so the boundary can be asserted: any overlap
+// between env.allow names and model-access intent is a configuration error.
+func (g Gate) AuthorizeModelAccess(p StationProfile, envAllow []string) error {
+	if err := g.EnsurePhase(PhaseModelAccess); err != nil {
+		return err
+	}
+	if p.ModelAccess.IsZero() || !p.ModelAccess.Enabled {
+		return fmt.Errorf("station profile %q has no enabled modelAccess policy", p.Name)
+	}
+	if err := p.ModelAccess.validate(p.Name); err != nil {
+		return err
+	}
+	// Model/tool credentials must never travel through ordinary repo env.allow.
+	// The gateway name doubles as the credential channel identifier, so its
+	// appearance in env.allow signals an attempt to smuggle credentials through
+	// the unaudited path.
+	for _, name := range envAllow {
+		if name == p.ModelAccess.Gateway {
+			return fmt.Errorf("station profile %q modelAccess gateway %q must not be forwarded via env.allow; it uses the separate audited delivery path", p.Name, p.ModelAccess.Gateway)
+		}
+	}
+	return nil
+}

--- a/internal/station/gate.go
+++ b/internal/station/gate.go
@@ -1,6 +1,9 @@
 package station
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Gate is the feature gate for the Station primitive. Its zero value is the
 // safe default: every phase is disabled, so no station lifecycle, no agent
@@ -117,14 +120,43 @@ func (g Gate) AuthorizeModelAccess(p StationProfile, envAllow []string) error {
 	if err := p.ModelAccess.validate(p.Name); err != nil {
 		return err
 	}
-	// Model/tool credentials must never travel through ordinary repo env.allow.
-	// The gateway name doubles as the credential channel identifier, so its
-	// appearance in env.allow signals an attempt to smuggle credentials through
-	// the unaudited path.
 	for _, name := range envAllow {
-		if name == p.ModelAccess.Gateway {
-			return fmt.Errorf("station profile %q modelAccess gateway %q must not be forwarded via env.allow; it uses the separate audited delivery path", p.Name, p.ModelAccess.Gateway)
+		if conflict, reason := modelAccessEnvAllowConflict(name, p.ModelAccess); conflict {
+			return fmt.Errorf("station profile %q modelAccess cannot authorize env.allow entry %q: %s; use the separate audited delivery path", p.Name, name, reason)
 		}
 	}
 	return nil
+}
+
+func modelAccessEnvAllowConflict(entry string, policy ModelAccessPolicy) (bool, string) {
+	name := strings.TrimSpace(entry)
+	if name == "" {
+		return false, ""
+	}
+	if name == strings.TrimSpace(policy.Gateway) {
+		return true, "gateway credential channel overlap"
+	}
+	if strings.HasSuffix(name, "*") {
+		prefix := strings.TrimSuffix(name, "*")
+		if prefix == "" {
+			return false, ""
+		}
+		return true, "wildcard forwarding is not allowed with modelAccess"
+	}
+	upper := strings.ToUpper(name)
+	for _, marker := range []string{
+		"API_KEY",
+		"ACCESS_KEY",
+		"AUTH_TOKEN",
+		"BEARER_TOKEN",
+		"CREDENTIAL",
+		"PASSWORD",
+		"SECRET",
+		"TOKEN",
+	} {
+		if strings.Contains(upper, marker) {
+			return true, "credential-like environment name"
+		}
+	}
+	return false, ""
 }

--- a/internal/station/gate_test.go
+++ b/internal/station/gate_test.go
@@ -1,0 +1,117 @@
+package station
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGateDisabledByDefault(t *testing.T) {
+	g := DefaultGate()
+	for _, p := range []Phase{PhaseGenericStation, PhaseAgentProfile, PhaseModelAccess} {
+		if g.Enabled(p) {
+			t.Fatalf("phase %s should be disabled by default", p)
+		}
+		err := g.EnsurePhase(p)
+		if err == nil {
+			t.Fatalf("EnsurePhase(%s) should fail while disabled", p)
+		}
+		if !IsNotEnabled(err) {
+			t.Fatalf("expected not-enabled error for %s, got %v", p, err)
+		}
+		if !strings.Contains(err.Error(), "not yet enabled") {
+			t.Fatalf("error message should say not yet enabled: %v", err)
+		}
+	}
+}
+
+func TestGateWithPhaseDoesNotEnableOthers(t *testing.T) {
+	g := DefaultGate().WithPhase(PhaseGenericStation)
+	if !g.Enabled(PhaseGenericStation) {
+		t.Fatalf("generic station should be enabled")
+	}
+	if g.Enabled(PhaseAgentProfile) || g.Enabled(PhaseModelAccess) {
+		t.Fatalf("only the requested phase should be enabled: %#v", g)
+	}
+	// Original gate is unchanged (copy semantics).
+	if DefaultGate().Enabled(PhaseGenericStation) {
+		t.Fatalf("DefaultGate must remain fully disabled")
+	}
+}
+
+func TestNewAgentProfileGated(t *testing.T) {
+	profile := StationProfile{
+		Name:          "agent",
+		Enabled:       true,
+		Agent:         true,
+		Command:       "scripts/agent-loop.sh",
+		RestartPolicy: RestartNever,
+	}
+
+	// Disabled gate refuses with a not-yet-enabled error.
+	if _, err := NewAgentProfile(DefaultGate(), profile); err == nil || !IsNotEnabled(err) {
+		t.Fatalf("expected not-enabled error, got %v", err)
+	}
+
+	// With the agent phase on, a valid agent profile is admitted.
+	g := DefaultGate().WithPhase(PhaseAgentProfile)
+	ap, err := NewAgentProfile(g, profile)
+	if err != nil {
+		t.Fatalf("NewAgentProfile: %v", err)
+	}
+	if ap.Command() != "scripts/agent-loop.sh" {
+		t.Fatalf("command = %q", ap.Command())
+	}
+
+	// A non-agent profile is rejected even with the phase on.
+	nonAgent := profile
+	nonAgent.Agent = false
+	if _, err := NewAgentProfile(g, nonAgent); err == nil || IsNotEnabled(err) {
+		t.Fatalf("expected non-agent rejection, got %v", err)
+	}
+}
+
+func TestAuthorizeModelAccessGatedAndSeparateFromEnvAllow(t *testing.T) {
+	profile := StationProfile{
+		Name:          "agent",
+		Enabled:       true,
+		Agent:         true,
+		Command:       "scripts/agent-loop.sh",
+		RestartPolicy: RestartNever,
+		ModelAccess: ModelAccessPolicy{
+			Enabled:       true,
+			Gateway:       "scoped-gateway",
+			AllowedModels: []string{"claude-opus-4-8"},
+			EgressProfile: "approved-anthropic",
+			BudgetUSD:     5,
+		},
+	}
+
+	// Disabled gate: refuses with not-yet-enabled.
+	if err := DefaultGate().AuthorizeModelAccess(profile, nil); err == nil || !IsNotEnabled(err) {
+		t.Fatalf("expected not-enabled error, got %v", err)
+	}
+
+	g := DefaultGate().WithPhase(PhaseModelAccess)
+
+	// Phase enabled and env.allow clean: authorized.
+	if err := g.AuthorizeModelAccess(profile, []string{"CI", "NODE_OPTIONS"}); err != nil {
+		t.Fatalf("AuthorizeModelAccess: %v", err)
+	}
+
+	// The gateway leaking through env.allow is rejected: credentials must use
+	// the separate audited delivery path, never env.allow forwarding.
+	err := g.AuthorizeModelAccess(profile, []string{"scoped-gateway"})
+	if err == nil || IsNotEnabled(err) {
+		t.Fatalf("expected env.allow separation error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "env.allow") {
+		t.Fatalf("error should mention env.allow: %v", err)
+	}
+
+	// A profile with no model access is rejected even when the phase is on.
+	noAccess := profile
+	noAccess.ModelAccess = ModelAccessPolicy{}
+	if err := g.AuthorizeModelAccess(noAccess, nil); err == nil || IsNotEnabled(err) {
+		t.Fatalf("expected no-policy rejection, got %v", err)
+	}
+}

--- a/internal/station/gate_test.go
+++ b/internal/station/gate_test.go
@@ -61,6 +61,10 @@ func TestNewAgentProfileGated(t *testing.T) {
 	if ap.Command() != "scripts/agent-loop.sh" {
 		t.Fatalf("command = %q", ap.Command())
 	}
+	// The boundary exposes the underlying station profile it admitted.
+	if got := ap.Profile(); got.Name != profile.Name || got.Command != profile.Command {
+		t.Fatalf("Profile() = %+v, want %+v", got, profile)
+	}
 
 	// A non-agent profile is rejected even with the phase on.
 	nonAgent := profile

--- a/internal/station/gate_test.go
+++ b/internal/station/gate_test.go
@@ -102,14 +102,22 @@ func TestAuthorizeModelAccessGatedAndSeparateFromEnvAllow(t *testing.T) {
 		t.Fatalf("AuthorizeModelAccess: %v", err)
 	}
 
-	// The gateway leaking through env.allow is rejected: credentials must use
-	// the separate audited delivery path, never env.allow forwarding.
-	err := g.AuthorizeModelAccess(profile, []string{"scoped-gateway"})
-	if err == nil || IsNotEnabled(err) {
-		t.Fatalf("expected env.allow separation error, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "env.allow") {
-		t.Fatalf("error should mention env.allow: %v", err)
+	for name, envAllow := range map[string][]string{
+		"gateway overlap":         {"scoped-gateway"},
+		"exact model secret":      {"OPENAI_API_KEY"},
+		"exact model token":       {"ANTHROPIC_AUTH_TOKEN"},
+		"wildcard model prefix":   {"MODEL_*"},
+		"wildcard project prefix": {"PROJECT_*"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := g.AuthorizeModelAccess(profile, envAllow)
+			if err == nil || IsNotEnabled(err) {
+				t.Fatalf("expected env.allow separation error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "env.allow") {
+				t.Fatalf("error should mention env.allow: %v", err)
+			}
+		})
 	}
 
 	// A profile with no model access is rejected even when the phase is on.

--- a/internal/station/station.go
+++ b/internal/station/station.go
@@ -1,0 +1,122 @@
+// Package station holds the first buildable slice of the Station profile
+// primitive described in docs/features/station-profiles.md (issue #193).
+//
+// A Station is a durable supervised-workload record bound to a warm lease.
+// This package intentionally ships only the config surface: a StationProfile
+// struct, parsing and validation, the agent-profile boundary, and the security
+// gating that keeps modelAccess separate from ordinary env.allow forwarding.
+//
+// Everything here is disabled by default and the lifecycle phase gates return
+// clear "not yet enabled" errors until a future PR turns each phase on. No
+// supervisor, lease, or credential delivery is wired up yet; that work lands in
+// later, separately reviewed phases per the roadmap.
+package station
+
+import "time"
+
+// Phase enumerates the staged rollout described in the roadmap. Each phase is
+// reviewed and enabled separately.
+type Phase int
+
+const (
+	// PhaseGenericStation is phase 1: a durable supervised workload with no
+	// model credentials.
+	PhaseGenericStation Phase = iota + 1
+	// PhaseAgentProfile is phase 2: the `agent` station profile, still with no
+	// model credentials by default.
+	PhaseAgentProfile
+	// PhaseModelAccess is phase 3: scoped modelAccess credential delivery,
+	// gated behind all of the modelAccess security requirements.
+	PhaseModelAccess
+)
+
+// String returns a stable identifier for the phase, used in error messages.
+func (p Phase) String() string {
+	switch p {
+	case PhaseGenericStation:
+		return "generic-station"
+	case PhaseAgentProfile:
+		return "agent-profile"
+	case PhaseModelAccess:
+		return "model-access"
+	default:
+		return "unknown"
+	}
+}
+
+// RestartPolicy controls whether a stopped station attempt may be restarted.
+// Agent loops are not safely replayable by default, so the zero value is
+// "never".
+type RestartPolicy string
+
+const (
+	// RestartNever never restarts a stopped attempt. This is the default.
+	RestartNever RestartPolicy = "never"
+	// RestartOnFailure restarts only on non-clean termination. Reserved for a
+	// later product decision; rejected by validation today.
+	RestartOnFailure RestartPolicy = "on-failure"
+)
+
+// StationProfile is a named station policy, for example `default` or `agent`.
+// It is the config selector referenced by `stationProfile` in the roadmap.
+//
+// A profile is inert until Enabled is true, and even then only the lifecycle
+// phases that have been turned on may run (see Gate).
+type StationProfile struct {
+	// Name is the profile selector, e.g. "default" or "agent".
+	Name string
+	// Enabled gates the profile. Profiles are disabled by default so that
+	// merely declaring one never changes run behavior.
+	Enabled bool
+	// Agent marks this as an agent station (stationProfile: agent). The agent
+	// loop is repo-owned; Crabbox supervises and records it but does not own
+	// the prompt loop or model choice.
+	Agent bool
+	// Command is the repo-owned workload entrypoint, e.g. scripts/agent-loop.sh.
+	Command string
+	// TTL is the hard upper bound on station lifetime. Credentials, if any,
+	// must expire at or before TTL.
+	TTL time.Duration
+	// IdleTimeout stops a station that has made no progress for this long.
+	IdleTimeout time.Duration
+	// RestartPolicy controls attempt restarts. Defaults to RestartNever.
+	RestartPolicy RestartPolicy
+	// ModelAccess is the security-gated credential-delivery policy. It is a
+	// distinct field and is NEVER populated from env.allow. It stays empty
+	// (disabled) until phase 3 and its own security gates are satisfied.
+	ModelAccess ModelAccessPolicy
+}
+
+// ModelAccessPolicy is the explicit, audited credential-delivery policy for
+// model/tool access. It is deliberately separate from env.allow forwarding:
+// model/tool credentials must never travel through ordinary repo env.allow.
+//
+// This type only records policy/receipt metadata. It never holds a secret
+// value; the secret delivery path lands in a later phase.
+type ModelAccessPolicy struct {
+	// Enabled turns on model access. It is rejected until the modelAccess
+	// phase is enabled and all security gates pass.
+	Enabled bool
+	// Gateway names the approved model/tool gateway.
+	Gateway string
+	// AllowedModels lists the models the workload may reach. Empty means none.
+	AllowedModels []string
+	// AllowedTools lists the tools the workload may reach. Empty means none.
+	AllowedTools []string
+	// EgressProfile names an approved egress profile. Egress defaults to deny,
+	// so an empty value means no egress is permitted.
+	EgressProfile string
+	// BudgetUSD caps spend for the station. Zero means unset (rejected when
+	// model access is enabled).
+	BudgetUSD float64
+}
+
+// IsZero reports whether the policy is the empty (disabled) policy.
+func (m ModelAccessPolicy) IsZero() bool {
+	return !m.Enabled &&
+		m.Gateway == "" &&
+		len(m.AllowedModels) == 0 &&
+		len(m.AllowedTools) == 0 &&
+		m.EgressProfile == "" &&
+		m.BudgetUSD == 0
+}

--- a/internal/station/station_test.go
+++ b/internal/station/station_test.go
@@ -1,9 +1,13 @@
 package station
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseAgentProfile(t *testing.T) {
@@ -38,6 +42,28 @@ profiles:
 	}
 	if profile.RestartPolicy != RestartNever {
 		t.Fatalf("restartPolicy = %q", profile.RestartPolicy)
+	}
+}
+
+func TestRoadmapAgentProfileExampleIsAdmitted(t *testing.T) {
+	doc, err := os.ReadFile(filepath.Join("..", "..", "docs", "features", "station-profiles.md"))
+	if err != nil {
+		t.Fatalf("read roadmap: %v", err)
+	}
+	sample, ok := fencedBlockAfter(string(doc), "## Agent Profile", "```yaml")
+	if !ok {
+		t.Fatalf("agent profile YAML sample missing from roadmap")
+	}
+	cfg, err := parseDocumentedStationSample(sample)
+	if err != nil {
+		t.Fatalf("Parse documented sample: %v", err)
+	}
+	profile, ok := cfg.Profiles["agent"]
+	if !ok {
+		t.Fatalf("documented sample did not define agent profile: %#v", cfg.Profiles)
+	}
+	if _, err := NewAgentProfile(DefaultGate().WithPhase(PhaseAgentProfile), profile); err != nil {
+		t.Fatalf("documented sample should be admitted as agent profile: %v", err)
 	}
 }
 
@@ -223,4 +249,39 @@ profiles:
 			}
 		})
 	}
+}
+
+func fencedBlockAfter(doc, heading, fence string) (string, bool) {
+	headingAt := strings.Index(doc, heading)
+	if headingAt < 0 {
+		return "", false
+	}
+	afterHeading := doc[headingAt+len(heading):]
+	fenceAt := strings.Index(afterHeading, fence)
+	if fenceAt < 0 {
+		return "", false
+	}
+	afterFence := afterHeading[fenceAt+len(fence):]
+	endAt := strings.Index(afterFence, "```")
+	if endAt < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(afterFence[:endAt]), true
+}
+
+func parseDocumentedStationSample(sample string) (Config, error) {
+	var root struct {
+		Station yaml.Node `yaml:"station"`
+	}
+	if err := yaml.Unmarshal([]byte(sample), &root); err != nil {
+		return Config{}, err
+	}
+	if root.Station.Kind == 0 {
+		return Parse([]byte(sample))
+	}
+	stationBlock, err := yaml.Marshal(&root.Station)
+	if err != nil {
+		return Config{}, err
+	}
+	return Parse(stationBlock)
 }

--- a/internal/station/station_test.go
+++ b/internal/station/station_test.go
@@ -1,0 +1,226 @@
+package station
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseAgentProfile(t *testing.T) {
+	cfg, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    agent: true
+    command: scripts/agent-loop.sh
+    ttl: 10h
+    idleTimeout: 45m
+    restartPolicy: never
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	profile, ok := cfg.Profiles["agent"]
+	if !ok {
+		t.Fatalf("agent profile missing: %#v", cfg.Profiles)
+	}
+	if !profile.Enabled || !profile.Agent {
+		t.Fatalf("expected enabled agent profile, got %#v", profile)
+	}
+	if profile.Command != "scripts/agent-loop.sh" {
+		t.Fatalf("command = %q", profile.Command)
+	}
+	if profile.TTL != 10*time.Hour {
+		t.Fatalf("ttl = %v", profile.TTL)
+	}
+	if profile.IdleTimeout != 45*time.Minute {
+		t.Fatalf("idleTimeout = %v", profile.IdleTimeout)
+	}
+	if profile.RestartPolicy != RestartNever {
+		t.Fatalf("restartPolicy = %q", profile.RestartPolicy)
+	}
+}
+
+func TestParseDefaultsDisabledAndRestartNever(t *testing.T) {
+	cfg, err := Parse([]byte(`
+profiles:
+  default: {}
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	profile := cfg.Profiles["default"]
+	if profile.Enabled {
+		t.Fatalf("profile should be disabled by default: %#v", profile)
+	}
+	if profile.RestartPolicy != RestartNever {
+		t.Fatalf("restartPolicy should default to never, got %q", profile.RestartPolicy)
+	}
+	if !profile.ModelAccess.IsZero() {
+		t.Fatalf("modelAccess should be empty by default: %#v", profile.ModelAccess)
+	}
+}
+
+func TestParseRejectsBadDuration(t *testing.T) {
+	_, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    command: scripts/agent-loop.sh
+    ttl: notaduration
+`))
+	if err == nil || !strings.Contains(err.Error(), "ttl") {
+		t.Fatalf("expected ttl parse error, got %v", err)
+	}
+}
+
+func TestValidateRejectsEnabledWithoutCommand(t *testing.T) {
+	_, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+`))
+	if err == nil || !strings.Contains(err.Error(), "no command") {
+		t.Fatalf("expected missing-command error, got %v", err)
+	}
+}
+
+func TestValidateRejectsIdleExceedingTTL(t *testing.T) {
+	_, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    command: scripts/agent-loop.sh
+    ttl: 10m
+    idleTimeout: 1h
+`))
+	if err == nil || !strings.Contains(err.Error(), "idleTimeout") {
+		t.Fatalf("expected idleTimeout > ttl error, got %v", err)
+	}
+}
+
+func TestValidateRejectsUnsupportedRestartPolicy(t *testing.T) {
+	_, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    command: scripts/agent-loop.sh
+    restartPolicy: on-failure
+`))
+	if err == nil || !strings.Contains(err.Error(), "restartPolicy") {
+		t.Fatalf("expected restartPolicy error, got %v", err)
+	}
+}
+
+func TestModelAccessIsSeparateFromEnvAllow(t *testing.T) {
+	// The station profile YAML shape has no env.allow field at all: declaring
+	// model access there must not be possible. Parsing a profile with an
+	// `envAllow` key should simply ignore it (it is not part of the schema),
+	// proving modelAccess cannot ride in on env.allow.
+	cfg, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    command: scripts/agent-loop.sh
+    envAllow:
+      - OPENAI_API_KEY
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !cfg.Profiles["agent"].ModelAccess.IsZero() {
+		t.Fatalf("env.allow must never populate modelAccess: %#v", cfg.Profiles["agent"].ModelAccess)
+	}
+}
+
+func TestModelAccessValidation(t *testing.T) {
+	// A fully-specified, enabled modelAccess policy parses.
+	cfg, err := Parse([]byte(`
+profiles:
+  agent:
+    enabled: true
+    agent: true
+    command: scripts/agent-loop.sh
+    ttl: 10h
+    modelAccess:
+      enabled: true
+      gateway: scoped-gateway
+      allowedModels:
+        - claude-opus-4-8
+      egressProfile: approved-anthropic
+      budgetUSD: 5
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ma := cfg.Profiles["agent"].ModelAccess
+	if !ma.Enabled || ma.Gateway != "scoped-gateway" || ma.BudgetUSD != 5 {
+		t.Fatalf("unexpected modelAccess: %#v", ma)
+	}
+
+	// modelAccess declared but missing required fields is rejected.
+	cases := map[string]string{
+		"missing gateway": `
+profiles:
+  a:
+    enabled: true
+    command: c
+    modelAccess:
+      enabled: true
+      allowedModels: [m]
+      egressProfile: e
+      budgetUSD: 1
+`,
+		"no models or tools": `
+profiles:
+  a:
+    enabled: true
+    command: c
+    modelAccess:
+      enabled: true
+      gateway: g
+      egressProfile: e
+      budgetUSD: 1
+`,
+		"missing egress profile": `
+profiles:
+  a:
+    enabled: true
+    command: c
+    modelAccess:
+      enabled: true
+      gateway: g
+      allowedModels: [m]
+      budgetUSD: 1
+`,
+		"non-positive budget": `
+profiles:
+  a:
+    enabled: true
+    command: c
+    modelAccess:
+      enabled: true
+      gateway: g
+      allowedModels: [m]
+      egressProfile: e
+`,
+		"configured but disabled": `
+profiles:
+  a:
+    enabled: true
+    command: c
+    modelAccess:
+      gateway: g
+      allowedModels: [m]
+      egressProfile: e
+      budgetUSD: 1
+`,
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(doc)); err == nil {
+				t.Fatalf("expected error for %s", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Documents the planned Station profile primitive, agent profile boundary, and phase gates from https://github.com/openclaw/crabbox/issues/193.
- Adds the initial unwired `internal/station` package for parsing Station profiles, agent profile phase gates, and modelAccess policy checks.
- Keeps `modelAccess` explicitly security-gated and separate from ordinary `env.allow` forwarding.
- Links the roadmap from feature docs and the security secrets section.
- Fixes the documented `agent` profile example so it is admitted by `NewAgentProfile`, with a regression test that extracts the roadmap YAML sample.

## Scope / merge note

This is a roadmap and internal skeleton PR. It does not wire Station profiles into the runtime path yet and should not be treated as closing the full Station/modelAccess product roadmap.

Because this introduces new security-boundary code under `internal/station`, it still needs maintainer/security signoff even though current CI and local validation are green.

## Verification

Maintainer validation on current head `b0aeec9cc23c55d6b85f19d73af2da083e6a0158`:

```text
go test ./internal/station
go test ./internal/station ./internal/cli ./cmd/crabbox
node scripts/check-command-docs.mjs
node scripts/check-docs-links.mjs
go vet ./...
go build -trimpath -o bin/crabbox ./cmd/crabbox
git diff --check
go test ./...
```

GitHub checks are green on the same head: Go, Apple VZ, Worker, Scripts, Docs, Release Check, and Socket checks.

Refs https://github.com/openclaw/crabbox/issues/193.