### PR TITLE
fix: bound Cloudflare Access key fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Prevented unauthenticated Cloudflare Access key fetches and bounded key-set refresh work for invalid JWT key IDs. Thanks @coygeek.
 - Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.
 - Source-bound Azure Dynamic Sessions bearer tokens to operator-approved endpoints instead of repository-selected destinations. Thanks @coygeek.
 - Let Islo use tenant defaults for implicit sandbox image and capacity while preserving every explicit config, environment, and flag override. Thanks @zozo123.

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -4,7 +4,14 @@ import type { Env } from "./types";
 const tokenPrefix = "cbxu_";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
-const accessKeyCache = new Map<string, CryptoKey>();
+const accessJwtHeaderMaxChars = 2048;
+const accessJwtMaxChars = 32 * 1024;
+const accessKidMaxChars = 256;
+const accessKeySetTTLMS = 5 * 60 * 1000;
+const accessKeySetFailureTTLMS = 30 * 1000;
+const accessKeySetCacheMaxEntries = 8;
+const accessKeySetCache = new Map<string, AccessKeySetCacheEntry>();
+const accessKeySetLoads = new Map<string, Promise<AccessKeySetCacheEntry>>();
 
 export interface AuthContext {
   authorized: boolean;
@@ -51,8 +58,8 @@ export async function authenticateRequest(
 ): Promise<AuthContext | undefined> {
   const token = bearerToken(request);
   const trustedIdentity = context.trustedProxy ? trustedProxyIdentity(request, env) : undefined;
-  const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
   if (env.CRABBOX_ADMIN_TOKEN && token === env.CRABBOX_ADMIN_TOKEN) {
+    const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
     return {
       authorized: true,
       admin: true,
@@ -66,6 +73,7 @@ export async function authenticateRequest(
     };
   }
   if (env.CRABBOX_SHARED_TOKEN && token === env.CRABBOX_SHARED_TOKEN) {
+    const accessIdentity = await verifiedAccessIdentity(request, env).catch(() => undefined);
     return {
       authorized: true,
       admin: false,
@@ -330,6 +338,19 @@ interface AccessPublicJwk extends JsonWebKey {
   kid?: string;
 }
 
+interface AccessKeySetCacheEntry {
+  expiresAt: number;
+  jwks: Map<string, AccessPublicJwk>;
+  imported: Map<string, CryptoKey>;
+  invalid: Set<string>;
+  missRefreshUsed: boolean;
+}
+
+interface AccessKeySetLookup {
+  entry: AccessKeySetCacheEntry;
+  fromCache: boolean;
+}
+
 async function verifiedAccessIdentity(
   request: Request,
   env: Pick<Env, "CRABBOX_ACCESS_TEAM_DOMAIN" | "CRABBOX_ACCESS_AUD">,
@@ -340,12 +361,29 @@ async function verifiedAccessIdentity(
   if (!jwt || !teamDomain || !expectedAud) {
     return undefined;
   }
-  const [encodedHeader, encodedPayload, encodedSignature] = jwt.split(".");
-  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+  if (jwt.length > accessJwtMaxChars) {
+    return undefined;
+  }
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    return undefined;
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  if (
+    !encodedHeader ||
+    encodedHeader.length > accessJwtHeaderMaxChars ||
+    !encodedPayload ||
+    !encodedSignature
+  ) {
     return undefined;
   }
   const header = JSON.parse(decoder.decode(base64URLDecode(encodedHeader))) as AccessJwtHeader;
-  if (header.alg !== "RS256" || !header.kid) {
+  if (
+    header.alg !== "RS256" ||
+    typeof header.kid !== "string" ||
+    header.kid.length === 0 ||
+    header.kid.length > accessKidMaxChars
+  ) {
     return undefined;
   }
   const key = await accessPublicKey(teamDomain, header.kid);
@@ -376,29 +414,121 @@ async function verifiedAccessIdentity(
 }
 
 async function accessPublicKey(teamDomain: string, kid: string): Promise<CryptoKey | undefined> {
-  const cacheKey = `${teamDomain}:${kid}`;
-  const cached = accessKeyCache.get(cacheKey);
+  const lookup = await accessKeySet(teamDomain);
+  let keySet = lookup.entry;
+  const cached = keySet.imported.get(kid);
   if (cached) {
     return cached;
   }
-  const response = await fetch(`https://${teamDomain}/cdn-cgi/access/certs`);
-  if (!response.ok) {
+  if (keySet.invalid.has(kid)) {
     return undefined;
   }
-  const certs = (await response.json()) as AccessCerts;
-  const jwk = certs.keys?.find((key) => key.kid === kid);
+  let jwk = keySet.jwks.get(kid);
+  if (!jwk && lookup.fromCache && !keySet.missRefreshUsed) {
+    keySet.missRefreshUsed = true;
+    keySet = await refreshAccessKeySet(teamDomain);
+    jwk = keySet.jwks.get(kid);
+  } else if (!jwk && lookup.fromCache) {
+    const refreshing = accessKeySetLoads.get(teamDomain);
+    if (refreshing) {
+      keySet = await refreshing;
+      jwk = keySet.jwks.get(kid);
+    }
+  }
   if (!jwk) {
     return undefined;
   }
-  const key = await crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["verify"],
+  try {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+    keySet.imported.set(kid, key);
+    return key;
+  } catch {
+    keySet.invalid.add(kid);
+    return undefined;
+  }
+}
+
+async function accessKeySet(teamDomain: string): Promise<AccessKeySetLookup> {
+  const loading = accessKeySetLoads.get(teamDomain);
+  if (loading) {
+    return { entry: await loading, fromCache: false };
+  }
+  const now = Date.now();
+  const cached = accessKeySetCache.get(teamDomain);
+  if (cached && cached.expiresAt > now) {
+    accessKeySetCache.delete(teamDomain);
+    accessKeySetCache.set(teamDomain, cached);
+    return { entry: cached, fromCache: true };
+  }
+  accessKeySetCache.delete(teamDomain);
+  const load = fetchAccessKeySet(teamDomain).finally(() => accessKeySetLoads.delete(teamDomain));
+  accessKeySetLoads.set(teamDomain, load);
+  return { entry: await load, fromCache: false };
+}
+
+async function refreshAccessKeySet(teamDomain: string): Promise<AccessKeySetCacheEntry> {
+  const loading = accessKeySetLoads.get(teamDomain);
+  if (loading) {
+    return loading;
+  }
+  accessKeySetCache.delete(teamDomain);
+  const load = fetchAccessKeySet(teamDomain, true).finally(() =>
+    accessKeySetLoads.delete(teamDomain),
   );
-  accessKeyCache.set(cacheKey, key);
-  return key;
+  accessKeySetLoads.set(teamDomain, load);
+  return load;
+}
+
+async function fetchAccessKeySet(
+  teamDomain: string,
+  missRefreshUsed = false,
+): Promise<AccessKeySetCacheEntry> {
+  let keys: AccessPublicJwk[] = [];
+  let ttl = accessKeySetFailureTTLMS;
+  try {
+    const response = await fetch(`https://${teamDomain}/cdn-cgi/access/certs`);
+    if (response.ok) {
+      const certs = (await response.json()) as AccessCerts;
+      if (Array.isArray(certs.keys)) {
+        keys = certs.keys;
+        ttl = accessKeySetTTLMS;
+      }
+    }
+  } catch {
+    // Cache fetch failures briefly so an upstream outage cannot amplify request load.
+  }
+  const entry: AccessKeySetCacheEntry = {
+    expiresAt: Date.now() + ttl,
+    jwks: new Map(
+      keys
+        .filter(
+          (key): key is AccessPublicJwk & { kid: string } =>
+            typeof key.kid === "string" &&
+            key.kid.length > 0 &&
+            key.kid.length <= accessKidMaxChars,
+        )
+        .map((key) => [key.kid, key]),
+    ),
+    imported: new Map(),
+    invalid: new Set(),
+    missRefreshUsed,
+  };
+  accessKeySetCache.delete(teamDomain);
+  accessKeySetCache.set(teamDomain, entry);
+  while (accessKeySetCache.size > accessKeySetCacheMaxEntries) {
+    const oldest = accessKeySetCache.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    accessKeySetCache.delete(oldest);
+  }
+  return entry;
 }
 
 function normalizedAccessTeamDomain(value: string | undefined): string {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -330,11 +330,162 @@ describe("coordinator auth", () => {
     }
   });
 
+  it("does not fetch Cloudflare Access keys before Crabbox bearer authentication", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const env = {
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_ACCESS_TEAM_DOMAIN: "preauth.example.cloudflareaccess.com",
+        CRABBOX_ACCESS_AUD: "access-aud",
+      };
+      await Promise.all(
+        [undefined, "Bearer wrong"].map(async (authorization) => {
+          const headers = new Headers({
+            "cf-access-jwt-assertion": accessJwtShape("unknown-kid"),
+          });
+          if (authorization) {
+            headers.set("authorization", authorization);
+          }
+          await expect(
+            authenticateRequest(new Request("https://example.test/v1/leases", { headers }), env),
+          ).resolves.toBeUndefined();
+        }),
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("bounds Cloudflare Access key fetches for unknown kids", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const env = {
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SHARED_OWNER: "automation@example.com",
+        CRABBOX_ACCESS_TEAM_DOMAIN: "unknown-kid.example.cloudflareaccess.com",
+        CRABBOX_ACCESS_AUD: "access-aud",
+      };
+      const authenticateKid = (kid: string) =>
+        authenticateRequest(
+          new Request("https://example.test/v1/leases", {
+            headers: {
+              authorization: "Bearer shared",
+              "cf-access-jwt-assertion": accessJwtShape(kid),
+            },
+          }),
+          env,
+        );
+      const [first, repeated, different] = await Promise.all([
+        authenticateKid("missing-one"),
+        authenticateKid("missing-one"),
+        authenticateKid("missing-two"),
+      ]);
+      expect([first?.owner, repeated?.owner, different?.owner]).toEqual([
+        "automation@example.com",
+        "automation@example.com",
+        "automation@example.com",
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("refreshes a cached Cloudflare Access key set once for key rotation", async () => {
+    const domain = "rotation.example.cloudflareaccess.com";
+    const firstKey = await accessJwt({
+      kid: "rotation-one",
+      aud: "access-aud",
+      iss: `https://${domain}`,
+      email: "first@example.com",
+    });
+    const rotatedKey = await accessJwt({
+      kid: "rotation-two",
+      aud: "access-aud",
+      iss: `https://${domain}`,
+      email: "second@example.com",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [firstKey.publicJwk] })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [rotatedKey.publicJwk] })));
+    try {
+      const env = {
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_ACCESS_TEAM_DOMAIN: domain,
+        CRABBOX_ACCESS_AUD: "access-aud",
+      };
+      const authenticate = (jwt: string) =>
+        authenticateRequest(
+          new Request("https://example.test/v1/leases", {
+            headers: {
+              authorization: "Bearer shared",
+              "cf-access-jwt-assertion": jwt,
+            },
+          }),
+          env,
+        );
+      await expect(authenticate(firstKey.jwt)).resolves.toMatchObject({
+        owner: "first@example.com",
+      });
+      const rotated = await Promise.all([
+        authenticate(rotatedKey.jwt),
+        authenticate(rotatedKey.jwt),
+        authenticate(rotatedKey.jwt),
+      ]);
+      expect(rotated.map((auth) => auth?.owner)).toEqual([
+        "second@example.com",
+        "second@example.com",
+        "second@example.com",
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("rejects oversized Cloudflare Access key ids without fetching", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ keys: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    try {
+      const auth = await authenticateRequest(
+        new Request("https://example.test/v1/leases", {
+          headers: {
+            authorization: "Bearer shared",
+            "cf-access-jwt-assertion": accessJwtShape("x".repeat(257)),
+          },
+        }),
+        {
+          CRABBOX_SHARED_TOKEN: "shared",
+          CRABBOX_SHARED_OWNER: "automation@example.com",
+          CRABBOX_ACCESS_TEAM_DOMAIN: "oversized.example.cloudflareaccess.com",
+          CRABBOX_ACCESS_AUD: "access-aud",
+        },
+      );
+      expect(auth?.owner).toBe("automation@example.com");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("normalizes Cloudflare Access team domains before fetching certs", async () => {
     const { jwt, publicJwk } = await accessJwt({
       kid: "access-test-kid-url",
       aud: "access-aud",
-      iss: "https://team.example.cloudflareaccess.com",
+      iss: "https://team-url.example.cloudflareaccess.com",
       email: "verified@example.com",
     });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -354,14 +505,14 @@ describe("coordinator auth", () => {
         {
           CRABBOX_SHARED_TOKEN: "shared",
           CRABBOX_DEFAULT_ORG: "example-org",
-          CRABBOX_ACCESS_TEAM_DOMAIN: "https://team.example.cloudflareaccess.com/path",
+          CRABBOX_ACCESS_TEAM_DOMAIN: "https://team-url.example.cloudflareaccess.com/path",
           CRABBOX_ACCESS_AUD: "access-aud",
         },
       );
 
       expect(auth.owner).toBe("verified@example.com");
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://team.example.cloudflareaccess.com/cdn-cgi/access/certs",
+        "https://team-url.example.cloudflareaccess.com/cdn-cgi/access/certs",
       );
     } finally {
       fetchMock.mockRestore();
@@ -722,4 +873,12 @@ async function accessJwt(input: {
     new TextEncoder().encode(`${header}.${payload}`),
   );
   return { jwt: `${header}.${payload}.${base64URL(new Uint8Array(signature))}`, publicJwk };
+}
+
+function accessJwtShape(kid: string): string {
+  return `${encodeAccessJwtPart({ alg: "RS256", kid, typ: "JWT" })}.${encodeAccessJwtPart({})}.signature`;
+}
+
+function encodeAccessJwtPart(value: object): string {
+  return base64URL(new TextEncoder().encode(JSON.stringify(value)));
 }


### PR DESCRIPTION
## Summary

- defer Cloudflare Access JWT verification until the request presents a valid Crabbox admin/shared bearer token
- cache JWK sets per normalized Access team domain with bounded TTL/LRU storage, single-flight loads, and short failure throttling
- permit one bounded refresh on cached key misses so normal Access signing-key rotation remains transparent
- bound JWT/header/key-ID input and cache invalid key imports
- add pre-auth, unknown-key, concurrency, rotation, and oversized-input regressions plus changelog credit

Fixes https://github.com/openclaw/crabbox/issues/462

## Verification

- `npm test --prefix worker -- --run test/http.test.ts` — 31 passed
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` — 639 passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --thinking high --parallel-tests "npm test --prefix worker"`

Autoreview found and drove two in-scope key-rotation fixes: refresh on cached key miss, then concurrent callers joining the in-flight refresh. Final autoreview: clean; no accepted/actionable findings.

## Security

Unauthenticated and invalid-token requests perform no Access certificate fetches. Requests with valid Crabbox bearer credentials retain verified Access owner attribution, including during a bounded signing-key rotation refresh.
