### PR TITLE
fix: keep runner token off SSH argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Kept GitHub Actions runner registration tokens off remote SSH command arguments. Thanks @coygeek.
 - Redacted Cloudflare runner bearer tokens from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Confined remote failure-bundle links to the generated archive subtree and omitted unsafe special entries. Thanks @coygeek.
 - Required actual Islo sandbox identifiers to already be canonical before raw-ID recovery can reach provider operations. Thanks @coygeek.

--- a/docs/commands/actions.md
+++ b/docs/commands/actions.md
@@ -71,7 +71,8 @@ Registers an existing box as a GitHub Actions self-hosted runner. Crabbox
 obtains a repository registration token through `gh api`, installs the official
 `actions/runner` package, and starts it under systemd on Linux/WSL2 or a
 detached PowerShell process on native Windows. Supports Linux and Windows
-targets only.
+targets only. Registration metadata and the short-lived token travel over SSH
+stdin rather than the remote process command line.
 
 ```sh
 crabbox actions register --id blue-lobster

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -362,8 +362,9 @@ func (a App) registerGitHubActionsRunner(ctx context.Context, cfg Config, target
 	}
 	labels := githubActionsRunnerLabels(cfg, leaseID, slug, extraLabels)
 	script := githubActionsRunnerInstallScriptForTarget(cfg.Actions.RunnerVersion, cfg.Actions.Ephemeral, target)
-	remote := githubActionsRunnerInstallRemoteCommand(target, ghRepo.Slug(), name, strings.Join(labels, ","), token)
-	if err := runSSHInputQuiet(ctx, target, remote, script); err != nil {
+	remote := githubActionsRunnerInstallRemoteCommand(target)
+	input := githubActionsRunnerInstallInput(ghRepo.Slug(), name, strings.Join(labels, ","), token, script)
+	if err := runSSHInputQuiet(ctx, target, remote, input); err != nil {
 		return exit(7, "register GitHub Actions runner on %s: %v", target.Host, err)
 	}
 	fmt.Fprintf(a.Stdout, "actions runner registered repo=%s name=%s labels=%s ephemeral=%t\n", ghRepo.Slug(), name, strings.Join(labels, ","), cfg.Actions.Ephemeral)
@@ -2485,13 +2486,18 @@ func githubActionsRunnerInstallScriptForTarget(version string, ephemeral bool, t
 	return githubActionsRunnerInstallScript(version, ephemeral)
 }
 
-func githubActionsRunnerInstallRemoteCommand(target SSHTarget, repo, name, labels, token string) string {
+func githubActionsRunnerInstallRemoteCommand(target SSHTarget) string {
 	if isWindowsNativeTarget(target) {
 		return powershellCommand(`$ErrorActionPreference = "Stop"
-$env:RUNNER_REPO = ` + psQuote(repo) + `
-$env:RUNNER_NAME = ` + psQuote(name) + `
-$env:RUNNER_LABELS = ` + psQuote(labels) + `
-$env:RUNNER_TOKEN = ` + psQuote(token) + `
+function Read-CrabboxRunnerValue {
+  $line = [Console]::In.ReadLine()
+  if ($null -eq $line) { throw "missing runner registration input" }
+  [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($line))
+}
+$env:RUNNER_REPO = Read-CrabboxRunnerValue
+$env:RUNNER_NAME = Read-CrabboxRunnerValue
+$env:RUNNER_LABELS = Read-CrabboxRunnerValue
+$env:RUNNER_TOKEN = Read-CrabboxRunnerValue
 $script = [Console]::In.ReadToEnd()
 $path = Join-Path $env:TEMP ("crabbox-actions-runner-" + [Guid]::NewGuid().ToString("N") + ".ps1")
 [System.IO.File]::WriteAllText($path, $script, [System.Text.UTF8Encoding]::new($false))
