### PR TITLE
fix: confine failure bundle links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Confined remote failure-bundle links to the generated archive subtree and omitted unsafe special entries. Thanks @coygeek.
 - Required actual Islo sandbox identifiers to already be canonical before raw-ID recovery can reach provider operations. Thanks @coygeek.
 - Required canonical generated Freestyle VM names before raw-ID recovery can reuse or delete provider resources. Thanks @coygeek.
 - Rejected plaintext non-loopback E2B API endpoints before provider credentials can be attached. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -368,6 +368,8 @@ JSON, command stdout/stderr, common debug paths such as `test-results`,
 gateway log tail when a known gateway log path exists. Implicit stdout/stderr
 entries are capped to keep bundles bounded; explicit `--capture-stdout` /
 `--capture-stderr` files are included as caller-created local files.
+Remote archive entries are confined to the bundle subtree; unsafe links and
+special files are omitted.
 `--capture-on-fail` remains accepted as a compatibility alias. Crabbox does not
 redact captured files; the caller owns redaction before sharing them.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -106,7 +106,8 @@ a generic gateway log tail when present. Blacksmith delegated runs bundle
 stdout/stderr plus timing and redacted env/config metadata. The stdout/stderr
 files captured inside automatic failure bundles are size-capped — pass
 `--capture-stdout` / `--capture-stderr` when you need a complete local stream
-file. `--capture-on-fail` is still accepted as a compatibility alias; failure
+file. Remote archive entries are confined to the bundle subtree; unsafe links
+and special files are omitted. `--capture-on-fail` is still accepted as a compatibility alias; failure
 bundles are saved automatically on non-zero exit regardless.
 
 Crabbox does **not** redact captured files. Treat every bundle and capture file

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -761,12 +762,28 @@ func appendRemoteFailureTar(tw *tar.Writer, remoteTarPath, prefix string) error 
 		if err != nil {
 			return exit(2, "failure bundle read remote tar %s: %v", remoteTarPath, err)
 		}
