### PR TITLE
fix: block cross-origin Azure session redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Rejected cross-origin Azure Dynamic Sessions redirects before command, environment, upload, or management bodies can be replayed. Thanks @coygeek.
 - Kept manual release publication on the reviewed default-branch GoReleaser configuration instead of allowing a selected tag to replace credentialed release behavior. Thanks @coygeek.
 - Rejected cross-origin coordinator redirects before bearer, Access, or local identity headers can be replayed. Thanks @coygeek.
 - Redacted configured Upstash Box API keys from HTTP and streamed error diagnostics. Thanks @coygeek.

--- a/docs/providers/azure-dynamic-sessions.md
+++ b/docs/providers/azure-dynamic-sessions.md
@@ -178,6 +178,8 @@ as `/`, `/tmp`, `/usr`, or bare `/workspace`; pick a dedicated subdirectory.
   `/v1/files`, extracts it under `workdir`, then streams the command over
   `/v1/exec` (NDJSON event stream). `--no-sync` skips the upload, `--sync-only`
   stops after sync. Acquired-but-not-kept sessions are stopped after the run.
+  API redirects are followed only when they remain on the configured endpoint's
+  origin, preventing credentials and request bodies from crossing trust boundaries.
 - **`status`** / **`list`** read `/.management/getSession` and
   `/.management/listSessions` and join them with local Crabbox claims. `status`
   can `--wait` for readiness.

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -225,10 +225,17 @@ func (c *azureDynamicSessionsClient) UploadFile(ctx context.Context, identifier,
 	if err != nil {
 		return err
 	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		redirectFile, err := os.Open(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("reopen upload file for redirect: %w", err)
+		}
+		return redirectFile, nil
+	}
 	c.setHeaders(req)
 	req.ContentLength = info.Size()
 	req.Header.Set("Content-Type", "application/octet-stream")
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.secureHTTPClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -251,7 +258,7 @@ func (c *azureDynamicSessionsClient) ExecStream(ctx context.Context, identifier 
 	}
 	c.setHeaders(req)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.secureHTTPClient().Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -394,7 +401,7 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.secureHTTPClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -417,6 +424,29 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 func (c *azureDynamicSessionsClient) responseError(resp *http.Response) error {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: summarizeJSON(data)}
+}
+
+func (c *azureDynamicSessionsClient) secureHTTPClient() *http.Client {
+	source := c.httpClient
+	if source == nil {
+		source = http.DefaultClient
+	}
+	client := *source
+	trusted, _ := url.Parse(c.endpoint)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameOriginURL(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
 }
 
 func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
@@ -450,7 +480,24 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveURLPort(a) == effectiveURLPort(b)
+}
+
+func effectiveURLPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func (c *azureDynamicSessionsClient) url(path string, query url.Values) string {

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -287,6 +288,90 @@ func TestAzureDynamicSessionsListSessionsRejectsCrossOriginNextLink(t *testing.T
 	}
 	if attackerCalled {
 		t.Fatal("cross-origin nextLink was requested")
+	}
+}
+
+func TestAzureDynamicSessionsClientRejectsCrossOriginRedirects(t *testing.T) {
+	var redirected atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirected.Add(1)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization=%q", got)
+		}
+		http.Redirect(w, r, target.URL+"/capture", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	archive := filepath.Join(t.TempDir(), "archive.tgz")
+	if err := os.WriteFile(archive, []byte("archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := &azureDynamicSessionsClient{
+		endpoint:             source.URL,
+		managementAPIVersion: "2025-02-02-preview",
+		token:                "test-token",
+		httpClient:           source.Client(),
+	}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "exec", run: func() error {
+			_, err := client.ExecStream(context.Background(), "azds-test", azureDynamicSessionsExecRequest{
+				Command: "env",
+				Env:     map[string]string{"MARKER": "fixture-value"},
+			}, io.Discard, io.Discard)
+			return err
+		}},
+		{name: "upload", run: func() error {
+			return client.UploadFile(context.Background(), "azds-test", archive, "/tmp/archive.tgz")
+		}},
+		{name: "json", run: func() error {
+			return client.DeleteSession(context.Background(), "azds-test")
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+				t.Fatalf("error=%v, want cross-origin redirect rejection", err)
+			}
+		})
+	}
+	if got := redirected.Load(); got != 0 {
+		t.Fatalf("redirect target received %d requests", got)
+	}
+}
+
+func TestAzureDynamicSessionsClientAllowsSameOriginRedirect(t *testing.T) {
+	var redirected atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization=%q", got)
+		}
+		if r.URL.Path == "/health" {
+			http.Redirect(w, r, "/health-ok", http.StatusTemporaryRedirect)
+			return
+		}
+		redirected.Add(1)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	client := &azureDynamicSessionsClient{
+		endpoint:   server.URL,
+		token:      "test-token",
+		httpClient: server.Client(),
+	}
+	if err := client.CheckRunner(context.Background(), "azds-test"); err != nil {
+		t.Fatal(err)
+	}
+	if got := redirected.Load(); got != 1 {
+		t.Fatalf("same-origin target received %d requests", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- enforce same-origin redirects for every Azure Dynamic Sessions API request
- preserve caller redirect policy and default redirect limits
- make file uploads replayable only for approved same-origin redirects
- document the trust-boundary behavior

Fixes https://github.com/openclaw/crabbox/issues/532

## Verification

- `go test -race ./internal/providers/azuredynamicsessions -count=1`
- `go test -race ./...`
- `go vet ./...`
- autoreview: clean

The regression test runs real loopback HTTP servers and verifies exec bodies, environment values, uploads, and management requests never reach a cross-origin redirect target while a same-origin redirect still succeeds.

## Live HTTP proof

Executed against the production client with two live loopback HTTP servers: a configured endpoint returning HTTP 307 and a cross-origin capture target. The capture target received zero requests for all body-bearing paths; a same-origin 307 reached its target once.

```text
=== RUN   TestAzureDynamicSessionsClientRejectsCrossOriginRedirects
=== RUN   TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/exec
=== RUN   TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/upload
=== RUN   TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/json
--- PASS: TestAzureDynamicSessionsClientRejectsCrossOriginRedirects
    --- PASS: TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/exec
    --- PASS: TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/upload
    --- PASS: TestAzureDynamicSessionsClientRejectsCrossOriginRedirects/json
=== RUN   TestAzureDynamicSessionsClientAllowsSameOriginRedirect
--- PASS: TestAzureDynamicSessionsClientAllowsSameOriginRedirect
PASS
```

Maintainer compatibility decision: cross-origin redirects intentionally fail closed. Redirecting command, environment, upload, or management bodies outside the configured endpoint origin is not a supported compatibility contract. The changelog entry is maintainer-owned release documentation for this user-visible security fix.
