### PR TITLE
fix: redact Freestyle API error secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Redacted configured Freestyle API keys from lifecycle, command, and file-operation error diagnostics. Thanks @coygeek.
 - Redacted configured OpenComputer API keys from control-plane and upload error diagnostics. Thanks @coygeek.
 - Rejected cross-origin Cloudflare runner redirects before command, environment, or upload bodies can be replayed. Thanks @coygeek.
 - Validated AWS region inputs before building SigV4-signed service endpoints, preventing request-selected hostname escapes. Thanks @coygeek.

--- a/docs/providers/freestyle.md
+++ b/docs/providers/freestyle.md
@@ -64,6 +64,8 @@ export FREESTYLE_API_KEY=...
 Freestyle API keys must not be passed as CLI flags. Crabbox reads them from
 environment variables only.
 
+Provider error diagnostics redact the configured API key before display.
+
 `FREESTYLE_API_URL`, `CRABBOX_FREESTYLE_API_URL`, or `freestyle.apiUrl` in the
 user config can override the default `https://api.freestyle.sh`. Repository
 config cannot override this credential destination. Custom endpoints must use

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -211,8 +211,7 @@ func (c *freestyleHTTPClient) CreateVM(ctx context.Context, req freestyleCreateV
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return freestyleVM{}, freestyleError("create vm", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return freestyleVM{}, c.responseError("create vm", resp)
 	}
 	var parsed freestyleCreateVMResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
@@ -228,8 +227,7 @@ func (c *freestyleHTTPClient) GetVM(ctx context.Context, id string) (freestyleVM
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return freestyleVM{}, freestyleError("get vm", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return freestyleVM{}, c.responseError("get vm", resp)
 	}
 	var vm freestyleVM
 	if err := json.NewDecoder(resp.Body).Decode(&vm); err != nil {
@@ -247,9 +245,9 @@ func (c *freestyleHTTPClient) ListVMs(ctx context.Context) ([]freestyleVM, error
 			return nil, freestyleError("list vms", err)
 		}
 		if resp.StatusCode >= 400 {
-			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			responseErr := c.responseError("list vms", resp)
 			_ = resp.Body.Close()
-			return nil, freestyleError("list vms", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+			return nil, responseErr
 		}
 		var parsed freestyleListVMsResponse
 		decodeErr := json.NewDecoder(resp.Body).Decode(&parsed)
@@ -277,8 +275,7 @@ func (c *freestyleHTTPClient) DeleteVM(ctx context.Context, id string) error {
 		return nil
 	}
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return freestyleError("delete vm", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return c.responseError("delete vm", resp)
 	}
 	return nil
 }
@@ -294,8 +291,7 @@ func (c *freestyleHTTPClient) Exec(ctx context.Context, id string, command strin
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 1, freestyleError("exec", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return 1, c.responseError("exec", resp)
 	}
 	var parsed freestyleExecResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
@@ -324,8 +320,7 @@ func (c *freestyleHTTPClient) WriteFile(ctx context.Context, id, path string, co
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return freestyleError("write file", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return c.responseError("write file", resp)
 	}
 	return nil
 }
@@ -340,8 +335,7 @@ func (c *freestyleHTTPClient) ReadFile(ctx context.Context, id, path string) (st
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return "", freestyleError("read file", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(snippet))))
+		return "", c.responseError("read file", resp)
 	}
 	var parsed freestyleReadFileResponse
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
@@ -362,6 +356,23 @@ func freestyleFileURLPath(id, path string) string {
 		path = "/" + path
 	}
 	return "/v1/vms/" + url.PathEscape(id) + "/files/" + url.PathEscape(path)
+}
+
+func (c *freestyleHTTPClient) responseError(action string, resp *http.Response) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	detail := redactFreestyleSecret(strings.TrimSpace(string(snippet)), c.apiKey)
+	return freestyleError(action, fmt.Errorf("%s: %s", resp.Status, detail))
+}
+
+func redactFreestyleSecret(value, apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return value
+	}
+	return strings.NewReplacer(
+		"Bearer "+apiKey, "Bearer [redacted]",
+		apiKey, "[redacted]",
+	).Replace(value)
 }
 
 func freestyleError(action string, err error) error {

--- a/internal/providers/freestyle/client_test.go
+++ b/internal/providers/freestyle/client_test.go
@@ -3,11 +3,72 @@ package freestyle
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestFreestyleClientRedactsAPIKeyFromAllResponseErrors(t *testing.T) {
+	const apiKey = "fs_test_response_secret"
+	tests := []struct {
+		name   string
+		invoke func(*freestyleHTTPClient) error
+	}{
+		{name: "create vm", invoke: func(client *freestyleHTTPClient) error {
+			_, err := client.CreateVM(context.Background(), freestyleCreateVMRequest{Name: "test"})
+			return err
+		}},
+		{name: "get vm", invoke: func(client *freestyleHTTPClient) error {
+			_, err := client.GetVM(context.Background(), "vm123")
+			return err
+		}},
+		{name: "list vms", invoke: func(client *freestyleHTTPClient) error {
+			_, err := client.ListVMs(context.Background())
+			return err
+		}},
+		{name: "delete vm", invoke: func(client *freestyleHTTPClient) error {
+			return client.DeleteVM(context.Background(), "vm123")
+		}},
+		{name: "exec", invoke: func(client *freestyleHTTPClient) error {
+			_, err := client.Exec(context.Background(), "vm123", "true", io.Discard, io.Discard)
+			return err
+		}},
+		{name: "write file", invoke: func(client *freestyleHTTPClient) error {
+			return client.WriteFile(context.Background(), "vm123", "/tmp/file", "content", "utf8")
+		}},
+		{name: "read file", invoke: func(client *freestyleHTTPClient) error {
+			_, err := client.ReadFile(context.Background(), "vm123", "/tmp/file")
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got, want := r.Header.Get("Authorization"), "Bearer "+apiKey; got != want {
+					t.Errorf("authorization header = %q, want %q", got, want)
+				}
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = io.WriteString(w, "rejected Bearer "+apiKey+" (key "+apiKey+")")
+			}))
+			defer server.Close()
+			client := &freestyleHTTPClient{apiKey: apiKey, apiURL: server.URL, httpClient: server.Client()}
+
+			err := tt.invoke(client)
+			if err == nil {
+				t.Fatal("expected response error")
+			}
+			if strings.Contains(err.Error(), apiKey) {
+				t.Fatalf("API key leaked in response error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "Bearer [redacted] (key [redacted])") {
+				t.Fatalf("response error was not redacted: %v", err)
+			}
+		})
+	}
+}
 
 func TestValidateFreestyleAPIURL(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- centralize Freestyle non-success response diagnostics at one client boundary
- redact both raw configured keys and `Bearer` forms before errors escape
- cover lifecycle, list, command, read, and write paths with a live local-server matrix

Fixes https://github.com/openclaw/crabbox/issues/491

## Verification

- `go test -race ./internal/providers/freestyle -run TestFreestyleClientRedactsAPIKeyFromAllResponseErrors -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- structured autoreview: clean

## Live proof

The focused table test exercises all seven Freestyle API operations against live local HTTP servers. Every server verifies the exact bearer header, echoes both bearer and raw key forms in a 401 response, and proves neither secret form escapes in the returned error.

Terminal-level proof used the built CLI against a live loopback Freestyle-compatible HTTP endpoint. The endpoint verified the bearer request and returned a 401 body containing both secret forms. Actual CLI output:

```text
$ bin/crabbox list --provider freestyle --refresh
freestyle list vms: freestyle list vms: 401 Unauthorized: rejected Bearer [redacted] (key [redacted])
exit=1
```
