### PR TITLE
fix: reject noncanonical signed user tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected non-canonical signed browser-session tokens so suffix changes cannot bypass Code portal logout revocation. Thanks @coygeek.
 - Required a matching local claim before Cloudflare container reuse, status, or stop operations can reach the runner. Thanks @coygeek.
 - Redacted configured Freestyle API keys from lifecycle, command, and file-operation error diagnostics. Thanks @coygeek.
 - Redacted configured OpenComputer API keys from control-plane and upload error diagnostics. Thanks @coygeek.

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -83,6 +83,7 @@ successful GitHub login through the same OAuth flow as `crabbox login`. The
 Worker converts the cookie to a `Bearer` token internally; an unauthenticated
 GET request to a portal page is redirected to `/portal/login` with a
 `returnTo` parameter. The session carries owner/org claims, and the Worker
+rejects altered or suffixed spellings of its signed session tokens. The session
 scopes every page to that identity.
 
 ```text

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -203,14 +203,11 @@ async function verifyUserToken(
   token: string,
   env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">,
 ): Promise<UserTokenPayload | undefined> {
-  if (!token.startsWith(tokenPrefix)) {
+  const parts = userTokenParts(token);
+  if (!parts) {
     return undefined;
   }
-  const raw = token.slice(tokenPrefix.length);
-  const [encodedPayload, signature] = raw.split(".", 2);
-  if (!encodedPayload || !signature) {
-    return undefined;
-  }
+  const { encodedPayload, signature } = parts;
   const expected = await sign(encodedPayload, sessionSecret(env));
   if (!constantTimeEqual(signature, expected)) {
     return undefined;
@@ -231,19 +228,28 @@ async function verifyUserToken(
 }
 
 function decodeUserTokenPayload(token: string): Partial<UserTokenPayload> {
-  if (!token.startsWith(tokenPrefix)) {
-    return {};
-  }
-  const raw = token.slice(tokenPrefix.length);
-  const [encodedPayload] = raw.split(".", 1);
-  if (!encodedPayload) {
+  const parts = userTokenParts(token);
+  if (!parts) {
     return {};
   }
   try {
-    return JSON.parse(decoder.decode(base64URLDecode(encodedPayload))) as Partial<UserTokenPayload>;
+    return JSON.parse(
+      decoder.decode(base64URLDecode(parts.encodedPayload)),
+    ) as Partial<UserTokenPayload>;
   } catch {
     return {};
   }
+}
+
+function userTokenParts(token: string): { encodedPayload: string; signature: string } | undefined {
+  if (!token.startsWith(tokenPrefix)) {
+    return undefined;
+  }
+  const parts = token.slice(tokenPrefix.length).split(".");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return undefined;
+  }
+  return { encodedPayload: parts[0], signature: parts[1] };
 }
 
 function sessionSecret(env: Pick<Env, "CRABBOX_SHARED_TOKEN" | "CRABBOX_SESSION_SECRET">): string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -12366,6 +12366,15 @@ describe("fleet lease identity and idle", () => {
     );
     expect(stalePortalSession.status).toBe(401);
     expect(await stalePortalSession.text()).toContain("Log in again to open Code.");
+
+    const suffixedPortalSession = await throughCoordinator(
+      new Request(codeEntry, {
+        headers: { cookie: `crabbox_session=${encodeURIComponent(`${token}.ignored`)}` },
+      }),
+    );
+    expect(suffixedPortalSession.status).toBe(302);
+    expect(suffixedPortalSession.headers.get("location")).toContain("/portal/login?");
+    expect(suffixedPortalSession.headers.get("location")).not.toContain("__crabbox_bootstrap");
   });
 
   it("keeps bridge tickets usable after endpoint binding mismatches", async () => {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -549,11 +549,11 @@ describe("coordinator auth", () => {
     const env = {
       CRABBOX_SHARED_TOKEN: "shared",
       CRABBOX_SESSION_SECRET: "session-secret",
-      CRABBOX_DEFAULT_ORG: "openclaw",
+      CRABBOX_DEFAULT_ORG: "example-org",
     };
     const token = await issueUserToken(env, {
       owner: "friend@example.com",
-      org: "openclaw",
+      org: "example-org",
       login: "friend",
     });
 

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -545,6 +545,31 @@ describe("coordinator auth", () => {
     expect(auth?.tokenExpiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("rejects non-canonical signed user token spellings", async () => {
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared",
+      CRABBOX_SESSION_SECRET: "session-secret",
+      CRABBOX_DEFAULT_ORG: "openclaw",
+    };
+    const token = await issueUserToken(env, {
+      owner: "friend@example.com",
+      org: "openclaw",
+      login: "friend",
+    });
+
+    const authResults = await Promise.all(
+      [`${token}.ignored`, `${token}.`, `${token}..ignored`].map((malformed) =>
+        authenticateRequest(
+          new Request("https://example.test/v1/whoami", {
+            headers: { authorization: `Bearer ${malformed}` },
+          }),
+          env,
+        ),
+      ),
+    );
+    expect(authResults).toEqual([undefined, undefined, undefined]);
+  });
+
   it("issues a distinct identity for each GitHub user session", async () => {
     const env = { CRABBOX_SESSION_SECRET: "session-secret" };
     const input = {


### PR DESCRIPTION
## Summary

- parse signed user tokens through one canonical two-segment boundary
- reject suffixed or otherwise non-canonical spellings before identity or expiry decoding
- prove altered portal cookies cannot obtain a fresh isolated Code viewer ticket after logout

Fixes https://github.com/openclaw/crabbox/issues/499

## Verification

- `npm test --prefix worker -- http.test.ts fleet.test.ts` (306 tests)
- `npm test --prefix worker` (646 tests)
- Worker format, lint, typecheck, and dry-run build
- `bash scripts/check-docs.sh`
- `go test -race ./...`
- `go vet ./...`
- structured autoreview: clean

## Live proof

The patched Worker ran under local Wrangler with a freshly HMAC-signed user token. Actual HTTP results:

```text
canonical_status=200
suffixed_status=401
[wrangler:info] GET /v1/whoami 200 OK
[wrangler:info] GET /v1/whoami 401 Unauthorized
```
