### PR TITLE
fix: block coordinator credential redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Rejected cross-origin coordinator redirects before bearer, Access, or local identity headers can be replayed. Thanks @coygeek.
 - Redacted configured Upstash Box API keys from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Redacted configured Semaphore API tokens from provider response diagnostics. Thanks @coygeek.
 - Kept GitHub Actions runner registration tokens off remote SSH command arguments. Thanks @coygeek.

--- a/docs/features/broker-auth-routing.md
+++ b/docs/features/broker-auth-routing.md
@@ -179,6 +179,10 @@ pre-minted JWT:
 fallbacks.) These credentials satisfy Cloudflare Access only — the Worker still requires the
 Crabbox bearer or signed user token.
 
+Coordinator HTTP requests follow redirects only when the scheme, host, and effective port
+remain unchanged. The curl transport fallback does not follow redirects, preventing bearer,
+Access, and local identity headers from being replayed to a different origin.
+
 For coordinators behind an upstream identity proxy that consumes the `Authorization` header,
 set `CRABBOX_COORDINATOR_TOKEN_COMMAND` to a JSON argv array. Crabbox executes it directly,
 without a shell, before each HTTP request and WebSocket reconnect. The command must print one

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1640,12 +1640,56 @@ func (c *CoordinatorClient) doHTTP(ctx context.Context, method, path string, dat
 	if err := c.addRequestHeaders(ctx, req.Header); err != nil {
 		return err
 	}
-	resp, err := c.Client.Do(req)
+	resp, err := c.secureHTTPClient().Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	return decodeCoordinatorResponse(method, path, resp.StatusCode, resp.Body, out)
+}
+
+func (c *CoordinatorClient) secureHTTPClient() *http.Client {
+	source := c.Client
+	if source == nil {
+		source = http.DefaultClient
+	}
+	client := *source
+	trusted, _ := url.Parse(c.BaseURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameCoordinatorOrigin(trusted, req.URL) {
+			return fmt.Errorf("coordinator refused cross-origin redirect to %s", req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameCoordinatorOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveCoordinatorPort(a) == effectiveCoordinatorPort(b)
+}
+
+func effectiveCoordinatorPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func (c *CoordinatorClient) addRequestHeaders(ctx context.Context, headers http.Header) error {
@@ -1723,7 +1767,9 @@ func (c *CoordinatorClient) doCurl(ctx context.Context, method, path string, dat
 	}
 	defer cleanup()
 
-	cmd := exec.CommandContext(ctx, "curl", "--config", "-")
+	// -q must be curl's first argument so ambient curlrc settings cannot
+	// re-enable redirects or otherwise change credential handling.
+	cmd := exec.CommandContext(ctx, "curl", "-q", "--config", "-")
 	cmd.Stdin = strings.NewReader(config)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -1770,7 +1816,6 @@ func (c *CoordinatorClient) curlConfig(ctx context.Context, method, path string,
 	curlConfigValue(&cfg, "max-time", strconv.Itoa(int(coordinatorHTTPTimeout/time.Second)))
 	curlConfigFlag(&cfg, "silent")
 	curlConfigFlag(&cfg, "show-error")
-	curlConfigFlag(&cfg, "location")
 	curlConfigValue(&cfg, "output", "-")
 	curlConfigValue(&cfg, "write-out", "\n%{http_code}")
 	if hasBody {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -196,10 +199,123 @@ func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
 			t.Fatalf("config missing %q:\n%s", want, config)
 		}
 	}
+	for _, line := range strings.Split(config, "\n") {
+		if strings.TrimSpace(line) == "location" {
+			t.Fatalf("credentialed curl config follows redirects:\n%s", config)
+		}
+	}
 	bodyPath := curlConfigValueForTest(t, config, "data-binary")
 	bodyPath = strings.TrimPrefix(bodyPath, "@")
 	if _, err := os.Stat(bodyPath); err != nil {
 		t.Fatalf("body file missing: %v", err)
+	}
+}
+
+func TestCoordinatorHTTPRejectsCrossOriginRedirect(t *testing.T) {
+	var redirected atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirected.Add(1)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer broker-token" {
+			t.Errorf("Authorization=%q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Secret"); got != "access-secret" {
+			t.Errorf("CF-Access-Client-Secret=%q", got)
+		}
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	client := CoordinatorClient{
+		BaseURL: source.URL,
+		Token:   "broker-token",
+		Access: AccessConfig{
+			ClientID:     "access-client",
+			ClientSecret: "access-secret",
+			Token:        "access-jwt",
+		},
+		Client: source.Client(),
+	}
+	err := client.doHTTP(context.Background(), http.MethodGet, "/v1/health", nil, false, nil)
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("error=%v, want cross-origin redirect rejection", err)
+	}
+	if got := redirected.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests", got)
+	}
+}
+
+func TestCoordinatorHTTPAllowsSameOriginRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/v1/health", http.StatusFound)
+			return
+		}
+		if r.URL.Path != "/v1/health" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	var response map[string]any
+	if err := client.doHTTP(context.Background(), http.MethodGet, "/redirect", nil, false, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["ok"] != true {
+		t.Fatalf("response=%v", response)
+	}
+}
+
+func TestCoordinatorCurlFallbackDoesNotFollowRedirect(t *testing.T) {
+	if _, err := exec.LookPath("curl"); err != nil {
+		t.Skip("curl is unavailable")
+	}
+	curlHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(curlHome, ".curlrc"), []byte("location\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CURL_HOME", curlHome)
+	t.Setenv("HOME", curlHome)
+	var redirected atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirected.Add(1)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer broker-token" {
+			t.Errorf("Authorization=%q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Secret"); got != "access-secret" {
+			t.Errorf("CF-Access-Client-Secret=%q", got)
+		}
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	client := CoordinatorClient{
+		BaseURL: source.URL,
+		Token:   "broker-token",
+		Access: AccessConfig{
+			ClientID:     "access-client",
+			ClientSecret: "access-secret",
+			Token:        "access-jwt",
+		},
+		Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("forced transport failure")
+		})},
+	}
+	err := client.Health(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "forced transport failure") || !strings.Contains(err.Error(), "curl fallback failed: coordinator GET /v1/health: http 302") {
+		t.Fatalf("error=%v, want transport and curl HTTP 302 errors", err)
+	}
+	if got := redirected.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject coordinator HTTP redirects that change scheme, host, or effective port before bearer, Cloudflare Access, or local identity headers can be replayed
- preserve same-origin redirects in the Go transport
- make the curl fallback non-redirecting and disable ambient curlrc processing so user configuration cannot re-enable redirects
- document the boundary and add real-curl attack-path coverage

Fixes https://github.com/openclaw/crabbox/issues/521

## Verification

- `go test -race ./internal/cli -run 'TestCoordinator(HTTPRejectsCrossOriginRedirect|HTTPAllowsSameOriginRedirect|CurlFallbackDoesNotFollowRedirect)|TestCurlConfigKeepsBearerTokenInConfig' -count=1 -v`
- `go vet ./...`
- `go test -race ./...`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- autoreview round 1 found ambient curlrc could re-enable redirects; fixed with first-argument `-q` and hostile-curlrc coverage
- autoreview round 2: clean, no accepted/actionable findings (correctness 0.86)

## Live proof

The regression harness executes the production fallback through the installed real `curl` binary:

1. A forced Go transport failure enters the curl fallback.
2. A hostile `.curlrc` contains `location`.
3. The configured coordinator verifies it received the dummy bearer and Access credentials, then redirects to a second loopback origin.
4. Crabbox surfaces the original transport error plus coordinator HTTP 302; the redirected origin's atomic request count remains exactly zero.

Independent loopback coverage verifies the Go HTTP path also rejects cross-origin redirects and still follows same-origin redirects. No real credentials or external coordinator resources were used.
