### PR TITLE
test(providers): enforce cleanup feature contracts

### DIFF
--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -365,6 +365,31 @@ func TestProviderKindFeatureContracts(t *testing.T) {
 	}
 }
 
+func TestCleanupFeatureRequiresCleanupBackend(t *testing.T) {
+	checked := 0
+	for _, name := range allBuiltInProviderNames() {
+		provider := mustProvider(t, name)
+		if !provider.Spec().Features.Has(core.FeatureCleanup) {
+			continue
+		}
+		cfg, ok := offlineConformanceConfig(name)
+		if !ok {
+			t.Fatalf("%s advertises %s; add an offline conformance config for it", name, core.FeatureCleanup)
+		}
+		backend, err := provider.Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
+		if err != nil {
+			t.Fatalf("%s configure error: %v", name, err)
+		}
+		if _, ok := backend.(core.CleanupBackend); !ok {
+			t.Fatalf("%s advertises %s but backend %T is not CleanupBackend", name, core.FeatureCleanup, backend)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatalf("no providers advertised %s; conformance test is stale", core.FeatureCleanup)
+	}
+}
+
 func TestPauseResumeFeatureRequiresPausableBackend(t *testing.T) {
 	checked := 0
 	for _, name := range allBuiltInProviderNames() {
@@ -495,30 +520,38 @@ func hasAnyFeature(features core.FeatureSet, wants ...core.Feature) bool {
 }
 
 func offlineConformanceConfig(provider string) (core.Config, bool) {
-	cfg := core.Config{Provider: provider}
+	cfg := core.BaseConfig()
+	cfg.Provider = provider
 	switch provider {
+	case "agent-sandbox":
+		cfg.AgentSandbox.Context = "agent-context"
+		cfg.AgentSandbox.WarmPool = "linux-pool"
+		return cfg, true
 	case "blacksmith-testbox":
+		return cfg, true
+	case "cloudflare-dynamic-workers":
+		cfg.CloudflareDynamicWorkers.LoaderURL = "https://loader.example.test"
+		cfg.CloudflareDynamicWorkers.Token = "test-token"
 		return cfg, true
 	case "e2b":
 		return cfg, true
+	case "external":
+		cfg.External.Command = "external-provider"
+		return cfg, true
 	case "codesandbox":
-		cfg.CodeSandbox = core.CodeSandboxConfig{
-			Workdir:                  "/project/workspace",
-			Privacy:                  "private",
-			AutomaticWakeupHTTP:      true,
-			AutomaticWakeupWebSocket: false,
-			BridgeCommand:            "node",
-			SDKPackage:               "@codesandbox/sdk@2.4.2",
-			DoctorListLimit:          1,
-			OperationTimeoutSecs:     30,
-		}
+		return cfg, true
+	case "hyperv":
+		cfg.TargetOS = core.TargetWindows
+		return cfg, true
+	case "kubevirt":
+		cfg.KubeVirt.Context = "agent-context"
 		return cfg, true
 	case "islo":
 		return cfg, true
 	case "railway":
 		return cfg, true
 	default:
-		return core.Config{}, false
+		return cfg, true
 	}
 }
 

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -337,6 +337,65 @@ func (b *codeSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
+func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	api, err := newCodeSandboxClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	claims, err := listCodeSandboxLeaseClaims()
+	if err != nil {
+		return err
+	}
+	now := b.now().UTC()
+	checked := 0
+	removed := 0
+	for _, listed := range claims {
+		if listed.Provider != providerName || !strings.HasPrefix(listed.LeaseID, leasePrefix) {
+			continue
+		}
+		claim, err := readLeaseClaim(listed.LeaseID)
+		if err != nil {
+			return err
+		}
+		if claim.LeaseID == "" || claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
+			continue
+		}
+		if err := validateCodeSandboxClaimScope(claim); err != nil {
+			return err
+		}
+		checked++
+		due, reason := claimCleanupDue(claim, now)
+		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
+		if !due {
+			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+			continue
+		}
+		sb, err := api.GetSandbox(ctx, sandboxID)
+		if err != nil {
+			return err
+		}
+		if err := validateCodeSandboxSandboxOwnership(claim, sb); err != nil {
+			return err
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+			continue
+		}
+		if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
+			return err
+		}
+		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+		removed++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d checked=%d\n", providerName, removed, checked)
+	}
+	return nil
+}
+
 func (b *codeSandboxBackend) Pause(ctx context.Context, req PauseRequest) error {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
@@ -543,6 +602,7 @@ var _ interface {
 	List(context.Context, ListRequest) ([]LeaseView, error)
 	Status(context.Context, StatusRequest) (StatusView, error)
 	Stop(context.Context, StopRequest) error
+	Cleanup(context.Context, CleanupRequest) error
 	Pause(context.Context, PauseRequest) error
 	Resume(context.Context, ResumeRequest) error
 	Ports(context.Context, PortsRequest) (string, error)

--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -106,6 +106,78 @@ func TestStopRejectsMissingOwnershipTagBeforeDelete(t *testing.T) {
 	}
 }
 
+func TestCleanupDeletesDueOwnedClaims(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeCodeSandboxAPI()
+	backend, stdout, _ := newFakeBackend(t, fake)
+	backend.rt.Clock = fixedClock{t: time.Now().UTC().Add(2 * time.Second)}
+	leaseID := leasePrefix + fake.sandboxID
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup err=%v", err)
+	}
+	if !reflect.DeepEqual(fake.deleted, []string{fake.sandboxID}) {
+		t.Fatalf("deleted=%v, want sandbox delete", fake.deleted)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim after cleanup=%#v err=%v, want removed", claim, err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "delete sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout") ||
+		!strings.Contains(got, "codesandbox cleanup removed=1 checked=1") {
+		t.Fatalf("stdout=%q", got)
+	}
+}
+
+func TestCleanupDryRunKeepsDueOwnedClaims(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeCodeSandboxAPI()
+	backend, stdout, _ := newFakeBackend(t, fake)
+	backend.rt.Clock = fixedClock{t: time.Now().UTC().Add(2 * time.Second)}
+	leaseID := leasePrefix + fake.sandboxID
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run err=%v", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v, want dry-run to skip delete", fake.deleted)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim after dry-run=%#v err=%v, want retained", claim, err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "would delete sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout") {
+		t.Fatalf("stdout=%q", got)
+	}
+}
+
+func TestCleanupSkipsClaimsBeforeIdleDeadline(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeCodeSandboxAPI()
+	backend, _, stderr := newFakeBackend(t, fake)
+	leaseID := leasePrefix + fake.sandboxID
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "fresh", providerName, fake.scope, "", "/repo", time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatalf("Cleanup err=%v", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%v, want not-due claim retained", fake.deleted)
+	}
+	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+		t.Fatalf("claim after cleanup=%#v err=%v, want retained", claim, err)
+	}
+	if got := stderr.String(); !strings.Contains(got, "skip sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout not reached") {
+		t.Fatalf("stderr=%q", got)
+	}
+}
+
 func TestPauseResumeUseSDKLifecycleAndKeepClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeCodeSandboxAPI()
