### PR TITLE
docs: define security boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Defined Crabbox's supported single-user and cooperative-team security boundary, clarified repository configuration as trusted project automation, and separated vulnerability reporting from compatibility-preserving hardening.
+
 ### Fixed
 
 - Restricted Crabbox-managed Windows credential files to the managed user, Administrators, and SYSTEM without changing desktop credential consumers. Thanks @coygeek.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ owns provider credentials and lease state, and a managed or delegated runner.
 Run the coordinator on Cloudflare Workers with a Durable Object, or as a
 Node.js service backed by PostgreSQL.
 
+## Trust model
+
+Crabbox is a developer execution tool, not a hostile multi-tenant platform or a
+uniform security sandbox. It assumes the local OS user, repository
+configuration, configured project tooling, and authenticated coordinator
+operators are trusted. Repository configuration is executable project
+automation: it can run local helpers, select runtimes, mount host resources,
+and control development infrastructure. Review unfamiliar repositories before
+running Crabbox.
+
+The optional coordinator is intended for a cooperative trusted team. Its
+authentication, ownership, and sharing controls prevent unauthorized access
+and accidental cross-owner operations, but do not provide isolation between
+mutually adversarial tenants. See the [Security Policy](SECURITY.md) for the
+supported boundary and [Operational security](docs/security.md) for deployment
+guidance.
+
 ## How it works
 
 ```text
@@ -267,11 +284,11 @@ and authoring guide.
 - **Stable timing records.** `--timing-json` on `run`, `warmup`, `prewarm`, and
   `actions hydrate` gives scripts one machine-readable sync/command/total
   timing schema across providers.
-- **Hardened coordinator auth.** GitHub browser login, owner-scoped leases,
+- **Coordinator access controls.** GitHub browser login, owner-scoped leases,
   admin-only routes, optional GitHub team allowlists, Cloudflare Access JWT
   verification, and service-token support keep normal use and operator
   automation separate. See [Auth and admin](docs/features/auth-admin.md) and
-  [Security](docs/security.md).
+  the [Security Policy](SECURITY.md).
 
 ## Machine classes
 
@@ -501,7 +518,7 @@ Cloudflare, Node/PostgreSQL, container, ingress, secrets, and DNS deployment liv
 - **Interactive QA:** [Interactive Desktop and VNC](docs/features/interactive-desktop-vnc.md), [Artifacts](docs/features/artifacts.md), [Portal](docs/features/portal.md)
 - **Integrate infrastructure:** [Bring Your Own Infrastructure](docs/features/bring-your-own-infrastructure.md), [Portable Coordinator](docs/features/portable-coordinator.md), [External Provider](docs/providers/external.md)
 - **Operate it:** [Operations](docs/operations.md), [Observability](docs/observability.md), [Troubleshooting](docs/troubleshooting.md), [Performance](docs/performance.md)
-- **Set it up or audit it:** [Infrastructure](docs/infrastructure.md), [Security](docs/security.md), [Getting Started](docs/getting-started.md), [Source Map](docs/source-map.md)
+- **Set it up or audit it:** [Infrastructure](docs/infrastructure.md), [Security Policy](SECURITY.md), [Operational Security](docs/security.md), [Getting Started](docs/getting-started.md), [Source Map](docs/source-map.md)
 - **Changes:** [CHANGELOG.md](CHANGELOG.md)
 
 The GitHub Pages site at <https://openclaw.github.io/crabbox/> is generated from

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,98 @@
+# Security Policy
+
+## Purpose and trust model
+
+Crabbox is a developer execution tool. It is designed for one trusted local OS
+user and, when a coordinator is used, a cooperative team of trusted operators.
+It is not designed to isolate mutually adversarial tenants, hostile users on a
+shared host, or untrusted operators behind one coordinator.
+
+Treat repository configuration as executable project automation, like a
+Makefile, package script, or CI workflow. It can select providers and local
+helper binaries, run commands, configure runtime arguments, mount host
+resources, and forward explicitly selected environment values. Review an
+unfamiliar repository and its Crabbox configuration before running it.
+
+Crabbox-created containers, virtual machines, portals, and provider resources
+are development execution environments, not a uniform security sandbox.
+Isolation depends on the selected provider and its documented behavior. In
+particular, local container socket pass-through gives the lease authority over
+the host container engine.
+
+The coordinator's authentication, ownership, and sharing controls remain
+product boundaries. They prevent unauthorized access and accidental
+cross-owner operations in the supported trusted-team model, but they are not a
+hostile multi-tenant isolation claim.
+
+See [Operational security](docs/security.md) for deployment guidance.
+
+## Supported versions
+
+Security fixes target the latest release and current `main`. Older releases do
+not receive a guaranteed backport or long-term support window.
+
+## In scope
+
+Examples of reports that cross a supported Crabbox boundary:
+
+- authentication bypass without a valid configured credential;
+- escalation from a non-admin identity to documented admin capabilities;
+- access to another owner's resources contrary to documented authorization;
+- Crabbox silently sending a trusted credential to a destination selected by a
+  different, lower-trust configuration source;
+- generated credentials being exposed beyond the current OS user by Crabbox;
+- destructive provider actions against resources Crabbox cannot strongly
+  identify as its own;
+- integrity failures in artifacts or images that Crabbox downloads and installs
+  as part of a documented default workflow;
+- command injection outside an explicitly configured command, helper, runtime,
+  or project-automation surface.
+
+## Hardening and expected behavior
+
+The following are normally hardening, reliability, or documented behavior
+rather than security vulnerabilities:
+
+- exposure to another process running as the same trusted OS user;
+- short-lived credentials in local browser history or local process metadata;
+- repository-configured commands, helpers, runtime arguments, guest
+  credentials, mounts, or container-engine access;
+- an admin credential exercising admin capabilities or choosing attribution;
+- trusted operators deliberately attacking each other;
+- public network reachability protected by documented key or token
+  authentication;
+- missing orphan cleanup, reconciliation, or cost-control coverage;
+- crashes or denial of service caused by a trusted operator or trusted project
+  configuration;
+- defense-in-depth and supply-chain improvements without a demonstrated bypass
+  of a supported boundary.
+
+Hardening is welcome when it preserves documented workflows. Prefer warnings,
+source-bound credentials, explicit operator consent, and opt-in stricter modes
+over silently removing useful capabilities. Changes that require a compatibility
+break need an explicit product decision and migration path.
+
+## Out of scope
+
+- hostile repository configuration or project scripts;
+- another process or user with access to the same OS account;
+- mutually adversarial users sharing one coordinator, shared token, pond, or
+  local host;
+- compromise of a configured provider, helper binary, container engine, image,
+  or external command;
+- secrets passed to commands or machines through an explicit allowlist or
+  project configuration;
+- arbitrary commands executed on a leased machine;
+- leaked credentials outside Crabbox's control.
+
+## Reporting
+
+Use [GitHub private vulnerability reporting](https://github.com/openclaw/crabbox/security/advisories/new)
+for a suspected vulnerability. Use a normal GitHub issue for non-sensitive
+hardening, reliability, documentation, or expected-behavior discussions.
+
+Do not publish live credentials, private infrastructure details, or an
+exploit-ready report containing sensitive deployment information. Reports
+should identify the supported boundary crossed, required attacker access,
+affected code path, and a reproduction where practical. CVSS scoring is useful
+only after the report is accepted as a vulnerability.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -11,6 +11,13 @@ Crabbox configuration is layered. The CLI loads values from several sources and
 merges them in a deterministic order. Every source is optional - the binary
 boots with sane defaults for everything.
 
+Repository configuration is executable project automation, comparable to a
+Makefile, package script, or CI workflow. It may select providers, helper
+commands, runtimes, images, and runtime arguments. Review unfamiliar repository
+configuration before running Crabbox. User config and environment variables
+remain the appropriate sources for operator credentials and machine-specific
+policy.
+
 ## Precedence
 
 ```text

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -109,10 +109,9 @@ ownership under those paths. System paths such as `/etc`, `/usr`, `/var`,
 `/home`, and `/tmp` are also rejected; use an application mount point such as
 `/mnt/my-app` or `/cache`.
 
