### PR TITLE
fix: validate AWS regions before signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Validated AWS region inputs before building SigV4-signed service endpoints, preventing request-selected hostname escapes. Thanks @coygeek.
 - Required run artifacts now reject dangling symlinks and symlinks to directories instead of treating them as proof files. Thanks @coygeek.
 - Rejected symlinked and non-regular artifact bundle entries before publish side effects, preventing files outside the selected bundle from being uploaded. Thanks @coygeek.
 - Kept `CRABBOX_ENV_ALLOW` authoritative over selected profile allowlists while preserving explicit `--allow-env` additions. Thanks @coygeek.

--- a/worker/src/aws-region.ts
+++ b/worker/src/aws-region.ts
@@ -1,0 +1,22 @@
+export class InvalidAWSRegionError extends Error {
+  constructor(field: string) {
+    super(`${field} must be an AWS region name`);
+    this.name = "InvalidAWSRegionError";
+  }
+}
+
+export function sanitizeAWSRegion(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const region = value.trim().toLowerCase();
+  return /^[a-z]{2}-[a-z-]+-[0-9]$/.test(region) ? region : "";
+}
+
+export function requireAWSRegion(value: unknown, field = "region"): string {
+  const region = sanitizeAWSRegion(value);
+  if (!region) {
+    throw new InvalidAWSRegionError(field);
+  }
+  return region;
+}

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,6 +1,7 @@
 import { AwsClient } from "aws4fetch";
 import { XMLParser } from "fast-xml-parser";
 
