### PR TITLE
Keep WebVNC credentials out of URLs

### DIFF
--- a/docs/commands/adapter.md
+++ b/docs/commands/adapter.md
@@ -381,11 +381,11 @@ without receiving or yielding a VNC credential. It then obtains the current port
 `crabbox webvnc status` and returns:
 
 ```json
-{"url":"https://broker.example.test/portal/leases/cbx_.../vnc#password=..."}
+{"url":"https://broker.example.test/portal/leases/cbx_.../vnc"}
 ```
 
-The credential-bearing URL is returned only by this endpoint and is never
-persisted or included in normal workspace responses. Returned URLs must use HTTPS;
+The portal URL is returned only by this endpoint and is never persisted or
+included in normal workspace responses. Returned URLs must use HTTPS;
 plain HTTP is accepted only for literal loopback hosts. `--vnc-url-template` can
 replace the returned URL only after live bridge verification succeeds. URL
 templates support `{workspaceId}`, `{leaseId}`, and `{slug}`, follow the same

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -46,9 +46,9 @@ nonce, recorded in its identity, rather than the adapter owner token. After
 the SSH tunnel opens, Crabbox
 proves that the exact expected SSH process owns the local listener before
 retrieving a VNC credential, completes a noVNC WebSocket and VNC password
-challenge, and rechecks ownership before printing any credential-bearing
-viewer URL. A missing/zero expected PID, unrelated listener, or unauthenticated
-endpoint never receives a password probe or URL.
+challenge, and rechecks ownership before printing the portal URL and separate
+credential lines. A missing/zero expected PID, unrelated listener, or
+unauthenticated endpoint never receives a password probe or portal URL.
 
 The data path is:
 
@@ -73,7 +73,7 @@ The local `crabbox webvnc` process is not just a launcher; it is the live
 bridge between the browser and the SSH-tunneled VNC socket. Keep it running
 while the browser tab is open. If the browser tab reloads or drops, the bridge
 re-registers so the portal retry can reconnect. If the SSH tunnel process
-exits, the foreground bridge exits instead of leaving a stale viewer URL; a
+exits, the foreground bridge exits instead of leaving a stale portal URL; a
 background supervisor observes that exit and starts a freshly resolved bridge.
 
 ### Existing local VNC tunnel
@@ -199,7 +199,7 @@ The reservation is a bound loopback datagram socket, so it has no replaceable
 filesystem pathname. macOS bridges claim a second reservation for their
 internal SSH-tunnel port before that tunnel starts; foreground macOS bridges
 also claim their browser-facing port before beginning SSH setup.
-The supervisor cannot start the credential-bearing bridge until its private
+The supervisor cannot start the VNC credential bridge until its private
 identity file is flushed and installed; loss of the starting process before
 that handshake closes the launch gate instead of leaving an untracked daemon.
 Ordinary manual and automatically registered daemon children keep their normal
@@ -216,7 +216,7 @@ also receives and validates the adapter's full persisted lease, attempt,
 slug, resource, and provider-scope identity. Direct-SSH status checks the exact
 listener owner before credential retrieval and immediately before and after its
 VNC authentication probe; without a positive expected owner PID it reports no
-credential or viewer URL.
+credential or portal URL.
 Adapter lifecycle
 reconciliation remains their sole owner.
 

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -239,7 +239,8 @@ ssh tunnel: ssh ... -o GatewayPorts=no -L 127.0.0.1:5901:127.0.0.1:5900 ...
 portal bridge: connected=true viewers=2 observers=1 slots=2
 portal controller: alice
 event: 2026-05-07T12:00:00Z bridge_connected
