### PR TITLE
fix: redact OpenComputer API error secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Redacted configured OpenComputer API keys from control-plane and upload error diagnostics. Thanks @coygeek.
 - Rejected cross-origin Cloudflare runner redirects before command, environment, or upload bodies can be replayed. Thanks @coygeek.
 - Validated AWS region inputs before building SigV4-signed service endpoints, preventing request-selected hostname escapes. Thanks @coygeek.
 - Required run artifacts now reject dangling symlinks and symlinks to directories instead of treating them as proof files. Thanks @coygeek.

--- a/docs/providers/opencomputer.md
+++ b/docs/providers/opencomputer.md
@@ -55,7 +55,8 @@ Crabbox resolves the API key from, in order, `CRABBOX_OPENCOMPUTER_API_KEY`,
 `OPENCOMPUTER_API_KEY`, then the `oc` CLI config file (`~/.oc/config.json`,
 if already configured). It is sent only in the `X-API-Key` header, never
 persisted in Crabbox config and never placed on argv. If no key is resolvable,
-operations fail with a clear error.
+operations fail with a clear error. Provider error diagnostics redact the
+configured key before display.
 
 Local lease claims are scoped to the normalized API URL and a random ownership
 marker stored in both the local claim and the sandbox tags. The API key is

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -243,7 +243,7 @@ func (c *ocAPIClient) doJSONWithTimeout(ctx context.Context, timeout time.Durati
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return apiError(method, path, resp)
+		return c.apiError(method, path, resp)
 	}
 	if out == nil {
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -334,12 +334,12 @@ func (c *ocAPIClient) uploadFile(ctx context.Context, id, remotePath string, con
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return apiError(http.MethodPut, "files?path="+remotePath, resp)
+		return c.apiError(http.MethodPut, "files?path="+remotePath, resp)
 	}
 	return nil
 }
 
-func apiError(method, path string, resp *http.Response) error {
+func (c *ocAPIClient) apiError(method, path string, resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	msg := strings.TrimSpace(string(body))
 	// Surface the API's {"error": "..."} message when present.
@@ -349,10 +349,22 @@ func apiError(method, path string, resp *http.Response) error {
 	if json.Unmarshal(body, &wrapped) == nil && wrapped.Error != "" {
 		msg = wrapped.Error
 	}
+	msg = redactOCSecrets(msg, c.apiKey)
+	path = redactOCSecrets(path, c.apiKey)
 	return &ocAPIError{
 		StatusCode: resp.StatusCode,
 		err:        exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg),
 	}
+}
+
+func redactOCSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		if strings.TrimSpace(secret) != "" {
+			redacted = strings.ReplaceAll(redacted, secret, "[redacted]")
+		}
+	}
+	return redacted
 }
 
 func isOCNotFound(err error) bool {

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -1198,6 +1198,58 @@ func TestAPIClientBlocksCrossOriginRedirects(t *testing.T) {
 	}
 }
 
+func TestAPIClientRedactsAPIKeyFromJSONErrors(t *testing.T) {
+	const apiKey = "osb_test_control_secret"
+	var gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"bad key osb_test_control_secret; X-API-Key: osb_test_control_secret"}`)
+	}))
+	defer server.Close()
+	client := &ocAPIClient{http: server.Client(), baseURL: server.URL, apiKey: apiKey}
+
+	err := client.probeSandboxes(context.Background())
+	if err == nil {
+		t.Fatal("expected probe error")
+	}
+	if gotAPIKey != apiKey {
+		t.Fatalf("X-API-Key = %q, want configured key", gotAPIKey)
+	}
+	if strings.Contains(err.Error(), apiKey) {
+		t.Fatalf("API key leaked in control error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("control error was not redacted: %v", err)
+	}
+}
+
+func TestAPIClientRedactsAPIKeyFromUploadErrors(t *testing.T) {
+	const apiKey = "osb_test_upload_secret"
+	var gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAPIKey = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "upload rejected: osb_test_upload_secret")
+	}))
+	defer server.Close()
+	client := &ocAPIClient{http: server.Client(), baseURL: server.URL, apiKey: apiKey}
+
+	err := client.uploadFile(context.Background(), "sb_123", "/tmp/archive.tgz", strings.NewReader("archive"))
+	if err == nil {
+		t.Fatal("expected upload error")
+	}
+	if gotAPIKey != apiKey {
+		t.Fatalf("X-API-Key = %q, want configured key", gotAPIKey)
+	}
+	if strings.Contains(err.Error(), apiKey) {
+		t.Fatalf("API key leaked in upload error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("upload error was not redacted: %v", err)
+	}
+}
+
 func TestSameOCOriginNormalizesDefaultPorts(t *testing.T) {
 	parse := func(raw string) *url.URL {
 		t.Helper()


### PR DESCRIPTION
## Summary

- redact the configured OpenComputer API key from JSON and plain-text API errors
- cover both ordinary control-plane requests and file uploads
- document the diagnostic guarantee

Fixes https://github.com/openclaw/crabbox/issues/492

## Verification

- `go test -race ./internal/providers/opencomputer -run 'TestAPIClientRedactsAPIKeyFrom(JSON|Upload)Errors' -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "go test -race ./internal/providers/opencomputer -run 'TestAPIClientRedactsAPIKeyFrom(JSON|Upload)Errors' -count=1"` (clean)

## Live proof

The focused tests use live local HTTP servers. Each server verifies that the configured key arrived in `X-API-Key`, echoes that exact key in a failing JSON or plain-text response, and proves the surfaced error contains `[redacted]` without the key.
