### PR TITLE
fix: make run outputs private on POSIX hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Created run downloads, captures, proofs, and failure bundles with private POSIX permissions. Thanks @coygeek.
 - Preserved single-use bridge tickets when presented to the wrong lease, role, or runtime-adapter endpoint. Thanks @coygeek.
 - Required lease manage access before resetting another operator's WebVNC bridge. Thanks @coygeek.
 - Aligned the `apple-container` provider fallback image with the portable OS default while preserving explicit image choices. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -344,7 +344,9 @@ the box. Downloads run only after a successful remote command, paths resolve
 relative to the remote workdir unless absolute, and Windows paths use `=`
 instead of `:` so drive letters stay unambiguous. Crabbox rejects local output
 path collisions between stdout capture, stderr capture, and downloads before
-command execution.
+command execution. On Unix-like hosts, Crabbox-created download, capture, proof,
+and failure-bundle files use owner-only permissions (`0600`), and newly created
+output directories use `0700`.
 
 See [artifacts](artifacts.md) for the richer collection and publishing workflow.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -110,7 +110,9 @@ file. `--capture-on-fail` is still accepted as a compatibility alias; failure
 bundles are saved automatically on non-zero exit regardless.
 
 Crabbox does **not** redact captured files. Treat every bundle and capture file
-as secret-bearing until you have reviewed it.
+as secret-bearing until you have reviewed it. On Unix-like hosts, Crabbox
+creates local captures, downloads, proofs, and failure bundles with owner-only
+file permissions (`0600`); new output directories use `0700`.
 
 To pull successful-run artifacts back without routing file bytes through the
 coordinator log, use `--download remote=local` (repeatable):

--- a/internal/cli/delegated_downloads.go
+++ b/internal/cli/delegated_downloads.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 )
 
@@ -67,12 +65,7 @@ func MaterializeDelegatedRunDownloads(ctx context.Context, backend DelegatedRunD
 		if err != nil {
 			return nil, err
 		}
-		if dir := filepath.Dir(spec.Local); dir != "." && dir != "" {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return nil, exit(2, "download %s: create %s: %v", spec.Remote, dir, err)
-			}
-		}
-		if err := os.WriteFile(spec.Local, data, 0o666); err != nil {
+		if err := writeRunDownloadFile(spec.Local, data); err != nil {
 			return nil, exit(2, "download %s: write %s: %v", spec.Remote, spec.Local, err)
 		}
 		fmt.Fprintf(stderr, "downloaded %s bytes=%d\n", spec.Local, len(data))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -328,7 +328,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	if strings.TrimSpace(*leaseOutput) != "" {
-		if err := preflightLocalOutputPath("lease output", strings.TrimSpace(*leaseOutput), false); err != nil {
+		if err := preflightLocalOutputPath("lease output", strings.TrimSpace(*leaseOutput), false, false); err != nil {
 			return err
 		}
 	}
@@ -350,7 +350,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 				return exit(2, "proof template %q is not configured for profile %q", strings.TrimSpace(*proofTemplate), cfg.Profile)
 			}
 		}
