### PR TITLE
fix: keep bridge tickets out of websocket URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept Code, WebVNC, and Egress bridge tickets out of WebSocket URLs while preserving ordinary coordinator authentication, older-coordinator bearer retries, and legacy-client compatibility.
 - Added opt-in per-lease Code portal origins with one-time viewer bootstrap and lease-scoped browser sessions, isolating proxied workspace content from coordinator and other lease origins without changing existing Code URLs. Thanks @coygeek.
 - Source-bound broker and direct-provider credentials to repository-configured endpoints, while preserving same-source custom deployments and explicit environment or CLI overrides.
 - Restricted Crabbox-managed Windows credential files to the managed user, Administrators, and SYSTEM without changing desktop credential consumers. Thanks @coygeek.

--- a/docs/commands/code.md
+++ b/docs/commands/code.md
@@ -40,10 +40,11 @@ browser
 
 The coordinator authenticates the browser through portal auth and authenticates
 the local bridge with a one-use, short-lived ticket. The CLI sends the ticket as
-an `Authorization: Bearer ...` header so it stays out of websocket URLs and
-proxy/access logs; the coordinator accepts a `?ticket=` query string only as a
-fallback for older CLIs. Because the trusted boundary is the portal plus the
-bridge ticket, `code-server` runs with auth disabled on the runner side.
+an `X-Crabbox-Bridge-Ticket` WebSocket upgrade header so it stays out of
+WebSocket URLs while leaving ordinary coordinator authentication intact. A
+bearer-header retry supports older coordinators, and the coordinator accepts
+query tickets only from older CLIs. Because the trusted boundary is the portal
+plus the bridge ticket, `code-server` runs with auth disabled on the runner side.
 
 The portal URL is lease-scoped:
 

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -137,9 +137,10 @@ WebVNC keeps the same security boundary as `crabbox vnc`:
 - The cloud provider does not open public VNC ingress.
 - The coordinator authenticates the browser through portal auth, and the bridge
   through a single-use short-lived ticket. The CLI sends the ticket as an
-  `Authorization: Bearer ...` header so it stays out of WebSocket URLs and
-  proxy/access logs; the coordinator falls back to a `?ticket=` query string for
-  older CLIs.
+  `X-Crabbox-Bridge-Ticket` WebSocket upgrade header so it stays out of
+  WebSocket URLs while leaving ordinary coordinator authentication intact. A
+  bearer-header retry supports older coordinators; query tickets remain accepted
+  only for older CLIs.
 - The noVNC client is served from the coordinator origin, not a third-party CDN.
 - The local `crabbox webvnc` process must keep running while the browser uses
   the desktop.

--- a/docs/features/egress.md
+++ b/docs/features/egress.md
@@ -197,8 +197,8 @@ bridges:
 
 ```text
 POST /v1/leases/{leaseID}/egress/ticket
-GET  /v1/leases/{leaseID}/egress/host?ticket=...     (WebSocket upgrade)
-GET  /v1/leases/{leaseID}/egress/client?ticket=...   (WebSocket upgrade)
+GET  /v1/leases/{leaseID}/egress/host     (ticketed WebSocket upgrade)
+GET  /v1/leases/{leaseID}/egress/client   (ticketed WebSocket upgrade)
 GET  /v1/leases/{leaseID}/egress/status
 ```
 

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -175,8 +175,10 @@ page — it is operator-driven and never opens an HTML view, so it lives under t
 [Interactive desktop and VNC](interactive-desktop-vnc.md),
 [code command](../commands/code.md), and [Mediated egress](egress.md).
 
