### PR TITLE
fix: redact shared lease bridge diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Redacted manage-only WebVNC bridge commands and egress session details from `use` share viewers. Thanks @coygeek.
 - Created run downloads, captures, proofs, and failure bundles with private POSIX permissions. Thanks @coygeek.
 - Rejected broker-supplied GitHub login URLs that do not use the expected HTTPS GitHub authorization endpoint.
 - Preserved single-use bridge tickets when presented to the wrong lease, role, or runtime-adapter endpoint. Thanks @coygeek.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -4706,7 +4706,12 @@ export class FleetCoordinator {
         404,
       );
     }
-    return portalMacHostDetail(host, host.lease ? this.leaseBridgeStatus(host.lease) : undefined);
+    const canManage = Boolean(
+      host.lease && this.leaseManageableByRequest(host.lease, request, isAdminRequest(request)),
+    );
+    return portalMacHostDetail(host, host.lease ? this.leaseBridgeStatus(host.lease) : undefined, {
+      canManage,
+    });
   }
 
   private async portalMacHostLeaseRedirect(
@@ -4736,7 +4741,9 @@ export class FleetCoordinator {
     }
     const error = action === "vnc" ? webVNCLeaseError(lease) : codeLeaseError(lease);
     if (action === "vnc" && error === "lease was not created with desktop=true") {
-      return portalMacHostDetail(host, this.leaseBridgeStatus(lease));
+      return portalMacHostDetail(host, this.leaseBridgeStatus(lease), {
+        canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
+      });
     }
     if (error) {
       return portalError(action === "vnc" ? "WebVNC unavailable" : "Code unavailable", error, 409);
@@ -5567,6 +5574,7 @@ export class FleetCoordinator {
     if (!lease) {
       return notFound();
     }
+    const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
     const session = this.egressSessions.get(lease.id);
     const key = session ? egressSocketKey(lease.id, session.sessionID) : undefined;
     const host = key ? this.egressHosts.get(key) : undefined;
@@ -5574,13 +5582,13 @@ export class FleetCoordinator {
     return json({
       leaseID: lease.id,
       slug: lease.slug,
-      sessionID: session?.sessionID ?? "",
-      profile: session?.profile ?? "",
-      allow: session?.allow ?? [],
+      sessionID: canManage ? (session?.sessionID ?? "") : "",
+      profile: canManage ? (session?.profile ?? "") : "",
+      allow: canManage ? (session?.allow ?? []) : [],
       hostConnected: host?.readyState === WebSocket.OPEN,
       clientConnected: client?.readyState === WebSocket.OPEN,
-      createdAt: session?.createdAt ?? "",
-      updatedAt: session?.updatedAt ?? "",
+      createdAt: canManage ? (session?.createdAt ?? "") : "",
+      updatedAt: canManage ? (session?.updatedAt ?? "") : "",
     });
   }
 
@@ -6317,7 +6325,8 @@ export class FleetCoordinator {
     const controller = controllerID
       ? this.webVNCViewers.get(lease.id)?.get(controllerID)
       : undefined;
-    const command = webVNCBridgeCommand(lease);
+    const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
+    const command = canManage ? webVNCBridgeCommand(lease) : "";
     return json({
       leaseID: lease.id,
       slug: lease.slug ?? "",
@@ -6346,7 +6355,9 @@ export class FleetCoordinator {
               ? "observer slots available"
               : "bridge connected"
             : "waiting for an available WebVNC observer slot"
-        : `WebVNC daemon not running; run: ${command}`,
+        : canManage
+          ? `WebVNC daemon not running; run: ${command}`
+          : "WebVNC daemon not running; ask a lease manager to start or refresh the bridge",
     });
   }
 
@@ -6937,11 +6948,14 @@ export class FleetCoordinator {
     }
     const agent = this.claimIdleWebVNCAgent(lease.id);
     if (!agent) {
-      const command = webVNCBridgeCommand(lease);
+      const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
+      const command = canManage ? webVNCBridgeCommand(lease) : "";
       return json(
         {
           error: "webvnc_bridge_missing",
-          message: `No WebVNC backend is available yet; start or refresh the bridge with: ${command}`,
+          message: canManage
+            ? `No WebVNC backend is available yet; start or refresh the bridge with: ${command}`
+            : "No WebVNC backend is available yet; ask a lease manager to start or refresh the bridge.",
           command,
         },
         { status: 409 },

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -505,6 +505,7 @@ export function portalLeaseDetail(
   const target = lease.target || "linux";
   const active = lease.state === "active";
   const registered = lease.lifecycle === "registered";
+  const canManage = options.canManage === true;
   const runRows = runs.length
     ? runs.map((run) => runRow(run)).join("")
     : `<tr><td colspan="8" class="empty">no recorded runs for this lease</td></tr>`;
@@ -518,18 +519,18 @@ export function portalLeaseDetail(
       : `<span class="muted">no code</span>`;
   const egressAction =
     active && bridgeStatus.egress
-      ? `<span class="muted">${escapeHTML(egressSummary(bridgeStatus.egress))}</span>`
+      ? `<span class="muted">${escapeHTML(canManage ? egressSummary(bridgeStatus.egress) : "active")}</span>`
       : `<span class="muted">no egress</span>`;
   const commands = active
     ? [
         commandBlock("shell", `crabbox ssh --id ${shellArg(slug)}`),
         commandBlock("run", `crabbox run --id ${shellArg(slug)} -- <command>`),
-        lease.desktop ? commandBlock("WebVNC bridge", webVNCBridgeCommand(lease)) : "",
+        lease.desktop && canManage ? commandBlock("WebVNC bridge", webVNCBridgeCommand(lease)) : "",
         lease.code ? commandBlock("code bridge", codeBridgeCommand(lease)) : "",
-        bridgeStatus.egress
+        bridgeStatus.egress && canManage
           ? commandBlock("egress status", `crabbox egress status --id ${shellArg(slug)}`)
           : "",
-        bridgeStatus.egress
+        bridgeStatus.egress && canManage
           ? commandBlock("egress stop", `crabbox egress stop --id ${shellArg(slug)}`)
           : "",
       ]
@@ -543,7 +544,7 @@ export function portalLeaseDetail(
         meta: `${escapeHTML(slug)} · ${escapeHTML(lease.provider)} ${escapeHTML(target)} ${registered ? "registered " : ""}lease <span class="mono">${escapeHTML(lease.id)}</span>`,
         actions: `
           ${
-            options.canManage
+            canManage
               ? `<a class="icon-btn" href="/portal/leases/${encodeURIComponent(lease.id)}/share" title="share lease" aria-label="share lease">${shareIcon}</a>`
               : ""
           }
@@ -570,7 +571,7 @@ export function portalLeaseDetail(
           </dl>
           ${leaseTelemetryTimeline(lease.telemetry, lease.telemetryHistory)}
           ${
-            active && options.canManage
+            active && canManage
               ? `<form method="post" action="/portal/leases/${encodeURIComponent(lease.id)}/release" class="stop-form" data-confirm="${escapeHTML(leaseReleaseConfirmation(lease))}">
                   <button class="button ${registered && !lease.runtimeAdapterID ? "secondary" : "danger"}" type="submit">${registered ? (lease.runtimeAdapterID ? "delete workspace" : "remove registration") : "stop lease"}</button>
                 </form>`
@@ -780,9 +781,11 @@ export function portalExternalRunnerDetail(
 export function portalMacHostDetail(
   host: PortalMacHostRecord,
   bridgeStatus: PortalLeaseBridgeStatus | undefined,
+  options: { canManage?: boolean } = {},
 ): Response {
   const lease = host.lease;
   const activeLease = lease?.state === "active" ? lease : undefined;
+  const canManage = options.canManage === true;
   const stateTone = macHostStateTone(host.state);
   const hostID = shortHostID(host.id);
   const startDesktopCommand = activeLease ? "" : macHostStartDesktopCommand(host);
@@ -806,7 +809,9 @@ export function portalMacHostDetail(
           "run",
           `crabbox run --id ${shellArg(activeLease.slug || activeLease.id)} -- <command>`,
         ),
-        activeLeaseVNC ? commandBlock("WebVNC bridge", webVNCBridgeCommand(activeLease)) : "",
+        activeLeaseVNC && canManage
+          ? commandBlock("WebVNC bridge", webVNCBridgeCommand(activeLease))
+          : "",
         activeLease.code ? commandBlock("code bridge", codeBridgeCommand(activeLease)) : "",
       ]
         .filter(Boolean)
@@ -1036,7 +1041,10 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
           org: "",
         },
       };
-  const bridgeCmd = webVNCBridgeCommand(lease);
+  const bridgeCmd = canManage ? webVNCBridgeCommand(lease) : "";
+  const bridgeMissingMessage = canManage
+    ? "WebVNC daemon not running; run the bridge command below"
+    : "WebVNC daemon not running; ask a lease manager to start or refresh the bridge";
   const fullscreenIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 9V4h5"/><path d="M20 9V4h-5"/><path d="M4 15v5h5"/><path d="M20 15v5h-5"/></svg>`;
   const reconnectIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>`;
   const pasteIcon = `<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2h6a2 2 0 0 1 2 2v1H7V4a2 2 0 0 1 2-2Z"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11v6"/><path d="m9 14 3 3 3-3"/></svg>`;
@@ -1059,11 +1067,15 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
         `,
       })}
       <section id="screen" class="screen" aria-label="WebVNC display" tabindex="0"></section>
-      <footer class="vnc-bridge">
+      ${
+        canManage
+          ? `<footer class="vnc-bridge">
         <span class="vnc-bridge-label">bridge</span>
         <code id="vnc-bridge-cmd" class="vnc-bridge-cmd">${escapeHTML(bridgeCmd)}</code>
         <button id="vnc-copy" class="icon-btn" type="button" title="copy command" aria-label="copy bridge command">${copyIcon}</button>
-      </footer>
+      </footer>`
+          : ""
+      }
       ${
         canManage
           ? `<dialog id="vnc-share-dialog" class="vnc-share-dialog" aria-label="Share lease">
@@ -1131,6 +1143,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       const username = fragment.get("username") || "";
       const password = fragment.get("password") || "";
       const takeControlOnConnect = fragment.get("control") === "take";
+      const bridgeMissingMessage = ${JSON.stringify(bridgeMissingMessage)};
       const credentials = {};
       if (username) credentials.username = username;
       if (password) credentials.password = password;
@@ -1356,7 +1369,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
             return;
           }
           if (state && !state.bridgeConnected) {
-            scheduleRetry(state.message || "WebVNC daemon not running; run the bridge command below");
+            scheduleRetry(state.message || bridgeMissingMessage);
             return;
           }
           if (state && state.availableViewerSlots === 0) {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11781,16 +11781,16 @@ describe("fleet lease identity and idle", () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
     const headers = {
-      "x-crabbox-owner": "peter@example.com",
-      "x-crabbox-org": "openclaw",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
     };
     storage.seed(
       "lease:cbx_000000000001",
       testLease({
         id: "cbx_000000000001",
         slug: "blue-lobster",
-        owner: "peter@example.com",
-        org: "openclaw",
+        owner: "alice@example.com",
+        org: "example-org",
         share: {
           users: {
             "viewer@example.com": "use",
@@ -11874,7 +11874,7 @@ describe("fleet lease identity and idle", () => {
 
     const viewerHeaders = {
       "x-crabbox-owner": "viewer@example.com",
-      "x-crabbox-org": "openclaw",
+      "x-crabbox-org": "example-org",
     };
     const viewerStatus = await fleet.fetch(
       request("GET", "/v1/leases/blue-lobster/egress/status", {
@@ -11909,7 +11909,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/v1/leases/blue-lobster/egress/status", {
         headers: {
           "x-crabbox-owner": "manager@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -12064,16 +12064,16 @@ describe("fleet lease identity and idle", () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
     const headers = {
-      "x-crabbox-owner": "peter@example.com",
-      "x-crabbox-org": "openclaw",
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
     };
     storage.seed(
       "lease:cbx_000000000001",
       testLease({
         id: "cbx_000000000001",
         slug: "blue-lobster",
-        owner: "peter@example.com",
-        org: "openclaw",
+        owner: "alice@example.com",
+        org: "example-org",
         desktop: true,
         share: {
           users: {
@@ -12090,8 +12090,8 @@ describe("fleet lease identity and idle", () => {
       testLease({
         id: "cbx_000000000002",
         slug: "plain-lobster",
-        owner: "peter@example.com",
-        org: "openclaw",
+        owner: "alice@example.com",
+        org: "example-org",
         desktop: false,
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       }),
@@ -12190,7 +12190,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/portal/leases/blue-lobster/vnc", {
         headers: {
           "x-crabbox-owner": "friend@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -12213,7 +12213,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/portal/leases/blue-lobster/vnc", {
         headers: {
           "x-crabbox-owner": "teammate@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -12226,7 +12226,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/portal/leases/blue-lobster/vnc/status", {
         headers: {
           "x-crabbox-owner": "friend@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -12241,7 +12241,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/portal/leases/blue-lobster/vnc/viewer", {
         headers: {
           "x-crabbox-owner": "friend@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
           upgrade: "websocket",
         },
       }),
@@ -12382,7 +12382,7 @@ describe("fleet lease identity and idle", () => {
     );
     const observerTheme = await fleet.fetch(
       request("POST", "/portal/leases/blue-lobster/vnc/theme", {
-        headers: { "x-crabbox-owner": "friend@example.com", "x-crabbox-org": "openclaw" },
+        headers: { "x-crabbox-owner": "friend@example.com", "x-crabbox-org": "example-org" },
         body: { theme: "dark", viewerID: "viewer_observer1" },
       }),
     );

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10828,6 +10828,8 @@ describe("fleet lease identity and idle", () => {
         hostId: "h-000000000001",
         cloudID: "i-000000000099",
         region: "eu-west-1",
+        owner: "alice@example.com",
+        org: "example-org",
         share: { users: { "friend@example.com": "use" } },
         createdAt: "2026-05-17T00:10:00.000Z",
         updatedAt: "2026-05-17T00:20:00.000Z",
@@ -10848,6 +10850,8 @@ describe("fleet lease identity and idle", () => {
         hostId: "h-000000000002",
         cloudID: "i-000000000100",
         region: "eu-west-1",
+        owner: "alice@example.com",
+        org: "example-org",
         createdAt: "2026-05-17T00:30:00.000Z",
         updatedAt: "2026-05-17T00:40:00.000Z",
         lastTouchedAt: "2026-05-17T00:40:00.000Z",
@@ -10867,8 +10871,8 @@ describe("fleet lease identity and idle", () => {
     const response = await fleet.fetch(
       request("GET", "/portal", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10896,8 +10900,8 @@ describe("fleet lease identity and idle", () => {
     const detail = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000001", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10915,7 +10919,7 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/portal/hosts/aws/h-000000000001", {
         headers: {
           "x-crabbox-owner": "friend@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10929,8 +10933,8 @@ describe("fleet lease identity and idle", () => {
     const vnc = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000001/vnc", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10940,8 +10944,8 @@ describe("fleet lease identity and idle", () => {
     const enablePage = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000002", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10953,8 +10957,8 @@ describe("fleet lease identity and idle", () => {
     const macVNC = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000002/vnc", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10964,8 +10968,8 @@ describe("fleet lease identity and idle", () => {
     const enabled = await fleet.fetch(
       request("POST", "/portal/hosts/aws/h-000000000002/vnc", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10976,8 +10980,8 @@ describe("fleet lease identity and idle", () => {
     const startPage = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000003/vnc", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
       }),
     );
@@ -10998,8 +11002,8 @@ describe("fleet lease identity and idle", () => {
     const idlePost = await fleet.fetch(
       request("POST", "/portal/hosts/aws/h-000000000003/vnc", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
         },
         body: {},
       }),

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10828,6 +10828,7 @@ describe("fleet lease identity and idle", () => {
         hostId: "h-000000000001",
         cloudID: "i-000000000099",
         region: "eu-west-1",
+        share: { users: { "friend@example.com": "use" } },
         createdAt: "2026-05-17T00:10:00.000Z",
         updatedAt: "2026-05-17T00:20:00.000Z",
         lastTouchedAt: "2026-05-17T00:20:00.000Z",
@@ -10906,6 +10907,24 @@ describe("fleet lease identity and idle", () => {
     expect(detailBody).toContain("attached lease");
     expect(detailBody).toContain("mac-mini / cbx_000000000099");
     expect(detailBody).toContain("/portal/leases/cbx_000000000099/vnc");
+    expect(detailBody).toContain(
+      "crabbox webvnc --provider aws --target macos --id mac-mini --open",
+    );
+
+    const friendDetail = await fleet.fetch(
+      request("GET", "/portal/hosts/aws/h-000000000001", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "openclaw",
+        },
+      }),
+    );
+    expect(friendDetail.status).toBe(200);
+    const friendDetailBody = await friendDetail.text();
+    expect(friendDetailBody).toContain("mac-mini / cbx_000000000099");
+    expect(friendDetailBody).not.toContain(
+      "crabbox webvnc --provider aws --target macos --id mac-mini --open",
+    );
 
     const vnc = await fleet.fetch(
       request("GET", "/portal/hosts/aws/h-000000000001/vnc", {
@@ -11768,6 +11787,13 @@ describe("fleet lease identity and idle", () => {
         slug: "blue-lobster",
         owner: "peter@example.com",
         org: "openclaw",
+        share: {
+          users: {
+            "viewer@example.com": "use",
+            "manager@example.com": "manage",
+          },
+          org: "use",
+        },
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       }),
     );
@@ -11825,6 +11851,9 @@ describe("fleet lease identity and idle", () => {
     expect(status.status).toBe(200);
     await expect(status.json()).resolves.toMatchObject({
       leaseID: "cbx_000000000001",
+      sessionID: "egress_camel123",
+      profile: "discord",
+      allow: ["discord.com"],
       hostConnected: false,
       clientConnected: false,
     });
@@ -11838,6 +11867,53 @@ describe("fleet lease identity and idle", () => {
     expect(portalBody).toContain("discord · discord.com");
     expect(portalBody).toContain("crabbox egress status --id blue-lobster");
     expect(portalBody).toContain("crabbox egress stop --id blue-lobster");
+
+    const viewerHeaders = {
+      "x-crabbox-owner": "viewer@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    const viewerStatus = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/egress/status", {
+        headers: viewerHeaders,
+      }),
+    );
+    expect(viewerStatus.status).toBe(200);
+    await expect(viewerStatus.json()).resolves.toMatchObject({
+      leaseID: "cbx_000000000001",
+      sessionID: "",
+      profile: "",
+      allow: [],
+      hostConnected: false,
+      clientConnected: false,
+      createdAt: "",
+      updatedAt: "",
+    });
+
+    const viewerPortal = await fleet.fetch(
+      request("GET", "/portal/leases/blue-lobster", { headers: viewerHeaders }),
+    );
+    expect(viewerPortal.status).toBe(200);
+    const viewerPortalBody = await viewerPortal.text();
+    expect(viewerPortalBody).toContain("<strong>egress</strong><small>waiting for host</small>");
+    expect(viewerPortalBody).toContain('<span class="muted">active</span>');
+    expect(viewerPortalBody).not.toContain("discord · discord.com");
+    expect(viewerPortalBody).not.toContain("*.discordcdn.com");
+    expect(viewerPortalBody).not.toContain("crabbox egress status --id blue-lobster");
+    expect(viewerPortalBody).not.toContain("crabbox egress stop --id blue-lobster");
+
+    const managerStatus = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/egress/status", {
+        headers: {
+          "x-crabbox-owner": "manager@example.com",
+          "x-crabbox-org": "openclaw",
+        },
+      }),
+    );
+    await expect(managerStatus.json()).resolves.toMatchObject({
+      sessionID: "egress_camel123",
+      profile: "discord",
+      allow: ["discord.com"],
+    });
 
     const missingTicket = await fleet.fetch(
       request("GET", "/v1/leases/blue-lobster/egress/host", {
@@ -12116,6 +12192,11 @@ describe("fleet lease identity and idle", () => {
     );
     expect(friendPage.status).toBe(200);
     const friendPageBody = await friendPage.text();
+    expect(friendPageBody).not.toContain(
+      "crabbox webvnc --provider hetzner --target linux --id blue-lobster --open",
+    );
+    expect(friendPageBody).not.toContain('id="vnc-bridge-cmd"');
+    expect(friendPageBody).not.toContain('id="vnc-copy"');
     expect(friendPageBody).not.toContain('<button id="vnc-share"');
     expect(friendPageBody).not.toContain('<dialog id="vnc-share-dialog"');
     expect(friendPageBody).not.toContain("People with access");
@@ -12123,6 +12204,51 @@ describe("fleet lease identity and idle", () => {
     expect(friendPageBody).not.toContain("friend@example.com");
     expect(friendPageBody).not.toContain("teammate@example.com");
     expect(friendPageBody).not.toContain('"org":"use"');
+
+    const managerPage = await fleet.fetch(
+      request("GET", "/portal/leases/blue-lobster/vnc", {
+        headers: {
+          "x-crabbox-owner": "teammate@example.com",
+          "x-crabbox-org": "openclaw",
+        },
+      }),
+    );
+    expect(managerPage.status).toBe(200);
+    expect(await managerPage.text()).toContain(
+      "crabbox webvnc --provider hetzner --target linux --id blue-lobster --open",
+    );
+
+    const friendStatus = await fleet.fetch(
+      request("GET", "/portal/leases/blue-lobster/vnc/status", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "openclaw",
+        },
+      }),
+    );
+    expect(friendStatus.status).toBe(200);
+    await expect(friendStatus.json()).resolves.toMatchObject({
+      leaseID: "cbx_000000000001",
+      command: "",
+      message: "WebVNC daemon not running; ask a lease manager to start or refresh the bridge",
+    });
+
+    const friendViewer = await fleet.fetch(
+      request("GET", "/portal/leases/blue-lobster/vnc/viewer", {
+        headers: {
+          "x-crabbox-owner": "friend@example.com",
+          "x-crabbox-org": "openclaw",
+          upgrade: "websocket",
+        },
+      }),
+    );
+    expect(friendViewer.status).toBe(409);
+    await expect(friendViewer.json()).resolves.toEqual({
+      error: "webvnc_bridge_missing",
+      message:
+        "No WebVNC backend is available yet; ask a lease manager to start or refresh the bridge.",
+      command: "",
+    });
 
     const status = await fleet.fetch(
       request("GET", "/portal/leases/blue-lobster/vnc/status", { headers }),


### PR DESCRIPTION
## Summary

- hide WebVNC bridge commands from `use` share viewers across lease, VNC, viewer-error, and dedicated-host portal surfaces
- redact egress session identifiers, profile, allowlist, and timestamps for `use` viewers while preserving connection-state visibility
- retain full diagnostics for owners, `manage` shares, and admins
- add focused authorization regressions and changelog coverage

Fixes https://github.com/openclaw/crabbox/issues/384

## Runtime proof

Focused Worker execution against the real request handlers; timestamps omitted from the manage response:

```text
use egress status:   {"sessionID":"","profile":"","allow":[],"hostConnected":false,"clientConnected":false,"createdAt":"","updatedAt":""}
use egress portal:   {"profileVisible":false,"statusCommandVisible":false,"stopCommandVisible":false}
manage egress status:{"sessionID":"egress_camel123","profile":"discord","allow":["discord.com"],"hostConnected":false,"clientConnected":false}
use WebVNC portal:   {"bridgeCommandVisible":false,"copyButtonVisible":false}
manage WebVNC portal:{"bridgeCommandVisible":true}
use WebVNC status:   {"command":"","message":"WebVNC daemon not running; ask a lease manager to start or refresh the bridge"}
manage WebVNC status:{"command":"crabbox webvnc --provider hetzner --target linux --id blue-lobster --open"}
```

Command:

```sh
npm test --prefix worker -- --run test/fleet.test.ts -t 'creates scoped egress tickets and reports bridge status|serves WebVNC pages only for desktop leases and requires an agent upgrade' --disableConsoleIntercept
```

Result: 2 passed, 255 skipped.

## Verification

- `npm test --prefix worker` (609 tests passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings, 0.99 confidence)
