### PR TITLE
fix: redact Upstash Box API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Redacted configured Upstash Box API keys from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Redacted configured Semaphore API tokens from provider response diagnostics. Thanks @coygeek.
 - Kept GitHub Actions runner registration tokens off remote SSH command arguments. Thanks @coygeek.
 - Redacted Cloudflare runner bearer tokens from HTTP and streamed error diagnostics. Thanks @coygeek.

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -39,6 +39,9 @@ export UPSTASH_BOX_API_KEY=...
 export CRABBOX_UPSTASH_BOX_API_KEY=...
 ```
 
+Crabbox redacts the configured API key from Upstash Box HTTP error bodies and
+exec-stream error events before displaying diagnostics.
+
 Rotate the key if it was ever pasted into a chat, shell history, issue, or log.
 
 ## Commands

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -154,6 +155,55 @@ func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 	}
 	if !reflect.DeepEqual(deleteBody["ids"], []any{"box_1"}) {
 		t.Fatalf("delete body=%v", deleteBody)
+	}
+}
+
+func TestClientRedactsAPIKeyFromErrors(t *testing.T) {
+	const apiKey = "box_secret_live_proof"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Box-Api-Key"); got != apiKey {
+			t.Errorf("X-Box-Api-Key=%q want configured key", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprintf(w, "rejected X-Box-Api-Key %s", r.Header.Get("X-Box-Api-Key"))
+	}))
+	defer srv.Close()
+
+	client := &client{apiKey: apiKey, base: srv.URL, http: srv.Client()}
+	archive := filepath.Join(t.TempDir(), "archive.tgz")
+	if err := os.WriteFile(archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "json", run: func() error {
+			_, err := client.ListBoxes(context.Background())
+			return err
+		}},
+		{name: "exec stream response", run: func() error {
+			_, err := client.ExecStream(context.Background(), "box_1", "true", "", io.Discard)
+			return err
+		}},
+		{name: "upload", run: func() error {
+			return client.UploadFile(context.Background(), "box_1", archive, "/tmp/archive.tgz")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil {
+				t.Fatal("expected API error")
+			}
+			message := err.Error()
+			if strings.Contains(message, apiKey) {
+				t.Fatalf("error contains API key: %q", message)
+			}
+			if !strings.Contains(message, "401 Unauthorized") || !strings.Contains(message, "[redacted]") {
+				t.Fatalf("error=%q, want status and redaction marker", message)
+			}
+		})
 	}
 }
 
@@ -345,6 +395,37 @@ func TestParseExecStreamRequiresExitEvent(t *testing.T) {
 	}
 	if stdout.String() != "partial output" {
 		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestParseExecStreamRedactsAPIKeyFromErrorEvent(t *testing.T) {
+	const apiKey = "box_secret_stream"
+	body := "event: error\ndata: provider rejected " + apiKey + "\n\n"
+	code, err := parseExecStream(strings.NewReader(body), io.Discard, apiKey)
+	if code != 1 || err == nil {
+		t.Fatalf("code=%d err=%v, want stream error", code, err)
+	}
+	if strings.Contains(err.Error(), apiKey) || !strings.Contains(err.Error(), "provider rejected [redacted]") {
+		t.Fatalf("error=%q, want redacted API key", err)
+	}
+}
+
+func TestRedactUpstashBoxSecretsIgnoresEmptyValues(t *testing.T) {
+	const message = "upstash-box response"
+	if got := redactUpstashBoxSecrets(message, "", "   "); got != message {
+		t.Fatalf("redacted=%q want %q", got, message)
+	}
+}
+
+func TestAPIErrorRedactsAPIKeyFromStatus(t *testing.T) {
+	const apiKey = "box_secret_status"
+	client := &client{apiKey: apiKey}
+	err := client.apiError(&http.Response{
+		Status: "401 rejected " + apiKey,
+		Body:   io.NopCloser(strings.NewReader("")),
+	})
+	if strings.Contains(err.Error(), apiKey) || !strings.Contains(err.Error(), "401 rejected [redacted]") {
+		t.Fatalf("error=%q, want redacted status", err)
 	}
 }
 

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -205,9 +205,9 @@ func (c *client) ExecStream(ctx context.Context, boxID, command, folder string, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, apiError(resp)
+		return 0, c.apiError(resp)
 	}
-	return parseExecStream(resp.Body, stdout)
+	return parseExecStream(resp.Body, stdout, c.apiKey)
 }
 
 func (c *client) UploadFile(ctx context.Context, boxID, localPath, remotePath string) error {
@@ -262,7 +262,7 @@ func (c *client) UploadFile(ctx context.Context, boxID, localPath, remotePath st
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return finishProducer(apiError(resp))
+		return finishProducer(c.apiError(resp))
 	}
 	return finishProducer(nil)
 }
@@ -299,7 +299,7 @@ func (c *client) doJSON(ctx context.Context, method, path string, query url.Valu
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return apiError(resp)
+		return c.apiError(resp)
 	}
 	if out == nil {
 		return nil
@@ -321,16 +321,26 @@ func (c *client) addHeaders(req *http.Request) {
 	req.Header.Set("X-Box-Api-Key", c.apiKey)
 }
 
-func apiError(resp *http.Response) error {
+func (c *client) apiError(resp *http.Response) error {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-	msg := strings.TrimSpace(string(data))
+	msg := redactUpstashBoxSecrets(strings.TrimSpace(string(data)), c.apiKey)
+	status := redactUpstashBoxSecrets(resp.Status, c.apiKey)
 	if msg == "" {
-		msg = resp.Status
+		msg = status
 	}
-	return fmt.Errorf("upstash-box API %s: %s", resp.Status, msg)
+	return fmt.Errorf("upstash-box API %s: %s", status, msg)
 }
 
-func parseExecStream(r io.Reader, stdout io.Writer) (int, error) {
+func redactUpstashBoxSecrets(value string, secrets ...string) string {
+	for _, secret := range secrets {
+		if strings.TrimSpace(secret) != "" {
+			value = strings.ReplaceAll(value, secret, "[redacted]")
+		}
+	}
+	return value
+}
+
+func parseExecStream(r io.Reader, stdout io.Writer, secrets ...string) (int, error) {
 	reader := bufio.NewReader(r)
 	var buffer strings.Builder
 	for {
@@ -341,7 +351,7 @@ func parseExecStream(r io.Reader, stdout io.Writer) (int, error) {
 			flushExecOutputCandidates(&buffer, stdout)
 		}
 		if readErr == io.EOF {
-			return finishExecStream(&buffer, stdout)
+			return finishExecStream(&buffer, stdout, secrets...)
 		}
 		if readErr != nil {
 			return 0, readErr
@@ -376,7 +386,7 @@ func flushExecOutputCandidates(buffer *strings.Builder, stdout io.Writer) {
 	}
 }
 
-func finishExecStream(buffer *strings.Builder, stdout io.Writer) (int, error) {
+func finishExecStream(buffer *strings.Builder, stdout io.Writer, secrets ...string) (int, error) {
 	text := buffer.String()
 	buffer.Reset()
 	exitIdx := strings.LastIndex(text, execExitMarker)
@@ -405,6 +415,7 @@ func finishExecStream(buffer *strings.Builder, stdout io.Writer) (int, error) {
 		if msg == "" {
 			msg = "stream error"
 		}
+		msg = redactUpstashBoxSecrets(msg, secrets...)
 		return 1, fmt.Errorf("upstash-box exec stream: %s", msg)
 	}
 	if text != "" {


### PR DESCRIPTION
## Summary

- redact the configured Upstash Box API key from every non-success HTTP response diagnostic
- redact the key from `exec-stream` error events before surfacing them
- retain useful status and provider error context; document the behavior and add regression coverage for JSON, streaming, and upload paths

Fixes https://github.com/openclaw/crabbox/issues/519

## Verification

- `go test -race ./internal/providers/upstashbox`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- autoreview: clean, no accepted/actionable findings (correctness 0.86)

## Live proof

Built the real CLI, pointed `crabbox list --provider upstash-box` at a loopback HTTP server that verifies and reflects `X-Box-Api-Key`, and asserted the configured dummy key was absent from combined output:

```text
exit=1
upstash-box API 401 Unauthorized: rejected [redacted]
```

No real provider resources or secrets were used.