-**Security:** This flag is CLI-only. It is intentionally not loaded from
-repo-local `.crabbox.yaml` because bind mounts expose host paths and must
-be an explicit operator action, not something an untrusted checkout can
-request.
+**Host access:** This flag is CLI-only. Crabbox does not load bind mounts from
+repo-local `.crabbox.yaml`; operators must name each host path explicitly on
+the command line.
 
 Environment overrides:
 
@@ -129,7 +128,7 @@ CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET
 
 Host bind mounts must be passed explicitly with `--local-container-volume`.
 Crabbox intentionally ignores `localContainer.volumes` from config files because
-repo-local config can come from untrusted checkouts.
+host paths are machine-specific and benefit from invocation-time review.
 
 For runtimes that use Docker contexts or Docker-compatible API sockets, the
 active socket is selected from `DOCKER_HOST` or the Docker context when socket
@@ -142,7 +141,10 @@ Set `localContainer.dockerSocket: true` or
 `CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=1` when commands inside the lease need to
 run `docker`. Crabbox mounts the active local Unix Docker-compatible socket into
 the container at `/var/run/docker.sock`, so in-lease `docker` commands run
-against the host engine. For Podman, point `DOCKER_HOST` at the Podman socket,
+against the host engine. This grants the lease the same effective authority as
+the user controlling that engine; it is not a container isolation boundary.
+Repository configuration is trusted project automation and can enable this
+mode. For Podman, point `DOCKER_HOST` at the Podman socket,
 for example `unix://$XDG_RUNTIME_DIR/podman/podman.sock`. Remote TCP hosts are
 rejected in this mode. Basic Podman leases do not require socket pass-through.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,7 +1,11 @@
