### PR TITLE
fix: pin runtime base image digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
         run: npm run build:node
         working-directory: worker
 
+      - name: Check runtime base image pins
+        run: node scripts/check-docker-base-images.mjs
+
       - name: Build Node runtime image
         run: docker build -f worker/Dockerfile.node worker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Pinned shipped runtime container base images to reviewed multi-platform digests and enforced the pins in CI. Thanks @coygeek.
 - Redacted manage-only WebVNC bridge commands and egress session details from `use` share viewers. Thanks @coygeek.
 - Created run downloads, captures, proofs, and failure bundles with private POSIX permissions. Thanks @coygeek.
 - Rejected broker-supplied GitHub login URLs that do not use the expected HTTPS GitHub authorization endpoint.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -169,6 +169,16 @@ docker run --rm -p 8080:8080 \
   crabbox-coordinator:local
 ```
 
+The checked-in runtime Dockerfiles keep readable base-image tags but pin them to
+multi-platform manifest digests. When refreshing a base image, resolve the
+current manifest-list digest, update the tag and digest together, build the
+affected image, and run the repository check:
+
+```sh
+docker buildx imagetools inspect <image>:<tag> --format '{{.Manifest.Digest}}'
+node scripts/check-docker-base-images.mjs
+```
+
 The service creates PostgreSQL schemas `crabbox` and `crabbox_jobs`. Use
 `GET /v1/health` for liveness and `GET /v1/ready` for database readiness.
 `SIGTERM` and `SIGINT` stop new requests, drain active HTTP/WebSocket and

--- a/scripts/check-docker-base-images.mjs
+++ b/scripts/check-docker-base-images.mjs
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const runtimeDockerfiles = [
+  "worker/cloudflare-container.Dockerfile",
+  "worker/azure-dynamic-sessions.Dockerfile",
+  "worker/Dockerfile.node",
+];
+
+export function unpinnedBaseImages(source, file = "Dockerfile") {
+  const findings = [];
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    const match = /^\s*FROM\s+(?:--platform=\S+\s+)?(\S+)/i.exec(line);
+    if (match && !/@sha256:[0-9a-f]{64}$/i.test(match[1])) {
+      findings.push(`${file}:${index + 1}: base image lacks a valid SHA-256 digest: ${match[1]}`);
+    }
+  }
+  return findings;
+}
+
+async function main(files = runtimeDockerfiles) {
+  const findings = [];
+  for (const file of files) {
+    findings.push(...unpinnedBaseImages(await readFile(file, "utf8"), file));
+  }
+  if (findings.length > 0) {
+    console.error(findings.join("\n"));
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main(process.argv.slice(2).length > 0 ? process.argv.slice(2) : runtimeDockerfiles);
+}

--- a/scripts/check-docker-base-images.test.js
+++ b/scripts/check-docker-base-images.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { unpinnedBaseImages } from "./check-docker-base-images.mjs";
+
+test("accepts digest-pinned base images with readable tags", () => {
+  const digest = "a".repeat(64);
+  assert.deepEqual(
+    unpinnedBaseImages(
+      `FROM --platform=$BUILDPLATFORM node:24-bookworm@sha256:${digest} AS build\nFROM node:24-bookworm@sha256:${digest}\n`,
+    ),
+    [],
+  );
+});
+
+test("reports unpinned and malformed base-image digests", () => {
+  assert.deepEqual(
+    unpinnedBaseImages(
+      "FROM node:24-bookworm AS build\nFROM node:24-bookworm@sha256:abc\n",
+      "Dockerfile",
+    ),
+    [
+      "Dockerfile:1: base image lacks a valid SHA-256 digest: node:24-bookworm",
+      "Dockerfile:2: base image lacks a valid SHA-256 digest: node:24-bookworm@sha256:abc",
+    ],
+  );
+});

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:22-bookworm-slim AS build
+FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752 AS build
 
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -12,7 +12,7 @@ COPY src ./src
 COPY tsconfig.json tsconfig.node.json ./
 RUN npm run build:node && npm prune --omit=dev
 
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/worker/azure-dynamic-sessions.Dockerfile
+++ b/worker/azure-dynamic-sessions.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/devcontainers/go:1.26-bookworm AS runner-build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/devcontainers/go:1.26-bookworm@sha256:de99286e746c99e359edddaf0c47cbfbed34f4d6a3cd6310c99c87fa27c3c341 AS runner-build
 
 ARG TARGETOS=linux
 ARG TARGETARCH
@@ -7,7 +7,7 @@ COPY cloudflare-container-runner/go.mod cloudflare-container-runner/main.go ./
 RUN target_arch="${TARGETARCH:-$(go env GOARCH)}" \
   && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH="$target_arch" go build -trimpath -ldflags="-s -w" -o /out/crabbox-container-runner .
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-bookworm-slim@sha256:608b519f61bce1ad7496a2544041d6c1538a5c48d056adf55af7fdc35f924283
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash ca-certificates curl git jq ripgrep tar \

--- a/worker/cloudflare-container.Dockerfile
+++ b/worker/cloudflare-container.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-bookworm AS runner-build
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS runner-build
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
@@ -6,9 +6,9 @@ WORKDIR /src
 COPY cloudflare-container-runner/go.mod cloudflare-container-runner/main.go ./
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /out/crabbox-cloudflare-container-runner .
 
-FROM docker.io/library/golang:1.26-bookworm AS go-runtime
+FROM docker.io/library/golang:1.26-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS go-runtime
 
-FROM docker.io/library/node:24-bookworm
+FROM docker.io/library/node:24-bookworm@sha256:40ad9f3064e67d6860b4bc3fe1880b2953934fd6320ada990e45fe0efa6badd7
 
 ARG TARGETARCH=amd64
 ARG GH_VERSION=2.92.0


### PR DESCRIPTION
## Summary

- pin all shipped Cloudflare, Azure Dynamic Sessions, and Node coordinator base images to reviewed multi-platform manifest digests
- add a scoped CI check requiring a complete 64-character SHA-256 digest on every shipped runtime `FROM` reference
- document the deliberate tag-plus-digest refresh procedure

This is defense-in-depth supply-chain hardening. It makes future base-image byte changes explicit and reviewable; it is not evidence that any current upstream image or registry is compromised. Multi-platform index digests preserve the existing architecture selection behavior.

## Verification

- `node --test scripts/check-docker-base-images.test.js`
- `node scripts/check-docker-base-images.mjs`
- `node scripts/build-docs-site.mjs`
- `docker build --platform linux/amd64 -f worker/Dockerfile.node worker`
- `docker build --platform linux/amd64 -f worker/cloudflare-container.Dockerfile worker`
- `docker build --platform linux/amd64 -f worker/azure-dynamic-sessions.Dockerfile worker`
- verified every pinned value with `docker buildx imagetools inspect`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node --test scripts/check-docker-base-images.test.js && node scripts/check-docker-base-images.mjs"` returned clean

Closes https://github.com/openclaw/crabbox/issues/386