### PR TITLE
feat(cli): recommend providers by workflow

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -8,13 +8,55 @@ does not contact any cloud, check credentials, or query quota. Use
 ```sh
 crabbox providers
 crabbox providers --json
+crabbox providers recommend ci-proof
+crabbox providers recommend agent-sandbox --json
 ```
 
 ## Flags
 
 - `--json`: emit the matrix as a JSON array instead of grouped text.
 
-The command takes no positional arguments.
+The matrix form takes no positional arguments. Use `providers recommend` for
+workflow-oriented selection guidance.
+
+## `providers recommend`
+
+`crabbox providers recommend` ranks the compiled provider inventory for a
+specific workflow without contacting any provider. It uses each provider's
+declared targets and features plus the checked-in provider category metadata.
+It is selection guidance, not a readiness check; run `crabbox doctor --provider
+<name>` before a live workflow.
+
+```sh
+crabbox providers recommend
+crabbox providers recommend ci-proof
+crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend worker-runtime --json
+```
+
+With no use case, the command lists supported use cases and examples.
+
+Supported use cases:
+
+- `agent-sandbox`: delegated sandboxes and managed devboxes for agent code
+  execution.
+- `byo-ssh`: existing SSH hosts.
+- `ci-proof`: CI proof runners and providers that return run proof or
+  artifacts.
+- `desktop`: providers with desktop/browser/code-server capabilities.
+- `gpu`: GPU-oriented execution providers.
+- `linux-vm`: general Linux VM or SSH-lease execution.
+- `local`: local containers, VMs, or local sandboxes.
+- `macos`: macOS targets.
+- `self-hosted`: private virtualization, external providers, and BYO SSH.
+- `windows`: native Windows and WSL2 targets.
+- `worker-runtime`: Worker/module-runtime execution.
+
+Recommendation flags:
+
+- `--use-case <name>`: pass the use case by flag instead of positionally.
+- `--limit <n>`: maximum recommendations to print. Defaults to `5`.
+- `--json`: emit recommendations as JSON.
 
 ## Output
 
@@ -112,6 +154,30 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
   - `never`: the provider always runs direct from the CLI.
+
+Recommendation JSON returns ranked objects:
+
+```json
+[
+  {
+    "provider": "blacksmith-testbox",
+    "kind": "delegated-run",
+    "category": "ci-proof-runner",
+    "targets": ["linux"],
+    "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
+    "score": 158,
+    "reasons": [
+      "CI proof runner",
+      "returns provider run proof",
+      "can reuse provider run sessions",
+      "can collect provider run artifacts or downloads"
+    ]
+  }
+]
+```
+
+Scores are relative within one use case. They are intentionally heuristic and
+stable enough for selection help, not a benchmark or live availability signal.
 
 ## Related docs
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -180,7 +180,7 @@ Commands:
   media       Create preview artifacts from recorded desktop videos
   artifacts   Collect, transform, and publish QA artifacts
   sync-plan   Show local sync manifest size hotspots
