### PR TITLE
fix: separate user token signing secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Separated shared automation tokens from signed user-token keys, preserving shared-token-only automation while requiring distinct session signing material for GitHub login.
 - Required retained coordinator ownership records before orphan sweeps delete AWS or Azure machines or release EC2 Mac hosts, while keeping tag-only and legacy candidates visible in reports.
 - Verified the pinned GitHub CLI release artifacts before installing them in the default Cloudflare sandbox image and preserved true AMD64/ARM64 target selection during cross-platform builds.
 - Pinned and verified the default Proxmox template cloud image before conversion, while preserving custom image URLs with a required matching SHA256.

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -87,7 +87,8 @@ https://<your-broker-host>/v1/auth/github/callback
 
 Set the same public origin in `CRABBOX_PUBLIC_URL` on the coordinator, then deploy
 `CRABBOX_GITHUB_CLIENT_ID`, `CRABBOX_GITHUB_CLIENT_SECRET`,
-`CRABBOX_SESSION_SECRET`, and the relevant `CRABBOX_GITHUB_ALLOWED_ORG(S)` or
+`CRABBOX_SESSION_SECRET` (distinct from `CRABBOX_SHARED_TOKEN`), and the relevant
+`CRABBOX_GITHUB_ALLOWED_ORG(S)` or
 `CRABBOX_GITHUB_ALLOWED_TEAMS` values. A GitHub `Invalid redirect_uri` error means
 the callback URL generated during `crabbox login` does not match one configured on
 that OAuth app.

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -82,8 +82,9 @@ matches the token in this precedence (`worker/src/auth.ts`):
 2. **Shared token** — equals `CRABBOX_SHARED_TOKEN`. Authorized but not admin; this is
    normal trusted automation.
 3. **Signed user token** — a token with the `cbxu_` prefix, an HMAC-SHA256 signature over a
-   base64url payload, verified with `CRABBOX_SESSION_SECRET` (falling back to
-   `CRABBOX_SHARED_TOKEN`). Minted by `crabbox login`, with a default 180-day expiry.
+   base64url payload, verified only with `CRABBOX_SESSION_SECRET`. The session
+   secret must be configured and distinct from `CRABBOX_SHARED_TOKEN`. Minted by
+   `crabbox login`, with a default 180-day expiry.
    User tokens are non-admin unless their GitHub email or login matches
    `CRABBOX_GITHUB_ADMIN_OWNERS` or `CRABBOX_GITHUB_ADMIN_LOGINS`.
 
@@ -159,7 +160,7 @@ CRABBOX_GITHUB_ALLOWED_ORG       # or CRABBOX_GITHUB_ALLOWED_ORGS (comma-separat
 CRABBOX_GITHUB_ALLOWED_TEAMS     # optional; comma-separated team slugs
 CRABBOX_GITHUB_ADMIN_OWNERS      # optional; comma-separated GitHub verified emails with admin
 CRABBOX_GITHUB_ADMIN_LOGINS      # optional; comma-separated GitHub logins with admin
-CRABBOX_SESSION_SECRET           # signs user tokens; falls back to CRABBOX_SHARED_TOKEN
+CRABBOX_SESSION_SECRET           # required for user tokens; must differ from CRABBOX_SHARED_TOKEN
 CRABBOX_USER_TOKEN_TTL_SECONDS   # optional; default 15552000 (180 days), clamped to 1h-365d
 ```
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -66,9 +66,10 @@ resolved in this order (`worker/src/auth.ts`):
 2. **Shared operator token** — matches `CRABBOX_SHARED_TOKEN`. Non-admin scope,
    owner from `CRABBOX_SHARED_OWNER`.
 3. **Signed user token** — prefix `cbxu_`, an HMAC-SHA256 signature over a
-   base64url payload, keyed by `CRABBOX_SESSION_SECRET` (falling back to
-   `CRABBOX_SHARED_TOKEN`). Issued by GitHub OAuth login; default 180-day expiry.
-   Carries `owner`, `org`, and GitHub `login`.
+   base64url payload, keyed only by `CRABBOX_SESSION_SECRET`. The session secret
+   must be configured and distinct from `CRABBOX_SHARED_TOKEN`. Issued by GitHub
+   OAuth login; default 180-day expiry. Carries `owner`, `org`, and GitHub
+   `login`.
 4. **Trusted reverse-proxy identity** — opt-in through
    `CRABBOX_TRUSTED_USER_HEADER` on the Node runtime, accepted only from peers in
    `CRABBOX_TRUSTED_PROXY_CIDRS`; the authenticated ingress must also strip

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -216,7 +216,7 @@ mechanism:
 ```text
 CRABBOX_GITHUB_CLIENT_ID
 CRABBOX_GITHUB_CLIENT_SECRET
