### PR TITLE
fix: require orphan sweep ownership proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Required retained coordinator ownership records before orphan sweeps delete AWS or Azure machines or release EC2 Mac hosts, while keeping tag-only and legacy candidates visible in reports.
 - Verified the pinned GitHub CLI release artifacts before installing them in the default Cloudflare sandbox image and preserved true AMD64/ARM64 target selection during cross-platform builds.
 - Pinned and verified the default Proxmox template cloud image before conversion, while preserving custom image URLs with a required matching SHA256.
 - Kept Code, WebVNC, and Egress bridge tickets out of WebSocket URLs while preserving ordinary coordinator authentication, older-coordinator bearer retries, and legacy-client compatibility.

--- a/docs/features/aws.md
+++ b/docs/features/aws.md
@@ -166,9 +166,10 @@ present, the Fleet Durable Object alarm periodically scans `CRABBOX_AWS_REGION`
 plus `CRABBOX_CAPACITY_REGIONS` for Crabbox-tagged EC2 instances; the Worker cron
 handler bootstraps the alarm for idle fleets after a deploy or config change. The
 sweep uses equivalent pg-boss scheduling and reconciliation on Node/PostgreSQL. The
-sweep only terminates confirmed orphan candidates when
-`CRABBOX_AWS_ORPHAN_SWEEP_DELETE=1`; otherwise it stores the latest report for
-admin inspection. Tune cadence and grace with
+sweep only terminates candidates with an exact retained coordinator lease
+binding when `CRABBOX_AWS_ORPHAN_SWEEP_DELETE=1`; provider tags alone remain
+report-only. Otherwise it stores the latest report for admin inspection. Tune
+cadence and grace with
 `CRABBOX_AWS_ORPHAN_SWEEP_INTERVAL_SECONDS` and
 `CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS`.
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -273,8 +273,9 @@ request 404s or 401s.
 **Expiry and cleanup.** A DO alarm and the cron both run maintenance:
 `expireLeases` deletes cloud servers for active leases past `expiresAt`
 (state `expired`), retrying after ~5 minutes on failure, and an AWS orphan sweep
-(report or delete, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*`) terminates untracked
-instances and releases idle Mac dedicated hosts. The next alarm is scheduled for
+(report or delete, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*`) reports untracked
+instances and deletes or releases only resources with exact retained coordinator
+bindings. The next alarm is scheduled for
 the soonest upcoming expiry or sweep time.
 
 Lease responses carry the canonical `cbx_...` ID, the friendly slug when present,

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -70,10 +70,11 @@ lease-audit`.
 
 ### AWS orphan sweep
 
-Independent of per-lease expiry, the Worker can sweep AWS resources that no
-longer map to an active lease — terminating untracked Crabbox instances and
-releasing idle Mac dedicated hosts. It runs from the same alarm/cron, in report
-or delete mode, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*` environment variables.
+Independent of per-lease expiry, the Worker can report AWS resources that no
+longer map to an active lease. Delete mode terminates instances or releases idle
+Mac dedicated hosts only when retained coordinator state binds the exact
+resource; tag-only and legacy candidates stay report-only. It runs from the same
+alarm/cron, gated by `CRABBOX_AWS_ORPHAN_SWEEP_*` environment variables.
 
 ## Direct-provider lifecycle
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -341,7 +341,7 @@ CRABBOX_AWS_INSTANCE_PROFILE
 CRABBOX_AWS_ROOT_GB
 CRABBOX_AWS_SSH_CIDRS                     # comma-separated SSH source CIDRs
 CRABBOX_AWS_ORPHAN_SWEEP_ENABLED         # defaults on when AWS broker credentials exist
-CRABBOX_AWS_ORPHAN_SWEEP_DELETE          # set 1 to terminate confirmed orphan instances
+CRABBOX_AWS_ORPHAN_SWEEP_DELETE          # set 1 to terminate coordinator-owned orphan instances
 CRABBOX_AWS_ORPHAN_SWEEP_INTERVAL_SECONDS
 CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -248,7 +248,7 @@ CRABBOX_ARTIFACTS_SESSION_TOKEN   optional
 CRABBOX_ARTIFACTS_UPLOAD_EXPIRES_SECONDS optional
 CRABBOX_ARTIFACTS_URL_EXPIRES_SECONDS    optional
 CRABBOX_AWS_ORPHAN_SWEEP_ENABLED  optional; defaults on when AWS broker credentials exist
