### PR TITLE
fix(cli): stabilize Testbox proof workdirs

### DIFF
--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -21,6 +21,13 @@ import (
 	"time"
 )
 
+func controllerSubprocessTestTimeout(base time.Duration) time.Duration {
+	if raceEnabled {
+		return 5 * base
+	}
+	return base
+}
+
 type fixedIdentityExecControllerRunner struct {
 	*execControllerWorkspaceRunner
 }
@@ -177,7 +184,7 @@ func TestControllerAcquireIdentityGateWaitsForPersistenceAcknowledgment(t *testi
 	go func() { done <- acknowledgeControllerAcquireIdentity(context.Background(), identity) }()
 	select {
 	case <-callbackStarted:
-	case <-time.After(time.Second):
+	case <-time.After(controllerSubprocessTestTimeout(time.Second)):
 		gate.close()
 		t.Fatal("identity callback did not start")
 	}
@@ -194,7 +201,7 @@ func TestControllerAcquireIdentityGateWaitsForPersistenceAcknowledgment(t *testi
 			gate.close()
 			t.Fatal(err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(controllerSubprocessTestTimeout(time.Second)):
 		gate.close()
 		t.Fatal("child did not receive identity acknowledgment")
 	}
@@ -346,7 +353,7 @@ func TestControllerTrackedChildWaitsForDurableLaunchGate(t *testing.T) {
 	}()
 	select {
 	case <-callbackStarted:
-	case <-time.After(time.Second):
+	case <-time.After(controllerSubprocessTestTimeout(time.Second)):
 		t.Fatal("tracked child callback did not start")
 	}
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
@@ -365,7 +372,7 @@ func TestControllerTrackedChildWaitsForDurableLaunchGate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(controllerSubprocessTestTimeout(time.Second)):
 		t.Fatal("tracked child did not finish")
 	}
 	if _, err := os.Stat(marker); err != nil {

--- a/internal/cli/race_disabled_test.go
+++ b/internal/cli/race_disabled_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package cli
+
+const raceEnabled = false

--- a/internal/cli/race_enabled_test.go
+++ b/internal/cli/race_enabled_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package cli
+
+const raceEnabled = true

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -29,13 +31,50 @@ func findRepo() (Repo, error) {
 		return Repo{Root: wd, Name: filepath.Base(wd)}, nil
 	}
 	root := strings.TrimSpace(string(out))
+	remoteURL := gitOutput(root, "remote", "get-url", "origin")
 	return Repo{
 		Root:      root,
-		Name:      filepath.Base(root),
-		RemoteURL: gitOutput(root, "remote", "get-url", "origin"),
+		Name:      repoNameFromRootAndRemote(root, remoteURL),
+		RemoteURL: remoteURL,
 		Head:      gitOutput(root, "rev-parse", "HEAD"),
 		BaseRef:   defaultBaseRef(root),
 	}, nil
+}
+
+func repoNameFromRootAndRemote(root, remoteURL string) string {
+	fallback := filepath.Base(root)
+	if repo, err := parseGitHubRepo(remoteURL); err == nil && repo.Name != "" {
+		return repo.Name
+	}
+	if name := repoNameFromRemoteURL(remoteURL); name != "" {
+		return name
+	}
+	return fallback
+}
+
+func repoNameFromRemoteURL(remoteURL string) string {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return ""
+	}
+	if strings.Contains(remoteURL, "://") {
+		if u, err := url.Parse(remoteURL); err == nil {
+			return cleanRemoteRepoName(path.Base(strings.Trim(u.Path, "/")))
+		}
+	}
+	remotePath := strings.TrimRight(remoteURL, "/")
+	if before, after, ok := strings.Cut(remotePath, ":"); ok && !strings.Contains(before, "/") {
+		remotePath = after
+	}
+	return cleanRemoteRepoName(path.Base(strings.Trim(remotePath, "/")))
+}
+
+func cleanRemoteRepoName(name string) string {
+	name = strings.TrimSuffix(strings.TrimSpace(name), ".git")
+	if name == "" || name == "." || name == "/" {
+		return ""
+	}
+	return name
 }
 
 func defaultExcludes() []string {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -9,6 +9,53 @@ import (
 	"testing"
 )
 
+func TestFindRepoUsesOriginNameInsideLinkedWorktree(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "crabbox")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.email", "test@example.com")
+	runGit(t, root, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(root, "README.md"), "crabbox\n")
+	runGit(t, root, "add", "README.md")
+	runGit(t, root, "commit", "-m", "init")
+	runGit(t, root, "remote", "add", "origin", "https://github.com/openclaw/crabbox.git")
+
+	worktree := filepath.Join(parent, "fix-blacksmith-success-workflow-state")
+	runGit(t, root, "worktree", "add", "-b", "fix/blacksmith-success-workflow-state", worktree)
+	t.Chdir(worktree)
+
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(repo.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRoot, err := filepath.EvalSymlinks(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("repo root=%q want %q", repo.Root, worktree)
+	}
+	if repo.Name != "crabbox" {
+		t.Fatalf("repo name=%q want crabbox", repo.Name)
+	}
+}
+
+func TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename(t *testing.T) {
+	if got := repoNameFromRootAndRemote("/tmp/worktrees/feature", "git@gitlab.example.com:team/project.git"); got != "project" {
+		t.Fatalf("repo name=%q want project", got)
+	}
+	if got := repoNameFromRootAndRemote("/tmp/worktrees/feature", ""); got != "feature" {
+		t.Fatalf("repo name=%q want feature", got)
+	}
+}
+
 func TestSyncManifestUsesGitFilesAndIgnoresIgnoredJunk(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init")

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -133,6 +133,8 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		}
 	}
 	shouldStop := acquired && !req.Keep
