### PR TITLE
fix: require canonical Freestyle ownership names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Required canonical generated Freestyle VM names before raw-ID recovery can reuse or delete provider resources. Thanks @coygeek.
 - Rejected plaintext non-loopback E2B API endpoints before provider credentials can be attached. Thanks @coygeek.
 - Rejected cross-origin RunPod REST redirects before bearer credentials or pod-create bodies can be replayed. Thanks @coygeek.
 - Rejected non-canonical signed browser-session tokens so suffix changes cannot bypass Code portal logout revocation. Thanks @coygeek.

--- a/docs/providers/freestyle.md
+++ b/docs/providers/freestyle.md
@@ -128,7 +128,8 @@ unavailable, Crabbox falls back to chunked base64 upload through exec. Sync stil
 completes reliably through the fallback path.
 
 The raw VM ID, Crabbox VM name, and generated slug shown by `crabbox list` can
-recover a Crabbox-owned VM after local claim state is lost.
+recover a Crabbox-owned VM after local claim state is lost. Recovery requires
+the provider VM name to already match Crabbox's canonical `crabbox-...` form.
 
 `--checksum` is not supported because Freestyle uses archive sync rather than
 Crabbox rsync checksum mode.

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -602,7 +602,7 @@ func newFreestyleSandboxName(repo Repo) string {
 }
 
 func isCrabboxFreestyleSandboxName(name string) bool {
-	return strings.HasPrefix(normalizeLeaseSlug(name), freestyleNamePrefix)
+	return name == normalizeLeaseSlug(name) && strings.HasPrefix(name, freestyleNamePrefix)
 }
 
 func freestyleRandomSuffix() string {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -191,6 +191,43 @@ func TestResolveFreestyleLeaseIDAcceptsCrabboxSandbox(t *testing.T) {
 	}
 }
 
+func TestResolveFreestyleLeaseIDRejectsMalformedCrabboxNames(t *testing.T) {
+	for _, name := range []string{
+		"crabbox repo abc123",
+		"crabbox/repo/abc123",
+		"crabbox?repo=abc123",
+		"Crabbox-repo-abc123",
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &fakeFreestyleClient{getVM: freestyleVM{ID: "vm123", Name: name, State: "running"}}
+			backend := &freestyleBackend{}
+			if _, _, err := backend.resolveLeaseID(context.Background(), client, "fsb_vm123", "", false); err == nil {
+				t.Fatalf("expected malformed Freestyle VM name %q to be rejected", name)
+			}
+		})
+	}
+}
+
+func TestFreestyleStopRejectsMalformedCrabboxNameWithoutDelete(t *testing.T) {
+	client := &fakeFreestyleClient{getVM: freestyleVM{
+		ID:    "vm123",
+		Name:  "crabbox repo abc123",
+		State: "running",
+	}}
+	oldClient := newFreestyleClient
+	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	t.Cleanup(func() { newFreestyleClient = oldClient })
+	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "fsb_vm123"})
+	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+		t.Fatalf("Stop error = %v, want ownership refusal", err)
+	}
+	if len(client.deleteIDs) != 0 {
+		t.Fatalf("DeleteVM called for malformed name: %#v", client.deleteIDs)
+	}
+}
+
 func TestResolveFreestyleLeaseIDClaimsRawSandboxForRepo(t *testing.T) {
 	client := &fakeFreestyleClient{getVM: freestyleVM{
 		ID:    "vm123",
@@ -1011,6 +1048,14 @@ func TestNewFreestyleSandboxNameUsesCrabboxPrefix(t *testing.T) {
 	}
 	if !isCrabboxFreestyleSandboxName(name) {
 		t.Fatalf("expected %q to be recognized as Crabbox-owned", name)
+	}
+}
+
+func TestFreestyleOwnershipRequiresCanonicalGeneratedName(t *testing.T) {
+	for _, name := range []string{"crabbox repo abc123", "crabbox/repo/abc123", "crabbox?repo=abc123", "Crabbox-repo-abc123"} {
+		if isCrabboxFreestyleSandboxName(name) {
+			t.Fatalf("malformed provider name %q recognized as Crabbox-owned", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- require provider-returned Freestyle names to already be canonical generated `crabbox-...` slugs before ownership recovery
- reject names that only acquire the ownership prefix after normalization
- cover raw-ID resolution and destructive stop behavior

Fixes https://github.com/openclaw/crabbox/issues/514

## Verification

- focused Freestyle ownership/stop race tests
- `go test -race ./...`
- `go vet ./...`
- `bash scripts/check-docs.sh`
- structured autoreview: clean

## Live proof

The built CLI called `stop` against a live loopback Freestyle-compatible endpoint returning `name: "crabbox repo abc123"`. It fetched the VM once, exited 4 with an ownership refusal, and the endpoint recorded `delete_requests=0`.
