### PR TITLE
feat(cli): expose run evidence capabilities

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -10,6 +10,7 @@ crabbox providers
 crabbox providers --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
+crabbox providers recommend run-evidence
 crabbox providers recommend versioned-workspace
 ```
 
@@ -32,6 +33,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend run-evidence
 crabbox providers recommend versioned-workspace
 crabbox providers recommend worker-runtime --json
 ```
@@ -50,6 +52,8 @@ Supported use cases:
 - `linux-vm`: general Linux VM or SSH-lease execution.
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.
+- `run-evidence`: providers that can return run proof, collect artifacts,
+  materialize downloads, or expose preview URLs.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.
 - `versioned-workspace`: providers with native checkpoint, fork, restore, or
   snapshot-reference capabilities.
@@ -80,6 +84,23 @@ parallels
   targets: linux,macos,windows/normal,windows/wsl2
   features: ssh,crabbox-sync,cleanup,desktop,browser,code,workspace-checkpoint,workspace-fork,workspace-restore,provider-snapshot
   workspace: checkpoint,fork,restore,snapshot-ref
+  coordinator: never
+
+blacksmith-testbox
+  family: blacksmith
+  kind: delegated-run
+  targets: linux
+  features: cache-volume,run-proof,run-session,run-artifacts
+  evidence: proof,artifacts,session
+  coordinator: never
+  aliases: blacksmith
+
+e2b
+  family: e2b
+  kind: delegated-run
+  targets: linux
+  features: url-bridge,run-session
+  evidence: preview-url,session
   coordinator: never
 
 wandb
@@ -126,12 +147,13 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "coordinator": "never"
   },
   {
-    "provider": "parallels",
-    "family": "parallels",
-    "kind": "ssh-lease",
-    "targets": ["linux", "macos", "windows/normal", "windows/wsl2"],
-    "features": ["ssh", "crabbox-sync", "cleanup", "desktop", "browser", "code", "workspace-checkpoint", "workspace-fork", "workspace-restore", "provider-snapshot"],
-    "workspace": ["checkpoint", "fork", "restore", "snapshot-ref"],
+    "provider": "blacksmith-testbox",
+    "family": "blacksmith",
+    "kind": "delegated-run",
+    "aliases": ["blacksmith"],
+    "targets": ["linux"],
+    "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
+    "evidence": ["proof", "artifacts", "session"],
     "coordinator": "never"
   }
 ]
@@ -167,6 +189,10 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
   flags. Possible values are `checkpoint`, `fork`, `restore`, and
   `snapshot-ref`. The field is omitted when a provider does not advertise any
   native workspace capabilities.
