### PR TITLE
fix: reject dangling required artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Required run artifacts now reject dangling symlinks and symlinks to directories instead of treating them as proof files. Thanks @coygeek.
 - Rejected symlinked and non-regular artifact bundle entries before publish side effects, preventing files outside the selected bundle from being uploaded. Thanks @coygeek.
 - Kept `CRABBOX_ENV_ALLOW` authoritative over selected profile allowlists while preserving explicit `--allow-env` additions. Thanks @coygeek.
 - Made desktop paste/type and POSIX launch/proof success depend on verified clipboard delivery or live/visible launch state, including clipboard-manager and wrapper handoffs. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -335,10 +335,11 @@ proof file, manifest, report, or other evidence artifact. Required artifact glob
 are checked after the remote command exits 0 and before `--download` files are
 written locally. They are also collected into the run artifact tarball. If any
 required glob matches nothing, the run fails even though the command itself
-succeeded. The same SSH-run target limits as
-`--artifact-glob` apply. Delegated providers that support bounded run artifact
-retrieval enforce provider-owned file and byte limits before returning local
-artifacts.
+succeeded. Matches must resolve to regular files, so dangling symlinks and
+symlinks to directories do not satisfy the proof gate. The same SSH-run target
+limits as `--artifact-glob` apply. Delegated providers that support bounded run
+artifact retrieval enforce provider-owned file and byte limits before returning
+local artifacts.
 
 Use repeatable `--download remote=local` when the command writes proof files on
 the box. Downloads run only after a successful remote command, paths resolve

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -25,7 +25,9 @@ collector; use Linux or Windows WSL2.
 Repeat `--require-artifact <glob>` when the run should fail unless a proof file,
 manifest, or report exists after the command exits successfully. Required
 artifacts use the same safe relative glob syntax and target limits as
