### PR TITLE
fix: protect KubeVirt SSH key paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Prevented repository-local KubeVirt config from selecting operator SSH key paths while preserving inline public keys. Thanks @coygeek.
 - Restricted lease sharing rosters to owners, admins, and `manage` recipients while keeping shared leases visible to `use` recipients. Thanks @coygeek.
 - Redacted credential-bearing Proxmox API URL userinfo from text and JSON `config show` output. Thanks @coygeek.
 - Restricted EC2 Mac Dedicated Host inventory to admins or callers with a visible attached lease, and required admin authentication for explicit brokered host pinning. Thanks @coygeek.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -705,6 +705,9 @@ kubevirt:
 The template must be one KubeVirt `VirtualMachine` using `runStrategy: Manual`.
 Crabbox sets its name, namespace, and lease labels, replaces documented
 placeholders, applies it with `kubectl`, and starts it with `virtctl`.
+Repository-local config may set inline `sshPublicKey` text, but Crabbox ignores
+`sshKey` and file-form `sshPublicKey` there. Put operator SSH key paths in
+trusted user config, environment variables, or explicit flags.
 
 ### External provider
 

--- a/docs/providers/kubevirt.md
+++ b/docs/providers/kubevirt.md
@@ -52,6 +52,10 @@ When `sshKey` is empty, Crabbox generates a per-lease key. When it is set,
 `sshPublicKey` may contain the matching public key text or a public-key file
 path; otherwise Crabbox reads `<sshKey>.pub`.
 
+Repository-local config may provide inline `sshPublicKey` text but cannot
+select `sshKey` or a file-form `sshPublicKey`. Configure operator key paths in
+trusted user config, environment variables, or explicit flags.
+
 Provider flags use the `--kubevirt-*` prefix. Environment overrides use the
 `CRABBOX_KUBEVIRT_*` prefix.
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3791,6 +3791,19 @@ func trustedConfigPath(path string) bool {
 	return userPath != "" && filepath.Clean(path) == filepath.Clean(userPath)
 }
 
