### PR TITLE
feat: add authenticated adapter ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `crabbox connect <lease-id-or-slug>` to open an interactive SSH session to key-, certificate-, and proxy-authenticated provider targets while keeping `crabbox ssh` as the print-only command surface for token-as-username providers.
+- Added `crabbox adapter ingress` as a provider-neutral authenticated HTTP and WebSocket bridge for loopback fleet services.
 - Added JSON API initiation of generation-fenced runtime-adapter workspace deletion through explicit registered lease release.
 - Added reusable Cloudflare container run-session handles with exact cleanup commands for `--keep --lease-output`. Thanks @zozo123.
 

--- a/docs/commands/adapter.md
+++ b/docs/commands/adapter.md
@@ -80,6 +80,52 @@ The command uses the production state decoder and record invariants, rejects
 unknown fields, incompatible versions, corrupt records, symlinks, and broad
 file permissions, and exits nonzero on failure.
 
+## Authenticated ingress
+
+`crabbox adapter ingress` exposes a loopback HTTP service through an exact
+identity-and-secret assertion supplied by a trusted upstream proxy. It is a
+small provider-neutral building block for a fleet UI or adapter deployment that
+needs HTTP streaming and WebSocket upgrades without maintaining a custom
+reverse proxy.
+
+The command accepts one private JSON config file:
+
+```json
+{
+  "listen": "0.0.0.0:8443",
+  "upstream": "http://127.0.0.1:8787",
+  "publicOrigin": "https://fleet.example.test",
+  "identityHeader": "X-Proxy-User",
+  "identity": "operator@example.test",
+  "secretHeader": "X-Proxy-Secret",
+  "secretFile": "/home/operator/.config/crabbox/proxy.secret",
+  "denyPaths": ["/login/provider", "/auth/provider/callback"],
+  "denyPrefixes": ["/api/admin/"],
+  "stripHeaderPrefixes": ["x-crabbox-", "x-fleet-private-"]
+}
+```
+
+```sh
+crabbox adapter ingress --config /home/operator/.config/crabbox/ingress.json
+```
+
+Both the config and secret must be current-user-owned regular non-symlink files
+with mode `0400` or `0600`. The config is strict JSON and rejects unknown keys.
+The command currently requires Linux or macOS.
+The listen host must be a literal IP address, the upstream must be one exact
+loopback HTTP origin, and the public origin must be one exact non-loopback HTTPS
+origin. Keep the listener behind the trusted proxy and terminate TLS there.
+
+For ordinary HTTP requests, `Origin` may be absent but must exactly match
+`publicOrigin` when present. WebSocket upgrades always require the exact origin.
+The ingress rejects duplicate or incorrect assertion headers, removes browser
+credentials, forwarding headers, hop-by-hop headers, and configured private
+header prefixes, then installs the configured assertion and sanitized public
+host/protocol forwarding headers before proxying. Header names containing
+underscores are rejected to prevent downstream dash/underscore aliasing.
+Denied routes return `404` before authentication. `/healthz` is forwarded
+without assertions only for loopback peers.
+
 ## Outbound connection
 
 `crabbox adapter connect` exposes a local `crabfleet/v1` runtime adapter to the

