### PR TITLE
feat: add fenced runtime adapter deletion API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added JSON API initiation of generation-fenced runtime-adapter workspace deletion through explicit registered lease release.
+
 ## 0.31.0 - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ automatically by default; set `broker.autoWebVNC: false` to opt out. The
 coordinator never receives provider credentials or directly calls a registered
 provider. By default it removes only registration metadata; an explicitly
 bound outbound runtime adapter can perform a user-confirmed workspace delete.
+API clients request the same generation-fenced delete with
+`POST /v1/leases/{id}/release` and body `{"delete":true}`.
 
 Forwarded environment is intentionally narrow: `NODE_OPTIONS` and `CI`. Do not
 pass secrets as command-line arguments. For live-secret smoke tests, use

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -263,7 +263,12 @@ the same body.
 
 **Release.** `POST /v1/leases/{id}/release` (body `{delete?}`, defaulting to
 `!keep`) deletes the cloud server when the lease is still active and sets state
-`released`. The CLI client retries as admin when a user request 404s or 401s.
+`released`. For a registered lease bound to a runtime-adapter workspace,
+explicit `{"delete":true}` instead initiates the same owner/org-scoped,
+immutable-registration-generation-fenced delete used by the portal and returns
+`202` while confirmed-absence cleanup is pending. Omitting `delete` preserves
+metadata-only registered release. The CLI client retries as admin when a user
+request 404s or 401s.
 
 **Expiry and cleanup.** A DO alarm and the cron both run maintenance:
 `expireLeases` deletes cloud servers for active leases past `expiresAt`

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -4020,6 +4020,24 @@ export class FleetCoordinator {
         admin,
       );
     }
+    if (
+      body.delete === true &&
+      isRegisteredLease(lease) &&
+      lease.runtimeAdapterID &&
+      lease.runtimeAdapterWorkspaceID
+    ) {
+      if (!lease.runtimeAdapterRegistrationID) {
+        return json(
+          {
+            error: "runtime_adapter_registration_required",
+            message:
+              "runtime adapter workspace deletion requires an immutable registration generation",
+          },
+          { status: 409 },
+        );
+      }
+      return await this.deleteRegisteredRuntimeAdapterWorkspace(request, lease);
+    }
     if (lease.runtimeAdapterDeleteRequestedAt) {
       return runtimeAdapterDeletePendingResponse(lease);
     }
