### PR TITLE
fix: source-bind credential destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Source-bound broker and direct-provider credentials to repository-configured endpoints, while preserving same-source custom deployments and explicit environment or CLI overrides.
 - Restricted Crabbox-managed Windows credential files to the managed user, Administrators, and SYSTEM without changing desktop credential consumers. Thanks @coygeek.
 - Created default artifact bundles and retained run logs/metadata with private local permissions while preserving explicit shared-output directories. Thanks @coygeek.
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -97,10 +97,13 @@ wrote /home/alice/.config/crabbox/config.yaml broker=https://broker.example.com 
 
 ## Where secrets belong
 
-Store broker tokens, Cloudflare runner tokens, and Access secrets in user
-config or environment variables, never in repo-local `crabbox.yaml` /
-`.crabbox.yaml`. The user config file is written with `0600` permissions, and
-`crabbox doctor` flags it when the permissions are broader than that.
+Prefer user config, environment variables, or a credential manager for broker
+tokens, provider tokens, and Access secrets. Repository config is trusted
+project automation and may intentionally define a complete custom
+endpoint-and-credential pair, but Crabbox refuses to combine a
+repository-defined destination with an inherited credential. The user config
+file is written with `0600` permissions, and `crabbox doctor` flags it when the
+permissions are broader than that.
 
 ## Repo-local config
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -18,6 +18,13 @@ configuration before running Crabbox. User config and environment variables
 remain the appropriate sources for operator credentials and machine-specific
 policy.
 
