### PR TITLE
feat(cli): list provider filter values

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -8,6 +8,8 @@ does not contact any cloud, check credentials, or query quota. Use
 ```sh
 crabbox providers
 crabbox providers --json
+crabbox providers filters
+crabbox providers filters --json
 crabbox providers --category delegated-sandbox --evidence preview-url
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
@@ -45,8 +47,37 @@ compiled provider matrix; unknown values fail before printing partial output.
 The same filters can be passed to `providers recommend` to rank only matching
 providers for a workflow.
 
+Run `crabbox providers filters` to print the exact filter values accepted by
+the current binary.
+
 The matrix form takes no positional arguments. Use `providers recommend` for
 workflow-oriented ranked selection guidance.
+
+## `providers filters`
+
+`crabbox providers filters` prints allowed filter values from the compiled
+provider matrix. It does not contact provider APIs. Use it before composing
+matrix or recommendation filters in scripts.
+
+```sh
+crabbox providers filters
+crabbox providers filters --json
+```
+
+Text output groups values by flag:
+
+```text
+provider filter values:
+  kind: delegated-run,service-control,ssh-lease
+  category: brokerable-cloud,byo-ssh,ci-proof-runner,delegated-sandbox,direct-cloud,external-provider,gpu-cloud,local-runtime,local-sandbox,local-vm,self-hosted-virtualization,service-control
+  target: linux,macos,windows/normal,windows/wsl2,worker-runtime
+  feature: archive-sync,browser,cache-volume,cleanup,code,crabbox-sync,desktop,module-run,pause-resume,provider-snapshot,run-artifacts,run-downloads,run-proof,run-session,ssh,tailscale,url-bridge,workspace-checkpoint,workspace-fork,workspace-restore
+  workspace: checkpoint,fork,restore,snapshot-ref
+  evidence: artifacts,downloads,preview-url,proof,session
+```
+
+JSON output returns one object with `kind`, `category`, `target`, `feature`,
+`workspace`, and `evidence` arrays.
 
 ## `providers recommend`
 

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -35,6 +35,15 @@ type providerRecommendationEntry struct {
 	Reasons   []string     `json:"reasons"`
 }
 
+type providerFilterValuesEntry struct {
+	Kind      []string `json:"kind"`
+	Category  []string `json:"category"`
+	Target    []string `json:"target"`
+	Feature   []string `json:"feature"`
+	Workspace []string `json:"workspace"`
+	Evidence  []string `json:"evidence"`
+}
+
 type providerMatrixFilters struct {
 	Kinds      []string
 	Categories []string
@@ -54,6 +63,9 @@ type providerMatrixFilterFlagValues struct {
 }
 
 func (a App) providers(_ context.Context, args []string) error {
+	if len(args) > 0 && args[0] == "filters" {
+		return a.providerFilters(args[1:])
+	}
 	if len(args) > 0 && args[0] == "recommend" {
 		return a.providerRecommendations(args[1:])
 	}
@@ -64,7 +76,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	filters := filterFlags.filters()
@@ -76,6 +88,23 @@ func (a App) providers(_ context.Context, args []string) error {
 		return json.NewEncoder(a.Stdout).Encode(entries)
 	}
 	printProviderMatrix(a.Stdout, entries)
+	return nil
+}
+
+func (a App) providerFilters(args []string) error {
+	fs := newFlagSet("providers filters", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return exit(2, "usage: crabbox providers filters [--json]")
+	}
+	values := providerMatrixFilterValues(providerMatrix())
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(values)
+	}
+	printProviderFilterValues(a.Stdout, values)
 	return nil
 }
 
@@ -206,7 +235,7 @@ func providerFilterValues(values stringListFlag) []string {
 	return out
 }
 
-func validateProviderMatrixFilters(filters providerMatrixFilters, entries []providerMatrixEntry) error {
+func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterValuesEntry {
 	allowed := map[string]map[string]bool{
 		"kind":      {},
 		"category":  {},
@@ -216,13 +245,25 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 		"evidence":  {},
 	}
 	for _, entry := range entries {
-		allowed["kind"][strings.ToLower(string(entry.Kind))] = true
+		addProviderFilterAllowed(allowed["kind"], []string{string(entry.Kind)})
 		addProviderFilterAllowed(allowed["category"], []string{entry.Category})
 		addProviderFilterAllowed(allowed["target"], entry.Targets)
 		addProviderFilterAllowed(allowed["feature"], featuresToStrings(entry.Features))
 		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
 		addProviderFilterAllowed(allowed["evidence"], entry.Evidence)
 	}
+	return providerFilterValuesEntry{
+		Kind:      sortedProviderFilterValues(allowed["kind"]),
+		Category:  sortedProviderFilterValues(allowed["category"]),
+		Target:    sortedProviderFilterValues(allowed["target"]),
+		Feature:   sortedProviderFilterValues(allowed["feature"]),
+		Workspace: sortedProviderFilterValues(allowed["workspace"]),
+		Evidence:  sortedProviderFilterValues(allowed["evidence"]),
+	}
+}
+
+func validateProviderMatrixFilters(filters providerMatrixFilters, entries []providerMatrixEntry) error {
+	allowed := providerMatrixFilterAllowedValues(entries)
 	check := func(name string, values []string) error {
 		for _, value := range values {
 			if !allowed[name][value] {
@@ -249,6 +290,26 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 	return check("evidence", filters.Evidence)
 }
 
+func providerMatrixFilterAllowedValues(entries []providerMatrixEntry) map[string]map[string]bool {
+	values := providerMatrixFilterValues(entries)
+	return map[string]map[string]bool{
+		"kind":      providerFilterAllowedSet(values.Kind),
+		"category":  providerFilterAllowedSet(values.Category),
+		"target":    providerFilterAllowedSet(values.Target),
+		"feature":   providerFilterAllowedSet(values.Feature),
+		"workspace": providerFilterAllowedSet(values.Workspace),
+		"evidence":  providerFilterAllowedSet(values.Evidence),
+	}
+}
+
+func providerFilterAllowedSet(values []string) map[string]bool {
+	allowed := make(map[string]bool, len(values))
+	for _, value := range values {
+		allowed[value] = true
+	}
+	return allowed
+}
+
 func addProviderFilterAllowed(allowed map[string]bool, values []string) {
 	for _, value := range values {
 		value = strings.ToLower(strings.TrimSpace(value))
@@ -265,6 +326,23 @@ func sortedProviderFilterValues(values map[string]bool) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func printProviderFilterValues(out io.Writer, values providerFilterValuesEntry) {
+	fmt.Fprintln(out, "provider filter values:")
+	fmt.Fprintf(out, "  kind: %s\n", providerFilterValueLine(values.Kind))
+	fmt.Fprintf(out, "  category: %s\n", providerFilterValueLine(values.Category))
+	fmt.Fprintf(out, "  target: %s\n", providerFilterValueLine(values.Target))
+	fmt.Fprintf(out, "  feature: %s\n", providerFilterValueLine(values.Feature))
+	fmt.Fprintf(out, "  workspace: %s\n", providerFilterValueLine(values.Workspace))
+	fmt.Fprintf(out, "  evidence: %s\n", providerFilterValueLine(values.Evidence))
+}
+
+func providerFilterValueLine(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ",")
 }
 
 func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixFilters) []providerMatrixEntry {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -317,6 +317,63 @@ func TestProvidersCommandRejectsUnknownFilter(t *testing.T) {
 	}
 }
 
+func TestProvidersFiltersCommandHumanOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"filters"})
+	if err != nil {
+		t.Fatalf("providers filters error=%v stderr=%q", err, stderr.String())
+	}
+	text := stdout.String()
+	for _, want := range []string{
+		"provider filter values:",
+		"  kind: ",
+		"delegated-run",
+		"  category: ",
+		"delegated-sandbox",
+		"  evidence: ",
+		"preview-url",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("providers filters output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestProvidersFiltersCommandJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"filters", "--json"})
+	if err != nil {
+		t.Fatalf("providers filters --json error=%v stderr=%q", err, stderr.String())
+	}
+	var values providerFilterValuesEntry
+	if err := json.Unmarshal(stdout.Bytes(), &values); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	for _, tc := range []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{name: "kind", values: values.Kind, want: "delegated-run"},
+		{name: "category", values: values.Category, want: "delegated-sandbox"},
+		{name: "evidence", values: values.Evidence, want: "preview-url"},
+		{name: "workspace", values: values.Workspace, want: "fork"},
+	} {
+		if !containsString(tc.values, tc.want) {
+			t.Fatalf("%s values=%v missing %q", tc.name, tc.values, tc.want)
+		}
+	}
+}
+
+func TestProvidersFiltersRejectsArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"filters", "kind"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("providers filters arg error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+}
+
 func TestProvidersRecommendListsUseCases(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend"})


### PR DESCRIPTION
## Summary
- add `crabbox providers filters` for discovering valid provider filter values
- reuse the compiled provider matrix as the source for filter validation and discovery
- document text and JSON output for the new command

## Verification
- `go test ./internal/cli -run 'TestProviders'`\n- `go build -trimpath -o bin/crabbox ./cmd/crabbox`\n- `bin/crabbox providers filters`\n- `bin/crabbox providers filters --json | node -e ...`\n- `bin/crabbox providers filters nope` exits 2\n- `node scripts/check-command-docs.mjs`\n- `node scripts/check-docs-links.mjs`\n- `go test ./...`\n- `git diff --check`\n\nNo live provider credentials were used.