### PR TITLE
fix: require Cloudflare claims for lifecycle access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Required a matching local claim before Cloudflare container reuse, status, or stop operations can reach the runner. Thanks @coygeek.
 - Redacted configured Freestyle API keys from lifecycle, command, and file-operation error diagnostics. Thanks @coygeek.
 - Redacted configured OpenComputer API keys from control-plane and upload error diagnostics. Thanks @coygeek.
 - Rejected cross-origin Cloudflare runner redirects before command, environment, or upload bodies can be replayed. Thanks @coygeek.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -226,7 +226,8 @@ crabbox run \
   type is too small.
 - `warmup` starts a container and leaves it alive until `crabbox stop` or the
   configured TTL/idle deadline expires.
-- `status` and `stop` resolve local Crabbox claims, then call the runner.
+- Reuse, `status`, and `stop` resolve local Crabbox claims before calling the
+  runner and reject raw sandbox IDs without a matching claim.
 - `list` reports local Cloudflare claims. Add `--refresh` to check runner state
   for those claims. The runner intentionally does not expose a global container
   enumeration API.

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -454,7 +454,7 @@ func (b *cloudflareBackend) resolveSandboxID(identifier, repoRoot string, reclai
 	if value == "" {
 		return "", "", "", "", exit(2, "%s id is required", providerName)
 	}
-	return value, value, newLeaseSlug(value), "", nil
+	return "", "", "", "", exit(2, "refusing to use %s sandbox %q without a local Crabbox claim", providerName, value)
 }
 
 func buildCloudflareCommand(command []string, shellMode bool) (string, error) {

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -759,6 +759,10 @@ func (w cloudflareErrWriter) Write([]byte) (int, error) {
 }
 
 func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	if err := claimLeaseForRepoProvider("cbx_test", "test-run", providerName, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
 	execCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/sandboxes/cbx_test/exec-stream" {
@@ -1095,6 +1099,57 @@ func TestCloudflareResolveClaimRequiresReclaimForOtherRepo(t *testing.T) {
 	}
 	if claim.RepoRoot != repoB {
 		t.Fatalf("claim repo = %q, want %q", claim.RepoRoot, repoB)
+	}
+}
+
+func TestCloudflareUnclaimedIDNeverReachesRunner(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke func(*cloudflareBackend) error
+	}{
+		{name: "run reuse", invoke: func(backend *cloudflareBackend) error {
+			_, err := backend.Run(context.Background(), RunRequest{
+				ID:      "raw-sandbox-id",
+				NoSync:  true,
+				Command: []string{"true"},
+			})
+			return err
+		}},
+		{name: "status", invoke: func(backend *cloudflareBackend) error {
+			_, err := backend.Status(context.Background(), StatusRequest{ID: "raw-sandbox-id"})
+			return err
+		}},
+		{name: "stop", invoke: func(backend *cloudflareBackend) error {
+			return backend.Stop(context.Background(), StopRequest{ID: "raw-sandbox-id"})
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				t.Errorf("unclaimed sandbox reached runner: %s %s", r.Method, r.URL.Path)
+				http.Error(w, "unexpected request", http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			cfg := Config{Provider: providerName}
+			cfg.Cloudflare.APIURL = server.URL
+			cfg.Cloudflare.Token = "token"
+			backend := &cloudflareBackend{
+				cfg: cfg,
+				rt:  Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard},
+			}
+
+			err := tt.invoke(backend)
+			if err == nil || !strings.Contains(err.Error(), "without a local Crabbox claim") {
+				t.Fatalf("error = %v, want local claim refusal", err)
+			}
+			if requests != 0 {
+				t.Fatalf("runner received %d requests, want 0", requests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- fail closed when Cloudflare container reuse, status, or stop cannot resolve a local claim
- preserve claimed-container reuse and stale-claim pruning behavior
- cover all three raw-ID paths with a live runner endpoint that must receive zero requests

Fixes https://github.com/openclaw/crabbox/issues/484

## Verification

- `go test -race ./internal/providers/cloudflare -run 'TestCloudflare(UnclaimedIDNeverReachesRunner|RunReportsCommandErrorAsFailure|ResolveClaimRequiresReclaimForOtherRepo|StatusPrunesExpiredClaim|StopPrunesMissingClaim)' -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- `npm test --prefix worker -- cloudflare-container-runner`
- Worker format, lint, typecheck, and dry-run build
- structured autoreview: clean

## Live proof

The built CLI ran against a live loopback runner with an empty claim store. Actual terminal output:

```text
$ crabbox stop --provider cloudflare raw-sandbox-id
refusing to use cloudflare sandbox "raw-sandbox-id" without a local Crabbox claim
$ crabbox status --provider cloudflare --id raw-sandbox-id
refusing to use cloudflare sandbox "raw-sandbox-id" without a local Crabbox claim
$ crabbox run --provider cloudflare --id raw-sandbox-id --no-sync -- true
refusing to use cloudflare sandbox "raw-sandbox-id" without a local Crabbox claim
stop_exit=2 status_exit=2 run_exit=2
runner_requests=0
```