-  providers   Show provider capabilities
+  providers   Show provider capabilities and recommendations
   history     List recorded remote runs
   logs        Print recorded run logs
   events      Print recorded run events

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -26,7 +26,7 @@ type crabboxKongCLI struct {
 	Media      mediaKongCmd      `cmd:"" help:"Create preview artifacts from recorded desktop videos."`
 	Artifacts  artifactsKongCmd  `cmd:"" help:"Collect, transform, and publish QA artifacts."`
 	SyncPlan   syncPlanKongCmd   `cmd:"" name:"sync-plan" passthrough:"" help:"Show local sync manifest size hotspots."`
-	Providers  providersKongCmd  `cmd:"" passthrough:"" help:"Show provider capabilities."`
+	Providers  providersKongCmd  `cmd:"" passthrough:"" help:"Show provider capabilities and recommendations."`
 	History    historyKongCmd    `cmd:"" passthrough:"" help:"List recorded remote runs."`
 	Logs       logsKongCmd       `cmd:"" passthrough:"" help:"Print recorded run logs."`
 	Events     eventsKongCmd     `cmd:"" passthrough:"" help:"Print recorded run events."`

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -18,20 +19,88 @@ type providerMatrixEntry struct {
 	Coordinator string       `json:"coordinator"`
 }
 
+type providerRecommendationEntry struct {
+	Provider string       `json:"provider"`
+	Kind     ProviderKind `json:"kind"`
+	Category string       `json:"category,omitempty"`
+	Targets  []string     `json:"targets"`
+	Features []Feature    `json:"features"`
+	Score    int          `json:"score"`
+	Reasons  []string     `json:"reasons"`
+}
+
 func (a App) providers(_ context.Context, args []string) error {
+	if len(args) > 0 && args[0] == "recommend" {
+		return a.providerRecommendations(args[1:])
+	}
 	fs := newFlagSet("providers", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json]")
+		return exit(2, "usage: crabbox providers [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(entries)
 	}
 	printProviderMatrix(a.Stdout, entries)
+	return nil
+}
+
+func (a App) providerRecommendations(args []string) error {
+	positionalUseCase := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") && !isHelpArg(args[0]) {
+		positionalUseCase = args[0]
+		args = args[1:]
+	}
+	fs := newFlagSet("providers recommend", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	limit := fs.Int("limit", 5, "maximum recommendations to print")
+	useCaseFlag := fs.String("use-case", "", "use case to optimize for")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if *limit <= 0 {
+		return exit(2, "--limit must be greater than 0")
+	}
+	useCase := strings.TrimSpace(*useCaseFlag)
+	if positionalUseCase != "" {
+		if useCase != "" {
+			return exit(2, "pass the use case either positionally or with --use-case, not both")
+		}
+		useCase = strings.TrimSpace(positionalUseCase)
+	}
+	switch fs.NArg() {
+	case 0:
+	case 1:
+		if useCase != "" {
+			return exit(2, "pass the use case either positionally or with --use-case, not both")
+		}
+		useCase = strings.TrimSpace(fs.Arg(0))
+	default:
+		return exit(2, "usage: crabbox providers recommend <use-case> [--limit N] [--json]")
+	}
+	if useCase == "" {
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(providerRecommendationUseCases())
+		}
+		printProviderRecommendationUseCases(a.Stdout)
+		return nil
+	}
+	canonical, ok := normalizeProviderRecommendationUseCase(useCase)
+	if !ok {
+		return exit(2, "unknown provider recommendation use case %q; try one of: %s", useCase, strings.Join(providerRecommendationUseCases(), ", "))
+	}
+	recommendations := recommendProvidersForUseCase(providerMatrix(), canonical, *limit)
+	if len(recommendations) == 0 {
+		return exit(1, "no providers matched use case %q", canonical)
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(recommendations)
+	}
+	printProviderRecommendations(a.Stdout, canonical, recommendations)
 	return nil
 }
 
@@ -51,6 +120,306 @@ func providerMatrix() []providerMatrixEntry {
 		})
 	}
 	return entries
