### PR TITLE
fix: redact Semaphore API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Redacted configured Semaphore API tokens from provider response diagnostics. Thanks @coygeek.
 - Kept GitHub Actions runner registration tokens off remote SSH command arguments. Thanks @coygeek.
 - Redacted Cloudflare runner bearer tokens from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Confined remote failure-bundle links to the generated archive subtree and omitted unsafe special entries. Thanks @coygeek.

--- a/docs/features/semaphore.md
+++ b/docs/features/semaphore.md
@@ -74,7 +74,8 @@ Defaults when unset: `machine: f1-standard-2`, `osImage: ubuntu2204`,
 | OS image    | `semaphore.osImage`  | `--semaphore-os-image`     | `CRABBOX_SEMAPHORE_OS_IMAGE`                       |
 | Idle timeout| `semaphore.idleTimeout` | `--semaphore-idle-timeout` | `CRABBOX_SEMAPHORE_IDLE_TIMEOUT`              |
 
-The token has no flag; pass it via env or config only.
+The token has no flag; pass it via env or config only. Semaphore API error
+bodies redact the configured token before they reach CLI diagnostics.
 
 Equivalent one-off invocations:
 

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -308,7 +308,7 @@ func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, ht
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, &semaphoreAPIError{Path: path, StatusCode: resp.StatusCode, Body: string(body)}
+		return nil, nil, c.responseError(path, resp.StatusCode, body)
 	}
 	return body, resp.Header, nil
 }
@@ -321,6 +321,25 @@ type semaphoreAPIError struct {
 
 func (e *semaphoreAPIError) Error() string {
 	return fmt.Sprintf("semaphore API %s returned %d: %s", e.Path, e.StatusCode, e.Body)
+}
+
+func (c *apiClient) responseError(path string, statusCode int, body []byte) *semaphoreAPIError {
+	return &semaphoreAPIError{
+		Path:       path,
+		StatusCode: statusCode,
+		Body:       redactSemaphoreSecrets(strings.TrimSpace(string(body)), c.token),
+	}
+}
+
+func redactSemaphoreSecrets(value string, secrets ...string) string {
+	redacted := value
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret != "" {
+			redacted = strings.ReplaceAll(redacted, secret, "[redacted]")
+		}
+	}
+	return redacted
 }
 
 func (c *apiClient) get(ctx context.Context, path string, target any) error {
@@ -339,7 +358,7 @@ func (c *apiClient) get(ctx context.Context, path string, target any) error {
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &semaphoreAPIError{Path: path, StatusCode: resp.StatusCode, Body: string(body)}
+		return c.responseError(path, resp.StatusCode, body)
 	}
 	if target != nil {
 		return json.Unmarshal(body, target)
@@ -372,7 +391,7 @@ func (c *apiClient) post(ctx context.Context, path string, payload any, target a
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &semaphoreAPIError{Path: path, StatusCode: resp.StatusCode, Body: string(body)}
+		return c.responseError(path, resp.StatusCode, body)
 	}
 	if target != nil {
 		return json.Unmarshal(body, target)

--- a/internal/providers/semaphore/backend_test.go
+++ b/internal/providers/semaphore/backend_test.go
@@ -21,6 +21,12 @@ type testClock struct{}
 
 func (testClock) Now() time.Time { return time.Now() }
 
+type semaphoreRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f semaphoreRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func testConfig(host string) core.Config {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
@@ -221,6 +227,88 @@ func TestStripLeasePrefix(t *testing.T) {
 }
 
 // --- API client tests with httptest ---
+
+func TestAPIClientRedactsTokenFromAllResponseErrors(t *testing.T) {
+	const token = "semaphore-secret-token"
+	tests := []struct {
+		name string
+		path string
+		call func(*apiClient, string) error
+	}{
+		{
+			name: "get with headers",
+			path: "/get-with-headers",
+			call: func(client *apiClient, path string) error {
+				_, _, err := client.getWithHeaders(context.Background(), path)
+				return err
+			},
+		},
+		{name: "get", path: "/get", call: func(client *apiClient, path string) error {
+			return client.get(context.Background(), path, nil)
+		}},
+		{name: "post", path: "/post", call: func(client *apiClient, path string) error {
+			return client.post(context.Background(), path, map[string]string{"value": "test"}, nil)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &apiClient{
+				host:  "semaphore.example.test",
+				token: token,
+				http: &http.Client{Transport: semaphoreRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if got := req.Header.Get("Authorization"); got != "Token "+token {
+						t.Fatalf("Authorization=%q", got)
+					}
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body:       io.NopCloser(strings.NewReader("bad Authorization: Token " + token)),
+						Header:     make(http.Header),
+					}, nil
+				})},
+			}
+			err := tc.call(client, tc.path)
+			if err == nil {
+				t.Fatal("API call returned nil")
+			}
+			if strings.Contains(err.Error(), token) {
+				t.Fatalf("API error leaked token: %v", err)
+			}
+			for _, want := range []string{tc.path, "401", "Token [redacted]"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("API error=%q, want %q", err, want)
+				}
+			}
+		})
+	}
+	if got := redactSemaphoreSecrets("keep body", " "); got != "keep body" {
+		t.Fatalf("empty secret changed response body: %q", got)
+	}
+}
+
+func TestAPIClientTLSRedactsReflectedToken(t *testing.T) {
+	const token = "semaphore-secret-token"
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if got := req.Header.Get("Authorization"); got != "Token "+token {
+			t.Fatalf("Authorization=%q", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad "+req.Header.Get("Authorization"))
+	}))
+	defer server.Close()
+
+	client := &apiClient{
+		host:  strings.TrimPrefix(server.URL, "https://"),
+		token: token,
+		http:  server.Client(),
+	}
+	err := client.get(context.Background(), "/api/v1alpha/projects", nil)
+	if err == nil {
+		t.Fatal("API call returned nil")
+	}
+	if strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "Token [redacted]") {
+		t.Fatalf("TLS API error was not redacted: %v", err)
+	}
+}
 
 func TestCreateJob(t *testing.T) {
 	var receivedBody map[string]any


### PR DESCRIPTION
## Summary

- route every Semaphore non-2xx response through one client error helper
- redact the configured API token before storing/forming diagnostic text
- retain endpoint path, status code, and non-secret response context
- cover GET-with-headers, GET, POST, empty-secret handling, and real TLS reflection

Fixes https://github.com/openclaw/crabbox/issues/518

## Verification

- `go test -race ./internal/providers/semaphore`
- `go test -race ./internal/providers/semaphore -run 'TestAPIClient.*Redact' -count=1 -v`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker` (646 tests)
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- repository autoreview: clean

## Live proof

The focused integration starts a real loopback TLS server, verifies that the production client submitted `Authorization: Token <dummy>`, returns that header in a 401 response body, and asserts the resulting error contains `Token [redacted]` but not the dummy token:

```console
=== RUN   TestAPIClientTLSRedactsReflectedToken
--- PASS: TestAPIClientTLSRedactsReflectedToken (0.01s)
PASS
```

The adjacent socket-free table executes every non-2xx construction path independently.
