### PR TITLE
docs(skill): refresh Crabbox agent guide

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -1,153 +1,197 @@
 ---
 name: crabbox
-description: "Use Crabbox for remote validation, warmed reusable boxes, Actions hydration, fresh PR checkouts, secret-safe env forwarding, scripts, timing, logs, results, captures, caches, and lease cleanup."
+description: "Use Crabbox for remote validation, fresh or warmed leases, Actions hydration, ready pools, jobs, profiles/presets, secret-safe env forwarding, desktop/WebVNC proof, artifacts, run logs/results, and lease cleanup."
 ---
 
 # Crabbox
 
-Use Crabbox when a project needs remote proof, larger cloud capacity, warm
-reusable runner state, Actions hydration, fresh PR checkouts, live-secret
-smoke tests, durable logs/results, or fast sync from a dirty local checkout.
+Use Crabbox when a project needs remote proof, larger cloud capacity, a fresh
+PR checkout, a reusable warmed box, GitHub Actions-style setup, durable run
+logs/results, UI proof artifacts, or sync from a dirty local checkout.
 
-## Before Running
+## Source Of Truth
 
-- Run from the repository root. Crabbox sync mirrors the current checkout.
-- Prefer local targeted tests for tight edit loops.
-- Check repo-local `crabbox.yaml` or `.crabbox.yaml` before adding flags.
-- Sanity-check the selected binary before remote work:
-  `command -v crabbox && crabbox --version && crabbox --help | sed -n '1,80p'`.
-- Install from the repository release docs or use `bin/crabbox` after a local
-  build.
-- Auth is required for brokered operation. First login needs the broker URL:
-  `crabbox login --url <broker-url>`.
-- After `broker.url` is configured, `crabbox login` reuses that broker URL.
-- Trusted operator automation can store the shared token with:
-  `printf '%s' "$CRABBOX_COORDINATOR_TOKEN" | crabbox login --url <broker-url> --provider aws --token-stdin`.
-- User config lives at `~/Library/Application Support/crabbox/config.yaml` on
-  macOS or the platform user config dir elsewhere. It should contain:
+- Run Crabbox from the repository root; sync mirrors the current checkout.
+- Treat repo-local `crabbox.yaml` or `.crabbox.yaml` as executable project
+  automation. Review it before remote runs, especially `provider`, `actions`,
+  `jobs`, `profiles`, `env.allow`, artifacts, and cleanup policy.
+- Verify the installed binary before relying on examples:
+  `command -v crabbox && crabbox --version && crabbox --help | sed -n '1,120p'`.
+- Use `crabbox providers` or `crabbox providers --json` for the current
+  provider/capability matrix; provider docs can lag the compiled binary.
+- Use `crabbox doctor` for live readiness checks and `crabbox config show` to
+  inspect merged config without printing secrets.
+- Prefer local targeted tests for tight edit loops. Move to Crabbox for broad
+  suites, package-heavy checks, Docker/E2E/live-provider proof, cross-OS proof,
+  UI proof, or commands that bog down the local machine.
 
-```yaml
-broker:
-  url: <broker-url>
-  token: <token>
-provider: aws
-```
+## Auth And Config
 
-## Pick The Proof
-
-- Small/narrow tests, docs link checks, formatting, and focused unit tests:
-  run locally first.
-- Broad suites, package-heavy checks, Docker/E2E/live-provider proof, or
-  cross-OS behavior: run on Crabbox.
-- If a local command starts fanning out or bogs down the Mac, stop it and move
-  the proof remote.
-- Before shipping a user-visible behavior fix, prefer one remote command that
-  starts from the user-facing entrypoint.
-- If remote proof is blocked, say exactly which capability is missing:
-  auth, capacity, provider support, target OS, hydration, or secret access.
-
-## OpenClaw Provider Choice
-
-For OpenClaw/OpenClawd validation, prefer Blacksmith Testbox first when the
-workflow already gives the needed setup and the delegated command path is enough:
+Brokered operation needs a coordinator URL and token. First login usually needs
+an explicit broker URL:
 
 ```sh
-crabbox run --provider blacksmith-testbox --timing-json -- pnpm test
+crabbox login --url <broker-url>
+crabbox whoami
+crabbox doctor
 ```
 
-If Blacksmith is queued, unavailable, unauthenticated, or lacks the SSH-backed
-feature needed for the proof, rerun the same command shape on AWS:
+After `broker.url` is configured, `crabbox login` can reuse it. Trusted operator
+automation can store a shared token without putting it on argv:
 
 ```sh
-crabbox run --provider aws --timing-json -- pnpm test
+printf '%s' "$CRABBOX_COORDINATOR_TOKEN" |
+  crabbox login --url <broker-url> --provider aws --token-stdin
 ```
 
