### PR TITLE
fix: require manage access for WebVNC reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required lease manage access before resetting another operator's WebVNC bridge. Thanks @coygeek.
 - Aligned the `apple-container` provider fallback image with the portable OS default while preserving explicit image choices. Thanks @coygeek.
 - Fixed `apple-container` inventory parsing for Apple container 1.0 object-form status and nested network addresses. Thanks @coygeek.
 - Added a dedicated route-scoped service credential for Crabfleet workspace lifecycle requests without granting general coordinator access.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -6343,9 +6343,13 @@ export class FleetCoordinator {
     if (request.method.toUpperCase() !== "POST") {
       return json({ error: "not_found" }, { status: 404 });
     }
-    const lease = await this.resolveLease(identifier, request, false);
+    const admin = isAdminRequest(request);
+    const lease = await this.resolveLease(identifier, request, admin);
     if (!lease) {
       return notFound();
+    }
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     const error = webVNCLeaseError(lease);
     if (error) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11768,6 +11768,74 @@ describe("fleet lease identity and idle", () => {
     ).toBe(true);
   });
 
+  it("requires manage access to reset a WebVNC bridge", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "shared-desktop",
+        owner: "owner@example.com",
+        org: "example-org",
+        desktop: true,
+        share: {
+          users: {
+            "viewer@example.com": "use",
+            "manager@example.com": "manage",
+          },
+          org: "use",
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const resetAs = (owner: string, org: string, admin = false) =>
+      fleet.fetch(
+        request("POST", "/v1/leases/shared-desktop/webvnc/reset", {
+          headers: {
+            "x-crabbox-owner": owner,
+            "x-crabbox-org": org,
+            ...(admin ? { "x-crabbox-admin": "true" } : {}),
+          },
+          body: {},
+        }),
+      );
+
+    const directUse = await resetAs("viewer@example.com", "example-org");
+    expect(directUse.status).toBe(403);
+    await expect(directUse.json()).resolves.toEqual({
+      error: "forbidden",
+      message: "lease manage access required",
+    });
+
+    const orgUse = await resetAs("org-viewer@example.com", "example-org");
+    expect(orgUse.status).toBe(403);
+    await expect(orgUse.json()).resolves.toEqual({
+      error: "forbidden",
+      message: "lease manage access required",
+    });
+
+    const status = await fleet.fetch(
+      request("GET", "/v1/leases/shared-desktop/webvnc/status", {
+        headers: {
+          "x-crabbox-owner": "owner@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    await expect(status.json()).resolves.toMatchObject({ events: [] });
+
+    const manager = await resetAs("manager@example.com", "example-org");
+    expect(manager.status).toBe(200);
+
+    const owner = await resetAs("owner@example.com", "example-org");
+    expect(owner.status).toBe(200);
+
+    const admin = await resetAs("admin@example.com", "other-org", true);
+    expect(admin.status).toBe(200);
+  });
+
   it("serves WebVNC pages only for desktop leases and requires an agent upgrade", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);


### PR DESCRIPTION
## Summary

- require owner, admin, or `manage` share access before resetting WebVNC bridge state
- reject direct and organization-wide `use` shares with `403 forbidden`
- add focused regression coverage and changelog credit

Fixes https://github.com/openclaw/crabbox/issues/369

## Verification

- `./worker/node_modules/.bin/vitest run worker/test/fleet.test.ts -t 'requires manage access to reset a WebVNC bridge'`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- Codex autoreview: clean, no accepted/actionable findings