-		cleanName := filepath.ToSlash(filepath.Clean(header.Name))
-		if cleanName == "." || cleanName == ".." || strings.HasPrefix(cleanName, "/") || strings.HasPrefix(cleanName, "../") {
+		cleanName, ok := cleanRemoteFailureTarPath(header.Name)
+		if !ok {
 			continue
 		}
 		next := *header
 		next.Name = prefix + cleanName
+		switch header.Typeflag {
+		case tar.TypeReg, tar.TypeRegA, tar.TypeDir:
+		case tar.TypeSymlink:
+			if !remoteFailureSymlinkTargetSafe(cleanName, header.Linkname) {
+				continue
+			}
+			next.Linkname = strings.ReplaceAll(header.Linkname, `\`, "/")
+		case tar.TypeLink:
+			cleanLink, ok := cleanRemoteFailureTarPath(header.Linkname)
+			if !ok {
+				continue
+			}
+			next.Linkname = prefix + cleanLink
+		default:
+			continue
+		}
 		if err := tw.WriteHeader(&next); err != nil {
 			return err
 		}
@@ -776,6 +793,34 @@ func appendRemoteFailureTar(tw *tar.Writer, remoteTarPath, prefix string) error 
 			}
 		}
 	}
+}
+
+func cleanRemoteFailureTarPath(name string) (string, bool) {
+	name = strings.ReplaceAll(name, `\`, "/")
+	if name == "" || remoteFailureTarPathRooted(name) {
+		return "", false
+	}
+	clean := path.Clean(name)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", false
+	}
+	return clean, true
+}
+
+func remoteFailureSymlinkTargetSafe(name, linkname string) bool {
+	linkname = strings.ReplaceAll(linkname, `\`, "/")
+	if linkname == "" || remoteFailureTarPathRooted(linkname) {
+		return false
+	}
+	_, ok := cleanRemoteFailureTarPath(path.Join(path.Dir(name), linkname))
+	return ok
+}
+
+func remoteFailureTarPathRooted(name string) bool {
+	if path.IsAbs(name) {
+		return true
+	}
+	return len(name) >= 2 && name[1] == ':' && ((name[0] >= 'a' && name[0] <= 'z') || (name[0] >= 'A' && name[0] <= 'Z'))
 }
 
 func failureEnvSummary(allowed []string, values map[string]string) string {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2221,6 +2221,73 @@ func TestWriteLocalFailureBundleIncludesMetadataStreamsAndRemoteFiles(t *testing
 	}
 }
 
+func TestWriteLocalFailureBundleConfinesRemoteLinks(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	remoteTar := filepath.Join(dir, "remote.tar.gz")
+	file, err := os.Create(remoteTar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	entries := []struct {
+		header tar.Header
+		data   string
+	}{
+		{header: tar.Header{Name: "logs/result.txt", Typeflag: tar.TypeReg, Mode: 0o600, Size: 6}, data: "result"},
+		{header: tar.Header{Name: "logs/result-link", Typeflag: tar.TypeSymlink, Linkname: "result.txt", Mode: 0o777}},
+		{header: tar.Header{Name: "logs/result-hard", Typeflag: tar.TypeLink, Linkname: "logs/result.txt", Mode: 0o600}},
+		{header: tar.Header{Name: "logs/symlink-out", Typeflag: tar.TypeSymlink, Linkname: "../../outside", Mode: 0o777}},
+		{header: tar.Header{Name: "logs/windows-link-out", Typeflag: tar.TypeSymlink, Linkname: `C:\outside`, Mode: 0o777}},
+		{header: tar.Header{Name: "logs/hardlink-out", Typeflag: tar.TypeLink, Linkname: "/etc/passwd", Mode: 0o600}},
+		{header: tar.Header{Name: "logs/empty-link", Typeflag: tar.TypeSymlink, Mode: 0o777}},
+		{header: tar.Header{Name: "logs/pipe", Typeflag: tar.TypeFifo, Mode: 0o600}},
+	}
+	for _, entry := range entries {
+		if err := tarWriter.WriteHeader(&entry.header); err != nil {
+			t.Fatal(err)
+		}
+		if entry.data != "" {
+			if _, err := io.WriteString(tarWriter, entry.data); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	local, _, err := writeLocalFailureBundle("bundle.tar.gz", remoteTar, FailureCaptureMetadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := readTarGzHeaders(t, local)
+	regular := headers["crabbox-artifacts/remote/logs/result.txt"]
+	if regular == nil || regular.Typeflag != tar.TypeReg {
+		t.Fatalf("safe regular entry missing: %#v", regular)
+	}
+	symlink := headers["crabbox-artifacts/remote/logs/result-link"]
+	if symlink == nil || symlink.Typeflag != tar.TypeSymlink || symlink.Linkname != "result.txt" {
+		t.Fatalf("safe symlink=%#v", symlink)
+	}
+	hardlink := headers["crabbox-artifacts/remote/logs/result-hard"]
+	if hardlink == nil || hardlink.Typeflag != tar.TypeLink || hardlink.Linkname != "crabbox-artifacts/remote/logs/result.txt" {
+		t.Fatalf("safe hardlink=%#v", hardlink)
+	}
+	for _, name := range []string{"symlink-out", "windows-link-out", "hardlink-out", "empty-link", "pipe"} {
+		if header := headers["crabbox-artifacts/remote/logs/"+name]; header != nil {
+			t.Fatalf("unsafe remote entry preserved: %#v", header)
+		}
+	}
+}
+
 func TestNativeWindowsFailureBundleUsesLocalStreams(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -2358,6 +2425,33 @@ func readTarGzContents(t *testing.T, path string) map[string][]byte {
 		}
 	}
 	return entries
+}
+
+func readTarGzHeaders(t *testing.T, path string) map[string]*tar.Header {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	entries := make(map[string]*tar.Header)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			return entries
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		copy := *header
+		entries[header.Name] = &copy
+	}
 }
 
 func TestPrintKeepOnFailureSSHHint(t *testing.T) {


### PR DESCRIPTION
## Summary

- confine remote failure-bundle member names and link targets to the prefixed remote subtree
- preserve safe relative symlinks and rewrite safe hardlinks after prefixing
- omit absolute, escaping, empty, cross-platform rooted, and special-file entries
- add crafted-archive regressions and document bundle behavior

Fixes https://github.com/openclaw/crabbox/issues/513

## Verification

- `go test -race ./internal/cli -run 'TestWriteLocalFailureBundle|TestRemoteFailureCapture' -count=1`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (646 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- repository autoreview: clean

## Live proof

Ran the patched CLI against a real Docker-backed `local-container` lease. The failing workload created `test-results/result.txt`, an escaping `test-results/symlink-out -> ../../outside`, then exited 7. Crabbox generated the automatic local failure bundle, retained the regular result, omitted the unsafe symlink, and released the lease. Listing and extracting the bundle with system `tar` confirmed the report content and no path outside the extraction root.

Redacted terminal proof:

```console
$ crabbox run --provider local-container --shell 'mkdir -p test-results && ln -s ../../outside test-results/symlink-out && printf result > test-results/result.txt && exit 7'
provisioning provider=local-container lease=<lease> runtime=docker image=ubuntu:26.04 keep=false
provisioned lease=<lease> container=<container> state=ready
running on <local-container> mkdir -p test-results && ln -s ../../outside test-results/symlink-out && printf result > test-results/result.txt && exit 7
failure-bundle local=.crabbox/captures/<lease>-20260621T073928Z.tar.gz bytes=1175 secret_risk=caller-redacts-before-sharing
lease cleanup stopped=true policy=auto lease=<lease> slug=<slug>
remote command exited 7
EXIT=7

$ tar -tvzf .crabbox/captures/<lease>-20260621T073928Z.tar.gz
... crabbox-artifacts/remote/test-results
-rw-r--r-- ... crabbox-artifacts/remote/test-results/result.txt

$ test "$(tar -tzf .crabbox/captures/<lease>-20260621T073928Z.tar.gz | grep -c symlink-out || true)" -eq 0
$ tar -xzf .crabbox/captures/<lease>-20260621T073928Z.tar.gz -C <temporary-root>
$ test "$(cat <temporary-root>/crabbox-artifacts/remote/test-results/result.txt)" = result
$ test ! -e <temporary-root>/outside
SAFE=1
```