-CRABBOX_SESSION_SECRET            # signs cbxu_ user tokens; falls back to CRABBOX_SHARED_TOKEN
+CRABBOX_SESSION_SECRET            # signs cbxu_ user tokens; required and distinct from CRABBOX_SHARED_TOKEN
 CRABBOX_GITHUB_ALLOWED_ORG       # or CRABBOX_GITHUB_ALLOWED_ORGS (comma-separated)
 CRABBOX_GITHUB_ALLOWED_TEAMS     # optional: restrict to org teams (alias CRABBOX_GITHUB_ALLOWED_TEAM)
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -221,7 +221,7 @@ CRABBOX_WORKSPACE_CLASS           optional workspace machine class; default stan
 CRABBOX_WORKSPACE_PREWARM_COUNT   optional ready spares per active organization; default 0, maximum 4
 CRABBOX_GITHUB_CLIENT_ID          required for browser login
 CRABBOX_GITHUB_CLIENT_SECRET      required for browser login
-CRABBOX_SESSION_SECRET            required for browser login
+CRABBOX_SESSION_SECRET            required for browser login; must differ from CRABBOX_SHARED_TOKEN
 CRABBOX_CODE_ORIGIN_TEMPLATE      optional per-lease Code origin isolation
 CRABBOX_GITHUB_ALLOWED_ORG or CRABBOX_GITHUB_ALLOWED_ORGS
 CRABBOX_GITHUB_ALLOWED_TEAMS      optional

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,10 +65,10 @@ authentication is resolved in `worker/src/auth.ts` in this precedence:
    non-admin shared identity for automation.
 3. **Signed user token** — a `cbxu_`-prefixed token issued by GitHub browser
    login. It is an HMAC-SHA256 signature (verified in constant time) over a
-   base64url payload signed with `CRABBOX_SESSION_SECRET` (falling back to
-   `CRABBOX_SHARED_TOKEN`). The payload carries `owner`, `org`, and GitHub
-   `login`, has a default 180-day expiry, and is rejected if it carries an
-   `admin` claim — browser login can never mint admin tokens.
+   base64url payload signed with `CRABBOX_SESSION_SECRET`, which must be set and
+   must differ from `CRABBOX_SHARED_TOKEN`. The payload carries `owner`, `org`,
+   and GitHub `login`, has a default 180-day expiry, and is rejected if it
+   carries an `admin` claim — browser login can never mint admin tokens.
 
 ### GitHub browser login
 
@@ -198,10 +198,11 @@ repo:
 - `CRABBOX_ADMIN_TOKEN` — admin and image-lifecycle routes.
 - `CRABBOX_RUNTIME_ADAPTER_TOKEN` — route-scoped service access to the
   `/v1/workspaces` lifecycle API only.
-- `CRABBOX_SHARED_TOKEN` — trusted operator automation; also the fallback
-  signing key when `CRABBOX_SESSION_SECRET` is unset.
+- `CRABBOX_SHARED_TOKEN` — trusted operator automation only.
 - `CRABBOX_GITHUB_CLIENT_ID`, `CRABBOX_GITHUB_CLIENT_SECRET`,