--- a/internal/cli/adapter_ingress.go
+++ b/internal/cli/adapter_ingress.go
@@ -1,0 +1,786 @@
+package cli
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/netip"
+	"net/url"
+	pathpkg "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	adapterIngressMaxConfigBytes = 16 << 10
+	adapterIngressMaxHeaderBytes = 16 << 10
+	adapterIngressMaxHeaders     = 100
+)
+
+type adapterIngressConfig struct {
+	Listen              string   `json:"listen"`
+	Upstream            string   `json:"upstream"`
+	PublicOrigin        string   `json:"publicOrigin"`
+	IdentityHeader      string   `json:"identityHeader"`
+	Identity            string   `json:"identity"`
+	SecretHeader        string   `json:"secretHeader"`
+	SecretFile          string   `json:"secretFile"`
+	DenyPaths           []string `json:"denyPaths,omitempty"`
+	DenyPrefixes        []string `json:"denyPrefixes,omitempty"`
+	StripHeaderPrefixes []string `json:"stripHeaderPrefixes,omitempty"`
+
+	upstreamURL     *url.URL
+	publicOriginURL *url.URL
+}
+
+type adapterIngressProxy struct {
+	config  adapterIngressConfig
+	secret  string
+	health  *http.Client
+	reverse *httputil.ReverseProxy
+}
+
+func (a App) adapterIngress(ctx context.Context, args []string) error {
+	fs := newFlagSet("adapter ingress", a.Stderr)
+	configPath := fs.String("config", getenv("CRABBOX_ADAPTER_INGRESS_CONFIG", ""), "private JSON ingress config file")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*configPath) == "" {
+		return exit(2, "usage: crabbox adapter ingress --config <path>")
+	}
+	config, err := loadAdapterIngressConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	proxy, err := newAdapterIngressProxy(config)
+	if err != nil {
+		return err
+	}
+	listener, err := net.Listen("tcp", config.Listen)
+	if err != nil {
+		return exit(5, "listen on %s: %v", config.Listen, err)
+	}
+	defer listener.Close()
+	serveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	server := &http.Server{
+		Handler:           proxy,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       5 * time.Minute,
+		IdleTimeout:       5 * time.Second,
+		MaxHeaderBytes:    adapterIngressMaxHeaderBytes,
+		BaseContext: func(net.Listener) context.Context {
+			return serveCtx
+		},
+	}
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		<-serveCtx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	fmt.Fprintf(a.Stderr, "adapter ingress listening=%s upstream=%s\n", listener.Addr(), config.upstreamURL)
+	err = server.Serve(listener)
+	cancel()
+	<-shutdownDone
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func loadAdapterIngressConfig(path string) (adapterIngressConfig, error) {
+	path = expandUserPath(strings.TrimSpace(path))
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return adapterIngressConfig{}, exit(2, "adapter ingress config path must be absolute and clean")
+	}
+	data, err := readPrivateAdapterFile(path, adapterIngressMaxConfigBytes, "adapter ingress config")
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var config adapterIngressConfig
+	if err := decoder.Decode(&config); err != nil {
+		return adapterIngressConfig{}, exit(2, "decode adapter ingress config: %v", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return adapterIngressConfig{}, exit(2, "decode adapter ingress config: %v", err)
+	}
+	return validateAdapterIngressConfig(config)
+}
+
+func readPrivateAdapterFile(path string, maximum int64, label string) ([]byte, error) {
+	file, err := openControllerTokenFile(path)
+	if err != nil {
+		return nil, exit(2, "read %s file: %v", label, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, exit(2, "stat %s file: %v", label, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, exit(2, "%s file must be regular", label)
+	}
+	if mode := info.Mode().Perm(); mode != 0o400 && mode != 0o600 {
+		return nil, exit(2, "%s file must have mode 0400 or 0600", label)
+	}
+	if info.Size() > maximum {
+		return nil, exit(2, "%s file is too large", label)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil {
+		return nil, exit(2, "read %s file: %v", label, err)
+	}
+	if int64(len(data)) > maximum {
+		return nil, exit(2, "%s file is too large", label)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return nil, exit(2, "stat %s file after reading: %v", label, err)
+	}
+	if !adapterIngressPrivateFileStable(info, after, int64(len(data))) {
+		return nil, exit(2, "%s file changed while it was being read", label)
+	}
+	return data, nil
+}
+
+func adapterIngressPrivateFileStable(before, after fs.FileInfo, readBytes int64) bool {
+	return before != nil && after != nil && readBytes == before.Size() && after.Size() == before.Size() && after.Mode() == before.Mode() && after.ModTime().Equal(before.ModTime())
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values are not allowed")
+		}
+		return err
+	}
+	return nil
+}
+
+func validateAdapterIngressConfig(config adapterIngressConfig) (adapterIngressConfig, error) {
+	listen, err := validateAdapterIngressListen(config.Listen)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	upstream, err := validateAdapterIngressUpstream(config.Upstream)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	if adapterIngressEndpointsOverlap(listen, upstream) {
+		return adapterIngressConfig{}, exit(2, "adapter ingress listen and upstream must differ")
+	}
+	publicOrigin, err := validateAdapterIngressPublicOrigin(config.PublicOrigin)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	identityHeader, err := validateAdapterIngressHeader(config.IdentityHeader, "identityHeader")
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	secretHeader, err := validateAdapterIngressHeader(config.SecretHeader, "secretHeader")
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	if strings.EqualFold(identityHeader, secretHeader) {
+		return adapterIngressConfig{}, exit(2, "adapter ingress identityHeader and secretHeader must differ")
+	}
+	for _, header := range []string{identityHeader, secretHeader} {
+		name := strings.ToLower(header)
+		if adapterIngressReservedAuthHeader(name) {
+			return adapterIngressConfig{}, exit(2, "adapter ingress authentication headers must not use reserved header %s", header)
+		}
+	}
+	identity := strings.TrimSpace(config.Identity)
+	if identity == "" || identity != config.Identity || len(identity) > 1024 || !validAdapterIngressHeaderValue(identity) {
+		return adapterIngressConfig{}, exit(2, "adapter ingress identity must be one nonempty bounded header value")
+	}
+	secretFile := expandUserPath(strings.TrimSpace(config.SecretFile))
+	if !filepath.IsAbs(secretFile) || filepath.Clean(secretFile) != secretFile {
+		return adapterIngressConfig{}, exit(2, "adapter ingress secretFile must be absolute and clean")
+	}
+	denyPaths, err := validateAdapterIngressRoutes(config.DenyPaths, false)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	denyPrefixes, err := validateAdapterIngressRoutes(config.DenyPrefixes, true)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	stripPrefixes, err := validateAdapterIngressHeaderPrefixes(config.StripHeaderPrefixes)
+	if err != nil {
+		return adapterIngressConfig{}, err
+	}
+	config.Listen = listen
+	config.Upstream = upstream.String()
+	config.PublicOrigin = publicOrigin
+	config.publicOriginURL, _ = url.Parse(publicOrigin)
+	config.IdentityHeader = identityHeader
+	config.Identity = identity
+	config.SecretHeader = secretHeader
+	config.SecretFile = secretFile
+	config.DenyPaths = denyPaths
+	config.DenyPrefixes = denyPrefixes
+	config.StripHeaderPrefixes = stripPrefixes
+	config.upstreamURL = upstream
+	return config, nil
+}
+
+func adapterIngressEndpointsOverlap(listen string, upstream *url.URL) bool {
+	listenHost, listenPort, listenErr := net.SplitHostPort(listen)
+	if listenErr != nil || upstream == nil || upstream.Port() != listenPort {
+		return false
+	}
+	listenAddress, listenErr := netip.ParseAddr(strings.Trim(listenHost, "[]"))
+	upstreamAddress, upstreamErr := netip.ParseAddr(strings.Trim(upstream.Hostname(), "[]"))
+	if listenErr != nil || upstreamErr != nil {
+		return false
+	}
+	listenAddress = listenAddress.WithZone("").Unmap()
+	upstreamAddress = upstreamAddress.Unmap()
+	return listenAddress.IsUnspecified() || listenAddress == upstreamAddress
+}
+
+func validateAdapterIngressListen(value string) (string, error) {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(value))
+	if err != nil || port == "0" {
+		return "", exit(2, "adapter ingress listen must be an IP address with a nonzero port")
+	}
+	address, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return "", exit(2, "adapter ingress listen host must be a literal IP address")
+	}
+	parsedPort, err := net.LookupPort("tcp", port)
+	if err != nil || parsedPort < 1 || parsedPort > 65535 {
+		return "", exit(2, "adapter ingress listen port must be from 1 through 65535")
+	}
+	return net.JoinHostPort(address.String(), fmt.Sprint(parsedPort)), nil
+}
+
+func validateAdapterIngressUpstream(value string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme != "http" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return nil, exit(2, "adapter ingress upstream must be one exact loopback HTTP origin")
+	}
+	host := strings.Trim(parsed.Hostname(), "[]")
+	address, err := netip.ParseAddr(host)
+	if err != nil || !address.Unmap().IsLoopback() || address.Zone() != "" || parsed.Port() == "" {
+		return nil, exit(2, "adapter ingress upstream must be one exact loopback HTTP origin")
+	}
+	port, err := net.LookupPort("tcp", parsed.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return nil, exit(2, "adapter ingress upstream must contain a valid nonzero port")
+	}
+	parsed.Host = net.JoinHostPort(address.Unmap().String(), fmt.Sprint(port))
+	parsed.Path = ""
+	return parsed, nil
+}
+
+func validateAdapterIngressPublicOrigin(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > 2048 || !adapterIngressVisibleASCII(value) {
+		return "", exit(2, "adapter ingress publicOrigin must be one exact non-loopback HTTPS origin")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") || parsed.Hostname() == "" {
+		return "", exit(2, "adapter ingress publicOrigin must be one exact non-loopback HTTPS origin")
+	}
+	host := strings.Trim(parsed.Hostname(), "[]")
+	if strings.HasSuffix(host, ".") || strings.EqualFold(host, "localhost") || strings.HasSuffix(strings.ToLower(host), ".localhost") {
+		return "", exit(2, "adapter ingress publicOrigin must be one exact non-loopback HTTPS origin")
+	}
+	if address, parseErr := netip.ParseAddr(host); parseErr == nil {
+		if address.Unmap().IsLoopback() || address.Zone() != "" || address.Is4In6() || host != address.String() {
+			return "", exit(2, "adapter ingress publicOrigin must be one exact non-loopback HTTPS origin")
+		}
+	} else if !validAdapterIngressDNSName(host) || looksLikeLegacyIPv4Host(host) {
+		return "", exit(2, "adapter ingress publicOrigin must contain a valid lowercase DNS hostname or IP address")
+	}
+	port, explicitPort, err := adapterIngressOriginPort(parsed)
+	if err != nil || (explicitPort && port == 443) {
+		return "", exit(2, "adapter ingress publicOrigin must contain a canonical valid HTTPS port")
+	}
+	origin := parsed.Scheme + "://" + parsed.Host
+	if value != origin {
+		return "", exit(2, "adapter ingress publicOrigin must be one exact non-loopback HTTPS origin")
+	}
+	return origin, nil
+}
+
+func looksLikeLegacyIPv4Host(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) > 4 {
+		return false
+	}
+	for _, part := range parts {
+		candidate := part
+		base := 10
+		if strings.HasPrefix(candidate, "0x") {
+			candidate = strings.TrimPrefix(candidate, "0x")
+			base = 16
+		}
+		if candidate == "" {
+			return false
+		}
+		for index := range len(candidate) {
+			character := candidate[index]
+			if base == 10 && (character < '0' || character > '9') {
+				return false
+			}
+			if base == 16 && !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func adapterIngressOriginPort(origin *url.URL) (int, bool, error) {
+	hostname := origin.Hostname()
+	canonicalHost := hostname
+	if strings.Contains(hostname, ":") {
+		canonicalHost = "[" + hostname + "]"
+	}
+	remainder := strings.TrimPrefix(origin.Host, canonicalHost)
+	if remainder == "" {
+		return 443, false, nil
+	}
+	if !strings.HasPrefix(remainder, ":") || len(remainder) == 1 {
+		return 0, true, errors.New("invalid origin port")
+	}
+	value := strings.TrimPrefix(remainder, ":")
+	port, err := strconv.Atoi(value)
+	if err != nil || port < 1 || port > 65535 || strconv.Itoa(port) != value {
+		return 0, true, errors.New("invalid origin port")
+	}
+	return port, true, nil
+}
+
+func validAdapterIngressDNSName(value string) bool {
+	if value == "" || value != strings.ToLower(value) || len(value) > 253 {
+		return false
+	}
+	for label := range strings.SplitSeq(value, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for index := range len(label) {
+			character := label[index]
+			if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func adapterIngressVisibleASCII(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := range len(value) {
+		if value[index] < 0x21 || value[index] > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func validateAdapterIngressHeader(value, label string) (string, error) {
+	value = strings.TrimSpace(value)
+	if !validHTTPToken(value) || strings.Contains(value, "_") {
+		return "", exit(2, "adapter ingress %s must be one valid HTTP header name", label)
+	}
+	return http.CanonicalHeaderKey(value), nil
+}
+
+func adapterIngressReservedAuthHeader(name string) bool {
+	if strings.HasPrefix(name, "x-forwarded-") || strings.HasPrefix(name, "sec-websocket-") || isHopByHopHeader(name) {
+		return true
+	}
+	switch name {
+	case "authorization", "content-length", "cookie", "expect", "forwarded", "host", "origin":
+		return true
+	default:
+		return false
+	}
+}
+
+func validAdapterIngressHeaderValue(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := range len(value) {
+		if value[index] < 0x20 || value[index] > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func validHTTPToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') {
+			continue
+		}
+		switch character {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validateAdapterIngressRoutes(values []string, prefix bool) ([]string, error) {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value, err := url.PathUnescape(value)
+		if err != nil || value == "" || !strings.HasPrefix(value, "/") || strings.ContainsAny(value, "?#\r\n") || strings.IndexFunc(value, func(character rune) bool { return character < 0x20 || character == 0x7f }) >= 0 {
+			return nil, exit(2, "adapter ingress denied routes must be absolute URL paths")
+		}
+		trailingSlash := strings.HasSuffix(value, "/")
+		value = pathpkg.Clean(value)
+		if prefix && trailingSlash && value != "/" {
+			value += "/"
+		}
+		if prefix && value == "/" {
+			return nil, exit(2, "adapter ingress denyPrefixes must not deny every route")
+		}
+		if _, ok := seen[value]; ok {
+			return nil, exit(2, "adapter ingress denied routes must not contain duplicates")
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func validateAdapterIngressHeaderPrefixes(values []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || value != strings.ToLower(value) || strings.Contains(value, "_") || !strings.HasSuffix(value, "-") || !validHTTPToken(value+"x") {
+			return nil, exit(2, "adapter ingress stripHeaderPrefixes must be lowercase HTTP header prefixes ending in a dash")
+		}
+		if _, ok := seen[value]; ok {
+			return nil, exit(2, "adapter ingress stripHeaderPrefixes must not contain duplicates")
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result, nil
+}
+
+func newAdapterIngressProxy(config adapterIngressConfig) (*adapterIngressProxy, error) {
+	if config.upstreamURL == nil || config.publicOriginURL == nil {
+		validated, err := validateAdapterIngressConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		config = validated
+	}
+	secret, err := readAdapterIngressSecret(config.SecretFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(secret) > 1024 || !adapterIngressVisibleASCII(secret) {
+		return nil, exit(2, "adapter ingress secret file must contain one bounded visible ASCII token")
+	}
+	transport := &http.Transport{
+		Proxy:                  nil,
+		DialContext:            (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		ForceAttemptHTTP2:      false,
+		MaxIdleConns:           32,
+		MaxIdleConnsPerHost:    32,
+		IdleConnTimeout:        90 * time.Second,
+		ResponseHeaderTimeout:  30 * time.Second,
+		MaxResponseHeaderBytes: adapterIngressMaxHeaderBytes,
+	}
+	proxy := &adapterIngressProxy{config: config, secret: secret}
+	proxy.health = &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	proxy.reverse = &httputil.ReverseProxy{
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(config.upstreamURL)
+			request.Out.URL.RawQuery = request.In.URL.RawQuery
+			request.Out.Host = config.upstreamURL.Host
+			stripAdapterIngressHeaders(request.Out.Header, config)
+			request.Out.Header.Set(config.IdentityHeader, config.Identity)
+			request.Out.Header.Set(config.SecretHeader, secret)
+			request.Out.Header.Set("X-Forwarded-Host", config.publicOriginURL.Host)
+			request.Out.Header.Set("X-Forwarded-Proto", config.publicOriginURL.Scheme)
+			if validAdapterIngressWebSocket(request.In) {
+				request.Out.Header.Set("Connection", "Upgrade")
+				request.Out.Header.Set("Upgrade", "websocket")
+			}
+		},
+		Transport:     transport,
+		FlushInterval: -1,
+		ErrorHandler: func(response http.ResponseWriter, _ *http.Request, _ error) {
+			writeAdapterIngressError(response, http.StatusBadGateway, "bad gateway")
+		},
+	}
+	return proxy, nil
+}
+
+func readAdapterIngressSecret(path string) (string, error) {
+	data, err := readPrivateAdapterFile(path, 8<<10, "adapter ingress secret")
+	if err != nil {
+		return "", err
+	}
+	defer clear(data)
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", exit(2, "adapter ingress secret file is empty")
+	}
+	if strings.ContainsAny(secret, "\r\n") {
+		return "", exit(2, "adapter ingress secret file must contain one token")
+	}
+	return secret, nil
+}
+
+func (proxy *adapterIngressProxy) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	if adapterIngressHeaderCount(request.Header) > adapterIngressMaxHeaders {
+		writeAdapterIngressError(response, http.StatusRequestHeaderFieldsTooLarge, "request headers too large")
+		return
+	}
+	if request.Method == http.MethodConnect || request.URL == nil || request.URL.IsAbs() || !strings.HasPrefix(request.RequestURI, "/") {
+		writeAdapterIngressError(response, http.StatusBadRequest, "bad request")
+		return
+	}
+	if adapterIngressHasUnderscoreHeader(request.Header) {
+		writeAdapterIngressError(response, http.StatusBadRequest, "bad request")
+		return
+	}
+	if strings.EqualFold(request.Method, http.MethodTrace) || strings.EqualFold(request.Method, "TRACK") {
+		writeAdapterIngressError(response, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if request.URL.Path == "/healthz" {
+		proxy.serveHealth(response, request)
+		return
+	}
+	if proxy.denied(request.URL.Path) {
+		writeAdapterIngressError(response, http.StatusNotFound, "not found")
+		return
+	}
+	if !proxy.authenticated(request) {
+		writeAdapterIngressError(response, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	websocket := validAdapterIngressWebSocket(request)
+	if adapterIngressHasUpgrade(request) && !websocket {
+		writeAdapterIngressError(response, http.StatusBadRequest, "bad websocket upgrade")
+		return
+	}
+	if !adapterIngressOriginAllowed(request, proxy.config.PublicOrigin, websocket) {
+		writeAdapterIngressError(response, http.StatusForbidden, "forbidden")
+		return
+	}
+	proxy.reverse.ServeHTTP(response, request)
+}
+
+func adapterIngressHasUnderscoreHeader(header http.Header) bool {
+	for name := range header {
+		if strings.Contains(name, "_") {
+			return true
+		}
+	}
+	return false
+}
+
+func (proxy *adapterIngressProxy) serveHealth(response http.ResponseWriter, request *http.Request) {
+	if !adapterIngressLoopbackRemote(request.RemoteAddr) {
+		writeAdapterIngressError(response, http.StatusNotFound, "not found")
+		return
+	}
+	if request.Method != http.MethodGet && request.Method != http.MethodHead {
+		writeAdapterIngressError(response, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	healthURL := *proxy.config.upstreamURL
+	healthURL.Path = "/healthz"
+	upstreamRequest, err := http.NewRequestWithContext(request.Context(), request.Method, healthURL.String(), nil)
+	if err != nil {
+		writeAdapterIngressError(response, http.StatusBadGateway, "bad gateway")
+		return
+	}
+	upstreamResponse, err := proxy.health.Do(upstreamRequest)
+	if err != nil {
+		writeAdapterIngressError(response, http.StatusBadGateway, "bad gateway")
+		return
+	}
+	defer upstreamResponse.Body.Close()
+	nominated := adapterIngressConnectionHeaders(upstreamResponse.Header)
+	for name, values := range upstreamResponse.Header {
+		lower := strings.ToLower(name)
+		if isHopByHopHeader(lower) || nominated[lower] {
+			continue
+		}
+		for _, value := range values {
+			response.Header().Add(name, value)
+		}
+	}
+	response.WriteHeader(upstreamResponse.StatusCode)
+	if request.Method != http.MethodHead {
+		_, _ = io.Copy(response, upstreamResponse.Body)
+	}
+}
+
+func (proxy *adapterIngressProxy) denied(requestPath string) bool {
+	paths := []string{requestPath}
+	if clean := pathpkg.Clean(requestPath); clean != requestPath {
+		paths = append(paths, clean)
+	}
+	for _, candidate := range paths {
+		for _, denied := range proxy.config.DenyPaths {
+			if candidate == denied {
+				return true
+			}
+		}
+		for _, denied := range proxy.config.DenyPrefixes {
+			if strings.HasPrefix(candidate, denied) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (proxy *adapterIngressProxy) authenticated(request *http.Request) bool {
+	identity, identityOK := exactAdapterIngressHeader(request.Header, proxy.config.IdentityHeader)
+	secret, secretOK := exactAdapterIngressHeader(request.Header, proxy.config.SecretHeader)
+	if !identityOK || !secretOK || identity != proxy.config.Identity || len(secret) != len(proxy.secret) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(secret), []byte(proxy.secret)) == 1
+}
+
+func exactAdapterIngressHeader(header http.Header, name string) (string, bool) {
+	values := header.Values(name)
+	returnValue := ""
+	if len(values) == 1 {
+		returnValue = values[0]
+	}
+	return returnValue, len(values) == 1
+}
+
+func adapterIngressHeaderCount(header http.Header) int {
+	count := 0
+	for _, values := range header {
+		count += len(values)
+	}
+	return count
+}
+
+func adapterIngressOriginAllowed(request *http.Request, publicOrigin string, required bool) bool {
+	origins := request.Header.Values("Origin")
+	if len(origins) == 0 {
+		return !required
+	}
+	return len(origins) == 1 && origins[0] == publicOrigin
+}
+
+func adapterIngressHasUpgrade(request *http.Request) bool {
+	return len(request.Header.Values("Upgrade")) > 0 || (len(request.Header.Values("Connection")) > 0 && headerHasToken(request.Header, "Connection", "upgrade"))
+}
+
+func validAdapterIngressWebSocket(request *http.Request) bool {
+	upgrades := request.Header.Values("Upgrade")
+	return request.Method == http.MethodGet && len(upgrades) == 1 && strings.EqualFold(upgrades[0], "websocket") && headerHasToken(request.Header, "Connection", "upgrade")
+}
+
+func headerHasToken(header http.Header, name, wanted string) bool {
+	for _, value := range header.Values(name) {
+		for token := range strings.SplitSeq(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), wanted) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func adapterIngressConnectionHeaders(header http.Header) map[string]bool {
+	result := make(map[string]bool)
+	for _, value := range header.Values("Connection") {
+		for token := range strings.SplitSeq(value, ",") {
+			name := strings.ToLower(strings.TrimSpace(token))
+			if validHTTPToken(name) {
+				result[name] = true
+			}
+		}
+	}
+	return result
+}
+
+func adapterIngressLoopbackRemote(remote string) bool {
+	host, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		return false
+	}
+	address, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	return err == nil && address.Unmap().IsLoopback()
+}
+
+func stripAdapterIngressHeaders(header http.Header, config adapterIngressConfig) {
+	for name := range header {
+		lower := strings.ToLower(name)
+		if lower == "authorization" || lower == "cookie" || lower == "x-authenticated-user" || lower == strings.ToLower(config.IdentityHeader) || lower == strings.ToLower(config.SecretHeader) || strings.HasPrefix(lower, "x-forwarded-") || isHopByHopHeader(lower) {
+			header.Del(name)
+			continue
+		}
+		for _, prefix := range config.StripHeaderPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				header.Del(name)
+				break
+			}
+		}
+	}
+}
+
+func isHopByHopHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "proxy-connection", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func writeAdapterIngressError(response http.ResponseWriter, status int, message string) {
+	body := fmt.Sprintf("{\"error\":%q}\n", message)
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("Content-Type", "application/json; charset=utf-8")
+	response.Header().Set("Connection", "close")
+	response.WriteHeader(status)
+	_, _ = io.WriteString(response, body)
+}

--- a/internal/cli/adapter_ingress_test.go
+++ b/internal/cli/adapter_ingress_test.go
@@ -1,0 +1,453 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	adapterIngressTestIdentity = "operator@example.test"
+	adapterIngressTestSecret   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	adapterIngressTestOrigin   = "https://fleet.example.test"
+)
+
+func TestAdapterIngressForwardsAuthenticatedHTTPAndReplacesPrivateHeaders(t *testing.T) {
+	type observedRequest struct {
+		method string
+		path   string
+		body   string
+		header http.Header
+		host   string
+	}
+	observed := make(chan observedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		observed <- observedRequest{request.Method, request.URL.RequestURI(), string(body), request.Header.Clone(), request.Host}
+		response.Header().Set("Connection", "X-Upstream-Private")
+		response.Header().Set("X-Upstream-Private", "drop")
+		response.Header().Set("X-Public", "keep")
+		response.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(response, "created")
+	}))
+	defer upstream.Close()
+	proxy := newAdapterIngressTestProxy(t, upstream.URL, nil)
+
+	request := httptest.NewRequest(http.MethodPost, "/api/workspaces?token=a;b&wait=1", strings.NewReader("payload"))
+	request.RemoteAddr = "203.0.113.10:4242"
+	setAdapterIngressTestAuth(request.Header)
+	request.Header.Set("Origin", adapterIngressTestOrigin)
+	request.Header.Set("Authorization", "Bearer browser-secret")
+	request.Header.Set("Cookie", "session=browser-secret")
+	request.Header.Set("X-Authenticated-User", "spoofed@example.test")
+	request.Header.Set("X-Forwarded-For", "198.51.100.10")
+	request.Header.Set("X-Crabbox-Claim", "spoofed")
+	request.Header.Set("X-Crabfleet-Claim", "spoofed")
+	request.Header.Set("X-Deployment-Claim", "spoofed")
+	request.Header.Set("Connection", "X-Remove-Me")
+	request.Header.Set("X-Remove-Me", "spoofed")
+	request.Header.Set("X-Public-Request", "keep")
+	response := httptest.NewRecorder()
+	proxy.ServeHTTP(response, request)
+
+	if response.Code != http.StatusCreated || response.Body.String() != "created" {
+		t.Fatalf("response code=%d body=%q", response.Code, response.Body.String())
+	}
+	if response.Header().Get("X-Public") != "keep" || response.Header().Get("X-Upstream-Private") != "" {
+		t.Fatalf("response headers=%v", response.Header())
+	}
+	got := <-observed
+	if got.method != http.MethodPost || got.path != "/api/workspaces?token=a;b&wait=1" || got.body != "payload" {
+		t.Fatalf("upstream request=%#v", got)
+	}
+	if got.host != strings.TrimPrefix(upstream.URL, "http://") {
+		t.Fatalf("upstream host=%q", got.host)
+	}
+	if got.header.Get("X-Test-User") != adapterIngressTestIdentity || got.header.Get("X-Test-Secret") != adapterIngressTestSecret {
+		t.Fatalf("trusted headers user=%q secret=%q", got.header.Get("X-Test-User"), got.header.Get("X-Test-Secret"))
+	}
+	if got.header.Get("X-Forwarded-Host") != "fleet.example.test" || got.header.Get("X-Forwarded-Proto") != "https" {
+		t.Fatalf("sanitized forwarding headers=%v", got.header)
+	}
+	for _, name := range []string{"Authorization", "Cookie", "X-Authenticated-User", "X-Forwarded-For", "X-Crabbox-Claim", "X-Crabfleet-Claim", "X-Deployment-Claim", "X-Remove-Me"} {
+		if value := got.header.Get(name); value != "" {
+			t.Errorf("private header %s reached upstream as %q", name, value)
+		}
+	}
+	if got.header.Get("X-Public-Request") != "keep" {
+		t.Fatalf("ordinary request header missing: %v", got.header)
+	}
+}
+
+func TestAdapterIngressRejectsAuthenticationOriginRoutesAndHeaderFloods(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+	}))
+	defer upstream.Close()
+	proxy := newAdapterIngressTestProxy(t, upstream.URL, func(config *adapterIngressConfig) {
+		config.DenyPaths = []string{"/login/provider", "/api/private", "/escaped/%70ath"}
+		config.DenyPrefixes = []string{"/api/private/"}
+	})
+
+	tests := []struct {
+		name   string
+		path   string
+		mutate func(*http.Request)
+		want   int
+	}{
+		{name: "missing auth", path: "/app", want: http.StatusUnauthorized},
+		{name: "wrong secret", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			request.Header.Set("X-Test-Secret", "wrong")
+		}, want: http.StatusUnauthorized},
+		{name: "duplicate identity", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			request.Header["X-Test-User"] = []string{adapterIngressTestIdentity, adapterIngressTestIdentity}
+		}, want: http.StatusUnauthorized},
+		{name: "wrong origin", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			request.Header.Set("Origin", "https://other.example.test")
+		}, want: http.StatusForbidden},
+		{name: "exact denied route", path: "/login/provider", want: http.StatusNotFound},
+		{name: "prefixed denied route", path: "/api/private/child", want: http.StatusNotFound},
+		{name: "encoded denied route", path: "/api/private%2fchild", want: http.StatusNotFound},
+		{name: "encoded configured route", path: "/escaped/path", want: http.StatusNotFound},
+		{name: "dot segment denied route", path: "/public/../api/private", want: http.StatusNotFound},
+		{name: "header flood", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			for index := 0; index < adapterIngressMaxHeaders; index++ {
+				request.Header.Add("X-Many", "value")
+			}
+		}, want: http.StatusRequestHeaderFieldsTooLarge},
+		{name: "underscore header alias", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			request.Header.Set("X_Forwarded_Host", "spoofed.example.test")
+		}, want: http.StatusBadRequest},
+		{name: "malformed upgrade", path: "/app", mutate: func(request *http.Request) {
+			setAdapterIngressTestAuth(request.Header)
+			request.Header.Set("Connection", "Upgrade")
+			request.Header.Set("Upgrade", "h2c")
+		}, want: http.StatusBadRequest},
+		{name: "mixed-case trace", path: "/app", mutate: func(request *http.Request) {
+			request.Method = "Trace"
+			setAdapterIngressTestAuth(request.Header)
+		}, want: http.StatusMethodNotAllowed},
+		{name: "track", path: "/app", mutate: func(request *http.Request) {
+			request.Method = "TRACK"
+			setAdapterIngressTestAuth(request.Header)
+		}, want: http.StatusMethodNotAllowed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request.RemoteAddr = "203.0.113.10:4242"
+			if test.mutate != nil {
+				test.mutate(request)
+			}
+			response := httptest.NewRecorder()
+			proxy.ServeHTTP(response, request)
+			if response.Code != test.want {
+				t.Fatalf("code=%d body=%q want=%d", response.Code, response.Body.String(), test.want)
+			}
+		})
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("rejected requests reached upstream %d times", calls.Load())
+	}
+}
+
+func TestAdapterIngressHealthIsLoopbackOnlyAndStripsConnectionHeaders(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		if request.URL.Path != "/healthz" || request.Header.Get("X-Test-Secret") != "" {
+			t.Errorf("health request path=%q headers=%v", request.URL.Path, request.Header)
+		}
+		response.Header().Set("Connection", "X-Internal")
+		response.Header().Set("X-Internal", "drop")
+		response.Header().Set("X-Health", "ok")
+		_, _ = io.WriteString(response, "healthy")
+	}))
+	defer upstream.Close()
+	proxy := newAdapterIngressTestProxy(t, upstream.URL, nil)
+
+	remote := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	remote.RemoteAddr = "203.0.113.10:4242"
+	remoteResponse := httptest.NewRecorder()
+	proxy.ServeHTTP(remoteResponse, remote)
+	if remoteResponse.Code != http.StatusNotFound || calls.Load() != 0 {
+		t.Fatalf("remote health code=%d calls=%d", remoteResponse.Code, calls.Load())
+	}
+
+	local := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	local.RemoteAddr = "127.0.0.1:4242"
+	localResponse := httptest.NewRecorder()
+	proxy.ServeHTTP(localResponse, local)
+	if localResponse.Code != http.StatusOK || localResponse.Body.String() != "healthy" || localResponse.Header().Get("X-Health") != "ok" {
+		t.Fatalf("local health code=%d body=%q headers=%v", localResponse.Code, localResponse.Body.String(), localResponse.Header())
+	}
+	if localResponse.Header().Get("Connection") != "" || localResponse.Header().Get("X-Internal") != "" {
+		t.Fatalf("hop headers leaked: %v", localResponse.Header())
+	}
+}
+
+func TestAdapterIngressHealthDoesNotFollowRedirects(t *testing.T) {
+	var redirectedCalls atomic.Int32
+	redirected := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectedCalls.Add(1)
+	}))
+	defer redirected.Close()
+	upstream := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		http.Redirect(response, &http.Request{}, redirected.URL, http.StatusFound)
+	}))
+	defer upstream.Close()
+	proxy := newAdapterIngressTestProxy(t, upstream.URL, nil)
+
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	request.RemoteAddr = "127.0.0.1:4242"
+	response := httptest.NewRecorder()
+	proxy.ServeHTTP(response, request)
+	if response.Code != http.StatusFound || redirectedCalls.Load() != 0 {
+		t.Fatalf("health redirect code=%d followed=%d", response.Code, redirectedCalls.Load())
+	}
+}
+
+func TestAdapterIngressTunnelsAuthenticatedWebSockets(t *testing.T) {
+	upstreamHeaders := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		connection, err := websocket.Accept(response, request, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer connection.Close(websocket.StatusNormalClosure, "")
+		upstreamHeaders <- request.Header.Clone()
+		messageType, message, err := connection.Read(request.Context())
+		if err == nil {
+			_ = connection.Write(request.Context(), messageType, message)
+		}
+	}))
+	defer upstream.Close()
+	proxy := newAdapterIngressTestProxy(t, upstream.URL, nil)
+	ingress := httptest.NewServer(proxy)
+	defer ingress.Close()
+
+	header := make(http.Header)
+	setAdapterIngressTestAuth(header)
+	header.Set("Origin", adapterIngressTestOrigin)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connection, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(ingress.URL, "http")+"/terminal", &websocket.DialOptions{HTTPHeader: header})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close(websocket.StatusNormalClosure, "")
+	if err := connection.Write(ctx, websocket.MessageText, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	messageType, message, err := connection.Read(ctx)
+	if err != nil || messageType != websocket.MessageText || string(message) != "hello" {
+		t.Fatalf("echo type=%v message=%q err=%v", messageType, message, err)
+	}
+	got := <-upstreamHeaders
+	if got.Get("X-Test-User") != adapterIngressTestIdentity || got.Get("X-Test-Secret") != adapterIngressTestSecret {
+		t.Fatalf("trusted websocket headers=%v", got)
+	}
+}
+
+func TestAdapterIngressConfigurationRequiresPrivateStrictFiles(t *testing.T) {
+	directory := t.TempDir()
+	secretPath := filepath.Join(directory, "secret")
+	if err := os.WriteFile(secretPath, []byte(adapterIngressTestSecret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := adapterIngressConfig{
+		Listen:         "0.0.0.0:8443",
+		Upstream:       "http://127.0.0.1:8787",
+		PublicOrigin:   adapterIngressTestOrigin,
+		IdentityHeader: "X-Test-User",
+		Identity:       adapterIngressTestIdentity,
+		SecretHeader:   "X-Test-Secret",
+		SecretFile:     secretPath,
+	}
+	data, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(directory, "ingress.json")
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadAdapterIngressConfig(configPath)
+	if err != nil || loaded.upstreamURL == nil {
+		t.Fatalf("load valid config=%#v err=%v", loaded, err)
+	}
+	if _, err := newAdapterIngressProxy(loaded); err != nil {
+		t.Fatalf("load valid secret: %v", err)
+	}
+
+	if err := os.Chmod(configPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadAdapterIngressConfig(configPath); err == nil {
+		t.Fatal("broad config permissions accepted")
+	}
+	if err := os.Chmod(configPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unknown := append(bytes.TrimSuffix(data, []byte("}")), []byte(`,"unknown":true}`)...)
+	if err := os.WriteFile(configPath, unknown, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadAdapterIngressConfig(configPath); err == nil {
+		t.Fatal("unknown config key accepted")
+	}
+	if err := os.Chmod(secretPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newAdapterIngressProxy(valid); err == nil {
+		t.Fatal("broad secret permissions accepted")
+	}
+}
+
+func TestValidateAdapterIngressConfigRejectsUnsafeEndpointsAndHeaders(t *testing.T) {
+	valid := adapterIngressConfig{
+		Listen:         "0.0.0.0:8443",
+		Upstream:       "http://127.0.0.1:8787",
+		PublicOrigin:   adapterIngressTestOrigin,
+		IdentityHeader: "X-Test-User",
+		Identity:       adapterIngressTestIdentity,
+		SecretHeader:   "X-Test-Secret",
+		SecretFile:     "/tmp/adapter-ingress-secret",
+	}
+	tests := map[string]func(*adapterIngressConfig){
+		"DNS listen":         func(config *adapterIngressConfig) { config.Listen = "localhost:8443" },
+		"recursive wildcard": func(config *adapterIngressConfig) { config.Listen = "0.0.0.0:8787" },
+		"recursive exact":    func(config *adapterIngressConfig) { config.Listen = "127.0.0.1:8787" },
+		"recursive IPv6 wildcard": func(config *adapterIngressConfig) {
+			config.Listen = "[::]:8787"
+			config.Upstream = "http://[::1]:8787"
+		},
+		"recursive IPv6 zone": func(config *adapterIngressConfig) {
+			config.Listen = "[::1%0]:8787"
+			config.Upstream = "http://[::1]:8787"
+		},
+		"non-loopback upstream":   func(config *adapterIngressConfig) { config.Upstream = "http://192.0.2.10:8787" },
+		"loopback public origin":  func(config *adapterIngressConfig) { config.PublicOrigin = "https://127.0.0.1" },
+		"legacy IPv4 origin":      func(config *adapterIngressConfig) { config.PublicOrigin = "https://127.1" },
+		"expanded IPv6 origin":    func(config *adapterIngressConfig) { config.PublicOrigin = "https://[2001:0db8:0:0:0:0:0:1]" },
+		"uppercase IPv6 origin":   func(config *adapterIngressConfig) { config.PublicOrigin = "https://[2001:DB8::1]" },
+		"uppercase public origin": func(config *adapterIngressConfig) { config.PublicOrigin = "https://FLEET.example.test" },
+		"empty origin port":       func(config *adapterIngressConfig) { config.PublicOrigin = "https://fleet.example.test:" },
+		"default origin port":     func(config *adapterIngressConfig) { config.PublicOrigin = "https://fleet.example.test:443" },
+		"large origin port":       func(config *adapterIngressConfig) { config.PublicOrigin = "https://fleet.example.test:65536" },
+		"padded origin port":      func(config *adapterIngressConfig) { config.PublicOrigin = "https://fleet.example.test:08443" },
+		"reserved auth header":    func(config *adapterIngressConfig) { config.IdentityHeader = "Authorization" },
+		"underscored auth header": func(config *adapterIngressConfig) { config.IdentityHeader = "X_Test_User" },
+		"same auth headers":       func(config *adapterIngressConfig) { config.SecretHeader = "x-test-user" },
+		"newline identity":        func(config *adapterIngressConfig) { config.Identity = "operator\nspoofed" },
+		"relative secret":         func(config *adapterIngressConfig) { config.SecretFile = "secret" },
+		"deny all prefix":         func(config *adapterIngressConfig) { config.DenyPrefixes = []string{"/"} },
+		"uppercase strip prefix":  func(config *adapterIngressConfig) { config.StripHeaderPrefixes = []string{"X-Private-"} },
+		"underscored strip prefix": func(config *adapterIngressConfig) {
+			config.StripHeaderPrefixes = []string{"x_private-"}
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := validateAdapterIngressConfig(config); err == nil {
+				t.Fatalf("unsafe config accepted: %#v", config)
+			}
+		})
+	}
+	valid.PublicOrigin = "https://fleet.example.test:8443"
+	if _, err := validateAdapterIngressConfig(valid); err != nil {
+		t.Fatalf("canonical non-default origin port rejected: %v", err)
+	}
+	valid.PublicOrigin = "https://[2001:db8::1]"
+	if _, err := validateAdapterIngressConfig(valid); err != nil {
+		t.Fatalf("canonical IPv6 origin rejected: %v", err)
+	}
+}
+
+func TestAdapterIngressPrivateFileStabilityDetectsSameSizeRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private")
+	if err := os.WriteFile(path, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !adapterIngressPrivateFileStable(before, before, before.Size()) {
+		t.Fatal("unchanged file reported unstable")
+	}
+	if err := os.WriteFile(path, []byte("other"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changedTime := before.ModTime().Add(time.Second)
+	if err := os.Chtimes(path, changedTime, changedTime); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapterIngressPrivateFileStable(before, after, before.Size()) {
+		t.Fatal("same-size rewrite reported stable")
+	}
+}
+
+func TestAdapterIngressCommandIsDiscoverable(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"adapter", "--help"})
+	if err != nil || !strings.Contains(stdout.String()+stderr.String(), "ingress") {
+		t.Fatalf("help err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+}
+
+func newAdapterIngressTestProxy(t *testing.T, upstream string, mutate func(*adapterIngressConfig)) *adapterIngressProxy {
+	t.Helper()
+	secretPath := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(secretPath, []byte(adapterIngressTestSecret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := adapterIngressConfig{
+		Listen:              "0.0.0.0:8443",
+		Upstream:            upstream,
+		PublicOrigin:        adapterIngressTestOrigin,
+		IdentityHeader:      "X-Test-User",
+		Identity:            adapterIngressTestIdentity,
+		SecretHeader:        "X-Test-Secret",
+		SecretFile:          secretPath,
+		StripHeaderPrefixes: []string{"x-crabbox-", "x-crabfleet-", "x-deployment-"},
+	}
+	if mutate != nil {
+		mutate(&config)
+	}
+	proxy, err := newAdapterIngressProxy(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return proxy
+}
+
+func setAdapterIngressTestAuth(header http.Header) {
+	header.Set("X-Test-User", adapterIngressTestIdentity)
+	header.Set("X-Test-Secret", adapterIngressTestSecret)
+}

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -494,9 +494,13 @@ type configSetBrokerKongCmd struct {
 type adapterKongCmd struct {
 	Serve   controllerServeKongCmd `cmd:"" passthrough:"" help:"Serve the authenticated workspace lifecycle API."`
 	Connect adapterConnectKongCmd  `cmd:"" passthrough:"" help:"Connect a local Unix-socket runtime adapter to the configured coordinator."`
+	Ingress adapterIngressKongCmd  `cmd:"" passthrough:"" help:"Serve an authenticated ingress for a loopback adapter or fleet service."`
 	State   controllerStateKongCmd `cmd:"" help:"Inspect adapter state without lifecycle side effects."`
 }
 type adapterConnectKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type adapterIngressKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type controllerServeKongCmd struct {
@@ -791,6 +795,10 @@ func (c *controllerStateValidateKongCmd) Run(app App) error {
 
 func (c *adapterConnectKongCmd) Run(ctx context.Context, app App) error {
 	return app.adapterConnect(ctx, stripKongCommandPath(c.Args, "adapter", "connect"))
+}
+
+func (c *adapterIngressKongCmd) Run(ctx context.Context, app App) error {
+	return app.adapterIngress(ctx, stripKongCommandPath(c.Args, "adapter", "ingress"))
 }
 
 func (c *azureLoginKongCmd) Run(ctx context.Context, app App) error {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -412,14 +412,6 @@ func (a App) resolveNetworkLeaseTargetForRepo(ctx context.Context, cfg Config, i
 	return a.resolveNetworkLeaseTargetForRepoWithConfig(ctx, &cfg, id, printFallback, reclaim)
 }
 
-func (a App) resolveNetworkLoginTargetForRepo(ctx context.Context, cfg Config, id string, printFallback, reclaim bool) (Server, SSHTarget, string, error) {
-	lease, err := a.resolveNetworkLoginLeaseTargetForRepo(ctx, &cfg, id, printFallback, reclaim, true)
-	if err != nil {
-		return Server{}, SSHTarget{}, "", err
-	}
-	return lease.Server, lease.SSH, lease.LeaseID, nil
-}
-
 func (a App) resolveNetworkLoginLeaseTargetForRepo(ctx context.Context, cfg *Config, id string, printFallback, reclaim, probeTransport bool) (LeaseTarget, error) {
 	repo, err := findRepo()
 	if err != nil {


### PR DESCRIPTION
## Summary

- add `crabbox adapter ingress` as a provider-neutral authenticated reverse proxy for loopback HTTP services
- support streaming HTTP, authenticated WebSocket upgrades, route denials, loopback-only health checks, and sanitized public-origin forwarding
- harden the boundary against assertion spoofing, hop-by-hop and underscore header aliases, TRACE reflection, non-canonical paths/origins, recursive listeners, SSRF, and unsafe private files
- remove one unreachable network-login wrapper left by the newly landed `connect` command so the rebased tree remains deadcode-clean
- document the strict private JSON configuration and add the user-visible changelog entry

## Verification

- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-adapter-ingress ./cmd/crabbox`
- `go test ./internal/cli -run 'TestAdapterIngress|TestValidateAdapterIngress' -count=1`
- `go test ./internal/cli -count=1` after rebasing onto current `main`
- `scripts/check-go-coverage.sh 90.0` (`90.9%` core coverage)
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- structured Codex autoreview: clean after five security-focused passes and again after the final rebase

## Configuration and secrets

The command accepts only one strict JSON config file. The config and secret files must be current-user-owned, non-symlink regular files with mode `0400` or `0600`; secrets are never accepted on argv.
