### PR TITLE
fix: verify Windows bootstrap artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Verified pinned OpenSSH, Git for Windows, TightVNC, and versioned Ubuntu WSL bootstrap artifacts before privileged extraction, installation, or import. Thanks @coygeek.
 - Preserved valid JUnit summaries when sibling reports are malformed, stopped silently truncating auto-discovered reports, and added opt-in failure status for parsed test failures. Thanks @coygeek.
 - Redacted WebVNC viewer URLs, usernames, and passwords from command output by default while preserving explicit private-terminal reveal. Thanks @coygeek.
 - Prevented repository-local KubeVirt config from selecting operator SSH key paths while preserving inline public keys. Thanks @coygeek.

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -149,12 +149,14 @@ trusted certificates, and treat `--xcp-ng-insecure-tls` as private-lab only.
 `--provider aws --target windows --windows-mode normal --desktop` creates a real
 AWS Windows Server lease. EC2Launch user data installs OpenSSH Server, Git for
 Windows, TightVNC Server, a per-lease local administrator named `crabbox`, and a
-loopback VNC password retrievable through `crabbox vnc --id <lease>`.
+loopback VNC password retrievable through `crabbox vnc --id <lease>`. The
+OpenSSH, Git, and TightVNC downloads are SHA-256 verified before use.
 
 `--provider aws --target windows --windows-mode wsl2` still creates a Windows
 Server host, then enables WSL, VirtualMachinePlatform, and HypervisorPlatform,
 reboots as needed, updates the WSL kernel, imports an Ubuntu rootfs, and
-prepares the Linux-side `crabbox-ready` toolchain. The launch enables nested
+prepares the Linux-side `crabbox-ready` toolchain. The rootfs uses a versioned
+URL and pinned SHA-256 verified before import. The launch enables nested
 virtualization and uses C8i, M8i, or R8i instance families. Commands and sync
 then use the POSIX WSL contract.
 
@@ -162,7 +164,8 @@ then use the POSIX WSL contract.
 
 `--provider azure --target windows` creates a native Windows Server lease, uses
 the VM Agent Custom Script Extension to install OpenSSH Server and Git for
-Windows, and configures the `crabbox` user for SSH/sync/run. Add `--desktop` to
+Windows, verifies both downloads by pinned SHA-256, and configures the `crabbox`
+user for SSH/sync/run. Add `--desktop` to
 run the shared Windows desktop bootstrap over SSH, install TightVNC, configure
 auto-logon, and expose VNC through the normal SSH tunnel. With
 `--windows-mode wsl2`, Crabbox enables WSL2 over SSH and uses the POSIX WSL

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -234,8 +234,10 @@ desktop session, x11vnc bound to `127.0.0.1:5900`, and an SSH local tunnel
 created by `crabbox vnc`. Azure native Windows desktop leases use the shared
 managed Windows bootstrap to install TightVNC, create the local `crabbox`
 administrator, enable auto-logon, and expose VNC only through an SSH tunnel.
+The OpenSSH, Git for Windows, and TightVNC downloads are pinned and SHA-256
+verified before extraction or execution.
 Azure WSL2 leases enable WSL, VirtualMachinePlatform, and HypervisorPlatform,
-update the WSL kernel, import the Ubuntu rootfs, and prepare the Linux-side
+update the WSL kernel, verify and import a versioned Ubuntu rootfs, and prepare the Linux-side
 `crabbox-ready` toolchain. Azure Windows does not provision browser/code
 targets.
 

--- a/docs/features/runner-bootstrap.md
+++ b/docs/features/runner-bootstrap.md
@@ -130,7 +130,10 @@ with per-OS scripts rather than cloud-init:
   port, and the VNC port `5900`.
 - **Windows** — a PowerShell script installs OpenSSH, configures key-only access
   for administrators, opens firewall rules on the SSH ports, and installs Git
