### PR TITLE
fix: trust reviewed release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,31 @@ jobs:
       - name: Verify Apple Silicon runner
         run: test "$(uname -m)" = arm64
 
+      - name: Verify manual release source and tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [ "$WORKFLOW_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "::error::manual releases must dispatch the workflow from $DEFAULT_BRANCH"
+            exit 1
+          fi
+          if ! [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::manual release tag must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          tag_ref="refs/tags/$RELEASE_TAG"
+          if ! git rev-parse --verify "$tag_ref^{commit}" >/dev/null; then
+            echo "::error::manual release tag does not exist: $RELEASE_TAG"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$tag_ref^{commit}" HEAD; then
+            echo "::error::manual release tag is not in $DEFAULT_BRANCH history: $RELEASE_TAG"
+            exit 1
+          fi
+
       - name: Stash current GoReleaser config
         run: cp .goreleaser.yaml /tmp/.goreleaser.yaml
 
@@ -34,14 +59,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-        run: git checkout "$RELEASE_TAG"
-
-      - name: Preserve pre-helper release configuration
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ ! -d cmd/crabbox-apple-vz-helper ]; then
-            cp .goreleaser.yaml /tmp/.goreleaser.yaml
-          fi
+        run: git checkout --detach "refs/tags/$RELEASE_TAG"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Kept manual release publication on the reviewed default-branch GoReleaser configuration instead of allowing a selected tag to replace credentialed release behavior. Thanks @coygeek.
 - Rejected cross-origin coordinator redirects before bearer, Access, or local identity headers can be replayed. Thanks @coygeek.
 - Redacted configured Upstash Box API keys from HTTP and streamed error diagnostics. Thanks @coygeek.
 - Redacted configured Semaphore API tokens from provider response diagnostics. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -273,6 +273,16 @@ Coordinator config values (not secret material):
 Local-only direct-provider secret: `CRABBOX_TAILSCALE_AUTH_KEY`. Do not forward
 it to commands, print it, or store it in repo config.
 
+## Release Integrity
+
+Release publication uses the GoReleaser configuration from the reviewed branch
+that dispatched the workflow, never configuration from a manually selected
+release tag. Manual re-releases must be dispatched from the default branch,
+accept only an existing exact `vMAJOR.MINOR.PATCH` tag in that branch's history,
+and may fail for historical tags that are incompatible with the current
+reviewed release configuration rather than falling back to tag-controlled
+publishing behavior.
+
 ## SSH
 
 SSH is the control and data path to a leased box; the broker manages leases but

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -7,26 +7,28 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 
 test("manual release checks out requested tag before setup-go reads go.mod", () => {
   const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "release.yml"), "utf8");
+  const verifySource = workflow.indexOf("- name: Verify manual release source and tag");
   const stashConfig = workflow.indexOf("- name: Stash current GoReleaser config");
   const checkoutTag = workflow.indexOf("- name: Checkout release tag");
-  const preservePreHelperConfig = workflow.indexOf("- name: Preserve pre-helper release configuration");
   const setupGo = workflow.indexOf("- name: Setup Go");
 
+  assert.notEqual(verifySource, -1);
   assert.notEqual(stashConfig, -1);
   assert.notEqual(checkoutTag, -1);
-  assert.notEqual(preservePreHelperConfig, -1);
   assert.notEqual(setupGo, -1);
+  assert.ok(verifySource < stashConfig, "manual source and tag should be verified before config is saved");
   assert.ok(stashConfig < checkoutTag, "GoReleaser config should be saved before checking out historical tags");
-  assert.ok(checkoutTag < preservePreHelperConfig, "pre-helper detection should inspect the requested release tag");
-  assert.ok(
-    preservePreHelperConfig < setupGo,
-    "pre-helper release configuration should be selected before setup-go",
-  );
-  assert.match(
-    workflow.slice(preservePreHelperConfig, setupGo),
-    /if \[ ! -d cmd\/crabbox-apple-vz-helper \]; then\s+cp \.goreleaser\.yaml \/tmp\/\.goreleaser\.yaml/s,
-  );
   assert.ok(checkoutTag < setupGo, "setup-go should read go.mod from the requested release tag");
+  assert.match(
+    workflow.slice(verifySource, stashConfig),
+    /WORKFLOW_REF.*refs\/heads\/\$DEFAULT_BRANCH[\s\S]*\^v\(0\|\[1-9\]\[0-9\]\*\)[\s\S]*tag_ref="refs\/tags\/\$RELEASE_TAG"[\s\S]*git merge-base --is-ancestor "\$tag_ref\^\{commit\}" HEAD/,
+  );
+  assert.match(workflow.slice(checkoutTag, setupGo), /git checkout --detach "refs\/tags\/\$RELEASE_TAG"/);
+  assert.doesNotMatch(
+    workflow.slice(checkoutTag),
+    /cp \.goreleaser\.yaml \/tmp\/\.goreleaser\.yaml/,
+    "the selected release tag must not replace the reviewed GoReleaser config",
+  );
   assert.match(workflow.slice(setupGo), /go-version-file:\s+go\.mod/);
 });
 


### PR DESCRIPTION
## Summary

- require manual releases to dispatch the workflow from the default branch
- accept only an existing exact stable release tag already contained in that branch's history
- always use the reviewed dispatch-branch GoReleaser configuration and remove the selected-tag fallback
- document the historical re-release compatibility tradeoff and add workflow regression coverage

Fixes https://github.com/openclaw/crabbox/issues/535

## Verification

- `node --test scripts/release-workflow.test.js`
- `actionlint .github/workflows/release.yml`
- `scripts/check-docs.sh`
- project autoreview: clean, no accepted/actionable findings (correctness 0.87)

## Proof and compatibility

The regression test verifies validation precedes config stashing and tag checkout, the selected ref is addressed only through `refs/tags/`, and no post-checkout command can replace `/tmp/.goreleaser.yaml`.

Live GitHub Actions proof: [release run 27919151499](https://github.com/openclaw/crabbox/actions/runs/27919151499) dispatched the patched workflow from `fix/release-config-trust` with existing tag `v0.32.0`. It failed at `Verify manual release source and tag` with `manual releases must dispatch the workflow from main`; config stashing, tag checkout, token verification, GoReleaser, notes publication, and Homebrew verification were all skipped. This proves the new guard executes on GitHub before any credentialed publication step. The upcoming `v0.33.0` tag release will exercise the normal positive publication path.

Manual re-release of a historical pre-helper tag may now fail under the current reviewed GoReleaser configuration. That is intentional fail-closed behavior; arbitrary tag-controlled publishing configuration is no longer supported.