-webvnc: https://broker.example.com/portal/leases/cbx_.../vnc#password=...
+webvnc: https://broker.example.com/portal/leases/cbx_.../vnc
+password: ...
 fallback: crabbox vnc --provider aws --target linux --network tailscale --id cbx_... --open
 ```
 
@@ -273,12 +274,10 @@ instead of granting general passwordless sudo.
 ## Portal and passwords
 
 `--open` opens the portal page after the bridge starts. When the VNC password is
-available, the command also places it in the URL fragment for the local browser
-tab and prints it on stdout. URL fragments are not sent to the coordinator, and
-Crabbox preserves special characters such as `!` when building the fragment. For
-macOS targets the lease username is also surfaced. If the portal login flow
-redirects first, the page may still prompt for the VNC password; use the
-password printed by the command. If an old tab is retrying with a stale
+available, the command prints it separately from the portal URL. The URL opened
+in the local browser does not include the password or username; the portal
+prompts for credentials when noVNC requires them. For macOS targets the lease
+username is also surfaced. If an old tab is retrying with a stale credential
 fragment, close it before opening the new bridge URL.
 
 The portal page may show `WebVNC daemon not running` or `waiting for VNC bridge`
@@ -290,8 +289,9 @@ crabbox webvnc --id <lease-id-or-slug>
 ```
 
 For human demos, prefer WebVNC over native VNC because `crabbox webvnc --open`
-preloads the per-lease password in the local browser URL fragment. Use native
-VNC only as the fallback printed by `webvnc status` or `webvnc reset`.
+uses the authenticated portal and keeps the per-lease password out of browser
+URLs. Use native VNC only as the fallback printed by `webvnc status` or
+`webvnc reset`.
 
 The WebVNC toolbar includes clipboard controls. The paste control reads the
 local browser clipboard, sends it through noVNC, then sends the target paste
@@ -389,8 +389,8 @@ If WebVNC remains unreliable, use the exact native fallback command printed by
 VNC authentication fails
 
 Use the password printed by `crabbox webvnc`. With `--open`, the command tries
-to pass the password in the browser URL fragment, but a portal login redirect
-can lose that fragment before noVNC sees it.
+to open the portal URL without embedding the password; enter the printed
+credential when the portal asks for it.
 
 ## Related docs
 

--- a/docs/features/interactive-desktop-vnc.md
+++ b/docs/features/interactive-desktop-vnc.md
@@ -93,8 +93,8 @@ local-to-portal path.
   `crabbox webvnc` process keeps the SSH tunnel open, connects to the
   coordinator with a one-use bridge ticket, and the authenticated portal serves
   bundled noVNC. The portal never connects to the runner directly, so the local
-  bridge must keep running. `--open` preloads the VNC password into the local
-  browser fragment.
+  bridge must keep running. `--open` opens the portal URL without embedding the
+  VNC password; the portal prompts for credentials when noVNC requires them.
 - `crabbox vnc` is for a native VNC client: when WebVNC status or reset reports
   the portal path is unhealthy, or when you need a native client feature.
 

