### PR TITLE
fix: harden Islo sandbox ownership checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Required actual Islo sandbox identifiers to already be canonical before raw-ID recovery can reach provider operations. Thanks @coygeek.
 - Required canonical generated Freestyle VM names before raw-ID recovery can reuse or delete provider resources. Thanks @coygeek.
 - Rejected plaintext non-loopback E2B API endpoints before provider credentials can be attached. Thanks @coygeek.
 - Rejected cross-origin RunPod REST redirects before bearer credentials or pod-create bodies can be replayed. Thanks @coygeek.

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -155,9 +155,9 @@ rejected before workspace preparation and sync.
   trim the checkout (more `.gitignore`/sync excludes) when a sync trips the
   large-archive guardrail.
 - `--shell` passes the raw shell string to `bash -lc` in the workdir.
-- `--id` accepts a Crabbox slug, an `isb_<name>` lease ID, or a Crabbox-created
-  sandbox name (one starting with `crabbox-`). Sandboxes not created by Crabbox
-  are rejected.
+- `--id` accepts a Crabbox slug, an `isb_<name>` lease ID, or a canonical
+  normalized sandbox name starting with `crabbox-`. Names that require case,
+  whitespace, or punctuation normalization and non-Crabbox sandboxes are rejected.
 
 Related docs:
 

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -920,7 +920,7 @@ func newIsloSandboxName(repo Repo) string {
 }
 
 func isCrabboxIsloSandboxName(name string) bool {
-	return strings.HasPrefix(normalizeLeaseSlug(name), isloNamePrefix)
+	return name == normalizeLeaseSlug(name) && strings.HasPrefix(name, isloNamePrefix)
 }
 
 func isloRandomSuffix() string {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -182,12 +182,40 @@ func TestResolveIsloLeaseIDRejectsUnclaimedRawSandbox(t *testing.T) {
 	if _, _, _, err := resolveIsloLeaseID("production", "", false); err == nil {
 		t.Fatal("expected raw non-Crabbox sandbox to be rejected")
 	}
+	for _, name := range []string{
+		"crabbox repo abc123",
+		"crabbox/repo/abc123",
+		"crabbox?repo=abc123",
+		"Crabbox-repo-abc123",
+	} {
+		for _, id := range []string{name, isloLeasePrefix + name} {
+			if _, _, _, err := resolveIsloLeaseID(id, "", false); err == nil {
+				t.Errorf("resolveIsloLeaseID(%q) accepted a non-canonical sandbox name", id)
+			}
+		}
+	}
 	leaseID, name, slug, err := resolveIsloLeaseID("crabbox-repo-abcdef", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if leaseID != "isb_crabbox-repo-abcdef" || name != "crabbox-repo-abcdef" || slug == "" {
 		t.Fatalf("lease=%q name=%q slug=%q", leaseID, name, slug)
+	}
+}
+
+func TestIsloStopRejectsNonCanonicalSandboxBeforeDelete(t *testing.T) {
+	client := &fakeIsloSyncClient{}
+	restore := swapNewIsloClient(client)
+	t.Cleanup(restore)
+	backend := &isloBackend{spec: (Provider{}).Spec(), cfg: Config{Provider: isloProvider}}
+
+	for _, id := range []string{"crabbox repo abc123", "isb_crabbox/repo/abc123"} {
+		if err := backend.Stop(context.Background(), StopRequest{ID: id}); err == nil {
+			t.Errorf("Stop(%q) accepted a non-canonical sandbox name", id)
+		}
+	}
+	if client.deleteCalls != 0 {
+		t.Fatalf("delete calls=%d, want 0", client.deleteCalls)
 	}
 }
 

--- a/internal/providers/islo/bridge_test.go
+++ b/internal/providers/islo/bridge_test.go
@@ -46,6 +46,21 @@ func newBridgeBackend(t *testing.T, fake *fakeBridgeClient) *isloBackend {
 	}
 }
 
+func TestIsloSandboxNameFromLeaseIDRejectsNonCanonicalNames(t *testing.T) {
+	for _, name := range []string{
+		"crabbox repo abc123",
+		"crabbox/repo/abc123",
+		"crabbox?repo=abc123",
+		"Crabbox-repo-abc123",
+	} {
+		for _, leaseID := range []string{name, isloLeasePrefix + name} {
+			if _, err := isloSandboxNameFromLeaseID(leaseID); err == nil {
+				t.Errorf("isloSandboxNameFromLeaseID(%q) accepted a non-canonical sandbox name", leaseID)
+			}
+		}
+	}
+}
+
 func TestPublishPeerReusesExistingShare(t *testing.T) {
 	fake := &fakeBridgeClient{
 		preexisting: []IsloShare{{ShareID: "shr_existing", URL: "https://existing.share.islo.dev", Port: 8080}},


### PR DESCRIPTION
## Summary

- require raw Islo sandbox identifiers to already equal their normalized canonical form
- reject malformed raw and `isb_` identifiers across lifecycle and bridge paths
- document recovery constraints and credit the reporter

Fixes https://github.com/openclaw/crabbox/issues/515

## Verification

- `go test -race ./internal/providers/islo`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (646 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- repository autoreview: clean

## Live proof

Built the patched CLI and pointed Islo at a local HTTP endpoint that logs every request. `crabbox stop --provider islo 'isb_crabbox/repo/abc123'` exited 4 with the ownership error; the endpoint observed zero requests, proving rejection occurs before provider access or deletion.