-  `CRABBOX_SESSION_SECRET` — GitHub browser login and user-token signing.
+  `CRABBOX_SESSION_SECRET` — GitHub browser login and user-token signing. The
+  session secret is required, must be independent from the shared token, and
+  should be rotated separately.
 - `CRABBOX_GITHUB_ADMIN_OWNERS`, `CRABBOX_GITHUB_ADMIN_LOGINS` — optional
   comma-separated GitHub verified emails and logins whose user tokens become
   admin at request time; set these per deployment, not in the reusable repo
@@ -212,6 +213,11 @@ repo:
   and optional `CRABBOX_ARTIFACTS_SESSION_TOKEN` — brokered artifact publishing.
   Scope these to the artifact bucket/prefix and use them only to sign
   short-lived upload/read URLs.
+
+Deployments that previously relied on `CRABBOX_SHARED_TOKEN` as the implicit
+user-token signing key must configure a new `CRABBOX_SESSION_SECRET`. Existing
+`cbxu_` tokens from the old key stop authenticating, so users must run
+`crabbox login` again. Direct shared-token automation is unaffected.
 
 Coordinator config values (not secret material):
 

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -232,11 +232,23 @@ function decodeUserTokenPayload(token: string): Partial<UserTokenPayload> {
 }
 
 function sessionSecret(env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">): string {
-  const secret = env.CRABBOX_SESSION_SECRET || env.CRABBOX_SHARED_TOKEN;
-  if (!secret) {
-    throw new Error("CRABBOX_SESSION_SECRET or CRABBOX_SHARED_TOKEN is required");
+  const error = userTokenSigningConfigurationError(env);
+  if (error) {
+    throw new Error(error);
   }
-  return secret;
+  return env.CRABBOX_SESSION_SECRET!;
+}
+
+export function userTokenSigningConfigurationError(
+  env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
+): string | undefined {
+  if (!env.CRABBOX_SESSION_SECRET) {
+    return "CRABBOX_SESSION_SECRET is required for signed user tokens";
+  }
+  if (env.CRABBOX_SHARED_TOKEN && env.CRABBOX_SESSION_SECRET === env.CRABBOX_SHARED_TOKEN) {
+    return "CRABBOX_SESSION_SECRET must differ from CRABBOX_SHARED_TOKEN";
+  }
+  return undefined;
 }
 
 interface AccessIdentity {

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -1,4 +1,9 @@
-import { issueUserToken, sha256Hex, userTokenExpiresAt } from "./auth";
+import {
+  issueUserToken,
+  sha256Hex,
+  userTokenExpiresAt,
+  userTokenSigningConfigurationError,
+} from "./auth";
 import type { CoordinatorRuntime, CoordinatorStorage } from "./coordinator-runtime";
 import { errorMessage, json, readJson } from "./http";
 import type { Env, Provider } from "./types";
@@ -83,6 +88,10 @@ export async function githubPortalLogin(
   if (!clientID || !env.CRABBOX_GITHUB_CLIENT_SECRET) {
     return html("Crabbox login unavailable", "GitHub OAuth is not configured.", 503);
   }
+  const signingError = userTokenSigningConfigurationError(env);
+  if (signingError) {
+    return html("Crabbox login unavailable", signingError, 503);
+  }
   const pendingCount = await cleanupExpiredPendingOAuth(storage);
   if (pendingCount >= maxPendingOAuthLogins) {
     return html("Crabbox login busy", "Too many pending GitHub logins. Try again shortly.", 429);
@@ -120,6 +129,10 @@ async function githubAuthStart(
       { error: "github_oauth_not_configured", message: "GitHub OAuth is not configured" },
       { status: 503 },
     );
+  }
+  const signingError = userTokenSigningConfigurationError(env);
+  if (signingError) {
+    return json({ error: "github_session_secret_invalid", message: signingError }, { status: 503 });
   }
   const input = await readJson<{
     pollSecretHash?: string;
@@ -208,6 +221,11 @@ async function githubAuthCallback(
       error: error || "missing_code",
     });
     return html("Crabbox login failed", "GitHub did not authorize the login.", 400);
+  }
+  const signingError = userTokenSigningConfigurationError(env);
+  if (signingError) {
+    await finishPendingOAuth(runtime, pending.id, claim, { error: signingError });
+    return html("Crabbox login unavailable", signingError, 503);
   }
   try {
     const accessToken = await exchangeGitHubCode(code, githubRedirectURI(request, env), env);

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -196,6 +196,7 @@ describe("coordinator runtimes", () => {
       CRABBOX_GITHUB_CLIENT_ID: "github-client",
       CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
       CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
     } as Env;
     const start = await runtime.runExclusive(() =>
       githubAuthRoute(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16349,6 +16349,7 @@ describe("fleet identity", () => {
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SESSION_SECRET: "session-secret",
       } as Env,
     );
     const pollSecret = "local-poll-secret";
@@ -16378,6 +16379,60 @@ describe("fleet identity", () => {
     );
     expect(poll.status).toBe(200);
     await expect(poll.json()).resolves.toMatchObject({ status: "pending" });
+  });
+
+  it("reports missing signing material before GitHub login starts", async () => {
+    const storage = new MemoryStorage();
+    const fleet = new FleetDurableObject(
+      { storage } as unknown as DurableObjectState,
+      {
+        CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_GITHUB_CLIENT_ID: "github-client",
+        CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+        CRABBOX_SHARED_TOKEN: "shared",
+      } as Env,
+    );
+
+    const start = await fleet.fetch(
+      request("POST", "/v1/auth/github/start", {
+        body: { pollSecretHash: await sha256HexForTest("local-poll-secret") },
+      }),
+    );
+    expect(start.status).toBe(503);
+    await expect(start.json()).resolves.toMatchObject({
+      error: "github_session_secret_invalid",
+      message: "CRABBOX_SESSION_SECRET is required for signed user tokens",
+    });
+
+    const portal = await fleet.fetch(request("GET", "/portal/login"));
+    expect(portal.status).toBe(503);
+    expect(await portal.text()).toContain(
+      "CRABBOX_SESSION_SECRET is required for signed user tokens",
+    );
+  });
+
+  it("rejects a shared token reused as GitHub signing material", async () => {
+    const fleet = new FleetDurableObject(
+      { storage: new MemoryStorage() } as unknown as DurableObjectState,
+      {
+        CRABBOX_DEFAULT_ORG: "openclaw",
+        CRABBOX_GITHUB_CLIENT_ID: "github-client",
+        CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SESSION_SECRET: "shared",
+      } as Env,
+    );
+
+    const start = await fleet.fetch(
+      request("POST", "/v1/auth/github/start", {
+        body: { pollSecretHash: await sha256HexForTest("local-poll-secret") },
+      }),
+    );
+    expect(start.status).toBe(503);
+    await expect(start.json()).resolves.toMatchObject({
+      error: "github_session_secret_invalid",
+      message: "CRABBOX_SESSION_SECRET must differ from CRABBOX_SHARED_TOKEN",
+    });
   });
 
   it("sets a portal session cookie after GitHub login", async () => {
@@ -16430,6 +16485,7 @@ describe("fleet identity", () => {
         CRABBOX_GITHUB_CLIENT_ID: "github-client",
         CRABBOX_GITHUB_CLIENT_SECRET: "github-secret",
         CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SESSION_SECRET: "session-secret",
       } as Env,
     );
     storage.seed("oauth:login_old", {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -362,7 +362,11 @@ describe("coordinator auth", () => {
   });
 
   it("accepts signed GitHub user tokens without admin rights", async () => {
-    const env = { CRABBOX_SHARED_TOKEN: "shared", CRABBOX_DEFAULT_ORG: "openclaw" };
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    };
     const token = await issueUserToken(env, {
       owner: "friend@example.com",
       org: "openclaw",
@@ -386,6 +390,7 @@ describe("coordinator auth", () => {
   it("promotes configured GitHub user tokens to admin", async () => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
       CRABBOX_DEFAULT_ORG: "openclaw",
       CRABBOX_GITHUB_ADMIN_OWNERS: "vincentkoc@ieee.org",
       CRABBOX_GITHUB_ADMIN_LOGINS: "steipete",
@@ -425,9 +430,13 @@ describe("coordinator auth", () => {
   });
 
   it("rejects signed user tokens with admin claims", async () => {
-    const env = { CRABBOX_SHARED_TOKEN: "shared", CRABBOX_DEFAULT_ORG: "openclaw" };
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    };
     const now = Math.floor(Date.now() / 1000);
-    const token = await signedUserToken("shared", {
+    const token = await signedUserToken("session-secret", {
       typ: "crabbox-user",
       owner: "friend@example.com",
       org: "openclaw",
@@ -449,7 +458,7 @@ describe("coordinator auth", () => {
 
   it("does not route admin-claim user tokens to the coordinator", async () => {
     const now = Math.floor(Date.now() / 1000);
-    const token = await signedUserToken("shared", {
+    const token = await signedUserToken("session-secret", {
       typ: "crabbox-user",
       owner: "friend@example.com",
       org: "openclaw",
@@ -460,6 +469,7 @@ describe("coordinator auth", () => {
     });
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
       CRABBOX_DEFAULT_ORG: "openclaw",
       FLEET: {
         idFromName: () => "default",
@@ -477,6 +487,46 @@ describe("coordinator auth", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  it("rejects user tokens signed with the shared automation token", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signedUserToken("shared", {
+      typ: "crabbox-user",
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+      iat: now,
+      exp: now + 300,
+    });
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    };
+
+    const auth = await authenticateRequest(
+      new Request("https://example.test/v1/whoami", {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      env,
+    );
+
+    expect(auth).toBeUndefined();
+  });
+
+  it("requires independent signing material when issuing user tokens", async () => {
+    const input = {
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+    };
+
+    await expect(issueUserToken({ CRABBOX_SHARED_TOKEN: "shared" }, input)).rejects.toThrow(
+      "CRABBOX_SESSION_SECRET is required",
+    );
+    await expect(
+      issueUserToken({ CRABBOX_SHARED_TOKEN: "shared", CRABBOX_SESSION_SECRET: "shared" }, input),
+    ).rejects.toThrow("CRABBOX_SESSION_SECRET must differ");
   });
 
   it("does not expose internal scheduled maintenance through public fetch", async () => {


### PR DESCRIPTION
## Summary

- require `CRABBOX_SESSION_SECRET` for signed `cbxu_` user tokens
- reject GitHub login configuration that reuses `CRABBOX_SHARED_TOKEN` as the signing key
- preserve direct shared-token automation and its fixed non-admin identity
- return precise CLI, portal, and callback configuration errors
- document the explicit rotation: existing fallback-signed user tokens require login again

This is credential-role hardening, not a removal of shared-token automation. Deployments that only use `CRABBOX_SHARED_TOKEN` for trusted automation continue to work unchanged.

Closes https://github.com/openclaw/crabbox/issues/377

## Verification

- `npm test --prefix worker`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- remote Blacksmith testbox: focused auth/OAuth suite, 7 passed

## Review

The required autoreview helper was attempted with Codex `gpt-5.5`, but its isolated reviewer subprocess again remained idle for ten minutes with no output, CPU use, or child process and was terminated. Equivalent manual review checked auth precedence, missing/equal-secret failure paths, callback behavior, shared bearer compatibility, and token-rotation documentation; no actionable findings remained.
