### PR TITLE
Add Nebius provider

### DIFF
--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -222,6 +222,9 @@ list, and cleanup.
   remain outside Crabbox.
 - **namespace-devbox** — Namespace owns Devbox auth and lifecycle through the
   `devbox` CLI; Crabbox treats the prepared Devbox as a normal Linux SSH lease.
+- **nebius** — creates a Nebius Compute VM through the authenticated `nebius`
+  CLI, injects a per-lease SSH key with cloud-init, waits for dynamic public
+  IPv4 and SSH readiness, then uses normal Crabbox SSH sync/run/release.
 - **runpod** — leases a RunPod GPU pod with public SSH (no Tailscale); auth from
   `RUNPOD_API_KEY`.
 - **semaphore** — creates a standalone Semaphore job, waits for host/port metadata

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,6 +61,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_L
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -78,6 +79,11 @@ Per-provider smoke prerequisites:
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
+- **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and
+  `nebius.subnetId`. `scripts/live-nebius-smoke.sh` is coordinator-free,
+  requires explicit `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius`, creates one
+  short-lived CPU-default VM, verifies status and `echo ok`, stops the lease,
+  runs dry-run cleanup, and prints a final classification.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 
@@ -95,6 +101,10 @@ Use `scripts/live-digitalocean-smoke.sh` for the repeatable direct DigitalOcean
 equivalent; it builds `bin/crabbox`, creates a guarded `digitalocean` scratch
 config, and verifies the Crabbox-owned inventory is empty before create and
 after stop/cleanup.
+Use `scripts/live-nebius-smoke.sh` for the repeatable direct Nebius equivalent;
+it builds or reuses `bin/crabbox`, uses the documented Nebius config and CLI
+profile, creates a unique `nebius-smoke-*` lease, and verifies the slug is absent
+after stop and dry-run cleanup.
 
 ## Deployment
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -60,7 +60,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 56 providers (32 SSH lease, 23 delegated run, 1 service control).
+Current built-in surface: 57 providers (33 SSH lease, 23 delegated run, 1 service control).
 
 Access terms:
 
