### PR TITLE
fix: preserve shared-lease run audit trails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Hardened shared-lease run auditability by preserving actor attribution while granting lease owners read-only access to runs, logs, events, telemetry, and portal history. Thanks @coygeek.
 - Pinned shipped runtime container base images to reviewed multi-platform digests and enforced the pins in CI. Thanks @coygeek.
 - Redacted manage-only WebVNC bridge commands and egress session details from `use` share viewers. Thanks @coygeek.
 - Created run downloads, captures, proofs, and failure bundles with private POSIX permissions. Thanks @coygeek.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,10 +230,13 @@ POST /v1/admin/aws-orphan-sweep
 ```
 
 `GET /v1/pool` and `/v1/admin/*` require the admin token. User tokens scope
-list, lookup, heartbeat, release, run history, logs, and usage to the token's
-owner/org. The CLI client wraps these in `internal/cli/coordinator.go`; when a
-user request 404s or 401s, an admin-token fallback re-resolves and retries as
-admin.
+list, lookup, heartbeat, release, run mutation, and usage to the token's
+owner/org. Run reads also permit every recorded backing lease owner so
+shared-lease and replacement activity remains auditable without granting those
+owners event, telemetry, or finish writes. The CLI client wraps these in
+`internal/cli/coordinator.go`;
+when a user request 404s or 401s, an admin-token fallback re-resolves and
+retries as admin.
 
 ## What Flows on a Run
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -296,7 +296,10 @@ directly against the runner over SSH:
 
 Read back with `GET /v1/runs`, `/v1/runs/{id}`, `/logs`, and `/events`. The
 `/v1/control` websocket lets clients subscribe to live run events and send lease
-heartbeats.
+heartbeats. A run keeps its initiating actor in `owner`/`org` plus every backing
+lease identity used by replacement flows. Each backing lease owner can read and
+subscribe for audit purposes, while only the actor or an admin can append
+events or telemetry and finish the run.
 
 ## CLI responsibilities
 

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -38,7 +38,8 @@ When the command exits, the CLI finishes the run with:
 
 - exit code;
 - sync duration, command duration, and total duration;
-- owner and org;
+- initiating actor owner and org;
+- backing lease IDs and owner/org identities for lease-backed runs;
 - provider, target, class, and server type;
 - the retained command log (capped — see below);
 - a parsed test-result summary when JUnit results are available;
@@ -63,6 +64,13 @@ crabbox attach run_a1b2c3d4          # follow an in-progress run live
 control WebSocket and falling back to polling. Use `attach` for active runs and
 `logs` for the retained output of a finished run. All four commands accept
 `--json`.
+
+Run records keep the initiating actor in `owner`/`org` and retain every backing
+lease identity used by a replacement flow. Each backing lease owner has
+read-only access to history, details, logs, events, telemetry, live event
+subscriptions, and portal pages for auditing work on their lease. Only the
+initiating actor or an admin can append events or telemetry and finish the run.
+Lease shares do not grant access to runs created by other actors.
 
 ## Storage limits
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,9 +65,12 @@ by coordinator config:
 - `CRABBOX_GITHUB_ALLOWED_TEAMS` (or `CRABBOX_GITHUB_ALLOWED_TEAM`) further
   narrows access to selected team slugs after org membership passes.
 
-User tokens can only see and mutate leases, runs, logs, and usage for their own
-`owner`/`org` identity. See [auth and admin](features/auth-admin.md) and
-[broker auth routing](features/broker-auth-routing.md) for the full flow.
+User tokens can only mutate leases, runs, and usage for their own `owner`/`org`
+identity. Lease owners also have read-only audit access to run history, logs,
+events, telemetry, and live event subscriptions for work recorded against
+their leases, including runs that later replace the active backing lease. See
+[auth and admin](features/auth-admin.md) and [broker auth
+routing](features/broker-auth-routing.md) for the full flow.
 
 ### Cloudflare Access (optional defense-in-depth)
 
@@ -119,7 +122,7 @@ and provider ingress rules.
 There are three effective roles:
 
 ```text
-user        acquire/heartbeat/release own leases; read own leases/runs/logs/usage
+user        acquire/heartbeat/release own leases; read own and owned-lease run audit data
 operator    shared automation identity via a shared bearer token
 admin       view all leases/runs/pool/usage; drain/delete machines; image lifecycle
 ```

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -386,35 +386,42 @@ type CoordinatorRunResponse struct {
 	Run CoordinatorRun `json:"run"`
 }
 
+type CoordinatorRunLeaseOwner struct {
+	Owner string `json:"owner"`
+	Org   string `json:"org"`
+}
+
 type CoordinatorRun struct {
-	ID           string               `json:"id"`
-	LeaseID      string               `json:"leaseID"`
-	Slug         string               `json:"slug,omitempty"`
-	Owner        string               `json:"owner"`
-	Org          string               `json:"org"`
-	Provider     string               `json:"provider"`
-	TargetOS     string               `json:"target,omitempty"`
-	WindowsMode  string               `json:"windowsMode,omitempty"`
-	Class        string               `json:"class"`
-	ServerType   string               `json:"serverType"`
-	Command      []string             `json:"command"`
-	Label        string               `json:"label,omitempty"`
-	State        string               `json:"state"`
-	Phase        string               `json:"phase,omitempty"`
-	ExitCode     *int                 `json:"exitCode,omitempty"`
-	SyncMs       int64                `json:"syncMs,omitempty"`
-	CommandMs    int64                `json:"commandMs,omitempty"`
-	DurationMs   int64                `json:"durationMs,omitempty"`
-	LogBytes     int64                `json:"logBytes"`
-	LogTruncated bool                 `json:"logTruncated"`
-	BlockedStage string               `json:"blockedStage,omitempty"`
-	RetryLikely  string               `json:"retryLikely,omitempty"`
-	Results      *TestResultSummary   `json:"results,omitempty"`
-	Telemetry    *RunTelemetrySummary `json:"telemetry,omitempty"`
-	StartedAt    string               `json:"startedAt"`
-	LastEventAt  string               `json:"lastEventAt,omitempty"`
-	EventCount   int                  `json:"eventCount,omitempty"`
-	EndedAt      string               `json:"endedAt,omitempty"`
+	ID           string                     `json:"id"`
+	LeaseID      string                     `json:"leaseID"`
+	LeaseIDs     []string                   `json:"leaseIDs,omitempty"`
+	Slug         string                     `json:"slug,omitempty"`
+	Owner        string                     `json:"owner"`
+	Org          string                     `json:"org"`
+	LeaseOwners  []CoordinatorRunLeaseOwner `json:"leaseOwners,omitempty"`
+	Provider     string                     `json:"provider"`
+	TargetOS     string                     `json:"target,omitempty"`
+	WindowsMode  string                     `json:"windowsMode,omitempty"`
+	Class        string                     `json:"class"`
+	ServerType   string                     `json:"serverType"`
+	Command      []string                   `json:"command"`
+	Label        string                     `json:"label,omitempty"`
+	State        string                     `json:"state"`
+	Phase        string                     `json:"phase,omitempty"`
+	ExitCode     *int                       `json:"exitCode,omitempty"`
+	SyncMs       int64                      `json:"syncMs,omitempty"`
+	CommandMs    int64                      `json:"commandMs,omitempty"`
+	DurationMs   int64                      `json:"durationMs,omitempty"`
+	LogBytes     int64                      `json:"logBytes"`
+	LogTruncated bool                       `json:"logTruncated"`
+	BlockedStage string                     `json:"blockedStage,omitempty"`
+	RetryLikely  string                     `json:"retryLikely,omitempty"`
+	Results      *TestResultSummary         `json:"results,omitempty"`
+	Telemetry    *RunTelemetrySummary       `json:"telemetry,omitempty"`
+	StartedAt    string                     `json:"startedAt"`
+	LastEventAt  string                     `json:"lastEventAt,omitempty"`
+	EventCount   int                        `json:"eventCount,omitempty"`
+	EndedAt      string                     `json:"endedAt,omitempty"`
 }
 
 type CoordinatorRunEventsResponse struct {

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -12,6 +12,34 @@ import (
 	"nhooyr.io/websocket"
 )
 
+func TestHistoryJSONPreservesLeaseAttribution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/runs" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+		_, _ = w.Write([]byte(`{"runs":[{"id":"run_123","leaseID":"cbx_2","leaseIDs":["cbx_1","cbx_2"],"owner":"bob@example.com","org":"elsewhere","leaseOwners":[{"owner":"alice@example.com","org":"example-org"},{"owner":"bob@example.com","org":"elsewhere"}],"provider":"aws","class":"standard","serverType":"t3.small","command":["true"],"state":"succeeded","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.history(context.Background(), []string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var runs []CoordinatorRun
+	if err := json.Unmarshal(stdout.Bytes(), &runs); err != nil {
+		t.Fatalf("decode history JSON: %v", err)
+	}
+	if len(runs) != 1 || len(runs[0].LeaseIDs) != 2 || runs[0].LeaseIDs[0] != "cbx_1" {
+		t.Fatalf("lease IDs not preserved: %#v", runs)
+	}
+	if len(runs[0].LeaseOwners) != 2 || runs[0].LeaseOwners[0].Owner != "alice@example.com" {
+		t.Fatalf("lease owners not preserved: %#v", runs[0].LeaseOwners)
+	}
+}
+
 func TestEventsCommandPassesPagination(t *testing.T) {
 	var path string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -624,6 +624,11 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		lease, err = resolveSSHLeaseTarget(ctx, sshBackend, ResolveRequest{Repo: repo, Options: options, ID: *leaseIDFlag, Reclaim: *reclaim, Prepare: true})
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+			if lease.Coordinator != nil {
+				coord = lease.Coordinator
+				useCoordinator = true
+				recorder.UseCoordinator(coord)
+			}
 			applyResolvedLeaseConfig(&cfg, server, &target)
 			if borrowedPool != nil {
 				target = applyReadyPoolEndpoint(target, borrowedPool.Entry)
@@ -920,6 +925,7 @@ func (a App) runCommand(ctx context.Context, args []string) (err error) {
 		acquired = true
 		coord = newLease.Coordinator
 		useCoordinator = coord != nil
+		recorder.UseCoordinator(coord)
 		applyResolvedServerConfig(&cfg, server)
 		if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 			return true, err

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -53,6 +53,13 @@ func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, c
 	return rec
 }
 
+func (r *runRecorder) UseCoordinator(coord *CoordinatorClient) {
+	if r == nil || coord == nil {
+		return
+	}
+	r.coord = coord
+}
+
 func (r *runRecorder) Event(kind, phase, message string) {
 	if r == nil || r.runID == "" || (r.finished && kind != "lease.released") {
 		return

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -155,6 +155,38 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 	}
 }
 
+func TestRunRecorderAttachLeaseUsesResolvedCoordinator(t *testing.T) {
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/runs/run_123/events" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
+	}))
+	defer server.Close()
+
+	rec := &runRecorder{
+		coord:  &CoordinatorClient{BaseURL: server.URL, Token: "user-token", Client: server.Client()},
+		runID:  "run_123",
+		stderr: io.Discard,
+	}
+	rec.UseCoordinator(&CoordinatorClient{
+		BaseURL: server.URL,
+		Token:   "admin-token",
+		Client:  server.Client(),
+	})
+	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+		Provider:   "aws",
+		Class:      "standard",
+		ServerType: "t3.small",
+	})
+
+	if authorization != "Bearer admin-token" {
+		t.Fatalf("authorization=%q, want resolved admin token", authorization)
+	}
+}
+
 func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	var stderr bytes.Buffer
 	var eventRequests int

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1261,7 +1261,8 @@ export class FleetCoordinator {
   ): Promise<void> {
     const runID = typeof input.runID === "string" ? input.runID : "";
     const run = runID ? await this.getRun(runID) : undefined;
-    if (!run || !this.runVisibleToControl(run, attachment)) {
+    const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+    if (!run || !this.runReadableToControl(run, attachment, lease)) {
       sendControl(socket, { type: "error", code: "not_found", message: "run not found" });
       return;
     }
@@ -4824,11 +4825,18 @@ export class FleetCoordinator {
         404,
       );
     }
-    const runs = (await this.runRecords())
-      .filter((run) => run.leaseID === lease.id && this.runVisibleToRequest(run, request))
+    const runs = await this.runRecords();
+    const leases = new Map((await this.leaseRecords()).map((record) => [record.id, record]));
+    leases.set(lease.id, lease);
+    await Promise.all(runs.map((run) => this.ensureRunLeaseAttribution(run, leases)));
+    const visibleRuns = runs
+      .filter(
+        (run) =>
+          this.runReferencesLease(run, lease.id) && this.runReadableToRequest(run, request, lease),
+      )
       .toSorted((a, b) => b.startedAt.localeCompare(a.startedAt))
       .slice(0, 12);
-    return portalLeaseDetail(lease, runs, this.leaseBridgeStatus(lease), {
+    return portalLeaseDetail(lease, visibleRuns, this.leaseBridgeStatus(lease), {
       canManage: this.leaseManageableByRequest(lease, request, isAdminRequest(request)),
     });
   }
@@ -5390,7 +5398,8 @@ export class FleetCoordinator {
     action?: string,
   ): Promise<Response> {
     const run = await this.getRun(runID);
-    if (!run || !this.runVisibleToRequest(run, request)) {
+    const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+    if (!run || !this.runReadableToRequest(run, request, lease)) {
       return notFound();
     }
     if (request.method.toUpperCase() !== "GET") {
@@ -8132,8 +8141,10 @@ export class FleetCoordinator {
     const run: RunRecord = {
       id: newRunID(),
       leaseID,
+      leaseIDs: [],
       owner,
       org,
+      leaseOwners: [],
       provider: lease?.provider ?? input.provider ?? "hetzner",
       target: lease?.target ?? input.target ?? "linux",
       class: lease?.class ?? input.class ?? "",
@@ -8147,6 +8158,9 @@ export class FleetCoordinator {
       lastEventAt: now,
       eventCount: 0,
     };
+    if (lease) {
+      this.setRunLeaseAttribution(run, lease);
+    }
     const windowsMode = lease?.windowsMode ?? input.windowsMode;
     if (windowsMode) {
       run.windowsMode = windowsMode;
@@ -8181,11 +8195,13 @@ export class FleetCoordinator {
     const method = request.method.toUpperCase();
     if (method === "GET" && action === undefined) {
       const run = await this.getRun(runID);
-      return run && this.runVisibleToRequest(run, request) ? json({ run }) : notFound();
+      const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+      return run && this.runReadableToRequest(run, request, lease) ? json({ run }) : notFound();
     }
     if (method === "GET" && action === "logs") {
       const run = await this.getRun(runID);
-      if (!run || !this.runVisibleToRequest(run, request)) {
+      const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+      if (!run || !this.runReadableToRequest(run, request, lease)) {
         return notFound();
       }
       const log = await this.readRunLog(runID);
@@ -8195,7 +8211,8 @@ export class FleetCoordinator {
     }
     if (method === "GET" && action === "events") {
       const run = await this.getRun(runID);
-      if (!run || !this.runVisibleToRequest(run, request)) {
+      const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+      if (!run || !this.runReadableToRequest(run, request, lease)) {
         return notFound();
       }
       const url = new URL(request.url);
@@ -8205,10 +8222,16 @@ export class FleetCoordinator {
     }
     if (method === "POST" && action === "events") {
       const run = await this.getRun(runID);
-      if (!run || !this.runVisibleToRequest(run, request)) {
+      if (!run || !this.runWritableByRequest(run, request)) {
         return notFound();
       }
       const input = await readJson<RunEventRequest>(request);
+      if (input.leaseID && input.leaseID !== run.leaseID) {
+        const lease = validLeaseID(input.leaseID) ? await this.getLease(input.leaseID) : undefined;
+        if (!lease || !this.leaseVisibleToRequest(lease, request, isAdminRequest(request))) {
+          return notFound();
+        }
+      }
       const event = await this.appendRunEventRecord(run, input);
       return json({ event }, { status: 201 });
     }
@@ -8223,7 +8246,7 @@ export class FleetCoordinator {
 
   private async appendRunTelemetry(request: Request, runID: string): Promise<Response> {
     const run = await this.getRun(runID);
-    if (!run || !this.runVisibleToRequest(run, request)) {
+    if (!run || !this.runWritableByRequest(run, request)) {
       return notFound();
     }
     const input = await readJson<RunTelemetryRequest>(request);
@@ -8238,7 +8261,7 @@ export class FleetCoordinator {
 
   private async finishRun(request: Request, runID: string): Promise<Response> {
     const run = await this.getRun(runID);
-    if (!run || !this.runVisibleToRequest(run, request)) {
+    if (!run || !this.runWritableByRequest(run, request)) {
       return notFound();
     }
     const input = await readJson<RunFinishRequest>(request);
@@ -8325,13 +8348,14 @@ export class FleetCoordinator {
     const limit = clampLimit(url.searchParams.get("limit"), 50);
     const admin = isAdminRequest(request);
     const runs = await this.runRecords();
-    const scopedOwner = admin ? owner : requestOwner(request);
-    const scopedOrg = admin ? org : requestOrg(request, this.env);
+    const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
+    await Promise.all(runs.map((run) => this.ensureRunLeaseAttribution(run, leases)));
     return json({
       runs: runs
-        .filter((run) => !leaseID || run.leaseID === leaseID)
-        .filter((run) => !scopedOwner || run.owner === scopedOwner)
-        .filter((run) => !scopedOrg || run.org === scopedOrg)
+        .filter((run) => !leaseID || this.runReferencesLease(run, leaseID))
+        .filter((run) => admin || this.runReadableToRequest(run, request, leases.get(run.leaseID)))
+        .filter((run) => !owner || run.owner === owner)
+        .filter((run) => !org || run.org === org)
         .filter((run) => !state || run.state === state)
         .toSorted((a, b) => b.startedAt.localeCompare(a.startedAt))
         .slice(0, limit),
@@ -9697,20 +9721,99 @@ export class FleetCoordinator {
     return undefined;
   }
 
-  private runVisibleToRequest(run: RunRecord, request: Request): boolean {
+  private runWritableByRequest(run: RunRecord, request: Request): boolean {
     return (
       isAdminRequest(request) ||
       (run.owner === requestOwner(request) && run.org === requestOrg(request, this.env))
     );
   }
 
-  private runVisibleToControl(
+  private runReadableToRequest(run: RunRecord, request: Request, lease?: LeaseRecord): boolean {
+    if (this.runWritableByRequest(run, request)) {
+      return true;
+    }
+    const owner = requestOwner(request);
+    const org = requestOrg(request, this.env);
+    return (
+      run.leaseOwners?.some(
+        (attribution) => attribution.owner === owner && attribution.org === org,
+      ) ||
+      (!run.leaseOwners?.length && lease?.owner === owner && lease.org === org)
+    );
+  }
+
+  private runReadableToControl(
     run: RunRecord,
     attachment: Extract<BridgeAttachment, { kind: "control" }>,
+    lease?: LeaseRecord,
   ): boolean {
     return Boolean(
-      attachment.admin || (run.owner === attachment.owner && run.org === attachment.org),
+      attachment.admin ||
+      (run.owner === attachment.owner && run.org === attachment.org) ||
+      run.leaseOwners?.some(
+        (attribution) =>
+          attribution.owner === attachment.owner && attribution.org === attachment.org,
+      ) ||
+      (!run.leaseOwners?.length &&
+        lease?.owner === attachment.owner &&
+        lease.org === attachment.org),
     );
+  }
+
+  private setRunLeaseAttribution(run: RunRecord, lease: LeaseRecord): void {
+    if (!run.leaseIDs?.includes(lease.id)) {
+      run.leaseIDs = [...(run.leaseIDs ?? []), lease.id];
+    }
+    if (
+      !run.leaseOwners?.some(
+        (attribution) => attribution.owner === lease.owner && attribution.org === lease.org,
+      )
+    ) {
+      run.leaseOwners = [...(run.leaseOwners ?? []), { owner: lease.owner, org: lease.org }];
+    }
+  }
+
+  private runReferencesLease(run: RunRecord, leaseID: string): boolean {
+    return run.leaseID === leaseID || run.leaseIDs?.includes(leaseID) === true;
+  }
+
+  private async ensureRunLeaseAttribution(
+    run: RunRecord,
+    knownLeases?: Map<string, LeaseRecord>,
+  ): Promise<LeaseRecord | undefined> {
+    if (run.leaseIDs !== undefined && run.leaseOwners !== undefined) {
+      return undefined;
+    }
+    const events = await this.state.storage.list<RunEventRecord>({
+      prefix: runEventPrefix(run.id),
+    });
+    const leaseIDs = new Set(
+      [...events.values()]
+        .toSorted((a, b) => a.seq - b.seq)
+        .map((event) => event.leaseID)
+        .filter((leaseID): leaseID is string => Boolean(leaseID && validLeaseID(leaseID))),
+    );
+    if (validLeaseID(run.leaseID)) {
+      leaseIDs.add(run.leaseID);
+    }
+    const ids = [...leaseIDs];
+    const leases = knownLeases
+      ? ids.map((leaseID) => knownLeases.get(leaseID))
+      : await Promise.all(ids.map((leaseID) => this.getLease(leaseID)));
+    run.leaseIDs = ids;
+    run.leaseOwners = [];
+    let currentLease: LeaseRecord | undefined;
+    for (const [index, lease] of leases.entries()) {
+      if (!lease) {
+        continue;
+      }
+      this.setRunLeaseAttribution(run, lease);
+      if (ids[index] === run.leaseID) {
+        currentLease = lease;
+      }
+    }
+    await this.putRun(run);
+    return currentLease;
   }
 
   private leaseVisibleToControl(
@@ -9794,7 +9897,17 @@ export class FleetCoordinator {
     const now = new Date().toISOString();
     const seq = (run.eventCount ?? 0) + 1;
     const event = boundedRunEvent(run.id, seq, now, input);
+    const previousLeaseID = run.leaseID;
     applyRunEventSummary(run, event);
+    if (
+      validLeaseID(run.leaseID) &&
+      (run.leaseID !== previousLeaseID || !run.leaseIDs?.includes(run.leaseID))
+    ) {
+      const lease = await this.getLease(run.leaseID);
+      if (lease) {
+        this.setRunLeaseAttribution(run, lease);
+      }
+    }
     run.eventCount = seq;
     run.lastEventAt = now;
     await this.state.storage.put(runEventKey(run.id, seq), event);
@@ -9821,7 +9934,11 @@ export class FleetCoordinator {
         continue;
       }
       const after = attachment.subscriptions?.[run.id];
-      if (after === undefined || after >= event.seq || !this.runVisibleToControl(run, attachment)) {
+      if (
+        after === undefined ||
+        after >= event.seq ||
+        !this.runReadableToControl(run, attachment)
+      ) {
         continue;
       }
       attachment.subscriptions = { ...attachment.subscriptions, [run.id]: event.seq };

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -513,9 +513,11 @@ export interface PromotedImageRecord extends ProviderImage {
 export interface RunRecord {
   id: string;
   leaseID: string;
+  leaseIDs?: string[];
   slug?: string;
   owner: string;
   org: string;
+  leaseOwners?: Array<{ owner: string; org: string }>;
   provider: string;
   target?: TargetOS;
   windowsMode?: WindowsMode;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11408,7 +11408,7 @@ describe("fleet lease identity and idle", () => {
     expect(body).toContain("/portal/runs/run_000000000001/logs");
     expect(body).toContain("/portal/runs/run_000000000001/events");
     expect(body).toContain("/portal/leases/cbx_000000000001/release");
-    expect(body).not.toContain("run_000000000002");
+    expect(body).toContain("run_000000000002");
 
     const logs = await fleet.fetch(
       request("GET", "/portal/runs/run_000000000001/logs", { headers }),
@@ -14628,6 +14628,345 @@ describe("fleet run history", () => {
       [2, "lease.created"],
       [3, "stdout"],
     ]);
+  });
+
+  it("gives lease owners read-only audit access to shared-user runs", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const actorHeaders = {
+      "x-crabbox-owner": "bob@example.com",
+      "x-crabbox-org": "elsewhere",
+    };
+    const strangerHeaders = {
+      "x-crabbox-owner": "stranger@example.com",
+      "x-crabbox-org": "elsewhere",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        share: { users: { "bob@example.com": "use" } },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        owner: "charlie@example.com",
+        org: "another-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000003",
+      testLease({
+        id: "cbx_000000000003",
+        owner: "bob@example.com",
+        org: "elsewhere",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: actorHeaders,
+        body: {
+          leaseID: "cbx_000000000001",
+          command: ["pnpm", "test"],
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const { run } = (await create.json()) as { run: RunRecord };
+    expect(run).toMatchObject({
+      owner: "bob@example.com",
+      org: "elsewhere",
+      leaseIDs: ["cbx_000000000001"],
+      leaseOwners: [{ owner: "alice@example.com", org: "example-org" }],
+    });
+
+    const reattribute = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: actorHeaders,
+        body: {
+          type: "lease.created",
+          leaseID: "cbx_000000000002",
+        },
+      }),
+    );
+    expect(reattribute.status).toBe(404);
+
+    const listed = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", { headers: ownerHeaders }),
+    );
+    await expect(listed.json()).resolves.toMatchObject({
+      runs: [
+        {
+          id: run.id,
+          owner: "bob@example.com",
+          leaseOwners: [{ owner: "alice@example.com", org: "example-org" }],
+        },
+      ],
+    });
+
+    const ownerRead = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}`, { headers: ownerHeaders }),
+    );
+    expect(ownerRead.status).toBe(200);
+    const ownerEvents = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/events`, { headers: ownerHeaders }),
+    );
+    expect(ownerEvents.status).toBe(200);
+
+    const deniedMutations = await Promise.all(
+      (
+        [
+          ["events", { type: "stdout", stream: "stdout", data: "forged\n" }],
+          [
+            "telemetry",
+            {
+              telemetry: {
+                capturedAt: "2026-05-01T00:00:10Z",
+                source: "ssh-linux",
+                load1: 1,
+              },
+            },
+          ],
+          ["finish", { exitCode: 0, log: "forged\n" }],
+        ] as const
+      ).map(([action, body]) =>
+        fleet.fetch(
+          request("POST", `/v1/runs/${run.id}/${action}`, {
+            headers: ownerHeaders,
+            body,
+          }),
+        ),
+      ),
+    );
+    for (const response of deniedMutations) {
+      expect(response.status).toBe(404);
+    }
+
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID: "owner-audit",
+      owner: "alice@example.com",
+      org: "example-org",
+      subscriptions: {},
+    });
+    (
+      fleet as unknown as {
+        controlSockets: Map<string, WebSocket>;
+      }
+    ).controlSockets.set("owner-audit", socket as unknown as WebSocket);
+    await fleet.webSocketMessage(
+      socket as unknown as WebSocket,
+      JSON.stringify({ type: "subscribe_run", runID: run.id, after: 0 }),
+    );
+    expect(socket.sentJSON()[0]).toMatchObject({
+      type: "run_events",
+      runID: run.id,
+      events: [{ type: "run.started" }],
+    });
+
+    const replacement = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: actorHeaders,
+        body: {
+          type: "lease.created",
+          leaseID: "cbx_000000000003",
+        },
+      }),
+    );
+    expect(replacement.status).toBe(201);
+    expect(socket.sentJSON()[1]).toMatchObject({
+      type: "run_events",
+      runID: run.id,
+      events: [{ type: "lease.created", leaseID: "cbx_000000000003" }],
+    });
+    const originalLeaseHistory = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", { headers: ownerHeaders }),
+    );
+    await expect(originalLeaseHistory.json()).resolves.toMatchObject({
+      runs: [{ id: run.id, leaseID: "cbx_000000000003" }],
+    });
+    expect(
+      (await fleet.fetch(request("GET", `/v1/runs/${run.id}`, { headers: ownerHeaders }))).status,
+    ).toBe(200);
+
+    const stdout = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/events`, {
+        headers: actorHeaders,
+        body: { type: "stdout", stream: "stdout", data: "ok\n" },
+      }),
+    );
+    expect(stdout.status).toBe(201);
+    expect(socket.sentJSON()[2]).toMatchObject({
+      type: "run_events",
+      runID: run.id,
+      events: [{ type: "stdout", data: "ok\n" }],
+    });
+
+    const telemetry = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/telemetry`, {
+        headers: actorHeaders,
+        body: {
+          telemetry: {
+            capturedAt: "2026-05-01T00:00:10Z",
+            source: "ssh-linux",
+            load1: 0.5,
+          },
+        },
+      }),
+    );
+    expect(telemetry.status).toBe(200);
+
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers: actorHeaders,
+        body: { exitCode: 0, log: "ok\n" },
+      }),
+    );
+    expect(finish.status).toBe(200);
+
+    const ownerLogs = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/logs`, { headers: ownerHeaders }),
+    );
+    expect(ownerLogs.status).toBe(200);
+    expect(await ownerLogs.text()).toBe("ok\n");
+
+    const leasePage = await fleet.fetch(
+      request("GET", "/portal/leases/blue-lobster", { headers: ownerHeaders }),
+    );
+    expect(leasePage.status).toBe(200);
+    expect(await leasePage.text()).toContain(run.id);
+    expect(
+      (await fleet.fetch(request("GET", `/portal/runs/${run.id}`, { headers: ownerHeaders })))
+        .status,
+    ).toBe(200);
+
+    const strangerList = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", {
+        headers: strangerHeaders,
+      }),
+    );
+    await expect(strangerList.json()).resolves.toEqual({ runs: [] });
+    expect(
+      (await fleet.fetch(request("GET", `/v1/runs/${run.id}`, { headers: strangerHeaders })))
+        .status,
+    ).toBe(404);
+  });
+
+  it("reconstructs backing lease audit access for legacy runs", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const ownerHeaders = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        owner: "alice@example.com",
+        org: "example-org",
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        owner: "bob@example.com",
+        org: "elsewhere",
+      }),
+    );
+    storage.seed(
+      "run:run_000000000001",
+      testRun({
+        id: "run_000000000001",
+        leaseID: "cbx_000000000002",
+        owner: "bob@example.com",
+        org: "elsewhere",
+        eventCount: 2,
+      }),
+    );
+    storage.seed("runevent:run_000000000001:000000000001", {
+      runID: "run_000000000001",
+      seq: 1,
+      type: "lease.created",
+      leaseID: "cbx_000000000001",
+      createdAt: "2026-05-01T00:00:01.000Z",
+    });
+    storage.seed("runevent:run_000000000001:000000000002", {
+      runID: "run_000000000001",
+      seq: 2,
+      type: "lease.created",
+      leaseID: "cbx_000000000002",
+      createdAt: "2026-05-01T00:00:02.000Z",
+    });
+
+    const listed = await fleet.fetch(
+      request("GET", "/v1/runs?leaseID=cbx_000000000001", { headers: ownerHeaders }),
+    );
+    await expect(listed.json()).resolves.toMatchObject({
+      runs: [{ id: "run_000000000001" }],
+    });
+    expect(
+      (await fleet.fetch(request("GET", "/v1/runs/run_000000000001", { headers: ownerHeaders })))
+        .status,
+    ).toBe(200);
+    expect(storage.value<RunRecord>("run:run_000000000001")).toMatchObject({
+      leaseIDs: ["cbx_000000000001", "cbx_000000000002"],
+      leaseOwners: [
+        { owner: "alice@example.com", org: "example-org" },
+        { owner: "bob@example.com", org: "elsewhere" },
+      ],
+    });
+  });
+
+  it("lets admins record a replacement lease outside their owner scope", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        owner: "alice@example.com",
+        org: "example-org",
+      }),
+    );
+    storage.seed(
+      "run:run_000000000001",
+      testRun({
+        id: "run_000000000001",
+        leaseID: "",
+        leaseIDs: [],
+        owner: "bob@example.com",
+        org: "elsewhere",
+        leaseOwners: [],
+      }),
+    );
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/runs/run_000000000001/events", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { type: "lease.created", leaseID: "cbx_000000000001" },
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(storage.value<RunRecord>("run:run_000000000001")).toMatchObject({
+      leaseID: "cbx_000000000001",
+      leaseIDs: ["cbx_000000000001"],
+      leaseOwners: [{ owner: "alice@example.com", org: "example-org" }],
+    });
   });
 
   it("streams run events and lease heartbeats over a control websocket", async () => {


### PR DESCRIPTION
## Summary

- preserve the initiating actor on each run while recording every backing lease ID and owner identity
- grant backing lease owners read-only access to run history, details, logs, events, telemetry, portal pages, and live subscriptions
- keep event, telemetry, and finish mutations restricted to the actor or an admin
- reconstruct attribution for legacy runs from stored lease events
- preserve attribution fields in CLI JSON output and retain the resolved admin client for documented explicit-lease fallback

This is audit hardening, not a new execution privilege. Lease shares still do not expose other actors' runs, and lease owners cannot mutate those runs.

## Verification

- `npm test --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm run build --prefix worker`
- `./scripts/check-docs.sh`
- `go test ./internal/cli -run 'TestRunRecorderAttachLeaseUsesResolvedCoordinator|TestHistoryJSONPreservesLeaseAttribution|TestRunWithExistingLeaseRequestsProviderPreparation'`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "npm test --prefix worker && go test ./internal/cli -run 'TestRunRecorderAttachLeaseUsesResolvedCoordinator|TestHistoryJSONPreservesLeaseAttribution|TestRunWithExistingLeaseRequestsProviderPreparation'"`

The complete local `go test ./internal/cli` run also reached unrelated existing macOS permission assertions in controller state/token tests; the focused changed paths pass, and CI provides the clean Linux gate.

Closes https://github.com/openclaw/crabbox/issues/383