### PR TITLE
feat(cli): filter provider capabilities

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -8,6 +8,8 @@ does not contact any cloud, check credentials, or query quota. Use
 ```sh
 crabbox providers
 crabbox providers --json
+crabbox providers --kind delegated-run --evidence preview-url
+crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
@@ -17,9 +19,27 @@ crabbox providers recommend versioned-workspace
 ## Flags
 
 - `--json`: emit the matrix as a JSON array instead of grouped text.
+- `--kind <kind>`: keep providers with this driver kind. Repeatable. Current
+  values include `ssh-lease`, `delegated-run`, and `service-control`.
+- `--target <target>`: keep providers that advertise this target, such as
+  `linux`, `macos`, `windows/normal`, `windows/wsl2`, or `worker-runtime`.
+  Repeatable.
+- `--feature <feature>`: keep providers that advertise this raw feature flag,
+  such as `ssh`, `crabbox-sync`, `run-proof`, or `url-bridge`. Repeatable.
+- `--workspace <capability>`: keep providers that advertise this normalized
+  workspace capability, such as `checkpoint`, `fork`, `restore`, or
+  `snapshot-ref`. Repeatable.
+- `--evidence <capability>`: keep providers that advertise this normalized
+  evidence capability, such as `proof`, `artifacts`, `downloads`,
+  `preview-url`, or `session`. Repeatable.
+
+Repeated filters are combined with AND semantics. Comma-separated values are also
+accepted, so `--workspace checkpoint,fork` means the same thing as passing
+`--workspace checkpoint --workspace fork`. Filter values are checked against the
+compiled provider matrix; unknown values fail before printing partial output.
 
 The matrix form takes no positional arguments. Use `providers recommend` for
-workflow-oriented selection guidance.
+workflow-oriented ranked selection guidance.
 
 ## `providers recommend`
 

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -33,19 +33,44 @@ type providerRecommendationEntry struct {
 	Reasons   []string     `json:"reasons"`
 }
 
+type providerMatrixFilters struct {
+	Kinds      []string
+	Targets    []string
+	Features   []string
+	Workspaces []string
+	Evidence   []string
+}
+
 func (a App) providers(_ context.Context, args []string) error {
 	if len(args) > 0 && args[0] == "recommend" {
 		return a.providerRecommendations(args[1:])
 	}
 	fs := newFlagSet("providers", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
+	var kindFilters, targetFilters, featureFilters, workspaceFilters, evidenceFilters stringListFlag
+	fs.Var(&kindFilters, "kind", "filter by provider kind; repeatable")
+	fs.Var(&targetFilters, "target", "filter by target such as linux or worker-runtime; repeatable")
+	fs.Var(&featureFilters, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
+	fs.Var(&workspaceFilters, "workspace", "filter by normalized workspace capability; repeatable")
+	fs.Var(&evidenceFilters, "evidence", "filter by normalized evidence capability; repeatable")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
+	filters := providerMatrixFilters{
+		Kinds:      providerFilterValues(kindFilters),
+		Targets:    providerFilterValues(targetFilters),
+		Features:   providerFilterValues(featureFilters),
+		Workspaces: providerFilterValues(workspaceFilters),
+		Evidence:   providerFilterValues(evidenceFilters),
+	}
+	if err := validateProviderMatrixFilters(filters, entries); err != nil {
+		return err
+	}
+	entries = filterProviderMatrix(entries, filters)
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(entries)
 	}
@@ -126,6 +151,117 @@ func providerMatrix() []providerMatrixEntry {
 		})
 	}
 	return entries
+}
+
+func providerFilterValues(values stringListFlag) []string {
+	var out []string
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.ToLower(strings.TrimSpace(part))
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
+func validateProviderMatrixFilters(filters providerMatrixFilters, entries []providerMatrixEntry) error {
+	allowed := map[string]map[string]bool{
+		"kind":      {},
+		"target":    {},
+		"feature":   {},
+		"workspace": {},
+		"evidence":  {},
+	}
+	for _, entry := range entries {
+		allowed["kind"][strings.ToLower(string(entry.Kind))] = true
+		addProviderFilterAllowed(allowed["target"], entry.Targets)
+		addProviderFilterAllowed(allowed["feature"], featuresToStrings(entry.Features))
+		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
+		addProviderFilterAllowed(allowed["evidence"], entry.Evidence)
+	}
+	check := func(name string, values []string) error {
+		for _, value := range values {
+			if !allowed[name][value] {
+				return exit(2, "unknown provider %s filter %q; try one of: %s", name, value, strings.Join(sortedProviderFilterValues(allowed[name]), ", "))
+			}
+		}
+		return nil
+	}
+	if err := check("kind", filters.Kinds); err != nil {
+		return err
+	}
+	if err := check("target", filters.Targets); err != nil {
+		return err
+	}
+	if err := check("feature", filters.Features); err != nil {
+		return err
+	}
+	if err := check("workspace", filters.Workspaces); err != nil {
+		return err
+	}
+	return check("evidence", filters.Evidence)
+}
+
+func addProviderFilterAllowed(allowed map[string]bool, values []string) {
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			allowed[value] = true
+		}
+	}
+}
+
+func sortedProviderFilterValues(values map[string]bool) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixFilters) []providerMatrixEntry {
+	if providerMatrixFiltersEmpty(filters) {
+		return entries
+	}
+	out := make([]providerMatrixEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !providerEntryMatchesFilters(entry, filters) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func providerMatrixFiltersEmpty(filters providerMatrixFilters) bool {
+	return len(filters.Kinds) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
+}
+
+func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatrixFilters) bool {
+	return providerFieldContainsAll([]string{string(entry.Kind)}, filters.Kinds) &&
+		providerFieldContainsAll(entry.Targets, filters.Targets) &&
+		providerFieldContainsAll(featuresToStrings(entry.Features), filters.Features) &&
+		providerFieldContainsAll(entry.Workspace, filters.Workspaces) &&
+		providerFieldContainsAll(entry.Evidence, filters.Evidence)
+}
+
+func providerFieldContainsAll(values, wants []string) bool {
+	if len(wants) == 0 {
+		return true
+	}
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		set[strings.ToLower(strings.TrimSpace(value))] = true
+	}
+	for _, want := range wants {
+		if !set[want] {
+			return false
+		}
+	}
+	return true
 }
 
 func providerRecommendationUseCases() []string {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -253,6 +253,63 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	}
 }
 
+func TestProvidersCommandFiltersJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"--kind", "delegated-run",
+		"--target", "linux",
+		"--evidence", "preview-url",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers filtered --json error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerMatrixEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected delegated preview providers")
+	}
+	for _, entry := range entries {
+		if entry.Kind != ProviderKindDelegatedRun || !containsString(entry.Targets, targetLinux) || !containsString(entry.Evidence, "preview-url") {
+			t.Fatalf("entry escaped filters: %#v", entry)
+		}
+	}
+}
+
+func TestProvidersCommandFiltersRequireAllCapabilities(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"--workspace", "checkpoint,fork",
+	})
+	if err != nil {
+		t.Fatalf("providers workspace filter error=%v stderr=%q", err, stderr.String())
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "local-container\n") {
+		t.Fatalf("workspace filter should include local-container:\n%s", text)
+	}
+	if !strings.Contains(text, "parallels\n") {
+		t.Fatalf("workspace filter should include parallels:\n%s", text)
+	}
+	if strings.Contains(text, "blacksmith-testbox\n") {
+		t.Fatalf("workspace filter should exclude providers without workspace capabilities:\n%s", text)
+	}
+}
+
+func TestProvidersCommandRejectsUnknownFilter(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"--evidence", "memory-fork"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("providers unknown filter error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), `unknown provider evidence filter "memory-fork"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestProvidersRecommendListsUseCases(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend"})


### PR DESCRIPTION
## Summary
- add static `crabbox providers` filters for provider kind, target, raw feature, normalized workspace capability, and normalized evidence capability
- validate filter values against the compiled provider matrix so typos fail clearly
- document repeatable/comma-separated filter semantics

## Verification
- `go test ./internal/cli -run 'TestProviders'`\n- `node scripts/check-command-docs.mjs && node scripts/check-docs-links.mjs`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers --kind delegated-run --target linux --evidence preview-url`\n- `bin/crabbox providers --workspace checkpoint,fork --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=JSON.parse(s); if(!a.length) throw new Error("empty"); for (const p of a) { if (!p.workspace?.includes("checkpoint") || !p.workspace?.includes("fork")) throw new Error(JSON.stringify(p)); } console.log(a.map(p=>p.provider).join(","));})'`\n- `bin/crabbox providers --evidence memory-fork >/tmp/crabbox-filter-out 2>/tmp/crabbox-filter-err; rc=$?; printf 'rc=%s\\n' "$rc"; cat /tmp/crabbox-filter-err; test "$rc" -eq 2`\n- `go test ./...`\n\nNo live provider credentials were used.