### PR TITLE
feat(cli): filter provider recommendations

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -13,6 +13,7 @@ crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
+crabbox providers recommend run-evidence --kind delegated-run --evidence preview-url
 crabbox providers recommend versioned-workspace
 ```
 
@@ -37,6 +38,8 @@ Repeated filters are combined with AND semantics. Comma-separated values are als
 accepted, so `--workspace checkpoint,fork` means the same thing as passing
 `--workspace checkpoint --workspace fork`. Filter values are checked against the
 compiled provider matrix; unknown values fail before printing partial output.
+The same filters can be passed to `providers recommend` to rank only matching
+providers for a workflow.
 
 The matrix form takes no positional arguments. Use `providers recommend` for
 workflow-oriented ranked selection guidance.
@@ -54,7 +57,9 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend run-evidence
+crabbox providers recommend run-evidence --kind delegated-run --evidence preview-url
 crabbox providers recommend versioned-workspace
+crabbox providers recommend versioned-workspace --target macos --workspace fork
 crabbox providers recommend worker-runtime --json
 ```
 
@@ -85,6 +90,9 @@ Recommendation flags:
 - `--use-case <name>`: pass the use case by flag instead of positionally.
 - `--limit <n>`: maximum recommendations to print. Defaults to `5`.
 - `--json`: emit recommendations as JSON.
+- `--kind`, `--target`, `--feature`, `--workspace`, `--evidence`: filter the
+  candidate provider matrix before scoring. These flags use the same values and
+  repeat/comma semantics as the base `providers` matrix command.
 
 ## Output
 

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"sort"
@@ -41,18 +42,21 @@ type providerMatrixFilters struct {
 	Evidence   []string
 }
 
