### PR TITLE
[codex] fix coordinator list auth routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Prevented unauthenticated Cloudflare Access key fetches and bounded key-set refresh work for invalid JWT key IDs. Thanks @coygeek.
 - Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.
 - Source-bound Azure Dynamic Sessions bearer tokens to operator-approved endpoints instead of repository-selected destinations. Thanks @coygeek.
+- Made coordinator-backed `crabbox list` query the user's active orchestrator leases directly, reserving admin-wide machine inventory for `--all` and avoiding stale admin-token warnings during ordinary listing.
 - Let Islo use tenant defaults for implicit sandbox image and capacity while preserving every explicit config, environment, and flag override. Thanks @zozo123.
 - Made new runtime-adapter ticket claims provisional until agent connection or lease registration, allowing authenticated recovery of expired inactive first claims while preserving all existing and confirmed adapter IDs.
 - Separated shared automation tokens from signed user-token keys, preserving shared-token-only automation while requiring distinct session signing material for GitHub login.

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -20,7 +20,8 @@ crabbox list --json
 The shape of the output depends on the selected `--provider`:
 
 - **Coordinator-backed providers** (`hetzner`, `aws`, `azure`, `gcp` with a broker
-  configured) list the leases the broker tracks for you.
+  configured) list the leases the broker tracks for you. Add `--all` to request
+  admin-wide provider inventory when an admin token is configured.
 - **Direct cloud / hypervisor / static providers** list the machines the provider
   itself reports. In `provider=ssh` mode this prints the single configured static
   target.

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -257,6 +257,13 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 }
 
 func (b *coordinatorLeaseBackend) List(ctx context.Context, req ListRequest) ([]Server, error) {
+	if !req.All {
+		leases, err := b.listUserLeases(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return coordinatorLeasesToServers(leases, b.cfg), nil
+	}
 	machines, activeLeaseIDs, err := b.listMachines(ctx)
 	if err != nil {
 		leases, fallbackErr := b.listLeasesFallback(ctx, err)
@@ -269,12 +276,22 @@ func (b *coordinatorLeaseBackend) List(ctx context.Context, req ListRequest) ([]
 }
 
 func (b *coordinatorLeaseBackend) ListJSON(ctx context.Context, req ListRequest) (any, error) {
-	_ = req
+	if !req.All {
+		return b.listUserLeases(ctx)
+	}
 	machines, _, err := b.listMachines(ctx)
 	if err != nil {
 		return b.listLeasesFallback(ctx, err)
 	}
 	return machines, nil
+}
+
+func (b *coordinatorLeaseBackend) listUserLeases(ctx context.Context) ([]CoordinatorLease, error) {
+	leases, err := b.coord.Leases(ctx, "active", 1000)
+	if err != nil {
+		return nil, err
+	}
+	return filterCoordinatorLeasesForProvider(leases, b.cfg.Provider), nil
 }
 
 func (b *coordinatorLeaseBackend) listMachines(ctx context.Context) ([]CoordinatorMachine, map[string]struct{}, error) {
@@ -311,11 +328,7 @@ func (b *coordinatorLeaseBackend) listLeasesFallback(ctx context.Context, adminE
 	} else if adminErr != nil {
 		return nil, adminErr
 	}
-	leases, err := b.coord.Leases(ctx, "active", 1000)
-	if err != nil {
-		return nil, err
-	}
-	return filterCoordinatorLeasesForProvider(leases, b.cfg.Provider), nil
+	return b.listUserLeases(ctx)
 }
 
 func coordinatorLeasesToServers(leases []CoordinatorLease, cfg Config) []Server {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -11,14 +11,12 @@ import (
 	"time"
 )
 
-func TestCoordinatorListFallsBackToUserLeasesWhenAdminTokenUnauthorized(t *testing.T) {
+func TestCoordinatorListUsesUserLeasesWithoutAdminProbe(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/pool":
-			if got := r.Header.Get("Authorization"); got != "Bearer stale-admin-token" {
-				t.Fatalf("pool auth=%q", got)
-			}
-			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			t.Error("ordinary list must not probe the admin pool")
+			http.Error(w, "unexpected admin probe", http.StatusInternalServerError)
 		case "/v1/leases":
 			if got := r.URL.Query().Get("state"); got != "active" {
 				t.Fatalf("leases state=%q", got)
@@ -76,12 +74,59 @@ func TestCoordinatorListFallsBackToUserLeasesWhenAdminTokenUnauthorized(t *testi
 	if servers[0].Labels["lease"] != "cbx_123" || servers[0].Labels["slug"] != "blue-lobster" {
 		t.Fatalf("server labels=%#v", servers[0].Labels)
 	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected warning: %q", stderr.String())
+	}
+}
+
+func TestCoordinatorListAllFallsBackToUserLeasesWhenAdminTokenUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/pool":
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-admin-token" {
+				t.Fatalf("pool auth=%q", got)
+			}
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		case "/v1/leases":
+			if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+				t.Fatalf("leases auth=%q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"leases": []CoordinatorLease{
+				{ID: "cbx_123", Provider: "aws", State: "active"},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var stderr bytes.Buffer
+	cfg := Config{
+		Provider:        "aws",
+		TargetOS:        targetLinux,
+		Coordinator:     server.URL,
+		CoordToken:      "user-token",
+		CoordAdminToken: "stale-admin-token",
+	}
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
+
+	servers, err := backend.List(context.Background(), ListRequest{All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Labels["lease"] != "cbx_123" {
+		t.Fatalf("servers=%#v", servers)
+	}
 	if !strings.Contains(stderr.String(), "falling back to user-visible leases") {
 		t.Fatalf("missing fallback warning: %q", stderr.String())
 	}
 }
 
-func TestCoordinatorListJSONFallsBackWhenAdminTokenMissing(t *testing.T) {
+func TestCoordinatorListJSONUsesUserLeasesWhenAdminTokenMissing(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/leases" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
@@ -100,7 +145,8 @@ func TestCoordinatorListJSONFallsBackWhenAdminTokenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
+	var stderr bytes.Buffer
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
 	view, err := backend.ListJSON(context.Background(), ListRequest{})
 	if err != nil {
@@ -112,6 +158,9 @@ func TestCoordinatorListJSONFallsBackWhenAdminTokenMissing(t *testing.T) {
 	}
 	if len(leases) != 1 || leases[0].ID != "cbx_123" {
 		t.Fatalf("leases=%#v", leases)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected warning: %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- query owner-scoped active leases directly for ordinary coordinator-backed `crabbox list`
- reserve admin-wide machine inventory for `crabbox list --all`, preserving its user-lease fallback
- add regression coverage and update command docs/changelog

## Root cause

Ordinary coordinator-backed listing probed the admin machine-pool endpoint before falling back to the owner-scoped lease endpoint. A stale operator credential therefore produced a misleading warning even though normal user authentication and listing worked.

## Validation

- `go test -race ./internal/cli -run '^TestCoordinatorList' -count=20`
- `go test ./internal/cli`
- `go vet ./...`
- structured Codex autoreview: clean, no actionable findings
