### PR TITLE
fix: keep collected run artifacts private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Created default artifact bundles and retained run logs/metadata with private local permissions while preserving explicit shared-output directories. Thanks @coygeek.
+
 ## 0.32.0 - 2026-06-15
 
 ### Added

--- a/docs/commands/artifacts.md
+++ b/docs/commands/artifacts.md
@@ -32,6 +32,10 @@ By default `collect` writes:
 - `webvnc-status.json` when a coordinator login is configured
 - `logs.txt` and `run.json` when `--run <run-id>` is provided
 
+The default bundle directory is private. An explicit `--output` directory keeps
+its existing sharing permissions, while retained `logs.txt` and `run.json`
+remain owner-only. Publishing is unchanged.
+
 `--all` enables `--video` and `--gif`, so the bundle also records `screen.mp4`,
 writes a `screen.contact.png` contact sheet, and produces a trimmed
 `screen.trimmed.gif`. `--gif` requires `--video` (or `--all`). Linux video uses

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -50,8 +50,10 @@ logs and test reports that back it.
 ## `artifacts collect`
 
 `crabbox artifacts collect --id <lease-id-or-slug>` writes a bundle directory.
-By default it lands in `artifacts/<slug>` (override with `--output <dir>`) and
-contains:
+By default it lands in a private `artifacts/<slug>` directory. An explicit
+`--output <dir>` preserves that directory's sharing permissions, while retained
+`logs.txt` and `run.json` remain owner-only. Publishing still uploads the
+selected files normally. The bundle contains:
 
 - `metadata.json`: Crabbox version, lease id, slug, provider, network, target
   OS, optional run id, and capture time.

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -162,10 +162,11 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 		return err
 	}
 	dir := strings.TrimSpace(*output)
+	explicitOutput := dir != ""
 	if dir == "" {
 		dir = defaultArtifactBundleDir(leaseID, serverSlug(server))
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := ensureArtifactBundleDir(dir, explicitOutput); err != nil {
 		return exit(2, "create artifact directory: %v", err)
 	}
 
@@ -616,6 +617,13 @@ func defaultArtifactBundleDir(leaseID, slug string) string {
 	return filepath.Join("artifacts", normalizeLeaseSlug(name))
 }
 
+func ensureArtifactBundleDir(path string, explicitOutput bool) error {
+	if explicitOutput {
+		return os.MkdirAll(path, 0o755)
+	}
+	return ensurePrivateRunOutputDir(path)
+}
+
 func writeJSONFile(path string, value any) error {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
@@ -623,6 +631,18 @@ func writeJSONFile(path string, value any) error {
 	}
 	data = append(data, '\n')
 	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return exit(2, "write %s: %v", path, err)
+	}
+	return nil
+}
+
+func writePrivateArtifactJSONFile(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return exit(2, "encode %s: %v", path, err)
+	}
+	data = append(data, '\n')
+	if err := writePrivateRunOutputFile(path, data); err != nil {
 		return exit(2, "write %s: %v", path, err)
 	}
 	return nil
@@ -715,10 +735,10 @@ func writeArtifactRunLogs(ctx context.Context, runID, dir string) (string, strin
 	}
 	logPath := filepath.Join(dir, "logs.txt")
 	runPath := filepath.Join(dir, "run.json")
-	if err := os.WriteFile(logPath, []byte(logText), 0o644); err != nil {
+	if err := writePrivateRunOutputFile(logPath, []byte(logText)); err != nil {
 		return "", "", exit(2, "write logs artifact: %v", err)
 	}
-	if err := writeJSONFile(runPath, run); err != nil {
+	if err := writePrivateArtifactJSONFile(runPath, run); err != nil {
 		return "", "", err
 	}
 	return logPath, runPath, nil

--- a/internal/cli/run_local_output_unix_test.go
+++ b/internal/cli/run_local_output_unix_test.go
@@ -142,6 +142,30 @@ func TestPrivateRunOutputPermissionsUnderPermissiveUmask(t *testing.T) {
 	assertRunOutputMode(t, filepath.Dir(proofPath), privateRunOutputDirMode)
 	assertRunOutputMode(t, proofPath, privateRunOutputFileMode)
 
+	artifactDir := filepath.Join(root, "artifacts", "private-bundle")
+	if err := ensureArtifactBundleDir(artifactDir, false); err != nil {
+		t.Fatal(err)
+	}
+	explicitArtifactDir := filepath.Join(root, "shared-artifacts")
+	if err := os.MkdirAll(explicitArtifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureArtifactBundleDir(explicitArtifactDir, true); err != nil {
+		t.Fatal(err)
+	}
+	artifactJSONPath := filepath.Join(artifactDir, "run.json")
+	if err := writePrivateArtifactJSONFile(artifactJSONPath, map[string]string{"state": "completed"}); err != nil {
+		t.Fatal(err)
+	}
+	artifactLogPath := filepath.Join(artifactDir, "logs.txt")
+	if err := writePrivateRunOutputFile(artifactLogPath, []byte("retained output")); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, artifactDir, privateRunOutputDirMode)
+	assertRunOutputMode(t, explicitArtifactDir, 0o755)
+	assertRunOutputMode(t, artifactJSONPath, privateRunOutputFileMode)
+	assertRunOutputMode(t, artifactLogPath, privateRunOutputFileMode)
+
 	t.Chdir(root)
 	if err := os.Mkdir(".crabbox", 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- create the default `artifacts/<slug>` bundle with owner-only permissions
- write retained `logs.txt` and `run.json` with owner-only permissions
- preserve existing permissions for explicitly selected `--output` directories
- document the permission contract and add permissive-umask regression coverage

This is filesystem hardening only. Artifact contents, paths, collection, explicit shared-output workflows, and publishing behavior remain unchanged.

Closes https://github.com/openclaw/crabbox/issues/420

## Verification

- `go test -race ./internal/cli -run 'TestPrivateRunOutputPermissionsUnderPermissiveUmask|TestArtifact' -count=1`
- `umask 022; go test -race ./internal/cli`
- `node scripts/check-docs-links.mjs`
- `node scripts/check-command-docs.mjs`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Autoreview: clean; no accepted/actionable findings.