-Actions setup remains repo-owned in both paths. Blacksmith owns Testbox workflow
-hydration and command transport. AWS uses Crabbox SSH sync/run and Actions
-hydration for the persistent workspace. This is operator choice, not automatic
-CLI fallback.
+Config precedence is `flags > env > repo config > user config > defaults`.
+Default user config is `~/Library/Application Support/crabbox/config.yaml` on
+macOS, `~/.config/crabbox/config.yaml` on Linux, or
+`$XDG_CONFIG_HOME/crabbox/config.yaml` when set. `crabbox config path` prints
+the active user config path.
 
-## Common Flow
+Keep provider and broker tokens out of repo config and command arguments. Use
+environment variables, a credential store, coordinator-managed secrets, or a
+short-lived token command.
+
+## Choose The Remote Surface
+
+- `crabbox run -- <command>`: one command on a fresh or reused box.
+- `crabbox warmup`: create a reusable lease and run commands later with `--id`.
+- `crabbox prewarm`: warm a reusable lease and hydrate it from configured
+  GitHub Actions.
+- `crabbox job run <name>`: use a repo-local named flow that expands to
+  warmup, optional hydration, run, and stop.
+- `crabbox run --pool <key>`: borrow a hydrated broker ready-pool lease, run,
+  then return/drain/release it according to `--pool-return`.
+- `crabbox run --fresh-pr ...`: ignore local sync and check out a GitHub PR on
+  the remote; add `--apply-local-patch` to test local uncommitted changes on
+  top of that PR.
+- `crabbox run --provider ssh`: use an existing macOS, Linux, or Windows host.
+- `crabbox warmup --desktop --browser`: provision a visible desktop/browser for
+  UI testing, WebVNC, screenshots, and artifacts.
+
+If remote proof is blocked, name the missing capability precisely: auth,
+coordinator, capacity, provider support, target OS, hydration, secret access,
+artifact storage, desktop support, or a delegated-provider limitation.
+
+## Common Remote Proof
 
 One-shot command:
 
 ```sh
-crabbox run --timing-json --preflight -- pnpm test
+crabbox run --preflight --timing-json -- pnpm test
 ```
 
-Warm a reusable box:
+Warm and reuse a lease:
 
 ```sh
-crabbox warmup --idle-timeout 90m
-crabbox warmup --provider aws --class beast --market on-demand --idle-timeout 90m
-crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env wayland
-crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env gnome
-```
-
-`ubuntu:26.04` is the preferred portable Linux OS selector where the provider
-catalog supports it. Use `--os ubuntu:24.04` only when a test must stay on the
-previous LTS. Explicit provider image flags still win over `--os`.
-
-Repos with `actions.workflow` hydrate automatically during `crabbox run`. Use
-manual hydration when you want to prepare a reused lease before running commands:
-
-```sh
-crabbox actions hydrate --id <cbx_id-or-slug>
-```
-
-Use `crabbox actions hydrate --github-runner --id <cbx_id-or-slug>` when the
-workflow needs full GitHub Actions semantics, repository secrets, OIDC, service
-containers, or unsupported `uses:` steps.
-
-Run commands:
-
-```sh
+crabbox warmup --class beast --idle-timeout 90m
+crabbox status --id <cbx_id-or-slug> --wait
 crabbox run --id <cbx_id-or-slug> -- pnpm test:changed
 crabbox run --id <cbx_id-or-slug> --full-resync -- pnpm test:changed
-crabbox run --id <cbx_id-or-slug> --shell "corepack enable && pnpm install --frozen-lockfile && pnpm test"
-```
-
-For package-manager commands on raw AWS/Hetzner boxes, rely on configured
-Actions hydration or include setup in the command; bootstrap only installs
-Crabbox plumbing, not project runtimes. Add `--timing-json` when comparing
-providers or sync phases.
-
-Stop boxes you created before handoff:
-
-```sh
 crabbox stop <cbx_id-or-slug>
 ```
 
-## Local Container
-
-Use `local-container` for fast local proof when the host has Docker or Podman.
-Run Crabbox from the repo you want synced. `warmup` does not sync; for an
-interactive synced container, use:
+Use a repo-local job when configured:
 
 ```sh
-crabbox run --provider local-container --keep --slug local-smoke --sync-only
-eval "$(crabbox ssh --provider local-container --id local-smoke)"
+crabbox job list
+crabbox job run --dry-run <job-name>
+crabbox job run <job-name>
+crabbox job run --id <cbx_id-or-slug> <job-name>
 ```
 
-Pass `--local-container-runtime docker` or `--local-container-runtime podman`
-when the engine matters, and keep that flag on reused lease commands such as
-`run --id`, `ssh`, `status`, and `stop`. `crabbox ssh` prints the SSH command;
-use `eval "$(crabbox ssh ...)"` to connect. After login, `cd` into the workdir
-printed by `run --sync-only`.
+Use a ready-pool lease when the coordinator has hydrated pool capacity:
 
-## Scripts, Secrets, And Fresh PRs
+```sh
+crabbox pool ready
+crabbox run --pool <pool-key> -- pnpm test
+crabbox run --pool <pool-key> --pool-return drain -- pnpm test:flaky
+```
 