-		if err := preflightLocalOutputPath("emit proof", strings.TrimSpace(*emitProof), true); err != nil {
+		if err := preflightLocalOutputPath("emit proof", strings.TrimSpace(*emitProof), true, true); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -329,11 +328,11 @@ func writeRunProof(path, templateName string, input proofRenderInput) (runArtifa
 		return runArtifact{}, err
 	}
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := createPrivateRunOutputDir(dir); err != nil {
 			return runArtifact{}, exit(2, "create proof directory: %v", err)
 		}
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := writePrivateRunOutputFile(path, []byte(content)); err != nil {
 		return runArtifact{}, exit(2, "write proof %s: %v", path, err)
 	}
 	return runArtifact{Kind: "proof", Path: path, Template: templateName, Bytes: len(content)}, nil

--- a/internal/cli/run_capture.go
+++ b/internal/cli/run_capture.go
@@ -73,7 +73,7 @@ func (c *failureStreamCapture) writer(base io.Writer, phase *phaseMarkerWriter, 
 		return base, false, nil
 	}
 	if c.explicitPath != "" {
-		file, err := os.Create(c.explicitPath)
+		file, err := openPrivateRunOutputFile(c.explicitPath)
 		if err != nil {
 			return nil, false, exit(2, "capture %s: %v", c.label, err)
 		}

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -63,17 +63,17 @@ func preflightRunLocalOutputs(captureStdout, captureStderr string, downloads []s
 		}
 	}
 	for _, download := range parsedDownloads {
-		if err := preflightLocalOutputPath("download "+download.Remote, download.Local, true); err != nil {
+		if err := preflightLocalOutputPath("download "+download.Remote, download.Local, true, true); err != nil {
 			return err
 		}
 	}
 	if captureStdout != "" {
-		if err := preflightLocalOutputPath("capture stdout", captureStdout, false); err != nil {
+		if err := preflightLocalOutputPath("capture stdout", captureStdout, false, true); err != nil {
 			return err
 		}
 	}
 	if captureStderr != "" {
-		if err := preflightLocalOutputPath("capture stderr", captureStderr, false); err != nil {
+		if err := preflightLocalOutputPath("capture stderr", captureStderr, false, true); err != nil {
 			return err
 		}
 	}
@@ -144,14 +144,25 @@ func sameLocalOutputPath(left, right string) (bool, error) {
 	return leftAbs == rightAbs, nil
 }
 
-func preflightLocalOutputPath(label, path string, allowMissingDirs bool) error {
+func preflightLocalOutputPath(label, path string, allowMissingDirs, replaceExisting bool) error {
 	dir := filepath.Dir(path)
-	if info, err := os.Stat(path); err == nil {
+	info, err := os.Stat(path)
+	if replaceExisting {
+		info, err = os.Lstat(path)
+	}
+	if err == nil {
 		if info.IsDir() {
 			return exit(2, "%s: %s is a directory", label, path)
 		}
+		if replaceExisting {
+			if err := checkWritableDir(label, firstNonBlank(dir, ".")); err != nil {
+				return err
+			}
+			return checkPrivateRunOutputReplaceable(label, path)
+		}
 		return checkWritableFile(label, path)
-	} else if !errors.Is(err, os.ErrNotExist) {
+	}
+	if !errors.Is(err, os.ErrNotExist) {
 		return exit(2, "%s: %v", label, err)
 	}
 	if dir == "." || dir == "" {
@@ -221,15 +232,19 @@ func downloadRemoteFile(ctx context.Context, target SSHTarget, workdir, specValu
 	if err != nil {
 		return 0, spec.Local, exit(7, "download %s: decode base64: %v", spec.Remote, err)
 	}
-	if dir := filepath.Dir(spec.Local); dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return 0, spec.Local, exit(2, "download %s: create %s: %v", spec.Remote, dir, err)
-		}
-	}
-	if err := os.WriteFile(spec.Local, data, 0o666); err != nil {
+	if err := writeRunDownloadFile(spec.Local, data); err != nil {
 		return 0, spec.Local, exit(2, "download %s: write %s: %v", spec.Remote, spec.Local, err)
 	}
 	return len(data), spec.Local, nil
+}
+
+func writeRunDownloadFile(path string, data []byte) error {
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := createPrivateRunOutputDir(dir); err != nil {
+			return err
+		}
+	}
+	return writePrivateRunOutputFile(path, data)
 }
 
 func remoteDownloadBase64Command(target SSHTarget, workdir, remotePath string) string {

--- a/internal/cli/run_local_output.go
+++ b/internal/cli/run_local_output.go
@@ -1,0 +1,12 @@
+package cli
+
+import "os"
+
+const (
+	privateRunOutputDirMode  = 0o700
+	privateRunOutputFileMode = 0o600
+)
+
+func createPrivateRunOutputDir(path string) error {
+	return os.MkdirAll(path, privateRunOutputDirMode)
+}

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func ensurePrivateRunOutputDir(path string) error {
+	if err := createPrivateRunOutputDir(path); err != nil {
+		return err
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+	return unix.Fchmod(fd, privateRunOutputDirMode)
+}
+
+func openPrivateRunOutputFile(path string) (*os.File, error) {
+	file, tempPath, err := createPrivateRunOutputTemp(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+		return nil, err
+	}
+	return file, nil
+}
+
+func writePrivateRunOutputFile(path string, data []byte) error {
+	file, tempPath, err := createPrivateRunOutputTemp(path)
+	if err != nil {
+		return err
+	}
+	cleanup := func() {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+	}
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		cleanup()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".crabbox-*")
+	if err != nil {
+		return nil, "", err
+	}
+	tempPath := file.Name()
+	if err := file.Chmod(privateRunOutputFileMode); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+		return nil, "", err
+	}
+	return file, tempPath, nil
+}
+
+func checkPrivateRunOutputReplaceable(label, path string) error {
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		return exit(2, "%s: %v", label, err)
+	}
+	fileInfo, err := os.Lstat(path)
+	if err != nil {
+		return exit(2, "%s: %v", label, err)
+	}
+	dirStat, dirOK := dirInfo.Sys().(*syscall.Stat_t)
+	fileStat, fileOK := fileInfo.Sys().(*syscall.Stat_t)
+	if !dirOK || !fileOK {
+		return nil
+	}
+	if !stickyRunOutputReplaceAllowed(uint32(os.Geteuid()), fileStat.Uid, dirStat.Uid, dirInfo.Mode()&os.ModeSticky != 0) {
+		return exit(2, "%s: cannot replace %s in sticky directory owned by another user", label, path)
+	}
+	return nil
+}
+
+func stickyRunOutputReplaceAllowed(euid, fileUID, dirUID uint32, sticky bool) bool {
+	return !sticky || euid == 0 || euid == fileUID || euid == dirUID
+}

--- a/internal/cli/run_local_output_unix_test.go
+++ b/internal/cli/run_local_output_unix_test.go
@@ -1,0 +1,206 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+const privateRunOutputUmaskTest = "CRABBOX_PRIVATE_RUN_OUTPUT_UMASK_TEST"
+
+func TestPrivateRunOutputPermissionsUnderPermissiveUmask(t *testing.T) {
+	if os.Getenv(privateRunOutputUmaskTest) == "" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestPrivateRunOutputPermissionsUnderPermissiveUmask$")
+		cmd.Env = append(os.Environ(), privateRunOutputUmaskTest+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("permission test subprocess failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	oldUmask := unix.Umask(0)
+	defer unix.Umask(oldUmask)
+
+	root := t.TempDir()
+	downloadPath := filepath.Join(root, "downloads", "report.txt")
+	if err := writeRunDownloadFile(downloadPath, []byte("download")); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, filepath.Dir(downloadPath), privateRunOutputDirMode)
+	assertRunOutputMode(t, downloadPath, privateRunOutputFileMode)
+
+	delegatedPath := filepath.Join(root, "delegated", "report.txt")
+	backend := &fakeDelegatedRunDownloadBackend{
+		files:   map[string][]byte{"reports/report.txt": []byte("delegated")},
+		fetches: map[string]int{},
+	}
+	if _, err := MaterializeDelegatedRunDownloads(t.Context(), backend, RunRequest{
+		Downloads: []string{"reports/report.txt=" + delegatedPath},
+	}, "lease-permissions", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, filepath.Dir(delegatedPath), privateRunOutputDirMode)
+	assertRunOutputMode(t, delegatedPath, privateRunOutputFileMode)
+
+	readOnlyPath := filepath.Join(root, "read-only.txt")
+	if err := os.WriteFile(readOnlyPath, []byte("old"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightRunLocalOutputs(readOnlyPath, "", nil); err != nil {
+		t.Fatalf("replacement preflight should not require old inode writability: %v", err)
+	}
+
+	symlinkTargetDir := filepath.Join(root, "symlink-target-dir")
+	if err := os.Mkdir(symlinkTargetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	preflightSymlink := filepath.Join(root, "preflight-symlink")
+	if err := os.Symlink(symlinkTargetDir, preflightSymlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightRunLocalOutputs(preflightSymlink, "", nil); err != nil {
+		t.Fatalf("replacement preflight should inspect the symlink entry, not its target: %v", err)
+	}
+
+	if os.Geteuid() != 0 {
+		lockedDir := filepath.Join(root, "locked")
+		if err := os.Mkdir(lockedDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		lockedPath := filepath.Join(lockedDir, "existing.txt")
+		if err := os.WriteFile(lockedPath, []byte("existing"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(lockedDir, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(lockedDir, 0o700)
+		if err := preflightRunLocalOutputs(lockedPath, "", nil); err == nil {
+			t.Fatal("preflight should reject an existing output in a non-writable directory")
+		}
+	}
+
+	capturePath := filepath.Join(root, "stdout.log")
+	if err := os.WriteFile(capturePath, []byte("old"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	oldCapture, err := os.Open(capturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldCapture.Close()
+	capture := &failureStreamCapture{label: "stdout", explicitPath: capturePath}
+	captureWriter, _, err := capture.writer(io.Discard, &phaseMarkerWriter{}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureWriter.Write([]byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := capture.closeQuiet(); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, capturePath, privateRunOutputFileMode)
+	if got, err := io.ReadAll(oldCapture); err != nil || !bytes.Equal(got, []byte("old")) {
+		t.Fatalf("old capture inode data=%q err=%v", got, err)
+	}
+
+	victimPath := filepath.Join(root, "victim.txt")
+	if err := os.WriteFile(victimPath, []byte("victim"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(root, "symlink-output")
+	if err := os.Symlink(victimPath, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateRunOutputFile(symlinkPath, []byte("output")); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(victimPath); err != nil || !bytes.Equal(got, []byte("victim")) {
+		t.Fatalf("symlink victim data=%q err=%v", got, err)
+	}
+	if info, err := os.Lstat(symlinkPath); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("output path should replace symlink with a regular file: info=%v err=%v", info, err)
+	}
+	assertRunOutputMode(t, symlinkPath, privateRunOutputFileMode)
+
+	proofPath := filepath.Join(root, "proofs", "proof.md")
+	if _, err := writeRunProof(proofPath, "", proofRenderInput{
+		Provider: "aws",
+		LeaseID:  "cbx_permissions",
+		Command:  "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, filepath.Dir(proofPath), privateRunOutputDirMode)
+	assertRunOutputMode(t, proofPath, privateRunOutputFileMode)
+
+	t.Chdir(root)
+	if err := os.Mkdir(".crabbox", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bundleTarget := filepath.Join(root, "bundle-target")
+	if err := os.Mkdir(bundleTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(bundleTarget, filepath.Join(".crabbox", "captures")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := writeLocalFailureBundle("rejected.tar.gz", "", FailureCaptureMetadata{}); err == nil {
+		t.Fatal("failure bundle directory symlink should be rejected")
+	}
+	assertRunOutputMode(t, bundleTarget, 0o755)
+	if err := os.Remove(filepath.Join(".crabbox", "captures")); err != nil {
+		t.Fatal(err)
+	}
+
+	bundlePath, _, err := writeLocalFailureBundle("failure.tar.gz", "", FailureCaptureMetadata{
+		Provider: "aws",
+		LeaseID:  "cbx_permissions",
+		RunID:    "run_permissions",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, filepath.Dir(bundlePath), privateRunOutputDirMode)
+	assertRunOutputMode(t, bundlePath, privateRunOutputFileMode)
+}
+
+func TestStickyRunOutputReplaceAllowed(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		euid, fileUID, dirUID uint32
+		sticky                bool
+		want                  bool
+	}{
+		{name: "non-sticky", euid: 1000, fileUID: 2000, dirUID: 3000, want: true},
+		{name: "root", euid: 0, fileUID: 2000, dirUID: 3000, sticky: true, want: true},
+		{name: "file owner", euid: 1000, fileUID: 1000, dirUID: 3000, sticky: true, want: true},
+		{name: "directory owner", euid: 1000, fileUID: 2000, dirUID: 1000, sticky: true, want: true},
+		{name: "foreign entry", euid: 1000, fileUID: 2000, dirUID: 3000, sticky: true, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stickyRunOutputReplaceAllowed(tc.euid, tc.fileUID, tc.dirUID, tc.sticky); got != tc.want {
+				t.Fatalf("replace allowed=%t want=%t", got, tc.want)
+			}
+		})
+	}
+}
+
+func assertRunOutputMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode=%#o want=%#o", path, got, want)
+	}
+}

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+func ensurePrivateRunOutputDir(path string) error {
+	if err := createPrivateRunOutputDir(path); err != nil {
+		return err
+	}
+	return os.Chmod(path, privateRunOutputDirMode)
+}
+
+func openPrivateRunOutputFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, privateRunOutputFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(privateRunOutputFileMode); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func writePrivateRunOutputFile(path string, data []byte) error {
+	file, err := openPrivateRunOutputFile(path)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(file, bytes.NewReader(data)); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func checkPrivateRunOutputReplaceable(_, _ string) error {
+	return nil
+}

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -624,10 +624,10 @@ func captureFailureBundle(ctx context.Context, target SSHTarget, workdir, leaseI
 
 func writeLocalFailureBundle(name, remoteTarPath string, meta FailureCaptureMetadata) (string, int, error) {
 	localPath := filepath.Join(".crabbox", "captures", name)
-	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+	if err := ensurePrivateRunOutputDir(filepath.Dir(localPath)); err != nil {
 		return localPath, 0, exit(2, "failure bundle create %s: %v", filepath.Dir(localPath), err)
 	}
-	file, err := os.Create(localPath)
+	file, err := openPrivateRunOutputFile(localPath)
 	if err != nil {
 		return localPath, 0, exit(2, "failure bundle create %s: %v", localPath, err)
 	}


### PR DESCRIPTION
## Summary

- create SSH and delegated run downloads, explicit captures, proof files, and failure bundles with private POSIX permissions
- publish completed downloads/proofs through fresh `0600` inodes, and use fresh private inodes for streaming captures/bundles
- create output directories as `0700`, reject unsafe capture-directory symlinks, and preflight normal/sticky-directory replacement rights
- document the Unix-like host permission contract

Fixes https://github.com/openclaw/crabbox/issues/378

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `scripts/test-go-modules.sh`
- `scripts/check-go-coverage.sh 90.0` (`90.9%` core coverage)
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go build -trimpath -o /tmp/crabbox-issue-378 ./cmd/crabbox`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/crabbox-cli-issue-378.test.exe ./internal/cli`
- `node scripts/check-command-docs.mjs`
- `node scripts/check-docs-links.mjs`
- `node scripts/build-docs-site.mjs`
- final autoreview: clean, no accepted/actionable findings

## Security/config implications

No secrets or configuration changes. On Unix-like hosts, Crabbox-created run output files now use `0600`; newly created output directories use `0700`.