-CRABBOX_AWS_ORPHAN_SWEEP_DELETE   optional; set 1 to terminate confirmed orphan EC2 instances
+CRABBOX_AWS_ORPHAN_SWEEP_DELETE   optional; set 1 to terminate coordinator-owned orphan EC2 instances
 CRABBOX_AWS_ORPHAN_SWEEP_INTERVAL_SECONDS optional; default 3600
 CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS    optional; default 900
 CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE optional; set 1 to release stale pending EC2 Mac hosts during orphan sweep
@@ -411,7 +411,7 @@ lease tags with active coordinator leases. Active matching leases always win,
 because provider `expires_at` tags are written at launch and can be older than a
 heartbeat-extended lease.
 
-The sweep reports a candidate when an instance is past its provider `expires_at` tag, has no active lease, is missing a lease label, or points at an active lease whose current cloud ID differs. It skips `keep=true` instances and applies the grace window before acting on missing or mismatched lease state. Set `CRABBOX_AWS_ORPHAN_SWEEP_DELETE=1` to terminate confirmed candidates automatically. With `CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE=1` also set, the same sweep releases Crabbox-tagged EC2 Mac Dedicated Hosts that have stayed in `pending` for at least one hour and are not attached to an active lease.
+The sweep reports a candidate when an instance is past its provider `expires_at` tag, has no active lease, is missing a lease label, or points at an active lease whose current cloud ID differs. It skips `keep=true` instances and applies the grace window before reporting missing or mismatched lease state. Provider tags are discovery metadata, not deletion authority. Set `CRABBOX_AWS_ORPHAN_SWEEP_DELETE=1` to terminate candidates only when an exact retained coordinator lease binds the same instance and region; tag-only and legacy candidates remain report-only. With `CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE=1` also set, the same rule permits release of a stale pending EC2 Mac Dedicated Host only when a retained coordinator lease binds that exact host.
 
 Trusted admins can inspect or trigger the sweep:
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -130,8 +130,8 @@ exist. On success the lease moves to `expired`.
 
 Maintenance runs at the earliest active-lease expiry or AWS orphan-sweep time.
 The orphan sweep (report or delete mode, gated by
-`CRABBOX_AWS_ORPHAN_SWEEP_*`) terminates untracked instances and releases idle
-Mac dedicated hosts.
+`CRABBOX_AWS_ORPHAN_SWEEP_*`) reports untracked instances and releases or
+terminates only exact resources retained in coordinator lease state.
 
 Direct cleanup only deletes machines that are clearly safe:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -315,10 +315,14 @@ running/provisioning machines after an extra stale-safety window. When a
 coordinator is configured, provider-side cleanup is disabled — the coordinator
 scheduler owns brokered cleanup.
 
-The brokered AWS orphan sweep treats live coordinator lease state as the
-authority and only acts on provider tags after a matching active lease is absent
-or points at a different cloud instance. It skips `keep=true` resources and
-applies a grace window before acting on missing labels or stale lease mappings.
+Brokered cloud orphan sweeps treat coordinator lease state as the authority.
+Provider tags discover candidates and explain why they look stale, but do not
+authorize a destructive action. Automatic AWS or Azure deletion requires an
+exact retained coordinator lease binding for the same provider resource and
+region; EC2 Mac host release likewise requires an exact retained host binding.
+Tag-only and legacy candidates remain report-only. Sweeps skip `keep=true`
+resources and apply a grace window before reporting missing labels or stale
+lease mappings.
 
 Release is idempotent, and delete tolerates already-deleted provider resources.
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -554,6 +554,8 @@ interface CloudOrphanSweepCandidate {
   createdAt?: string;
   expiresAt?: string;
   activeCloudID?: string;
+  ownership: "coordinator-lease" | "provider-tags-only";
+  ownershipLeaseID?: string;
   action: "reported" | "terminated" | "terminate_failed";
   error?: string;
 }
@@ -570,6 +572,8 @@ interface AWSMacHostSweepCandidate {
   allocationTime?: string;
   activeLeaseID?: string;
   reason: string;
+  ownership: "coordinator-lease" | "provider-tags-only";
+  ownershipLeaseID?: string;
   action: "reported" | "released" | "release_failed";
   error?: string;
 }
@@ -9393,11 +9397,11 @@ export class FleetCoordinator {
       ...(await this.state.storage.list<LeaseRecord>({ prefix: "lease:" })).values(),
     ]);
     const now = Date.now();