-Prefer uploaded scripts for multi-line commands. This avoids giant quoted shell
-strings and preserves the script in failure bundles:
+Use GitHub Actions hydration when the repository already owns setup in CI:
+
+```sh
+crabbox warmup --idle-timeout 90m
+crabbox actions hydrate --id <cbx_id-or-slug>
+crabbox run --id <cbx_id-or-slug> -- pnpm test
+```
+
+Use `--github-runner` only when the workflow needs full GitHub Actions
+semantics such as repository secrets, OIDC, service containers, job containers,
+or unsupported `uses:` steps:
+
+```sh
+crabbox actions hydrate --github-runner --id <cbx_id-or-slug>
+```
+
+## Sync And Fresh Checkouts
+
+Normal sync transfers tracked files plus non-ignored untracked files, excludes
+ignored dependency/build/cache output, honors `.crabboxignore` and
+`sync.exclude`, seeds the remote checkout from `origin` when possible, and skips
+rsync when the sync fingerprint matches.
+
+Use `crabbox sync-plan` before large runs. Unexpected counts usually mean
+local generated churn; update `.crabboxignore` or `sync.exclude` instead of
+forcing huge uploads.
+
+```sh
+crabbox sync-plan
+crabbox run --debug --timing-json -- pnpm test
+crabbox run --full-resync -- pnpm test
+```
+
+Use fresh PR checkout when local dependency churn or dirty sync would confuse
+the result:
+
+```sh
+crabbox run --fresh-pr example-org/my-app#123 --script ./scripts/e2e-smoke.sh
+crabbox run --fresh-pr 123 --apply-local-patch -- pnpm test
+```
+
+`--fresh-pr` accepts `owner/repo#number`, GitHub PR URLs, or a numeric PR from
+the current GitHub origin. Non-GitHub hosts are rejected. Fresh PR checkout is
+an SSH-run sync feature; delegated providers and native Windows targets reject
+it.
+
+When a warm lease smells stale, prefer `--full-resync` (alias `--fresh-sync`) to
+reset the remote workdir, skip the sync fingerprint fast path, reseed Git when
+possible, and upload the checkout from scratch.
+
+## Scripts, Shells, And Windows Targets
+
+Use plain argv after `--` for one executable. Use `--shell` for multi-statement
+shell snippets, pipes, or shell expansion:
+
+```sh
+crabbox run --id <lease> -- go test ./...
+crabbox run --id <lease> --shell 'corepack enable && pnpm install --frozen-lockfile && pnpm test'
+```
+
+Prefer uploaded scripts for multi-line commands. Scripts are included in failure
+bundles and avoid brittle quoted shell strings:
 
 ```sh
 crabbox run --script ./scripts/e2e-smoke.sh --timing-json
 printf '%s\n' 'echo CRABBOX_PHASE:test' 'pnpm test' | crabbox run --script-stdin
 ```
 
-For live-secret smoke tests, use explicit allowlists. Never print values:
+Native Windows targets use PowerShell and tar-based manifest sync. Prefer plain
+argv for one executable such as `dotnet test`; use `--shell` for multi-statement
+PowerShell and `--script <file.ps1>` for longer scripts. POSIX script helpers
+and fresh PR checkout are not native Windows features.
+
+## Secrets And Environment Forwarding
+
+Crabbox does not forward the whole local environment. Forwarding is name-based:
+only allowlisted names that are actually set locally or in an allowed profile
+cross the boundary. Avoid allowlisting secret-shaped names unless the run is an
+explicit live-secret smoke.
 
 ```sh
+crabbox run --allow-env CI,NODE_OPTIONS -- pnpm test
 crabbox run \
   --env-from-profile ~/.project-live.profile \
   --allow-env API_TOKEN \
@@ -155,48 +199,77 @@ crabbox run \
   --script ./scripts/live-smoke.sh
 ```
 
-Crabbox parses simple `export NAME=value` and `NAME=value` profile lines
-without executing the profile. It probes the uploaded profile remotely and
-prints names plus redacted presence/length metadata only. On POSIX SSH leases,
-add `--env-helper <name>` when follow-up commands should reuse a remote
-`.crabbox/env/<name>` wrapper:
+`--env-from-profile` parses simple `export NAME=value` and `NAME=value` lines
+without executing the profile. Crabbox prints redacted presence/length metadata,
+not values. POSIX SSH leases can persist a helper for later commands on a lease
+you control:
 
 ```sh
 crabbox run \
   --env-from-profile ~/.project-live.profile \
   --allow-env API_TOKEN \
   --env-helper live \
-  -- ./.crabbox/env/live ./scripts/live-smoke.sh
+  -- true
+crabbox run --id <lease> -- ./.crabbox/env/live ./scripts/live-smoke.sh
 ```
 