+- `evidence`: normalized run-evidence and preview capabilities derived from
+  feature flags. Possible values are `proof`, `artifacts`, `downloads`,
+  `preview-url`, and `session`. The field is omitted when a provider does not
+  advertise any run evidence or preview capabilities.
 - `coordinator`: whether the provider can route leases through the broker.
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
@@ -182,6 +208,7 @@ Recommendation JSON returns ranked objects:
     "category": "ci-proof-runner",
     "targets": ["linux"],
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
+    "evidence": ["proof", "artifacts", "session"],
     "score": 158,
     "reasons": [
       "CI proof runner",

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -214,6 +214,13 @@ capabilities as any other provider that can checkpoint and fork workspace state;
 its Firecracker, Kubernetes, or image identifiers belong inside the adapter and
 checkpoint metadata.
 
+Run evidence follows the same rule. Declare `FeatureRunProof`,
+`FeatureRunArtifacts`, `FeatureRunDownloads`, `FeatureURLBridge`, and
+`FeatureRunSession` only when the provider really exposes those contracts.
+`crabbox providers --json` normalizes them as `proof`, `artifacts`,
+`downloads`, `preview-url`, and `session`, and
+`crabbox providers recommend run-evidence` ignores session-only providers.
+
 ## Step 5. Own Provider-Specific Flags
 
 Go's `flag` package rejects unknown flags, so provider flags must be registered

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -54,6 +54,7 @@ Use these rules before adding a new adapter:
 | Workflow | Prefer | Why |
 | --- | --- | --- |
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
+| Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
 | Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |
 | Local disposable Linux | `local-container`, `apple-container`, `apple-vz`, `multipass` | Fast local iteration without cloud credentials. |
@@ -90,7 +91,8 @@ If Crabbox does not support Mitos directly, the user-facing behavior should be:
 - a clear note that Mitos is observed but unsupported;
 - reusable capability work for snapshot, fork, durable workspace, MCP, preview
   URLs, run proof, and delegated artifacts. `crabbox providers --json` exposes
-  normalized workspace capability names so this stays provider-neutral.
+  normalized workspace and run-evidence capability names so this stays
+  provider-neutral.
 
 That preserves optionality. If Mitos later has real demand and the contract is
 stable enough, it can arrive as either a delegated-run provider or an SSH-lease

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -459,6 +459,21 @@ Use that normalized field for workflow selection and external comparisons. Keep
 provider-specific snapshot names, CRDs, image IDs, and fork engines behind the
 provider adapter.
 
+The same provider matrix exposes normalized run-evidence capabilities:
+
+| Feature | Evidence capability |
+| --- | --- |
+| `FeatureRunProof` | `proof` |
+| `FeatureRunArtifacts` | `artifacts` |
+| `FeatureRunDownloads` | `downloads` |
+| `FeatureURLBridge` | `preview-url` |
+| `FeatureRunSession` | `session` |
+
+`providers recommend run-evidence` requires at least one proof, artifact,
+download, or preview-url capability. A bare session handle is useful metadata,
+but it is not enough by itself to claim the provider returns user-facing
+evidence.
+
 ## Flags and config
 
 Provider flags are registered before parsing because Go's `flag` package rejects

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -17,6 +17,7 @@ type providerMatrixEntry struct {
 	Targets     []string     `json:"targets"`
 	Features    []Feature    `json:"features"`
 	Workspace   []string     `json:"workspace,omitempty"`
+	Evidence    []string     `json:"evidence,omitempty"`
 	Coordinator string       `json:"coordinator"`
 }
 
@@ -27,6 +28,7 @@ type providerRecommendationEntry struct {
 	Targets   []string     `json:"targets"`
 	Features  []Feature    `json:"features"`
 	Workspace []string     `json:"workspace,omitempty"`
+	Evidence  []string     `json:"evidence,omitempty"`
 	Score     int          `json:"score"`
 	Reasons   []string     `json:"reasons"`
 }
@@ -119,6 +121,7 @@ func providerMatrix() []providerMatrixEntry {
 			Targets:     formatProviderTargets(spec.Targets),
 			Features:    append(FeatureSet{}, spec.Features...),
 			Workspace:   workspaceCapabilitiesForFeatures(spec.Features),
+			Evidence:    evidenceCapabilitiesForFeatures(spec.Features),
 			Coordinator: string(spec.Coordinator),
 		})
 	}
@@ -135,6 +138,7 @@ func providerRecommendationUseCases() []string {
 		"linux-vm",
 		"local",
 		"macos",
+		"run-evidence",
 		"self-hosted",
 		"versioned-workspace",
 		"windows",
@@ -160,6 +164,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "local", true
 	case "mac", "macos", "darwin":
 		return "macos", true
+	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download", "preview", "preview-url", "url-bridge":
+		return "run-evidence", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
 		return "self-hosted", true
 	case "versioned-workspace", "workspace", "workspaces", "checkpoint", "checkpoints", "snapshot", "snapshots", "fork", "forks":
@@ -187,6 +193,7 @@ func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string,
 			Targets:   append([]string(nil), entry.Targets...),
 			Features:  append([]Feature(nil), entry.Features...),
 			Workspace: append([]string(nil), entry.Workspace...),
+			Evidence:  append([]string(nil), entry.Evidence...),
 			Score:     score,
 			Reasons:   reasons,
 		})
@@ -336,6 +343,26 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureSnapshot) || hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) {
 			add(10, "supports provider state reuse")
 		}
