### PR TITLE
fix: block normalized internal coordinator routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.
 - Source-bound Azure Dynamic Sessions bearer tokens to operator-approved endpoints instead of repository-selected destinations. Thanks @coygeek.
 - Let Islo use tenant defaults for implicit sandbox image and capacity while preserving every explicit config, environment, and flag override. Thanks @zozo123.
 - Made new runtime-adapter ticket claims provisional until agent connection or lease registration, allowing authenticated recovery of expired inactive first claims while preserving all existing and confirmed adapter IDs.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -118,6 +118,7 @@ export function requestWithAuthContext(request: Request, auth: AuthContext): Req
   const headers = new Headers(request.headers);
   headers.delete("cf-access-authenticated-user-email");
   headers.delete("cf-access-jwt-assertion");
+  headers.delete("x-crabbox-internal");
   headers.delete("x-crabbox-proxy-secret");
   headers.set("x-crabbox-auth", auth.auth);
   headers.set("x-crabbox-admin", auth.admin ? "true" : "false");
@@ -136,11 +137,15 @@ export function requestWithAuthContext(request: Request, auth: AuthContext): Req
   return new Request(request, { headers });
 }
 
-export function requestWithoutProxySecret(request: Request): Request {
-  if (!request.headers.has("x-crabbox-proxy-secret")) {
+export function requestWithoutTrustedHeaders(request: Request): Request {
+  if (
+    !request.headers.has("x-crabbox-internal") &&
+    !request.headers.has("x-crabbox-proxy-secret")
+  ) {
     return request;
   }
   const headers = new Headers(request.headers);
+  headers.delete("x-crabbox-internal");
   headers.delete("x-crabbox-proxy-secret");
   return new Request(request, { headers });
 }

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -1,12 +1,12 @@
 import {
   authenticateRequest,
   requestWithAuthContext,
-  requestWithoutProxySecret,
+  requestWithoutTrustedHeaders,
   type AuthContext,
   type AuthRequestContext,
 } from "./auth";
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
-import { bearerToken, json } from "./http";
+import { bearerToken, json, pathParts } from "./http";
 import type { Env } from "./types";
 
 export type CoordinatorFetch = (request: Request) => Promise<Response>;
@@ -48,12 +48,13 @@ export async function prepareCoordinatorRequest(
     return { response: canonicalPortal, authenticated: false };
   }
   if (url.pathname.startsWith("/v1/auth/")) {
-    return { request: requestWithoutProxySecret(request), authenticated: false };
+    return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
   if (url.pathname === "/portal/login" || url.pathname === "/portal/logout") {
-    return { request: requestWithoutProxySecret(request), authenticated: false };
+    return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
-  if (url.pathname.startsWith("/v1/internal/")) {
+  const route = pathParts(request);
+  if (route[0] === "v1" && route[1] === "internal") {
     return {
       response: json({ error: "not_found" }, { status: 404 }),
       authenticated: false,
@@ -61,7 +62,7 @@ export async function prepareCoordinatorRequest(
   }
   if (isolatedCode) {
     return {
-      request: requestWithoutProxySecret(request),
+      request: requestWithoutTrustedHeaders(request),
       authenticated: false,
       bodyLimit: codeProxyRequestBodyBytes,
     };
@@ -72,12 +73,12 @@ export async function prepareCoordinatorRequest(
     isEgressAgentUpgrade(request, url) ||
     isRuntimeAdapterAgentUpgrade(request, url)
   ) {
-    return { request: requestWithoutProxySecret(request), authenticated: false };
+    return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
   const runtimeAdapterAuth = runtimeAdapterServiceAuth(request, env, url);
   if (runtimeAdapterAuth) {
     return {
-      request: requestWithAuthContext(requestWithoutProxySecret(request), runtimeAdapterAuth),
+      request: requestWithAuthContext(requestWithoutTrustedHeaders(request), runtimeAdapterAuth),
       authenticated: true,
     };
   }

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -134,7 +134,7 @@ describe("coordinator auth", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("strips the reverse-proxy secret from unauthenticated pass-through routes", async () => {
+  it("strips trusted headers from unauthenticated pass-through routes", async () => {
     const requests = [
       new Request("https://example.test/v1/auth/github/callback", {
         headers: { "x-crabbox-proxy-secret": "proxy-secret" },
@@ -153,6 +153,7 @@ describe("coordinator auth", () => {
         },
       }),
     ];
+    requests.forEach((request) => request.headers.set("x-crabbox-internal", "scheduled"));
 
     const routedRequests = await Promise.all(
       requests.map(async (request) => {
@@ -165,6 +166,12 @@ describe("coordinator auth", () => {
     );
 
     expect(routedRequests.map((request) => request.headers.get("x-crabbox-proxy-secret"))).toEqual([
+      null,
+      null,
+      null,
+      null,
+    ]);
+    expect(routedRequests.map((request) => request.headers.get("x-crabbox-internal"))).toEqual([
       null,
       null,
       null,
@@ -529,7 +536,12 @@ describe("coordinator auth", () => {
     ).rejects.toThrow("CRABBOX_SESSION_SECRET must differ");
   });
 
-  it("does not expose internal scheduled maintenance through public fetch", async () => {
+  it.each([
+    "/v1/internal/scheduled",
+    "/v1//internal/scheduled",
+    "/v1///internal/scheduled",
+    "//v1/internal/scheduled",
+  ])("does not expose internal scheduled maintenance through public fetch: %s", async (path) => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",
       CRABBOX_DEFAULT_ORG: "example-org",
@@ -542,7 +554,7 @@ describe("coordinator auth", () => {
     } as unknown as Env;
 
     const response = await coordinator.fetch(
-      new Request("https://example.test/v1/internal/scheduled", {
+      new Request(`https://example.test${path}`, {
         method: "POST",
         headers: {
           authorization: "Bearer shared",
@@ -562,6 +574,7 @@ describe("coordinator auth", () => {
       headers: {
         "cf-access-authenticated-user-email": "spoof@example.com",
         "x-crabbox-proxy-secret": "proxy-secret",
+        "x-crabbox-internal": "scheduled",
         "x-crabbox-owner": "spoof@example.com",
       },
     });
@@ -577,6 +590,7 @@ describe("coordinator auth", () => {
     expect(next.headers.get("cf-access-authenticated-user-email")).toBeNull();
     expect(next.headers.get("cf-access-jwt-assertion")).toBeNull();
     expect(next.headers.get("x-crabbox-proxy-secret")).toBeNull();
+    expect(next.headers.get("x-crabbox-internal")).toBeNull();
     expect(requestOwner(next)).toBe("friend@example.com");
     await expect(next.text()).resolves.toBe("request-body");
   });


### PR DESCRIPTION
## Summary

- detect external internal routes through the same normalized path parts used by Fleet dispatch
- block exact, double-slash, triple-slash, and repeated-leading-slash variants before authentication or Durable Object forwarding
- strip caller-controlled `x-crabbox-internal` and proxy-secret trust headers from authenticated and unauthenticated pass-through requests
- add coordinator regressions and changelog credit

Fixes https://github.com/openclaw/crabbox/issues/466

## Verification

- `npm test --prefix worker -- --run test/http.test.ts` — 27 passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 635 passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking high --parallel-tests "npm test --prefix worker"`

Autoreview result: clean; no accepted/actionable findings.

## Security

The Cloudflare scheduled handler still invokes Fleet directly with its internal header. Public Worker and Node coordinator requests are normalized and denied before Fleet, and all public pass-through paths remove the internal header defensively.
