### PR TITLE
fix: release failed prewarm leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Released newly created SSH leases when `prewarm` hydration, probe, or ready-pool registration fails, preventing paid lease leaks. Thanks @coygeek.
 - Revoked isolated Code viewer sessions when their GitHub portal session logs out, preventing stale viewer cookies from retaining prior-owner lease access. Thanks @coygeek.
 - Prevented unauthenticated Cloudflare Access key fetches and bounded key-set refresh work for invalid JWT key IDs. Thanks @coygeek.
 - Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 ### Fixed
 
-- Released newly created SSH leases when `prewarm` hydration, probe, or ready-pool registration fails, preventing paid lease leaks. Thanks @coygeek.
 - Revoked isolated Code viewer sessions when their GitHub portal session logs out, preventing stale viewer cookies from retaining prior-owner lease access. Thanks @coygeek.
 - Prevented unauthenticated Cloudflare Access key fetches and bounded key-set refresh work for invalid JWT key IDs. Thanks @coygeek.
 - Blocked normalized empty-segment variants of internal coordinator routes and stripped caller-supplied internal headers before fleet dispatch. Thanks @coygeek.

--- a/docs/commands/prewarm.md
+++ b/docs/commands/prewarm.md
@@ -15,6 +15,12 @@ crabbox prewarm --dry-run
 The command prints the lease id and keeps the box running. Stop it with
 `crabbox stop <id>` when the test burst is done.
 
+If Actions hydration, the optional probe, or ready-pool registration fails,
+`prewarm` automatically releases a newly created SSH lease. If automatic
+release cannot resolve or stop the lease, the error output prints the exact
+`crabbox stop` command to run; delegated-run providers retain their
+provider-owned lifecycle behavior.
+
 ## Reuse
 
 Run follow-up commands against the printed lease id or slug:

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -275,7 +275,10 @@ func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backen
 		lease = LeaseTarget{LeaseID: leaseID}
 	}
 	fmt.Fprintf(a.Stderr, "prewarm cleanup: releasing id=%s after %s failure\n", leaseID, stage)
-	if err := a.releaseBackendLeaseBestEffort(cleanupCtx, sshBackend, cfg, lease); err != nil {
+	a.cleanupBackendLeaseConnectionsBestEffort(cleanupCtx, lease)
+	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmFailureCleanupTimeout)
+	defer releaseCancel()
+	if err := a.releaseBackendLease(releaseCtx, sshBackend, cfg, lease); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s failed: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
 		return
 	}

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const prewarmFailureCleanupTimeout = 2 * time.Minute
+
 func (a App) prewarm(ctx context.Context, args []string) error {
 	started := time.Now()
 	defaults := defaultConfig()
@@ -107,7 +109,9 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 		hydration = "actions"
 		hydrateStarted := time.Now()
 		hydrateArgs = prewarmHydrateArgs(cfg, leaseID, *githubRunner, *waitTimeout, *keepAliveMinutes, followupArgs)
-		if err := a.actionsHydrate(ctx, hydrateArgs); err != nil {
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "actions hydration", func() error {
+			return a.actionsHydrate(ctx, hydrateArgs)
+		}); err != nil {
 			return err
 		}
 		hydrateMs = time.Since(hydrateStarted).Milliseconds()
@@ -117,14 +121,17 @@ func (a App) prewarm(ctx context.Context, args []string) error {
 	probeMs := int64(0)
 	if strings.TrimSpace(*probeCommand) != "" {
 		probeStarted := time.Now()
-		if err := a.runCommand(ctx, prewarmProbeArgs(cfg, leaseID, *probeCommand, followupArgs)); err != nil {
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "probe", func() error {
+			return a.runCommand(ctx, prewarmProbeArgs(cfg, leaseID, *probeCommand, followupArgs))
+		}); err != nil {
 			return err
 		}
 		probeMs = time.Since(probeStarted).Milliseconds()
 	}
 	if readyPoolKey != "" {
-		if err := a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *githubRunner); err != nil {
-			a.releasePrewarmLeaseAfterPoolFailure(ctx, backend, cfg, leaseID, err)
+		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, leaseID, "pool registration", func() error {
+			return a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *githubRunner)
+		}); err != nil {
 			return err
 		}
 	}