+}
+
+func providerRecommendationUseCases() []string {
+	return []string{
+		"agent-sandbox",
+		"byo-ssh",
+		"ci-proof",
+		"desktop",
+		"gpu",
+		"linux-vm",
+		"local",
+		"macos",
+		"self-hosted",
+		"windows",
+		"worker-runtime",
+	}
+}
+
+func normalizeProviderRecommendationUseCase(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "agent", "agents", "agent-sandbox", "sandbox", "sandboxes", "devbox", "devboxes":
+		return "agent-sandbox", true
+	case "byo", "byo-ssh", "ssh", "static", "static-ssh":
+		return "byo-ssh", true
+	case "ci", "ci-proof", "proof", "testbox", "repro":
+		return "ci-proof", true
+	case "desktop", "browser", "code", "vnc":
+		return "desktop", true
+	case "gpu", "cuda", "ml":
+		return "gpu", true
+	case "linux", "linux-vm", "vm":
+		return "linux-vm", true
+	case "local", "local-vm", "local-runtime", "local-sandbox":
+		return "local", true
+	case "mac", "macos", "darwin":
+		return "macos", true
+	case "self-hosted", "selfhosted", "homelab", "virtualization":
+		return "self-hosted", true
+	case "windows", "win":
+		return "windows", true
+	case "worker", "worker-runtime", "module", "module-run":
+		return "worker-runtime", true
+	default:
+		return "", false
+	}
+}
+
+func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string, limit int) []providerRecommendationEntry {
+	recommendations := make([]providerRecommendationEntry, 0, len(entries))
+	for _, entry := range entries {
+		score, reasons := scoreProviderRecommendation(entry, useCase)
+		if score <= 0 {
+			continue
+		}
+		recommendations = append(recommendations, providerRecommendationEntry{
+			Provider: entry.Provider,
+			Kind:     entry.Kind,
+			Category: benchmarkProviderCategories[entry.Provider],
+			Targets:  append([]string(nil), entry.Targets...),
+			Features: append([]Feature(nil), entry.Features...),
+			Score:    score,
+			Reasons:  reasons,
+		})
+	}
+	sort.SliceStable(recommendations, func(i, j int) bool {
+		if recommendations[i].Score != recommendations[j].Score {
+			return recommendations[i].Score > recommendations[j].Score
+		}
+		return recommendations[i].Provider < recommendations[j].Provider
+	})
+	if len(recommendations) > limit {
+		recommendations = recommendations[:limit]
+	}
+	return recommendations
+}
+
+func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int, []string) {
+	score := 0
+	var reasons []string
+	add := func(points int, reason string) {
+		score += points
+		reasons = append(reasons, reason)
+	}
+	category := benchmarkProviderCategories[entry.Provider]
+	hasTarget := func(target string) bool { return providerRecommendationHasString(entry.Targets, target) }
+	hasFeature := func(feature Feature) bool { return providerRecommendationHasFeature(entry.Features, feature) }
+	switch useCase {
+	case "agent-sandbox":
+		if category == "delegated-sandbox" {
+			add(70, "delegated sandbox provider")
+		}
+		if hasFeature(FeatureArchiveSync) {
+			add(25, "accepts archive sync from the current checkout")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(20, "returns reusable run sessions")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(12, "can expose provider-native URLs")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(12, "supports pause and resume")
+		}
+		if hasFeature(FeatureModuleRun) {
+			add(10, "runs source modules in a worker runtime")
+		}
+		if entry.Kind == ProviderKindSSHLease && hasTarget(targetLinux) && category == "direct-cloud" {
+			add(18, "managed Linux devbox with normal Crabbox SSH workflow")
+		}
+	case "byo-ssh":
+		if category == "byo-ssh" {
+			add(90, "bring-your-own SSH host")
+		}
+		if hasFeature(FeatureSSH) {
+			add(20, "supports Crabbox-managed SSH access")
+		}
+		if hasFeature(FeatureCrabboxSync) {
+			add(15, "uses Crabbox sync and run")
+		}
+		if hasFeature(FeatureDesktop) || hasFeature(FeatureBrowser) || hasFeature(FeatureCode) {
+			add(10, "can expose interactive lease capabilities when the host supports them")
+		}
+	case "ci-proof":
+		if category == "ci-proof-runner" {
+			add(90, "CI proof runner")
+		}
+		if hasFeature(FeatureRunProof) {
+			add(30, "returns provider run proof")
+		}
+		if hasFeature(FeatureRunSession) && (category == "ci-proof-runner" || hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads)) {
+			add(20, "can reuse provider run sessions")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(18, "can collect provider run artifacts or downloads")
+		}
+		if category == "ci-proof-runner" && entry.Kind == ProviderKindSSHLease && hasFeature(FeatureCrabboxSync) {
+			add(12, "can debug through normal Crabbox sync and SSH")
+		}
+	case "desktop":
+		if hasFeature(FeatureDesktop) {
+			add(70, "supports visible desktop leases")
+		}
+		if hasFeature(FeatureBrowser) {
+			add(25, "can provision a browser")
+		}
+		if hasFeature(FeatureCode) {
+			add(20, "can provision code-server")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports Linux desktop/browser flows")
+		}
+		if hasTarget(targetMacOS) || hasTarget(targetWindows+"/"+WindowsModeNormal) {
+			add(8, "supports native desktop OS targets")
+		}
+	case "gpu":
+		if category == "gpu-cloud" {
+			add(90, "GPU-oriented provider")
+		}
+		if hasTarget(targetLinux) {
+			add(10, "supports Linux GPU workloads")
+		}
+		if hasFeature(FeatureSSH) {
+			add(8, "supports SSH debugging")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(8, "supports reusable run sessions")
+		}
+	case "linux-vm":
+		if hasTarget(targetLinux) {
+			add(30, "supports Linux")
+		}
+		if entry.Kind == ProviderKindSSHLease {
+			add(35, "normal SSH lease lifecycle")
+		}
+		if hasFeature(FeatureCrabboxSync) {
+			add(25, "uses Crabbox sync")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(15, "can clean up owned resources")
+		}
+		if category == "brokerable-cloud" {
+			add(20, "can use coordinator spend and cleanup controls")
+		}
+		if category == "direct-cloud" {
+			add(14, "direct cloud lease path")
+		}
+	case "local":
+		if strings.HasPrefix(category, "local-") {
+			add(80, "local execution provider")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(18, "can sync the current checkout")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(12, "cleans up local runtime state")
+		}
+	case "macos":
+		if hasTarget(targetMacOS) {
+			add(80, "supports macOS")
+		}
+		if hasFeature(FeatureSSH) {
+			add(15, "supports SSH access")
+		}
+		if hasFeature(FeatureDesktop) {
+			add(12, "supports desktop access")
+		}
+		if hasFeature(FeatureSnapshot) || hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) {
+			add(10, "supports provider state reuse")
+		}
+	case "self-hosted":
+		if category == "self-hosted-virtualization" {
+			add(80, "self-hosted virtualization provider")
+		}
+		if category == "external-provider" {
+			add(60, "external provider contract for private infrastructure")
+		}
+		if category == "byo-ssh" {
+			add(50, "bring-your-own host")
+		}
+		if hasFeature(FeatureSSH) {
+			add(15, "supports Crabbox-managed SSH")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(10, "can clean up owned resources")
+		}
+	case "windows":
+		if hasTarget(targetWindows + "/" + WindowsModeNormal) {
+			add(80, "supports native Windows")
+		}
+		if hasTarget(targetWindows + "/" + WindowsModeWSL2) {
+			add(45, "supports Windows WSL2")
+		}
+		if hasFeature(FeatureSSH) {
+			add(15, "supports SSH access")
+		}
+		if hasFeature(FeatureArchiveSync) || hasFeature(FeatureCrabboxSync) {
+			add(12, "can sync the current checkout")
+		}
+	case "worker-runtime":
+		if hasTarget(targetWorkerRuntime) {
+			add(90, "runs in a worker runtime")
+		}
+		if hasFeature(FeatureModuleRun) {
+			add(35, "supports module source execution")
+		}
+		if hasFeature(FeatureRunSession) && (hasTarget(targetWorkerRuntime) || hasFeature(FeatureModuleRun)) {
+			add(10, "returns reusable run sessions")
+		}
+	}
+	if entry.Kind == ProviderKindServiceControl && useCase != "desktop" {
+		score -= 40
+		reasons = append(reasons, "service-control provider cannot run arbitrary commands")
+	}
+	if score <= 0 {
+		return 0, nil
+	}
+	return score, reasons
+}
+
+func providerRecommendationHasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func providerRecommendationHasFeature(values []Feature, want Feature) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func printProviderRecommendationUseCases(out io.Writer) {
+	fmt.Fprintln(out, "provider recommendation use cases:")
+	for _, useCase := range providerRecommendationUseCases() {
+		fmt.Fprintf(out, "  %s\n", useCase)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "examples:")
+	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
+	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
+	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+}
+
+func printProviderRecommendations(out io.Writer, useCase string, entries []providerRecommendationEntry) {
+	fmt.Fprintf(out, "recommended providers for %s:\n", useCase)
+	for _, entry := range entries {
+		fmt.Fprintf(out, "%s\n", entry.Provider)
+		fmt.Fprintf(out, "  score: %d\n", entry.Score)
+		fmt.Fprintf(out, "  kind: %s\n", entry.Kind)
+		fmt.Fprintf(out, "  category: %s\n", blank(entry.Category, "-"))
+		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
+		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
+		fmt.Fprintf(out, "  reasons: %s\n", strings.Join(entry.Reasons, "; "))
+	}
 }
 
 func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -183,6 +183,75 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	}
 }
 
