### PR TITLE
[codex] add FastAPI Cloud service-control provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
+
 ## 0.33.0 - 2026-06-22
 
 ### Added

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -60,7 +60,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 59 providers (35 SSH lease, 23 delegated run, 1 service control).
+Current built-in surface: 60 providers (35 SSH lease, 23 delegated run, 2 service control).
 
 Access terms:
 
@@ -89,6 +89,7 @@ Access terms:
 | [e2b](e2b.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `provider-owned` · direct only; features: `url-bridge`, `run-session` | `linux`; E2B Firecracker sandbox | `provider-managed`; GPU: no | E2B; sandbox kill or expiry | Hosted ephemeral code sandbox | URL bridge is provider-specific; no normal SSH lease |
 | [exe-dev](exe-dev.md) (`exe`, `exedev`) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; exe.dev managed VM | `provider-managed`; GPU: unknown | exe.dev; provider lifecycle | Fast managed Linux VM exposed over SSH | Public SSH only; provider CLI owns auth |
 | [external](external.md) (`exec-provider`) | built-in; `ssh-lease` · external-provider | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code` | `linux`; Configured executable contract | `byo`; GPU: unknown | external executable; contract-defined | Private or organization-specific provider integration | Safety and semantics depend on the configured executable |
+| [fastapi-cloud](fastapi-cloud.md) (`fastapicloud`, `fastapi`) | specialized; `service-control` · service-control | SSH not applicable; `none` · direct only; features: none | `linux`; FastAPI Cloud app | `cloud`; GPU: unknown | FastAPI Cloud; not exposed | Inspecting FastAPI Cloud app deployment readiness | Cannot execute arbitrary Crabbox run commands or stop apps |
 | [freestyle](freestyle.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; Freestyle VM | `provider-managed`; GPU: unknown | Freestyle; provider VM cleanup | Hosted delegated Linux VM execution | No Crabbox-managed SSH path |
 | [gcp](gcp.md) (`google`, `google-cloud`) | built-in; `ssh-lease` · brokerable-cloud | Crabbox-managed SSH; `crabbox-sync` · coordinator optional; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Google Compute Engine VM | `cloud`; GPU: optional | Crabbox or coordinator; instance and firewall cleanup | Linux compute with broad machine selection | Project, IAM, quota, and firewall setup required |
 | [hetzner](hetzner.md) | built-in; `ssh-lease` · brokerable-cloud | Crabbox-managed SSH; `crabbox-sync` · coordinator optional; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code`, `tailscale` | `linux`; Hetzner Cloud server | `cloud`; GPU: no | Crabbox or coordinator; server delete | Cost-effective high-CPU Linux VM | Linux-only and capacity varies by location |

--- a/docs/providers/fastapi-cloud.md
+++ b/docs/providers/fastapi-cloud.md
@@ -1,0 +1,151 @@
+# FastAPI Cloud Provider
+
+Read when:
+
+- choosing `provider: fastapi-cloud`;
+- pointing Crabbox at an existing FastAPI Cloud app;
+- changing `internal/providers/fastapicloud`.
+
+[FastAPI Cloud](https://fastapicloud.com) is a deployment platform for FastAPI
+apps. Its CLI packages and uploads an app, then FastAPI Cloud builds, deploys,
+and verifies that service. Crabbox models FastAPI Cloud as a `service-control`
+provider: it can inspect apps and their latest deployment status through the
+FastAPI Cloud API, but it cannot create an SSH lease, sync a workspace, or run
+an arbitrary command.
+
+## When To Use
+
+Use FastAPI Cloud when the workload is already a FastAPI Cloud app and you want
+Crabbox to report its deployment readiness from the same provider matrix as
+other backends.
+
+Do not use this provider for generic sandbox execution. FastAPI Cloud deploys a
+configured application; it does not expose a synchronous `run(cmd)` or SSH
+primitive that Crabbox can use for ad-hoc tests. For command execution, choose a
+delegated-run provider such as `e2b`, `modal`, or `docker-sandbox`, or an
+SSH-lease provider such as `aws`, `hetzner`, or `ssh`.
+
+## Run Contract
+
+`crabbox run --provider fastapi-cloud ... -- <command>` fails before calling the
+FastAPI Cloud API. Accepting the command would imply Crabbox executed it inside
+the app, which FastAPI Cloud does not expose.
+
+Deploy with FastAPI Cloud's own deployment path instead:
+
+```sh
+fastapi deploy --app-id "$FASTAPI_CLOUD_APP_ID"
+```
+
+or through a FastAPI Cloud deploy token in CI. Then use Crabbox for inspection:
+
+```sh
+crabbox status --provider fastapi-cloud --id "$FASTAPI_CLOUD_APP_ID"
+crabbox list --provider fastapi-cloud --fastapi-cloud-team-id "$FASTAPI_CLOUD_TEAM_ID"
+```
+
+`warmup` is rejected because app creation and deployment belong to FastAPI
+Cloud. `stop` is rejected because this provider does not expose an app stop or
+delete operation.
+
+## Auth
+
+```sh
+export FASTAPI_CLOUD_TOKEN=...      # deploy token or compatible bearer token
+export FASTAPI_CLOUD_APP_ID=...     # optional default app for status/list
+export FASTAPI_CLOUD_TEAM_ID=...    # optional team for list/doctor
+```
+
+`CRABBOX_FASTAPI_CLOUD_TOKEN` is also accepted and wins over
+`FASTAPI_CLOUD_TOKEN`. The token is read from the environment only; the provider
+does not register a CLI flag for it, so it is never passed on the command line.
+
+The provider sends REST requests to `https://api.fastapicloud.com/api/v1` with
+`Authorization: Bearer <token>` and `Accept: application/json`.
+If a token is scoped to one app, use `FASTAPI_CLOUD_APP_ID`; team-wide `list`
+may require a token that can read that team.
+
+## Config
+
+```yaml
+provider: fastapi-cloud
+target: linux
+fastapiCloud:
+  apiUrl: https://api.fastapicloud.com/api/v1
+  appId: <app-id>
+  teamId: <team-id>
+```
+
+Provider flags:
+
+```text
+--fastapi-cloud-url
+--fastapi-cloud-app-id
+--fastapi-cloud-team-id
+```
+
+Environment overrides:
+
+```text
+CRABBOX_FASTAPI_CLOUD_TOKEN    (or FASTAPI_CLOUD_TOKEN)
+CRABBOX_FASTAPI_CLOUD_API_URL  (or FASTAPI_CLOUD_API_URL)
+CRABBOX_FASTAPI_CLOUD_APP_ID   (or FASTAPI_CLOUD_APP_ID)
+CRABBOX_FASTAPI_CLOUD_TEAM_ID  (or FASTAPI_CLOUD_TEAM_ID)
+```
+
+The API URL must use `https` unless it targets localhost for tests.
+
+## Commands
+
+```sh
+crabbox status --provider fastapi-cloud --id "$FASTAPI_CLOUD_APP_ID"
+```
+
+`status` fetches the app and its latest deployment. FastAPI Cloud `success` and
+`verifying_skipped` deployments are reported as ready; known build, extraction,
+deployment, and verification failures are reported as failed; in-progress
+states are surfaced as the upstream status string.
+
+```sh
+crabbox list --provider fastapi-cloud --fastapi-cloud-team-id "$FASTAPI_CLOUD_TEAM_ID"
+```
+
+`list` returns apps for a configured team ID. If no team ID is configured but an
+app ID is configured, `list` returns that single app.
+
+```sh
+crabbox doctor --provider fastapi-cloud
+```
+
+`doctor` verifies the configured app or team can be read with the current token.
+
+## Capabilities
+
+- Target: Linux only.
+- SSH: no.
+- Crabbox sync: no. `--no-sync` is required for `run`, which then rejects the
+  command.
+- Provider sync: FastAPI Cloud deploy flow only, outside this provider.
+- Generic `run`: no.
+- Warmup: no.
+- Stop/delete: no.
+- Desktop/browser/code: no.
+- Coordinator: no (direct from CLI only).
+
+## Gotchas
+
+- FastAPI Cloud is a deployment platform, not a remote shell or Crabbox
+  sandbox.
+- `--keep`, `--reclaim`, `--class`, and `--type` are rejected because FastAPI
+  Cloud owns app lifecycle and sizing.
+- Sync options are rejected: `--no-sync` is required, and `--sync-only`,
+  `--checksum`, `--force-sync-large`, and `--full-resync` all error out.
+- App listing needs a team ID; status can use either `--id` or a configured app
+  ID.
+- API compatibility is based on the app and deployment endpoints used by the
+  public FastAPI Cloud CLI. If the upstream API changes, this provider should be
+  updated with matching tests.
+
+Related docs:
+
+- [Provider backends](../provider-backends.md)

--- a/docs/providers/fastapi-cloud.md
+++ b/docs/providers/fastapi-cloud.md
@@ -145,6 +145,8 @@ crabbox doctor --provider fastapi-cloud
   Cloud owns app lifecycle and sizing.
 - Sync options are rejected: `--no-sync` is required, and `--sync-only`,
   `--checksum`, `--force-sync-large`, and `--full-resync` all error out.
+- `--shell` is rejected (no interactive session) and `--env-summary` is rejected
+  (this provider cannot forward per-run environment variables).
 - App listing needs a team ID; status can use either `--id` or a configured app
   ID.
 - API compatibility is based on the app and deployment endpoints used by the

--- a/docs/providers/fastapi-cloud.md
+++ b/docs/providers/fastapi-cloud.md
@@ -93,7 +93,12 @@ CRABBOX_FASTAPI_CLOUD_APP_ID   (or FASTAPI_CLOUD_APP_ID)
 CRABBOX_FASTAPI_CLOUD_TEAM_ID  (or FASTAPI_CLOUD_TEAM_ID)
 ```
 
-The API URL must use `https` unless it targets localhost for tests.
+The API URL must use `https` unless it targets localhost for tests. The loopback
+exception (`localhost`, `127.0.0.1`, `::1`) is matched on the parsed hostname, so
+spoofed authorities such as `http://localhost@example.com` are correctly rejected.
+Note that an `http://localhost...` URL transmits the bearer token in cleartext to
+whatever process listens on that port, so the exception is intended only for local
+testing against a trusted listener.
 
 ## Commands
 

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -265,6 +265,20 @@
     "caveat": "Safety and semantics depend on the configured executable",
     "docs": "external.md"
   },
+  "fastapi-cloud": {
+    "status": "specialized",
+    "category": "service-control",
+    "substrate": "FastAPI Cloud app",
+    "location": "cloud",
+    "ssh": "not-applicable",
+    "sync": "none",
+    "gpu": "unknown",
+    "lifecycle": "FastAPI Cloud",
+    "cleanup": "not exposed",
+    "bestFit": "Inspecting FastAPI Cloud app deployment readiness",
+    "caveat": "Cannot execute arbitrary Crabbox run commands or stop apps",
+    "docs": "fastapi-cloud.md"
+  },
   "freestyle": {
     "status": "built-in",
     "category": "delegated-sandbox",

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -15,10 +15,10 @@ Crabbox has three implementation surfaces:
 - **CLI** — Go, under `cmd/crabbox` (entrypoint) and `internal/cli` (commands,
   flags, lease/sync/run logic).
 - **Provider adapters** — Go, under `internal/providers/<name>`. Each adapter
-  registers a provider and implements either an SSH-lease backend or a
-  delegated-run backend. `internal/providers/all/all.go` imports every adapter
-  for its registration side effects; `internal/providers/shared` holds common
-  helpers.
+  registers a provider and implements an SSH-lease, delegated-run, or
+  service-control backend. `internal/providers/all/all.go` imports every
+  adapter for its registration side effects; `internal/providers/shared` holds
+  common helpers.
 - **Coordinator** — TypeScript, under `worker/src` and `worker/node`. Shared
   `FleetCoordinator` behavior runs either in a Cloudflare Worker plus one
   Durable Object or in Node.js backed by PostgreSQL and pg-boss. Only `aws`,
@@ -63,7 +63,9 @@ Provider adapters live under `internal/providers/<name>` and each expose
 `Name()`, `Aliases()`, and `Spec()` in their `provider.go`. The `Spec.Kind`
 field distinguishes an SSH-lease backend (Crabbox provisions and connects to an
 SSH-reachable box) from a delegated-run backend (the provider owns sync and run;
-there is no SSH lease). `internal/providers/all/all.go` imports them all.
+there is no SSH lease) or service-control backend (Crabbox inspects a
+provider-owned service without command execution). `internal/providers/all/all.go`
+imports them all.
 
 SSH-lease providers:
 
@@ -85,10 +87,9 @@ SSH-lease providers:
 - Canonical Multipass local Ubuntu VM: `internal/providers/multipass`
 - Cirrus Labs tart local macOS VM: `internal/providers/tart`
 - Microsoft Hyper-V local Windows VM: `internal/providers/hyperv`
-- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites, Railway:
+- Daytona, Morph, exe.dev, KubeVirt, External, Tenki, Namespace devbox, RunPod, Semaphore, Sprites:
   `internal/providers/daytona`, `internal/providers/morph`, `internal/providers/exedev`, `internal/providers/kubevirt`, `internal/providers/external`, `internal/providers/tenki`, `internal/providers/namespace`,
-  `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`,
-  `internal/providers/railway`
+  `internal/providers/runpod`, `internal/providers/semaphore`, `internal/providers/sprites`
 
 Delegated-run providers (no SSH lease):
 
@@ -106,6 +107,11 @@ Delegated-run providers (no SSH lease):
 - Anthropic Sandbox Runtime live local enforcement smoke: `scripts/live-anthropic-sandbox-runtime-smoke.sh`
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`
+
+Service-control providers (no SSH lease and no arbitrary command execution):
+
+- Railway service control: `internal/providers/railway`
+- FastAPI Cloud app inspection: `internal/providers/fastapicloud`
 
 Shared and registration:
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -153,6 +153,7 @@ type Config struct {
 	E2B                           E2BConfig
 	ExeDev                        ExeDevConfig
 	Railway                       RailwayConfig
+	FastAPICloud                  FastAPICloudConfig
 	Runpod                        RunpodConfig
 	NvidiaBrev                    NvidiaBrevConfig
 	nvidiaBrevWorkRootExplicit    bool
@@ -523,6 +524,13 @@ type RailwayConfig struct {
 	APIURL        string
 	ProjectID     string
 	EnvironmentID string
+}
+
+type FastAPICloudConfig struct {
+	Token  string
+	APIURL string
+	AppID  string
+	TeamID string
 }
 
 type RunpodConfig struct {
@@ -2284,6 +2292,9 @@ func baseConfig() Config {
 		Railway: RailwayConfig{
 			APIURL: "https://backboard.railway.com/graphql/v2",
 		},
+		FastAPICloud: FastAPICloudConfig{
+			APIURL: "https://api.fastapicloud.com/api/v1",
+		},
 		Runpod: RunpodConfig{
 			APIURL:     "https://rest.runpod.io/v1",
 			CloudType:  "SECURE",
@@ -2569,6 +2580,7 @@ type fileConfig struct {
 	E2B                      *fileE2BConfig                      `yaml:"e2b,omitempty"`
 	ExeDev                   *fileExeDevConfig                   `yaml:"exeDev,omitempty"`
 	Railway                  *fileRailwayConfig                  `yaml:"railway,omitempty"`
+	FastAPICloud             *fileFastAPICloudConfig             `yaml:"fastapiCloud,omitempty"`
 	Runpod                   *fileRunpodConfig                   `yaml:"runpod,omitempty"`
 	NvidiaBrev               *fileNvidiaBrevConfig               `yaml:"nvidiaBrev,omitempty"`
 	Hostinger                *fileHostingerConfig                `yaml:"hostinger,omitempty"`
@@ -3021,6 +3033,12 @@ type fileRailwayConfig struct {
 	APIURL        string `yaml:"apiUrl,omitempty"`
 	ProjectID     string `yaml:"projectId,omitempty"`
 	EnvironmentID string `yaml:"environmentId,omitempty"`
+}
+
+type fileFastAPICloudConfig struct {
+	APIURL string `yaml:"apiUrl,omitempty"`
+	AppID  string `yaml:"appId,omitempty"`
+	TeamID string `yaml:"teamId,omitempty"`
 }
 
 type fileRunpodConfig struct {
@@ -4833,6 +4851,18 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.Railway.EnvironmentID = file.Railway.EnvironmentID
 		}
 	}
+	if file.FastAPICloud != nil {
+		if file.FastAPICloud.APIURL != "" {
+			cfg.FastAPICloud.APIURL = file.FastAPICloud.APIURL
+			cfg.credentialProvenance.fastAPICloudAPIURL = credentialSource
+		}
+		if file.FastAPICloud.AppID != "" {
+			cfg.FastAPICloud.AppID = file.FastAPICloud.AppID
+		}
+		if file.FastAPICloud.TeamID != "" {
+			cfg.FastAPICloud.TeamID = file.FastAPICloud.TeamID
+		}
+	}
 	if file.Runpod != nil {
 		if file.Runpod.APIURL != "" {
 			cfg.Runpod.APIURL = file.Runpod.APIURL
@@ -6613,6 +6643,16 @@ func applyEnv(cfg *Config) error {
 	}
 	cfg.Railway.ProjectID = getenv("CRABBOX_RAILWAY_PROJECT_ID", getenv("RAILWAY_PROJECT_ID", cfg.Railway.ProjectID))
 	cfg.Railway.EnvironmentID = getenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", getenv("RAILWAY_ENVIRONMENT_ID", cfg.Railway.EnvironmentID))
+	if value, ok := firstNonEmptyEnv("CRABBOX_FASTAPI_CLOUD_TOKEN", "FASTAPI_CLOUD_TOKEN"); ok {
+		cfg.FastAPICloud.Token = value
+		cfg.credentialProvenance.fastAPICloudToken = credentialSourceEnvironment
+	}
+	if value, ok := firstNonEmptyEnv("CRABBOX_FASTAPI_CLOUD_API_URL", "FASTAPI_CLOUD_API_URL"); ok {
+		cfg.FastAPICloud.APIURL = value
+		cfg.credentialProvenance.fastAPICloudAPIURL = credentialSourceEnvironment
+	}
+	cfg.FastAPICloud.AppID = getenv("CRABBOX_FASTAPI_CLOUD_APP_ID", getenv("FASTAPI_CLOUD_APP_ID", cfg.FastAPICloud.AppID))
+	cfg.FastAPICloud.TeamID = getenv("CRABBOX_FASTAPI_CLOUD_TEAM_ID", getenv("FASTAPI_CLOUD_TEAM_ID", cfg.FastAPICloud.TeamID))
 	if value, ok := firstNonEmptyEnv("CRABBOX_RUNPOD_API_KEY", "RUNPOD_API_KEY"); ok {
 		cfg.Runpod.APIKey = value
 		cfg.credentialProvenance.runpodAPIKey = credentialSourceEnvironment

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -300,6 +300,12 @@ func configShowView(cfg Config) map[string]any {
 			"auth":    tokenState(cfg.Cloudflare.Token),
 			"workdir": cfg.Cloudflare.Workdir,
 		},
+		"fastapiCloud": map[string]any{
+			"apiUrl": cfg.FastAPICloud.APIURL,
+			"auth":   tokenState(cfg.FastAPICloud.Token),
+			"appId":  cfg.FastAPICloud.AppID,
+			"teamId": cfg.FastAPICloud.TeamID,
+		},
 		"cloudflareDynamicWorkers": map[string]any{
 			"loaderUrl":          redactedConfigURLWithoutQuery(cfg.CloudflareDynamicWorkers.LoaderURL),
 			"auth":               tokenState(cfg.CloudflareDynamicWorkers.Token),
@@ -523,6 +529,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "multipass cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s disk=%s launch_timeout=%s\n", cfg.Multipass.CLIPath, cfg.Multipass.Image, cfg.Multipass.User, cfg.Multipass.WorkRoot, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), cfg.Multipass.LaunchTimeout)
 	fmt.Fprintf(w, "tart image=%s user=%s work_root=%s cpus=%d memory=%d disk=%d\n", cfg.Tart.Image, cfg.Tart.User, cfg.Tart.WorkRoot, cfg.Tart.CPUs, cfg.Tart.Memory, cfg.Tart.Disk)
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(cfg.Cloudflare.APIURL, "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
+	fmt.Fprintf(w, "fastapi_cloud api_url=%s app_id=%s team_id=%s auth=%s\n", blank(cfg.FastAPICloud.APIURL, "-"), blank(cfg.FastAPICloud.AppID, "-"), blank(cfg.FastAPICloud.TeamID, "-"), tokenState(cfg.FastAPICloud.Token))
 	fmt.Fprintf(w, "cloudflare_dynamic_workers loader_url=%s compatibility_date=%s compatibility_flags=%s cache_mode=%s egress=%s cpu_ms=%d subrequests=%d timeout_secs=%d metadata=%d auth=%s\n", blank(redactedConfigURLWithoutQuery(cfg.CloudflareDynamicWorkers.LoaderURL), "-"), blank(cfg.CloudflareDynamicWorkers.CompatibilityDate, "-"), blank(strings.Join(cfg.CloudflareDynamicWorkers.CompatibilityFlags, ","), "-"), cfg.CloudflareDynamicWorkers.CacheMode, cfg.CloudflareDynamicWorkers.Egress, cfg.CloudflareDynamicWorkers.CPUMs, cfg.CloudflareDynamicWorkers.Subrequests, cfg.CloudflareDynamicWorkers.TimeoutSecs, len(cfg.CloudflareDynamicWorkers.Metadata), tokenState(cfg.CloudflareDynamicWorkers.Token))
 	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
 	fmt.Fprintf(w, "results junit=%s auto=%t fail_on_failures=%t\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"), cfg.Results.Auto, cfg.Results.FailOnFailures)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -390,6 +390,14 @@ func clearConfigEnv(t *testing.T) {
 		"RAILWAY_PROJECT_ID",
 		"CRABBOX_RAILWAY_ENVIRONMENT_ID",
 		"RAILWAY_ENVIRONMENT_ID",
+		"CRABBOX_FASTAPI_CLOUD_TOKEN",
+		"FASTAPI_CLOUD_TOKEN",
+		"CRABBOX_FASTAPI_CLOUD_API_URL",
+		"FASTAPI_CLOUD_API_URL",
+		"CRABBOX_FASTAPI_CLOUD_APP_ID",
+		"FASTAPI_CLOUD_APP_ID",
+		"CRABBOX_FASTAPI_CLOUD_TEAM_ID",
+		"FASTAPI_CLOUD_TEAM_ID",
 		"CRABBOX_NVIDIA_BREV_CLI",
 		"CRABBOX_NVIDIA_BREV_ORG",
 		"CRABBOX_NVIDIA_BREV_TYPE",
@@ -4447,6 +4455,14 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_RAILWAY_PROJECT_ID", "railway-project-env")
 	t.Setenv("RAILWAY_ENVIRONMENT_ID", "railway-environment-file")
 	t.Setenv("CRABBOX_RAILWAY_ENVIRONMENT_ID", "railway-environment-env")
+	t.Setenv("FASTAPI_CLOUD_TOKEN", "fastapi-token-file")
+	t.Setenv("CRABBOX_FASTAPI_CLOUD_TOKEN", "fastapi-token-env")
+	t.Setenv("FASTAPI_CLOUD_API_URL", "https://fastapi-file.example/api/v1")
+	t.Setenv("CRABBOX_FASTAPI_CLOUD_API_URL", "https://fastapi-env.example/api/v1")
+	t.Setenv("FASTAPI_CLOUD_APP_ID", "fastapi-app-file")
+	t.Setenv("CRABBOX_FASTAPI_CLOUD_APP_ID", "fastapi-app-env")
+	t.Setenv("FASTAPI_CLOUD_TEAM_ID", "fastapi-team-file")
+	t.Setenv("CRABBOX_FASTAPI_CLOUD_TEAM_ID", "fastapi-team-env")
 	t.Setenv("RUNPOD_API_KEY", "runpod-key-file")
 	t.Setenv("CRABBOX_RUNPOD_API_KEY", "runpod-key-env")
 	t.Setenv("RUNPOD_API_URL", "https://runpod-file.example/v1")
@@ -4699,6 +4715,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Railway.APIToken != "railway-token-env" || cfg.Railway.APIURL != "https://railway-env.example/graphql/v2" || cfg.Railway.ProjectID != "railway-project-env" || cfg.Railway.EnvironmentID != "railway-environment-env" {
 		t.Fatalf("unexpected railway env: %#v", cfg.Railway)
+	}
+	if cfg.FastAPICloud.Token != "fastapi-token-env" || cfg.FastAPICloud.APIURL != "https://fastapi-env.example/api/v1" || cfg.FastAPICloud.AppID != "fastapi-app-env" || cfg.FastAPICloud.TeamID != "fastapi-team-env" {
+		t.Fatalf("unexpected fastapi-cloud env: %#v", cfg.FastAPICloud)
 	}
 	if cfg.Runpod.APIKey != "runpod-key-env" || cfg.Runpod.APIURL != "https://runpod-env.example/v1" || cfg.Runpod.CloudType != "SECURE" || cfg.Runpod.InstanceID != "NVIDIA L4" || cfg.Runpod.Image != "runpod/pytorch:env" || cfg.Runpod.TemplateID != "tpl-env" || cfg.Runpod.DiskGB != 30 || cfg.Runpod.User != "runpod-env-user" || cfg.Runpod.WorkRoot != "/work/runpod-env" {
 		t.Fatalf("unexpected runpod env: %#v", cfg.Runpod)

--- a/internal/cli/credential_provenance.go
+++ b/internal/cli/credential_provenance.go
@@ -41,6 +41,8 @@ type credentialDestinationProvenance struct {
 	e2bAPIKey           credentialValueSource
 	railwayAPIURL       credentialValueSource
 	railwayAPIToken     credentialValueSource
+	fastAPICloudAPIURL  credentialValueSource
+	fastAPICloudToken   credentialValueSource
 	runpodAPIURL        credentialValueSource
 	runpodAPIKey        credentialValueSource
 	isloBaseURL         credentialValueSource
@@ -119,6 +121,9 @@ func markCredentialDestinationFlagSources(cfg *Config, fs *flag.FlagSet) {
 	}
 	if flagWasSet(fs, "railway-url") {
 		provenance.railwayAPIURL = credentialSourceFlag
+	}
+	if flagWasSet(fs, "fastapi-cloud-url") {
+		provenance.fastAPICloudAPIURL = credentialSourceFlag
 	}
 	if flagWasSet(fs, "runpod-url") {
 		provenance.runpodAPIURL = credentialSourceFlag
@@ -231,6 +236,11 @@ func validateProviderCredentialDestination(cfg Config) error {
 		if provenance.railwayAPIURL == credentialSourceRepository &&
 			inheritedCredential(sourcedCredential{cfg.Railway.APIToken, provenance.railwayAPIToken}) {
 			return repositoryCredentialDestinationError("railway", "railway.apiUrl", "CRABBOX_RAILWAY_API_URL or --railway-url")
+		}
+	case "fastapi-cloud":
+		if provenance.fastAPICloudAPIURL == credentialSourceRepository &&
+			inheritedCredential(sourcedCredential{cfg.FastAPICloud.Token, provenance.fastAPICloudToken}) {
+			return repositoryCredentialDestinationError("fastapi-cloud", "fastapiCloud.apiUrl", "CRABBOX_FASTAPI_CLOUD_API_URL or --fastapi-cloud-url")
 		}
 	case "runpod":
 		if provenance.runpodAPIURL == credentialSourceRepository &&

--- a/internal/cli/credential_provenance_test.go
+++ b/internal/cli/credential_provenance_test.go
@@ -112,6 +112,18 @@ func TestRepositoryCredentialDestinationsRejectInheritedCredentials(t *testing.T
 			want: "railway.apiUrl",
 		},
 		{
+			name: "fastapi cloud api",
+			cfg: Config{
+				Provider:     "fastapi-cloud",
+				FastAPICloud: FastAPICloudConfig{APIURL: "https://repo.example.test", Token: "secret"},
+				credentialProvenance: credentialDestinationProvenance{
+					fastAPICloudAPIURL: credentialSourceRepository,
+					fastAPICloudToken:  credentialSourceEnvironment,
+				},
+			},
+			want: "fastapiCloud.apiUrl",
+		},
+		{
 			name: "runpod api",
 			cfg: Config{
 				Provider: "runpod",

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -22,6 +22,7 @@ var benchmarkProviderCategories = map[string]string{
 	"e2b":                        "delegated-sandbox",
 	"exe-dev":                    "direct-cloud",
 	"external":                   "external-provider",
+	"fastapi-cloud":              "service-control",
 	"freestyle":                  "delegated-sandbox",
 	"gcp":                        "brokerable-cloud",
 	"hetzner":                    "brokerable-cloud",

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -2126,6 +2126,15 @@ type testServiceControlBackend struct {
 
 func (b testServiceControlBackend) Spec() ProviderSpec { return b.spec }
 
+var testServiceControlStatusHook func(StatusRequest) (StatusView, error)
+
+func (b testServiceControlBackend) Status(_ context.Context, req StatusRequest) (StatusView, error) {
+	if testServiceControlStatusHook != nil {
+		return testServiceControlStatusHook(req)
+	}
+	return StatusView{}, exit(2, "service-control-test status unavailable")
+}
+
 func (b testDelegatedBackend) Spec() ProviderSpec { return b.spec }
 func (b testDelegatedBackend) Warmup(context.Context, WarmupRequest) error {
 	return nil

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -32,12 +32,17 @@ func (a App) status(ctx context.Context, args []string) error {
 	if err := applyProviderFlags(&cfg, fs, providerFlags); err != nil {
 		return err
 	}
-	if err := requireLeaseID(*id, "crabbox status --id <lease-id-or-slug>", cfg); err != nil {
-		return err
-	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
+	}
+	// Service-control providers may resolve status from configured application
+	// context instead of a lease ID. Let the provider own that contract and its
+	// missing-context diagnostic.
+	if backend.Spec().Kind != ProviderKindServiceControl {
+		if err := requireLeaseID(*id, "crabbox status --id <lease-id-or-slug>", cfg); err != nil {
+			return err
+		}
 	}
 	statusBackend, isStatus := backend.(interface {
 		Status(context.Context, StatusRequest) (statusView, error)

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -25,6 +25,34 @@ func TestStatusWaitDoneTreatsTerminalStatesAsDone(t *testing.T) {
 	}
 }
 
+func TestStatusAllowsServiceControlProviderToResolveConfiguredID(t *testing.T) {
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	testServiceControlStatusHook = func(req StatusRequest) (StatusView, error) {
+		if req.ID != "" {
+			t.Fatalf("status ID = %q, want provider-resolved empty ID", req.ID)
+		}
+		return StatusView{
+			ID:       "configured-app",
+			Provider: "service-control-test",
+			TargetOS: targetLinux,
+			State:    "ready",
+			Ready:    true,
+		}, nil
+	}
+	defer func() { testServiceControlStatusHook = nil }()
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.status(context.Background(), []string{"--provider", "service-control-test"}); err != nil {
+		t.Fatalf("status returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "configured-app") {
+		t.Fatalf("status output = %q, want configured app", stdout.String())
+	}
+}
+
 func TestStatusWaitTerminalErrorFailsNonReadyTerminalState(t *testing.T) {
 	err := statusWaitTerminalError("cbx_123", statusView{State: "stopped"})
 	var exitErr ExitError

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/e2b"
 	_ "github.com/openclaw/crabbox/internal/providers/exedev"
 	_ "github.com/openclaw/crabbox/internal/providers/external"
+	_ "github.com/openclaw/crabbox/internal/providers/fastapicloud"
 	_ "github.com/openclaw/crabbox/internal/providers/freestyle"
 	_ "github.com/openclaw/crabbox/internal/providers/gcp"
 	_ "github.com/openclaw/crabbox/internal/providers/hetzner"

--- a/internal/providers/fastapicloud/backend.go
+++ b/internal/providers/fastapicloud/backend.go
@@ -1,0 +1,207 @@
+package fastapicloud
+
+import (
+	"context"
+	"net/url"
+	"strings"
+)
+
+func NewFastAPICloudBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	cfg.Provider = providerName
+	return &fastAPICloudBackend{spec: spec, cfg: cfg, rt: rt}
+}
+
+type fastAPICloudBackend struct {
+	spec   ProviderSpec
+	cfg    Config
+	rt     Runtime
+	client fastAPICloudAPI
+}
+
+func (b *fastAPICloudBackend) Spec() ProviderSpec { return b.spec }
+
+func (b *fastAPICloudBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s does not support warmup; create and deploy the FastAPI Cloud app out-of-band", providerName)
+}
+
+func (b *fastAPICloudBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	_ = ctx
+	if err := rejectFastAPICloudRunOptions(req); err != nil {
+		return RunResult{}, err
+	}
+	if len(req.Command) == 0 {
+		return RunResult{}, exit(2, "missing command")
+	}
+	return RunResult{}, exit(2, "provider=%s cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI", providerName)
+}
+
+func (b *fastAPICloudBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	_ = req
+	client, err := b.api()
+	if err != nil {
+		return nil, err
+	}
+	if teamID := strings.TrimSpace(b.cfg.FastAPICloud.TeamID); teamID != "" {
+		apps, err := client.ListApps(ctx, teamID)
+		if err != nil {
+			return nil, err
+		}
+		servers := make([]Server, 0, len(apps))
+		for _, app := range apps {
+			servers = append(servers, fastAPICloudServer(app))
+		}
+		return servers, nil
+	}
+	if appID := strings.TrimSpace(b.cfg.FastAPICloud.AppID); appID != "" {
+		app, err := client.GetApp(ctx, appID)
+		if err != nil {
+			return nil, err
+		}
+		return []LeaseView{fastAPICloudServer(app)}, nil
+	}
+	return nil, exit(2, "provider=%s list requires --fastapi-cloud-team-id or --fastapi-cloud-app-id", providerName)
+}
+
+func (b *fastAPICloudBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	if strings.TrimSpace(b.cfg.FastAPICloud.AppID) != "" {
+		if _, err := b.Status(ctx, StatusRequest{}); err != nil {
+			return DoctorResult{}, err
+		}
+		return inventoryDoctorResult(providerName, 1), nil
+	}
+	servers, err := b.List(ctx, ListRequest{})
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	return inventoryDoctorResult(providerName, len(servers)), nil
+}
+
+func (b *fastAPICloudBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	appID := strings.TrimSpace(req.ID)
+	if appID == "" {
+		appID = strings.TrimSpace(b.cfg.FastAPICloud.AppID)
+	}
+	if appID == "" {
+		return StatusView{}, exit(2, "provider=%s status requires --id <fastapi-cloud-app-id> or --fastapi-cloud-app-id", providerName)
+	}
+	client, err := b.api()
+	if err != nil {
+		return StatusView{}, err
+	}
+	app, err := client.GetApp(ctx, appID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	deployment, ok, err := client.LatestDeployment(ctx, appID)
+	if err != nil {
+		return StatusView{}, err
+	}
+	state := "no-deployment"
+	ready := false
+	if ok {
+		state = deployment.Status.State()
+		ready = deployment.Status.IsReady()
+	}
+	view := StatusView{
+		ID:         app.ID,
+		Slug:       app.Slug,
+		Provider:   providerName,
+		TargetOS:   targetLinux,
+		State:      state,
+		ServerID:   app.ID,
+		ServerType: "fastapi-cloud-app",
+		Host:       hostFromAppURL(app.URL),
+		Network:    networkPublic,
+		Ready:      ready,
+		Labels:     fastAPICloudLabels(app, deployment, ok),
+	}
+	return view, nil
+}
+
+func (b *fastAPICloudBackend) Stop(ctx context.Context, req StopRequest) error {
+	_ = ctx
+	_ = req
+	return exit(2, "provider=%s does not support stop; FastAPI Cloud does not expose app stop/delete through this provider", providerName)
+}
+
+func (b *fastAPICloudBackend) api() (fastAPICloudAPI, error) {
+	if b.client != nil {
+		return b.client, nil
+	}
+	return newFastAPICloudClient(b.cfg, b.rt)
+}
+
+func fastAPICloudServer(app fastAPICloudApp) Server {
+	return Server{
+		CloudID:  app.ID,
+		Provider: providerName,
+		Name:     blank(app.Name, app.Slug),
+		Labels:   fastAPICloudLabels(app, fastAPICloudDeployment{}, false),
+	}
+}
+
+func fastAPICloudLabels(app fastAPICloudApp, deployment fastAPICloudDeployment, hasDeployment bool) map[string]string {
+	labels := map[string]string{}
+	addLabel(labels, "teamId", app.TeamID)
+	addLabel(labels, "slug", app.Slug)
+	addLabel(labels, "directory", app.Directory)
+	addLabel(labels, "url", app.URL)
+	addLabel(labels, "region", app.Region)
+	addLabel(labels, "updatedAt", app.UpdatedAt)
+	if hasDeployment {
+		addLabel(labels, "deploymentId", deployment.ID)
+		addLabel(labels, "deploymentSlug", deployment.Slug)
+		addLabel(labels, "deploymentStatus", string(deployment.Status.Normalized()))
+		addLabel(labels, "deploymentCreatedAt", deployment.CreatedAt)
+		addLabel(labels, "deploymentUrl", deployment.URL)
+		addLabel(labels, "deploymentDashboardUrl", deployment.DashboardURL)
+	}
+	return labels
+}
+
+func addLabel(labels map[string]string, key, value string) {
+	if strings.TrimSpace(value) != "" {
+		labels[key] = value
+	}
+}
+
+func hostFromAppURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+	return strings.TrimSpace(raw)
+}
+
+func rejectFastAPICloudRunOptions(req RunRequest) error {
+	if req.Keep {
+		return exit(2, "provider=%s lifecycle is owned by FastAPI Cloud; --keep is not supported", providerName)
+	}
+	if req.Reclaim {
+		return exit(2, "provider=%s lifecycle is owned by FastAPI Cloud; --reclaim is not supported", providerName)
+	}
+	if !req.NoSync {
+		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
+	}
+	if req.SyncOnly {
+		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
+	}
+	if req.ChecksumSync {
+		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
+	}
+	if req.ForceSyncLarge {
+		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
+	}
+	if req.FullResync {
+		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
+	}
+	if req.ShellMode {
+		return exit(2, "provider=%s cannot open an interactive shell; --shell is not supported", providerName)
+	}
+	if req.EnvSummary {
+		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
+	}
+	return nil
+}

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -91,7 +91,7 @@ func TestFastAPICloudClientSendsBearerAndUsesRESTPaths(t *testing.T) {
 				Count: 1,
 			})
 		case "/api/v1/apps/app-1/deployments/":
-			if r.URL.Query().Get("limit") != "1" || r.URL.Query().Get("skip") != "0" {
+			if r.URL.Query().Get("limit") != "100" || r.URL.Query().Get("skip") != "0" {
 				http.Error(w, fmt.Sprintf("query = %s", r.URL.RawQuery), http.StatusBadRequest)
 				return
 			}
@@ -282,6 +282,120 @@ func TestApplyFastAPICloudProviderFlagsRejectsClassAndType(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "--"+flagName+" is not supported") {
 			t.Fatalf("err = %v, want --%s rejection", err, flagName)
 		}
+	}
+}
+
+func TestFastAPICloudWarmupRejected(t *testing.T) {
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
+	err := backend.Warmup(context.Background(), WarmupRequest{})
+	if err == nil || !strings.Contains(err.Error(), "does not support warmup") {
+		t.Fatalf("err = %v, want warmup rejection", err)
+	}
+}
+
+func TestFastAPICloudStopRejected(t *testing.T) {
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
+	err := backend.Stop(context.Background(), StopRequest{})
+	if err == nil || !strings.Contains(err.Error(), "does not support stop") {
+		t.Fatalf("err = %v, want stop rejection", err)
+	}
+}
+
+func TestFastAPICloudListWithTeamID(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{
+		apps: []fastAPICloudApp{
+			{ID: "app-1", TeamID: "team-1", Slug: "one", Name: "One", URL: "https://one.fastapicloud.app"},
+			{ID: "app-2", TeamID: "team-1", Slug: "two", Name: "Two", URL: "https://two.fastapicloud.app"},
+		},
+	}
+	cfg := Config{}
+	cfg.FastAPICloud.TeamID = "team-1"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 2 || views[0].CloudID != "app-1" || views[1].CloudID != "app-2" {
+		t.Fatalf("views = %#v, want two apps for the team", views)
+	}
+	if views[0].Provider != providerName || views[0].Labels["url"] == "" {
+		t.Fatalf("view metadata = %#v, want provider + url labels", views[0])
+	}
+	if fake.listCalls != 1 || fake.getCalls != 0 {
+		t.Fatalf("calls list=%d get=%d, want list only", fake.listCalls, fake.getCalls)
+	}
+}
+
+// Guards the pagination fix: a full first page with the "count" field absent must
+// not be mistaken for the final page.
+func TestFastAPICloudClientListAppsPaginatesWithoutCount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps/" {
+			http.NotFound(w, r)
+			return
+		}
+		var data []fastAPICloudApp
+		switch r.URL.Query().Get("skip") {
+		case "0":
+			for i := 0; i < 100; i++ {
+				data = append(data, fastAPICloudApp{ID: fmt.Sprintf("app-%d", i), TeamID: "team-1"})
+			}
+		case "100":
+			for i := 100; i < 150; i++ {
+				data = append(data, fastAPICloudApp{ID: fmt.Sprintf("app-%d", i), TeamID: "team-1"})
+			}
+		}
+		// Deliberately omit "count" to exercise the count-absent termination path.
+		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{Data: data})
+	}))
+	defer server.Close()
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "test-token"
+	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
+	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	apps, err := client.ListApps(context.Background(), "team-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(apps) != 150 {
+		t.Fatalf("got %d apps, want 150 (pagination must not stop early when count is absent)", len(apps))
+	}
+}
+
+// Guards the ordering fix: LatestDeployment must select the newest by created_at,
+// not assume the API returns newest-first.
+func TestFastAPICloudClientLatestDeploymentPicksNewest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/apps/app-1/deployments/" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudDeployment]{
+			Data: []fastAPICloudDeployment{
+				{ID: "dep-old", AppID: "app-1", Status: fastAPICloudStatusSuccess, CreatedAt: "2026-06-01T10:00:00Z"},
+				{ID: "dep-new", AppID: "app-1", Status: fastAPICloudStatusSuccess, CreatedAt: "2026-06-21T10:00:00Z"},
+				{ID: "dep-mid", AppID: "app-1", Status: fastAPICloudStatusSuccess, CreatedAt: "2026-06-10T10:00:00Z"},
+			},
+			Count: 3,
+		})
+	}))
+	defer server.Close()
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "test-token"
+	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
+	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dep, ok, err := client.LatestDeployment(context.Background(), "app-1")
+	if err != nil || !ok {
+		t.Fatalf("LatestDeployment err=%v ok=%v", err, ok)
+	}
+	if dep.ID != "dep-new" {
+		t.Fatalf("latest = %q, want dep-new (newest by created_at)", dep.ID)
 	}
 }
 

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -73,6 +73,7 @@ func TestFastAPICloudClientSendsBearerAndUsesRESTPaths(t *testing.T) {
 			http.Error(w, "missing accept", http.StatusBadRequest)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		got = append(got, r.URL.String())
 		switch r.URL.Path {
 		case "/api/v1/apps/app-1":
@@ -348,6 +349,7 @@ func TestFastAPICloudClientListAppsPaginatesWithoutCount(t *testing.T) {
 			}
 		}
 		// Deliberately omit "count" to exercise the count-absent termination path.
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{Data: data})
 	}))
 	defer server.Close()
@@ -375,6 +377,7 @@ func TestFastAPICloudClientLatestDeploymentPicksNewest(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudDeployment]{
 			Data: []fastAPICloudDeployment{
 				{ID: "dep-old", AppID: "app-1", Status: fastAPICloudStatusSuccess, CreatedAt: "2026-06-01T10:00:00Z"},
@@ -447,6 +450,7 @@ func TestFastAPICloudAPIErrorMessage(t *testing.T) {
 
 func TestFastAPICloudClientMalformedJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"id":`)
 	}))
 	defer server.Close()
