### PR TITLE
fix: validate GitHub login browser targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Created run downloads, captures, proofs, and failure bundles with private POSIX permissions. Thanks @coygeek.
+- Rejected broker-supplied GitHub login URLs that do not use the expected HTTPS GitHub authorization endpoint.
 - Preserved single-use bridge tickets when presented to the wrong lease, role, or runtime-adapter endpoint. Thanks @coygeek.
 - Required lease manage access before resetting another operator's WebVNC bridge. Thanks @coygeek.
 - Aligned the `apple-container` provider fallback image with the portable OS default while preserving explicit image choices. Thanks @coygeek.

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -95,6 +95,9 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 	if err != nil {
 		return err
 	}
+	if err := validateGitHubLoginURL(start.URL); err != nil {
+		return exit(3, "GitHub login returned an invalid authorization URL: %v", err)
+	}
 	if canonicalBrokerURL, ok := canonicalBrokerURLFromLoginURL(start.URL); ok && !sameBrokerURL(brokerURL, canonicalBrokerURL) {
 		brokerURL = canonicalBrokerURL
 		client, err = coordinatorClientForLogin(brokerURL, provider)
@@ -104,6 +107,9 @@ func (a App) loginWithGitHub(ctx context.Context, brokerURL, provider string, br
 		start, err = client.StartGitHubLogin(ctx, pollSecretHash, provider)
 		if err != nil {
 			return err
+		}
+		if err := validateGitHubLoginURL(start.URL); err != nil {
+			return exit(3, "GitHub login returned an invalid authorization URL: %v", err)
 		}
 	}
 	if noBrowser {
@@ -204,6 +210,29 @@ func coordinatorClientForLogin(brokerURL, provider string) (*CoordinatorClient, 
 		return nil, exit(2, "login requires a broker URL")
 	}
 	return coord, nil
+}
+
+func validateGitHubLoginURL(loginURL string) error {
+	u, err := url.Parse(loginURL)
+	if err != nil {
+		return fmt.Errorf("parse URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("scheme must be https")
+	}
+	if u.User != nil {
+		return fmt.Errorf("user information is not allowed")
+	}
+	if !strings.EqualFold(u.Hostname(), "github.com") || u.Port() != "" {
+		return fmt.Errorf("host must be github.com")
+	}
+	if u.EscapedPath() != "/login/oauth/authorize" {
+		return fmt.Errorf("path must be /login/oauth/authorize")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("fragment is not allowed")
+	}
+	return nil
 }
 
 func canonicalBrokerURLFromLoginURL(loginURL string) (string, bool) {

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -655,6 +655,80 @@ func TestCanonicalBrokerURLFromLoginURL(t *testing.T) {
 	}
 }
 
+func TestValidateGitHubLoginURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "valid", value: "https://github.com/login/oauth/authorize?client_id=test&state=test"},
+		{name: "case insensitive host", value: "https://GitHub.com/login/oauth/authorize?state=test"},
+		{name: "http", value: "http://github.com/login/oauth/authorize?state=test", wantErr: true},
+		{name: "other host", value: "https://github.example.com/login/oauth/authorize?state=test", wantErr: true},
+		{name: "host suffix", value: "https://github.com.example.com/login/oauth/authorize?state=test", wantErr: true},
+		{name: "userinfo", value: "https://github.com@evil.example/login/oauth/authorize?state=test", wantErr: true},
+		{name: "custom port", value: "https://github.com:443/login/oauth/authorize?state=test", wantErr: true},
+		{name: "wrong path", value: "https://github.com/login?state=test", wantErr: true},
+		{name: "escaped path", value: "https://github.com/login/oauth/%61uthorize?state=test", wantErr: true},
+		{name: "fragment", value: "https://github.com/login/oauth/authorize?state=test#fragment", wantErr: true},
+		{name: "custom scheme", value: "itms-services://github.com/login/oauth/authorize", wantErr: true},
+		{name: "local file", value: "file:///tmp/login.html", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateGitHubLoginURL(test.value)
+			if test.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGitHubLoginRejectsInvalidAuthorizationURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	t.Setenv("CRABBOX_PROVIDER", "")
+
+	var pollCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/auth/github/start":
+			_ = json.NewEncoder(w).Encode(CoordinatorGitHubLoginStart{
+				LoginID:   "login_test",
+				URL:       "file:///tmp/fake-login.html",
+				ExpiresAt: time.Now().Add(time.Minute).Format(time.RFC3339),
+			})
+		case "/v1/auth/github/poll":
+			pollCount++
+			http.Error(w, "unexpected poll", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.login(context.Background(), []string{"--url", server.URL, "--no-browser"})
+	if err == nil || !strings.Contains(err.Error(), "invalid authorization URL") {
+		t.Fatalf("error=%v", err)
+	}
+	if pollCount != 0 {
+		t.Fatalf("poll count=%d want 0", pollCount)
+	}
+	if strings.Contains(stderr.String(), "file:///") {
+		t.Fatalf("stderr exposed rejected URL: %q", stderr.String())
+	}
+}
+
 func githubAuthorizeURLForTest(base string) string {
 	return "https://github.com/login/oauth/authorize?redirect_uri=" + url.QueryEscape(base+"/v1/auth/github/callback") + "&state=test"
 }


### PR DESCRIPTION
## Summary
- validate broker-returned GitHub OAuth URLs before browser dispatch, manual output, canonical broker migration, or polling
- accept only the expected `https://github.com/login/oauth/authorize` endpoint shape
- add focused regression coverage for accepted/rejected URL forms and the full login flow
- add the required maintainer changelog entry for this user-facing security fix

Fixes https://github.com/openclaw/crabbox/issues/373

## Verification
- `go test -race ./internal/cli -run 'TestGitHubLogin|TestValidateGitHubLoginURL|TestCanonicalBrokerURL' -count=1`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'go test -race ./...'` reported no accepted/actionable findings
- exact-head CI after rebasing onto current `main`: https://github.com/openclaw/crabbox/actions/runs/27538305527

### CLI behavior proof
Built the PR head and ran the real CLI against a local mock broker that returned `file:///tmp/rejected-login.html`. The mock counted poll requests:

```text
GitHub login returned an invalid authorization URL: scheme must be https
mock broker poll requests: 0
exit code: 3
```

The rejected URL was neither printed nor dispatched, and polling never started.

## Local full-suite note
`go test -race ./...` also exposed three pre-existing permission-test failures on the original checkout. They reproduced with this patch stashed and were unrelated to this change:

- `TestControllerStateLockRejectsSymlinkWithoutChangingTarget`
- `TestControllerStateLockRejectsBroadExistingFileWithoutChmod`
- `TestReadControllerTokenRequiresPrivateRegularFile`

The changelog entry remains intentionally: repository maintainer instructions require a changelog entry for user-facing fixes, and this PR is maintainer-authored rather than an external contributor PR. The branch is now rebased onto https://github.com/openclaw/crabbox/pull/392 and the changelog conflict is resolved by retaining both entries.