### PR TITLE
test(providers): enforce cache volume feature contracts

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1144,7 +1144,8 @@ func validateCacheVolume(volume CacheVolumeConfig) error {
 	return nil
 }
 
-func validateCacheVolumesForProvider(cfg Config) error {
+// ValidateCacheVolumesForProvider checks provider support for configured cache volumes.
+func ValidateCacheVolumesForProvider(cfg Config) error {
 	if len(cfg.Cache.Volumes) == 0 {
 		return nil
 	}

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -163,7 +163,7 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	if err := applyProviderConfigDefaults(cfg); err != nil {
 		return err
 	}
-	if err := validateCacheVolumesForProvider(*cfg); err != nil {
+	if err := ValidateCacheVolumesForProvider(*cfg); err != nil {
 		return err
 	}
 	if err := validateProviderTarget(*cfg); err != nil {

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -441,6 +441,35 @@ func TestCleanupFeatureRequiresCleanupBackend(t *testing.T) {
 	}
 }
 
+func TestCacheVolumeFeatureGatesRequiredCacheVolumes(t *testing.T) {
+	checked := 0
+	for _, name := range allBuiltInProviderNames() {
+		provider := mustProvider(t, name)
+		cfg := core.BaseConfig()
+		cfg.Provider = name
+		cfg.Cache.Volumes = []core.CacheVolumeConfig{{
+			Name:     "pnpm",
+			Key:      "repo-linux-node24-lock",
+			Path:     "/var/cache/crabbox/pnpm",
+			Required: true,
+		}}
+		err := core.ValidateCacheVolumesForProvider(cfg)
+		if provider.Spec().Features.Has(core.FeatureCacheVolume) {
+			if err != nil {
+				t.Fatalf("%s advertises %s but rejects required cache volume: %v", name, core.FeatureCacheVolume, err)
+			}
+			checked++
+			continue
+		}
+		if err == nil {
+			t.Fatalf("%s accepts required cache volume without %s", name, core.FeatureCacheVolume)
+		}
+	}
+	if checked == 0 {
+		t.Fatalf("no providers advertised %s; conformance test is stale", core.FeatureCacheVolume)
+	}
+}
+
 func TestDirectTailscaleFeatureRequiresMetadataBackend(t *testing.T) {
 	checked := 0
 	for _, name := range allBuiltInProviderNames() {


### PR DESCRIPTION
## Summary
- expose the cache-volume provider validator for cross-package conformance coverage
- add an all-provider test that required cache volumes are accepted only by providers advertising cache-volume support

## Verification
- go test -count=1 ./internal/providers/all -run TestCacheVolumeFeatureGatesRequiredCacheVolumes
- go test -count=1 ./internal/cli ./internal/providers/all
- go test -count=1 ./...
- go vet ./...
- git diff --check