### PR TITLE
fix: restrict runtime adapter terminal access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Restricted runtime-adapter service credentials to workspace lifecycle and desktop-connection routes, excluding interactive terminal attachment. Thanks @coygeek.
 - Rejected cross-origin Azure Dynamic Sessions redirects before command, environment, upload, or management bodies can be replayed. Thanks @coygeek.
 - Kept manual release publication on the reviewed default-branch GoReleaser configuration instead of allowing a selected tag to replace credentialed release behavior. Thanks @coygeek.
 - Rejected cross-origin coordinator redirects before bearer, Access, or local identity headers can be replayed. Thanks @coygeek.

--- a/docs/security.md
+++ b/docs/security.md
@@ -54,10 +54,11 @@ are rejected `401 unauthorized`. The Node runtime can instead accept an
 explicitly configured trusted reverse-proxy identity from allowlisted peer
 CIDRs. The generally unauthenticated routes are `GET /v1/health`, the GitHub
 login/OAuth and portal login/logout routes, and bridge agent upgrades that use
-short-lived tickets. The `/v1/workspaces` route tree also accepts the dedicated
-`CRABBOX_RUNTIME_ADAPTER_TOKEN` as a non-admin `service@openclaw.org` identity;
-that credential is rejected from every other coordinator route. Normal
-authentication is resolved in `worker/src/auth.ts` in this precedence:
+short-lived tickets. The workspace lifecycle and desktop-connection routes also
+accept the dedicated `CRABBOX_RUNTIME_ADAPTER_TOKEN` as a non-admin service
+identity. That credential cannot attach workspace terminals and is rejected from
+every other coordinator route. Normal authentication is resolved in
+`worker/src/auth.ts` in this precedence:
 
 1. **Admin token** — the request token equals the coordinator secret
    `CRABBOX_ADMIN_TOKEN`. Grants admin scope.
@@ -234,8 +235,8 @@ Inject these as Cloudflare Worker secrets or Node service secrets, never in the
 repo:
 
 - `CRABBOX_ADMIN_TOKEN` — admin and image-lifecycle routes.
-- `CRABBOX_RUNTIME_ADAPTER_TOKEN` — route-scoped service access to the
-  `/v1/workspaces` lifecycle API only.
+- `CRABBOX_RUNTIME_ADAPTER_TOKEN` — route-scoped service access to workspace
+  lifecycle and desktop-connection APIs only; it cannot attach terminals.
 - `CRABBOX_SHARED_TOKEN` — trusted operator automation only.
 - `CRABBOX_GITHUB_CLIENT_ID`, `CRABBOX_GITHUB_CLIENT_SECRET`,
   `CRABBOX_SESSION_SECRET` — GitHub browser login and user-token signing. The

--- a/worker/src/coordinator-entry.ts
+++ b/worker/src/coordinator-entry.ts
@@ -7,6 +7,7 @@ import {
 } from "./auth";
 import { codeProxyRequestBodyBytes, isIsolatedCodeRequest } from "./code-origin";
 import { bearerToken, json, pathParts } from "./http";
+import { runtimeAdapterProxyPath, runtimeAdapterRelayMethodAllowed } from "./runtime-adapter-relay";
 import type { Env } from "./types";
 
 export type CoordinatorFetch = (request: Request) => Promise<Response>;
@@ -75,7 +76,7 @@ export async function prepareCoordinatorRequest(
   ) {
     return { request: requestWithoutTrustedHeaders(request), authenticated: false };
   }
