### PR TITLE
test(providers): cover registered provider list

### DIFF
--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -883,6 +883,16 @@ func registeredProviders() []Provider {
 	return providers
 }
 
+// RegisteredProviderNames returns the canonical names of every registered provider.
+func RegisteredProviderNames() []string {
+	providers := registeredProviders()
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		names = append(names, provider.Name())
+	}
+	return names
+}
+
 func normalizeProviderName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -2,6 +2,7 @@ package all
 
 import (
 	"io"
+	"slices"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -331,6 +332,16 @@ func TestAllBuiltInProvidersExposeDoctor(t *testing.T) {
 				t.Fatalf("%s does not implement DoctorProvider", name)
 			}
 		})
+	}
+}
+
+func TestAllBuiltInProviderNamesCoverRegistry(t *testing.T) {
+	want := core.RegisteredProviderNames()
+	got := append([]string(nil), allBuiltInProviderNames()...)
+	slices.Sort(got)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("allBuiltInProviderNames()=%v, registered providers=%v", got, want)
 	}
 }
 
@@ -724,6 +735,7 @@ func allBuiltInProviderNames() []string {
 		"mxc",
 		"namespace-devbox",
 		"namespace-instance",
+		"nebius",
 		"nvidia-brev",
 		"opencomputer",
 		"opensandbox",
@@ -733,6 +745,7 @@ func allBuiltInProviderNames() []string {
 		"proxmox",
 		"railway",
 		"runpod",
+		"scaleway",
 		"anthropic-sandbox-runtime",
 		"semaphore",
 		"smolvm",


### PR DESCRIPTION
## Summary
- expose canonical registered provider names for internal conformance checks
- assert the all-provider conformance list matches the provider registry
- add missing nebius and scaleway entries to the conformance list

## Verification
- go test ./internal/providers/all -run 'TestAllBuiltInProviderNamesCoverRegistry|TestAllBuiltInProvidersExposeDoctor|TestProviderKindRequiresBackendInterface|TestCleanupFeatureRequiresCleanupBackend|TestSSHFeatureRequiresSSHLoginBackend|TestCrabboxSyncFeatureRequiresSSHLeaseBackend|TestDirectTailscaleFeatureRequiresMetadataBackend|TestURLBridgeFeatureRequiresBridgeProvider|TestPauseResumeFeatureRequiresPausableBackend|TestWorkspaceFeaturesRequireNativeCheckpointProvider|TestRunEvidenceFeaturesRequireDelegatedBackends'
- go test ./internal/providers/all
- go test ./...
- go vet ./...
- git diff --check