### PR TITLE
fix: verify Proxmox template images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Pinned and verified the default Proxmox template cloud image before conversion, while preserving custom image URLs with a required matching SHA256.
 - Kept Code, WebVNC, and Egress bridge tickets out of WebSocket URLs while preserving ordinary coordinator authentication, older-coordinator bearer retries, and legacy-client compatibility.
 - Added opt-in per-lease Code portal origins with one-time viewer bootstrap and lease-scoped browser sessions, isolating proxied workspace content from coordinator and other lease origins without changing existing Code URLs. Thanks @coygeek.
 - Source-bound broker and direct-provider credentials to repository-configured endpoints, while preserving same-source custom deployments and explicit environment or CLI overrides.

--- a/docs/providers/proxmox.md
+++ b/docs/providers/proxmox.md
@@ -79,11 +79,11 @@ CRABBOX_PROXMOX_USER=crabbox \
 ./scripts/proxmox-build-template.sh
 ```
 
-The helper downloads the public Ubuntu Noble cloud image, optionally verifies
-`CRABBOX_PROXMOX_IMAGE_SHA256`, customizes a local copy, imports it into the
-selected storage, attaches a cloud-init drive, and converts the VM to a
-template. It does not use Proxmox API tokens, Crabbox coordinator tokens, or
-lease SSH keys, and it bakes no secrets into the image.
+The helper downloads a pinned Ubuntu Noble release image, verifies its built-in
+SHA256 before conversion, customizes a local copy, imports it into the selected
+storage, attaches a cloud-init drive, and converts the VM to a template. It does
+not use Proxmox API tokens, Crabbox coordinator tokens, or lease SSH keys, and it
+bakes no secrets into the image.
 
 If the target VMID already exists, the helper stops before changing it. Set
 `CRABBOX_PROXMOX_REPLACE_TEMPLATE=1` only when you intentionally want to destroy
@@ -97,8 +97,8 @@ CRABBOX_PROXMOX_TEMPLATE_NAME      template name (default: crabbox-ubuntu-2404)
 CRABBOX_PROXMOX_STORAGE            target storage (default: local-lvm)
 CRABBOX_PROXMOX_BRIDGE             network bridge (default: vmbr0)
 CRABBOX_PROXMOX_USER               cloud-init user (default: crabbox)
-CRABBOX_PROXMOX_IMAGE_URL          cloud image URL (default: Ubuntu Noble cloudimg)
-CRABBOX_PROXMOX_IMAGE_SHA256       optional expected image sha256
+CRABBOX_PROXMOX_IMAGE_URL          custom cloud image URL
+CRABBOX_PROXMOX_IMAGE_SHA256       expected image sha256; required with a custom URL
 CRABBOX_PROXMOX_CORES              template vCPU count (default: 2)
 CRABBOX_PROXMOX_MEMORY_MB          template memory in MiB (default: 4096)
 CRABBOX_PROXMOX_DISK_SIZE          root disk size, qm syntax (default: 32G)
@@ -107,6 +107,12 @@ CRABBOX_PROXMOX_REPLACE_TEMPLATE   destroy an existing VM/template first when 1
 
 It requires Proxmox's `qm` and `pvesm` commands plus `qemu-img`,
 `virt-customize`, and either `curl` or `wget`.
+
+To update the built-in image, choose a dated directory under Ubuntu's
+`https://cloud-images.ubuntu.com/releases/noble/` index, then update
+`default_image_url` and `default_image_sha256` together from that directory's
+signed `SHA256SUMS`. Do not point the built-in default at `current` or `release`;
+those aliases change without a repository review.
 
 The resulting Crabbox config looks like:
 

--- a/scripts/proxmox-build-template.sh
+++ b/scripts/proxmox-build-template.sh
@@ -16,7 +16,7 @@ Environment:
   CRABBOX_PROXMOX_BRIDGE             Network bridge (default: vmbr0)
   CRABBOX_PROXMOX_USER               Cloud-init user Crabbox configures (default: crabbox)
   CRABBOX_PROXMOX_IMAGE_URL          Cloud image URL
