### PR TITLE
fix: recover stale runtime adapter claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Made new runtime-adapter ticket claims provisional until agent connection or lease registration, allowing authenticated recovery of expired inactive first claims while preserving all existing and confirmed adapter IDs.
 - Separated shared automation tokens from signed user-token keys, preserving shared-token-only automation while requiring distinct session signing material for GitHub login.
 - Required retained coordinator ownership records before orphan sweeps delete AWS or Azure machines or release EC2 Mac hosts, while keeping tag-only and legacy candidates visible in reports.
 - Verified the pinned GitHub CLI release artifacts before installing them in the default Cloudflare sandbox image and preserved true AMD64/ARM64 target selection during cross-platform builds.

--- a/docs/commands/adapter.md
+++ b/docs/commands/adapter.md
@@ -155,6 +155,14 @@ atomically rotated token is never pinned in the relay process. Coordinator
 authentication may be a static login token or the normal shell-free
 token-command configuration.
 
+The first ticket for a previously unused adapter ID creates a ten-minute
+provisional owner/org claim. A successful agent connection or registered lease
+binding makes that claim durable. Another normally authenticated owner may
+recover an expired provisional claim only when it has no connected agent,
+pending relay request, unexpired ticket, live registered lease, or pending
+workspace deletion. Existing adapter claims created before this contract are
+treated as durable, so upgrades do not change current adapter ownership.
+
 `--local-socket` is required. It must be an absolute, clean Unix-socket path in
 an existing directory owned by the current user and not writable by group or
 others. The socket must also be owned by the current user with mode `0600`.

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -141,9 +141,14 @@ WebVNC/share operation still requires the record to exist.
 
 Runtime adapters connect outbound to `/agent`, so their local lifecycle service
 does not need an inbound public route. The coordinator issues a short-lived,
-single-use ticket after normal owner authentication. The first ticket safely
-claims the adapter ID for that owner and organization; lease registration
-rejects unclaimed IDs and claims owned by another identity. The relay permits
+single-use ticket after normal owner authentication. The first ticket for a new
+adapter ID creates a ten-minute provisional owner/org claim. Agent connection or
+successful registered lease binding confirms it as durable. An expired
+provisional claim can be recovered by another normally authenticated owner only
+when no connected agent, pending relay request, unexpired ticket, live registered
+lease, or pending workspace deletion still uses it. Existing and confirmed
+claims remain durable. Lease registration rejects unclaimed IDs and claims owned
+by another identity. The relay permits
 only the versioned workspace create, inspect, delete, and desktop-connection
 methods. Public proxy `DELETE` requests are rejected; destructive dispatch must
 go through a registered lease release so the coordinator can fence its immutable

--- a/docs/features/runtime-adapter-stack.md
+++ b/docs/features/runtime-adapter-stack.md
@@ -86,7 +86,10 @@ files, or provider credentials. Keep the bearer token between the fleet UI and
 ### Outbound coordinator control
 
 1. `adapter connect` authenticates to the coordinator using normal Crabbox
-   configuration and obtains a short-lived relay ticket.
+   configuration and obtains a short-lived relay ticket. A new adapter ID starts
+   with a ten-minute provisional owner/org claim; agent connection or successful
+   lease registration makes it durable. Only expired inactive provisional claims
+   are recoverable, and existing adapter claims remain durable across upgrades.
 2. It opens an outbound WebSocket and accepts only the documented typed
    workspace operations.
 3. Each operation is forwarded through the verified, current-user-owned Unix

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -143,6 +143,7 @@ const codeViewerTicketTTLSeconds = 120;
 const codeViewerSessionTTLSeconds = 8 * 60 * 60;
 const egressTicketTTLSeconds = 120;
 const runtimeAdapterTicketTTLSeconds = 120;
+const runtimeAdapterProvisionalClaimTTLSeconds = 10 * 60;
 const runtimeAdapterDeleteRetryBaseMs = 5_000;
 const runtimeAdapterDeleteRetryMaxMs = 60_000;
 const runtimeAdapterDeleteDispatchGraceMs = 1_000;