-  const runtimeAdapterAuth = runtimeAdapterServiceAuth(request, env, url);
+  const runtimeAdapterAuth = runtimeAdapterServiceAuth(request, env, route);
   if (runtimeAdapterAuth) {
     return {
       request: requestWithAuthContext(requestWithoutTrustedHeaders(request), runtimeAdapterAuth),
@@ -140,9 +141,10 @@ function isRuntimeAdapterAgentUpgrade(request: Request, url: URL): boolean {
 function runtimeAdapterServiceAuth(
   request: Request,
   env: Pick<Env, "CRABBOX_RUNTIME_ADAPTER_TOKEN" | "CRABBOX_DEFAULT_ORG">,
-  url: URL,
+  route: string[],
 ): AuthContext | undefined {
-  if (url.pathname !== "/v1/workspaces" && !url.pathname.startsWith("/v1/workspaces/")) {
+  const path = runtimeAdapterProxyPath(route);
+  if (!path || !runtimeAdapterRelayMethodAllowed(request.method, path)) {
     return undefined;
   }
   const expected = env.CRABBOX_RUNTIME_ADAPTER_TOKEN?.trim();

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -180,17 +180,45 @@ describe("coordinator auth", () => {
   });
 
   it("requires normal coordinator authentication for workspace terminals", async () => {
-    const prepared = await prepareCoordinatorRequest(
+    const unauthorized = await prepareCoordinatorRequest(
       new Request("https://example.test/v1/workspaces/fleet-is-101/terminal", {
         headers: { upgrade: "websocket" },
       }),
       {},
     );
+    const authorized = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/workspaces/fleet-is-101/terminal", {
+        headers: { upgrade: "websocket", authorization: "Bearer shared" },
+      }),
+      {
+        CRABBOX_SHARED_TOKEN: "shared",
+        CRABBOX_SHARED_OWNER: "alice@example.com",
+        CRABBOX_DEFAULT_ORG: "example-org",
+      },
+    );
+    const authorizedRequest = "request" in authorized ? authorized.request : undefined;
 
-    expect(prepared).toMatchObject({
+    expect(unauthorized).toMatchObject({
       authenticated: false,
       response: { status: 401 },
     });
+    expect(authorized).toMatchObject({ authenticated: true });
+    expect(authorizedRequest?.headers.get("x-crabbox-owner")).toBe("alice@example.com");
+    expect(authorizedRequest?.headers.get("x-crabbox-org")).toBe("example-org");
+  });
+
+  it("rejects the runtime adapter token from workspace terminals", async () => {
+    const prepared = await prepareCoordinatorRequest(
+      new Request("https://example.test/v1/workspaces/fleet-is-101/terminal", {
+        headers: {
+          upgrade: "websocket",
+          authorization: "Bearer runtime-adapter",
+        },
+      }),
+      { CRABBOX_RUNTIME_ADAPTER_TOKEN: "runtime-adapter" },
+    );
+
+    expect(prepared).toMatchObject({ authenticated: false, response: { status: 401 } });
   });
 
   it("accepts the runtime adapter token only for workspace routes", async () => {
@@ -202,8 +230,8 @@ describe("coordinator auth", () => {
       [
         new Request("https://example.test/v1/workspaces", { method: "POST" }),
         new Request("https://example.test/v1/workspaces/fleet-is-101"),
-        new Request("https://example.test/v1/workspaces/fleet-is-101/terminal", {
-          headers: { upgrade: "websocket" },
+        new Request("https://example.test/v1/workspaces/fleet-is-101/connections/desktop", {
+          method: "POST",
         }),
       ].map((request) => {
         request.headers.set("authorization", "Bearer runtime-adapter");
@@ -228,6 +256,15 @@ describe("coordinator auth", () => {
 
     const denied = await Promise.all(
       [
+        new Request("https://example.test/v1/workspaces", {
+          headers: { authorization: "Bearer runtime-adapter" },
+        }),
+        new Request("https://example.test/v1/workspaces/fleet-is-101/terminal", {
+          headers: {
+            upgrade: "websocket",
+            authorization: "Bearer runtime-adapter",
+          },
+        }),
         new Request("https://example.test/v1/leases", {
           headers: { authorization: "Bearer runtime-adapter" },
         }),
@@ -244,6 +281,8 @@ describe("coordinator auth", () => {
           : null,
       ),
     ).toEqual([
+      { authenticated: false, status: 401 },
+      { authenticated: false, status: 401 },
       { authenticated: false, status: 401 },
       { authenticated: false, status: 401 },
     ]);


### PR DESCRIPTION
## Summary

- share the runtime-adapter relay route/method allowlist with coordinator service authentication
- reject runtime-adapter credentials from workspace terminal attachment
- preserve normal authenticated user terminal access
- document the exact credential scope

Fixes https://github.com/openclaw/crabbox/issues/534

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` (23 files, 647 tests)
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- autoreview: clean

## Live HTTP/WebSocket proof

Built the production coordinator entry module into a loopback Node HTTP harness, then made real HTTP and WebSocket-upgrade requests through it:

```text
runtime lifecycle: 204 owner=service@openclaw.org
runtime terminal: 401 body={"error":"unauthorized"}
normal-user terminal: 101 owner=alice@example.com
```

This proves the dedicated service credential retains its intended workspace lifecycle access, cannot attach an interactive terminal, and does not break normal authenticated terminal upgrades.