-  for Windows so `git` and `tar` are on the machine PATH. `--windows-mode wsl2`
+  for Windows so `git` and `tar` are on the machine PATH. Crabbox verifies pinned
+  SHA-256 values before extracting or executing those downloads; desktop
+  TightVNC and the versioned WSL rootfs use the same fail-closed check.
+  `--windows-mode wsl2`
   additionally enables the WSL feature set, imports an Ubuntu rootfs, and runs
   the minimal Linux base inside WSL; `--desktop` adds TightVNC. The work root
   defaults to `C:\crabbox` (native) or the Linux default inside WSL.

--- a/docs/features/vnc-windows.md
+++ b/docs/features/vnc-windows.md
@@ -63,7 +63,9 @@ Bootstrap flow:
   Custom Script Extension copies `C:\AzureData\CustomData.bin` to
   `C:\AzureData\crabbox-bootstrap.ps1` and runs it.
 - The script installs OpenSSH, Git for Windows, and TightVNC, creates the `crabbox`
-  administrator, and configures auto-logon.
+  administrator, and configures auto-logon. Every downloaded installer/archive
+  is pinned to a release URL and verified with SHA-256 before extraction or
+  execution; a mismatch deletes the download and stops bootstrap.
 - In desktop mode the bootstrap reboots once to land the auto-logon console
   session, then Crabbox waits for SSH and VNC readiness.
 - VNC listens on port `5900` and is reachable only through the SSH tunnel.
@@ -107,7 +109,8 @@ Linux tooling on Windows-capable nested-virtualization VM families.
 
 The bootstrap enables the `Microsoft-Windows-Subsystem-Linux`,
 `VirtualMachinePlatform`, and `HypervisorPlatform` features, updates the WSL kernel,
-and imports a `Crabbox` distribution from an Ubuntu rootfs. Enabling the features
+and imports a `Crabbox` distribution from a versioned Ubuntu rootfs whose
+SHA-256 is verified before import. Enabling the features
 and updating the kernel each trigger a reboot, so the first WSL2 warmup takes longer
 than a native Windows warmup.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -284,6 +284,14 @@ and may fail for historical tags that are incompatible with the current
 reviewed release configuration rather than falling back to tag-controlled
 publishing behavior.
 
+## Managed Windows Bootstrap Integrity
+
+Managed Windows bootstrap pins the OpenSSH-Win64 archive, Git for Windows
+installer, TightVNC installer, and versioned Ubuntu WSL rootfs to SHA-256
+digests embedded alongside their URLs. Generated PowerShell verifies every
+download before extraction, execution, or WSL import, removes mismatched bytes,
+and fails bootstrap closed. URL and digest updates are reviewed together.
+
 ## SSH
 
 SSH is the control and data path to a leased box; the broker manages leases but

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -9,9 +9,13 @@ import (
 
 const (
 	tightVNCMSIURL              = "https://www.tightvnc.com/download/2.8.85/tightvnc-2.8.85-gpl-setup-64bit.msi"
+	tightVNCMSISHA256           = "d8fbed7b27ebab86df6f780f6e86f723668f3715cee521ccaa4568812aef5f3e"
 	gitForWindowsSetupURL       = "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/Git-2.52.0-64-bit.exe"
+	gitForWindowsSetupSHA256    = "d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c"
 	openSSHWin64ZipURL          = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.3.0p2-Preview/OpenSSH-Win64.zip"
-	ubuntuWSLRootFSURL          = "https://cloud-images.ubuntu.com/wsl/releases/24.04/current/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz"
+	openSSHWin64ZipSHA256       = "0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54"
+	ubuntuWSLRootFSURL          = "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz"
+	ubuntuWSLRootFSSHA256       = "8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea"
 	defaultTailscaleVersion     = "1.98.4"
 	defaultTailscaleAMD64SHA256 = "e6c08a8ee7e63e69aaf1b62ecd12672b3883fbcd2a176bf6cfa42a15fdce0b6b"
 	defaultTailscaleARM64SHA256 = "3cb068eb1368b6bb218d0ef0aa0a7a679a7156b7c979e2279cc2c2321b5f05c7"
@@ -133,6 +137,14 @@ function Retry($ScriptBlock) {
     }
   }
 }