-  CRABBOX_PROXMOX_IMAGE_SHA256       Optional expected image sha256
+  CRABBOX_PROXMOX_IMAGE_SHA256       Expected image sha256; required with a custom URL
   CRABBOX_PROXMOX_CORES              Template vCPU count (default: 2)
   CRABBOX_PROXMOX_MEMORY_MB          Template memory in MiB (default: 4096)
   CRABBOX_PROXMOX_DISK_SIZE          Final root disk size, qm syntax (default: 32G)
@@ -37,8 +37,15 @@ template_name="${CRABBOX_PROXMOX_TEMPLATE_NAME:-crabbox-ubuntu-2404}"
 storage="${CRABBOX_PROXMOX_STORAGE:-local-lvm}"
 bridge="${CRABBOX_PROXMOX_BRIDGE:-vmbr0}"
 vm_user="${CRABBOX_PROXMOX_USER:-crabbox}"
-image_url="${CRABBOX_PROXMOX_IMAGE_URL:-https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img}"
-image_sha256="${CRABBOX_PROXMOX_IMAGE_SHA256:-}"
+# Ubuntu Noble released image serial and digest from its signed SHA256SUMS.
+default_image_url="https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-amd64.img"
+default_image_sha256="53fdde898feed8b027d94baa9cfe8229867f330a1d9c49dc7d84465ee7f229f7"
+image_url="${CRABBOX_PROXMOX_IMAGE_URL:-$default_image_url}"
+if [[ -n "${CRABBOX_PROXMOX_IMAGE_URL:-}" ]]; then
+  image_sha256="${CRABBOX_PROXMOX_IMAGE_SHA256:-}"
+else
+  image_sha256="${CRABBOX_PROXMOX_IMAGE_SHA256:-$default_image_sha256}"
+fi
 cores="${CRABBOX_PROXMOX_CORES:-2}"
 memory_mb="${CRABBOX_PROXMOX_MEMORY_MB:-4096}"
 disk_size="${CRABBOX_PROXMOX_DISK_SIZE:-32G}"
@@ -77,6 +84,7 @@ fi
 is_uint "$template_id" || die "CRABBOX_PROXMOX_TEMPLATE_ID must be numeric"
 is_uint "$cores" || die "CRABBOX_PROXMOX_CORES must be numeric"
 is_uint "$memory_mb" || die "CRABBOX_PROXMOX_MEMORY_MB must be numeric"
+[[ "$image_sha256" =~ ^[a-fA-F0-9]{64}$ ]] || die "CRABBOX_PROXMOX_IMAGE_SHA256 must be a 64-character hex digest and is required with CRABBOX_PROXMOX_IMAGE_URL"
 
 need_cmd qm
 need_cmd pvesm
@@ -115,9 +123,7 @@ custom_image="$workdir/${template_name}.qcow2"
 printf 'downloading %s\n' "$image_url" >&2
 fetch_image "$image_url" "$source_image"
 
-if [[ -n "$image_sha256" ]]; then
-  printf '%s  %s\n' "$image_sha256" "$source_image" | sha256sum -c -
-fi
+printf '%s  %s\n' "$image_sha256" "$source_image" | sha256sum -c -
 
 printf 'customizing image packages and services\n' >&2
 qemu-img convert -O qcow2 "$source_image" "$custom_image"

--- a/scripts/proxmox-build-template.test.js
+++ b/scripts/proxmox-build-template.test.js
@@ -75,7 +75,8 @@ printf 'fake image\\n' >"$dest"
     path.join(dir, "sha256sum"),
     `#!/usr/bin/env bash
 set -euo pipefail
-printf 'sha256sum %s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+input="$(cat)"
+printf 'sha256sum %s input=%s\\n' "$*" "$input" >>"\${CRABBOX_FAKE_LOG:?}"
 if [[ "\${CRABBOX_FAKE_SHA_FAIL:-0}" == "1" ]]; then exit 1; fi
 exit 0
 `,
