### PR TITLE
fix: preserve env allowlist override precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Kept `CRABBOX_ENV_ALLOW` authoritative over selected profile allowlists while preserving explicit `--allow-env` additions. Thanks @coygeek.
 - Made desktop paste/type and POSIX launch/proof success depend on verified clipboard delivery or live/visible launch state, including clipboard-manager and wrapper handoffs. Thanks @coygeek.
 - Released newly created SSH leases when prewarm hydration, probe, or ready-pool registration fails, preventing paid lease leaks. Thanks @coygeek.
 - Preserved transient run-history creation retries until a replacement lease attaches successfully.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -136,6 +136,7 @@ type Config struct {
 	Sync                          SyncConfig
 	Run                           RunConfig
 	EnvAllow                      []string
+	envAllowOverriddenByEnv       bool
 	Capacity                      CapacityConfig
 	Actions                       ActionsConfig
 	Blacksmith                    BlacksmithConfig
@@ -7187,6 +7188,7 @@ func applyEnv(cfg *Config) error {
 	cfg.Sync.BaseRef = getenv("CRABBOX_SYNC_BASE_REF", cfg.Sync.BaseRef)
 	if envAllow := os.Getenv("CRABBOX_ENV_ALLOW"); envAllow != "" {
 		cfg.EnvAllow = splitCommaList(envAllow)
+		cfg.envAllowOverriddenByEnv = true
 	}
 	if tools := os.Getenv("CRABBOX_PREFLIGHT_TOOLS"); tools != "" {
 		cfg.Run.PreflightTools = normalizePreflightToolNames(splitCommaList(tools))

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -35,7 +35,9 @@ func applySelectedProfileConfig(cfg *Config) error {
 	if err := validateProfileConfig(name, profile); err != nil {
 		return err
 	}
-	cfg.EnvAllow = appendUniqueStrings(cfg.EnvAllow, profile.EnvAllow...)
+	if !cfg.envAllowOverriddenByEnv {
+		cfg.EnvAllow = appendUniqueStrings(cfg.EnvAllow, profile.EnvAllow...)
+	}
 	if len(profile.Presets) > 0 {
 		if cfg.Presets == nil {
 			cfg.Presets = map[string]PresetConfig{}

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -149,6 +149,50 @@ profiles:
 	}
 }
 
+func TestProfileEnvAllowRespectsEnvironmentAndCLIPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		profile string
+	}{
+		{
+			name: "env allow",
+			profile: `env:
+      allow:
+        - PROFILE_SECRET`,
+		},
+		{
+			name: "legacy envAllow",
+			profile: `envAllow:
+      - PROFILE_SECRET`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, ".crabbox.yaml")
+			t.Setenv("CRABBOX_CONFIG", cfgPath)
+			t.Setenv("CRABBOX_ENV_ALLOW", "ENV_ONLY")
+			contents := "profile: qa\nenv:\n  allow:\n    - GLOBAL_SECRET\nprofiles:\n  qa:\n    " + tt.profile + "\n"
+			if err := os.WriteFile(cfgPath, []byte(contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := applySelectedProfileConfig(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			applyRunEnvAllowFlags(&cfg, []string{"CLI_ONLY,CLI_SECOND"})
+
+			if got := strings.Join(cfg.EnvAllow, ","); got != "ENV_ONLY,CLI_ONLY,CLI_SECOND" {
+				t.Fatalf("env allow=%q", got)
+			}
+		})
+	}
+}
+
 func TestPresetCommandPreservesQuotedArguments(t *testing.T) {
 	cfg := Config{
 		Profile: "qa",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -396,9 +396,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 	}
-	for _, value := range allowEnvFlags {
-		cfg.EnvAllow = appendUniqueStrings(cfg.EnvAllow, splitCommaList(value)...)
-	}
+	applyRunEnvAllowFlags(&cfg, allowEnvFlags)
 	if *preflightTools != "" {
 		cfg.Run.PreflightTools = normalizePreflightToolNames(splitCommaList(*preflightTools))
 	}
@@ -1624,6 +1622,12 @@ afterSync:
 		return recordFailure(ExitError{Code: code, Message: fmt.Sprintf("remote command exited %d", code)})
 	}
 	return nil
+}
+
+func applyRunEnvAllowFlags(cfg *Config, values []string) {
+	for _, value := range values {
+		cfg.EnvAllow = appendUniqueStrings(cfg.EnvAllow, splitCommaList(value)...)
+	}
 }
 
 func writeRunLeaseOutput(path string, session *RunSessionHandle) error {


### PR DESCRIPTION
## Summary

- keep `CRABBOX_ENV_ALLOW` authoritative when a selected profile also defines an environment allowlist
- preserve explicit `--allow-env` additions after the environment override
- cover both `env.allow` and legacy `envAllow` profile syntax

Fixes https://github.com/openclaw/crabbox/issues/474

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- local-container live run: profile secret excluded, environment-selected variable forwarded, CLI-selected variable forwarded, command exited 0, lease auto-cleaned
- autoreview clean: no accepted/actionable findings

## Configuration

No new configuration. Restores the documented precedence: config and profile allowlists, then replacing `CRABBOX_ENV_ALLOW`, then additive `--allow-env` flags.