@@ -2503,7 +2509,27 @@ try {
 }
 `)
 	}
-	return fmt.Sprintf("RUNNER_REPO=%s RUNNER_NAME=%s RUNNER_LABELS=%s RUNNER_TOKEN=%s bash -s", shellQuote(repo), shellQuote(name), shellQuote(labels), shellQuote(token))
+	return `set -eu
+IFS= read -r crabbox_runner_repo
+IFS= read -r crabbox_runner_name
+IFS= read -r crabbox_runner_labels
+IFS= read -r crabbox_runner_token
+export RUNNER_REPO="$(printf '%s' "$crabbox_runner_repo" | base64 -d)"
+export RUNNER_NAME="$(printf '%s' "$crabbox_runner_name" | base64 -d)"
+export RUNNER_LABELS="$(printf '%s' "$crabbox_runner_labels" | base64 -d)"
+export RUNNER_TOKEN="$(printf '%s' "$crabbox_runner_token" | base64 -d)"
+unset crabbox_runner_repo crabbox_runner_name crabbox_runner_labels crabbox_runner_token
+exec bash -s`
+}
+
+func githubActionsRunnerInstallInput(repo, name, labels, token, script string) string {
+	var input strings.Builder
+	for _, value := range []string{repo, name, labels, token} {
+		input.WriteString(base64.StdEncoding.EncodeToString([]byte(value)))
+		input.WriteByte('\n')
+	}
+	input.WriteString(script)
+	return input.String()
 }
 
 func githubActionsRunnerInstallPowerShellScript(version string, ephemeral bool) string {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"encoding/base64"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -174,6 +176,59 @@ func TestGitHubActionsRunnerInstallPowerShellScriptUsesOfficialWindowsRunner(t *
 		if !strings.Contains(got, want) {
 			t.Fatalf("windows install script missing %q", want)
 		}
+	}
+}
+
+func TestGitHubActionsRunnerInstallTransportKeepsValuesOffRemoteCommand(t *testing.T) {
+	values := []string{"example-org/my-app", "runner name", "linux,x64", "sentinel-registration-token"}
+	script := "printf transport-ok\\n"
+	input := githubActionsRunnerInstallInput(values[0], values[1], values[2], values[3], script)
+	parts := strings.SplitN(input, "\n", 5)
+	if len(parts) != 5 || parts[4] != script {
+		t.Fatalf("install input framing failed: %#v", parts)
+	}
+	for i, encoded := range parts[:4] {
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("decode field %d: %v", i, err)
+		}
+		if string(decoded) != values[i] {
+			t.Fatalf("field %d=%q, want %q", i, decoded, values[i])
+		}
+	}
+
+	for _, target := range []SSHTarget{
+		{TargetOS: targetLinux},
+		{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+		{TargetOS: targetWindows, WindowsMode: windowsModeNormal},
+	} {
+		remote := githubActionsRunnerInstallRemoteCommand(target)
+		for _, value := range values {
+			if strings.Contains(remote, value) {
+				t.Fatalf("target=%#v remote command leaked %q: %s", target, value, remote)
+			}
+		}
+	}
+}
+
+func TestGitHubActionsRunnerInstallTransportExecutesLinuxPayload(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required")
+	}
+	if _, err := exec.LookPath("base64"); err != nil {
+		t.Skip("base64 is required")
+	}
+	script := `printf 'repo=%s\nname=%s\nlabels=%s\ntoken=%s\n' "$RUNNER_REPO" "$RUNNER_NAME" "$RUNNER_LABELS" "$RUNNER_TOKEN"`
+	input := githubActionsRunnerInstallInput("example-org/my-app", "runner name", "linux,x64", "sentinel-registration-token", script)
+	cmd := exec.Command("bash", "-c", githubActionsRunnerInstallRemoteCommand(SSHTarget{TargetOS: targetLinux}))
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute install transport: %v\n%s", err, out)
+	}
+	want := "repo=example-org/my-app\nname=runner name\nlabels=linux,x64\ntoken=sentinel-registration-token\n"
+	if string(out) != want {
+		t.Fatalf("transport output=%q, want %q", out, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- remove repository metadata, runner labels/name, and registration token from SSH remote command text
- frame those values as base64 lines on existing SSH stdin, followed by the unchanged install script
- decode the framing in fixed Linux/WSL2 and native-Windows wrappers
- add secrecy, framing, and executable Linux transport regressions

Fixes https://github.com/openclaw/crabbox/issues/511

## Verification

- `go test -race ./internal/cli -run 'TestGitHubActionsRunnerInstall' -count=1`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (646 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- repository autoreview: clean

## Live proof

Executed the real fixed Linux wrapper in a disposable Ubuntu Docker container with a sentinel token supplied only through framed stdin. The install payload inspected its own `/proc/$$/cmdline`, failed if the sentinel appeared there, and confirmed that the decoded token arrived:

```console
CMDLINE=bash -s
REPO=example-org/my-app
TOKEN_RECEIVED=yes
```

The same regression table asserts Linux, WSL2, and native-Windows remote command strings contain none of the supplied repo/name/labels/token values. Native-Windows framing is structurally covered; no repository runner was registered during validation.
