### PR TITLE
fix: redact Cloudflare runner errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Redacted Cloudflare runner bearer tokens from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Confined remote failure-bundle links to the generated archive subtree and omitted unsafe special entries. Thanks @coygeek.
 - Required actual Islo sandbox identifiers to already be canonical before raw-ID recovery can reach provider operations. Thanks @coygeek.
 - Required canonical generated Freestyle VM names before raw-ID recovery can reuse or delete provider resources. Thanks @coygeek.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -81,6 +81,8 @@ command-line arguments can be captured in shell history and process listings.
 Runner redirects are followed only when they keep the configured scheme, host,
 and effective port. Cross-origin redirects fail before command, environment, or
 upload bodies can be replayed to another destination.
+Runner error bodies and streamed error events redact the configured token and
+bearer-shaped credentials before they reach CLI diagnostics.
 
 The workdir defaults to `/workspace/crabbox` and must resolve to an absolute
 path. Broad system paths (`/`, `/workspace`, `/usr`, `/var`, and similar) are

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -345,6 +345,60 @@ func TestCloudflareDoctorChecksRunnerAuth(t *testing.T) {
 	}
 }
 
+func TestCloudflareClientRedactsRunnerResponseErrors(t *testing.T) {
+	const token = "runner-secret-token"
+	client := &cloudflareClient{token: token}
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "json", body: `{"error":"bad Authorization: Bearer runner-secret-token"}`},
+		{name: "text", body: "proxy echoed runner-secret-token and Bearer reflected-token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				Status:     "401 Unauthorized",
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+			err := client.responseError(resp)
+			if err == nil {
+				t.Fatal("responseError returned nil")
+			}
+			if strings.Contains(err.Error(), token) || strings.Contains(err.Error(), "reflected-token") {
+				t.Fatalf("response error leaked bearer token: %v", err)
+			}
+			if !strings.Contains(err.Error(), "[redacted]") {
+				t.Fatalf("response error omitted redaction marker: %v", err)
+			}
+		})
+	}
+}
+
+func TestCloudflareClientRedactsStreamError(t *testing.T) {
+	const token = "runner-secret-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = io.WriteString(w, `{"type":"error","error":"bad Authorization: Bearer runner-secret-token"}`+"\n")
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.Cloudflare.APIURL = server.URL
+	cfg.Cloudflare.Token = token
+	client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.execStream(context.Background(), "cbx_test", execStreamRequest{Command: "true"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("execStream returned nil")
+	}
+	if strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "Bearer [redacted]") {
+		t.Fatalf("stream error was not redacted: %v", err)
+	}
+}
+
 func TestCloudflareDoctorTimesOutStalledRunnerReadiness(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/readiness" || r.Method != http.MethodGet {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -62,6 +63,8 @@ type execStreamEvent struct {
 const cloudflareDefaultResponseHeaderTimeout = 30 * time.Second
 
 var cloudflareCleanupTimeout = 15 * time.Second
+
+var cloudflareBearerPattern = regexp.MustCompile(`(?i)\bbearer[ \t]+[A-Za-z0-9._~+/=-]+`)
 
 func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 	apiURL := strings.TrimSpace(cfg.Cloudflare.APIURL)
@@ -288,7 +291,7 @@ func (c *cloudflareClient) execStream(ctx context.Context, sandboxID string, req
 			if event.Error == "" {
 				event.Error = "stream error"
 			}
-			return exitCode, errors.New(event.Error)
+			return exitCode, errors.New(redactCloudflareRunnerSecrets(event.Error, c.token))
 		case "start", "heartbeat":
 		default:
 			return exitCode, fmt.Errorf("unknown %s stream event %q", providerName, event.Type)
@@ -342,13 +345,24 @@ func (c *cloudflareClient) responseError(resp *http.Response) error {
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
-		return fmt.Errorf("%s API %s: %s", providerName, resp.Status, payload.Error)
+		return fmt.Errorf("%s API %s: %s", providerName, resp.Status, redactCloudflareRunnerSecrets(payload.Error, c.token))
 	}
 	text := strings.TrimSpace(string(body))
 	if text == "" {
 		text = resp.Status
 	}
-	return fmt.Errorf("%s API %s: %s", providerName, resp.Status, text)
+	return fmt.Errorf("%s API %s: %s", providerName, resp.Status, redactCloudflareRunnerSecrets(text, c.token))
+}
+
+func redactCloudflareRunnerSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret != "" {
+			redacted = strings.ReplaceAll(redacted, secret, "[redacted]")
+		}
+	}
+	return cloudflareBearerPattern.ReplaceAllString(redacted, "Bearer [redacted]")
 }
 
 func remoteArchivePath() string {


### PR DESCRIPTION
## Summary

- redact the configured Cloudflare runner token from JSON and text HTTP errors
- redact generic bearer-shaped credentials from runner diagnostics
- apply the same protection to 2xx streamed error events
- add regression coverage and document diagnostic behavior

Fixes https://github.com/openclaw/crabbox/issues/512

## Verification

- `go test -race ./internal/providers/cloudflare`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (646 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- repository autoreview: clean

## Live proof

Built the patched CLI and ran `doctor` against a local HTTP runner that returned its received dummy `Authorization` header inside a JSON 401 error. The runner observed the authenticated readiness request; the CLI failed as expected and exposed only the redaction marker:

```console
$ CRABBOX_CLOUDFLARE_RUNNER_URL=http://127.0.0.1:<port> \
  CRABBOX_CLOUDFLARE_RUNNER_TOKEN=<dummy-token> \
  crabbox doctor --provider cloudflare
failed  provider provider=cloudflare class=auth hint=check_cloudflare_readiness_url_and_credentials cloudflare API 401 Unauthorized: bad Authorization: Bearer [redacted]
doctor found problems
EXIT=1 REDACTED=1

runner: REQUEST GET /v1/readiness
```

The shell also asserted that output did not contain the submitted dummy token.