+function Assert-CrabboxFileSHA256([string]$Path, [string]$Expected) {
+  if (-not (Test-Path -LiteralPath $Path)) { throw "downloaded artifact is missing: $Path" }
+  $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actual -ne $Expected.ToLowerInvariant()) {
+    Remove-Item -Force -LiteralPath $Path -ErrorAction SilentlyContinue
+    throw "SHA-256 mismatch for downloaded artifact: $Path"
+  }
+}
 function New-CrabboxPassword {
   $bytes = New-Object byte[] 18
   $rng = [Security.Cryptography.RandomNumberGenerator]::Create()
@@ -189,6 +201,7 @@ icacls.exe $userSSHDir /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-5
 icacls.exe $userAuthorizedKeys /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F" | Out-Null
 if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) {
   Retry { Invoke-WebRequest -Uri ` + psQuote(openSSHWin64ZipURL) + ` -OutFile $openSSHZip -UseBasicParsing }
+  Assert-CrabboxFileSHA256 $openSSHZip ` + psQuote(openSSHWin64ZipSHA256) + `
   Remove-Item -Recurse -Force "C:\Program Files\OpenSSH" -ErrorAction SilentlyContinue
   Expand-Archive -LiteralPath $openSSHZip -DestinationPath "C:\Program Files" -Force
   if (Test-Path -LiteralPath "C:\Program Files\OpenSSH-Win64") {
@@ -233,6 +246,7 @@ Set-Service -Name sshd -StartupType Automatic
 Start-Service sshd
 if (-not (Test-Path -LiteralPath "C:\Program Files\Git\cmd\git.exe")) {
   Retry { Invoke-WebRequest -Uri ` + psQuote(gitForWindowsSetupURL) + ` -OutFile $gitInstaller -UseBasicParsing }
+  Assert-CrabboxFileSHA256 $gitInstaller ` + psQuote(gitForWindowsSetupSHA256) + `
   Start-Process -FilePath $gitInstaller -ArgumentList "/VERYSILENT","/NORESTART","/NOCANCEL","/SP-" -Wait
 }
 $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
@@ -365,9 +379,11 @@ func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	      if ($expectedLength -gt 0 -and $actualLength -ne $expectedLength) {
 	        throw "downloaded WSL rootfs is incomplete: $actualLength of $expectedLength bytes"
 	      }
+	      Assert-CrabboxFileSHA256 $wslRootfsDownload ` + psQuote(ubuntuWSLRootFSSHA256) + `
 	    }
 	    Move-Item -Force -LiteralPath $wslRootfsDownload -Destination $wslRootfs
 	  }
+	  Assert-CrabboxFileSHA256 $wslRootfs ` + psQuote(ubuntuWSLRootFSSHA256) + `
 	  wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2 | Out-Host
 	  if ($LASTEXITCODE -ne 0) { throw "wsl --import failed with exit $LASTEXITCODE" }
 	  wsl.exe --set-default $wslDistro | Out-Host