@@ -4833,135 +4851,188 @@ export class FleetCoordinator {
       return portalError("Stop unavailable", "Lease manage access is required.", 403);
     }
     if (isRegisteredLease(lease) && lease.runtimeAdapterID && lease.runtimeAdapterWorkspaceID) {
-      const adapterID = lease.runtimeAdapterID;
-      const workspaceID = lease.runtimeAdapterWorkspaceID;
-      return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
-        const current = await this.state.runExclusive(() => this.getLease(lease.id));
-        if (!current || !leaseIsLive(current)) {
-          return portalError("Delete unavailable", "That lease is no longer active.", 409);
-        }
-        if (!this.leaseManageableByRequest(current, request, isAdminRequest(request))) {
-          return portalError("Delete unavailable", "Lease manage access is required.", 403);
-        }
-        if (
-          current.runtimeAdapterID !== adapterID ||
-          current.runtimeAdapterWorkspaceID !== workspaceID ||
-          current.runtimeAdapterRegistrationID !== lease.runtimeAdapterRegistrationID
-        ) {
-          return portalError("Delete unavailable", "The runtime adapter binding changed.", 409);
-        }
-        const deleteClaim = await this.markRuntimeAdapterDeletePending(
-          current,
-          runtimeAdapterDeleteInitialRetryMs,
-        );
-        if (!deleteClaim) {
-          return portalError("Delete unavailable", "That lease is no longer active.", 409);
-        }
-        const dispatch = await this.beginRuntimeAdapterDeleteDispatch(current, deleteClaim);
-        if (!dispatch) {
-          return portalError(
-            "Delete unavailable",
-            "Another delete for this workspace is still settling. Try again shortly.",
-            503,
-          );
-        }
-        const proxyResult = await (async () => {
-          let result: RuntimeAdapterProxyResult | undefined;
-          try {
-            result = await this.runtimeAdapterProxyResult(
-              new Request(request.url, { method: "DELETE", headers: request.headers }),
-              adapterID,
-              ["v1", "workspaces", workspaceID],
-              { owner: current.owner, org: current.org },
-              dispatch.deadlineMs,
-            );
-            return result;
-          } finally {
-            await this.finishRuntimeAdapterDeleteDispatch(
-              dispatch,
-              result !== undefined && (await runtimeAdapterDeleteDispatchSafeToClear(result)),
-            );
-          }
-        })();
-        const response = proxyResult.response;
-        let body:
-          | { id?: unknown; status?: unknown; message?: unknown; error?: unknown }
-          | undefined;
-        if (response.status !== 204) {
-          body = (await response
-            .clone()
-            .json()
-            .catch(() => undefined)) as
-            | { status?: unknown; message?: unknown; error?: unknown }
-            | undefined;
-        }
-        if (!response.ok) {
-          const relayRetryable =
-            proxyResult.origin === "relay" &&
-            ["runtime_adapter_busy", "runtime_adapter_backpressure"].includes(
-              runtimeAdapterErrorCode(body) ?? "",
-            );
-          if (deleteClaim.created && !proxyResult.dispatched && !relayRetryable) {
-            await this.clearRuntimeAdapterDeletePending(current, deleteClaim);
-          }
-          const unavailable =
-            response.status === 429 || response.status === 503 || response.status === 504;
-          return portalError(
-            unavailable ? "Delete unavailable" : "Delete failed",
-            unavailable
-              ? "The runtime adapter is offline or did not respond. Try again after its lifecycle agent reconnects."
-              : "The runtime adapter rejected the delete request. The workspace is still registered.",
-            unavailable ? 503 : 502,
-          );
-        }
-        if (
-          response.ok &&
-          response.status !== 204 &&
-          (body?.id !== workspaceID ||
-            !["stopping", "stopped", "expired"].includes(String(body?.status)))
-        ) {
-          return portalError(
-            "Delete failed",
-            "The runtime adapter returned an invalid workspace confirmation. The workspace is still registered.",
-            502,
-          );
-        }
-        const applied = await this.scheduleRuntimeAdapterDeleteRetry(
-          current,
-          deleteClaim,
-          runtimeAdapterDeleteRetryBaseMs,
-        );
-        if (!applied) {
-          const latest = await this.getLease(lease.id);
-          if (
-            latest &&
-            !leaseIsLive(latest) &&
-            !latest.runtimeAdapterDeleteRequestedAt &&
-            latest.runtimeAdapterID === adapterID &&
-            latest.runtimeAdapterWorkspaceID === workspaceID &&
-            latest.runtimeAdapterRegistrationID === lease.runtimeAdapterRegistrationID
-          ) {
-            return new Response(null, {
-              status: 303,
-              headers: { location: portalReturnLocation(request) },
-            });
-          }
-          return portalError(
-            "Delete unavailable",
-            "The lease changed while the runtime adapter was deleting its workspace.",
-            409,
-          );
-        }
+      const response = await this.deleteRegisteredRuntimeAdapterWorkspace(request, lease);
+      if (response.ok) {
         return new Response(null, {
           status: 303,
           headers: { location: portalReturnLocation(request) },
         });
-      });
+      }
+      const body = (await response.json().catch(() => undefined)) as
+        | { title?: unknown; message?: unknown }
+        | undefined;
+      return portalError(
+        typeof body?.title === "string" ? body.title : "Delete unavailable",
+        typeof body?.message === "string"
+          ? body.message
+          : "The runtime adapter could not delete this workspace.",
+        response.status,
+      );
     }
     await this.releaseResolvedLease(lease, { deleteServer: true, keep: false });
     return new Response(null, {
       status: 303,
       headers: { location: portalReturnLocation(request) },
+    });
+  }
+
+  private async deleteRegisteredRuntimeAdapterWorkspace(
+    request: Request,
+    lease: LeaseRecord,
+  ): Promise<Response> {
+    const adapterID = lease.runtimeAdapterID;
+    const workspaceID = lease.runtimeAdapterWorkspaceID;
+    if (!adapterID || !workspaceID || !isRegisteredLease(lease)) {
+      return runtimeAdapterWorkspaceDeleteError(
+        "runtime_adapter_binding_required",
+        "Delete unavailable",
+        "That lease is not bound to a runtime adapter workspace.",
+        409,
+      );
+    }
+    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+      const current = await this.state.runExclusive(() => this.getLease(lease.id));
+      if (!current || !leaseIsLive(current)) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_lease_inactive",
+          "Delete unavailable",
+          "That lease is no longer active.",
+          409,
+        );
+      }
+      if (!this.leaseManageableByRequest(current, request, isAdminRequest(request))) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "forbidden",
+          "Delete unavailable",
+          "Lease manage access is required.",
+          403,
+        );
+      }
+      if (
+        current.runtimeAdapterID !== adapterID ||
+        current.runtimeAdapterWorkspaceID !== workspaceID ||
+        current.runtimeAdapterRegistrationID !== lease.runtimeAdapterRegistrationID
+      ) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_binding_changed",
+          "Delete unavailable",
+          "The runtime adapter binding changed.",
+          409,
+        );
+      }
+      const deleteClaim = await this.markRuntimeAdapterDeletePending(
+        current,
+        runtimeAdapterDeleteInitialRetryMs,
+      );
+      if (!deleteClaim) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_lease_inactive",
+          "Delete unavailable",
+          "That lease is no longer active.",
+          409,
+        );
+      }
+      const dispatch = await this.beginRuntimeAdapterDeleteDispatch(current, deleteClaim);
+      if (!dispatch) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_delete_in_flight",
+          "Delete unavailable",
+          "Another delete for this workspace is still settling. Try again shortly.",
+          503,
+        );
+      }
+      const proxyResult = await (async () => {
+        let result: RuntimeAdapterProxyResult | undefined;
+        try {
+          result = await this.runtimeAdapterProxyResult(
+            new Request(request.url, { method: "DELETE", headers: request.headers }),
+            adapterID,
+            ["v1", "workspaces", workspaceID],
+            { owner: current.owner, org: current.org },
+            dispatch.deadlineMs,
+          );
+          return result;
+        } finally {
+          await this.finishRuntimeAdapterDeleteDispatch(
+            dispatch,
+            result !== undefined && (await runtimeAdapterDeleteDispatchSafeToClear(result)),
+          );
+        }
+      })();
+      const response = proxyResult.response;
+      let body: { id?: unknown; status?: unknown; message?: unknown; error?: unknown } | undefined;
+      if (response.status !== 204) {
+        body = (await response
+          .clone()
+          .json()
+          .catch(() => undefined)) as
+          | { status?: unknown; message?: unknown; error?: unknown }
+          | undefined;
+      }
+      if (!response.ok) {
+        const relayRetryable =
+          proxyResult.origin === "relay" &&
+          ["runtime_adapter_busy", "runtime_adapter_backpressure"].includes(
+            runtimeAdapterErrorCode(body) ?? "",
+          );
+        if (deleteClaim.created && !proxyResult.dispatched && !relayRetryable) {
+          await this.clearRuntimeAdapterDeletePending(current, deleteClaim);
+        }
+        const unavailable =
+          response.status === 429 || response.status === 503 || response.status === 504;
+        return runtimeAdapterWorkspaceDeleteError(
+          unavailable ? "runtime_adapter_unavailable" : "runtime_adapter_delete_rejected",
+          unavailable ? "Delete unavailable" : "Delete failed",
+          unavailable
+            ? "The runtime adapter is offline or did not respond. Try again after its lifecycle agent reconnects."
+            : "The runtime adapter rejected the delete request. The workspace is still registered.",
+          unavailable ? 503 : 502,
+        );
+      }
+      if (
+        response.ok &&
+        response.status !== 204 &&
+        (body?.id !== workspaceID ||
+          !["stopping", "stopped", "expired"].includes(String(body?.status)))
+      ) {
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_invalid_response",
+          "Delete failed",
+          "The runtime adapter returned an invalid workspace confirmation. The workspace is still registered.",
+          502,
+        );
+      }
+      const applied = await this.scheduleRuntimeAdapterDeleteRetry(
+        current,
+        deleteClaim,
+        runtimeAdapterDeleteRetryBaseMs,
+      );
+      if (!applied) {
+        const latest = await this.getLease(lease.id);
+        if (
+          latest &&
+          !leaseIsLive(latest) &&
+          !latest.runtimeAdapterDeleteRequestedAt &&
+          latest.runtimeAdapterID === adapterID &&
+          latest.runtimeAdapterWorkspaceID === workspaceID &&
+          latest.runtimeAdapterRegistrationID === lease.runtimeAdapterRegistrationID
+        ) {
+          return json({ lease: latest, status: "deleted" });
+        }
+        return runtimeAdapterWorkspaceDeleteError(
+          "runtime_adapter_lease_changed",
+          "Delete unavailable",
+          "The lease changed while the runtime adapter was deleting its workspace.",
+          409,
+        );
+      }
+      return json(
+        {
+          lease: (await this.getLease(lease.id)) ?? current,
+          status: "deleting",
+        },
+        { status: 202 },
+      );
     });
   }
 