-Bridge tickets travel as `Authorization: Bearer ...` headers on the agent
-WebSocket upgrade, with a `?ticket=` query-string fallback for older CLIs.
+Current clients send bridge tickets in an `X-Crabbox-Bridge-Ticket` WebSocket
+upgrade header, with a bearer-header retry for older coordinators. Coordinators
+still accept query tickets from older CLIs, but current clients never place
+bridge credentials in request URLs.
 
 ## Run detail `/portal/runs/{run-id}`
 

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -238,18 +238,17 @@ func connectCodeBridge(ctx context.Context, coord *CoordinatorClient, leaseID, h
 	if err != nil {
 		return nil, err
 	}
+	headers, err := bridgeUpgradeTicketHeaders(ctx, coord, ticket.Ticket)
+	if err != nil {
+		return nil, err
+	}
 	ws, resp, err := websocket.Dial(ctx, webCodeAgentURL(coord.BaseURL, leaseID), &websocket.DialOptions{
-		HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
+		HTTPHeader: headers,
 	})
-	if retryBridgeTicketInQuery(resp, err) {
-		headers, headerErr := coord.webVNCAccessHeaders(ctx)
-		if headerErr != nil {
-			err = headerErr
-		} else {
-			ws, _, err = websocket.Dial(ctx, webCodeAgentURLWithTicket(coord.BaseURL, leaseID, ticket.Ticket), &websocket.DialOptions{
-				HTTPHeader: headers,
-			})
-		}
+	if retryBridgeTicketInAuthorization(resp, err) {
+		ws, _, err = websocket.Dial(ctx, webCodeAgentURL(coord.BaseURL, leaseID), &websocket.DialOptions{
+			HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
+		})
 	}
 	if err != nil {
 		return nil, err
@@ -766,18 +765,6 @@ func webCodeAgentURL(base, leaseID string) string {
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/v1/leases/" + url.PathEscape(leaseID) + "/code/agent"
 	u.RawQuery = ""
-	u.Fragment = ""
-	return u.String()
-}
-
-func webCodeAgentURLWithTicket(base, leaseID, ticket string) string {
-	u, err := url.Parse(webCodeAgentURL(base, leaseID))
-	if err != nil {
-		return base
-	}
-	values := url.Values{}
-	values.Set("ticket", ticket)
-	u.RawQuery = values.Encode()
 	u.Fragment = ""
 	return u.String()
 }

--- a/internal/cli/code_test.go
+++ b/internal/cli/code_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,9 +20,6 @@ func TestWebCodeURLs(t *testing.T) {
 	if got := webCodeAgentURL("https://broker.example.com", "cbx_abcdef123456"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/code/agent" {
 		t.Fatalf("agent URL=%q", got)
 	}
-	if got := webCodeAgentURLWithTicket("https://broker.example.com", "cbx_abcdef123456", "code_abc"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/code/agent?ticket=code_abc" {
-		t.Fatalf("agent fallback URL=%q", got)
-	}
 	if got := webCodePortalURL("https://broker.example.com/", "cbx_abcdef123456"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/code/" {
 		t.Fatalf("portal URL=%q", got)
 	}
@@ -30,7 +28,7 @@ func TestWebCodeURLs(t *testing.T) {
 	}
 }
 
-func TestConnectCodeBridgeSendsTicketInAuthorizationHeader(t *testing.T) {
+func TestConnectCodeBridgeSendsTicketInDedicatedHeader(t *testing.T) {
 	agentConnected := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -49,8 +47,11 @@ func TestConnectCodeBridgeSendsTicketInAuthorizationHeader(t *testing.T) {
 			if got := r.URL.Query().Get("ticket"); got != "" {
 				t.Errorf("query ticket=%q", got)
 			}
-			if got := r.Header.Get("Authorization"); got != "Bearer code_abcdef1234567890abcdef1234567890" {
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
 				t.Errorf("bridge authorization=%q", got)
+			}
+			if got := r.Header.Get("X-Crabbox-Bridge-Ticket"); got != "code_abcdef1234567890abcdef1234567890" {
+				t.Errorf("bridge ticket=%q", got)
 			}
 			conn, err := websocket.Accept(w, r, nil)
 			if err != nil {
@@ -79,6 +80,56 @@ func TestConnectCodeBridgeSendsTicketInAuthorizationHeader(t *testing.T) {
 	case <-agentConnected:
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
+	}
+}
+
+func TestConnectCodeBridgeRetriesBearerWithoutTicketURL(t *testing.T) {
+	var agentAttempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/leases/cbx_abcdef123456/code/ticket":
+			_ = json.NewEncoder(w).Encode(coordinatorCodeTicket{
+				Ticket:  "code_abcdef1234567890abcdef1234567890",
+				LeaseID: "cbx_abcdef123456",
+			})
+		case "/v1/leases/cbx_abcdef123456/code/agent":
+			attempt := agentAttempts.Add(1)
+			if got := r.URL.Query().Get("ticket"); got != "" {
+				t.Errorf("attempt %d query ticket=%q", attempt, got)
+			}
+			if attempt == 1 {
+				if got := r.Header.Get("X-Crabbox-Bridge-Ticket"); got == "" {
+					t.Error("first attempt missing dedicated bridge ticket")
+				}
+				http.Error(w, "older coordinator", http.StatusUnauthorized)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer code_abcdef1234567890abcdef1234567890" {
+				t.Errorf("fallback authorization=%q", got)
+			}
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				t.Errorf("websocket accept: %v", err)
+				return
+			}
+			_, _, _ = conn.Read(context.Background())
+			_ = conn.Close(websocket.StatusNormalClosure, "test done")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	coord := &CoordinatorClient{BaseURL: server.URL, Token: "test-token", Client: server.Client()}
+	bridge, err := connectCodeBridge(ctx, coord, "cbx_abcdef123456", "127.0.0.1", "8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Close(websocket.StatusNormalClosure, "test done")
+	if got := agentAttempts.Load(); got != 2 {
+		t.Fatalf("agent attempts=%d want 2", got)
 	}
 }
 

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -360,13 +360,18 @@ func connectEgressBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 	} else if strings.TrimSpace(sessionID) == "" {
 		sessionID = "egress_manual"
 	}
-	headers, err := coord.webVNCAccessHeaders(ctx)
+	headers, err := bridgeUpgradeTicketHeaders(ctx, coord, ticket)
 	if err != nil {
 		return nil, err
 	}
-	ws, _, err := websocket.Dial(ctx, egressAgentURL(coord.BaseURL, leaseID, role, ticket), &websocket.DialOptions{
+	ws, resp, err := websocket.Dial(ctx, egressAgentURL(coord.BaseURL, leaseID, role), &websocket.DialOptions{
 		HTTPHeader: headers,
 	})
+	if retryBridgeTicketInAuthorization(resp, err) {
+		ws, _, err = websocket.Dial(ctx, egressAgentURL(coord.BaseURL, leaseID, role), &websocket.DialOptions{
+			HTTPHeader: bridgeTicketHeaders(coord, ticket),
+		})
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -761,7 +766,7 @@ func egressStartCoordinatorConfig(cfg Config, coordinatorURL string) (Config, er
 	return cfg, nil
 }
 
-func egressAgentURL(base, leaseID, role, ticket string) string {
+func egressAgentURL(base, leaseID, role string) string {
 	u, err := url.Parse(base)
 	if err != nil {
 		return base
@@ -772,9 +777,7 @@ func egressAgentURL(base, leaseID, role, ticket string) string {
 		u.Scheme = "ws"
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/v1/leases/" + url.PathEscape(leaseID) + "/egress/" + role
-	values := url.Values{}
-	values.Set("ticket", ticket)
-	u.RawQuery = values.Encode()
+	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String()
 }

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -9,6 +9,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
 )
 
 func TestEgressHostAllowedMatchesExactAndWildcards(t *testing.T) {
@@ -233,10 +236,62 @@ func TestEgressRequestHostPort(t *testing.T) {
 }
 
 func TestEgressAgentURL(t *testing.T) {
-	got := egressAgentURL("https://broker.example.com", "cbx_abcdef123456", "host", "egress_abc")
-	want := "wss://broker.example.com/v1/leases/cbx_abcdef123456/egress/host?ticket=egress_abc"
+	got := egressAgentURL("https://broker.example.com", "cbx_abcdef123456", "host")
+	want := "wss://broker.example.com/v1/leases/cbx_abcdef123456/egress/host"
 	if got != want {
 		t.Fatalf("egressAgentURL=%q want %q", got, want)
+	}
+}
+
+func TestConnectEgressBridgeSendsTicketInDedicatedHeader(t *testing.T) {
+	agentConnected := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/leases/cbx_abcdef123456/egress/host" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("ticket"); got != "" {
+			t.Errorf("query ticket=%q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer coordinator-token" {
+			t.Errorf("authorization=%q", got)
+		}
+		if got := r.Header.Get("X-Crabbox-Bridge-Ticket"); got != "egress_abcdef1234567890abcdef1234567890" {
+			t.Errorf("bridge ticket=%q", got)
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("websocket accept: %v", err)
+			return
+		}
+		close(agentConnected)
+		_, _, _ = conn.Read(context.Background())
+		_ = conn.Close(websocket.StatusNormalClosure, "test done")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	coord := &CoordinatorClient{BaseURL: server.URL, Token: "coordinator-token", Client: server.Client()}
+	bridge, err := connectEgressBridge(
+		ctx,
+		coord,
+		"cbx_abcdef123456",
+		"host",
+		"egress_abcdef1234567890abcdef1234567890",
+		"egress_session",
+		"",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.close()
+
+	select {
+	case <-agentConnected:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
 	}
 }
 

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -2313,18 +2313,18 @@ func connectWebVNCBridge(ctx context.Context, coord *CoordinatorClient, leaseID,
 		return nil, err
 	}
 	capabilities := webVNCBridgeCapabilities(ctx, target)
+	headers, err := bridgeUpgradeTicketHeaders(ctx, coord, ticket.Ticket)
+	if err != nil {
+		_ = tcp.Close()
+		return nil, err
+	}
 	ws, resp, err := websocket.Dial(ctx, webVNCAgentURLWithCapabilities(coord.BaseURL, leaseID, capabilities), &websocket.DialOptions{
-		HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
+		HTTPHeader: headers,
 	})
-	if retryBridgeTicketInQuery(resp, err) {
-		headers, headerErr := coord.webVNCAccessHeaders(ctx)
-		if headerErr != nil {
-			err = headerErr
-		} else {
-			ws, _, err = websocket.Dial(ctx, webVNCAgentURLWithTicketAndCapabilities(coord.BaseURL, leaseID, ticket.Ticket, capabilities), &websocket.DialOptions{
-				HTTPHeader: headers,
-			})
-		}
+	if retryBridgeTicketInAuthorization(resp, err) {
+		ws, _, err = websocket.Dial(ctx, webVNCAgentURLWithCapabilities(coord.BaseURL, leaseID, capabilities), &websocket.DialOptions{
+			HTTPHeader: bridgeTicketHeaders(coord, ticket.Ticket),
+		})
 	}
 	if err != nil {
 		_ = tcp.Close()
@@ -3694,7 +3694,16 @@ func bridgeTicketHeaders(coord *CoordinatorClient, ticket string) http.Header {
 	return headers
 }
 
-func retryBridgeTicketInQuery(resp *http.Response, err error) bool {
+func bridgeUpgradeTicketHeaders(ctx context.Context, coord *CoordinatorClient, ticket string) (http.Header, error) {
+	headers, err := coord.webVNCAccessHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	headers.Set("X-Crabbox-Bridge-Ticket", ticket)
+	return headers, nil
+}
+
+func retryBridgeTicketInAuthorization(resp *http.Response, err error) bool {
 	if err == nil || resp == nil {
 		return false
 	}
@@ -3724,22 +3733,6 @@ func webVNCAgentURLWithCapabilities(base, leaseID, capabilities string) string {
 	if strings.TrimSpace(capabilities) != "" {
 		values.Set("capabilities", capabilities)
 	}
-	u.RawQuery = values.Encode()
-	u.Fragment = ""
-	return u.String()
-}
-
-func webVNCAgentURLWithTicket(base, leaseID, ticket string) string {
-	return webVNCAgentURLWithTicketAndCapabilities(base, leaseID, ticket, "")
-}
-
-func webVNCAgentURLWithTicketAndCapabilities(base, leaseID, ticket, capabilities string) string {
-	u, err := url.Parse(webVNCAgentURLWithCapabilities(base, leaseID, capabilities))
-	if err != nil {
-		return base
-	}
-	values := u.Query()
-	values.Set("ticket", ticket)
 	u.RawQuery = values.Encode()
 	u.Fragment = ""
 	return u.String()

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -37,12 +37,6 @@ func TestWebVNCURLs(t *testing.T) {
 	if got := webVNCAgentURLWithCapabilities("https://broker.example.com", "cbx_abcdef123456", "desktop_theme"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent?capabilities=desktop_theme" {
 		t.Fatalf("agent capability URL=%q", got)
 	}
-	if got := webVNCAgentURLWithTicket("https://broker.example.com", "cbx_abcdef123456", "wvnc_abc"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent?ticket=wvnc_abc" {
-		t.Fatalf("agent fallback URL=%q", got)
-	}
-	if got := webVNCAgentURLWithTicketAndCapabilities("https://broker.example.com", "cbx_abcdef123456", "wvnc_abc", "desktop_theme"); got != "wss://broker.example.com/v1/leases/cbx_abcdef123456/webvnc/agent?capabilities=desktop_theme&ticket=wvnc_abc" {
-		t.Fatalf("agent capability fallback URL=%q", got)
-	}
 	if got := webVNCPortalURL("https://broker.example.com/", "cbx_abcdef123456", "", "secret value"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/vnc#password=secret+value" {
 		t.Fatalf("portal URL=%q", got)
 	}
@@ -779,8 +773,11 @@ func TestConnectWebVNCBridgeRegistersAgentBeforeServe(t *testing.T) {
 			if got := r.URL.Query().Get("ticket"); got != "" {
 				t.Errorf("query ticket=%q", got)
 			}
-			if got := r.Header.Get("Authorization"); got != "Bearer wvnc_abcdef1234567890abcdef1234567890" {
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
 				t.Errorf("bridge authorization=%q", got)
+			}
+			if got := r.Header.Get("X-Crabbox-Bridge-Ticket"); got != "wvnc_abcdef1234567890abcdef1234567890" {
+				t.Errorf("bridge ticket=%q", got)
 			}
 			conn, err := websocket.Accept(w, r, nil)
 			if err != nil {
@@ -971,19 +968,19 @@ func TestWebVNCObserverSlotsExhausted(t *testing.T) {
 	}
 }
 
-func TestRetryBridgeTicketInQuery(t *testing.T) {
+func TestRetryBridgeTicketInAuthorization(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusUnauthorized,
 		Body:       io.NopCloser(strings.NewReader("old broker needs query ticket")),
 	}
-	if !retryBridgeTicketInQuery(resp, errors.New("websocket rejected")) {
-		t.Fatal("expected unauthorized websocket response to retry with query ticket")
+	if !retryBridgeTicketInAuthorization(resp, errors.New("websocket rejected")) {
+		t.Fatal("expected unauthorized websocket response to retry with bearer ticket")
 	}
-	if !retryBridgeTicketInQuery(&http.Response{StatusCode: http.StatusForbidden}, errors.New("forbidden")) {
-		t.Fatal("expected upstream auth rejection to retry with query ticket")
+	if !retryBridgeTicketInAuthorization(&http.Response{StatusCode: http.StatusForbidden}, errors.New("forbidden")) {
+		t.Fatal("expected upstream auth rejection to retry with bearer ticket")
 	}
-	if retryBridgeTicketInQuery(resp, nil) {
-		t.Fatal("successful dial should not retry with query ticket")
+	if retryBridgeTicketInAuthorization(resp, nil) {
+		t.Fatal("successful dial should not retry with bearer ticket")
 	}
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -12020,20 +12020,27 @@ function codeViewerSessionCookie(session: CodeViewerSessionRecord, maxAgeSeconds
 }
 
 export function bridgeTicketFromRequest(request: Request): string {
-  const queryTicket = new URL(request.url).searchParams.get("ticket") ?? "";
-  if (
-    validWebVNCTicket(queryTicket) ||
-    validCodeTicket(queryTicket) ||
-    validEgressTicket(queryTicket)
-  ) {
-    return queryTicket;
+  const upgradeTicket = request.headers.get("x-crabbox-bridge-ticket")?.trim() ?? "";
+  if (validBridgeTicket(upgradeTicket)) {
+    return upgradeTicket;
   }
   const auth = request.headers.get("authorization")?.trim() ?? "";
   const match = /^Bearer\s+(.+)$/i.exec(auth);
-  if (match?.[1]) {
-    return match[1].trim();
+  const bearerTicket = match?.[1]?.trim() ?? "";
+  if (validBridgeTicket(bearerTicket)) {
+    return bearerTicket;
   }
-  return queryTicket;
+  // Legacy clients sent tickets in the request target. Keep accepting them for
+  // compatibility, but current clients use the dedicated upgrade header.
+  const queryTicket = new URL(request.url).searchParams.get("ticket") ?? "";
+  if (validBridgeTicket(queryTicket)) {
+    return queryTicket;
+  }
+  return upgradeTicket || bearerTicket || queryTicket;
+}
+
+function validBridgeTicket(value: string): boolean {
+  return validWebVNCTicket(value) || validCodeTicket(value) || validEgressTicket(value);
 }
 
 function validEgressTicket(value: string | undefined): value is string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -11995,7 +11995,33 @@ describe("fleet lease identity and idle", () => {
     expect(runtime.timers).toEqual([]);
   });
 
-  it("prefers valid query bridge tickets over unrelated bearer authorization", () => {
+  it("prefers dedicated upgrade bridge tickets over bearer and legacy query credentials", () => {
+    const upgradeTicket = `code_${"c".repeat(32)}`;
+    const queryTicket = `code_${"a".repeat(32)}`;
+    expect(
+      bridgeTicketFromRequest(
+        request("GET", `/v1/leases/blue-lobster/code/agent?ticket=${queryTicket}`, {
+          headers: {
+            authorization: `Bearer code_${"b".repeat(32)}`,
+            "x-crabbox-bridge-ticket": upgradeTicket,
+          },
+        }),
+      ),
+    ).toBe(upgradeTicket);
+  });
+
+  it("prefers bearer bridge tickets over legacy query credentials", () => {
+    const headerTicket = `code_${"b".repeat(32)}`;
+    expect(
+      bridgeTicketFromRequest(
+        request("GET", `/v1/leases/blue-lobster/code/agent?ticket=code_${"a".repeat(32)}`, {
+          headers: { authorization: `Bearer ${headerTicket}` },
+        }),
+      ),
+    ).toBe(headerTicket);
+  });
+
+  it("accepts legacy query bridge tickets with unrelated proxy authorization", () => {
     const queryTicket = `code_${"a".repeat(32)}`;
     expect(
       bridgeTicketFromRequest(
@@ -12004,17 +12030,6 @@ describe("fleet lease identity and idle", () => {
         }),
       ),
     ).toBe(queryTicket);
-  });
-
-  it("uses bearer bridge tickets when the query value is absent or invalid", () => {
-    const headerTicket = `code_${"b".repeat(32)}`;
-    expect(
-      bridgeTicketFromRequest(
-        request("GET", "/v1/leases/blue-lobster/code/agent?ticket=invalid", {
-          headers: { authorization: `Bearer ${headerTicket}` },
-        }),
-      ),
-    ).toBe(headerTicket);
   });
 
   it("uses a VS Code-compatible CSP for code proxy responses", () => {


### PR DESCRIPTION
## Summary

- send Code, WebVNC, and Egress bridge tickets in a dedicated WebSocket upgrade header instead of request URLs
- preserve ordinary coordinator authentication on the primary path and retry bearer tickets for older coordinators
- retain legacy query-ticket acceptance for older clients, but prefer dedicated and bearer credentials
- update bridge documentation and add real WebSocket regression coverage

This is compatibility-preserving hardening for https://github.com/openclaw/crabbox/issues/372. It removes URL emission from current clients without disabling existing clients or intermediaries that reject WebSocket `Authorization` headers.

## Verification

- `go test -race ./internal/cli -run 'Test(WebCodeURLs|ConnectCodeBridgeSendsTicketInDedicatedHeader|ConnectCodeBridgeRetriesBearerWithoutTicketURL|WebVNCURLs|ConnectWebVNCBridgeRegistersAgentBeforeServe|RetryBridgeTicketInAuthorization|EgressAgentURL|ConnectEgressBridgeSendsTicketInDedicatedHeader)$'`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `npm test --prefix worker` (625 tests)
- `npm run check --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run build --prefix worker`

The full local `go test -race ./internal/cli/...` run has the same three pre-existing macOS filesystem-permission failures as `main`; all bridge-focused tests pass.

Autoreview was attempted with Codex at xhigh/high and an alternate model, but the local Codex subprocesses stalled without results. Claude, Pi, and OpenCode fallbacks were unavailable due local authentication/version configuration. A manual compatibility/security review found no actionable issue.

Closes https://github.com/openclaw/crabbox/issues/372