@@ -105,6 +105,7 @@ Access terms:
 | [mxc](mxc.md) (`execution-container`) | built-in; `delegated-run` · local-sandbox | No SSH; `provider-owned` · direct only; features: none | `windows/normal`; Microsoft Execution Container | `local`; GPU: no | Windows runtime; container termination | Local isolated Windows command execution | Windows host and execution-container support required |
 | [namespace-devbox](namespace-devbox.md) (`namespace`, `namespace-devboxes`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Devbox | `provider-managed`; GPU: unknown | Namespace devbox CLI; stop by default; optional delete | Fast managed development box over SSH | Uses the devbox product, not Namespace Compute instances |
 | [namespace-instance](namespace-instance.md) (`namespace-compute`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Namespace Compute instance | `provider-managed`; GPU: unknown | Namespace nsc CLI; instance delete | Short-lived managed Linux compute over SSH | Requires the nsc CLI and direct provider credentials |
+| [nebius](nebius.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Nebius Compute VM | `cloud`; GPU: optional | Nebius CLI; owned VM delete | Direct Linux VM lease with optional GPU selection | Requires Nebius CLI auth, project/subnet setup, quota, and public SSH |
 | [nvidia-brev](nvidia-brev.md) (`brev`, `nvidia`) | built-in; `ssh-lease` · gpu-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; NVIDIA Brev GPU workspace | `provider-managed`; GPU: yes | NVIDIA Brev CLI; delete by default; optional stop | Managed NVIDIA GPU workspace over SSH | Requires Brev CLI auth, quota, and available GPU capacity |
 | [opencomputer](opencomputer.md) (`oc`, `open-computer`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; OpenComputer Linux VM | `provider-managed`; GPU: unknown | OpenComputer; VM delete | Hosted delegated Linux VM execution | REST execution contract, not an SSH lease |
 | [opensandbox](opensandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; OpenSandbox sandbox | `provider-managed`; GPU: unknown | OpenSandbox; sandbox delete | Hosted delegated sandbox through an open SDK | Requires compatible OpenSandbox control and exec endpoints |

--- a/docs/providers/nebius.md
+++ b/docs/providers/nebius.md
@@ -1,0 +1,318 @@
+# Nebius Provider
+
+Read this when you are:
+
+- choosing `provider: nebius`;
+- validating a direct Nebius Compute lease;
+- changing `internal/providers/nebius` or the guarded live smoke.
+
+Nebius is a Linux-only **SSH lease** provider. Crabbox shells out to the local
+`nebius` CLI, creates a VM in a configured parent/project and subnet, injects a
+per-lease SSH key through cloud-init, labels the VM with Crabbox ownership
+metadata, waits for a public IPv4 address and SSH readiness, then uses the
+normal Crabbox SSH sync, `run`, `status`, `list`, `stop`, and `cleanup` path.
+
+Crabbox does not store or accept Nebius secrets. Authentication stays in Nebius
+CLI profiles or service-account profiles managed by the Nebius CLI.
+
+Nebius is **direct-only** in this release. It does not run through the Crabbox
+coordinator, so the local CLI process must have Nebius credentials and direct
+cleanup remains the operator's responsibility.
+
+## Prerequisites
+
+- Install the Nebius CLI and authenticate it with the profile you want Crabbox
+  to use.
+- Confirm the CLI can list instances in the target parent/project:
+
+  ```sh
+  nebius compute instance list --parent-id <parent-id> --format json
+  ```
+
+- Choose a subnet that can attach dynamic public IPv4 addresses.
+- Keep OpenSSH and `rsync` available locally for Crabbox's SSH workflow.
+- Use an account with enough VM, disk, network, public IP, and optional GPU
+  quota for the configured platform and preset.
+
+Do not pass service-account JSON, OAuth tokens, API keys, or private keys to
+Crabbox config or command-line flags. Configure those through Nebius-owned
+credential stores and select them with `nebius.profile` or `--nebius-profile`.
+
+## Capabilities
+
+| Capability | Supported |
+| --- | --- |
+| OS targets | Linux only |
+| SSH | Yes, Crabbox-managed SSH |
+| Crabbox sync (rsync over SSH) | Yes |
+| Provider-managed sync | No |
+| Desktop / browser / code | No |
+| Actions hydration | Yes, as a normal Linux SSH lease |
+| Coordinator (broker) | No - direct only |
+| Tailscale | No in phase 1 |
+| Cleanup | Yes, for complete Crabbox-owned Nebius VMs in the configured scope |
+
+Aliases: none.
+
+## Configuration
+
+```yaml
+provider: nebius
+target: linux
+nebius:
+  cli: nebius
+  profile: ""
+  parentId: project-example
+  subnetId: subnet-example
+  platform: cpu-d3
+  preset: 4vcpu-16gb
+  imageFamily: ubuntu24.04-driverless
+  diskType: network_ssd
+  diskSizeGiB: 50
+  user: crabbox
+  publicIP: dynamic
+  securityGroupIds: []
+  serviceAccountId: ""
+  recoveryPolicy: fail
+```
+
+Required for lifecycle operations:
+
+- `nebius.parentId`
+- `nebius.subnetId`
+
+Defaults:
+
+- `cli`: `nebius`
+- `platform`: `cpu-d3`
+- `preset`: `4vcpu-16gb`
+- `imageFamily`: `ubuntu24.04-driverless`
+- `diskType`: `network_ssd`
+- `diskSizeGiB`: `50`
+- `user`: `crabbox`
+- `publicIP`: `dynamic`
+- `recoveryPolicy`: `fail`
+
+Provider flags:
+
+```text
+--nebius-cli
+--nebius-profile
+--nebius-parent-id
+--nebius-subnet-id
+--nebius-platform
+--nebius-preset
+--nebius-image-family
+--nebius-disk-type
+--nebius-disk-size-gib
+--nebius-user
+--nebius-public-ip
+--nebius-security-group-ids
+--nebius-service-account-id
+--nebius-recovery-policy
+```
+
+Environment overrides:
+
+```text
+CRABBOX_NEBIUS_CLI
+CRABBOX_NEBIUS_PROFILE
+CRABBOX_NEBIUS_PARENT_ID
+CRABBOX_NEBIUS_SUBNET_ID
+CRABBOX_NEBIUS_PLATFORM
+CRABBOX_NEBIUS_PRESET
+CRABBOX_NEBIUS_IMAGE_FAMILY
+CRABBOX_NEBIUS_DISK_TYPE
+CRABBOX_NEBIUS_DISK_SIZE_GIB
+CRABBOX_NEBIUS_USER
+CRABBOX_NEBIUS_PUBLIC_IP
+CRABBOX_NEBIUS_SECURITY_GROUP_IDS
+CRABBOX_NEBIUS_SERVICE_ACCOUNT_ID
+CRABBOX_NEBIUS_RECOVERY_POLICY
+```
+
+`--nebius-cli` and `nebius.cli` are trusted-local settings. Project-local
+untrusted config cannot redirect the Nebius CLI path. Authentication material is
+never accepted as a Crabbox flag or config key.
+
+## Lifecycle
+
+### Doctor
+
+`doctor` is read-only:
+
+```sh
+crabbox doctor --provider nebius
+crabbox doctor --provider nebius --json
+```
+
+It validates the configured CLI surface, parent/project inventory access, target
+subnet, image family, and the selected platform or preset without creating or
+deleting a VM.
+
+### Acquire
+
+`warmup` and `run` create cost-bearing Nebius VMs:
+
+```sh
+crabbox warmup --provider nebius --slug my-app --keep --ttl 20m
+crabbox run --provider nebius --no-sync -- echo ok
+```
+
+Acquire flow:
+
+1. list instances in `nebius.parentId` to allocate a Crabbox slug;
+2. generate a per-lease SSH key in the local Crabbox testbox key store;
+3. render cloud-init for `nebius.user`;
+4. create a Nebius Compute instance with the configured platform, preset, image
+   family, boot disk type, disk size, subnet, optional security groups, optional
+   service account, and dynamic public IP by default;
+5. wait until the instance is running and exposes a public IPv4 address;
+6. wait for SSH readiness;
+7. update labels from provisioning to ready;
+8. write a local Crabbox lease claim and run the normal SSH workflow.
+
+Crabbox names Nebius instances with its normal `crabbox-<slug>-<lease-suffix>`
+pattern and labels them with both generic direct-lease labels and Nebius-specific
+scope labels.
+
+### GPU and image selection
+
+The default Nebius profile is CPU-oriented. To use a GPU VM, select a Nebius
+platform, preset, image family, and disk size that match the desired accelerator
+and account quota:
+
+```sh
+crabbox run \
+  --provider nebius \
+  --nebius-platform gpu-h100 \
+  --nebius-preset 1gpu-16vcpu-200gb \
+  --nebius-image-family ubuntu22.04-cuda \
+  --nebius-disk-size-gib 120 \
+  -- nvidia-smi
+```
+
+Crabbox does not infer GPU driver readiness beyond the selected Nebius image.
+Use a CUDA-ready image family or bootstrap the workload yourself.
+
+### Public IP and Tailscale
+
+`nebius.publicIP` supports `dynamic` and `none` at configuration validation time,
+but the phase 1 provider requires a reachable public IPv4 address before it can
+complete acquisition. Use `dynamic` for normal Crabbox runs.
+
+Tailscale routing is rejected for `provider=nebius` in this release. The provider
+is direct public-SSH only until a private-network path is implemented and live
+proven.
+
+### Release and cleanup
+
+Stop deletes the owned Nebius VM and removes local lease state:
+
+```sh
+crabbox stop --provider nebius my-app
+```
+
+`--id` accepts the canonical lease id, friendly slug, Nebius instance id, or
+Nebius instance name when it resolves to a complete Crabbox-owned VM in the
+configured scope.
+
+Cleanup only mutates VMs with a complete Crabbox Nebius ownership predicate:
+
+```sh
+crabbox cleanup --provider nebius --dry-run
+crabbox cleanup --provider nebius
+```
+
+The ownership predicate includes the Crabbox marker, provider, target, lease,
+slug, expiration, normalized Nebius parent/project id, optional profile, and a
+scope hash derived from provider, profile, parent/project, and subnet. Foreign,
+partial, malformed, or differently scoped Crabbox-looking VMs are skipped or
+refused rather than deleted.
+
+If create returns an indeterminate Nebius CLI error, Crabbox retains a recovery
+claim when possible. Retry `crabbox stop --provider nebius <lease-or-slug>` after
+checking Nebius inventory rather than deleting same-named resources manually.
+
+## Examples
+
+Run a short CPU command and delete the VM afterward:
+
+```sh
+crabbox run --provider nebius --no-sync -- echo ok
+```
+
+Warm a reusable VM, run a command, then release it:
+
+```sh
+crabbox warmup --provider nebius --slug my-app --keep --ttl 30m
+crabbox run --provider nebius --id my-app --no-sync -- uname -a
+crabbox status --provider nebius --id my-app --wait
+crabbox stop --provider nebius my-app
+```
+
+Use a named Nebius profile and explicit network scope:
+
+```sh
+crabbox run \
+  --provider nebius \
+  --nebius-profile dev \
+  --nebius-parent-id project-example \
+  --nebius-subnet-id subnet-example \
+  -- echo ok
+```
+
+## Guarded live smoke
+
+The repeatable live check is opt-in because it creates a billable Nebius VM:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
+```
+
+The script builds `bin/crabbox` when needed, checks `doctor`, creates a small
+CPU-default lease with a unique `nebius-smoke-*` slug, waits for ready status,
+runs `echo ok`, verifies `list --json`, stops the lease, runs dry-run cleanup,
+and verifies the slug is absent from the final list output.
+
+Final classifications include:
+
+```text
+classification=live_nebius_smoke_passed
+classification=environment_blocked
+classification=quota_blocked
+classification=validation_failed
+```
+
+The script exits without live operations unless both `CRABBOX_LIVE=1` and
+`CRABBOX_LIVE_PROVIDERS=nebius` are present. Missing credentials, CLI profile,
+parent/project, subnet, or local tools are reported as `environment_blocked`.
+Quota, capacity, rate-limit, or limit errors are reported as `quota_blocked`.
+
+If cleanup fails, use the reported slug with:
+
+```sh
+crabbox list --provider nebius --json
+crabbox stop --provider nebius <slug>
+crabbox cleanup --provider nebius --dry-run
+```
+
+## Gotchas
+
+- Nebius is direct-only. Coordinator secrets and broker-side cost controls do
+  not cover these VMs.
+- Dynamic public IP is the practical phase 1 mode. `publicIP: none` prevents the
+  provider from completing SSH acquisition.
+- `parentId`, `subnetId`, and optional `profile` are part of cleanup scope.
+  Switching them can make existing local claims unresolvable until the original
+  scope is restored.
+- `securityGroupIds` must allow inbound SSH from the operator network.
+- `recoveryPolicy` currently supports `fail` only.
+- The generated provider matrix is updated from the live CLI provider spec plus
+  `docs/providers/provider-metadata.json`; do not hand-edit the generated table.
+
+## Related Docs
+
+- [Provider reference](README.md)
+- [Provider feature guide](../features/providers.md)
+- [Operations guide](../operations.md)

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -489,6 +489,20 @@
     "caveat": "Requires Brev CLI auth, quota, and available GPU capacity",
     "docs": "nvidia-brev.md"
   },
+  "nebius": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Nebius Compute VM",
+    "location": "cloud",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "optional",
+    "lifecycle": "Nebius CLI",
+    "cleanup": "owned VM delete",
+    "bestFit": "Direct Linux VM lease with optional GPU selection",
+    "caveat": "Requires Nebius CLI auth, project/subnet setup, quota, and public SSH",
+    "docs": "nebius.md"
+  },
   "namespace-devbox": {
     "status": "built-in",
     "category": "direct-cloud",

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	Linode                        LinodeConfig
 	linodeImageExplicit           bool
 	linodeTypeExplicit            bool
+	Nebius                        NebiusConfig
 	OVH                           OVHConfig
 	ovhImageExplicit              bool
 	Incus                         IncusConfig
@@ -241,6 +242,25 @@ type LinodeConfig struct {
 	Type       string
 	FirewallID string
 	SSHCIDRs   []string
+}
+
+// NebiusConfig is intentionally non-secret. Authentication stays in the
+// Nebius CLI profile store and is never accepted as Crabbox config or argv.
+type NebiusConfig struct {
+	CLI              string
+	Profile          string
+	ParentID         string
+	SubnetID         string
+	Platform         string
+	Preset           string
+	ImageFamily      string
+	DiskType         string
+	DiskSizeGiB      int
+	User             string
+	PublicIP         string
+	SecurityGroupIDs []string
+	ServiceAccountID string
+	RecoveryPolicy   string
 }
 
 // OVHConfig contains non-secret OVHcloud Public Cloud settings. OVH
@@ -1382,6 +1402,60 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
+	if cfg.Provider == "nebius" {
+		if cfg.Nebius.CLI == "" {
+			cfg.Nebius.CLI = "nebius"
+		}
+		if cfg.Nebius.Platform == "" {
+			cfg.Nebius.Platform = "cpu-d3"
+		}
+		if cfg.Nebius.Preset == "" {
+			cfg.Nebius.Preset = "4vcpu-16gb"
+		}
+		if cfg.Nebius.ImageFamily == "" {
+			cfg.Nebius.ImageFamily = "ubuntu24.04-driverless"
+		}
+		if cfg.Nebius.DiskType == "" {
+			cfg.Nebius.DiskType = "network_ssd"
+		}
+		if cfg.Nebius.DiskSizeGiB == 0 {
+			cfg.Nebius.DiskSizeGiB = 50
+		}
+		if cfg.Nebius.User == "" {
+			cfg.Nebius.User = "crabbox"
+		}
+		if cfg.Nebius.PublicIP == "" {
+			cfg.Nebius.PublicIP = "dynamic"
+		}
+		if cfg.Nebius.RecoveryPolicy == "" {
+			cfg.Nebius.RecoveryPolicy = "fail"
+		}
+		if !IsTargetExplicit(cfg) {
+			cfg.TargetOS = targetLinux
+		}
+		if cfg.explicitWindowsMode != "" {
+			cfg.WindowsMode = cfg.explicitWindowsMode
+		} else {
+			cfg.WindowsMode = windowsModeNormal
+		}
+		if cfg.explicitWorkRoot != "" {
+			cfg.WorkRoot = cfg.explicitWorkRoot
+		} else {
+			cfg.WorkRoot = defaultPOSIXWorkRoot
+		}
+		if cfg.explicitSSHUser != "" {
+			cfg.SSHUser = cfg.explicitSSHUser
+		} else {
+			cfg.SSHUser = cfg.Nebius.User
+		}
+		if cfg.explicitSSHPort != "" {
+			cfg.SSHPort = cfg.explicitSSHPort
+		} else {
+			cfg.SSHPort = baseConfig().SSHPort
+		}
+		normalizeTargetConfig(cfg)
+		return validateTargetConfig(*cfg)
+	}
 	if cfg.Provider == "ovh" {
 		if cfg.OVH.Endpoint == "" {
 			cfg.OVH.Endpoint = "https://api.us.ovhcloud.com/1.0"
@@ -2093,6 +2167,17 @@ func baseConfig() Config {
 			Target:        "container",
 			WorkRoot:      "/tmp/crabbox",
 		},
+		Nebius: NebiusConfig{
+			CLI:            "nebius",
+			Platform:       "cpu-d3",
+			Preset:         "4vcpu-16gb",
+			ImageFamily:    "ubuntu24.04-driverless",
+			DiskType:       "network_ssd",
+			DiskSizeGiB:    50,
+			User:           "crabbox",
+			PublicIP:       "dynamic",
+			RecoveryPolicy: "fail",
+		},
 		Hostinger: HostingerConfig{
 			APIURL:         "https://developers.hostinger.com",
 			HostnamePrefix: "crabbox",
@@ -2323,6 +2408,7 @@ type fileConfig struct {
 	Hetzner                  *fileHetznerConfig                  `yaml:"hetzner,omitempty"`
 	DigitalOcean             *fileDigitalOceanConfig             `yaml:"digitalocean,omitempty"`
 	Linode                   *fileLinodeConfig                   `yaml:"linode,omitempty"`
+	Nebius                   *fileNebiusConfig                   `yaml:"nebius,omitempty"`
 	OVH                      *fileOVHConfig                      `yaml:"ovh,omitempty"`
 	AWS                      *fileAWSConfig                      `yaml:"aws,omitempty"`
 	Azure                    *fileAzureConfig                    `yaml:"azure,omitempty"`
@@ -2433,6 +2519,23 @@ type fileLinodeConfig struct {
 	Type       string   `yaml:"type,omitempty"`
 	FirewallID string   `yaml:"firewall,omitempty"`
 	SSHCIDRs   []string `yaml:"sshCIDRs,omitempty"`
+}
+
+type fileNebiusConfig struct {
+	CLI              string   `yaml:"cli,omitempty"`
+	Profile          string   `yaml:"profile,omitempty"`
+	ParentID         string   `yaml:"parentId,omitempty"`
+	SubnetID         string   `yaml:"subnetId,omitempty"`
+	Platform         string   `yaml:"platform,omitempty"`
+	Preset           string   `yaml:"preset,omitempty"`
+	ImageFamily      string   `yaml:"imageFamily,omitempty"`
+	DiskType         string   `yaml:"diskType,omitempty"`
+	DiskSizeGiB      int      `yaml:"diskSizeGiB,omitempty"`
+	User             string   `yaml:"user,omitempty"`
+	PublicIP         string   `yaml:"publicIP,omitempty"`
+	SecurityGroupIDs []string `yaml:"securityGroupIds,omitempty"`
+	ServiceAccountID string   `yaml:"serviceAccountId,omitempty"`
+	RecoveryPolicy   string   `yaml:"recoveryPolicy,omitempty"`
 }
 
 type fileOVHConfig struct {
@@ -3673,6 +3776,50 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if len(file.Linode.SSHCIDRs) > 0 {
 			cfg.Linode.SSHCIDRs = file.Linode.SSHCIDRs
+		}
+	}
+	if file.Nebius != nil {
+		if trusted && file.Nebius.CLI != "" {
+			cfg.Nebius.CLI = file.Nebius.CLI
+		}
+		if file.Nebius.Profile != "" {
+			cfg.Nebius.Profile = file.Nebius.Profile
+		}
+		if file.Nebius.ParentID != "" {
+			cfg.Nebius.ParentID = file.Nebius.ParentID
+		}
+		if file.Nebius.SubnetID != "" {
+			cfg.Nebius.SubnetID = file.Nebius.SubnetID
+		}
+		if file.Nebius.Platform != "" {
+			cfg.Nebius.Platform = file.Nebius.Platform
+		}
+		if file.Nebius.Preset != "" {
+			cfg.Nebius.Preset = file.Nebius.Preset
+		}
+		if file.Nebius.ImageFamily != "" {
+			cfg.Nebius.ImageFamily = file.Nebius.ImageFamily
+		}
+		if file.Nebius.DiskType != "" {
+			cfg.Nebius.DiskType = file.Nebius.DiskType
+		}
+		if file.Nebius.DiskSizeGiB > 0 {
+			cfg.Nebius.DiskSizeGiB = file.Nebius.DiskSizeGiB
+		}
+		if file.Nebius.User != "" {
+			cfg.Nebius.User = file.Nebius.User
+		}
+		if file.Nebius.PublicIP != "" {
+			cfg.Nebius.PublicIP = file.Nebius.PublicIP
+		}
+		if len(file.Nebius.SecurityGroupIDs) > 0 {
+			cfg.Nebius.SecurityGroupIDs = file.Nebius.SecurityGroupIDs
+		}
+		if file.Nebius.ServiceAccountID != "" {
+			cfg.Nebius.ServiceAccountID = file.Nebius.ServiceAccountID
+		}
+		if file.Nebius.RecoveryPolicy != "" {
+			cfg.Nebius.RecoveryPolicy = file.Nebius.RecoveryPolicy
 		}
 	}
 	if file.OVH != nil {
@@ -5828,6 +5975,22 @@ func applyEnv(cfg *Config) error {
 	if cidrs := os.Getenv("CRABBOX_LINODE_SSH_CIDRS"); cidrs != "" {
 		cfg.Linode.SSHCIDRs = splitCommaList(cidrs)
 	}
+	cfg.Nebius.CLI = getenv("CRABBOX_NEBIUS_CLI", cfg.Nebius.CLI)
+	cfg.Nebius.Profile = getenv("CRABBOX_NEBIUS_PROFILE", cfg.Nebius.Profile)
+	cfg.Nebius.ParentID = getenv("CRABBOX_NEBIUS_PARENT_ID", cfg.Nebius.ParentID)
+	cfg.Nebius.SubnetID = getenv("CRABBOX_NEBIUS_SUBNET_ID", cfg.Nebius.SubnetID)
+	cfg.Nebius.Platform = getenv("CRABBOX_NEBIUS_PLATFORM", cfg.Nebius.Platform)
+	cfg.Nebius.Preset = getenv("CRABBOX_NEBIUS_PRESET", cfg.Nebius.Preset)
+	cfg.Nebius.ImageFamily = getenv("CRABBOX_NEBIUS_IMAGE_FAMILY", cfg.Nebius.ImageFamily)
+	cfg.Nebius.DiskType = getenv("CRABBOX_NEBIUS_DISK_TYPE", cfg.Nebius.DiskType)
+	cfg.Nebius.DiskSizeGiB = getenvInt("CRABBOX_NEBIUS_DISK_SIZE_GIB", cfg.Nebius.DiskSizeGiB)
+	cfg.Nebius.User = getenv("CRABBOX_NEBIUS_USER", cfg.Nebius.User)
+	cfg.Nebius.PublicIP = getenv("CRABBOX_NEBIUS_PUBLIC_IP", cfg.Nebius.PublicIP)
+	if groups := os.Getenv("CRABBOX_NEBIUS_SECURITY_GROUP_IDS"); groups != "" {
+		cfg.Nebius.SecurityGroupIDs = splitCommaList(groups)
+	}
+	cfg.Nebius.ServiceAccountID = getenv("CRABBOX_NEBIUS_SERVICE_ACCOUNT_ID", cfg.Nebius.ServiceAccountID)
+	cfg.Nebius.RecoveryPolicy = getenv("CRABBOX_NEBIUS_RECOVERY_POLICY", cfg.Nebius.RecoveryPolicy)
 	cfg.OVH.Endpoint = getenv("OVH_ENDPOINT", cfg.OVH.Endpoint)
 	cfg.OVH.ProjectID = getenv("CRABBOX_OVH_PROJECT_ID", cfg.OVH.ProjectID)
 	cfg.OVH.Region = getenv("CRABBOX_OVH_REGION", cfg.OVH.Region)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3782,7 +3782,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if trusted && file.Nebius.CLI != "" {
 			cfg.Nebius.CLI = file.Nebius.CLI
 		}
-		if file.Nebius.Profile != "" {
+		if trusted && file.Nebius.Profile != "" {
 			cfg.Nebius.Profile = file.Nebius.Profile
 		}
 		if file.Nebius.ParentID != "" {
@@ -3815,7 +3815,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if len(file.Nebius.SecurityGroupIDs) > 0 {
 			cfg.Nebius.SecurityGroupIDs = file.Nebius.SecurityGroupIDs
 		}
-		if file.Nebius.ServiceAccountID != "" {
+		if trusted && file.Nebius.ServiceAccountID != "" {
 			cfg.Nebius.ServiceAccountID = file.Nebius.ServiceAccountID
 		}
 		if file.Nebius.RecoveryPolicy != "" {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -170,6 +170,23 @@ func configShowView(cfg Config) map[string]any {
 			"user":          cfg.NvidiaBrev.User,
 			"workRoot":      cfg.NvidiaBrev.WorkRoot,
 		},
+		"nebius": map[string]any{
+			"cli":              cfg.Nebius.CLI,
+			"auth":             "cli",
+			"profile":          cfg.Nebius.Profile,
+			"parentId":         cfg.Nebius.ParentID,
+			"subnetId":         cfg.Nebius.SubnetID,
+			"platform":         cfg.Nebius.Platform,
+			"preset":           cfg.Nebius.Preset,
+			"imageFamily":      cfg.Nebius.ImageFamily,
+			"diskType":         cfg.Nebius.DiskType,
+			"diskSizeGiB":      cfg.Nebius.DiskSizeGiB,
+			"user":             cfg.Nebius.User,
+			"publicIP":         cfg.Nebius.PublicIP,
+			"securityGroupIds": cfg.Nebius.SecurityGroupIDs,
+			"serviceAccountId": cfg.Nebius.ServiceAccountID,
+			"recoveryPolicy":   cfg.Nebius.RecoveryPolicy,
+		},
 		"hostinger": map[string]any{
 			"apiUrl":          cfg.Hostinger.APIURL,
 			"auth":            tokenState(cfg.Hostinger.APIToken),
@@ -501,6 +518,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "digitalocean region=%s image=%s vpc=%s ssh_cidrs=%s\n", cfg.DigitalOcean.Region, cfg.DigitalOcean.Image, blank(cfg.DigitalOcean.VPCUUID, "-"), blank(strings.Join(cfg.DigitalOcean.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "nvidia_brev cli=%s org=%s type=%s gpu_name=%s provider=%s mode=%s launchable=%s startup_script=%s release_action=%s target=%s user=%s work_root=%s auth=cli\n", blank(cfg.NvidiaBrev.CLI, "-"), blank(cfg.NvidiaBrev.Org, "-"), blank(cfg.NvidiaBrev.Type, "-"), blank(cfg.NvidiaBrev.GPUName, "-"), blank(cfg.NvidiaBrev.Provider, "-"), blank(cfg.NvidiaBrev.Mode, "-"), blank(cfg.NvidiaBrev.Launchable, "-"), blank(cfg.NvidiaBrev.StartupScript, "-"), blank(cfg.NvidiaBrev.ReleaseAction, "-"), blank(cfg.NvidiaBrev.Target, "-"), blank(cfg.NvidiaBrev.User, "-"), blank(cfg.NvidiaBrev.WorkRoot, "-"))
+	fmt.Fprintf(w, "nebius cli=%s profile=%s parent_id=%s subnet_id=%s platform=%s preset=%s image_family=%s disk_type=%s disk_size_gib=%d user=%s public_ip=%s security_group_ids=%s service_account_id=%s recovery_policy=%s auth=cli\n", blank(cfg.Nebius.CLI, "-"), blank(cfg.Nebius.Profile, "-"), blank(cfg.Nebius.ParentID, "-"), blank(cfg.Nebius.SubnetID, "-"), blank(cfg.Nebius.Platform, "-"), blank(cfg.Nebius.Preset, "-"), blank(cfg.Nebius.ImageFamily, "-"), blank(cfg.Nebius.DiskType, "-"), cfg.Nebius.DiskSizeGiB, blank(cfg.Nebius.User, "-"), blank(cfg.Nebius.PublicIP, "-"), blank(strings.Join(cfg.Nebius.SecurityGroupIDs, ","), "-"), blank(cfg.Nebius.ServiceAccountID, "-"), blank(cfg.Nebius.RecoveryPolicy, "-"))
 	fmt.Fprintf(w, "hostinger api_url=%s item_id=%s payment_method_id=%s template_id=%s data_center_id=%s hostname_prefix=%s user=%s work_root=%s allow_purchase=%t release_action=%s auth=%s\n", blank(cfg.Hostinger.APIURL, "-"), blank(cfg.Hostinger.ItemID, "-"), blank(cfg.Hostinger.PaymentMethodID, "-"), blank(cfg.Hostinger.TemplateID, "-"), blank(cfg.Hostinger.DataCenterID, "-"), blank(cfg.Hostinger.HostnamePrefix, "-"), blank(cfg.Hostinger.User, "-"), blank(cfg.Hostinger.WorkRoot, "-"), cfg.Hostinger.AllowPurchase, blank(cfg.Hostinger.ReleaseAction, "-"), tokenState(cfg.Hostinger.APIToken))
 	fmt.Fprintf(w, "ovh endpoint=%s project_id=%s region=%s image=%s flavor=%s auth=%s\n", blank(redactedConfigURL(cfg.OVH.Endpoint), "-"), blank(cfg.OVH.ProjectID, "-"), blank(cfg.OVH.Region, "-"), blank(cfg.OVH.Image, "-"), blank(cfg.OVH.Flavor, "-"), ovhAuthState())
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(cfg.AzureDynamicSessions.Endpoint, "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -755,6 +755,103 @@ func TestConfigShowIncludesNvidiaBrevWithoutSecretSurface(t *testing.T) {
 	}
 }
 
+func TestConfigShowIncludesNebiusWithoutSecretSurface(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_NEBIUS_PROFILE", "env-profile")
+	if err := os.WriteFile(configPath, []byte(`provider: nebius
+nebius:
+  cli: /usr/local/bin/nebius
+  parentId: project-123
+  subnetId: subnet-123
+  platform: cpu-d3
+  preset: 4vcpu-16gb
+  imageFamily: ubuntu24.04-driverless
+  diskType: network_ssd
+  diskSizeGiB: 50
+  user: crabbox
+  publicIP: dynamic
+  securityGroupIds: [sg-1, sg-2]
+  serviceAccountId: sa-123
+  recoveryPolicy: fail
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	text := stdout.String()
+	want := "nebius cli=/usr/local/bin/nebius profile=env-profile parent_id=project-123 subnet_id=subnet-123 platform=cpu-d3 preset=4vcpu-16gb image_family=ubuntu24.04-driverless disk_type=network_ssd disk_size_gib=50 user=crabbox public_ip=dynamic security_group_ids=sg-1,sg-2 service_account_id=sa-123 recovery_policy=fail auth=cli"
+	if !strings.Contains(text, want) {
+		t.Fatalf("config show missing nebius summary: %q", text)
+	}
+	for _, secretFragment := range []string{"token", "api_key", "private_key", "password"} {
+		if strings.Contains(strings.ToLower(text), secretFragment) {
+			t.Fatalf("config show text exposed %q: %q", secretFragment, text)
+		}
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Nebius struct {
+			CLI              string   `json:"cli"`
+			Auth             string   `json:"auth"`
+			Profile          string   `json:"profile"`
+			ParentID         string   `json:"parentId"`
+			SubnetID         string   `json:"subnetId"`
+			Platform         string   `json:"platform"`
+			Preset           string   `json:"preset"`
+			ImageFamily      string   `json:"imageFamily"`
+			DiskType         string   `json:"diskType"`
+			DiskSizeGiB      int      `json:"diskSizeGiB"`
+			User             string   `json:"user"`
+			PublicIP         string   `json:"publicIP"`
+			SecurityGroupIDs []string `json:"securityGroupIds"`
+			ServiceAccountID string   `json:"serviceAccountId"`
+			RecoveryPolicy   string   `json:"recoveryPolicy"`
+		} `json:"nebius"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Nebius.CLI != "/usr/local/bin/nebius" ||
+		got.Nebius.Auth != "cli" ||
+		got.Nebius.Profile != "env-profile" ||
+		got.Nebius.ParentID != "project-123" ||
+		got.Nebius.SubnetID != "subnet-123" ||
+		got.Nebius.Platform != "cpu-d3" ||
+		got.Nebius.Preset != "4vcpu-16gb" ||
+		got.Nebius.ImageFamily != "ubuntu24.04-driverless" ||
+		got.Nebius.DiskType != "network_ssd" ||
+		got.Nebius.DiskSizeGiB != 50 ||
+		got.Nebius.User != "crabbox" ||
+		got.Nebius.PublicIP != "dynamic" ||
+		strings.Join(got.Nebius.SecurityGroupIDs, ",") != "sg-1,sg-2" ||
+		got.Nebius.ServiceAccountID != "sa-123" ||
+		got.Nebius.RecoveryPolicy != "fail" {
+		t.Fatalf("unexpected nebius json: %#v", got.Nebius)
+	}
+	nebiusJSON, err := json.Marshal(got.Nebius)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secretFragment := range []string{"token", "apiKey", "privateKey", "password"} {
+		if strings.Contains(string(nebiusJSON), secretFragment) {
+			t.Fatalf("nebius config show json exposed %q: %s", secretFragment, nebiusJSON)
+		}
+	}
+}
+
 func TestConfigShowAppliesNvidiaBrevGenericWorkRoot(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "nvidia-brev"

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1588,11 +1588,15 @@ func TestNebiusConfigFileEnvAndDefaults(t *testing.T) {
 func TestNebiusUntrustedConfigCannotRedirectCLI(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Nebius.CLI = "/trusted/nebius"
+	cfg.Nebius.Profile = "trusted-profile"
+	cfg.Nebius.ServiceAccountID = "trusted-service-account"
 	file := fileConfig{
 		Nebius: &fileNebiusConfig{
-			CLI:      "/tmp/untrusted-nebius",
-			ParentID: "project-repo",
-			SubnetID: "subnet-repo",
+			CLI:              "/tmp/untrusted-nebius",
+			Profile:          "untrusted-profile",
+			ParentID:         "project-repo",
+			SubnetID:         "subnet-repo",
+			ServiceAccountID: "untrusted-service-account",
 		},
 	}
 	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
@@ -1600,6 +1604,12 @@ func TestNebiusUntrustedConfigCannotRedirectCLI(t *testing.T) {
 	}
 	if cfg.Nebius.CLI != "/trusted/nebius" {
 		t.Fatalf("untrusted CLI override applied: %q", cfg.Nebius.CLI)
+	}
+	if cfg.Nebius.Profile != "trusted-profile" {
+		t.Fatalf("untrusted profile override applied: %q", cfg.Nebius.Profile)
+	}
+	if cfg.Nebius.ServiceAccountID != "trusted-service-account" {
+		t.Fatalf("untrusted service account override applied: %q", cfg.Nebius.ServiceAccountID)
 	}
 	if cfg.Nebius.ParentID != "project-repo" || cfg.Nebius.SubnetID != "subnet-repo" {
 		t.Fatalf("safe untrusted nebius settings not applied: %#v", cfg.Nebius)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -65,6 +65,20 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_LINODE_TYPE",
 		"CRABBOX_LINODE_FIREWALL",
 		"CRABBOX_LINODE_SSH_CIDRS",
+		"CRABBOX_NEBIUS_CLI",
+		"CRABBOX_NEBIUS_PROFILE",
+		"CRABBOX_NEBIUS_PARENT_ID",
+		"CRABBOX_NEBIUS_SUBNET_ID",
+		"CRABBOX_NEBIUS_PLATFORM",
+		"CRABBOX_NEBIUS_PRESET",
+		"CRABBOX_NEBIUS_IMAGE_FAMILY",
+		"CRABBOX_NEBIUS_DISK_TYPE",
+		"CRABBOX_NEBIUS_DISK_SIZE_GIB",
+		"CRABBOX_NEBIUS_USER",
+		"CRABBOX_NEBIUS_PUBLIC_IP",
+		"CRABBOX_NEBIUS_SECURITY_GROUP_IDS",
+		"CRABBOX_NEBIUS_SERVICE_ACCOUNT_ID",
+		"CRABBOX_NEBIUS_RECOVERY_POLICY",
 		"OVH_ENDPOINT",
 		"OVH_APPLICATION_KEY",
 		"OVH_APPLICATION_SECRET",
@@ -1495,6 +1509,139 @@ func TestLinodeConfigFileAndEnv(t *testing.T) {
 	}
 	if got := serverTypeForConfig(cfg); got != "g6-nanode-1" {
 		t.Fatalf("serverTypeForConfig=%q", got)
+	}
+}
+
+func TestNebiusConfigFileEnvAndDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, fileConfig{
+		Provider: "nebius",
+		Nebius: &fileNebiusConfig{
+			CLI:              "/opt/nebius/bin/nebius",
+			Profile:          "file-profile",
+			ParentID:         "project-file",
+			SubnetID:         "subnet-file",
+			Platform:         "cpu-e2",
+			Preset:           "8vcpu-32gb",
+			ImageFamily:      "ubuntu24.04-driverless",
+			DiskType:         "network_ssd_nonreplicated",
+			DiskSizeGiB:      80,
+			User:             "builder",
+			PublicIP:         "none",
+			SecurityGroupIDs: []string{"sg-file"},
+			ServiceAccountID: "sa-file",
+			RecoveryPolicy:   "fail",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "nebius" || cfg.Nebius.CLI != "/opt/nebius/bin/nebius" || cfg.Nebius.Profile != "file-profile" || cfg.Nebius.ParentID != "project-file" || cfg.Nebius.SubnetID != "subnet-file" {
+		t.Fatalf("file nebius config not applied: %#v", cfg.Nebius)
+	}
+	if cfg.Nebius.Platform != "cpu-e2" || cfg.Nebius.Preset != "8vcpu-32gb" || cfg.Nebius.DiskSizeGiB != 80 || strings.Join(cfg.Nebius.SecurityGroupIDs, ",") != "sg-file" {
+		t.Fatalf("file nebius sizing/network config not applied: %#v", cfg.Nebius)
+	}
+
+	t.Setenv("CRABBOX_NEBIUS_CLI", "/usr/local/bin/nebius")
+	t.Setenv("CRABBOX_NEBIUS_PROFILE", "env-profile")
+	t.Setenv("CRABBOX_NEBIUS_PARENT_ID", "project-env")
+	t.Setenv("CRABBOX_NEBIUS_SUBNET_ID", "subnet-env")
+	t.Setenv("CRABBOX_NEBIUS_PLATFORM", "gpu-h100")
+	t.Setenv("CRABBOX_NEBIUS_PRESET", "1gpu-16vcpu-200gb")
+	t.Setenv("CRABBOX_NEBIUS_IMAGE_FAMILY", "ubuntu22.04-cuda")
+	t.Setenv("CRABBOX_NEBIUS_DISK_TYPE", "network_ssd")
+	t.Setenv("CRABBOX_NEBIUS_DISK_SIZE_GIB", "120")
+	t.Setenv("CRABBOX_NEBIUS_USER", "alice")
+	t.Setenv("CRABBOX_NEBIUS_PUBLIC_IP", "dynamic")
+	t.Setenv("CRABBOX_NEBIUS_SECURITY_GROUP_IDS", "sg-a, sg-b")
+	t.Setenv("CRABBOX_NEBIUS_SERVICE_ACCOUNT_ID", "sa-env")
+	t.Setenv("CRABBOX_NEBIUS_RECOVERY_POLICY", "fail")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatalf("applyEnv err=%v", err)
+	}
+	if cfg.Nebius.CLI != "/usr/local/bin/nebius" || cfg.Nebius.Profile != "env-profile" || cfg.Nebius.ParentID != "project-env" || cfg.Nebius.SubnetID != "subnet-env" {
+		t.Fatalf("env nebius identity config not applied: %#v", cfg.Nebius)
+	}
+	if cfg.Nebius.Platform != "gpu-h100" || cfg.Nebius.Preset != "1gpu-16vcpu-200gb" || cfg.Nebius.ImageFamily != "ubuntu22.04-cuda" || cfg.Nebius.DiskSizeGiB != 120 || strings.Join(cfg.Nebius.SecurityGroupIDs, ",") != "sg-a,sg-b" {
+		t.Fatalf("env nebius sizing/network config not applied: %#v", cfg.Nebius)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatalf("applyProviderConfigDefaults err=%v", err)
+	}
+	base := baseConfig()
+	if cfg.TargetOS != targetLinux || cfg.WorkRoot != defaultPOSIXWorkRoot || cfg.SSHUser != "alice" || cfg.SSHPort != base.SSHPort {
+		t.Fatalf("nebius target defaults not applied: target=%q root=%q user=%q port=%q", cfg.TargetOS, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort)
+	}
+
+	defaulted := baseConfig()
+	defaulted.Provider = "nebius"
+	defaulted.Nebius = NebiusConfig{}
+	if err := applyProviderConfigDefaults(&defaulted); err != nil {
+		t.Fatal(err)
+	}
+	if defaulted.Nebius.CLI != "nebius" || defaulted.Nebius.Platform != "cpu-d3" || defaulted.Nebius.Preset != "4vcpu-16gb" || defaulted.Nebius.ImageFamily != "ubuntu24.04-driverless" || defaulted.Nebius.DiskSizeGiB != 50 || defaulted.Nebius.PublicIP != "dynamic" {
+		t.Fatalf("nebius conservative defaults not applied: %#v", defaulted.Nebius)
+	}
+}
+
+func TestNebiusUntrustedConfigCannotRedirectCLI(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Nebius.CLI = "/trusted/nebius"
+	file := fileConfig{
+		Nebius: &fileNebiusConfig{
+			CLI:      "/tmp/untrusted-nebius",
+			ParentID: "project-repo",
+			SubnetID: "subnet-repo",
+		},
+	}
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Nebius.CLI != "/trusted/nebius" {
+		t.Fatalf("untrusted CLI override applied: %q", cfg.Nebius.CLI)
+	}
+	if cfg.Nebius.ParentID != "project-repo" || cfg.Nebius.SubnetID != "subnet-repo" {
+		t.Fatalf("safe untrusted nebius settings not applied: %#v", cfg.Nebius)
+	}
+}
+
+func TestNebiusEnvDoesNotMutateGenericFieldsForOtherProviders(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "ssh"
+	t.Setenv("CRABBOX_NEBIUS_PARENT_ID", "project-env")
+	t.Setenv("CRABBOX_NEBIUS_USER", "nebius-user")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Nebius.ParentID != "project-env" || cfg.Nebius.User != "nebius-user" {
+		t.Fatalf("nebius env not stored: %#v", cfg.Nebius)
+	}
+	base := baseConfig()
+	if cfg.SSHUser != base.SSHUser || cfg.WorkRoot != base.WorkRoot || cfg.TargetOS != base.TargetOS {
+		t.Fatalf("nebius env leaked into generic config: %#v", cfg)
+	}
+}
+
+func TestNebiusDefaultsPreserveExplicitGenericWorkRoot(t *testing.T) {
+	cfg := baseConfig()
+	if err := applyFileConfig(&cfg, fileConfig{
+		Provider: "nebius",
+		WorkRoot: "/srv/crabbox",
+		SSH:      &fileSSHConfig{User: "alice", Port: "2200"},
+		Nebius:   &fileNebiusConfig{ParentID: "project", SubnetID: "subnet"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyProviderConfigDefaults(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorkRoot != "/srv/crabbox" || cfg.SSHUser != "alice" || cfg.SSHPort != "2200" {
+		t.Fatalf("explicit generic SSH settings not preserved: root=%q user=%q port=%q", cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort)
 	}
 }
 

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -14,6 +14,7 @@ func init() {
 	RegisterProvider(testHetznerProvider{})
 	RegisterProvider(testDigitalOceanProvider{})
 	RegisterProvider(testLinodeProvider{})
+	RegisterProvider(testNebiusProvider{})
 	RegisterProvider(testAWSProvider{})
 	RegisterProvider(testAzureProvider{})
 	RegisterProvider(testAzureDynamicSessionsProvider{})
@@ -357,6 +358,28 @@ func (testLinodeProvider) ServerTypeForConfig(cfg Config) string {
 }
 func (testLinodeProvider) ServerTypeForClass(string) string { return "g6-standard-1" }
 func (p testLinodeProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	return testSSHBackend{spec: p.Spec()}, nil
+}
+
+type testNebiusProvider struct{}
+
+func (testNebiusProvider) Name() string      { return "nebius" }
+func (testNebiusProvider) Aliases() []string { return nil }
+func (testNebiusProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name:        "nebius",
+		Family:      "nebius",
+		Kind:        ProviderKindSSHLease,
+		Targets:     []TargetSpec{{OS: targetLinux}},
+		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup},
+		Coordinator: CoordinatorNever,
+	}
+}
+func (testNebiusProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (testNebiusProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p testNebiusProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -15,6 +15,7 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	var digitalOcean *providerMatrixEntry
 	var nvidiaBrev *providerMatrixEntry
 	var linode *providerMatrixEntry
+	var nebius *providerMatrixEntry
 	var moduleRuntime *providerMatrixEntry
 	for i := range entries {
 		if entries[i].Provider == "aws" {
@@ -31,6 +32,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		}
 		if entries[i].Provider == "linode" {
 			linode = &entries[i]
+		}
+		if entries[i].Provider == "nebius" {
+			nebius = &entries[i]
 		}
 		if entries[i].Provider == "module-runtime-test" {
 			moduleRuntime = &entries[i]
@@ -50,6 +54,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if linode == nil {
 		t.Fatal("linode provider not found")
+	}
+	if nebius == nil {
+		t.Fatal("nebius provider not found")
 	}
 	if aws.Kind != ProviderKindSSHLease {
 		t.Fatalf("aws kind=%q", aws.Kind)
@@ -85,6 +92,15 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if !containsString(linode.Targets, targetLinux) {
 		t.Fatalf("linode targets=%v", linode.Targets)
+	}
+	if nebius.Kind != ProviderKindSSHLease || nebius.Family != "nebius" || nebius.Coordinator != string(CoordinatorNever) {
+		t.Fatalf("nebius kind/family/coordinator=%q/%q/%q", nebius.Kind, nebius.Family, nebius.Coordinator)
+	}
+	if !containsString(nebius.Targets, targetLinux) {
+		t.Fatalf("nebius targets=%v", nebius.Targets)
+	}
+	if !containsFeature(nebius.Features, FeatureSSH) || !containsFeature(nebius.Features, FeatureCrabboxSync) || !containsFeature(nebius.Features, FeatureCleanup) {
+		t.Fatalf("nebius features=%v", nebius.Features)
 	}
 	if moduleRuntime == nil {
 		t.Fatal("module-runtime-test provider not found")

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/mxc"
 	_ "github.com/openclaw/crabbox/internal/providers/namespace"
 	_ "github.com/openclaw/crabbox/internal/providers/namespaceinstance"
+	_ "github.com/openclaw/crabbox/internal/providers/nebius"
 	_ "github.com/openclaw/crabbox/internal/providers/nvidiabrev"
 	_ "github.com/openclaw/crabbox/internal/providers/opencomputer"
 	_ "github.com/openclaw/crabbox/internal/providers/opensandbox"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -75,6 +75,36 @@ func TestNvidiaBrevRegistersCanonicalAndAliases(t *testing.T) {
 	}
 }
 
+func TestNebiusRegistersWithoutAliases(t *testing.T) {
+	provider, err := core.ProviderFor("nebius")
+	if err != nil {
+		t.Fatalf("ProviderFor(nebius): %v", err)
+	}
+	if provider.Name() != "nebius" {
+		t.Fatalf("ProviderFor(nebius).Name=%q", provider.Name())
+	}
+	if _, ok := provider.(core.DoctorProvider); !ok {
+		t.Fatal("nebius provider does not expose doctor")
+	}
+	spec := provider.Spec()
+	if spec.Family != "nebius" || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("nebius spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("nebius targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("nebius features=%v missing %s", spec.Features, feature)
+		}
+	}
+	for _, alias := range []string{"nebius-ai", "nebius-compute", "nb"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == "nebius" {
+			t.Fatalf("%q alias unexpectedly resolves to nebius", alias)
+		}
+	}
+}
+
 func TestAgentSandboxRegistersWithoutAliases(t *testing.T) {
 	provider, err := core.ProviderFor("agent-sandbox")
 	if err != nil {

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -95,7 +95,7 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target L
 		}
 		claimErr := b.persistRecoveryClaim(leaseID, slug, created.ID, cfg, req.Repo.Root, labels, req.Reclaim)
 		cleanupCtx := context.WithoutCancel(ctx)
-		if cleanupErr := client.DeleteInstance(cleanupCtx, created.ID); cleanupErr != nil && !isNebiusNotFound(cleanupErr) {
+		if cleanupErr := client.DeleteInstance(cleanupCtx, created.ID); cleanupErr != nil && !isNebiusInstanceNotFound(cleanupErr, created.ID) {
 			err = fmt.Errorf("%v; nebius rollback failed: %w", err, errors.Join(claimErr, cleanupErr))
 			return
 		}
@@ -290,7 +290,7 @@ func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) err
 			if liveServer.Labels["lease"] != server.Labels["lease"] || liveServer.Labels["slug"] != server.Labels["slug"] {
 				return core.Exit(3, "nebius live ownership changed for instance %s; refusing release", server.DisplayID())
 			}
-		} else if !isNebiusNotFound(err) {
+		} else if !isNebiusInstanceNotFound(err, server.CloudID) {
 			return err
 		} else {
 			confirmedAbsent = true
@@ -298,7 +298,7 @@ func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) err
 	}
 	if !confirmedAbsent {
 		if err := client.DeleteInstance(ctx, server.CloudID); err != nil {
-			if isNebiusNotFound(err) {
+			if isNebiusInstanceNotFound(err, server.CloudID) {
 				confirmedAbsent = true
 			} else if isIndeterminateNebiusError(err) {
 				return err
@@ -357,12 +357,20 @@ func isIndeterminateNebiusError(err error) bool {
 	return strings.Contains(text, "timeout") || strings.Contains(text, "connection reset") || strings.Contains(text, "context deadline") || strings.Contains(text, "lost")
 }
 
-func isNebiusNotFound(err error) bool {
+func isNebiusInstanceNotFound(err error, id string) bool {
 	if err == nil {
 		return false
 	}
 	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "not found") || strings.Contains(text, "404")
+	hasNotFound := strings.Contains(text, "not found") || strings.Contains(text, "404")
+	if !hasNotFound {
+		return false
+	}
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id != "" && strings.Contains(text, id) {
+		return true
+	}
+	return strings.Contains(text, "instance not found")
 }
 
 func nebiusServerType(cfg Config) string {
@@ -488,14 +496,18 @@ func (b *backend) checkImage(ctx context.Context, client cliRunner) DoctorCheck 
 	if err != nil {
 		return doctorCheck("image", "error", err.Error(), map[string]string{"imageFamily": imageFamily})
 	}
-	if !isJSON(result.Stdout) {
-		return doctorCheck("image", "error", "image list did not return JSON", map[string]string{"imageFamily": imageFamily})
+	ok, err := containsIDOrName(result.Stdout, imageFamily)
+	if err != nil {
+		return doctorCheck("image", "error", "image list did not return expected JSON", map[string]string{"imageFamily": imageFamily})
+	}
+	if !ok {
+		return doctorCheck("image", "error", "configured image family not found", map[string]string{"imageFamily": imageFamily})
 	}
 	return doctorCheck("image", "ok", "image family readable", map[string]string{"imageFamily": imageFamily})
 }
 
 func (b *backend) checkJSON(ctx context.Context, client cliRunner) DoctorCheck {
-	result, err := client.run(ctx, "config", "get", "parent-id", "--format", "json")
+	result, err := client.run(ctx, "config", "profile", "list", "--format", "json")
 	if err != nil {
 		return doctorCheck("json", "error", err.Error(), nil)
 	}

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -1,0 +1,169 @@
+package nebius
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+	rt   Runtime
+}
+
+func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &backend{spec: spec, cfg: cfg, rt: rt}
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, notImplemented("acquire")
+}
+
+func (b *backend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, notImplemented("resolve")
+}
+
+func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, notImplemented("list")
+}
+
+func (b *backend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
+	return notImplemented("release")
+}
+
+func (b *backend) Touch(context.Context, TouchRequest) error {
+	return notImplemented("touch")
+}
+
+func (b *backend) Cleanup(context.Context, CleanupRequest) error {
+	return notImplemented("cleanup")
+}
+
+func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if b.rt.Exec == nil {
+		return DoctorResult{}, exit(2, "provider=nebius doctor requires command runner")
+	}
+	client := newCLIRunner(b.cfg.Nebius, b.rt)
+	checks := []DoctorCheck{
+		b.checkVersion(ctx, client),
+		b.checkProfile(ctx, client),
+		b.checkParentID(ctx, client),
+		b.checkSubnet(ctx, client),
+		b.checkPlatform(ctx, client),
+		b.checkImage(ctx, client),
+		b.checkJSON(ctx, client),
+	}
+	status := "ok"
+	for _, check := range checks {
+		if check.Status != "ok" {
+			status = "error"
+			break
+		}
+	}
+	return DoctorResult{
+		Provider: providerName,
+		Status:   status,
+		Message:  fmt.Sprintf("cli=%s control_plane=read_only mutation=false", status),
+		Checks:   checks,
+	}, nil
+}
+
+func (b *backend) checkVersion(ctx context.Context, client cliRunner) DoctorCheck {
+	result, err := client.run(ctx, "--version")
+	if err != nil {
+		return doctorCheck("cli", "error", err.Error(), nil)
+	}
+	return doctorCheck("cli", "ok", "nebius cli available", map[string]string{"version": redactNebiusText(firstNonBlank(result.Stdout, result.Stderr))})
+}
+
+func (b *backend) checkProfile(ctx context.Context, client cliRunner) DoctorCheck {
+	result, err := client.run(ctx, "config", "profile", "list", "--format", "json")
+	if err != nil {
+		return doctorCheck("profile", "error", err.Error(), nil)
+	}
+	if !isJSON(result.Stdout) {
+		return doctorCheck("profile", "error", "profile list did not return JSON", nil)
+	}
+	return doctorCheck("profile", "ok", "profile store readable", nil)
+}
+
+func (b *backend) checkParentID(ctx context.Context, client cliRunner) DoctorCheck {
+	parentID := strings.TrimSpace(b.cfg.Nebius.ParentID)
+	if parentID == "" {
+		return doctorCheck("parent-id", "error", "nebius.parentId is required", nil)
+	}
+	result, err := client.run(ctx, "iam", "project", "get", parentID, "--format", "json")
+	if err != nil {
+		return doctorCheck("parent-id", "error", err.Error(), map[string]string{"parentId": parentID})
+	}
+	if !isJSON(result.Stdout) {
+		return doctorCheck("parent-id", "error", "project lookup did not return JSON", map[string]string{"parentId": parentID})
+	}
+	return doctorCheck("parent-id", "ok", "project readable", map[string]string{"parentId": parentID})
+}
+
+func (b *backend) checkSubnet(ctx context.Context, client cliRunner) DoctorCheck {
+	subnetID := strings.TrimSpace(b.cfg.Nebius.SubnetID)
+	if subnetID == "" {
+		return doctorCheck("subnet", "error", "nebius.subnetId is required", nil)
+	}
+	result, err := client.run(ctx, "vpc", "subnet", "list", "--parent-id", b.cfg.Nebius.ParentID, "--format", "json")
+	if err != nil {
+		return doctorCheck("subnet", "error", err.Error(), map[string]string{"subnetId": subnetID})
+	}
+	ok, err := containsIDOrName(result.Stdout, subnetID)
+	if err != nil {
+		return doctorCheck("subnet", "error", "subnet list did not return expected JSON", map[string]string{"subnetId": subnetID})
+	}
+	if !ok {
+		return doctorCheck("subnet", "error", "configured subnet not found", map[string]string{"subnetId": subnetID})
+	}
+	return doctorCheck("subnet", "ok", "subnet readable", map[string]string{"subnetId": subnetID})
+}
+
+func (b *backend) checkPlatform(ctx context.Context, client cliRunner) DoctorCheck {
+	platform := strings.TrimSpace(b.cfg.Nebius.Platform)
+	result, err := client.run(ctx, "compute", "platform", "list", "--format", "json")
+	if err != nil {
+		return doctorCheck("platform", "error", err.Error(), map[string]string{"platform": platform})
+	}
+	ok, err := containsIDOrName(result.Stdout, platform)
+	if err != nil {
+		return doctorCheck("platform", "error", "platform list did not return expected JSON", map[string]string{"platform": platform})
+	}
+	if !ok {
+		return doctorCheck("platform", "error", "configured platform not found", map[string]string{"platform": platform})
+	}
+	return doctorCheck("platform", "ok", "platform readable", map[string]string{"platform": platform})
+}
+
+func (b *backend) checkImage(ctx context.Context, client cliRunner) DoctorCheck {
+	imageFamily := strings.TrimSpace(b.cfg.Nebius.ImageFamily)
+	result, err := client.run(ctx, "compute", "image", "list", "--family", imageFamily, "--format", "json")
+	if err != nil {
+		return doctorCheck("image", "error", err.Error(), map[string]string{"imageFamily": imageFamily})
+	}
+	if !isJSON(result.Stdout) {
+		return doctorCheck("image", "error", "image list did not return JSON", map[string]string{"imageFamily": imageFamily})
+	}
+	return doctorCheck("image", "ok", "image family readable", map[string]string{"imageFamily": imageFamily})
+}
+
+func (b *backend) checkJSON(ctx context.Context, client cliRunner) DoctorCheck {
+	result, err := client.run(ctx, "config", "get", "parent-id", "--format", "json")
+	if err != nil {
+		return doctorCheck("json", "error", err.Error(), nil)
+	}
+	if !isJSON(result.Stdout) {
+		return doctorCheck("json", "error", "json output is unavailable", nil)
+	}
+	return doctorCheck("json", "ok", "json output available", nil)
+}
+
+func doctorCheck(name, status, message string, details map[string]string) DoctorCheck {
+	return DoctorCheck{Check: name, Status: status, Message: redactNebiusText(message), Details: details}
+}

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -2,52 +2,393 @@ package nebius
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	shared.DirectSSHBackend
+	clientFactory func(Runtime) nebiusAPI
+	waitSSH       func(context.Context, *core.SSHTarget, string, time.Duration) error
+	now           func() time.Time
 }
 
 func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
-	return &backend{spec: spec, cfg: cfg, rt: rt}
+	b := &backend{
+		DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true},
+		now:              time.Now,
+	}
+	b.clientFactory = func(rt Runtime) nebiusAPI { return newNebiusClient(cfg.Nebius, rt) }
+	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
+	}
+	b.Delete = b.deleteServer
+	return b
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
-
-func (b *backend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
-	return LeaseTarget{}, notImplemented("acquire")
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+		return b.acquireOnce(ctx, req)
+	})
 }
 
-func (b *backend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
-	return LeaseTarget{}, notImplemented("resolve")
+func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target LeaseTarget, err error) {
+	cfg := b.Cfg
+	if err := validateNebiusAcquireConfig(cfg); err != nil {
+		return LeaseTarget{}, err
+	}
+	client := b.clientFactory(b.RT)
+	leaseID := core.NewLeaseID()
+	existing, err := client.ListInstances(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := ownedServers(existing, cfg)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	committed := false
+	defer func() {
+		if err != nil && !committed {
+			if !isIndeterminateNebiusError(err) {
+				core.RemoveStoredTestboxKey(leaseID)
+			}
+		}
+	}()
+	cfg.SSHKey = keyPath
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	cfg.ServerType = nebiusServerType(cfg)
+	now := b.now().UTC()
+	labels := nebiusLeaseLabels(cfg, leaseID, slug, "provisioning", req.Keep, now)
+	created := nebiusInstance{}
+	userData, err := renderNebiusCloudInit(cfg.Nebius.User, publicKey)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	fmt.Fprintf(b.RT.Stderr, "provisioning provider=nebius lease=%s slug=%s platform=%s preset=%s keep=%v\n", leaseID, slug, cfg.Nebius.Platform, cfg.Nebius.Preset, req.Keep)
+	created, err = client.CreateInstance(ctx, nebiusCreateRequest{
+		Name:      core.LeaseProviderName(leaseID, slug),
+		Labels:    labels,
+		UserData:  userData,
+		PublicKey: publicKey,
+	})
+	if err != nil {
+		if isIndeterminateNebiusError(err) {
+			_ = b.persistRecoveryClaim(leaseID, slug, "", cfg, req.Repo.Root, labels, req.Reclaim)
+		}
+		return LeaseTarget{}, err
+	}
+	defer func() {
+		if err == nil || committed || strings.TrimSpace(created.ID) == "" {
+			return
+		}
+		claimErr := b.persistRecoveryClaim(leaseID, slug, created.ID, cfg, req.Repo.Root, labels, req.Reclaim)
+		cleanupCtx := context.WithoutCancel(ctx)
+		if cleanupErr := client.DeleteInstance(cleanupCtx, created.ID); cleanupErr != nil && !isNebiusNotFound(cleanupErr) {
+			err = fmt.Errorf("%v; nebius rollback failed: %w", err, errors.Join(claimErr, cleanupErr))
+			return
+		}
+		if claimErr == nil {
+			core.RemoveLeaseClaim(leaseID)
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+	}()
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(core.LeaseTarget{LeaseID: leaseID, Server: serverFromInstance(created, cfg)}); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	ready, err := client.WaitInstance(ctx, created.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	server := serverFromInstance(ready, cfg)
+	if server.PublicNet.IPv4.IP == "" {
+		return LeaseTarget{}, core.Exit(5, "nebius instance %s has no public IP", server.DisplayID())
+	}
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := b.waitSSH(ctx, &ssh, "nebius bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return LeaseTarget{}, err
+	}
+	readyLabels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", req.Keep, now)
+	if err := client.UpdateLabels(ctx, server.CloudID, readyLabels); err != nil {
+		return LeaseTarget{}, err
+	}
+	server.Labels = readyLabels
+	server.Status = "ready"
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		return LeaseTarget{}, err
+	}
+	committed = true
+	return LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
 }
 
-func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) {
-	return nil, notImplemented("list")
+func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	client := b.clientFactory(b.RT)
+	items, err := client.ListInstances(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := ownedServers(items, b.Cfg)
+	byCloudID := make(map[string]nebiusInstance, len(items))
+	for _, item := range items {
+		byCloudID[item.ID] = item
+	}
+	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if leaseID == "" {
+		for _, s := range servers {
+			if s.CloudID == req.ID || s.Name == req.ID {
+				server = s
+				leaseID = s.Labels["lease"]
+				break
+			}
+		}
+	}
+	if leaseID == "" && req.ReleaseOnly {
+		return b.releaseTargetFromClaim(req.ID)
+	}
+	if leaseID == "" {
+		return LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", req.ID)
+	}
+	item := byCloudID[server.CloudID]
+	if item.ID != "" {
+		server = serverFromInstance(item, b.Cfg)
+	}
+	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
+		return LeaseTarget{}, err
+	}
+	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+	core.UseStoredTestboxKey(&ssh, leaseID)
+	return LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
 }
 
-func (b *backend) ReleaseLease(context.Context, ReleaseLeaseRequest) error {
-	return notImplemented("release")
+func (b *backend) releaseTargetFromClaim(id string) (LeaseTarget, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(id, providerName)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !ok {
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	if !ok {
+		return LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", id)
+	}
+	if err := validateNebiusOwnership(claim.Labels, b.Cfg); err != nil {
+		return LeaseTarget{}, err
+	}
+	server := Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
+	return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
 
-func (b *backend) Touch(context.Context, TouchRequest) error {
-	return notImplemented("touch")
+func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	items, err := b.clientFactory(b.RT).ListInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	servers := ownedServers(items, b.Cfg)
+	out := make([]LeaseView, 0, len(servers))
+	for _, server := range servers {
+		out = append(out, server)
+	}
+	return out, nil
 }
 
-func (b *backend) Cleanup(context.Context, CleanupRequest) error {
-	return notImplemented("cleanup")
+func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
+		return err
+	}
+	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
 }
+
+func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	return fmt.Sprintf("deleted lease=%s nebius_instance=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
+}
+
+func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
+		return Server{}, err
+	}
+	client := b.clientFactory(b.RT)
+	live, err := client.GetInstance(ctx, server.CloudID)
+	if err != nil {
+		return Server{}, err
+	}
+	liveServer := serverFromInstance(live, b.Cfg)
+	if err := validateNebiusOwnership(liveServer.Labels, b.Cfg); err != nil {
+		return Server{}, err
+	}
+	if liveServer.Labels["lease"] != server.Labels["lease"] || liveServer.Labels["slug"] != server.Labels["slug"] {
+		return Server{}, core.Exit(3, "nebius live ownership changed for instance %s; refusing touch", server.DisplayID())
+	}
+	cfg := b.Cfg
+	labels := liveServer.Labels
+	if req.IdleTimeout > 0 {
+		cfg.IdleTimeout = req.IdleTimeout
+		labels = cloneStringMap(labels)
+		delete(labels, "idle_timeout")
+		delete(labels, "idle_timeout_secs")
+	}
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now().UTC())
+	labels = addNebiusScopeLabels(labels, cfg)
+	if err := client.UpdateLabels(ctx, server.CloudID, labels); err != nil {
+		return Server{}, err
+	}
+	liveServer.Labels = labels
+	return liveServer, nil
+}
+
+func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	items, err := b.clientFactory(b.RT).ListInstances(ctx)
+	if err != nil {
+		return err
+	}
+	servers := make([]Server, 0, len(items))
+	for _, item := range items {
+		server := serverFromInstance(item, b.Cfg)
+		if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
+			if strings.EqualFold(server.Labels["crabbox"], "true") || strings.EqualFold(server.Labels[nebiusProviderLabel], providerName) || strings.EqualFold(server.Labels["provider"], providerName) {
+				fmt.Fprintf(b.RT.Stderr, "skip nebius instance id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, err)
+			}
+			continue
+		}
+		servers = append(servers, server)
+	}
+	return b.CleanupServers(ctx, req, servers)
+}
+
+func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) error {
+	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
+		return err
+	}
+	client := b.clientFactory(b.RT)
+	confirmedAbsent := false
+	if server.CloudID != "" {
+		live, err := client.GetInstance(ctx, server.CloudID)
+		if err == nil {
+			liveServer := serverFromInstance(live, b.Cfg)
+			if err := validateNebiusOwnership(liveServer.Labels, b.Cfg); err != nil {
+				return err
+			}
+			if liveServer.Labels["lease"] != server.Labels["lease"] || liveServer.Labels["slug"] != server.Labels["slug"] {
+				return core.Exit(3, "nebius live ownership changed for instance %s; refusing release", server.DisplayID())
+			}
+		} else if !isNebiusNotFound(err) {
+			return err
+		} else {
+			confirmedAbsent = true
+		}
+	}
+	if !confirmedAbsent {
+		if err := client.DeleteInstance(ctx, server.CloudID); err != nil {
+			if isNebiusNotFound(err) {
+				confirmedAbsent = true
+			} else if isIndeterminateNebiusError(err) {
+				return err
+			} else {
+				return err
+			}
+		}
+	}
+	if confirmedAbsent {
+		fmt.Fprintf(b.RT.Stderr, "nebius instance id=%s already absent; cleaning local lease state\n", server.DisplayID())
+	}
+	if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
+	}
+	return nil
+}
+
+func (b *backend) persistRecoveryClaim(leaseID, slug, cloudID string, cfg Config, repoRoot string, labels map[string]string, reclaim bool) error {
+	server := Server{Provider: providerName, CloudID: cloudID, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, SSHTarget{}, repoRoot, cfg.IdleTimeout, reclaim)
+}
+
+func ownedServers(items []nebiusInstance, cfg Config) []Server {
+	servers := make([]Server, 0, len(items))
+	for _, item := range items {
+		server := serverFromInstance(item, cfg)
+		if validateNebiusOwnership(server.Labels, cfg) == nil {
+			servers = append(servers, server)
+		}
+	}
+	return servers
+}
+
+func validateNebiusAcquireConfig(cfg Config) error {
+	if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
+		return core.Exit(2, "provider=nebius supports target=linux only")
+	}
+	if strings.TrimSpace(cfg.Nebius.ParentID) == "" {
+		return core.Exit(2, "nebius.parentId is required")
+	}
+	if strings.TrimSpace(cfg.Nebius.SubnetID) == "" {
+		return core.Exit(2, "nebius.subnetId is required")
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Nebius.PublicIP), "none") {
+		return core.Exit(2, "provider=nebius requires public_ip=dynamic for direct SSH lifecycle")
+	}
+	return nil
+}
+
+func isIndeterminateNebiusError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "timeout") || strings.Contains(text, "connection reset") || strings.Contains(text, "context deadline") || strings.Contains(text, "lost")
+}
+
+func isNebiusNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "not found") || strings.Contains(text, "404")
+}
+
+func nebiusServerType(cfg Config) string {
+	if strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	return strings.TrimSpace(cfg.Nebius.Preset)
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+var _ core.SSHLeaseBackend = (*backend)(nil)
+var _ core.CleanupBackend = (*backend)(nil)
+var _ core.ReleaseLeaseReporter = (*backend)(nil)
 
 func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	if b.rt.Exec == nil {
+	if b.RT.Exec == nil {
 		return DoctorResult{}, exit(2, "provider=nebius doctor requires command runner")
 	}
-	client := newCLIRunner(b.cfg.Nebius, b.rt)
+	client := newCLIRunner(b.Cfg.Nebius, b.RT)
 	checks := []DoctorCheck{
 		b.checkVersion(ctx, client),
 		b.checkProfile(ctx, client),
@@ -92,7 +433,7 @@ func (b *backend) checkProfile(ctx context.Context, client cliRunner) DoctorChec
 }
 
 func (b *backend) checkParentID(ctx context.Context, client cliRunner) DoctorCheck {
-	parentID := strings.TrimSpace(b.cfg.Nebius.ParentID)
+	parentID := strings.TrimSpace(b.Cfg.Nebius.ParentID)
 	if parentID == "" {
 		return doctorCheck("parent-id", "error", "nebius.parentId is required", nil)
 	}
@@ -107,11 +448,11 @@ func (b *backend) checkParentID(ctx context.Context, client cliRunner) DoctorChe
 }
 
 func (b *backend) checkSubnet(ctx context.Context, client cliRunner) DoctorCheck {
-	subnetID := strings.TrimSpace(b.cfg.Nebius.SubnetID)
+	subnetID := strings.TrimSpace(b.Cfg.Nebius.SubnetID)
 	if subnetID == "" {
 		return doctorCheck("subnet", "error", "nebius.subnetId is required", nil)
 	}
-	result, err := client.run(ctx, "vpc", "subnet", "list", "--parent-id", b.cfg.Nebius.ParentID, "--format", "json")
+	result, err := client.run(ctx, "vpc", "subnet", "list", "--parent-id", b.Cfg.Nebius.ParentID, "--format", "json")
 	if err != nil {
 		return doctorCheck("subnet", "error", err.Error(), map[string]string{"subnetId": subnetID})
 	}
@@ -126,7 +467,7 @@ func (b *backend) checkSubnet(ctx context.Context, client cliRunner) DoctorCheck
 }
 
 func (b *backend) checkPlatform(ctx context.Context, client cliRunner) DoctorCheck {
-	platform := strings.TrimSpace(b.cfg.Nebius.Platform)
+	platform := strings.TrimSpace(b.Cfg.Nebius.Platform)
 	result, err := client.run(ctx, "compute", "platform", "list", "--format", "json")
 	if err != nil {
 		return doctorCheck("platform", "error", err.Error(), map[string]string{"platform": platform})
@@ -142,7 +483,7 @@ func (b *backend) checkPlatform(ctx context.Context, client cliRunner) DoctorChe
 }
 
 func (b *backend) checkImage(ctx context.Context, client cliRunner) DoctorCheck {
-	imageFamily := strings.TrimSpace(b.cfg.Nebius.ImageFamily)
+	imageFamily := strings.TrimSpace(b.Cfg.Nebius.ImageFamily)
 	result, err := client.run(ctx, "compute", "image", "list", "--family", imageFamily, "--format", "json")
 	if err != nil {
 		return doctorCheck("image", "error", err.Error(), map[string]string{"imageFamily": imageFamily})

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -1,0 +1,131 @@
+package nebius
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type cliRunner struct {
+	cfg NebiusConfig
+	rt  Runtime
+}
+
+type cliResult struct {
+	Stdout string
+	Stderr string
+}
+
+var tokenLikePattern = regexp.MustCompile(`(?i)(osb_|ncp_|iam_token|oauth[_-]?token|access[_-]?token|refresh[_-]?token|private[_-]?key|BEGIN [A-Z ]*PRIVATE KEY)[A-Za-z0-9._:/+=@ -]*`)
+
+func newCLIRunner(cfg NebiusConfig, rt Runtime) cliRunner {
+	return cliRunner{cfg: cfg, rt: rt}
+}
+
+func (c cliRunner) run(ctx context.Context, args ...string) (cliResult, error) {
+	commandArgs := c.withProfile(args)
+	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: c.cfg.CLI,
+		Args: commandArgs,
+	})
+	if err != nil {
+		return cliResult{Stdout: result.Stdout, Stderr: result.Stderr}, fmt.Errorf("nebius cli %s failed: %s", strings.Join(commandArgs, " "), redactNebiusText(firstNonBlank(result.Stderr, err.Error())))
+	}
+	return cliResult{Stdout: result.Stdout, Stderr: result.Stderr}, nil
+}
+
+func (c cliRunner) withProfile(args []string) []string {
+	out := make([]string, 0, len(args)+2)
+	if strings.TrimSpace(c.cfg.Profile) != "" {
+		out = append(out, "--profile", strings.TrimSpace(c.cfg.Profile))
+	}
+	out = append(out, args...)
+	return out
+}
+
+func parseJSONObject(output string) (map[string]any, error) {
+	var object map[string]any
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.UseNumber()
+	if err := decoder.Decode(&object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func parseJSONArray(output string) ([]map[string]any, error) {
+	var objects []map[string]any
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.UseNumber()
+	if err := decoder.Decode(&objects); err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
+func stringField(object map[string]any, names ...string) string {
+	for _, name := range names {
+		if value, ok := object[name]; ok {
+			switch typed := value.(type) {
+			case string:
+				if strings.TrimSpace(typed) != "" {
+					return typed
+				}
+			case json.Number:
+				return typed.String()
+			}
+		}
+	}
+	return ""
+}
+
+func containsIDOrName(output, want string) (bool, error) {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return false, nil
+	}
+	items, err := parseJSONArray(output)
+	if err != nil {
+		object, objectErr := parseJSONObject(output)
+		if objectErr != nil {
+			return false, err
+		}
+		items = []map[string]any{object}
+	}
+	for _, item := range items {
+		if stringField(item, "id", "metadata.id") == want || stringField(item, "name", "family") == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func redactNebiusText(text string) string {
+	text = tokenLikePattern.ReplaceAllString(text, "[REDACTED]")
+	return strings.TrimSpace(text)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func isJSON(output string) bool {
+	var raw any
+	return json.Unmarshal([]byte(output), &raw) == nil
+}
+
+func validationError(format string, args ...any) error {
+	return exit(2, format, args...)
+}
+
+func notImplemented(action string) error {
+	return errors.New("provider=nebius " + action + " is not implemented until Nebius lifecycle support lands")
+}

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -143,23 +143,19 @@ func (c *nebiusClient) CreateInstance(ctx context.Context, req nebiusCreateReque
 		"--name", req.Name,
 		"--resources-platform", c.cfg.Platform,
 		"--resources-preset", c.cfg.Preset,
-		"--boot-disk-image-family", c.cfg.ImageFamily,
-		"--boot-disk-type", c.cfg.DiskType,
-		"--boot-disk-size-gib", strconv.Itoa(c.cfg.DiskSizeGiB),
+		"--boot-disk-managed-disk-source-image-family-image-family", c.cfg.ImageFamily,
+		"--boot-disk-managed-disk-source-image-family-parent-id", c.cfg.ParentID,
+		"--boot-disk-managed-disk-type", c.cfg.DiskType,
+		"--boot-disk-managed-disk-size-gibibytes", strconv.Itoa(c.cfg.DiskSizeGiB),
 		"--cloud-init-user-data", path,
-		"--network-interface", renderNetworkInterface(c.cfg),
+		"--network-interfaces", renderNetworkInterfaces(c.cfg),
 		"--recovery-policy", firstNonBlank(c.cfg.RecoveryPolicy, "fail"),
-	}
-	for _, sg := range c.cfg.SecurityGroupIDs {
-		if strings.TrimSpace(sg) != "" {
-			args = append(args, "--network-interface-security-group-id", strings.TrimSpace(sg))
-		}
 	}
 	if strings.TrimSpace(c.cfg.ServiceAccountID) != "" {
 		args = append(args, "--service-account-id", strings.TrimSpace(c.cfg.ServiceAccountID))
 	}
-	for _, label := range renderLabelArgs(req.Labels) {
-		args = append(args, "--label", label)
+	if labels := renderLabels(req.Labels); labels != "" {
+		args = append(args, "--labels", labels)
 	}
 	args = append(args, "--format", "json")
 	result, err := c.cli.run(ctx, args...)
@@ -191,8 +187,8 @@ func (c *nebiusClient) WaitInstance(ctx context.Context, id string) (nebiusInsta
 
 func (c *nebiusClient) UpdateLabels(ctx context.Context, id string, labels map[string]string) error {
 	args := []string{"compute", "instance", "update", id}
-	for _, label := range renderLabelArgs(labels) {
-		args = append(args, "--label", label)
+	if labelsArg := renderLabels(labels); labelsArg != "" {
+		args = append(args, "--labels-add", labelsArg)
 	}
 	args = append(args, "--format", "json")
 	_, err := c.cli.run(ctx, args...)
@@ -207,22 +203,6 @@ func (c *nebiusClient) DeleteInstance(ctx context.Context, id string) error {
 	return err
 }
 
-func stringField(object map[string]any, names ...string) string {
-	for _, name := range names {
-		if value, ok := object[name]; ok {
-			switch typed := value.(type) {
-			case string:
-				if strings.TrimSpace(typed) != "" {
-					return typed
-				}
-			case json.Number:
-				return typed.String()
-			}
-		}
-	}
-	return ""
-}
-
 func containsIDOrName(output, want string) (bool, error) {
 	want = strings.TrimSpace(want)
 	if want == "" {
@@ -234,14 +214,27 @@ func containsIDOrName(output, want string) (bool, error) {
 		if objectErr != nil {
 			return false, err
 		}
-		items = []map[string]any{object}
+		if nested, ok := arrayField(object, "items", "instances"); ok {
+			items = nested
+		} else {
+			items = []map[string]any{object}
+		}
 	}
 	for _, item := range items {
-		if stringField(item, "id", "metadata.id") == want || stringField(item, "name", "family") == want {
+		if hasStringField(item, want, "id", "metadata.id", "name", "metadata.name", "family", "metadata.family", "spec.family") {
 			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func hasStringField(object map[string]any, want string, paths ...string) bool {
+	for _, path := range paths {
+		if stringFromAny(pathValue(object, path)) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func parseNebiusInstances(output string) ([]nebiusInstance, error) {
@@ -340,15 +333,32 @@ func cleanIP(value string) string {
 	return strings.TrimSpace(value)
 }
 
-func renderNetworkInterface(cfg NebiusConfig) string {
-	parts := []string{"subnet-id=" + strings.TrimSpace(cfg.SubnetID)}
-	if !strings.EqualFold(strings.TrimSpace(cfg.PublicIP), "none") {
-		parts = append(parts, "public-ip-address={}")
+func renderNetworkInterfaces(cfg NebiusConfig) string {
+	item := map[string]any{
+		"name":       "eth0",
+		"subnet_id":  strings.TrimSpace(cfg.SubnetID),
+		"ip_address": map[string]any{},
 	}
-	return strings.Join(parts, ",")
+	if !strings.EqualFold(strings.TrimSpace(cfg.PublicIP), "none") {
+		item["public_ip_address"] = map[string]any{}
+	}
+	securityGroups := make([]map[string]string, 0, len(cfg.SecurityGroupIDs))
+	for _, sg := range cfg.SecurityGroupIDs {
+		if sg = strings.TrimSpace(sg); sg != "" {
+			securityGroups = append(securityGroups, map[string]string{"id": sg})
+		}
+	}
+	if len(securityGroups) > 0 {
+		item["security_groups"] = securityGroups
+	}
+	data, err := json.Marshal([]map[string]any{item})
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
 }
 
-func renderLabelArgs(labels map[string]string) []string {
+func renderLabels(labels map[string]string) string {
 	keys := make([]string, 0, len(labels))
 	for key := range labels {
 		keys = append(keys, key)
@@ -360,7 +370,7 @@ func renderLabelArgs(labels map[string]string) []string {
 			out = append(out, key+"="+labels[key])
 		}
 	}
-	return out
+	return strings.Join(out, ",")
 }
 
 func normalizeNebiusState(state string) string {

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -495,7 +495,3 @@ func isJSON(output string) bool {
 func validationError(format string, args ...any) error {
 	return exit(2, format, args...)
 }
-
-func notImplemented(action string) error {
-	return errors.New("provider=nebius " + action + " is not implemented until Nebius lifecycle support lands")
-}

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -5,8 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"os"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type cliRunner struct {
@@ -21,8 +26,42 @@ type cliResult struct {
 
 var tokenLikePattern = regexp.MustCompile(`(?i)(osb_|ncp_|iam_token|oauth[_-]?token|access[_-]?token|refresh[_-]?token|private[_-]?key|BEGIN [A-Z ]*PRIVATE KEY)[A-Za-z0-9._:/+=@ -]*`)
 
+type nebiusAPI interface {
+	ListInstances(context.Context) ([]nebiusInstance, error)
+	GetInstance(context.Context, string) (nebiusInstance, error)
+	CreateInstance(context.Context, nebiusCreateRequest) (nebiusInstance, error)
+	WaitInstance(context.Context, string) (nebiusInstance, error)
+	UpdateLabels(context.Context, string, map[string]string) error
+	DeleteInstance(context.Context, string) error
+}
+
+type nebiusClient struct {
+	cfg NebiusConfig
+	cli cliRunner
+}
+
+type nebiusCreateRequest struct {
+	Name      string
+	Labels    map[string]string
+	UserData  string
+	PublicKey string
+}
+
+type nebiusInstance struct {
+	ID       string
+	Name     string
+	Status   string
+	Labels   map[string]string
+	PublicIP string
+	Raw      map[string]any
+}
+
 func newCLIRunner(cfg NebiusConfig, rt Runtime) cliRunner {
 	return cliRunner{cfg: cfg, rt: rt}
+}
+
+func newNebiusClient(cfg NebiusConfig, rt Runtime) *nebiusClient {
+	return &nebiusClient{cfg: cfg, cli: newCLIRunner(cfg, rt)}
 }
 
 func (c cliRunner) run(ctx context.Context, args ...string) (cliResult, error) {
@@ -66,6 +105,108 @@ func parseJSONArray(output string) ([]map[string]any, error) {
 	return objects, nil
 }
 
+func (c *nebiusClient) ListInstances(ctx context.Context) ([]nebiusInstance, error) {
+	result, err := c.cli.run(ctx, "compute", "instance", "list", "--parent-id", c.cfg.ParentID, "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+	return parseNebiusInstances(result.Stdout)
+}
+
+func (c *nebiusClient) GetInstance(ctx context.Context, id string) (nebiusInstance, error) {
+	result, err := c.cli.run(ctx, "compute", "instance", "get", id, "--format", "json")
+	if err != nil {
+		return nebiusInstance{}, err
+	}
+	return parseNebiusInstance(result.Stdout)
+}
+
+func (c *nebiusClient) CreateInstance(ctx context.Context, req nebiusCreateRequest) (nebiusInstance, error) {
+	tmp, err := os.CreateTemp("", "crabbox-nebius-cloud-init-*.yaml")
+	if err != nil {
+		return nebiusInstance{}, err
+	}
+	path := tmp.Name()
+	if _, err := tmp.WriteString(req.UserData); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(path)
+		return nebiusInstance{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(path)
+		return nebiusInstance{}, err
+	}
+	defer os.Remove(path)
+	args := []string{
+		"compute", "instance", "create",
+		"--parent-id", c.cfg.ParentID,
+		"--name", req.Name,
+		"--resources-platform", c.cfg.Platform,
+		"--resources-preset", c.cfg.Preset,
+		"--boot-disk-image-family", c.cfg.ImageFamily,
+		"--boot-disk-type", c.cfg.DiskType,
+		"--boot-disk-size-gib", strconv.Itoa(c.cfg.DiskSizeGiB),
+		"--cloud-init-user-data", path,
+		"--network-interface", renderNetworkInterface(c.cfg),
+		"--recovery-policy", firstNonBlank(c.cfg.RecoveryPolicy, "fail"),
+	}
+	for _, sg := range c.cfg.SecurityGroupIDs {
+		if strings.TrimSpace(sg) != "" {
+			args = append(args, "--network-interface-security-group-id", strings.TrimSpace(sg))
+		}
+	}
+	if strings.TrimSpace(c.cfg.ServiceAccountID) != "" {
+		args = append(args, "--service-account-id", strings.TrimSpace(c.cfg.ServiceAccountID))
+	}
+	for _, label := range renderLabelArgs(req.Labels) {
+		args = append(args, "--label", label)
+	}
+	args = append(args, "--format", "json")
+	result, err := c.cli.run(ctx, args...)
+	if err != nil {
+		return nebiusInstance{}, err
+	}
+	return parseNebiusInstance(result.Stdout)
+}
+
+func (c *nebiusClient) WaitInstance(ctx context.Context, id string) (nebiusInstance, error) {
+	var last nebiusInstance
+	for attempt := 0; attempt < 60; attempt++ {
+		item, err := c.GetInstance(ctx, id)
+		if err != nil {
+			return nebiusInstance{}, err
+		}
+		last = item
+		if item.PublicIP != "" && instanceRunning(item.Status) {
+			return item, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nebiusInstance{}, context.Cause(ctx)
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return last, fmt.Errorf("timeout waiting for nebius instance %s public IP/readiness", id)
+}
+
+func (c *nebiusClient) UpdateLabels(ctx context.Context, id string, labels map[string]string) error {
+	args := []string{"compute", "instance", "update", id}
+	for _, label := range renderLabelArgs(labels) {
+		args = append(args, "--label", label)
+	}
+	args = append(args, "--format", "json")
+	_, err := c.cli.run(ctx, args...)
+	return err
+}
+
+func (c *nebiusClient) DeleteInstance(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return validationError("nebius instance id is required for delete")
+	}
+	_, err := c.cli.run(ctx, "compute", "instance", "delete", id, "--quiet", "--format", "json")
+	return err
+}
+
 func stringField(object map[string]any, names ...string) string {
 	for _, name := range names {
 		if value, ok := object[name]; ok {
@@ -101,6 +242,225 @@ func containsIDOrName(output, want string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func parseNebiusInstances(output string) ([]nebiusInstance, error) {
+	items, err := parseJSONArray(output)
+	if err != nil {
+		object, objectErr := parseJSONObject(output)
+		if objectErr != nil {
+			return nil, err
+		}
+		if nested, ok := arrayField(object, "items", "instances"); ok {
+			items = nested
+		} else {
+			items = []map[string]any{object}
+		}
+	}
+	out := make([]nebiusInstance, 0, len(items))
+	for _, item := range items {
+		out = append(out, instanceFromObject(item))
+	}
+	return out, nil
+}
+
+func parseNebiusInstance(output string) (nebiusInstance, error) {
+	object, err := parseJSONObject(output)
+	if err != nil {
+		items, itemsErr := parseJSONArray(output)
+		if itemsErr != nil {
+			return nebiusInstance{}, err
+		}
+		if len(items) == 0 {
+			return nebiusInstance{}, errors.New("empty nebius instance response")
+		}
+		object = items[0]
+	}
+	return instanceFromObject(object), nil
+}
+
+func instanceFromObject(object map[string]any) nebiusInstance {
+	labels := mapFromAny(firstPath(object, "metadata.labels", "labels", "metadataLabels"))
+	return nebiusInstance{
+		ID:       stringFromAny(firstPath(object, "metadata.id", "id")),
+		Name:     stringFromAny(firstPath(object, "metadata.name", "name")),
+		Status:   stringFromAny(firstPath(object, "status.state", "status", "state")),
+		Labels:   labels,
+		PublicIP: extractNebiusPublicIP(object),
+		Raw:      object,
+	}
+}
+
+func serverFromInstance(item nebiusInstance, cfg Config) Server {
+	labels := make(map[string]string, len(item.Labels))
+	for key, value := range item.Labels {
+		labels[key] = value
+	}
+	server := Server{
+		CloudID:  item.ID,
+		Provider: providerName,
+		Name:     firstNonBlank(item.Name, labels["slug"]),
+		Status:   normalizeNebiusState(item.Status),
+		Labels:   labels,
+	}
+	server.PublicNet.IPv4.IP = item.PublicIP
+	server.ServerType.Name = nebiusServerType(cfg)
+	return server
+}
+
+func extractNebiusPublicIP(object map[string]any) string {
+	for _, path := range []string{
+		"status.network_interfaces.0.public_ip_address.address",
+		"status.networkInterfaces.0.publicIpAddress.address",
+		"network_interfaces.0.public_ip_address.address",
+		"networkInterfaces.0.publicIpAddress.address",
+		"public_ip_address.address",
+		"publicIpAddress.address",
+		"public_ip",
+		"publicIP",
+	} {
+		if ip := cleanIP(stringFromAny(pathValue(object, path))); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func cleanIP(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if ip, _, err := net.ParseCIDR(value); err == nil {
+		return ip.String()
+	}
+	if strings.Contains(value, "/") {
+		value, _, _ = strings.Cut(value, "/")
+	}
+	return strings.TrimSpace(value)
+}
+
+func renderNetworkInterface(cfg NebiusConfig) string {
+	parts := []string{"subnet-id=" + strings.TrimSpace(cfg.SubnetID)}
+	if !strings.EqualFold(strings.TrimSpace(cfg.PublicIP), "none") {
+		parts = append(parts, "public-ip-address={}")
+	}
+	return strings.Join(parts, ",")
+}
+
+func renderLabelArgs(labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if strings.TrimSpace(key) != "" && strings.TrimSpace(labels[key]) != "" {
+			out = append(out, key+"="+labels[key])
+		}
+	}
+	return out
+}
+
+func normalizeNebiusState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "running", "ready":
+		return "ready"
+	case "creating", "provisioning", "starting":
+		return "provisioning"
+	case "stopped":
+		return "stopped"
+	case "deleting":
+		return "deleting"
+	default:
+		return strings.ToLower(strings.TrimSpace(state))
+	}
+}
+
+func instanceRunning(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "running", "ready":
+		return true
+	default:
+		return false
+	}
+}
+
+func arrayField(object map[string]any, names ...string) ([]map[string]any, bool) {
+	for _, name := range names {
+		value, ok := object[name]
+		if !ok {
+			continue
+		}
+		raw, ok := value.([]any)
+		if !ok {
+			continue
+		}
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			if obj, ok := item.(map[string]any); ok {
+				out = append(out, obj)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func firstPath(object map[string]any, paths ...string) any {
+	for _, path := range paths {
+		if value := pathValue(object, path); value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func pathValue(object map[string]any, path string) any {
+	var current any = object
+	for _, part := range strings.Split(path, ".") {
+		switch typed := current.(type) {
+		case map[string]any:
+			current = typed[part]
+		case []any:
+			index, err := strconv.Atoi(part)
+			if err != nil || index < 0 || index >= len(typed) {
+				return nil
+			}
+			current = typed[index]
+		default:
+			return nil
+		}
+	}
+	return current
+}
+
+func stringFromAny(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return typed.String()
+	case float64:
+		return strconv.FormatInt(int64(typed), 10)
+	default:
+		return ""
+	}
+}
+
+func mapFromAny(value any) map[string]string {
+	out := map[string]string{}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return out
+	}
+	for key, raw := range object {
+		if value := stringFromAny(raw); value != "" {
+			out[key] = value
+		}
+	}
+	return out
 }
 
 func redactNebiusText(text string) string {

--- a/internal/providers/nebius/cloudinit.go
+++ b/internal/providers/nebius/cloudinit.go
@@ -1,0 +1,43 @@
+package nebius
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var linuxUsernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
+
+func renderNebiusCloudInit(user, publicKey string) (string, error) {
+	user = strings.TrimSpace(user)
+	publicKey = strings.TrimSpace(publicKey)
+	if err := validateNebiusUser(user); err != nil {
+		return "", err
+	}
+	if publicKey == "" {
+		return "", validationError("ssh public key is required for nebius cloud-init")
+	}
+	return fmt.Sprintf(`#cloud-config
+users:
+  - name: %s
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    ssh_authorized_keys:
+      - %s
+ssh_pwauth: false
+disable_root: true
+`, user, publicKey), nil
+}
+
+func validateNebiusUser(user string) error {
+	user = strings.TrimSpace(user)
+	switch strings.ToLower(user) {
+	case "", "root", "admin":
+		return validationError("nebius.user must be a non-reserved Linux username")
+	}
+	if !linuxUsernamePattern.MatchString(user) {
+		return validationError("nebius.user must match Linux username pattern %s", linuxUsernamePattern.String())
+	}
+	return nil
+}

--- a/internal/providers/nebius/core.go
+++ b/internal/providers/nebius/core.go
@@ -1,0 +1,40 @@
+package nebius
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type NebiusConfig = core.NebiusConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type DoctorCheck = core.DoctorCheck
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type CleanupRequest = core.CleanupRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+
+const (
+	providerName = "nebius"
+	targetLinux  = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}

--- a/internal/providers/nebius/core.go
+++ b/internal/providers/nebius/core.go
@@ -25,6 +25,7 @@ type LeaseTarget = core.LeaseTarget
 type Server = core.Server
 type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
+type SSHTarget = core.SSHTarget
 
 const (
 	providerName = "nebius"

--- a/internal/providers/nebius/flags.go
+++ b/internal/providers/nebius/flags.go
@@ -1,0 +1,108 @@
+package nebius
+
+import (
+	"flag"
+	"strings"
+)
+
+type nebiusFlagValues struct {
+	CLI              *string
+	Profile          *string
+	ParentID         *string
+	SubnetID         *string
+	Platform         *string
+	Preset           *string
+	ImageFamily      *string
+	DiskType         *string
+	DiskSizeGiB      *int
+	User             *string
+	PublicIP         *string
+	SecurityGroupIDs *string
+	ServiceAccountID *string
+	RecoveryPolicy   *string
+}
+
+// RegisterNebiusProviderFlags exposes only non-secret Nebius settings.
+// Authentication is owned by Nebius CLI profiles, not Crabbox argv.
+func RegisterNebiusProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return nebiusFlagValues{
+		CLI:              fs.String("nebius-cli", defaults.Nebius.CLI, "Nebius CLI path"),
+		Profile:          fs.String("nebius-profile", defaults.Nebius.Profile, "Nebius CLI profile name"),
+		ParentID:         fs.String("nebius-parent-id", defaults.Nebius.ParentID, "Nebius parent/project ID"),
+		SubnetID:         fs.String("nebius-subnet-id", defaults.Nebius.SubnetID, "Nebius subnet ID"),
+		Platform:         fs.String("nebius-platform", defaults.Nebius.Platform, "Nebius compute platform"),
+		Preset:           fs.String("nebius-preset", defaults.Nebius.Preset, "Nebius compute preset"),
+		ImageFamily:      fs.String("nebius-image-family", defaults.Nebius.ImageFamily, "Nebius boot image family"),
+		DiskType:         fs.String("nebius-disk-type", defaults.Nebius.DiskType, "Nebius boot disk type"),
+		DiskSizeGiB:      fs.Int("nebius-disk-size-gib", defaults.Nebius.DiskSizeGiB, "Nebius boot disk size in GiB"),
+		User:             fs.String("nebius-user", defaults.Nebius.User, "SSH user for Nebius VMs"),
+		PublicIP:         fs.String("nebius-public-ip", defaults.Nebius.PublicIP, "Nebius public IP mode: dynamic or none"),
+		SecurityGroupIDs: fs.String("nebius-security-group-ids", "", "comma-separated Nebius security group IDs"),
+		ServiceAccountID: fs.String("nebius-service-account-id", defaults.Nebius.ServiceAccountID, "Nebius service account ID for VMs"),
+		RecoveryPolicy:   fs.String("nebius-recovery-policy", defaults.Nebius.RecoveryPolicy, "Nebius create recovery policy: fail"),
+	}
+}
+
+func ApplyNebiusProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(nebiusFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "nebius-cli") {
+		cfg.Nebius.CLI = *v.CLI
+	}
+	if flagWasSet(fs, "nebius-profile") {
+		cfg.Nebius.Profile = *v.Profile
+	}
+	if flagWasSet(fs, "nebius-parent-id") {
+		cfg.Nebius.ParentID = *v.ParentID
+	}
+	if flagWasSet(fs, "nebius-subnet-id") {
+		cfg.Nebius.SubnetID = *v.SubnetID
+	}
+	if flagWasSet(fs, "nebius-platform") {
+		cfg.Nebius.Platform = *v.Platform
+	}
+	if flagWasSet(fs, "nebius-preset") {
+		cfg.Nebius.Preset = *v.Preset
+	}
+	if flagWasSet(fs, "nebius-image-family") {
+		cfg.Nebius.ImageFamily = *v.ImageFamily
+	}
+	if flagWasSet(fs, "nebius-disk-type") {
+		cfg.Nebius.DiskType = *v.DiskType
+	}
+	if flagWasSet(fs, "nebius-disk-size-gib") {
+		cfg.Nebius.DiskSizeGiB = *v.DiskSizeGiB
+	}
+	if flagWasSet(fs, "nebius-user") {
+		cfg.Nebius.User = *v.User
+	}
+	if flagWasSet(fs, "nebius-public-ip") {
+		cfg.Nebius.PublicIP = *v.PublicIP
+	}
+	if flagWasSet(fs, "nebius-security-group-ids") {
+		cfg.Nebius.SecurityGroupIDs = splitCommaList(*v.SecurityGroupIDs)
+	}
+	if flagWasSet(fs, "nebius-service-account-id") {
+		cfg.Nebius.ServiceAccountID = *v.ServiceAccountID
+	}
+	if flagWasSet(fs, "nebius-recovery-policy") {
+		cfg.Nebius.RecoveryPolicy = *v.RecoveryPolicy
+	}
+	if cfg.Provider == providerName {
+		return Provider{}.ValidateConfig(*cfg)
+	}
+	return nil
+}
+
+func splitCommaList(value string) []string {
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
+}

--- a/internal/providers/nebius/labels.go
+++ b/internal/providers/nebius/labels.go
@@ -1,0 +1,122 @@
+package nebius
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	nebiusProviderLabel = "crabbox_provider"
+	nebiusLeaseLabel    = "crabbox_lease"
+	nebiusSlugLabel     = "crabbox_slug"
+	nebiusTargetLabel   = "crabbox_target"
+	nebiusScopeLabel    = "crabbox_scope"
+	nebiusParentLabel   = "crabbox_parent_id"
+	nebiusProfileLabel  = "crabbox_profile"
+)
+
+func nebiusLeaseLabels(cfg Config, leaseID, slug, state string, keep bool, now time.Time) map[string]string {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+	labels["state"] = state
+	return addNebiusScopeLabels(labels, cfg)
+}
+
+func addNebiusScopeLabels(labels map[string]string, cfg Config) map[string]string {
+	out := make(map[string]string, len(labels)+8)
+	for key, value := range labels {
+		out[normalizeNebiusLabelKey(key)] = normalizeNebiusLabelValue(value)
+	}
+	out["crabbox"] = "true"
+	out["provider"] = providerName
+	out["target"] = targetLinux
+	out[nebiusProviderLabel] = providerName
+	out[nebiusLeaseLabel] = out["lease"]
+	out[nebiusSlugLabel] = out["slug"]
+	out[nebiusTargetLabel] = targetLinux
+	out[nebiusScopeLabel] = nebiusScopeHash(cfg)
+	out[nebiusParentLabel] = normalizeNebiusLabelValue(cfg.Nebius.ParentID)
+	if strings.TrimSpace(cfg.Nebius.Profile) != "" {
+		out[nebiusProfileLabel] = normalizeNebiusLabelValue(cfg.Nebius.Profile)
+	}
+	return out
+}
+
+func validateNebiusOwnership(labels map[string]string, cfg Config) error {
+	if labels == nil {
+		return core.Exit(3, "nebius resource has no labels; refusing lifecycle action")
+	}
+	required := map[string]string{
+		"crabbox":           "true",
+		"provider":          providerName,
+		"target":            targetLinux,
+		nebiusProviderLabel: providerName,
+		nebiusTargetLabel:   targetLinux,
+		nebiusScopeLabel:    nebiusScopeHash(cfg),
+		nebiusParentLabel:   normalizeNebiusLabelValue(cfg.Nebius.ParentID),
+	}
+	for key, want := range required {
+		if got := strings.TrimSpace(labels[key]); got != want {
+			return core.Exit(3, "nebius ownership mismatch for %s: expected %q, found %q", key, want, got)
+		}
+	}
+	if strings.TrimSpace(labels["lease"]) == "" || labels["lease"] != labels[nebiusLeaseLabel] {
+		return core.Exit(3, "nebius ownership requires matching lease labels")
+	}
+	if strings.TrimSpace(labels["slug"]) == "" || labels["slug"] != labels[nebiusSlugLabel] {
+		return core.Exit(3, "nebius ownership requires matching slug labels")
+	}
+	if strings.TrimSpace(labels["expires_at"]) == "" {
+		return core.Exit(3, "nebius ownership requires expires_at label")
+	}
+	if wantProfile := strings.TrimSpace(cfg.Nebius.Profile); wantProfile != "" {
+		if got := strings.TrimSpace(labels[nebiusProfileLabel]); got != normalizeNebiusLabelValue(wantProfile) {
+			return core.Exit(3, "nebius profile mismatch: expected %q, found %q", normalizeNebiusLabelValue(wantProfile), got)
+		}
+	}
+	return nil
+}
+
+func nebiusScopeHash(cfg Config) string {
+	parts := []string{
+		"provider=" + providerName,
+		"profile=" + strings.TrimSpace(cfg.Nebius.Profile),
+		"parent=" + strings.TrimSpace(cfg.Nebius.ParentID),
+		"subnet=" + strings.TrimSpace(cfg.Nebius.SubnetID),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])[:24]
+}
+
+func normalizeNebiusLabelKey(key string) string {
+	key = strings.TrimSpace(strings.ToLower(key))
+	key = strings.NewReplacer(".", "_", "-", "_", "/", "_", " ", "_").Replace(key)
+	if key == "" {
+		return "label"
+	}
+	return key
+}
+
+func normalizeNebiusLabelValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 256 {
+		value = value[:256]
+	}
+	return value
+}
+
+func labelsContainNebiusOwnership(labels map[string]string, cfg Config) bool {
+	return validateNebiusOwnership(labels, cfg) == nil
+}
+
+func ownershipDebug(labels map[string]string, cfg Config) string {
+	err := validateNebiusOwnership(labels, cfg)
+	if err == nil {
+		return "owned"
+	}
+	return fmt.Sprint(err)
+}

--- a/internal/providers/nebius/labels.go
+++ b/internal/providers/nebius/labels.go
@@ -3,7 +3,6 @@ package nebius
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
 
@@ -107,16 +106,4 @@ func normalizeNebiusLabelValue(value string) string {
 		value = value[:256]
 	}
 	return value
-}
-
-func labelsContainNebiusOwnership(labels map[string]string, cfg Config) bool {
-	return validateNebiusOwnership(labels, cfg) == nil
-}
-
-func ownershipDebug(labels map[string]string, cfg Config) string {
-	err := validateNebiusOwnership(labels, cfg)
-	if err == nil {
-		return "owned"
-	}
-	return fmt.Sprint(err)
 }

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -67,6 +67,7 @@ func (f *fakeNebiusAPI) DeleteInstance(_ context.Context, id string) error {
 func newTestBackend(t *testing.T, api *fakeNebiusAPI) *backend {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cfg := testConfig()
 	cfg.IdleTimeout = time.Hour
 	cfg.TTL = 2 * time.Hour

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -1,0 +1,427 @@
+package nebius
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeNebiusAPI struct {
+	items           []nebiusInstance
+	createReq       nebiusCreateRequest
+	created         nebiusInstance
+	waited          nebiusInstance
+	updatedLabels   map[string]string
+	deletedIDs      []string
+	getErr          error
+	deleteErr       error
+	createErr       error
+	listErr         error
+	waitErr         error
+	updateLabelsErr error
+}
+
+func (f *fakeNebiusAPI) ListInstances(context.Context) ([]nebiusInstance, error) {
+	return append([]nebiusInstance(nil), f.items...), f.listErr
+}
+
+func (f *fakeNebiusAPI) GetInstance(_ context.Context, id string) (nebiusInstance, error) {
+	if f.getErr != nil {
+		return nebiusInstance{}, f.getErr
+	}
+	for _, item := range f.items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	if f.waited.ID == id {
+		return f.waited, nil
+	}
+	return nebiusInstance{}, errors.New("not found")
+}
+
+func (f *fakeNebiusAPI) CreateInstance(_ context.Context, req nebiusCreateRequest) (nebiusInstance, error) {
+	f.createReq = req
+	return f.created, f.createErr
+}
+
+func (f *fakeNebiusAPI) WaitInstance(context.Context, string) (nebiusInstance, error) {
+	return f.waited, f.waitErr
+}
+
+func (f *fakeNebiusAPI) UpdateLabels(_ context.Context, _ string, labels map[string]string) error {
+	f.updatedLabels = labels
+	return f.updateLabelsErr
+}
+
+func (f *fakeNebiusAPI) DeleteInstance(_ context.Context, id string) error {
+	f.deletedIDs = append(f.deletedIDs, id)
+	return f.deleteErr
+}
+
+func newTestBackend(t *testing.T, api *fakeNebiusAPI) *backend {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	cfg := testConfig()
+	cfg.IdleTimeout = time.Hour
+	cfg.TTL = 2 * time.Hour
+	cfg.Nebius.SecurityGroupIDs = []string{"sg-a", "sg-b"}
+	cfg.Nebius.ServiceAccountID = "sa-a"
+	b := NewBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*backend)
+	b.clientFactory = func(Runtime) nebiusAPI { return api }
+	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
+	b.now = func() time.Time { return time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC) }
+	return b
+}
+
+func TestCloudInitRendersUserAndKey(t *testing.T) {
+	got, err := renderNebiusCloudInit("crabbox", "ssh-ed25519 AAAA test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"#cloud-config", "name: crabbox", "NOPASSWD", "ssh-ed25519 AAAA test", "disable_root: true"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("cloud-init missing %q:\n%s", want, got)
+		}
+	}
+	if _, err := renderNebiusCloudInit("root", "ssh-ed25519 AAAA test"); err == nil {
+		t.Fatal("reserved root user accepted")
+	}
+	for _, user := range []string{"alice\n  - name: root", "Alice", "bad user", "1alice", "alice:$evil"} {
+		if _, err := renderNebiusCloudInit(user, "ssh-ed25519 AAAA test"); err == nil {
+			t.Fatalf("unsafe user %q accepted", user)
+		}
+	}
+}
+
+func TestLabelOwnershipRequiresCompleteMatchingScope(t *testing.T) {
+	cfg := testConfig()
+	cfg.IdleTimeout = time.Hour
+	labels := nebiusLeaseLabels(cfg, "cbx_123456789abc", "demo", "ready", false, time.Unix(1000, 0))
+	if err := validateNebiusOwnership(labels, cfg); err != nil {
+		t.Fatalf("complete labels rejected: %v", err)
+	}
+	partial := cloneLabels(labels)
+	delete(partial, nebiusScopeLabel)
+	if err := validateNebiusOwnership(partial, cfg); err == nil {
+		t.Fatal("partial ownership accepted")
+	}
+	foreign := cloneLabels(labels)
+	foreign[nebiusParentLabel] = "other-project"
+	if err := validateNebiusOwnership(foreign, cfg); err == nil {
+		t.Fatal("foreign parent ownership accepted")
+	}
+}
+
+func TestCommandConstructionUsesManagedDiskPublicIPLabelsAndNoSecrets(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		joined := strings.Join(req.Args, " ")
+		if !strings.Contains(joined, "compute instance create") {
+			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+		}
+		if strings.Contains(joined, "osb_") || strings.Contains(joined, "private_key") {
+			return LocalCommandResult{}, errors.New("secret-like value passed on argv")
+		}
+		if !strings.Contains(joined, "--network-interface subnet-id=subnet-123,public-ip-address={}") {
+			return LocalCommandResult{}, errors.New("missing dynamic public IP network interface: " + joined)
+		}
+		if !strings.Contains(joined, "--boot-disk-image-family ubuntu24.04-driverless") || !strings.Contains(joined, "--boot-disk-type network_ssd") {
+			return LocalCommandResult{}, errors.New("missing managed boot disk args: " + joined)
+		}
+		if !strings.Contains(joined, "--label crabbox_provider=nebius") || !strings.Contains(joined, "--label crabbox_scope=") {
+			return LocalCommandResult{}, errors.New("missing ownership labels: " + joined)
+		}
+		return LocalCommandResult{Stdout: `{"metadata":{"id":"vm-1","name":"cbx-demo","labels":{"crabbox":"true"}},"status":{"state":"RUNNING","network_interfaces":[{"public_ip_address":{"address":"203.0.113.10/32"}}]}}`}, nil
+	}}
+	client := newNebiusClient(testConfig().Nebius, Runtime{Exec: runner})
+	labels := nebiusLeaseLabels(testConfig(), "cbx_123456789abc", "demo", "ready", false, time.Unix(1000, 0))
+	item, err := client.CreateInstance(context.Background(), nebiusCreateRequest{Name: "cbx-demo", Labels: labels, UserData: "#cloud-config\n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.PublicIP != "203.0.113.10" {
+		t.Fatalf("PublicIP=%q", item.PublicIP)
+	}
+}
+
+func TestPublicIPParsesNestedCIDR(t *testing.T) {
+	item, err := parseNebiusInstance(`{"metadata":{"id":"vm-1","name":"n"},"status":{"state":"RUNNING","network_interfaces":[{"public_ip_address":{"address":"198.51.100.7/32"}}]}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.PublicIP != "198.51.100.7" {
+		t.Fatalf("PublicIP=%q", item.PublicIP)
+	}
+}
+
+func TestAcquirePersistsClaimAndSSHReadyTarget(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_existing1", "old", "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{
+		items:   []nebiusInstance{{ID: "vm-old", Name: "old", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.9"}},
+		created: nebiusInstance{ID: "vm-new", Name: "pending", Status: "CREATING", Labels: map[string]string{}},
+		waited:  nebiusInstance{ID: "vm-new", Name: "ready", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.20"},
+	}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Host != "203.0.113.20" || lease.SSH.User != "crabbox" || lease.SSH.Key == "" {
+		t.Fatalf("ssh target=%#v", lease.SSH)
+	}
+	if api.createReq.Labels[nebiusLeaseLabel] == "" || api.updatedLabels["state"] != "ready" {
+		t.Fatalf("labels not persisted/ready: create=%v update=%v", api.createReq.Labels, api.updatedLabels)
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName)
+	if err != nil || !ok {
+		t.Fatalf("claim ok=%v err=%v", ok, err)
+	}
+	if claim.CloudID != "vm-new" || claim.SSHHost != "203.0.113.20" {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestResolveListStatusByAliases(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_123456789abc", "demo", "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{items: []nebiusInstance{
+		{ID: "vm-1", Name: core.LeaseProviderName("cbx_123456789abc", "demo"), Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.10"},
+		{ID: "foreign", Name: "foreign", Status: "RUNNING", Labels: map[string]string{"crabbox": "true"}, PublicIP: "203.0.113.11"},
+	}}
+	b := newTestBackend(t, api)
+	list, err := b.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].CloudID != "vm-1" || list[0].Status != "ready" {
+		t.Fatalf("list=%#v", list)
+	}
+	for _, id := range []string{"cbx_123456789abc", "demo", "vm-1", core.LeaseProviderName("cbx_123456789abc", "demo")} {
+		got, err := b.Resolve(context.Background(), ResolveRequest{ID: id})
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", id, err)
+		}
+		if got.LeaseID != "cbx_123456789abc" || got.Server.CloudID != "vm-1" {
+			t.Fatalf("Resolve(%q)=%#v", id, got)
+		}
+	}
+}
+
+func TestReleaseAndCleanupRefuseForeignOrAmbiguousResources(t *testing.T) {
+	cfg := testConfig()
+	owned := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "old", "leased", false, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	foreign := cloneLabels(owned)
+	foreign[nebiusScopeLabel] = "foreign"
+	api := &fakeNebiusAPI{items: []nebiusInstance{
+		{ID: "vm-owned", Name: "old", Status: "RUNNING", Labels: owned, PublicIP: "203.0.113.10"},
+		{ID: "vm-foreign", Name: "foreign", Status: "RUNNING", Labels: foreign, PublicIP: "203.0.113.11"},
+		{ID: "vm-partial", Name: "partial", Status: "RUNNING", Labels: map[string]string{"crabbox": "true", "provider": providerName}, PublicIP: "203.0.113.12"},
+	}}
+	b := newTestBackend(t, api)
+	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deletedIDs) != 0 {
+		t.Fatalf("dry-run deleted: %v", api.deletedIDs)
+	}
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(api.deletedIDs, ",") != "vm-owned" {
+		t.Fatalf("deletedIDs=%v", api.deletedIDs)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: Server{CloudID: "vm-foreign", Labels: foreign}}}); err == nil {
+		t.Fatal("ReleaseLease accepted foreign ownership")
+	}
+}
+
+func TestTouchUpdatesLabelsWithoutLosingOwnership(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_123456789abc", "demo", "leased", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.10"}}}
+	b := newTestBackend(t, api)
+	server, err := b.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: "cbx_123456789abc", Server: Server{CloudID: "vm-1", Labels: labels}}, State: "ready", IdleTimeout: 30 * time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server.Labels["state"] != "ready" || api.updatedLabels[nebiusScopeLabel] == "" {
+		t.Fatalf("touch labels=%v", server.Labels)
+	}
+	if api.updatedLabels["idle_timeout_secs"] != "1800" {
+		t.Fatalf("idle timeout override ignored: labels=%v", api.updatedLabels)
+	}
+	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
+		t.Fatalf("touched labels no longer owned: %v", err)
+	}
+}
+
+func TestTouchRefusesLiveOwnershipMismatch(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_123456789abc", "demo", "leased", false, time.Unix(1000, 0))
+	liveLabels := cloneLabels(labels)
+	liveLabels["lease"] = "cbx_other123456"
+	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
+	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
+	b := newTestBackend(t, api)
+	_, err := b.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: "cbx_123456789abc", Server: Server{CloudID: "vm-1", Labels: labels}}, State: "ready"})
+	if err == nil {
+		t.Fatal("Touch accepted changed live ownership")
+	}
+	if len(api.updatedLabels) != 0 {
+		t.Fatalf("labels updated despite mismatch: %v", api.updatedLabels)
+	}
+}
+
+func TestManagedDiskAcquireRejectsPublicIPNone(t *testing.T) {
+	cfg := testConfig()
+	cfg.Nebius.PublicIP = "none"
+	if err := validateNebiusAcquireConfig(cfg); err == nil {
+		t.Fatal("public_ip=none accepted for direct SSH acquire")
+	}
+}
+
+func TestAcquireRecoveryRetainsClaimOnIndeterminateCreate(t *testing.T) {
+	api := &fakeNebiusAPI{createErr: errors.New("connection reset after create")}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "recover"})
+	if err == nil {
+		t.Fatal("Acquire succeeded unexpectedly")
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("recover", providerName)
+	if claimErr != nil || !ok {
+		t.Fatalf("recovery claim ok=%v err=%v", ok, claimErr)
+	}
+	if claim.Slug != "recover" || claim.Labels["state"] != "provisioning" {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestAcquireRollsBackCreatedInstanceWhenOnAcquiredFails(t *testing.T) {
+	api := &fakeNebiusAPI{
+		created: nebiusInstance{ID: "vm-new", Name: "pending", Status: "CREATING", Labels: map[string]string{}},
+		waited:  nebiusInstance{ID: "vm-new", Name: "ready", Status: "RUNNING", Labels: map[string]string{}, PublicIP: "203.0.113.20"},
+	}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "rollback",
+		OnAcquired: func(LeaseTarget) error {
+			return errors.New("controller rejected identity")
+		},
+	})
+	if err == nil {
+		t.Fatal("Acquire succeeded unexpectedly")
+	}
+	if strings.Join(api.deletedIDs, ",") != "vm-new" {
+		t.Fatalf("rollback deletedIDs=%v", api.deletedIDs)
+	}
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider("rollback", providerName); claimErr != nil || ok {
+		t.Fatalf("rollback claim ok=%v err=%v", ok, claimErr)
+	}
+}
+
+func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{getErr: errors.New("not found")}
+	b := newTestBackend(t, api)
+	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
+	server.PublicNet.IPv4.IP = "203.0.113.10"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deletedIDs) != 0 {
+		t.Fatalf("delete called despite confirmed absence: %v", api.deletedIDs)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("gone", providerName); err != nil || ok {
+		t.Fatalf("claim still present ok=%v err=%v", ok, err)
+	}
+}
+
+func TestResolveReleaseOnlyFindsClaimByCloudID(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{}
+	b := newTestBackend(t, api)
+	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "vm-gone", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != "cbx_deadbeef1234" || lease.Server.CloudID != "vm-gone" {
+		t.Fatalf("lease=%#v", lease)
+	}
+}
+
+func TestReleaseRefusesLiveOwnershipMismatch(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	liveLabels := cloneLabels(labels)
+	liveLabels["lease"] = "cbx_other123456"
+	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
+	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "other", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
+	b := newTestBackend(t, api)
+	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: Server{CloudID: "vm-1", Labels: labels}}})
+	if err == nil {
+		t.Fatal("ReleaseLease accepted changed live ownership")
+	}
+	if len(api.deletedIDs) != 0 {
+		t.Fatalf("deleted despite mismatch: %v", api.deletedIDs)
+	}
+}
+
+func TestAcquireRollbackFailureRetainsCreatedInstanceIDClaim(t *testing.T) {
+	api := &fakeNebiusAPI{
+		created:   nebiusInstance{ID: "vm-new", Name: "pending", Status: "CREATING", Labels: map[string]string{}},
+		deleteErr: errors.New("lost delete response"),
+	}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
+		RequestedSlug: "rollback-failed",
+		OnAcquired: func(LeaseTarget) error {
+			return errors.New("controller rejected identity")
+		},
+	})
+	if err == nil {
+		t.Fatal("Acquire succeeded unexpectedly")
+	}
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("rollback-failed", providerName)
+	if claimErr != nil || !ok {
+		t.Fatalf("recovery claim ok=%v err=%v", ok, claimErr)
+	}
+	if claim.CloudID != "vm-new" {
+		t.Fatalf("recovery claim lost cloud id: %#v", claim)
+	}
+}
+
+func TestClassifyNebiusIndeterminateErrors(t *testing.T) {
+	for _, text := range []string{"timeout waiting", "connection reset by peer", "lost delete response"} {
+		if !isIndeterminateNebiusError(errors.New(text)) {
+			t.Fatalf("%q not classified indeterminate", text)
+		}
+	}
+	if isIndeterminateNebiusError(errors.New("validation failed")) {
+		t.Fatal("validation error classified indeterminate")
+	}
+}
+
+func cloneLabels(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -331,56 +331,65 @@ func TestAcquireRollsBackCreatedInstanceWhenOnAcquiredFails(t *testing.T) {
 
 func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
 	cfg := testConfig()
-	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
-	api := &fakeNebiusAPI{getErr: errors.New("instance vm-gone not found")}
+	leaseID := "cbx_absent123456"
+	slug := "gone-absent"
+	cloudID := "vm-gone-absent"
+	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{getErr: errors.New("instance " + cloudID + " not found")}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
+	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
 	server.PublicNet.IPv4.IP = "203.0.113.10"
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: server}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deletedIDs) != 0 {
 		t.Fatalf("delete called despite confirmed absence: %v", api.deletedIDs)
 	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider("gone", providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
 		t.Fatalf("claim still present ok=%v err=%v", ok, err)
 	}
 }
 
 func TestReleaseDoesNotCleanClaimOnUnrelatedNotFound(t *testing.T) {
 	cfg := testConfig()
-	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	leaseID := "cbx_unrelated123"
+	slug := "gone-unrelated"
+	cloudID := "vm-gone-unrelated"
+	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{getErr: errors.New("profile production not found")}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: server}}); err == nil {
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err == nil {
 		t.Fatal("ReleaseLease cleaned state after unrelated not-found error")
 	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider("gone", providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || !ok {
 		t.Fatalf("claim removed after unrelated not-found ok=%v err=%v", ok, err)
 	}
 }
 
 func TestResolveReleaseOnlyFindsClaimByCloudID(t *testing.T) {
 	cfg := testConfig()
-	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	leaseID := "cbx_resolve12345"
+	slug := "gone-resolve"
+	cloudID := "vm-gone-resolve"
+	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "vm-gone", ReleaseOnly: true})
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: cloudID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.LeaseID != "cbx_deadbeef1234" || lease.Server.CloudID != "vm-gone" {
+	if lease.LeaseID != leaseID || lease.Server.CloudID != cloudID {
 		t.Fatalf("lease=%#v", lease)
 	}
 }

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -42,7 +42,7 @@ func (f *fakeNebiusAPI) GetInstance(_ context.Context, id string) (nebiusInstanc
 	if f.waited.ID == id {
 		return f.waited, nil
 	}
-	return nebiusInstance{}, errors.New("not found")
+	return nebiusInstance{}, errors.New("instance " + id + " not found")
 }
 
 func (f *fakeNebiusAPI) CreateInstance(_ context.Context, req nebiusCreateRequest) (nebiusInstance, error) {
@@ -127,13 +127,16 @@ func TestCommandConstructionUsesManagedDiskPublicIPLabelsAndNoSecrets(t *testing
 		if strings.Contains(joined, "osb_") || strings.Contains(joined, "private_key") {
 			return LocalCommandResult{}, errors.New("secret-like value passed on argv")
 		}
-		if !strings.Contains(joined, "--network-interface subnet-id=subnet-123,public-ip-address={}") {
+		if !strings.Contains(joined, "--network-interfaces") || !strings.Contains(joined, `"subnet_id":"subnet-123"`) || !strings.Contains(joined, `"public_ip_address":{}`) {
 			return LocalCommandResult{}, errors.New("missing dynamic public IP network interface: " + joined)
 		}
-		if !strings.Contains(joined, "--boot-disk-image-family ubuntu24.04-driverless") || !strings.Contains(joined, "--boot-disk-type network_ssd") {
+		if !strings.Contains(joined, "--boot-disk-managed-disk-source-image-family-image-family ubuntu24.04-driverless") ||
+			!strings.Contains(joined, "--boot-disk-managed-disk-source-image-family-parent-id project-123") ||
+			!strings.Contains(joined, "--boot-disk-managed-disk-type network_ssd") ||
+			!strings.Contains(joined, "--boot-disk-managed-disk-size-gibibytes 50") {
 			return LocalCommandResult{}, errors.New("missing managed boot disk args: " + joined)
 		}
-		if !strings.Contains(joined, "--label crabbox_provider=nebius") || !strings.Contains(joined, "--label crabbox_scope=") {
+		if !strings.Contains(joined, "--labels ") || !strings.Contains(joined, "crabbox_provider=nebius") || !strings.Contains(joined, "crabbox_scope=") {
 			return LocalCommandResult{}, errors.New("missing ownership labels: " + joined)
 		}
 		return LocalCommandResult{Stdout: `{"metadata":{"id":"vm-1","name":"cbx-demo","labels":{"crabbox":"true"}},"status":{"state":"RUNNING","network_interfaces":[{"public_ip_address":{"address":"203.0.113.10/32"}}]}}`}, nil
@@ -329,7 +332,7 @@ func TestAcquireRollsBackCreatedInstanceWhenOnAcquiredFails(t *testing.T) {
 func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
 	cfg := testConfig()
 	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
-	api := &fakeNebiusAPI{getErr: errors.New("not found")}
+	api := &fakeNebiusAPI{getErr: errors.New("instance vm-gone not found")}
 	b := newTestBackend(t, api)
 	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
 	server.PublicNet.IPv4.IP = "203.0.113.10"
@@ -344,6 +347,23 @@ func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider("gone", providerName); err != nil || ok {
 		t.Fatalf("claim still present ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReleaseDoesNotCleanClaimOnUnrelatedNotFound(t *testing.T) {
+	cfg := testConfig()
+	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
+	api := &fakeNebiusAPI{getErr: errors.New("profile production not found")}
+	b := newTestBackend(t, api)
+	server := Server{Provider: providerName, CloudID: "vm-gone", Name: "gone", Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "gone", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: server}}); err == nil {
+		t.Fatal("ReleaseLease cleaned state after unrelated not-found error")
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider("gone", providerName); err != nil || !ok {
+		t.Fatalf("claim removed after unrelated not-found ok=%v err=%v", ok, err)
 	}
 }
 
@@ -415,6 +435,15 @@ func TestClassifyNebiusIndeterminateErrors(t *testing.T) {
 	}
 	if isIndeterminateNebiusError(errors.New("validation failed")) {
 		t.Fatal("validation error classified indeterminate")
+	}
+}
+
+func TestClassifyNebiusInstanceNotFoundRequiresInstanceEvidence(t *testing.T) {
+	if !isNebiusInstanceNotFound(errors.New("instance vm-gone not found"), "vm-gone") {
+		t.Fatal("instance-specific not found was not classified")
+	}
+	if isNebiusInstanceNotFound(errors.New("profile production not found"), "vm-gone") {
+		t.Fatal("unrelated not found classified as instance absence")
 	}
 }
 

--- a/internal/providers/nebius/provider.go
+++ b/internal/providers/nebius/provider.go
@@ -65,9 +65,8 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	if strings.TrimSpace(neb.CLI) == "" {
 		return exit(2, "nebius.cli is required")
 	}
-	switch strings.ToLower(strings.TrimSpace(neb.User)) {
-	case "root", "admin":
-		return exit(2, "nebius.user must not be root or admin")
+	if err := validateNebiusUser(neb.User); err != nil {
+		return err
 	}
 	if neb.DiskSizeGiB <= 0 {
 		return exit(2, "nebius.diskSizeGiB must be positive")

--- a/internal/providers/nebius/provider.go
+++ b/internal/providers/nebius/provider.go
@@ -1,0 +1,86 @@
+package nebius
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindSSHLease,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterNebiusProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyNebiusProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
+		return nil, exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, exit(2, "--tailscale is not supported for provider=%s in the Nebius provider foundation", providerName)
+	}
+	if err := p.ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return NewBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, exit(2, "nebius doctor backend unavailable")
+	}
+	return doctor, nil
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	neb := cfg.Nebius
+	if strings.TrimSpace(neb.CLI) == "" {
+		return exit(2, "nebius.cli is required")
+	}
+	switch strings.ToLower(strings.TrimSpace(neb.User)) {
+	case "root", "admin":
+		return exit(2, "nebius.user must not be root or admin")
+	}
+	if neb.DiskSizeGiB <= 0 {
+		return exit(2, "nebius.diskSizeGiB must be positive")
+	}
+	switch strings.ToLower(strings.TrimSpace(neb.PublicIP)) {
+	case "", "dynamic", "none":
+	default:
+		return exit(2, "nebius.publicIP must be dynamic or none")
+	}
+	switch strings.ToLower(strings.TrimSpace(neb.RecoveryPolicy)) {
+	case "", "fail":
+	default:
+		return exit(2, "nebius.recoveryPolicy must be fail")
+	}
+	return nil
+}

--- a/internal/providers/nebius/provider_test.go
+++ b/internal/providers/nebius/provider_test.go
@@ -103,10 +103,10 @@ func TestApplyFlags(t *testing.T) {
 }
 
 func TestValidateConfigRejectsReservedUsers(t *testing.T) {
-	for _, user := range []string{"root", "admin"} {
+	for _, user := range []string{"root", "admin", "alice\n  - name: root", "Alice", "bad user", "1alice"} {
 		cfg := testConfig()
 		cfg.Nebius.User = user
-		if err := (Provider{}).ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "must not be root or admin") {
+		if err := (Provider{}).ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "nebius.user must") {
 			t.Fatalf("ValidateConfig(%q) err=%v", user, err)
 		}
 	}

--- a/internal/providers/nebius/provider_test.go
+++ b/internal/providers/nebius/provider_test.go
@@ -134,6 +134,18 @@ func TestParseHelpers(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("containsIDOrName object ok=%v err=%v", ok, err)
 	}
+	ok, err = containsIDOrName(`{"metadata":{"id":"subnet-123","name":"default"}}`, "subnet-123")
+	if err != nil || !ok {
+		t.Fatalf("containsIDOrName metadata.id ok=%v err=%v", ok, err)
+	}
+	ok, err = containsIDOrName(`{"items":[{"metadata":{"name":"cpu-d3"}}]}`, "cpu-d3")
+	if err != nil || !ok {
+		t.Fatalf("containsIDOrName wrapped metadata.name ok=%v err=%v", ok, err)
+	}
+	ok, err = containsIDOrName(`{"items":[{"metadata":{"id":"image-opaque"},"spec":{"family":"ubuntu24.04-driverless"}}]}`, "ubuntu24.04-driverless")
+	if err != nil || !ok {
+		t.Fatalf("containsIDOrName later family ok=%v err=%v", ok, err)
+	}
 	if _, err := containsIDOrName(`not-json`, "x"); err == nil {
 		t.Fatal("malformed JSON accepted")
 	}
@@ -168,8 +180,6 @@ func TestDoctorUsesReadOnlyCLICommands(t *testing.T) {
 			return LocalCommandResult{Stdout: `[{"id":"cpu-d3"}]`}, nil
 		case "--profile sandbox compute image list --family ubuntu24.04-driverless --format json":
 			return LocalCommandResult{Stdout: `[{"family":"ubuntu24.04-driverless"}]`}, nil
-		case "--profile sandbox config get parent-id --format json":
-			return LocalCommandResult{Stdout: `{"parent-id":"project-123"}`}, nil
 		default:
 			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
 		}
@@ -188,4 +198,43 @@ func TestDoctorUsesReadOnlyCLICommands(t *testing.T) {
 	if len(runner.calls) != 7 {
 		t.Fatalf("calls=%#v", runner.calls)
 	}
+}
+
+func TestDoctorRejectsMissingImageFamily(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		joined := strings.Join(req.Args, " ")
+		switch joined {
+		case "--profile sandbox --version":
+			return LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
+		case "--profile sandbox config profile list --format json":
+			return LocalCommandResult{Stdout: `[{"name":"sandbox","active":true}]`}, nil
+		case "--profile sandbox iam project get project-123 --format json":
+			return LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
+		case "--profile sandbox vpc subnet list --parent-id project-123 --format json":
+			return LocalCommandResult{Stdout: `[{"metadata":{"id":"subnet-123"}}]`}, nil
+		case "--profile sandbox compute platform list --format json":
+			return LocalCommandResult{Stdout: `[{"metadata":{"id":"cpu-d3"}}]`}, nil
+		case "--profile sandbox compute image list --family ubuntu24.04-driverless --format json":
+			return LocalCommandResult{Stdout: `[]`}, nil
+		default:
+			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+		}
+	}}
+	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Exec: runner}).(*backend)
+	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "error" {
+		t.Fatalf("status=%q checks=%#v", result.Status, result.Checks)
+	}
+	for _, check := range result.Checks {
+		if check.Check == "image" {
+			if check.Status != "error" || !strings.Contains(check.Message, "configured image family not found") {
+				t.Fatalf("image check=%#v", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing image check: %#v", result.Checks)
 }

--- a/internal/providers/nebius/provider_test.go
+++ b/internal/providers/nebius/provider_test.go
@@ -1,0 +1,191 @@
+package nebius
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls [][]string
+	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+}
+
+func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	call := append([]string{req.Name}, req.Args...)
+	r.calls = append(r.calls, call)
+	if r.fn != nil {
+		return r.fn(req)
+	}
+	return LocalCommandResult{}, nil
+}
+
+func testConfig() Config {
+	return Config{
+		Provider: providerName,
+		TargetOS: targetLinux,
+		SSHUser:  "crabbox",
+		SSHPort:  "22",
+		WorkRoot: "/tmp/crabbox",
+		Nebius: NebiusConfig{
+			CLI:            "nebius",
+			Profile:        "sandbox",
+			ParentID:       "project-123",
+			SubnetID:       "subnet-123",
+			Platform:       "cpu-d3",
+			Preset:         "4vcpu-16gb",
+			ImageFamily:    "ubuntu24.04-driverless",
+			DiskType:       "network_ssd",
+			DiskSizeGiB:    50,
+			User:           "crabbox",
+			PublicIP:       "dynamic",
+			RecoveryPolicy: "fail",
+		},
+	}
+}
+
+func TestProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName || spec.Family != providerName || spec.Kind != core.ProviderKindSSHLease || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("features=%v missing %s", spec.Features, feature)
+		}
+	}
+	if aliases := (Provider{}).Aliases(); len(aliases) != 0 {
+		t.Fatalf("aliases=%v, want none", aliases)
+	}
+}
+
+func TestApplyFlags(t *testing.T) {
+	cfg := testConfig()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	values := (Provider{}).RegisterFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--nebius-cli", "/opt/nebius",
+		"--nebius-profile", "profile-a",
+		"--nebius-parent-id", "project-a",
+		"--nebius-subnet-id", "subnet-a",
+		"--nebius-platform", "gpu-h100",
+		"--nebius-preset", "1gpu-16vcpu-200gb",
+		"--nebius-image-family", "ubuntu22.04-cuda",
+		"--nebius-disk-type", "network_ssd_nonreplicated",
+		"--nebius-disk-size-gib", "160",
+		"--nebius-user", "alice",
+		"--nebius-public-ip", "none",
+		"--nebius-security-group-ids", "sg-a, sg-b",
+		"--nebius-service-account-id", "sa-a",
+		"--nebius-recovery-policy", "fail",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Nebius.CLI != "/opt/nebius" || cfg.Nebius.Profile != "profile-a" || cfg.Nebius.ParentID != "project-a" || cfg.Nebius.SubnetID != "subnet-a" {
+		t.Fatalf("identity flags not applied: %#v", cfg.Nebius)
+	}
+	if cfg.Nebius.Platform != "gpu-h100" || cfg.Nebius.Preset != "1gpu-16vcpu-200gb" || cfg.Nebius.DiskSizeGiB != 160 || strings.Join(cfg.Nebius.SecurityGroupIDs, ",") != "sg-a,sg-b" {
+		t.Fatalf("sizing/network flags not applied: %#v", cfg.Nebius)
+	}
+}
+
+func TestValidateConfigRejectsReservedUsers(t *testing.T) {
+	for _, user := range []string{"root", "admin"} {
+		cfg := testConfig()
+		cfg.Nebius.User = user
+		if err := (Provider{}).ValidateConfig(cfg); err == nil || !strings.Contains(err.Error(), "must not be root or admin") {
+			t.Fatalf("ValidateConfig(%q) err=%v", user, err)
+		}
+	}
+}
+
+func TestCLIRunnerAddsProfileBeforeCommand(t *testing.T) {
+	runner := &recordingRunner{}
+	cfg := testConfig()
+	client := newCLIRunner(cfg.Nebius, Runtime{Exec: runner})
+	if _, err := client.run(context.Background(), "compute", "platform", "list", "--format", "json"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"nebius", "--profile", "sandbox", "compute", "platform", "list", "--format", "json"}
+	if !reflect.DeepEqual(runner.calls[0], want) {
+		t.Fatalf("call=%#v want %#v", runner.calls[0], want)
+	}
+}
+
+func TestParseHelpers(t *testing.T) {
+	ok, err := containsIDOrName(`[{"id":"subnet-123"},{"name":"cpu-d3"}]`, "cpu-d3")
+	if err != nil || !ok {
+		t.Fatalf("containsIDOrName name ok=%v err=%v", ok, err)
+	}
+	ok, err = containsIDOrName(`{"id":"project-123"}`, "project-123")
+	if err != nil || !ok {
+		t.Fatalf("containsIDOrName object ok=%v err=%v", ok, err)
+	}
+	if _, err := containsIDOrName(`not-json`, "x"); err == nil {
+		t.Fatal("malformed JSON accepted")
+	}
+}
+
+func TestRedactNebiusText(t *testing.T) {
+	input := "request failed token=osb_secret private_key=-----BEGIN PRIVATE KEY-----"
+	got := redactNebiusText(input)
+	if strings.Contains(got, "osb_secret") || strings.Contains(got, "BEGIN PRIVATE KEY") {
+		t.Fatalf("secret was not redacted: %q", got)
+	}
+}
+
+func TestDoctorUsesReadOnlyCLICommands(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		joined := strings.Join(req.Args, " ")
+		for _, forbidden := range []string{" create", " delete", " update", " compute instance", " disk create", " disk delete", " allocation create", " allocation delete"} {
+			if strings.Contains(" "+joined, forbidden) {
+				return LocalCommandResult{}, errors.New("mutating command invoked: " + joined)
+			}
+		}
+		switch joined {
+		case "--profile sandbox --version":
+			return LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
+		case "--profile sandbox config profile list --format json":
+			return LocalCommandResult{Stdout: `[{"name":"sandbox","active":true}]`}, nil
+		case "--profile sandbox iam project get project-123 --format json":
+			return LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
+		case "--profile sandbox vpc subnet list --parent-id project-123 --format json":
+			return LocalCommandResult{Stdout: `[{"id":"subnet-123"}]`}, nil
+		case "--profile sandbox compute platform list --format json":
+			return LocalCommandResult{Stdout: `[{"id":"cpu-d3"}]`}, nil
+		case "--profile sandbox compute image list --family ubuntu24.04-driverless --format json":
+			return LocalCommandResult{Stdout: `[{"family":"ubuntu24.04-driverless"}]`}, nil
+		case "--profile sandbox config get parent-id --format json":
+			return LocalCommandResult{Stdout: `{"parent-id":"project-123"}`}, nil
+		default:
+			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+		}
+	}}
+	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Exec: runner}).(*backend)
+	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Provider != providerName || result.Status != "ok" {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(result.Checks) != 7 {
+		t.Fatalf("checks=%#v", result.Checks)
+	}
+	if len(runner.calls) != 7 {
+		t.Fatalf("calls=%#v", runner.calls)
+	}
+}

