### PR TITLE
fix: block cross-origin RunPod redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected cross-origin RunPod REST redirects before bearer credentials or pod-create bodies can be replayed. Thanks @coygeek.
 - Rejected non-canonical signed browser-session tokens so suffix changes cannot bypass Code portal logout revocation. Thanks @coygeek.
 - Required a matching local claim before Cloudflare container reuse, status, or stop operations can reach the runner. Thanks @coygeek.
 - Redacted configured Freestyle API keys from lifecycle, command, and file-operation error diagnostics. Thanks @coygeek.

--- a/docs/providers/runpod.md
+++ b/docs/providers/runpod.md
@@ -96,7 +96,8 @@ curl https://rest.runpod.io/v1/pods \
 ```
 
 Crabbox sends the identical `Authorization: Bearer $RUNPOD_API_KEY` header to
-the REST pod endpoints.
+the REST pod endpoints. Cross-origin redirects are rejected before credentials
+or pod-create bodies can be replayed to another destination.
 
 ## Config
 

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -533,6 +533,98 @@ func TestRunpodClientSendsBearerAndRESTRequest(t *testing.T) {
 	}
 }
 
+func TestRunpodClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+	cfg := Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: trusted.URL}}
+	client, err := newRunpodClient(cfg, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.DeployPod(context.Background(), runpodDeployInput{
+		Name: "test-pod", ImageName: "example/image", InstanceID: "NVIDIA L4", Ports: "22/tcp",
+	})
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("DeployPod error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestRunpodClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth string
+	var redirectedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/pods":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			if err := json.NewDecoder(r.Body).Decode(&redirectedBody); err != nil {
+				t.Errorf("decode redirected body: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"id":"pod_ok","status":"RUNNING"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	cfg := Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: server.URL}}
+	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod, err := client.DeployPod(context.Background(), runpodDeployInput{
+		Name: "test-pod", ImageName: "example/image", InstanceID: "NVIDIA L4", Ports: "22/tcp",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pod.ID != "pod_ok" || redirectedAuth != "Bearer test-key" || redirectedBody["name"] != "test-pod" {
+		t.Fatalf("pod=%#v auth=%q body=%#v", pod, redirectedAuth, redirectedBody)
+	}
+}
+
+func TestRunpodClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	client, err := newRunpodClient(
+		Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: server.URL}},
+		Runtime{HTTP: httpClient},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Whoami(context.Background())
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("Whoami error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
 func TestRunpodClientRetriesGPUCapacityFallbacks(t *testing.T) {
 	var seen []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -130,7 +130,47 @@ func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: httpClient}, nil
+	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: secureRunpodHTTPClient(httpClient, apiURL)}, nil
+}
+
+func secureRunpodHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameRunpodOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameRunpodOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveRunpodPort(a) == effectiveRunpodPort(b)
+}
+
+func effectiveRunpodPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func (c *runpodClient) do(ctx context.Context, method, path string, body any, out any) error {


### PR DESCRIPTION
## Summary

- clone the configured RunPod HTTP client and reject redirects that change scheme, hostname, or effective port
- preserve caller-provided same-origin redirect policy and Go's default redirect limit
- cover credential/body non-replay and supported same-origin 307 behavior with live HTTP servers

Fixes https://github.com/openclaw/crabbox/issues/508

## Verification

- `go test -race ./internal/providers/runpod -run 'TestRunpodClient(RefusesCrossOriginRedirectBeforeReplay|FollowsSameOriginRedirect|PreservesCallerRedirectPolicy|SendsBearerAndRESTRequest)' -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- structured autoreview: clean

## Live proof

Focused tests use live local HTTP servers. A RunPod pod-create request received a cross-origin 307; the target recorded zero requests, so neither bearer token nor JSON body was replayed. A same-origin 307 preserved the bearer and exact pod-create body, and a custom caller redirect policy remained authoritative.
