### PR TITLE
fix: reject unsafe artifact publish entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected symlinked and non-regular artifact bundle entries before publish side effects, preventing files outside the selected bundle from being uploaded. Thanks @coygeek.
 - Kept `CRABBOX_ENV_ALLOW` authoritative over selected profile allowlists while preserving explicit `--allow-env` additions. Thanks @coygeek.
 - Made desktop paste/type and POSIX launch/proof success depend on verified clipboard delivery or live/visible launch state, including clipboard-manager and wrapper handoffs. Thanks @coygeek.
 - Released newly created SSH leases when prewarm hydration, probe, or ready-pool registration fails, preventing paid lease leaks. Thanks @coygeek.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -122,7 +122,9 @@ renders Markdown with inline image/GIF links, writes that body to
 `published-artifacts.md`, writes and publishes `artifact-manifest.json`, and
 posts the body with `gh`.
 
-`--dir <bundle>` is required. Storage backends (`--storage`):
+`--dir <bundle>` is required. Publishing rejects symlinks and other non-regular
+bundle entries before upload, manifest, or Markdown side effects. Storage
+backends (`--storage`):
 
 - `auto` (default): use brokered publishing when a coordinator with a token is
   configured, otherwise fall back to `local`.

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -144,14 +144,19 @@ func listArtifactBundleFiles(dir string) ([]artifactFile, error) {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("artifact bundle contains symlink: %s", filepath.ToSlash(rel))
 		}
+		name := entry.Name()
+		generatedOutput := name == "published-artifacts.md" || name == artifactManifestFilename
+		reservedOutputPath := rel == "published-artifacts.md" || rel == artifactManifestFilename
+		if reservedOutputPath && info.IsDir() {
+			return fmt.Errorf("artifact bundle contains directory at reserved output path: %s", filepath.ToSlash(rel))
+		}
 		if info.IsDir() {
 			return nil
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("artifact bundle contains non-regular file: %s", filepath.ToSlash(rel))
 		}
