### PR TITLE
fix: harden GCP resource recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Hardened GCP operator inventory and workspace recovery by requiring deterministic Crabbox instance names plus canonical provider labels before accepting resources. Thanks @coygeek.
 - Hardened shared-lease run auditability by preserving actor attribution while granting lease owners read-only access to runs, logs, events, telemetry, and portal history. Thanks @coygeek.
 - Pinned shipped runtime container base images to reviewed multi-platform digests and enforced the pins in CI. Thanks @coygeek.
 - Redacted manage-only WebVNC bridge commands and egress session details from `use` share viewers. Thanks @coygeek.

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -300,8 +300,18 @@ env -u CRABBOX_COORDINATOR -u CRABBOX_COORDINATOR_TOKEN \
 ```
 
 Cleanup lists Crabbox-labeled instances across the project's visible zones using
-aggregated instance listing with partial success enabled, then deletes expired or
-released leases in the zone recorded on each VM. Brokered cleanup is
+aggregated instance listing with partial success enabled. Inventory accepts only
+deterministically named instances with the canonical `crabbox`, `created_by`,
+`provider`, and valid lease labels, then deletes expired or released leases in
+the zone recorded on each VM. Brokered workspace recovery first resolves the
+exact deterministic instance name in the lease's recorded project and zone. A
+zonal miss falls back to cross-zone inventory for that exact name so interrupted
+pre-upgrade fallback creates remain recoverable. Both paths check the same
+canonical labels; neither adopts the first project-wide lease-label match, and
+duplicate exact-name matches fail as ambiguous. These checks are
+defense-in-depth against accidental or ambiguous resource adoption. GCP labels
+are operator metadata, not an authorization boundary against another principal
+that can already mutate instances in the same project. Brokered cleanup is
 coordinator-owned; direct cleanup is best-effort label cleanup.
 
 Three independent safety nets enforce expiry:

--- a/internal/cli/gcp.go
+++ b/internal/cli/gcp.go
@@ -371,7 +371,10 @@ func (c *GCPClient) listCrabboxServers(ctx context.Context, returnPartialSuccess
 			if instanceZone == "" {
 				instanceZone = c.Zone
 			}
-			servers = append(servers, gcpInstanceToServer(instanceZone, instance))
+			server := gcpInstanceToServer(instanceZone, instance)
+			if IsCanonicalGCPServer(server) {
+				servers = append(servers, server)
+			}
 		}
 	}
 	sort.Slice(servers, func(i, j int) bool {
@@ -381,6 +384,21 @@ func (c *GCPClient) listCrabboxServers(ctx context.Context, returnPartialSuccess
 		return servers[i].Name < servers[j].Name
 	})
 	return servers, nil
+}
+
+func IsCanonicalGCPServer(server Server) bool {
+	labels := server.Labels
+	if labels == nil {
+		return false
+	}
+	leaseID := strings.TrimSpace(labels["lease"])
+	slug := strings.TrimSpace(labels["slug"])
+	return isCanonicalLeaseID(leaseID) &&
+		slug != "" &&
+		server.Name == leaseProviderName(leaseID, slug) &&
+		labels["crabbox"] == "true" &&
+		labels["created_by"] == "crabbox" &&
+		labels["provider"] == "gcp"
 }
 
 func (c *GCPClient) DeleteServer(ctx context.Context, name string) error {

--- a/internal/cli/gcp_test.go
+++ b/internal/cli/gcp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -82,6 +83,43 @@ func TestGCPInstanceToServerHandlesNilLabels(t *testing.T) {
 	}
 }
 
+func TestIsCanonicalGCPServer(t *testing.T) {
+	leaseID := "cbx_123456abcdef"
+	slug := "blue-box"
+	canonical := Server{
+		Name: leaseProviderName(leaseID, slug),
+		Labels: map[string]string{
+			"crabbox":    "true",
+			"created_by": "crabbox",
+			"provider":   "gcp",
+			"lease":      leaseID,
+			"slug":       slug,
+		},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Server)
+		want   bool
+	}{
+		{name: "canonical", mutate: func(*Server) {}, want: true},
+		{name: "wrong name", mutate: func(server *Server) { server.Name = "crabbox-forged" }},
+		{name: "invalid lease", mutate: func(server *Server) { server.Labels["lease"] = "cbx_invalid" }},
+		{name: "missing slug", mutate: func(server *Server) { delete(server.Labels, "slug") }},
+		{name: "missing creator", mutate: func(server *Server) { delete(server.Labels, "created_by") }},
+		{name: "wrong provider", mutate: func(server *Server) { server.Labels["provider"] = "aws" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := canonical
+			server.Labels = maps.Clone(canonical.Labels)
+			test.mutate(&server)
+			if got := IsCanonicalGCPServer(server); got != test.want {
+				t.Fatalf("IsCanonicalGCPServer()=%v want %v server=%#v", got, test.want, server)
+			}
+		})
+	}
+}
+
 func TestGCPFirewallNameForNetwork(t *testing.T) {
 	cases := map[string]string{
 		"default":                                   "crabbox-ssh",
@@ -153,6 +191,12 @@ func TestGCPListCrabboxServersAggregatesZones(t *testing.T) {
 	var gotPath string
 	var gotFilter string
 	var gotPartialSuccess string
+	fallbackLeaseID := "cbx_333333333333"
+	fallbackSlug := "fallback-zone"
+	fallbackName := leaseProviderName(fallbackLeaseID, fallbackSlug)
+	otherLeaseID := "cbx_444444444444"
+	otherSlug := "other-zone"
+	otherName := leaseProviderName(otherLeaseID, otherSlug)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotFilter = r.URL.Query().Get("filter")
@@ -161,19 +205,32 @@ func TestGCPListCrabboxServersAggregatesZones(t *testing.T) {
 			"items": map[string]any{
 				"zones/europe-west2-b": map[string]any{
 					"instances": []map[string]any{{
-						"name":   "crabbox-fallback-zone",
+						"name":   fallbackName,
 						"status": "RUNNING",
-						"labels": map[string]string{"crabbox": "true", "lease": "cbx_333333333333"},
+						"labels": map[string]string{
+							"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+							"lease": fallbackLeaseID, "slug": fallbackSlug,
+						},
 						"networkInterfaces": []map[string]any{{
 							"accessConfigs": []map[string]string{{"natIP": "203.0.113.33"}},
 						}},
+					}, {
+						"name":   "crabbox-forged",
+						"status": "RUNNING",
+						"labels": map[string]string{
+							"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+							"lease": "cbx_555555555555", "slug": "forged",
+						},
 					}},
 				},
 				"zones/us-central1-a": map[string]any{
 					"instances": []map[string]any{{
-						"name":   "crabbox-other-zone",
+						"name":   otherName,
 						"status": "RUNNING",
-						"labels": map[string]string{"crabbox": "true", "lease": "cbx_444444444444"},
+						"labels": map[string]string{
+							"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+							"lease": otherLeaseID, "slug": otherSlug,
+						},
 					}},
 				},
 			},
@@ -202,10 +259,10 @@ func TestGCPListCrabboxServersAggregatesZones(t *testing.T) {
 	if len(servers) != 2 {
 		t.Fatalf("servers=%v", servers)
 	}
-	if servers[0].Name != "crabbox-fallback-zone" || servers[0].Labels["zone"] != "europe-west2-b" || servers[0].PublicNet.IPv4.IP != "203.0.113.33" {
+	if servers[0].Name != fallbackName || servers[0].Labels["zone"] != "europe-west2-b" || servers[0].PublicNet.IPv4.IP != "203.0.113.33" {
 		t.Fatalf("fallback server=%#v", servers[0])
 	}
-	if servers[1].Name != "crabbox-other-zone" || servers[1].Labels["zone"] != "us-central1-a" {
+	if servers[1].Name != otherName || servers[1].Labels["zone"] != "us-central1-a" {
 		t.Fatalf("other server=%#v", servers[1])
 	}
 

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -158,16 +158,7 @@ func (b *gcpLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 }
 
 func isCrabboxGCPLease(server Server) bool {
-	if server.Labels == nil {
-		return false
-	}
-	if server.Labels["crabbox"] != "true" {
-		return false
-	}
-	if provider := server.Labels["provider"]; provider != "" && provider != "gcp" {
-		return false
-	}
-	return true
+	return core.IsCanonicalGCPServer(server)
 }
 
 func (b *gcpLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -176,7 +167,17 @@ func (b *gcpLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseVie
 	if err != nil {
 		return nil, err
 	}
-	return client.ListCrabboxServers(ctx)
+	servers, err := client.ListCrabboxServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	canonical := make([]Server, 0, len(servers))
+	for _, server := range servers {
+		if isCrabboxGCPLease(server) {
+			canonical = append(canonical, server)
+		}
+	}
+	return canonical, nil
 }
 
 func (b *gcpLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
@@ -249,6 +250,9 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 	}
 	liveLeaseIDs := make(map[string]struct{}, len(completeServers))
 	for _, server := range completeServers {
+		if !isCrabboxGCPLease(server) {
+			continue
+		}
 		if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
 			liveLeaseIDs[leaseID] = struct{}{}
 		}

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -126,24 +126,38 @@ func TestGCPAcquireCleansUpCreatedServerOnFallbackClientFailure(t *testing.T) {
 func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := t.TempDir()
-	if err := core.ClaimLeaseForRepoProviderScope("cbx_expired", "expired-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+	expiredLeaseID := "cbx_111111111111"
+	staleLeaseID := "cbx_222222222222"
+	otherProjectLeaseID := "cbx_333333333333"
+	if err := core.ClaimLeaseForRepoProviderScope(expiredLeaseID, "expired-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.ClaimLeaseForRepoProviderScope("cbx_stale", "stale-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope(staleLeaseID, "stale-box", "gcp", "project:project-a", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.ClaimLeaseForRepoProviderScope("cbx_other_project", "other-box", "gcp", "project:project-b", repo, time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope(otherProjectLeaseID, "other-box", "gcp", "project:project-b", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeGCPDoctorClient{servers: []Server{{
-		CloudID: "crabbox-expired",
-		Name:    "crabbox-expired",
-		Labels: map[string]string{
-			"lease":      "cbx_expired",
-			"state":      "ready",
-			"expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
+	fake := &fakeGCPDoctorClient{servers: []Server{
+		{
+			CloudID: core.LeaseProviderName(expiredLeaseID, "expired-box"),
+			Name:    core.LeaseProviderName(expiredLeaseID, "expired-box"),
+			Labels: map[string]string{
+				"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+				"lease": expiredLeaseID, "slug": "expired-box",
+				"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
+			},
 		},
-	}}}
+		{
+			CloudID: "crabbox-forged",
+			Name:    "crabbox-forged",
+			Labels: map[string]string{
+				"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+				"lease": "cbx_444444444444", "slug": "forged",
+				"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
+			},
+		},
+	}}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
 		return fake, nil
@@ -159,10 +173,10 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if err := cleaner.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.deleted) != 1 {
-		t.Fatalf("deleted=%v want one deleted server", fake.deleted)
+	if len(fake.deleted) != 1 || fake.deleted[0] != core.LeaseProviderName(expiredLeaseID, "expired-box") {
+		t.Fatalf("deleted=%v want canonical expired server", fake.deleted)
 	}
-	for _, leaseID := range []string{"cbx_expired", "cbx_stale"} {
+	for _, leaseID := range []string{expiredLeaseID, staleLeaseID} {
 		claim, err := core.ReadLeaseClaim(leaseID)
 		if err != nil {
 			t.Fatal(err)
@@ -171,7 +185,7 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 			t.Fatalf("claim %s still present: %#v", leaseID, claim)
 		}
 	}
-	claim, err := core.ReadLeaseClaim("cbx_other_project")
+	claim, err := core.ReadLeaseClaim(otherProjectLeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,13 +193,29 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 		t.Fatal("other project claim was removed")
 	}
 	out := stderr.String()
-	if !strings.Contains(out, "delete server id=crabbox-expired") || !strings.Contains(out, "remove stale claim lease=cbx_stale") {
+	if !strings.Contains(out, "delete server id="+core.LeaseProviderName(expiredLeaseID, "expired-box")) ||
+		!strings.Contains(out, "remove stale claim lease="+staleLeaseID) {
 		t.Fatalf("cleanup output=%q", out)
 	}
 }
 
 func TestGCPDoctorListsInventoryOnly(t *testing.T) {
-	fake := &fakeGCPDoctorClient{servers: []Server{{CloudID: "crabbox-one"}, {CloudID: "crabbox-two"}}}
+	server := func(leaseID, slug string) Server {
+		name := core.LeaseProviderName(leaseID, slug)
+		return Server{
+			CloudID: name,
+			Name:    name,
+			Labels: map[string]string{
+				"crabbox": "true", "created_by": "crabbox", "provider": "gcp",
+				"lease": leaseID, "slug": slug,
+			},
+		}
+	}
+	fake := &fakeGCPDoctorClient{servers: []Server{
+		server("cbx_555555555555", "one"),
+		server("cbx_666666666666", "two"),
+		{CloudID: "crabbox-forged", Name: "crabbox-forged", Labels: map[string]string{"crabbox": "true"}},
+	}}
 	old := newGCPClient
 	newGCPClient = func(context.Context, Config) (gcpClient, error) {
 		return fake, nil

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1756,12 +1756,18 @@ export class FleetCoordinator {
             lastProvisioningTarget = { ...target };
             await prepared.provisioning?.onTargetAttempt?.(target);
             const region = target.region;
-            if (record.provider !== "aws" || !region) {
+            if (!region) {
               return;
             }
             await this.state.runExclusive(async () => {
               const current = (await this.getLease(record.id)) ?? record;
-              await this.markAWSIngressReconcilePending({ ...current, region });
+              if (record.provider === "aws") {
+                await this.markAWSIngressReconcilePending({ ...current, region });
+              } else {
+                current.region = region;
+                current.updatedAt = new Date().toISOString();
+                await this.putLease(current);
+              }
               await this.scheduleAlarm();
             });
           },
@@ -2642,7 +2648,9 @@ export class FleetCoordinator {
     const provider = this.provider(workspace.provider, lease.region, lease.providerProject);
     let server: ProviderMachine | undefined;
     try {
-      if (lease.cloudID && provider.getServer) {
+      if (provider.recoverServer) {
+        server = await provider.recoverServer(lease);
+      } else if (lease.cloudID && provider.getServer) {
         server = await provider.getServer(lease.cloudID);
       } else if (provider.findServerByLease) {
         server = await provider.findServerByLease(lease.id);
@@ -13714,6 +13722,7 @@ function parseProviderLabelTime(value: string | undefined): number {
 
 interface CloudProvider {
   listCrabboxServers(): Promise<ProviderMachine[]>;
+  recoverServer?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
   findServerByLease?(leaseID: string): Promise<ProviderMachine | undefined>;
   getServer?(id: string): Promise<ProviderMachine>;
   prepareLeaseConfig?(
@@ -14064,6 +14073,14 @@ class GCPProvider implements CloudProvider {
     return this.client.listCrabboxServers();
   }
 
+  getServer(id: string): Promise<ProviderMachine> {
+    return this.client.getServer(id);
+  }
+
+  recoverServer(lease: LeaseRecord): Promise<ProviderMachine | undefined> {
+    return this.client.recoverServerForLease(lease.id, lease.slug);
+  }
+
   async prepareLeaseConfig(
     config: ReturnType<typeof leaseConfig>,
   ): Promise<ReturnType<typeof leaseConfig>> {
@@ -14076,18 +14093,26 @@ class GCPProvider implements CloudProvider {
     };
   }
 
+  prepareLeaseCreate(
+    config: ReturnType<typeof leaseConfig>,
+    lease: LeaseRecord,
+  ): Promise<ProviderLeaseCreatePreparation> {
+    return Promise.resolve({ config, lease, provisioning: {} });
+  }
+
   createServerWithFallback(
     config: ReturnType<typeof leaseConfig>,
     leaseID: string,
     slug: string,
     owner: string,
+    provisioning?: ProviderProvisioningContext,
   ): Promise<{
     server: ProviderMachine;
     serverType: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    return this.client.createServerWithFallback(config, leaseID, slug, owner);
+    return this.client.createServerWithFallback(config, leaseID, slug, owner, provisioning);
   }
 
   deleteServer(id: string): Promise<void> {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -105,12 +105,45 @@ export class GCPClient {
       if (isNotFound(error)) return { items: [] };
       throw error;
     });
-    return Object.entries(data.items ?? {}).flatMap(([scope, list]) => {
-      const zone = lastPathPart(scope);
-      return (list.instances ?? []).map((instance) =>
-        toMachine(instance, lastPathPart(instance.zone ?? zone)),
+    return Object.entries(data.items ?? {})
+      .flatMap(([scope, list]) => {
+        const zone = lastPathPart(scope);
+        return (list.instances ?? []).map((instance) =>
+          toMachine(instance, lastPathPart(instance.zone ?? zone)),
+        );
+      })
+      .filter(canonicalGCPMachine);
+  }
+
+  async recoverServerForLease(
+    leaseID: string,
+    slug: string | undefined,
+  ): Promise<ProviderMachine | undefined> {
+    const expectedName = leaseProviderName(leaseID, slug);
+    let server: ProviderMachine | undefined;
+    try {
+      server = await this.getServer(expectedName);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      // Pre-upgrade fallback attempts may have created the canonical instance
+      // before the selected zone was persisted on the lease.
+      const matches = (await this.listCrabboxServers()).filter(
+        (candidate) => candidate.name === expectedName && candidate.labels["lease"] === leaseID,
       );
-    });
+      if (matches.length > 1) {
+        throw new Error(
+          `ambiguous GCP recovery for ${leaseID}: ${matches.length} canonical instances named ${expectedName}`,
+          { cause: error },
+        );
+      }
+      server = matches[0];
+    }
+    if (!server) return undefined;
+    return server.name === expectedName &&
+      canonicalGCPMachine(server) &&
+      server.labels["lease"] === leaseID
+      ? server
+      : undefined;
   }
 
   async createServerWithFallback(
@@ -118,6 +151,7 @@ export class GCPClient {
     leaseID: string,
     slug: string,
     owner: string,
+    provisioning?: { onTargetAttempt?: (target: { region?: string }) => Promise<void> },
   ): Promise<{
     server: ProviderMachine;
     serverType: string;
@@ -142,6 +176,9 @@ export class GCPClient {
           : new GCPClient(this.env, zone, project);
       for (const machineType of candidates) {
         try {
+          // Persist the zone before an instance create can outlive the coordinator request.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- fallback must preserve capacity order.
+          await provisioning?.onTargetAttempt?.({ region: zone });
           // oxlint-disable-next-line eslint/no-await-in-loop -- fallback must preserve capacity order.
           const server = await client.createServer(
             { ...config, gcpZone: zone, serverType: machineType },
@@ -181,6 +218,9 @@ export class GCPClient {
             : new GCPClient(this.env, zone, project);
         for (const machineType of candidates) {
           try {
+            // Persist the zone before an instance create can outlive the coordinator request.
+            // oxlint-disable-next-line eslint/no-await-in-loop -- fallback must preserve capacity order.
+            await provisioning?.onTargetAttempt?.({ region: zone });
             // oxlint-disable-next-line eslint/no-await-in-loop -- fallback must preserve capacity order.
             const server = await client.createServer(
               {
@@ -660,6 +700,19 @@ function toMachine(instance: GCPInstance, zone: string): ProviderMachine {
     host,
     labels: { ...instance.labels, zone },
   };
+}
+
+function canonicalGCPMachine(machine: ProviderMachine): boolean {
+  const leaseID = machine.labels["lease"] ?? "";
+  const slug = machine.labels["slug"] ?? "";
+  return (
+    /^cbx_[a-f0-9]{12}$/.test(leaseID) &&
+    slug.length > 0 &&
+    machine.name === leaseProviderName(leaseID, slug) &&
+    machine.labels["crabbox"] === "true" &&
+    machine.labels["created_by"] === "crabbox" &&
+    machine.labels["provider"] === "gcp"
+  );
 }
 
 function gcpLabels(labels: Record<string, string>): Record<string, string> {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4693,6 +4693,155 @@ describe("fleet lease identity and idle", () => {
     expect(providerReleases).toBe(1);
   });
 
+  it("uses provider-owned GCP recovery instead of project-wide label inventory", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    let inventoryCalls = 0;
+    let recoveryCalls = 0;
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onList: () => {
+          inventoryCalls += 1;
+          return [
+            {
+              provider: "gcp",
+              id: 999,
+              cloudID: "foreign-instance",
+              name: "foreign-instance",
+              status: "running",
+              serverType: "e2-micro",
+              host: "192.0.2.99",
+              labels: { crabbox: "true", lease: leaseID },
+            },
+          ];
+        },
+        onRecoverServer: (lease) => {
+          recoveryCalls += 1;
+          expect(lease.id).toBe(leaseID);
+          expect(lease.slug).toBe("fleet-is-gcp-recovery");
+          return {
+            provider: "gcp",
+            id: 123,
+            cloudID: "crabbox-fleet-is-gcp-recovery-c80c2195",
+            name: "crabbox-fleet-is-gcp-recovery-c80c2195",
+            status: "running",
+            serverType: "e2-micro",
+            region: "us-central1-a",
+            host: "192.0.2.10",
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              provider: "gcp",
+              lease: leaseID,
+            },
+          };
+        },
+      }),
+    });
+    const now = new Date().toISOString();
+    storage.seed("workspace:example-org:alice%40example.com:fleet-is-gcp-recovery", {
+      id: "fleet-is-gcp-recovery",
+      leaseID,
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      provider: "gcp",
+      class: "standard",
+      desktop: false,
+      ttlSeconds: 1800,
+      idleTimeoutSeconds: 360,
+      provisionClaim: "expired-claim",
+      provisionClaimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+      createdAt: now,
+      updatedAt: now,
+    });
+    storage.seed(`lease:${leaseID}`, {
+      id: leaseID,
+      slug: "fleet-is-gcp-recovery",
+      workspaceID: "fleet-is-gcp-recovery",
+      provider: "gcp",
+      providerProject: "proj",
+      region: "us-central1-a",
+      target: "linux",
+      desktop: false,
+      browser: false,
+      code: false,
+      cloudID: "stale-cloud-id",
+      owner: "alice@example.com",
+      org: "example-org",
+      profile: "default",
+      class: "standard",
+      serverType: "e2-micro",
+      requestedServerType: "e2-micro",
+      serverID: 0,
+      serverName: "",
+      providerKey: "workspace-test",
+      host: "",
+      sshUser: "root",
+      sshPort: "22",
+      workRoot: "/workspaces/crabbox",
+      keep: false,
+      ttlSeconds: 1800,
+      idleTimeoutSeconds: 360,
+      estimatedHourlyUSD: 0,
+      maxEstimatedUSD: 0,
+      state: "provisioning",
+      provisioningRequestStartedAt: now,
+      createdAt: now,
+      updatedAt: now,
+      lastTouchedAt: now,
+      expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    } as LeaseRecord);
+
+    await fleet.alarm();
+
+    expect(recoveryCalls).toBe(1);
+    expect(inventoryCalls).toBe(0);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "active",
+      cloudID: "crabbox-fleet-is-gcp-recovery-c80c2195",
+      host: "192.0.2.10",
+    });
+  });
+
+  it("persists the active GCP fallback zone before provider mutation", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onPrepareLeaseCreate(config, lease) {
+          return { config, lease, provisioning: {} };
+        },
+        async onCreateProvisioning(provisioning) {
+          await provisioning?.onTargetAttempt?.({ region: "us-central1-a" });
+          await provisioning?.onTargetAttempt?.({ region: "us-central1-b" });
+          throw new Error("capacity unavailable");
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "proj",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      region: "us-central1-b",
+    });
+  });
+
   it("fails deterministic workspace provisioning errors without waiting for the lease TTL", async () => {
     const storage = new MemoryStorage();
     let providerLookups = 0;
@@ -16427,6 +16576,9 @@ function fakeProvider(
           lease: LeaseRecord;
         }
       | undefined;
+    onRecoverServer?: (
+      lease: LeaseRecord,
+    ) => Promise<ProviderMachine | undefined> | ProviderMachine | undefined;
   } = {},
   onDelete?: (id: string) => Promise<void>,
   onGet?: (id: string) => Promise<ProviderMachine> | ProviderMachine,
@@ -16442,6 +16594,13 @@ function fakeProvider(
       }
       return result.servers ?? [];
     },
+    ...(result.onRecoverServer
+      ? {
+          async recoverServer(lease: LeaseRecord) {
+            return await result.onRecoverServer?.(lease);
+          },
+        }
+      : {}),
     async findServerByLease(leaseID: string) {
       const servers = result.onList ? await result.onList() : (result.servers ?? []);
       return servers.find((server) => server.labels?.["lease"] === leaseID);

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -9,10 +9,12 @@ import {
   isFallbackProvisioningError,
   operationDone,
 } from "../src/gcp";
+import { leaseProviderName } from "../src/slug";
 import type { Env, ProviderMachine } from "../src/types";
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe("gcp provider", () => {
@@ -151,9 +153,27 @@ describe("gcp provider", () => {
             instances: [
               {
                 id: "1",
-                name: "crabbox-a",
+                name: leaseProviderName("cbx_000000000001", "alpha"),
                 machineType: "zones/us-central1-a/machineTypes/e2-micro",
-                labels: { crabbox: "true" },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "gcp",
+                  lease: "cbx_000000000001",
+                  slug: "alpha",
+                },
+              },
+              {
+                id: "forged",
+                name: "crabbox-wrong-deterministic-name",
+                machineType: "zones/us-central1-a/machineTypes/e2-micro",
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "gcp",
+                  lease: "cbx_000000000099",
+                  slug: "forged",
+                },
               },
             ],
           },
@@ -161,10 +181,16 @@ describe("gcp provider", () => {
             instances: [
               {
                 id: "2",
-                name: "crabbox-b",
+                name: leaseProviderName("cbx_000000000002", "bravo"),
                 zone: "projects/default-project/zones/europe-west2-b",
                 machineType: "zones/europe-west2-b/machineTypes/c4-standard-32",
-                labels: { crabbox: "true" },
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "gcp",
+                  lease: "cbx_000000000002",
+                  slug: "bravo",
+                },
               },
             ],
           },
@@ -174,9 +200,176 @@ describe("gcp provider", () => {
 
     const servers = await client.listCrabboxServers();
     expect(servers.map((server) => [server.name, server.region])).toEqual([
-      ["crabbox-a", "us-central1-a"],
-      ["crabbox-b", "europe-west2-b"],
+      [leaseProviderName("cbx_000000000001", "alpha"), "us-central1-a"],
+      [leaseProviderName("cbx_000000000002", "bravo"), "europe-west2-b"],
     ]);
+  });
+
+  it("recovers a lease only through its deterministic canonical instance", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    let leaseLabel = "cbx_abcdef123456";
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe(
+        "/compute/v1/projects/default-project/zones/us-central1-a/instances/crabbox-blue-lobster-c80c2195",
+      );
+      return Response.json({
+        id: "1",
+        name: "crabbox-blue-lobster-c80c2195",
+        machineType: "zones/us-central1-a/machineTypes/e2-micro",
+        labels: {
+          crabbox: "true",
+          created_by: "crabbox",
+          provider: "gcp",
+          lease: leaseLabel,
+          slug: "blue-lobster",
+        },
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease("cbx_abcdef123456", "blue-lobster"),
+    ).resolves.toMatchObject({
+      name: "crabbox-blue-lobster-c80c2195",
+      labels: { lease: "cbx_abcdef123456" },
+    });
+    leaseLabel = "cbx_000000000001";
+    await expect(
+      client.recoverServerForLease("cbx_abcdef123456", "blue-lobster"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("recovers pre-upgrade fallback-zone instances by exact canonical name", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const expectedName = leaseProviderName("cbx_abcdef123456", "blue-lobster");
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith(`/instances/${expectedName}`)) {
+        return new Response("not found", { status: 404 });
+      }
+      expect(url.pathname).toBe("/compute/v1/projects/default-project/aggregated/instances");
+      return Response.json({
+        items: {
+          "zones/us-central1-b": {
+            instances: [
+              {
+                id: "1",
+                name: expectedName,
+                zone: "projects/default-project/zones/us-central1-b",
+                machineType: "zones/us-central1-b/machineTypes/e2-micro",
+                labels: {
+                  crabbox: "true",
+                  created_by: "crabbox",
+                  provider: "gcp",
+                  lease: "cbx_abcdef123456",
+                  slug: "blue-lobster",
+                },
+              },
+            ],
+          },
+        },
+      });
+    };
+
+    await expect(
+      client.recoverServerForLease("cbx_abcdef123456", "blue-lobster"),
+    ).resolves.toMatchObject({
+      name: expectedName,
+      region: "us-central1-b",
+    });
+  });
+
+  it("rejects ambiguous exact-name fallback-zone recovery", async () => {
+    const client = new GCPClient(env);
+    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+      token: "test-token",
+      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+    };
+    const leaseID = "cbx_abcdef123456";
+    const slug = "blue-lobster";
+    const expectedName = leaseProviderName(leaseID, slug);
+    client.fetcher = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith(`/instances/${expectedName}`)) {
+        return new Response("not found", { status: 404 });
+      }
+      const instance = (zone: string) => ({
+        id: zone,
+        name: expectedName,
+        zone: `projects/default-project/zones/${zone}`,
+        machineType: `zones/${zone}/machineTypes/e2-micro`,
+        labels: {
+          crabbox: "true",
+          created_by: "crabbox",
+          provider: "gcp",
+          lease: leaseID,
+          slug,
+        },
+      });
+      return Response.json({
+        items: {
+          "zones/us-central1-b": { instances: [instance("us-central1-b")] },
+          "zones/us-central1-c": { instances: [instance("us-central1-c")] },
+        },
+      });
+    };
+
+    await expect(client.recoverServerForLease(leaseID, slug)).rejects.toThrow(
+      "ambiguous GCP recovery",
+    );
+  });
+
+  it("publishes each fallback zone before creating an instance", async () => {
+    const client = new GCPClient(env);
+    const attemptedZones: string[] = [];
+    const createCalls: string[] = [];
+    vi.spyOn(GCPClient.prototype, "createServer").mockImplementation(async (config) => {
+      createCalls.push(config.gcpZone);
+      if (config.gcpZone === "us-central1-a") {
+        throw new Error("ZONE_RESOURCE_POOL_EXHAUSTED");
+      }
+      return {
+        provider: "gcp",
+        id: 1,
+        cloudID: "crabbox-blue-lobster-c80c2195",
+        name: "crabbox-blue-lobster-c80c2195",
+        status: "running",
+        serverType: config.serverType,
+        region: config.gcpZone,
+        host: "192.0.2.10",
+        labels: {},
+      };
+    });
+
+    await client.createServerWithFallback(
+      leaseConfig({
+        provider: "gcp",
+        gcpZone: "us-central1-a",
+        capacity: { availabilityZones: ["us-central1-b"] },
+        serverType: "e2-micro",
+        serverTypeExplicit: true,
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      "cbx_abcdef123456",
+      "blue-lobster",
+      "alice@example.com",
+      {
+        async onTargetAttempt(target) {
+          attemptedZones.push(target.region ?? "");
+        },
+      },
+    );
+
+    expect(attemptedZones).toEqual(["us-central1-a", "us-central1-b"]);
+    expect(createCalls).toEqual(["us-central1-a", "us-central1-b"]);
   });
 
   it("creates and deletes machine images through Compute Engine", async () => {


### PR DESCRIPTION
## Summary

- require deterministic GCP instance names plus canonical Crabbox labels for Worker and direct CLI inventory
- recover interrupted workspaces by exact instance identity, with migration-safe cross-zone lookup and ambiguity rejection
- persist each GCP fallback zone before provider mutation so later recovery targets the actual zone
- apply the same canonical filter to direct cleanup and exact-name resolution

This is defense-in-depth hardening, not a new authorization boundary. A principal that can mutate Compute Engine resources in the same project remains trusted at the GCP control plane; these checks prevent accidental, stale, or ambiguous resource adoption.

## Verification

- `go test ./internal/cli -run 'Test(IsCanonicalGCPServer|GCPListCrabboxServersAggregatesZones)$'`
- `go test ./internal/providers/gcp`
- `npm test --prefix worker` (618 tests)
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- docs site build
- autoreview clean

Full `go test ./internal/cli ./internal/providers/gcp` reached three pre-existing macOS permission-mode assertion failures in controller lock/token tests; all GCP-focused Go tests passed.

Closes https://github.com/openclaw/crabbox/issues/389