### PR TITLE
Add Scaleway direct SSH-lease provider

### DIFF
--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -129,6 +129,12 @@ Droplet size.
 Linode maps every class to the smallest Phase 1 default size `g6-standard-1`.
 Use `--type <linode-type-slug>` when you need a different exact instance type.
 
+Scaleway maps every class to the smallest foundation default type `DEV1-S`.
+Use `--type <scaleway-commercial-type>` when you need a different exact
+Scaleway Instances commercial type. The live lifecycle backend is not
+implemented yet, so this is a config/provider contract rather than a live
+capacity fallback path in this branch.
+
 ## Brokered provider behavior
 
 ### Hetzner
@@ -229,6 +235,10 @@ list, and cleanup.
   machine image, secret context, and cache plane as Semaphore CI.
 - **sprites** — creates a sprite, installs OpenSSH and rsync inside it, and reaches
   SSH through `sprite proxy` for a fast Linux microVM on the standard SSH path.
+- **scaleway** — is registered as a direct Linux SSH-lease provider for Scaleway
+  Instances with Scaleway SDK credentials, per-lease managed IAM SSH keys,
+  cloud-init bootstrap, Crabbox-owned tags, and direct cleanup. `doctor` checks
+  SDK config and auth material discovery without creating resources.
 
 Delegated-run providers (`cloudflare`, `azure-dynamic-sessions`, `e2b`, `islo`,
 `modal`, `tensorlake`, `upstash-box`, `blacksmith-testbox`, `wandb`,

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -216,6 +216,7 @@ internal/providers/azuredynamicsessions # Azure Container Apps delegated runner
 internal/providers/gcp                  # GCP Compute Engine SSH lease backend (coordinator)
 internal/providers/hetzner              # Hetzner Cloud SSH lease backend (coordinator)
 internal/providers/linode               # Linode SSH lease backend
+internal/providers/scaleway             # Scaleway SSH lease backend
 internal/providers/proxmox              # Proxmox VE SSH lease backend
 internal/providers/parallels            # Parallels macOS VM host SSH lease backend
 internal/providers/localcontainer       # local Docker container SSH backend

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -60,7 +60,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 56 providers (32 SSH lease, 23 delegated run, 1 service control).
+Current built-in surface: 57 providers (33 SSH lease, 23 delegated run, 1 service control).
 
 Access terms:
 
@@ -113,6 +113,7 @@ Access terms:
 | [proxmox](proxmox.md) | built-in; `ssh-lease` · self-hosted-virtualization | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Proxmox VE QEMU clone | `self-hosted`; GPU: optional | Crabbox; VM delete | Self-hosted Linux VM fleet | Needs a prepared template, guest agent, and network |
 | [railway](railway.md) (`rail`, `railwayapp`) | specialized; `service-control` · service-control | SSH not applicable; `none` · direct only; features: `url-bridge` | `linux`; Railway service | `cloud`; GPU: unknown | Railway; service stop only | Inspecting or stopping an existing Railway service | Cannot execute arbitrary Crabbox run commands |
 | [runpod](runpod.md) (`run-pod`, `runpodio`) | built-in; `ssh-lease` · gpu-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; RunPod GPU pod | `cloud`; GPU: yes | RunPod; pod release | GPU-backed Linux workload over public SSH | Capacity, GPU pricing, and public SSH vary |
+| [scaleway](scaleway.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Scaleway Instance | `cloud`; GPU: optional | Crabbox; instance and managed key delete | Direct Linux VM on Scaleway Instances | Direct-only; security groups must already allow SSH |
 | [semaphore](semaphore.md) (`sem`) | built-in; `ssh-lease` · ci-proof-runner | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Semaphore CI job | `provider-managed`; GPU: optional | Semaphore; job stop | Debugging in the same image and secret plane as CI | Depends on debug SSH metadata from the job |
 | [smolvm](smolvm.md) (`smol`, `smolmachines`, `smolfleet`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; Smol Machines microVM | `provider-managed`; GPU: no | smolfleet; microVM delete | Lightweight hosted microVM execution | Delegated execution through smolfleet |
 | [sprites](sprites.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Sprite microVM | `provider-managed`; GPU: no | Sprites; sprite delete | Fast Linux microVM over provider SSH proxy | SSH transport depends on sprite proxy |

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -601,6 +601,20 @@
     "caveat": "Capacity, GPU pricing, and public SSH vary",
     "docs": "runpod.md"
   },
+  "scaleway": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Scaleway Instance",
+    "location": "cloud",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "optional",
+    "lifecycle": "Crabbox",
+    "cleanup": "instance and managed key delete",
+    "bestFit": "Direct Linux VM on Scaleway Instances",
+    "caveat": "Direct-only; security groups must already allow SSH",
+    "docs": "scaleway.md"
+  },
   "semaphore": {
     "status": "built-in",
     "category": "ci-proof-runner",

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -1,0 +1,244 @@
+# Scaleway Provider
+
+Read this when you are:
+
+- choosing `provider: scaleway`;
+- validating Scaleway SDK config and auth material discovery;
+- changing `internal/providers/scaleway` or guarded live smoke support.
+
+Scaleway is registered as a Linux-only **SSH lease** provider. The provider
+implements the normal Crabbox SSH, sync, cleanup, and Tailscale command
+surface for Scaleway Instances. It validates Scaleway SDK credentials plus
+non-secret provider config, creates per-lease Scaleway IAM SSH keys, provisions
+Instances with Crabbox ownership tags and cloud-init bootstrap, and deletes only
+resources whose live Scaleway tags still prove Crabbox ownership.
+
+Scaleway is **direct-only**. It does not run through the coordinator, so the
+local CLI must have Scaleway credentials and direct cleanup remains the
+operator's responsibility.
+
+## When To Use It
+
+Use Scaleway for simple Linux lease work when a Scaleway Instance is the desired
+execution surface and direct local credentials are acceptable. Prefer AWS,
+Azure, GCP, or Hetzner when you need a brokered team path, coordinator-side
+credentials, or integrated cloud cost accounting.
+
+## Commands
+
+SDK config and auth material discovery can be checked without creating
+resources:
+
+```sh
+crabbox doctor --provider scaleway
+```
+
+The provider is registered for the normal SSH-lease command surface, but live
+lifecycle methods are not implemented in this branch yet:
+
+```sh
+crabbox warmup --provider scaleway --class standard
+crabbox run --provider scaleway --type DEV1-S -- pnpm test
+crabbox ssh --provider scaleway --id my-app
+crabbox stop --provider scaleway my-app
+crabbox cleanup --provider scaleway --dry-run
+```
+
+Those commands create, inspect, resolve, touch, release, and clean up Scaleway
+Instances through the local Scaleway SDK profile. They are cost-bearing when
+they create live Instances, so use `doctor` and `cleanup --dry-run` before
+running live workflows.
+
+`--type` is the exact Scaleway Instances commercial type, such as `DEV1-S`.
+There is no separate Scaleway size flag for the generic lease commands.
+
+## Configuration
+
+```yaml
+provider: scaleway
+target: linux
+class: standard
+scaleway:
+  region: fr-par
+  zone: fr-par-1
+  image: ubuntu_noble
+  type: DEV1-S
+  projectId: "<scaleway-project-id>"
+  organizationId: "<scaleway-organization-id>"
+  securityGroup: ""
+  sshCIDRs: []
+```
+
+Config keys under `scaleway:`:
+
+| Key | Maps to | Default | Notes |
+| --- | --- | --- | --- |
+| `region` | `cfg.Scaleway.Region` | `fr-par` | Scaleway region. |
+| `zone` | `cfg.Scaleway.Zone` | `fr-par-1` | Scaleway zone used for Instances and local image lookup. |
+| `image` | `cfg.Scaleway.Image` | `ubuntu_noble` | Scaleway image label or ID. |
+| `type` | `cfg.Scaleway.Type` | `DEV1-S` | Scaleway Instances commercial type. |
+| `projectId` | `cfg.Scaleway.ProjectID` | empty | Required through config, env, or the active Scaleway SDK profile before the SDK client is usable. |
+| `organizationId` | `cfg.Scaleway.OrganizationID` | empty | Optional override for SDK profile organization identity. |
+| `securityGroup` | `cfg.Scaleway.SecurityGroup` | empty | Optional existing Scaleway security group ID attached at Instance creation. Crabbox does not create or mutate security groups. |
+| `sshCIDRs` | `cfg.Scaleway.SSHCIDRs` | empty | Reserved for future security-group mutation. Non-empty values fail fast because this provider does not create ingress rules. |
+
+Provider-specific flags:
+
+```text
+--scaleway-region <region>
+--scaleway-zone <zone>
+--scaleway-image <image-label-or-id>
+--scaleway-type <commercial-type>
+--scaleway-project-id <project-id>
+--scaleway-organization-id <organization-id>
+--scaleway-security-group <security-group-id>
+--scaleway-ssh-cidrs <cidr[,cidr...]>
+```
+
+The portable `--os ubuntu:24.04` selector maps to `ubuntu_noble`. Other
+explicit portable OS selectors are rejected unless `scaleway.image`,
+`CRABBOX_SCALEWAY_IMAGE`, or `--scaleway-image` provides an explicit Scaleway
+image label or ID.
+
+Scaleway leases default to `root` on SSH port `22` with no fallback port.
+Explicit generic `ssh.user` and `ssh.port` values remain authoritative. The
+effective values appear in `crabbox config show` without retaining defaults
+from another provider when a command overrides the provider.
+
+Environment overrides:
+
+```text
+CRABBOX_SCALEWAY_REGION             Override the region
+CRABBOX_SCALEWAY_ZONE               Override the zone
+CRABBOX_SCALEWAY_IMAGE              Override the image label or ID
+CRABBOX_SCALEWAY_TYPE               Override the commercial type
+CRABBOX_SCALEWAY_PROJECT_ID         Override the project ID
+CRABBOX_SCALEWAY_ORGANIZATION_ID    Override the organization ID
+CRABBOX_SCALEWAY_SECURITY_GROUP     Override the security group ID
+CRABBOX_SCALEWAY_SSH_CIDRS          Comma-separated SSH CIDRs; currently fails fast when non-empty
+```
+
+## Credentials
+
+Crabbox uses the official Scaleway SDK config surfaces and environment profile.
+It does not store Scaleway secrets in Crabbox config and does not accept them as
+provider-specific flags. `doctor` proves that required auth material and
+project configuration are discoverable enough to construct the SDK client; it
+does not create resources or perform a live authorization probe.
+
+Supported Scaleway credential and profile inputs include:
+
+```text
+SCW_ACCESS_KEY
+SCW_SECRET_KEY
+SCW_DEFAULT_ORGANIZATION_ID
+SCW_DEFAULT_PROJECT_ID
+SCW_DEFAULT_REGION
+SCW_DEFAULT_ZONE
+SCW_PROFILE
+SCW_CONFIG_PATH
+```
+
+`SCW_ACCESS_KEY` and `SCW_SECRET_KEY`, or equivalent Scaleway SDK profile
+credentials, are required. A project ID is also required through
+`SCW_DEFAULT_PROJECT_ID`, `CRABBOX_SCALEWAY_PROJECT_ID`, or the active SDK
+profile's `default_project_id`.
+
+Do not pass Scaleway credentials as command-line arguments. Keep them in the
+environment, the Scaleway SDK config, or a local secret manager. Crabbox
+redacts configured Scaleway env values from SDK client errors before returning
+them.
+
+## Lifecycle
+
+The provider implements a direct Linux SSH lease over Scaleway Instances:
+
+1. Generate a per-lease SSH key under the Crabbox testbox key directory.
+2. Create the matching project-scoped Scaleway IAM SSH key.
+3. Create a Scaleway Instance with `region`, `zone`, `image`, `type`, project,
+   SSH key, optional security group, cloud-init user data, and Crabbox tags.
+4. Wait for a public IPv4 address and Crabbox SSH bootstrap readiness.
+5. Add ready-state Crabbox tags and claim the lease locally.
+6. Run normal Crabbox sync/run/ssh workflows over SSH.
+7. Update timeout tags on touch.
+8. Delete owned Scaleway Instances and managed IAM SSH keys on `stop`; `cleanup`
+   deletes only resources with a complete Crabbox Scaleway ownership tag set.
+
+`list` uses all-pages Scaleway inventory. `resolve` accepts local claims and
+live tag-owned resources. Recovery claims retain enough Scaleway identity to
+finish release or cleanup after interrupted acquire paths.
+
+## Ownership And Cleanup
+
+The foundation tag helpers encode intended ownership tags such as:
+
+```text
+crabbox
+crabbox:provider:scaleway
+crabbox:lease:cbx_abcdef123456
+crabbox:slug:my-app
+crabbox:target:linux
+crabbox:expires_at:<unix-seconds>
+```
+
+Release and cleanup require a complete ownership predicate: Crabbox marker,
+provider marker, lease id, slug, and Linux target. Resources with partial,
+foreign, or malformed Crabbox-like tags are skipped or refused. A stale local
+claim is not enough for destructive release: Crabbox re-fetches the live
+Scaleway Instance by ID and validates current tags before deletion. If Scaleway
+confirms the Instance is already absent, release removes the managed SSH key and
+local claim idempotently.
+
+`crabbox cleanup --provider scaleway --dry-run` reports expired owned resources
+without deleting them. Use the Scaleway console or `scw` only for manual account
+inspection; do not treat manual cleanup as Crabbox lifecycle proof.
+
+## Guarded Live Smoke
+
+The guarded opt-in command name is:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway scripts/live-scaleway-smoke.sh
+```
+
+Expected classifications:
+
+```text
+classification=live_scaleway_smoke_passed
+classification=environment_blocked
+classification=quota_blocked
+classification=validation_failed
+classification=cleanup_failed
+```
+
+## Capabilities
+
+- **SSH** and **Crabbox sync**: implemented through the normal Linux SSH lease
+  path.
+- **Tailscale**: declared through the standard Linux cloud-init path.
+- **Desktop / browser / code**: not advertised.
+- **Cleanup**: implemented for Crabbox-owned Scaleway Instances and managed IAM
+  SSH keys.
+- **Coordinator**: never; direct CLI only.
+
+## Gotchas
+
+- `scaleway` has no aliases; use the canonical provider name.
+- `scaleway` is direct-only. Coordinator secrets and cost accounting do not
+  cover these Instances.
+- `crabbox doctor --provider scaleway` checks SDK config and auth material
+  discovery, but it does not create resources or prove credentials are
+  authorized.
+- `warmup`, `run`, `ssh`, `stop`, `list`, and `cleanup` are live command
+  surfaces that can create or delete Scaleway resources.
+- `--type` must be a valid Scaleway Instances commercial type such as `DEV1-S`.
+- `securityGroup` must name an existing Scaleway security group. Non-empty
+  `sshCIDRs` fails fast because this branch does not create or mutate Scaleway
+  firewall/security-group rules.
+
+## Related Docs
+
+- [Provider reference](README.md)
+- [Provider backends](../provider-backends.md)
+- [Provider feature overview](../features/providers.md)
+- [Operations](../operations.md)

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -33,8 +33,7 @@ resources:
 crabbox doctor --provider scaleway
 ```
 
-The provider is registered for the normal SSH-lease command surface, but live
-lifecycle methods are not implemented in this branch yet:
+The provider is registered for the normal SSH-lease command surface:
 
 ```sh
 crabbox warmup --provider scaleway --class standard
@@ -195,21 +194,62 @@ inspection; do not treat manual cleanup as Crabbox lifecycle proof.
 
 ## Guarded Live Smoke
 
-The guarded opt-in command name is:
+The guarded opt-in command builds `bin/crabbox`, verifies the current Scaleway
+Crabbox inventory is empty, creates a short-lived `DEV1-S` lease by default,
+waits for readiness, runs `echo ok`, verifies the active lease appears in
+`list --json`, stops it, runs `cleanup --dry-run`, and verifies the final
+inventory is empty.
+
+Run it only when live Scaleway credentials, IDs, region, zone, and quota are
+available:
 
 ```sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway scripts/live-scaleway-smoke.sh
 ```
 
+Required environment:
+
+```text
+CRABBOX_LIVE=1
+CRABBOX_LIVE_PROVIDERS=scaleway
+SCW_ACCESS_KEY
+SCW_SECRET_KEY
+SCW_DEFAULT_ORGANIZATION_ID or CRABBOX_SCALEWAY_ORGANIZATION_ID
+SCW_DEFAULT_PROJECT_ID or CRABBOX_SCALEWAY_PROJECT_ID
+SCW_DEFAULT_REGION or CRABBOX_SCALEWAY_REGION
+SCW_DEFAULT_ZONE or CRABBOX_SCALEWAY_ZONE
+```
+
+Optional smoke defaults:
+
+```text
+CRABBOX_SCALEWAY_TYPE=DEV1-S
+CRABBOX_SCALEWAY_IMAGE=ubuntu_noble
+CRABBOX_SCALEWAY_CLEANUP_ATTEMPTS=65
+```
+
 Expected classifications:
 
 ```text
-classification=live_scaleway_smoke_passed
-classification=environment_blocked
+classification=environment_blocked reason=CRABBOX_LIVE_not_enabled
+classification=environment_blocked reason=scaleway_not_selected
+classification=environment_blocked reason=SCW_ACCESS_KEY_missing
+classification=environment_blocked reason=SCW_SECRET_KEY_missing
+classification=environment_blocked reason=SCW_DEFAULT_ORGANIZATION_ID_missing
+classification=environment_blocked reason=SCW_DEFAULT_PROJECT_ID_missing
 classification=quota_blocked
 classification=validation_failed
 classification=cleanup_failed
+classification=live_scaleway_smoke_passed
 ```
+
+`environment_blocked` means local live gates, credentials, IDs, region, or zone
+are unavailable. `quota_blocked` means Scaleway rejected the create path with
+quota, capacity, rate-limit, or account-limit language. `validation_failed`
+means the smoke's safety checks failed, such as non-empty initial inventory or
+unexpected list JSON. `cleanup_failed` means the targeted stop retry loop could
+not prove cleanup. The script redacts the configured Scaleway access and secret
+keys from captured command output before printing.
 
 ## Capabilities
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/islo-labs/go-sdk v0.0.0-20260528125833-04a38f6f507c
 	github.com/lima-vm/go-qcow2reader v0.7.1
 	github.com/lxc/incus/v7 v7.1.0
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	github.com/zitadel/oidc/v3 v3.47.5
 	golang.org/x/crypto v0.52.0
@@ -126,4 +127,5 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 h1:ObX9hZmK+VmijreZO/8x9pQ8/P/ToHD/bdSb4Eg4tUo=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36/go.mod h1:LEsDu4BubxK7/cWhtlQWfuxwL4rf/2UEpxXz1o1EMtM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
@@ -362,6 +364,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.6 h1:PiJkrakkmzc5s7EfBnZOnyiLwi7o7A9fwPzN0X2uwe0=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.6/go.mod h1:sbq5oMEcM4PXngbcNbHhzfCP9OdZodLhrbRYoyg09HY=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -105,6 +105,9 @@ type Config struct {
 	linodeTypeExplicit            bool
 	OVH                           OVHConfig
 	ovhImageExplicit              bool
+	Scaleway                      ScalewayConfig
+	scalewayImageExplicit         bool
+	scalewayTypeExplicit          bool
 	Incus                         IncusConfig
 	Proxmox                       ProxmoxConfig
 	XCPNg                         XCPNgConfig
@@ -252,6 +255,20 @@ type OVHConfig struct {
 	Region    string
 	Image     string
 	Flavor    string
+}
+
+// ScalewayConfig contains non-secret Scaleway Instances settings. Scaleway
+// credentials are intentionally loaded by the provider client from the official
+// SDK environment/config surfaces and are not persisted in Crabbox config.
+type ScalewayConfig struct {
+	Region         string
+	Zone           string
+	Image          string
+	Type           string
+	ProjectID      string
+	OrganizationID string
+	SecurityGroup  string
+	SSHCIDRs       []string
 }
 
 type ActionsConfig struct {
@@ -1418,6 +1435,51 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "scaleway" {
+		if cfg.Scaleway.Region == "" {
+			cfg.Scaleway.Region = "fr-par"
+		}
+		if cfg.Scaleway.Zone == "" {
+			cfg.Scaleway.Zone = "fr-par-1"
+		}
+		if cfg.osImageExplicit && !cfg.scalewayImageExplicit {
+			if cfg.OSImage == "ubuntu:24.04" {
+				cfg.Scaleway.Image = "ubuntu_noble"
+			} else {
+				cfg.Scaleway.Image = ""
+			}
+		} else if cfg.Scaleway.Image == "" {
+			cfg.Scaleway.Image = "ubuntu_noble"
+		}
+		if cfg.Scaleway.Type == "" {
+			cfg.Scaleway.Type = "DEV1-S"
+		}
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+		} else {
+			cfg.WorkRoot = defaultPOSIXWorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else {
+			cfg.SSHUser = "root"
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = "22"
+		}
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "hyperv" {
 		if !IsTargetExplicit(cfg) {
 			cfg.TargetOS = targetWindows
@@ -1975,6 +2037,12 @@ func baseConfig() Config {
 			Image:    "Ubuntu 24.04",
 			Flavor:   "b3-8",
 		},
+		Scaleway: ScalewayConfig{
+			Region: "fr-par",
+			Zone:   "fr-par-1",
+			Image:  "ubuntu_noble",
+			Type:   "DEV1-S",
+		},
 		Incus: IncusConfig{
 			Remote:          "local",
 			Project:         "",
@@ -2324,6 +2392,7 @@ type fileConfig struct {
 	DigitalOcean             *fileDigitalOceanConfig             `yaml:"digitalocean,omitempty"`
 	Linode                   *fileLinodeConfig                   `yaml:"linode,omitempty"`
 	OVH                      *fileOVHConfig                      `yaml:"ovh,omitempty"`
+	Scaleway                 *fileScalewayConfig                 `yaml:"scaleway,omitempty"`
 	AWS                      *fileAWSConfig                      `yaml:"aws,omitempty"`
 	Azure                    *fileAzureConfig                    `yaml:"azure,omitempty"`
 	AzureDynamicSessions     *fileAzureDynamicSessionsConfig     `yaml:"azureDynamicSessions,omitempty"`
@@ -2441,6 +2510,17 @@ type fileOVHConfig struct {
 	Region    string `yaml:"region,omitempty"`
 	Image     string `yaml:"image,omitempty"`
 	Flavor    string `yaml:"flavor,omitempty"`
+}
+
+type fileScalewayConfig struct {
+	Region         string   `yaml:"region,omitempty"`
+	Zone           string   `yaml:"zone,omitempty"`
+	Image          string   `yaml:"image,omitempty"`
+	Type           string   `yaml:"type,omitempty"`
+	ProjectID      string   `yaml:"projectId,omitempty"`
+	OrganizationID string   `yaml:"organizationId,omitempty"`
+	SecurityGroup  string   `yaml:"securityGroup,omitempty"`
+	SSHCIDRs       []string `yaml:"sshCIDRs,omitempty"`
 }
 
 type fileAWSConfig struct {
@@ -3691,6 +3771,34 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.OVH.Flavor != "" {
 			cfg.OVH.Flavor = file.OVH.Flavor
+		}
+	}
+	if file.Scaleway != nil {
+		if file.Scaleway.Region != "" {
+			cfg.Scaleway.Region = file.Scaleway.Region
+		}
+		if file.Scaleway.Zone != "" {
+			cfg.Scaleway.Zone = file.Scaleway.Zone
+		}
+		if file.Scaleway.Image != "" {
+			cfg.Scaleway.Image = file.Scaleway.Image
+			cfg.scalewayImageExplicit = true
+		}
+		if file.Scaleway.Type != "" {
+			cfg.Scaleway.Type = file.Scaleway.Type
+			cfg.scalewayTypeExplicit = true
+		}
+		if file.Scaleway.ProjectID != "" {
+			cfg.Scaleway.ProjectID = file.Scaleway.ProjectID
+		}
+		if file.Scaleway.OrganizationID != "" {
+			cfg.Scaleway.OrganizationID = file.Scaleway.OrganizationID
+		}
+		if file.Scaleway.SecurityGroup != "" {
+			cfg.Scaleway.SecurityGroup = file.Scaleway.SecurityGroup
+		}
+		if len(file.Scaleway.SSHCIDRs) > 0 {
+			cfg.Scaleway.SSHCIDRs = file.Scaleway.SSHCIDRs
 		}
 	}
 	if file.AWS != nil {
@@ -5836,6 +5944,22 @@ func applyEnv(cfg *Config) error {
 		cfg.ovhImageExplicit = true
 	}
 	cfg.OVH.Flavor = getenv("CRABBOX_OVH_FLAVOR", cfg.OVH.Flavor)
+	cfg.Scaleway.Region = getenv("CRABBOX_SCALEWAY_REGION", cfg.Scaleway.Region)
+	cfg.Scaleway.Zone = getenv("CRABBOX_SCALEWAY_ZONE", cfg.Scaleway.Zone)
+	if image := os.Getenv("CRABBOX_SCALEWAY_IMAGE"); image != "" {
+		cfg.Scaleway.Image = image
+		cfg.scalewayImageExplicit = true
+	}
+	if serverType := os.Getenv("CRABBOX_SCALEWAY_TYPE"); serverType != "" {
+		cfg.Scaleway.Type = serverType
+		cfg.scalewayTypeExplicit = true
+	}
+	cfg.Scaleway.ProjectID = getenv("CRABBOX_SCALEWAY_PROJECT_ID", cfg.Scaleway.ProjectID)
+	cfg.Scaleway.OrganizationID = getenv("CRABBOX_SCALEWAY_ORGANIZATION_ID", cfg.Scaleway.OrganizationID)
+	cfg.Scaleway.SecurityGroup = getenv("CRABBOX_SCALEWAY_SECURITY_GROUP", cfg.Scaleway.SecurityGroup)
+	if cidrs := os.Getenv("CRABBOX_SCALEWAY_SSH_CIDRS"); cidrs != "" {
+		cfg.Scaleway.SSHCIDRs = splitCommaList(cidrs)
+	}
 	cfg.Proxmox.APIURL = getenv("CRABBOX_PROXMOX_API_URL", cfg.Proxmox.APIURL)
 	cfg.Proxmox.TokenID = getenv("CRABBOX_PROXMOX_TOKEN_ID", cfg.Proxmox.TokenID)
 	cfg.Proxmox.TokenSecret = getenv("CRABBOX_PROXMOX_TOKEN_SECRET", cfg.Proxmox.TokenSecret)

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -61,6 +61,16 @@ func effectiveConfigForShow(cfg Config) Config {
 		}
 		cfg.SSHFallbackPorts = nil
 	}
+	if cfg.Provider == "scaleway" {
+		base := baseConfig()
+		if !IsSSHUserExplicit(&cfg) && (cfg.SSHUser == "" || cfg.SSHUser == base.SSHUser) {
+			cfg.SSHUser = "root"
+		}
+		if !IsSSHPortExplicit(&cfg) && (cfg.SSHPort == "" || cfg.SSHPort == base.SSHPort) {
+			cfg.SSHPort = "22"
+		}
+		cfg.SSHFallbackPorts = nil
+	}
 	if cfg.Provider == "hostinger" {
 		cfg.WorkRoot = cfg.Hostinger.WorkRoot
 		cfg.SSHUser = cfg.Hostinger.User
@@ -190,6 +200,17 @@ func configShowView(cfg Config) map[string]any {
 			"image":     cfg.OVH.Image,
 			"flavor":    cfg.OVH.Flavor,
 			"auth":      ovhAuthState(),
+		},
+		"scaleway": map[string]any{
+			"region":         cfg.Scaleway.Region,
+			"zone":           cfg.Scaleway.Zone,
+			"image":          cfg.Scaleway.Image,
+			"type":           cfg.Scaleway.Type,
+			"projectId":      cfg.Scaleway.ProjectID,
+			"organizationId": cfg.Scaleway.OrganizationID,
+			"securityGroup":  cfg.Scaleway.SecurityGroup,
+			"sshCIDRs":       cfg.Scaleway.SSHCIDRs,
+			"auth":           scalewayAuthState(),
 		},
 		"azureDynamicSessions": map[string]any{
 			"endpoint":        cfg.AzureDynamicSessions.Endpoint,
@@ -503,6 +524,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "nvidia_brev cli=%s org=%s type=%s gpu_name=%s provider=%s mode=%s launchable=%s startup_script=%s release_action=%s target=%s user=%s work_root=%s auth=cli\n", blank(cfg.NvidiaBrev.CLI, "-"), blank(cfg.NvidiaBrev.Org, "-"), blank(cfg.NvidiaBrev.Type, "-"), blank(cfg.NvidiaBrev.GPUName, "-"), blank(cfg.NvidiaBrev.Provider, "-"), blank(cfg.NvidiaBrev.Mode, "-"), blank(cfg.NvidiaBrev.Launchable, "-"), blank(cfg.NvidiaBrev.StartupScript, "-"), blank(cfg.NvidiaBrev.ReleaseAction, "-"), blank(cfg.NvidiaBrev.Target, "-"), blank(cfg.NvidiaBrev.User, "-"), blank(cfg.NvidiaBrev.WorkRoot, "-"))
 	fmt.Fprintf(w, "hostinger api_url=%s item_id=%s payment_method_id=%s template_id=%s data_center_id=%s hostname_prefix=%s user=%s work_root=%s allow_purchase=%t release_action=%s auth=%s\n", blank(cfg.Hostinger.APIURL, "-"), blank(cfg.Hostinger.ItemID, "-"), blank(cfg.Hostinger.PaymentMethodID, "-"), blank(cfg.Hostinger.TemplateID, "-"), blank(cfg.Hostinger.DataCenterID, "-"), blank(cfg.Hostinger.HostnamePrefix, "-"), blank(cfg.Hostinger.User, "-"), blank(cfg.Hostinger.WorkRoot, "-"), cfg.Hostinger.AllowPurchase, blank(cfg.Hostinger.ReleaseAction, "-"), tokenState(cfg.Hostinger.APIToken))
 	fmt.Fprintf(w, "ovh endpoint=%s project_id=%s region=%s image=%s flavor=%s auth=%s\n", blank(redactedConfigURL(cfg.OVH.Endpoint), "-"), blank(cfg.OVH.ProjectID, "-"), blank(cfg.OVH.Region, "-"), blank(cfg.OVH.Image, "-"), blank(cfg.OVH.Flavor, "-"), ovhAuthState())
+	fmt.Fprintf(w, "scaleway region=%s zone=%s image=%s type=%s project_id=%s organization_id=%s security_group=%s ssh_cidrs=%s auth=%s\n", blank(cfg.Scaleway.Region, "-"), blank(cfg.Scaleway.Zone, "-"), blank(cfg.Scaleway.Image, "-"), blank(cfg.Scaleway.Type, "-"), blank(cfg.Scaleway.ProjectID, "-"), blank(cfg.Scaleway.OrganizationID, "-"), blank(cfg.Scaleway.SecurityGroup, "-"), blank(strings.Join(cfg.Scaleway.SSHCIDRs, ","), "-"), scalewayAuthState())
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(cfg.AzureDynamicSessions.Endpoint, "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)
 	fmt.Fprintf(w, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(cfg.Proxmox.APIURL, "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
@@ -795,6 +817,27 @@ func ovhAuthState() string {
 		os.Getenv("OVH_APPLICATION_KEY"),
 		os.Getenv("OVH_APPLICATION_SECRET"),
 		os.Getenv("OVH_CONSUMER_KEY"),
+	}
+	configured := 0
+	for _, value := range values {
+		if value != "" {
+			configured++
+		}
+	}
+	switch configured {
+	case 0:
+		return "missing"
+	case len(values):
+		return "configured"
+	default:
+		return "partial"
+	}
+}
+
+func scalewayAuthState() string {
+	values := []string{
+		os.Getenv("SCW_ACCESS_KEY"),
+		os.Getenv("SCW_SECRET_KEY"),
 	}
 	configured := 0
 	for _, value := range values {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -582,6 +583,95 @@ func TestConfigShowIncludesDigitalOceanProviderConfig(t *testing.T) {
 	}
 	if got.SSHUser != "root" || got.SSHPort != "22" || len(got.SSHFallbackPorts) != 0 {
 		t.Fatalf("unexpected digitalocean ssh json: %#v", got)
+	}
+}
+
+func TestConfigShowIncludesScalewayProviderConfigWithoutSecrets(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("SCW_ACCESS_KEY", "redaction-fixture-access")
+	t.Setenv("SCW_SECRET_KEY", "redaction-fixture-private")
+	if err := os.WriteFile(configPath, []byte("provider: scaleway\nscaleway:\n  region: fr-par\n  zone: fr-par-1\n  image: ubuntu_noble\n  type: DEV1-S\n  projectId: project-123\n  organizationId: org-123\n  securityGroup: sg-123\n  sshCIDRs: [203.0.113.0/24, 2001:db8::/64]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "scaleway region=fr-par zone=fr-par-1 image=ubuntu_noble type=DEV1-S project_id=project-123 organization_id=org-123 security_group=sg-123 ssh_cidrs=203.0.113.0/24,2001:db8::/64 auth=configured") {
+		t.Fatalf("config show missing scaleway summary: %q", text)
+	}
+	if !strings.Contains(text, "ssh=root@<host>:22 fallback_ports=-") {
+		t.Fatalf("config show missing effective scaleway ssh defaults: %q", text)
+	}
+	for _, secret := range []string{"redaction-fixture-access", "redaction-fixture-private"} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("config show leaked Scaleway secret %q: %q", secret, text)
+		}
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		SSHUser  string `json:"sshUser"`
+		SSHPort  string `json:"sshPort"`
+		Scaleway struct {
+			Region         string   `json:"region"`
+			Zone           string   `json:"zone"`
+			Image          string   `json:"image"`
+			Type           string   `json:"type"`
+			ProjectID      string   `json:"projectId"`
+			OrganizationID string   `json:"organizationId"`
+			SecurityGroup  string   `json:"securityGroup"`
+			SSHCIDRs       []string `json:"sshCIDRs"`
+			Auth           string   `json:"auth"`
+		} `json:"scaleway"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scaleway.Region != "fr-par" ||
+		got.Scaleway.Zone != "fr-par-1" ||
+		got.Scaleway.Image != "ubuntu_noble" ||
+		got.Scaleway.Type != "DEV1-S" ||
+		got.Scaleway.ProjectID != "project-123" ||
+		got.Scaleway.OrganizationID != "org-123" ||
+		got.Scaleway.SecurityGroup != "sg-123" ||
+		got.Scaleway.Auth != "configured" ||
+		strings.Join(got.Scaleway.SSHCIDRs, ",") != "203.0.113.0/24,2001:db8::/64" {
+		t.Fatalf("unexpected scaleway json: %#v", got.Scaleway)
+	}
+	if got.SSHUser != "root" || got.SSHPort != "22" {
+		t.Fatalf("unexpected scaleway ssh json: %#v", got)
+	}
+	rendered := stdout.String()
+	for _, secret := range []string{"redaction-fixture-access", "redaction-fixture-private"} {
+		if strings.Contains(rendered, secret) {
+			t.Fatalf("config show json leaked Scaleway secret %q: %q", secret, rendered)
+		}
+	}
+}
+
+func TestConfigShowScalewayPartialAuth(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("SCW_ACCESS_KEY", "redaction-fixture-access")
+	cfg := Config{Provider: "scaleway"}
+	view := configShowView(cfg)["scaleway"].(map[string]any)
+	if got := view["auth"]; got != "partial" {
+		t.Fatalf("auth=%v, want partial", got)
+	}
+	rendered := fmt.Sprint(view)
+	if strings.Contains(rendered, "redaction-fixture-access") {
+		t.Fatalf("config show leaked Scaleway access key: %s", rendered)
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -73,6 +73,22 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_OVH_REGION",
 		"CRABBOX_OVH_IMAGE",
 		"CRABBOX_OVH_FLAVOR",
+		"CRABBOX_SCALEWAY_REGION",
+		"CRABBOX_SCALEWAY_ZONE",
+		"CRABBOX_SCALEWAY_IMAGE",
+		"CRABBOX_SCALEWAY_TYPE",
+		"CRABBOX_SCALEWAY_PROJECT_ID",
+		"CRABBOX_SCALEWAY_ORGANIZATION_ID",
+		"CRABBOX_SCALEWAY_SECURITY_GROUP",
+		"CRABBOX_SCALEWAY_SSH_CIDRS",
+		"SCW_ACCESS_KEY",
+		"SCW_SECRET_KEY",
+		"SCW_DEFAULT_ORGANIZATION_ID",
+		"SCW_DEFAULT_PROJECT_ID",
+		"SCW_DEFAULT_REGION",
+		"SCW_DEFAULT_ZONE",
+		"SCW_PROFILE",
+		"SCW_CONFIG_PATH",
 		"CRABBOX_DAYTONA_API_KEY",
 		"DAYTONA_API_KEY",
 		"CRABBOX_DAYTONA_JWT_TOKEN",
@@ -980,6 +996,143 @@ func TestOVHConfigShowRedactsEnvCredentials(t *testing.T) {
 	t.Setenv("OVH_CONSUMER_KEY", "")
 	if got := configShowView(cfg)["ovh"].(map[string]any)["auth"]; got != "partial" {
 		t.Fatalf("partial auth=%v, want partial", got)
+	}
+}
+
+func TestScalewayConfigFileEnvAndDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, fileConfig{
+		Provider: "scaleway",
+		Scaleway: &fileScalewayConfig{
+			Region:         "nl-ams",
+			Zone:           "nl-ams-1",
+			Image:          "ubuntu_jammy",
+			Type:           "DEV1-M",
+			ProjectID:      "project-file",
+			OrganizationID: "org-file",
+			SecurityGroup:  "sg-file",
+			SSHCIDRs:       []string{"203.0.113.0/24"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "scaleway" || cfg.Scaleway.Region != "nl-ams" || cfg.Scaleway.Zone != "nl-ams-1" || cfg.Scaleway.Image != "ubuntu_jammy" || cfg.Scaleway.Type != "DEV1-M" || cfg.Scaleway.ProjectID != "project-file" || cfg.Scaleway.OrganizationID != "org-file" || cfg.Scaleway.SecurityGroup != "sg-file" {
+		t.Fatalf("file scaleway config not applied: %#v", cfg.Scaleway)
+	}
+	if strings.Join(cfg.Scaleway.SSHCIDRs, ",") != "203.0.113.0/24" {
+		t.Fatalf("file scaleway ssh cidrs=%v", cfg.Scaleway.SSHCIDRs)
+	}
+	if !cfg.scalewayImageExplicit || !cfg.scalewayTypeExplicit {
+		t.Fatalf("file scaleway image/type should be explicit: image=%t type=%t", cfg.scalewayImageExplicit, cfg.scalewayTypeExplicit)
+	}
+
+	t.Setenv("CRABBOX_SCALEWAY_REGION", "fr-par")
+	t.Setenv("CRABBOX_SCALEWAY_ZONE", "fr-par-2")
+	t.Setenv("CRABBOX_SCALEWAY_IMAGE", "ubuntu_noble")
+	t.Setenv("CRABBOX_SCALEWAY_TYPE", "DEV1-S")
+	t.Setenv("CRABBOX_SCALEWAY_PROJECT_ID", "project-env")
+	t.Setenv("CRABBOX_SCALEWAY_ORGANIZATION_ID", "org-env")
+	t.Setenv("CRABBOX_SCALEWAY_SECURITY_GROUP", "sg-env")
+	t.Setenv("CRABBOX_SCALEWAY_SSH_CIDRS", "198.51.100.0/24,2001:db8::/64")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatalf("applyEnv err=%v", err)
+	}
+	if cfg.Scaleway.Region != "fr-par" || cfg.Scaleway.Zone != "fr-par-2" || cfg.Scaleway.Image != "ubuntu_noble" || cfg.Scaleway.Type != "DEV1-S" || cfg.Scaleway.ProjectID != "project-env" || cfg.Scaleway.OrganizationID != "org-env" || cfg.Scaleway.SecurityGroup != "sg-env" {
+		t.Fatalf("env scaleway config not applied: %#v", cfg.Scaleway)
+	}
+	if strings.Join(cfg.Scaleway.SSHCIDRs, ",") != "198.51.100.0/24,2001:db8::/64" {
+		t.Fatalf("env scaleway ssh cidrs=%v", cfg.Scaleway.SSHCIDRs)
+	}
+
+	cfg.Scaleway = ScalewayConfig{}
+	cfg.scalewayImageExplicit = false
+	cfg.scalewayTypeExplicit = false
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatalf("applyProviderConfigDefaults err=%v", err)
+	}
+	if cfg.TargetOS != targetLinux || cfg.Scaleway.Region != "fr-par" || cfg.Scaleway.Zone != "fr-par-1" || cfg.Scaleway.Image != "ubuntu_noble" || cfg.Scaleway.Type != "DEV1-S" || cfg.SSHUser != "root" || cfg.SSHPort != "22" || cfg.WorkRoot != defaultPOSIXWorkRoot {
+		t.Fatalf("scaleway defaults not applied: cfg=%#v scaleway=%#v", cfg, cfg.Scaleway)
+	}
+	if cfg.scalewayImageExplicit || cfg.scalewayTypeExplicit {
+		t.Fatalf("default scaleway image/type should not be explicit: image=%t type=%t", cfg.scalewayImageExplicit, cfg.scalewayTypeExplicit)
+	}
+}
+
+func TestScalewayPortableOSSelection(t *testing.T) {
+	t.Run("supported selector maps to provider image", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "scaleway"
+		cfg.OSImage = "ubuntu:24.04"
+		cfg.osImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Scaleway.Image != "ubuntu_noble" {
+			t.Fatalf("Scaleway.Image=%q", cfg.Scaleway.Image)
+		}
+	})
+
+	t.Run("unsupported selector is deferred to acquisition", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "scaleway"
+		cfg.OSImage = "ubuntu:26.04"
+		cfg.osImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Scaleway.Image != "" {
+			t.Fatalf("Scaleway.Image=%q, want unresolved provider image", cfg.Scaleway.Image)
+		}
+	})
+
+	t.Run("provider image overrides portable selector", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Provider = "scaleway"
+		cfg.OSImage = "ubuntu:26.04"
+		cfg.osImageExplicit = true
+		cfg.Scaleway.Image = "custom-image"
+		cfg.scalewayImageExplicit = true
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Scaleway.Image != "custom-image" {
+			t.Fatalf("Scaleway.Image=%q", cfg.Scaleway.Image)
+		}
+	})
+}
+
+func TestScalewayDefaultsPreserveExplicitGenericWorkRoot(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "scaleway"
+	cfg.explicitWorkRoot = "/work/custom"
+	cfg.explicitSSHUser = "ubuntu"
+	cfg.explicitSSHPort = "2222"
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorkRoot != "/work/custom" || cfg.SSHUser != "ubuntu" || cfg.SSHPort != "2222" {
+		t.Fatalf("explicit generic values not preserved: work_root=%q ssh=%s:%s", cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort)
+	}
+}
+
+func TestScalewayEnvDoesNotMutateGenericFieldsForOtherProviders(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "hetzner"
+	originalLocation := cfg.Location
+	originalImage := cfg.Image
+	t.Setenv("CRABBOX_SCALEWAY_REGION", "fr-par")
+	t.Setenv("CRABBOX_SCALEWAY_IMAGE", "ubuntu_noble")
+	t.Setenv("CRABBOX_SCALEWAY_TYPE", "DEV1-S")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatalf("applyEnv err=%v", err)
+	}
+	if cfg.Scaleway.Region != "fr-par" || cfg.Scaleway.Image != "ubuntu_noble" || cfg.Scaleway.Type != "DEV1-S" {
+		t.Fatalf("scaleway env not stored: %#v", cfg.Scaleway)
+	}
+	if cfg.Location != originalLocation || cfg.Image != originalImage {
+		t.Fatalf("scaleway env leaked into generic fields: location=%q image=%q", cfg.Location, cfg.Image)
 	}
 }
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -254,6 +254,22 @@ func SetOVHImageExplicit(cfg *Config) {
 	cfg.ovhImageExplicit = true
 }
 