-		name := entry.Name()
-		if name == "published-artifacts.md" || name == artifactManifestFilename {
+		if generatedOutput {
 			return nil
 		}
 		files = append(files, artifactFile{Kind: artifactKindForPath(path), Name: filepath.ToSlash(rel), Path: path})

--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -133,16 +133,26 @@ func listArtifactBundleFiles(dir string) ([]artifactFile, error) {
 		if err != nil {
 			return err
 		}
-		if entry.IsDir() {
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("artifact bundle contains symlink: %s", filepath.ToSlash(rel))
+		}
+		if info.IsDir() {
 			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("artifact bundle contains non-regular file: %s", filepath.ToSlash(rel))
 		}
 		name := entry.Name()
 		if name == "published-artifacts.md" || name == artifactManifestFilename {
 			return nil
-		}
-		rel, err := filepath.Rel(dir, path)
-		if err != nil {
-			return err
 		}
 		files = append(files, artifactFile{Kind: artifactKindForPath(path), Name: filepath.ToSlash(rel), Path: path})
 		return nil

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -339,6 +339,39 @@ func TestListArtifactBundleFilesSkipsPublishedMarkdown(t *testing.T) {
 	}
 }
 
+func TestArtifactsPublishRejectsSymlinksBeforeSideEffects(t *testing.T) {
+	for _, linkName := range []string{"screenshot.png", artifactManifestFilename, "published-artifacts.md"} {
+		t.Run(linkName, func(t *testing.T) {
+			dir := t.TempDir()
+			outside := filepath.Join(t.TempDir(), "outside-secret.txt")
+			mustWriteFile(t, outside, "outside-secret")
+			mustWriteFile(t, filepath.Join(dir, "safe.txt"), "safe")
+			if err := os.Symlink(outside, filepath.Join(dir, linkName)); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+
+			var stdout bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: io.Discard}).artifactsPublish(context.Background(), []string{
+				"--dir", dir,
+				"--storage", "local",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("error=%v, want exit 2", err)
+			}
+			if !strings.Contains(exitErr.Message, "symlink") || !strings.Contains(exitErr.Message, linkName) {
+				t.Fatalf("message=%q", exitErr.Message)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout=%q, want no publish output", stdout.String())
+			}
+			if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "outside-secret" {
+				t.Fatalf("outside file changed: data=%q err=%v", got, readErr)
+			}
+		})
+	}
+}
+
 func TestArtifactsPublishWritesManifestByDefault(t *testing.T) {
 	dir := t.TempDir()
 	data := []byte("png-data")

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -325,6 +325,7 @@ func TestListArtifactBundleFilesSkipsPublishedMarkdown(t *testing.T) {
 	mustWriteFile(t, filepath.Join(dir, "published-artifacts.md"), "old")
 	mustWriteFile(t, filepath.Join(dir, artifactManifestFilename), "{}")
 	mustWriteFile(t, filepath.Join(dir, "nested", "logs.txt"), "logs")
+	mustWriteFile(t, filepath.Join(dir, "nested", "published-artifacts.md", "child.txt"), "child")
 	files, err := listArtifactBundleFiles(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -334,7 +335,7 @@ func TestListArtifactBundleFilesSkipsPublishedMarkdown(t *testing.T) {
 		names = append(names, file.Name)
 	}
 	got := strings.Join(names, ",")
-	if got != "nested/logs.txt,screenshot.png" {
+	if got != "nested/logs.txt,nested/published-artifacts.md/child.txt,screenshot.png" {
 		t.Fatalf("files=%s", got)
 	}
 }
@@ -367,6 +368,32 @@ func TestArtifactsPublishRejectsSymlinksBeforeSideEffects(t *testing.T) {
 			}
 			if got, readErr := os.ReadFile(outside); readErr != nil || string(got) != "outside-secret" {
 				t.Fatalf("outside file changed: data=%q err=%v", got, readErr)
+			}
+		})
+	}
+}
+
+func TestArtifactsPublishRejectsReservedOutputDirectoriesBeforeSideEffects(t *testing.T) {
+	for _, reservedName := range []string{artifactManifestFilename, "published-artifacts.md"} {
+		t.Run(reservedName, func(t *testing.T) {
+			dir := t.TempDir()
+			mustWriteFile(t, filepath.Join(dir, "safe.txt"), "safe")
+			mustWriteFile(t, filepath.Join(dir, reservedName, "nested.txt"), "nested")
+
+			var stdout bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: io.Discard}).artifactsPublish(context.Background(), []string{
+				"--dir", dir,
+				"--storage", "local",
+			})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("error=%v, want exit 2", err)
+			}
+			if !strings.Contains(exitErr.Message, "reserved output path") || !strings.Contains(exitErr.Message, reservedName) {
+				t.Fatalf("message=%q", exitErr.Message)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout=%q, want no publish output", stdout.String())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- reject symlinks and other non-regular artifact bundle entries during enumeration
- perform rejection before skipping or writing generated manifest and Markdown filenames
- cover ordinary artifact links, symlinked generated-output names, and reserved output directories

Fixes https://github.com/openclaw/crabbox/issues/495

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- live CLI smoke: local publish of a bundle containing an outside-file symlink exited 2, reported the symlink, created no manifest or Markdown, and left the outside file unchanged
- autoreview clean: no accepted/actionable findings

Sanitized live terminal output:

```text
$ crabbox artifacts publish --dir /tmp/redacted/bundle --storage local
read artifact directory: artifact bundle contains symlink: screenshot.png
$ verify-result
exit=2 no_side_effects=true outside_unchanged=true
$ crabbox artifacts publish --dir /tmp/redacted/reserved-bundle --storage local
read artifact directory: artifact bundle contains directory at reserved output path: artifact-manifest.json
$ verify-result
exit=2 no_publish_output=true
```

## Security

The selected artifact directory now acts as a regular-file-only publication boundary. Existing regular generated metadata files remain skipped during enumeration and are regenerated normally.
