### PR TITLE
fix: verify desktop helper success

### DIFF
--- a/docs/commands/desktop.md
+++ b/docs/commands/desktop.md
@@ -41,9 +41,10 @@ connectivity.
 `crabbox desktop launch` starts an app inside the desktop session without
 attaching a VNC viewer first. It waits for the loopback VNC service, starts the
 process detached from the SSH session, and verifies that the process remains
-alive through startup. Linux browser launches additionally require a visible
-browser window or browser process. macOS `open` launches wait on the opened app
-so an immediately failed launch is not reported as successful.
+alive through startup. A short-lived Linux/X11 wrapper can also succeed by
+creating a new visible window. Linux browser launches additionally require a
+visible browser window or browser process. macOS `open` launches wait on the
+opened app so an immediately failed launch is not reported as successful.
 
 With `--browser`, Crabbox probes the target browser the same way
 `run --browser` does and launches the resolved `BROWSER` when no explicit

--- a/docs/commands/desktop.md
+++ b/docs/commands/desktop.md
@@ -42,9 +42,10 @@ connectivity.
 attaching a VNC viewer first. It waits for the loopback VNC service, starts the
 process detached from the SSH session, and verifies that the process remains
 alive through startup. A short-lived Linux/X11 wrapper can also succeed by
-creating a new visible window. Linux browser launches additionally require a
-visible browser window or browser process. macOS `open` launches wait on the
-opened app so an immediately failed launch is not reported as successful.
+creating a new visible window or focusing a different existing visible window.
+Linux browser launches additionally require a visible browser window or browser
+process. macOS `open` launches wait on the opened app so an immediately failed
+launch is not reported as successful.
 
 With `--browser`, Crabbox probes the target browser the same way
 `run --browser` does and launches the resolved `BROWSER` when no explicit
@@ -91,9 +92,10 @@ inline images when `--sixel` is set. On macOS it launches Ghostty via
 `open -W -na Ghostty.app`.
 
 POSIX launches must remain alive through startup. X11 terminals also receive a
-per-lease title and must expose that visible window before `launched terminal:`
-or any capture output is printed. This rejects commands that make the terminal
-exit immediately.
+per-lease title and must create a new visible window before `launched terminal:`
+or any capture output is printed. Verification follows the stable X11 window ID,
+so commands may change the window title. This rejects commands that make the
+terminal exit immediately.
 
 Add `--screenshot <path>` or `--record <path>` to capture proof after launch;
 `--wait-visible <duration>` controls the settle delay before capture (defaults

--- a/docs/commands/desktop.md
+++ b/docs/commands/desktop.md
@@ -219,9 +219,9 @@ them instead of hand-written input snippets.
   routed through the clipboard/paste path so keyboard layouts cannot corrupt
   special characters. Linux only.
 - `desktop paste` pastes text from `--text` or stdin via the remote clipboard.
-  Linux only. The clipboard helper must still own the clipboard when Ctrl+V is
-  sent and must exit successfully after serving the paste; helper failure makes
-  the command fail without printing `pasted:`.
+  Linux only. Crabbox verifies clipboard ownership before Ctrl+V and propagates
+  supported helper delivery failures; helper failure makes the command fail
+  without printing `pasted:`.
 - `desktop key` sends an `xdotool` key sequence (or a single modifier+key
   combination on Wayland). Linux only.
 

--- a/docs/commands/desktop.md
+++ b/docs/commands/desktop.md
@@ -39,8 +39,11 @@ connectivity.
 ## desktop launch
 
 `crabbox desktop launch` starts an app inside the desktop session without
-attaching a VNC viewer first. It waits for the loopback VNC service, then starts
-the process detached from the SSH session.
+attaching a VNC viewer first. It waits for the loopback VNC service, starts the
+process detached from the SSH session, and verifies that the process remains
+alive through startup. Linux browser launches additionally require a visible
+browser window or browser process. macOS `open` launches wait on the opened app
+so an immediately failed launch is not reported as successful.
 
 With `--browser`, Crabbox probes the target browser the same way
 `run --browser` does and launches the resolved `BROWSER` when no explicit
@@ -84,7 +87,12 @@ desktop launch --id <lease-id-or-slug>
 `gnome-terminal` on Wayland/GNOME desktop envs). On native Windows it launches
 Git-for-Windows `mintty`, which is present after bootstrap and can render Sixel
 inline images when `--sixel` is set. On macOS it launches Ghostty via
