### PR TITLE
fix: isolate external lifecycle env

### DIFF
--- a/docs/providers/external.md
+++ b/docs/providers/external.md
@@ -169,6 +169,19 @@ external:
         DEVBOX_TOKEN: "{{env.DEVBOX_TOKEN}}"
 ```
 
+Declarative lifecycle subprocesses do not inherit the caller's complete
+environment. Crabbox starts each lifecycle child with a small safe base copied
+from the current process (`HOME`, `LANG`, `PATH`, `TEMP`, `TMP`, `TMPDIR`,
+`TZ`, and `LC_*` variables), then overlays that operation's `env:` map. If an
+existing helper relies on other ambient values such as `AWS_PROFILE`,
+`AWS_REGION`, `GOOGLE_APPLICATION_CREDENTIALS`, `KUBECONFIG`, `SSH_AUTH_SOCK`,
+provider-specific config paths, or custom tool variables, migrate them into
+the relevant `lifecycle.<operation>.env` map before upgrading. Repeat the
+entry for every operation that needs it (`acquire`, `resolve`, `list`,
+`release`, `touch`, or `cleanup`); environment entries are per-operation, not
+global. Prefer `{{env.NAME}}` values so the variable stays in the child
+environment and out of argv.
+
 For non-secret environment-backed arguments, set `allowEnvArgv: true` on that
 operation. For non-secret environment-backed resource names, also set
 `connection.allowEnvResourceName: true`; Crabbox records that provenance so a

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,6 +153,10 @@ Handling rules:
   allow a variable for a Docker Sandbox run, Docker Sandbox receives that value
   through its `sbx exec --env-file` path even though Crabbox keeps the value out
   of local process arguments.
+- Declarative external-provider lifecycle helpers receive only a safe base
+  environment plus variables listed in `lifecycle.<operation>.env`; add any
+  required provider profiles, SDK config paths, sockets, or custom helper
+  variables there instead of relying on ambient inheritance.
 - User config files are written `0600`. `crabbox doctor` flags any local config
   whose permissions are broader, because broker tokens may live there.
 

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -701,10 +701,7 @@ func expandLifecycleValueTracked(value string, templateCtx lifecycleTemplateCont
 }
 
 func expandLifecycleEnv(env map[string]string, templateCtx lifecycleTemplateContext) ([]string, error) {
-	expanded := make([]string, 0, len(env))
-	if len(env) == 0 {
-		return expanded, nil
-	}
+	expanded := lifecycleBaseEnv(os.Environ())
 	keys := make([]string, 0, len(env))
 	for name := range env {
 		keys = append(keys, name)
@@ -721,7 +718,48 @@ func expandLifecycleEnv(env map[string]string, templateCtx lifecycleTemplateCont
 		if strings.ContainsRune(value, '\x00') {
 			return nil, fmt.Errorf("%s contains a NUL byte", name)
 		}
-		expanded = append(expanded, name+"="+value)
+		expanded = appendOrReplaceLifecycleEnv(expanded, name, value)
 	}
 	return expanded, nil
+}
+
+func lifecycleBaseEnv(environ []string) []string {
+	values := map[string]string{}
+	names := make([]string, 0, len(environ))
+	for _, item := range environ {
+		name, value, ok := strings.Cut(item, "=")
+		if !ok || name == "" || !lifecycleBaseEnvNameAllowed(name) {
+			continue
+		}
+		if _, exists := values[name]; !exists {
+			names = append(names, name)
+		}
+		values[name] = value
+	}
+	sort.Strings(names)
+	base := make([]string, 0, len(names))
+	for _, name := range names {
+		base = append(base, name+"="+values[name])
+	}
+	return base
+}
+
+func lifecycleBaseEnvNameAllowed(name string) bool {
+	switch name {
+	case "HOME", "LANG", "PATH", "TEMP", "TMP", "TMPDIR", "TZ":
+		return true
+	default:
+		return strings.HasPrefix(name, "LC_")
+	}
+}
+
+func appendOrReplaceLifecycleEnv(env []string, name, value string) []string {
+	prefix := name + "="
+	for index, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			env[index] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
 }

--- a/internal/providers/external/lifecycle.go
+++ b/internal/providers/external/lifecycle.go
@@ -701,15 +701,15 @@ func expandLifecycleValueTracked(value string, templateCtx lifecycleTemplateCont
 }
 
 func expandLifecycleEnv(env map[string]string, templateCtx lifecycleTemplateContext) ([]string, error) {
+	expanded := make([]string, 0, len(env))
 	if len(env) == 0 {
-		return nil, nil
+		return expanded, nil
 	}
 	keys := make([]string, 0, len(env))
 	for name := range env {
 		keys = append(keys, name)
 	}
 	sort.Strings(keys)
-	expanded := append([]string(nil), os.Environ()...)
 	for _, name := range keys {
 		if !lifecycleEnvNamePattern.MatchString(name) {
 			return nil, fmt.Errorf("invalid environment variable name %q", name)

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -1198,6 +1198,7 @@ func TestDeclarativeLifecycleExpandsExplicitEnvironmentPlaceholder(t *testing.T)
 func TestInvokeDeclarativeLifecyclePassesSecretEnvWithoutArgvExposure(t *testing.T) {
 	t.Setenv("DEVBOX_TOKEN", "super-secret-token")
 	t.Setenv("GITHUB_TOKEN", "ambient-secret-token")
+	t.Setenv("PATH", "/usr/bin")
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
 		Lifecycle: core.ExternalLifecycleConfig{
@@ -1234,14 +1235,14 @@ func TestInvokeDeclarativeLifecyclePassesSecretEnvWithoutArgvExposure(t *testing
 	if strings.Contains(gotArgv, "super-secret-token") {
 		t.Fatalf("secret leaked through argv: %q", gotArgv)
 	}
-	if len(runner.requests[0].Env) != 2 {
-		t.Fatalf("env=%#v, want only configured lifecycle entries", runner.requests[0].Env)
-	}
 	if !envContains(runner.requests[0].Env, "DEVBOX_TOKEN=super-secret-token") {
 		t.Fatal("env missing DEVBOX_TOKEN entry")
 	}
 	if !envContains(runner.requests[0].Env, "DEVBOX_NAME=devbox-fast-coral") {
 		t.Fatal("env missing DEVBOX_NAME entry")
+	}
+	if !envContains(runner.requests[0].Env, "PATH=/usr/bin") {
+		t.Fatalf("env missing safe PATH base: %#v", runner.requests[0].Env)
 	}
 	if envContains(runner.requests[0].Env, "GITHUB_TOKEN=ambient-secret-token") {
 		t.Fatalf("env inherited unrelated ambient secret: %#v", runner.requests[0].Env)
@@ -1250,6 +1251,7 @@ func TestInvokeDeclarativeLifecyclePassesSecretEnvWithoutArgvExposure(t *testing
 
 func TestInvokeDeclarativeLifecycleExecDoesNotInheritAmbientEnvWhenUnset(t *testing.T) {
 	t.Setenv("CRABBOX_AMBIENT_SECRET", "ambient-secret-token")
+	t.Setenv("PATH", "/usr/bin")
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
 		Lifecycle: core.ExternalLifecycleConfig{
@@ -1279,11 +1281,15 @@ func TestInvokeDeclarativeLifecycleExecDoesNotInheritAmbientEnvWhenUnset(t *test
 	if got := response.Lease.Labels["configuredToken"]; got != "" {
 		t.Fatalf("lifecycle child received unexpected configured token %q", got)
 	}
+	if got := response.Lease.Labels["path"]; got != "/usr/bin" {
+		t.Fatalf("lifecycle child PATH=%q, want safe base env", got)
+	}
 }
 
 func TestInvokeDeclarativeLifecycleExecPassesOnlyConfiguredEnv(t *testing.T) {
 	t.Setenv("CRABBOX_AMBIENT_SECRET", "ambient-secret-token")
 	t.Setenv("DEVBOX_TOKEN", "configured-token")
+	t.Setenv("PATH", "/usr/bin")
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
 		Lifecycle: core.ExternalLifecycleConfig{
@@ -1315,6 +1321,9 @@ func TestInvokeDeclarativeLifecycleExecPassesOnlyConfiguredEnv(t *testing.T) {
 	}
 	if got := response.Lease.Labels["ambientSecret"]; got != "" {
 		t.Fatalf("lifecycle child inherited ambient secret %q", got)
+	}
+	if got := response.Lease.Labels["path"]; got != "/usr/bin" {
+		t.Fatalf("lifecycle child PATH=%q, want safe base env", got)
 	}
 }
 
@@ -3321,6 +3330,9 @@ func TestExternalLifecycleEnvHelperProcess(t *testing.T) {
 	}
 	if value := os.Getenv("DEVBOX_TOKEN"); value != "" {
 		labels["configuredToken"] = value
+	}
+	if value := os.Getenv("PATH"); value != "" {
+		labels["path"] = value
 	}
 	lease := protocolLease{
 		LeaseID: "cbx_abcdef123456",

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -1197,6 +1197,7 @@ func TestDeclarativeLifecycleExpandsExplicitEnvironmentPlaceholder(t *testing.T)
 
 func TestInvokeDeclarativeLifecyclePassesSecretEnvWithoutArgvExposure(t *testing.T) {
 	t.Setenv("DEVBOX_TOKEN", "super-secret-token")
+	t.Setenv("GITHUB_TOKEN", "ambient-secret-token")
 	cfg := core.BaseConfig()
 	cfg.External = core.ExternalConfig{
 		Lifecycle: core.ExternalLifecycleConfig{
@@ -1233,11 +1234,87 @@ func TestInvokeDeclarativeLifecyclePassesSecretEnvWithoutArgvExposure(t *testing
 	if strings.Contains(gotArgv, "super-secret-token") {
 		t.Fatalf("secret leaked through argv: %q", gotArgv)
 	}
+	if len(runner.requests[0].Env) != 2 {
+		t.Fatalf("env=%#v, want only configured lifecycle entries", runner.requests[0].Env)
+	}
 	if !envContains(runner.requests[0].Env, "DEVBOX_TOKEN=super-secret-token") {
 		t.Fatal("env missing DEVBOX_TOKEN entry")
 	}
 	if !envContains(runner.requests[0].Env, "DEVBOX_NAME=devbox-fast-coral") {
 		t.Fatal("env missing DEVBOX_NAME entry")
+	}
+	if envContains(runner.requests[0].Env, "GITHUB_TOKEN=ambient-secret-token") {
+		t.Fatalf("env inherited unrelated ambient secret: %#v", runner.requests[0].Env)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleExecDoesNotInheritAmbientEnvWhenUnset(t *testing.T) {
+	t.Setenv("CRABBOX_AMBIENT_SECRET", "ambient-secret-token")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Argv:   []string{os.Args[0], "-test.run=TestExternalLifecycleEnvHelperProcess", "--"},
+				Output: lifecycleOutputJSONLease,
+			},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+		},
+	}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: processRunner{}}}
+	response, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired:   &desiredLease{LeaseID: "cbx_abcdef123456", Slug: "fast-coral", Name: "devbox-fast-coral"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Lease == nil {
+		t.Fatalf("response=%#v", response)
+	}
+	if got := response.Lease.Labels["ambientSecret"]; got != "" {
+		t.Fatalf("lifecycle child inherited ambient secret %q", got)
+	}
+	if got := response.Lease.Labels["configuredToken"]; got != "" {
+		t.Fatalf("lifecycle child received unexpected configured token %q", got)
+	}
+}
+
+func TestInvokeDeclarativeLifecycleExecPassesOnlyConfiguredEnv(t *testing.T) {
+	t.Setenv("CRABBOX_AMBIENT_SECRET", "ambient-secret-token")
+	t.Setenv("DEVBOX_TOKEN", "configured-token")
+	cfg := core.BaseConfig()
+	cfg.External = core.ExternalConfig{
+		Lifecycle: core.ExternalLifecycleConfig{
+			Acquire: core.ExternalLifecycleOperation{
+				Argv: []string{os.Args[0], "-test.run=TestExternalLifecycleEnvHelperProcess", "--"},
+				Env: map[string]string{
+					"DEVBOX_TOKEN": "{{env.DEVBOX_TOKEN}}",
+				},
+				Output: lifecycleOutputJSONLease,
+			},
+		},
+		Connection: core.ExternalConnectionConfig{
+			SSH: core.ExternalSSHConnectionConfig{User: "developer", Host: "{{name}}"},
+		},
+	}
+	backend := &leaseBackend{cfg: cfg, rt: core.Runtime{Stderr: io.Discard, Exec: processRunner{}}}
+	response, err := backend.invokeLifecycle(context.Background(), protocolRequest{
+		Operation: "acquire",
+		Desired:   &desiredLease{LeaseID: "cbx_abcdef123456", Slug: "fast-coral", Name: "devbox-fast-coral"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Lease == nil {
+		t.Fatalf("response=%#v", response)
+	}
+	if got := response.Lease.Labels["configuredToken"]; got != "configured-token" {
+		t.Fatalf("configured lifecycle env=%q, want configured-token", got)
+	}
+	if got := response.Lease.Labels["ambientSecret"]; got != "" {
+		t.Fatalf("lifecycle child inherited ambient secret %q", got)
 	}
 }
 
@@ -3234,6 +3311,30 @@ func TestExternalProviderHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+func TestExternalLifecycleEnvHelperProcess(t *testing.T) {
+	if !strings.Contains(strings.Join(os.Args, " "), "TestExternalLifecycleEnvHelperProcess") {
+		return
+	}
+	labels := map[string]string{}
+	if value := os.Getenv("CRABBOX_AMBIENT_SECRET"); value != "" {
+		labels["ambientSecret"] = value
+	}
+	if value := os.Getenv("DEVBOX_TOKEN"); value != "" {
+		labels["configuredToken"] = value
+	}
+	lease := protocolLease{
+		LeaseID: "cbx_abcdef123456",
+		Slug:    "env-proof",
+		Name:    "env-proof",
+		CloudID: "env-proof-cloud",
+		Labels:  labels,
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(lease); err != nil {
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
 type recordingRunner struct {
 	name     string
 	args     []string
@@ -3315,6 +3416,8 @@ type processRunner struct{}
 
 func (processRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = req.Env
+	cmd.Dir = req.Dir
 	cmd.Stdin = req.Stdin
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
Closes #419.

Summary:
- Run declarative external lifecycle commands with a minimal safe base environment plus explicitly configured lifecycle env entries.
- Preserve PATH and other basic process settings while keeping unrelated ambient secrets out of lifecycle subprocesses.
- Document the migration path for helpers that need non-base lifecycle environment variables.
- Add subprocess-backed regression coverage for unset, configured, and safe-base lifecycle env behavior.
