### PR TITLE
fix(doctor): report expired broker tokens

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -263,7 +264,18 @@ func (a App) doctor(ctx context.Context, args []string) error {
 						class = "broker_auth"
 					}
 					hint := doctorErrorHint("broker", class)
-					record("failed", "broker", fmt.Sprintf("class=%s hint=%s %v", class, hint, err), map[string]string{"class": class, "hint": hint, "error": err.Error()})
+					message := fmt.Sprintf("class=%s hint=%s %v", class, hint, err)
+					details := map[string]string{"class": class, "hint": hint, "error": err.Error()}
+					if class == "broker_auth" {
+						if tokenInfo, ok := brokerTokenInfo(cfg.CoordToken, time.Now()); ok {
+							details["token_expires"] = tokenInfo.expiresAt
+							details["token_state"] = tokenInfo.state
+							if tokenInfo.state == "expired" {
+								message = fmt.Sprintf("class=%s hint=%s token_state=expired token_expires=%s %v", class, hint, tokenInfo.expiresAt, err)
+							}
+						}
+					}
+					record("failed", "broker", message, details)
 					ok = false
 					brokerOK = false
 				} else {
@@ -559,6 +571,41 @@ func doctorBrokerOKMessage(whoami CoordinatorWhoami, serverType string) string {
 		parts = append(parts, "token_expires="+whoami.TokenExpiresAt)
 	}
 	return strings.Join(parts, " ")
+}
+
+type localBrokerTokenInfo struct {
+	expiresAt string
+	state     string
+}
+
+func brokerTokenInfo(token string, now time.Time) (localBrokerTokenInfo, bool) {
+	if !strings.HasPrefix(token, "cbxu_") {
+		return localBrokerTokenInfo{}, false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(token, "cbxu_"), ".", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return localBrokerTokenInfo{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return localBrokerTokenInfo{}, false
+	}
+	var decoded struct {
+		Type string `json:"typ"`
+		Exp  int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return localBrokerTokenInfo{}, false
+	}
+	if decoded.Type != "crabbox-user" || decoded.Exp <= 0 {
+		return localBrokerTokenInfo{}, false
+	}
+	expiresAt := time.Unix(decoded.Exp, 0).UTC()
+	state := "present"
+	if !now.Before(expiresAt) {
+		state = "expired"
+	}
+	return localBrokerTokenInfo{expiresAt: expiresAt.Format(time.RFC3339), state: state}, true
 }
 
 func doctorErrorClass(err error) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCoordinatorProviderReadinessSupported(t *testing.T) {
@@ -463,6 +465,56 @@ func TestDoctorBrokerAuthFailureSkipsProviderReadiness(t *testing.T) {
 	}
 }
 
+func TestDoctorBrokerAuthFailureReportsExpiredUserToken(t *testing.T) {
+	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("missing local doctor tool %s: %v", tool, err)
+		}
+	}
+	clearConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		case "/v1/whoami":
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", testCrabboxUserToken(t, time.Now().Add(-time.Hour)))
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).doctor(context.Background(), []string{"--provider", "aws", "--json"})
+	if err == nil {
+		t.Fatalf("doctor succeeded unexpectedly stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	var view doctorJSONOutput
+	if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+		t.Fatalf("doctor JSON invalid: %v\n%s", err, stdout.String())
+	}
+	for _, check := range view.Checks {
+		if check.Check != "broker" {
+			continue
+		}
+		if check.Details["token_state"] != "expired" {
+			t.Fatalf("token_state=%q details=%#v", check.Details["token_state"], check.Details)
+		}
+		if check.Details["token_expires"] == "" || !strings.Contains(check.Message, "token_state=expired") {
+			t.Fatalf("missing expiry detail/message: %#v", check)
+		}
+		return
+	}
+	t.Fatalf("missing broker check: %#v", view.Checks)
+}
+
 func TestDoctorSkipsProviderReadinessForCoordinatorUnsupportedProvider(t *testing.T) {
 	for _, tool := range []string{"git", "ssh", "ssh-keygen", "rsync", "curl"} {
 		if _, err := exec.LookPath(tool); err != nil {
@@ -504,4 +556,20 @@ func TestDoctorSkipsProviderReadinessForCoordinatorUnsupportedProvider(t *testin
 	if strings.Contains(stdout.String(), "failed  provider") {
 		t.Fatalf("unexpected provider failure: %q", stdout.String())
 	}
+}
+
+func testCrabboxUserToken(t *testing.T, expiresAt time.Time) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"typ":   "crabbox-user",
+		"owner": "alice@example.test",
+		"org":   "example-org",
+		"login": "alice",
+		"iat":   expiresAt.Add(-time.Hour).Unix(),
+		"exp":   expiresAt.Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "cbxu_" + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
 }


### PR DESCRIPTION
Summary:
- report decoded Crabbox user-token expiry metadata on broker auth failures
- surface expired broker tokens as `token_state=expired` in doctor JSON/details

Verification:
- go test ./internal/cli -run 'TestDoctorBrokerAuthFailure|TestDoctorSkipsProviderReadinessForCoordinatorUnsupportedProvider'
- go test ./internal/cli
- go run ./cmd/crabbox doctor -json (expected local failure; confirmed expired broker token is reported)
