### PR TITLE
fix: gate local-container docker socket config

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -534,7 +534,7 @@ localContainer:
   cpus: 0
   memory: ""
   network: bridge
-  dockerSocket: false
+  dockerSocket: false      # trusted user/explicit config only; repo-local values are ignored
 ```
 
 `provider: docker`, `provider: container`, and `provider: local-docker` are
@@ -542,9 +542,13 @@ aliases for `local-container`. The backend uses Docker-compatible CLI commands,
 so Docker Desktop, OrbStack, Colima, Podman, and similar local runtimes work.
 Crabbox detects an installed `docker` or `podman` CLI and uses that runtime; if
 both are present, `docker` is selected unless `localContainer.runtime` is set
-explicitly. Set `dockerSocket: true` only when commands inside the lease must
-use the host Docker-compatible API; Crabbox then mounts the active local Unix
-socket from `DOCKER_HOST` or the Docker context and rejects remote TCP contexts.
+explicitly. Set `dockerSocket: true` in trusted user config only when commands
+inside the lease must use the host Docker-compatible API; repo-local
+`crabbox.yaml` and `.crabbox.yaml` values are ignored. Operators can also enable
+socket pass-through with `CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1` or
+`--local-container-docker-socket`. When enabled, Crabbox mounts the active local
+Unix socket from `DOCKER_HOST` or the Docker context and rejects remote TCP
+contexts.
 With the socket enabled and no explicit work root, Crabbox chooses a host-visible
 cache work root so nested bind mounts can see the synced checkout.
 

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -78,7 +78,7 @@ localContainer:
   cpus: 0                  # CPU limit; 0 leaves the runtime default
   memory: ""               # memory limit, e.g. 8g
   network: bridge          # container network
-  dockerSocket: false      # mount the host Docker-compatible socket into the lease
+  dockerSocket: false      # trusted user/explicit config only; repo-local values are ignored
 ```
 
 Defaults applied when unset: `runtime=docker`, `image=debian:bookworm`,
@@ -112,7 +112,10 @@ ownership under those paths. System paths such as `/etc`, `/usr`, `/var`,
 **Security:** This flag is CLI-only. It is intentionally not loaded from
 repo-local `.crabbox.yaml` because bind mounts expose host paths and must
 be an explicit operator action, not something an untrusted checkout can
-request.
+request. Socket pass-through follows the same trust boundary: repo-local
+`localContainer.dockerSocket` values are ignored, so use trusted user config,
+`CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1`, or
+`--local-container-docker-socket` when a workflow needs the host Docker API.
 
 Environment overrides:
 
@@ -138,13 +141,17 @@ Crabbox connects to the published SSH port from the local machine.
 
 ### Socket pass-through
 
-Set `localContainer.dockerSocket: true` or
-`CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1` when commands inside the lease need to
-run `docker`. Crabbox mounts the active local Unix Docker-compatible socket into
-the container at `/var/run/docker.sock`, so in-lease `docker` commands run
-against the host engine. For Podman, point `DOCKER_HOST` at the Podman socket,
-for example `unix://$XDG_RUNTIME_DIR/podman/podman.sock`. Remote TCP hosts are
-rejected in this mode. Basic Podman leases do not require socket pass-through.
+Set `--local-container-docker-socket`,
+`CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1`, or
+`localContainer.dockerSocket: true` in trusted user config when commands inside
+the lease need to run `docker`. Repo-local `crabbox.yaml` and `.crabbox.yaml`
+values for this setting are intentionally ignored because they would let an
+untrusted checkout request host socket access. When enabled, Crabbox mounts the
+active local Unix Docker-compatible socket into the container at
+`/var/run/docker.sock`, so in-lease `docker` commands run against the host
+engine. For Podman, point `DOCKER_HOST` at the Podman socket, for example
+`unix://$XDG_RUNTIME_DIR/podman/podman.sock`. Remote TCP hosts are rejected in
+this mode. Basic Podman leases do not require socket pass-through.
 
 When the socket is enabled and no work root is explicitly configured, Crabbox
 uses a host-visible cache work root so nested Docker bind mounts can see the

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5025,13 +5025,13 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.LocalContainer.Network != "" {
 			cfg.LocalContainer.Network = file.LocalContainer.Network
 		}
-		if file.LocalContainer.DockerSocket != nil {
+		if trusted && file.LocalContainer.DockerSocket != nil {
 			cfg.LocalContainer.DockerSocket = *file.LocalContainer.DockerSocket
 		}
-		// NOTE: localContainer.volumes is intentionally NOT loaded from
-		// repo-local config files. Bind mounts expose host paths and must
-		// be an explicit CLI action (--local-container-volume), not
-		// something an untrusted checkout can request via .crabbox.yaml.
+		// NOTE: localContainer.dockerSocket and localContainer.volumes are
+		// intentionally NOT loaded from repo-local config files. Host-exposing
+		// mounts must be an explicit operator action, not something an
+		// untrusted checkout can request via .crabbox.yaml.
 	}
 	if file.AppleContainer != nil {
 		if file.AppleContainer.CLIPath != "" {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4493,6 +4493,92 @@ localContainer:
 	}
 }
 
+func TestRepoConfigDoesNotApplyLocalContainerDockerSocket(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	for _, name := range []string{"crabbox.yaml", ".crabbox.yaml"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			if err := os.WriteFile(name, []byte(`
+provider: local-container
+localContainer:
+  dockerSocket: true
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Provider != "local-container" {
+				t.Fatalf("repo config was not loaded: provider=%q", cfg.Provider)
+			}
+			if cfg.LocalContainer.DockerSocket {
+				t.Fatal("repo config enabled local-container docker socket")
+			}
+		})
+	}
+}
+
+func TestTrustedConfigCanEnableLocalContainerDockerSocket(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		explicit bool
+	}{
+		{name: "user config"},
+		{name: "explicit config", explicit: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			cfgPath := userConfigPath()
+			if tc.explicit {
+				cfgPath = filepath.Join(home, "trusted-crabbox.yaml")
+				t.Setenv("CRABBOX_CONFIG", cfgPath)
+			}
+			if err := os.MkdirAll(filepath.Dir(cfgPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(cfgPath, []byte(`
+provider: local-container
+localContainer:
+  dockerSocket: true
+`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !cfg.LocalContainer.DockerSocket {
+				t.Fatal("trusted config did not enable local-container docker socket")
+			}
+		})
+	}
+}
+
+func TestLocalContainerDockerSocketEnvStillApplies(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET", "true")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.LocalContainer.DockerSocket {
+		t.Fatal("env did not enable local-container docker socket")
+	}
+}
+
 func TestPortableOSDefaultsRespectTargetAlias(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()


### PR DESCRIPTION
Closes #414.

Summary:
- Treat `localContainer.dockerSocket` like other host-exposing mounts by only applying it from trusted config paths.
- Add regression coverage showing repo-local `crabbox.yaml` and `.crabbox.yaml` cannot enable socket mode, while trusted config and env overrides still can.