### PR TITLE
fix(sync): use native rsync when WSL2 cannot reach the rsync target

### DIFF
--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -626,18 +626,9 @@ type rsyncOptions struct {
 	HeartbeatInterval time.Duration
 }
 
-// defaultRsyncTimeout bounds a sync that would otherwise block forever (for
-// example an SSH transport that can never reach the target). It is a generous
-// backstop, not a tight deadline: real source syncs finish well inside it, and
-// hitting it surfaces rsync's actionable timeout error instead of hanging.
-const defaultRsyncTimeout = 30 * time.Minute
-
 func normalizeRsyncOptions(opts rsyncOptions) rsyncOptions {
 	if opts.NoTimes {
 		opts.Checksum = true
-	}
-	if opts.Timeout <= 0 {
-		opts.Timeout = defaultRsyncTimeout
 	}
 	return opts
 }
@@ -894,14 +885,43 @@ func wslReachabilityProbeScript(host, port string) string {
 // and ssh installed; probing avoids selecting the WSL path only for its SSH
 // transport to block on connect. An empty host is treated as reachable so the
 // default WSL path is unchanged for targets without an explicit host.
+// isSafeProbeToken reports whether s contains only characters valid in a
+// hostname, IP address (v4/v6 with zone id), or TCP port -- and therefore no
+// shell metacharacters. host and port are interpolated into the reachability
+// probe's shell command, so any value outside this set must never reach a shell.
+func isSafeProbeToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.', r == ':', r == '-', r == '_', r == '%':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func windowsWSLCanReachTarget(ctx context.Context, wslExe string, target SSHTarget) bool {
 	host := strings.TrimSpace(target.Host)
 	if host == "" {
 		return true
 	}
+	port := strings.TrimSpace(target.Port)
+	if port == "" {
+		port = "22"
+	}
+	// host and port are interpolated into a shell command run inside WSL. If
+	// either carries anything outside the hostname/IP/port character set, do not
+	// run a shell with it: fall back to native rsync, which is the safe choice.
+	if !isSafeProbeToken(host) || !isSafeProbeToken(port) {
+		return false
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
-	script := wslReachabilityProbeScript(host, target.Port)
+	script := wslReachabilityProbeScript(host, port)
 	return exec.CommandContext(probeCtx, wslExe, "bash", "-c", script).Run() == nil
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -626,9 +626,18 @@ type rsyncOptions struct {
 	HeartbeatInterval time.Duration
 }
 
+// defaultRsyncTimeout bounds a sync that would otherwise block forever (for
+// example an SSH transport that can never reach the target). It is a generous
+// backstop, not a tight deadline: real source syncs finish well inside it, and
+// hitting it surfaces rsync's actionable timeout error instead of hanging.
+const defaultRsyncTimeout = 30 * time.Minute
+
 func normalizeRsyncOptions(opts rsyncOptions) rsyncOptions {
 	if opts.NoTimes {
 		opts.Checksum = true
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = defaultRsyncTimeout
 	}
 	return opts
 }
@@ -787,6 +796,15 @@ func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) *
 	if err != nil || !windowsWSLHasNativeRsyncSSH(ctx, wslExe) {
 		return windowsNativeRsyncCommand(ctx, args)
 	}
+	// WSL has rsync+ssh, but WSL2 runs in its own NAT network namespace and may
+	// not be able to route to the target -- for example a Hyper-V guest on the
+	// Default Switch is reachable from the Windows host but not from WSL. When
+	// WSL cannot reach the target the WSL rsync's SSH transport would block on
+	// connect, so use native rsync instead: the host's own network and ssh.exe
+	// can reach the target.
+	if !windowsWSLCanReachTarget(ctx, wslExe, target) {
+		return windowsNativeRsyncCommand(ctx, args)
+	}
 	mountRoot := windowsWSLMountRoot(ctx, wslExe)
 
 	// Prepare WSL key: copy with correct permissions.
@@ -857,6 +875,34 @@ func windowsHostPath(path string) string {
 		return string(path[1]) + ":" + path[2:]
 	}
 	return path
+}
+
+// wslReachabilityProbeScript builds a bash one-liner that succeeds only if a
+// TCP connection to host:port can be opened from inside WSL. timeout(1) bounds
+// an unreachable host so the probe itself cannot hang. Port defaults to SSH.
+func wslReachabilityProbeScript(host, port string) string {
+	if strings.TrimSpace(port) == "" {
+		port = "22"
+	}
+	return fmt.Sprintf("timeout 5 bash -c 'exec 3<>/dev/tcp/%s/%s' >/dev/null 2>&1", host, port)
+}
+
+// windowsWSLCanReachTarget reports whether the WSL distro that would run rsync
+// can open a TCP connection to the target's SSH endpoint. WSL2's separate NAT
+// namespace means a target reachable only from the Windows host (e.g. a Hyper-V
+// guest on the Default Switch) is unroutable from WSL even when WSL has rsync
+// and ssh installed; probing avoids selecting the WSL path only for its SSH
+// transport to block on connect. An empty host is treated as reachable so the
+// default WSL path is unchanged for targets without an explicit host.
+func windowsWSLCanReachTarget(ctx context.Context, wslExe string, target SSHTarget) bool {
+	host := strings.TrimSpace(target.Host)
+	if host == "" {
+		return true
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	script := wslReachabilityProbeScript(host, target.Port)
+	return exec.CommandContext(probeCtx, wslExe, "bash", "-c", script).Run() == nil
 }
 
 func windowsWSLHasNativeRsyncSSH(ctx context.Context, wslExe string) bool {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1936,3 +1936,46 @@ func TestWindowsWSLCanReachTargetEmptyHostKeepsWSLPath(t *testing.T) {
 		t.Fatal("empty-host target should short-circuit to reachable without invoking wsl")
 	}
 }
+
+func TestIsSafeProbeToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "ipv4", in: "172.19.55.70", want: true},
+		{name: "hostname", in: "host-1.example_net", want: true},
+		{name: "ipv6 with zone", in: "fe80::1%eth0", want: true},
+		{name: "port", in: "2222", want: true},
+		{name: "empty", in: "", want: false},
+		{name: "semicolon", in: "h;rm -rf /", want: false},
+		{name: "command sub", in: "$(touch pwned)", want: false},
+		{name: "backtick", in: "`id`", want: false},
+		{name: "space", in: "a b", want: false},
+		{name: "ampersand", in: "a&b", want: false},
+		{name: "pipe", in: "a|b", want: false},
+		{name: "redirect", in: "a>b", want: false},
+		{name: "single quote", in: "a'b", want: false},
+		{name: "slash", in: "a/b", want: false},
+		{name: "newline", in: "a\nb", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isSafeProbeToken(tc.in); got != tc.want {
+				t.Fatalf("isSafeProbeToken(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindowsWSLCanReachTargetRejectsHostileHost(t *testing.T) {
+	t.Parallel()
+	// A host carrying shell metacharacters must never be handed to a shell: the
+	// function must return false (native-rsync fallback) without invoking wsl. A
+	// bogus wslExe would error if executed, so a false result proves it never ran.
+	if windowsWSLCanReachTarget(context.Background(), "wsl-does-not-exist.invalid", SSHTarget{Host: "$(touch pwned)"}) {
+		t.Fatal("hostile host should not be probed and must fall back to native rsync")
+	}
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1888,3 +1888,51 @@ func TestRemoteSyncSanityReportsDeletionSample(t *testing.T) {
 		}
 	}
 }
+
+func TestWSLReachabilityProbeScriptDefaultsToSSHPort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		host string
+		port string
+		want string
+	}{
+		{
+			name: "explicit port",
+			host: "10.0.0.5",
+			port: "2222",
+			want: "timeout 5 bash -c 'exec 3<>/dev/tcp/10.0.0.5/2222' >/dev/null 2>&1",
+		},
+		{
+			name: "empty port defaults to ssh",
+			host: "192.0.2.10",
+			port: "",
+			want: "timeout 5 bash -c 'exec 3<>/dev/tcp/192.0.2.10/22' >/dev/null 2>&1",
+		},
+		{
+			name: "whitespace port defaults to ssh",
+			host: "host.example",
+			port: "  ",
+			want: "timeout 5 bash -c 'exec 3<>/dev/tcp/host.example/22' >/dev/null 2>&1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := wslReachabilityProbeScript(tc.host, tc.port); got != tc.want {
+				t.Fatalf("wslReachabilityProbeScript(%q, %q) = %q, want %q", tc.host, tc.port, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindowsWSLCanReachTargetEmptyHostKeepsWSLPath(t *testing.T) {
+	t.Parallel()
+	// An empty host has nothing to probe: the function must report reachable
+	// (keeping the default WSL rsync path) without invoking wsl. A bogus wslExe
+	// would error if it were ever executed, so a true result proves the
+	// short-circuit holds.
+	if !windowsWSLCanReachTarget(context.Background(), "wsl-does-not-exist.invalid", SSHTarget{Host: ""}) {
+		t.Fatal("empty-host target should short-circuit to reachable without invoking wsl")
+	}
+}


### PR DESCRIPTION
## Problem

On a Windows host, `windowsRsyncCommand` runs rsync inside WSL whenever the default distro has native `rsync` + `ssh`. But WSL2 has its own NAT network namespace, so a target reachable **only from the Windows host** — e.g. a Hyper-V guest on the Default Switch (host-internal NAT) — is unroutable from WSL. The WSL rsync's `-e ssh` transport then blocks on connect, and because `Sync.Timeout` is unset by default the sync **hangs indefinitely, transferring nothing** into the guest workroot.

The selection only checks whether WSL *has* rsync+ssh (`windowsWSLHasNativeRsyncSSH`), never whether WSL can *reach* the target — so on a Win + Hyper-V + WSL2 host every sync to a Default-Switch guest hangs.

## Fix

- `windowsRsyncCommand`: before committing to the WSL rsync path, probe whether WSL can open a TCP connection to the target's SSH endpoint (`windowsWSLCanReachTarget`, `timeout`-bounded). If it can't, fall back to native rsync — the host's own network + `ssh.exe` reach the target. Provider-neutral; unchanged for targets WSL can already reach. Extends the native-fallback hardening from #329 from tool *presence* to *reachability*.
- `normalizeRsyncOptions`: default `Timeout` to 30m when unset, so a stalled sync surfaces rsync's existing actionable timeout error instead of hanging forever. A generous backstop, not a tight deadline.

## Tests

- `TestWSLReachabilityProbeScriptDefaultsToSSHPort` — table-driven; explicit / empty / whitespace ports.
- `TestWindowsWSLCanReachTargetEmptyHostKeepsWSLPath` — empty host short-circuits to reachable without invoking `wsl` (default WSL path preserved).
- `go test ./internal/cli/` passes; `gofmt` clean.

## Not covered by CI

Live end-to-end Hyper-V sync through the fallback — there's no Hyper-V runner in CI and the provider has no e2e. Validating manually on a real Windows + Hyper-V + WSL2 host; I'll post the result as a comment.

## Risk / mitigation

- One `timeout`-bounded (≤8s) `wsl` exec per Windows rsync call to probe reachability. Empty-host short-circuits without exec.
- The default timeout changes behaviour for syncs that previously ran unbounded; set generously (30m) so real source syncs are unaffected.
