### PR TITLE
fix: trust-gate provider runtime config

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5034,7 +5034,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		// something an untrusted checkout can request via .crabbox.yaml.
 	}
 	if file.AppleContainer != nil {
-		if file.AppleContainer.CLIPath != "" {
+		if trusted && file.AppleContainer.CLIPath != "" {
 			cfg.AppleContainer.CLIPath = file.AppleContainer.CLIPath
 		}
 		if file.AppleContainer.Image != "" {
@@ -5053,7 +5053,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.AppleContainer.Memory != "" {
 			cfg.AppleContainer.Memory = file.AppleContainer.Memory
 		}
-		if len(file.AppleContainer.ExtraRunArgs) > 0 {
+		if trusted && len(file.AppleContainer.ExtraRunArgs) > 0 {
 			cfg.AppleContainer.ExtraRunArgs = append([]string(nil), file.AppleContainer.ExtraRunArgs...)
 		}
 	}
@@ -5198,10 +5198,10 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.HyperV.Switch != "" {
 			cfg.HyperV.Switch = file.HyperV.Switch
 		}
-		if file.HyperV.GuestPassword != "" {
+		if trusted && file.HyperV.GuestPassword != "" {
 			cfg.HyperV.GuestPassword = file.HyperV.GuestPassword
 		}
-		if file.HyperV.InitPassword != nil {
+		if trusted && file.HyperV.InitPassword != nil {
 			cfg.HyperV.InitPassword = *file.HyperV.InitPassword
 		}
 	}

--- a/internal/cli/config_hyperv_test.go
+++ b/internal/cli/config_hyperv_test.go
@@ -39,6 +39,41 @@ func TestApplyFileHyperVConfig(t *testing.T) {
 	}
 }
 
+func TestApplyFileHyperVUntrustedConfigCannotSetCredentialFields(t *testing.T) {
+	explicitFalse := false
+	cfg := baseConfig()
+	cfg.HyperV.GuestPassword = "trusted-secret"
+	cfg.HyperV.InitPassword = true
+
+	err := applyFileConfigWithTrust(&cfg, fileConfig{
+		HyperV: &fileHyperVConfig{
+			Image:         `D:\images\repo.vhdx`,
+			User:          "RepoUser",
+			WorkRoot:      `D:\repo-work`,
+			CPUs:          4,
+			Memory:        2048,
+			Switch:        "Repo Switch",
+			GuestPassword: "repo-secret",
+			InitPassword:  &explicitFalse,
+		},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.HyperV.GuestPassword != "trusted-secret" || !cfg.HyperV.InitPassword {
+		t.Fatalf("untrusted Hyper-V credential settings applied: %#v", cfg.HyperV)
+	}
+	if cfg.HyperV.Image != `D:\images\repo.vhdx` ||
+		cfg.HyperV.User != "RepoUser" ||
+		cfg.HyperV.WorkRoot != `D:\repo-work` ||
+		cfg.HyperV.CPUs != 4 ||
+		cfg.HyperV.Memory != 2048 ||
+		cfg.HyperV.Switch != "Repo Switch" {
+		t.Fatalf("safe Hyper-V project settings not applied: %#v", cfg.HyperV)
+	}
+}
+
 // initPassword is a *bool in the file config so an absent key must leave the
 // existing value alone while an explicit false must still win.
 func TestApplyFileHyperVInitPasswordTriState(t *testing.T) {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -2008,6 +2008,41 @@ func TestAppleContainerConfigDefaultsFileAndEnv(t *testing.T) {
 	}
 }
 
+func TestAppleContainerUntrustedConfigCannotRedirectRuntime(t *testing.T) {
+	cfg := baseConfig()
+	cfg.AppleContainer.CLIPath = "/trusted/bin/container"
+	cfg.AppleContainer.ExtraRunArgs = []string{"--dns", "9.9.9.9"}
+
+	err := applyFileConfigWithTrust(&cfg, fileConfig{
+		AppleContainer: &fileAppleContainerConfig{
+			CLIPath:      "/repo/bin/container-wrapper",
+			Image:        "example-org/repo:latest",
+			User:         "runner",
+			WorkRoot:     "/work/repo",
+			CPUs:         3,
+			Memory:       "6g",
+			ExtraRunArgs: []string{"--mount", "type=virtiofs,source=$HOME,target=/host"},
+		},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.AppleContainer.CLIPath != "/trusted/bin/container" ||
+		len(cfg.AppleContainer.ExtraRunArgs) != 2 ||
+		cfg.AppleContainer.ExtraRunArgs[0] != "--dns" ||
+		cfg.AppleContainer.ExtraRunArgs[1] != "9.9.9.9" {
+		t.Fatalf("untrusted Apple Container runtime controls applied: %#v", cfg.AppleContainer)
+	}
+	if cfg.AppleContainer.Image != "example-org/repo:latest" ||
+		cfg.AppleContainer.User != "runner" ||
+		cfg.AppleContainer.WorkRoot != "/work/repo" ||
+		cfg.AppleContainer.CPUs != 3 ||
+		cfg.AppleContainer.Memory != "6g" {
+		t.Fatalf("safe Apple Container project settings not applied: %#v", cfg.AppleContainer)
+	}
+}
+
 func TestAppleVZConfigDefaultsFileAndEnv(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()


### PR DESCRIPTION
## Summary
- ignore repo-local `appleContainer.cliPath` and `appleContainer.extraRunArgs` unless the config source is trusted
- ignore repo-local `hyperv.guestPassword` and `hyperv.initPassword` unless the config source is trusted
- keep non-secret project-level Apple Container and Hyper-V settings repo-configurable
- add regression coverage for both trust boundaries

## Verification
- `go test ./internal/cli -run 'TestAppleContainer(UntrustedConfigCannotRedirectRuntime|ConfigDefaultsFileAndEnv)|TestApplyFileHyperV(Config|UntrustedConfigCannotSetCredentialFields|InitPasswordTriState)' -count=1`
- `git diff --check`

## Note
A broader `go test ./internal/cli -count=1` run currently fails in existing controller-state permission tests (`TestControllerStateLockRejectsSymlinkWithoutChangingTarget`, `TestControllerStateLockRejectsBroadExistingFileWithoutChmod`, `TestReadControllerTokenRequiresPrivateRegularFile`); those paths are outside this config change.

Fixes openclaw/crabbox#423
Fixes openclaw/crabbox#424