+func TestProvidersRecommendListsUseCases(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend"})
+	if err != nil {
+		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "worker-runtime"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestProvidersRecommendCIPrefersProofRunner(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "ci-proof", 3)
+	if len(recommendations) == 0 {
+		t.Fatal("expected ci-proof recommendations")
+	}
+	if recommendations[0].Provider != "blacksmith-testbox" {
+		t.Fatalf("top ci-proof provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	if !providerRecommendationHasFeature(recommendations[0].Features, FeatureRunProof) {
+		t.Fatalf("top ci-proof recommendation missing run-proof feature: %#v", recommendations[0])
+	}
+}
+
+func TestProvidersRecommendWorkerRuntimeFindsModuleProvider(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "worker-runtime", 5)
+	if len(recommendations) == 0 {
+		t.Fatal("expected worker-runtime recommendations")
+	}
+	if !providerRecommendationHasString(recommendations[0].Targets, targetWorkerRuntime) {
+		t.Fatalf("top worker-runtime recommendation lacks worker target: %#v", recommendations[0])
+	}
+	if !providerRecommendationHasFeature(recommendations[0].Features, FeatureModuleRun) {
+		t.Fatalf("top worker-runtime recommendation lacks module-run feature: %#v", recommendations[0])
+	}
+}
+
+func TestProvidersRecommendCommandJSONAndLimit(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "linux-vm", "--limit", "2", "--json"})
+	if err != nil {
+		t.Fatalf("providers recommend --json error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 2 {
+		t.Fatalf("recommendation count=%d want=2 entries=%#v", len(entries), entries)
+	}
+	for _, entry := range entries {
+		if entry.Score <= 0 || len(entry.Reasons) == 0 {
+			t.Fatalf("entry missing score/reasons: %#v", entry)
+		}
+	}
+}
+
+func TestProvidersRecommendRejectsUnknownUseCase(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "moon-base"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("providers recommend unknown error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+}
+
 func containsFeature(values []Feature, want Feature) bool {
 	for _, value := range values {
 		if value == want {


### PR DESCRIPTION
## Summary
- add `crabbox providers recommend` for workflow-oriented provider selection
- rank providers from compiled capability/category metadata without contacting live providers
- document recommendation use cases, flags, and JSON output

## Verification
- `go test ./internal/cli -run 'TestProviders|TestTopLevelAndCommandHelpDescribeInteractiveConnect|TestTopLevelHelpListsRegisteredXCPNgProvider'`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers recommend ci-proof`\n- `bin/crabbox providers recommend --use-case worker-runtime --limit 3`\n- `bin/crabbox providers recommend linux-vm --limit 2 --json`\n- `go test ./internal/cli`\n- `node scripts/check-command-docs.mjs && node scripts/check-provider-matrix.mjs && node scripts/check-docs-links.mjs`\n- `node scripts/build-docs-site.mjs`\n- `go test ./...`\n- `git diff --check`\n\nNo live provider credentials were required or used.