-`open -na Ghostty.app`.
+`open -W -na Ghostty.app`.
+
+POSIX launches must remain alive through startup. X11 terminals also receive a
+per-lease title and must expose that visible window before `launched terminal:`
+or any capture output is printed. This rejects commands that make the terminal
+exit immediately.
 
 Add `--screenshot <path>` or `--record <path>` to capture proof after launch;
 `--wait-visible <duration>` controls the settle delay before capture (defaults
@@ -139,9 +147,10 @@ Defaults: `--duration 10s`, `--fps 15`, `--contact-sheet-frames 5`,
 ## desktop proof
 
 `crabbox desktop proof` is the one-shot visual QA command for terminal smokes.
-It launches the terminal command, waits for the UI to settle (`--wait-visible`,
-default 2s), and writes a bundle into `--output` (default
-`artifacts/<slug>-proof`):
+It launches and verifies the terminal command, waits for the UI to settle
+(`--wait-visible`, default 2s), and writes a bundle into `--output` (default
+`artifacts/<slug>-proof`). A failed launch returns before metadata, screenshot,
+diagnostics, video, contact-sheet, or final `proof:` output is written:
 
 - `metadata.json`
 - `screenshot.png`
@@ -209,7 +218,9 @@ them instead of hand-written input snippets.
   routed through the clipboard/paste path so keyboard layouts cannot corrupt
   special characters. Linux only.
 - `desktop paste` pastes text from `--text` or stdin via the remote clipboard.
-  Linux only.
+  Linux only. The clipboard helper must still own the clipboard when Ctrl+V is
+  sent and must exit successfully after serving the paste; helper failure makes
+  the command fail without printing `pasted:`.
 - `desktop key` sends an `xdotool` key sequence (or a single modifier+key
   combination on Wayland). Linux only.
 

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -710,7 +710,7 @@ func posixDesktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[s
 		b.WriteString("export " + key + "\n")
 	}
 	b.WriteString("log=${TMPDIR:-/tmp}/crabbox-desktop-launch.log\n")
-	if opts.VerifyProcess && target.TargetOS == targetLinux && strings.TrimSpace(opts.VisibleWindowTitle) == "" {
+	if opts.VerifyProcess && target.TargetOS == targetLinux {
 		b.WriteString(posixDesktopLaunchWindowSnapshotCommand())
 	}
 	b.WriteString("if command -v setsid >/dev/null 2>&1; then\n")
@@ -751,6 +751,7 @@ launch_before_windows=""
 if command -v xdotool >/dev/null 2>&1 && xdotool getmouselocation >/dev/null 2>&1; then
   launch_can_check_windows=1
   launch_before_windows=" $(xdotool search --onlyvisible --name '.*' 2>/dev/null | tr '\n' ' ' || true) "
+  launch_before_active="$(xdotool getactivewindow 2>/dev/null || true)"
 fi
 desktop_launch_new_window() {
   for launch_window in $(xdotool search --onlyvisible --name '.*' 2>/dev/null || true); do
@@ -759,6 +760,15 @@ desktop_launch_new_window() {
       *) return 0 ;;
     esac
   done
+  return 1
+}
+desktop_launch_observed_window() {
+  desktop_launch_new_window && return 0
+  launch_active="$(xdotool getactivewindow 2>/dev/null || true)"
+  [ -n "$launch_before_active" ] && [ -n "$launch_active" ] && [ "$launch_active" != "$launch_before_active" ] || return 1
+  case "$launch_before_windows" in
+    *" $launch_active "*) return 0 ;;
+  esac
   return 1
 }
 `
@@ -795,7 +805,7 @@ sleep 1
   if [ "$launch_can_check_windows" -eq 1 ]; then
     launch_attempt=0
     while [ "$launch_attempt" -lt 10 ]; do
-      if desktop_launch_new_window; then
+      if desktop_launch_observed_window; then
         launch_visible=1
         break
       fi
@@ -822,7 +832,7 @@ if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "wayland" ] && command -v xdotool >/dev/n
   launch_visible=0
   launch_attempt=0
   while [ "$launch_attempt" -lt 10 ]; do
-    if xdotool search --onlyvisible --name ` + shellQuote(visibleWindowTitle) + ` >/dev/null 2>&1; then
+    if [ "$launch_can_check_windows" -eq 1 ] && desktop_launch_new_window; then
       launch_visible=1
       break
     fi

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -710,6 +710,9 @@ func posixDesktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[s
 		b.WriteString("export " + key + "\n")
 	}
 	b.WriteString("log=${TMPDIR:-/tmp}/crabbox-desktop-launch.log\n")
+	if opts.VerifyProcess && target.TargetOS == targetLinux && strings.TrimSpace(opts.VisibleWindowTitle) == "" {
+		b.WriteString(posixDesktopLaunchWindowSnapshotCommand())
+	}
 	b.WriteString("if command -v setsid >/dev/null 2>&1; then\n")
 	b.WriteString("  setsid ")
 	writeShellArgv(&b, command)
@@ -742,24 +745,70 @@ func desktopMacOpenWaitCommand(target SSHTarget, command []string) []string {
 	return append(out, command[1:]...)
 }
 
+func posixDesktopLaunchWindowSnapshotCommand() string {
+	return `launch_can_check_windows=0
+launch_before_windows=""
+if command -v xdotool >/dev/null 2>&1 && xdotool getmouselocation >/dev/null 2>&1; then
+  launch_can_check_windows=1
+  launch_before_windows=" $(xdotool search --onlyvisible --name '.*' 2>/dev/null | tr '\n' ' ' || true) "
+fi
+desktop_launch_new_window() {
+  for launch_window in $(xdotool search --onlyvisible --name '.*' 2>/dev/null || true); do
+    case "$launch_before_windows" in
+      *" $launch_window "*) ;;
+      *) return 0 ;;
+    esac
+  done
+  return 1
+}
+`
+}
+
 // posixDesktopLaunchVerificationCommand keeps detached launch success tied to
 // the spawned process and, where X11 exposes it, the intended terminal window.
 func posixDesktopLaunchVerificationCommand(target SSHTarget, visibleWindowTitle string) string {
 	var b bytes.Buffer
 	b.WriteString(`launch_pid=$!
 desktop_launch_failed() {
-  set +e
-  wait "$launch_pid"
-  launch_status=$?
-  set -e
+	launch_status="${1:-}"
+	if [ -z "$launch_status" ]; then
+		set +e
+		wait "$launch_pid"
+		launch_status=$?
+		set -e
+	fi
   [ "$launch_status" -ne 0 ] || launch_status=1
   echo "desktop command exited during launch (status=$launch_status)" >&2
   if [ -s "$log" ]; then tail -n 20 "$log" >&2; fi
   exit "$launch_status"
 }
 sleep 1