+	case "run-evidence":
+		hasEvidenceCapability := hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) || hasFeature(FeatureURLBridge)
+		if !hasEvidenceCapability {
+			break
+		}
+		if hasFeature(FeatureRunProof) {
+			add(45, "returns provider run proof")
+		}
+		if hasFeature(FeatureRunArtifacts) {
+			add(35, "can collect provider run artifacts")
+		}
+		if hasFeature(FeatureRunDownloads) {
+			add(30, "can materialize provider run downloads")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(25, "can expose provider-native preview URLs")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(15, "returns reusable run sessions for later inspection")
+		}
 	case "self-hosted":
 		if category == "self-hosted-virtualization" {
 			add(80, "self-hosted virtualization provider")
@@ -437,6 +464,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 }
 
@@ -452,6 +480,9 @@ func printProviderRecommendations(out io.Writer, useCase string, entries []provi
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
 		}
+		if len(entry.Evidence) > 0 {
+			fmt.Fprintf(out, "  evidence: %s\n", commaOrDash(entry.Evidence))
+		}
 		fmt.Fprintf(out, "  reasons: %s\n", strings.Join(entry.Reasons, "; "))
 	}
 }
@@ -465,6 +496,9 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
+		}
+		if len(entry.Evidence) > 0 {
+			fmt.Fprintf(out, "  evidence: %s\n", commaOrDash(entry.Evidence))
 		}
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
@@ -499,6 +533,21 @@ func workspaceCapabilitiesForFeatures(features []Feature) []string {
 	add(FeatureFork, "fork")
 	add(FeatureRestore, "restore")
 	add(FeatureSnapshot, "snapshot-ref")
+	return out
+}
+
+func evidenceCapabilitiesForFeatures(features []Feature) []string {
+	var out []string
+	add := func(feature Feature, capability string) {
+		if FeatureSet(features).Has(feature) {
+			out = append(out, capability)
+		}
+	}
+	add(FeatureRunProof, "proof")
+	add(FeatureRunArtifacts, "artifacts")
+	add(FeatureRunDownloads, "downloads")
+	add(FeatureURLBridge, "preview-url")
+	add(FeatureRunSession, "session")
 	return out
 }
 

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -965,7 +965,7 @@ func (testBlacksmithProvider) Spec() ProviderSpec {
 		Name:        "blacksmith-testbox",
 		Kind:        ProviderKindDelegatedRun,
 		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureCacheVolume, FeatureRunProof, FeatureRunSession},
+		Features:    FeatureSet{FeatureCacheVolume, FeatureRunProof, FeatureRunSession, FeatureRunArtifacts},
 		Coordinator: CoordinatorNever,
 	}
 }

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -17,6 +17,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	var linode *providerMatrixEntry
 	var nebius *providerMatrixEntry
 	var scaleway *providerMatrixEntry
+	var blacksmith *providerMatrixEntry
+	var e2b *providerMatrixEntry
+	var islo *providerMatrixEntry
 	var localContainer *providerMatrixEntry
 	var parallels *providerMatrixEntry
 	var moduleRuntime *providerMatrixEntry
@@ -41,6 +44,15 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		}
 		if entries[i].Provider == "scaleway" {
 			scaleway = &entries[i]
+		}
+		if entries[i].Provider == "blacksmith-testbox" {
+			blacksmith = &entries[i]
+		}
+		if entries[i].Provider == "e2b" {
+			e2b = &entries[i]
+		}
+		if entries[i].Provider == "islo" {
+			islo = &entries[i]
 		}
 		if entries[i].Provider == "local-container" {
 			localContainer = &entries[i]
@@ -72,6 +84,15 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if scaleway == nil {
 		t.Fatal("scaleway provider not found")
+	}
+	if blacksmith == nil {
+		t.Fatal("blacksmith-testbox provider not found")
+	}
+	if e2b == nil {
+		t.Fatal("e2b provider not found")
+	}
+	if islo == nil {
+		t.Fatal("islo provider not found")
 	}
 	if localContainer == nil {
 		t.Fatal("local-container provider not found")
@@ -163,6 +184,21 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 			t.Fatalf("parallels workspace=%v missing %s", parallels.Workspace, capability)
 		}
 	}