@@ -429,6 +501,14 @@ type fakeCodeSandboxAPI struct {
 	waitedPorts    []int
 	commandResults []CommandResult
 	blockRun       bool
+}
+
+type fixedClock struct {
+	t time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.t
 }
 
 func newFakeCodeSandboxAPI() *fakeCodeSandboxAPI {

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -275,6 +275,21 @@ func (b *codeSandboxBackend) cleanupCreateFailure(ctx context.Context, api codeS
 	return cause
 }
 
+func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
+	if claim.IdleTimeoutSeconds <= 0 {
+		return false, "idle timeout disabled"
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil {
+		return false, "invalid last-used time"
+	}
+	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
+	if now.Before(deadline) {
+		return false, "idle timeout not reached"
+	}
+	return true, "idle timeout"
+}
+
 func (b *codeSandboxBackend) execTimeoutSecs() int {
 	return codeSandboxExecTimeout
 }

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -23,6 +23,7 @@ type RunRequest = core.RunRequest
 type RunResult = core.RunResult
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
+type CleanupRequest = core.CleanupRequest
 type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
@@ -102,6 +103,10 @@ func listCodeSandboxLeaseClaims() ([]LeaseClaim, error) {
 
 func removeLeaseClaim(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
+}
+
+func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {


### PR DESCRIPTION
## Summary
- add cleanup feature conformance coverage for built-in providers
- make CodeSandbox implement CleanupBackend with ownership-tag validation and unchanged-claim removal
- cover CodeSandbox cleanup delete, dry-run, and not-yet-due behavior

## Verification
- go test ./internal/providers/codesandbox ./internal/providers/all -run 'TestCleanup|TestCleanupFeatureRequiresCleanupBackend|TestPauseResumeFeatureRequiresPausableBackend|TestRunEvidenceFeaturesRequireDelegatedBackends|TestURLBridgeFeatureRequiresBridgeProvider'
- go test ./internal/providers/codesandbox ./internal/providers/all
- go test ./...
- go vet ./...
- git diff --check