@@ -108,7 +109,7 @@ async function runTemplateScript(extraEnv = {}) {
     PATH: `${fake.dir}:${process.env.PATH}`,
     CRABBOX_FAKE_LOG: fake.log,
     CRABBOX_PROXMOX_ALLOW_NONROOT_FOR_TEST: "1",
-    CRABBOX_PROXMOX_IMAGE_SHA256: "unused",
+    CRABBOX_PROXMOX_IMAGE_SHA256: "a".repeat(64),
     ...extraEnv,
   };
   const result = await new Promise((resolve) => {
@@ -128,6 +129,33 @@ async function runTemplateScript(extraEnv = {}) {
   return { ...result, log };
 }
 
+test("default image uses the pinned release URL and digest", async () => {
+  const result = await runTemplateScript({
+    CRABBOX_PROXMOX_IMAGE_SHA256: "",
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(
+    result.log,
+    /curl .*https:\/\/cloud-images\.ubuntu\.com\/releases\/noble\/release-20260518\/ubuntu-24\.04-server-cloudimg-amd64\.img/,
+  );
+  assert.match(
+    result.log,
+    /sha256sum .*input=53fdde898feed8b027d94baa9cfe8229867f330a1d9c49dc7d84465ee7f229f7 /,
+  );
+});
+
+test("custom image URL requires a sha256 before download or mutation", async () => {
+  const result = await runTemplateScript({
+    CRABBOX_PROXMOX_IMAGE_URL: "https://images.example.test/custom.img",
+    CRABBOX_PROXMOX_IMAGE_SHA256: "",
+  });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /SHA256.*required with CRABBOX_PROXMOX_IMAGE_URL/);
+  assert.equal(result.log, "");
+});
+
 test("replace mode keeps existing template when image validation fails", async () => {
   const result = await runTemplateScript({
     CRABBOX_FAKE_TEMPLATE_EXISTS: "1",
@@ -137,7 +165,21 @@ test("replace mode keeps existing template when image validation fails", async (
 
   assert.notEqual(result.code, 0);
   assert.match(result.stderr, /will be replaced after the new image is validated/);
+  assert.doesNotMatch(result.log, /qemu-img|virt-customize|qm create|qm importdisk|qm template/);
   assert.doesNotMatch(result.log, /qm destroy 9400 --purge 1/);
+});
+
+test("custom image with a matching sha256 preserves template creation", async () => {
+  const digest = "b".repeat(64);
+  const result = await runTemplateScript({
+    CRABBOX_PROXMOX_IMAGE_URL: "https://images.example.test/custom.img",
+    CRABBOX_PROXMOX_IMAGE_SHA256: digest,
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.log, /curl .*https:\/\/images\.example\.test\/custom\.img/);
+  assert.match(result.log, new RegExp(`sha256sum .*input=${digest} `));
+  assert.match(result.log, /qm template 9400/);
 });
 
 test("post-create failure destroys the partial VM", async () => {


### PR DESCRIPTION
## Summary

- pin the default Proxmox Ubuntu Noble image to release serial `20260518`
- verify the published SHA256 before conversion or Proxmox mutation
- require a valid matching SHA256 whenever operators supply a custom image URL
- document the reviewed image-update procedure
- cover default, missing, wrong, correct, rollback, and success paths

This is compatibility-preserving supply-chain hardening for https://github.com/openclaw/crabbox/issues/374. Custom image URLs remain supported; they now require explicit artifact identity.

## Verification

- `node --test scripts/proxmox-build-template.test.js` (6 tests)
- `shellcheck scripts/proxmox-build-template.sh`
- `bash -n scripts/proxmox-build-template.sh`
- `scripts/check-docs.sh`
- live official artifact metadata: the pinned URL returned HTTP 200 and Ubuntu's dated `SHA256SUMS` matched `53fdde898feed8b027d94baa9cfe8229867f330a1d9c49dc7d84465ee7f229f7`

The repository-wide `node --test scripts/*.test.js` run passed 244/245 tests; the only failure is the pre-existing macOS symlink-mode assertion in `proxmox-live-smoke.test.js`. All template-helper tests pass.

Autoreview was attempted with Codex, but the local reviewer subprocess stalled without returning findings. Manual compatibility and shell review found no actionable issue.

Closes https://github.com/openclaw/crabbox/issues/374