+	for _, capability := range []string{"proof", "artifacts", "session"} {
+		if !containsString(blacksmith.Evidence, capability) {
+			t.Fatalf("blacksmith evidence=%v missing %s", blacksmith.Evidence, capability)
+		}
+	}
+	for _, capability := range []string{"preview-url", "session"} {
+		if !containsString(e2b.Evidence, capability) {
+			t.Fatalf("e2b evidence=%v missing %s", e2b.Evidence, capability)
+		}
+	}
+	for _, capability := range []string{"downloads", "preview-url", "session"} {
+		if !containsString(islo.Evidence, capability) {
+			t.Fatalf("islo evidence=%v missing %s", islo.Evidence, capability)
+		}
+	}
 }
 
 func TestProvidersCommandJSON(t *testing.T) {
@@ -184,6 +220,9 @@ func TestProvidersCommandJSON(t *testing.T) {
 		}
 		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
 			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
+		}
+		if entry.Provider == "blacksmith-testbox" && !containsString(entry.Evidence, "proof") {
+			t.Fatalf("blacksmith json missing evidence proof: %#v", entry)
 		}
 	}
 }
@@ -209,6 +248,9 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	if !strings.Contains(text, "parallels\n") || !strings.Contains(text, "  workspace: checkpoint,fork,restore,snapshot-ref\n") {
 		t.Fatalf("providers output missing workspace contract:\n%s", text)
 	}
+	if !strings.Contains(text, "blacksmith-testbox\n") || !strings.Contains(text, "  evidence: proof,artifacts,session\n") {
+		t.Fatalf("providers output missing evidence contract:\n%s", text)
+	}
 }
 
 func TestProvidersRecommendListsUseCases(t *testing.T) {
@@ -218,9 +260,32 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "run-evidence", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestProvidersRecommendRunEvidence(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "run-evidence", 5)
+	if len(recommendations) == 0 {
+		t.Fatal("expected run-evidence recommendations")
+	}
+	if recommendations[0].Provider != "blacksmith-testbox" {
+		t.Fatalf("top run-evidence provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	for _, capability := range []string{"proof", "artifacts", "session"} {
+		if !containsString(recommendations[0].Evidence, capability) {
+			t.Fatalf("top recommendation evidence=%v missing %s", recommendations[0].Evidence, capability)
+		}
+	}
+	for _, recommendation := range recommendations {
+		if len(recommendation.Evidence) == 0 {
+			t.Fatalf("run-evidence recommendation lacks evidence capabilities: %#v", recommendation)
+		}
+		if recommendation.Provider == "wandb" {
+			t.Fatalf("run-evidence should not recommend session-only providers: %#v", recommendation)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add normalized `evidence` capabilities to `crabbox providers --json` and human output
- add `providers recommend run-evidence` for proof/artifact/download/preview-oriented provider selection
- document the provider-neutral evidence contract and keep session-only providers out of the evidence recommender

## Verification
- `go test ./internal/cli -run 'TestProviders|TestTopLevelAndCommandHelpDescribeInteractiveConnect|TestTopLevelHelpListsRegisteredXCPNgProvider'`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers recommend run-evidence`\n- `bin/crabbox providers recommend preview --limit 5 --json`\n- `bin/crabbox providers --json` evidence smoke for `blacksmith-testbox` and `e2b`\n- `node scripts/check-command-docs.mjs && node scripts/check-provider-matrix.mjs && node scripts/check-docs-links.mjs`\n- `node scripts/build-docs-site.mjs`\n- `go test ./internal/cli`\n- `go test ./internal/applevzhelper -run TestRunStartReportsHelperExitWithoutWaitingForReadinessTimeout -count=1 -v` after one full-suite timing failure in that unrelated test\n- `go test ./...` clean on rerun\n- `git diff --check`\n\nNo live provider credentials were required or used.