### PR TITLE
fix: validate E2B API endpoint security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected plaintext non-loopback E2B API endpoints before provider credentials can be attached. Thanks @coygeek.
 - Rejected cross-origin RunPod REST redirects before bearer credentials or pod-create bodies can be replayed. Thanks @coygeek.
 - Rejected non-canonical signed browser-session tokens so suffix changes cannot bypass Code portal logout revocation. Thanks @coygeek.
 - Required a matching local claim before Cloudflare container reuse, status, or stop operations can reach the runner. Thanks @coygeek.

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -49,7 +49,8 @@ Do not pass the key as a command-line argument.
 Endpoint overrides:
 
 - `CRABBOX_E2B_API_URL` / `E2B_API_URL` or `e2b.apiUrl` override the default API
-  URL `https://api.e2b.app`.
+  URL `https://api.e2b.app`. Overrides must use HTTPS; plain HTTP is accepted
+  only for localhost or loopback development endpoints.
 - `CRABBOX_E2B_DOMAIN` / `E2B_DOMAIN` or `e2b.domain` override the default sandbox
   domain `e2b.app`.
 

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -39,6 +39,42 @@ func TestParseE2BProcessStream(t *testing.T) {
 	}
 }
 
+func TestValidateE2BAPIURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{name: "https", raw: "HTTPS://API.E2B.APP:443/v1/", want: "https://api.e2b.app/v1"},
+		{name: "loopback", raw: "http://127.0.0.1:8080/api/", want: "http://127.0.0.1:8080/api"},
+		{name: "localhost", raw: "http://localhost:8080", want: "http://localhost:8080"},
+		{name: "IPv6 loopback", raw: "http://[::1]:8080/", want: "http://[::1]:8080"},
+		{name: "remote HTTP", raw: "http://api.e2b.app", wantErr: "must use HTTPS"},
+		{name: "relative", raw: "/api", wantErr: "absolute HTTPS URL"},
+		{name: "userinfo", raw: "https://user:pass@api.e2b.app", wantErr: "must not contain userinfo"},
+		{name: "query", raw: "https://api.e2b.app?token=secret", wantErr: "must not contain userinfo"},
+		{name: "fragment", raw: "https://api.e2b.app/#secret", wantErr: "must not contain userinfo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateE2BAPIURL(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("validateE2BAPIURL(%q) error = %v, want %q", tt.raw, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("validateE2BAPIURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseE2BProcessStreamRequiresEndEvent(t *testing.T) {
 	body := bytes.Join([][]byte{
 		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("partial"))}}}),

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -97,9 +98,49 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	apiURL := strings.TrimRight(blank(cfg.E2B.APIURL, "https://api.e2b.app"), "/")
+	apiURL, err := validateE2BAPIURL(blank(cfg.E2B.APIURL, "https://api.e2b.app"))
+	if err != nil {
+		return nil, err
+	}
 	domain := strings.TrimSpace(blank(cfg.E2B.Domain, "e2b.app"))
 	return &e2bClient{apiKey: apiKey, apiURL: apiURL, domain: domain, user: cfg.E2B.User, httpClient: httpClient}, nil
+}
+
+func validateE2BAPIURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", exit(2, "provider=e2b API URL must be an absolute HTTPS URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isE2BLoopbackHost(parsed.Hostname())) {
+		return "", exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints")
+	}
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func isE2BLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {


### PR DESCRIPTION
## Summary

- validate and normalize E2B API base URLs before constructing the credentialed client
- require HTTPS except for localhost/loopback development endpoints
- reject userinfo, query parameters, fragments, relative URLs, and unsupported schemes

Fixes https://github.com/openclaw/crabbox/issues/504

## Verification

- `go test -race ./internal/providers/e2b -run 'TestValidateE2BAPIURL|TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape' -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- structured autoreview: clean

## Live proof

The built CLI rejected `http://api.e2b.app` with exit 2 before any provider request. Against a live loopback HTTP endpoint, `crabbox list --provider e2b --json` returned `[]` with exit 0; the endpoint recorded exactly one request with the expected `X-API-Key`.