-Persist helpers only on leases you control; the profile remains on the remote
-workdir until cleanup, lease reset, or `--full-resync`.
+The profile remains in the remote workdir until cleanup, lease reset, or
+`--full-resync`; do not persist helpers on shared or untrusted leases.
 
-Use fresh PR checkout when local dependency churn or dirty sync would confuse
-the result:
+## Profiles, Presets, Proof, And Results
+
+Repo config can define profiles, presets, doctor requirements, artifact globs,
+required artifacts, and proof templates. Use them for stable validation lanes
+instead of encoding project knowledge in agent prompts.
 
 ```sh
-crabbox run --fresh-pr owner/repo#123 --script ./scripts/e2e-smoke.sh
-crabbox run --fresh-pr 123 --apply-local-patch -- pnpm test
+crabbox run \
+  --profile live-qa \
+  --preset qa-live \
+  --scenario login-regression \
+  --emit-proof /tmp/proof.md \
+  --stop-after success
 ```
 
-`--fresh-pr` accepts `owner/repo#number`, `github.com` PR URLs, or a numeric PR
-from the current GitHub origin. Non-GitHub hosts are rejected.
+Use `--preflight` for a target capability snapshot before the command, not as
+an installer. Use `--preflight-tools` to tune probes:
 
-When sync guardrails look high because the checkout is noisy, prefer
-`--fresh-pr ... --apply-local-patch`. Normal sync output prints both the full
-candidate and the dirty delta; guardrails use the dirty delta when present.
-When a warm lease smells stale, use `--full-resync` (alias `--fresh-sync`) to
-reset the remote workdir, skip the sync fingerprint fast path, reseed Git when
-possible, and upload the checkout from scratch.
+```sh
+crabbox run --preflight --preflight-tools node,bun,docker -- bun test
+crabbox run --preflight --preflight-tools default,uv -- node --test
+```
 
-## Observability And Captures
+Attach structured results and proof artifacts when the command emits them:
 
-Add `--preflight` for remote user/cwd/runtime capability checks before the
-command. Add `--timing-json` when comparing providers, sync behavior, or flaky
-latency.
+```sh
+crabbox run --junit reports/junit.xml -- go test ./...
+crabbox run --artifact-glob 'reports/**' --require-artifact reports/summary.json -- pnpm test:e2e
+crabbox run --download reports/summary.json=.crabbox/logs/summary.json -- pnpm test:e2e
+```
 
-Commands can create subphases by printing markers:
+`--require-artifact` fails the run if the remote command exits 0 but the proof
+file is missing. Keep required artifacts bounded and scrubbed; do not collect
+raw datasets, secrets, credentials, signed URLs, or unredacted customer rows.
+
+## Run Handles And Observability
+
+Coordinator-backed runs print a durable `run_...` handle before leasing starts.
+Keep that run ID in status updates and PR notes.
+
+```sh
+crabbox history --limit 20
+crabbox history --lease <cbx_id-or-slug> --limit 20
+crabbox attach <run_id>
+crabbox attach <run_id> --after <seq>
+crabbox events <run_id> --after <seq> --limit 100
+crabbox events <run_id> --json
+crabbox logs <run_id>
+crabbox results <run_id>
+```
+
+Use `--timing-json` on `run`, `warmup`, and `actions hydrate` when a stable
+machine-readable timing record is needed. Commands can mark subphases by
+printing markers on stdout or stderr:
 
 ```sh
 echo CRABBOX_PHASE:install
@@ -205,185 +278,187 @@ echo CRABBOX_PHASE:test
 pnpm test
 ```
 
-For terminal-hostile or large output:
+Output events are capped previews. Use `logs` for retained output tails and
+`results` for parsed test summaries.
+
+## Desktop, WebVNC, And UI Proof
+
+Create desktop/browser leases for visual QA, headed browser automation, or UI
+proof:
 
 ```sh
-mkdir -p .crabbox/logs
-crabbox run \
-  --capture-stdout .crabbox/logs/run.stdout.log \
-  --capture-stderr .crabbox/logs/run.stderr.log \
-  --keep-on-failure \
-  --download test-results/report.json=.crabbox/logs/report.json \
-  -- pnpm test:e2e
+crabbox warmup --desktop --browser
+crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env wayland
+crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env gnome
 ```
 
-Failed SSH runs save `.crabbox/captures/*.tar.gz` automatically. Add
-`--keep-on-failure` for live debugging when you want the exact failed lease left
-alive for SSH inspection until idle/TTL expiry. Captured files and failure
-bundles are local-only and not redacted by Crabbox; review before sharing.
+`ubuntu:26.04` is the default portable Linux OS selector where the provider
+catalog supports it. Use `--os ubuntu:24.04` only when a test must stay on the
+previous LTS. Explicit provider image flags still win over `--os`.
 
