### PR TITLE
fix(workspace): keep terminal shell alive

### DIFF
--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11328,7 +11328,15 @@ function workspaceTerminalBootstrapCommand(workspace: WorkspaceRecord, lease: Le
   } else {
     setup.push(`mkdir -p ${shellQuote(workspaceRoot)}`);
   }
-  setup.push(`cd ${shellQuote(workspaceRoot)}`, `exec bash -lc ${shellQuote(command)}`);
+  setup.push(
+    `cd ${shellQuote(workspaceRoot)}`,
+    "printf '\\033[2J\\033[H'",
+    "set +e",
+    `bash -lc ${shellQuote(command)}`,
+    "command_status=$?",
+    "printf '\\nWorkspace command exited with status %s. The terminal remains available.\\n' \"$command_status\"",
+    "exec bash -l",
+  );
   const runner = `bash -lc ${shellQuote(setup.join("\n"))}`;
   const session = `crabbox-workspace-${workspace.id}`.slice(0, 80);
   return [

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4205,6 +4205,11 @@ describe("fleet lease identity and idle", () => {
     expect(bootstrap).toContain("rev-parse --verify 'HEAD^{commit}'");
     expect(bootstrap).toContain(".clone.XXXXXX");
     expect(bootstrap).toContain("if ! git clone");
+    expect(bootstrap).toContain("printf '\\\\033[2J\\\\033[H'");
+    expect(bootstrap).toContain("set +e");
+    expect(bootstrap).toContain("Workspace command exited with status %s");
+    expect(bootstrap).toContain("exec bash -l");
+    expect(bootstrap).not.toContain("exec bash -lc ${shellQuote(command)}");
     expect(bootstrap).not.toContain("/crabfleet/");
   });
 

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -135,6 +135,8 @@ describe("NodeCoordinatorRuntime", () => {
     expect(bootstrap).toContain('workspace.command?.trim() || "exec bash -l"');
     expect(bootstrap).not.toContain("checkout -B");
     expect(bootstrap).not.toContain("fetch --depth=1");
+    expect(bootstrap).toContain("Workspace command exited with status %s");
+    expect(bootstrap).toContain("exec bash -l");
   });
 
   it("bounds terminal input by bytes and queued frame count", async () => {


### PR DESCRIPTION
## Summary

- keep the tmux workspace alive after the initial Codex command exits
- clear successful bootstrap command noise before handing control to the workspace
- report the initial command exit status and fall back to a reusable login shell

## Validation

- `npm test --prefix worker -- --run test/fleet.test.ts test/node-runtime.test.ts` (268 tests)
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- deployed rebased Worker version `966358de-ecc1-4aed-8d33-8b1286f8fcca`