### PR TITLE
fix: redact WebVNC credentials by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Redacted WebVNC viewer URLs, usernames, and passwords from command output by default while preserving explicit private-terminal reveal. Thanks @coygeek.
 - Prevented repository-local KubeVirt config from selecting operator SSH key paths while preserving inline public keys. Thanks @coygeek.
 - Restricted lease sharing rosters to owners, admins, and `manage` recipients while keeping shared leases visible to `use` recipients. Thanks @coygeek.
 - Redacted credential-bearing Proxmox API URL userinfo from text and JSON `config show` output. Thanks @coygeek.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -230,7 +230,8 @@ automation should use the explicit `daemon` subcommands.
 `crabbox webvnc status --id <lease-id-or-slug>` prints the full health view:
 local daemon pid/log, the SSH tunnel command, target VNC reachability, the
 coordinator bridge/viewer state, recent bridge log events, the portal URL and
-password, and the exact native VNC fallback command.
+credential state, and the exact native VNC fallback command. Credential-bearing
+viewer URLs, usernames, and passwords are redacted by default.
 
 ```text
 lease: cbx_0123456789ab slug=swift-crab provider=aws target=linux
@@ -240,7 +241,7 @@ ssh tunnel: ssh ... -o GatewayPorts=no -L 127.0.0.1:5901:127.0.0.1:5900 ...
 portal bridge: connected=true viewers=2 observers=1 slots=2
 portal controller: alice
 event: 2026-05-07T12:00:00Z bridge_connected
-webvnc: https://broker.example.com/portal/leases/cbx_.../vnc#password=...
+webvnc: [redacted]
 fallback: crabbox vnc --provider aws --target linux --network tailscale --id cbx_... --open
 ```
 
@@ -253,6 +254,12 @@ output also prints the native `crabbox vnc ... --open` fallback with the same
 provider/target/network flags. Running `status` with `--network public` or
 `--network tailscale` carries that same network selection into the printed
 fallback.
+
+`--open` still hands credentials directly to the browser without printing
+them. Credential-free viewer URLs and recovery commands remain visible. For a
+manual credential handoff in a private terminal, explicitly pass
+`--redact-credentials=false`; treat that output as a reusable secret while the
+bridge remains active. Daemon and controller output always stays redacted.
 
 ### reset
 
@@ -274,13 +281,15 @@ instead of granting general passwordless sudo.
 ## Portal and passwords
 
 `--open` opens the portal page after the bridge starts. When the VNC password is
-available, the command also places it in the URL fragment for the local browser
-tab and prints it on stdout. URL fragments are not sent to the coordinator, and
-Crabbox preserves special characters such as `!` when building the fragment. For
-macOS targets the lease username is also surfaced. If the portal login flow
-redirects first, the page may still prompt for the VNC password; use the
-password printed by the command. If an old tab is retrying with a stale
-fragment, close it before opening the new bridge URL.
+available, the command places it in the URL fragment handed to the local browser
+tab. URL fragments are not sent to the coordinator, and Crabbox preserves
+special characters such as `!` when building the fragment. Credential-bearing
+viewer URLs, usernames, and passwords remain redacted on stdout unless the
+operator explicitly sets `--redact-credentials=false`. Credential-free URLs and
+recovery commands remain visible. If the portal login flow redirects first,
+the page may still prompt for the VNC password; use the explicit reveal only in
+a private terminal. If an old tab is retrying with a stale fragment, close it
+before opening the new bridge URL.
 
 The portal page may show `WebVNC daemon not running` or `waiting for VNC bridge`
 until the local command has connected. If you opened the portal first, start the
@@ -317,6 +326,7 @@ explicit instead of fully automatic.
 --local-port <port>         local VNC tunnel port (auto-selected when unset)
 --open                      open the portal VNC page once the bridge connects
 --take-control              ask the portal viewer to request control after connecting