-    const activeAWSLeases = leases.filter(
-      (lease) =>
-        lease.provider === "aws" &&
-        !isRegisteredLease(lease) &&
-        leaseOwnsCloudResourceDuringSweep(lease, now),
+    const awsLeases = leases.filter(
+      (lease) => lease.provider === "aws" && !isRegisteredLease(lease),
+    );
+    const activeAWSLeases = awsLeases.filter((lease) =>
+      leaseOwnsCloudResourceDuringSweep(lease, now),
     );
     const activeLeases = new Map(activeAWSLeases.map((lease) => [lease.id, lease]));
     const activeCloudIDs = new Set(activeAWSLeases.map((lease) => lease.cloudID).filter(Boolean));
@@ -9422,7 +9426,15 @@ export class FleetCoordinator {
           if (!candidate) {
             continue;
           }
-          if (config.deleteEnabled) {
+          const ownershipLease = cloudOrphanSweepOwnershipLease(
+            machine,
+            awsLeases,
+            "aws",
+            region,
+            now,
+          );
+          recordCloudOrphanSweepOwnership(candidate, ownershipLease);
+          if (config.deleteEnabled && ownershipLease) {
             try {
               // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
               await this.provider("aws", region).deleteServer(
@@ -9454,7 +9466,9 @@ export class FleetCoordinator {
             if (!candidate) {
               continue;
             }
-            if (config.deleteEnabled) {
+            const ownershipLease = awsMacHostSweepOwnershipLease(host, awsLeases, region, now);
+            recordAWSMacHostSweepOwnership(candidate, ownershipLease);
+            if (config.deleteEnabled && ownershipLease) {
               try {
                 // oxlint-disable-next-line eslint/no-await-in-loop -- release failures must stay attached to the host.
                 await client.releaseMacHost(host.id);
@@ -9620,7 +9634,15 @@ export class FleetCoordinator {
           if (!candidate) {
             continue;
           }
-          if (config.deleteEnabled) {
+          const ownershipLease = cloudOrphanSweepOwnershipLease(
+            machine,
+            leases,
+            "azure",
+            candidateRegion,
+            now,
+          );
+          recordCloudOrphanSweepOwnership(candidate, ownershipLease);
+          if (config.deleteEnabled && ownershipLease) {
             try {
               // oxlint-disable-next-line eslint/no-await-in-loop -- delete failures must stay attached to the candidate.
               await this.provider("azure", candidateRegion).deleteServer(
@@ -14006,6 +14028,7 @@ function cloudOrphanSweepCandidate(
     status: machine.status,
     serverType: machine.serverType,
     reason,
+    ownership: "provider-tags-only",
     action: "reported",
   };
   if (machine.host) {
@@ -14030,6 +14053,37 @@ function cloudOrphanSweepCandidate(
     candidate.activeCloudID = activeLease.cloudID;
   }
   return candidate;
+}
+
+function cloudOrphanSweepOwnershipLease(
+  machine: ProviderMachine,
+  leases: LeaseRecord[],
+  provider: "aws" | "azure",
+  region: string,
+  now: number,
+): LeaseRecord | undefined {
+  const cloudID = machine.cloudID || machine.name || String(machine.id);
+  return leases.find(
+    (lease) =>
+      lease.provider === provider &&
+      !isRegisteredLease(lease) &&
+      lease.cloudID === cloudID &&
+      lease.region === region &&
+      !lease.keep &&
+      lease.releaseDeletesServer !== false &&
+      !leaseOwnsCloudResourceDuringSweep(lease, now),
+  );
+}
+
+function recordCloudOrphanSweepOwnership(
+  candidate: CloudOrphanSweepCandidate,
+  lease: LeaseRecord | undefined,
+): void {
+  if (!lease) {
+    return;
+  }
+  candidate.ownership = "coordinator-lease";
+  candidate.ownershipLeaseID = lease.id;
 }
 
 function leaseOwnsCloudResourceDuringSweep(lease: LeaseRecord, now: number): boolean {
@@ -14074,8 +14128,35 @@ function awsMacHostSweepCandidate(
     availabilityZone: host.availabilityZone,
     allocationTime: new Date(allocationTime).toISOString(),
     reason: "stale-pending-mac-host",
+    ownership: "provider-tags-only",
     action: "reported",
   };
+}
+
+function awsMacHostSweepOwnershipLease(
+  host: AWSMacHost,
+  leases: LeaseRecord[],
+  region: string,
+  now: number,
+): LeaseRecord | undefined {
+  return leases.find(
+    (lease) =>
+      leaseHostID(lease) === host.id &&
+      lease.region === region &&
+      !lease.keep &&
+      !leaseOwnsCloudResourceDuringSweep(lease, now),
+  );
+}
+
+function recordAWSMacHostSweepOwnership(
+  candidate: AWSMacHostSweepCandidate,
+  lease: LeaseRecord | undefined,
+): void {
+  if (!lease) {
+    return;
+  }
+  candidate.ownership = "coordinator-lease";
+  candidate.ownershipLeaseID = lease.id;
 }
 
 function parseProviderLabelTime(value: string | undefined): number {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6317,7 +6317,7 @@ describe("fleet lease identity and idle", () => {
     expect(storage.alarm()).toBeGreaterThan(Date.now());
   });
 
-  it("terminates AWS orphan sweep candidates only when delete is enabled", async () => {
+  it("keeps tag-only AWS orphan sweep candidates report-only in delete mode", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
@@ -6360,15 +6360,119 @@ describe("fleet lease identity and idle", () => {
       terminated: number;
       candidates: Array<Record<string, unknown>>;
     }>("aws-orphan-sweep:last");
-    expect(deleted).toEqual(["i-orphan"]);
-    expect(sweep).toMatchObject({ mode: "delete", terminated: 1 });
-    expect(sweep?.candidates[0]).toMatchObject({ action: "terminated" });
+    expect(deleted).toEqual([]);
+    expect(sweep).toMatchObject({ mode: "delete", terminated: 0 });
+    expect(sweep?.candidates[0]).toMatchObject({
+      cloudID: "i-orphan",
+      ownership: "provider-tags-only",
+      action: "reported",
+    });
   });
 
-  it("terminates Azure orphan sweep candidates only when delete is enabled", async () => {
+  it("terminates AWS orphan sweep candidates with exact coordinator ownership", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
     const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "aws",
+        cloudID: "i-orphan",
+        region: "eu-west-1",
+        state: "expired",
+        keep: false,
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000774",
+      testLease({
+        id: "cbx_000000000774",
+        provider: "aws",
+        cloudID: "i-wrong-region",
+        region: "us-east-1",
+        state: "expired",
+        keep: false,
+      }),
+    );
+    const fleet = testFleet(
+      storage,
+      {
+        aws: fakeProvider(
+          undefined,
+          {
+            provider: "aws",
+            servers: [
+              testMachine({
+                cloudID: "i-orphan",
+                labels: {
+                  crabbox: "true",
+                  lease: "cbx_missing",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                cloudID: "i-wrong-region",
+                labels: {
+                  crabbox: "true",
+                  lease: "cbx_000000000774",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+            ],
+          },
+          async (id) => {
+            deleted.push(id);
+          },
+        ),
+      },
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AWS_ORPHAN_SWEEP_GRACE_SECONDS: "1",
+      },
+    );
+
+    await fleet.alarm();
+
+    const sweep = storage.value<{
+      mode: string;
+      terminated: number;
+      candidates: Array<Record<string, unknown>>;
+    }>("aws-orphan-sweep:last");
+    expect(deleted).toEqual(["i-orphan"]);
+    expect(sweep).toMatchObject({ mode: "delete", terminated: 1 });
+    expect(sweep?.candidates[0]).toMatchObject({
+      cloudID: "i-orphan",
+      ownership: "coordinator-lease",
+      ownershipLeaseID: "cbx_000000000776",
+      action: "terminated",
+    });
+    expect(sweep?.candidates[1]).toMatchObject({
+      cloudID: "i-wrong-region",
+      ownership: "provider-tags-only",
+      action: "reported",
+    });
+  });
+
+  it("deletes only coordinator-owned Azure orphan sweep candidates", async () => {
+    const storage = new MemoryStorage();
+    const deleted: string[] = [];
+    const oldSeconds = String(Math.trunc((Date.now() - 60 * 60 * 1000) / 1000));
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "azure",
+        cloudID: "vm-orphan",
+        region: "westus2",
+        state: "expired",
+        keep: false,
+      }),
+    );
     storage.seed(
       "lease:cbx_000000000777",
       testLease({
@@ -6443,6 +6547,18 @@ describe("fleet lease identity and idle", () => {
                 labels: {
                   crabbox: "true",
                   keep: "true",
+                  lease: "cbx_missing",
+                  created_at: oldSeconds,
+                  expires_at: oldSeconds,
+                },
+              }),
+              testMachine({
+                provider: "azure",
+                cloudID: "vm-tag-only",
+                region: "westus2",
+                name: "vm-tag-only",
+                labels: {
+                  crabbox: "true",
                   lease: "cbx_missing",
                   created_at: oldSeconds,
                   expires_at: oldSeconds,
@@ -6525,7 +6641,15 @@ describe("fleet lease identity and idle", () => {
         region: "westus2",
         leaseID: "cbx_missing",
         reason: "expired-provider-tag",
+        ownership: "coordinator-lease",
+        ownershipLeaseID: "cbx_000000000776",
         action: "terminated",
+      }),
+      expect.objectContaining({
+        cloudID: "vm-tag-only",
+        region: "westus2",
+        ownership: "provider-tags-only",
+        action: "reported",
       }),
     ]);
   });
@@ -6534,6 +6658,18 @@ describe("fleet lease identity and idle", () => {
     const storage = new MemoryStorage();
     const actions: string[] = [];
     let releaseHostID = "";
+    storage.seed(
+      "lease:cbx_000000000775",
+      testLease({
+        id: "cbx_000000000775",
+        provider: "aws",
+        cloudID: "i-terminated",
+        region: "eu-west-1",
+        hostID: "h-stale",
+        state: "expired",
+        keep: false,
+      }),
+    );
     const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
       async (input, init) => {
         const params = new URLSearchParams(await requestBodyForTest(input, init));
@@ -6591,7 +6727,64 @@ describe("fleet lease identity and idle", () => {
     expect(sweep?.macHostCandidates[0]).toMatchObject({
       hostID: "h-stale",
       reason: "stale-pending-mac-host",
+      ownership: "coordinator-lease",
+      ownershipLeaseID: "cbx_000000000775",
       action: "released",
+    });
+  });
+
+  it("keeps tag-only EC2 Mac hosts report-only in release mode", async () => {
+    const storage = new MemoryStorage();
+    const actions: string[] = [];
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async (input, init) => {
+        const params = new URLSearchParams(await requestBodyForTest(input, init));
+        const action = params.get("Action") ?? "";
+        actions.push(action);
+        if (action === "DescribeHosts") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <DescribeHostsResponse>
+            <hostSet>
+              <item>
+                <hostId>h-tag-only</hostId>
+                <hostState>pending</hostState>
+                <availabilityZone>eu-west-1a</availabilityZone>
+                <autoPlacement>off</autoPlacement>
+                <allocationTime>2026-05-01T00:00:00Z</allocationTime>
+                <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+                <tagSet><item><key>crabbox</key><value>true</value></item></tagSet>
+              </item>
+            </hostSet>
+          </DescribeHostsResponse>`);
+        }
+        return ec2XMLResponse("<ErrorResponse />", 500);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const fleet = testFleet(
+      storage,
+      { aws: fakeProvider(undefined, { provider: "aws", servers: [] }) },
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        CRABBOX_AWS_ORPHAN_SWEEP_DELETE: "1",
+        CRABBOX_AWS_MAC_HOST_SWEEP_RELEASE: "1",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+
+    await fleet.alarm();
+
+    const sweep = storage.value<{
+      macHostsReleased: number;
+      macHostCandidates: Array<Record<string, unknown>>;
+    }>("aws-orphan-sweep:last");
+    expect(actions).toEqual(["DescribeHosts"]);
+    expect(sweep?.macHostsReleased).toBe(0);
+    expect(sweep?.macHostCandidates[0]).toMatchObject({
+      hostID: "h-tag-only",
+      ownership: "provider-tags-only",
+      action: "reported",
     });
   });
 


### PR DESCRIPTION
## Summary

- treat AWS and Azure provider tags as orphan discovery metadata, not deletion authority
- require an exact retained coordinator lease binding for the same provider resource and region before automatic deletion
- apply the same ownership rule to EC2 Mac Dedicated Host release
- keep tag-only, legacy, wrong-region, active, and kept resources visible or protected without disabling report mode

This is compatibility-preserving hardening. Existing report mode is unchanged, and delete mode still cleans resources that Crabbox can tie to durable coordinator state. Legacy/tag-only candidates remain report-only instead of being silently omitted.

Closes https://github.com/openclaw/crabbox/issues/376

## Verification

- `npm test --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- remote Blacksmith testbox: focused orphan-sweep suite, 7 passed

## Review

The required autoreview helper was attempted with Codex `gpt-5.5`, but its isolated reviewer subprocess remained idle for ten minutes with no output, CPU use, or child process and was terminated. Equivalent manual review found and fixed a missing exact-region requirement; the full local and remote gates were rerun after that fix.
