### PR TITLE
[codex] Show CPU capacity in lease telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added Linux CPU capacity to lease telemetry and portal status details.
+
 ### Changed
 
 - Defined Crabbox's supported single-user and cooperative-team security boundary, clarified repository configuration as trusted project automation, and separated vulnerability reporting from compatibility-preserving hardening.

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -140,7 +140,8 @@ The lease detail page shows:
 
 - compact provider/target badges and the lease state pill;
 - a status card with host, SSH endpoint, work root, expiry, and the latest
-  Linux telemetry sample as gauges (with sparklines and high-load /
+  Linux telemetry sample with CPU capacity and gauges (with sparklines and
+  high-load /
   high-memory / high-disk / stale-telemetry pills when thresholds are
   exceeded);
 - a bridge panel reporting connection state for the WebVNC, code-server, and

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -18,6 +18,7 @@ For a Linux lease, the CLI runs a small read-only script over the lease's SSH
 connection whenever it already has a reason to talk to the box during a run (a
 run heartbeat or a mid-run sample). The script reads:
 
+- `cpuCount` from the number of online logical processors;
 - `load1`, `load5`, `load15` from `/proc/loadavg`;
 - `memoryTotalBytes`, `memoryUsedBytes`, `memoryPercent` derived from
   `MemTotal` and `MemAvailable` in `/proc/meminfo`;
@@ -30,6 +31,7 @@ Each sample is parsed into a `LeaseTelemetry` record:
 {
   "capturedAt": "2026-05-07T07:42:18Z",
   "source": "ssh-linux",
+  "cpuCount": 16,
   "load1": 0.42,
   "load5": 0.3,
   "load15": 0.18,
@@ -97,8 +99,9 @@ that sample was captured.
 - **`crabbox history`** appends `resources=load=0.42 mem=32% disk=20%
   mem_delta=+512.0MiB` for runs that carry telemetry. `mem_delta` is the
   difference between the `start` and `end` memory snapshots.
-- **`/portal/leases/{id-or-slug}`** renders the latest sample as health pills
-  and draws load, memory, and disk sparklines once at least two samples exist
+- **`/portal/leases/{id-or-slug}`** renders CPU capacity alongside the latest
+  load, memory, disk, uptime, and sample age; it also draws load, memory, and
+  disk sparklines once at least two samples exist
   (until then each line reads "waiting for samples"). A sample older than
   10 minutes shows a `stale <age>` pill; otherwise a `live` pill. Memory or
   disk at or above 85% adds a `memory N%` / `disk N%` pill; `load1` at or

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -16,6 +16,7 @@ type LeaseTelemetry struct {
 	Load1            *float64 `json:"load1,omitempty"`
 	Load5            *float64 `json:"load5,omitempty"`
 	Load15           *float64 `json:"load15,omitempty"`
+	CPUCount         *int64   `json:"cpuCount,omitempty"`
 	MemoryUsedBytes  *int64   `json:"memoryUsedBytes,omitempty"`
 	MemoryTotalBytes *int64   `json:"memoryTotalBytes,omitempty"`
 	MemoryPercent    *float64 `json:"memoryPercent,omitempty"`
@@ -68,6 +69,7 @@ func collectLeaseTelemetryBestEffort(ctx context.Context, collector leaseTelemet
 
 func remoteLeaseTelemetryScript() string {
 	return `set +e
+getconf _NPROCESSORS_ONLN 2>/dev/null | awk '$1 ~ /^[0-9]+$/ && $1 > 0 {print "cpuCount="$1; exit}'
 if [ -r /proc/loadavg ]; then awk '{print "load1="$1; print "load5="$2; print "load15="$3}' /proc/loadavg; fi
 if [ -r /proc/meminfo ]; then awk '
   /^MemTotal:/ { total=$2*1024 }
@@ -103,6 +105,8 @@ func parseLeaseTelemetry(output string, capturedAt time.Time, source string) *Le
 			hasMetric = setFloat(&telemetry.Load5, raw) || hasMetric
 		case "load15":
 			hasMetric = setFloat(&telemetry.Load15, raw) || hasMetric
+		case "cpuCount":
+			hasMetric = setInt64(&telemetry.CPUCount, raw) || hasMetric
 		case "memoryUsedBytes":
 			hasMetric = setInt64(&telemetry.MemoryUsedBytes, raw) || hasMetric
 		case "memoryTotalBytes":

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestParseLeaseTelemetry(t *testing.T) {
 	telemetry := parseLeaseTelemetry(strings.Join([]string{
+		"cpuCount=16",
 		"load1=0.12",
 		"load5=0.34",
 		"load15=0.56",
@@ -27,6 +28,9 @@ func TestParseLeaseTelemetry(t *testing.T) {
 	}
 	if telemetry.Load1 == nil || *telemetry.Load1 != 0.12 {
 		t.Fatalf("load1=%v", telemetry.Load1)
+	}
+	if telemetry.CPUCount == nil || *telemetry.CPUCount != 16 {
+		t.Fatalf("cpuCount=%v", telemetry.CPUCount)
 	}
 	if telemetry.MemoryUsedBytes == nil || *telemetry.MemoryUsedBytes != 1073741824 {
 		t.Fatalf("memoryUsedBytes=%v", telemetry.MemoryUsedBytes)

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13394,6 +13394,11 @@ function sanitizeLeaseTelemetry(
     telemetry.source = source.slice(0, 32);
   }
   let hasMetric = false;
+  const cpuCount = sanitizeTelemetryNumber(input.cpuCount, 1_000_000);
+  if (cpuCount !== undefined && cpuCount >= 1) {
+    telemetry.cpuCount = Math.trunc(cpuCount);
+    hasMetric = true;
+  }
   for (const [key, max] of [
     ["load1", 10_000],
     ["load5", 10_000],

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -2567,6 +2567,7 @@ function leaseTelemetryRows(telemetry: LeaseRecord["telemetry"]): string {
   }
   return [
     metaRow("load", telemetryLoad(telemetry)),
+    metaRow("cpu", telemetryCPUCount(telemetry.cpuCount)),
     metaRow(
       "memory",
       telemetryStorage(
@@ -2828,6 +2829,13 @@ function telemetryLoad(telemetry: LeaseRecord["telemetry"]): string | undefined 
   const load5 = telemetry.load5 === undefined ? "" : ` / ${telemetry.load5.toFixed(2)}`;
   const load15 = telemetry.load15 === undefined ? "" : ` / ${telemetry.load15.toFixed(2)}`;
   return `${telemetry.load1.toFixed(2)}${load5}${load15}`;
+}
+
+function telemetryCPUCount(count: number | undefined): string | undefined {
+  if (count === undefined) {
+    return undefined;
+  }
+  return `${count} vCPU${count === 1 ? "" : "s"}`;
 }
 
 function telemetryStorage(

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -276,6 +276,7 @@ export interface LeaseTelemetry {
   load1?: number;
   load5?: number;
   load15?: number;
+  cpuCount?: number;
   memoryUsedBytes?: number;
   memoryTotalBytes?: number;
   memoryPercent?: number;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10902,6 +10902,7 @@ describe("fleet lease identity and idle", () => {
           telemetry: {
             capturedAt: "2026-05-05T01:02:03Z",
             source: "ssh-linux",
+            cpuCount: 16,
             load1: 0.42,
             memoryUsedBytes: 1024,
             memoryTotalBytes: 2048,
@@ -10918,6 +10919,7 @@ describe("fleet lease identity and idle", () => {
     expect(lease.telemetry).toMatchObject({
       capturedAt: "2026-05-05T01:02:03.000Z",
       source: "ssh-linux",
+      cpuCount: 16,
       load1: 0.42,
       memoryUsedBytes: 1024,
       memoryTotalBytes: 2048,
@@ -11754,6 +11756,7 @@ describe("fleet lease identity and idle", () => {
         telemetry: {
           capturedAt: new Date(Date.now() - 15_000).toISOString(),
           source: "ssh-linux",
+          cpuCount: 16,
           load1: 0.42,
           load5: 0.24,
           load15: 0.12,
@@ -11887,6 +11890,7 @@ describe("fleet lease identity and idle", () => {
     expect(body).toContain('data-provider="hetzner"');
     expect(body).toContain('data-target="linux"');
     expect(body).toContain("<dt>load</dt><dd>0.42 / 0.24 / 0.12</dd>");
+    expect(body).toContain("<dt>cpu</dt><dd>16 vCPUs</dd>");
     expect(body).toContain("<dt>memory</dt><dd>1.0 KiB / 2.0 KiB (50%)</dd>");
     expect(body).toContain("<dt>disk</dt><dd>1.0 GiB / 4.0 GiB (25%)</dd>");
     expect(body).toContain("<dt>uptime</dt><dd>1h</dd>");


### PR DESCRIPTION
## Summary

- collect the online logical CPU count with Linux lease telemetry
- sanitize and persist `cpuCount` alongside existing load, memory, disk, and uptime metrics
- show a compact CPU field in the lease status card
- document the metric and add parser, sanitizer, and portal regression coverage

## Why

The lease detail view already reports memory and disk capacity, but load has no CPU-capacity context. Showing the online vCPU count makes the box shape immediately legible without changing the existing telemetry charts.

## User impact

Linux leases report `N vCPUs` in the status card after the next telemetry sample. Existing telemetry payloads remain compatible; non-Linux and unsampled leases are unchanged.

## Validation

- `go test ./internal/cli`
- `npm test --prefix worker -- test/fleet.test.ts` (270 tests)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no actionable findings)

## Visual verification

The existing-profile Chrome bridge was unavailable during local verification. Exact rendered-HTML coverage asserts the new `CPU / 16 vCPUs` status field; no CSS or layout rules changed.