-Use `crabbox sync-plan` before large runs. Unexpected counts usually mean
-generated churn; add project-specific excludes to `.crabboxignore` or
-`sync.exclude`. If quiet rsync watchdogs or SSH timeouts print `next_action=`,
-follow that hint: usually retry with `--full-resync`, then replace the lease if
-the problem persists.
+For human demos, prefer WebVNC over native VNC because `crabbox webvnc --open`
+preloads the lease password in the browser fragment:
+
+```sh
+crabbox webvnc --id <lease> --open --take-control
+crabbox webvnc status --id <lease>
+crabbox webvnc reset --id <lease> --open --take-control
+crabbox vnc --id <lease> --open
+```
+
+For input automation, use first-class helpers instead of hand-written
+`xdotool`:
+
+```sh
+crabbox desktop doctor --id <lease>
+crabbox desktop launch --id <lease> --browser --url https://example.com --webvnc --open --take-control
+crabbox desktop click --id <lease> --x 640 --y 420
+crabbox desktop paste --id <lease> --text "user@example.com"
+printf 'user@example.com' | crabbox desktop paste --id <lease>
+crabbox desktop type --id <lease> --text "user+qa@example.com"
+crabbox desktop key --id <lease> ctrl+l
+crabbox screenshot --id <lease> --output desktop.png
+```
+
+When desktop/WebVNC hangs, trust the inline rescue output first: `problem:` and
+`rescue:` lines usually name exact next commands such as `webvnc status/reset`,
+`desktop doctor`, or native `vnc --open`.
+
+Use artifacts for UI QA proof instead of committing screenshots or videos to a
+product repo branch:
+
+```sh
+crabbox artifacts collect --id <lease> --all --output artifacts/<slug>
+crabbox artifacts publish --dir artifacts/<slug> --pr <number>
+crabbox artifacts list <artifact-manifest-url-or-dir>
+crabbox artifacts pull <artifact-manifest-url-or-dir> --output /tmp/<slug>-proof
+```
+
+`artifacts publish` uses brokered storage when configured, or explicit S3/R2 /
+Cloudflare/local hosting flags. Use `--dry-run` before public PR comments when
+reviewing generated Markdown or storage commands.
+
+## Provider Boundaries
+
+SSH-lease providers support the full sync/run surface when the target supports
+it: scripts, fresh PR checkouts, captures, downloads, Actions hydration, SSH,
+ports, WebVNC, code-server, desktop, browser, cache volumes, and cleanup.
+
+Delegated-run providers own command transport. Expect them to reject SSH-run
+features such as `--capture-stdout`, `--capture-stderr`, `--capture-on-fail`,
+`--script`, `--script-stdin`, `--fresh-pr`, local captures, `--download`,
+`--full-resync`, and `--env-helper` unless `crabbox providers --json` and the
+provider docs advertise the matching capability. `--keep-on-failure` is still
+useful for one-shot delegated providers that Crabbox would otherwise stop after
+a failed command.
+
+Module-runtime delegated providers, such as Cloudflare Dynamic Workers, run
+source modules rather than Linux shell commands. Use `--script <file>` or
+`--script-stdin` for module source; trailing `-- <command>`, SSH, rsync, ports,
+Actions hydration, desktop, browser, and code-server do not apply unless the
+provider explicitly documents them.
+
+Use `--market spot|on-demand` on AWS `warmup` or one-shot `run` when account
+quota or capacity testing needs a temporary market override. An explicit
+`--type` means exact type; Crabbox reports quota/capacity/policy failures
+instead of silently falling back.
+
+## Local And Static Targets
+
+Use `local-container` for fast local proof when the host has Docker or Podman.
+`warmup` creates a container but does not sync; for an interactive synced
+container, use `run --keep --sync-only`:
+
+```sh
+crabbox run --provider local-container --keep --slug local-smoke --sync-only
+eval "$(crabbox ssh --provider local-container --id local-smoke)"
+```
+
+Pass `--local-container-runtime docker` or `--local-container-runtime podman`
+when the engine matters, and keep that flag on reused lease commands such as
+`run --id`, `ssh`, `status`, and `stop`. `crabbox ssh` prints an SSH command;
+use `eval "$(crabbox ssh ...)"` to connect. After login, `cd` into the workdir
+printed by `run --sync-only`.
+
+Use static SSH for existing machines:
+
+```sh
+crabbox run --provider ssh --target macos --static-host mac.example.com -- xcodebuild test
+crabbox run --provider ssh --target windows --windows-mode normal --static-host win.example.com -- dotnet test
+```
+
+Static hosts are host-managed: Crabbox does not provision or delete them.
 
 ## Useful Commands
 
 ```sh
-crabbox status --id <id-or-slug> --wait
-crabbox inspect --id <id-or-slug> --json
-crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env wayland
-crabbox warmup --provider aws --os ubuntu:26.04 --desktop --browser --desktop-env gnome
-crabbox webvnc --id <id-or-slug> --open
-crabbox webvnc daemon start --id <id-or-slug> --open
-crabbox webvnc daemon status --id <id-or-slug>
-crabbox webvnc daemon stop --id <id-or-slug>
-crabbox webvnc status --id <id-or-slug>
-crabbox webvnc reset --id <id-or-slug> --open
-crabbox desktop doctor --id <id-or-slug>
-crabbox desktop click --id <id-or-slug> --x 640 --y 420
-crabbox desktop paste --id <id-or-slug> --text "user@example.com"
-crabbox desktop type --id <id-or-slug> --text "user+qa@example.com"
-crabbox desktop key --id <id-or-slug> ctrl+l
-crabbox artifacts collect --id <id-or-slug> --all --output artifacts/<slug>
-crabbox artifacts publish --dir artifacts/<slug> --pr <number>
+crabbox providers
+crabbox providers --json
+crabbox doctor
+crabbox config path
+crabbox config show
+crabbox whoami
 crabbox sync-plan
-crabbox history --lease <id-or-slug>
+crabbox warmup --class beast
+crabbox prewarm
+crabbox status --id <lease> --wait
+crabbox inspect --id <lease> --json
+crabbox run --id <lease> --preflight --timing-json -- pnpm test
+crabbox job list
+crabbox job run --dry-run <job-name>
+crabbox pool ready
+crabbox history --lease <lease>
 crabbox events <run_id> --json
 crabbox attach <run_id>
 crabbox logs <run_id>
 crabbox results <run_id>
-crabbox cache stats --id <id-or-slug>
-crabbox ssh --id <id-or-slug>
+crabbox cache stats --id <lease>
+crabbox cache volumes
+crabbox ssh --id <lease>
+crabbox connect <lease>
+crabbox ports --id <lease> --publish 8080
+crabbox cp --id <lease> ./coverage.xml SANDBOX:/tmp/coverage.xml
+crabbox webvnc --id <lease> --open
+crabbox code --id <lease> --open
+crabbox egress start --id <lease> --profile discord --daemon
+crabbox desktop doctor --id <lease>
+crabbox desktop proof --id <lease> --output artifacts/<slug>-proof -- ./scripts/visual-smoke.sh
+crabbox artifacts collect --id <lease> --all --output artifacts/<slug>
+crabbox artifacts publish --dir artifacts/<slug> --pr <number> --dry-run
 crabbox usage --scope org
+crabbox pause <lease>
+crabbox resume <lease>
+crabbox stop <lease>
 ```