+func inlineSSHPublicKey(value string) bool {
+	fields := strings.Fields(value)
+	if len(fields) < 2 {
+		return false
+	}
+	switch fields[0] {
+	case "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
+		return true
+	default:
+		return false
+	}
+}
+
 func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error {
 	credentialSource := credentialSourceForFile(trusted)
 	if file.Profile != "" {
@@ -4539,10 +4552,10 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 		if file.KubeVirt.SSHUser != "" {
 			cfg.KubeVirt.SSHUser = file.KubeVirt.SSHUser
 		}
-		if file.KubeVirt.SSHKey != "" {
+		if trusted && file.KubeVirt.SSHKey != "" {
 			cfg.KubeVirt.SSHKey = expandUserPath(file.KubeVirt.SSHKey)
 		}
-		if file.KubeVirt.SSHPublicKey != "" {
+		if file.KubeVirt.SSHPublicKey != "" && (trusted || inlineSSHPublicKey(file.KubeVirt.SSHPublicKey)) {
 			cfg.KubeVirt.SSHPublicKey = expandUserPath(file.KubeVirt.SSHPublicKey)
 		}
 		if file.KubeVirt.SSHPort != "" {

--- a/internal/cli/config_kubevirt_external_test.go
+++ b/internal/cli/config_kubevirt_external_test.go
@@ -88,6 +88,37 @@ func TestLoadKubeVirtConfigExpandsUserPaths(t *testing.T) {
 	}
 }
 
+func TestKubeVirtRepositoryConfigCannotSelectSSHKeyPaths(t *testing.T) {
+	cfg := baseConfig()
+	cfg.KubeVirt.SSHKey = "/trusted/id_ed25519"
+	cfg.KubeVirt.SSHPublicKey = "/trusted/id_ed25519.pub"
+	file := fileConfig{KubeVirt: &fileKubeVirtConfig{
+		Context:      "repo-context",
+		Namespace:    "repo-namespace",
+		Template:     "./repo-vm.yaml",
+		SSHKey:       "~/.ssh/id_ed25519",
+		SSHPublicKey: "~/.ssh/id_ed25519.pub",
+	}}
+
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.KubeVirt.Context != "repo-context" || cfg.KubeVirt.Namespace != "repo-namespace" || cfg.KubeVirt.Template != "./repo-vm.yaml" {
+		t.Fatalf("safe repository settings not applied: %#v", cfg.KubeVirt)
+	}
+	if cfg.KubeVirt.SSHKey != "/trusted/id_ed25519" || cfg.KubeVirt.SSHPublicKey != "/trusted/id_ed25519.pub" {
+		t.Fatalf("repository config replaced trusted SSH key paths: %#v", cfg.KubeVirt)
+	}
+
+	file.KubeVirt.SSHPublicKey = "ssh-ed25519 AAAA repo@example.com"
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.KubeVirt.SSHPublicKey != "ssh-ed25519 AAAA repo@example.com" {
+		t.Fatalf("inline repository public key not applied: %q", cfg.KubeVirt.SSHPublicKey)
+	}
+}
+
 func TestKubeVirtEnvExpandsUserPaths(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/providers/kubevirt/backend.go
+++ b/internal/providers/kubevirt/backend.go
@@ -591,6 +591,9 @@ func readKubeVirtPublicKeyFile(path string) (string, error) {
 	if publicKey == "" {
 		return "", core.Exit(2, "KubeVirt SSH public key %s is empty", path)
 	}
+	if !looksLikeInlineSSHPublicKey(publicKey) {
+		return "", core.Exit(2, "KubeVirt SSH public key %s is not a supported OpenSSH public key", path)
+	}
 	return publicKey, nil
 }
 

--- a/internal/providers/kubevirt/provider_test.go
+++ b/internal/providers/kubevirt/provider_test.go
@@ -236,6 +236,19 @@ func TestSSHKeyReadsFileFormPublicKey(t *testing.T) {
 	}
 }
 
+func TestSSHKeyRejectsNonPublicKeyFile(t *testing.T) {
+	cfg := testConfig(t)
+	path := filepath.Join(t.TempDir(), "not-a-public-key")
+	if err := os.WriteFile(path, []byte("private or unrelated file contents\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg.KubeVirt.SSHPublicKey = path
+	backend := &leaseBackend{cfg: cfg}
+	if _, _, err := backend.sshKey("cbx_123"); err == nil || !strings.Contains(err.Error(), "not a supported OpenSSH public key") {
+		t.Fatalf("err=%v, want public-key validation failure", err)
+	}
+}
+
 func TestRenderManifestSetsIdentityLabelsAndPlaceholders(t *testing.T) {
 	cfg := testConfig(t)
 	data, err := renderManifest(cfg.KubeVirt.Template, "crabbox-test-deadbeef", "test-ns", "cbx_123", "test", cfg.KubeVirt.SSHPublicKey, map[string]string{


### PR DESCRIPTION
## Summary

- prevent repository-local KubeVirt config from selecting operator private-key or public-key file paths
- preserve inline public-key text and safe repository routing/template settings
- reject file contents that are not supported OpenSSH public keys before manifest rendering

Fixes https://github.com/openclaw/crabbox/issues/494

## Verification

- `go test ./internal/cli -run 'KubeVirt.*Config|LoadKubeVirtConfig'`
- `go test ./internal/providers/kubevirt`
- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- structured autoreview: clean

Live built-CLI proof:

- ran `crabbox warmup --provider kubevirt` from a repository config selecting nonexistent operator SSH key paths
- the CLI generated its own per-lease key and reached a fake KubeVirt apply boundary
- neither repository-selected operator path was read
- fake provider boundary only; no cluster operation or paid resource