@@ -237,24 +244,42 @@ func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, 
 	return nil
 }
 
-func (a App) releasePrewarmLeaseAfterPoolFailure(ctx context.Context, backend Backend, cfg Config, leaseID string, cause error) {
+func (a App) runPrewarmPostWarmupStep(ctx context.Context, backend Backend, cfg Config, leaseID, stage string, step func() error) error {
+	err := step()
+	if err == nil {
+		return nil
+	}
+	a.releasePrewarmLeaseAfterFailure(ctx, backend, cfg, leaseID, stage)
+	return err
+}
+
+func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backend, cfg Config, leaseID, stage string) {
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
 		return
 	}
-	lease, err := sshBackend.Resolve(ctx, ResolveRequest{
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmFailureCleanupTimeout)
+	defer cancel()
+	lease, err := sshBackend.Resolve(cleanupCtx, ResolveRequest{
 		Repo:        Repo{},
 		Options:     leaseOptionsFromConfig(cfg),
 		ID:          leaseID,
 		ReleaseOnly: true,
 	})
 	if err != nil {
-		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release skipped: %v\n", leaseID, cause, err)
+		if backendCoordinator(backend) == nil {
+			fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s skipped: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
+			return
+		}
+		fmt.Fprintf(a.Stderr, "warning: could not inspect lease %s before prewarm cleanup: %v; releasing by lease ID\n", leaseID, err)
+		lease = LeaseTarget{LeaseID: leaseID}
+	}
+	fmt.Fprintf(a.Stderr, "prewarm cleanup: releasing id=%s after %s failure\n", leaseID, stage)
+	if err := a.releaseBackendLeaseBestEffort(cleanupCtx, sshBackend, cfg, lease); err != nil {
+		fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s failed: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
 		return
 	}
-	if err := a.releaseBackendLeaseBestEffort(ctx, sshBackend, cfg, lease); err != nil {
-		fmt.Fprintf(a.Stderr, "warning: pool registration failed for %s: %v; release failed: %v\n", leaseID, cause, err)
-	}
+	fmt.Fprintf(a.Stderr, "prewarm cleanup: released id=%s after %s failure\n", leaseID, stage)
 }
 
 func prewarmReadyPoolCommit(cfg Config, repo Repo, githubRunner bool) string {

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -21,6 +21,8 @@ type prewarmCleanupTestBackend struct {
 	releaseCalls    int
 	resolveCanceled bool
 	releaseCanceled bool
+	resolveCtx      context.Context
+	releaseCtx      context.Context
 	resolveErr      error
 	releaseErr      error
 }
@@ -39,6 +41,7 @@ func (b *prewarmCleanupTestBackend) Acquire(context.Context, AcquireRequest) (Le
 }
 func (b *prewarmCleanupTestBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
 	b.resolveCalls++
+	b.resolveCtx = ctx
 	b.resolveCanceled = ctx.Err() != nil
 	if b.resolveErr != nil {
 		return LeaseTarget{}, b.resolveErr
@@ -52,6 +55,7 @@ func (b *prewarmCleanupTestBackend) List(context.Context, ListRequest) ([]LeaseV
 }
 func (b *prewarmCleanupTestBackend) ReleaseLease(ctx context.Context, _ ReleaseLeaseRequest) error {
 	b.releaseCalls++
+	b.releaseCtx = ctx
 	b.releaseCanceled = ctx.Err() != nil
 	return b.releaseErr
 }
@@ -81,6 +85,9 @@ func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
 			}
 			if backend.resolveCanceled || backend.releaseCanceled {
 				t.Fatalf("cleanup inherited canceled context: resolve=%v release=%v", backend.resolveCanceled, backend.releaseCanceled)
+			}
+			if backend.resolveCtx == backend.releaseCtx {
+				t.Fatal("provider release reused the pre-release cleanup context")
 			}
 			for _, want := range []string{
 				"prewarm cleanup: releasing id=cbx_abcdef123456 after " + stage + " failure",

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -3,6 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +15,177 @@ import (
 	"sync/atomic"
 	"testing"
 )
+
+type prewarmCleanupTestBackend struct {
+	resolveCalls    int
+	releaseCalls    int
+	resolveCanceled bool
+	releaseCanceled bool
+	resolveErr      error
+	releaseErr      error
+}
+
+type prewarmDelegatedTestBackend struct{}
+
+func (prewarmDelegatedTestBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "prewarm-delegated-test", Kind: ProviderKindDelegatedRun}
+}
+
+func (b *prewarmCleanupTestBackend) Spec() ProviderSpec {
+	return ProviderSpec{Name: "prewarm-cleanup-test", Kind: ProviderKindSSHLease}
+}
+func (b *prewarmCleanupTestBackend) Acquire(context.Context, AcquireRequest) (LeaseTarget, error) {
+	return LeaseTarget{}, nil
+}
+func (b *prewarmCleanupTestBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	b.resolveCalls++
+	b.resolveCanceled = ctx.Err() != nil
+	if b.resolveErr != nil {
+		return LeaseTarget{}, b.resolveErr
+	}
+	server := Server{Provider: "prewarm-cleanup-test"}
+	server.ServerType.Name = "test"
+	return LeaseTarget{LeaseID: req.ID, Server: server}, nil
+}
+func (b *prewarmCleanupTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
+func (b *prewarmCleanupTestBackend) ReleaseLease(ctx context.Context, _ ReleaseLeaseRequest) error {
+	b.releaseCalls++
+	b.releaseCanceled = ctx.Err() != nil
+	return b.releaseErr
+}
+func (b *prewarmCleanupTestBackend) Touch(context.Context, TouchRequest) (Server, error) {
+	return Server{}, nil
+}
+
+func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
+	for _, stage := range []string{"actions hydration", "probe", "pool registration"} {
+		t.Run(stage, func(t *testing.T) {
+			backend := &prewarmCleanupTestBackend{}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			cause := errors.New("step failed")
+			var stderr bytes.Buffer
+			app := App{Stdout: io.Discard, Stderr: &stderr}
+
+			err := app.runPrewarmPostWarmupStep(ctx, backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", stage, func() error {
+				return cause
+			})
+
+			if !errors.Is(err, cause) {
+				t.Fatalf("step error=%v, want %v", err, cause)
+			}
+			if backend.resolveCalls != 1 || backend.releaseCalls != 1 {
+				t.Fatalf("cleanup calls resolve=%d release=%d", backend.resolveCalls, backend.releaseCalls)
+			}
+			if backend.resolveCanceled || backend.releaseCanceled {
+				t.Fatalf("cleanup inherited canceled context: resolve=%v release=%v", backend.resolveCanceled, backend.releaseCanceled)
+			}
+			for _, want := range []string{
+				"prewarm cleanup: releasing id=cbx_abcdef123456 after " + stage + " failure",
+				"prewarm cleanup: released id=cbx_abcdef123456 after " + stage + " failure",
+			} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func TestPrewarmSuccessfulStepDoesNotReleaseLease(t *testing.T) {
+	backend := &prewarmCleanupTestBackend{}
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).runPrewarmPostWarmupStep(
+		context.Background(), backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", "probe", func() error { return nil },
+	)
+	if err != nil || backend.resolveCalls != 0 || backend.releaseCalls != 0 {
+		t.Fatalf("successful step err=%v resolve=%d release=%d", err, backend.resolveCalls, backend.releaseCalls)
+	}
+}
+
+func TestPrewarmCleanupFailurePrintsStopCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		backend *prewarmCleanupTestBackend
+		want    string
+	}{
+		{name: "resolve", backend: &prewarmCleanupTestBackend{resolveErr: errors.New("resolve unavailable")}, want: "automatic release of cbx_abcdef123456 skipped: resolve unavailable"},
+		{name: "release", backend: &prewarmCleanupTestBackend{releaseErr: errors.New("release unavailable")}, want: "automatic release of cbx_abcdef123456 failed: release unavailable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			cause := errors.New("hydrate failed")
+			err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
+				context.Background(), tc.backend, Config{Provider: "prewarm-cleanup-test"}, "cbx_abcdef123456", "actions hydration", func() error { return cause },
+			)
+			if !errors.Is(err, cause) {
+				t.Fatalf("step error=%v, want %v", err, cause)
+			}
+			for _, want := range []string{tc.want, "next: crabbox stop --provider prewarm-cleanup-test --id cbx_abcdef123456"} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func TestPrewarmFailureDoesNotReleaseDelegatedProvider(t *testing.T) {
+	cause := errors.New("delegated step failed")
+	var stderr bytes.Buffer
+	err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
+		context.Background(), prewarmDelegatedTestBackend{}, Config{Provider: "prewarm-delegated-test"}, "run_abcdef123456", "probe", func() error { return cause },
+	)
+	if !errors.Is(err, cause) {
+		t.Fatalf("step error=%v, want %v", err, cause)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("delegated provider emitted SSH cleanup output:\n%s", stderr.String())
+	}
+}
+
+func TestPrewarmCoordinatorCleanupReleasesByIDWhenResolveFails(t *testing.T) {
+	released := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123456":
+			http.Error(w, `{"error":"resolve unavailable"}`, http.StatusServiceUnavailable)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_abcdef123456/release":
+			released = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_abcdef123456", Provider: "aws", State: "released"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{Provider: "aws", Coordinator: server.URL, CoordToken: "test-token"}
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{
+		spec:  ProviderSpec{Name: "aws", Kind: ProviderKindSSHLease},
+		cfg:   cfg,
+		coord: coord,
+		rt:    Runtime{Stderr: io.Discard},
+	}
+	var stderr bytes.Buffer
+	cause := errors.New("probe failed")
+	err = (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(
+		context.Background(), backend, cfg, "cbx_abcdef123456", "probe", func() error { return cause },
+	)
+	if !errors.Is(err, cause) {
+		t.Fatalf("step error=%v, want %v", err, cause)
+	}
+	if !released {
+		t.Fatal("coordinator lease was not released by ID")
+	}
+	if !strings.Contains(stderr.String(), "releasing by lease ID") {
+		t.Fatalf("stderr missing resolve fallback:\n%s", stderr.String())
+	}
+}
 
 func TestPrewarmDryRunPlansHydratedLease(t *testing.T) {
 	clearConfigEnv(t)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2654,9 +2654,17 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 }
 
 func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
+	a.cleanupBackendLeaseConnectionsBestEffort(ctx, lease)
+	return a.releaseBackendLease(ctx, backend, cfg, lease)
+}
+
+func (a App) cleanupBackendLeaseConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
 	a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
 	a.cleanupMediatedEgressBestEffort(ctx, lease.LeaseID, lease)
 	a.logoutRemoteTailscaleBestEffort(ctx, lease)
+}
+
+func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
 	fmt.Fprintf(a.Stderr, "releasing %s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 	if err := backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: release failed for %s: %v\n", lease.LeaseID, err)


### PR DESCRIPTION
## Summary

- release newly created SSH leases when Actions hydration, probe execution, or ready-pool registration fails
- use a bounded cleanup context independent of caller cancellation
- preserve delegated-provider lifecycle ownership and fall back to coordinator release-by-ID when inspection fails
- document cleanup behavior and manual recovery guidance

Reported by @coygeek.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- branch autoreview: clean

## Live proof

- AWS on-demand `t3.small`: injected probe exit 17; automatic release completed; follow-up inventory found zero matching leases
- AWS on-demand `t3.small`: injected Actions hydration failure with a missing workflow; automatic release completed; follow-up inventory found zero matching leases
- AWS on-demand `t3.small`: repeated probe-failure smoke after review fix; automatic release completed; follow-up inventory found zero matching leases

Fixes https://github.com/openclaw/crabbox/issues/479