-
-For human desktop demos, prefer WebVNC over native VNC because
-`crabbox webvnc --open` preloads the lease password in the browser fragment.
-Use native `crabbox vnc --id <id-or-slug> --open` as the fallback printed by
-`crabbox webvnc status` or `crabbox webvnc reset`. For input automation, use
-`crabbox desktop click/paste/type/key` instead of hand-written `xdotool`;
-`desktop type` switches to clipboard paste for symbol-heavy text such as emails
-and passwords. `desktop key` accepts both `--id <lease> <keys>` and positional
-`<lease> <keys>` forms for shortcuts.
-
-GNOME desktop profile means labwc/WayVNC with GNOME Panel taskbars and GNOME
-apps. Do not add Waybar. Browser/terminal windows use Xwayland so GNOME Panel
-can list them.
-
-When desktop/WebVNC hangs, trust the inline rescue output first: `problem: VNC
-bridge disconnected`, `problem: browser not launched`, `problem: input stack
-dead`, or similar will be followed by exact `rescue:` commands such as
-`crabbox webvnc status/reset` or `crabbox desktop doctor`.
-
-For UI QA proof, use `crabbox artifacts collect` instead of ad hoc screenshots
-and shell recordings. It can bundle screenshots, MP4 recordings, trimmed GIFs,
-desktop doctor output, WebVNC status, run logs, and metadata, then
-`crabbox artifacts publish --pr <n>` can publish inline-ready Markdown through
-the configured coordinator artifact backend and an artifact manifest URL. Never
-push screenshots, videos, proof images, or proof assets to a product repo branch
-or temporary artifact branch. Use explicit `--storage s3`, `--storage r2`, or
-`--storage local` only as a local fallback.
-
-## Run Inspection Workflow
-
-Use the CLI for durable run inspection.
-
-Find recent runs:
-
-```sh
-crabbox history --limit 20
-crabbox history --lease <id-or-slug> --limit 20
-```
-
-Follow an active run:
-
-```sh
-crabbox attach <run_id>
-crabbox attach <run_id> --after <seq>
-```
-
-Page through recorded events:
-
-```sh
-crabbox events <run_id> --after <seq> --limit 100
-crabbox events <run_id> --json
-```
-
-Inspect completed output and structured test summaries:
-
-```sh
-crabbox logs <run_id>
-crabbox results <run_id>
-```
-
-Use `--debug` on `run` when measuring sync timing.
-Use `--timing-json` on `warmup`, `actions hydrate`, and `run` when a stable
-machine-readable timing record is needed.
-Use `--market spot|on-demand` on AWS `warmup` or one-shot `run` when account
-quota or capacity testing needs a temporary market override.
-
-## Provider Boundaries
-
-SSH-backed providers support core sync/run features such as scripts, fresh PR
-checkouts, captures, downloads, Actions hydration, SSH, and WebVNC when the
-target supports them.
-
-Delegated run providers own command transport. Expect them to reject SSH-run
-features such as `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr
-captures, `--capture-on-fail`, `--download`, `--full-resync`, and
-`--env-helper`, unless that provider doc says otherwise. `--keep-on-failure` is
-still useful for one-shot delegated providers that Crabbox would otherwise stop
-after a failed command.
-
-Native Windows targets use PowerShell and tar-based manifest sync. Prefer
-plain argv for one executable and `--shell` for multi-statement PowerShell.
-Scripts and fresh PR checkout are POSIX SSH-run features, not native Windows
-features.
-
-## Run Handles
-
-Coordinator-backed `crabbox run` prints `recording run run_...` before leasing
-starts. Keep that run ID in status updates. Use `crabbox events run_...` for
-ordered lifecycle/output events, `crabbox attach run_...` to follow an active
-run, and `crabbox logs run_...` or `crabbox results run_...` after completion.
-
-Output events are a capped preview, not unlimited logs. Use `logs` for the
-retained command output tail when debugging noisy runs.
-
-## Hydration Boundary
-
-Repository setup belongs in the repository hydration workflow. That workflow
-owns checkout, runtime setup, dependencies, services, secret-backed preparation,
-the ready marker, and keepalive.
-
-Crabbox owns runner registration, workflow dispatch, SSH sync, command
-execution, logs/results, local lease claims, and idle cleanup. Do not add
-project-specific setup to the Crabbox binary.
 
 ## Failure Triage
 
-- Provider missing or old CLI: verify `crabbox --help` lists the provider and
-  rebuild or install a current binary before falling back.
-- Bad local config: pass `--provider ...` explicitly and compare
-  `crabbox config show`.
-- Sync surprise: run `crabbox sync-plan`, then `crabbox run --debug
-  --timing-json`.
-- Raw box missing Node/pnpm/Docker: use `--preflight`; hydrate first if the repo
-  has an Actions workflow.
-- Command failed: rerun the focused failing shard/file before a full suite.
-- Cleanup uncertain: `crabbox list`, `crabbox inspect --json`, then stop only
-  leases or provider resources you created.
+- Provider missing or old CLI: verify `crabbox --help` and `crabbox providers`
+  list the provider, then rebuild or install a current binary.
+- Bad local config: compare `crabbox config show`, pass `--provider ...`
+  explicitly, and run `crabbox doctor`.
+- Sync surprise: run `crabbox sync-plan`, add excludes, then retry with
+  `--debug --timing-json` or `--full-resync`.
+- Raw box missing Node/pnpm/Docker: use `--preflight`; hydrate first if the
+  repo has an Actions workflow, or include setup in the command/script.
+- Command failed: keep the `run_...` handle, inspect `results`, then rerun the
+  focused failing shard/file before a full suite.
+- Desktop unhealthy: run `desktop doctor`, then follow `problem:` / `rescue:`
+  output from `webvnc status` or `webvnc reset`.
+- Cleanup uncertain: use `crabbox list`, `crabbox inspect --json`, and only
+  stop leases or provider resources you created.
 - Broker/auth confusion: use `crabbox doctor`, `crabbox whoami`, and
   `crabbox config show` before asking for cloud credentials.
 
 ## Cleanup
 
-Brokered leases have coordinator-owned idle expiry and local lease claims, so
-projects should not maintain their own lease ledger. Default idle timeout is 30
-minutes unless config or flags set a different value. Still stop boxes you
-created when done.
+Brokered leases have coordinator-owned idle expiry and local lease claims.
+Default idle timeout is 30 minutes unless config or flags set a different
+value. Still stop boxes you created when done:
+
+```sh
+crabbox stop <cbx_id-or-slug>
+```
 
 When `crabbox list` prints `orphan=no-active-lease`, treat it as an operator
 review hint: verify the provider machine is not referenced by an active

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crabbox
-description: "Use Crabbox for remote validation, fresh or warmed leases, Actions hydration, ready pools, jobs, profiles/presets, secret-safe env forwarding, desktop/WebVNC proof, artifacts, run logs/results, and lease cleanup."
+description: "Crabbox remote validation and lease workflows."
 ---
 
 # Crabbox
@@ -153,8 +153,8 @@ crabbox run --fresh-pr 123 --apply-local-patch -- pnpm test
 
 `--fresh-pr` accepts `owner/repo#number`, GitHub PR URLs, or a numeric PR from
 the current GitHub origin. Non-GitHub hosts are rejected. Fresh PR checkout is