+When repository config supplies a credential destination such as a broker,
+provider API, sandbox domain, or SSH gateway, Crabbox source-binds credentials
+to that layer. A destination and credential intentionally defined by the same
+repository remain valid. An inherited user-config or environment credential is
+not sent to a repository-defined destination unless the operator explicitly
+overrides that destination through its environment variable or CLI flag.
+
 ## Precedence
 
 ```text
@@ -1092,7 +1099,7 @@ MODAL_TOKEN_ID / MODAL_TOKEN_SECRET
 
 | Setting | User config | Repo config | Profile | Notes |
 |:--------|:------------|:------------|:--------|:------|
-| `broker.url` and `broker.token` | yes | no | no | Per-machine identity. |
+| `broker.url` and `broker.token` | yes | yes | no | Prefer user config; repo endpoint/auth must come from the same source or be explicitly approved. |
 | `provider`, `class`, `architecture`, `serverType` | optional default | yes | yes | Per-repo defaults; profiles for lanes. |
 | `sync.exclude`, `sync.fingerprint`, `sync.baseRef` | no | yes | yes | Lives with the repo. |
 | `env.allow` | no | yes | yes | Repo decides what is safe to forward. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,8 +99,10 @@ the Worker strips caller-supplied `cf-access-authenticated-user-email` and
 
 The local service-token credentials `CRABBOX_ACCESS_CLIENT_ID` and
 `CRABBOX_ACCESS_CLIENT_SECRET` only satisfy the Access edge; they authorize no
-Crabbox action by themselves. Store them in user config or env, never in repo
-config.
+Crabbox action by themselves. Prefer user config or env. If a trusted
+repository intentionally defines both a custom broker URL and matching Access
+credentials, Crabbox treats them as one source; it will not send inherited
+Access credentials to a repository-defined broker URL.
 
 ### Trusted reverse proxy identity
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	CoordToken                    string
 	CoordTokenCommand             []string
 	CoordAdminToken               string
+	credentialProvenance          credentialDestinationProvenance
 	HostID                        string
 	Access                        AccessConfig
 	Location                      string
@@ -1214,6 +1215,7 @@ func loadConfigWithOverrides(coordinator, provider string) (Config, error) {
 	applyCloudflareDynamicWorkersRepositoryCaps(&cfg)
 	if coordinator = strings.TrimSpace(coordinator); coordinator != "" {
 		cfg.Coordinator = coordinator
+		markCoordinatorDestinationExplicit(&cfg)
 	}
 	if provider = strings.TrimSpace(provider); provider != "" {
 		cfg.Provider = provider
@@ -2990,15 +2992,17 @@ type fileCloudflareDynamicWorkersConfig struct {
 	Metadata           map[string]string `yaml:"metadata,omitempty"`
 }
 
-func applyCloudflareFileConfig(cfg *Config, file *fileCloudflareConfig) {
+func applyCloudflareFileConfig(cfg *Config, file *fileCloudflareConfig, source credentialValueSource) {
 	if file == nil {
 		return
 	}
 	if file.APIURL != "" {
 		cfg.Cloudflare.APIURL = file.APIURL
+		cfg.credentialProvenance.cloudflareAPIURL = source
 	}
 	if file.Token != "" {
 		cfg.Cloudflare.Token = file.Token
+		cfg.credentialProvenance.cloudflareToken = source
 	}
 	if file.Workdir != "" {
 		cfg.Cloudflare.Workdir = file.Workdir
@@ -3534,6 +3538,7 @@ func trustedConfigPath(path string) bool {
 }
 
 func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error {
+	credentialSource := credentialSourceForFile(trusted)
 	if file.Profile != "" {
 		cfg.Profile = file.Profile
 	}
@@ -3589,9 +3594,11 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	}
 	if file.Coordinator != "" {
 		cfg.Coordinator = file.Coordinator
+		cfg.credentialProvenance.coordinator = credentialSource
 	}
 	if file.CoordinatorToken != "" {
 		cfg.CoordToken = file.CoordinatorToken
+		cfg.credentialProvenance.coordToken = credentialSource
 	}
 	if file.HostID != "" {
 		cfg.HostID = file.HostID
@@ -3599,9 +3606,11 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Broker != nil {
 		if file.Broker.URL != "" {
 			cfg.Coordinator = file.Broker.URL
+			cfg.credentialProvenance.coordinator = credentialSource
 		}
 		if file.Broker.Token != "" {
 			cfg.CoordToken = file.Broker.Token
+			cfg.credentialProvenance.coordToken = credentialSource
 		}
 		if file.Broker.Mode != "" {
 			cfg.BrokerMode = BrokerMode(file.Broker.Mode)
@@ -3611,6 +3620,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Broker.AdminToken != "" {
 			cfg.CoordAdminToken = file.Broker.AdminToken
+			cfg.credentialProvenance.coordAdminToken = credentialSource
 		}
 		if file.Broker.Provider != "" {
 			cfg.Provider = file.Broker.Provider
@@ -3619,12 +3629,15 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.Broker.Access != nil {
 			if file.Broker.Access.ClientID != "" {
 				cfg.Access.ClientID = file.Broker.Access.ClientID
+				cfg.credentialProvenance.accessClientID = credentialSource
 			}
 			if file.Broker.Access.ClientSecret != "" {
 				cfg.Access.ClientSecret = file.Broker.Access.ClientSecret
+				cfg.credentialProvenance.accessClientSecret = credentialSource
 			}
 			if file.Broker.Access.Token != "" {
 				cfg.Access.Token = file.Broker.Access.Token
+				cfg.credentialProvenance.accessToken = credentialSource
 			}
 		}
 	}
@@ -3877,12 +3890,15 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Proxmox != nil {
 		if file.Proxmox.APIURL != "" {
 			cfg.Proxmox.APIURL = file.Proxmox.APIURL
+			cfg.credentialProvenance.proxmoxAPIURL = credentialSource
 		}
 		if file.Proxmox.TokenID != "" {
 			cfg.Proxmox.TokenID = file.Proxmox.TokenID
+			cfg.credentialProvenance.proxmoxTokenID = credentialSource
 		}
 		if file.Proxmox.TokenSecret != "" {
 			cfg.Proxmox.TokenSecret = file.Proxmox.TokenSecret
+			cfg.credentialProvenance.proxmoxTokenSecret = credentialSource
 		}
 		if file.Proxmox.Node != "" {
 			cfg.Proxmox.Node = file.Proxmox.Node
@@ -3910,6 +3926,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Proxmox.InsecureTLS != nil {
 			cfg.Proxmox.InsecureTLS = *file.Proxmox.InsecureTLS
+			cfg.credentialProvenance.proxmoxInsecureTLS = credentialSource
 		}
 	}
 	if file.XCPNg != nil {
@@ -4334,15 +4351,18 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Morph != nil {
 		if file.Morph.APIKey != "" {
 			cfg.Morph.APIKey = file.Morph.APIKey
+			cfg.credentialProvenance.morphAPIKey = credentialSource
 		}
 		if file.Morph.APIURL != "" {
 			cfg.Morph.APIURL = file.Morph.APIURL
+			cfg.credentialProvenance.morphAPIURL = credentialSource
 		}
 		if file.Morph.Snapshot != "" {
 			cfg.Morph.Snapshot = file.Morph.Snapshot
 		}
 		if file.Morph.SSHGatewayHost != "" {
 			cfg.Morph.SSHGatewayHost = file.Morph.SSHGatewayHost
+			cfg.credentialProvenance.morphSSHGatewayHost = credentialSource
 		}
 		if file.Morph.WorkRoot != "" {
 			cfg.Morph.WorkRoot = file.Morph.WorkRoot
@@ -4358,6 +4378,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Daytona != nil {
 		if file.Daytona.APIURL != "" {
 			cfg.Daytona.APIURL = file.Daytona.APIURL
+			cfg.credentialProvenance.daytonaAPIURL = credentialSource
 		}
 		if file.Daytona.Snapshot != "" {
 			cfg.Daytona.Snapshot = file.Daytona.Snapshot
@@ -4373,6 +4394,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Daytona.SSHGatewayHost != "" {
 			cfg.Daytona.SSHGatewayHost = file.Daytona.SSHGatewayHost
+			cfg.credentialProvenance.daytonaSSHGateway = credentialSource
 		}
 		if file.Daytona.SSHAccessMinutes > 0 {
 			cfg.Daytona.SSHAccessMinutes = file.Daytona.SSHAccessMinutes
@@ -4381,9 +4403,11 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.E2B != nil {
 		if file.E2B.APIURL != "" {
 			cfg.E2B.APIURL = file.E2B.APIURL
+			cfg.credentialProvenance.e2bAPIURL = credentialSource
 		}
 		if file.E2B.Domain != "" {
 			cfg.E2B.Domain = file.E2B.Domain
+			cfg.credentialProvenance.e2bDomain = credentialSource
 		}
 		if file.E2B.Template != "" {
 			cfg.E2B.Template = file.E2B.Template
@@ -4427,6 +4451,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Railway != nil {
 		if file.Railway.APIURL != "" {
 			cfg.Railway.APIURL = file.Railway.APIURL
+			cfg.credentialProvenance.railwayAPIURL = credentialSource
 		}
 		if file.Railway.ProjectID != "" {
 			cfg.Railway.ProjectID = file.Railway.ProjectID
@@ -4438,6 +4463,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Runpod != nil {
 		if file.Runpod.APIURL != "" {
 			cfg.Runpod.APIURL = file.Runpod.APIURL
+			cfg.credentialProvenance.runpodAPIURL = credentialSource
 		}
 		if file.Runpod.CloudType != "" {
 			cfg.Runpod.CloudType = file.Runpod.CloudType
@@ -4553,6 +4579,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Islo != nil {
 		if file.Islo.BaseURL != "" {
 			cfg.Islo.BaseURL = file.Islo.BaseURL
+			cfg.credentialProvenance.isloBaseURL = credentialSource
 		}
 		if file.Islo.Image != "" {
 			cfg.Islo.Image = file.Islo.Image
@@ -4597,9 +4624,11 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		}
 		if file.Tenki.Endpoint != "" {
 			cfg.Tenki.Endpoint = file.Tenki.Endpoint
+			cfg.credentialProvenance.tenkiEndpoint = credentialSource
 		}
 		if file.Tenki.Gateway != "" {
 			cfg.Tenki.Gateway = file.Tenki.Gateway
+			cfg.credentialProvenance.tenkiGateway = credentialSource
 		}
 		if file.Tenki.Workspace != "" {
 			cfg.Tenki.Workspace = file.Tenki.Workspace
@@ -4629,6 +4658,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Tensorlake != nil {
 		if file.Tensorlake.APIURL != "" {
 			cfg.Tensorlake.APIURL = file.Tensorlake.APIURL
+			cfg.credentialProvenance.tensorlakeAPIURL = credentialSource
 		}
 		if file.Tensorlake.CLIPath != "" {
 			cfg.Tensorlake.CLIPath = file.Tensorlake.CLIPath
@@ -4923,6 +4953,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.UpstashBox != nil {
 		if file.UpstashBox.BaseURL != "" {
 			cfg.UpstashBox.BaseURL = file.UpstashBox.BaseURL
+			cfg.credentialProvenance.upstashBoxBaseURL = credentialSource
 		}
 		if file.UpstashBox.Runtime != "" {
 			cfg.UpstashBox.Runtime = file.UpstashBox.Runtime
@@ -4940,6 +4971,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Smolvm != nil {
 		if file.Smolvm.BaseURL != "" {
 			cfg.Smolvm.BaseURL = file.Smolvm.BaseURL
+			cfg.credentialProvenance.smolvmBaseURL = credentialSource
 		}
 		if file.Smolvm.Image != "" {
 			cfg.Smolvm.Image = file.Smolvm.Image
@@ -4963,6 +4995,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.AsciiBox != nil {
 		if file.AsciiBox.BaseURL != "" {
 			cfg.AsciiBox.BaseURL = file.AsciiBox.BaseURL
+			cfg.credentialProvenance.asciiBoxBaseURL = credentialSource
 		}
 		if file.AsciiBox.CLIPath != "" {
 			cfg.AsciiBox.CLIPath = file.AsciiBox.CLIPath
@@ -4971,14 +5004,16 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.AsciiBox.Workdir = file.AsciiBox.Workdir
 		}
 	}
-	applyCloudflareFileConfig(cfg, file.Cloudflare)
+	applyCloudflareFileConfig(cfg, file.Cloudflare, credentialSource)
 	applyCloudflareDynamicWorkersFileConfig(cfg, file.CloudflareDynamicWorkers, trusted)
 	if file.Semaphore != nil {
 		if file.Semaphore.Host != "" {
 			cfg.Semaphore.Host = file.Semaphore.Host
+			cfg.credentialProvenance.semaphoreHost = credentialSource
 		}
 		if file.Semaphore.Token != "" {
 			cfg.Semaphore.Token = file.Semaphore.Token
+			cfg.credentialProvenance.semaphoreToken = credentialSource
 		}
 		if file.Semaphore.Project != "" {
 			cfg.Semaphore.Project = file.Semaphore.Project
@@ -4996,6 +5031,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.Sprites != nil {
 		if file.Sprites.APIURL != "" {
 			cfg.Sprites.APIURL = file.Sprites.APIURL
+			cfg.credentialProvenance.spritesAPIURL = credentialSource
 		}
 		if file.Sprites.WorkRoot != "" {
 			cfg.Sprites.WorkRoot = file.Sprites.WorkRoot
@@ -5668,12 +5704,18 @@ func applyEnv(cfg *Config) error {
 		cfg.ServerTypeExplicit = true
 	}
 	cfg.ServerType = getenv("CRABBOX_SERVER_TYPE", cfg.ServerType)
-	cfg.Coordinator = getenv("CRABBOX_COORDINATOR", cfg.Coordinator)
+	if value := os.Getenv("CRABBOX_COORDINATOR"); value != "" {
+		cfg.Coordinator = value
+		cfg.credentialProvenance.coordinator = credentialSourceEnvironment
+	}
 	cfg.BrokerMode = BrokerMode(getenv("CRABBOX_COORDINATOR_MODE", string(cfg.BrokerMode)))
 	if value, ok := getenvBool("CRABBOX_COORDINATOR_AUTO_WEBVNC"); ok {
 		cfg.BrokerAutoWebVNC = value
 	}
-	cfg.CoordToken = getenv("CRABBOX_COORDINATOR_TOKEN", cfg.CoordToken)
+	if value := os.Getenv("CRABBOX_COORDINATOR_TOKEN"); value != "" {
+		cfg.CoordToken = value
+		cfg.credentialProvenance.coordToken = credentialSourceEnvironment
+	}
 	if raw := strings.TrimSpace(os.Getenv("CRABBOX_COORDINATOR_TOKEN_COMMAND")); raw != "" {
 		var command []string
 		if err := json.Unmarshal([]byte(raw), &command); err != nil {
@@ -5688,12 +5730,25 @@ func applyEnv(cfg *Config) error {
 			}
 		}
 		cfg.CoordTokenCommand = append([]string(nil), command...)
+		cfg.credentialProvenance.coordTokenCommand = credentialSourceEnvironment
 	}
-	cfg.CoordAdminToken = getenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", getenv("CRABBOX_ADMIN_TOKEN", cfg.CoordAdminToken))
+	if value, ok := firstNonEmptyEnv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "CRABBOX_ADMIN_TOKEN"); ok {
+		cfg.CoordAdminToken = value
+		cfg.credentialProvenance.coordAdminToken = credentialSourceEnvironment
+	}
 	cfg.HostID = getenv("CRABBOX_HOST_ID", cfg.HostID)
-	cfg.Access.ClientID = getenv("CRABBOX_ACCESS_CLIENT_ID", getenv("CF_ACCESS_CLIENT_ID", cfg.Access.ClientID))
-	cfg.Access.ClientSecret = getenv("CRABBOX_ACCESS_CLIENT_SECRET", getenv("CF_ACCESS_CLIENT_SECRET", cfg.Access.ClientSecret))
-	cfg.Access.Token = getenv("CRABBOX_ACCESS_TOKEN", getenv("CF_ACCESS_TOKEN", cfg.Access.Token))
+	if value, ok := firstNonEmptyEnv("CRABBOX_ACCESS_CLIENT_ID", "CF_ACCESS_CLIENT_ID"); ok {
+		cfg.Access.ClientID = value
+		cfg.credentialProvenance.accessClientID = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_ACCESS_CLIENT_SECRET", "CF_ACCESS_CLIENT_SECRET"); ok {
+		cfg.Access.ClientSecret = value
+		cfg.credentialProvenance.accessClientSecret = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_ACCESS_TOKEN", "CF_ACCESS_TOKEN"); ok {
+		cfg.Access.Token = value
+		cfg.credentialProvenance.accessToken = credentialSourceEnvironment
+	}
 	if location := os.Getenv("CRABBOX_HETZNER_LOCATION"); location != "" {
 		cfg.Location = location
 		cfg.locationExplicit = true
@@ -5836,9 +5891,18 @@ func applyEnv(cfg *Config) error {
 		cfg.ovhImageExplicit = true
 	}
 	cfg.OVH.Flavor = getenv("CRABBOX_OVH_FLAVOR", cfg.OVH.Flavor)
-	cfg.Proxmox.APIURL = getenv("CRABBOX_PROXMOX_API_URL", cfg.Proxmox.APIURL)
-	cfg.Proxmox.TokenID = getenv("CRABBOX_PROXMOX_TOKEN_ID", cfg.Proxmox.TokenID)
-	cfg.Proxmox.TokenSecret = getenv("CRABBOX_PROXMOX_TOKEN_SECRET", cfg.Proxmox.TokenSecret)
+	if value := os.Getenv("CRABBOX_PROXMOX_API_URL"); value != "" {
+		cfg.Proxmox.APIURL = value
+		cfg.credentialProvenance.proxmoxAPIURL = credentialSourceEnvironment
+	}
+	if value := os.Getenv("CRABBOX_PROXMOX_TOKEN_ID"); value != "" {
+		cfg.Proxmox.TokenID = value
+		cfg.credentialProvenance.proxmoxTokenID = credentialSourceEnvironment
+	}
+	if value := os.Getenv("CRABBOX_PROXMOX_TOKEN_SECRET"); value != "" {
+		cfg.Proxmox.TokenSecret = value
+		cfg.credentialProvenance.proxmoxTokenSecret = credentialSourceEnvironment
+	}
 	cfg.Proxmox.Node = getenv("CRABBOX_PROXMOX_NODE", cfg.Proxmox.Node)
 	cfg.Proxmox.TemplateID = getenvInt("CRABBOX_PROXMOX_TEMPLATE_ID", cfg.Proxmox.TemplateID)
 	cfg.Proxmox.Storage = getenv("CRABBOX_PROXMOX_STORAGE", cfg.Proxmox.Storage)
@@ -5851,6 +5915,7 @@ func applyEnv(cfg *Config) error {
 	}
 	if value, ok := getenvBool("CRABBOX_PROXMOX_INSECURE_TLS"); ok {
 		cfg.Proxmox.InsecureTLS = value
+		cfg.credentialProvenance.proxmoxInsecureTLS = credentialSourceEnvironment
 	}
 	cfg.XCPNg.APIURL = getenv("CRABBOX_XCP_NG_API_URL", cfg.XCPNg.APIURL)
 	cfg.XCPNg.Username = getenv("CRABBOX_XCP_NG_USERNAME", cfg.XCPNg.Username)
@@ -6035,10 +6100,19 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_NAMESPACE_INSTANCE_BARE"); ok {
 		cfg.NamespaceInstance.Bare = value
 	}
-	cfg.Morph.APIKey = getenv("CRABBOX_MORPH_API_KEY", getenv("MORPH_API_KEY", cfg.Morph.APIKey))
-	cfg.Morph.APIURL = getenv("CRABBOX_MORPH_API_URL", cfg.Morph.APIURL)
+	if value, ok := firstNonEmptyEnv("CRABBOX_MORPH_API_KEY", "MORPH_API_KEY"); ok {
+		cfg.Morph.APIKey = value
+		cfg.credentialProvenance.morphAPIKey = credentialSourceEnvironment
+	}
+	if value := os.Getenv("CRABBOX_MORPH_API_URL"); value != "" {
+		cfg.Morph.APIURL = value
+		cfg.credentialProvenance.morphAPIURL = credentialSourceEnvironment
+	}
 	cfg.Morph.Snapshot = getenv("CRABBOX_MORPH_SNAPSHOT", cfg.Morph.Snapshot)
-	cfg.Morph.SSHGatewayHost = getenv("CRABBOX_MORPH_SSH_GATEWAY_HOST", cfg.Morph.SSHGatewayHost)
+	if value := os.Getenv("CRABBOX_MORPH_SSH_GATEWAY_HOST"); value != "" {
+		cfg.Morph.SSHGatewayHost = value
+		cfg.credentialProvenance.morphSSHGatewayHost = credentialSourceEnvironment
+	}
 	cfg.Morph.WorkRoot = getenv("CRABBOX_MORPH_WORK_ROOT", cfg.Morph.WorkRoot)
 	if value, ok := getenvBool("CRABBOX_MORPH_DELETE_ON_RELEASE"); ok {
 		cfg.Morph.DeleteOnRelease = value
@@ -6047,19 +6121,40 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_MORPH_WAKE_ON_SSH"); ok {
 		cfg.Morph.WakeOnSSH = value
 	}
-	cfg.Daytona.APIKey = getenv("CRABBOX_DAYTONA_API_KEY", getenv("DAYTONA_API_KEY", cfg.Daytona.APIKey))
-	cfg.Daytona.JWTToken = getenv("CRABBOX_DAYTONA_JWT_TOKEN", getenv("DAYTONA_JWT_TOKEN", cfg.Daytona.JWTToken))
+	if value, ok := firstNonEmptyEnv("CRABBOX_DAYTONA_API_KEY", "DAYTONA_API_KEY"); ok {
+		cfg.Daytona.APIKey = value
+		cfg.credentialProvenance.daytonaAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_DAYTONA_JWT_TOKEN", "DAYTONA_JWT_TOKEN"); ok {
+		cfg.Daytona.JWTToken = value
+		cfg.credentialProvenance.daytonaJWTToken = credentialSourceEnvironment
+	}
 	cfg.Daytona.OrganizationID = getenv("CRABBOX_DAYTONA_ORGANIZATION_ID", getenv("DAYTONA_ORGANIZATION_ID", cfg.Daytona.OrganizationID))
-	cfg.Daytona.APIURL = getenv("CRABBOX_DAYTONA_API_URL", getenv("DAYTONA_API_URL", cfg.Daytona.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_DAYTONA_API_URL", "DAYTONA_API_URL"); ok {
+		cfg.Daytona.APIURL = value
+		cfg.credentialProvenance.daytonaAPIURL = credentialSourceEnvironment
+	}
 	cfg.Daytona.Snapshot = getenv("CRABBOX_DAYTONA_SNAPSHOT", getenv("DAYTONA_SNAPSHOT", cfg.Daytona.Snapshot))
 	cfg.Daytona.Target = getenv("CRABBOX_DAYTONA_TARGET", getenv("DAYTONA_TARGET", cfg.Daytona.Target))
 	cfg.Daytona.User = getenv("CRABBOX_DAYTONA_USER", cfg.Daytona.User)
 	cfg.Daytona.WorkRoot = getenv("CRABBOX_DAYTONA_WORK_ROOT", cfg.Daytona.WorkRoot)
-	cfg.Daytona.SSHGatewayHost = getenv("CRABBOX_DAYTONA_SSH_GATEWAY_HOST", cfg.Daytona.SSHGatewayHost)
+	if value := os.Getenv("CRABBOX_DAYTONA_SSH_GATEWAY_HOST"); value != "" {
+		cfg.Daytona.SSHGatewayHost = value
+		cfg.credentialProvenance.daytonaSSHGateway = credentialSourceEnvironment
+	}
 	cfg.Daytona.SSHAccessMinutes = getenvInt("CRABBOX_DAYTONA_SSH_ACCESS_MINUTES", cfg.Daytona.SSHAccessMinutes)
-	cfg.E2B.APIKey = getenv("CRABBOX_E2B_API_KEY", getenv("E2B_API_KEY", cfg.E2B.APIKey))
-	cfg.E2B.APIURL = getenv("CRABBOX_E2B_API_URL", getenv("E2B_API_URL", cfg.E2B.APIURL))
-	cfg.E2B.Domain = getenv("CRABBOX_E2B_DOMAIN", getenv("E2B_DOMAIN", cfg.E2B.Domain))
+	if value, ok := firstNonEmptyEnv("CRABBOX_E2B_API_KEY", "E2B_API_KEY"); ok {
+		cfg.E2B.APIKey = value
+		cfg.credentialProvenance.e2bAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_E2B_API_URL", "E2B_API_URL"); ok {
+		cfg.E2B.APIURL = value
+		cfg.credentialProvenance.e2bAPIURL = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_E2B_DOMAIN", "E2B_DOMAIN"); ok {
+		cfg.E2B.Domain = value
+		cfg.credentialProvenance.e2bDomain = credentialSourceEnvironment
+	}
 	cfg.E2B.Template = getenv("CRABBOX_E2B_TEMPLATE", cfg.E2B.Template)
 	cfg.E2B.Workdir = getenv("CRABBOX_E2B_WORKDIR", cfg.E2B.Workdir)
 	cfg.E2B.User = getenv("CRABBOX_E2B_USER", cfg.E2B.User)
@@ -6074,12 +6169,24 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_EXE_DEV_NO_EMAIL"); ok {
 		cfg.ExeDev.NoEmail = value
 	}
-	cfg.Railway.APIToken = getenv("CRABBOX_RAILWAY_API_TOKEN", getenv("RAILWAY_API_TOKEN", cfg.Railway.APIToken))
-	cfg.Railway.APIURL = getenv("CRABBOX_RAILWAY_API_URL", getenv("RAILWAY_API_URL", cfg.Railway.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_RAILWAY_API_TOKEN", "RAILWAY_API_TOKEN"); ok {
+		cfg.Railway.APIToken = value
+		cfg.credentialProvenance.railwayAPIToken = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_RAILWAY_API_URL", "RAILWAY_API_URL"); ok {
+		cfg.Railway.APIURL = value
+		cfg.credentialProvenance.railwayAPIURL = credentialSourceEnvironment
+	}
 	cfg.Railway.ProjectID = getenv("CRABBOX_RAILWAY_PROJECT_ID", getenv("RAILWAY_PROJECT_ID", cfg.Railway.ProjectID))
 	cfg.Railway.EnvironmentID = getenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", getenv("RAILWAY_ENVIRONMENT_ID", cfg.Railway.EnvironmentID))
-	cfg.Runpod.APIKey = getenv("CRABBOX_RUNPOD_API_KEY", getenv("RUNPOD_API_KEY", cfg.Runpod.APIKey))
-	cfg.Runpod.APIURL = getenv("CRABBOX_RUNPOD_API_URL", getenv("RUNPOD_API_URL", cfg.Runpod.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_RUNPOD_API_KEY", "RUNPOD_API_KEY"); ok {
+		cfg.Runpod.APIKey = value
+		cfg.credentialProvenance.runpodAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_RUNPOD_API_URL", "RUNPOD_API_URL"); ok {
+		cfg.Runpod.APIURL = value
+		cfg.credentialProvenance.runpodAPIURL = credentialSourceEnvironment
+	}
 	cfg.Runpod.CloudType = getenv("CRABBOX_RUNPOD_CLOUD_TYPE", getenv("RUNPOD_CLOUD_TYPE", cfg.Runpod.CloudType))
 	cfg.Runpod.InstanceID = getenv("CRABBOX_RUNPOD_INSTANCE_ID", getenv("RUNPOD_INSTANCE_ID", cfg.Runpod.InstanceID))
 	cfg.Runpod.Image = getenv("CRABBOX_RUNPOD_IMAGE", getenv("RUNPOD_IMAGE", cfg.Runpod.Image))
@@ -6129,8 +6236,14 @@ func applyEnv(cfg *Config) error {
 	cfg.Wandb.APIKey = getenv("CRABBOX_WANDB_API_KEY", cfg.Wandb.APIKey)
 	cfg.Wandb.DefaultImage = getenv("CRABBOX_WANDB_DEFAULT_IMAGE", getenv("WANDB_DEFAULT_IMAGE", cfg.Wandb.DefaultImage))
 	cfg.Wandb.MaxLifetimeSeconds = getenvInt("CRABBOX_WANDB_MAX_LIFETIME_SECONDS", getenvInt("WANDB_MAX_LIFETIME_SECONDS", cfg.Wandb.MaxLifetimeSeconds))
-	cfg.Islo.APIKey = getenv("CRABBOX_ISLO_API_KEY", getenv("ISLO_API_KEY", cfg.Islo.APIKey))
-	cfg.Islo.BaseURL = getenv("CRABBOX_ISLO_BASE_URL", getenv("ISLO_BASE_URL", cfg.Islo.BaseURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_ISLO_API_KEY", "ISLO_API_KEY"); ok {
+		cfg.Islo.APIKey = value
+		cfg.credentialProvenance.isloAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_ISLO_BASE_URL", "ISLO_BASE_URL"); ok {
+		cfg.Islo.BaseURL = value
+		cfg.credentialProvenance.isloBaseURL = credentialSourceEnvironment
+	}
 	if image := os.Getenv("CRABBOX_ISLO_IMAGE"); image != "" {
 		cfg.Islo.Image = image
 		cfg.isloImageExplicit = true
@@ -6147,8 +6260,14 @@ func applyEnv(cfg *Config) error {
 	cfg.Freestyle.VCPUs = getenvInt("CRABBOX_FREESTYLE_VCPUS", cfg.Freestyle.VCPUs)
 	cfg.Freestyle.MemoryGB = getenvInt("CRABBOX_FREESTYLE_MEMORY_GB", cfg.Freestyle.MemoryGB)
 	cfg.Tenki.CLIPath = getenv("CRABBOX_TENKI_CLI", getenv("TENKI_CLI", cfg.Tenki.CLIPath))
-	cfg.Tenki.Endpoint = getenv("CRABBOX_TENKI_ENDPOINT", getenv("TENKI_ENDPOINT", cfg.Tenki.Endpoint))
-	cfg.Tenki.Gateway = getenv("CRABBOX_TENKI_GATEWAY", getenv("TENKI_GATEWAY", cfg.Tenki.Gateway))
+	if value, ok := firstNonEmptyEnv("CRABBOX_TENKI_ENDPOINT", "TENKI_ENDPOINT"); ok {
+		cfg.Tenki.Endpoint = value
+		cfg.credentialProvenance.tenkiEndpoint = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_TENKI_GATEWAY", "TENKI_GATEWAY"); ok {
+		cfg.Tenki.Gateway = value
+		cfg.credentialProvenance.tenkiGateway = credentialSourceEnvironment
+	}
 	cfg.Tenki.Workspace = getenv("CRABBOX_TENKI_WORKSPACE", cfg.Tenki.Workspace)
 	cfg.Tenki.Project = getenv("CRABBOX_TENKI_PROJECT", cfg.Tenki.Project)
 	cfg.Tenki.Image = getenv("CRABBOX_TENKI_IMAGE", cfg.Tenki.Image)
@@ -6157,8 +6276,14 @@ func applyEnv(cfg *Config) error {
 	cfg.Tenki.CPUs = getenvInt("CRABBOX_TENKI_CPUS", cfg.Tenki.CPUs)
 	cfg.Tenki.MemoryMB = getenvInt("CRABBOX_TENKI_MEMORY_MB", cfg.Tenki.MemoryMB)
 	cfg.Tenki.DiskGB = getenvInt("CRABBOX_TENKI_DISK_GB", cfg.Tenki.DiskGB)
-	cfg.Tensorlake.APIKey = getenv("CRABBOX_TENSORLAKE_API_KEY", getenv("TENSORLAKE_API_KEY", cfg.Tensorlake.APIKey))
-	cfg.Tensorlake.APIURL = getenv("CRABBOX_TENSORLAKE_API_URL", getenv("TENSORLAKE_API_URL", cfg.Tensorlake.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_TENSORLAKE_API_KEY", "TENSORLAKE_API_KEY"); ok {
+		cfg.Tensorlake.APIKey = value
+		cfg.credentialProvenance.tensorlakeAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_TENSORLAKE_API_URL", "TENSORLAKE_API_URL"); ok {
+		cfg.Tensorlake.APIURL = value
+		cfg.credentialProvenance.tensorlakeAPIURL = credentialSourceEnvironment
+	}
 	cfg.Tensorlake.CLIPath = getenv("CRABBOX_TENSORLAKE_CLI", cfg.Tensorlake.CLIPath)
 	cfg.Tensorlake.Image = getenv("CRABBOX_TENSORLAKE_IMAGE", cfg.Tensorlake.Image)
 	cfg.Tensorlake.Snapshot = getenv("CRABBOX_TENSORLAKE_SNAPSHOT", cfg.Tensorlake.Snapshot)
@@ -6314,16 +6439,28 @@ func applyEnv(cfg *Config) error {
 	cfg.Modal.Image = getenv("CRABBOX_MODAL_IMAGE", cfg.Modal.Image)
 	cfg.Modal.Workdir = getenv("CRABBOX_MODAL_WORKDIR", cfg.Modal.Workdir)
 	cfg.Modal.Python = getenv("CRABBOX_MODAL_PYTHON", cfg.Modal.Python)
-	cfg.UpstashBox.APIKey = getenv("CRABBOX_UPSTASH_BOX_API_KEY", getenv("UPSTASH_BOX_API_KEY", cfg.UpstashBox.APIKey))
-	cfg.UpstashBox.BaseURL = getenv("CRABBOX_UPSTASH_BOX_BASE_URL", getenv("UPSTASH_BOX_BASE_URL", cfg.UpstashBox.BaseURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_UPSTASH_BOX_API_KEY", "UPSTASH_BOX_API_KEY"); ok {
+		cfg.UpstashBox.APIKey = value
+		cfg.credentialProvenance.upstashBoxAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_UPSTASH_BOX_BASE_URL", "UPSTASH_BOX_BASE_URL"); ok {
+		cfg.UpstashBox.BaseURL = value
+		cfg.credentialProvenance.upstashBoxBaseURL = credentialSourceEnvironment
+	}
 	cfg.UpstashBox.Runtime = getenv("CRABBOX_UPSTASH_BOX_RUNTIME", cfg.UpstashBox.Runtime)
 	cfg.UpstashBox.Size = getenv("CRABBOX_UPSTASH_BOX_SIZE", cfg.UpstashBox.Size)
 	cfg.UpstashBox.Workdir = getenv("CRABBOX_UPSTASH_BOX_WORKDIR", cfg.UpstashBox.Workdir)
 	if value, ok := getenvBool("CRABBOX_UPSTASH_BOX_KEEP_ALIVE"); ok {
 		cfg.UpstashBox.KeepAlive = value
 	}
-	cfg.Smolvm.APIKey = getenv("CRABBOX_SMOLVM_API_KEY", getenv("SMOLMACHINES_API_KEY", getenv("SMK_API_KEY", cfg.Smolvm.APIKey)))
-	cfg.Smolvm.BaseURL = getenv("CRABBOX_SMOLVM_BASE_URL", cfg.Smolvm.BaseURL)
+	if value, ok := firstNonEmptyEnv("CRABBOX_SMOLVM_API_KEY", "SMOLMACHINES_API_KEY", "SMK_API_KEY"); ok {
+		cfg.Smolvm.APIKey = value
+		cfg.credentialProvenance.smolvmAPIKey = credentialSourceEnvironment
+	}
+	if value := os.Getenv("CRABBOX_SMOLVM_BASE_URL"); value != "" {
+		cfg.Smolvm.BaseURL = value
+		cfg.credentialProvenance.smolvmBaseURL = credentialSourceEnvironment
+	}
 	cfg.Smolvm.Image = getenv("CRABBOX_SMOLVM_IMAGE", cfg.Smolvm.Image)
 	cfg.Smolvm.Workdir = getenv("CRABBOX_SMOLVM_WORKDIR", cfg.Smolvm.Workdir)
 	cfg.Smolvm.CPUs = getenvInt("CRABBOX_SMOLVM_CPUS", cfg.Smolvm.CPUs)
@@ -6332,12 +6469,24 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_SMOLVM_KEEP"); ok {
 		cfg.Smolvm.Keep = value
 	}
-	cfg.AsciiBox.APIKey = getenv("CRABBOX_ASCII_BOX_API_KEY", getenv("ASCII_BOX_API_KEY", cfg.AsciiBox.APIKey))
-	cfg.AsciiBox.BaseURL = getenv("CRABBOX_ASCII_BOX_BASE_URL", getenv("ASCII_BOX_BASE_URL", cfg.AsciiBox.BaseURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_ASCII_BOX_API_KEY", "ASCII_BOX_API_KEY"); ok {
+		cfg.AsciiBox.APIKey = value
+		cfg.credentialProvenance.asciiBoxAPIKey = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_ASCII_BOX_BASE_URL", "ASCII_BOX_BASE_URL"); ok {
+		cfg.AsciiBox.BaseURL = value
+		cfg.credentialProvenance.asciiBoxBaseURL = credentialSourceEnvironment
+	}
 	cfg.AsciiBox.CLIPath = getenv("CRABBOX_ASCII_BOX_CLI", getenv("BOX_CLI", cfg.AsciiBox.CLIPath))
 	cfg.AsciiBox.Workdir = getenv("CRABBOX_ASCII_BOX_WORKDIR", cfg.AsciiBox.Workdir)
-	cfg.Cloudflare.APIURL = getenv("CRABBOX_CLOUDFLARE_RUNNER_URL", cfg.Cloudflare.APIURL)
-	cfg.Cloudflare.Token = getenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN", cfg.Cloudflare.Token)
+	if value := os.Getenv("CRABBOX_CLOUDFLARE_RUNNER_URL"); value != "" {
+		cfg.Cloudflare.APIURL = value
+		cfg.credentialProvenance.cloudflareAPIURL = credentialSourceEnvironment
+	}
+	if value := os.Getenv("CRABBOX_CLOUDFLARE_RUNNER_TOKEN"); value != "" {
+		cfg.Cloudflare.Token = value
+		cfg.credentialProvenance.cloudflareToken = credentialSourceEnvironment
+	}
 	cfg.Cloudflare.Workdir = getenv("CRABBOX_CLOUDFLARE_WORKDIR", cfg.Cloudflare.Workdir)
 	cfg.CloudflareDynamicWorkers.LoaderURL = getenv("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_URL", getenv("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_LOADER_URL", cfg.CloudflareDynamicWorkers.LoaderURL))
 	cfg.CloudflareDynamicWorkers.Token = getenv("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN", cfg.CloudflareDynamicWorkers.Token)
@@ -6350,14 +6499,26 @@ func applyEnv(cfg *Config) error {
 	cfg.CloudflareDynamicWorkers.CPUMs = getenvInt("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_CPU_MS", cfg.CloudflareDynamicWorkers.CPUMs)
 	cfg.CloudflareDynamicWorkers.Subrequests = getenvInt("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_SUBREQUESTS", cfg.CloudflareDynamicWorkers.Subrequests)
 	cfg.CloudflareDynamicWorkers.TimeoutSecs = getenvInt("CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TIMEOUT_SECS", cfg.CloudflareDynamicWorkers.TimeoutSecs)
-	cfg.Semaphore.Host = getenv("CRABBOX_SEMAPHORE_HOST", getenv("SEMAPHORE_HOST", cfg.Semaphore.Host))
-	cfg.Semaphore.Token = getenv("CRABBOX_SEMAPHORE_TOKEN", getenv("SEMAPHORE_API_TOKEN", cfg.Semaphore.Token))
+	if value, ok := firstNonEmptyEnv("CRABBOX_SEMAPHORE_HOST", "SEMAPHORE_HOST"); ok {
+		cfg.Semaphore.Host = value
+		cfg.credentialProvenance.semaphoreHost = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_SEMAPHORE_TOKEN", "SEMAPHORE_API_TOKEN"); ok {
+		cfg.Semaphore.Token = value
+		cfg.credentialProvenance.semaphoreToken = credentialSourceEnvironment
+	}
 	cfg.Semaphore.Project = getenv("CRABBOX_SEMAPHORE_PROJECT", getenv("SEMAPHORE_PROJECT", cfg.Semaphore.Project))
 	cfg.Semaphore.Machine = getenv("CRABBOX_SEMAPHORE_MACHINE", cfg.Semaphore.Machine)
 	cfg.Semaphore.OSImage = getenv("CRABBOX_SEMAPHORE_OS_IMAGE", cfg.Semaphore.OSImage)
 	cfg.Semaphore.IdleTimeout = getenv("CRABBOX_SEMAPHORE_IDLE_TIMEOUT", cfg.Semaphore.IdleTimeout)
-	cfg.Sprites.Token = getenv("CRABBOX_SPRITES_TOKEN", getenv("SPRITES_TOKEN", getenv("SPRITE_TOKEN", getenv("SETUP_SPRITE_TOKEN", cfg.Sprites.Token))))
-	cfg.Sprites.APIURL = getenv("CRABBOX_SPRITES_API_URL", getenv("SPRITES_API_URL", cfg.Sprites.APIURL))
+	if value, ok := firstNonEmptyEnv("CRABBOX_SPRITES_TOKEN", "SPRITES_TOKEN", "SPRITE_TOKEN", "SETUP_SPRITE_TOKEN"); ok {
+		cfg.Sprites.Token = value
+		cfg.credentialProvenance.spritesToken = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_SPRITES_API_URL", "SPRITES_API_URL"); ok {
+		cfg.Sprites.APIURL = value
+		cfg.credentialProvenance.spritesAPIURL = credentialSourceEnvironment
+	}
 	cfg.Sprites.WorkRoot = getenv("CRABBOX_SPRITES_WORK_ROOT", cfg.Sprites.WorkRoot)
 	if runtimeName := os.Getenv("CRABBOX_LOCAL_CONTAINER_RUNTIME"); runtimeName != "" {
 		cfg.LocalContainer.Runtime = runtimeName

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -638,6 +638,9 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 	if cfg.Coordinator == "" {
 		return nil, false, nil
 	}
+	if err := validateCoordinatorCredentialDestination(cfg); err != nil {
+		return nil, true, err
+	}
 	base, err := url.Parse(cfg.Coordinator)
 	if err != nil {
 		return nil, true, exit(2, "invalid CRABBOX_COORDINATOR: %v", err)

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -1,0 +1,314 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+type credentialValueSource uint8
+
+const (
+	credentialSourceUnknown credentialValueSource = iota
+	credentialSourceTrustedFile
+	credentialSourceRepository
+	credentialSourceEnvironment
+	credentialSourceFlag
+)
+
+type credentialDestinationProvenance struct {
+	coordinator         credentialValueSource
+	coordToken          credentialValueSource
+	coordTokenCommand   credentialValueSource
+	coordAdminToken     credentialValueSource
+	accessClientID      credentialValueSource
+	accessClientSecret  credentialValueSource
+	accessToken         credentialValueSource
+	proxmoxAPIURL       credentialValueSource
+	proxmoxTokenID      credentialValueSource
+	proxmoxTokenSecret  credentialValueSource
+	proxmoxInsecureTLS  credentialValueSource
+	morphAPIURL         credentialValueSource
+	morphAPIKey         credentialValueSource
+	morphSSHGatewayHost credentialValueSource
+	daytonaAPIURL       credentialValueSource
+	daytonaAPIKey       credentialValueSource
+	daytonaJWTToken     credentialValueSource
+	daytonaSSHGateway   credentialValueSource
+	e2bAPIURL           credentialValueSource
+	e2bDomain           credentialValueSource
+	e2bAPIKey           credentialValueSource
+	railwayAPIURL       credentialValueSource
+	railwayAPIToken     credentialValueSource
+	runpodAPIURL        credentialValueSource
+	runpodAPIKey        credentialValueSource
+	isloBaseURL         credentialValueSource
+	isloAPIKey          credentialValueSource
+	tenkiEndpoint       credentialValueSource
+	tenkiGateway        credentialValueSource
+	tensorlakeAPIURL    credentialValueSource
+	tensorlakeAPIKey    credentialValueSource
+	upstashBoxBaseURL   credentialValueSource
+	upstashBoxAPIKey    credentialValueSource
+	smolvmBaseURL       credentialValueSource
+	smolvmAPIKey        credentialValueSource
+	asciiBoxBaseURL     credentialValueSource
+	asciiBoxAPIKey      credentialValueSource
+	cloudflareAPIURL    credentialValueSource
+	cloudflareToken     credentialValueSource
+	semaphoreHost       credentialValueSource
+	semaphoreToken      credentialValueSource
+	spritesAPIURL       credentialValueSource
+	spritesToken        credentialValueSource
+}
+
+type sourcedCredential struct {
+	value  string
+	source credentialValueSource
+}
+
+func credentialSourceForFile(trusted bool) credentialValueSource {
+	if trusted {
+		return credentialSourceTrustedFile
+	}
+	return credentialSourceRepository
+}
+
+func firstNonEmptyEnv(names ...string) (string, bool) {
+	for _, name := range names {
+		if value := os.Getenv(name); value != "" {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func markCoordinatorDestinationExplicit(cfg *Config) {
+	cfg.credentialProvenance.coordinator = credentialSourceFlag
+}
+
+func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	provenance := &cfg.credentialProvenance
+	if flagWasSet(fs, "proxmox-api-url") {
+		provenance.proxmoxAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "proxmox-insecure-tls") {
+		provenance.proxmoxInsecureTLS = credentialSourceFlag
+	}
+	if flagWasSet(fs, "morph-api-url") {
+		provenance.morphAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "morph-ssh-gateway-host") {
+		provenance.morphSSHGatewayHost = credentialSourceFlag
+	}
+	if flagWasSet(fs, "daytona-api-url") {
+		provenance.daytonaAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "daytona-ssh-gateway-host") {
+		provenance.daytonaSSHGateway = credentialSourceFlag
+	}
+	if flagWasSet(fs, "e2b-api-url") {
+		provenance.e2bAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "e2b-domain") {
+		provenance.e2bDomain = credentialSourceFlag
+	}
+	if flagWasSet(fs, "railway-url") {
+		provenance.railwayAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "runpod-url") {
+		provenance.runpodAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "islo-base-url") {
+		provenance.isloBaseURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "tenki-endpoint") {
+		provenance.tenkiEndpoint = credentialSourceFlag
+	}
+	if flagWasSet(fs, "tenki-gateway") {
+		provenance.tenkiGateway = credentialSourceFlag
+	}
+	if flagWasSet(fs, "tensorlake-api-url") {
+		provenance.tensorlakeAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "upstash-box-base-url") {
+		provenance.upstashBoxBaseURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "smolvm-base-url") {
+		provenance.smolvmBaseURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "ascii-box-base-url") {
+		provenance.asciiBoxBaseURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "cloudflare-url") {
+		provenance.cloudflareAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "semaphore-host") {
+		provenance.semaphoreHost = credentialSourceFlag
+	}
+	if flagWasSet(fs, "sprites-api-url") {
+		provenance.spritesAPIURL = credentialSourceFlag
+	}
+}
+
+func validateCoordinatorCredentialDestination(cfg Config) error {
+	if cfg.credentialProvenance.coordinator != credentialSourceRepository {
+		return nil
+	}
+	provenance := cfg.credentialProvenance
+	coordTokenSource := provenance.coordToken
+	if coordTokenSource == credentialSourceUnknown && cfg.CoordToken != "" && cfg.CoordToken == cfg.CoordAdminToken {
+		coordTokenSource = provenance.coordAdminToken
+	}
+	credentials := []sourcedCredential{
+		{cfg.CoordToken, coordTokenSource},
+		{strings.Join(cfg.CoordTokenCommand, "\x00"), provenance.coordTokenCommand},
+		{cfg.CoordAdminToken, provenance.coordAdminToken},
+		{cfg.Access.ClientSecret, provenance.accessClientSecret},
+		{cfg.Access.Token, provenance.accessToken},
+	}
+	if inheritedCredential(credentials...) {
+		return exit(2, "repository-configured broker.url cannot be combined with inherited coordinator credentials; set CRABBOX_COORDINATOR or pass an explicit coordinator URL to approve the credential destination")
+	}
+	return nil
+}
+
+func validateProviderCredentialDestination(cfg Config) error {
+	provenance := cfg.credentialProvenance
+	providerName := normalizeProviderName(cfg.Provider)
+	if provider, err := ProviderFor(providerName); err == nil {
+		providerName = provider.Name()
+	}
+	switch providerName {
+	case "proxmox":
+		credentials := []sourcedCredential{
+			{cfg.Proxmox.TokenID, provenance.proxmoxTokenID},
+			{cfg.Proxmox.TokenSecret, provenance.proxmoxTokenSecret},
+		}
+		if provenance.proxmoxAPIURL == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("proxmox", "proxmox.apiUrl", "CRABBOX_PROXMOX_API_URL or --proxmox-api-url")
+		}
+		if cfg.Proxmox.InsecureTLS && provenance.proxmoxInsecureTLS == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("proxmox", "proxmox.insecureTLS", "CRABBOX_PROXMOX_INSECURE_TLS or --proxmox-insecure-tls")
+		}
+	case "morph":
+		credentials := []sourcedCredential{{cfg.Morph.APIKey, provenance.morphAPIKey}}
+		if provenance.morphAPIURL == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("morph", "morph.apiUrl", "CRABBOX_MORPH_API_URL or --morph-api-url")
+		}
+		if provenance.morphSSHGatewayHost == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("morph", "morph.sshGatewayHost", "CRABBOX_MORPH_SSH_GATEWAY_HOST or --morph-ssh-gateway-host")
+		}
+	case "daytona":
+		credentials := []sourcedCredential{
+			{cfg.Daytona.APIKey, provenance.daytonaAPIKey},
+			{cfg.Daytona.JWTToken, provenance.daytonaJWTToken},
+		}
+		if provenance.daytonaAPIURL == credentialSourceRepository &&
+			inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("daytona", "daytona.apiUrl", "CRABBOX_DAYTONA_API_URL or --daytona-api-url")
+		}
+		if provenance.daytonaSSHGateway == credentialSourceRepository &&
+			inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("daytona", "daytona.sshGatewayHost", "CRABBOX_DAYTONA_SSH_GATEWAY_HOST or --daytona-ssh-gateway-host")
+		}
+	case "e2b":
+		credentials := []sourcedCredential{{cfg.E2B.APIKey, provenance.e2bAPIKey}}
+		if provenance.e2bAPIURL == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("e2b", "e2b.apiUrl", "CRABBOX_E2B_API_URL or --e2b-api-url")
+		}
+		if provenance.e2bDomain == credentialSourceRepository && inheritedCredential(credentials...) {
+			return repositoryCredentialDestinationError("e2b", "e2b.domain", "CRABBOX_E2B_DOMAIN or --e2b-domain")
+		}
+	case "railway":
+		if provenance.railwayAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Railway.APIToken, provenance.railwayAPIToken}) {
+			return repositoryCredentialDestinationError("railway", "railway.apiUrl", "CRABBOX_RAILWAY_API_URL or --railway-url")
+		}
+	case "runpod":
+		if provenance.runpodAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Runpod.APIKey, provenance.runpodAPIKey}) {
+			return repositoryCredentialDestinationError("runpod", "runpod.apiUrl", "CRABBOX_RUNPOD_API_URL or --runpod-url")
+		}
+	case "islo":
+		if provenance.isloBaseURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Islo.APIKey, provenance.isloAPIKey}) {
+			return repositoryCredentialDestinationError("islo", "islo.baseUrl", "CRABBOX_ISLO_BASE_URL or --islo-base-url")
+		}
+	case "tensorlake":
+		if provenance.tensorlakeAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Tensorlake.APIKey, provenance.tensorlakeAPIKey}) {
+			return repositoryCredentialDestinationError("tensorlake", "tensorlake.apiUrl", "CRABBOX_TENSORLAKE_API_URL or --tensorlake-api-url")
+		}
+	case "upstash-box":
+		if provenance.upstashBoxBaseURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.UpstashBox.APIKey, provenance.upstashBoxAPIKey}) {
+			return repositoryCredentialDestinationError("upstash-box", "upstashBox.baseUrl", "CRABBOX_UPSTASH_BOX_BASE_URL or --upstash-box-base-url")
+		}
+	case "smolvm":
+		if provenance.smolvmBaseURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Smolvm.APIKey, provenance.smolvmAPIKey}) {
+			return repositoryCredentialDestinationError("smolvm", "smolvm.baseUrl", "CRABBOX_SMOLVM_BASE_URL or --smolvm-base-url")
+		}
+	case "ascii-box":
+		if provenance.asciiBoxBaseURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.AsciiBox.APIKey, provenance.asciiBoxAPIKey}) {
+			return repositoryCredentialDestinationError("ascii-box", "asciiBox.baseUrl", "CRABBOX_ASCII_BOX_BASE_URL or --ascii-box-base-url")
+		}
+	case "cloudflare":
+		if provenance.cloudflareAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Cloudflare.Token, provenance.cloudflareToken}) {
+			return repositoryCredentialDestinationError("cloudflare", "cloudflare.apiUrl", "CRABBOX_CLOUDFLARE_RUNNER_URL or --cloudflare-url")
+		}
+	case "semaphore":
+		if provenance.semaphoreHost == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Semaphore.Token, provenance.semaphoreToken}) {
+			return repositoryCredentialDestinationError("semaphore", "semaphore.host", "CRABBOX_SEMAPHORE_HOST or --semaphore-host")
+		}
+	case "sprites":
+		if provenance.spritesAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.Sprites.Token, provenance.spritesToken}) {
+			return repositoryCredentialDestinationError("sprites", "sprites.apiUrl", "CRABBOX_SPRITES_API_URL or --sprites-api-url")
+		}
+	}
+	return nil
+}
+
+// ValidateNativeCredentialDestination is called only when a provider is about
+// to use credentials from its native CLI store.
+func ValidateNativeCredentialDestination(cfg Config, provider string) error {
+	provenance := cfg.credentialProvenance
+	switch normalizeProviderName(provider) {
+	case "daytona":
+		if provenance.daytonaAPIURL == credentialSourceRepository {
+			return repositoryCredentialDestinationError("daytona", "daytona.apiUrl", "CRABBOX_DAYTONA_API_URL or --daytona-api-url")
+		}
+		if provenance.daytonaSSHGateway == credentialSourceRepository {
+			return repositoryCredentialDestinationError("daytona", "daytona.sshGatewayHost", "CRABBOX_DAYTONA_SSH_GATEWAY_HOST or --daytona-ssh-gateway-host")
+		}
+	case "tenki":
+		if provenance.tenkiEndpoint == credentialSourceRepository {
+			return repositoryCredentialDestinationError("tenki", "tenki.endpoint", "CRABBOX_TENKI_ENDPOINT or --tenki-endpoint")
+		}
+		if provenance.tenkiGateway == credentialSourceRepository {
+			return repositoryCredentialDestinationError("tenki", "tenki.gateway", "CRABBOX_TENKI_GATEWAY or --tenki-gateway")
+		}
+	}
+	return nil
+}
+
+func inheritedCredential(credentials ...sourcedCredential) bool {
+	for _, credential := range credentials {
+		if strings.TrimSpace(credential.value) != "" && credential.source != credentialSourceRepository {
+			return true
+		}
+	}
+	return false
+}
+
+func repositoryCredentialDestinationError(provider, field, override string) error {
+	return exit(2, "provider=%s refuses repository-configured %s with inherited credentials; set %s to explicitly approve the credential destination", provider, field, override)
+}

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -1,0 +1,624 @@
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRepositoryCredentialDestinationsRejectInheritedCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "proxmox api",
+			cfg: Config{
+				Provider: "proxmox",
+				Proxmox:  ProxmoxConfig{APIURL: "https://repo.example.test", TokenID: "user@pve!token", TokenSecret: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					proxmoxAPIURL:      credentialSourceRepository,
+					proxmoxTokenID:     credentialSourceTrustedFile,
+					proxmoxTokenSecret: credentialSourceTrustedFile,
+				},
+			},
+			want: "proxmox.apiUrl",
+		},
+		{
+			name: "proxmox tls",
+			cfg: Config{
+				Provider: "proxmox",
+				Proxmox:  ProxmoxConfig{APIURL: "https://trusted.example.test", TokenID: "user@pve!token", TokenSecret: "secret", InsecureTLS: true},
+				credentialProvenance: credentialDestinationProvenance{
+					proxmoxAPIURL:      credentialSourceTrustedFile,
+					proxmoxTokenID:     credentialSourceTrustedFile,
+					proxmoxTokenSecret: credentialSourceTrustedFile,
+					proxmoxInsecureTLS: credentialSourceRepository,
+				},
+			},
+			want: "proxmox.insecureTLS",
+		},
+		{
+			name: "morph api",
+			cfg: Config{
+				Provider: "morph",
+				Morph:    MorphConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					morphAPIURL: credentialSourceRepository,
+					morphAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "morph.apiUrl",
+		},
+		{
+			name: "morph gateway",
+			cfg: Config{
+				Provider: "morph",
+				Morph:    MorphConfig{APIKey: "secret", SSHGatewayHost: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					morphAPIKey:         credentialSourceEnvironment,
+					morphSSHGatewayHost: credentialSourceRepository,
+				},
+			},
+			want: "morph.sshGatewayHost",
+		},
+		{
+			name: "e2b api",
+			cfg: Config{
+				Provider: "e2b",
+				E2B:      E2BConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					e2bAPIURL: credentialSourceRepository,
+					e2bAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "e2b.apiUrl",
+		},
+		{
+			name: "e2b domain",
+			cfg: Config{
+				Provider: "e2b",
+				E2B:      E2BConfig{Domain: "repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					e2bDomain: credentialSourceRepository,
+					e2bAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "e2b.domain",
+		},
+		{
+			name: "daytona api with environment credential",
+			cfg: Config{
+				Provider: "daytona",
+				Daytona:  DaytonaConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					daytonaAPIURL: credentialSourceRepository,
+					daytonaAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "daytona.apiUrl",
+		},
+		{
+			name: "railway api",
+			cfg: Config{
+				Provider: "railway",
+				Railway:  RailwayConfig{APIURL: "https://repo.example.test", APIToken: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					railwayAPIURL:   credentialSourceRepository,
+					railwayAPIToken: credentialSourceEnvironment,
+				},
+			},
+			want: "railway.apiUrl",
+		},
+		{
+			name: "runpod api",
+			cfg: Config{
+				Provider: "runpod",
+				Runpod:   RunpodConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					runpodAPIURL: credentialSourceRepository,
+					runpodAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "runpod.apiUrl",
+		},
+		{
+			name: "islo api",
+			cfg: Config{
+				Provider: "islo",
+				Islo:     IsloConfig{BaseURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					isloBaseURL: credentialSourceRepository,
+					isloAPIKey:  credentialSourceEnvironment,
+				},
+			},
+			want: "islo.baseUrl",
+		},
+		{
+			name: "tensorlake api",
+			cfg: Config{
+				Provider:   "tensorlake",
+				Tensorlake: TensorlakeConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					tensorlakeAPIURL: credentialSourceRepository,
+					tensorlakeAPIKey: credentialSourceEnvironment,
+				},
+			},
+			want: "tensorlake.apiUrl",
+		},
+		{
+			name: "upstash box api",
+			cfg: Config{
+				Provider:   "upstash-box",
+				UpstashBox: UpstashBoxConfig{BaseURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					upstashBoxBaseURL: credentialSourceRepository,
+					upstashBoxAPIKey:  credentialSourceEnvironment,
+				},
+			},
+			want: "upstashBox.baseUrl",
+		},
+		{
+			name: "smolvm api",
+			cfg: Config{
+				Provider: "smolvm",
+				Smolvm:   SmolvmConfig{BaseURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					smolvmBaseURL: credentialSourceRepository,
+					smolvmAPIKey:  credentialSourceEnvironment,
+				},
+			},
+			want: "smolvm.baseUrl",
+		},
+		{
+			name: "ascii box api",
+			cfg: Config{
+				Provider: "ascii-box",
+				AsciiBox: AsciiBoxConfig{BaseURL: "https://repo.example.test", APIKey: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					asciiBoxBaseURL: credentialSourceRepository,
+					asciiBoxAPIKey:  credentialSourceEnvironment,
+				},
+			},
+			want: "asciiBox.baseUrl",
+		},
+		{
+			name: "cloudflare api",
+			cfg: Config{
+				Provider:   "cloudflare",
+				Cloudflare: CloudflareConfig{APIURL: "https://repo.example.test", Token: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					cloudflareAPIURL: credentialSourceRepository,
+					cloudflareToken:  credentialSourceEnvironment,
+				},
+			},
+			want: "cloudflare.apiUrl",
+		},
+		{
+			name: "semaphore host",
+			cfg: Config{
+				Provider:  "semaphore",
+				Semaphore: SemaphoreConfig{Host: "repo.example.test", Token: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					semaphoreHost:  credentialSourceRepository,
+					semaphoreToken: credentialSourceEnvironment,
+				},
+			},
+			want: "semaphore.host",
+		},
+		{
+			name: "sprites api",
+			cfg: Config{
+				Provider: "sprites",
+				Sprites:  SpritesConfig{APIURL: "https://repo.example.test", Token: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					spritesAPIURL: credentialSourceRepository,
+					spritesToken:  credentialSourceEnvironment,
+				},
+			},
+			want: "sprites.apiUrl",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateProviderCredentialDestination(test.cfg)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v want field %s", err, test.want)
+			}
+		})
+	}
+}
+
+func TestNativeCredentialDestinationsRejectRepositoryEndpointsAtUse(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		cfg      Config
+		want     string
+	}{
+		{
+			name:     "daytona api",
+			provider: "daytona",
+			cfg: Config{
+				Daytona: DaytonaConfig{APIURL: "https://repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					daytonaAPIURL: credentialSourceRepository,
+				},
+			},
+			want: "daytona.apiUrl",
+		},
+		{
+			name:     "daytona gateway",
+			provider: "daytona",
+			cfg: Config{
+				Daytona: DaytonaConfig{SSHGatewayHost: "repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					daytonaSSHGateway: credentialSourceRepository,
+				},
+			},
+			want: "daytona.sshGatewayHost",
+		},
+		{
+			name:     "tenki endpoint",
+			provider: "tenki",
+			cfg: Config{
+				Tenki: TenkiConfig{Endpoint: "https://repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					tenkiEndpoint: credentialSourceRepository,
+				},
+			},
+			want: "tenki.endpoint",
+		},
+		{
+			name:     "tenki gateway",
+			provider: "tenki",
+			cfg: Config{
+				Tenki: TenkiConfig{Gateway: "wss://repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					tenkiGateway: credentialSourceRepository,
+				},
+			},
+			want: "tenki.gateway",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateNativeCredentialDestination(test.cfg, test.provider)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v want field %s", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRepositoryCredentialDestinationsAllowSameSourceCredentials(t *testing.T) {
+	tests := []Config{
+		{
+			Provider: "proxmox",
+			Proxmox:  ProxmoxConfig{APIURL: "https://repo.example.test", TokenID: "user@pve!token", TokenSecret: "secret", InsecureTLS: true},
+			credentialProvenance: credentialDestinationProvenance{
+				proxmoxAPIURL:      credentialSourceRepository,
+				proxmoxTokenID:     credentialSourceRepository,
+				proxmoxTokenSecret: credentialSourceRepository,
+				proxmoxInsecureTLS: credentialSourceRepository,
+			},
+		},
+		{
+			Provider: "morph",
+			Morph:    MorphConfig{APIURL: "https://repo.example.test", APIKey: "secret", SSHGatewayHost: "ssh.repo.example.test"},
+			credentialProvenance: credentialDestinationProvenance{
+				morphAPIURL:         credentialSourceRepository,
+				morphAPIKey:         credentialSourceRepository,
+				morphSSHGatewayHost: credentialSourceRepository,
+			},
+		},
+		{
+			Provider:   "cloudflare",
+			Cloudflare: CloudflareConfig{APIURL: "https://repo.example.test", Token: "secret"},
+			credentialProvenance: credentialDestinationProvenance{
+				cloudflareAPIURL: credentialSourceRepository,
+				cloudflareToken:  credentialSourceRepository,
+			},
+		},
+		{
+			Provider:  "semaphore",
+			Semaphore: SemaphoreConfig{Host: "repo.example.test", Token: "secret"},
+			credentialProvenance: credentialDestinationProvenance{
+				semaphoreHost:  credentialSourceRepository,
+				semaphoreToken: credentialSourceRepository,
+			},
+		},
+	}
+
+	for _, cfg := range tests {
+		if err := validateProviderCredentialDestination(cfg); err != nil {
+			t.Fatalf("provider=%s rejected same-source config: %v", cfg.Provider, err)
+		}
+	}
+}
+
+func TestRepositoryCredentialDestinationAllowsExplicitFlagOverride(t *testing.T) {
+	cfg := Config{
+		Provider: "proxmox",
+		Proxmox:  ProxmoxConfig{APIURL: "https://repo.example.test", TokenID: "user@pve!token", TokenSecret: "secret"},
+		credentialProvenance: credentialDestinationProvenance{
+			proxmoxAPIURL:      credentialSourceRepository,
+			proxmoxTokenID:     credentialSourceEnvironment,
+			proxmoxTokenSecret: credentialSourceEnvironment,
+		},
+	}
+	fs := newFlagSet("test", io.Discard)
+	values := registerProviderFlags(fs, cfg)
+	if err := parseFlags(fs, []string{"--proxmox-api-url", "https://approved.example.test"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("explicit flag override rejected: %v", err)
+	}
+	if cfg.Proxmox.APIURL != "https://approved.example.test" {
+		t.Fatalf("proxmox apiUrl=%q", cfg.Proxmox.APIURL)
+	}
+}
+
+func TestRepositoryCredentialDestinationWithoutCredentialRemainsInspectable(t *testing.T) {
+	cfg := Config{
+		Provider: "e2b",
+		E2B:      E2BConfig{APIURL: "https://repo.example.test", Domain: "repo.example.test"},
+		credentialProvenance: credentialDestinationProvenance{
+			e2bAPIURL: credentialSourceRepository,
+			e2bDomain: credentialSourceRepository,
+		},
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("credential-free repository endpoint rejected: %v", err)
+	}
+}
+
+func TestRepositoryProviderSettingsRemainApplied(t *testing.T) {
+	cfg := baseConfig()
+	file := fileConfig{
+		Morph: &fileMorphConfig{
+			APIURL:         "https://repo.example.test",
+			Snapshot:       "snapshot-project",
+			SSHGatewayHost: "ssh.repo.example.test",
+			WorkRoot:       "/workspace/project",
+		},
+		Cloudflare: &fileCloudflareConfig{
+			APIURL:  "https://runner.repo.example.test",
+			Workdir: "/workspace/project",
+		},
+		Semaphore: &fileSemaphoreConfig{
+			Host:        "repo.example.test",
+			Project:     "project",
+			Machine:     "f1-standard-4",
+			OSImage:     "ubuntu2404",
+			IdleTimeout: "20m",
+		},
+	}
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Morph.Snapshot != "snapshot-project" || cfg.Morph.WorkRoot != "/workspace/project" {
+		t.Fatalf("morph project settings changed: %#v", cfg.Morph)
+	}
+	if cfg.Cloudflare.Workdir != "/workspace/project" {
+		t.Fatalf("cloudflare workdir=%q", cfg.Cloudflare.Workdir)
+	}
+	if cfg.Semaphore.Project != "project" || cfg.Semaphore.Machine != "f1-standard-4" || cfg.Semaphore.OSImage != "ubuntu2404" || cfg.Semaphore.IdleTimeout != "20m" {
+		t.Fatalf("semaphore project settings changed: %#v", cfg.Semaphore)
+	}
+}
+
+func TestRepositoryBrokerDestinationRejectsInheritedCredentials(t *testing.T) {
+	cfg := Config{
+		Coordinator: "https://repo.example.test",
+		CoordToken:  "secret",
+		credentialProvenance: credentialDestinationProvenance{
+			coordinator: credentialSourceRepository,
+			coordToken:  credentialSourceTrustedFile,
+		},
+	}
+	if err := validateCoordinatorCredentialDestination(cfg); err == nil {
+		t.Fatal("inherited coordinator credential was accepted")
+	}
+	if _, configured, err := newCoordinatorClient(cfg); err == nil || !configured {
+		t.Fatalf("newCoordinatorClient configured=%t error=%v", configured, err)
+	}
+
+	cfg.credentialProvenance.coordToken = credentialSourceRepository
+	if err := validateCoordinatorCredentialDestination(cfg); err != nil {
+		t.Fatalf("same-source coordinator credential rejected: %v", err)
+	}
+
+	markCoordinatorDestinationExplicit(&cfg)
+	cfg.credentialProvenance.coordToken = credentialSourceEnvironment
+	if err := validateCoordinatorCredentialDestination(cfg); err != nil {
+		t.Fatalf("explicit coordinator destination rejected: %v", err)
+	}
+}
+
+func TestLoadBackendRejectsRepositoryCredentialDestination(t *testing.T) {
+	cfg := Config{
+		Provider: "e2b",
+		E2B:      E2BConfig{APIURL: "https://repo.example.test", APIKey: "secret"},
+		credentialProvenance: credentialDestinationProvenance{
+			e2bAPIURL: credentialSourceRepository,
+			e2bAPIKey: credentialSourceEnvironment,
+		},
+	}
+	if _, err := loadBackend(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "e2b.apiUrl") {
+		t.Fatalf("loadBackend error=%v", err)
+	}
+}
+
+func TestConfigMergeTracksCredentialDestinationSources(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "e2b"
+	if err := applyFileConfigWithTrust(&cfg, fileConfig{
+		E2B: &fileE2BConfig{
+			APIURL:   "https://repo.example.test",
+			Domain:   "repo.example.test",
+			Template: "project-template",
+			Workdir:  "project-workdir",
+		},
+	}, false); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_E2B_API_KEY", "secret")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(cfg); err == nil {
+		t.Fatal("merged repository endpoint and environment credential were accepted")
+	}
+	if cfg.E2B.Template != "project-template" || cfg.E2B.Workdir != "project-workdir" {
+		t.Fatalf("safe repository settings changed: %#v", cfg.E2B)
+	}
+
+	t.Setenv("CRABBOX_E2B_API_URL", "https://approved.example.test")
+	t.Setenv("CRABBOX_E2B_DOMAIN", "approved.example.test")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("explicit environment destinations rejected: %v", err)
+	}
+}
+
+func TestConfigMergeSourceBindsDirectProviderCredentials(t *testing.T) {
+	tests := []struct {
+		name          string
+		provider      string
+		file          fileConfig
+		credentialEnv string
+		approveEnv    string
+	}{
+		{
+			name:          "daytona",
+			provider:      "daytona",
+			file:          fileConfig{Daytona: &fileDaytonaConfig{APIURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_DAYTONA_API_KEY",
+			approveEnv:    "CRABBOX_DAYTONA_API_URL",
+		},
+		{
+			name:          "railway",
+			provider:      "railway",
+			file:          fileConfig{Railway: &fileRailwayConfig{APIURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_RAILWAY_API_TOKEN",
+			approveEnv:    "CRABBOX_RAILWAY_API_URL",
+		},
+		{
+			name:          "runpod",
+			provider:      "runpod",
+			file:          fileConfig{Runpod: &fileRunpodConfig{APIURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_RUNPOD_API_KEY",
+			approveEnv:    "CRABBOX_RUNPOD_API_URL",
+		},
+		{
+			name:          "islo",
+			provider:      "islo",
+			file:          fileConfig{Islo: &fileIsloConfig{BaseURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_ISLO_API_KEY",
+			approveEnv:    "CRABBOX_ISLO_BASE_URL",
+		},
+		{
+			name:       "tenki",
+			provider:   "tenki",
+			file:       fileConfig{Tenki: &fileTenkiConfig{Endpoint: "https://repo.example.test"}},
+			approveEnv: "CRABBOX_TENKI_ENDPOINT",
+		},
+		{
+			name:          "tensorlake",
+			provider:      "tensorlake",
+			file:          fileConfig{Tensorlake: &fileTensorlakeConfig{APIURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_TENSORLAKE_API_KEY",
+			approveEnv:    "CRABBOX_TENSORLAKE_API_URL",
+		},
+		{
+			name:          "upstash box",
+			provider:      "upstash-box",
+			file:          fileConfig{UpstashBox: &fileUpstashBoxConfig{BaseURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_UPSTASH_BOX_API_KEY",
+			approveEnv:    "CRABBOX_UPSTASH_BOX_BASE_URL",
+		},
+		{
+			name:          "smolvm",
+			provider:      "smolvm",
+			file:          fileConfig{Smolvm: &fileSmolvmConfig{BaseURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_SMOLVM_API_KEY",
+			approveEnv:    "CRABBOX_SMOLVM_BASE_URL",
+		},
+		{
+			name:          "ascii box",
+			provider:      "ascii-box",
+			file:          fileConfig{AsciiBox: &fileAsciiBoxConfig{BaseURL: "https://repo.example.test"}},
+			credentialEnv: "CRABBOX_ASCII_BOX_API_KEY",
+			approveEnv:    "CRABBOX_ASCII_BOX_BASE_URL",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			cfg := baseConfig()
+			cfg.Provider = test.provider
+			if err := applyFileConfigWithTrust(&cfg, test.file, false); err != nil {
+				t.Fatal(err)
+			}
+			if test.credentialEnv != "" {
+				t.Setenv(test.credentialEnv, "secret")
+			}
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			err := validateProviderCredentialDestination(cfg)
+			if err == nil {
+				err = ValidateNativeCredentialDestination(cfg, test.provider)
+			}
+			if err == nil {
+				t.Fatal("repository destination with inherited auth was accepted")
+			}
+
+			t.Setenv(test.approveEnv, "https://approved.example.test")
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateProviderCredentialDestination(cfg); err != nil {
+				t.Fatalf("explicit environment destination rejected: %v", err)
+			}
+			if err := ValidateNativeCredentialDestination(cfg, test.provider); err != nil {
+				t.Fatalf("explicit environment destination rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigMergeAllowsRepositoryEndpointAndCredentialPair(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "proxmox"
+	insecureTLS := true
+	if err := applyFileConfigWithTrust(&cfg, fileConfig{
+		Proxmox: &fileProxmoxConfig{
+			APIURL:      "https://repo.example.test",
+			TokenID:     "user@pve!project",
+			TokenSecret: "secret",
+			InsecureTLS: &insecureTLS,
+			Node:        "pve-project",
+		},
+	}, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		t.Fatalf("repository endpoint and credential pair rejected: %v", err)
+	}
+	if cfg.Proxmox.Node != "pve-project" {
+		t.Fatalf("proxmox node=%q", cfg.Proxmox.Node)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -339,6 +339,13 @@ func (a App) doctor(ctx context.Context, args []string) error {
 
 	doctorProvider, doctorSupported := providerDef.(DoctorProvider)
 	if doctorSupported {
+		if err := validateProviderConfig(cfg); err != nil {
+			class := doctorErrorClass(err)
+			hint := doctorErrorHint(providerDef.Name(), class)
+			record("failed", "provider", fmt.Sprintf("provider=%s class=%s hint=%s %v", providerDef.Name(), class, hint, err), map[string]string{"provider": providerDef.Name(), "class": class, "hint": hint, "error": err.Error()})
+			ok = false
+			return finish()
+		}
 		doctor, err := doctorProvider.ConfigureDoctor(cfg, runtimeForApp(a))
 		if err != nil {
 			class := doctorErrorClass(err)

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -313,6 +313,7 @@ func (a App) egressCoordinatorAndLease(ctx context.Context, provider, coordinato
 	cfg.Provider = provider
 	if strings.TrimSpace(coordinatorURL) != "" {
 		cfg.Coordinator = strings.TrimRight(strings.TrimSpace(coordinatorURL), "/")
+		markCoordinatorDestinationExplicit(&cfg)
 	}
 	coord, useCoordinator, err := newTargetCoordinatorClient(cfg)
 	if err != nil {
@@ -750,6 +751,7 @@ func egressCoordinatorNeedsAccess(access AccessConfig) bool {
 func egressStartCoordinatorConfig(cfg Config, coordinatorURL string) (Config, error) {
 	if override := strings.TrimSpace(coordinatorURL); override != "" {
 		cfg.Coordinator = strings.TrimRight(override, "/")
+		markCoordinatorDestinationExplicit(&cfg)
 		cfg.Access = AccessConfig{}
 		return cfg, nil
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -983,6 +983,7 @@ func applyProviderFlags(cfg *Config, fs *flag.FlagSet, values providerFlagValues
 	after, err := ProviderFor(cfg.Provider)
 	if err != nil || after.Name() == before {
 		if err == nil {
+			markCredentialDestinationFlagSources(cfg, fs)
 			applyCloudflareDynamicWorkersRepositoryCaps(cfg)
 		}
 		return err
@@ -991,11 +992,15 @@ func applyProviderFlags(cfg *Config, fs *flag.FlagSet, values providerFlagValues
 	if err := after.ApplyFlags(cfg, fs, values[after.Name()]); err != nil {
 		return err
 	}
+	markCredentialDestinationFlagSources(cfg, fs)
 	applyCloudflareDynamicWorkersRepositoryCaps(cfg)
 	return nil
 }
 
 func validateProviderConfig(cfg Config) error {
+	if err := validateProviderCredentialDestination(cfg); err != nil {
+		return err
+	}
 	provider, err := ProviderFor(cfg.Provider)
 	if err != nil {
 		return err
@@ -1185,6 +1190,9 @@ func loadBackend(cfg Config, rt Runtime) (Backend, error) {
 func configureProviderBackend(provider Provider, cfg *Config, rt Runtime) (Backend, error) {
 	cfg.Provider = provider.Name()
 	applySingleProviderTargetDefault(cfg)
+	if err := validateProviderConfig(*cfg); err != nil {
+		return nil, err
+	}
 	return provider.Configure(*cfg, rt)
 }
 

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -87,6 +87,9 @@ func daytonaAuthConfig(cfg Config) (daytonaAuth, error) {
 	if auth.APIKey == "" && auth.JWTToken != "" && auth.OrganizationID == "" {
 		return daytonaAuth{}, exit(3, "provider=daytona with DAYTONA_JWT_TOKEN requires DAYTONA_ORGANIZATION_ID")
 	}
+	if err := validateNativeCredentialDestination(cfg); err != nil {
+		return daytonaAuth{}, err
+	}
 	return auth, nil
 }
 

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -194,3 +194,7 @@ func summarizeJSON(data []byte) string {
 func baseConfig() Config {
 	return core.BaseConfig()
 }
+
+func validateNativeCredentialDestination(cfg Config) error {
+	return core.ValidateNativeCredentialDestination(cfg, daytonaProvider)
+}

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -105,6 +105,9 @@ func NewTenkiBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, error)
 	if err := validateTenkiOptions(cfg); err != nil {
 		return nil, err
 	}
+	if err := validateNativeCredentialDestination(cfg); err != nil {
+		return nil, err
+	}
 	cfg.Provider = tenkiProvider
 	cfg.TargetOS = targetLinux
 	cfg.SSHUser = "tenki"

--- a/internal/providers/tenki/core.go
+++ b/internal/providers/tenki/core.go
@@ -81,6 +81,10 @@ func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) e
 	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
 }
 
+func validateNativeCredentialDestination(cfg Config) error {
+	return core.ValidateNativeCredentialDestination(cfg, tenkiProvider)
+}
+
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }


### PR DESCRIPTION
## Summary

- track whether coordinator URLs, provider credential destinations, credentials, and TLS downgrade controls came from trusted config, repository config, environment, or explicit flags
- reject only mixed repository destinations plus inherited credentials; preserve same-source custom deployments, credential-free inspection, and explicit environment or CLI approval
- apply the rule to broker auth and direct providers, including native Daytona and Tenki credential stores at provider use rather than during config inspection

Closes https://github.com/openclaw/crabbox/issues/410
Closes https://github.com/openclaw/crabbox/issues/412
Closes https://github.com/openclaw/crabbox/issues/422

## Compatibility

Repository config remains executable project automation. Images, snapshots, machine sizes, projects, workdirs, lifetimes, and other non-destination settings are unchanged. Custom endpoints remain supported when the credential comes from the same repository source where supported, no inherited credential is present, or the operator explicitly sets the endpoint through environment or a provider flag. `config show` remains available for inspection without triggering native credential use.

## Verification

- focused provenance, config merge, coordinator, and provider tests
- full tests for Daytona, E2B, Railway, RunPod, Islo, Tenki, Tensorlake, Upstash Box, SmolVM, ASCII Box, Cloudflare, Semaphore, Sprites, Morph, and Proxmox
- Go vet for affected packages
- documentation validation and docs-site build
- built-binary E2E proving config inspection, mixed-source rejection, and explicit destination approval for Daytona and Tenki
- autoreview: clean, no actionable findings

The complete local Go suite passed every package except three pre-existing macOS filesystem-permission assertions in internal/cli; the same failures reproduce on main. CI remains the authoritative Linux gate.