@@ -424,6 +440,7 @@ func windowsDesktopBootstrapPowerShell() string {
 	return `
 	if (-not (Test-Path -LiteralPath "C:\Program Files\TightVNC\tvnserver.exe")) {
 	  Retry { Invoke-WebRequest -Uri ` + psQuote(tightVNCMSIURL) + ` -OutFile $tightVNCInstaller -UseBasicParsing }
+	  Assert-CrabboxFileSHA256 $tightVNCInstaller ` + psQuote(tightVNCMSISHA256) + `
 	  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
 	  Start-Process -FilePath msiexec.exe -ArgumentList @(
     "/i", $tightVNCInstaller, "/quiet", "/norestart",

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -519,7 +519,10 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 	}
 	got := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
+		"function Assert-CrabboxFileSHA256",
+		"Get-FileHash -LiteralPath $Path -Algorithm SHA256",
 		"OpenSSH-Win64.zip",
+		openSSHWin64ZipSHA256,
 		"install-sshd.ps1",
 		"administrators_authorized_keys",
 		"Match Group administrators",
@@ -528,7 +531,9 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 		"Port $port",
 		"crabbox-sshd-$port",
 		"Git-2.52.0-64-bit.exe",
+		gitForWindowsSetupSHA256,
 		"tightvnc-2.8.85-gpl-setup-64bit.msi",
+		tightVNCMSISHA256,
 		"VALUE_OF_PASSWORD=$vncPassword",
 		"VALUE_OF_ALLOWLOOPBACK=1",
 		"CrabboxUserVNC",
@@ -567,6 +572,17 @@ func TestAWSUserDataWindowsProfile(t *testing.T) {
 	if strings.Contains(got, "Start-Service -Name tvnserver") {
 		t.Fatalf("windows user data should not start service-session VNC")
 	}
+	for _, pair := range [][2]string{
+		{"Assert-CrabboxFileSHA256 $openSSHZip", "Expand-Archive -LiteralPath $openSSHZip"},
+		{"Assert-CrabboxFileSHA256 $gitInstaller", "Start-Process -FilePath $gitInstaller"},
+		{"Assert-CrabboxFileSHA256 $tightVNCInstaller", "Start-Process -FilePath msiexec.exe"},
+	} {
+		verifyIndex := strings.Index(got, pair[0])
+		useIndex := strings.Index(got, pair[1])
+		if verifyIndex < 0 || useIndex < 0 || verifyIndex > useIndex {
+			t.Fatalf("windows bootstrap must run %q before %q", pair[0], pair[1])
+		}
+	}
 	mirrorIndex := strings.Index(got, "$credentialPaths += $passwordMirrorPath")
 	aclIndex := strings.Index(got, "foreach ($credentialPath in $credentialPaths)")
 	if mirrorIndex < 0 || aclIndex < 0 || mirrorIndex > aclIndex {
@@ -582,8 +598,11 @@ func TestAWSUserDataWindowsCoreProfileSkipsDesktop(t *testing.T) {
 	cfg.WorkRoot = `C:\crabbox`
 	got := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
 	for _, want := range []string{
+		"function Assert-CrabboxFileSHA256",
 		"OpenSSH-Win64.zip",
+		openSSHWin64ZipSHA256,
 		"Git-2.52.0-64-bit.exe",
+		gitForWindowsSetupSHA256,
 		"$passwordPath = $windowsPasswordPath",
 		"$credentialPaths = @($passwordPath)",
 		`icacls.exe $credentialPath /inheritance:r /grant "*${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F"`,
@@ -634,6 +653,9 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		"wsl.exe --update --web-download",
 		"wsl.exe --set-default-version 2",
 		ubuntuWSLRootFSURL,
+		ubuntuWSLRootFSSHA256,
+		"Assert-CrabboxFileSHA256 $wslRootfsDownload",
+		"Assert-CrabboxFileSHA256 $wslRootfs",
 		"$wslRootfsMinBytes = 100 * 1024 * 1024",
 		`$wslRootfsDownload = "$wslRootfs.download"`,
 		"Remove-Item -Force -LiteralPath $wslRootfs",
@@ -667,6 +689,9 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("windows WSL2 bootstrap should not include %q", notWant)
 		}
+	}
+	if verifyIndex, importIndex := strings.LastIndex(got, "Assert-CrabboxFileSHA256 $wslRootfs"), strings.Index(got, "wsl.exe --import $wslDistro"); verifyIndex < 0 || importIndex < 0 || verifyIndex > importIndex {
+		t.Fatalf("windows WSL2 bootstrap must verify the rootfs before import")
 	}
 }
 

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -2,12 +2,16 @@ import { sshPorts, type LeaseConfig } from "./config";
 
 const tightVNCMSIURL =
   "https://www.tightvnc.com/download/2.8.85/tightvnc-2.8.85-gpl-setup-64bit.msi";
+const tightVNCMSISHA256 = "d8fbed7b27ebab86df6f780f6e86f723668f3715cee521ccaa4568812aef5f3e";
 const gitForWindowsSetupURL =
   "https://github.com/git-for-windows/git/releases/download/v2.52.0.windows.1/Git-2.52.0-64-bit.exe";
+const gitForWindowsSetupSHA256 = "d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c";
 const openSSHWin64ZipURL =
   "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.3.0p2-Preview/OpenSSH-Win64.zip";
+const openSSHWin64ZipSHA256 = "0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54";
 const ubuntuWSLRootFSURL =
-  "https://cloud-images.ubuntu.com/wsl/releases/24.04/current/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz";
+  "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz";
+const ubuntuWSLRootFSSHA256 = "8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea";
 
 export function awsUserData(config: LeaseConfig): string {
   if (config.target === "windows") {
@@ -153,6 +157,14 @@ function Retry($ScriptBlock) {
     }
   }
 }
+function Assert-CrabboxFileSHA256([string]$Path, [string]$Expected) {
+  if (-not (Test-Path -LiteralPath $Path)) { throw "downloaded artifact is missing: $Path" }
+  $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actual -ne $Expected.ToLowerInvariant()) {
+    Remove-Item -Force -LiteralPath $Path -ErrorAction SilentlyContinue
+    throw "SHA-256 mismatch for downloaded artifact: $Path"
+  }
+}
 function New-CrabboxPassword {
   $bytes = New-Object byte[] 18
   $rng = [Security.Cryptography.RandomNumberGenerator]::Create()
@@ -209,6 +221,7 @@ icacls.exe $userSSHDir /inheritance:r /grant "*\${userSID}:F" /grant "*S-1-5-32-
 icacls.exe $userAuthorizedKeys /inheritance:r /grant "*\${userSID}:F" /grant "*S-1-5-32-544:F" /grant "*S-1-5-18:F" | Out-Null
 if (-not (Get-Service -Name sshd -ErrorAction SilentlyContinue)) {
   Retry { Invoke-WebRequest -Uri ${psQuote(openSSHWin64ZipURL)} -OutFile $openSSHZip -UseBasicParsing }
+  Assert-CrabboxFileSHA256 $openSSHZip ${psQuote(openSSHWin64ZipSHA256)}
   Remove-Item -Recurse -Force "C:\\Program Files\\OpenSSH" -ErrorAction SilentlyContinue
   Expand-Archive -LiteralPath $openSSHZip -DestinationPath "C:\\Program Files" -Force
   if (Test-Path -LiteralPath "C:\\Program Files\\OpenSSH-Win64") {
@@ -253,6 +266,7 @@ Set-Service -Name sshd -StartupType Automatic
 Start-Service sshd
 if (-not (Test-Path -LiteralPath "C:\\Program Files\\Git\\cmd\\git.exe")) {
   Retry { Invoke-WebRequest -Uri ${psQuote(gitForWindowsSetupURL)} -OutFile $gitInstaller -UseBasicParsing }
+  Assert-CrabboxFileSHA256 $gitInstaller ${psQuote(gitForWindowsSetupSHA256)}
   Start-Process -FilePath $gitInstaller -ArgumentList "/VERYSILENT","/NORESTART","/NOCANCEL","/SP-" -Wait
 }
 $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
@@ -380,9 +394,11 @@ function windowsWSL2BootstrapPowerShell(config: LeaseConfig): string {
 	      if ($expectedLength -gt 0 -and $actualLength -ne $expectedLength) {
 	        throw "downloaded WSL rootfs is incomplete: $actualLength of $expectedLength bytes"
 	      }
+	      Assert-CrabboxFileSHA256 $wslRootfsDownload ${psQuote(ubuntuWSLRootFSSHA256)}
 	    }
 	    Move-Item -Force -LiteralPath $wslRootfsDownload -Destination $wslRootfs
 	  }
+	  Assert-CrabboxFileSHA256 $wslRootfs ${psQuote(ubuntuWSLRootFSSHA256)}
 	  wsl.exe --import $wslDistro $wslRoot $wslRootfs --version 2 | Out-Host
 	  if ($LASTEXITCODE -ne 0) { throw "wsl --import failed with exit $LASTEXITCODE" }
 	  wsl.exe --set-default $wslDistro | Out-Host
@@ -439,6 +455,7 @@ function windowsDesktopBootstrapPowerShell(): string {
   return `
 	if (-not (Test-Path -LiteralPath "C:\\Program Files\\TightVNC\\tvnserver.exe")) {
 	  Retry { Invoke-WebRequest -Uri ${psQuote(tightVNCMSIURL)} -OutFile $tightVNCInstaller -UseBasicParsing }
+	  Assert-CrabboxFileSHA256 $tightVNCInstaller ${psQuote(tightVNCMSISHA256)}
 	  $vncPassword = Get-Content -Raw -Path $vncPasswordPath
 	  Start-Process -FilePath msiexec.exe -ArgumentList @(
     "/i", $tightVNCInstaller, "/quiet", "/norestart",

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -465,7 +465,10 @@ describe("cloud-init bootstrap", () => {
     expect(awsUserData(input)).toContain("version: 1.1");
     expect(awsUserData(input)).toContain("task: enableOpenSsh");
     const got = windowsBootstrapPowerShell(input);
+    expect(got).toContain("function Assert-CrabboxFileSHA256");
+    expect(got).toContain("Get-FileHash -LiteralPath $Path -Algorithm SHA256");
     expect(got).toContain("OpenSSH-Win64.zip");
+    expect(got).toContain("0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54");
     expect(got).toContain("install-sshd.ps1");
     expect(got).toContain("administrators_authorized_keys");
     expect(got).toContain("Match Group administrators");
@@ -474,6 +477,8 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("Port $port");
     expect(got).toContain("crabbox-sshd-$port");
     expect(got).toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");
+    expect(got).toContain("d8fbed7b27ebab86df6f780f6e86f723668f3715cee521ccaa4568812aef5f3e");
+    expect(got).toContain("d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c");
     expect(got).toContain("NewNetworkWindowOff");
     expect(got).toContain("DoNotOpenServerManagerAtLogon");
     expect(got).toContain("VALUE_OF_PASSWORD=$vncPassword");
@@ -502,6 +507,15 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("AutoAdminLogon");
     expect(got).toContain("Restart-Computer -Force");
     expect(got).toContain("exit 0");
+    expect(got.indexOf("Assert-CrabboxFileSHA256 $openSSHZip")).toBeLessThan(
+      got.indexOf("Expand-Archive -LiteralPath $openSSHZip"),
+    );
+    expect(got.indexOf("Assert-CrabboxFileSHA256 $gitInstaller")).toBeLessThan(
+      got.indexOf("Start-Process -FilePath $gitInstaller"),
+    );
+    expect(got.indexOf("Assert-CrabboxFileSHA256 $tightVNCInstaller")).toBeLessThan(
+      got.indexOf("Start-Process -FilePath msiexec.exe"),
+    );
     expect(got.indexOf("$credentialPaths += $passwordMirrorPath")).toBeLessThan(
       got.indexOf("foreach ($credentialPath in $credentialPaths)"),
     );
@@ -520,8 +534,11 @@ describe("cloud-init bootstrap", () => {
       workRoot: "C:\\crabbox",
     } as const;
     const got = windowsBootstrapPowerShell(input);
+    expect(got).toContain("function Assert-CrabboxFileSHA256");
     expect(got).toContain("OpenSSH-Win64.zip");
+    expect(got).toContain("0ca131f3a78f404dc819a6336606caec0db1663a692ccc3af1e90232706ada54");
     expect(got).toContain("Git-2.52.0-64-bit.exe");
+    expect(got).toContain("d8de7a3152266c8bb13577eab850ea1df6dccf8c2aa48be5b4a1c58b7190d62c");
     expect(got).toContain("$passwordPath = $windowsPasswordPath");
     expect(got).toContain("$credentialPaths = @($passwordPath)");
     expect(got).toContain(
@@ -560,7 +577,12 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain("bcdedit.exe /set hypervisorlaunchtype auto");
     expect(got).toContain("wsl.exe --update --web-download");
     expect(got).toContain("wsl.exe --set-default-version 2");
-    expect(got).toContain("ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz");
+    expect(got).toContain(
+      "https://cloud-images.ubuntu.com/wsl/releases/24.04/20240423/ubuntu-noble-wsl-amd64-wsl.rootfs.tar.gz",
+    );
+    expect(got).toContain("8251e27ffff381a4af5f41dcb94d867de3e0d9774a9241908ab34555d99315ea");
+    expect(got).toContain("Assert-CrabboxFileSHA256 $wslRootfsDownload");
+    expect(got).toContain("Assert-CrabboxFileSHA256 $wslRootfs");
     expect(got).toContain("$wslRootfsMinBytes = 100 * 1024 * 1024");
     expect(got).toContain("curl.exe -fL --retry 8");
     expect(got).toContain("downloaded WSL rootfs is incomplete");
@@ -571,6 +593,9 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain(":WSLInterop:M::MZ::/init:PF");
     expect(got).toContain("test -e /proc/sys/fs/binfmt_misc/WSLInterop");
     expect(got).toContain("test -w '/work/crabbox'");
+    expect(got.lastIndexOf("Assert-CrabboxFileSHA256 $wslRootfs")).toBeLessThan(
+      got.indexOf("wsl.exe --import $wslDistro"),
+    );
     const setupIndex = got.indexOf(
       "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
     );


### PR DESCRIPTION
## Summary

- pin SHA-256 digests for OpenSSH-Win64, Git for Windows, TightVNC, and the Ubuntu WSL rootfs in both Windows bootstrap generators
- replace the moving Ubuntu `current` URL with Canonical's versioned 24.04/20240423 artifact
- verify downloads before extraction, installer execution, or WSL import; delete mismatched bytes and fail bootstrap closed

Fixes https://github.com/openclaw/crabbox/issues/465

## Verification

- `go test -race ./...` (one unrelated SSH fallback timing flake on the first run; isolated `-count=5` and full rerun passed)
- `go vet ./...`
- Worker format, lint, typecheck, 647 tests, and dry-run build
- `node scripts/build-docs-site.mjs`
- structured autoreview: clean on the first pass

## Live proof

- downloaded all four artifacts from their pinned upstream URLs and calculated their SHA-256 values
- Git for Windows matched the digest published by its GitHub Release; the WSL rootfs matched Canonical's `SHA256SUMS`
- executed the generated `Get-FileHash` verifier in PowerShell against all four real downloads: `verified=4`
- passed a deliberately wrong digest for a copied MSI: PowerShell raised `SHA-256 mismatch for downloaded artifact` and deleted the copied file
- final built CLI completed a real AWS Windows desktop lease; OpenSSH service, Git, TightVNC, SSH stability, and VNC readiness passed, then the lease released
- final built CLI completed a real AWS Windows WSL2 lease through its feature/kernel reboot cycle; the versioned rootfs verified/imported, Linux readiness passed, then the lease released

No credentials or private artifacts are included in this PR.