--- a/scripts/live-nebius-smoke.sh
+++ b/scripts/live-nebius-smoke.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider_enabled() {
+  local list="${CRABBOX_LIVE_PROVIDERS:-}"
+  local item
+  IFS=',' read -ra items <<<"$list"
+  for item in "${items[@]}"; do
+    item="${item//[[:space:]]/}"
+    if [[ "$item" == "nebius" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+classify_blocker() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  local classification="environment_blocked"
+  local lower
+  lower="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *quota* || "$lower" == *"rate limit"* || "$lower" == *capacity* || "$lower" == *"limit exceeded"* || "$lower" == *"not enough"* || "$lower" == *"insufficient"* || "$lower" == *"resource exhausted"* ]]; then
+    classification="quota_blocked"
+  fi
+  printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [[ "$status" -ne 0 ]]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox_slug") == slug):
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" -ne 0 ]]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_absent_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox_slug") == slug):
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if has_slug(payload):
+    print(f"list JSON still includes slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$status" -ne 0 ]]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_echo_ok() {
+  local command="$1"
+  local output="$2"
+  if [[ "$output" != *"ok"* ]]; then
+    classify_validation_failure "$command" 1 "remote command output did not include ok"
+    exit 1
+  fi
+}
+
+if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
+  printf 'classification=environment_blocked reason=CRABBOX_LIVE_not_enabled\n'
+  exit 0
+fi
+
+if ! provider_enabled; then
+  printf 'classification=environment_blocked reason=nebius_not_selected providers=%q\n' "${CRABBOX_LIVE_PROVIDERS:-}"
+  exit 0
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ ! -x "$crabbox_bin" ]]; then
+  mkdir -p bin
+  go build -trimpath -o bin/crabbox ./cmd/crabbox
+  crabbox_bin="bin/crabbox"
+fi
+
+nonce="$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
+slug="nebius-smoke-$(date +%s)-$$-$nonce"
+cleanup_armed=0
+provider_args=(--provider nebius)
+
+cleanup() {
+  local status=$?
+  if [[ "$cleanup_armed" -eq 1 ]]; then
+    local cleanup_output=""
+    local cleanup_status=1
+    local attempt
+    for attempt in 1 2 3; do
+      set +e
+      cleanup_output="$("$crabbox_bin" stop "${provider_args[@]}" "$slug" 2>&1)"
+      cleanup_status=$?
+      set -e
+      if [[ "$cleanup_status" -eq 0 ]]; then
+        cleanup_armed=0
+        break
+      fi
+      sleep 2
+    done
+    if [[ "$cleanup_status" -ne 0 ]]; then
+      printf 'classification=environment_blocked reason=cleanup_failed command=%q exit=%s slug=%s\n' "stop --provider nebius $slug" "$cleanup_status" "$slug" >&2
+      printf '%s\n' "$cleanup_output" >&2
+      if [[ "$status" -eq 0 ]]; then
+        status="$cleanup_status"
+      fi
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+run_capture "doctor --provider nebius" "$crabbox_bin" doctor "${provider_args[@]}" >/dev/null
+run_capture "list --provider nebius --json" "$crabbox_bin" list "${provider_args[@]}" --json >/dev/null
+
+cleanup_armed=1
+run_capture "warmup --provider nebius --slug $slug --keep" \
+  "$crabbox_bin" warmup "${provider_args[@]}" --slug "$slug" --keep --ttl 20m --idle-timeout 5m >/dev/null
+
+run_capture "status --provider nebius --id $slug --wait" \
+  "$crabbox_bin" status "${provider_args[@]}" --id "$slug" --wait --wait-timeout 300s >/dev/null
+
+run_output="$(run_capture "run --provider nebius --id $slug --no-sync -- echo ok" \
+  "$crabbox_bin" run "${provider_args[@]}" --id "$slug" --no-sync -- echo ok)"
+validate_echo_ok "run --provider nebius --id $slug --no-sync -- echo ok" "$run_output"
+
+list_output="$(run_capture "list --provider nebius --json" "$crabbox_bin" list "${provider_args[@]}" --json)"
+validate_list_json_contains_slug "list --provider nebius --json" "$list_output"
+
+run_capture "stop --provider nebius $slug" "$crabbox_bin" stop "${provider_args[@]}" "$slug" >/dev/null
+cleanup_armed=0
+
+run_capture "cleanup --provider nebius --dry-run" "$crabbox_bin" cleanup "${provider_args[@]}" --dry-run >/dev/null
+final_list_output="$(run_capture "list --provider nebius --json" "$crabbox_bin" list "${provider_args[@]}" --json)"
+validate_list_json_absent_slug "list --provider nebius --json" "$final_list_output"
+
+echo "classification=live_nebius_smoke_passed slug=$slug"

--- a/scripts/live-nebius-smoke.test.js
+++ b/scripts/live-nebius-smoke.test.js
@@ -1,0 +1,367 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function prepareSmokeRepo(dir) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, "live-nebius-smoke.sh");
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(path.join(repoRoot, "scripts", "live-nebius-smoke.sh"), smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+if [[ ! -d "$(dirname "$out")" ]]; then
+  printf 'output directory missing: %s\\n' "$(dirname "$out")" >&2
+  exit 88
+fi
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}
+
+const shellArgHelper = `
+arg_after() {
+  local want="$1"
+  shift
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "$want" ]]; then
+      printf '%s' "$2"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+`;
+
+test("live nebius smoke skips unless globally opted in", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-skip-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_LIVE_not_enabled/);
+});
+
+test("live nebius smoke skips unless nebius is selected", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-provider-skip-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+  writeExecutable(path.join(binDir, "go"), "#!/usr/bin/env bash\nexit 99\n");
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "digitalocean",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /classification=environment_blocked reason=nebius_not_selected/);
+});
+
+test("live nebius smoke runs guarded lifecycle without real credentials", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+${shellArgHelper}
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready leases=0 runtime=unchecked\\n'
+    ;;
+  warmup)
+    arg_after --slug "$@" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"crabbox_slug":"%s"},"provider":"nebius"}]\\n' "$slug"
+    fi
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip nebius instance id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: " nebius ",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_nebius_smoke_passed/);
+
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider nebius");
+  assert.equal(seen[1], "list --provider nebius --json");
+  assert.match(seen[2], /^warmup --provider nebius --slug nebius-smoke-\d+-\d+-[0-9a-f]{8} --keep --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider nebius --json");
+  assert.match(seen[6], /^stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}$/);
+  assert.equal(seen[7], "cleanup --provider nebius --dry-run");
+  assert.equal(seen[8], "list --provider nebius --json");
+});
+
+test("live nebius smoke attempts cleanup after partial failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "$1" == "doctor" || "$1" == "list" ]]; then
+  [[ "$1" == "list" ]] && printf '[]\\n' || printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'created vm before failing\\n' >&2
+  exit 37
+fi
+if [[ "$1" == "stop" ]]; then
+  exit 0
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=environment_blocked/);
+  assert.match(result.stderr, /created vm before failing/);
+  assert.match(fs.readFileSync(calls, "utf8"), /warmup .* --keep /);
+  assert.match(fs.readFileSync(calls, "utf8"), /stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}/);
+});
+
+test("live nebius smoke validates list JSON contains the smoke slug", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-bad-list-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+${shellArgHelper}
+case "$1" in
+  doctor)
+    printf 'auth=ready\\n'
+    ;;
+  warmup)
+    arg_after --slug "$@" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  list)
+    printf '[{"labels":{"slug":"different"}}]\\n'
+    ;;
+  stop)
+    exit 0
+    ;;
+  cleanup)
+    exit 0
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /list JSON did not include slug/);
+});
+
+test("live nebius smoke classifies quota and capacity failures", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-quota-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "doctor" || "$1" == "list" ]]; then
+  [[ "$1" == "list" ]] && printf '[]\\n' || printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'quota limit exceeded for platform\\n' >&2
+  exit 42
+fi
+if [[ "$1" == "stop" ]]; then
+  exit 0
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /classification=quota_blocked/);
+});
+
+test("live nebius smoke reports targeted cleanup failure", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-cleanup-fail-"));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "doctor" || "$1" == "list" ]]; then
+  [[ "$1" == "list" ]] && printf '[]\\n' || printf 'auth=ready\\n'
+  exit 0
+fi
+if [[ "$1" == "warmup" ]]; then
+  printf 'created vm before failing\\n' >&2
+  exit 37
+fi
+if [[ "$1" == "stop" ]]; then
+  printf 'nebius instance still deleting\\n' >&2
+  exit 5
+fi
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 37, result.stdout + result.stderr);
+  assert.match(result.stderr, /reason=cleanup_failed/);
+  assert.match(result.stderr, /nebius instance still deleting/);
+});