-# Security
+# Operational Security
 
 Read this when you are standing up a shared broker, deciding what secrets to
 forward, or reasoning about who can reach a leased box.
+
+The root [Security Policy](https://github.com/openclaw/crabbox/blob/main/SECURITY.md)
+defines the supported security boundary and reporting scope. This guide covers
+deployment and operational hardening within that boundary.
 
 Crabbox spans three trust layers, and each owns a different part of the security
 posture:
@@ -22,6 +26,9 @@ and explicitly forwarded environment values.
 Crabbox is built for trusted operators on a shared team, not for arbitrary
 untrusted tenants. Assume:
 
+- The local OS user and configured provider tooling are trusted.
+- Repository configuration is executable project automation and must be
+  reviewed like a Makefile, package script, or CI workflow.
 - Operators can run arbitrary commands on the boxes they lease.
 - A box may observe any local environment value the CLI forwards to it.
 - Operators are trusted not to attack each other deliberately.
@@ -29,7 +36,9 @@ untrusted tenants. Assume:
 
 Do not place mutually untrusted tenants on the same broker, in the same
 [pond](features/pond.md), or behind a single shared token. Per-lease and
-per-tenant isolation is not the current security boundary.
+per-tenant isolation is not the current security boundary. Local providers and
+portal bridges are development execution surfaces, not a uniform sandbox for
+hostile project configuration or mutually adversarial workloads.
 
 ## Authentication
 
@@ -139,8 +148,11 @@ closed for non-health routes.
 
 ## Secrets
 
-There is no central project secret store. Secrets stay on the operator's
-machine and are forwarded to a box only when explicitly allowed.
+There is no central project secret store. Remote command environment values
+stay on the operator's machine unless explicitly allowed for forwarding.
+Local helper processes, including External provider lifecycle commands, inherit
+the Crabbox process environment unless their own runtime provides stronger
+isolation.
 
 Handling rules:
 
@@ -271,8 +283,11 @@ Crabbox-managed VNC to public interfaces or to the Tailscale `100.x` interface.
 
 ## Cleanup
 
-Cleanup is security-sensitive: a leaked box keeps spending money and stays
-reachable. See [lifecycle and cleanup](features/lifecycle-cleanup.md).
+Cleanup is operationally important for cost control and stale resource
+management. Missing reconciliation or provider coverage is normally
+reliability hardening. Deleting a resource that Crabbox cannot strongly
+identify as its own crosses a safety boundary. See
+[lifecycle and cleanup](features/lifecycle-cleanup.md).
 
 Layered protections:
 


### PR DESCRIPTION
## Summary

- add a canonical root `SECURITY.md` defining Crabbox's supported trust boundary
- describe repository configuration as trusted executable project automation
- distinguish vulnerabilities from compatibility-preserving hardening and operational reliability
- align README, configuration, local-container, and operational security documentation

## Verification

- `scripts/check-docs.sh`
- `node scripts/build-docs-site.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'scripts/check-docs.sh' --stream-engine-output`

Autoreview: clean after fixing the generated-docs policy link identified in the first review pass.