-an SSH-run sync feature; delegated providers and native Windows targets reject
-it.
+an SSH-run sync feature; delegated providers reject it. Native Windows SSH
+targets are supported.
 
 When a warm lease smells stale, prefer `--full-resync` (alias `--fresh-sync`) to
 reset the remote workdir, skip the sync fingerprint fast path, reseed Git when
@@ -180,8 +180,7 @@ printf '%s\n' 'echo CRABBOX_PHASE:test' 'pnpm test' | crabbox run --script-stdin
 
 Native Windows targets use PowerShell and tar-based manifest sync. Prefer plain
 argv for one executable such as `dotnet test`; use `--shell` for multi-statement
-PowerShell and `--script <file.ps1>` for longer scripts. POSIX script helpers
-and fresh PR checkout are not native Windows features.
+PowerShell and `--script <file.ps1>` for longer scripts.
 
 ## Secrets And Environment Forwarding
 
@@ -193,6 +192,7 @@ explicit live-secret smoke.
 ```sh
 crabbox run --allow-env CI,NODE_OPTIONS -- pnpm test
 crabbox run \
+  --id <lease> \
   --env-from-profile ~/.project-live.profile \
   --allow-env API_TOKEN \
   --preflight \
@@ -213,8 +213,9 @@ crabbox run \
 crabbox run --id <lease> -- ./.crabbox/env/live ./scripts/live-smoke.sh
 ```
 
