### PR TITLE
fix: guard Cloudflare runner redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected cross-origin Cloudflare runner redirects before command, environment, or upload bodies can be replayed. Thanks @coygeek.
 - Validated AWS region inputs before building SigV4-signed service endpoints, preventing request-selected hostname escapes. Thanks @coygeek.
 - Required run artifacts now reject dangling symlinks and symlinks to directories instead of treating them as proof files. Thanks @coygeek.
 - Rejected symlinked and non-regular artifact bundle entries before publish side effects, preventing files outside the selected bundle from being uploaded. Thanks @coygeek.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -78,6 +78,9 @@ export CRABBOX_CLOUDFLARE_RUNNER_TOKEN=...
 
 The token is intentionally **not** exposed as a command-line flag, because
 command-line arguments can be captured in shell history and process listings.
+Runner redirects are followed only when they keep the configured scheme, host,
+and effective port. Cross-origin redirects fail before command, environment, or
+upload bodies can be replayed to another destination.
 
 The workdir defaults to `/workspace/crabbox` and must resolve to an absolute
 path. Broad system paths (`/`, `/workspace`, `/usr`, `/var`, and similar) are

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -158,6 +158,114 @@ func TestCloudflareClientUsesBoundedDefaultTransport(t *testing.T) {
 	}
 }
 
+func TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay(t *testing.T) {
+	for _, status := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			attackerCalls := 0
+			attacker := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				attackerCalls++
+			}))
+			defer attacker.Close()
+			runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", attacker.URL+"/stolen")
+				w.WriteHeader(status)
+			}))
+			defer runner.Close()
+
+			cfg := Config{}
+			cfg.Cloudflare.APIURL = runner.URL
+			cfg.Cloudflare.Token = "token"
+			client, err := newCloudflareClient(cfg, Runtime{HTTP: runner.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = client.execStream(context.Background(), "cbx_test", execStreamRequest{
+				Command: "deploy",
+				Env:     map[string]string{"DEPLOY_TOKEN": "sensitive"},
+			}, io.Discard, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+				t.Fatalf("execStream error = %v, want cross-origin redirect rejection", err)
+			}
+			if attackerCalls != 0 {
+				t.Fatalf("attacker calls = %d, want no body replay", attackerCalls)
+			}
+		})
+	}
+}
+
+func TestCloudflareClientRejectsCrossOriginUploadRedirect(t *testing.T) {
+	attackerCalls := 0
+	attacker := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		attackerCalls++
+	}))
+	defer attacker.Close()
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", attacker.URL+"/stolen")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer runner.Close()
+
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = runner.URL
+	cfg.Cloudflare.Token = "token"
+	client, err := newCloudflareClient(cfg, Runtime{HTTP: runner.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := t.TempDir() + "/archive.tgz"
+	if err := os.WriteFile(local, []byte("sensitive archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = client.uploadFile(context.Background(), "cbx_test", local, "/tmp/archive.tgz")
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("uploadFile error = %v, want cross-origin redirect rejection", err)
+	}
+	if attackerCalls != 0 {
+		t.Fatalf("attacker calls = %d, want no redirected upload", attackerCalls)
+	}
+}
+
+func TestCloudflareClientAllowsSameOriginRedirectAndPreservesCallerPolicy(t *testing.T) {
+	redirectChecks := 0
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/readiness":
+			w.Header().Set("Location", "/redirected-readiness")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/redirected-readiness":
+			if r.Header.Get("Authorization") != "Bearer token" {
+				t.Fatalf("redirected authorization = %q", r.Header.Get("Authorization"))
+			}
+			_, _ = io.WriteString(w, `{"ok":true,"runner":"cloudflare"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer runner.Close()
+	source := runner.Client()
+	source.CheckRedirect = func(*http.Request, []*http.Request) error {
+		redirectChecks++
+		return nil
+	}
+
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = runner.URL
+	cfg.Cloudflare.Token = "token"
+	client, err := newCloudflareClient(cfg, Runtime{HTTP: source})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.http == source {
+		t.Fatal("newCloudflareClient mutated the caller HTTP client")
+	}
+	if err := client.checkAuth(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if redirectChecks != 1 {
+		t.Fatalf("caller redirect checks = %d, want 1", redirectChecks)
+	}
+}
+
 func TestCloudflareClientRejectsURLQueryAndFragment(t *testing.T) {
 	for _, rawURL := range []string{
 		"https://runner.example.com?",

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -104,7 +104,7 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 		baseURL:      baseURL,
 		token:        token,
 		instanceType: instanceType,
-		http:         httpClient,
+		http:         secureCloudflareHTTPClient(httpClient, baseURL),
 	}, nil
 }
 
@@ -122,6 +122,46 @@ func defaultCloudflareHTTPClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = cloudflareDefaultResponseHeaderTimeout
 	return &http.Client{Transport: transport}
+}
+
+func secureCloudflareHTTPClient(source *http.Client, baseURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(baseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameCloudflareOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameCloudflareOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveCloudflarePort(a) == effectiveCloudflarePort(b)
+}
+
+func effectiveCloudflarePort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {


### PR DESCRIPTION
## Summary

- clone the selected Cloudflare runner HTTP client and install a same-origin redirect guard
- compare scheme, hostname, and effective port before any redirect is followed
- preserve caller-supplied same-origin redirect policy and Go's default redirect bound
- cover exec 307/308 body replay, upload redirects, same-origin auth, and caller-client immutability

Fixes https://github.com/openclaw/crabbox/issues/490

## Verification

- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- adjacent redirect-guard provider tests: Freestyle, OpenComputer, and Superserve passed
- autoreview clean: no accepted/actionable findings

Live local HTTP-server proof:

```text
=== RUN   TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay/Temporary_Redirect
=== RUN   TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay/Permanent_Redirect
--- PASS: TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay
--- PASS: TestCloudflareClientRejectsCrossOriginUploadRedirect
--- PASS: TestCloudflareClientAllowsSameOriginRedirectAndPreservesCallerPolicy
PASS
```

The cross-origin server received zero requests in each rejection test. The same-origin redirect retained the runner bearer header and invoked the caller's redirect callback exactly once.

## Compatibility

Same-origin redirects remain supported. Redirects that change scheme, hostname, or effective port now fail before replay; the caller's original `http.Client` is not mutated.