+type providerMatrixFilterFlagValues struct {
+	Kinds      stringListFlag
+	Targets    stringListFlag
+	Features   stringListFlag
+	Workspaces stringListFlag
+	Evidence   stringListFlag
+}
+
 func (a App) providers(_ context.Context, args []string) error {
 	if len(args) > 0 && args[0] == "recommend" {
 		return a.providerRecommendations(args[1:])
 	}
 	fs := newFlagSet("providers", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
-	var kindFilters, targetFilters, featureFilters, workspaceFilters, evidenceFilters stringListFlag
-	fs.Var(&kindFilters, "kind", "filter by provider kind; repeatable")
-	fs.Var(&targetFilters, "target", "filter by target such as linux or worker-runtime; repeatable")
-	fs.Var(&featureFilters, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
-	fs.Var(&workspaceFilters, "workspace", "filter by normalized workspace capability; repeatable")
-	fs.Var(&evidenceFilters, "evidence", "filter by normalized evidence capability; repeatable")
+	filterFlags := registerProviderMatrixFilterFlags(fs)
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -60,13 +64,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
-	filters := providerMatrixFilters{
-		Kinds:      providerFilterValues(kindFilters),
-		Targets:    providerFilterValues(targetFilters),
-		Features:   providerFilterValues(featureFilters),
-		Workspaces: providerFilterValues(workspaceFilters),
-		Evidence:   providerFilterValues(evidenceFilters),
-	}
+	filters := filterFlags.filters()
 	if err := validateProviderMatrixFilters(filters, entries); err != nil {
 		return err
 	}
@@ -88,6 +86,7 @@ func (a App) providerRecommendations(args []string) error {
 	jsonOut := fs.Bool("json", false, "print JSON")
 	limit := fs.Int("limit", 5, "maximum recommendations to print")
 	useCaseFlag := fs.String("use-case", "", "use case to optimize for")
+	filterFlags := registerProviderMatrixFilterFlags(fs)
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -112,6 +111,9 @@ func (a App) providerRecommendations(args []string) error {
 		return exit(2, "usage: crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	if useCase == "" {
+		if !providerMatrixFiltersEmpty(filterFlags.filters()) {
+			return exit(2, "provider recommendation filters require a use case")
+		}
 		if *jsonOut {
 			return json.NewEncoder(a.Stdout).Encode(providerRecommendationUseCases())
 		}
@@ -122,9 +124,18 @@ func (a App) providerRecommendations(args []string) error {
 	if !ok {
 		return exit(2, "unknown provider recommendation use case %q; try one of: %s", useCase, strings.Join(providerRecommendationUseCases(), ", "))
 	}
-	recommendations := recommendProvidersForUseCase(providerMatrix(), canonical, *limit)
+	entries := providerMatrix()
+	filters := filterFlags.filters()
+	if err := validateProviderMatrixFilters(filters, entries); err != nil {
+		return err
+	}
+	entries = filterProviderMatrix(entries, filters)
+	recommendations := recommendProvidersForUseCase(entries, canonical, *limit)
 	if len(recommendations) == 0 {
-		return exit(1, "no providers matched use case %q", canonical)
+		if providerMatrixFiltersEmpty(filters) {
+			return exit(1, "no providers matched use case %q", canonical)
+		}
+		return exit(1, "no providers matched use case %q with the requested filters", canonical)
 	}
 	if *jsonOut {
 		return json.NewEncoder(a.Stdout).Encode(recommendations)
@@ -151,6 +162,29 @@ func providerMatrix() []providerMatrixEntry {
 		})
 	}
 	return entries
+}
+
+func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFlagValues {
+	values := &providerMatrixFilterFlagValues{}
+	fs.Var(&values.Kinds, "kind", "filter by provider kind; repeatable")
+	fs.Var(&values.Targets, "target", "filter by target such as linux or worker-runtime; repeatable")
+	fs.Var(&values.Features, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
+	fs.Var(&values.Workspaces, "workspace", "filter by normalized workspace capability; repeatable")
+	fs.Var(&values.Evidence, "evidence", "filter by normalized evidence capability; repeatable")
+	return values
+}
+
+func (values *providerMatrixFilterFlagValues) filters() providerMatrixFilters {
+	if values == nil {
+		return providerMatrixFilters{}
+	}
+	return providerMatrixFilters{
+		Kinds:      providerFilterValues(values.Kinds),
+		Targets:    providerFilterValues(values.Targets),
+		Features:   providerFilterValues(values.Features),
+		Workspaces: providerFilterValues(values.Workspaces),
+		Evidence:   providerFilterValues(values.Evidence),
+	}
 }
 
 func providerFilterValues(values stringListFlag) []string {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -413,6 +413,55 @@ func TestProvidersRecommendCommandJSONAndLimit(t *testing.T) {
 	}
 }
 
+func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "run-evidence",
+		"--kind", "delegated-run",
+		"--evidence", "preview-url",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend filtered --json error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected filtered run-evidence recommendations")
+	}
+	for _, entry := range entries {
+		if entry.Kind != ProviderKindDelegatedRun || !containsString(entry.Evidence, "preview-url") {
+			t.Fatalf("recommendation escaped filters: %#v", entry)
+		}
+	}
+}
+
+func TestProvidersRecommendFiltersRequireUseCase(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "--kind", "ssh-lease"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("providers recommend filter without use case error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), "provider recommendation filters require a use case") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProvidersRecommendFilteredNoMatch(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "run-evidence", "--workspace", "checkpoint"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("providers recommend filtered no-match error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), `no providers matched use case "run-evidence" with the requested filters`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestProvidersRecommendRejectsUnknownUseCase(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "moon-base"})


### PR DESCRIPTION
## Summary
- let `crabbox providers recommend` use the same kind/target/feature/workspace/evidence filters as the provider matrix
- validate recommendation filters before scoring and keep no-match errors explicit
- document filtered recommendation examples and shared filter semantics

## Verification
- `go test ./internal/cli -run 'TestProviders'`\n- `node scripts/check-command-docs.mjs && node scripts/check-docs-links.mjs`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers recommend run-evidence --kind delegated-run --evidence preview-url --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=JSON.parse(s); if(!a.length) throw new Error("empty"); for (const p of a) { if (p.kind !== "delegated-run" || !p.evidence?.includes("preview-url")) throw new Error(JSON.stringify(p)); } console.log(a.map(p=>p.provider).join(","));})'`\n- `bin/crabbox providers recommend --kind ssh-lease >/tmp/crabbox-rec-filter-out 2>/tmp/crabbox-rec-filter-err; rc=$?; printf 'rc=%s\\n' "$rc"; cat /tmp/crabbox-rec-filter-err; test "$rc" -eq 2`\n- `bin/crabbox providers recommend run-evidence --workspace checkpoint >/tmp/crabbox-rec-nomatch-out 2>/tmp/crabbox-rec-nomatch-err; rc=$?; printf 'rc=%s\\n' "$rc"; cat /tmp/crabbox-rec-nomatch-err; test "$rc" -eq 1`\n- `go test ./...`\n\nNo live provider credentials were used.