+	finalExitCode := -1
+	finalActionsURL := ""
 	if shouldStop {
 		defer func() {
 			if !shouldStop {
@@ -144,6 +146,9 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			}
 			removeLeaseClaim(leaseID)
 			removeStoredTestboxKey(leaseID)
+			if finalExitCode == 0 {
+				printBlacksmithOneShotActionsWarning(b.rt.Stderr, finalActionsURL)
+			}
 		}()
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=blacksmith-testbox id=%s sync=delegated auth=blacksmith\n", leaseID)
@@ -250,6 +255,8 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		result.ActionsURL = proof.ActionsURL
 		result.Artifacts = append(result.Artifacts, proof.Artifacts...)
 	}
+	finalExitCode = code
+	finalActionsURL = result.ActionsURL
 	result.Session = &core.RunSessionHandle{
 		Provider:       blacksmithTestboxProvider,
 		LeaseID:        leaseID,
@@ -284,6 +291,17 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		return result, ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
 	}
 	return result, nil
+}
+
+func printBlacksmithOneShotActionsWarning(w io.Writer, actionsURL string) {
+	if w == nil {
+		return
+	}
+	fmt.Fprint(w, "blacksmith proof note: stopped one-shot Testbox after success; the backing GitHub Actions run may show a cancelled Testbox step because Blacksmith owns the delegated session lifecycle")
+	if strings.TrimSpace(actionsURL) != "" {
+		fmt.Fprintf(w, " actions=%s", strings.TrimSpace(actionsURL))
+	}
+	fmt.Fprintln(w)
 }
 
 func blacksmithArtifactFailureExitCode(err error) int {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -482,16 +482,27 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	var stderr bytes.Buffer
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
 			return LocalCommandResult{Stdout: "ready tbx_abc123\n"}, nil
+		}
+		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			if req.Stdout != nil {
+				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/123456789\n"))
+			}
+			return LocalCommandResult{}, nil
 		}
 		return LocalCommandResult{}, nil
 	}}
 
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-	backend := newTestBlacksmithBackend(cfg, runner)
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
 	_, err := backend.Run(context.Background(), RunRequest{
 		Repo:    Repo{Root: "/repo"},
 		Command: []string{"true"},
@@ -511,6 +522,15 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 		t.Fatal(err)
 	} else if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("key leaked after one-shot stop: %v", err)
+	}
+	for _, want := range []string{
+		"blacksmith proof note: stopped one-shot Testbox after success",
+		"backing GitHub Actions run may show a cancelled Testbox step",
+		"actions=https://github.com/example-org/my-app/actions/runs/123456789",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q in:\n%s", want, stderr.String())
+		}
 	}
 }
 


### PR DESCRIPTION
Summary
- explain why successful one-shot Blacksmith Testbox proof can leave the backing Actions step cancelled after Crabbox stops the delegated session
- derive repo names from origin remotes so linked worktrees keep stable remote workdirs like crabbox instead of branch worktree names

Verification
- go test ./internal/cli -run 'TestFindRepoUsesOriginNameInsideLinkedWorktree|TestRepoNameFromRootAndRemoteFallsBackToRemoteBasename|TestCheckpointRestoreDryRunUsesStoredLeaseTarget' -count=1
- go test ./internal/providers/blacksmith -run 'TestBlacksmithOneShotRunRemovesClaimAfterStop' -count=1
- go test ./internal/...
- go test ./cmd/... ./scripts
- git diff --check
