### PR TITLE
docs(providers): document selection strategy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@ Pick whichever matches your intent:
   [Telemetry](features/telemetry.md), [Sync](features/sync.md).
 - **Pick or add a target:** [Provider reference](providers/README.md),
   [Providers feature overview](features/providers.md),
+  [Provider selection](features/provider-selection.md),
   [Provider authoring](features/provider-authoring.md),
   [Provider backends](provider-backends.md),
   [Capacity fallback](features/capacity-fallback.md),

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -186,4 +186,6 @@ stable enough for selection help, not a benchmark or live availability signal.
 - [Provider decision matrix](../providers/README.md#provider-decision-matrix) —
   richer provider selection guidance, including substrate, access, GPU,
   lifecycle, cleanup, best fit, and caveats.
+- [Provider selection](../features/provider-selection.md) — workflow selection
+  rules and adjacent-system guidance.
 - [Provider reference](../providers/README.md) — per-provider setup and config.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -39,6 +39,8 @@ Read when:
 ## Providers
 
 - [Providers](providers.md): provider overview, target matrix, classes, and fallback.
+- [Provider selection](provider-selection.md): choose a provider, compare adjacent
+  systems, and decide when not to add a first-class adapter.
 - [Provider reference](../providers/README.md): per-adapter pages for every registered provider.
 - [Capacity and fallback](capacity-fallback.md): class chains, market spot/on-demand, and region/AZ routing.
 - [Provider backends](../provider-backends.md): contract reference for backend interfaces and registration.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -1,0 +1,112 @@
+# Provider Selection
+
+Read when:
+
+- choosing where a workload should run;
+- comparing a Crabbox provider with an external sandbox or dev-environment tool;
+- deciding whether a new provider belongs in Crabbox.
+
+Crabbox should support provider families, not every interesting runtime by name.
+Prefer the provider that fits the workflow and its evidence requirements. Add a
+new first-class provider only when the runtime exposes a stable lifecycle,
+execution, authentication, cleanup, and proof contract that Crabbox can test
+without special operator knowledge.
+
+## Fast path
+
+Start with the command-backed recommendation list:
+
+```sh
+crabbox providers recommend
+crabbox providers recommend ci-proof
+crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend agent-sandbox --json
+```
+
+The recommendation command uses the built-in provider spec and checked-in
+selection metadata only. It does not contact live providers, inspect quota, or
+prove credentials. Treat it as routing advice, then run:
+
+```sh
+crabbox doctor --provider <name>
+```
+
+before spending real capacity.
+
+## Selection rules
+
+Use these rules before adding a new adapter:
+
+1. If the provider can expose a stable SSH target, prefer an SSH-lease backend.
+   That keeps sync, Actions hydration, VNC, code-server, cache, result parsing,
+   and downloads in core.
+2. If the provider owns filesystem sync and command execution, use a delegated
+   run backend and declare only the features the provider actually supports.
+3. If the provider only starts, stops, or inspects an existing service, use a
+   service-control provider. Do not route arbitrary `crabbox run` there.
+4. If the integration depends on local scripts or a private fleet contract,
+   start with `external` or `ssh` before adding built-in provider code.
+5. If the provider cannot be validated without live credentials, add offline
+   unit tests and docs first; keep live proof as an opt-in smoke.
+
+## Workflow map
+
+| Workflow | Prefer | Why |
+| --- | --- | --- |
+| CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
+| Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
+| Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |
+| Local disposable Linux | `local-container`, `apple-container`, `apple-vz`, `multipass` | Fast local iteration without cloud credentials. |
+| Native desktop/browser/code-server | `aws`, `azure`, `hetzner`, `parallels`, `local-container`, `ssh` | These advertise the interactive lease features. |
+| GPU-oriented run | `runpod`, `nvidia-brev`, cloud VM providers with GPU types, `modal`, `wandb` | Pick SSH leases for normal debugging, delegated runs for provider-owned ML execution. |
+| Worker/module execution | `cloudflare-dynamic-workers` | It advertises the `worker-runtime` target and `module-run` feature. |
+| Self-hosted virtualization | `proxmox`, `xcp-ng`, `incus`, `kubevirt`, `external`, `ssh` | Keeps private infrastructure behind explicit provider boundaries. |
+
+## Related external systems
+
+External projects are useful comparison points, but they should not become
+first-class providers just because they are adjacent.
+
+| System | Crabbox stance |
+| --- | --- |
+| [Mitos](https://github.com/mitos-run/mitos) | Observe, do not support as a first-class provider yet. Its forkable microVM/Kubernetes model is interesting, but Crabbox should first harden generic snapshot, fork, workspace, and delegated-run contracts that any future adapter could use. |
+| [E2B](../providers/e2b.md) | Already supported as delegated run. Use it for hosted sandbox execution where provider-owned templates, filesystem APIs, and session handles are the contract. |
+| [Daytona](../providers/daytona.md) | Already supported as a direct sandbox/devbox provider. Use it when Daytona's sandbox lifecycle is the desired substrate and short-lived SSH is enough. |
+| [Modal](../providers/modal.md) | Already supported as delegated run. Use it for provider-owned container execution, especially Python/GPU-shaped jobs. |
+| [Morph](../providers/morph.md) | Already supported as an SSH lease. Use it when a managed Linux VM with provider-side state reuse fits better than a pure delegated sandbox. |
+| [Kubernetes Agent Sandbox](../providers/agent-sandbox.md) | Already supported as delegated run. Use it for Kubernetes-hosted SandboxClaim workflows. |
+| [Coder](https://github.com/coder/coder) | Do not mirror as a first-class provider unless there is a narrow lifecycle contract. For now, connect through `ssh` or an `external` provider when a Coder workspace exposes a stable host contract. |
+| [DevPod](https://github.com/loft-sh/devpod) | Do not mirror as a first-class provider. It is already a provider-agnostic dev environment layer; use its resulting SSH/container target through `ssh`, `local-container`, or `external` when needed. |
+| [Cloudflare Sandbox SDK](https://developers.cloudflare.com/sandbox/) | Keep separate from the existing Cloudflare providers until the runtime contract maps cleanly to a Crabbox backend. Prefer the current Cloudflare providers for built-in Worker/container flows. |
+
+## Mitos decision
+
+If Crabbox does not support Mitos directly, the user-facing behavior should be:
+
+- no `provider: mitos` option;
+- no Mitos-specific flags in core commands;
+- no Mitos-specific branching in provider-neutral code;
+- a clear note that Mitos is observed but unsupported;
+- reusable capability work for snapshot, fork, durable workspace, MCP, preview
+  URLs, run proof, and delegated artifacts.
+
+That preserves optionality. If Mitos later has real demand and the contract is
+stable enough, it can arrive as either a delegated-run provider or an SSH-lease
+provider without changing the CLI surface again.
+
+## Support threshold
+
+Add a new built-in provider only when the PR can prove:
+
+- the execution model is honestly represented by `ProviderSpec.Kind`;
+- declared targets and features match real behavior;
+- credentials are read from documented env/config locations and never argv;
+- cleanup behavior is explicit for success, failure, and keep/expiry paths;
+- offline tests cover parsing, command rejection, status/list rendering, and
+  provider errors;
+- live smoke is documented and opt-in when credentials are required;
+- the provider docs say what works, what does not, and which workflow it is for.
+
+If that bar is too high for the first version, use `ssh` or `external` and
+document the manual contract instead of baking an unstable provider into
+Crabbox.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -215,6 +215,7 @@ surface stay in `internal/cli`.
 
 Related docs:
 
+- [Provider selection](../features/provider-selection.md)
 - [Provider backends](../provider-backends.md)
 - [Feature overview](../features/providers.md)
 - [Source map](../source-map.md)

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -138,7 +138,7 @@ Provider docs:
 
 - Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
 - Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, and `docs/providers/superserve.md` for delegated Superserve execution and live proof
-- Provider/backend authoring guide: `docs/provider-backends.md`, `docs/features/provider-authoring.md`
+- Provider selection and backend authoring guide: `docs/features/provider-selection.md`, `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`
 
 ## Capabilities, Desktop, And Access Bridges


### PR DESCRIPTION
## Summary
- add a provider selection guide for choosing workflows and deciding when not to add first-class adapters
- document the no-first-class-Mitos stance while preserving a future adapter path
- link the guide from provider docs, command docs, feature index, and source map

## Verification
- `node scripts/check-docs-links.mjs`
- `node scripts/build-docs-site.mjs`
- `node scripts/check-command-docs.mjs`
- `git diff --check`

No live provider credentials were required or used.