### PR TITLE
fix(webvnc): force VNC password authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Added an explicit `webvnc local --security-type vnc` mode that forces standard VNC password authentication when a server advertises account authentication first.
 - Fixed coordinator hibernation recovery to preserve unambiguous live bridges while rejecting duplicate or stale restored endpoints.
 - Fixed portable Node coordinator startup when the production bundle loads the external CommonJS `ssh2` dependency.
 - Fixed CodeSandbox ownership tags, one-shot SDK bridge shutdown, mount-safe root workspace replacement, runtime-only resume responses, and authenticated preview URLs, preventing lifecycle rejection, command hangs, archive-sync failures, and unusable private port links.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -87,6 +87,7 @@ secret-command | crabbox webvnc local \
   --vnc-port 5900 \
   --username admin \
   --password-stdin \
+  --security-type vnc \
   --open
 ```
 
@@ -97,6 +98,13 @@ the RFB banner before reading the password from stdin. The browser listener is
 also bound to `127.0.0.1`; use `--local-port <port>` only when a fixed browser
 port is required. The command stays in the foreground and must remain running
 alongside the underlying tunnel.
+
+Use `--security-type vnc` when the server advertises account-based security
+types ahead of standard VNC password authentication but the supplied password
+is the independent legacy VNC password. Crabbox then filters only the initial
+RFB security offer so the browser must choose type 2; all subsequent VNC bytes
+remain end-to-end between noVNC and the loopback source. The default `auto`
+preserves the server's advertised order.
 
 The self-contained noVNC handoff is a mode-`0600` temporary file. It contains
 only a fresh per-process bridge token, never the VNC password. The username is

--- a/internal/cli/macos_webvnc.go
+++ b/internal/cli/macos_webvnc.go
@@ -96,6 +96,7 @@ func (a App) macOSWebVNCBridge(ctx context.Context, cfg Config, id, webPort stri
 		webPort,
 		credentials,
 		openViewer,
+		false,
 		func(ctx context.Context) (net.Conn, error) {
 			return dialVNCForegroundTunnel(ctx, tunnel, vncPort)
 		},

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -147,7 +147,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), "Usage:")
 		fmt.Fprintln(fs.Output(), "  crabbox webvnc --id <lease-id-or-slug> [--open]")
-		fmt.Fprintln(fs.Output(), "  crabbox webvnc local --vnc-host 127.0.0.1 --vnc-port <port> --username <user> --password-stdin [--open]")
+		fmt.Fprintln(fs.Output(), "  crabbox webvnc local --vnc-host 127.0.0.1 --vnc-port <port> --username <user> --password-stdin [--security-type auto|vnc] [--local-port <port>] [--open]")
 		fmt.Fprintln(fs.Output(), "  crabbox webvnc status --id <lease-id-or-slug>")
 		fmt.Fprintln(fs.Output(), "  crabbox webvnc reset --id <lease-id-or-slug> [--open]")
 		fmt.Fprintln(fs.Output(), "  crabbox webvnc daemon start|status|stop --id <lease-id-or-slug>")

--- a/internal/cli/webvnc_local.go
+++ b/internal/cli/webvnc_local.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,13 @@ import (
 const maxLocalWebVNCPasswordBytes = 4096
 
 const localWebVNCListenerOwnershipInterval = time.Second
+
+const (
+	localWebVNCSecurityAuto = "auto"
+	localWebVNCSecurityVNC  = "vnc"
+)
+
+const localWebVNCSecurityTypePassword byte = 2
 
 const (
 	localWebVNCReadTimeout   = 10 * time.Second
@@ -43,12 +51,13 @@ func (a App) webVNCLocal(ctx context.Context, args []string) error {
 	fs := newFlagSet("webvnc local", a.Stderr)
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), "Usage:")
-		fmt.Fprintln(fs.Output(), "  crabbox webvnc local --vnc-host 127.0.0.1 --vnc-port <port> --username <user> --password-stdin [--local-port <port>] [--open]")
+		fmt.Fprintln(fs.Output(), "  crabbox webvnc local --vnc-host 127.0.0.1 --vnc-port <port> --username <user> --password-stdin [--security-type auto|vnc] [--local-port <port>] [--open]")
 	}
 	vncHost := fs.String("vnc-host", "127.0.0.1", "loopback VNC source host")
 	vncPort := fs.String("vnc-port", "", "loopback VNC source port")
 	username := fs.String("username", "", "VNC username")
 	passwordStdin := fs.Bool("password-stdin", false, "read the VNC password from stdin")
+	securityType := fs.String("security-type", localWebVNCSecurityAuto, "RFB security negotiation: auto or vnc")
 	localPort := fs.String("local-port", "", "local WebVNC browser port")
 	openViewer := fs.Bool("open", false, "open the local WebVNC viewer")
 	if err := parseFlags(fs, args); err != nil {
@@ -65,6 +74,9 @@ func (a App) webVNCLocal(ctx context.Context, args []string) error {
 	}
 	if err := validateLocalWebVNCUsername(*username); err != nil {
 		return err
+	}
+	if *securityType != localWebVNCSecurityAuto && *securityType != localWebVNCSecurityVNC {
+		return exit(2, "--security-type must be auto or vnc")
 	}
 	if !*passwordStdin {
 		return exit(2, "webvnc local requires --password-stdin")
@@ -107,7 +119,16 @@ func (a App) webVNCLocal(ctx context.Context, args []string) error {
 	}
 	credentials := rfbCredentials{Username: *username, Password: password}
 	fmt.Fprintf(a.Stdout, "bridge: serving noVNC locally; VNC source %s:%s; keep this running while viewing\n", *vncHost, *vncPort)
-	return a.serveLocalWebVNCBridge(bridgeCtx, webListener, webPort, credentials, *openViewer, dialVNC, nil)
+	return a.serveLocalWebVNCBridge(
+		bridgeCtx,
+		webListener,
+		webPort,
+		credentials,
+		*openViewer,
+		*securityType == localWebVNCSecurityVNC,
+		dialVNC,
+		nil,
+	)
 }
 
 func reserveLocalWebVNCBrowserPort(requested string, excluded ...string) (*webVNCDaemonPortReservation, error) {
@@ -270,6 +291,7 @@ func (a App) serveLocalWebVNCBridge(
 	webPort string,
 	credentials rfbCredentials,
 	openViewer bool,
+	forceVNCAuthentication bool,
 	dialVNC localWebVNCDialer,
 	handoffOutput func(macOSWebVNCHandoff),
 ) error {
@@ -317,6 +339,10 @@ func (a App) serveLocalWebVNCBridge(
 			return
 		}
 		defer tcp.Close()
+		if forceVNCAuthentication {
+			_ = relayWebSocketVNCWithVNCAuthentication(relayCtx, ws, tcp)
+			return
+		}
 		relayWebSocketVNC(relayCtx, ws, tcp)
 	})
 
@@ -360,4 +386,176 @@ func (a App) serveLocalWebVNCBridge(
 	case err := <-serverErrors:
 		return exit(5, "serve local WebVNC: %v", err)
 	}
+}
+
+func relayWebSocketVNCWithVNCAuthentication(ctx context.Context, ws *websocket.Conn, tcp net.Conn) error {
+	browser := websocket.NetConn(context.Background(), ws, websocket.MessageBinary)
+	negotiationCtx, cancelNegotiation := context.WithCancel(ctx)
+	negotiation := make(chan error, 1)
+	go func() {
+		negotiation <- forceRFBVNCAuthentication(negotiationCtx, browser, tcp)
+	}()
+	timer := time.NewTimer(localWebVNCReadTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-negotiation:
+		cancelNegotiation()
+		if cause := context.Cause(ctx); cause != nil {
+			_ = ws.Close(websocket.StatusGoingAway, "bridge stopped")
+			return cause
+		}
+		if err != nil {
+			_ = ws.Close(websocket.StatusPolicyViolation, "VNC authentication negotiation failed")
+			return err
+		}
+	case <-ctx.Done():
+		_ = ws.Close(websocket.StatusGoingAway, "bridge stopped")
+		cancelNegotiation()
+		<-negotiation
+		return context.Cause(ctx)
+	case <-timer.C:
+		_ = ws.Close(websocket.StatusPolicyViolation, "VNC authentication negotiation timed out")
+		cancelNegotiation()
+		<-negotiation
+		return fmt.Errorf("VNC authentication negotiation timed out")
+	}
+	errors := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(tcp, browser)
+		errors <- err
+	}()
+	go func() {
+		_, err := io.Copy(browser, tcp)
+		errors <- err
+	}()
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case err := <-errors:
+		return err
+	}
+}
+
+func forceRFBVNCAuthentication(ctx context.Context, browser, server net.Conn) error {
+	deadline := time.Now().Add(localWebVNCReadTimeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
+	if err := browser.SetDeadline(deadline); err != nil {
+		return fmt.Errorf("set RFB browser authentication deadline: %w", err)
+	}
+	if err := server.SetDeadline(deadline); err != nil {
+		_ = browser.SetDeadline(time.Time{})
+		return fmt.Errorf("set RFB server authentication deadline: %w", err)
+	}
+	cancellationDone := make(chan struct{})
+	stopCancellation := context.AfterFunc(ctx, func() {
+		defer close(cancellationDone)
+		_ = browser.SetDeadline(time.Now())
+		_ = server.SetDeadline(time.Now())
+	})
+	defer func() {
+		if !stopCancellation() {
+			<-cancellationDone
+		}
+		_ = browser.SetDeadline(time.Time{})
+		_ = server.SetDeadline(time.Time{})
+	}()
+
+	serverVersion := make([]byte, 12)
+	if _, err := io.ReadFull(server, serverVersion); err != nil {
+		return fmt.Errorf("read RFB server version: %w", err)
+	}
+	if err := validateRFBServerVersion(serverVersion); err != nil {
+		return fmt.Errorf("invalid RFB server version: %w", err)
+	}
+	if _, err := browser.Write(serverVersion); err != nil {
+		return fmt.Errorf("write RFB server version: %w", err)
+	}
+
+	browserVersion := make([]byte, 12)
+	if _, err := io.ReadFull(browser, browserVersion); err != nil {
+		return fmt.Errorf("read RFB browser version: %w", err)
+	}
+	major, minor, err := parseRFBVersion(browserVersion)
+	if err != nil {
+		return fmt.Errorf("invalid RFB browser version: %w", err)
+	}
+	if _, err := server.Write(browserVersion); err != nil {
+		return fmt.Errorf("write RFB browser version: %w", err)
+	}
+
+	if major == 3 && minor < 7 {
+		security := make([]byte, 4)
+		if _, err := io.ReadFull(server, security); err != nil {
+			return fmt.Errorf("read RFB 3.3 security type: %w", err)
+		}
+		if binary.BigEndian.Uint32(security) != uint32(localWebVNCSecurityTypePassword) {
+			return fmt.Errorf("RFB server did not select VNC password authentication")
+		}
+		if _, err := browser.Write(security); err != nil {
+			return fmt.Errorf("write RFB 3.3 security type: %w", err)
+		}
+		return nil
+	}
+
+	count := []byte{0}
+	if _, err := io.ReadFull(server, count); err != nil {
+		return fmt.Errorf("read RFB security type count: %w", err)
+	}
+	if count[0] == 0 {
+		return fmt.Errorf("RFB server rejected security negotiation")
+	}
+	types := make([]byte, int(count[0]))
+	if _, err := io.ReadFull(server, types); err != nil {
+		return fmt.Errorf("read RFB security types: %w", err)
+	}
+	passwordAuth := false
+	for _, securityType := range types {
+		if securityType == localWebVNCSecurityTypePassword {
+			passwordAuth = true
+			break
+		}
+	}
+	if !passwordAuth {
+		return fmt.Errorf("RFB server did not offer VNC password authentication")
+	}
+	if _, err := browser.Write([]byte{1, localWebVNCSecurityTypePassword}); err != nil {
+		return fmt.Errorf("write filtered RFB security types: %w", err)
+	}
+	selected := []byte{0}
+	if _, err := io.ReadFull(browser, selected); err != nil {
+		return fmt.Errorf("read RFB browser security selection: %w", err)
+	}
+	if selected[0] != localWebVNCSecurityTypePassword {
+		return fmt.Errorf("RFB browser did not select VNC password authentication")
+	}
+	if _, err := server.Write(selected); err != nil {
+		return fmt.Errorf("write RFB server security selection: %w", err)
+	}
+	return nil
+}
+
+func validateRFBServerVersion(version []byte) error {
+	if _, _, err := parseRFBVersion(version); err == nil {
+		return nil
+	}
+	switch string(version) {
+	case "RFB 004.000\n", "RFB 004.001\n", "RFB 005.000\n":
+		return nil
+	default:
+		return fmt.Errorf("unsupported protocol version %q", string(version))
+	}
+}
+
+func parseRFBVersion(version []byte) (int, int, error) {
+	if len(version) != 12 || string(version[:4]) != "RFB " || version[7] != '.' || version[11] != '\n' {
+		return 0, 0, fmt.Errorf("unexpected protocol banner")
+	}
+	major, majorErr := strconv.Atoi(string(version[4:7]))
+	minor, minorErr := strconv.Atoi(string(version[8:11]))
+	if majorErr != nil || minorErr != nil || major != 3 {
+		return 0, 0, fmt.Errorf("unsupported protocol version %q", string(version))
+	}
+	return major, minor, nil
 }

--- a/internal/cli/webvnc_local_test.go
+++ b/internal/cli/webvnc_local_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -91,6 +92,207 @@ func TestReserveLocalWebVNCBrowserPortUsesKernelAssignedPort(t *testing.T) {
 	}
 	if got := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port); got != port {
 		t.Fatalf("listener port=%q reservation port=%q", got, port)
+	}
+}
+
+func TestForceRFBVNCAuthenticationFiltersServerPreference(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	browser, bridgeBrowser := net.Pipe()
+	server, bridgeServer := net.Pipe()
+	defer browser.Close()
+	defer bridgeBrowser.Close()
+	defer server.Close()
+	defer bridgeServer.Close()
+
+	negotiation := make(chan error, 1)
+	go func() {
+		negotiation <- forceRFBVNCAuthentication(ctx, bridgeBrowser, bridgeServer)
+	}()
+	serverResult := make(chan error, 1)
+	go func() {
+		if _, err := server.Write([]byte("RFB 003.889\n")); err != nil {
+			serverResult <- err
+			return
+		}
+		version := make([]byte, 12)
+		if _, err := io.ReadFull(server, version); err != nil {
+			serverResult <- err
+			return
+		}
+		if string(version) != "RFB 003.008\n" {
+			serverResult <- fmt.Errorf("browser version=%q", version)
+			return
+		}
+		if _, err := server.Write([]byte{2, rfbSecurityARD, localWebVNCSecurityTypePassword}); err != nil {
+			serverResult <- err
+			return
+		}
+		selected := []byte{0}
+		if _, err := io.ReadFull(server, selected); err != nil {
+			serverResult <- err
+			return
+		}
+		if selected[0] != localWebVNCSecurityTypePassword {
+			serverResult <- fmt.Errorf("selected security type=%d", selected[0])
+			return
+		}
+		serverResult <- nil
+	}()
+
+	version := make([]byte, 12)
+	if _, err := io.ReadFull(browser, version); err != nil {
+		t.Fatal(err)
+	}
+	if string(version) != "RFB 003.889\n" {
+		t.Fatalf("server version=%q", version)
+	}
+	if _, err := browser.Write([]byte("RFB 003.008\n")); err != nil {
+		t.Fatal(err)
+	}
+	filtered := make([]byte, 2)
+	if _, err := io.ReadFull(browser, filtered); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(filtered, []byte{1, localWebVNCSecurityTypePassword}) {
+		t.Fatalf("filtered security types=%v", filtered)
+	}
+	if _, err := browser.Write([]byte{localWebVNCSecurityTypePassword}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-serverResult; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-negotiation; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateRFBServerVersionSupportsNoVNCAliases(t *testing.T) {
+	for _, version := range []string{
+		"RFB 003.889\n",
+		"RFB 004.000\n",
+		"RFB 004.001\n",
+		"RFB 005.000\n",
+	} {
+		t.Run(version[4:11], func(t *testing.T) {
+			if err := validateRFBServerVersion([]byte(version)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	if err := validateRFBServerVersion([]byte("RFB 006.000\n")); err == nil {
+		t.Fatal("unsupported server version was accepted")
+	}
+}
+
+func TestForceRFBVNCAuthenticationStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	browser, bridgeBrowser := net.Pipe()
+	server, bridgeServer := net.Pipe()
+	defer browser.Close()
+	defer bridgeBrowser.Close()
+	defer server.Close()
+	defer bridgeServer.Close()
+	result := make(chan error, 1)
+	go func() {
+		result <- forceRFBVNCAuthentication(ctx, bridgeBrowser, bridgeServer)
+	}()
+	cancel()
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("canceled authentication negotiation returned no error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("authentication negotiation did not stop after cancellation")
+	}
+}
+
+func TestForceRFBVNCAuthenticationStopsAtDeadlineWhenBrowserStallsAfterServerVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	browser, bridgeBrowser := net.Pipe()
+	server, bridgeServer := net.Pipe()
+	defer browser.Close()
+	defer bridgeBrowser.Close()
+	defer server.Close()
+	defer bridgeServer.Close()
+	result := make(chan error, 1)
+	go func() {
+		result <- forceRFBVNCAuthentication(ctx, bridgeBrowser, bridgeServer)
+	}()
+
+	if _, err := server.Write([]byte("RFB 003.889\n")); err != nil {
+		t.Fatal(err)
+	}
+	version := make([]byte, 12)
+	if _, err := io.ReadFull(browser, version); err != nil {
+		t.Fatal(err)
+	}
+	if string(version) != "RFB 003.889\n" {
+		t.Fatalf("server version=%q", version)
+	}
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expired authentication negotiation returned no error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("authentication negotiation did not reach its deadline while browser version was stalled")
+	}
+}
+
+func TestForceRFBVNCAuthenticationStopsWhenBrowserStallsAfterSecurityOffer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	browser, bridgeBrowser := net.Pipe()
+	server, bridgeServer := net.Pipe()
+	defer browser.Close()
+	defer bridgeBrowser.Close()
+	defer server.Close()
+	defer bridgeServer.Close()
+	result := make(chan error, 1)
+	go func() {
+		result <- forceRFBVNCAuthentication(ctx, bridgeBrowser, bridgeServer)
+	}()
+
+	if _, err := server.Write([]byte("RFB 003.889\n")); err != nil {
+		t.Fatal(err)
+	}
+	serverVersion := make([]byte, 12)
+	if _, err := io.ReadFull(browser, serverVersion); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := browser.Write([]byte("RFB 003.008\n")); err != nil {
+		t.Fatal(err)
+	}
+	browserVersion := make([]byte, 12)
+	if _, err := io.ReadFull(server, browserVersion); err != nil {
+		t.Fatal(err)
+	}
+	if string(browserVersion) != "RFB 003.008\n" {
+		t.Fatalf("browser version=%q", browserVersion)
+	}
+	if _, err := server.Write([]byte{2, rfbSecurityARD, localWebVNCSecurityTypePassword}); err != nil {
+		t.Fatal(err)
+	}
+	filtered := make([]byte, 2)
+	if _, err := io.ReadFull(browser, filtered); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(filtered, []byte{1, localWebVNCSecurityTypePassword}) {
+		t.Fatalf("filtered security types=%v", filtered)
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("canceled authentication negotiation returned no error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("authentication negotiation did not stop while browser selection was stalled")
 	}
 }
 
@@ -194,6 +396,11 @@ func TestWebVNCLocalRejectsUnsafeInputBeforeReadingPassword(t *testing.T) {
 			name: "missing stdin flag",
 			args: []string{"--vnc-host", "127.0.0.1", "--vnc-port", "5900", "--username", "admin"},
 			want: "requires --password-stdin",
+		},
+		{
+			name: "invalid security type",
+			args: []string{"--vnc-host", "127.0.0.1", "--vnc-port", "5900", "--username", "admin", "--password-stdin", "--security-type", "ard"},
+			want: "--security-type must be auto or vnc",
 		},
 	}
 	for _, tt := range tests {
@@ -371,6 +578,7 @@ func TestServeLocalWebVNCBridgeRelaysWithoutExposingCredentials(t *testing.T) {
 			listener,
 			webPort,
 			rfbCredentials{Username: "admin", Password: "super-secret"},
+			false,
 			false,
 			dial,
 			nil,


### PR DESCRIPTION
## Summary

- add `webvnc local --security-type auto|vnc`
- force standard VNC password authentication for macOS launchers while preserving the existing default
- cover RFB negotiation, cancellation, and flag validation

## Why

macOS Screen Sharing can advertise Apple Remote Desktop authentication before standard VNC password authentication. noVNC follows that order, so browser connections can fail even when legacy VNC authentication is enabled. The bridge now filters only the initial RFB security offer when explicitly requested and leaves the rest of the stream untouched.

## Validation

- `go test ./internal/cli -run 'Test(ForceRFBVNCAuthentication|MacOSWebVNC|WebVNCLocal|ServeLocalWebVNCBridge|ReadLocalWebVNCPassword|ReserveLocalWebVNCBrowserPort)' -count=1`
- `go vet ./internal/cli`
- docs build