--- a/internal/cli/controller_service.go
+++ b/internal/cli/controller_service.go
@@ -2884,6 +2884,9 @@ func validateControllerConnectionURL(value string) error {
 	if u.User != nil {
 		return fmt.Errorf("desktop connection URL must not contain user information")
 	}
+	if urlContainsCredentialParams(u) {
+		return fmt.Errorf("desktop connection URL must not contain credentials")
+	}
 	if u.Scheme == "https" {
 		return nil
 	}
@@ -2892,6 +2895,26 @@ func validateControllerConnectionURL(value string) error {
 		return nil
 	}
 	return fmt.Errorf("desktop connection URL must use HTTPS or loopback HTTP")
+}
+
+func urlContainsCredentialParams(u *url.URL) bool {
+	fragment := u.RawFragment
+	if fragment == "" && u.Fragment != "" {
+		fragment = u.EscapedFragment()
+	}
+	for _, values := range []string{u.RawQuery, fragment} {
+		if values == "" {
+			continue
+		}
+		params, err := url.ParseQuery(values)
+		if err != nil {
+			continue
+		}
+		if params.Has("username") || params.Has("password") {
+			return true
+		}
+	}
+	return false
 }
 
 func expandControllerURLTemplate(value string, record controllerWorkspaceRecord) string {

--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -103,7 +103,7 @@ func (r *shutdownAwareControllerRunner) Stop(ctx context.Context, _ string, _ co
 func newFakeControllerWorkspaceRunner() *fakeControllerWorkspaceRunner {
 	return &fakeControllerWorkspaceRunner{
 		ready:                  map[string]StatusView{},
-		desktopURL:             "https://portal.example.test/desktop#password=secret",
+		desktopURL:             "https://portal.example.test/desktop#control=take",
 		providerRoute:          "external",
 		providerScope:          "test-provider-scope",
 		idempotentFixedLeaseID: true,

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -592,8 +592,8 @@ func TestControllerTrackedChildParentHelper(t *testing.T) {
 }
 
 func TestControllerWebVNCURLParser(t *testing.T) {
-	output := "vnc target: reachable 127.0.0.1:5900 managed=true\nportal bridge: connected=true\nwebvnc: https://portal.example.test/vnc#password=secret\npassword: secret\n"
-	if got := controllerWebVNCURL(output); got != "https://portal.example.test/vnc#password=secret" {
+	output := "vnc target: reachable 127.0.0.1:5900 managed=true\nportal bridge: connected=true\nwebvnc: https://portal.example.test/vnc\npassword: secret\n"
+	if got := controllerWebVNCURL(output); got != "https://portal.example.test/vnc" {
 		t.Fatalf("URL=%q", got)
 	}
 	if got := controllerWebVNCURL("webvnc: run crabbox webvnc --id demo\n"); got != "" {
@@ -613,7 +613,7 @@ func TestControllerWebVNCReadyParser(t *testing.T) {
 	for _, output := range []string{
 		"portal bridge: connected=true\n",
 		"vnc target: reachable 127.0.0.1:5900 managed=true\nportal bridge: connected=false\n",
-		"vnc target: reachable 127.0.0.1:5900 managed=true\ndirect ssh webvnc: unauthenticated (wrong password)\nwebvnc: http://127.0.0.1:5942/vnc.html?password=secret\n",
+		"vnc target: reachable 127.0.0.1:5900 managed=true\ndirect ssh webvnc: unauthenticated (wrong password)\nwebvnc: http://127.0.0.1:5942/vnc.html\n",
 		"vnc target: unreachable 127.0.0.1:5900\nwebvnc: https://portal.example.test/vnc\n",
 	} {
 		if controllerWebVNCReady(output) {
@@ -1477,7 +1477,7 @@ if [ "$1 $2 $3" = 'webvnc daemon status' ]; then
   printf 'webvnc daemon: pid=DAEMON_PID log=/tmp/bridge.log\nwebvnc daemon: controller-owned=true no-provider-side-effects=true owner-match=true\nwebvnc daemon: command=/bin/sh -c crabbox-webvnc --no-provider-side-effects=true --local-port DIRECT_PORT\n'
 fi
 if [ "$1 $2" = 'webvnc status' ]; then
-  printf 'vnc target: reachable 127.0.0.1:5900 managed=false\ndirect ssh webvnc: running\nwebvnc: http://127.0.0.1:DIRECT_PORT/vnc.html?password=secret\n'
+  printf 'vnc target: reachable 127.0.0.1:5900 managed=false\ndirect ssh webvnc: running\nwebvnc: http://127.0.0.1:DIRECT_PORT/vnc.html\npassword: secret\n'
 fi
 `)
 	if err := os.WriteFile(binary, []byte(script), 0o700); err != nil {
@@ -1566,8 +1566,9 @@ func stopControllerListenerHelper(cmd *exec.Cmd) {
 
 func TestValidateControllerConnectionURL(t *testing.T) {
 	for _, value := range []string{
-		"https://portal.example.test/vnc#password=secret",
+		"https://portal.example.test/vnc#control=take",
 		"http://127.0.0.1:6080/vnc.html",
+		"http://127.0.0.1:6080/vnc.html?autoconnect=1&path=websockify",
 		"http://localhost:6080/vnc.html",
 		"http://[::1]:6080/vnc.html",
 	} {
@@ -1575,7 +1576,14 @@ func TestValidateControllerConnectionURL(t *testing.T) {
 			t.Fatalf("URL %q rejected: %v", value, err)
 		}
 	}
-	for _, value := range []string{"http://example.test/vnc", "file:///tmp/viewer.html", "https://user:secret@example.test/vnc"} {
+	for _, value := range []string{
+		"http://example.test/vnc",
+		"file:///tmp/viewer.html",
+		"https://user:secret@example.test/vnc",
+		"https://portal.example.test/vnc#password=secret",
+		"https://portal.example.test/vnc#username=admin",
+		"http://127.0.0.1:6080/vnc.html?password=secret",
+	} {
 		if err := validateControllerConnectionURL(value); err == nil {
 			t.Fatalf("URL %q accepted", value)
 		}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -997,6 +997,9 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	fmt.Fprintf(a.Stdout, "webvnc: %s\n", portal)
 	if strings.TrimSpace(password) != "" {
 		fmt.Fprintf(a.Stdout, "password: %s\n", strings.TrimSpace(password))
+		if strings.TrimSpace(username) != "" {
+			fmt.Fprintf(a.Stdout, "username: %s\n", strings.TrimSpace(username))
+		}
 	}
 	fmt.Fprintf(a.Stdout, "fallback: %s\n", nativeVNCOpenCommand(cfg, target, leaseID))
 	return nil
@@ -2806,7 +2809,7 @@ func (a App) directSSHWebVNCReset(ctx context.Context, cfg Config, id string, op
 	return nil
 }
 
-func directSSHWebVNCURL(localPort, password string) string {
+func directSSHWebVNCURL(localPort, _ string) string {
 	values := url.Values{}
 	values.Set("host", "127.0.0.1")
 	values.Set("port", localPort)
@@ -2815,9 +2818,6 @@ func directSSHWebVNCURL(localPort, password string) string {
 	values.Set("resize", "scale")
 	values.Set("compression", "0")
 	values.Set("quality", "6")
-	if strings.TrimSpace(password) != "" {
-		values.Set("password", strings.TrimSpace(password))
-	}
 	return "http://127.0.0.1:" + localPort + "/vnc.html?" + values.Encode()
 }
 
@@ -3749,7 +3749,7 @@ type webVNCPortalOptions struct {
 	TakeControl bool
 }
 
-func webVNCPortalURL(base, leaseID, username, password string, opts ...webVNCPortalOptions) string {
+func webVNCPortalURL(base, leaseID, _, _ string, opts ...webVNCPortalOptions) string {
 	u, err := url.Parse(base)
 	if err != nil {
 		return base
@@ -3762,17 +3762,9 @@ func webVNCPortalURL(base, leaseID, username, password string, opts ...webVNCPor
 	for _, opt := range opts {
 		takeControl = takeControl || opt.TakeControl
 	}
-	if strings.TrimSpace(username) != "" || strings.TrimSpace(password) != "" || takeControl {
+	if takeControl {
 		values := url.Values{}
-		if strings.TrimSpace(username) != "" {
-			values.Set("username", strings.TrimSpace(username))
-		}
-		if strings.TrimSpace(password) != "" {
-			values.Set("password", strings.TrimSpace(password))
-		}
-		if takeControl {
-			values.Set("control", "take")
-		}
+		values.Set("control", "take")
 		u.RawFragment = values.Encode()
 		if fragment, err := url.PathUnescape(u.RawFragment); err == nil {
 			u.Fragment = fragment

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,13 +42,13 @@ func TestWebVNCURLs(t *testing.T) {
 	if got := webVNCAgentURLWithTicketAndCapabilities("https://broker.example.com", "cbx_abcdef123456", "wvnc_abc", "desktop_theme"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent?capabilities=desktop_theme&ticket=wvnc_abc" {
 		t.Fatalf("agent capability fallback URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=secret+value" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
 		t.Fatalf("portal URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "ec2-user", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=secret+value&username=ec2-user" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "ec2-user", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
 		t.Fatalf("portal URL=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "Cb1!abc"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=Cb1%21abc" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "Cb1!abc"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
 		t.Fatalf("portal URL=%q", got)
 	}
 	if got := webVNCPortalURL("https://broker.example.com/#stale", "cbx_abcdef123456", "", ""); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
@@ -58,25 +57,14 @@ func TestWebVNCURLs(t *testing.T) {
 	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take" {
 		t.Fatalf("portal URL with control=%q", got)
 	}
-	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take&password=secret+value" {
+	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value", webVNCPortalOptions{TakeControl: true}); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#control=take" {
 		t.Fatalf("portal URL with password and control=%q", got)
 	}
 	got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "JVS/yMb%2B")
-	if got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=JVS%2FyMb%252B" {
+	if got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc" {
 		t.Fatalf("portal URL with escaped password=%q", got)
 	}
-	fragment, ok := strings.CutPrefix(got, "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#")
-	if !ok {
-		t.Fatalf("portal URL missing expected fragment: %q", got)
-	}
-	values, err := url.ParseQuery(fragment)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if values.Get("password") != "JVS/yMb%2B" {
-		t.Fatalf("decoded portal password=%q", values.Get("password"))
-	}
-	if got := directSSHWebVNCURL("5901", "p+a ss"); got != "http://127.0.0.1:5901/vnc.html?autoconnect=1&compression=0&host=127.0.0.1&password=p%2Ba+ss&path=websockify&port=5901&quality=6&resize=scale" {
+	if got := directSSHWebVNCURL("5901", "p+a ss"); got != "http://127.0.0.1:5901/vnc.html?autoconnect=1&compression=0&host=127.0.0.1&path=websockify&port=5901&quality=6&resize=scale" {
 		t.Fatalf("local container WebVNC URL=%q", got)
 	}
 	if !isLocalContainerProvider("docker") || !isLocalContainerProvider("local-container") {
@@ -90,6 +78,41 @@ func TestWebVNCURLs(t *testing.T) {
 	if supportsDirectSSHWebVNC("static") || supportsDirectSSHWebVNC("aws") {
 		t.Fatal("static and coordinator-backed providers should not use direct SSH WebVNC")
 	}
+}
+
+func TestWebVNCOpenURLAndOutputKeepCredentialsOutOfURL(t *testing.T) {
+	const password = "secret value"
+	const username = "ec2-user"
+	portal := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", username, password, webVNCPortalOptions{TakeControl: true})
+	if strings.Contains(portal, "password=") || strings.Contains(portal, password) || strings.Contains(portal, "username=") || strings.Contains(portal, username) {
+		t.Fatalf("portal URL leaked credentials: %q", portal)
+	}
+	if !strings.Contains(portal, "#control=take") {
+		t.Fatalf("portal URL lost non-secret control fragment: %q", portal)
+	}
+	_, args := openURLCommand(portal)
+	if strings.Contains(strings.Join(args, " "), "password=") || strings.Contains(strings.Join(args, " "), password) || strings.Contains(strings.Join(args, " "), username) {
+		t.Fatalf("open URL args leaked credentials: %#v", args)
+	}
+	direct := directSSHWebVNCURL("5901", password)
+	if strings.Contains(direct, "password=") || strings.Contains(direct, password) {
+		t.Fatalf("direct WebVNC URL leaked credentials: %q", direct)
+	}
+	output := fmt.Sprintf("webvnc: %s\npassword: %s\nusername: %s\nopened: %s\n", portal, password, username, portal)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "webvnc: ") && !strings.HasPrefix(line, "opened: ") {
+			continue
+		}
+		if strings.Contains(line, "password=") || strings.Contains(line, password) || strings.Contains(line, "username=") || strings.Contains(line, username) {
+			t.Fatalf("output URL leaked credentials: %q", output)
+		}
+	}
+	if !strings.Contains(output, "password: "+password) || !strings.Contains(output, "username: "+username) {
+		t.Fatalf("credential lines missing from output: %q", output)
+	}
+	t.Logf("portal/open URL: %s", portal)
+	t.Logf("direct WebVNC URL: %s", direct)
+	t.Logf("separate credential lines: password: %s; username: %s", password, username)
 }
 
 func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1140,19 +1140,45 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       statusURL.searchParams.set("viewer", viewerID);
       const fragment = new URLSearchParams(window.location.hash.slice(1));
       const target = ${JSON.stringify(target)};
-      const username = fragment.get("username") || "";
-      const password = fragment.get("password") || "";
+      const credentialFragmentPresent = fragment.has("username") || fragment.has("password");
+      fragment.delete("username");
+      fragment.delete("password");
+      let username = "";
+      let password = "";
       const takeControlOnConnect = fragment.get("control") === "take";
+      if (credentialFragmentPresent) {
+        try {
+          const cleanURL = new URL(window.location.href);
+          cleanURL.hash = fragment.toString();
+          window.history.replaceState(null, "", cleanURL);
+        } catch (_) {}
+      }
       const bridgeMissingMessage = ${JSON.stringify(bridgeMissingMessage)};
-      const credentials = {};
-      if (username) credentials.username = username;
-      if (password) credentials.password = password;
-      const options = Object.keys(credentials).length ? { credentials } : {};
-      const missingVNCCredentialMessage = "VNC credentials missing; open WebVNC from crabbox webvnc status";
-      const failedVNCCredentialMessage = "VNC authentication failed; reopen WebVNC from crabbox webvnc status";
+      const missingVNCCredentialMessage = "VNC credentials missing; enter the credentials printed by crabbox webvnc status";
+      const failedVNCCredentialMessage = "VNC authentication failed; check the credentials printed by crabbox webvnc status";
       function setStatus(value, tone = "") {
         status.textContent = value;
         status.dataset.tone = tone;
+      }
+      function viewerOptions() {
+        const credentials = {};
+        if (username) credentials.username = username;
+        if (password) credentials.password = password;
+        return Object.keys(credentials).length ? { credentials } : {};
+      }
+      async function promptVNCCredential(kind) {
+        if (kind === "username" && username) return username;
+        if (kind === "password" && password) return password;
+        const label = kind === "username" ? "VNC username" : "VNC password";
+        const value = await window.crabboxDialog?.prompt(
+          "Enter the " + label.toLowerCase() + " printed by crabbox webvnc status.",
+          { title: "VNC credentials", label, confirmLabel: "connect" },
+        );
+        const credential = String(value || "").trim();
+        if (!credential) return "";
+        if (kind === "username") username = credential;
+        else password = credential;
+        return credential;
       }
       let rfb;
       let retryTimer;
@@ -1376,13 +1402,9 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
             scheduleRetry(state.message || "waiting for an available WebVNC observer slot");
             return;
           }
-          if (target === "macos" && !password) {
-            stopPolling(missingVNCCredentialMessage);
-            return;
-          }
           setStatus(retryAttempt ? "bridge connected; opening viewer" : "connecting");
           clearDesktopThemeSyncState();
-          rfb = new RFB(screen, wsURL.toString(), options);
+          rfb = new RFB(screen, wsURL.toString(), viewerOptions());
           rfb.showDotCursor = true;
           rfb.focusOnClick = true;
           rfb.scaleViewport = true;
@@ -1421,33 +1443,36 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
             connected = false;
             clearDesktopThemeSyncState();
             if (!wasConnected && (authenticationFailed || credentialsSent)) {
-              stopPolling(authenticationFailed ? failedVNCCredentialMessage : "VNC authentication timed out; reopen WebVNC from crabbox webvnc status");
+              stopPolling(authenticationFailed ? failedVNCCredentialMessage : "VNC authentication timed out; check the credentials printed by crabbox webvnc status");
               return;
             }
             scheduleRetry(wasConnected ? "VNC bridge disconnected" : "waiting for VNC bridge");
           });
-          rfb.addEventListener("credentialsrequired", (event) => {
+          rfb.addEventListener("credentialsrequired", async (event) => {
             const types = event.detail?.types || ["password"];
             const values = {};
             if (types.includes("username")) {
-              if (!username) {
+              const promptedUsername = await promptVNCCredential("username");
+              if (!promptedUsername) {
                 stopPolling(missingVNCCredentialMessage);
                 return;
               }
-              values.username = username;
+              values.username = promptedUsername;
             }
             if (types.includes("password")) {
-              if (!password) {
+              const promptedPassword = await promptVNCCredential("password");
+              if (!promptedPassword) {
                 stopPolling(missingVNCCredentialMessage);
                 return;
               }
-              values.password = password;
+              values.password = promptedPassword;
             }
             credentialsSent = true;
             rfb.sendCredentials(values);
           });
           rfb.addEventListener("securityfailure", () => {
             authenticationFailed = true;
+            password = "";
             stopPolling(failedVNCCredentialMessage);
           });
         } catch (error) {
@@ -1512,8 +1537,7 @@ export function portalVNC(lease: LeaseRecord, options: { canManage?: boolean } =
       function shareableWebVNCURL() {
         const url = new URL(window.location.href);
         const linkFragment = new URLSearchParams();
-        if (username) linkFragment.set("username", username);
-        if (password) linkFragment.set("password", password);
+        if (takeControlOnConnect) linkFragment.set("control", "take");
         url.hash = linkFragment.toString();
         return url.toString();
       }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -12267,8 +12267,8 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain("saveShare");
     expect(pageBody).toContain("teammate@example.com");
     expect(pageBody).toContain("shareableWebVNCURL");
-    expect(pageBody).toContain('linkFragment.set("username", username)');
-    expect(pageBody).toContain('linkFragment.set("password", password)');
+    expect(pageBody).not.toContain('linkFragment.set("username", username)');
+    expect(pageBody).not.toContain('linkFragment.set("password", password)');
     expect(pageBody).toContain("await refreshShareState()");
     expect(pageBody).toContain("writeClipboardText(shareableWebVNCURL())");
     expect(pageBody).toContain('document.getElementById("vnc-share")');
@@ -12325,15 +12325,20 @@ describe("fleet lease identity and idle", () => {
     expect(pageBody).toContain("rfb.viewOnly = !controlling");
     expect(pageBody).toContain("state?.terminal");
     expect(pageBody).toContain("stopPolling(state.message");
-    expect(pageBody).toContain('fragment.get("username")');
+    expect(pageBody).toContain('fragment.delete("username")');
+    expect(pageBody).toContain('fragment.delete("password")');
     expect(pageBody).toContain('types.includes("username")');
-    expect(pageBody).toContain("VNC credentials missing; open WebVNC from crabbox webvnc status");
     expect(pageBody).toContain(
-      "VNC authentication failed; reopen WebVNC from crabbox webvnc status",
+      "VNC credentials missing; enter the credentials printed by crabbox webvnc status",
     );
     expect(pageBody).toContain(
-      "VNC authentication timed out; reopen WebVNC from crabbox webvnc status",
+      "VNC authentication failed; check the credentials printed by crabbox webvnc status",
     );
+    expect(pageBody).toContain(
+      "VNC authentication timed out; check the credentials printed by crabbox webvnc status",
+    );
+    expect(pageBody).toContain("promptVNCCredential");
+    expect(pageBody).toContain("window.crabboxDialog?.prompt(");
     expect(pageBody).toContain("credentialsSent = true");
     expect(pageBody).not.toContain('window.prompt("VNC username")');
     expect(pageBody).not.toContain('window.prompt("VNC password")');


### PR DESCRIPTION
Closes #417.

Summary:
- Stop embedding WebVNC username/password values in managed portal fragments, direct noVNC URLs, opened browser URLs, and controller desktop URLs.
- Keep credentials available through separate CLI output and have the portal prompt when noVNC requires them.
- Scrub legacy credential fragments from the portal page and keep copied WebVNC links credential-free.

Proof: regression coverage now shows sanitized WebVNC URLs while the separate `password:`/`username:` output remains available.