### PR DESCRIPTION
Closes #364

Summary:
- add Nebius as a direct Linux SSH-lease provider with non-secret config, CLI/env registration, provider registration, and lifecycle support through the Nebius CLI
- add ownership-scoped cleanup/release safety, rollback recovery, doctor checks, and trust-boundary hardening for untrusted config fields
- add Nebius provider docs, generated provider matrix metadata, and a guarded opt-in live smoke script with tests

Verification:
- `go test ./internal/providers/nebius -run 'CommandConstruction|Labels|Release|Classify|Doctor|ParseHelpers'`
- `go test ./internal/providers/nebius ./internal/providers/all ./internal/cli`
- `go test ./...`
- `node --test scripts/live-nebius-smoke.test.js`
- `node scripts/generate-provider-matrix.mjs --check`
- `scripts/check-docs.sh`
- `env -u CRABBOX_LIVE -u CRABBOX_LIVE_PROVIDERS scripts/live-nebius-smoke.sh` -> `classification=environment_blocked reason=CRABBOX_LIVE_not_enabled`

Notes:
- The live Nebius smoke remains opt-in and did not create cost-bearing resources without `CRABBOX_LIVE=1` and `CRABBOX_LIVE_PROVIDERS=nebius`.
- The final autoreview rerun was intentionally interrupted at the request of the local coordinator after prior material review findings had been addressed and the verification gauntlet was green.
