### PR TITLE
fix: restrict shared lease roster access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Restricted lease sharing rosters to owners, admins, and `manage` recipients while keeping shared leases visible to `use` recipients. Thanks @coygeek.
 - Redacted credential-bearing Proxmox API URL userinfo from text and JSON `config show` output. Thanks @coygeek.
 - Restricted EC2 Mac Dedicated Host inventory to admins or callers with a visible attached lease, and required admin authentication for explicit brokered host pinning. Thanks @coygeek.
 - Restricted runtime-adapter service credentials to workspace lifecycle and desktop-connection routes, excluding interactive terminal attachment. Thanks @coygeek.

--- a/docs/commands/share.md
+++ b/docs/commands/share.md
@@ -35,6 +35,10 @@ The lease can be addressed by its canonical id (`cbx_…`) or its slug, either v
 When you pass neither `--user` nor `--org` (or pass `--list`), the command prints
 the current sharing instead of changing it.
 
+Only the lease owner, an admin, or a user with `manage` access can list or change
+sharing. A user with `use` access can see the lease but cannot enumerate its
+sharing roster.
+
 ## Roles
 
 ```text

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -108,7 +108,7 @@ GET  /v1/leases/{id-or-slug}     resolves only if visible to the caller
 POST /v1/leases/{id}/heartbeat   owner, manage share, or admin
 POST /v1/leases/{id}/release     owner, manage share, or admin
 POST /v1/leases/{id}/tailscale   owner, manage share, or admin
-PUT/DELETE /v1/leases/{id}/share owner, manage share, or admin
+GET/PUT/DELETE /v1/leases/{id}/share owner, manage share, or admin
 GET  /v1/runs and logs/events    own runs only
 GET  /v1/usage                   own usage only
 GET  /v1/pool                    admin token only
@@ -134,6 +134,10 @@ shared bearer or admin token. Roles:
 - **use** — see the lease and open visible portal bridges (WebVNC, code).
 - **manage** — everything `use` allows, plus heartbeat/touch the lease, update
   non-secret Tailscale metadata, change sharing, and stop the lease.
+
+Ordinary lease detail and list responses omit the sharing roster for `use`
+recipients. Listing or changing the roster requires owner, admin, or `manage`
+access.
 
 ```sh
 crabbox share --id swift-crab --user alice@example.com           # default role: use

--- a/docs/features/portal.md
+++ b/docs/features/portal.md
@@ -167,7 +167,9 @@ header. The share page (`/share`) adds or removes individual users, sets
 org-wide access (`use`, `manage`, or off), or clears sharing entirely; it can
 also render embedded (`?embed=1`) inside the VNC viewer's share dialog. A
 `use` share can open visible lease pages and portal bridges; a `manage` share