-`--artifact-glob`; each required glob must match at least one file or symlink.
+`--artifact-glob`; each required glob must resolve to at least one regular file.
+A symlink counts only when its target is a regular file; dangling symlinks and
+symlinks to directories do not satisfy the proof gate or enter artifact archives.
 Crabbox checks required artifacts before local `--download` outputs, then
 includes required artifacts in the run artifact tarball. Callers can pair
 `--require-artifact reports/data/manifest.json` with a broader

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -1096,6 +1097,107 @@ func TestRunArtifactRequireScriptFailsOnMissingArtifacts(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "missing required artifact: reports/data/manifest.json") {
 		t.Fatalf("missing required artifact output:\n%s", out)
+	}
+}
+
+func TestRunArtifactRequireScriptSymlinkPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		glob     string
+		setup    func(t *testing.T, dir, proof string)
+		wantPass bool
+	}{
+		{
+			name: "symlink to regular file",
+			glob: "reports/data/proof.json",
+			setup: func(t *testing.T, dir, proof string) {
+				target := filepath.Join(dir, "reports", "data", "target.json")
+				if err := os.WriteFile(target, []byte("{}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, proof); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+			wantPass: true,
+		},
+		{
+			name: "dangling symlink",
+			glob: "reports/data/proof.json",
+			setup: func(t *testing.T, dir, proof string) {
+				if err := os.Symlink(filepath.Join(dir, "missing.json"), proof); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+		{
+			name: "symlink to directory",
+			glob: "reports/data/proof.json",
+			setup: func(t *testing.T, dir, proof string) {
+				target := filepath.Join(dir, "proof-dir")
+				if err := os.Mkdir(target, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, proof); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+		{
+			name: "recursive dangling symlink",
+			glob: "reports/data/**/*.json",
+			setup: func(t *testing.T, dir, proof string) {
+				if err := os.Symlink(filepath.Join(dir, "missing.json"), proof); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			proofDir := filepath.Join(dir, "reports", "data")
+			if err := os.MkdirAll(proofDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tt.setup(t, dir, filepath.Join(proofDir, "proof.json"))
+
+			out, err := exec.Command("bash", "-lc", runArtifactRequireScript(dir, []string{tt.glob})).CombinedOutput()
+			if tt.wantPass {
+				if err != nil || !strings.Contains(string(out), "matched=1") {
+					t.Fatalf("error=%v output=%s", err, out)
+				}
+				return
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+				t.Fatalf("error=%v, want exit 8; output=%s", err, out)
+			}
+			if !strings.Contains(string(out), "missing required artifact: "+tt.glob) {
+				t.Fatalf("missing required artifact output:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestRunArtifactCollectScriptSkipsDanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	artifactDir := filepath.Join(dir, ".artifacts")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "missing.txt"), filepath.Join(artifactDir, "proof.txt")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+	out, err := exec.Command("bash", "-lc", runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{".artifacts/**"})).CombinedOutput()
+	if err != nil {
+		t.Fatalf("collect script failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "warning: no artifact matches") {
+		t.Fatalf("missing empty artifact warning:\n%s", out)
+	}
+	if names := tarGzNames(t, archivePath); len(names) != 0 {
+		t.Fatalf("archive contains dangling symlink: %#v", names)
 	}
 }
 

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -159,7 +159,7 @@ func runArtifactRequireScript(workdir string, globs []string) string {
 	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("missing=()\n")
 	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
-	b.WriteString("check_artifact_file() { local f=\"$1\" rel; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
+	b.WriteString("check_artifact_file() { local f=\"$1\" rel; [ -f \"$f\" ] || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
 	b.WriteString("add_required_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
 	for _, glob := range globs {
 		b.WriteString("matches=()\n")
@@ -185,7 +185,7 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("files=()\n")
 	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
-	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 0; rel=$(artifact_rel_path \"$f\") || return 0; case \"$rel\" in " + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
+	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; [ -f \"$f\" ] || return 0; rel=$(artifact_rel_path \"$f\") || return 0; case \"$rel\" in " + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
 	for _, glob := range globs {
 		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
 		if strings.Contains(glob, "**") {
@@ -211,7 +211,7 @@ func DelegatedRunArtifactScript(requiredGlobs, artifactGlobs []string, maxFiles 
 	b.WriteString("set -euo pipefail\n")
 	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
-	b.WriteString("check_artifact_file() { local f=\"$1\" rel; { [ -f \"$f\" ] || [ -L \"$f\" ]; } || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
+	b.WriteString("check_artifact_file() { local f=\"$1\" rel; [ -f \"$f\" ] || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
 	b.WriteString("dedupe_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
 	appendArtifactGlobMatches := func(glob string) {
 		b.WriteString("for f in " + glob + "; do dedupe_artifact_match \"$f\"; done\n")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1391,6 +1391,26 @@ done
 	}
 }
 
+func TestDelegatedRunArtifactScriptRejectsDanglingRequiredArtifact(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Join("reports", "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "missing.json"), filepath.Join("reports", "data", "proof.json")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	out, err := exec.Command("bash", "-c", DelegatedRunArtifactScript([]string{"reports/data/**/*.json"}, nil, 16, 1024*1024)).CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+		t.Fatalf("error=%v, want exit 8; output=%s", err, out)
+	}
+	if !strings.Contains(string(out), "missing required artifact: reports/data/**/*.json") {
+		t.Fatalf("missing required artifact output:\n%s", out)
+	}
+}
+
 func TestRunCommandCleansEnvProfileWhenProbeFails(t *testing.T) {
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)


### PR DESCRIPTION
## Summary

- require artifact paths to resolve to regular files in direct, collection, and delegated scripts
- reject dangling symlinks and symlinks to directories while preserving symlinks to regular files
- cover exact, recursive, archive-collection, and delegated artifact paths

Fixes https://github.com/openclaw/crabbox/issues/475

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- autoreview clean: no accepted/actionable findings

Sanitized live local-container output:

```text
$ crabbox run --provider local-container --no-sync --require-artifact reports/proof.json -- sh -c 'mkdir -p reports && ln -s /nonexistent/proof.json reports/proof.json'
missing required artifact: reports/proof.json
run summary ... exit=7
lease cleanup stopped=true policy=auto

$ crabbox run --provider local-container --no-sync --require-artifact reports/proof.json -- sh -c 'mkdir -p reports && printf proof > reports/target.json && ln -s target.json reports/proof.json'
required artifact reports/proof.json matched=1
artifact kind=artifact-glob ...
run summary ... exit=0
lease cleanup stopped=true policy=auto
```

## Compatibility

Symlinks to regular files remain accepted. Only paths that do not resolve to regular proof content now fail the existence gate and are omitted from artifact archives.
