### PR TITLE
feat(cli): expose provider categories

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -8,12 +8,12 @@ does not contact any cloud, check credentials, or query quota. Use
 ```sh
 crabbox providers
 crabbox providers --json
-crabbox providers --kind delegated-run --evidence preview-url
+crabbox providers --category delegated-sandbox --evidence preview-url
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --kind delegated-run --evidence preview-url
+crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
 crabbox providers recommend versioned-workspace
 ```
 
@@ -22,6 +22,10 @@ crabbox providers recommend versioned-workspace
 - `--json`: emit the matrix as a JSON array instead of grouped text.
 - `--kind <kind>`: keep providers with this driver kind. Repeatable. Current
   values include `ssh-lease`, `delegated-run`, and `service-control`.
+- `--category <category>`: keep providers in this checked-in provider category,
+  such as `delegated-sandbox`, `direct-cloud`, `brokerable-cloud`,
+  `ci-proof-runner`, `gpu-cloud`, `local-vm`, or
+  `self-hosted-virtualization`. Repeatable.
 - `--target <target>`: keep providers that advertise this target, such as
   `linux`, `macos`, `windows/normal`, `windows/wsl2`, or `worker-runtime`.
   Repeatable.
@@ -57,7 +61,7 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --kind delegated-run --evidence preview-url
+crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
 crabbox providers recommend versioned-workspace
 crabbox providers recommend versioned-workspace --target macos --workspace fork
 crabbox providers recommend worker-runtime --json
@@ -90,9 +94,10 @@ Recommendation flags:
 - `--use-case <name>`: pass the use case by flag instead of positionally.
 - `--limit <n>`: maximum recommendations to print. Defaults to `5`.
 - `--json`: emit recommendations as JSON.
-- `--kind`, `--target`, `--feature`, `--workspace`, `--evidence`: filter the
-  candidate provider matrix before scoring. These flags use the same values and
-  repeat/comma semantics as the base `providers` matrix command.
+- `--kind`, `--category`, `--target`, `--feature`, `--workspace`,
+  `--evidence`: filter the candidate provider matrix before scoring. These flags
+  use the same values and repeat/comma semantics as the base `providers` matrix
+  command.
 
 ## Output
 
@@ -102,6 +107,7 @@ Text output lists every provider as a block of indented fields:
 aws
   family: aws
   kind: ssh-lease
+  category: brokerable-cloud
   targets: linux,windows/normal,windows/wsl2,macos
   features: ssh,crabbox-sync,cleanup,desktop,browser,code
   coordinator: supported
@@ -109,6 +115,7 @@ aws
 parallels
   family: parallels
   kind: ssh-lease
+  category: local-vm
   targets: linux,macos,windows/normal,windows/wsl2
   features: ssh,crabbox-sync,cleanup,desktop,browser,code,workspace-checkpoint,workspace-fork,workspace-restore,provider-snapshot
   workspace: checkpoint,fork,restore,snapshot-ref
@@ -117,6 +124,7 @@ parallels
 blacksmith-testbox
   family: blacksmith
   kind: delegated-run
+  category: ci-proof-runner
   targets: linux
   features: cache-volume,run-proof,run-session,run-artifacts
   evidence: proof,artifacts,session
@@ -126,6 +134,7 @@ blacksmith-testbox
 e2b
   family: e2b
   kind: delegated-run
+  category: delegated-sandbox
   targets: linux
   features: url-bridge,run-session
   evidence: preview-url,session
@@ -134,6 +143,7 @@ e2b
 wandb
   family: wandb
   kind: delegated-run
+  category: gpu-cloud
   targets: linux
   features: -
   coordinator: never
@@ -142,6 +152,7 @@ wandb
 module-runtime-example
   family: module-runtime-example
   kind: delegated-run
+  category: -
   targets: worker-runtime
   features: module-run
   coordinator: never
@@ -149,6 +160,7 @@ module-runtime-example
 hostinger
   family: hostinger
   kind: ssh-lease
+  category: direct-cloud
   targets: linux
   features: ssh,crabbox-sync,cleanup
   coordinator: never
@@ -170,6 +182,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "provider": "hostinger",
     "family": "hostinger",
     "kind": "ssh-lease",
+    "category": "direct-cloud",
     "targets": ["linux"],
     "features": ["ssh", "crabbox-sync", "cleanup"],
     "coordinator": "never"
@@ -178,6 +191,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "provider": "blacksmith-testbox",
     "family": "blacksmith",
     "kind": "delegated-run",
