### PR TITLE
fix: verify Cloudflare image GitHub CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Verified the pinned GitHub CLI release artifacts before installing them in the default Cloudflare sandbox image and preserved true AMD64/ARM64 target selection during cross-platform builds.
 - Pinned and verified the default Proxmox template cloud image before conversion, while preserving custom image URLs with a required matching SHA256.
 - Kept Code, WebVNC, and Egress bridge tickets out of WebSocket URLs while preserving ordinary coordinator authentication, older-coordinator bearer retries, and legacy-client compatibility.
 - Added opt-in per-lease Code portal origins with one-time viewer bootstrap and lease-scoped browser sessions, isolating proxied workspace content from coordinator and other lease origins without changing existing Code URLs. Thanks @coygeek.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -227,9 +227,9 @@ crabbox run \
 - `list` reports local Cloudflare claims. Add `--refresh` to check runner state
   for those claims. The runner intentionally does not expose a global container
   enumeration API.
-- The default image includes Git, GitHub CLI (`gh`), `jq`, `ripgrep`, `curl`,
-  Go, Node, and `pnpm`; repo-specific dependencies still belong to the repo
-  setup command.
+- The default image includes Git, checksum-verified GitHub CLI (`gh`), `jq`,
+  `ripgrep`, `curl`, Go, Node, and `pnpm`; repo-specific dependencies still
+  belong to the repo setup command.
 - npm and pnpm caches live under `/var/cache/crabbox`
   (`NPM_CONFIG_CACHE=/var/cache/crabbox/npm`, pnpm store
   `/var/cache/crabbox/pnpm`), and the container filesystem persists while the

--- a/scripts/cloudflare-container-image.test.js
+++ b/scripts/cloudflare-container-image.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const dockerfile = await readFile("worker/cloudflare-container.Dockerfile", "utf8");
+
+test("Cloudflare image pins GitHub CLI artifacts for each supported architecture", () => {
+  assert.match(dockerfile, /^ARG TARGETARCH$/m);
+  assert.doesNotMatch(dockerfile, /^ARG TARGETARCH=/m);
+  assert.match(dockerfile, /^ARG GH_VERSION=2\.92\.0$/m);
+  assert.match(dockerfile, /^ARG GH_SHA256_AMD64=[0-9a-f]{64}$/m);
+  assert.match(dockerfile, /^ARG GH_SHA256_ARM64=[0-9a-f]{64}$/m);
+  assert.match(dockerfile, /amd64\) gh_arch="amd64"; gh_sha256="\$\{GH_SHA256_AMD64\}" ;;/);
+  assert.match(dockerfile, /arm64\) gh_arch="arm64"; gh_sha256="\$\{GH_SHA256_ARM64\}" ;;/);
+});
+
+test("Cloudflare image verifies GitHub CLI before extraction", () => {
+  const download = dockerfile.indexOf('curl -fsSL "https://github.com/cli/cli/releases/');
+  const verify = dockerfile.indexOf("sha256sum -c -");
+  const extract = dockerfile.indexOf("tar -xzf /tmp/gh.tgz");
+
+  assert.notEqual(download, -1);
+  assert.ok(verify > download, "checksum verification must follow the download");
+  assert.ok(extract > verify, "archive extraction must follow checksum verification");
+  assert.match(dockerfile, /printf '%s  %s\\n' "\$\{gh_sha256\}" \/tmp\/gh\.tgz \| sha256sum -c -/);
+});

--- a/worker/cloudflare-container.Dockerfile
+++ b/worker/cloudflare-container.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS runner-build
 
 ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 WORKDIR /src
 COPY cloudflare-container-runner/go.mod cloudflare-container-runner/main.go ./
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags="-s -w" -o /out/crabbox-cloudflare-container-runner .
@@ -10,8 +10,10 @@ FROM docker.io/library/golang:1.26-bookworm@sha256:5f68ec6805843bd3981a951ffada8
 
 FROM docker.io/library/node:24-bookworm@sha256:40ad9f3064e67d6860b4bc3fe1880b2953934fd6320ada990e45fe0efa6badd7
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 ARG GH_VERSION=2.92.0
+ARG GH_SHA256_AMD64=b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4
+ARG GH_SHA256_ARM64=c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee
 ARG PNPM_VERSION=10.24.0
 ENV NPM_CONFIG_CACHE=/var/cache/crabbox/npm \
     PATH=/usr/local/go/bin:$PATH
@@ -21,10 +23,12 @@ RUN apt-get update \
   && mkdir -p /var/cache/crabbox/npm /var/cache/crabbox/pnpm \
   && rm -rf /var/lib/apt/lists/* \
   && case "${TARGETARCH}" in \
-      amd64|arm64) gh_arch="${TARGETARCH}" ;; \
+      amd64) gh_arch="amd64"; gh_sha256="${GH_SHA256_AMD64}" ;; \
+      arm64) gh_arch="arm64"; gh_sha256="${GH_SHA256_ARM64}" ;; \
       *) echo "unsupported GitHub CLI target arch: ${TARGETARCH}" >&2; exit 1 ;; \
     esac \
   && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${gh_arch}.tar.gz" -o /tmp/gh.tgz \
+  && printf '%s  %s\n' "${gh_sha256}" /tmp/gh.tgz | sha256sum -c - \
   && tar -xzf /tmp/gh.tgz -C /tmp \
   && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${gh_arch}/bin/gh" /usr/local/bin/gh \
   && rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_${gh_arch}" \


### PR DESCRIPTION
## Summary

- pin the official GitHub CLI 2.92.0 release digests for AMD64 and ARM64
- verify each downloaded archive before extraction or installation
- preserve BuildKit's real target architecture instead of overriding ARM64 builds to AMD64
- add regression coverage for architecture mapping and verify-before-extract ordering

This is narrow supply-chain hardening for https://github.com/openclaw/crabbox/issues/375. The installed GitHub CLI version and Cloudflare provider workflow are unchanged.

## Verification

- `node --test scripts/cloudflare-container-image.test.js scripts/check-docker-base-images.test.js`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `scripts/check-docs.sh`
- real no-cache Docker builds for `linux/amd64` and `linux/arm64`
- both builds printed `/tmp/gh.tgz: OK`
- resulting images contained native-architecture `gh` and runner binaries and reported `gh version 2.92.0`

Autoreview was attempted with a bounded Codex run, but the local reviewer subprocess timed out without returning findings. Manual review caught and fixed the pre-existing `TARGETARCH=amd64` override before commit.

Closes https://github.com/openclaw/crabbox/issues/375
