### PR TITLE
fix: restrict Windows credential ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Restricted Crabbox-managed Windows credential files to the managed user, Administrators, and SYSTEM without changing desktop credential consumers. Thanks @coygeek.
 - Created default artifact bundles and retained run logs/metadata with private local permissions while preserving explicit shared-output directories. Thanks @coygeek.
 
 ## 0.32.0 - 2026-06-15

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -171,10 +171,15 @@ if (-not (Get-LocalUser -Name $user -ErrorAction SilentlyContinue)) {
 }
 Add-LocalGroupMember -Group "Administrators" -Member $user -ErrorAction SilentlyContinue
 Set-Content -NoNewline -Encoding ASCII -Path $usernamePath -Value $user
+$userSID = (Get-LocalUser -Name $user).SID.Value
+$credentialPaths = @($passwordPath)
 if ($passwordMirrorPath) {
   Set-Content -NoNewline -Encoding ASCII -Path $passwordMirrorPath -Value $userPassword
+  $credentialPaths += $passwordMirrorPath
 }
-$userSID = (Get-LocalUser -Name $user).SID.Value
+foreach ($credentialPath in $credentialPaths) {
+  icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F" | Out-Null
+}
 icacls.exe $workRoot /grant "*${userSID}:(OI)(CI)F" | Out-Null
 $userSSHDir = Join-Path (Join-Path "C:\Users" $user) ".ssh"
 $userAuthorizedKeys = Join-Path $userSSHDir "authorized_keys"

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -546,6 +546,9 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 		"Stop-Service -Name tvnserver",
 		"New-CrabboxPassword",
 		"${userSID}:F",
+		"$credentialPaths = @($passwordPath)",
+		"$credentialPaths += $passwordMirrorPath",
+		`icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"`,
 		`C:\ProgramData\crabbox\vnc.password`,
 		`C:\ProgramData\crabbox\windows.username`,
 		"AutoAdminLogon",
@@ -564,6 +567,11 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 	if strings.Contains(got, "Start-Service -Name tvnserver") {
 		t.Fatalf("windows user data should not start service-session VNC")
 	}
+	mirrorIndex := strings.Index(got, "$credentialPaths += $passwordMirrorPath")
+	aclIndex := strings.Index(got, "foreach ($credentialPath in $credentialPaths)")
+	if mirrorIndex < 0 || aclIndex < 0 || mirrorIndex > aclIndex {
+		t.Fatalf("windows password mirror must be included before credential ACL hardening")
+	}
 }
 
 func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
@@ -577,6 +585,8 @@ func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
 		"OpenSSH-Win64.zip",
 		"Git-2.52.0-64-bit.exe",
 		"$passwordPath = $windowsPasswordPath",
+		"$credentialPaths = @($passwordPath)",
+		`icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"`,
 		"Restart-Service sshd -Force",
 		"Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
 	} {
@@ -598,6 +608,8 @@ func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
 		"CrabboxUserVNC",
 		"AutoAdminLogon",
 		"Restart-Computer -Force",
+		"*S-1-5-32-545:",
+		"Authenticated Users",
 	} {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("windows core bootstrap should not include %q", notWant)

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -191,10 +191,15 @@ if (-not (Get-LocalUser -Name $user -ErrorAction SilentlyContinue)) {
 }
 Add-LocalGroupMember -Group "Administrators" -Member $user -ErrorAction SilentlyContinue
 Set-Content -NoNewline -Encoding ASCII -Path $usernamePath -Value $user
+$userSID = (Get-LocalUser -Name $user).SID.Value
+$credentialPaths = @($passwordPath)
 if ($passwordMirrorPath) {
   Set-Content -NoNewline -Encoding ASCII -Path $passwordMirrorPath -Value $userPassword
+  $credentialPaths += $passwordMirrorPath
 }
-$userSID = (Get-LocalUser -Name $user).SID.Value
+foreach ($credentialPath in $credentialPaths) {
+  icacls.exe $credentialPath /inheritance:r /grant "*\${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F" | Out-Null
+}
 icacls.exe $workRoot /grant "*\${userSID}:(OI)(CI)F" | Out-Null
 $userSSHDir = Join-Path (Join-Path "C:\\Users" $user) ".ssh"
 $userAuthorizedKeys = Join-Path $userSSHDir "authorized_keys"

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -493,10 +493,18 @@ describe("cloud-init bootstrap", () => {
     expect(got).not.toContain("Start-Service -Name tvnserver");
     expect(got).toContain("New-CrabboxPassword");
     expect(got).toContain("${userSID}:F");
+    expect(got).toContain("$credentialPaths = @($passwordPath)");
+    expect(got).toContain("$credentialPaths += $passwordMirrorPath");
+    expect(got).toContain(
+      'icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"',
+    );
     expect(got).toContain("C:\\ProgramData\\crabbox\\windows.username");
     expect(got).toContain("AutoAdminLogon");
     expect(got).toContain("Restart-Computer -Force");
     expect(got).toContain("exit 0");
+    expect(got.indexOf("$credentialPaths += $passwordMirrorPath")).toBeLessThan(
+      got.indexOf("foreach ($credentialPath in $credentialPaths)"),
+    );
     const setupIndex = got.indexOf(
       "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
     );
@@ -515,6 +523,10 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("OpenSSH-Win64.zip");
     expect(got).toContain("Git-2.52.0-64-bit.exe");
     expect(got).toContain("$passwordPath = $windowsPasswordPath");
+    expect(got).toContain("$credentialPaths = @($passwordPath)");
+    expect(got).toContain(
+      'icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"',
+    );
     expect(got).toContain("Restart-Service sshd -Force");
     expect(got).toContain("Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath");
     const setupIndex = got.indexOf(
@@ -528,6 +540,8 @@ describe("cloud-init bootstrap", () => {
     expect(got).not.toContain("CrabboxUserVNC");
     expect(got).not.toContain("AutoAdminLogon");
     expect(got).not.toContain("Restart-Computer -Force");
+    expect(got).not.toContain("*S-1-5-32-545:");
+    expect(got).not.toContain("Authenticated Users");
   });
 
   it("builds Windows WSL2 bootstrap without desktop/VNC", () => {


### PR DESCRIPTION
## Summary

- remove inherited ACLs from Crabbox-managed Windows credential files
- retain full access for the managed Windows user, BUILTIN\Administrators, and SYSTEM
- cover both the primary password file and the managed-desktop mirror in Go and Worker bootstrap generators

## Compatibility

This is filesystem hardening only. Credential paths, plaintext file format, account creation, desktop/VNC behavior, SSH behavior, and scheduled-task consumers are unchanged. Every supported reader runs as the managed user, an administrator, or SYSTEM, and those principals retain full access.

## Verification

- `umask 022; go test -race ./internal/cli`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (618 tests)
- autoreview: clean, no accepted/actionable findings

Closes https://github.com/openclaw/crabbox/issues/418
