### PR TITLE
fix: revoke Code viewer sessions on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Revoked isolated Code viewer sessions when their GitHub portal session logs out, preventing stale viewer cookies from retaining prior-owner lease access. Thanks @coygeek.
 - Prevented unauthenticated Cloudflare Access key fetches and bounded key-set refresh work for invalid JWT key IDs. Thanks @coygeek.
 - Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.
 - Source-bound Azure Dynamic Sessions bearer tokens to operator-approved endpoints instead of repository-selected destinations. Thanks @coygeek.

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -33,7 +33,7 @@ GET  /portal/runners/{provider}/{runner-id}      external runner detail
 GET  /portal/hosts/{provider}/{host-id}          dedicated host detail
 POST /portal/hosts/{provider}/{host-id}/vnc      enable VNC on the host's lease
 GET  /portal/login                               GitHub OAuth login redirect
-GET  /portal/logout                              clear the session cookie
+GET  /portal/logout                              end the portal and isolated Code sessions
 ```
 
 The WebVNC viewer page also drives a small set of bridge sub-routes that the
@@ -67,6 +67,9 @@ use the Code session on other portal routes or lease origins. The ingress must
 provide wildcard TLS and WebSocket routing for the template.
 Proxied responses may set only code-server's `vscode-tkn` cookie; Crabbox removes
 domain scope and confines it to that lease's Code path.
+Portal logout revokes isolated Code viewer sessions server-side, so their
+separate host-scoped cookies cannot retain access after the portal cookie is
+cleared.
 
 The setting is opt-in because Crabbox cannot provision an operator's wildcard
 DNS, certificate, or ingress route. When the setting is absent or invalid, Code

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -29,6 +29,7 @@ export interface AuthRequestContext {
 
 interface UserTokenPayload {
   typ: "crabbox-user";
+  jti?: string;
   owner: string;
   org: string;
   login: string;
@@ -175,6 +176,7 @@ export async function issueUserToken(
   const now = Math.floor(Date.now() / 1000);
   const payload: UserTokenPayload = {
     typ: "crabbox-user",
+    jti: crypto.randomUUID(),
     owner: input.owner,
     org: input.org,
     login: input.login,

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1041,6 +1041,7 @@ export class FleetCoordinator {
     const now = Date.now();
     const revoked = new Map<string, string>();
     const revokedCodeViewers = new Map<WebSocket, string>();
+    const codeViewersToCheck: Array<{ socket: WebSocket; portalSessionHash?: string }> = [];
     for (const socket of this.restoredLeaseBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment || !("leaseID" in attachment)) {
@@ -1054,12 +1055,25 @@ export class FleetCoordinator {
         );
         continue;
       }
-      if (
-        attachment.kind === "code-viewer" &&
-        attachment.auth === "github" &&
-        (!validPortalSessionHash(attachment.portalSessionHash) ||
-          (await this.codeViewerPortalSessionRevoked(attachment.portalSessionHash)))
-      ) {
+      if (attachment.kind === "code-viewer" && attachment.auth === "github") {
+        codeViewersToCheck.push({
+          socket,
+          ...(attachment.portalSessionHash
+            ? { portalSessionHash: attachment.portalSessionHash }
+            : {}),
+        });
+      }
+    }
+    const codeViewerRevocations = await Promise.all(
+      codeViewersToCheck.map(async ({ socket, portalSessionHash }) => ({
+        socket,
+        revoked:
+          !validPortalSessionHash(portalSessionHash) ||
+          (await this.codeViewerPortalSessionRevoked(portalSessionHash)),
+      })),
+    );
+    for (const { socket, revoked: portalSessionRevoked } of codeViewerRevocations) {
+      if (portalSessionRevoked) {
         revokedCodeViewers.set(socket, "portal session ended");
       }
     }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3,7 +3,13 @@ import ssh2, { type Client as SSHClient, type ClientChannel } from "ssh2";
 const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 
 import { artifactUploadResponse, type ArtifactUploadRequest } from "./artifacts";
-import { isAdminRequest, requestWithAuthContext, sha256Hex, type AuthContext } from "./auth";
+import {
+  authenticateRequest,
+  isAdminRequest,
+  requestWithAuthContext,
+  sha256Hex,
+  type AuthContext,
+} from "./auth";
 import {
   EC2SpotClient,
   awsConfiguredSecurityGroupID,
@@ -44,7 +50,7 @@ import {
   hetznerProvisioningFailureRetryable,
   sshPublicKeyIdentity,
 } from "./hetzner";
-import { errorMessage, json, pathParts, readJson, requestOwner } from "./http";
+import { bearerToken, errorMessage, json, pathParts, readJson, requestOwner } from "./http";
 import { githubAuthRoute, githubPortalLogin, githubPortalLogout } from "./oauth";
 import { defaultOSImage, normalizeOSImage } from "./os-image";
 import {
@@ -225,6 +231,7 @@ interface CodeViewerTicketRecord {
   owner: string;
   org: string;
   login?: string;
+  portalSessionHash?: string;
   returnTo: string;
   viewerExpiresAt?: string;
   createdAt: string;
@@ -239,6 +246,13 @@ interface CodeViewerSessionRecord {
   owner: string;
   org: string;
   login?: string;
+  portalSessionHash?: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+interface CodeViewerSessionRevocationRecord {
+  portalSessionHash: string;
   createdAt: string;
   expiresAt: string;
 }
@@ -735,7 +749,7 @@ export class FleetCoordinator {
         return await githubPortalLogin(request, this.state.storage, this.env);
       }
       if (method === "GET" && parts.join("/") === "portal/logout") {
-        return githubPortalLogout();
+        return await this.portalLogout(request);
       }
       if (parts[0] === "portal") {
         return await this.portalRoute(request, parts);
@@ -6721,10 +6735,22 @@ export class FleetCoordinator {
   ): Promise<Response> {
     await this.cleanupExpiredCodeViewerAuth();
     const now = new Date();
+    const auth = requestAuthType(request);
+    let portalSessionHash: string | undefined;
+    if (auth === "github") {
+      const token = bearerToken(request);
+      if (!token) {
+        return portalError("Code session ended", "Log in again to open Code.", 401);
+      }
+      portalSessionHash = await sha256Hex(token);
+      if (await this.codeViewerPortalSessionRevoked(portalSessionHash)) {
+        return portalError("Code session ended", "Log in again to open Code.", 401);
+      }
+    }
     const ticket: CodeViewerTicketRecord = {
       ticket: newCodeViewerTicket(),
       leaseID: lease.id,
-      auth: requestAuthType(request),
+      auth,
       admin: isAdminRequest(request),
       owner: requestOwner(request),
       org: requestOrg(request, this.env),
@@ -6732,6 +6758,9 @@ export class FleetCoordinator {
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + codeViewerTicketTTLSeconds * 1000).toISOString(),
     };
+    if (portalSessionHash) {
+      ticket.portalSessionHash = portalSessionHash;
+    }
     const login = request.headers.get("x-crabbox-github-login")?.trim();
     if (login) {
       ticket.login = login;
@@ -6765,6 +6794,16 @@ export class FleetCoordinator {
         { status: 401, headers: { "cache-control": "no-store" } },
       );
     }
+    if (
+      (ticket.auth === "github" && !validPortalSessionHash(ticket.portalSessionHash)) ||
+      (ticket.portalSessionHash &&
+        (await this.codeViewerPortalSessionRevoked(ticket.portalSessionHash)))
+    ) {
+      return json(
+        { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
+        { status: 401, headers: { "cache-control": "no-store" } },
+      );
+    }
     const now = new Date();
     const defaultExpiresAt = now.getTime() + codeViewerSessionTTLSeconds * 1000;
     const tokenExpiresAt = Date.parse(ticket.viewerExpiresAt ?? "");
@@ -6783,6 +6822,9 @@ export class FleetCoordinator {
     };
     if (ticket.login) {
       session.login = ticket.login;
+    }
+    if (ticket.portalSessionHash) {
+      session.portalSessionHash = ticket.portalSessionHash;
     }
     await this.state.storage.put(codeViewerSessionKey(session.session), session);
     return new Response(null, {
@@ -6814,7 +6856,10 @@ export class FleetCoordinator {
       !session ||
       session.session !== value ||
       session.leaseID !== leaseID ||
-      Date.parse(session.expiresAt) <= Date.now()
+      Date.parse(session.expiresAt) <= Date.now() ||
+      (session.auth === "github" && !validPortalSessionHash(session.portalSessionHash)) ||
+      (session.portalSessionHash &&
+        (await this.codeViewerPortalSessionRevoked(session.portalSessionHash)))
     ) {
       if (session) {
         await this.state.storage.delete(codeViewerSessionKey(value));
@@ -6875,9 +6920,13 @@ export class FleetCoordinator {
   private async cleanupExpiredCodeViewerAuth(): Promise<void> {
     const now = Date.now();
     await Promise.all(
-      [codeViewerTicketPrefix(), codeViewerSessionPrefix()].map(async (prefix) => {
+      [
+        codeViewerTicketPrefix(),
+        codeViewerSessionPrefix(),
+        codeViewerSessionRevocationPrefix(),
+      ].map(async (prefix) => {
         const records = await this.state.storage.list<
-          CodeViewerTicketRecord | CodeViewerSessionRecord
+          CodeViewerTicketRecord | CodeViewerSessionRecord | CodeViewerSessionRevocationRecord
         >({ prefix });
         await Promise.all(
           [...records.entries()]
@@ -6886,6 +6935,47 @@ export class FleetCoordinator {
         );
       }),
     );
+  }
+
+  private async portalLogout(request: Request): Promise<Response> {
+    await this.cleanupExpiredCodeViewerAuth();
+    const token = cookieValue(request.headers.get("cookie") ?? "", "crabbox_session");
+    if (token) {
+      const headers = new Headers(request.headers);
+      headers.set("authorization", `Bearer ${token}`);
+      const auth = await authenticateRequest(new Request(request, { headers }), this.env);
+      if (auth?.auth === "github") {
+        const portalSessionHash = await sha256Hex(token);
+        const now = new Date();
+        const tokenExpiresAt = Date.parse(auth.tokenExpiresAt ?? "");
+        const revocationExpiresAt = now.getTime() + codeViewerSessionTTLSeconds * 1000;
+        const expiresAt = Number.isFinite(tokenExpiresAt)
+          ? Math.min(revocationExpiresAt, tokenExpiresAt)
+          : revocationExpiresAt;
+        await this.state.storage.put<CodeViewerSessionRevocationRecord>(
+          codeViewerSessionRevocationKey(portalSessionHash),
+          {
+            portalSessionHash,
+            createdAt: now.toISOString(),
+            expiresAt: new Date(expiresAt).toISOString(),
+          },
+        );
+      }
+    }
+    return githubPortalLogout();
+  }
+
+  private async codeViewerPortalSessionRevoked(portalSessionHash: string): Promise<boolean> {
+    const key = codeViewerSessionRevocationKey(portalSessionHash);
+    const revocation = await this.state.storage.get<CodeViewerSessionRevocationRecord>(key);
+    if (!revocation || revocation.portalSessionHash !== portalSessionHash) {
+      return false;
+    }
+    if (Date.parse(revocation.expiresAt) > Date.now()) {
+      return true;
+    }
+    await this.state.storage.delete(key);
+    return false;
   }
 
   private codePortalHealth(lease: LeaseRecord, agent: WebSocket | undefined): Response {
@@ -11113,6 +11203,14 @@ function codeViewerSessionKey(session: string): string {
   return `${codeViewerSessionPrefix()}${session}`;
 }
 
+function codeViewerSessionRevocationPrefix(): string {
+  return "code-viewer-session-revocation:";
+}
+
+function codeViewerSessionRevocationKey(portalSessionHash: string): string {
+  return `${codeViewerSessionRevocationPrefix()}${portalSessionHash}`;
+}
+
 function egressTicketPrefix(): string {
   return "egress-ticket:";
 }
@@ -12074,6 +12172,10 @@ function validCodeViewerTicket(value: string | undefined): value is string {
 
 function validCodeViewerSession(value: string | undefined): value is string {
   return typeof value === "string" && /^code_session_[a-f0-9]{32}$/.test(value);
+}
+
+function validPortalSessionHash(value: string | undefined): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
 }
 
 function canonicalCodeReturnTo(request: Request, leaseID: string): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -639,7 +639,13 @@ type BridgeAttachment =
       label: string;
     }
   | { kind: "code-agent"; leaseID: string }
-  | { kind: "code-viewer"; leaseID: string; id: string }
+  | {
+      kind: "code-viewer";
+      leaseID: string;
+      id: string;
+      auth: AuthContext["auth"];
+      portalSessionHash?: string;
+    }
   | { kind: "egress-host"; leaseID: string; sessionID: string }
   | { kind: "egress-client"; leaseID: string; sessionID: string }
   | {
@@ -1034,6 +1040,7 @@ export class FleetCoordinator {
     const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
     const now = Date.now();
     const revoked = new Map<string, string>();
+    const revokedCodeViewers = new Map<WebSocket, string>();
     for (const socket of this.restoredLeaseBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
       if (!attachment || !("leaseID" in attachment)) {
@@ -1045,6 +1052,15 @@ export class FleetCoordinator {
           attachment.leaseID,
           lease && leaseIsLive(lease) ? "lease expired" : "lease ended",
         );
+        continue;
+      }
+      if (
+        attachment.kind === "code-viewer" &&
+        attachment.auth === "github" &&
+        (!validPortalSessionHash(attachment.portalSessionHash) ||
+          (await this.codeViewerPortalSessionRevoked(attachment.portalSessionHash)))
+      ) {
+        revokedCodeViewers.set(socket, "portal session ended");
       }
     }
     for (const [leaseID, reason] of revoked) {
@@ -1057,6 +1073,14 @@ export class FleetCoordinator {
       if (reason) {
         closeSocket(socket, 1008, reason);
       }
+    }
+    for (const [socket, reason] of revokedCodeViewers) {
+      const attachment = this.bridgeAttachment(socket);
+      if (attachment?.kind !== "code-viewer") {
+        continue;
+      }
+      this.clearCodeViewer(attachment.leaseID, attachment.id, socket, 1008, reason);
+      closeSocket(socket, 1008, reason);
     }
     this.restoredLeaseBridgeSockets.clear();
   }
@@ -6679,6 +6703,7 @@ export class FleetCoordinator {
       return await this.bootstrapCodeViewer(request, identifier);
     }
     let authorizedRequest = request;
+    let viewerSession: CodeViewerSessionRecord | undefined;
     if (isolated) {
       const session = await this.codeViewerSession(request, identifier);
       if (!session) {
@@ -6690,6 +6715,7 @@ export class FleetCoordinator {
           { status: 403 },
         );
       }
+      viewerSession = session;
       authorizedRequest = requestWithAuthContext(request, {
         authorized: true,
         admin: session.admin,
@@ -6723,7 +6749,25 @@ export class FleetCoordinator {
       return portalCode(lease);
     }
     if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-      return this.codeViewerWebSocket(authorizedRequest, lease, agent);
+      const auth = viewerSession?.auth ?? requestAuthType(authorizedRequest);
+      let portalSessionHash = viewerSession?.portalSessionHash;
+      if (auth === "github" && !portalSessionHash) {
+        const token = bearerToken(authorizedRequest);
+        if (!token) {
+          return json(
+            { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
+            { status: 401, headers: { "cache-control": "no-store" } },
+          );
+        }
+        portalSessionHash = await sha256Hex(token);
+      }
+      return await this.codeViewerWebSocket(
+        authorizedRequest,
+        lease,
+        agent,
+        auth,
+        portalSessionHash,
+      );
     }
     return await this.codeProxyHTTP(authorizedRequest, lease, agent);
   }
@@ -6952,14 +6996,17 @@ export class FleetCoordinator {
         const expiresAt = Number.isFinite(tokenExpiresAt)
           ? Math.min(revocationExpiresAt, tokenExpiresAt)
           : revocationExpiresAt;
-        await this.state.storage.put<CodeViewerSessionRevocationRecord>(
-          codeViewerSessionRevocationKey(portalSessionHash),
-          {
-            portalSessionHash,
-            createdAt: now.toISOString(),
-            expiresAt: new Date(expiresAt).toISOString(),
-          },
-        );
+        await this.withBridgeTicketLock(async () => {
+          await this.state.storage.put<CodeViewerSessionRevocationRecord>(
+            codeViewerSessionRevocationKey(portalSessionHash),
+            {
+              portalSessionHash,
+              createdAt: now.toISOString(),
+              expiresAt: new Date(expiresAt).toISOString(),
+            },
+          );
+          this.closeCodeViewersForPortalSession(portalSessionHash);
+        });
       }
     }
     return githubPortalLogout();
@@ -7037,21 +7084,44 @@ export class FleetCoordinator {
     });
   }
 
-  private codeViewerWebSocket(request: Request, lease: LeaseRecord, agent: WebSocket): Response {
-    const upgrade = this.state.createWebSocketUpgrade();
-    const viewer = upgrade.socket;
-    const id = crypto.randomUUID();
-    this.codeViewers.set(id, viewer);
-    this.acceptBridgeWebSocket(viewer, { kind: "code-viewer", leaseID: lease.id, id });
-    const url = new URL(request.url);
-    const open: CodeWebSocketOpen = {
-      type: "ws_open",
-      id,
-      path: `${url.pathname}${url.search}`,
-      headers: codeForwardHeaders(request.headers),
-    };
-    agent.send(JSON.stringify(open));
-    return upgrade.response;
+  private async codeViewerWebSocket(
+    request: Request,
+    lease: LeaseRecord,
+    agent: WebSocket,
+    auth: AuthContext["auth"],
+    portalSessionHash?: string,
+  ): Promise<Response> {
+    return await this.withBridgeTicketLock(async () => {
+      if (
+        (auth === "github" && !validPortalSessionHash(portalSessionHash)) ||
+        (portalSessionHash && (await this.codeViewerPortalSessionRevoked(portalSessionHash)))
+      ) {
+        return json(
+          { error: "code_viewer_session_revoked", message: "Code viewer session has ended" },
+          { status: 401, headers: { "cache-control": "no-store" } },
+        );
+      }
+      const upgrade = this.state.createWebSocketUpgrade();
+      const viewer = upgrade.socket;
+      const id = crypto.randomUUID();
+      this.codeViewers.set(id, viewer);
+      this.acceptBridgeWebSocket(viewer, {
+        kind: "code-viewer",
+        leaseID: lease.id,
+        id,
+        auth,
+        ...(portalSessionHash ? { portalSessionHash } : {}),
+      });
+      const url = new URL(request.url);
+      const open: CodeWebSocketOpen = {
+        type: "ws_open",
+        id,
+        path: `${url.pathname}${url.search}`,
+        headers: codeForwardHeaders(request.headers),
+      };
+      agent.send(JSON.stringify(open));
+      return upgrade.response;
+    });
   }
 
   private sendCodeWebSocketData(agent: WebSocket, message: CodeWebSocketData): void {
@@ -7219,6 +7289,20 @@ export class FleetCoordinator {
     const message: CodeWebSocketClose = { type: "ws_close", id, code, reason };
     if (agent?.readyState === WebSocket.OPEN) {
       agent.send(JSON.stringify(message));
+    }
+  }
+
+  private closeCodeViewersForPortalSession(portalSessionHash: string): void {
+    for (const [id, viewer] of this.codeViewers) {
+      const attachment = this.bridgeAttachment(viewer);
+      if (
+        attachment?.kind !== "code-viewer" ||
+        attachment.portalSessionHash !== portalSessionHash
+      ) {
+        continue;
+      }
+      this.clearCodeViewer(attachment.leaseID, id, viewer, 1008, "portal session ended");
+      closeSocket(viewer, 1008, "portal session ended");
     }
   }
 
@@ -12821,7 +12905,18 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
     case "code-agent":
       return typeof attachment.leaseID === "string" ? attachment : undefined;
     case "code-viewer":
-      return typeof attachment.leaseID === "string" && typeof attachment.id === "string"
+      if (typeof attachment.leaseID !== "string" || typeof attachment.id !== "string") {
+        return undefined;
+      }
+      if (attachment.auth === undefined) {
+        // Pre-revocation attachments carried no auth binding; restore them only long enough to
+        // fail closed through the normal viewer/agent shutdown path.
+        return { ...attachment, auth: "github" };
+      }
+      return (attachment.auth === "bearer" ||
+        attachment.auth === "github" ||
+        attachment.auth === "proxy") &&
+        (attachment.auth !== "github" || validPortalSessionHash(attachment.portalSessionHash))
         ? attachment
         : undefined;
     case "egress-host":

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3,7 +3,7 @@ import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { issueUserToken } from "../src/auth";
+import { issueUserToken, sha256Hex } from "../src/auth";
 import { EC2SpotClient } from "../src/aws";
 import {
   awsPromotedAMIConfigKey,
@@ -209,6 +209,71 @@ describe("runtime adapter relay", () => {
     };
     expect(relay.codeAgents.get(lease.id)).toBe(restored[0]);
     expect(relay.runtimeAdapterAgents.get("example-adapter")).toBe(restored[3]);
+  });
+
+  it("rejects hibernated Code viewers whose portal session logged out", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000001",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const portalSessionHash = "a".repeat(64);
+    storage.seed(`code-viewer-session-revocation:${portalSessionHash}`, {
+      portalSessionHash,
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const agent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const viewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "viewer-revoked",
+      auth: "github",
+      portalSessionHash,
+    });
+    const legacyViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "viewer-legacy",
+    });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () => [agent, viewer, legacyViewer] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    expect(viewer.closeCode).toBe(1008);
+    expect(viewer.closeReason).toBe("portal session ended");
+    expect(legacyViewer.closeCode).toBe(1008);
+    expect(legacyViewer.closeReason).toBe("portal session ended");
+    expect(agent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: "viewer-revoked",
+        code: 1008,
+        reason: "portal session ended",
+      },
+      {
+        type: "ws_close",
+        id: "viewer-legacy",
+        code: 1008,
+        reason: "portal session ended",
+      },
+    ]);
+    const relay = fleet as unknown as { codeViewers: Map<string, WebSocket> };
+    expect(relay.codeViewers.size).toBe(0);
+
+    await fleet.webSocketMessage(viewer as unknown as WebSocket, "post-logout-frame");
+    expect(agent.sentJSON()).toHaveLength(2);
   });
 
   it("fails closed ambiguous and invalid hibernated bridge sockets", () => {
@@ -1880,6 +1945,8 @@ describe("runtime adapter relay", () => {
       kind: "code-viewer",
       leaseID: lease.id,
       id: "code-viewer-expiry",
+      auth: "github",
+      portalSessionHash: "f".repeat(64),
     });
     const egressHost = new FakeWebSocket({
       kind: "egress-host",
@@ -12235,6 +12302,23 @@ describe("fleet lease identity and idle", () => {
     );
     expect(page.status).toBe(200);
 
+    const activeViewerID = "active-code-viewer";
+    const portalSessionHash = await sha256Hex(token);
+    const activeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const activeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: activeViewerID,
+      auth: "github",
+      portalSessionHash,
+    });
+    const codeBridgeState = fleet as unknown as {
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+    };
+    codeBridgeState.codeAgents.set(leaseID, activeAgent as unknown as WebSocket);
+    codeBridgeState.codeViewers.set(activeViewerID, activeViewer as unknown as WebSocket);
+
     const expiredRevocationKey = `code-viewer-session-revocation:${"f".repeat(64)}`;
     storage.seed(expiredRevocationKey, {
       portalSessionHash: "f".repeat(64),
@@ -12250,6 +12334,18 @@ describe("fleet lease identity and idle", () => {
     expect(logout.headers.get("set-cookie")).toContain("crabbox_session=");
     expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
     expect(storage.value(expiredRevocationKey)).toBeUndefined();
+    expect(activeViewer.closeCode).toBe(1008);
+    expect(activeViewer.closeReason).toBe("portal session ended");
+    expect(activeAgent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: activeViewerID,
+        code: 1008,
+        reason: "portal session ended",
+      },
+    ]);
+    await fleet.webSocketMessage(activeViewer as unknown as WebSocket, "post-logout-frame");
+    expect(activeAgent.sentJSON()).toHaveLength(1);
 
     const staleViewer = await throughCoordinator(
       new Request(isolatedPage, { headers: { cookie: codeCookie } }),

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -3,6 +3,7 @@ import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { issueUserToken } from "../src/auth";
 import { EC2SpotClient } from "../src/aws";
 import {
   awsPromotedAMIConfigKey,
@@ -10,6 +11,7 @@ import {
   workspaceProviderKeyPrefix,
   type LeaseConfig,
 } from "../src/config";
+import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import {
   AWSProvider,
   FleetDurableObject,
@@ -12069,6 +12071,7 @@ describe("fleet lease identity and idle", () => {
     const leaseID = "cbx_000000000001";
     const tokenExpiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
     const headers = {
+      authorization: "Bearer portal-session-token",
       "x-crabbox-auth": "github",
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
@@ -12177,6 +12180,96 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(malformedSession.status).toBe(302);
+  });
+
+  it("revokes isolated Code viewer access end to end when the portal session logs out", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_CODE_ORIGIN_TEMPLATE: "https://{lease}.code.example.test",
+      CRABBOX_PUBLIC_URL: "https://crabbox.test",
+      CRABBOX_SESSION_SECRET: "session-secret",
+    } as Env;
+    const fleet = testFleet(storage, {}, env);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        code: true,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const token = await issueUserToken(env, {
+      owner: "alice@example.com",
+      org: "example-org",
+      login: "alice",
+      ttlSeconds: 60 * 60,
+    });
+    const portalCookie = `crabbox_session=${encodeURIComponent(token)}`;
+    const throughCoordinator = async (input: Request): Promise<Response> =>
+      await routeCoordinatorRequest(input, env, async (prepared) => await fleet.fetch(prepared));
+    const codeEntry = "https://crabbox.test/portal/leases/blue-lobster/code/";
+
+    const redirect = await throughCoordinator(
+      new Request(codeEntry, { headers: { cookie: portalCookie } }),
+    );
+    expect(redirect.status).toBe(302);
+    const bootstrapURL = redirect.headers.get("location") || "";
+    expect(bootstrapURL).toContain("/__crabbox_bootstrap?ticket=code_view_");
+
+    const pendingRedirect = await throughCoordinator(
+      new Request(codeEntry, { headers: { cookie: portalCookie } }),
+    );
+    const pendingBootstrapURL = pendingRedirect.headers.get("location") || "";
+    expect(pendingRedirect.status).toBe(302);
+
+    const bootstrap = await throughCoordinator(new Request(bootstrapURL));
+    expect(bootstrap.status).toBe(303);
+    const codeCookie = (bootstrap.headers.get("set-cookie") || "").split(";", 1)[0] || "";
+    const isolatedPage = new URL(bootstrap.headers.get("location") || "", bootstrapURL).toString();
+    const page = await throughCoordinator(
+      new Request(isolatedPage, { headers: { cookie: codeCookie } }),
+    );
+    expect(page.status).toBe(200);
+
+    const expiredRevocationKey = `code-viewer-session-revocation:${"f".repeat(64)}`;
+    storage.seed(expiredRevocationKey, {
+      portalSessionHash: "f".repeat(64),
+      createdAt: new Date(Date.now() - 2_000).toISOString(),
+      expiresAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const logout = await throughCoordinator(
+      new Request("https://crabbox.test/portal/logout", {
+        headers: { cookie: portalCookie },
+      }),
+    );
+    expect(logout.status).toBe(200);
+    expect(logout.headers.get("set-cookie")).toContain("crabbox_session=");
+    expect(logout.headers.get("set-cookie")).toContain("Max-Age=0");
+    expect(storage.value(expiredRevocationKey)).toBeUndefined();
+
+    const staleViewer = await throughCoordinator(
+      new Request(isolatedPage, { headers: { cookie: codeCookie } }),
+    );
+    expect(staleViewer.status).toBe(302);
+    expect(staleViewer.headers.get("location")).toBe(
+      `https://crabbox.test/portal/leases/${leaseID}/code/`,
+    );
+
+    const staleBootstrap = await throughCoordinator(new Request(pendingBootstrapURL));
+    expect(staleBootstrap.status).toBe(401);
+    await expect(staleBootstrap.json()).resolves.toMatchObject({
+      error: "code_viewer_session_revoked",
+    });
+
+    const stalePortalSession = await throughCoordinator(
+      new Request(codeEntry, { headers: { cookie: portalCookie } }),
+    );
+    expect(stalePortalSession.status).toBe(401);
+    expect(await stalePortalSession.text()).toContain("Log in again to open Code.");
   });
 
   it("keeps bridge tickets usable after endpoint binding mismatches", async () => {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -545,6 +545,20 @@ describe("coordinator auth", () => {
     expect(auth?.tokenExpiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("issues a distinct identity for each GitHub user session", async () => {
+    const env = { CRABBOX_SESSION_SECRET: "session-secret" };
+    const input = {
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+    };
+
+    const first = await issueUserToken(env, input);
+    const second = await issueUserToken(env, input);
+
+    expect(second).not.toBe(first);
+  });
+
   it("promotes configured GitHub user tokens to admin", async () => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",


### PR DESCRIPTION
## Summary

- bind isolated Code viewer tickets and sessions to the authenticated GitHub portal session
- record bounded server-side revocation on portal logout and reject stale viewer cookies, pending bootstraps, and remint attempts
- atomically close active and hibernated Code viewer WebSockets, notify the Code agent, and block post-logout frame forwarding
- give every newly issued GitHub user token a distinct session identity while continuing to accept existing tokens
- fail closed through the normal socket shutdown path for legacy unbound viewer records and clean expired auth records on logout

## Root cause

The isolated Code origin introduced a separate durable viewer credential, but that credential carried only a copied owner/auth context. Portal logout cleared the main-origin cookie without revoking the durable viewer session.

## Verification

- end-to-end Vitest: authenticated portal entry -> isolated bootstrap -> viewer access -> logout -> stale viewer replay denied
- same E2E rejects a ticket minted before logout and refuses a new viewer ticket from the logged-out portal token
- active and hibernated WebSocket regression proof: logout closes the browser socket with policy code 1008, sends the agent `ws_close`, and ignores later viewer frames
- `npm test --prefix worker` (642 tests)
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run build --prefix worker`
- `go test -race ./...`
- `go vet ./...`
- `scripts/check-docs.sh`
- autoreview clean after fixing expired revocation-record accumulation, upgrade/logout races, restored-socket revocation, and legacy shutdown handling

## Browser proof

The existing-Chrome bridge attached but exposed no real tabs, so no authenticated deployed browser target was available. The in-process E2E exercises the coordinator auth boundary, Fleet Durable Object persistence, isolated origin routing, logout, and replay paths.

Closes https://github.com/openclaw/crabbox/issues/463