-can also change sharing and use the matching stop or deregistration action.
+can also view or change the sharing roster and use the matching stop or
+deregistration action. Lease API responses shown to `use` recipients omit the
+sharing roster.
 For adapter-managed registrations, that matching action deletes the external
 workspace rather than only removing coordinator metadata.
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3595,7 +3595,7 @@ export class FleetCoordinator {
     }
     if (method === "GET" && action === undefined) {
       const admin = isAdminRequest(request);
-      const lease = await this.resolveLease(leaseID, request, admin);
+      const lease = await this.resolveLease(leaseID, request, false);
       return lease ? json({ lease: this.leaseForRequest(lease, request, admin) }) : notFound();
     }
     if (method === "POST" && action === "heartbeat") {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3594,8 +3594,9 @@ export class FleetCoordinator {
       return await this.registerLease(request, leaseID);
     }
     if (method === "GET" && action === undefined) {
-      const lease = await this.resolveLease(leaseID, request, false);
-      return lease ? json({ lease }) : notFound();
+      const admin = isAdminRequest(request);
+      const lease = await this.resolveLease(leaseID, request, admin);
+      return lease ? json({ lease: this.leaseForRequest(lease, request, admin) }) : notFound();
     }
     if (method === "POST" && action === "heartbeat") {
       return this.heartbeatLease(request, leaseID);
@@ -4318,15 +4319,16 @@ export class FleetCoordinator {
 
   private async shareLeaseRoute(request: Request, leaseID: string): Promise<Response> {
     const method = request.method.toUpperCase();
-    const lease = await this.resolveLease(leaseID, request, isAdminRequest(request));
+    const admin = isAdminRequest(request);
+    const lease = await this.resolveLease(leaseID, request, admin);
     if (!lease) {
       return notFound();
     }
+    if (!this.leaseManageableByRequest(lease, request, admin)) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
+    }
     if (method === "GET") {
       return json({ leaseID: lease.id, share: normalizedLeaseShare(lease.share) });
-    }
-    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
-      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
     if (method === "PUT") {
       const input = await readJson<Partial<LeaseShare>>(request);
@@ -8224,10 +8226,11 @@ export class FleetCoordinator {
   }
 
   private async listLeases(request: Request): Promise<Response> {
-    const leases = isAdminRequest(request)
+    const admin = isAdminRequest(request);
+    const leases = admin
       ? this.filterLeases(await this.leaseRecords(), request)
       : this.filterLeasesForRequest(await this.leaseRecords(), request);
-    return json({ leases });
+    return json({ leases: leases.map((lease) => this.leaseForRequest(lease, request, admin)) });
   }
 
   private async adminLeases(request: Request): Promise<Response> {
@@ -10300,6 +10303,15 @@ export class FleetCoordinator {
   private leaseManageableByRequest(lease: LeaseRecord, request: Request, admin: boolean): boolean {
     const role = this.leaseAccessRole(lease, request, admin);
     return role === "owner" || role === "manage";
+  }
+
+  private leaseForRequest(lease: LeaseRecord, request: Request, admin: boolean): LeaseRecord {
+    if (!lease.share || this.leaseManageableByRequest(lease, request, admin)) {
+      return lease;
+    }
+    const visible = { ...lease };
+    delete visible.share;
+    return visible;
   }
 
   private leaseAccessRole(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -7555,6 +7555,26 @@ describe("fleet lease identity and idle", () => {
         expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       }),
     );
+    storage.seed(
+      "lease:cbx_000000000002",
+      testLease({
+        id: "cbx_000000000002",
+        slug: "blue-lobster",
+        owner: "other@example.com",
+        org: "elsewhere",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const scopedAdminLease = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster", {
+        headers: { ...ownerHeaders, "x-crabbox-admin": "true" },
+      }),
+    );
+    expect(scopedAdminLease.status).toBe(200);
+    await expect(scopedAdminLease.json()).resolves.toMatchObject({
+      lease: { id: "cbx_000000000001" },
+    });
 
     const hidden = await fleet.fetch(
       request("GET", "/v1/leases/blue-lobster", { headers: friendHeaders }),

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -7577,9 +7577,27 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/v1/leases/blue-lobster", { headers: friendHeaders }),
     );
     expect(friendLease.status).toBe(200);
-    await expect(friendLease.json()).resolves.toMatchObject({
-      lease: { id: "cbx_000000000001", share: { users: { "friend@example.com": "use" } } },
+    const friendLeaseBody = (await friendLease.json()) as {
+      lease: { id: string; slug: string; share?: unknown };
+    };
+    expect(friendLeaseBody.lease).toMatchObject({
+      id: "cbx_000000000001",
+      slug: "blue-lobster",
     });
+    expect(friendLeaseBody.lease.share).toBeUndefined();
+
+    const friendLeases = await fleet.fetch(
+      request("GET", "/v1/leases", { headers: friendHeaders }),
+    );
+    expect(friendLeases.status).toBe(200);
+    const friendLeaseList = (await friendLeases.json()) as { leases: Array<{ share?: unknown }> };
+    expect(friendLeaseList.leases).toHaveLength(1);
+    expect(friendLeaseList.leases[0]?.share).toBeUndefined();
+
+    const friendShare = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/share", { headers: friendHeaders }),
+    );
+    expect(friendShare.status).toBe(403);
 
     const friendTicket = await fleet.fetch(
       request("POST", "/v1/leases/blue-lobster/webvnc/ticket", {
@@ -7637,6 +7655,14 @@ describe("fleet lease identity and idle", () => {
     );
     expect(orgShared.status).toBe(200);
     await expect(orgShared.json()).resolves.toMatchObject({
+      share: { users: { "friend@example.com": "use" }, org: "manage" },
+    });
+
+    const friendManageShare = await fleet.fetch(
+      request("GET", "/v1/leases/blue-lobster/share", { headers: friendHeaders }),
+    );
+    expect(friendManageShare.status).toBe(200);
+    await expect(friendManageShare.json()).resolves.toMatchObject({
       share: { users: { "friend@example.com": "use" }, org: "manage" },
     });
 


### PR DESCRIPTION
## Summary

- require lease `manage` access before returning the sharing roster
- omit sharing rosters from ordinary detail and list responses for `use` recipients
- document the owner/admin/manage boundary and add regression coverage

Fixes https://github.com/openclaw/crabbox/issues/496

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker` (647 tests)
- `npm run build --prefix worker`
- `npm run build:cloudflare --prefix worker`
- `npm run build:cloudflare-dynamic-workers --prefix worker`
- `npm run build:node --prefix worker`
- `go test ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- structured autoreview: clean

Live local Worker HTTP proof with two independently signed users:

- owner registered an external lease and granted `use` access
- `use` recipient: detail/list HTTP 200 with no `share` field; roster HTTP 403
- after owner upgraded recipient to `manage`: roster HTTP 200 with expected entry
- no provider operation or paid resource