-kill -0 "$launch_pid" >/dev/null 2>&1 || desktop_launch_failed
 `)
+	if target.TargetOS == targetLinux && strings.TrimSpace(visibleWindowTitle) == "" {
+		b.WriteString(`if ! kill -0 "$launch_pid" >/dev/null 2>&1; then
+  set +e
+  wait "$launch_pid"
+  launch_status=$?
+  set -e
+  [ "$launch_status" -eq 0 ] || desktop_launch_failed "$launch_status"
+  launch_visible=0
+  if [ "$launch_can_check_windows" -eq 1 ]; then
+    launch_attempt=0
+    while [ "$launch_attempt" -lt 10 ]; do
+      if desktop_launch_new_window; then
+        launch_visible=1
+        break
+      fi
+      launch_attempt=$((launch_attempt + 1))
+      sleep 0.5
+    done
+  fi
+  [ "$launch_visible" -eq 1 ] || desktop_launch_failed 1
+fi
+`)
+	} else {
+		b.WriteString("kill -0 \"$launch_pid\" >/dev/null 2>&1 || desktop_launch_failed\n")
+	}
 	if target.TargetOS != targetLinux || strings.TrimSpace(visibleWindowTitle) == "" {
 		return b.String()
 	}

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -127,7 +127,11 @@ func (a App) desktopLaunchWithCommand(ctx context.Context, args []string, comman
 	}
 	workdir := remoteJoin(cfg, leaseID, repo.Name)
 	rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
-	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, command, *browser && !*fullscreen)); err != nil {
+	launchOptions := desktopLaunchOptions{
+		WindowedBrowser: *browser && !*fullscreen,
+		VerifyProcess:   !expectBrowserLaunch || target.TargetOS != targetLinux,
+	}
+	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, command, launchOptions)); err != nil {
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueCtx), desktopLaunchRetryCommand(rescueCtx, command))
 		return exit(5, "launch desktop command: %v", err)
 	}
@@ -220,11 +224,13 @@ func (a App) desktopTerminal(ctx context.Context, args []string) error {
 	if err := waitForLoopbackVNC(ctx, &target); err != nil {
 		return err
 	}
+	terminalTitle := desktopTerminalWindowTitle(leaseID)
 	terminalCommand, err := desktopTerminalCommand(target, command, desktopTerminalOptions{
 		FontSize: *fontSize,
 		Cols:     *cols,
 		Rows:     *rows,
 		Sixel:    *sixel,
+		Title:    terminalTitle,
 	})
 	if err != nil {
 		return err
@@ -240,7 +246,10 @@ func (a App) desktopTerminal(ctx context.Context, args []string) error {
 		}
 	}
 	rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
-	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, terminalCommand, false)); err != nil {
+	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, terminalCommand, desktopLaunchOptions{
+		VerifyProcess:      true,
+		VisibleWindowTitle: terminalTitle,
+	})); err != nil {
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueCtx), desktopLaunchRetryCommand(rescueCtx, terminalCommand))
 		return exit(5, "launch desktop terminal: %v", err)
 	}
@@ -415,11 +424,13 @@ func (a App) desktopProof(ctx context.Context, args []string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return exit(2, "create proof directory: %v", err)
 	}
+	terminalTitle := desktopTerminalWindowTitle(leaseID)
 	terminalCommand, err := desktopTerminalCommand(target, command, desktopTerminalOptions{
 		FontSize: *fontSize,
 		Cols:     *cols,
 		Rows:     *rows,
 		Sixel:    *sixel,
+		Title:    terminalTitle,
 	})
 	if err != nil {
 		return err
@@ -433,7 +444,10 @@ func (a App) desktopProof(ctx context.Context, args []string) error {
 		return err
 	}
 	rescueCtx := rescueContext{Cfg: cfg, Target: target, LeaseID: leaseID}
-	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, terminalCommand, false)); err != nil {
+	if out, err := runSSHCombinedOutput(ctx, target, desktopLaunchRemoteCommand(target, workdir, env, terminalCommand, desktopLaunchOptions{
+		VerifyProcess:      true,
+		VisibleWindowTitle: terminalTitle,
+	})); err != nil {
 		printRescue(a.Stdout, classifyDesktopFailure(out), trimFailureDetail(out), desktopDoctorCommand(rescueCtx), desktopLaunchRetryCommand(rescueCtx, terminalCommand))
 		return exit(5, "launch desktop proof terminal: %v", err)
 	}
@@ -536,6 +550,7 @@ type desktopTerminalOptions struct {
 	Cols     int
 	Rows     int
 	Sixel    bool
+	Title    string
 }
 
 func desktopTerminalCommand(target SSHTarget, command []string, opts desktopTerminalOptions) ([]string, error) {
@@ -547,6 +562,9 @@ func desktopTerminalCommand(target SSHTarget, command []string, opts desktopTerm
 	}
 	if opts.Rows <= 0 {
 		opts.Rows = 32
+	}
+	if strings.TrimSpace(opts.Title) == "" {
+		opts.Title = "Crabbox Desktop"
 	}
 	if isWindowsNativeTarget(target) {
 		shellCommand := ""
@@ -565,6 +583,7 @@ func desktopTerminalCommand(target SSHTarget, command []string, opts desktopTerm
 		}
 		return []string{
 			`C:\Program Files\Git\usr\bin\mintty.exe`,
+			"-t", opts.Title,
 			"-o", fmt.Sprintf("FontHeight=%d", opts.FontSize),
 			"-o", fmt.Sprintf("Columns=%d", opts.Cols),
 			"-o", fmt.Sprintf("Rows=%d", opts.Rows),
@@ -579,8 +598,8 @@ func desktopTerminalCommand(target SSHTarget, command []string, opts desktopTerm
 		}
 		prefix := "export TERM=${TERM:-xterm-ghostty}; export GIFGREP_INLINE=${GIFGREP_INLINE:-kitty}; export GIFGREP_SOFTWARE_ANIM=${GIFGREP_SOFTWARE_ANIM:-1}; "
 		return []string{
-			"open", "-na", "Ghostty.app", "--args",
-			"--title=gifgrep tui",
+			"open", "-W", "-na", "Ghostty.app", "--args",
+			"--title=" + opts.Title,
 			fmt.Sprintf("--font-size=%d", opts.FontSize),
 			fmt.Sprintf("--window-width=%d", opts.Cols),
 			fmt.Sprintf("--window-height=%d", opts.Rows),
@@ -603,21 +622,32 @@ if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
   if [ "${CRABBOX_DESKTOP_ENV:-}" = "gnome" ] && command -v gnome-terminal >/dev/null 2>&1; then
     export DISPLAY="${DISPLAY:-:0}"
     export GDK_BACKEND=x11 MOZ_ENABLE_WAYLAND=0
-    exec gnome-terminal --working-directory="$PWD" -- bash -lc %s
+    exec gnome-terminal --wait --title=%s --working-directory="$PWD" -- bash -lc %s
   fi
   command -v foot >/dev/null 2>&1 || { echo "missing foot; warm a new Wayland desktop lease or install foot" >&2; exit 127; }
-  exec foot --title='Crabbox Desktop' --font=%s bash -lc %s
+  exec foot --title=%s --font=%s bash -lc %s
 fi
 export DISPLAY="${DISPLAY:-:99}"
-exec xterm -fa monospace -fs %s -geometry %s -e bash -lc %s`,
+exec xterm -title %s -fa monospace -fs %s -geometry %s -e bash -lc %s`,
+		shellQuote(opts.Title),
 		shellQuote(shellCommand),
+		shellQuote(opts.Title),
 		shellQuote(fmt.Sprintf("monospace:size=%d", opts.FontSize)),
 		shellQuote(shellCommand),
+		shellQuote(opts.Title),
 		shellQuote(fmt.Sprintf("%d", opts.FontSize)),
 		shellQuote(fmt.Sprintf("%dx%d", opts.Cols, opts.Rows)),
 		shellQuote(shellCommand),
 	)
 	return []string{"sh", "-lc", terminalScript}, nil
+}
+
+func desktopTerminalWindowTitle(leaseID string) string {
+	suffix := normalizeLeaseSlug(leaseID)
+	if suffix == "" {
+		suffix = "session"
+	}
+	return "Crabbox Desktop " + suffix
 }
 
 func shellJoin(args []string) string {
@@ -654,18 +684,22 @@ func firstNonBlank(values ...string) string {
 	return ""
 }
 
-func desktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[string]string, command []string, windowedBrowser bool) string {
+type desktopLaunchOptions struct {
+	WindowedBrowser    bool
+	VerifyProcess      bool
+	VisibleWindowTitle string
+}
+
+func desktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[string]string, command []string, opts desktopLaunchOptions) string {
 	if isWindowsNativeTarget(target) {
 		return windowsDesktopLaunchRemoteCommand(workdir, env, command)
 	}
-	if target.TargetOS == targetMacOS {
-		return posixDesktopLaunchRemoteCommand(workdir, env, command, windowedBrowser)
-	}
-	return posixDesktopLaunchRemoteCommand(workdir, env, command, windowedBrowser)
+	return posixDesktopLaunchRemoteCommand(target, workdir, env, command, opts)
 }
 
-func posixDesktopLaunchRemoteCommand(workdir string, env map[string]string, command []string, windowedBrowser bool) string {
+func posixDesktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[string]string, command []string, opts desktopLaunchOptions) string {
 	var b bytes.Buffer
+	command = desktopMacOpenWaitCommand(target, command)
 	b.WriteString("set -eu\n")
 	if workdir != "" {
 		b.WriteString("mkdir -p " + shellQuote(workdir) + "\n")
@@ -685,9 +719,76 @@ func posixDesktopLaunchRemoteCommand(workdir string, env map[string]string, comm
 	writeShellArgv(&b, command)
 	b.WriteString(" >\"$log\" 2>&1 < /dev/null &\n")
 	b.WriteString("fi\n")
-	if windowedBrowser {
+	if opts.VerifyProcess {
+		b.WriteString(posixDesktopLaunchVerificationCommand(target, opts.VisibleWindowTitle))
+	}
+	if opts.WindowedBrowser {
 		b.WriteString(posixWindowBrowserCommand())
 	}
+	return b.String()
+}
+
+func desktopMacOpenWaitCommand(target SSHTarget, command []string) []string {
+	if target.TargetOS != targetMacOS || len(command) == 0 || filepath.Base(command[0]) != "open" {
+		return command
+	}
+	for _, arg := range command[1:] {
+		if arg == "-W" || arg == "--wait-apps" {
+			return command
+		}
+	}
+	out := make([]string, 0, len(command)+1)
+	out = append(out, command[0], "-W")
+	return append(out, command[1:]...)
+}
+
+// posixDesktopLaunchVerificationCommand keeps detached launch success tied to
+// the spawned process and, where X11 exposes it, the intended terminal window.
+func posixDesktopLaunchVerificationCommand(target SSHTarget, visibleWindowTitle string) string {
+	var b bytes.Buffer
+	b.WriteString(`launch_pid=$!
+desktop_launch_failed() {
+  set +e
+  wait "$launch_pid"
+  launch_status=$?
+  set -e
+  [ "$launch_status" -ne 0 ] || launch_status=1
+  echo "desktop command exited during launch (status=$launch_status)" >&2
+  if [ -s "$log" ]; then tail -n 20 "$log" >&2; fi
+  exit "$launch_status"
+}
+sleep 1
+kill -0 "$launch_pid" >/dev/null 2>&1 || desktop_launch_failed
+`)
+	if target.TargetOS != targetLinux || strings.TrimSpace(visibleWindowTitle) == "" {
+		return b.String()
+	}
+	b.WriteString(`if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
+if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "wayland" ] && command -v xdotool >/dev/null 2>&1; then
+  if [ "${CRABBOX_DESKTOP_ENV:-xfce}" = "xfce" ]; then
+    export DISPLAY="${DISPLAY:-:99}"
+  else
+    export DISPLAY="${DISPLAY:-:0}"
+  fi
+  launch_visible=0
+  launch_attempt=0
+  while [ "$launch_attempt" -lt 10 ]; do
+    if xdotool search --onlyvisible --name ` + shellQuote(visibleWindowTitle) + ` >/dev/null 2>&1; then
+      launch_visible=1
+      break
+    fi
+    kill -0 "$launch_pid" >/dev/null 2>&1 || desktop_launch_failed
+    launch_attempt=$((launch_attempt + 1))
+    sleep 0.5
+  done
+  if [ "$launch_visible" -ne 1 ]; then
+    echo "desktop window not visible: ` + shellQuote(visibleWindowTitle) + `" >&2
+    if [ -s "$log" ]; then tail -n 20 "$log" >&2; fi
+    kill "$launch_pid" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+`)
 	return b.String()
 }
 

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -458,7 +458,8 @@ xdotool type --clearmodifiers --delay 1 -- ` + shellQuote(text)
 func desktopPasteRemoteCommand() string {
 	return `set -eu
 tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
+clip_pid=""
+trap 'if [ -n "$clip_pid" ]; then kill "$clip_pid" 2>/dev/null || true; wait "$clip_pid" 2>/dev/null || true; fi; rm -f "$tmp"' EXIT
 cat > "$tmp"
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
 if [ "${CRABBOX_DESKTOP_ENV:-xfce}" != "xfce" ]; then
@@ -482,22 +483,39 @@ case "$active_class $active_name $active_proc" in
     exit 0
     ;;
 esac
+# Keep every clipboard server in the foreground so clip_pid tracks delivery.
 if command -v xclip >/dev/null 2>&1; then
-  timeout 5s xclip -selection clipboard -loops 1 "$tmp" &
+  timeout 5s xclip -quiet -selection clipboard -loops 1 "$tmp" &
   clip_pid=$!
 elif command -v xsel >/dev/null 2>&1; then
-  timeout 5s xsel --clipboard --input < "$tmp" &
+  timeout 5s xsel --nodetach --clipboard --input < "$tmp" &
   clip_pid=$!
 elif command -v wl-copy >/dev/null 2>&1; then
-  wl-copy --paste-once < "$tmp" &
+  wl-copy --foreground --paste-once < "$tmp" &
   clip_pid=$!
 else
   echo "missing clipboard tool; warm a new --desktop lease or install xclip/xsel" >&2
   exit 127
 fi
 sleep 0.2
+if ! kill -0 "$clip_pid" >/dev/null 2>&1; then
+  set +e
+  wait "$clip_pid"
+  clip_status=$?
+  set -e
+  [ "$clip_status" -ne 0 ] || clip_status=1
+  echo "clipboard helper exited before paste (status=$clip_status)" >&2
+  exit "$clip_status"
+fi
 xdotool key --clearmodifiers ctrl+v
-wait "$clip_pid" || true`
+set +e
+wait "$clip_pid"
+clip_status=$?
+set -e
+if [ "$clip_status" -ne 0 ]; then
+  echo "clipboard helper failed while serving paste (status=$clip_status)" >&2
+  exit "$clip_status"
+fi`
 }
 
 func desktopWaylandWtypeKeyArgs(keys string) ([]string, bool) {

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -459,6 +459,7 @@ func desktopPasteRemoteCommand() string {
 	return `set -eu
 tmp="$(mktemp)"
 clip_pid=""
+clip_backend=""
 trap 'if [ -n "$clip_pid" ]; then kill "$clip_pid" 2>/dev/null || true; wait "$clip_pid" 2>/dev/null || true; fi; rm -f "$tmp"' EXIT
 cat > "$tmp"
 if [ -f /var/lib/crabbox/desktop.env ]; then . /var/lib/crabbox/desktop.env; fi
@@ -488,6 +489,7 @@ esac
 if command -v xclip >/dev/null 2>&1; then
   timeout 5s xclip -quiet -selection clipboard -loops 1 "$tmp" &
   clip_pid=$!
+  clip_backend=xclip
 elif command -v xsel >/dev/null 2>&1; then
   xsel --nodetach --selectionTimeout 5000 --clipboard --input < "$tmp" &
   clip_pid=$!
@@ -526,6 +528,7 @@ elif command -v xsel >/dev/null 2>&1; then
 elif command -v wl-copy >/dev/null 2>&1; then
   wl-copy --foreground --paste-once < "$tmp" &
   clip_pid=$!
+  clip_backend=wl-copy
 else
   echo "missing clipboard tool; warm a new --desktop lease or install xclip/xsel" >&2
   exit 127
@@ -536,6 +539,11 @@ if ! kill -0 "$clip_pid" >/dev/null 2>&1; then
   wait "$clip_pid"
   clip_status=$?
   set -e
+  if [ "$clip_status" -eq 0 ] && [ "$clip_backend" = xclip ] && timeout 1s xclip -selection clipboard -o | cmp -s - "$tmp"; then
+    clip_pid=""
+    xdotool key --clearmodifiers ctrl+v
+    exit 0
+  fi
   [ "$clip_status" -ne 0 ] || clip_status=1
   echo "clipboard helper exited before paste (status=$clip_status)" >&2
   exit "$clip_status"

--- a/internal/cli/desktop_input.go
+++ b/internal/cli/desktop_input.go
@@ -483,13 +483,46 @@ case "$active_class $active_name $active_proc" in
     exit 0
     ;;
 esac
-# Keep every clipboard server in the foreground so clip_pid tracks delivery.
+# Keep foreground-capable clipboard servers supervised; xsel is verified by
+# exact readback because it has no paste-once mode.
 if command -v xclip >/dev/null 2>&1; then
   timeout 5s xclip -quiet -selection clipboard -loops 1 "$tmp" &
   clip_pid=$!
 elif command -v xsel >/dev/null 2>&1; then
-  timeout 5s xsel --nodetach --clipboard --input < "$tmp" &
+  xsel --nodetach --selectionTimeout 5000 --clipboard --input < "$tmp" &
   clip_pid=$!
+  clip_verified=0
+  clip_attempt=0
+  while [ "$clip_attempt" -lt 10 ]; do
+    if ! kill -0 "$clip_pid" >/dev/null 2>&1; then
+      set +e
+      wait "$clip_pid"
+      clip_status=$?
+      set -e
+      [ "$clip_status" -ne 0 ] || clip_status=1
+      clip_pid=""
+      echo "clipboard helper exited before paste (xsel status=$clip_status)" >&2
+      exit "$clip_status"
+    fi
+    if timeout 1s xsel --clipboard --output | cmp -s - "$tmp"; then
+      clip_verified=1
+      break
+    fi
+    clip_attempt=$((clip_attempt + 1))
+    sleep 0.05
+  done
+  if [ "$clip_verified" -ne 1 ]; then
+    echo "clipboard helper failed to provide requested contents (xsel)" >&2
+    exit 1
+  fi
+  xdotool key --clearmodifiers ctrl+v
+  # xsel has no paste-once mode. Give the target time to request the selection,
+  # then stop the supervised owner so pasted contents do not remain exposed.
+  sleep 0.2
+  kill "$clip_pid" 2>/dev/null || true
+  wait "$clip_pid" 2>/dev/null || true
+  clip_pid=""
+  exit 0
 elif command -v wl-copy >/dev/null 2>&1; then
   wl-copy --foreground --paste-once < "$tmp" &
   clip_pid=$!

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -265,6 +265,7 @@ func TestDesktopPasteRemoteCommandPrefersClipboardTools(t *testing.T) {
 		`CRABBOX_DESKTOP_ENV:-xfce`,
 		"wtype -d 1 -",
 		"timeout 5s xclip -quiet -selection clipboard -loops 1",
+		`timeout 1s xclip -selection clipboard -o | cmp -s - "$tmp"`,
 		"xsel --nodetach --selectionTimeout 5000 --clipboard --input",
 		`timeout 1s xsel --clipboard --output | cmp -s - "$tmp"`,
 		"clipboard helper failed to provide requested contents (xsel)",
@@ -307,6 +308,39 @@ func TestDesktopPasteRemoteCommandPropagatesClipboardHelperFailure(t *testing.T)
 	}
 	if !strings.Contains(string(out), "clipboard helper") || !strings.Contains(string(out), "status=42") {
 		t.Fatalf("paste failure output=%q", out)
+	}
+}
+
+func TestDesktopPasteRemoteCommandAcceptsXclipManagerHandoff(t *testing.T) {
+	dir := t.TempDir()
+	clipboard := filepath.Join(dir, "clipboard")
+	pasted := filepath.Join(dir, "pasted")
+	for _, name := range []string{"cat", "cmp", "mktemp", "rm", "sleep", "tr"} {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(path, filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, script := range map[string]string{
+		"timeout": "#!/bin/sh\nshift\nexec \"$@\"\n",
+		"xdotool": "#!/bin/sh\nif [ \"$1\" = key ]; then : > " + shellQuote(pasted) + "; exit 0; fi\nexit 1\n",
+		"xclip":   "#!/bin/sh\ncase \" $* \" in\n  *\" -o \"*) cat " + shellQuote(clipboard) + ";;\n  *)\n    for arg do input=$arg; done\n    cat \"$input\" > " + shellQuote(clipboard) + "\n    ;;\nesac\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("sh", "-c", desktopPasteRemoteCommand())
+	cmd.Env = append(os.Environ(), "PATH="+dir, "CRABBOX_DESKTOP_ENV=xfce", "DISPLAY=:99")
+	cmd.Stdin = strings.NewReader("xclip manager clipboard value")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("xclip manager handoff failed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(pasted); err != nil {
+		t.Fatalf("xclip manager handoff did not send Ctrl+V: %v", err)
 	}
 }
 

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -27,6 +27,8 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 		"MOZ_ENABLE_WAYLAND='0'",
 		"setsid '/usr/bin/chromium' 'https://example.com'",
 		"crabbox-desktop-launch.log",
+		"launch_before_windows=",
+		"desktop_launch_new_window",
 		"launch_pid=$!",
 		`kill -0 "$launch_pid"`,
 		"wmctrl -r :ACTIVE: -b remove,fullscreen",
@@ -59,6 +61,66 @@ func TestDesktopLaunchRemoteCommandRejectsExitedPOSIXProcess(t *testing.T) {
 	}
 }
 
+func TestDesktopLaunchRemoteCommandAcceptsNewVisibleWindowFromWrapper(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "window-created")
+	xdotool := `#!/bin/sh
+if [ "$1" = getmouselocation ]; then exit 0; fi
+if [ "$1" = search ]; then
+  [ -f ` + shellQuote(marker) + ` ] && echo 20
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "xdotool"), []byte(xdotool), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	remote := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"sh", "-c", "touch " + shellQuote(marker)},
+		desktopLaunchOptions{VerifyProcess: true},
+	)
+	cmd := exec.Command("sh", "-c", remote)
+	cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "DISPLAY=:99")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("wrapper launch with new visible window failed: %v\n%s", err, out)
+	}
+}
+
+func TestDesktopLaunchRemoteCommandRejectsFailedWrapperWithNewWindow(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "error-window-created")
+	xdotool := `#!/bin/sh
+if [ "$1" = getmouselocation ]; then exit 0; fi
+if [ "$1" = search ]; then
+  [ -f ` + shellQuote(marker) + ` ] && echo 20
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "xdotool"), []byte(xdotool), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	remote := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"sh", "-c", "touch " + shellQuote(marker) + "; exit 23"},
+		desktopLaunchOptions{VerifyProcess: true},
+	)
+	cmd := exec.Command("sh", "-c", remote)
+	cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "DISPLAY=:99")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("failed wrapper with a new window was accepted:\n%s", out)
+	}
+	if !strings.Contains(string(out), "desktop command exited during launch (status=23)") {
+		t.Fatalf("wrapper failure output=%q", out)
+	}
+}
+
 func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
 	got := desktopLaunchRemoteCommand(
 		SSHTarget{TargetOS: targetLinux},
@@ -75,6 +137,9 @@ func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("launch visibility check missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "launch_before_windows=") {
+		t.Fatalf("terminal verification should use its unique title, not generic window snapshots:\n%s", got)
 	}
 }
 

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -29,6 +29,7 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 		"crabbox-desktop-launch.log",
 		"launch_before_windows=",
 		"desktop_launch_new_window",