+    "category": "ci-proof-runner",
     "aliases": ["blacksmith"],
     "targets": ["linux"],
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
@@ -202,6 +216,12 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     itself; there is no SSH lease.
   - `service-control`: Crabbox can inspect or stop a provider-owned service but
     cannot execute arbitrary run commands there.
+- `category`: checked-in provider selection category used by recommendations and
+  benchmark grouping. Examples include `brokerable-cloud`, `direct-cloud`,
+  `delegated-sandbox`, `ci-proof-runner`, `gpu-cloud`, `local-runtime`,
+  `local-vm`, `local-sandbox`, `self-hosted-virtualization`, `byo-ssh`,
+  `external-provider`, and `service-control`. Omitted from JSON when no category
+  is known; text output prints `-`.
 - `targets`: supported OS, Windows mode, or runtime category combinations, such
   as `linux`, `macos`, `windows/normal`, `windows/wsl2`, and
   `worker-runtime`. `worker-runtime` means a hosted module or Worker-isolate

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -15,6 +15,7 @@ type providerMatrixEntry struct {
 	Family      string       `json:"family"`
 	Aliases     []string     `json:"aliases,omitempty"`
 	Kind        ProviderKind `json:"kind"`
+	Category    string       `json:"category,omitempty"`
 	Targets     []string     `json:"targets"`
 	Features    []Feature    `json:"features"`
 	Workspace   []string     `json:"workspace,omitempty"`
@@ -36,6 +37,7 @@ type providerRecommendationEntry struct {
 
 type providerMatrixFilters struct {
 	Kinds      []string
+	Categories []string
 	Targets    []string
 	Features   []string
 	Workspaces []string
@@ -44,6 +46,7 @@ type providerMatrixFilters struct {
 
 type providerMatrixFilterFlagValues struct {
 	Kinds      stringListFlag
+	Categories stringListFlag
 	Targets    stringListFlag
 	Features   stringListFlag
 	Workspaces stringListFlag
@@ -61,7 +64,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	filters := filterFlags.filters()
@@ -154,6 +157,7 @@ func providerMatrix() []providerMatrixEntry {
 			Family:      firstNonBlank(spec.Family, provider.Name()),
 			Aliases:     append([]string(nil), provider.Aliases()...),
 			Kind:        spec.Kind,
+			Category:    benchmarkProviderCategories[firstNonBlank(spec.Name, provider.Name())],
 			Targets:     formatProviderTargets(spec.Targets),
 			Features:    append(FeatureSet{}, spec.Features...),
 			Workspace:   workspaceCapabilitiesForFeatures(spec.Features),
@@ -167,6 +171,7 @@ func providerMatrix() []providerMatrixEntry {
 func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFlagValues {
 	values := &providerMatrixFilterFlagValues{}
 	fs.Var(&values.Kinds, "kind", "filter by provider kind; repeatable")
+	fs.Var(&values.Categories, "category", "filter by provider category; repeatable")
 	fs.Var(&values.Targets, "target", "filter by target such as linux or worker-runtime; repeatable")
 	fs.Var(&values.Features, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
 	fs.Var(&values.Workspaces, "workspace", "filter by normalized workspace capability; repeatable")
@@ -180,6 +185,7 @@ func (values *providerMatrixFilterFlagValues) filters() providerMatrixFilters {
 	}
 	return providerMatrixFilters{
 		Kinds:      providerFilterValues(values.Kinds),
+		Categories: providerFilterValues(values.Categories),
 		Targets:    providerFilterValues(values.Targets),
 		Features:   providerFilterValues(values.Features),
 		Workspaces: providerFilterValues(values.Workspaces),
@@ -203,6 +209,7 @@ func providerFilterValues(values stringListFlag) []string {
 func validateProviderMatrixFilters(filters providerMatrixFilters, entries []providerMatrixEntry) error {
 	allowed := map[string]map[string]bool{
 		"kind":      {},
+		"category":  {},
 		"target":    {},
 		"feature":   {},
 		"workspace": {},
@@ -210,6 +217,7 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 	}
 	for _, entry := range entries {
 		allowed["kind"][strings.ToLower(string(entry.Kind))] = true
+		addProviderFilterAllowed(allowed["category"], []string{entry.Category})
 		addProviderFilterAllowed(allowed["target"], entry.Targets)
 		addProviderFilterAllowed(allowed["feature"], featuresToStrings(entry.Features))
 		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
@@ -224,6 +232,9 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 		return nil
 	}
 	if err := check("kind", filters.Kinds); err != nil {
+		return err
+	}
+	if err := check("category", filters.Categories); err != nil {
 		return err
 	}
 	if err := check("target", filters.Targets); err != nil {
@@ -271,11 +282,12 @@ func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixF
 }
 
 func providerMatrixFiltersEmpty(filters providerMatrixFilters) bool {
-	return len(filters.Kinds) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
+	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
 }
 
 func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatrixFilters) bool {
 	return providerFieldContainsAll([]string{string(entry.Kind)}, filters.Kinds) &&
+		providerFieldContainsAll([]string{entry.Category}, filters.Categories) &&
 		providerFieldContainsAll(entry.Targets, filters.Targets) &&
 		providerFieldContainsAll(featuresToStrings(entry.Features), filters.Features) &&
 		providerFieldContainsAll(entry.Workspace, filters.Workspaces) &&
@@ -662,6 +674,7 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "%s\n", entry.Provider)
 		fmt.Fprintf(out, "  family: %s\n", entry.Family)
 		fmt.Fprintf(out, "  kind: %s\n", entry.Kind)
+		fmt.Fprintf(out, "  category: %s\n", blank(entry.Category, "-"))
 		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
 		if len(entry.Workspace) > 0 {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -106,6 +106,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if aws.Family != "aws" {
 		t.Fatalf("aws family=%q", aws.Family)
 	}
+	if aws.Category != "brokerable-cloud" {
+		t.Fatalf("aws category=%q", aws.Category)
+	}
 	if !containsString(aws.Targets, targetLinux) || !containsString(aws.Targets, targetMacOS) {
 		t.Fatalf("aws targets=%v", aws.Targets)
 	}
@@ -218,6 +221,9 @@ func TestProvidersCommandJSON(t *testing.T) {
 		if entry.Features == nil {
 			t.Fatalf("provider %s encoded nil features", entry.Provider)
 		}
+		if entry.Provider == "aws" && entry.Category != "brokerable-cloud" {
+			t.Fatalf("aws json category=%q", entry.Category)
+		}
 		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
 			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
 		}
@@ -234,7 +240,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 		t.Fatalf("providers error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  features: "} {
+	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: "} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers output missing %q:\n%s", want, text)
 		}
@@ -257,6 +263,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
 		"--kind", "delegated-run",
+		"--category", "delegated-sandbox",
 		"--target", "linux",
 		"--evidence", "preview-url",
 		"--json",
@@ -272,7 +279,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		t.Fatal("expected delegated preview providers")
 	}
 	for _, entry := range entries {
-		if entry.Kind != ProviderKindDelegatedRun || !containsString(entry.Targets, targetLinux) || !containsString(entry.Evidence, "preview-url") {
+		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("entry escaped filters: %#v", entry)
 		}
 	}
@@ -417,7 +424,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
 		"recommend", "run-evidence",
-		"--kind", "delegated-run",
+		"--category", "delegated-sandbox",
 		"--evidence", "preview-url",
 		"--json",
 	})
@@ -432,7 +439,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 		t.Fatal("expected filtered run-evidence recommendations")
 	}
 	for _, entry := range entries {
-		if entry.Kind != ProviderKindDelegatedRun || !containsString(entry.Evidence, "preview-url") {
+		if entry.Category != "delegated-sandbox" || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("recommendation escaped filters: %#v", entry)
 		}
 	}


### PR DESCRIPTION
## Summary
- expose checked-in provider category metadata in `crabbox providers` text and JSON output
- add repeatable/comma-separated `--category` filters to `providers` and `providers recommend`
- document category examples and field semantics

## Verification
- `go test ./internal/cli -run 'TestProviders'`\n- `node scripts/check-command-docs.mjs && node scripts/check-docs-links.mjs`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers --category delegated-sandbox --evidence preview-url --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=JSON.parse(s); if(!a.length) throw new Error("empty"); for (const p of a) { if (p.category !== "delegated-sandbox" || !p.evidence?.includes("preview-url")) throw new Error(JSON.stringify(p)); } console.log(a.map(p=>p.provider).join(","));})'`\n- `bin/crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url --json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const a=JSON.parse(s); if(!a.length) throw new Error("empty"); for (const p of a) { if (p.category !== "delegated-sandbox" || !p.evidence?.includes("preview-url")) throw new Error(JSON.stringify(p)); } console.log(a.map(p=>p.provider).join(","));})'`\n- `bin/crabbox providers --category moon-base >/tmp/crabbox-category-out 2>/tmp/crabbox-category-err; rc=$?; printf 'rc=%s\\n' "$rc"; cat /tmp/crabbox-category-err; test "$rc" -eq 2`\n- `go test ./...`\n\nNo live provider credentials were used.