### PR TITLE
test(docs): harden markdown link anchors

### DIFF
--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -76,7 +76,7 @@ function headingAnchors(markdown) {
 }
 
 function splitMarkdownTarget(href) {
-  const trimmed = href.replace(/\s+["'][^"']*["']\s*$/, "");
+  const trimmed = href.replace(/\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*$/, "");
   return stripAngleBrackets(trimmed);
 }
 

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -11,7 +11,7 @@ for (const file of files) {
   const headings = headingAnchors(markdown);
   const links = markdown.matchAll(/\[[^\]]+\]\(([^)]+)\)/g);
   for (const match of links) {
-    const href = match[1].trim();
+    const href = splitMarkdownTarget(match[1].trim());
     if (!href || href.startsWith("http://") || href.startsWith("https://") || href.startsWith("mailto:")) {
       continue;
     }
@@ -51,6 +51,7 @@ function walk(dir) {
 
 function headingAnchors(markdown) {
   const anchors = new Set();
+  const seen = new Map();
   for (const rawLine of markdown.split("\n")) {
     const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
     let hashes = 0;
@@ -60,9 +61,20 @@ function headingAnchors(markdown) {
     if (hashes < 1 || hashes > 6 || line[hashes] !== " ") {
       continue;
     }
-    anchors.add(slugify(line.slice(hashes + 1)));
+    const base = slugify(line.slice(hashes + 1));
+    if (!base) {
+      continue;
+    }
+    const count = seen.get(base) || 0;
+    seen.set(base, count + 1);
+    anchors.add(count === 0 ? base : `${base}-${count}`);
   }
   return anchors;
+}
+
+function splitMarkdownTarget(href) {
+  const trimmed = href.replace(/\s+["'][^"']*["']\s*$/, "");
+  return stripAngleBrackets(trimmed);
 }
 
 function slugify(text) {

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -51,7 +51,6 @@ function walk(dir) {
 
 function headingAnchors(markdown) {
   const anchors = new Set();
-  const seen = new Map();
   for (const rawLine of markdown.split("\n")) {
     const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
     let hashes = 0;
@@ -65,9 +64,13 @@ function headingAnchors(markdown) {
     if (!base) {
       continue;
     }
-    const count = seen.get(base) || 0;
-    seen.set(base, count + 1);
-    anchors.add(count === 0 ? base : `${base}-${count}`);
+    let anchor = base;
+    let suffix = 0;
+    while (anchors.has(anchor)) {
+      suffix += 1;
+      anchor = `${base}-${suffix}`;
+    }
+    anchors.add(anchor);
   }
   return anchors;
 }

--- a/scripts/check-docs-links.test.js
+++ b/scripts/check-docs-links.test.js
@@ -18,6 +18,16 @@ test("docs link checker accepts GitHub duplicate heading anchors", (t) => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("docs link checker avoids collisions with suffixed headings", (t) => {
+  const dir = newDocsFixture(t);
+  writeFile(path.join(dir, "README.md"), "[suffixed setup](docs/guide.md#setup-1-1)\n");
+  writeFile(path.join(dir, "docs", "guide.md"), "# Setup\n\n# Setup\n\n# Setup-1\n");
+
+  const result = runChecker(dir);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
 test("docs link checker rejects missing duplicate heading anchors", (t) => {
   const dir = newDocsFixture(t);
   writeFile(path.join(dir, "README.md"), "[third setup](docs/guide.md#setup-2)\n");

--- a/scripts/check-docs-links.test.js
+++ b/scripts/check-docs-links.test.js
@@ -41,7 +41,15 @@ test("docs link checker rejects missing duplicate heading anchors", (t) => {
 
 test("docs link checker accepts local links with titles and angle brackets", (t) => {
   const dir = newDocsFixture(t);
-  writeFile(path.join(dir, "README.md"), '[guide](<docs/guide.md#quoted-heading> "Guide page")\n');
+  writeFile(
+    path.join(dir, "README.md"),
+    [
+      '[guide](<docs/guide.md#quoted-heading> "Contributor\'s guide")',
+      '[guide](<docs/guide.md#quoted-heading> \'The "guide" page\')',
+      '[guide](<docs/guide.md#quoted-heading> "A \\"quoted\\" guide")',
+      "",
+    ].join("\n"),
+  );
   writeFile(path.join(dir, "docs", "guide.md"), "# Quoted Heading\n");
 
   const result = runChecker(dir);

--- a/scripts/check-docs-links.test.js
+++ b/scripts/check-docs-links.test.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const checker = path.join(repoRoot, "scripts", "check-docs-links.mjs");
+
+test("docs link checker accepts GitHub duplicate heading anchors", (t) => {
+  const dir = newDocsFixture(t);
+  writeFile(path.join(dir, "README.md"), "[second setup](docs/guide.md#setup-1)\n");
+  writeFile(path.join(dir, "docs", "guide.md"), "# Setup\n\n## Details\n\n# Setup\n");
+
+  const result = runChecker(dir);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("docs link checker rejects missing duplicate heading anchors", (t) => {
+  const dir = newDocsFixture(t);
+  writeFile(path.join(dir, "README.md"), "[third setup](docs/guide.md#setup-2)\n");
+  writeFile(path.join(dir, "docs", "guide.md"), "# Setup\n\n# Setup\n");
+
+  const result = runChecker(dir);
+
+  assert.notEqual(result.status, 0, result.stdout);
+  assert.match(result.stderr, /missing heading docs\/guide\.md#setup-2/);
+});
+
+test("docs link checker accepts local links with titles and angle brackets", (t) => {
+  const dir = newDocsFixture(t);
+  writeFile(path.join(dir, "README.md"), '[guide](<docs/guide.md#quoted-heading> "Guide page")\n');
+  writeFile(path.join(dir, "docs", "guide.md"), "# Quoted Heading\n");
+
+  const result = runChecker(dir);
+
+  assert.equal(result.status, 0, result.stderr);
+});
+
+function newDocsFixture(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-docs-links-"));
+  fs.mkdirSync(path.join(dir, "docs"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function writeFile(file, body) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body, "utf8");
+}
+
+function runChecker(cwd) {
+  return spawnSync(process.execPath, [checker], {
+    cwd,
+    encoding: "utf8",
+  });
+}


### PR DESCRIPTION
## Summary
- teach `scripts/check-docs-links.mjs` GitHub-style duplicate heading anchors, such as `#setup-1`
- accept local Markdown links that use angle-bracket targets and titles
- add focused `node:test` coverage for duplicate anchors, missing anchors, and titled links

## Verification
- `node --test scripts/check-docs-links.test.js`
- `node scripts/check-docs-links.mjs`
- `scripts/check-docs.sh`
- `git diff --check`

## Broad test note
- `node --test scripts/*.test.js` was also attempted. The new docs-link tests passed, but the broad script suite has unrelated existing failures in dynamic Cloudflare worker smoke, Vercel sandbox smoke, and Proxmox proof-directory tests on this machine.