@@ -10602,6 +10673,15 @@ function workspaceManagedLeaseResponse(): Response {
     },
     { status: 409 },
   );
+}
+
+function runtimeAdapterWorkspaceDeleteError(
+  error: string,
+  title: string,
+  message: string,
+  status: number,
+): Response {
+  return json({ error, title, message }, { status });
 }
 
 function runtimeAdapterDeletePendingResponse(lease: LeaseRecord): Response {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -782,6 +782,146 @@ describe("runtime adapter relay", () => {
     await expect(Promise.all(alicePending)).resolves.toHaveLength(32);
   });
 
+  it("deletes a generation-bound adapter workspace through the JSON release API", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const lease = testLease({
+      id: "cbx_000000000071",
+      provider: "external",
+      lifecycle: "registered",
+      runtimeAdapterID: "example-adapter",
+      runtimeAdapterWorkspaceID: "example-workspace-71",
+      runtimeAdapterRegistrationID: "registration-generation-71",
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: true,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    const legacyLease = testLease({
+      ...lease,
+      id: "cbx_000000000070",
+      runtimeAdapterWorkspaceID: "example-workspace-70",
+      runtimeAdapterRegistrationID: undefined,
+    });
+    storage.seed("runtime-adapter-identity:example-adapter", {
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    storage.seed(`lease:${legacyLease.id}`, legacyLease);
+
+    const unfenced = await fleet.fetch(
+      request("POST", `/v1/leases/${legacyLease.id}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(unfenced.status).toBe(409);
+    await expect(unfenced.json()).resolves.toMatchObject({
+      error: "runtime_adapter_registration_required",
+    });
+    expect(storage.value<LeaseRecord>(`lease:${legacyLease.id}`)?.state).toBe("active");
+
+    const wrongOwner = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: {
+          "x-crabbox-owner": "mallory@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { delete: true },
+      }),
+    );
+    expect(wrongOwner.status).toBe(404);
+
+    const socket = new FakeWebSocket({
+      kind: "runtime-adapter-agent",
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+    });
+    const relayState = fleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set("example-adapter", socket as unknown as WebSocket);
+    socket.onSend = (data) => {
+      const message = JSON.parse(data) as {
+        id: string;
+        method: string;
+        path: string;
+        body?: string;
+      };
+      expect(message).toMatchObject({
+        method: "DELETE",
+        path: "/v1/workspaces/example-workspace-71",
+      });
+      expect(message.body).toBeUndefined();
+      void fleet.webSocketMessage(
+        socket as unknown as WebSocket,
+        JSON.stringify({
+          type: "response",
+          id: message.id,
+          status: 202,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "example-workspace-71", status: "stopping" }),
+        }),
+      );
+    };
+
+    const deleted = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(deleted.status).toBe(202);
+    await expect(deleted.json()).resolves.toMatchObject({
+      status: "deleting",
+      lease: {
+        id: lease.id,
+        owner: "alice@example.com",
+        org: "example-org",
+        runtimeAdapterID: "example-adapter",
+        runtimeAdapterWorkspaceID: "example-workspace-71",
+        runtimeAdapterRegistrationID: "registration-generation-71",
+        runtimeAdapterDeleteRequestedAt: expect.any(String),
+      },
+    });
+    expect(socket.sentJSON()).toHaveLength(1);
+
+    const rawDelete = await fleet.fetch(
+      request("DELETE", "/v1/adapters/example-adapter/proxy/v1/workspaces/example-workspace-71", {
+        headers,
+      }),
+    );
+    expect(rawDelete.status).toBe(409);
+    await expect(rawDelete.json()).resolves.toMatchObject({
+      error: "runtime_adapter_delete_requires_lease",
+    });
+    expect(socket.sentJSON()).toHaveLength(1);
+
+    const wrongGeneration = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers,
+        body: {
+          runtimeAdapterDeleteCompletion: {
+            adapterID: "example-adapter",
+            workspaceID: "example-workspace-71",
+            registrationID: "registration-generation-other",
+            status: "absent",
+          },
+        },
+      }),
+    );
+    expect(wrongGeneration.status).toBe(409);
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("active");
+  });
+
   it("routes portal Delete through the bound adapter and keeps deregistration as fallback", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);


### PR DESCRIPTION
## Summary

- add an explicit JSON API path for deleting registered runtime-adapter workspaces
- reuse the portal's owner/org-scoped, generation-fenced deletion workflow
- preserve metadata-only release and keep raw adapter `DELETE` blocked

## Verification

- `npm test --prefix worker` (605 tests)
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- autoreview: no findings
