### PR TITLE
fix(coordinator): harden bridge restart recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Fixed coordinator hibernation recovery to preserve unambiguous live bridges while rejecting duplicate or stale restored endpoints.
 - Fixed portable Node coordinator startup when the production bundle loads the external CommonJS `ssh2` dependency.
 - Fixed CodeSandbox ownership tags, one-shot SDK bridge shutdown, mount-safe root workspace replacement, runtime-only resume responses, and authenticated preview URLs, preventing lifecycle rejection, command hangs, archive-sync failures, and unusable private port links.
 - Hardened runtime-adapter relays with end-to-end absolute deadlines, durable generation-scoped dispatch fences retained across ambiguous connector failures, atomic owner-only legacy cleanup, rejection of unfenced proxy deletes, per-owner in-flight quotas, post-cancellation accounting, response-delivery grace, connector-matched request validation, restart-safe TTL-first live-bridge revocation, retry-safe upstream rejection handling, generation-fenced confirmed-absence acknowledgments, and cleanup-fenced workspace bindings.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -639,7 +639,8 @@ export class FleetCoordinator {
   private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
-  private readonly bridgeRestoreReady: Promise<boolean>;
+  private readonly restoredLeaseBridgeSockets = new Set<WebSocket>();
+  private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private awsIngressBarrier: Promise<void> = Promise.resolve();
   private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
@@ -651,17 +652,19 @@ export class FleetCoordinator {
     private readonly testProviders: Partial<Record<Provider, CloudProvider>> = {},
   ) {
     this.restoreBridgeWebSockets();
-    this.bridgeRestoreReady = this.revokeInactiveRestoredBridgeSockets().then(
-      () => true,
-      (error) => {
-        console.warn("could not reconcile restored lease bridges", errorMessage(error));
-        return false;
-      },
-    );
   }
 
   async fetch(request: Request): Promise<Response> {
     try {
+      if (!(await this.restoredLeaseBridgesReady())) {
+        return json(
+          {
+            error: "bridge_state_unavailable",
+            message: "restored bridge lease state is temporarily unavailable",
+          },
+          { status: 503, headers: { "retry-after": "1" } },
+        );
+      }
       const parts = pathParts(request);
       const method = request.method.toUpperCase();
       const adminError = adminRouteError(request, method, parts);
@@ -907,6 +910,7 @@ export class FleetCoordinator {
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
     const attachment = this.bridgeAttachment(socket);
     if (!attachment) {
+      this.rejectRestoredBridgeSocket(socket, undefined);
       return;
     }
     await this.handleBridgeMessage(socket, attachment, message);
@@ -921,12 +925,43 @@ export class FleetCoordinator {
   }
 
   private restoreBridgeWebSockets(): void {
+    const candidates: Array<{
+      socket: WebSocket;
+      attachment: BridgeAttachment;
+      endpoint: string;
+    }> = [];
+    const endpointCounts = new Map<string, number>();
+    const egressSessions = new Map<string, Set<string>>();
     for (const socket of this.state.getWebSockets()) {
       const attachment = this.bridgeAttachment(socket);
-      if (!attachment || socket.readyState !== WebSocket.OPEN) {
+      if (!attachment) {
+        this.rejectRestoredBridgeSocket(socket, undefined);
+        continue;
+      }
+      if (socket.readyState !== WebSocket.OPEN) {
+        continue;
+      }
+      const endpoint = restoredBridgeEndpoint(attachment);
+      candidates.push({ socket, attachment, endpoint });
+      endpointCounts.set(endpoint, (endpointCounts.get(endpoint) ?? 0) + 1);
+      if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
+        const sessions = egressSessions.get(attachment.leaseID) ?? new Set<string>();
+        sessions.add(attachment.sessionID);
+        egressSessions.set(attachment.leaseID, sessions);
+      }
+    }
+    for (const { socket, attachment, endpoint } of candidates) {
+      const ambiguousEgressLease =
+        (attachment.kind === "egress-host" || attachment.kind === "egress-client") &&
+        (egressSessions.get(attachment.leaseID)?.size ?? 0) > 1;
+      if ((endpointCounts.get(endpoint) ?? 0) > 1 || ambiguousEgressLease) {
+        this.rejectRestoredBridgeSocket(socket, attachment);
         continue;
       }
       this.trackBridgeSocket(socket, attachment);
+      if ("leaseID" in attachment) {
+        this.restoredLeaseBridgeSockets.add(socket);
+      }
     }
   }
 
@@ -934,7 +969,7 @@ export class FleetCoordinator {
     const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
     const now = Date.now();
     const revoked = new Map<string, string>();
-    for (const socket of this.state.getWebSockets()) {
+    for (const socket of this.restoredLeaseBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment || !("leaseID" in attachment)) {
         continue;
@@ -950,6 +985,48 @@ export class FleetCoordinator {
     for (const [leaseID, reason] of revoked) {
       this.closeLeaseBridges(leaseID, 1008, reason);
     }
+    for (const socket of this.restoredLeaseBridgeSockets) {
+      const attachment = this.bridgeAttachment(socket);
+      const reason =
+        attachment && "leaseID" in attachment ? revoked.get(attachment.leaseID) : undefined;
+      if (reason) {
+        closeSocket(socket, 1008, reason);
+      }
+    }
+    this.restoredLeaseBridgeSockets.clear();
+  }
+
+  private async restoredLeaseBridgesReady(): Promise<boolean> {
+    if (this.restoredLeaseBridgeSockets.size === 0) {
+      return true;
+    }
+    const pending =
+      this.bridgeRestoreReady ??
+      this.revokeInactiveRestoredBridgeSockets().then(
+        () => true,
+        (error) => {
+          console.warn("could not reconcile restored lease bridges", errorMessage(error));
+          return false;
+        },
+      );
+    this.bridgeRestoreReady = pending;
+    const ready = await pending;
+    if (this.bridgeRestoreReady === pending) {
+      this.bridgeRestoreReady = undefined;
+    }
+    return ready;
+  }
+
+  private rejectRestoredBridgeSocket(
+    socket: WebSocket,
+    attachment: BridgeAttachment | undefined,
+  ): void {
+    const webVNCAgent = attachment?.kind === "webvnc-agent";
+    closeSocket(
+      socket,
+      webVNCAgent ? 1011 : 1012,
+      webVNCAgent ? "WebVNC bridge reset" : "coordinator restarted",
+    );
   }
 
   private acceptBridgeWebSocket(socket: WebSocket, attachment: BridgeAttachment): void {
@@ -966,6 +1043,32 @@ export class FleetCoordinator {
 
   private bridgeAttachment(socket: WebSocket): BridgeAttachment | undefined {
     return bridgeAttachment(this.state.socketAttachment(socket));
+  }
+
+  private bridgeSocketIsCurrent(socket: WebSocket, attachment: BridgeAttachment): boolean {
+    switch (attachment.kind) {
+      case "webvnc-agent":
+        return this.webVNCAgents.get(attachment.leaseID)?.get(attachment.id) === socket;
+      case "webvnc-viewer":
+        return this.webVNCViewers.get(attachment.leaseID)?.get(attachment.id)?.socket === socket;
+      case "code-agent":
+        return this.codeAgents.get(attachment.leaseID) === socket;
+      case "code-viewer":
+        return this.codeViewers.get(attachment.id) === socket;
+      case "egress-host":
+        return (
+          this.egressHosts.get(egressSocketKey(attachment.leaseID, attachment.sessionID)) === socket
+        );
+      case "egress-client":
+        return (
+          this.egressClients.get(egressSocketKey(attachment.leaseID, attachment.sessionID)) ===
+          socket
+        );
+      case "runtime-adapter-agent":
+        return this.runtimeAdapterAgents.get(attachment.adapterID) === socket;
+      case "control":
+        return this.controlSockets.get(attachment.clientID) === socket;
+    }
   }
 
   private trackBridgeSocket(socket: WebSocket, attachment: BridgeAttachment): void {
@@ -1231,8 +1334,16 @@ export class FleetCoordinator {
     attachment: BridgeAttachment,
     message: string | ArrayBuffer | Blob,
   ): Promise<void> {
-    if (!(await this.bridgeRestoreReady)) {
-      closeSocket(socket, 1011, "lease state unavailable");
+    if (socket.readyState !== WebSocket.OPEN || !this.bridgeSocketIsCurrent(socket, attachment)) {
+      this.rejectRestoredBridgeSocket(socket, attachment);
+      return;
+    }
+    if (!(await this.restoredLeaseBridgesReady())) {
+      this.restoredLeaseBridgeSockets.delete(socket);
+      this.rejectRestoredBridgeSocket(socket, attachment);
+      return;
+    }
+    if (socket.readyState !== WebSocket.OPEN || !this.bridgeSocketIsCurrent(socket, attachment)) {
       return;
     }
     switch (attachment.kind) {
@@ -1294,8 +1405,9 @@ export class FleetCoordinator {
   }
 
   private handleBridgeClose(socket: WebSocket, code: number, reason: string): void {
+    this.restoredLeaseBridgeSockets.delete(socket);
     const attachment = this.bridgeAttachment(socket);
-    if (!attachment) {
+    if (!attachment || !this.bridgeSocketIsCurrent(socket, attachment)) {
       return;
     }
     switch (attachment.kind) {
@@ -1329,6 +1441,9 @@ export class FleetCoordinator {
   }
 
   async alarm(): Promise<void> {
+    if (!(await this.restoredLeaseBridgesReady())) {
+      throw new Error("restored bridge lease state is temporarily unavailable");
+    }
     await this.expireLeases();
     await this.reconcileRuntimeAdapterDeletes();
     await this.maintainWorkspacePrewarm();
@@ -11868,6 +11983,26 @@ function bridgeTags(attachment: BridgeAttachment): string[] {
     return [`adapter:${attachment.adapterID}`, attachment.kind];
   }
   return [`lease:${attachment.leaseID}`, attachment.kind];
+}
+
+function restoredBridgeEndpoint(attachment: BridgeAttachment): string {
+  switch (attachment.kind) {
+    case "webvnc-agent":
+      return JSON.stringify([attachment.kind, attachment.leaseID, attachment.id]);
+    case "webvnc-viewer":
+      return JSON.stringify([attachment.kind, attachment.leaseID, attachment.id]);
+    case "code-agent":
+      return JSON.stringify([attachment.kind, attachment.leaseID]);
+    case "code-viewer":
+      return JSON.stringify([attachment.kind, attachment.leaseID, attachment.id]);
+    case "egress-host":
+    case "egress-client":
+      return JSON.stringify([attachment.kind, attachment.leaseID, attachment.sessionID]);
+    case "runtime-adapter-agent":
+      return JSON.stringify([attachment.kind, attachment.adapterID]);
+    case "control":
+      return JSON.stringify([attachment.kind, attachment.clientID]);
+  }
 }
 
 function sendControl(socket: WebSocket, payload: unknown): void {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -147,6 +147,197 @@ class FakeWebSocket {
 }
 
 describe("runtime adapter relay", () => {
+  it("restores unambiguous hibernated bridge sockets after validating lease state", async () => {
+    const storage = new MemoryStorage();
+    const list = vi.spyOn(storage, "list");
+    const lease = testLease({
+      id: "cbx_000000000001",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const webVNCAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_restart",
+      capabilities: new Set<string>(),
+    });
+    const restored = [
+      new FakeWebSocket({ kind: "code-agent", leaseID: lease.id }),
+      new FakeWebSocket({
+        kind: "egress-host",
+        leaseID: lease.id,
+        sessionID: "egress_restart",
+      }),
+      new FakeWebSocket({
+        kind: "egress-client",
+        leaseID: lease.id,
+        sessionID: "egress_restart",
+      }),
+      new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      }),
+    ];
+
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => [webVNCAgent, ...restored] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect(list).not.toHaveBeenCalled();
+    for (const socket of [webVNCAgent, ...restored]) {
+      expect(socket.closeCode).toBeUndefined();
+    }
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    expect(list).toHaveBeenCalledTimes(1);
+    const relay = fleet as unknown as {
+      codeAgents: Map<string, WebSocket>;
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    expect(relay.codeAgents.get(lease.id)).toBe(restored[0]);
+    expect(relay.runtimeAdapterAgents.get("example-adapter")).toBe(restored[3]);
+  });
+
+  it("fails closed ambiguous and invalid hibernated bridge sockets", () => {
+    const storage = new MemoryStorage();
+    const list = vi.spyOn(storage, "list");
+    const duplicateAdapters = [
+      new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      }),
+      new FakeWebSocket({
+        kind: "runtime-adapter-agent",
+        adapterID: "example-adapter",
+        owner: "alice@example.com",
+        org: "example-org",
+      }),
+    ];
+    const competingEgressSessions = ["egress_old", "egress_new"].flatMap((sessionID) => [
+      new FakeWebSocket({
+        kind: "egress-host",
+        leaseID: "cbx_000000000001",
+        sessionID,
+      }),
+      new FakeWebSocket({
+        kind: "egress-client",
+        leaseID: "cbx_000000000001",
+        sessionID,
+      }),
+    ]);
+    const invalid = new FakeWebSocket({ kind: "invalid-restored-attachment" });
+
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () =>
+          [...duplicateAdapters, ...competingEgressSessions, invalid] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect(list).not.toHaveBeenCalled();
+    const relay = fleet as unknown as {
+      egressHosts: Map<string, WebSocket>;
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    expect(relay.egressHosts.size).toBe(0);
+    expect(relay.runtimeAdapterAgents.size).toBe(0);
+    for (const socket of [...duplicateAdapters, ...competingEgressSessions, invalid]) {
+      expect(socket.closeCode).toBe(1012);
+      expect(socket.closeReason).toBe("coordinator restarted");
+    }
+  });
+
+  it("retries transient restored-lease reconciliation without dropping sockets", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000002",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const list = vi.spyOn(storage, "list").mockRejectedValueOnce(new Error("storage unavailable"));
+    const socket = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => [socket] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    const unavailable = await fleet.fetch(request("GET", "/v1/health"));
+    expect(unavailable.status).toBe(503);
+    expect(unavailable.headers.get("retry-after")).toBe("1");
+    expect(socket.closeCode).toBeUndefined();
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(socket.closeCode).toBeUndefined();
+  });
+
+  it("rejects omitted restored messages and ignores their delayed closes", async () => {
+    const fleet = new FleetDurableObject(
+      {
+        storage: new MemoryStorage(),
+        getWebSockets: () => [],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+    const staleHost = new FakeWebSocket({
+      kind: "egress-host",
+      leaseID: "cbx_000000000001",
+      sessionID: "egress_omitted",
+    });
+    const client = new FakeWebSocket({
+      kind: "egress-client",
+      leaseID: "cbx_000000000001",
+      sessionID: "egress_omitted",
+    });
+    const currentAdapter = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const staleAdapter = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relay = fleet as unknown as {
+      egressClients: Map<string, WebSocket>;
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relay.egressClients.set("cbx_000000000001\0egress_omitted", client as unknown as WebSocket);
+    relay.runtimeAdapterAgents.set("example-adapter", currentAdapter as unknown as WebSocket);
+
+    await fleet.webSocketMessage(staleHost as unknown as WebSocket, "stale frame");
+    fleet.webSocketClose(staleAdapter as unknown as WebSocket, 1006, "late close", false);
+
+    expect(staleHost.closeCode).toBe(1012);
+    expect(staleHost.closeReason).toBe("coordinator restarted");
+    expect(client.sentJSON()).toEqual([]);
+    expect(relay.runtimeAdapterAgents.get("example-adapter")).toBe(currentAdapter);
+  });
+
   it("issues owner-scoped tickets and proxies only typed lifecycle requests", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -296,6 +487,10 @@ describe("runtime adapter relay", () => {
       id: "unknown-request",
       padding: "x".repeat(runtimeAdapterRelayFrameLimit),
     });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
 
     await fleet.webSocketMessage(socket as unknown as WebSocket, message);
 


### PR DESCRIPTION
## Summary

- restore hibernated coordinator bridge sockets only when their endpoint topology is unambiguous
- fail closed on duplicate, stale, or competing egress, WebVNC, code, and runtime-adapter endpoints
- fence delayed messages and closes by the current live routing-map identity while preserving normal reconnect behavior

## Why

Cloudflare Durable Object hibernation invokes the coordinator constructor again on wake. The coordinator must rebuild safe in-memory routing without disconnecting healthy idle bridges or allowing stale sockets to replace current peers.

This is a focused restart-safety follow-up to #339.

## Verification

- Worker test suite: 604/604
- Worker and Node TypeScript checks
- lint and format checks
- `git diff --check`
- structured autoreview clean with no actionable findings