@@ -257,6 +258,10 @@ interface RuntimeAdapterIdentityRecord {
   owner: string;
   org: string;
   createdAt: string;
+  claimVersion?: 1;
+  claimState?: "provisional" | "confirmed";
+  claimExpiresAt?: string;
+  confirmedAt?: string;
 }
 
 interface RuntimeAdapterPendingRequest {
@@ -3675,6 +3680,7 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
+    let runtimeAdapterIdentity: RuntimeAdapterIdentityRecord | undefined;
     if (effectiveRuntimeAdapterID && effectiveRuntimeAdapterWorkspaceID) {
       const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(
         runtimeAdapterIdentityKey(effectiveRuntimeAdapterID),
@@ -3701,6 +3707,7 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
+      runtimeAdapterIdentity = identity;
     }
 
     const leases = await this.leaseRecords();
@@ -3817,6 +3824,9 @@ export class FleetCoordinator {
       clearRuntimeAdapterDeleteMetadata(record);
     }
     await this.putLease(record);
+    if (runtimeAdapterIdentity) {
+      await this.confirmRuntimeAdapterIdentity(runtimeAdapterIdentity, nowISO);
+    }
     await this.scheduleAlarm();
     return json({ lease: record }, { status: existing ? 200 : 201 });
   }
@@ -5802,28 +5812,49 @@ export class FleetCoordinator {
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const identityKey = runtimeAdapterIdentityKey(adapterID);
-    const identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(identityKey);
+    await this.cleanupExpiredRuntimeAdapterTickets();
+    const now = new Date();
+    let identity = await this.state.storage.get<RuntimeAdapterIdentityRecord>(identityKey);
     if (
       identity &&
       (identity.adapterID !== adapterID || identity.owner !== owner || identity.org !== org)
     ) {
-      return json(
-        {
-          error: "adapter_id_conflict",
-          message: "runtime adapter id belongs to another owner or organization",
-        },
-        { status: 409 },
-      );
+      if (!(await this.runtimeAdapterIdentityReclaimable(identity, adapterID, now.getTime()))) {
+        return json(
+          {
+            error: "adapter_id_conflict",
+            message: "runtime adapter id belongs to another owner or organization",
+          },
+          { status: 409 },
+        );
+      }
+      identity = undefined;
     }
-    await this.cleanupExpiredRuntimeAdapterTickets();
-    const now = new Date();
     if (!identity) {
-      await this.state.storage.put<RuntimeAdapterIdentityRecord>(identityKey, {
+      identity = {
         adapterID,
         owner,
         org,
         createdAt: now.toISOString(),
-      });
+        claimVersion: 1,
+        claimState: "provisional",
+        claimExpiresAt: new Date(
+          now.getTime() + runtimeAdapterProvisionalClaimTTLSeconds * 1000,
+        ).toISOString(),
+      };
+      await this.state.storage.put<RuntimeAdapterIdentityRecord>(identityKey, identity);
+    } else if (
+      identity.claimVersion === 1 &&
+      identity.claimState === "provisional" &&
+      !identity.confirmedAt
+    ) {
+      identity = {
+        ...identity,
+        claimExpiresAt: new Date(
+          now.getTime() + runtimeAdapterProvisionalClaimTTLSeconds * 1000,
+        ).toISOString(),
+      };
+      await this.state.storage.put<RuntimeAdapterIdentityRecord>(identityKey, identity);
     }
     const ticket: RuntimeAdapterTicketRecord = {
       ticket: newRuntimeAdapterTicket(),
@@ -5877,6 +5908,7 @@ export class FleetCoordinator {
         { status: 401 },
       );
     }
+    await this.confirmRuntimeAdapterIdentity(identity, new Date().toISOString());
     const upgrade = this.state.createWebSocketUpgrade({
       maxPayload: runtimeAdapterRelayFrameLimit,
     });
@@ -7419,6 +7451,63 @@ export class FleetCoordinator {
         .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
         .map(([key]) => this.state.storage.delete(key)),
     );
+  }
+
+  private async runtimeAdapterIdentityReclaimable(
+    identity: RuntimeAdapterIdentityRecord,
+    adapterID: string,
+    now: number,
+  ): Promise<boolean> {
+    if (
+      identity.adapterID !== adapterID ||
+      identity.claimVersion !== 1 ||
+      identity.claimState !== "provisional" ||
+      identity.confirmedAt !== undefined ||
+      !Number.isFinite(Date.parse(identity.claimExpiresAt ?? "")) ||
+      Date.parse(identity.claimExpiresAt ?? "") > now ||
+      this.runtimeAdapterAgents.has(adapterID) ||
+      [...this.runtimeAdapterPending.values()].some((pending) => pending.adapterID === adapterID)
+    ) {
+      return false;
+    }
+    const [tickets, leases] = await Promise.all([
+      this.state.storage.list<RuntimeAdapterTicketRecord>({
+        prefix: runtimeAdapterTicketPrefix(),
+      }),
+      this.leaseRecords(),
+    ]);
+    if (
+      [...tickets.values()].some(
+        (ticket) => ticket.adapterID === adapterID && Date.parse(ticket.expiresAt) > now,
+      )
+    ) {
+      return false;
+    }
+    return !leases.some(
+      (lease) =>
+        lease.runtimeAdapterID === adapterID &&
+        (leaseIsLive(lease) || Boolean(lease.runtimeAdapterDeleteRequestedAt)),
+    );
+  }
+
+  private async confirmRuntimeAdapterIdentity(
+    identity: RuntimeAdapterIdentityRecord,
+    confirmedAt: string,
+  ): Promise<void> {
+    if (
+      identity.claimVersion !== 1 ||
+      identity.claimState !== "provisional" ||
+      identity.confirmedAt !== undefined
+    ) {
+      return;
+    }
+    const confirmed: RuntimeAdapterIdentityRecord = {
+      ...identity,
+      claimState: "confirmed",
+      confirmedAt,
+    };
+    delete confirmed.claimExpiresAt;
+    await this.state.storage.put(runtimeAdapterIdentityKey(identity.adapterID), confirmed);
   }
 
   private async consumeWebVNCTicket(

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -39,6 +39,10 @@ class MemoryStorage implements CoordinatorStorage {
         .map(([key, value]) => [key, value as T]),
     );
   }
+
+  value<T>(key: string): T | undefined {
+    return this.values.get(key) as T | undefined;
+  }
 }
 
 class MemoryRuntime implements CoordinatorRuntime {
@@ -148,6 +152,11 @@ describe("coordinator runtimes", () => {
     expect(runtime.upgradeOptions).toEqual({ maxPayload: runtimeAdapterRelayFrameLimit });
     expect(runtime.acceptedTags).toEqual(["adapter:example-adapter", "runtime-adapter-agent"]);
     expect(runtime.acceptedAttachment).toMatchObject({ desktopTimeoutMs: 180_000 });
+    expect(runtime.storage.value("runtime-adapter-identity:example-adapter")).toMatchObject({
+      claimVersion: 1,
+      claimState: "confirmed",
+      confirmedAt: expect.any(String),
+    });
   });
 
   it("keeps provider-backed portal requests outside the lifecycle queue", () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -362,6 +362,14 @@ describe("runtime adapter relay", () => {
       adapterID: "example-adapter",
       ticket: expect.stringMatching(/^adapter_[a-f0-9]{32}$/),
     });
+    expect(storage.value("runtime-adapter-identity:example-adapter")).toMatchObject({
+      adapterID: "example-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      claimVersion: 1,
+      claimState: "provisional",
+      claimExpiresAt: expect.any(String),
+    });
     const conflictingTicket = await fleet.fetch(
       request("POST", "/v1/adapters/example-adapter/ticket", {
         headers: {
@@ -661,6 +669,142 @@ describe("runtime adapter relay", () => {
       }),
     );
     expect(relayState.runtimeAdapterPending.size).toBe(0);
+  });
+
+  it("recovers only inactive expired provisional runtime adapter claims", async () => {
+    const challengerHeaders = {
+      "x-crabbox-owner": "mallory@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const claim = (fleet: FleetDurableObject, adapterID: string) =>
+      fleet.fetch(
+        request("POST", `/v1/adapters/${adapterID}/ticket`, {
+          headers: challengerHeaders,
+          body: {},
+        }),
+      );
+    const expectConflict = async (fleet: FleetDurableObject, adapterID: string) => {
+      const response = await claim(fleet, adapterID);
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toMatchObject({ error: "adapter_id_conflict" });
+    };
+
+    const recoverableStorage = new MemoryStorage();
+    recoverableStorage.seed(
+      "runtime-adapter-identity:recoverable-adapter",
+      expiredRuntimeAdapterClaim("recoverable-adapter"),
+    );
+    const recovered = await claim(testFleet(recoverableStorage), "recoverable-adapter");
+    expect(recovered.status).toBe(200);
+    expect(recoverableStorage.value("runtime-adapter-identity:recoverable-adapter")).toMatchObject({
+      owner: "mallory@example.com",
+      org: "example-org",
+      claimVersion: 1,
+      claimState: "provisional",
+      claimExpiresAt: expect.any(String),
+    });
+
+    const durableStorage = new MemoryStorage();
+    durableStorage.seed("runtime-adapter-identity:legacy-adapter", {
+      adapterID: "legacy-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    durableStorage.seed("runtime-adapter-identity:confirmed-adapter", {
+      ...expiredRuntimeAdapterClaim("confirmed-adapter"),
+      claimState: "confirmed",
+      confirmedAt: "2026-06-01T00:01:00.000Z",
+    });
+    durableStorage.seed("runtime-adapter-identity:fresh-adapter", {
+      ...expiredRuntimeAdapterClaim("fresh-adapter"),
+      claimExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const durableFleet = testFleet(durableStorage);
+    await expectConflict(durableFleet, "legacy-adapter");
+    await expectConflict(durableFleet, "confirmed-adapter");
+    await expectConflict(durableFleet, "fresh-adapter");
+
+    const ticketStorage = new MemoryStorage();
+    ticketStorage.seed(
+      "runtime-adapter-identity:ticketed-adapter",
+      expiredRuntimeAdapterClaim("ticketed-adapter"),
+    );
+    ticketStorage.seed("runtime-adapter-ticket:adapter_00000000000000000000000000000000", {
+      ticket: "adapter_00000000000000000000000000000000",
+      adapterID: "ticketed-adapter",
+      owner: "alice@example.com",
+      org: "example-org",
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await expectConflict(testFleet(ticketStorage), "ticketed-adapter");
+
+    const leaseStorage = new MemoryStorage();
+    leaseStorage.seed(
+      "runtime-adapter-identity:leased-adapter",
+      expiredRuntimeAdapterClaim("leased-adapter"),
+    );
+    const lease = testLease({
+      id: "cbx_000000000099",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      runtimeAdapterID: "leased-adapter",
+      runtimeAdapterWorkspaceID: "leased-workspace",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    leaseStorage.seed(`lease:${lease.id}`, lease);
+    await expectConflict(testFleet(leaseStorage), "leased-adapter");
+
+    const deletingStorage = new MemoryStorage();
+    deletingStorage.seed(
+      "runtime-adapter-identity:deleting-adapter",
+      expiredRuntimeAdapterClaim("deleting-adapter"),
+    );
+    const deletingLease = testLease({
+      id: "cbx_000000000098",
+      provider: "external",
+      lifecycle: "registered",
+      state: "released",
+      owner: "alice@example.com",
+      org: "example-org",
+      runtimeAdapterID: "deleting-adapter",
+      runtimeAdapterWorkspaceID: "deleting-workspace",
+      runtimeAdapterDeleteRequestedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    deletingStorage.seed(`lease:${deletingLease.id}`, deletingLease);
+    await expectConflict(testFleet(deletingStorage), "deleting-adapter");
+
+    const connectedStorage = new MemoryStorage();
+    connectedStorage.seed(
+      "runtime-adapter-identity:connected-adapter",
+      expiredRuntimeAdapterClaim("connected-adapter"),
+    );
+    const connectedFleet = testFleet(connectedStorage);
+    const relayState = connectedFleet as unknown as {
+      runtimeAdapterAgents: Map<string, WebSocket>;
+    };
+    relayState.runtimeAdapterAgents.set(
+      "connected-adapter",
+      new FakeWebSocket() as unknown as WebSocket,
+    );
+    await expectConflict(connectedFleet, "connected-adapter");
+
+    const pendingStorage = new MemoryStorage();
+    pendingStorage.seed(
+      "runtime-adapter-identity:pending-adapter",
+      expiredRuntimeAdapterClaim("pending-adapter"),
+    );
+    const pendingFleet = testFleet(pendingStorage);
+    const pendingState = pendingFleet as unknown as {
+      runtimeAdapterPending: Map<string, { adapterID: string }>;
+    };
+    pendingState.runtimeAdapterPending.set("pending-request", { adapterID: "pending-adapter" });
+    await expectConflict(pendingFleet, "pending-adapter");
   });
 
   it("isolates ordinary relay capacity by owner while preserving delete capacity", async () => {
@@ -5746,6 +5890,11 @@ describe("fleet lease identity and idle", () => {
         runtimeAdapterWorkspaceID: "example-workspace-96",
         runtimeAdapterRegistrationID: "registration-generation-96",
       },
+    });
+    expect(storage.value("runtime-adapter-identity:example-adapter")).toMatchObject({
+      claimVersion: 1,
+      claimState: "confirmed",
+      confirmedAt: expect.any(String),
     });
 
     const duplicateBinding = await fleet.fetch(
@@ -16911,6 +17060,18 @@ function testFleet(
     { CRABBOX_DEFAULT_ORG: "default-org", ...env } as Env,
     providers,
   );
+}
+
+function expiredRuntimeAdapterClaim(adapterID: string) {
+  return {
+    adapterID,
+    owner: "alice@example.com",
+    org: "example-org",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    claimVersion: 1,
+    claimState: "provisional",
+    claimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+  };
 }
 
 function fakeProvider(


### PR DESCRIPTION
## Summary

- make only newly created runtime-adapter ID claims provisional for ten minutes
- confirm claims durably when an agent connects or a registered lease binding succeeds
- allow another normally authenticated owner to recover only expired inactive provisional claims
- block recovery while any agent, relay request, ticket, live lease, or pending deletion still uses the ID
- preserve every legacy and confirmed adapter identity and keep existing owner/org relay checks unchanged

This is product and availability hardening, not a new adversarial multi-tenant security guarantee. Normal `adapter connect` behavior is unchanged: it obtains a ticket and connects immediately, which confirms the claim.

Closes https://github.com/openclaw/crabbox/issues/370

## Verification

- `npm test --prefix worker` (632 passed)
- `npm test --prefix worker -- --run test/fleet.test.ts test/coordinator-runtime.test.ts` (278 passed)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- live Blacksmith testbox under the required Node 22 runtime: focused fleet/coordinator suite, 278 passed

## Review

The required autoreview helper was attempted with Codex `gpt-5.5`. Its subprocess remained blocked on stdin for seven minutes with no CPU use, network socket, child process, or review output, so the failed subprocess was terminated. Equivalent manual review checked legacy-record compatibility, owner/org authorization, ticket and agent races, registration confirmation, active relay and deletion fences, and Node coordinator lifecycle serialization; no actionable findings remained.