+		"desktop_launch_observed_window",
 		"launch_pid=$!",
 		`kill -0 "$launch_pid"`,
 		"wmctrl -r :ACTIVE: -b remove,fullscreen",
@@ -121,6 +122,38 @@ exit 1
 	}
 }
 
+func TestDesktopLaunchRemoteCommandAcceptsExistingWindowHandoff(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "existing-window-focused")
+	xdotool := `#!/bin/sh
+if [ "$1" = getmouselocation ]; then exit 0; fi
+if [ "$1" = getactivewindow ]; then
+  if [ -f ` + shellQuote(marker) + ` ]; then echo 20; else echo 10; fi
+  exit 0
+fi
+if [ "$1" = search ]; then
+  printf '10\n20\n'
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "xdotool"), []byte(xdotool), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	remote := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"sh", "-c", "touch " + shellQuote(marker)},
+		desktopLaunchOptions{VerifyProcess: true},
+	)
+	cmd := exec.Command("sh", "-c", remote)
+	cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "DISPLAY=:99")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("existing-window handoff failed: %v\n%s", err, out)
+	}
+}
+
 func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
 	got := desktopLaunchRemoteCommand(
 		SSHTarget{TargetOS: targetLinux},
@@ -130,7 +163,8 @@ func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
 		desktopLaunchOptions{VerifyProcess: true, VisibleWindowTitle: "Crabbox Desktop cbx-test"},
 	)
 	for _, want := range []string{
-		`xdotool search --onlyvisible --name 'Crabbox Desktop cbx-test'`,
+		"launch_before_windows=",
+		`&& desktop_launch_new_window`,
 		"desktop window not visible",
 		`kill "$launch_pid"`,
 	} {
@@ -138,8 +172,38 @@ func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
 			t.Fatalf("launch visibility check missing %q:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "launch_before_windows=") {
-		t.Fatalf("terminal verification should use its unique title, not generic window snapshots:\n%s", got)
+	if strings.Contains(got, `xdotool search --onlyvisible --name 'Crabbox Desktop cbx-test'`) {
+		t.Fatalf("terminal verification should not depend on a mutable title:\n%s", got)
+	}
+}
+
+func TestDesktopLaunchRemoteCommandAcceptsRetitledTerminalWindow(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "terminal-window-created")
+	xdotool := `#!/bin/sh
+if [ "$1" = getmouselocation ]; then exit 0; fi
+if [ "$1" = getactivewindow ]; then echo 10; exit 0; fi
+if [ "$1" = search ]; then
+  echo 10
+  [ -f ` + shellQuote(marker) + ` ] && echo 20
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(dir, "xdotool"), []byte(xdotool), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	remote := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"sh", "-c", "touch " + shellQuote(marker) + "; sleep 2"},
+		desktopLaunchOptions{VerifyProcess: true, VisibleWindowTitle: "Crabbox Desktop cbx-test"},
+	)
+	cmd := exec.Command("sh", "-c", remote)
+	cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "DISPLAY=:99")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("retitled terminal window failed stable-identity verification: %v\n%s", err, out)
 	}
 }
 

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -201,7 +201,9 @@ func TestDesktopPasteRemoteCommandPrefersClipboardTools(t *testing.T) {
 		`CRABBOX_DESKTOP_ENV:-xfce`,
 		"wtype -d 1 -",
 		"timeout 5s xclip -quiet -selection clipboard -loops 1",
-		"timeout 5s xsel --nodetach --clipboard --input",
+		"xsel --nodetach --selectionTimeout 5000 --clipboard --input",
+		`timeout 1s xsel --clipboard --output | cmp -s - "$tmp"`,
+		"clipboard helper failed to provide requested contents (xsel)",
 		"wl-copy --foreground --paste-once",
 		"getactivewindow getwindowclassname",
 		"getactivewindow getwindowpid",
@@ -241,6 +243,43 @@ func TestDesktopPasteRemoteCommandPropagatesClipboardHelperFailure(t *testing.T)
 	}
 	if !strings.Contains(string(out), "clipboard helper") || !strings.Contains(string(out), "status=42") {
 		t.Fatalf("paste failure output=%q", out)
+	}
+}
+
+func TestDesktopPasteRemoteCommandVerifiesXselByReadback(t *testing.T) {
+	dir := t.TempDir()
+	clipboard := filepath.Join(dir, "clipboard")
+	pasted := filepath.Join(dir, "pasted")
+	stopped := filepath.Join(dir, "stopped")
+	for _, name := range []string{"cat", "cmp", "mktemp", "rm", "sleep", "tr"} {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(path, filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, script := range map[string]string{
+		"timeout": "#!/bin/sh\nshift\nexec \"$@\"\n",
+		"xdotool": "#!/bin/sh\nif [ \"$1\" = key ]; then : > " + shellQuote(pasted) + "; exit 0; fi\nexit 1\n",
+		"xsel":    "#!/bin/sh\ncase \"$*\" in\n  *--input*)\n    cat > " + shellQuote(clipboard) + "\n    trap ': > " + shellQuote(stopped) + "; exit 0' TERM INT\n    while :; do sleep 0.05; done\n    ;;\n  *--output*) cat " + shellQuote(clipboard) + ";;\nesac\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("sh", "-c", desktopPasteRemoteCommand())
+	cmd.Env = append(os.Environ(), "PATH="+dir, "CRABBOX_DESKTOP_ENV=xfce", "DISPLAY=:99")
+	cmd.Stdin = strings.NewReader("xsel clipboard value")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("xsel paste command failed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(pasted); err != nil {
+		t.Fatalf("xsel paste did not send Ctrl+V: %v", err)
+	}
+	if _, err := os.Stat(stopped); err != nil {
+		t.Fatalf("xsel clipboard owner was not stopped: %v", err)
 	}
 }
 

--- a/internal/cli/desktop_test.go
+++ b/internal/cli/desktop_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -13,7 +16,7 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 		"/work/crabbox/cbx_1/repo",
 		map[string]string{"DISPLAY": ":99", "BROWSER": "/usr/bin/chromium", "GDK_BACKEND": "x11", "MOZ_ENABLE_WAYLAND": "0"},
 		[]string{"/usr/bin/chromium", "https://example.com"},
-		true,
+		desktopLaunchOptions{WindowedBrowser: true, VerifyProcess: true},
 	)
 	for _, want := range []string{
 		"mkdir -p '/work/crabbox/cbx_1/repo'",
@@ -24,6 +27,8 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 		"MOZ_ENABLE_WAYLAND='0'",
 		"setsid '/usr/bin/chromium' 'https://example.com'",
 		"crabbox-desktop-launch.log",
+		"launch_pid=$!",
+		`kill -0 "$launch_pid"`,
 		"wmctrl -r :ACTIVE: -b remove,fullscreen",
 		"xdotool search --onlyvisible --class google-chrome",
 		"windowsize \"$window\" 1500 900",
@@ -34,6 +39,55 @@ func TestDesktopLaunchRemoteCommandUsesDetachedPOSIXSession(t *testing.T) {
 	}
 	if strings.Contains(got, "swaymsg") {
 		t.Fatalf("desktop launch command should not use Sway-specific window commands:\n%s", got)
+	}
+}
+
+func TestDesktopLaunchRemoteCommandRejectsExitedPOSIXProcess(t *testing.T) {
+	remote := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"sh", "-c", "exit 23"},
+		desktopLaunchOptions{VerifyProcess: true},
+	)
+	out, err := exec.Command("sh", "-c", remote).CombinedOutput()
+	if err == nil {
+		t.Fatalf("launch command succeeded after child exited:\n%s", out)
+	}
+	if !strings.Contains(string(out), "desktop command exited during launch (status=23)") {
+		t.Fatalf("launch failure output=%q", out)
+	}
+}
+
+func TestDesktopLaunchRemoteCommandChecksLinuxTerminalVisibility(t *testing.T) {
+	got := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetLinux},
+		"",
+		nil,
+		[]string{"xterm"},
+		desktopLaunchOptions{VerifyProcess: true, VisibleWindowTitle: "Crabbox Desktop cbx-test"},
+	)
+	for _, want := range []string{
+		`xdotool search --onlyvisible --name 'Crabbox Desktop cbx-test'`,
+		"desktop window not visible",
+		`kill "$launch_pid"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("launch visibility check missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestDesktopLaunchRemoteCommandMakesMacOpenWait(t *testing.T) {
+	got := desktopLaunchRemoteCommand(
+		SSHTarget{TargetOS: targetMacOS},
+		"",
+		nil,
+		[]string{"open", "-na", "Ghostty.app"},
+		desktopLaunchOptions{VerifyProcess: true},
+	)
+	if !strings.Contains(got, "open' '-W' '-na' 'Ghostty.app") {
+		t.Fatalf("macOS open command does not wait for the app:\n%s", got)
 	}
 }
 
@@ -81,19 +135,47 @@ func TestDesktopPasteRemoteCommandPrefersClipboardTools(t *testing.T) {
 	for _, want := range []string{
 		`CRABBOX_DESKTOP_ENV:-xfce`,
 		"wtype -d 1 -",
-		"timeout 5s xclip -selection clipboard -loops 1",
-		"timeout 5s xsel --clipboard --input",
-		"wl-copy --paste-once",
+		"timeout 5s xclip -quiet -selection clipboard -loops 1",
+		"timeout 5s xsel --nodetach --clipboard --input",
+		"wl-copy --foreground --paste-once",
 		"getactivewindow getwindowclassname",
 		"getactivewindow getwindowpid",
 		`*xterm*|*terminal*|*konsole*|*alacritty*|*kitty*|*wezterm*)`,
 		`xdotool type --clearmodifiers --delay 1 --file "$tmp"`,
 		"xdotool key --clearmodifiers ctrl+v",
-		"wait \"$clip_pid\" || true",
+		`kill -0 "$clip_pid"`,
+		"clipboard helper exited before paste",
+		"clipboard helper failed while serving paste",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("paste command missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, `wait "$clip_pid" || true`) {
+		t.Fatalf("paste command still swallows clipboard helper failure:\n%s", got)
+	}
+}
+
+func TestDesktopPasteRemoteCommandPropagatesClipboardHelperFailure(t *testing.T) {
+	dir := t.TempDir()
+	for name, script := range map[string]string{
+		"timeout": "#!/bin/sh\nshift\nexec \"$@\"\n",
+		"xdotool": "#!/bin/sh\n[ \"$1\" = key ] && exit 0\nexit 1\n",
+		"xclip":   "#!/bin/sh\nexit 42\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("sh", "-c", desktopPasteRemoteCommand())
+	cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "CRABBOX_DESKTOP_ENV=xfce", "DISPLAY=:99")
+	cmd.Stdin = strings.NewReader("new clipboard value")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("paste command succeeded after clipboard helper failure:\n%s", out)
+	}
+	if !strings.Contains(string(out), "clipboard helper") || !strings.Contains(string(out), "status=42") {
+		t.Fatalf("paste failure output=%q", out)
 	}
 }
 
@@ -111,11 +193,11 @@ func TestDesktopLinuxTerminalSupportsWaylandAndX11(t *testing.T) {
 		"CRABBOX_DESKTOP_ENV:-xfce",
 		"export DISPLAY=\"${DISPLAY:-:0}\"",
 		"export GDK_BACKEND=x11 MOZ_ENABLE_WAYLAND=0",
-		"exec gnome-terminal --working-directory=\"$PWD\" -- bash -lc",
+		"exec gnome-terminal --wait --title='Crabbox Desktop' --working-directory=\"$PWD\" -- bash -lc",
 		"exec foot --title='Crabbox Desktop'",
 		"monospace:size=16",
 		"export DISPLAY=\"${DISPLAY:-:99}\"",
-		"exec xterm -fa monospace -fs '16' -geometry '120x40'",
+		"exec xterm -title 'Crabbox Desktop' -fa monospace -fs '16' -geometry '120x40'",
 		"bash -lc ''\\''bash'\\'' '\\''-lc'\\'' '\\''echo hello'\\'''",
 	} {
 		if !strings.Contains(joined, want) {
@@ -302,7 +384,7 @@ func TestDesktopLaunchRemoteCommandCanPassEgressProxyToBrowser(t *testing.T) {
 		"/work/crabbox/cbx_1/repo",
 		map[string]string{"DISPLAY": ":99", "BROWSER": "/usr/bin/chromium"},
 		[]string{"/usr/bin/chromium", "--proxy-server=http://127.0.0.1:3128", "https://discord.com/login"},
-		true,
+		desktopLaunchOptions{WindowedBrowser: true},
 	)
 	if !strings.Contains(got, "'/usr/bin/chromium' '--proxy-server=http://127.0.0.1:3128' 'https://discord.com/login'") {
 		t.Fatalf("desktop launch command missing egress proxy arg:\n%s", got)
@@ -344,7 +426,7 @@ func TestWindowsDesktopLaunchRemoteCommandUsesInteractiveTask(t *testing.T) {
 		`C:\crabbox\cbx_1\repo`,
 		map[string]string{"BROWSER": `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`},
 		[]string{`C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`, "https://example.com"},
-		true,
+		desktopLaunchOptions{WindowedBrowser: true},
 	)
 	for _, want := range []string{
 		"CrabboxDesktopLaunch-",
@@ -425,8 +507,8 @@ func TestMacOSDesktopTerminalUsesGhostty(t *testing.T) {
 	}
 	joined := strings.Join(got, " ")
 	for _, want := range []string{
-		"open -na Ghostty.app --args",
-		"--title=gifgrep tui",
+		"open -W -na Ghostty.app --args",
+		"--title=Crabbox Desktop",
 		"--font-size=18",
 		"--window-width=118",
 		"--window-height=34",

--- a/internal/cli/rescue.go
+++ b/internal/cli/rescue.go
@@ -7,18 +7,20 @@ import (
 )
 
 const (
-	rescueBrowserNotLaunched      = "browser not launched"
-	rescueClipboardUnavailable    = "clipboard unavailable"
-	rescueDesktopSessionMissing   = "desktop session missing"
-	rescueInputStackDead          = "input stack dead"
-	rescueVNCBridgeDisconnected   = "VNC bridge disconnected"
-	rescueVNCBridgeNotRunning     = "WebVNC daemon not running"
-	rescueVNCObserverSlotsFull    = "WebVNC observer slots exhausted"
-	rescueVNCStaleViewer          = "WebVNC viewer already active"
-	rescueVNCTargetUnreachable    = "VNC target unreachable"
-	rescueWindowManagerMissing    = "window manager missing"
-	rescueScreenshotCaptureBroken = "screenshot capture broken"
-	rescueArtifactCaptureFailed   = "artifact capture failed"
+	rescueBrowserNotLaunched        = "browser not launched"
+	rescueClipboardDeliveryFailed   = "clipboard delivery failed"
+	rescueClipboardUnavailable      = "clipboard unavailable"
+	rescueDesktopCommandNotLaunched = "desktop command not launched"
+	rescueDesktopSessionMissing     = "desktop session missing"
+	rescueInputStackDead            = "input stack dead"
+	rescueVNCBridgeDisconnected     = "VNC bridge disconnected"
+	rescueVNCBridgeNotRunning       = "WebVNC daemon not running"
+	rescueVNCObserverSlotsFull      = "WebVNC observer slots exhausted"
+	rescueVNCStaleViewer            = "WebVNC viewer already active"
+	rescueVNCTargetUnreachable      = "VNC target unreachable"
+	rescueWindowManagerMissing      = "window manager missing"
+	rescueScreenshotCaptureBroken   = "screenshot capture broken"
+	rescueArtifactCaptureFailed     = "artifact capture failed"
 )
 
 type rescueContext struct {
@@ -118,6 +120,10 @@ func classifyDesktopFailure(output string) string {
 		return rescueInputStackDead
 	case strings.Contains(text, "missing clipboard tool"), strings.Contains(text, "xclip: not found"), strings.Contains(text, "xsel: not found"):
 		return rescueClipboardUnavailable
+	case strings.Contains(text, "clipboard helper exited"), strings.Contains(text, "clipboard helper failed"):
+		return rescueClipboardDeliveryFailed
+	case strings.Contains(text, "desktop command exited during launch"), strings.Contains(text, "desktop window not visible"):
+		return rescueDesktopCommandNotLaunched
 	case strings.Contains(text, "browser window not visible"), strings.Contains(text, "browser process not found"):
 		return rescueBrowserNotLaunched
 	case strings.Contains(text, "can't open display"), strings.Contains(text, "unable to open display"), strings.Contains(text, "display"):

--- a/internal/cli/rescue_test.go
+++ b/internal/cli/rescue_test.go
@@ -13,6 +13,8 @@ func TestClassifyDesktopFailure(t *testing.T) {
 	}{
 		{output: "missing xdotool; warm a new --desktop lease", want: rescueInputStackDead},
 		{output: "missing clipboard tool; install xclip or xsel", want: rescueClipboardUnavailable},
+		{output: "clipboard helper failed while serving paste (status=124)", want: rescueClipboardDeliveryFailed},
+		{output: "desktop command exited during launch (status=1)", want: rescueDesktopCommandNotLaunched},
 		{output: "browser process not found", want: rescueBrowserNotLaunched},
 		{output: "Error: Can't open display: :99", want: rescueDesktopSessionMissing},
 		{output: "capture failed screenshot repair=restart desktop services", want: rescueScreenshotCaptureBroken},


### PR DESCRIPTION
## Summary

- supervise `xclip`, `wl-copy`, and `xsel`; verify clipboard-manager/xsel handoffs by exact readback, terminate xsel after paste, and propagate delivery failure
- verify generic POSIX launch liveness; preserve successful Linux/X11 wrappers that create a window or focus a different existing window
- require terminal/proof to create a new stable X11 window ID before success or proof capture, independent of later title changes
- make macOS `open` wait on the launched app and improve launch/clipboard rescue classification
- document verified launch, proof, and clipboard semantics

Reported by @coygeek.

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- final branch autoreview: clean
- executable regressions cover xclip manager handoff, xsel owner shutdown, empty-desktop wrapper success, existing-window handoff, mutable terminal titles, and nonzero wrapper failure even when a window appears

## Live Linux desktop proof

- exact head `e1c99382`: repeated false-launch rejection, retitled-terminal visible-window verification with locally inspected screenshot, browser paste, paste-backed symbol-heavy type, and zero-lease cleanup
- AWS on-demand `t3.small`, XFCE, browser-enabled lease
- `desktop launch -- /bin/false`: failed before `launched:`
- `desktop proof -- /bin/false`: failed before `launched terminal:`/`proof:`; zero artifact files created
- visible terminal command: passed visible-window verification and produced a locally inspected screenshot containing the expected command output
- forced `/usr/bin/xclip` execution failure with Chromium focused: returned `clipboard delivery failed`; no `pasted:` output; mode restored
- restored foreground `xclip`: `desktop paste` succeeded; symbol-heavy `desktop type` succeeded through `method=paste`
- lease released; follow-up inventory found zero matching leases

Fixes https://github.com/openclaw/crabbox/issues/482