@@ -496,6 +500,7 @@ func TestFastAPICloudClientEscapesAppID(t *testing.T) {
 	var gotPath, gotRaw string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath, gotRaw = r.URL.EscapedPath(), r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"id":"x"}`)
 	}))
 	defer server.Close()
@@ -514,6 +519,7 @@ func TestFastAPICloudClientEncodesTeamID(t *testing.T) {
 	var gotTeam, gotRaw string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotTeam, gotRaw = r.URL.Query().Get("team_id"), r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{})
 	}))
 	defer server.Close()
@@ -610,7 +616,15 @@ func TestFastAPICloudDeploymentStatusMapping(t *testing.T) {
 
 func TestFastAPICloudStatusNoDeployment(t *testing.T) {
 	fake := &fakeFastAPICloudAPI{
-		app:           fastAPICloudApp{ID: "app-1", Slug: "my-app", URL: "https://my-app.fastapicloud.app"},
+		app: fastAPICloudApp{
+			ID:        "app-1",
+			TeamID:    "team-1",
+			Slug:      "my-app",
+			Directory: "src",
+			URL:       "https://my-app.fastapicloud.app",
+			Region:    "us-east",
+			UpdatedAt: "2024-01-01T00:00:00Z",
+		},
 		hasDeployment: false,
 	}
 	cfg := Config{}
@@ -622,6 +636,60 @@ func TestFastAPICloudStatusNoDeployment(t *testing.T) {
 	}
 	if view.State != "no-deployment" || view.Ready {
 		t.Fatalf("view = %#v, want no-deployment and not ready", view)
+	}
+	// App-level labels must still be populated when there is no deployment.
+	for key, want := range map[string]string{
+		"teamId":    "team-1",
+		"slug":      "my-app",
+		"directory": "src",
+		"url":       "https://my-app.fastapicloud.app",
+		"region":    "us-east",
+		"updatedAt": "2024-01-01T00:00:00Z",
+	} {
+		if view.Labels[key] != want {
+			t.Fatalf("Labels[%q] = %q, want %q", key, view.Labels[key], want)
+		}
+	}
+	// No deployment-scoped labels may appear when no deployment exists.
+	for _, key := range []string{"deploymentId", "deploymentSlug", "deploymentStatus", "deploymentCreatedAt", "deploymentUrl", "deploymentDashboardUrl"} {
+		if _, ok := view.Labels[key]; ok {
+			t.Fatalf("Labels contains %q with no deployment present", key)
+		}
+	}
+}
+
+func TestFastAPICloudHostFromAppURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"https host", "https://my-app.fastapicloud.app", "my-app.fastapicloud.app"},
+		{"ipv6 loopback strips brackets", "http://[::1]:8000", "::1"},
+		{"non-url falls back to raw", "not a url", "not a url"},
+		{"empty", "", ""},
+		{"whitespace trimmed", "  staging.example  ", "staging.example"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostFromAppURL(tc.raw); got != tc.want {
+				t.Fatalf("hostFromAppURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFastAPICloudClientRejectsNonJSONContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>not json</html>"))
+	}))
+	defer server.Close()
+	client := newTestFastAPICloudClient(t, server)
+	_, err := client.GetApp(context.Background(), "app-1")
+	if err == nil || !strings.Contains(err.Error(), "application/json") {
+		t.Fatalf("err = %v, want a content-type mismatch error", err)
 	}
 }
 

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -1,0 +1,325 @@
+package fastapicloud
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFastAPICloudProviderSpec(t *testing.T) {
+	spec := Provider{}.Spec()
+	if spec.Name != providerName {
+		t.Fatalf("spec.Name = %q, want %q", spec.Name, providerName)
+	}
+	if spec.Kind != "service-control" {
+		t.Fatalf("spec.Kind = %q, want service-control", spec.Kind)
+	}
+	aliases := Provider{}.Aliases()
+	if len(aliases) != 2 || aliases[0] != "fastapicloud" || aliases[1] != "fastapi" {
+		t.Fatalf("aliases = %#v, want [fastapicloud fastapi]", aliases)
+	}
+}
+
+func TestFastAPICloudClientRequiresToken(t *testing.T) {
+	cfg := Config{}
+	cfg.FastAPICloud.APIURL = "https://api.fastapicloud.com/api/v1"
+	if _, err := newFastAPICloudClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newFastAPICloudClient accepted empty token")
+	}
+}
+
+func TestFastAPICloudClientRejectsBareHTTPURL(t *testing.T) {
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "test-token"
+	cfg.FastAPICloud.APIURL = "http://api.fastapicloud.com/api/v1"
+	if _, err := newFastAPICloudClient(cfg, Runtime{}); err == nil {
+		t.Fatal("newFastAPICloudClient accepted plaintext http URL")
+	}
+}
+
+func TestFastAPICloudTokenFlagIsNotRegistered(t *testing.T) {
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "secret-token"
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterFastAPICloudProviderFlags(fs, cfg)
+	for _, name := range []string{"fastapi-cloud-token", "fastapi-cloud-api-token", "fastapi-cloud-key", "fastapi-cloud-api-key"} {
+		if fs.Lookup(name) != nil {
+			t.Fatalf("FastAPI Cloud token surfaced as a flag --%s", name)
+		}
+	}
+	for _, name := range []string{"fastapi-cloud-url", "fastapi-cloud-app-id", "fastapi-cloud-team-id"} {
+		if fs.Lookup(name) == nil {
+			t.Fatalf("%s flag missing", name)
+		}
+	}
+}
+
+func TestFastAPICloudClientSendsBearerAndUsesRESTPaths(t *testing.T) {
+	var got []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			http.Error(w, "missing bearer", http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			http.Error(w, "missing accept", http.StatusBadRequest)
+			return
+		}
+		got = append(got, r.URL.String())
+		switch r.URL.Path {
+		case "/api/v1/apps/app-1":
+			_ = json.NewEncoder(w).Encode(fastAPICloudApp{
+				ID:     "app-1",
+				TeamID: "team-1",
+				Slug:   "my-app",
+				Name:   "My App",
+				URL:    "https://my-app.fastapicloud.app",
+			})
+		case "/api/v1/apps/":
+			if r.URL.Query().Get("team_id") != "team-1" || r.URL.Query().Get("limit") != "100" || r.URL.Query().Get("skip") != "0" {
+				http.Error(w, fmt.Sprintf("query = %s", r.URL.RawQuery), http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{
+				Data:  []fastAPICloudApp{{ID: "app-1", TeamID: "team-1", Slug: "my-app", Name: "My App"}},
+				Count: 1,
+			})
+		case "/api/v1/apps/app-1/deployments/":
+			if r.URL.Query().Get("limit") != "1" || r.URL.Query().Get("skip") != "0" {
+				http.Error(w, fmt.Sprintf("query = %s", r.URL.RawQuery), http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudDeployment]{
+				Data: []fastAPICloudDeployment{{
+					ID:        "dep-1",
+					AppID:     "app-1",
+					Slug:      "my-app-abc",
+					Status:    fastAPICloudStatusSuccess,
+					CreatedAt: "2026-06-21T10:00:00Z",
+				}},
+				Count: 1,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "test-token"
+	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
+	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	app, err := client.GetApp(context.Background(), "app-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	apps, err := client.ListApps(context.Background(), "team-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment, ok, err := client.LatestDeployment(context.Background(), "app-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app.ID != "app-1" || len(apps) != 1 || apps[0].ID != "app-1" || !ok || deployment.ID != "dep-1" {
+		t.Fatalf("unexpected client data app=%#v apps=%#v deployment=%#v ok=%t", app, apps, deployment, ok)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got paths = %#v, want 3 requests", got)
+	}
+}
+
+func TestFastAPICloudClientSurfacesNon2xxAsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden by token", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "wrong-token"
+	cfg.FastAPICloud.APIURL = server.URL
+	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.GetApp(context.Background(), "app-1")
+	if err == nil {
+		t.Fatal("GetApp accepted 403 response")
+	}
+	apiErr, ok := err.(*fastAPICloudAPIError)
+	if !ok {
+		t.Fatalf("err = %T, want *fastAPICloudAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Body, "forbidden by token") {
+		t.Fatalf("body = %q, want forbidden snippet", apiErr.Body)
+	}
+}
+
+func TestFastAPICloudRunRejectsBeforeAPI(t *testing.T) {
+	backend := &fastAPICloudBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    Config{},
+		client: panicFastAPICloudAPI{},
+	}
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"pytest"}})
+	if err == nil || !strings.Contains(err.Error(), "cannot execute arbitrary run commands") {
+		t.Fatalf("err = %v, want arbitrary command rejection", err)
+	}
+}
+
+func TestFastAPICloudListRequiresAppOrTeam(t *testing.T) {
+	backend := &fastAPICloudBackend{
+		spec:   Provider{}.Spec(),
+		cfg:    Config{},
+		client: &fakeFastAPICloudAPI{},
+	}
+	_, err := backend.List(context.Background(), ListRequest{})
+	if err == nil || !strings.Contains(err.Error(), "requires --fastapi-cloud-team-id or --fastapi-cloud-app-id") {
+		t.Fatalf("err = %v, want app/team requirement", err)
+	}
+}
+
+func TestFastAPICloudListWithAppID(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{
+		app: fastAPICloudApp{ID: "app-1", TeamID: "team-1", Slug: "my-app", Name: "My App", URL: "https://my-app.fastapicloud.app"},
+	}
+	cfg := Config{}
+	cfg.FastAPICloud.AppID = "app-1"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	views, err := backend.List(context.Background(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 || views[0].CloudID != "app-1" || views[0].Provider != providerName || views[0].Labels["url"] == "" {
+		t.Fatalf("views = %#v, want one FastAPI Cloud app", views)
+	}
+	if fake.getCalls != 1 || fake.listCalls != 0 {
+		t.Fatalf("calls get=%d list=%d, want get only", fake.getCalls, fake.listCalls)
+	}
+}
+
+func TestFastAPICloudStatusMapsDeploymentReadiness(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{
+		app:           fastAPICloudApp{ID: "app-1", TeamID: "team-1", Slug: "my-app", Name: "My App", URL: "https://my-app.fastapicloud.app"},
+		deployment:    fastAPICloudDeployment{ID: "dep-1", AppID: "app-1", Slug: "my-app-abc", Status: fastAPICloudStatusSuccess, URL: "https://deployment.example"},
+		hasDeployment: true,
+	}
+	cfg := Config{}
+	cfg.FastAPICloud.AppID = "app-1"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	view, err := backend.Status(context.Background(), StatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "app-1" || view.State != "ready" || !view.Ready || view.Host != "my-app.fastapicloud.app" {
+		t.Fatalf("view = %#v, want ready app status", view)
+	}
+	if view.Labels["deploymentId"] != "dep-1" || view.Labels["deploymentStatus"] != "success" {
+		t.Fatalf("labels = %#v, want deployment metadata", view.Labels)
+	}
+}
+
+func TestFastAPICloudStatusMapsFailure(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{
+		app:           fastAPICloudApp{ID: "app-1", TeamID: "team-1", Slug: "my-app", Name: "My App"},
+		deployment:    fastAPICloudDeployment{ID: "dep-1", AppID: "app-1", Status: fastAPICloudStatusVerifyingFailed},
+		hasDeployment: true,
+	}
+	cfg := Config{}
+	cfg.FastAPICloud.AppID = "app-1"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	view, err := backend.Status(context.Background(), StatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != "failed" || view.Ready {
+		t.Fatalf("view = %#v, want failed and not ready", view)
+	}
+}
+
+func TestApplyFastAPICloudProviderFlags(t *testing.T) {
+	cfg := Config{Provider: providerName}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := RegisterFastAPICloudProviderFlags(fs, Config{})
+	if err := fs.Parse([]string{
+		"--fastapi-cloud-url", "http://localhost:8000/api/v1",
+		"--fastapi-cloud-app-id", "app-1",
+		"--fastapi-cloud-team-id", "team-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyFastAPICloudProviderFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.FastAPICloud.APIURL != "http://localhost:8000/api/v1" || cfg.FastAPICloud.AppID != "app-1" || cfg.FastAPICloud.TeamID != "team-1" {
+		t.Fatalf("cfg.FastAPICloud = %#v", cfg.FastAPICloud)
+	}
+}
+
+func TestApplyFastAPICloudProviderFlagsRejectsClassAndType(t *testing.T) {
+	for _, flagName := range []string{"class", "type"} {
+		cfg := Config{Provider: providerName}
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		fs.String(flagName, "", "")
+		values := RegisterFastAPICloudProviderFlags(fs, Config{})
+		if err := fs.Parse([]string{"--" + flagName, "small"}); err != nil {
+			t.Fatal(err)
+		}
+		err := ApplyFastAPICloudProviderFlags(&cfg, fs, values)
+		if err == nil || !strings.Contains(err.Error(), "--"+flagName+" is not supported") {
+			t.Fatalf("err = %v, want --%s rejection", err, flagName)
+		}
+	}
+}
+
+type fakeFastAPICloudAPI struct {
+	app           fastAPICloudApp
+	apps          []fastAPICloudApp
+	deployment    fastAPICloudDeployment
+	hasDeployment bool
+	getCalls      int
+	listCalls     int
+	latestCalls   int
+}
+
+func (f *fakeFastAPICloudAPI) GetApp(context.Context, string) (fastAPICloudApp, error) {
+	f.getCalls++
+	return f.app, nil
+}
+
+func (f *fakeFastAPICloudAPI) ListApps(context.Context, string) ([]fastAPICloudApp, error) {
+	f.listCalls++
+	return append([]fastAPICloudApp(nil), f.apps...), nil
+}
+
+func (f *fakeFastAPICloudAPI) LatestDeployment(context.Context, string) (fastAPICloudDeployment, bool, error) {
+	f.latestCalls++
+	return f.deployment, f.hasDeployment, nil
+}
+
+type panicFastAPICloudAPI struct{}
+
+func (panicFastAPICloudAPI) GetApp(context.Context, string) (fastAPICloudApp, error) {
+	panic("GetApp should not be called")
+}
+
+func (panicFastAPICloudAPI) ListApps(context.Context, string) ([]fastAPICloudApp, error) {
+	panic("ListApps should not be called")
+}
+
+func (panicFastAPICloudAPI) LatestDeployment(context.Context, string) (fastAPICloudDeployment, bool, error) {
+	panic("LatestDeployment should not be called")
+}

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -1,8 +1,10 @@
 package fastapicloud
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -399,11 +401,258 @@ func TestFastAPICloudClientLatestDeploymentPicksNewest(t *testing.T) {
 	}
 }
 
+func newTestFastAPICloudClient(t *testing.T, server *httptest.Server) fastAPICloudAPI {
+	t.Helper()
+	cfg := Config{}
+	cfg.FastAPICloud.Token = "secret-tok"
+	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
+	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestFastAPICloudClientUnauthorizedNoTokenLeak(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret-tok" {
+			http.Error(w, "bad bearer", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"detail":"Invalid credentials"}`)
+	}))
+	defer server.Close()
+	_, err := newTestFastAPICloudClient(t, server).GetApp(context.Background(), "app-1")
+	var apiErr *fastAPICloudAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *fastAPICloudAPIError", err)
+	}
+	if apiErr.StatusCode != 401 || !strings.Contains(apiErr.Body, "Invalid credentials") {
+		t.Fatalf("apiErr = %#v, want 401 with detail body", apiErr)
+	}
+	if strings.Contains(err.Error(), "secret-tok") {
+		t.Fatal("token leaked into error message")
+	}
+}
+
+func TestFastAPICloudAPIErrorMessage(t *testing.T) {
+	if got := (&fastAPICloudAPIError{Status: "502 Bad Gateway"}).Error(); got != "502 Bad Gateway" {
+		t.Fatalf("empty-body Error() = %q", got)
+	}
+	if got := (&fastAPICloudAPIError{Status: "500 X", Body: "boom"}).Error(); got != "500 X: boom" {
+		t.Fatalf("non-empty Error() = %q", got)
+	}
+}
+
+func TestFastAPICloudClientMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"id":`)
+	}))
+	defer server.Close()
+	_, err := newTestFastAPICloudClient(t, server).GetApp(context.Background(), "app-1")
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("err = %v, want decode error", err)
+	}
+	if errors.Unwrap(err) == nil {
+		t.Fatal("decode error must wrap the underlying json error")
+	}
+}
+
+func TestFastAPICloudClientResponseTooLarge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("a"), fastAPICloudMaxResponseBytes+1))
+	}))
+	defer server.Close()
+	_, err := newTestFastAPICloudClient(t, server).GetApp(context.Background(), "app-1")
+	if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("err = %v, want size-limit error", err)
+	}
+	var apiErr *fastAPICloudAPIError
+	if errors.As(err, &apiErr) {
+		t.Fatal("size-limit failure must not be a *fastAPICloudAPIError")
+	}
+}
+
+func TestFastAPICloudClientContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	client := newTestFastAPICloudClient(t, server)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := client.GetApp(ctx, "app-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	var apiErr *fastAPICloudAPIError
+	if errors.As(err, &apiErr) {
+		t.Fatal("transport cancellation must not be a *fastAPICloudAPIError")
+	}
+}
+
+func TestFastAPICloudClientEscapesAppID(t *testing.T) {
+	var gotPath, gotRaw string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotRaw = r.URL.EscapedPath(), r.URL.RawQuery
+		_, _ = io.WriteString(w, `{"id":"x"}`)
+	}))
+	defer server.Close()
+	if _, err := newTestFastAPICloudClient(t, server).GetApp(context.Background(), "a/b?c#d"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotPath, "a%2Fb%3Fc%23d") {
+		t.Fatalf("escaped path = %q, want the app id percent-escaped", gotPath)
+	}
+	if gotRaw != "" {
+		t.Fatalf("raw query = %q, want none (a malicious id must not inject a query)", gotRaw)
+	}
+}
+
+func TestFastAPICloudClientEncodesTeamID(t *testing.T) {
+	var gotTeam, gotRaw string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTeam, gotRaw = r.URL.Query().Get("team_id"), r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{})
+	}))
+	defer server.Close()
+	if _, err := newTestFastAPICloudClient(t, server).ListApps(context.Background(), "team a&b=c"); err != nil {
+		t.Fatal(err)
+	}
+	if gotTeam != "team a&b=c" {
+		t.Fatalf("decoded team_id = %q", gotTeam)
+	}
+	if !strings.Contains(gotRaw, "team_id=team+a%26b%3Dc") {
+		t.Fatalf("raw query = %q, want percent-encoded team_id", gotRaw)
+	}
+}
+
+func TestFastAPICloudClientLoopbackHTTPAccepted(t *testing.T) {
+	for _, u := range []string{
+		"http://localhost:8000/api/v1",
+		"http://127.0.0.1:8000/api/v1",
+		"http://[::1]:8000/api/v1",
+		"http://LOCALHOST:8000/api/v1",
+	} {
+		cfg := Config{}
+		cfg.FastAPICloud.Token = "t"
+		cfg.FastAPICloud.APIURL = u
+		if _, err := newFastAPICloudClient(cfg, Runtime{}); err != nil {
+			t.Fatalf("loopback %q rejected: %v", u, err)
+		}
+	}
+}
+
+func TestFastAPICloudClientLoopbackSpoofRejected(t *testing.T) {
+	for _, u := range []string{
+		"http://localhost@evil.com/api/v1",
+		"http://127.0.0.1.evil.com/api/v1",
+		"http://localhost.evil.com/api/v1",
+		"http://0x7f000001/api/v1",
+	} {
+		cfg := Config{}
+		cfg.FastAPICloud.Token = "t"
+		cfg.FastAPICloud.APIURL = u
+		_, err := newFastAPICloudClient(cfg, Runtime{})
+		if err == nil || !strings.Contains(err.Error(), "must use https") {
+			t.Fatalf("spoofed loopback %q: err = %v, want https rejection", u, err)
+		}
+	}
+}
+
+func TestFastAPICloudClientInvalidURL(t *testing.T) {
+	for _, u := range []string{"://nohost", "https://", "not a url"} {
+		cfg := Config{}
+		cfg.FastAPICloud.Token = "t"
+		cfg.FastAPICloud.APIURL = u
+		_, err := newFastAPICloudClient(cfg, Runtime{})
+		if err == nil || !strings.Contains(err.Error(), "is invalid") {
+			t.Fatalf("invalid url %q: err = %v, want invalid", u, err)
+		}
+	}
+}
+
+func TestFastAPICloudDeploymentStatusMapping(t *testing.T) {
+	cases := []struct {
+		status fastAPICloudDeploymentStatus
+		state  string
+		ready  bool
+	}{
+		{"waiting_upload", "waiting_upload", false},
+		{"upload_cancelled", "failed", false},
+		{"ready_for_build", "ready_for_build", false},
+		{"building", "building", false},
+		{"extracting", "extracting", false},
+		{"extracting_failed", "failed", false},
+		{"building_image", "building_image", false},
+		{"building_image_failed", "failed", false},
+		{"deploying", "deploying", false},
+		{"deploying_failed", "failed", false},
+		{"verifying", "verifying", false},
+		{"verifying_failed", "failed", false},
+		{"verifying_skipped", "ready", true},
+		{"success", "ready", true},
+		{"expired", "expired", false},
+		{"failed", "failed", false},
+		{"", "unknown", false},
+		{"SUCCESS", "ready", true}, // normalization is case-insensitive
+	}
+	for _, c := range cases {
+		if got := c.status.State(); got != c.state {
+			t.Errorf("State(%q) = %q, want %q", c.status, got, c.state)
+		}
+		if got := c.status.IsReady(); got != c.ready {
+			t.Errorf("IsReady(%q) = %v, want %v", c.status, got, c.ready)
+		}
+	}
+}
+
+func TestFastAPICloudStatusNoDeployment(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{
+		app:           fastAPICloudApp{ID: "app-1", Slug: "my-app", URL: "https://my-app.fastapicloud.app"},
+		hasDeployment: false,
+	}
+	cfg := Config{}
+	cfg.FastAPICloud.AppID = "app-1"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	view, err := backend.Status(context.Background(), StatusRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != "no-deployment" || view.Ready {
+		t.Fatalf("view = %#v, want no-deployment and not ready", view)
+	}
+}
+
+func TestFastAPICloudStatusAppNotFound(t *testing.T) {
+	fake := &fakeFastAPICloudAPI{getErr: errors.New("app not found")}
+	cfg := Config{}
+	cfg.FastAPICloud.AppID = "missing"
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
+	_, err := backend.Status(context.Background(), StatusRequest{})
+	if err == nil || !strings.Contains(err.Error(), "app not found") {
+		t.Fatalf("err = %v, want propagated app lookup error", err)
+	}
+	if fake.latestCalls != 0 {
+		t.Fatalf("latestCalls = %d, want 0 (must not query deployments once the app lookup fails)", fake.latestCalls)
+	}
+}
+
+func TestFastAPICloudStatusRequiresAppID(t *testing.T) {
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
+	_, err := backend.Status(context.Background(), StatusRequest{})
+	if err == nil || !strings.Contains(err.Error(), "status requires") {
+		t.Fatalf("err = %v, want app-id requirement before any API call", err)
+	}
+}
+
 type fakeFastAPICloudAPI struct {
 	app           fastAPICloudApp
 	apps          []fastAPICloudApp
 	deployment    fastAPICloudDeployment
 	hasDeployment bool
+	getErr        error
 	getCalls      int
 	listCalls     int
 	latestCalls   int
@@ -411,6 +660,9 @@ type fakeFastAPICloudAPI struct {
 
 func (f *fakeFastAPICloudAPI) GetApp(context.Context, string) (fastAPICloudApp, error) {
 	f.getCalls++
+	if f.getErr != nil {
+		return fastAPICloudApp{}, f.getErr
+	}
 	return f.app, nil
 }
 

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -257,6 +258,12 @@ func (c *fastAPICloudClient) get(ctx context.Context, apiPath string, params url
 		return &fastAPICloudAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
 	}
 	if out != nil {
+		// A 2xx with a non-JSON body (an HTML error page from a proxy, a
+		// misconfigured gateway) would otherwise surface only as an opaque
+		// json.Unmarshal error; check the media type first for a clearer message.
+		if mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type")); mediaType != "" && mediaType != "application/json" {
+			return fmt.Errorf("%s expected application/json response, got %q", providerName, resp.Header.Get("Content-Type"))
+		}
 		if err := json.Unmarshal(data, out); err != nil {
 			return fmt.Errorf("decode %s response: %w", providerName, err)
 		}

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type fastAPICloudAPI interface {
@@ -173,7 +174,10 @@ func (c *fastAPICloudClient) ListApps(ctx context.Context, teamID string) ([]fas
 			return nil, err
 		}
 		apps = append(apps, page.Data...)
-		if len(page.Data) == 0 || len(apps) >= page.Count || len(page.Data) < fastAPICloudListPageSize {
+		// A short/empty page is the canonical end-of-pages signal. Only trust the
+		// envelope's count when it is actually present (>0): a full page with an
+		// absent/zero "count" must not be mistaken for the final page.
+		if len(page.Data) == 0 || len(page.Data) < fastAPICloudListPageSize || (page.Count > 0 && len(apps) >= page.Count) {
 			return apps, nil
 		}
 		skip += len(page.Data)
@@ -185,9 +189,13 @@ func (c *fastAPICloudClient) LatestDeployment(ctx context.Context, appID string)
 	if appID == "" {
 		return fastAPICloudDeployment{}, false, fmt.Errorf("latest deployment: app id is required")
 	}
+	// The deployments endpoint's default sort order is not a documented part of the
+	// contract, so don't assume Data[0] is newest: fetch a page and select the latest
+	// by created_at client-side. (Latest-deployment readiness is the common case and
+	// sits well within a single page.)
 	var page fastAPICloudListResponse[fastAPICloudDeployment]
 	params := url.Values{
-		"limit": []string{"1"},
+		"limit": []string{fmt.Sprint(fastAPICloudListPageSize)},
 		"skip":  []string{"0"},
 	}
 	if err := c.get(ctx, "/apps/"+url.PathEscape(appID)+"/deployments/", params, &page); err != nil {
@@ -196,7 +204,25 @@ func (c *fastAPICloudClient) LatestDeployment(ctx context.Context, appID string)
 	if len(page.Data) == 0 {
 		return fastAPICloudDeployment{}, false, nil
 	}
-	return page.Data[0], true, nil
+	latest := page.Data[0]
+	for _, d := range page.Data[1:] {
+		if fastAPICloudDeploymentNewer(d, latest) {
+			latest = d
+		}
+	}
+	return latest, true, nil
+}
+
+// fastAPICloudDeploymentNewer reports whether a is more recent than b by created_at.
+// Timestamps are RFC3339; fall back to lexical comparison (which also sorts RFC3339
+// chronologically) when either value cannot be parsed.
+func fastAPICloudDeploymentNewer(a, b fastAPICloudDeployment) bool {
+	at, aerr := time.Parse(time.RFC3339, a.CreatedAt)
+	bt, berr := time.Parse(time.RFC3339, b.CreatedAt)
+	if aerr == nil && berr == nil {
+		return at.After(bt)
+	}
+	return a.CreatedAt > b.CreatedAt
 }
 
 type fastAPICloudListResponse[T any] struct {

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -1,0 +1,261 @@
+package fastapicloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type fastAPICloudAPI interface {
+	GetApp(ctx context.Context, appID string) (fastAPICloudApp, error)
+	ListApps(ctx context.Context, teamID string) ([]fastAPICloudApp, error)
+	LatestDeployment(ctx context.Context, appID string) (fastAPICloudDeployment, bool, error)
+}
+
+type fastAPICloudClient struct {
+	token      string
+	apiURL     string
+	httpClient *http.Client
+}
+
+const (
+	fastAPICloudMaxResponseBytes = 16 << 20
+	fastAPICloudListPageSize     = 100
+)
+
+type fastAPICloudAPIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *fastAPICloudAPIError) Error() string {
+	if e.Body == "" {
+		return e.Status
+	}
+	return e.Status + ": " + e.Body
+}
+
+type fastAPICloudApp struct {
+	ID        string `json:"id"`
+	TeamID    string `json:"team_id"`
+	Slug      string `json:"slug"`
+	Name      string `json:"name"`
+	Directory string `json:"directory"`
+	URL       string `json:"url"`
+	Region    string `json:"region"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type fastAPICloudDeployment struct {
+	ID           string                       `json:"id"`
+	AppID        string                       `json:"app_id"`
+	Slug         string                       `json:"slug"`
+	Status       fastAPICloudDeploymentStatus `json:"status"`
+	CreatedAt    string                       `json:"created_at"`
+	URL          string                       `json:"url"`
+	DashboardURL string                       `json:"dashboard_url"`
+}
+
+type fastAPICloudDeploymentStatus string
+
+const (
+	fastAPICloudStatusWaitingUpload       fastAPICloudDeploymentStatus = "waiting_upload"
+	fastAPICloudStatusUploadCancelled     fastAPICloudDeploymentStatus = "upload_cancelled"
+	fastAPICloudStatusReadyForBuild       fastAPICloudDeploymentStatus = "ready_for_build"
+	fastAPICloudStatusBuilding            fastAPICloudDeploymentStatus = "building"
+	fastAPICloudStatusExtracting          fastAPICloudDeploymentStatus = "extracting"
+	fastAPICloudStatusExtractingFailed    fastAPICloudDeploymentStatus = "extracting_failed"
+	fastAPICloudStatusBuildingImage       fastAPICloudDeploymentStatus = "building_image"
+	fastAPICloudStatusBuildingImageFailed fastAPICloudDeploymentStatus = "building_image_failed"
+	fastAPICloudStatusDeploying           fastAPICloudDeploymentStatus = "deploying"
+	fastAPICloudStatusDeployingFailed     fastAPICloudDeploymentStatus = "deploying_failed"
+	fastAPICloudStatusVerifying           fastAPICloudDeploymentStatus = "verifying"
+	fastAPICloudStatusVerifyingFailed     fastAPICloudDeploymentStatus = "verifying_failed"
+	fastAPICloudStatusVerifyingSkipped    fastAPICloudDeploymentStatus = "verifying_skipped"
+	fastAPICloudStatusSuccess             fastAPICloudDeploymentStatus = "success"
+	fastAPICloudStatusExpired             fastAPICloudDeploymentStatus = "expired"
+	fastAPICloudStatusFailed              fastAPICloudDeploymentStatus = "failed"
+)
+
+func (s *fastAPICloudDeploymentStatus) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = fastAPICloudDeploymentStatus(strings.ToLower(strings.TrimSpace(raw)))
+	return nil
+}
+
+func (s fastAPICloudDeploymentStatus) Normalized() fastAPICloudDeploymentStatus {
+	return fastAPICloudDeploymentStatus(strings.ToLower(strings.TrimSpace(string(s))))
+}
+
+func (s fastAPICloudDeploymentStatus) IsReady() bool {
+	switch s.Normalized() {
+	case fastAPICloudStatusSuccess, fastAPICloudStatusVerifyingSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s fastAPICloudDeploymentStatus) State() string {
+	switch s.Normalized() {
+	case fastAPICloudStatusSuccess, fastAPICloudStatusVerifyingSkipped:
+		return "ready"
+	case fastAPICloudStatusFailed,
+		fastAPICloudStatusVerifyingFailed,
+		fastAPICloudStatusDeployingFailed,
+		fastAPICloudStatusBuildingImageFailed,
+		fastAPICloudStatusExtractingFailed,
+		fastAPICloudStatusUploadCancelled:
+		return "failed"
+	case fastAPICloudStatusExpired:
+		return "expired"
+	case "":
+		return "unknown"
+	default:
+		return string(s.Normalized())
+	}
+}
+
+func newFastAPICloudClient(cfg Config, rt Runtime) (fastAPICloudAPI, error) {
+	token := strings.TrimSpace(cfg.FastAPICloud.Token)
+	if token == "" {
+		return nil, exit(2, "provider=%s requires FASTAPI_CLOUD_TOKEN", providerName)
+	}
+	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.FastAPICloud.APIURL, "https://api.fastapicloud.com/api/v1")), "/")
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+	}
+	httpClient := rt.HTTP
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &fastAPICloudClient{token: token, apiURL: apiURL, httpClient: httpClient}, nil
+}
+
+func (c *fastAPICloudClient) GetApp(ctx context.Context, appID string) (fastAPICloudApp, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return fastAPICloudApp{}, fmt.Errorf("get app: app id is required")
+	}
+	var app fastAPICloudApp
+	if err := c.get(ctx, "/apps/"+url.PathEscape(appID), nil, &app); err != nil {
+		return fastAPICloudApp{}, err
+	}
+	return app, nil
+}
+
+func (c *fastAPICloudClient) ListApps(ctx context.Context, teamID string) ([]fastAPICloudApp, error) {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" {
+		return nil, fmt.Errorf("list apps: team id is required")
+	}
+	var apps []fastAPICloudApp
+	for skip := 0; ; {
+		var page fastAPICloudListResponse[fastAPICloudApp]
+		params := url.Values{
+			"team_id": []string{teamID},
+			"limit":   []string{fmt.Sprint(fastAPICloudListPageSize)},
+			"skip":    []string{fmt.Sprint(skip)},
+		}
+		if err := c.get(ctx, "/apps/", params, &page); err != nil {
+			return nil, err
+		}
+		apps = append(apps, page.Data...)
+		if len(page.Data) == 0 || len(apps) >= page.Count || len(page.Data) < fastAPICloudListPageSize {
+			return apps, nil
+		}
+		skip += len(page.Data)
+	}
+}
+
+func (c *fastAPICloudClient) LatestDeployment(ctx context.Context, appID string) (fastAPICloudDeployment, bool, error) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return fastAPICloudDeployment{}, false, fmt.Errorf("latest deployment: app id is required")
+	}
+	var page fastAPICloudListResponse[fastAPICloudDeployment]
+	params := url.Values{
+		"limit": []string{"1"},
+		"skip":  []string{"0"},
+	}
+	if err := c.get(ctx, "/apps/"+url.PathEscape(appID)+"/deployments/", params, &page); err != nil {
+		return fastAPICloudDeployment{}, false, err
+	}
+	if len(page.Data) == 0 {
+		return fastAPICloudDeployment{}, false, nil
+	}
+	return page.Data[0], true, nil
+}
+
+type fastAPICloudListResponse[T any] struct {
+	Data  []T `json:"data"`
+	Count int `json:"count"`
+}
+
+func (c *fastAPICloudClient) get(ctx context.Context, apiPath string, params url.Values, out any) error {
+	endpoint, err := c.endpoint(apiPath, params)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(io.LimitReader(resp.Body, fastAPICloudMaxResponseBytes+1))
+	if readErr != nil {
+		return readErr
+	}
+	if len(data) > fastAPICloudMaxResponseBytes {
+		return fmt.Errorf("%s response exceeds %d bytes", providerName, fastAPICloudMaxResponseBytes)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &fastAPICloudAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: strings.TrimSpace(string(data))}
+	}
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("decode %s response: %w", providerName, err)
+		}
+	}
+	return nil
+}
+
+func (c *fastAPICloudClient) endpoint(apiPath string, params url.Values) (string, error) {
+	if !strings.HasPrefix(apiPath, "/") {
+		apiPath = "/" + apiPath
+	}
+	parsed, err := url.Parse(c.apiURL + apiPath)
+	if err != nil {
+		return "", err
+	}
+	if len(params) > 0 {
+		parsed.RawQuery = params.Encode()
+	}
+	return parsed.String(), nil
+}
+
+func isLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/providers/fastapicloud/core.go
+++ b/internal/providers/fastapicloud/core.go
@@ -1,0 +1,48 @@
+package fastapicloud
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type FastAPICloudConfig = core.FastAPICloudConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type Server = core.Server
+type ExitError = core.ExitError
+
+const (
+	providerName = "fastapi-cloud"
+	targetLinux  = core.TargetLinux
+
+	networkPublic = core.NetworkPublic
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}
+
+func inventoryDoctorResult(provider string, leases int) DoctorResult {
+	return core.InventoryDoctorResult(provider, leases)
+}