+func ScalewayImageWasExplicit(cfg Config) bool {
+	return cfg.scalewayImageExplicit
+}
+
+func SetScalewayImageExplicit(cfg *Config) {
+	cfg.scalewayImageExplicit = true
+}
+
+func ScalewayTypeWasExplicit(cfg Config) bool {
+	return cfg.scalewayTypeExplicit
+}
+
+func SetScalewayTypeExplicit(cfg *Config) {
+	cfg.scalewayTypeExplicit = true
+}
+
 func CrabboxStateDir() (string, error) {
 	return crabboxStateDir()
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -14,6 +14,7 @@ func init() {
 	RegisterProvider(testHetznerProvider{})
 	RegisterProvider(testDigitalOceanProvider{})
 	RegisterProvider(testLinodeProvider{})
+	RegisterProvider(testScalewayProvider{})
 	RegisterProvider(testAWSProvider{})
 	RegisterProvider(testAzureProvider{})
 	RegisterProvider(testAzureDynamicSessionsProvider{})
@@ -357,6 +358,38 @@ func (testLinodeProvider) ServerTypeForConfig(cfg Config) string {
 }
 func (testLinodeProvider) ServerTypeForClass(string) string { return "g6-standard-1" }
 func (p testLinodeProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testScalewayProvider struct{}
+
+func (testScalewayProvider) Name() string      { return "scaleway" }
+func (testScalewayProvider) Aliases() []string { return nil }
+func (testScalewayProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "scaleway",
+		Family:      "scaleway",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testScalewayProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (testScalewayProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (testScalewayProvider) ServerTypeForConfig(cfg Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.Scaleway.Type != "" {
+		return cfg.Scaleway.Type
+	}
+	return "DEV1-S"
+}
+func (testScalewayProvider) ServerTypeForClass(string) string { return "DEV1-S" }
+func (p testScalewayProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -15,6 +15,7 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	var digitalOcean *providerMatrixEntry
 	var nvidiaBrev *providerMatrixEntry
 	var linode *providerMatrixEntry
+	var scaleway *providerMatrixEntry
 	var moduleRuntime *providerMatrixEntry
 	for i := range entries {
 		if entries[i].Provider == "aws" {
@@ -31,6 +32,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		}
 		if entries[i].Provider == "linode" {
 			linode = &entries[i]
+		}
+		if entries[i].Provider == "scaleway" {
+			scaleway = &entries[i]
 		}
 		if entries[i].Provider == "module-runtime-test" {
 			moduleRuntime = &entries[i]
@@ -50,6 +54,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if linode == nil {
 		t.Fatal("linode provider not found")
+	}
+	if scaleway == nil {
+		t.Fatal("scaleway provider not found")
 	}
 	if aws.Kind != ProviderKindSSHLease {
 		t.Fatalf("aws kind=%q", aws.Kind)
@@ -85,6 +92,17 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if !containsString(linode.Targets, targetLinux) {
 		t.Fatalf("linode targets=%v", linode.Targets)
+	}
+	if scaleway.Kind != ProviderKindSSHLease || scaleway.Family != "scaleway" || scaleway.Coordinator != string(CoordinatorNever) {
+		t.Fatalf("scaleway kind/family/coordinator=%q/%q/%q", scaleway.Kind, scaleway.Family, scaleway.Coordinator)
+	}
+	if !containsString(scaleway.Targets, targetLinux) {
+		t.Fatalf("scaleway targets=%v", scaleway.Targets)
+	}
+	for _, feature := range []Feature{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale} {
+		if !containsFeature(scaleway.Features, feature) {
+			t.Fatalf("scaleway features=%v missing %s", scaleway.Features, feature)
+		}
 	}
 	if moduleRuntime == nil {
 		t.Fatal("module-runtime-test provider not found")

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/proxmox"
 	_ "github.com/openclaw/crabbox/internal/providers/railway"
 	_ "github.com/openclaw/crabbox/internal/providers/runpod"
+	_ "github.com/openclaw/crabbox/internal/providers/scaleway"
 	_ "github.com/openclaw/crabbox/internal/providers/semaphore"
 	_ "github.com/openclaw/crabbox/internal/providers/smolvm"
 	_ "github.com/openclaw/crabbox/internal/providers/sprites"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -119,6 +119,34 @@ func TestSuperserveRegistersWithoutAliases(t *testing.T) {
 	}
 }
 
+func TestScalewayRegistersWithoutAliases(t *testing.T) {
+	provider, err := core.ProviderFor("scaleway")
+	if err != nil {
+		t.Fatalf("ProviderFor(scaleway): %v", err)
+	}
+	if provider.Name() != "scaleway" {
+		t.Fatalf("ProviderFor(scaleway).Name=%q", provider.Name())
+	}
+	if provider.Aliases() != nil {
+		t.Fatalf("scaleway aliases=%v, want none", provider.Aliases())
+	}
+	spec := provider.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Family != "scaleway" || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("scaleway spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("scaleway targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("scaleway features=%v missing %s", spec.Features, feature)
+		}
+	}
+	if _, ok := provider.(core.DoctorProvider); !ok {
+		t.Fatal("scaleway does not expose doctor")
+	}
+}
+
 func TestNamespaceInstanceRegistersWithoutAliasCollision(t *testing.T) {
 	for _, name := range []string{"namespace-instance", "namespace-compute"} {
 		provider, err := core.ProviderFor(name)

--- a/internal/providers/scaleway/backend_lifecycle_test.go
+++ b/internal/providers/scaleway/backend_lifecycle_test.go
@@ -1,0 +1,478 @@
+package scaleway
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	instance "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	marketplace "github.com/scaleway/scaleway-sdk-go/api/marketplace/v2"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestScalewayAcquireListResolveTouchReleaseLifecycle(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	var observed core.LeaseTarget
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "blue-box",
+		OnAcquired: func(target core.LeaseTarget) error {
+			observed = target
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if lease.LeaseID == "" || lease.Server.CloudID == "" || lease.SSH.Host != "203.0.113.10" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if observed.Server.CloudID != lease.Server.CloudID || observed.LeaseID != lease.LeaseID || observed.SSH.Host != lease.SSH.Host {
+		t.Fatalf("OnAcquired observed=%#v lease=%#v", observed, lease)
+	}
+	if len(fake.keys) != 1 {
+		t.Fatalf("created keys=%#v", fake.keys)
+	}
+	if fake.lastCreate == nil || fake.lastCreate.DynamicIPRequired == nil || !*fake.lastCreate.DynamicIPRequired {
+		t.Fatalf("create request did not request dynamic IP: %#v", fake.lastCreate)
+	}
+	if fake.lastCreate.Project == nil || *fake.lastCreate.Project != "project-1" || fake.lastCreate.Zone != scw.Zone("fr-par-1") {
+		t.Fatalf("create project/zone=%#v", fake.lastCreate)
+	}
+	if fake.lastCreate.SecurityGroup == nil || *fake.lastCreate.SecurityGroup != "sg-1" {
+		t.Fatalf("security group=%#v", fake.lastCreate.SecurityGroup)
+	}
+	if fake.lastListOptions == 0 {
+		t.Fatal("inventory list did not request all pages")
+	}
+	if !strings.Contains(fake.userData, "ssh_authorized_keys") {
+		t.Fatalf("cloud-init user data missing ssh keys: %s", fake.userData)
+	}
+	if !fake.poweredOn {
+		t.Fatal("server was not powered on after cloud-init user data was set")
+	}
+	if got := labelsFromTags(fake.server.Tags); got["state"] != "ready" || got["scaleway_project"] != "project-1" || got["scaleway_ssh_key_id"] == "" {
+		t.Fatalf("ready tags labels=%#v tags=%v", got, fake.server.Tags)
+	}
+
+	list, err := backend.List(context.Background(), core.ListRequest{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].CloudID != fake.server.ID {
+		t.Fatalf("list=%#v", list)
+	}
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "blue-box"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.LeaseID != lease.LeaseID || resolved.Server.CloudID != fake.server.ID {
+		t.Fatalf("resolved=%#v", resolved)
+	}
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "running", IdleTimeout: 4 * time.Hour})
+	if err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	if touched.Labels["state"] != "running" {
+		t.Fatalf("touch labels=%#v", touched.Labels)
+	}
+	if touched.Labels["idle_timeout_secs"] != "14400" {
+		t.Fatalf("touch did not persist idle timeout override: %#v", touched.Labels)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatalf("ReleaseLease: %v", err)
+	}
+	if !fake.deletedServer || !fake.deletedKey {
+		t.Fatalf("deleted server=%t key=%t", fake.deletedServer, fake.deletedKey)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName); err != nil || ok {
+		t.Fatalf("claim after release ok=%t err=%v", ok, err)
+	}
+}
+
+func TestScalewayAcquireOnAcquiredErrorRollsBack(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "reject",
+		OnAcquired: func(core.LeaseTarget) error {
+			return errors.New("controller rejected identity")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "controller rejected identity") {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	if !fake.deletedServer || !fake.deletedKey {
+		t.Fatalf("rollback deleted server=%t key=%t", fake.deletedServer, fake.deletedKey)
+	}
+	claims, claimErr := core.ListLeaseClaims()
+	if claimErr != nil {
+		t.Fatal(claimErr)
+	}
+	if len(claims) != 0 {
+		t.Fatalf("rollback should remove recovery claim after cleanup: %#v", claims)
+	}
+}
+
+func TestScalewayAcquireRejectsUnsupportedSSHCIDRs(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	backend.cfg.Scaleway.SSHCIDRs = []string{"203.0.113.0/24"}
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "cidrs"})
+	if err == nil || !strings.Contains(err.Error(), "does not yet manage security-group SSH CIDRs") {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	if fake.lastCreate != nil {
+		t.Fatalf("server was created despite unsupported CIDRs: %#v", fake.lastCreate)
+	}
+}
+
+func TestScalewayCleanupSkipsForeignAndDeletesExpiredOwned(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	now := backend.clockNow()
+	ownedLabels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_owned", "owned", providerName, "", false, now.Add(-3*time.Hour))
+	ownedLabels["scaleway_project"] = "project-1"
+	ownedLabels["scaleway_zone"] = "fr-par-1"
+	ownedLabels["scaleway_ssh_key_id"] = "key-owned"
+	fake.servers = []*instance.Server{
+		testServer("srv-owned", "crabbox-cbx-owned", tagsFromLabels(ownedLabels), "203.0.113.11"),
+		testServer("srv-foreign", "foreign", []string{"crabbox", "crabbox:provider:other"}, "203.0.113.12"),
+	}
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if !fake.deletedServer {
+		t.Fatal("owned expired server was not deleted")
+	}
+	if fake.deletedServerID != "srv-owned" {
+		t.Fatalf("deleted server id=%q", fake.deletedServerID)
+	}
+}
+
+func TestScalewayCleanupRefusesMismatchedProject(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_bad", "bad", providerName, "", false, backend.clockNow().Add(-3*time.Hour))
+	labels["scaleway_project"] = "other-project"
+	labels["scaleway_zone"] = "fr-par-1"
+	fake.servers = []*instance.Server{testServer("srv-bad", "crabbox-cbx-bad", tagsFromLabels(labels), "203.0.113.13")}
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("mismatched project should be skipped as foreign ownership, got: %v", err)
+	}
+	if fake.deletedServer {
+		t.Fatal("mismatched project server was deleted")
+	}
+}
+
+func TestScalewayAmbiguousCreatePersistsRecoveryClaim(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	fake.createErr = context.DeadlineExceeded
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ambiguous"})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	claims, claimErr := core.ListLeaseClaims()
+	if claimErr != nil {
+		t.Fatal(claimErr)
+	}
+	if len(claims) != 1 {
+		t.Fatalf("claims=%#v", claims)
+	}
+	if claims[0].Provider != providerName || claims[0].Labels["recovery"] != "ambiguous-create" || claims[0].Labels["scaleway_ssh_key_name"] == "" || claims[0].Labels["scaleway_ssh_key_id"] == "" {
+		t.Fatalf("claim=%#v", claims[0])
+	}
+	if fake.deletedKey {
+		t.Fatal("ambiguous create must retain the managed Scaleway SSH key for recovery")
+	}
+}
+
+func TestScalewayReleaseRetainsIdentitylessRecoveryClaim(t *testing.T) {
+	backend, _ := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	labels := core.DirectLeaseLabels(cfg, "cbx_recover", "recover", providerName, "", false, backend.clockNow())
+	labels["recovery"] = "ambiguous-create"
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	server := core.Server{Provider: providerName, Name: "recover", Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig("cbx_recover", "recover", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_recover", Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "claim retained") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_recover", providerName); claimErr != nil || !ok {
+		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
+	}
+}
+
+func TestScalewayReleaseCleansClaimAndKeyWhenServerAlreadyDeleted(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	fake.deleteErr = &scw.ResourceNotFoundError{}
+	cfg := backend.cfgForRun()
+	labels := core.DirectLeaseLabels(cfg, "cbx_gone", "gone", providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-gone"
+	server := core.Server{Provider: providerName, CloudID: "srv-gone", Name: "gone", Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig("cbx_gone", "gone", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_gone", Server: server}}); err != nil {
+		t.Fatalf("ReleaseLease: %v", err)
+	}
+	if !fake.deletedKey {
+		t.Fatal("release did not delete managed SSH key after server not found")
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_gone", providerName); claimErr != nil || ok {
+		t.Fatalf("claim after stale release ok=%t err=%v", ok, claimErr)
+	}
+}
+
+func TestScalewayReleaseOnlyRefusesLiveServerWithChangedTags(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	cfg := backend.cfgForRun()
+	labels := core.DirectLeaseLabels(cfg, "cbx_stale", "stale", providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	labels["scaleway_ssh_key_id"] = "key-stale"
+	claimServer := core.Server{Provider: providerName, CloudID: "srv-stale", Name: "stale", Labels: labels}
+	if err := core.ClaimLeaseTargetForConfig("cbx_stale", "stale", cfg, claimServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	fake.server = testServer("srv-stale", "changed", []string{"foreign"}, "203.0.113.20")
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_stale", ReleaseOnly: true})
+	if err == nil || !strings.Contains(err.Error(), "non-Crabbox Scaleway") {
+		t.Fatalf("Resolve release-only err=%v", err)
+	}
+}
+
+func TestScalewayDoctorReportsInventoryAndMissingAuth(t *testing.T) {
+	backend, fake := newTestBackend(t)
+	labels := core.DirectLeaseLabels(backend.cfgForRun(), "cbx_doc", "doc", providerName, "", false, backend.clockNow())
+	labels["scaleway_project"] = "project-1"
+	labels["scaleway_zone"] = "fr-par-1"
+	fake.servers = []*instance.Server{testServer("srv-doc", "crabbox-cbx-doc", tagsFromLabels(labels), "203.0.113.14")}
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if result.Status != "ok" || !strings.Contains(result.Message, "leases=1") || strings.Contains(result.Message, "secret") {
+		t.Fatalf("doctor=%#v", result)
+	}
+	if fake.lastConfig.Scaleway.Zone != "fr-par-1" {
+		t.Fatalf("doctor did not use default-normalized config: %#v", fake.lastConfig.Scaleway)
+	}
+
+	backend.newClient = func(core.Config, core.Runtime) (Client, error) {
+		return nil, core.Exit(3, "SCW_SECRET_KEY or Scaleway SDK secret_key is required")
+	}
+	result, err = backend.Doctor(context.Background(), core.DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor missing auth: %v", err)
+	}
+	if result.Status != "failed" || !strings.Contains(result.Message, "SCW_SECRET_KEY") {
+		t.Fatalf("missing auth doctor=%#v", result)
+	}
+}
+
+func newTestBackend(t *testing.T) (*Backend, *fakeScalewayClient) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	fake := newFakeScalewayClient()
+	cfg := core.Config{
+		Provider: providerName,
+		TargetOS: core.TargetLinux,
+		SSHUser:  "root",
+		SSHPort:  "22",
+		WorkRoot: "/work/crabbox",
+		Class:    "standard",
+		Scaleway: core.ScalewayConfig{
+			Region:        "fr-par",
+			Zone:          "fr-par-1",
+			Image:         "ubuntu_noble",
+			Type:          "DEV1-S",
+			ProjectID:     "project-1",
+			SecurityGroup: "sg-1",
+		},
+	}
+	backend := &Backend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (Client, error) {
+			return fake, nil
+		},
+		waitSSH: func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil },
+		now:     func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	}
+	backend.newClient = func(cfg core.Config, rt core.Runtime) (Client, error) {
+		fake.lastConfig = cfg
+		return fake, nil
+	}
+	return backend, fake
+}
+
+type fakeScalewayClient struct {
+	instance *fakeInstanceAPI
+	iam      *fakeIAMAPI
+	market   *fakeMarketplaceAPI
+
+	servers         []*instance.Server
+	server          *instance.Server
+	keys            []*iam.SSHKey
+	lastCreate      *instance.CreateServerRequest
+	lastListOptions int
+	lastConfig      core.Config
+	userData        string
+	deletedServer   bool
+	deletedServerID string
+	deletedKey      bool
+	poweredOn       bool
+	createErr       error
+	deleteErr       error
+}
+
+func newFakeScalewayClient() *fakeScalewayClient {
+	f := &fakeScalewayClient{}
+	f.instance = &fakeInstanceAPI{f: f}
+	f.iam = &fakeIAMAPI{f: f}
+	f.market = &fakeMarketplaceAPI{}
+	return f
+}
+
+func (f *fakeScalewayClient) Instance() InstanceAPI       { return f.instance }
+func (f *fakeScalewayClient) IAM() IAMAPI                 { return f.iam }
+func (f *fakeScalewayClient) Marketplace() MarketplaceAPI { return f.market }
+func (f *fakeScalewayClient) ProjectID() string           { return "project-1" }
+func (f *fakeScalewayClient) OrganizationID() string      { return "org-1" }
+func (f *fakeScalewayClient) Region() string              { return "fr-par" }
+func (f *fakeScalewayClient) Zone() string                { return "fr-par-1" }
+
+type fakeInstanceAPI struct{ f *fakeScalewayClient }
+
+func (api *fakeInstanceAPI) ListServers(req *instance.ListServersRequest, opts ...scw.RequestOption) (*instance.ListServersResponse, error) {
+	api.f.lastListOptions = len(opts)
+	if api.f.servers != nil {
+		return &instance.ListServersResponse{Servers: api.f.servers}, nil
+	}
+	if api.f.server == nil {
+		return &instance.ListServersResponse{}, nil
+	}
+	return &instance.ListServersResponse{Servers: []*instance.Server{api.f.server}}, nil
+}
+
+func (api *fakeInstanceAPI) GetServer(req *instance.GetServerRequest, _ ...scw.RequestOption) (*instance.GetServerResponse, error) {
+	for _, server := range append(api.f.servers, api.f.server) {
+		if server != nil && server.ID == req.ServerID {
+			return &instance.GetServerResponse{Server: server}, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (api *fakeInstanceAPI) CreateServer(req *instance.CreateServerRequest, _ ...scw.RequestOption) (*instance.CreateServerResponse, error) {
+	api.f.lastCreate = req
+	if api.f.createErr != nil {
+		return nil, api.f.createErr
+	}
+	api.f.server = testServer("srv-1", req.Name, req.Tags, "203.0.113.10")
+	api.f.server.CommercialType = req.CommercialType
+	return &instance.CreateServerResponse{Server: api.f.server}, nil
+}
+
+func (api *fakeInstanceAPI) UpdateServer(req *instance.UpdateServerRequest, _ ...scw.RequestOption) (*instance.UpdateServerResponse, error) {
+	server := api.f.server
+	if server == nil {
+		for _, candidate := range api.f.servers {
+			if candidate.ID == req.ServerID {
+				server = candidate
+				break
+			}
+		}
+	}
+	if server == nil {
+		return nil, errors.New("not found")
+	}
+	if req.Tags != nil {
+		server.Tags = *req.Tags
+	}
+	return &instance.UpdateServerResponse{Server: server}, nil
+}
+
+func (api *fakeInstanceAPI) DeleteServer(req *instance.DeleteServerRequest, _ ...scw.RequestOption) error {
+	api.f.deletedServer = true
+	api.f.deletedServerID = req.ServerID
+	if api.f.deleteErr != nil {
+		return api.f.deleteErr
+	}
+	return nil
+}
+
+func (api *fakeInstanceAPI) SetServerUserData(req *instance.SetServerUserDataRequest, _ ...scw.RequestOption) error {
+	data, err := io.ReadAll(req.Content)
+	if err != nil {
+		return err
+	}
+	api.f.userData = string(data)
+	return nil
+}
+
+func (api *fakeInstanceAPI) ServerAction(req *instance.ServerActionRequest, _ ...scw.RequestOption) (*instance.ServerActionResponse, error) {
+	if req.Action == instance.ServerActionPoweron {
+		api.f.poweredOn = true
+	}
+	return &instance.ServerActionResponse{}, nil
+}
+
+type fakeIAMAPI struct{ f *fakeScalewayClient }
+
+func (api *fakeIAMAPI) ListSSHKeys(req *iam.ListSSHKeysRequest, _ ...scw.RequestOption) (*iam.ListSSHKeysResponse, error) {
+	return &iam.ListSSHKeysResponse{SSHKeys: api.f.keys}, nil
+}
+func (api *fakeIAMAPI) GetSSHKey(req *iam.GetSSHKeyRequest, _ ...scw.RequestOption) (*iam.SSHKey, error) {
+	for _, key := range api.f.keys {
+		if key.ID == req.SSHKeyID {
+			return key, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+func (api *fakeIAMAPI) CreateSSHKey(req *iam.CreateSSHKeyRequest, _ ...scw.RequestOption) (*iam.SSHKey, error) {
+	key := &iam.SSHKey{ID: "key-1", Name: req.Name, PublicKey: req.PublicKey, ProjectID: req.ProjectID}
+	api.f.keys = append(api.f.keys, key)
+	return key, nil
+}
+func (api *fakeIAMAPI) DeleteSSHKey(req *iam.DeleteSSHKeyRequest, _ ...scw.RequestOption) error {
+	api.f.deletedKey = true
+	return nil
+}
+
+type fakeMarketplaceAPI struct{}
+
+func (api *fakeMarketplaceAPI) GetLocalImageByLabel(req *marketplace.GetLocalImageByLabelRequest, _ ...scw.RequestOption) (*marketplace.LocalImage, error) {
+	if req.ImageLabel == "ubuntu_noble" && req.Zone == scw.Zone("fr-par-1") && strings.EqualFold(req.CommercialType, "DEV1-S") {
+		return &marketplace.LocalImage{ID: "image-1", Label: req.ImageLabel, Zone: req.Zone, CompatibleCommercialTypes: []string{"DEV1-S"}}, nil
+	}
+	return nil, errors.New("no image")
+}
+
+func testServer(id, name string, tags []string, publicIP string) *instance.Server {
+	return &instance.Server{
+		ID:             id,
+		Name:           name,
+		Project:        "project-1",
+		Organization:   "org-1",
+		Zone:           scw.Zone("fr-par-1"),
+		State:          instance.ServerStateRunning,
+		CommercialType: "DEV1-S",
+		Tags:           append([]string(nil), tags...),
+		PublicIP:       &instance.ServerIP{Address: net.ParseIP(publicIP), Dynamic: true},
+	}
+}

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -29,7 +29,10 @@ type InstanceAPI interface {
 	ListServers(req *instance.ListServersRequest, opts ...scw.RequestOption) (*instance.ListServersResponse, error)
 	GetServer(req *instance.GetServerRequest, opts ...scw.RequestOption) (*instance.GetServerResponse, error)
 	CreateServer(req *instance.CreateServerRequest, opts ...scw.RequestOption) (*instance.CreateServerResponse, error)
+	UpdateServer(req *instance.UpdateServerRequest, opts ...scw.RequestOption) (*instance.UpdateServerResponse, error)
 	DeleteServer(req *instance.DeleteServerRequest, opts ...scw.RequestOption) error
+	SetServerUserData(req *instance.SetServerUserDataRequest, opts ...scw.RequestOption) error
+	ServerAction(req *instance.ServerActionRequest, opts ...scw.RequestOption) (*instance.ServerActionResponse, error)
 }
 
 type IAMAPI interface {

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -1,0 +1,169 @@
+package scaleway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	instance "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	marketplace "github.com/scaleway/scaleway-sdk-go/api/marketplace/v2"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Client interface {
+	Instance() InstanceAPI
+	IAM() IAMAPI
+	Marketplace() MarketplaceAPI
+	ProjectID() string
+	OrganizationID() string
+	Region() string
+	Zone() string
+}
+
+type InstanceAPI interface {
+	ListServers(req *instance.ListServersRequest, opts ...scw.RequestOption) (*instance.ListServersResponse, error)
+	GetServer(req *instance.GetServerRequest, opts ...scw.RequestOption) (*instance.GetServerResponse, error)
+	CreateServer(req *instance.CreateServerRequest, opts ...scw.RequestOption) (*instance.CreateServerResponse, error)
+	DeleteServer(req *instance.DeleteServerRequest, opts ...scw.RequestOption) error
+}
+
+type IAMAPI interface {
+	ListSSHKeys(req *iam.ListSSHKeysRequest, opts ...scw.RequestOption) (*iam.ListSSHKeysResponse, error)
+	GetSSHKey(req *iam.GetSSHKeyRequest, opts ...scw.RequestOption) (*iam.SSHKey, error)
+	CreateSSHKey(req *iam.CreateSSHKeyRequest, opts ...scw.RequestOption) (*iam.SSHKey, error)
+	DeleteSSHKey(req *iam.DeleteSSHKeyRequest, opts ...scw.RequestOption) error
+}
+
+type MarketplaceAPI interface {
+	GetLocalImageByLabel(req *marketplace.GetLocalImageByLabelRequest, opts ...scw.RequestOption) (*marketplace.LocalImage, error)
+}
+
+type sdkClient struct {
+	client         *scw.Client
+	instanceAPI    InstanceAPI
+	iamAPI         IAMAPI
+	marketplaceAPI MarketplaceAPI
+	projectID      string
+	organizationID string
+	region         string
+	zone           string
+}
+
+func (c *sdkClient) Instance() InstanceAPI       { return c.instanceAPI }
+func (c *sdkClient) IAM() IAMAPI                 { return c.iamAPI }
+func (c *sdkClient) Marketplace() MarketplaceAPI { return c.marketplaceAPI }
+func (c *sdkClient) ProjectID() string           { return c.projectID }
+func (c *sdkClient) OrganizationID() string      { return c.organizationID }
+func (c *sdkClient) Region() string              { return c.region }
+func (c *sdkClient) Zone() string                { return c.zone }
+
+func newClient(cfg core.Config, rt core.Runtime) (Client, error) {
+	profile, err := scalewayProfileFromSDKConfig()
+	if err != nil {
+		return nil, err
+	}
+	envProfile := scw.LoadEnvProfile()
+	profile = scw.MergeProfiles(profile, envProfile)
+	applyCrabboxScalewayOverrides(profile, cfg)
+
+	accessKey := stringPtrValue(profile.AccessKey)
+	secretKey := stringPtrValue(profile.SecretKey)
+	switch {
+	case accessKey == "" && secretKey == "":
+		return nil, core.Exit(3, "SCW_ACCESS_KEY and SCW_SECRET_KEY or Scaleway SDK config credentials are required")
+	case accessKey == "":
+		return nil, core.Exit(3, "SCW_ACCESS_KEY or Scaleway SDK access_key is required")
+	case secretKey == "":
+		return nil, core.Exit(3, "SCW_SECRET_KEY or Scaleway SDK secret_key is required")
+	}
+
+	opts := []scw.ClientOption{scw.WithProfile(profile)}
+	if rt.HTTP != nil {
+		opts = append(opts, scw.WithHTTPClient(rt.HTTP))
+	}
+	client, err := scw.NewClient(opts...)
+	if err != nil {
+		return nil, core.Exit(3, "Scaleway SDK client configuration failed: %s", sanitizeSDKError(err))
+	}
+	out := &sdkClient{
+		client:         client,
+		instanceAPI:    instance.NewAPI(client),
+		iamAPI:         iam.NewAPI(client),
+		marketplaceAPI: marketplace.NewAPI(client),
+		projectID:      stringPtrValue(profile.DefaultProjectID),
+		organizationID: stringPtrValue(profile.DefaultOrganizationID),
+		region:         stringPtrValue(profile.DefaultRegion),
+		zone:           stringPtrValue(profile.DefaultZone),
+	}
+	if out.projectID == "" {
+		return nil, core.Exit(3, "SCW_DEFAULT_PROJECT_ID, CRABBOX_SCALEWAY_PROJECT_ID, or Scaleway SDK default_project_id is required")
+	}
+	return out, nil
+}
+
+func scalewayProfileFromSDKConfig() (*scw.Profile, error) {
+	cfg, err := scw.LoadConfig()
+	if err != nil {
+		var notFound *scw.ConfigFileNotFoundError
+		if errors.As(err, &notFound) {
+			return &scw.Profile{}, nil
+		}
+		return nil, core.Exit(3, "Scaleway SDK config load failed: %s", sanitizeSDKError(err))
+	}
+	profile, err := cfg.GetActiveProfile()
+	if err != nil {
+		return nil, core.Exit(3, "Scaleway SDK active profile load failed: %s", sanitizeSDKError(err))
+	}
+	return profile, nil
+}
+
+func applyCrabboxScalewayOverrides(profile *scw.Profile, cfg core.Config) {
+	if value := strings.TrimSpace(cfg.Scaleway.ProjectID); value != "" {
+		profile.DefaultProjectID = scw.StringPtr(value)
+	}
+	if value := strings.TrimSpace(cfg.Scaleway.OrganizationID); value != "" {
+		profile.DefaultOrganizationID = scw.StringPtr(value)
+	}
+	if value := strings.TrimSpace(cfg.Scaleway.Region); value != "" {
+		profile.DefaultRegion = scw.StringPtr(value)
+	}
+	if value := strings.TrimSpace(cfg.Scaleway.Zone); value != "" {
+		profile.DefaultZone = scw.StringPtr(value)
+	}
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func sanitizeSDKError(err error) string {
+	message := fmt.Sprint(err)
+	for _, env := range []string{
+		"SCW_ACCESS_KEY",
+		"SCW_SECRET_KEY",
+		"SCW_DEFAULT_ORGANIZATION_ID",
+		"SCW_DEFAULT_PROJECT_ID",
+		"SCW_DEFAULT_REGION",
+		"SCW_DEFAULT_ZONE",
+	} {
+		if value := strings.TrimSpace(os.Getenv(env)); value != "" {
+			message = strings.ReplaceAll(message, value, "<redacted>")
+		}
+	}
+	return message
+}
+
+func ensureClientUsableForPlan02(_ context.Context, client Client) error {
+	if client == nil || client.Instance() == nil || client.IAM() == nil || client.Marketplace() == nil {
+		return core.Exit(2, "scaleway client seam is incomplete")
+	}
+	return nil
+}

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -1,7 +1,6 @@
 package scaleway
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -162,11 +161,4 @@ func sanitizeSDKError(err error) string {
 		}
 	}
 	return message
-}
-
-func ensureClientUsableForPlan02(_ context.Context, client Client) error {
-	if client == nil || client.Instance() == nil || client.IAM() == nil || client.Marketplace() == nil {
-		return core.Exit(2, "scaleway client seam is incomplete")
-	}
-	return nil
 }

--- a/internal/providers/scaleway/client_test.go
+++ b/internal/providers/scaleway/client_test.go
@@ -1,0 +1,74 @@
+package scaleway
+
+import (
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestNewClientReportsMissingAuthWithoutSecrets(t *testing.T) {
+	clearScalewayEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_, err := newClient(core.Config{}, core.Runtime{})
+	if err == nil || !strings.Contains(err.Error(), "SCW_ACCESS_KEY and SCW_SECRET_KEY") {
+		t.Fatalf("newClient err=%v", err)
+	}
+}
+
+func TestNewClientReportsPartialAuthWithoutSecretValue(t *testing.T) {
+	clearScalewayEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("SCW_ACCESS_KEY", "SCW11111111111111111")
+	_, err := newClient(core.Config{}, core.Runtime{})
+	if err == nil || !strings.Contains(err.Error(), "SCW_SECRET_KEY") {
+		t.Fatalf("newClient err=%v", err)
+	}
+	if strings.Contains(err.Error(), "SCW11111111111111111") {
+		t.Fatalf("partial auth error leaked access key: %v", err)
+	}
+}
+
+func TestNewClientSanitizesSDKValidationError(t *testing.T) {
+	clearScalewayEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("SCW_ACCESS_KEY", "invalid-access-key")
+	t.Setenv("SCW_SECRET_KEY", "invalid-secret-key")
+	t.Setenv("CRABBOX_SCALEWAY_PROJECT_ID", "project-1")
+	_, err := newClient(core.Config{Scaleway: core.ScalewayConfig{ProjectID: "project-1"}}, core.Runtime{})
+	if err == nil {
+		t.Fatal("newClient unexpectedly succeeded")
+	}
+	text := err.Error()
+	for _, secret := range []string{"invalid-access-key", "invalid-secret-key"} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("SDK error leaked %q: %v", secret, err)
+		}
+	}
+	if !strings.Contains(text, "<redacted>") {
+		t.Fatalf("SDK error did not include redaction marker: %v", err)
+	}
+}
+
+func clearScalewayEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"SCW_ACCESS_KEY",
+		"SCW_SECRET_KEY",
+		"SCW_DEFAULT_ORGANIZATION_ID",
+		"SCW_DEFAULT_PROJECT_ID",
+		"SCW_DEFAULT_REGION",
+		"SCW_DEFAULT_ZONE",
+		"SCW_PROFILE",
+		"SCW_CONFIG_PATH",
+		"CRABBOX_SCALEWAY_PROJECT_ID",
+		"CRABBOX_SCALEWAY_ORGANIZATION_ID",
+		"CRABBOX_SCALEWAY_REGION",
+		"CRABBOX_SCALEWAY_ZONE",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/providers/scaleway/config.go
+++ b/internal/providers/scaleway/config.go
@@ -1,0 +1,64 @@
+package scaleway
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	defaultRegion = "fr-par"
+	defaultZone   = "fr-par-1"
+	defaultImage  = "ubuntu_noble"
+	defaultType   = "DEV1-S"
+)
+
+func regionForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.Scaleway.Region); value != "" {
+		return value
+	}
+	return defaultRegion
+}
+
+func zoneForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.Scaleway.Zone); value != "" {
+		return value
+	}
+	return defaultZone
+}
+
+func imageForConfig(cfg core.Config) string {
+	if value := strings.TrimSpace(cfg.Scaleway.Image); value != "" {
+		return value
+	}
+	return defaultImage
+}
+
+func serverTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if value := strings.TrimSpace(cfg.Scaleway.Type); value != "" {
+		return value
+	}
+	return scalewayServerTypeForClass(cfg.Class)
+}
+
+func validateFoundationConfig(cfg core.Config) error {
+	if strings.TrimSpace(regionForConfig(cfg)) == "" {
+		return core.Exit(2, "scaleway region is required")
+	}
+	if strings.TrimSpace(zoneForConfig(cfg)) == "" {
+		return core.Exit(2, "scaleway zone is required")
+	}
+	if core.OSImageWasExplicit(cfg) && strings.TrimSpace(cfg.Scaleway.Image) == "" {
+		return core.Exit(2, "provider=scaleway does not support os %q; set scaleway.image or CRABBOX_SCALEWAY_IMAGE to an explicit Scaleway image", cfg.OSImage)
+	}
+	if strings.TrimSpace(imageForConfig(cfg)) == "" {
+		return core.Exit(2, "scaleway image is required")
+	}
+	if strings.TrimSpace(serverTypeForConfig(cfg)) == "" {
+		return core.Exit(2, "scaleway type is required")
+	}
+	return nil
+}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1,0 +1,191 @@
+package scaleway
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const providerName = "scaleway"
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+type flagValues struct {
+	Region         *string
+	Zone           *string
+	Image          *string
+	Type           *string
+	ProjectID      *string
+	OrganizationID *string
+	SecurityGroup  *string
+	SSHCIDRs       *string
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return flagValues{
+		Region:         fs.String("scaleway-region", defaults.Scaleway.Region, "Scaleway region"),
+		Zone:           fs.String("scaleway-zone", defaults.Scaleway.Zone, "Scaleway zone"),
+		Image:          fs.String("scaleway-image", defaults.Scaleway.Image, "Scaleway image label or ID"),
+		Type:           fs.String("scaleway-type", defaults.Scaleway.Type, "Scaleway Instances commercial type"),
+		ProjectID:      fs.String("scaleway-project-id", defaults.Scaleway.ProjectID, "Scaleway project ID"),
+		OrganizationID: fs.String("scaleway-organization-id", defaults.Scaleway.OrganizationID, "Scaleway organization ID"),
+		SecurityGroup:  fs.String("scaleway-security-group", defaults.Scaleway.SecurityGroup, "Scaleway security group ID"),
+		SSHCIDRs:       fs.String("scaleway-ssh-cidrs", "", "comma-separated Scaleway SSH source CIDRs"),
+	}
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if core.FlagWasSet(fs, "scaleway-region") {
+		cfg.Scaleway.Region = *v.Region
+	}
+	if core.FlagWasSet(fs, "scaleway-zone") {
+		cfg.Scaleway.Zone = *v.Zone
+	}
+	if core.FlagWasSet(fs, "scaleway-image") {
+		cfg.Scaleway.Image = *v.Image
+		core.SetScalewayImageExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "scaleway-type") {
+		cfg.Scaleway.Type = *v.Type
+		core.SetScalewayTypeExplicit(cfg)
+	}
+	if core.FlagWasSet(fs, "scaleway-project-id") {
+		cfg.Scaleway.ProjectID = *v.ProjectID
+	}
+	if core.FlagWasSet(fs, "scaleway-organization-id") {
+		cfg.Scaleway.OrganizationID = *v.OrganizationID
+	}
+	if core.FlagWasSet(fs, "scaleway-security-group") {
+		cfg.Scaleway.SecurityGroup = *v.SecurityGroup
+	}
+	if core.FlagWasSet(fs, "scaleway-ssh-cidrs") {
+		cfg.Scaleway.SSHCIDRs = splitCommaList(*v.SSHCIDRs)
+	}
+	return nil
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	return validateFoundationConfig(cfg)
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return cfg.ServerType
+	}
+	if cfg.Scaleway.Type != "" {
+		return cfg.Scaleway.Type
+	}
+	return scalewayServerTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	return scalewayServerTypeForClass(class)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return &Backend{spec: p.Spec(), cfg: cfg, rt: rt, newClient: newClient}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "scaleway doctor backend unavailable")
+	}
+	return doctor, nil
+}
+
+type Backend struct {
+	spec      core.ProviderSpec
+	cfg       core.Config
+	rt        core.Runtime
+	newClient func(core.Config, core.Runtime) (Client, error)
+}
+
+func (b *Backend) Spec() core.ProviderSpec { return b.spec }
+
+func (b *Backend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error) {
+	if _, err := b.newClient(b.cfg, b.rt); err != nil {
+		return core.DoctorResult{Provider: providerName, Message: err.Error(), Status: "failed", Checks: []core.DoctorCheck{{
+			Status:  "failed",
+			Check:   "auth",
+			Message: err.Error(),
+			Details: map[string]string{"mutation": "false"},
+		}}}, nil
+	}
+	return core.DoctorResult{Provider: providerName, Message: "auth=ready mutation=false", Status: "ok", Checks: []core.DoctorCheck{{
+		Status:  "ok",
+		Check:   "auth",
+		Message: "auth=ready mutation=false",
+		Details: map[string]string{"mutation": "false"},
+	}}}, nil
+}
+
+func (b *Backend) Acquire(context.Context, core.AcquireRequest) (core.LeaseTarget, error) {
+	return core.LeaseTarget{}, core.Exit(2, "provider=scaleway acquire is not implemented yet")
+}
+
+func (b *Backend) Resolve(context.Context, core.ResolveRequest) (core.LeaseTarget, error) {
+	return core.LeaseTarget{}, core.Exit(2, "provider=scaleway resolve is not implemented yet")
+}
+
+func (b *Backend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) {
+	return nil, core.Exit(2, "provider=scaleway list is not implemented yet")
+}
+
+func (b *Backend) ReleaseLease(context.Context, core.ReleaseLeaseRequest) error {
+	return core.Exit(2, "provider=scaleway release is not implemented yet")
+}
+
+func (b *Backend) Touch(context.Context, core.TouchRequest) (core.Server, error) {
+	return core.Server{}, core.Exit(2, "provider=scaleway touch is not implemented yet")
+}
+
+func scalewayServerTypeForClass(class string) string {
+	switch class {
+	case "standard", "fast", "large", "beast":
+		return "DEV1-S"
+	default:
+		return "DEV1-S"
+	}
+}
+
+func splitCommaList(value string) []string {
+	if value == "" {
+		return nil
+	}
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -2,10 +2,21 @@ package scaleway
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
+	"time"
+
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	instance "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	marketplace "github.com/scaleway/scaleway-sdk-go/api/marketplace/v2"
+	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "scaleway"
@@ -126,12 +137,15 @@ type Backend struct {
 	cfg       core.Config
 	rt        core.Runtime
 	newClient func(core.Config, core.Runtime) (Client, error)
+	waitSSH   func(context.Context, *core.SSHTarget, string, time.Duration) error
+	now       func() time.Time
 }
 
 func (b *Backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *Backend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error) {
-	if _, err := b.newClient(b.cfg, b.rt); err != nil {
+func (b *Backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
 		return core.DoctorResult{Provider: providerName, Message: err.Error(), Status: "failed", Checks: []core.DoctorCheck{{
 			Status:  "failed",
 			Check:   "auth",
@@ -139,7 +153,17 @@ func (b *Backend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult
 			Details: map[string]string{"mutation": "false"},
 		}}}, nil
 	}
-	return core.DoctorResult{Provider: providerName, Message: "auth=ready mutation=false", Status: "ok", Checks: []core.DoctorCheck{{
+	servers, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return core.DoctorResult{}, err
+	}
+	count := 0
+	for _, item := range servers {
+		if b.ownedServer(item) {
+			count++
+		}
+	}
+	return core.DoctorResult{Provider: providerName, Message: fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d zone=%s project=%s", count, client.Zone(), client.ProjectID()), Status: "ok", Checks: []core.DoctorCheck{{
 		Status:  "ok",
 		Check:   "auth",
 		Message: "auth=ready mutation=false",
@@ -147,24 +171,662 @@ func (b *Backend) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult
 	}}}, nil
 }
 
-func (b *Backend) Acquire(context.Context, core.AcquireRequest) (core.LeaseTarget, error) {
-	return core.LeaseTarget{}, core.Exit(2, "provider=scaleway acquire is not implemented yet")
+func (b *Backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.rt, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
 }
 
-func (b *Backend) Resolve(context.Context, core.ResolveRequest) (core.LeaseTarget, error) {
-	return core.LeaseTarget{}, core.Exit(2, "provider=scaleway resolve is not implemented yet")
+func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
+	cfg := b.cfgForRun()
+	if err := validateFoundationConfig(cfg); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return core.LeaseTarget{}, core.Exit(2, "provider=scaleway only supports target=linux")
+	}
+	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key", cfg.Tailscale.AuthKeyEnv)
+	}
+	if len(cfg.Scaleway.SSHCIDRs) > 0 {
+		return core.LeaseTarget{}, core.Exit(2, "provider=scaleway does not yet manage security-group SSH CIDRs; attach a preconfigured scaleway.securityGroup or remove scaleway.sshCIDRs")
+	}
+	client, err := b.newClient(cfg, b.rt)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := core.NewLeaseID()
+	servers, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	coreServers := make([]core.Server, 0, len(servers))
+	for _, item := range servers {
+		if b.ownedServer(item) {
+			coreServers = append(coreServers, b.serverFromScaleway(item))
+		}
+	}
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, coreServers)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	cleanupKey := true
+	defer func() {
+		if cleanupKey {
+			core.RemoveStoredTestboxKey(leaseID)
+		}
+	}()
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	cfg.ServerType = serverTypeForConfig(cfg)
+	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
+		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
+	}
+	now := b.clockNow()
+	keyName := providerKeyName(leaseID)
+	sshKey, err := client.IAM().CreateSSHKey(&iam.CreateSSHKeyRequest{Name: keyName, PublicKey: publicKey, ProjectID: client.ProjectID()})
+	if err != nil {
+		if isAmbiguousScalewayError(err) {
+			if claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, client, "", "", "", keyName, "ambiguous-key-create", req.Keep, now); claimErr != nil {
+				return core.LeaseTarget{}, errors.Join(err, fmt.Errorf("persist Scaleway ambiguous key recovery: %w", claimErr))
+			}
+			cleanupKey = false
+		}
+		return core.LeaseTarget{}, err
+	}
+	labels := labelsFromTags(leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now))
+	labels["scaleway_project"] = client.ProjectID()
+	labels["scaleway_organization"] = client.OrganizationID()
+	labels["scaleway_region"] = client.Region()
+	labels["scaleway_zone"] = client.Zone()
+	labels["scaleway_ssh_key_id"] = sshKey.ID
+	labels["scaleway_ssh_key_name"] = sshKey.Name
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=scaleway lease=%s slug=%s type=%s zone=%s image=%s keep=%v\n", leaseID, slug, cfg.ServerType, client.Zone(), imageForConfig(cfg), req.Keep)
+	imageID, err := b.resolveImage(ctx, client, cfg)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	createReq := &instance.CreateServerRequest{
+		Zone:              scw.Zone(client.Zone()),
+		Name:              core.LeaseProviderName(leaseID, slug),
+		DynamicIPRequired: scw.BoolPtr(true),
+		CommercialType:    cfg.ServerType,
+		Image:             scw.StringPtr(imageID),
+		Project:           scw.StringPtr(client.ProjectID()),
+		Tags:              replaceCrabboxTags(nil, tagsFromLabels(labels)),
+	}
+	if sg := strings.TrimSpace(cfg.Scaleway.SecurityGroup); sg != "" {
+		createReq.SecurityGroup = scw.StringPtr(sg)
+	}
+	var created *instance.Server
+	committed := false
+	defer func() {
+		if err == nil || committed {
+			return
+		}
+		if created == nil || created.ID == "" {
+			if cleanupKey {
+				_ = client.IAM().DeleteSSHKey(&iam.DeleteSSHKeyRequest{SSHKeyID: sshKey.ID})
+			}
+			return
+		}
+		recovery := "rollback-cleanup"
+		if req.Keep {
+			recovery = "kept-after-failure"
+		}
+		claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, client, created.ID, publicIPv4(created), sshKey.ID, sshKey.Name, recovery, req.Keep, now)
+		if !req.Keep {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			deleteErr := client.Instance().DeleteServer(&instance.DeleteServerRequest{Zone: scw.Zone(client.Zone()), ServerID: created.ID})
+			keyErr := client.IAM().DeleteSSHKey(&iam.DeleteSSHKeyRequest{SSHKeyID: sshKey.ID})
+			if deleteErr != nil || keyErr != nil {
+				cleanupKey = false
+				err = errors.Join(err, fmt.Errorf("scaleway rollback cleanup failed"), claimErr, deleteErr, keyErr, cleanupCtx.Err())
+				return
+			}
+			if claimErr == nil {
+				core.RemoveLeaseClaim(leaseID)
+			}
+		} else {
+			cleanupKey = false
+			if claimErr != nil {
+				err = errors.Join(err, fmt.Errorf("persist kept Scaleway recovery: %w", claimErr))
+			}
+		}
+	}()
+	createResp, err := client.Instance().CreateServer(createReq)
+	if err != nil {
+		if isAmbiguousScalewayError(err) {
+			if claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, client, "", "", sshKey.ID, sshKey.Name, "ambiguous-create", req.Keep, now); claimErr != nil {
+				return core.LeaseTarget{}, errors.Join(err, fmt.Errorf("persist Scaleway ambiguous-create recovery: %w", claimErr))
+			}
+			cleanupKey = false
+		}
+		return core.LeaseTarget{}, err
+	}
+	created = createResp.Server
+	if created == nil || created.ID == "" {
+		err = core.Exit(5, "Scaleway create server response omitted server id")
+		return core.LeaseTarget{}, err
+	}
+	if err := client.Instance().SetServerUserData(&instance.SetServerUserDataRequest{
+		Zone:     scw.Zone(client.Zone()),
+		ServerID: created.ID,
+		Key:      "cloud-init",
+		Content:  strings.NewReader(core.CloudInitUserData(cfg, publicKey)),
+	}); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if _, err := client.Instance().ServerAction(&instance.ServerActionRequest{
+		Zone:     scw.Zone(client.Zone()),
+		ServerID: created.ID,
+		Action:   instance.ServerActionPoweron,
+	}); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	waited, err := b.waitForPublicIPv4(ctx, client, created.ID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	created = waited
+	server := b.serverFromScaleway(created)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if b.waitSSH == nil {
+		b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+			return core.WaitForSSHReady(ctx, target, b.rt.Stderr, phase, timeout)
+		}
+	}
+	if err := b.waitSSH(ctx, &ssh, "scaleway bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	readyLabels := labelsFromTags(leaseTags(cfg, leaseID, slug, "ready", req.Keep, now))
+	for key, value := range labels {
+		if strings.HasPrefix(key, "scaleway_") {
+			readyLabels[key] = value
+		}
+	}
+	updateResp, err := client.Instance().UpdateServer(&instance.UpdateServerRequest{
+		Zone:     scw.Zone(client.Zone()),
+		ServerID: created.ID,
+		Tags:     ptrTags(replaceCrabboxTags(created.Tags, tagsFromLabels(readyLabels))),
+	})
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if updateResp != nil && updateResp.Server != nil {
+		created = updateResp.Server
+	}
+	server = b.serverFromScaleway(created)
+	server.Labels = readyLabels
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	committed = true
+	cleanupKey = false
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s scaleway_server=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
 }
 
-func (b *Backend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) {
-	return nil, core.Exit(2, "provider=scaleway list is not implemented yet")
+func (b *Backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	servers, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	coreServers := make([]core.Server, 0, len(servers))
+	byID := map[string]*instance.Server{}
+	for _, item := range servers {
+		if !b.ownedServer(item) {
+			continue
+		}
+		server := b.serverFromScaleway(item)
+		coreServers = append(coreServers, server)
+		byID[server.CloudID] = item
+	}
+	server, leaseID, err := core.FindServerByAlias(coreServers, req.ID)
+	if err == nil && leaseID != "" {
+		return b.targetFromServer(ctx, client, byID[server.CloudID], req)
+	}
+	if err != nil && !req.ReleaseOnly {
+		return core.LeaseTarget{}, err
+	}
+	if item, ok := byID[strings.TrimSpace(req.ID)]; ok {
+		return b.targetFromServer(ctx, client, item, req)
+	}
+	if req.ReleaseOnly {
+		return b.releaseTargetFromClaim(ctx, client, req.ID)
+	}
+	return core.LeaseTarget{}, core.Exit(4, "lease/scaleway server not found: %s", req.ID)
 }
 
-func (b *Backend) ReleaseLease(context.Context, core.ReleaseLeaseRequest) error {
-	return core.Exit(2, "provider=scaleway release is not implemented yet")
+func (b *Backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
+		return nil, err
+	}
+	servers, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.LeaseView, 0, len(servers))
+	for _, item := range servers {
+		if b.ownedServer(item) {
+			out = append(out, b.serverFromScaleway(item))
+		}
+	}
+	return out, nil
 }
 
-func (b *Backend) Touch(context.Context, core.TouchRequest) (core.Server, error) {
-	return core.Server{}, core.Exit(2, "provider=scaleway touch is not implemented yet")
+func (b *Backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
+		return err
+	}
+	return b.deleteServer(ctx, client, req.Lease.Server)
+}
+
+func (b *Backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s scaleway_server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
+		return core.Server{}, err
+	}
+	item, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: req.Lease.Server.CloudID})
+	if err != nil {
+		return core.Server{}, err
+	}
+	if item.Server == nil {
+		return core.Server{}, core.Exit(4, "scaleway server not found: %s", req.Lease.Server.CloudID)
+	}
+	live := b.serverFromScaleway(item.Server)
+	if err := b.validateLiveServer(live, req.Lease.Server); err != nil {
+		return core.Server{}, err
+	}
+	cfg := b.cfgForRun()
+	labels := live.Labels
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+		labels = make(map[string]string, len(live.Labels))
+		for key, value := range live.Labels {
+			labels[key] = value
+		}
+		delete(labels, "idle_timeout")
+		delete(labels, "idle_timeout_secs")
+	}
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.clockNow())
+	updateResp, err := client.Instance().UpdateServer(&instance.UpdateServerRequest{
+		Zone:     scw.Zone(client.Zone()),
+		ServerID: item.Server.ID,
+		Tags:     ptrTags(replaceCrabboxTags(item.Server.Tags, tagsFromLabels(labels))),
+	})
+	if err != nil {
+		return core.Server{}, err
+	}
+	if updateResp != nil && updateResp.Server != nil {
+		live = b.serverFromScaleway(updateResp.Server)
+	}
+	live.Labels = labels
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
+	if claimErr != nil {
+		return core.Server{}, claimErr
+	}
+	if ok {
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(req.Lease.LeaseID, labels["slug"], cfg, live, req.Lease.SSH, claim.RepoRoot, req.IdleTimeout, false, claim, true); err != nil {
+			return core.Server{}, err
+		}
+	}
+	return live, nil
+}
+
+func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	client, err := b.newClient(b.cfgForRun(), b.rt)
+	if err != nil {
+		return err
+	}
+	servers, err := b.listScalewayServers(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, item := range servers {
+		server := b.serverFromScaleway(item)
+		if !b.ownedServer(item) {
+			fmt.Fprintf(b.rt.Stderr, "skip scaleway_server=%s reason=foreign-or-incomplete-ownership\n", item.ID)
+			continue
+		}
+		remove, reason := core.ShouldCleanupServer(server, b.clockNow())
+		if !remove {
+			fmt.Fprintf(b.rt.Stderr, "skip scaleway_server=%s reason=%s\n", item.ID, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would delete scaleway_server=%s lease=%s reason=%s\n", item.ID, server.Labels["lease"], reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "delete scaleway_server=%s lease=%s reason=%s\n", item.ID, server.Labels["lease"], reason)
+		if err := b.deleteServer(ctx, client, server); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *Backend) cfgForRun() core.Config {
+	cfg := b.cfg
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = core.TargetLinux
+	}
+	if cfg.SSHUser == "" {
+		cfg.SSHUser = "root"
+	}
+	if cfg.SSHPort == "" {
+		cfg.SSHPort = "22"
+	}
+	if cfg.WorkRoot == "" {
+		cfg.WorkRoot = "/work/crabbox"
+	}
+	cfg.Scaleway.Region = regionForConfig(cfg)
+	cfg.Scaleway.Zone = zoneForConfig(cfg)
+	cfg.Scaleway.Image = imageForConfig(cfg)
+	cfg.Scaleway.Type = serverTypeForConfig(cfg)
+	if cfg.ServerType == "" {
+		cfg.ServerType = cfg.Scaleway.Type
+	}
+	return cfg
+}
+
+func (b *Backend) listScalewayServers(_ context.Context, client Client) ([]*instance.Server, error) {
+	resp, err := client.Instance().ListServers(&instance.ListServersRequest{Zone: scw.Zone(client.Zone()), Project: scw.StringPtr(client.ProjectID()), Tags: []string{tagCrabbox, "crabbox:provider:" + providerName}}, scw.WithAllPages())
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.Servers, nil
+}
+
+func (b *Backend) resolveImage(_ context.Context, client Client, cfg core.Config) (string, error) {
+	image := imageForConfig(cfg)
+	if image == "" {
+		return "", core.Exit(2, "scaleway image is required")
+	}
+	local, err := client.Marketplace().GetLocalImageByLabel(&marketplace.GetLocalImageByLabelRequest{
+		ImageLabel:     image,
+		Zone:           scw.Zone(client.Zone()),
+		CommercialType: serverTypeForConfig(cfg),
+		Type:           marketplace.LocalImageTypeInstanceLocal,
+	})
+	if err == nil && local != nil && local.ID != "" {
+		return local.ID, nil
+	}
+	if strings.Contains(image, "-") || strings.Contains(image, "_") {
+		return image, nil
+	}
+	return "", err
+}
+
+func (b *Backend) targetFromServer(ctx context.Context, client Client, item *instance.Server, req core.ResolveRequest) (core.LeaseTarget, error) {
+	if item == nil {
+		return core.LeaseTarget{}, core.Exit(4, "lease/scaleway server not found: %s", req.ID)
+	}
+	server := b.serverFromScaleway(item)
+	if err := validateScalewayLabels(server.Labels); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if err := b.validateProviderIdentity(server.Labels, client); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	leaseID := server.Labels["lease"]
+	if req.ReleaseOnly {
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	ssh := core.SSHTargetFromConfig(b.cfgForRun(), server.PublicNet.IPv4.IP)
+	core.UseStoredTestboxKey(&ssh, leaseID)
+	if req.Repo.Root != "" && !req.NoLocalStateMutations {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.cfgForRun(), server, ssh, req.Repo.Root, b.cfgForRun().IdleTimeout, req.Reclaim, claim, exists); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	_ = ctx
+	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
+}
+
+func (b *Backend) releaseTargetFromClaim(_ context.Context, client Client, id string) (core.LeaseTarget, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(id, providerName)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if !ok {
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	if !ok {
+		return core.LeaseTarget{}, core.Exit(4, "lease/scaleway server not found: %s", id)
+	}
+	if err := validateScalewayLabels(claim.Labels); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if err := b.validateProviderIdentity(claim.Labels, client); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if strings.TrimSpace(claim.CloudID) != "" {
+		resp, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: claim.CloudID})
+		if err == nil && resp != nil && resp.Server != nil {
+			server := b.serverFromScaleway(resp.Server)
+			if err := validateScalewayLabels(server.Labels); err != nil {
+				return core.LeaseTarget{}, err
+			}
+			if err := b.validateProviderIdentity(server.Labels, client); err != nil {
+				return core.LeaseTarget{}, err
+			}
+			if server.Labels["lease"] != claim.LeaseID || server.Labels["slug"] != claim.Slug {
+				return core.LeaseTarget{}, core.Exit(2, "refusing to release Scaleway server %s from stale local claim", claim.CloudID)
+			}
+			return core.LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+		}
+		if err != nil && !isScalewayNotFound(err) {
+			return core.LeaseTarget{}, err
+		}
+	}
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
+	if parsed, err := strconv.ParseInt(claim.CloudID, 10, 64); err == nil {
+		server.ID = parsed
+	}
+	server.PublicNet.IPv4.IP = claim.SSHHost
+	ssh := core.SSHTargetFromConfig(b.cfgForRun(), claim.SSHHost)
+	if claim.SSHPort > 0 {
+		ssh.Port = strconv.Itoa(claim.SSHPort)
+	}
+	core.UseStoredTestboxKey(&ssh, claim.LeaseID)
+	return core.LeaseTarget{Server: server, LeaseID: claim.LeaseID, SSH: ssh}, nil
+}
+
+func (b *Backend) deleteServer(_ context.Context, client Client, server core.Server) error {
+	if err := validateScalewayLabels(server.Labels); err != nil {
+		return err
+	}
+	if err := b.validateProviderIdentity(server.Labels, client); err != nil {
+		return err
+	}
+	leaseID := server.Labels["lease"]
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return err
+	}
+	if exists && claim.Provider == providerName {
+		if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
+			return core.Exit(2, "refusing to release Scaleway server %s from stale local claim", server.CloudID)
+		}
+	}
+	if server.CloudID == "" {
+		return core.Exit(4, "scaleway recovery claim for lease=%s has no server identity; credentials and claim retained", leaseID)
+	}
+	if server.CloudID != "" {
+		err = client.Instance().DeleteServer(&instance.DeleteServerRequest{Zone: scw.Zone(client.Zone()), ServerID: server.CloudID})
+		if err != nil && !isScalewayNotFound(err) {
+			return err
+		}
+	}
+	if keyID := strings.TrimSpace(server.Labels["scaleway_ssh_key_id"]); keyID != "" {
+		if err := client.IAM().DeleteSSHKey(&iam.DeleteSSHKeyRequest{SSHKeyID: keyID}); err != nil && !isScalewayNotFound(err) {
+			return err
+		}
+	}
+	if exists && claim.Provider == providerName {
+		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			return fmt.Errorf("finalize Scaleway cleanup claim: %w", err)
+		}
+	} else {
+		core.RemoveLeaseClaim(leaseID)
+	}
+	core.RemoveStoredTestboxKey(leaseID)
+	return nil
+}
+
+func (b *Backend) waitForPublicIPv4(ctx context.Context, client Client, serverID string) (*instance.Server, error) {
+	deadline := b.clockNow().Add(5 * time.Minute)
+	for {
+		resp, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: serverID})
+		if err != nil {
+			return nil, err
+		}
+		if resp != nil && resp.Server != nil && publicIPv4(resp.Server) != "" {
+			return resp.Server, nil
+		}
+		if b.clockNow().After(deadline) {
+			return nil, core.Exit(5, "timed out waiting for Scaleway Instance public IPv4")
+		}
+		timer := time.NewTimer(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *Backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot string, client Client, serverID, host, keyID, keyName, recovery string, keep bool, now time.Time) error {
+	labels := labelsFromTags(leaseTags(cfg, leaseID, slug, "provisioning", keep, now))
+	labels["recovery"] = recovery
+	labels["scaleway_project"] = client.ProjectID()
+	labels["scaleway_organization"] = client.OrganizationID()
+	labels["scaleway_region"] = client.Region()
+	labels["scaleway_zone"] = client.Zone()
+	labels["scaleway_ssh_key_id"] = keyID
+	labels["scaleway_ssh_key_name"] = keyName
+	server := core.Server{Provider: providerName, CloudID: serverID, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	server.PublicNet.IPv4.IP = host
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	}
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
+}
+
+func (b *Backend) serverFromScaleway(item *instance.Server) core.Server {
+	if item == nil {
+		return core.Server{Provider: providerName}
+	}
+	labels := labelsFromTags(item.Tags)
+	if labels["provider_key"] == "" && labels["lease"] != "" {
+		labels["provider_key"] = core.ProviderKeyForLease(labels["lease"])
+	}
+	if labels["scaleway_project"] == "" {
+		labels["scaleway_project"] = item.Project
+	}
+	if labels["scaleway_organization"] == "" {
+		labels["scaleway_organization"] = item.Organization
+	}
+	if labels["scaleway_zone"] == "" {
+		labels["scaleway_zone"] = string(item.Zone)
+	}
+	server := core.Server{
+		CloudID:  item.ID,
+		Provider: providerName,
+		Name:     item.Name,
+		Status:   normalizeScalewayStatus(item.State),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = publicIPv4(item)
+	server.ServerType.Name = item.CommercialType
+	return server
+}
+
+func (b *Backend) ownedServer(item *instance.Server) bool {
+	if item == nil {
+		return false
+	}
+	labels := labelsFromTags(item.Tags)
+	if err := validateScalewayLabels(labels); err != nil {
+		return false
+	}
+	if labels["scaleway_project"] != "" && item.Project != "" && labels["scaleway_project"] != item.Project {
+		return false
+	}
+	if labels["scaleway_zone"] != "" && item.Zone != "" && labels["scaleway_zone"] != string(item.Zone) {
+		return false
+	}
+	return true
+}
+
+func (b *Backend) validateLiveServer(live, expected core.Server) error {
+	if err := validateScalewayLabels(live.Labels); err != nil {
+		return err
+	}
+	if live.CloudID != expected.CloudID ||
+		live.Labels["lease"] != expected.Labels["lease"] ||
+		live.Labels["slug"] != expected.Labels["slug"] ||
+		live.Labels["provider_key"] != expected.Labels["provider_key"] {
+		return core.Exit(2, "refusing to operate on changed Scaleway server %s", expected.CloudID)
+	}
+	return nil
+}
+
+func (b *Backend) validateProviderIdentity(labels map[string]string, client Client) error {
+	if expected := strings.TrimSpace(labels["scaleway_project"]); expected != "" && client.ProjectID() != "" && expected != client.ProjectID() {
+		return core.Exit(3, "scaleway project mismatch: current project %s does not match lease project %s", client.ProjectID(), expected)
+	}
+	if expected := strings.TrimSpace(labels["scaleway_zone"]); expected != "" && client.Zone() != "" && expected != client.Zone() {
+		return core.Exit(3, "scaleway zone mismatch: current zone %s does not match lease zone %s", client.Zone(), expected)
+	}
+	return nil
+}
+
+func (b *Backend) clockNow() time.Time {
+	if b.now != nil {
+		return b.now().UTC()
+	}
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
 }
 
 func scalewayServerTypeForClass(class string) string {
@@ -174,6 +836,84 @@ func scalewayServerTypeForClass(class string) string {
 	default:
 		return "DEV1-S"
 	}
+}
+
+func validateScalewayLabels(labels map[string]string) error {
+	if labels == nil ||
+		labels[ownershipTagConflictLabel] != "" ||
+		labels["crabbox"] != "true" ||
+		labels["created_by"] != "crabbox" ||
+		labels["provider"] != providerName ||
+		labels["lease"] == "" ||
+		labels["slug"] == "" ||
+		labels["target"] != core.TargetLinux {
+		return core.Exit(2, "refusing to operate on non-Crabbox Scaleway Instance")
+	}
+	return nil
+}
+
+func replaceCrabboxTags(existing, desired []string) []string {
+	tags := append([]string(nil), desired...)
+	for _, tag := range existing {
+		lower := strings.ToLower(strings.TrimSpace(tag))
+		if lower == tagCrabbox || strings.HasPrefix(lower, tagPrefix) {
+			continue
+		}
+		tags = append(tags, tag)
+	}
+	return normalizeTags(tags)
+}
+
+func publicIPv4(item *instance.Server) string {
+	if item == nil {
+		return ""
+	}
+	if item.PublicIP != nil && strings.Contains(item.PublicIP.Address.String(), ".") {
+		return item.PublicIP.Address.String()
+	}
+	for _, ip := range item.PublicIPs {
+		if ip != nil && strings.Contains(ip.Address.String(), ".") {
+			return ip.Address.String()
+		}
+	}
+	return ""
+}
+
+func normalizeScalewayStatus(state instance.ServerState) string {
+	switch state {
+	case instance.ServerStateRunning:
+		return "ready"
+	case "":
+		return "unknown"
+	default:
+		return string(state)
+	}
+}
+
+func providerKeyName(leaseID string) string {
+	return strings.ReplaceAll("crabbox-"+leaseID, "_", "-")
+}
+
+func ptrTags(tags []string) *[]string {
+	return &tags
+}
+
+func isScalewayNotFound(err error) bool {
+	var notFound *scw.ResourceNotFoundError
+	return errors.As(err, &notFound)
+}
+
+func isAmbiguousScalewayError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	text := strings.ToLower(err.Error())
+	for _, marker := range []string{"eof", "timeout", "timed out", "connection reset", "broken pipe", "transport is closing"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func splitCommaList(value string) []string {

--- a/internal/providers/scaleway/provider_test.go
+++ b/internal/providers/scaleway/provider_test.go
@@ -1,0 +1,83 @@
+package scaleway
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndServerType(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName || p.Aliases() != nil {
+		t.Fatalf("provider name/aliases=%q/%v", p.Name(), p.Aliases())
+	}
+	spec := p.Spec()
+	if spec.Kind != core.ProviderKindSSHLease || spec.Family != providerName || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+
+	cfg := core.Config{Scaleway: core.ScalewayConfig{Type: "DEV1-M"}}
+	if got := p.ServerTypeForConfig(cfg); got != "DEV1-M" {
+		t.Fatalf("server type=%q", got)
+	}
+	cfg.ServerType = "custom-type"
+	cfg.ServerTypeExplicit = true
+	if got := p.ServerTypeForConfig(cfg); got != "custom-type" {
+		t.Fatalf("explicit server type=%q", got)
+	}
+}
+
+func TestProviderApplyFlags(t *testing.T) {
+	p := Provider{}
+	cfg := core.Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := p.RegisterFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--scaleway-region", "nl-ams",
+		"--scaleway-zone", "nl-ams-1",
+		"--scaleway-image", "ubuntu_jammy",
+		"--scaleway-type", "DEV1-M",
+		"--scaleway-project-id", "project-1",
+		"--scaleway-organization-id", "org-1",
+		"--scaleway-security-group", "sg-1",
+		"--scaleway-ssh-cidrs", "203.0.113.0/24, 2001:db8::/64",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Scaleway.Region != "nl-ams" || cfg.Scaleway.Zone != "nl-ams-1" || cfg.Scaleway.Image != "ubuntu_jammy" || cfg.Scaleway.Type != "DEV1-M" || cfg.Scaleway.ProjectID != "project-1" || cfg.Scaleway.OrganizationID != "org-1" || cfg.Scaleway.SecurityGroup != "sg-1" {
+		t.Fatalf("flags not applied: %#v", cfg.Scaleway)
+	}
+	if !core.ScalewayImageWasExplicit(cfg) || !core.ScalewayTypeWasExplicit(cfg) {
+		t.Fatal("scaleway image/type flags should mark explicit provider values")
+	}
+	if strings.Join(cfg.Scaleway.SSHCIDRs, ",") != "203.0.113.0/24,2001:db8::/64" {
+		t.Fatalf("ssh cidrs=%v", cfg.Scaleway.SSHCIDRs)
+	}
+}
+
+func TestValidateFoundationConfigDefersUnsupportedPortableOS(t *testing.T) {
+	cfg := core.Config{OSImage: "ubuntu:26.04"}
+	core.SetOSImageExplicit(&cfg)
+	if err := (Provider{}).ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "provider=scaleway does not support os") {
+		t.Fatalf("ValidateConfig err=%v", err)
+	}
+	cfg.Scaleway.Image = "custom-image"
+	if err := (Provider{}).ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig with explicit image: %v", err)
+	}
+}

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -1,0 +1,192 @@
+package scaleway
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	tagCrabbox                = "crabbox"
+	tagPrefix                 = "crabbox:"
+	ownershipTagConflictLabel = "_scaleway_ownership_tag_conflict"
+)
+
+var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
+
+func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
+	}
+	return tagsFromLabels(labels)
+}
+
+func tagsFromLabels(labels map[string]string) []string {
+	tags := []string{
+		tagCrabbox,
+		"crabbox:provider:" + providerName,
+		"crabbox:target:" + core.TargetLinux,
+	}
+	for _, key := range tagLabelKeys() {
+		if value := labels[key]; value != "" {
+			tags = append(tags, encodeTagKV(key, value))
+		}
+	}
+	return normalizeTags(tags)
+}
+
+func tagLabelKeys() []string {
+	return []string{
+		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
+		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
+		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
+		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
+		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
+	}
+}
+
+func encodeTagKV(key, value string) string {
+	key = sanitizeTagPart(key)
+	if exactTagValueKey(key) {
+		key += "_v1"
+		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
+	}
+	return tagPrefix + key + ":" + sanitizeTagPart(value)
+}
+
+func sanitizeTagPart(value string) string {
+	value = strings.TrimSpace(value)
+	value = tagSafeRe.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "unknown"
+	}
+	if len(value) > 64 {
+		return value[:64]
+	}
+	return value
+}
+
+func exactTagValueKey(key string) bool {
+	switch key {
+	case "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node":
+		return true
+	default:
+		return false
+	}
+}
+
+func versionedExactTagValueKey(key string) (string, bool) {
+	logical := strings.TrimSuffix(key, "_v1")
+	return logical, logical != key && exactTagValueKey(logical)
+}
+
+func encodeExactTagValue(value string, maxLen int) string {
+	value = strings.TrimSpace(value)
+	const hex = "0123456789abcdef"
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == ':' {
+			if out.Len()+1 > maxLen {
+				break
+			}
+			out.WriteByte(ch)
+			continue
+		}
+		if out.Len()+3 > maxLen {
+			break
+		}
+		out.WriteByte('_')
+		out.WriteByte(hex[ch>>4])
+		out.WriteByte(hex[ch&0x0f])
+	}
+	if out.Len() == 0 {
+		return "unknown"
+	}
+	return out.String()
+}
+
+func decodeExactTagValue(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '_' && i+2 < len(value) {
+			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
+			if err == nil {
+				out.WriteByte(byte(decoded))
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(value[i])
+	}
+	return out.String()
+}
+
+func normalizeTags(tags []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func labelsFromTags(tags []string) map[string]string {
+	labels := map[string]string{}
+	ownershipConflicts := map[string]bool{}
+	for _, tag := range tags {
+		lowerTag := strings.ToLower(tag)
+		switch {
+		case lowerTag == tagCrabbox:
+			labels["crabbox"] = "true"
+			labels["created_by"] = "crabbox"
+		case strings.HasPrefix(lowerTag, tagPrefix):
+			parts := strings.SplitN(tag[len(tagPrefix):], ":", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			key := strings.ToLower(parts[0])
+			value := parts[1]
+			if logical, ok := versionedExactTagValueKey(key); ok {
+				labels[logical] = decodeExactTagValue(value)
+				continue
+			}
+			switch key {
+			case "provider", "lease", "slug", "target":
+				if prior := labels[key]; prior != "" && prior != value {
+					ownershipConflicts[key] = true
+				}
+				if key == "provider" || key == "target" {
+					value = strings.ToLower(value)
+				}
+				labels[key] = value
+			case "state":
+				labels[key] = strings.ToLower(value)
+			default:
+				labels[key] = value
+			}
+		}
+	}
+	if len(ownershipConflicts) > 0 {
+		keys := make([]string, 0, len(ownershipConflicts))
+		for key := range ownershipConflicts {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
+	}
+	return labels
+}

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -48,6 +48,7 @@ func tagLabelKeys() []string {
 		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
 		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
 		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
+		"recovery", "scaleway_project", "scaleway_organization", "scaleway_region", "scaleway_zone", "scaleway_ssh_key_id", "scaleway_ssh_key_name",
 	}
 }
 

--- a/internal/providers/scaleway/tags_test.go
+++ b/internal/providers/scaleway/tags_test.go
@@ -1,0 +1,58 @@
+package scaleway
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestLeaseTagsRoundTripOwnershipLabels(t *testing.T) {
+	cfg := core.Config{
+		Provider:   providerName,
+		TargetOS:   core.TargetLinux,
+		Class:      "standard",
+		ServerType: "DEV1-S",
+		Profile:    "daily",
+	}
+	tags := leaseTags(cfg, "cbx_123", "blue-box", "ready", true, time.Unix(1700000000, 0).UTC())
+	for _, want := range []string{tagCrabbox, "crabbox:provider:scaleway", "crabbox:target:linux", "crabbox:lease:cbx_123", "crabbox:slug:blue-box", "crabbox:state:ready"} {
+		if !containsTag(tags, want) {
+			t.Fatalf("tags=%v missing %q", tags, want)
+		}
+	}
+	labels := labelsFromTags(tags)
+	if labels["provider"] != providerName || labels["lease"] != "cbx_123" || labels["slug"] != "blue-box" || labels["state"] != "ready" || labels["target"] != core.TargetLinux {
+		t.Fatalf("labels=%v", labels)
+	}
+}
+
+func TestExactTagsPreserveTailscaleValues(t *testing.T) {
+	labels := map[string]string{
+		"provider":           providerName,
+		"lease":              "cbx_123",
+		"slug":               "blue-box",
+		"target":             core.TargetLinux,
+		"tailscale_hostname": "cbx-blue.example.ts.net",
+		"tailscale_tags":     "tag:ci,tag:dev",
+	}
+	tags := tagsFromLabels(labels)
+	joined := strings.Join(tags, " ")
+	if strings.Contains(joined, "tag:ci,tag:dev") {
+		t.Fatalf("tailscale tags were not encoded: %v", tags)
+	}
+	got := labelsFromTags(tags)
+	if got["tailscale_hostname"] != "cbx-blue.example.ts.net" || got["tailscale_tags"] != "tag:ci,tag:dev" {
+		t.Fatalf("decoded labels=%v tags=%v", got, tags)
+	}
+}
+
+func containsTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/scaleway/types.go
+++ b/internal/providers/scaleway/types.go
@@ -1,0 +1,33 @@
+package scaleway
+
+type Server struct {
+	ID        string
+	Name      string
+	State     string
+	PublicIP  string
+	Zone      string
+	Type      string
+	Image     string
+	Tags      []string
+	ProjectID string
+}
+
+type SSHKey struct {
+	ID          string
+	Name        string
+	PublicKey   string
+	ProjectID   string
+	Fingerprint string
+}
+
+type Image struct {
+	ID    string
+	Label string
+	Name  string
+	Zone  string
+}
+
+type ServerType struct {
+	Name string
+	Zone string
+}

--- a/scripts/live-scaleway-smoke.sh
+++ b/scripts/live-scaleway-smoke.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo="${CRABBOX_LIVE_REPO:-$root}"
+cb="${CRABBOX_BIN:-$root/bin/crabbox}"
+if [[ "$cb" != /* ]]; then
+  cb="$PWD/$cb"
+fi
+
+run_crabbox() {
+  (cd "$repo" && "$cb" "$@")
+}
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-scaleway}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ "$item" == "scaleway" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+redact_output() {
+  local output="$1"
+  local secret
+  for secret in "${SCW_ACCESS_KEY:-}" "${SCW_SECRET_KEY:-}"; do
+    if [[ -n "$secret" ]]; then
+      output="${output//"$secret"/[redacted]}"
+    fi
+  done
+  printf '%s\n' "$output"
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *capacity* || "$lower" == *"insufficient funds"* || "$lower" == *"not enough"* || "$lower" == *"resource exhausted"* || "$lower" == *"limit exceeded"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  redact_output "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  redact_output "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  redact_output "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print("Scaleway Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+local_testbox_key_snapshot() {
+  local roots=(
+    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
+    "$HOME/Library/Application Support/crabbox/testboxes"
+  )
+  local root
+  for root in "${roots[@]}"; do
+    if [ -d "$root" ]; then
+      find "$root" -type f -print
+    fi
+  done | sort -u
+}
+
+cleanup_armed=0
+slug="scaleway-smoke-$(date +%Y%m%d%H%M%S)-$$"
+config_file=""
+initial_local_key_snapshot=""
+
+cleanup() {
+  local status=$?
+  if [ "$cleanup_armed" -eq 1 ]; then
+    local cleanup_output=""
+    local cleanup_status=1
+    local attempt
+    local cleanup_attempts="${CRABBOX_SCALEWAY_CLEANUP_ATTEMPTS:-65}"
+    for ((attempt = 1; attempt <= cleanup_attempts; attempt++)); do
+      set +e
+      cleanup_output="$(run_crabbox stop --provider scaleway "$slug" 2>&1)"
+      cleanup_status=$?
+      set -e
+      if [ "$cleanup_status" -eq 0 ]; then
+        cleanup_armed=0
+        break
+      fi
+      local lower_cleanup_output
+      lower_cleanup_output="$(printf '%s' "$cleanup_output" | tr '[:upper:]' '[:lower:]')"
+      if [ "$cleanup_status" -eq 4 ] && [[ "$lower_cleanup_output" == *"lease/scaleway server not found:"* || "$lower_cleanup_output" == *"scaleway server not found"* ]]; then
+        local current_local_key_snapshot
+        current_local_key_snapshot="$(local_testbox_key_snapshot)"
+        if [ "$current_local_key_snapshot" = "$initial_local_key_snapshot" ]; then
+          cleanup_status=0
+          cleanup_armed=0
+          break
+        fi
+      fi
+      if [ "$attempt" -lt "$cleanup_attempts" ]; then
+        sleep 2
+      fi
+    done
+    if [ "$cleanup_status" -ne 0 ]; then
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider scaleway $slug" "$cleanup_status" "$slug" >&2
+      redact_output "$cleanup_output" >&2
+      if [ "$status" -eq 0 ]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  if [ -n "$config_file" ]; then
+    rm -f "$config_file"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=scaleway_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+for required in SCW_ACCESS_KEY SCW_SECRET_KEY; do
+  if [[ -z "${!required:-}" ]]; then
+    printf 'classification=environment_blocked reason=%s_missing\n' "$required"
+    exit 0
+  fi
+done
+
+scaleway_project_id="${CRABBOX_SCALEWAY_PROJECT_ID:-${SCW_DEFAULT_PROJECT_ID:-}}"
+scaleway_organization_id="${CRABBOX_SCALEWAY_ORGANIZATION_ID:-${SCW_DEFAULT_ORGANIZATION_ID:-}}"
+scaleway_region="${CRABBOX_SCALEWAY_REGION:-${SCW_DEFAULT_REGION:-}}"
+scaleway_zone="${CRABBOX_SCALEWAY_ZONE:-${SCW_DEFAULT_ZONE:-}}"
+scaleway_image="${CRABBOX_SCALEWAY_IMAGE:-ubuntu_noble}"
+scaleway_type="${CRABBOX_SCALEWAY_TYPE:-DEV1-S}"
+
+if [[ -z "$scaleway_organization_id" ]]; then
+  printf 'classification=environment_blocked reason=SCW_DEFAULT_ORGANIZATION_ID_missing\n'
+  exit 0
+fi
+
+if [[ -z "$scaleway_project_id" ]]; then
+  printf 'classification=environment_blocked reason=SCW_DEFAULT_PROJECT_ID_missing\n'
+  exit 0
+fi
+
+if [[ -z "$scaleway_region" ]]; then
+  printf 'classification=environment_blocked reason=SCW_DEFAULT_REGION_missing\n'
+  exit 0
+fi
+
+if [[ -z "$scaleway_zone" ]]; then
+  printf 'classification=environment_blocked reason=SCW_DEFAULT_ZONE_missing\n'
+  exit 0
+fi
+
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$root/bin"
+  (cd "$root" && go build -trimpath -o "$cb" ./cmd/crabbox)
+elif [[ ! -x "$cb" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_BIN_not_executable path=%q\n' "$cb"
+  exit 0
+fi
+
+config_file="$(mktemp)"
+cat >"$config_file" <<YAML
+provider: scaleway
+target: linux
+scaleway:
+  region: "$scaleway_region"
+  zone: "$scaleway_zone"
+  image: "$scaleway_image"
+  type: "$scaleway_type"
+  projectId: "$scaleway_project_id"
+  organizationId: "$scaleway_organization_id"
+YAML
+
+export CRABBOX_CONFIG="$config_file"
+export CRABBOX_COORDINATOR=
+export SCW_ACCESS_KEY
+export SCW_SECRET_KEY
+
+doctor_output="$(run_capture "bin/crabbox doctor --provider scaleway" run_crabbox doctor --provider scaleway)"
+printf '%s\n' "$doctor_output"
+initial_list_output="$(run_capture "bin/crabbox list --provider scaleway --json" run_crabbox list --provider scaleway --json)"
+validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$initial_list_output"
+initial_local_key_snapshot="$(local_testbox_key_snapshot)"
+cleanup_armed=1
+run_capture "bin/crabbox warmup --provider scaleway --slug $slug --keep --type $scaleway_type --ttl 20m --idle-timeout 5m" run_crabbox warmup --provider scaleway --slug "$slug" --keep --type "$scaleway_type" --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "bin/crabbox status --provider scaleway --id $slug --wait --wait-timeout 300s" run_crabbox status --provider scaleway --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_capture "bin/crabbox run --provider scaleway --id $slug --no-sync -- echo ok" run_crabbox run --provider scaleway --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "bin/crabbox list --provider scaleway --json" run_crabbox list --provider scaleway --json)"
+printf '%s\n' "$list_output"
+validate_list_json_contains_slug "bin/crabbox list --provider scaleway --json" "$list_output"
+run_capture "bin/crabbox stop --provider scaleway $slug" run_crabbox stop --provider scaleway "$slug" >/dev/null
+cleanup_output="$(run_capture "bin/crabbox cleanup --provider scaleway --dry-run" run_crabbox cleanup --provider scaleway --dry-run)"
+post_list_output="$(run_capture "bin/crabbox list --provider scaleway --json" run_crabbox list --provider scaleway --json)"
+validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$post_list_output"
+cleanup_armed=0
+printf '%s\n' "$cleanup_output"
+printf '%s\n' "$post_list_output"
+printf 'classification=live_scaleway_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-scaleway-smoke.test.js
+++ b/scripts/live-scaleway-smoke.test.js
@@ -1,0 +1,571 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function prepareSmokeRepo(dir) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, "live-scaleway-smoke.sh");
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, "scripts", "live-scaleway-smoke.sh"), smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}
+
+const validEnv = {
+  CRABBOX_LIVE: "1",
+  CRABBOX_LIVE_PROVIDERS: "scaleway",
+  SCW_ACCESS_KEY: "test-scaleway-access",
+  SCW_SECRET_KEY: "test-scaleway-secret",
+  SCW_DEFAULT_ORGANIZATION_ID: "org-test",
+  SCW_DEFAULT_PROJECT_ID: "project-test",
+  SCW_DEFAULT_REGION: "fr-par",
+  SCW_DEFAULT_ZONE: "fr-par-1",
+};
+
+test("live scaleway smoke skips unless opted in", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-skip-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: { ...process.env, CRABBOX_LIVE: "", SCW_SECRET_KEY: "" },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_LIVE_not_enabled/);
+});
+
+test("live scaleway smoke requires provider selection", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-filter-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      CRABBOX_LIVE_PROVIDERS: "aws,digitalocean",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=scaleway_not_selected/);
+});
+
+test("live scaleway smoke validates required env before building", () => {
+  const cases = [
+    ["SCW_ACCESS_KEY", /reason=SCW_ACCESS_KEY_missing/],
+    ["SCW_SECRET_KEY", /reason=SCW_SECRET_KEY_missing/],
+    ["SCW_DEFAULT_ORGANIZATION_ID", /reason=SCW_DEFAULT_ORGANIZATION_ID_missing/],
+    ["SCW_DEFAULT_PROJECT_ID", /reason=SCW_DEFAULT_PROJECT_ID_missing/],
+    ["SCW_DEFAULT_REGION", /reason=SCW_DEFAULT_REGION_missing/],
+    ["SCW_DEFAULT_ZONE", /reason=SCW_DEFAULT_ZONE_missing/],
+  ];
+
+  for (const [missing, reason] of cases) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `crabbox-live-scaleway-${missing}-`));
+    const binDir = path.join(dir, "bin");
+    const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+    fs.mkdirSync(binDir, { recursive: true });
+    writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+    const result = spawnSync("bash", [smokeScript], {
+      cwd: tempRoot,
+      env: {
+        ...process.env,
+        ...validEnv,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        [missing]: "",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, reason);
+  }
+});
+
+test("live scaleway smoke runs guarded lifecycle and redacts keys", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${SCW_ACCESS_KEY:-}" != "test-scaleway-access" || "\${SCW_SECRET_KEY:-}" != "test-scaleway-secret" ]]; then
+  printf 'missing scaleway auth\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 region=fr-par zone=fr-par-1 type=DEV1-S\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip scaleway_server=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_scaleway_smoke_passed/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-scaleway-access|test-scaleway-secret/);
+
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider scaleway");
+  assert.equal(seen[1], "list --provider scaleway --json");
+  assert.match(seen[2], /^warmup --provider scaleway --slug scaleway-smoke-\d{14}-\d+ --keep --type DEV1-S --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider scaleway --id scaleway-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider scaleway --id scaleway-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider scaleway --json");
+  assert.match(seen[6], /^stop --provider scaleway scaleway-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "cleanup --provider scaleway --dry-run");
+  assert.equal(seen[8], "list --provider scaleway --json");
+});
+
+test("live scaleway smoke builds from the script root when cwd differs", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-cwd-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$PWD:$*" >>"${calls}"
+case "$1" in
+  doctor|cleanup)
+    printf 'auth=ready\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status|run|stop)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+      touch "${slugFile}.stopped"
+    fi
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_scaleway_smoke_passed/);
+  const firstCall = fs.readFileSync(calls, "utf8").trim().split("\n")[0];
+  const normalizeMacTmpPath = (value) => value.replace(/^\/private\/var\//, "/var/");
+  assert.equal(
+    normalizeMacTmpPath(firstCall),
+    `${normalizeMacTmpPath(tempRoot)}:doctor --provider scaleway`,
+  );
+});
+
+test("live scaleway smoke honors CRABBOX_BIN and CRABBOX_LIVE_REPO overrides", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-bin-"));
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const candidateDir = path.join(dir, "candidate");
+  const candidateBin = path.join(candidateDir, "candidate-crabbox");
+  const liveRepo = path.join(dir, "live-repo");
+  const calls = path.join(dir, "candidate-calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(candidateDir, { recursive: true });
+  fs.mkdirSync(liveRepo, { recursive: true });
+
+  writeExecutable(
+    candidateBin,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$PWD:$*" >>"${calls}"
+case "$1" in
+  doctor|cleanup)
+    printf 'auth=ready\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status|run|stop)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+      touch "${slugFile}.stopped"
+    fi
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      ...validEnv,
+      CRABBOX_BIN: candidateBin,
+      CRABBOX_LIVE_REPO: liveRepo,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_scaleway_smoke_passed/);
+  const firstCall = fs.readFileSync(calls, "utf8").trim().split("\n")[0];
+  const normalizeMacTmpPath = (value) => value.replace(/^\/private\/var\//, "/var/");
+  assert.equal(
+    normalizeMacTmpPath(firstCall),
+    `${normalizeMacTmpPath(liveRepo)}:doctor --provider scaleway`,
+  );
+  assert.equal(fs.existsSync(path.join(tempRoot, "bin", "crabbox")), false);
+});
+
+test("live scaleway smoke attempts targeted cleanup after partial failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopped = path.join(dir, "stopped.log");
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "$1" == "doctor" ]]; then
+  printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "list" ]]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'created scaleway instance before failing\\n' >&2
+  exit 37
+fi
+if [[ "$1" == "stop" ]]; then
+  printf '%s\\n' "$4" >>"${stopped}"
+  exit 0
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=environment_blocked/);
+  assert.match(result.stderr, /created scaleway instance before failing/);
+  assert.match(fs.readFileSync(stopped, "utf8"), /^scaleway-smoke-\d{14}-\d+\n$/);
+  assert.doesNotMatch(fs.readFileSync(calls, "utf8"), /^cleanup /m);
+});
+
+test("live scaleway smoke refuses non-empty initial inventory before mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-nonempty-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[{"labels":{"slug":"existing"}}]\\n'
+    ;;
+  *)
+    printf 'mutation must not run\\n' >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /Scaleway Crabbox inventory is not empty/);
+  assert.deepEqual(fs.readFileSync(calls, "utf8").trim().split("\n"), [
+    "doctor --provider scaleway",
+    "list --provider scaleway --json",
+  ]);
+});
+
+test("live scaleway smoke classifies quota output and redacts leaked keys", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-quota-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf 'quota exceeded for key %s secret %s\\n' "\${SCW_ACCESS_KEY}" "\${SCW_SECRET_KEY}" >&2
+    exit 42
+    ;;
+  stop)
+    exit 0
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=quota_blocked/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-scaleway-access|test-scaleway-secret/);
+  assert.match(result.stderr, /\[redacted\]/);
+});
+
+test("live scaleway smoke treats not-found cleanup after quota as nothing to clean", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-quota-notfound-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  warmup)
+    printf 'quota exceeded before server allocation\\n' >&2
+    exit 42
+    ;;
+  stop)
+    printf 'lease/scaleway server not found: %s\\n' "$4" >&2
+    exit 4
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=quota_blocked/);
+  assert.doesNotMatch(result.stderr, /classification=cleanup_failed/);
+});
+
+test("live scaleway smoke keeps cleanup armed until final inventory is empty", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-final-list-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const stopAttempts = path.join(dir, "stop-attempts.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  warmup)
+    printf '%s\\n' "$5" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf '%s\\n' "$4" >>"${stopAttempts}"
+    ;;
+  cleanup)
+    printf 'skip scaleway_server=none reason=missing labels\\n'
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.equal(fs.readFileSync(stopAttempts, "utf8").trim().split("\n").length, 2);
+});

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -894,6 +894,10 @@ if has_provider hetzner; then
   provider_smoke hetzner --class "${CRABBOX_LIVE_HETZNER_CLASS:-standard}" --ttl 15m --idle-timeout 2m
 fi
 
+if has_provider scaleway; then
+  "$root/scripts/live-scaleway-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi


### PR DESCRIPTION
Closes #366

## Summary
- Add Scaleway as a direct Linux SSH-lease provider with typed non-secret config, SDK client setup, provider registration, and secret-safe config display.
- Implement the Scaleway lease lifecycle: acquire, list, resolve, touch, release, cleanup, recovery/rollback safety, per-lease IAM SSH keys, cloud-init bootstrap, all-pages inventory, ownership-tag validation, and doctor readiness.
- Add Scaleway provider documentation, generated provider matrix metadata, and a guarded live smoke script with deterministic tests and explicit live-environment classifications.

## Verification
- `go test ./internal/cli ./internal/providers/scaleway ./internal/providers/all ./cmd/crabbox`
- `go test ./...`
- `go vet ./...`
- `node --test scripts/live-scaleway-smoke.test.js`
- `node scripts/check-provider-matrix.mjs`
- `bash scripts/check-docs.sh`
- `bash scripts/live-scaleway-smoke.sh` -> `classification=environment_blocked reason=CRABBOX_LIVE_not_enabled` without live Scaleway gates, so no live resource creation was attempted.
- Built `bin/crabbox` and verified from outside the repo that `crabbox providers --json` reports `scaleway` as `ssh-lease` with `ssh`, `crabbox-sync`, `cleanup`, and `tailscale`.

## Review Fixes
- Kept Scaleway smoke cleanup armed through final empty-inventory proof.
- Rooted the smoke script to its own repo path when invoked from another working directory.
- Treated not-found cleanup after failed create as clean only when the local key snapshot is unchanged.
- Honored `CRABBOX_BIN` and `CRABBOX_LIVE_REPO` so generic live-smoke runs test the selected candidate binary.