+import { requireAWSRegion, sanitizeAWSRegion } from "./aws-region";
 import { awsRunInstancesUserData } from "./bootstrap";
 import {
   awsPromotedAMIConfigKey,
@@ -225,12 +226,12 @@ export class EC2SpotClient {
     private readonly env: Env,
     region: string,
   ) {
+    this.region = requireAWSRegion(region || env.CRABBOX_AWS_REGION || "eu-west-1");
     const accessKeyId = env.AWS_ACCESS_KEY_ID;
     const secretAccessKey = env.AWS_SECRET_ACCESS_KEY;
     if (!accessKeyId || !secretAccessKey) {
       throw new Error("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secrets are required");
     }
-    this.region = region || env.CRABBOX_AWS_REGION || "eu-west-1";
     this.endpoint = `https://ec2.${this.region}.amazonaws.com/`;
     this.serviceQuotasEndpoint = `https://servicequotas.${this.region}.amazonaws.com/`;
     this.stsEndpoint = `https://sts.${this.region}.amazonaws.com/`;
@@ -2110,15 +2111,21 @@ export function awsRegionCandidates(
     config.target === "macos" &&
     (config.hostID || config.awsMacHostID || config.awsAMI || config.awsSnapshot)
   ) {
-    return uniqueStrings([config.awsRegion || preferredRegion || env.CRABBOX_AWS_REGION || ""]);
+    return validAWSRegionCandidates([
+      config.awsRegion || preferredRegion || env.CRABBOX_AWS_REGION || "",
+    ]);
   }
-  return uniqueStrings([
+  return validAWSRegionCandidates([
     preferredRegion,
     config.awsRegion,
     env.CRABBOX_AWS_REGION ?? "",
     ...splitCommaList(env.CRABBOX_CAPACITY_REGIONS ?? ""),
     ...config.capacityRegions,
   ]);
+}
+
+function validAWSRegionCandidates(values: string[]): string[] {
+  return uniqueStrings(values.map(sanitizeAWSRegion).filter(Boolean));
 }
 
 export function awsAvailabilityZoneForRegion(

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -1,3 +1,4 @@
+import { requireAWSRegion } from "./aws-region";
 import { normalizeOSImage, osImageSpec } from "./os-image";
 import type { LeaseRequest, Provider, TargetOS, WindowsMode } from "./types";
 
@@ -240,6 +241,17 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
   if (tailscaleExitNodeAllowLanAccess && !tailscaleExitNode) {
     throw new Error("tailscaleExitNodeAllowLanAccess requires tailscaleExitNode");
   }
+  const requestedAWSRegion =
+    typeof input.awsRegion === "string" ? input.awsRegion.trim() : input.awsRegion;
+  const awsRegion = requireAWSRegion(requestedAWSRegion || "eu-west-1", "awsRegion");
+  const capacityRegions =
+    provider === "aws"
+      ? uniqueStrings(
+          (input.capacity?.regions ?? [])
+            .filter((region) => typeof region !== "string" || region.trim() !== "")
+            .map((region) => requireAWSRegion(region, "capacity.regions entry")),
+        )
+      : (input.capacity?.regions ?? []);
   return {
     provider,
     target,
@@ -266,7 +278,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     hostID: input.hostId ?? input.hostID ?? "",
     location: input.location ?? "fsn1",
     image: input.image ?? linuxOSImage?.hetznerImage ?? "ubuntu-24.04",
-    awsRegion: input.awsRegion ?? "eu-west-1",
+    awsRegion,
     awsAMI: input.awsAMI ?? "",
     awsUseStockImage: false,
     awsPromotedAMIs: {},
@@ -295,7 +307,7 @@ export function leaseConfig(input: LeaseRequest, defaults: LeaseConfigDefaults =
     capacityMarket: input.capacity?.market ?? "spot",
     capacityStrategy: input.capacity?.strategy ?? "most-available",
     capacityFallback: input.capacity?.fallback ?? "on-demand-after-120s",
-    capacityRegions: input.capacity?.regions ?? [],
+    capacityRegions,
     capacityAvailabilityZones: input.capacity?.availabilityZones ?? [],
     capacityHints: input.capacity?.hints ?? true,
     sshUser,

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -22,6 +22,7 @@ import {
   isAWSSecurityGroupRuleLimitError,
   type AWSMacHost,
 } from "./aws";
+import { InvalidAWSRegionError, sanitizeAWSRegion } from "./aws-region";
 import { AzureClient, azureRegionCandidates, type AzureDeferredCleanupRequest } from "./azure";
 import {
   codeOriginForLease,
@@ -1583,7 +1584,15 @@ export class FleetCoordinator {
     const azureWindowsARM64Image = this.env.CRABBOX_AZURE_WINDOWS_ARM64_IMAGE?.trim();
     if (azureWindowsARM64Image) defaults.azureWindowsARM64Image = azureWindowsARM64Image;
     if (this.env.CRABBOX_AZURE_OS_DISK) defaults.azureOSDisk = this.env.CRABBOX_AZURE_OS_DISK;
-    let config = leaseConfig(input, defaults);
+    let config: LeaseConfig;
+    try {
+      config = leaseConfig(input, defaults);
+    } catch (error) {
+      if (error instanceof InvalidAWSRegionError) {
+        return json({ error: "invalid_region", message: error.message }, { status: 400 });
+      }
+      throw error;
+    }
     if (workspaceID) {
       const hostKeys = workspaceSSHHostKeysFromRequest(request);
       if (!hostKeys) {
@@ -4367,6 +4376,13 @@ export class FleetCoordinator {
       );
     }
     const url = new URL(request.url);
+    const requestedAWSRegion = provider === "aws" ? url.searchParams.get("region") : null;
+    if (requestedAWSRegion && !sanitizeAWSRegion(requestedAWSRegion)) {
+      return json(
+        { error: "invalid_region", message: "region must be an AWS region name" },
+        { status: 400 },
+      );
+    }
     const readiness = this.providerConfigurationReadiness(
       provider,
       url.searchParams.get("gcpProject") ?? undefined,
@@ -4422,7 +4438,7 @@ export class FleetCoordinator {
     }
     const region = params.get("region");
     if (region) {
-      leaseRequest.awsRegion = region;
+      leaseRequest.awsRegion = sanitizeAWSRegion(region);
     }
     const config = leaseConfig(leaseRequest);
     return await new EC2SpotClient(this.env, config.awsRegion).capacityReadinessChecks(config);
@@ -11200,11 +11216,6 @@ function awsImageArchitectureForLease(
     return "arm64";
   }
   return awsImageArchitectureForTarget(target, serverType);
-}
-
-function sanitizeAWSRegion(value: string): string {
-  const region = value.trim().toLowerCase();
-  return /^[a-z]{2}-[a-z-]+-[0-9]$/.test(region) ? region : "";
 }
 
 function boolFromUnknown(value: unknown): boolean {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1201,6 +1201,26 @@ describe("aws provider", () => {
         "us-east-1",
       ),
     ).toEqual(["us-east-1"]);
+    expect(
+      awsRegionCandidates(
+        { awsRegion: "evil.example/", capacityRegions: ["us-east-1", "bad/"] },
+        { CRABBOX_AWS_REGION: "also.bad/", CRABBOX_CAPACITY_REGIONS: "eu-west-1,evil/" },
+        "eu-central-1",
+      ),
+    ).toEqual(["eu-central-1", "eu-west-1", "us-east-1"]);
+  });
+
+  it("rejects invalid regions before constructing signed endpoints", () => {
+    expect(
+      () =>
+        new EC2SpotClient(
+          {
+            AWS_ACCESS_KEY_ID: "test",
+            AWS_SECRET_ACCESS_KEY: "secret",
+          } as never,
+          "evil.example/",
+        ),
+    ).toThrow("region must be an AWS region name");
   });
 
   it("treats macOS host and image misses as retryable regional AWS failures", () => {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -443,6 +443,31 @@ describe("lease config", () => {
     expect(config.os).toBe("ubuntu:26.04");
   });
 
+  it("validates and normalizes AWS lease regions", () => {
+    const config = leaseConfig({
+      provider: "aws",
+      sshPublicKey: "ssh-ed25519 test",
+      awsRegion: " US-EAST-1 ",
+      capacity: { regions: ["EU-WEST-1", "eu-west-1", ""] },
+    });
+    expect(config.awsRegion).toBe("us-east-1");
+    expect(config.capacityRegions).toEqual(["eu-west-1"]);
+    expect(() =>
+      leaseConfig({
+        provider: "aws",
+        sshPublicKey: "ssh-ed25519 test",
+        awsRegion: "evil.example/",
+      }),
+    ).toThrow("awsRegion must be an AWS region name");
+    expect(() =>
+      leaseConfig({
+        provider: "aws",
+        sshPublicKey: "ssh-ed25519 test",
+        capacity: { regions: ["eu-west-1", "evil.example/"] },
+      }),
+    ).toThrow("capacity.regions entry must be an AWS region name");
+  });
+
   it("uses Azure defaults when requested", () => {
     const config = leaseConfig({
       provider: "azure",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17111,6 +17111,48 @@ describe("fleet identity", () => {
     );
   });
 
+  it("rejects path-bearing AWS regions before signed requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    const fleet = testFleet(
+      undefined,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      },
+    );
+
+    const readiness = await fleet.fetch(
+      request("GET", "/v1/providers/aws/readiness?region=evil.example/"),
+    );
+    expect(readiness.status).toBe(400);
+    await expect(readiness.json()).resolves.toMatchObject({ error: "invalid_region" });
+
+    const responses = await Promise.all(
+      [
+        { awsRegion: "evil.example/" },
+        { capacity: { regions: ["eu-west-1", "evil.example/"] } },
+      ].map((body) =>
+        fleet.fetch(
+          request("POST", "/v1/leases", {
+            body: {
+              provider: "aws",
+              sshPublicKey: "ssh-ed25519 test",
+              ...body,
+            },
+          }),
+        ),
+      ),
+    );
+    expect(responses.map((response) => response.status)).toEqual([400, 400]);
+    const responseBodies = await Promise.all(responses.map((response) => response.json()));
+    for (const body of responseBodies) {
+      expect(body).toMatchObject({ error: "invalid_region" });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fails brokered Azure leases with provider_not_configured before constructing Azure", async () => {
     const fleet = testFleet();
     const response = await fleet.fetch(


### PR DESCRIPTION
## Summary

- centralize AWS region normalization and validation
- reject invalid readiness, lease `awsRegion`, and AWS `capacity.regions` inputs with HTTP 400
- validate again inside `EC2SpotClient` before constructing signed service endpoints
- filter invalid environment/config fallback candidates before regional retries

Fixes https://github.com/openclaw/crabbox/issues/477

## Verification

- `npm test --prefix worker` — 645 tests passed
- `npm run format:check --prefix worker`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run build --prefix worker`
- autoreview clean: no accepted/actionable findings

Sanitized live Wrangler output:

```text
GET /v1/providers/aws/readiness?region=evil.example/
{"error":"invalid_region","message":"region must be an AWS region name"}
status=400

POST /v1/leases {"provider":"aws","awsRegion":"evil.example/",...}
{"error":"invalid_region","message":"awsRegion must be an AWS region name"}
status=400

POST /v1/leases {"provider":"aws","capacity":{"regions":["eu-west-1","evil.example/"]},...}
{"error":"invalid_region","message":"capacity.regions entry must be an AWS region name"}
status=400
```

The local Worker logged all three requests as 400 responses; no AWS fetch was made.

## Compatibility

Valid region names are trimmed and lowercased. Empty `awsRegion` retains the existing `eu-west-1` default; duplicate capacity regions are deduplicated. Non-AWS capacity region formats are unchanged.
