### PR TITLE
ci: pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -77,13 +77,13 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Verify Apple Silicon runner
         run: test "$(uname -m)" = arm64
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -109,10 +109,10 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
@@ -167,15 +167,15 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -193,15 +193,15 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -224,13 +224,13 @@ jobs:
         run: test "$(uname -m)" = arm64
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/hydrate.yml
+++ b/.github/workflows/hydrate.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,10 +29,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
@@ -40,13 +40,13 @@ jobs:
         run: node scripts/build-docs-site.mjs
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist/docs-site
 
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Pinned GitHub Actions workflow dependencies to reviewed immutable commits and added CI enforcement against mutable references. Thanks @coygeek.
 - Hardened XCP-Ng repository config so it cannot override trusted provider credentials. Thanks @coygeek.
 - Replaced browser-native portal confirmation and clipboard prompts with themed, keyboard-accessible HTML dialogs.
 - Hardened GCP operator inventory and workspace recovery by requiring deterministic Crabbox instance names plus canonical provider labels before accepting resources. Thanks @coygeek.

--- a/scripts/hydrate-workflow.test.js
+++ b/scripts/hydrate-workflow.test.js
@@ -10,7 +10,7 @@ const workflow = path.join(repoRoot, ".github", "workflows", "hydrate.yml");
 
 test("hydrate workflow does not mutate shared runner tool cache", async () => {
   const text = await readFile(workflow, "utf8");
-  assert.match(text, /uses:\s+actions\/setup-go@v6/);
+  assert.match(text, /uses:\s+actions\/setup-go@[0-9a-f]{40}/);
   assert.doesNotMatch(text, /rm\s+-rf\s+["']?\$RUNNER_TOOL_CACHE\/go/);
   assert.doesNotMatch(text, /tar\s+-C\s+["']?\$RUNNER_TOOL_CACHE/);
 });

--- a/scripts/workflow-action-pins.test.js
+++ b/scripts/workflow-action-pins.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("workflow action references are immutable", () => {
+  const result = spawnSync("go", ["run", "./scripts/workflow_action_pins.go"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});

--- a/scripts/workflow_action_pins.go
+++ b/scripts/workflow_action_pins.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	actionCommitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	dockerDigestPattern = regexp.MustCompile(`@sha256:[0-9a-f]{64}$`)
+)
+
+type workflowChecker struct {
+	root         string
+	localActions map[string]bool
+}
+
+func main() {
+	if err := checkWorkflowDir(filepath.Join(".github", "workflows")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func checkWorkflowDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	absoluteDir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	checker := workflowChecker{
+		root:         filepath.Dir(filepath.Dir(absoluteDir)),
+		localActions: make(map[string]bool),
+	}
+	var findings []error
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yml" && ext != ".yaml" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if err := checker.checkWorkflowFile(path); err != nil {
+			findings = append(findings, err)
+		}
+	}
+	return errors.Join(findings...)
+}
+
+func (checker *workflowChecker) checkWorkflowFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	var findings []error
+	for {
+		var document yaml.Node
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		findings = append(findings, checkWorkflowNode(path, &document)...)
+		for _, action := range workflowActionNodes(&document) {
+			action = resolvedNode(action)
+			if action.Kind == yaml.ScalarNode && strings.HasPrefix(action.Value, "./") {
+				findings = append(findings, checker.checkLocalAction(path, action)...)
+			}
+		}
+	}
+	return errors.Join(findings...)
+}
+
+func (checker *workflowChecker) checkLocalAction(source string, action *yaml.Node) []error {
+	target := action.Value
+	if strings.HasPrefix(target, "./.github/workflows/") {
+		ext := filepath.Ext(target)
+		if ext == ".yml" || ext == ".yaml" {
+			return nil
+		}
+	}
+
+	localPath := filepath.Clean(filepath.Join(checker.root, filepath.FromSlash(strings.TrimPrefix(target, "./"))))
+	relative, err := filepath.Rel(checker.root, localPath)
+	if err != nil {
+		return []error{fmt.Errorf("%s:%d invalid local action path %s: %w", source, action.Line, target, err)}
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return []error{fmt.Errorf("%s:%d local action escapes the repository: %s", source, action.Line, target)}
+	}
+
+	var manifests []string
+	for _, name := range []string{"action.yml", "action.yaml"} {
+		manifest := filepath.Join(localPath, name)
+		if info, err := os.Stat(manifest); err == nil && !info.IsDir() {
+			manifests = append(manifests, manifest)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return []error{fmt.Errorf("%s:%d inspect local action %s: %w", source, action.Line, target, err)}
+		}
+	}
+	if len(manifests) == 0 {
+		return []error{fmt.Errorf("%s:%d local action has no action.yml or action.yaml: %s", source, action.Line, target)}
+	}
+
+	var findings []error
+	for _, manifest := range manifests {
+		if checker.localActions[manifest] {
+			continue
+		}
+		checker.localActions[manifest] = true
+		findings = append(findings, checker.checkLocalActionManifest(manifest)...)
+	}
+	return findings
+}
+
+func (checker *workflowChecker) checkLocalActionManifest(path string) []error {
+	file, err := os.Open(path)
+	if err != nil {
+		return []error{err}
+	}
+	defer file.Close()
+
+	var document yaml.Node
+	if err := yaml.NewDecoder(file).Decode(&document); err != nil {
+		return []error{fmt.Errorf("%s: %w", path, err)}
+	}
+	var findings []error
+	for _, runs := range mappingValues(resolvedNode(&document), "runs", nil) {
+		for _, steps := range mappingValues(resolvedNode(runs), "steps", nil) {
+			steps = resolvedNode(steps)
+			if steps.Kind != yaml.SequenceNode {
+				continue
+			}
+			for _, step := range steps.Content {
+				for _, action := range mappingValues(resolvedNode(step), "uses", nil) {
+					action = resolvedNode(action)
+					if action.Kind != yaml.ScalarNode {
+						findings = append(findings, fmt.Errorf("%s:%d uses must be a scalar action reference", path, action.Line))
+						continue
+					}
+					if err := validateActionTarget(action.Value); err != nil {
+						findings = append(findings, fmt.Errorf("%s:%d: %w", path, action.Line, err))
+						continue
+					}
+					if strings.HasPrefix(action.Value, "./") {
+						findings = append(findings, checker.checkLocalAction(path, action)...)
+					}
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func checkWorkflowNode(path string, node *yaml.Node) []error {
+	var findings []error
+	for _, value := range workflowActionNodes(node) {
+		value = resolvedNode(value)
+		if value.Kind != yaml.ScalarNode {
+			findings = append(findings, fmt.Errorf("%s:%d uses must be a scalar action reference", path, value.Line))
+		} else if err := validateActionTarget(value.Value); err != nil {
+			findings = append(findings, fmt.Errorf("%s:%d: %w", path, value.Line, err))
+		}
+	}
+	return findings
+}
+
+func workflowActionNodes(document *yaml.Node) []*yaml.Node {
+	var actions []*yaml.Node
+	for _, jobs := range mappingValues(resolvedNode(document), "jobs", nil) {
+		jobs = resolvedNode(jobs)
+		if jobs.Kind != yaml.MappingNode {
+			continue
+		}
+		for index := 1; index < len(jobs.Content); index += 2 {
+			job := resolvedNode(jobs.Content[index])
+			actions = append(actions, mappingValues(job, "uses", nil)...)
+			for _, steps := range mappingValues(job, "steps", nil) {
+				steps = resolvedNode(steps)
+				if steps.Kind != yaml.SequenceNode {
+					continue
+				}
+				for _, step := range steps.Content {
+					actions = append(actions, mappingValues(resolvedNode(step), "uses", nil)...)
+				}
+			}
+		}
+	}
+	return actions
+}
+
+func mappingValues(node *yaml.Node, key string, visited map[*yaml.Node]bool) []*yaml.Node {
+	node = resolvedNode(node)
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	if visited == nil {
+		visited = make(map[*yaml.Node]bool)
+	}
+	if visited[node] {
+		return nil
+	}
+	visited[node] = true
+	defer delete(visited, node)
+
+	var values []*yaml.Node
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		entryKey := scalarNodeValue(node.Content[index])
+		entryValue := node.Content[index+1]
+		if entryKey == key {
+			values = append(values, entryValue)
+		}
+		if entryKey == "<<" {
+			merged := resolvedNode(entryValue)
+			if merged.Kind == yaml.SequenceNode {
+				for _, item := range merged.Content {
+					values = append(values, mappingValues(item, key, visited)...)
+				}
+			} else {
+				values = append(values, mappingValues(merged, key, visited)...)
+			}
+		}
+	}
+	return values
+}
+
+func resolvedNode(node *yaml.Node) *yaml.Node {
+	for node != nil && (node.Kind == yaml.DocumentNode || node.Kind == yaml.AliasNode) {
+		if node.Kind == yaml.AliasNode {
+			node = node.Alias
+			continue
+		}
+		if len(node.Content) == 0 {
+			return node
+		}
+		node = node.Content[0]
+	}
+	return node
+}
+
+func scalarNodeValue(node *yaml.Node) string {
+	node = resolvedNode(node)
+	if node.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return node.Value
+}
+
+func validateActionTarget(target string) error {
+	if strings.HasPrefix(target, "./") {
+		return nil
+	}
+	if strings.HasPrefix(target, "docker://") {
+		if dockerDigestPattern.MatchString(target) {
+			return nil
+		}
+		return fmt.Errorf("container action must use an immutable digest: %s", target)
+	}
+	separator := strings.LastIndex(target, "@")
+	if separator <= 0 || !actionCommitPattern.MatchString(target[separator+1:]) {
+		return fmt.Errorf("action must use a full commit SHA: %s", target)
+	}
+	return nil
+}

--- a/scripts/workflow_action_pins_test.go
+++ b/scripts/workflow_action_pins_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckWorkflowNodeRejectsMutableUsesSyntaxes(t *testing.T) {
+	tests := map[string]string{
+		"step shorthand":    "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n",
+		"quoted block key":  "jobs:\n  test:\n    \"uses\": actions/example/.github/workflows/test.yml@main\n",
+		"quoted flow key":   "jobs: { test: { steps: [ { \"uses\": \"actions/checkout@v6\" } ] } }\n",
+		"aliased uses key":  "usesKey: &usesKey uses\njobs:\n  test:\n    *usesKey: actions/checkout@v6\n",
+		"mutable container": "jobs:\n  test:\n    steps:\n      - uses: docker://alpine:3.20\n",
+	}
+	for name, workflow := range tests {
+		t.Run(name, func(t *testing.T) {
+			var document yaml.Node
+			if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+				t.Fatal(err)
+			}
+			findings := checkWorkflowNode("test.yml", &document)
+			if len(findings) == 0 {
+				t.Fatal("expected mutable action reference to be rejected")
+			}
+		})
+	}
+}
+
+func TestCheckWorkflowNodeAcceptsImmutableUsesSyntaxes(t *testing.T) {
+	sha := strings.Repeat("a", 40)
+	digest := strings.Repeat("b", 64)
+	workflow := "jobs:\n  local:\n    uses: ./.github/workflows/local.yml\n  remote:\n    uses: example/repo/.github/workflows/test.yml@" + sha +
+		"\n  test:\n    steps:\n      - uses: actions/checkout@" + sha +
+		"\n      - uses: docker://example.invalid/action@sha256:" + digest + "\n"
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+		t.Fatal(err)
+	}
+	if findings := checkWorkflowNode("test.yml", &document); len(findings) != 0 {
+		t.Fatalf("unexpected findings: %v", findings)
+	}
+}
+
+func TestCheckWorkflowNodeIgnoresUnrelatedUsesKeys(t *testing.T) {
+	workflow := "env:\n  uses: not-an-action\njobs:\n  test:\n    steps:\n      - run: echo ok\n"
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+		t.Fatal(err)
+	}
+	if findings := checkWorkflowNode("test.yml", &document); len(findings) != 0 {
+		t.Fatalf("unexpected findings: %v", findings)
+	}
+}
+
+func TestCheckWorkflowDirRejectsMutableCompositeActionDependencies(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, ".github/workflows/test.yml", "jobs:\n  test:\n    steps:\n      - uses: ./.github/actions/example\n")
+	writeTestFile(t, root, ".github/actions/example/action.yml", "runs:\n  using: composite\n  steps:\n    - uses: example/external@main\n")
+	if err := checkWorkflowDir(filepath.Join(root, ".github", "workflows")); err == nil {
+		t.Fatal("expected mutable composite action dependency to be rejected")
+	}
+}
+
+func TestCheckWorkflowDirFollowsNestedLocalCompositeActions(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, ".github/workflows/test.yml", "jobs:\n  test:\n    steps:\n      - uses: ./.github/actions/outer\n")
+	writeTestFile(t, root, ".github/actions/outer/action.yml", "runs:\n  using: composite\n  steps:\n    - uses: ./.github/actions/inner\n")
+	writeTestFile(t, root, ".github/actions/inner/action.yaml", "runs:\n  using: composite\n  steps:\n    - uses: example/external@main\n")
+	if err := checkWorkflowDir(filepath.Join(root, ".github", "workflows")); err == nil {
+		t.Fatal("expected nested mutable composite action dependency to be rejected")
+	}
+}
+
+func TestCheckWorkflowDirAcceptsPinnedCompositeActionDependencies(t *testing.T) {
+	root := t.TempDir()
+	sha := strings.Repeat("a", 40)
+	writeTestFile(t, root, ".github/workflows/test.yml", "jobs:\n  test:\n    steps:\n      - uses: ./.github/actions/example\n")
+	writeTestFile(t, root, ".github/actions/example/action.yml", "runs:\n  using: composite\n  steps:\n    - uses: example/external@"+sha+"\n")
+	if err := checkWorkflowDir(filepath.Join(root, ".github", "workflows")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- pin every GitHub Actions dependency to the commit behind its current release tag
- keep readable release-version comments beside each immutable reference
- add structural YAML enforcement for workflow jobs, steps, Docker actions, reusable workflows, aliases, merges, and nested local composite actions

This is supply-chain hardening only. Action versions, inputs, permissions, credentials, job order, and release behavior are unchanged. Token scoping and Homebrew artifact policy are deliberately outside this PR.

Fixes https://github.com/openclaw/crabbox/issues/387

## Verification

- `go test ./scripts -run 'TestCheckWorkflow|TestCheckWorkflowDir' -count=1`
- `node --test scripts/workflow-action-pins.test.js scripts/hydrate-workflow.test.js scripts/release-workflow.test.js scripts/blacksmith-testbox-workflow.test.js`
- `actionlint .github/workflows/ci.yml .github/workflows/hydrate.yml .github/workflows/pages.yml .github/workflows/release.yml`
- parsed all workflow YAML files with Ruby Psych
- structured Codex autoreview: clean, no actionable findings

The complete local Node script suite has one unrelated proof-directory symlink mode failure that reproduces unchanged on clean `main` in this macOS environment.