+--redact-credentials=false  reveal viewer URLs, usernames, and passwords (unsafe)
 --reclaim                   claim this lease for the current repo
 ```
 
@@ -389,9 +399,10 @@ If WebVNC remains unreliable, use the exact native fallback command printed by
 
 VNC authentication fails
 
-Use the password printed by `crabbox webvnc`. With `--open`, the command tries
-to pass the password in the browser URL fragment, but a portal login redirect
-can lose that fragment before noVNC sees it.
+Retry with `--open` so Crabbox hands the credential directly to the browser. If
+manual entry is required, run the command in a private terminal with
+`--redact-credentials=false`; avoid copying that output into logs, issues, or
+chat. A portal login redirect can lose the URL fragment before noVNC sees it.
 
 ## Related docs
 

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -302,7 +302,9 @@ func (r *execControllerWorkspaceRunner) DesktopConnection(ctx context.Context, i
 	if err != nil {
 		return "", err
 	}
-	statusArgs := r.appendProviderArg([]string{"webvnc", "status", "--id", identifier}, request)
+	// This subprocess output is bounded and parsed in-process; the controller needs
+	// the credential-bearing URL without exposing it in human-facing command output.
+	statusArgs := r.appendProviderArg([]string{"webvnc", "status", "--id", identifier, "--redact-credentials=false"}, request)
 	statusArgs = append(statusArgs,
 		"--local-port", localPort,
 		"--expected-listener-owner-pid", strconv.Itoa(initialDaemonPID),
@@ -507,7 +509,7 @@ func controllerWebVNCURL(output string) string {
 	for _, line := range strings.Split(output, "\n") {
 		if value, ok := strings.CutPrefix(strings.TrimSpace(line), "webvnc: "); ok {
 			value = strings.TrimSpace(value)
-			if value != "" && !strings.HasPrefix(value, "run ") {
+			if value != "" && value != "[redacted]" && !strings.HasPrefix(value, "run ") {
 				return value
 			}
 		}

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -606,6 +606,9 @@ func TestControllerWebVNCURLParser(t *testing.T) {
 	if got := controllerWebVNCURL("webvnc: run crabbox webvnc --id demo\n"); got != "" {
 		t.Fatalf("command hint parsed as URL: %q", got)
 	}
+	if got := controllerWebVNCURL("webvnc: [redacted]\n"); got != "" {
+		t.Fatalf("redaction marker parsed as URL: %q", got)
+	}
 }
 
 func TestControllerWebVNCReadyParser(t *testing.T) {
@@ -1280,7 +1283,7 @@ fi
 		"webvnc daemon stop --id cbx_legacy123",
 		"webvnc daemon start --id cbx_legacy123 --provider external",
 		"--controller-owned=true",
-		"webvnc status --id cbx_legacy123 --provider external --local-port",
+		"webvnc status --id cbx_legacy123 --redact-credentials=false --provider external --local-port",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("calls missing %q:\n%s", want, got)

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -165,6 +165,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		fmt.Fprintln(fs.Output(), "  --local-port <port>")
 		fmt.Fprintln(fs.Output(), "  --open")
 		fmt.Fprintln(fs.Output(), "  --take-control")
+		fmt.Fprintln(fs.Output(), "  --redact-credentials=false  reveal viewer credentials (unsafe)")
 		fmt.Fprintln(fs.Output(), "  --reclaim")
 	}
 	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
@@ -175,7 +176,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
 	takeControl := fs.Bool("take-control", false, "ask the portal viewer to take keyboard and mouse control after connecting")
-	redactCredentials := fs.Bool("redact-credentials", false, "omit credential-bearing URLs and passwords from output")
+	redactCredentials := registerWebVNCCredentialOutputFlag(fs)
 	daemon := fs.Bool("daemon", false, "compatibility alias for daemon start")
 	background := fs.Bool("background", false, "compatibility alias for daemon start")
 	daemonStatus := fs.Bool("status", false, "compatibility alias for daemon status")
@@ -663,13 +664,22 @@ type webVNCRedactingWriter struct {
 	io.Writer
 }
 
+func registerWebVNCCredentialOutputFlag(fs *flag.FlagSet) *bool {
+	return fs.Bool("redact-credentials", true, "omit credential-bearing URLs and passwords from output; set false to reveal (unsafe)")
+}
+
 func (w webVNCRedactingWriter) Write(data []byte) (int, error) {
 	text := string(data)
 	lines := strings.SplitAfter(text, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		for _, prefix := range []string{"webvnc:", "password:", "username:", "opened:"} {
+		for _, prefix := range []string{"password:", "username:", "webvnc:", "opened:"} {
 			if strings.HasPrefix(trimmed, prefix) {
+				if (prefix == "webvnc:" || prefix == "opened:") &&
+					!strings.Contains(trimmed, "password=") &&
+					!strings.Contains(trimmed, "username=") {
+					break
+				}
 				ending := ""
 				if strings.HasSuffix(line, "\n") {
 					ending = "\n"
@@ -761,6 +771,7 @@ func (a App) webVNCDaemonListCommand(args []string) error {
 func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("webvnc status", a.Stderr)
+	redactCredentials := registerWebVNCCredentialOutputFlag(fs)
 	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	localPort := fs.String("local-port", "", "local VNC tunnel port")
@@ -772,6 +783,9 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *redactCredentials {
+		a.Stdout = webVNCRedactingWriter{Writer: a.Stdout}
 	}
 	expectedIdentity, err := expectedIdentityFlags.value(fs)
 	if err != nil {
@@ -917,6 +931,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("webvnc reset", a.Stderr)
+	redactCredentials := registerWebVNCCredentialOutputFlag(fs)
 	provider := fs.String("provider", defaults.Provider, "desktop SSH provider")
 	id := fs.String("id", "", "lease id or slug")
 	openPortal := fs.Bool("open", false, "open the web portal VNC page")
@@ -926,6 +941,9 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	networkFlags := registerNetworkModeFlag(fs, defaults)
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *redactCredentials {
+		a.Stdout = webVNCRedactingWriter{Writer: a.Stdout}
 	}
 	setIDFromFirstArg(fs, id)
 	if *id == "" {

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -676,8 +676,7 @@ func (w webVNCRedactingWriter) Write(data []byte) (int, error) {
 		for _, prefix := range []string{"password:", "username:", "webvnc:", "opened:"} {
 			if strings.HasPrefix(trimmed, prefix) {
 				if (prefix == "webvnc:" || prefix == "opened:") &&
-					!strings.Contains(trimmed, "password=") &&
-					!strings.Contains(trimmed, "username=") {
+					!webVNCOutputURLHasCredentials(strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))) {
 					break
 				}
 				ending := ""
@@ -694,6 +693,14 @@ func (w webVNCRedactingWriter) Write(data []byte) (int, error) {
 		return 0, err
 	}
 	return len(data), nil
+}
+
+func webVNCOutputURLHasCredentials(value string) bool {
+	if strings.Contains(value, "password=") || strings.Contains(value, "username=") {
+		return true
+	}
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.User != nil
 }
 
 func (a App) webVNCDaemonStatusCommand(args []string) error {

--- a/internal/cli/webvnc_local.go
+++ b/internal/cli/webvnc_local.go
@@ -52,7 +52,9 @@ func (a App) webVNCLocal(ctx context.Context, args []string) error {
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), "Usage:")
 		fmt.Fprintln(fs.Output(), "  crabbox webvnc local --vnc-host 127.0.0.1 --vnc-port <port> --username <user> --password-stdin [--security-type auto|vnc] [--local-port <port>] [--open]")
+		fmt.Fprintln(fs.Output(), "  --redact-credentials=false  reveal viewer credentials (unsafe)")
 	}
+	redactCredentials := registerWebVNCCredentialOutputFlag(fs)
 	vncHost := fs.String("vnc-host", "127.0.0.1", "loopback VNC source host")
 	vncPort := fs.String("vnc-port", "", "loopback VNC source port")
 	username := fs.String("username", "", "VNC username")
@@ -62,6 +64,9 @@ func (a App) webVNCLocal(ctx context.Context, args []string) error {
 	openViewer := fs.Bool("open", false, "open the local WebVNC viewer")
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *redactCredentials {
+		a.Stdout = webVNCRedactingWriter{Writer: a.Stdout}
 	}
 	if !localWebVNCSupported() {
 		return exit(2, "webvnc local is supported only on macOS and Linux")

--- a/internal/cli/webvnc_local_test.go
+++ b/internal/cli/webvnc_local_test.go
@@ -482,7 +482,7 @@ func TestWebVNCLocalRunsWithPasswordOnlyOnStdin(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("timed out waiting for local WebVNC command")
 	}
-	if got := output.String(); strings.Contains(got, "stdin-only-secret") || !strings.Contains(got, "VNC source 127.0.0.1:") {
+	if got := output.String(); strings.Contains(got, "stdin-only-secret") || !strings.Contains(got, "VNC source 127.0.0.1:") || !strings.Contains(got, "webvnc: file:") {
 		t.Fatalf("unexpected command output: %q", got)
 	}
 	cancel()

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -89,7 +89,7 @@ func TestWebVNCURLs(t *testing.T) {
 func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {
 	var output bytes.Buffer
 	writer := webVNCRedactingWriter{Writer: &output}
-	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\n"
+	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\nwebvnc: run crabbox webvnc --id demo\nwebvnc: https://portal.example/vnc\n"
 	if _, err := writer.Write([]byte(input)); err != nil {
 		t.Fatal(err)
 	}
@@ -99,6 +99,29 @@ func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {
 	}
 	if !strings.Contains(got, "bridge: connected") || strings.Count(got, "[redacted]") != 3 {
 		t.Fatalf("unexpected redacted output: %q", got)
+	}
+	if !strings.Contains(got, "webvnc: run crabbox webvnc --id demo") || !strings.Contains(got, "webvnc: https://portal.example/vnc") {
+		t.Fatalf("non-secret WebVNC output was redacted: %q", got)
+	}
+}
+
+func TestWebVNCCredentialOutputDefaultsToRedacted(t *testing.T) {
+	fs := newFlagSet("webvnc-test", io.Discard)
+	redact := registerWebVNCCredentialOutputFlag(fs)
+	if err := parseFlags(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !*redact {
+		t.Fatal("WebVNC credential output must default to redacted")
+	}
+
+	fs = newFlagSet("webvnc-test", io.Discard)
+	redact = registerWebVNCCredentialOutputFlag(fs)
+	if err := parseFlags(fs, []string{"--redact-credentials=false"}); err != nil {
+		t.Fatal(err)
+	}
+	if *redact {
+		t.Fatal("explicit private-terminal reveal was ignored")
 	}
 }
 

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -89,15 +89,15 @@ func TestWebVNCURLs(t *testing.T) {
 func TestWebVNCRedactingWriterKeepsCredentialsOutOfDaemonLogs(t *testing.T) {
 	var output bytes.Buffer
 	writer := webVNCRedactingWriter{Writer: &output}
-	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\nwebvnc: run crabbox webvnc --id demo\nwebvnc: https://portal.example/vnc\n"
+	input := "bridge: connected\nwebvnc: https://portal.example/vnc#password=secret\npassword: secret\nusername: crabbox\nwebvnc: https://broker-user:broker-secret@portal.example/vnc\nopened: https://other-user:other-secret@portal.example/vnc\nwebvnc: run crabbox webvnc --id demo\nwebvnc: https://portal.example/vnc\n"
 	if _, err := writer.Write([]byte(input)); err != nil {
 		t.Fatal(err)
 	}
 	got := output.String()
-	if strings.Contains(got, "secret") || strings.Contains(got, "#password=") {
+	if strings.Contains(got, "secret") || strings.Contains(got, "broker-user") || strings.Contains(got, "other-user") || strings.Contains(got, "#password=") {
 		t.Fatalf("credential leaked: %q", got)
 	}
-	if !strings.Contains(got, "bridge: connected") || strings.Count(got, "[redacted]") != 3 {
+	if !strings.Contains(got, "bridge: connected") || strings.Count(got, "[redacted]") != 5 {
 		t.Fatalf("unexpected redacted output: %q", got)
 	}
 	if !strings.Contains(got, "webvnc: run crabbox webvnc --id demo") || !strings.Contains(got, "webvnc: https://portal.example/vnc") {


### PR DESCRIPTION
## Summary

- redact credential-bearing WebVNC URLs plus raw usernames/passwords by default across foreground, status, reset, and local commands
- preserve credential-free URLs and recovery commands, with explicit `--redact-credentials=false` private-terminal reveal
- keep controller URL discovery working through a bounded internal subprocess channel while rejecting redaction markers

Fixes https://github.com/openclaw/crabbox/issues/476

## Verification

- `go test ./internal/cli -run 'WebVNC|Controller'`
- `go test -race ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- structured autoreview: clean after addressing output-contract and URL-userinfo findings

Live built-CLI proof:

- served a live loopback RFB listener and ran `crabbox webvnc local` with a fixture username/password
- stdout showed a credential-free local handoff URL
- fixture username and password were absent from stdout
- no remote provider or paid resource

Inspectable stdout (temporary path normalized):

```text
bridge: serving noVNC locally; VNC source 127.0.0.1:18979; keep this running while viewing
webvnc: file:///.../crabbox-webvnc-256383704.html
```

The fixture values `live-user` and `live-loopback-secret` do not appear. The secure-default compatibility change is intentional; scripts requiring revealed credentials must opt in with `--redact-credentials=false` in a private terminal.
