### PR TITLE
fix: bind Azure Dynamic Sessions credential destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Source-bound Azure Dynamic Sessions bearer tokens to operator-approved endpoints instead of repository-selected destinations. Thanks @coygeek.
 - Let Islo use tenant defaults for implicit sandbox image and capacity while preserving every explicit config, environment, and flag override. Thanks @zozo123.
 - Made new runtime-adapter ticket claims provisional until agent connection or lease registration, allowing authenticated recovery of expired inactive first claims while preserving all existing and confirmed adapter IDs.
 - Separated shared automation tokens from signed user-token keys, preserving shared-token-only automation while requiring distinct session signing material for GitHub login.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3850,6 +3850,7 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 	if file.AzureDynamicSessions != nil {
 		if file.AzureDynamicSessions.Endpoint != "" {
 			cfg.AzureDynamicSessions.Endpoint = file.AzureDynamicSessions.Endpoint
+			cfg.credentialProvenance.azSessionsEndpoint = credentialSource
 		}
 		if file.AzureDynamicSessions.Pool != "" {
 			cfg.AzureDynamicSessions.Pool = file.AzureDynamicSessions.Pool
@@ -5897,7 +5898,10 @@ func applyEnv(cfg *Config) error {
 		cfg.AzureSSHCIDRs = splitCommaList(cidrs)
 	}
 	cfg.AzureNetwork = getenv("CRABBOX_AZURE_NETWORK", cfg.AzureNetwork)
-	cfg.AzureDynamicSessions.Endpoint = getenv("CRABBOX_AZURE_DYNAMIC_SESSIONS_ENDPOINT", cfg.AzureDynamicSessions.Endpoint)
+	if value := os.Getenv("CRABBOX_AZURE_DYNAMIC_SESSIONS_ENDPOINT"); value != "" {
+		cfg.AzureDynamicSessions.Endpoint = value
+		cfg.credentialProvenance.azSessionsEndpoint = credentialSourceEnvironment
+	}
 	cfg.AzureDynamicSessions.Pool = getenv("CRABBOX_AZURE_DYNAMIC_SESSIONS_POOL", cfg.AzureDynamicSessions.Pool)
 	cfg.AzureDynamicSessions.APIVersion = getenv("CRABBOX_AZURE_DYNAMIC_SESSIONS_API_VERSION", cfg.AzureDynamicSessions.APIVersion)
 	cfg.AzureDynamicSessions.Workdir = getenv("CRABBOX_AZURE_DYNAMIC_SESSIONS_WORKDIR", cfg.AzureDynamicSessions.Workdir)

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -24,6 +24,7 @@ type credentialDestinationProvenance struct {
 	accessClientID      credentialValueSource
 	accessClientSecret  credentialValueSource
 	accessToken         credentialValueSource
+	azSessionsEndpoint  credentialValueSource
 	proxmoxAPIURL       credentialValueSource
 	proxmoxTokenID      credentialValueSource
 	proxmoxTokenSecret  credentialValueSource
@@ -151,6 +152,9 @@ func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
 	}
 	if flagWasSet(fs, "sprites-api-url") {
 		provenance.spritesAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "azure-dynamic-sessions-endpoint") {
+		provenance.azSessionsEndpoint = credentialSourceFlag
 	}
 }
 
@@ -282,6 +286,10 @@ func validateProviderCredentialDestination(cfg Config) error {
 func ValidateNativeCredentialDestination(cfg Config, provider string) error {
 	provenance := cfg.credentialProvenance
 	switch normalizeProviderName(provider) {
+	case "azure-dynamic-sessions":
+		if provenance.azSessionsEndpoint == credentialSourceRepository {
+			return repositoryCredentialDestinationError("azure-dynamic-sessions", "azureDynamicSessions.endpoint", "CRABBOX_AZURE_DYNAMIC_SESSIONS_ENDPOINT or --azure-dynamic-sessions-endpoint")
+		}
 	case "daytona":
 		if provenance.daytonaAPIURL == credentialSourceRepository {
 			return repositoryCredentialDestinationError("daytona", "daytona.apiUrl", "CRABBOX_DAYTONA_API_URL or --daytona-api-url")

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -239,6 +239,17 @@ func TestNativeCredentialDestinationsRejectRepositoryEndpointsAtUse(t *testing.T
 		want     string
 	}{
 		{
+			name:     "azure dynamic sessions endpoint",
+			provider: "azure-dynamic-sessions",
+			cfg: Config{
+				AzureDynamicSessions: AzureDynamicSessionsConfig{Endpoint: "https://repo.example.test"},
+				credentialProvenance: credentialDestinationProvenance{
+					azSessionsEndpoint: credentialSourceRepository,
+				},
+			},
+			want: "azureDynamicSessions.endpoint",
+		},
+		{
 			name:     "daytona api",
 			provider: "daytona",
 			cfg: Config{
@@ -363,6 +374,28 @@ func TestRepositoryCredentialDestinationAllowsExplicitFlagOverride(t *testing.T)
 	}
 	if cfg.Proxmox.APIURL != "https://approved.example.test" {
 		t.Fatalf("proxmox apiUrl=%q", cfg.Proxmox.APIURL)
+	}
+}
+
+func TestAzureDynamicSessionsCredentialDestinationAllowsExplicitFlagOverride(t *testing.T) {
+	cfg := Config{
+		Provider: "azure-dynamic-sessions",
+		AzureDynamicSessions: AzureDynamicSessionsConfig{
+			Endpoint: "https://repo.pool.eastus.azurecontainerapps.io",
+		},
+		credentialProvenance: credentialDestinationProvenance{
+			azSessionsEndpoint: credentialSourceRepository,
+		},
+	}
+	fs := newFlagSet("test", io.Discard)
+	endpoint := fs.String("azure-dynamic-sessions-endpoint", cfg.AzureDynamicSessions.Endpoint, "")
+	if err := parseFlags(fs, []string{"--azure-dynamic-sessions-endpoint", "https://approved.pool.eastus.azurecontainerapps.io"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.AzureDynamicSessions.Endpoint = *endpoint
+	markCredentialDestinationFlagSources(&cfg, fs)
+	if err := ValidateNativeCredentialDestination(cfg, cfg.Provider); err != nil {
+		t.Fatalf("explicit flag override rejected: %v", err)
 	}
 }
 
@@ -500,6 +533,12 @@ func TestConfigMergeSourceBindsDirectProviderCredentials(t *testing.T) {
 		credentialEnv string
 		approveEnv    string
 	}{
+		{
+			name:       "azure dynamic sessions",
+			provider:   "azure-dynamic-sessions",
+			file:       fileConfig{AzureDynamicSessions: &fileAzureDynamicSessionsConfig{Endpoint: "https://repo.example.test"}},
+			approveEnv: "CRABBOX_AZURE_DYNAMIC_SESSIONS_ENDPOINT",
+		},
 		{
 			name:          "daytona",
 			provider:      "daytona",

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -90,6 +90,9 @@ func (e *azureDynamicSessionsAPIError) Error() string {
 }
 
 var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Runtime) (azureDynamicSessionsAPI, error) {
+	if err := validateNativeCredentialDestination(cfg); err != nil {
+		return nil, err
+	}
 	endpoint, err := azureDynamicSessionsEndpoint(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -60,6 +60,10 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
 }
 
+func validateNativeCredentialDestination(cfg Config) error {
+	return core.ValidateNativeCredentialDestination(cfg, providerName)
+}
+
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }


### PR DESCRIPTION
## Summary

- record Azure Dynamic Sessions endpoint provenance across trusted/repository config, environment, and CLI flags
- reject repository-selected endpoints immediately before inherited environment or Azure CLI bearer-token acquisition
- preserve explicit endpoint approval through `CRABBOX_AZURE_DYNAMIC_SESSIONS_ENDPOINT` or `--azure-dynamic-sessions-endpoint`
- add focused provenance regressions and changelog credit

Fixes https://github.com/openclaw/crabbox/issues/464

## Verification

- `go test ./internal/cli -run 'Test(NativeCredentialDestinationsRejectRepositoryEndpointsAtUse|ConfigMergeSourceBindsDirectProviderCredentials|AzureDynamicSessionsCredentialDestinationAllowsExplicitFlagOverride)' -count=1`
- `go test ./internal/providers/azuredynamicsessions -count=1`
- `go vet ./...`
- `go test -race ./internal/cli ./internal/providers/azuredynamicsessions`
- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking high --parallel-tests "go test -race ./internal/cli ./internal/providers/azuredynamicsessions"`

Autoreview result: clean; no accepted/actionable findings.

## Security/configuration

Repository configuration can still describe the endpoint for inspection and same-repository workflows, but Crabbox will not send inherited Azure Dynamic Sessions credentials there until the operator explicitly approves the destination through environment or CLI configuration.
