### PR TITLE
fix: redact Proxmox URL credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Redacted credential-bearing Proxmox API URL userinfo from text and JSON `config show` output. Thanks @coygeek.
 - Restricted EC2 Mac Dedicated Host inventory to admins or callers with a visible attached lease, and required admin authentication for explicit brokered host pinning. Thanks @coygeek.
 - Restricted runtime-adapter service credentials to workspace lifecycle and desktop-connection routes, excluding interactive terminal attachment. Thanks @coygeek.
 - Rejected cross-origin Azure Dynamic Sessions redirects before command, environment, upload, or management bodies can be replayed. Thanks @coygeek.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -42,6 +42,7 @@ it reports.
 
 Secrets are never printed. Token-bearing fields are reduced to a status word:
 
+- Credential-bearing URL userinfo is replaced with `<redacted>@`.
 - Broker tokens, Cloudflare/Proxmox/Upstash tokens: `configured` or `missing`.
 - Cloudflare Access auth: `missing`, `service-token` (client ID + secret),
   `token` (service token), `service-token+token`, or `incomplete` (only one of

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -42,7 +42,7 @@ it reports.
 
 Secrets are never printed. Token-bearing fields are reduced to a status word:
 
-- Credential-bearing URL userinfo is replaced with `<redacted>@`.
+- Proxmox API URL userinfo is replaced with `<redacted>@`.
 - Broker tokens, Cloudflare/Proxmox/Upstash tokens: `configured` or `missing`.
 - Cloudflare Access auth: `missing`, `service-token` (client ID + secret),
   `token` (service token), `service-token+token`, or `incomplete` (only one of

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -40,7 +40,7 @@ Two commands expose the resolved view:
 - `crabbox config show` prints the merged configuration as the CLI sees it
   after every layer runs. `--json` is stable enough to diff in scripts, and
   neither form prints secret values (tokens render as a state such as
-  `configured` or `missing`, and URL userinfo renders as `<redacted>@`).
+  `configured` or `missing`; Proxmox API URL userinfo renders as `<redacted>@`).
 - `crabbox config path` prints the user config file path so other tools can
   edit it without parsing prose.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -40,7 +40,7 @@ Two commands expose the resolved view:
 - `crabbox config show` prints the merged configuration as the CLI sees it
   after every layer runs. `--json` is stable enough to diff in scripts, and
   neither form prints secret values (tokens render as a state such as
-  `configured` or `missing`).
+  `configured` or `missing`, and URL userinfo renders as `<redacted>@`).
 - `crabbox config path` prints the user config file path so other tools can
   edit it without parsing prose.
 

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -447,7 +447,7 @@ func configShowView(cfg Config) map[string]any {
 			"serviceAccount": cfg.GCPServiceAccount,
 		},
 		"proxmox": map[string]any{
-			"apiUrl":      cfg.Proxmox.APIURL,
+			"apiUrl":      redactedConfigURL(cfg.Proxmox.APIURL),
 			"auth":        tokenState(cfg.Proxmox.TokenSecret),
 			"tokenId":     cfg.Proxmox.TokenID,
 			"node":        cfg.Proxmox.Node,
@@ -545,7 +545,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "scaleway region=%s zone=%s image=%s type=%s project_id=%s organization_id=%s security_group=%s ssh_cidrs=%s auth=%s\n", blank(cfg.Scaleway.Region, "-"), blank(cfg.Scaleway.Zone, "-"), blank(cfg.Scaleway.Image, "-"), blank(cfg.Scaleway.Type, "-"), blank(cfg.Scaleway.ProjectID, "-"), blank(cfg.Scaleway.OrganizationID, "-"), blank(cfg.Scaleway.SecurityGroup, "-"), blank(strings.Join(cfg.Scaleway.SSHCIDRs, ","), "-"), scalewayAuthState())
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(cfg.AzureDynamicSessions.Endpoint, "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)
 	fmt.Fprintf(w, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
-	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(cfg.Proxmox.APIURL, "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
+	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(redactedConfigURL(cfg.Proxmox.APIURL), "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
 	fmt.Fprintf(w, "xcp_ng api_url=%s username=%s template=%s template_uuid=%s sr=%s sr_uuid=%s network=%s network_uuid=%s host=%s user=%s work_root=%s insecure_tls=%t auth=%s\n", blank(redactedConfigURL(cfg.XCPNg.APIURL), "-"), blank(cfg.XCPNg.Username, "-"), blank(cfg.XCPNg.Template, "-"), blank(cfg.XCPNg.TemplateUUID, "-"), blank(cfg.XCPNg.SR, "-"), blank(cfg.XCPNg.SRUUID, "-"), blank(cfg.XCPNg.Network, "-"), blank(cfg.XCPNg.NetworkUUID, "-"), blank(cfg.XCPNg.Host, "-"), cfg.XCPNg.User, cfg.XCPNg.WorkRoot, cfg.XCPNg.InsecureTLS, tokenState(cfg.XCPNg.Password))
 	fmt.Fprintf(w, "parallels template=%s source=%s source_id=%s snapshot=%s snapshot_id=%s clone_mode=%s host=%s user=%s work_root=%s startup_timeout=%s templates=%d hosts=%d\n", blank(cfg.Parallels.Template, "-"), blank(cfg.Parallels.Source, "-"), blank(cfg.Parallels.SourceID, "-"), blank(cfg.Parallels.SourceSnapshot, "-"), blank(cfg.Parallels.SourceSnapshotID, "-"), cfg.Parallels.CloneMode, blank(cfg.Parallels.Host, "local"), cfg.Parallels.User, cfg.Parallels.WorkRoot, cfg.Parallels.StartupTimeout, len(cfg.Parallels.Templates), len(cfg.Parallels.Hosts))
 }

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -1258,6 +1258,60 @@ func TestConfigShowRedactsXCPNgAPIURLUserinfo(t *testing.T) {
 	}
 }
 
+func TestConfigShowRedactsProxmoxAPIURLUserinfo(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	config := []byte(`proxmox:
+  apiUrl: https://proxy-user:proxy-pass@pve.example.test:8006/api2/json?view=1
+  tokenId: crabbox@pve!ci
+  tokenSecret: proxmox-token-secret
+`)
+	if err := os.WriteFile(configPath, config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil {
+		t.Fatal(err)
+	}
+	wantURL := "https://<redacted>@pve.example.test:8006/api2/json?view=1"
+	if !strings.Contains(stdout.String(), "proxmox api_url="+wantURL) {
+		t.Fatalf("config show text missing redacted Proxmox API URL: %q", stdout.String())
+	}
+	for _, secret := range []string{"proxy-user", "proxy-pass", "proxy-user:proxy-pass", "proxmox-token-secret"} {
+		if strings.Contains(stdout.String(), secret) {
+			t.Fatalf("config show text leaked %q: %q", secret, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Proxmox struct {
+			APIURL string `json:"apiUrl"`
+			Auth   string `json:"auth"`
+		} `json:"proxmox"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Proxmox.APIURL != wantURL || got.Proxmox.Auth != "configured" {
+		t.Fatalf("unexpected Proxmox json: %#v", got.Proxmox)
+	}
+	for _, secret := range []string{"proxy-user", "proxy-pass", "proxy-user:proxy-pass", "proxmox-token-secret"} {
+		if strings.Contains(stdout.String(), secret) {
+			t.Fatalf("config show json leaked %q: %q", secret, stdout.String())
+		}
+	}
+}
+
 func TestConfigShowRedactsSchemeLessXCPNgAPIURLUserinfo(t *testing.T) {
 	clearConfigEnv(t)
 	home := t.TempDir()


### PR DESCRIPTION
## Summary

- redact Proxmox API URL userinfo in text and JSON `config show`
- reuse the existing provider URL redaction invariant
- document URL-userinfo redaction and add regression coverage

Fixes https://github.com/openclaw/crabbox/issues/500

## Verification

- `go test -race ./internal/cli -run 'TestConfigShowRedacts(Proxmox|XCPNg)APIURLUserinfo' -count=1 -v`
- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- autoreview: clean

## Live built-CLI proof

Built `bin/crabbox`, loaded a temporary Proxmox config containing fixture URL userinfo and a fixture token secret, then validated both real command outputs without printing their contents:

```text
$ crabbox config show | redaction-validator
redacted=true fixture_secrets_absent=true
$ crabbox config show --json | redaction-validator
redacted=true fixture_secrets_absent=true
```

Maintainer policy decision: uphold the documented `config show` secret-redaction contract. URL userinfo is accepted input today, so diagnostic output must redact it rather than silently exposing it.
