### PR TITLE
fix: protect XCP-Ng credentials from repo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Hardened XCP-Ng repository config so it cannot override trusted provider credentials. Thanks @coygeek.
 - Replaced browser-native portal confirmation and clipboard prompts with themed, keyboard-accessible HTML dialogs.
 - Hardened GCP operator inventory and workspace recovery by requiring deterministic Crabbox instance names plus canonical provider labels before accepting resources. Thanks @coygeek.
 - Hardened shared-lease run auditability by preserving actor attribution while granting lease owners read-only access to runs, logs, events, telemetry, and portal history. Thanks @coygeek.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3914,14 +3914,14 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	}
 	if file.XCPNg != nil {
 		// Project config is repository-controlled. Do not let it redirect
-		// inherited user or environment credentials to another XAPI endpoint.
+		// or replace inherited user or environment XAPI credentials.
 		if trusted && file.XCPNg.APIURL != "" {
 			cfg.XCPNg.APIURL = file.XCPNg.APIURL
 		}
-		if file.XCPNg.Username != "" {
+		if trusted && file.XCPNg.Username != "" {
 			cfg.XCPNg.Username = file.XCPNg.Username
 		}
-		if file.XCPNg.Password != "" {
+		if trusted && file.XCPNg.Password != "" {
 			cfg.XCPNg.Password = file.XCPNg.Password
 		}
 		if file.XCPNg.Template != "" {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3201,7 +3201,7 @@ func TestRepoConfigCannotRedirectInheritedXCPNgCredentials(t *testing.T) {
 	if err := os.Chdir(repo); err != nil {
 		t.Fatal(err)
 	}
-	projectConfig := "xcpNg:\n  apiUrl: https://attacker.example.test\n  insecureTls: true\n  template: project-template\n"
+	projectConfig := "xcpNg:\n  apiUrl: https://attacker.example.test\n  username: attacker\n  password: attacker-secret\n  insecureTls: true\n  template: project-template\n"
 	if err := os.WriteFile(".crabbox.yaml", []byte(projectConfig), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -3213,7 +3213,7 @@ func TestRepoConfigCannotRedirectInheritedXCPNgCredentials(t *testing.T) {
 	if cfg.XCPNg.APIURL != "https://trusted.example.test" || cfg.XCPNg.InsecureTLS {
 		t.Fatalf("project config changed trusted connection: %#v", cfg.XCPNg)
 	}
-	if cfg.XCPNg.Password != "user-secret" || cfg.XCPNg.Template != "project-template" {
+	if cfg.XCPNg.Username != "root" || cfg.XCPNg.Password != "user-secret" || cfg.XCPNg.Template != "project-template" {
 		t.Fatalf("unexpected merged xcp-ng config: %#v", cfg.XCPNg)
 	}
 }


### PR DESCRIPTION
## Summary

- require trusted config for XCP-Ng API URL, username, and password
- keep repository-controlled template, storage, network, host, user, and work-root settings unchanged
- extend the existing regression test with hostile username and password overrides

This is security hardening of the existing repository-config trust boundary. It does not change trusted user config, explicit config, environment credentials, or non-secret repository workspace selection.

Fixes https://github.com/openclaw/crabbox/issues/405

## Verification

- `go test ./internal/cli -run 'TestRepoConfigCannotRedirectInheritedXCPNgCredentials|TestXCPNg' -count=1`
- `go test ./internal/providers/xcpng -count=1`
- `go vet ./...`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)

The complete `go test ./internal/cli -count=1` run reached three unrelated controller permission tests that also fail unchanged on clean `main` in this macOS environment.