-The profile remains in the remote workdir until cleanup, lease reset, or
-`--full-resync`; do not persist helpers on shared or untrusted leases.
+The generated helper and matching secret profile remain in the remote workdir
+until cleanup, lease reset, or `--full-resync`; do not persist helpers on shared
+or untrusted leases.
 
 ## Profiles, Presets, Proof, And Results
 
@@ -242,7 +243,7 @@ crabbox run --preflight --preflight-tools default,uv -- node --test
 Attach structured results and proof artifacts when the command emits them:
 
 ```sh
-crabbox run --junit reports/junit.xml -- go test ./...
+crabbox run --junit reports/junit.xml -- ./scripts/test-with-junit.sh
 crabbox run --artifact-glob 'reports/**' --require-artifact reports/summary.json -- pnpm test:e2e
 crabbox run --download reports/summary.json=.crabbox/logs/summary.json -- pnpm test:e2e
 ```

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -192,7 +192,6 @@ explicit live-secret smoke.
 ```sh
 crabbox run --allow-env CI,NODE_OPTIONS -- pnpm test
 crabbox run \
-  --id <lease> \
   --env-from-profile ~/.project-live.profile \
   --allow-env API_TOKEN \
   --preflight \
@@ -206,6 +205,7 @@ you control:
 
 ```sh
 crabbox run \
+  --id <lease> \
   --env-from-profile ~/.project-live.profile \
   --allow-env API_TOKEN \
   --env-helper live \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added Linux CPU capacity to lease telemetry and portal status details.
 ### Changed
 
+- Refreshed the bundled Crabbox agent skill for current remote-proof, job, pool, artifact, desktop, and provider-boundary workflows. Thanks @coygeek.
 - Defined Crabbox's supported single-user and cooperative-team security boundary, clarified repository configuration as trusted project automation, and separated vulnerability reporting from compatibility-preserving hardening.
 
 ### Fixed

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -162,7 +162,8 @@ hint, and `sync.timeout` kills stalled syncs.
   repository's GitHub origin. Only `github.com` PR URLs are accepted; other
   hosts are rejected. Add `--apply-local-patch` to apply the local `git diff
   --binary HEAD` on top of the PR checkout. `--fresh-pr` needs the SSH-run sync
-  path; delegated providers and native Windows targets reject it.
+  path; delegated providers reject it. Native Windows SSH targets are
+  supported.
 
 ## Actions hydration
 


### PR DESCRIPTION
Closes #460

## Summary

- refresh `.agents/skills/crabbox/SKILL.md` for the current Crabbox CLI and documentation surface
- remove stale project-specific provider guidance and keep the skill product-neutral
- add current workflows for `prewarm`, jobs, ready pools, profiles/presets/proof, run artifacts, desktop/WebVNC proof, and delegated-provider boundaries
- correct canonical run docs for supported native Windows fresh-PR checkouts
- keep the `crabbox init` generated skill intentionally minimal; this PR updates the maintained repo-local operator skill

## Validation

- `git diff --check`
- YAML-parsed the final skill frontmatter
- built the current CLI and validated top-level/run help plus every named skill flag against source
- `go test ./internal/cli -run FreshPR`
- `bash scripts/check-docs.sh`
- autoreview clean for both the maintainer patch and the complete committed branch

After-fix terminal proof:

```text
frontmatter_ok name=crabbox description_chars=46
providers=58 sshLease=34 delegated=23
ok github.com/openclaw/crabbox/internal/cli 0.598s
checked 49 command docs: command surface ok
checked provider matrix: 58 providers
checked 183 markdown files: internal links ok
built docs site: dist/docs-site
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

No live lease or secret-bearing workflow was needed for this documentation-only change.
