### PR TITLE
feat(cli): expose workspace provider capabilities

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -10,6 +10,7 @@ crabbox providers
 crabbox providers --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
+crabbox providers recommend versioned-workspace
 ```
 
 ## Flags
@@ -31,6 +32,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend versioned-workspace
 crabbox providers recommend worker-runtime --json
 ```
 
@@ -49,6 +51,8 @@ Supported use cases:
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.
+- `versioned-workspace`: providers with native checkpoint, fork, restore, or
+  snapshot-reference capabilities.
 - `windows`: native Windows and WSL2 targets.
 - `worker-runtime`: Worker/module-runtime execution.
 
@@ -69,6 +73,14 @@ aws
   targets: linux,windows/normal,windows/wsl2,macos
   features: ssh,crabbox-sync,cleanup,desktop,browser,code
   coordinator: supported
+
+parallels
+  family: parallels
+  kind: ssh-lease
+  targets: linux,macos,windows/normal,windows/wsl2
+  features: ssh,crabbox-sync,cleanup,desktop,browser,code,workspace-checkpoint,workspace-fork,workspace-restore,provider-snapshot
+  workspace: checkpoint,fork,restore,snapshot-ref
+  coordinator: never
 
 wandb
   family: wandb
@@ -114,12 +126,13 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "coordinator": "never"
   },
   {
-    "provider": "aws",
-    "family": "aws",
+    "provider": "parallels",
+    "family": "parallels",
     "kind": "ssh-lease",
-    "targets": ["linux", "windows/normal", "windows/wsl2", "macos"],
-    "features": ["ssh", "crabbox-sync", "cleanup", "desktop", "browser", "code"],
-    "coordinator": "supported"
+    "targets": ["linux", "macos", "windows/normal", "windows/wsl2"],
+    "features": ["ssh", "crabbox-sync", "cleanup", "desktop", "browser", "code", "workspace-checkpoint", "workspace-fork", "workspace-restore", "provider-snapshot"],
+    "workspace": ["checkpoint", "fork", "restore", "snapshot-ref"],
+    "coordinator": "never"
   }
 ]
 ```
@@ -150,6 +163,10 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
   `module-run`. `module-run` means delegated `crabbox run --script` or
   `--script-stdin` source-module execution; it does not imply POSIX command
   argv, archive sync, ports, or SSH access.
+- `workspace`: normalized versioned-workspace capabilities derived from feature
+  flags. Possible values are `checkpoint`, `fork`, `restore`, and
+  `snapshot-ref`. The field is omitted when a provider does not advertise any
+  native workspace capabilities.
 - `coordinator`: whether the provider can route leases through the broker.
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -206,6 +206,14 @@ repo metadata, logs, and artifacts. Set the checkpoint-related flags only when
 you can preserve or recreate state the generic ledger cannot, such as sandbox
 filesystem state, VM snapshot IDs, or copy-on-write forks.
 
+The provider matrix normalizes those flags into a `workspace` capability array:
+`checkpoint`, `fork`, `restore`, and `snapshot-ref`. New providers should make
+that normalized contract true instead of adding provider-specific command
+branches. For example, a future forkable microVM runtime should declare the same
+capabilities as any other provider that can checkpoint and fork workspace state;
+its Firecracker, Kubernetes, or image identifiers belong inside the adapter and
+checkpoint metadata.
+
 ## Step 5. Own Provider-Specific Flags
 
 Go's `flag` package rejects unknown flags, so provider flags must be registered

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -60,6 +60,7 @@ Use these rules before adding a new adapter:
 | Native desktop/browser/code-server | `aws`, `azure`, `hetzner`, `parallels`, `local-container`, `ssh` | These advertise the interactive lease features. |
 | GPU-oriented run | `runpod`, `nvidia-brev`, cloud VM providers with GPU types, `modal`, `wandb` | Pick SSH leases for normal debugging, delegated runs for provider-owned ML execution. |
 | Worker/module execution | `cloudflare-dynamic-workers` | It advertises the `worker-runtime` target and `module-run` feature. |
+| Versioned workspace reuse | `parallels`, `local-container` | They advertise normalized checkpoint/fork/restore/snapshot-reference capabilities in `crabbox providers` and `providers recommend versioned-workspace`. |
 | Self-hosted virtualization | `proxmox`, `xcp-ng`, `incus`, `kubevirt`, `external`, `ssh` | Keeps private infrastructure behind explicit provider boundaries. |
 
 ## Related external systems
@@ -88,7 +89,8 @@ If Crabbox does not support Mitos directly, the user-facing behavior should be:
 - no Mitos-specific branching in provider-neutral code;
 - a clear note that Mitos is observed but unsupported;
 - reusable capability work for snapshot, fork, durable workspace, MCP, preview
-  URLs, run proof, and delegated artifacts.
+  URLs, run proof, and delegated artifacts. `crabbox providers --json` exposes
+  normalized workspace capability names so this stays provider-neutral.
 
 That preserves optionality. If Mitos later has real demand and the contract is
 stable enough, it can arrive as either a delegated-run provider or an SSH-lease

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -445,6 +445,20 @@ Do not set the checkpoint flags for plain SSH access alone. Generic
 Git/archive/log checkpoints are core-owned and work even when a provider
 advertises no native checkpoint features.
 
+`crabbox providers --json` also exposes a normalized `workspace` array derived
+from these feature flags:
+
+| Feature | Workspace capability |
+| --- | --- |
+| `FeatureCheckpoint` | `checkpoint` |
+| `FeatureFork` | `fork` |
+| `FeatureRestore` | `restore` |
+| `FeatureSnapshot` | `snapshot-ref` |
+
+Use that normalized field for workflow selection and external comparisons. Keep
+provider-specific snapshot names, CRDs, image IDs, and fork engines behind the
+provider adapter.
+
 ## Flags and config
 
 Provider flags are registered before parsing because Go's `flag` package rejects

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -16,17 +16,19 @@ type providerMatrixEntry struct {
 	Kind        ProviderKind `json:"kind"`
 	Targets     []string     `json:"targets"`
 	Features    []Feature    `json:"features"`
+	Workspace   []string     `json:"workspace,omitempty"`
 	Coordinator string       `json:"coordinator"`
 }
 
 type providerRecommendationEntry struct {
-	Provider string       `json:"provider"`
-	Kind     ProviderKind `json:"kind"`
-	Category string       `json:"category,omitempty"`
-	Targets  []string     `json:"targets"`
-	Features []Feature    `json:"features"`
-	Score    int          `json:"score"`
-	Reasons  []string     `json:"reasons"`
+	Provider  string       `json:"provider"`
+	Kind      ProviderKind `json:"kind"`
+	Category  string       `json:"category,omitempty"`
+	Targets   []string     `json:"targets"`
+	Features  []Feature    `json:"features"`
+	Workspace []string     `json:"workspace,omitempty"`
+	Score     int          `json:"score"`
+	Reasons   []string     `json:"reasons"`
 }
 
 func (a App) providers(_ context.Context, args []string) error {
@@ -116,6 +118,7 @@ func providerMatrix() []providerMatrixEntry {
 			Kind:        spec.Kind,
 			Targets:     formatProviderTargets(spec.Targets),
 			Features:    append(FeatureSet{}, spec.Features...),
+			Workspace:   workspaceCapabilitiesForFeatures(spec.Features),
 			Coordinator: string(spec.Coordinator),
 		})
 	}
@@ -133,6 +136,7 @@ func providerRecommendationUseCases() []string {
 		"local",
 		"macos",
 		"self-hosted",
+		"versioned-workspace",
 		"windows",
 		"worker-runtime",
 	}
@@ -158,6 +162,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "macos", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
 		return "self-hosted", true
+	case "versioned-workspace", "workspace", "workspaces", "checkpoint", "checkpoints", "snapshot", "snapshots", "fork", "forks":
+		return "versioned-workspace", true
 	case "windows", "win":
 		return "windows", true
 	case "worker", "worker-runtime", "module", "module-run":
@@ -175,13 +181,14 @@ func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string,
 			continue
 		}
 		recommendations = append(recommendations, providerRecommendationEntry{
-			Provider: entry.Provider,
-			Kind:     entry.Kind,
-			Category: benchmarkProviderCategories[entry.Provider],
-			Targets:  append([]string(nil), entry.Targets...),
-			Features: append([]Feature(nil), entry.Features...),
-			Score:    score,
-			Reasons:  reasons,
+			Provider:  entry.Provider,
+			Kind:      entry.Kind,
+			Category:  benchmarkProviderCategories[entry.Provider],
+			Targets:   append([]string(nil), entry.Targets...),
+			Features:  append([]Feature(nil), entry.Features...),
+			Workspace: append([]string(nil), entry.Workspace...),
+			Score:     score,
+			Reasons:   reasons,
 		})
 	}
 	sort.SliceStable(recommendations, func(i, j int) bool {
@@ -345,6 +352,29 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureCleanup) {
 			add(10, "can clean up owned resources")
 		}
+	case "versioned-workspace":
+		hasWorkspaceCapability := hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) || hasFeature(FeatureRestore) || hasFeature(FeatureSnapshot)
+		if !hasWorkspaceCapability {
+			break
+		}
+		if hasFeature(FeatureCheckpoint) {
+			add(45, "can create provider-aware checkpoints")
+		}
+		if hasFeature(FeatureFork) {
+			add(45, "can fork a new workspace from checkpoint state")
+		}
+		if hasFeature(FeatureRestore) {
+			add(30, "can restore an existing workspace to checkpoint state")
+		}
+		if hasFeature(FeatureSnapshot) {
+			add(20, "exposes provider-native snapshot identifiers")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(10, "can seed checkpointable state from the current checkout")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(8, "can clean up provider-owned workspace resources")
+		}
 	case "windows":
 		if hasTarget(targetWindows + "/" + WindowsModeNormal) {
 			add(80, "supports native Windows")
@@ -407,6 +437,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 }
 
 func printProviderRecommendations(out io.Writer, useCase string, entries []providerRecommendationEntry) {
@@ -418,6 +449,9 @@ func printProviderRecommendations(out io.Writer, useCase string, entries []provi
 		fmt.Fprintf(out, "  category: %s\n", blank(entry.Category, "-"))
 		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
+		if len(entry.Workspace) > 0 {
+			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
+		}
 		fmt.Fprintf(out, "  reasons: %s\n", strings.Join(entry.Reasons, "; "))
 	}
 }
@@ -429,6 +463,9 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  kind: %s\n", entry.Kind)
 		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
+		if len(entry.Workspace) > 0 {
+			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
+		}
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
 			fmt.Fprintf(out, "  aliases: %s\n", strings.Join(entry.Aliases, ","))
@@ -448,6 +485,20 @@ func formatProviderTargets(targets []TargetSpec) []string {
 		}
 		out = append(out, value)
 	}
+	return out
+}
+
+func workspaceCapabilitiesForFeatures(features []Feature) []string {
+	var out []string
+	add := func(feature Feature, capability string) {
+		if FeatureSet(features).Has(feature) {
+			out = append(out, capability)
+		}
+	}
+	add(FeatureCheckpoint, "checkpoint")
+	add(FeatureFork, "fork")
+	add(FeatureRestore, "restore")
+	add(FeatureSnapshot, "snapshot-ref")
 	return out
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -17,6 +17,8 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	var linode *providerMatrixEntry
 	var nebius *providerMatrixEntry
 	var scaleway *providerMatrixEntry
+	var localContainer *providerMatrixEntry
+	var parallels *providerMatrixEntry
 	var moduleRuntime *providerMatrixEntry
 	for i := range entries {
 		if entries[i].Provider == "aws" {
@@ -39,6 +41,12 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		}
 		if entries[i].Provider == "scaleway" {
 			scaleway = &entries[i]
+		}
+		if entries[i].Provider == "local-container" {
+			localContainer = &entries[i]
+		}
+		if entries[i].Provider == "parallels" {
+			parallels = &entries[i]
 		}
 		if entries[i].Provider == "module-runtime-test" {
 			moduleRuntime = &entries[i]
@@ -64,6 +72,12 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if scaleway == nil {
 		t.Fatal("scaleway provider not found")
+	}
+	if localContainer == nil {
+		t.Fatal("local-container provider not found")
+	}
+	if parallels == nil {
+		t.Fatal("parallels provider not found")
 	}
 	if aws.Kind != ProviderKindSSHLease {
 		t.Fatalf("aws kind=%q", aws.Kind)
@@ -141,6 +155,14 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if !containsString(nvidiaBrev.Aliases, "brev") || !containsString(nvidiaBrev.Aliases, "nvidia") {
 		t.Fatalf("nvidia-brev aliases=%v", nvidiaBrev.Aliases)
 	}
+	if !containsString(localContainer.Workspace, "checkpoint") || !containsString(localContainer.Workspace, "fork") {
+		t.Fatalf("local-container workspace=%v", localContainer.Workspace)
+	}
+	for _, capability := range []string{"checkpoint", "fork", "restore", "snapshot-ref"} {
+		if !containsString(parallels.Workspace, capability) {
+			t.Fatalf("parallels workspace=%v missing %s", parallels.Workspace, capability)
+		}
+	}
 }
 
 func TestProvidersCommandJSON(t *testing.T) {
@@ -159,6 +181,9 @@ func TestProvidersCommandJSON(t *testing.T) {
 	for _, entry := range entries {
 		if entry.Features == nil {
 			t.Fatalf("provider %s encoded nil features", entry.Provider)
+		}
+		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
+			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
 		}
 	}
 }
@@ -181,6 +206,9 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	if !strings.Contains(text, "incus\n") {
 		t.Fatalf("providers output missing incus:\n%s", text)
 	}
+	if !strings.Contains(text, "parallels\n") || !strings.Contains(text, "  workspace: checkpoint,fork,restore,snapshot-ref\n") {
+		t.Fatalf("providers output missing workspace contract:\n%s", text)
+	}
 }
 
 func TestProvidersRecommendListsUseCases(t *testing.T) {
@@ -190,9 +218,29 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestProvidersRecommendVersionedWorkspace(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "versioned-workspace", 3)
+	if len(recommendations) == 0 {
+		t.Fatal("expected versioned-workspace recommendations")
+	}
+	if recommendations[0].Provider != "parallels" {
+		t.Fatalf("top versioned-workspace provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	for _, capability := range []string{"checkpoint", "fork", "restore", "snapshot-ref"} {
+		if !containsString(recommendations[0].Workspace, capability) {
+			t.Fatalf("top recommendation workspace=%v missing %s", recommendations[0].Workspace, capability)
+		}
+	}
+	for _, recommendation := range recommendations {
+		if len(recommendation.Workspace) == 0 {
+			t.Fatalf("versioned-workspace recommendation lacks workspace capabilities: %#v", recommendation)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add normalized workspace capabilities to `crabbox providers --json` and human output
- add `providers recommend versioned-workspace` for checkpoint/fork/snapshot-oriented provider selection
- document the provider-neutral workspace contract so future forkable runtimes do not need bespoke core branching

## Verification
- `go test ./internal/cli -run 'TestProviders|TestTopLevelAndCommandHelpDescribeInteractiveConnect|TestTopLevelHelpListsRegisteredXCPNgProvider'`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers recommend versioned-workspace`\n- `bin/crabbox providers recommend checkpoint --limit 5 --json`\n- `bin/crabbox providers --json` workspace smoke for `parallels`\n- `node scripts/check-command-docs.mjs && node scripts/check-provider-matrix.mjs && node scripts/check-docs-links.mjs`\n- `node scripts/build-docs-site.mjs`\n- `go test ./internal/cli`\n- `go test ./...`\n- `git diff --check`\n\nNo live provider credentials were required or used.