--- a/internal/providers/fastapicloud/flags.go
+++ b/internal/providers/fastapicloud/flags.go
@@ -1,0 +1,58 @@
+package fastapicloud
+
+import (
+	"flag"
+	"strings"
+)
+
+type fastAPICloudFlagValues struct {
+	APIURL *string
+	AppID  *string
+	TeamID *string
+}
+
+// RegisterFastAPICloudProviderFlags exposes only non-secret provider flags.
+// Deploy tokens are sourced from FASTAPI_CLOUD_TOKEN /
+// CRABBOX_FASTAPI_CLOUD_TOKEN so they are not passed as command-line
+// arguments.
+func RegisterFastAPICloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	return fastAPICloudFlagValues{
+		APIURL: fs.String("fastapi-cloud-url", defaults.FastAPICloud.APIURL, "FastAPI Cloud API URL"),
+		AppID:  fs.String("fastapi-cloud-app-id", defaults.FastAPICloud.AppID, "FastAPI Cloud app ID"),
+		TeamID: fs.String("fastapi-cloud-team-id", defaults.FastAPICloud.TeamID, "FastAPI Cloud team ID for listing apps"),
+	}
+}
+
+func ApplyFastAPICloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if isFastAPICloudProviderName(cfg.Provider) {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=%s", providerName)
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=%s", providerName)
+		}
+	}
+	v, ok := values.(fastAPICloudFlagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "fastapi-cloud-url") {
+		cfg.FastAPICloud.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "fastapi-cloud-app-id") {
+		cfg.FastAPICloud.AppID = *v.AppID
+	}
+	if flagWasSet(fs, "fastapi-cloud-team-id") {
+		cfg.FastAPICloud.TeamID = *v.TeamID
+	}
+	return nil
+}
+
+func isFastAPICloudProviderName(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case providerName, "fastapicloud", "fastapi":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/fastapicloud/provider.go
+++ b/internal/providers/fastapicloud/provider.go
@@ -1,0 +1,51 @@
+package fastapicloud
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return []string{"fastapicloud", "fastapi"} }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      "fastapi-cloud",
+		Kind:        core.ProviderKindServiceControl,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterFastAPICloudProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyFastAPICloudProviderFlags(cfg, fs, values)
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	return NewFastAPICloudBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}


### PR DESCRIPTION
## Summary

- add a `fastapi-cloud` service-control provider for inspecting FastAPI Cloud apps and latest deployment readiness
- wire non-secret config, env overrides, provider registration, and credential destination safeguards
- document the provider as app/deployment inspection only; `run`, `warmup`, and `stop` reject unsupported sandbox semantics

## Validation

- `go test -count=1 ./internal/providers/fastapicloud ./internal/providers/all ./internal/cli`
- `node scripts/generate-provider-matrix.mjs --check`
- `git diff --check`

## Notes

No real FastAPI Cloud token was used or committed. The provider reads `FASTAPI_CLOUD_TOKEN` / `CRABBOX_FASTAPI_CLOUD_TOKEN` from the environment only.