### PR TITLE
test(providers): enforce run session contracts

### DIFF
--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -833,6 +833,27 @@ type RunSessionHandle struct {
 	CleanupCommand string `json:"cleanupCommand"`
 }
 
+func ValidateRunSessionForSpec(spec ProviderSpec, result RunResult) error {
+	session := result.Session
+	if session == nil {
+		return nil
+	}
+	provider := blank(strings.TrimSpace(spec.Name), "provider")
+	if !featureSetHas(spec.Features, FeatureRunSession) {
+		return exit(2, "%s returned a run session but does not advertise %s", provider, FeatureRunSession)
+	}
+	if strings.TrimSpace(session.Provider) == "" {
+		return exit(2, "%s returned a run session without provider", provider)
+	}
+	if strings.TrimSpace(session.LeaseID) == "" {
+		return exit(2, "%s returned a run session without lease id", provider)
+	}
+	if strings.TrimSpace(session.CleanupCommand) == "" {
+		return exit(2, "%s returned a run session without cleanup command", provider)
+	}
+	return nil
+}
+
 type LeaseTarget struct {
 	Server      Server
 	SSH         SSHTarget

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1177,6 +1177,43 @@ func TestRejectDelegatedSyncOptionsAllowsModuleRunScriptOnly(t *testing.T) {
 	}
 }
 
+func TestValidateRunSessionForSpec(t *testing.T) {
+	spec := ProviderSpec{Name: "e2b", Kind: ProviderKindDelegatedRun, Features: FeatureSet{FeatureRunSession}}
+	valid := RunResult{Session: &RunSessionHandle{
+		Provider:       "e2b",
+		LeaseID:        "cbx_test",
+		CleanupCommand: "crabbox stop --provider e2b cbx_test",
+	}}
+	if err := ValidateRunSessionForSpec(spec, RunResult{}); err != nil {
+		t.Fatalf("nil session should be allowed: %v", err)
+	}
+	if err := ValidateRunSessionForSpec(spec, valid); err != nil {
+		t.Fatalf("valid session rejected: %v", err)
+	}
+	if err := ValidateRunSessionForSpec(ProviderSpec{Name: "plain"}, valid); err == nil || !strings.Contains(err.Error(), "does not advertise run-session") {
+		t.Fatalf("missing feature err=%v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*RunSessionHandle)
+		wantErr string
+	}{
+		{name: "provider", mutate: func(s *RunSessionHandle) { s.Provider = " " }, wantErr: "without provider"},
+		{name: "lease id", mutate: func(s *RunSessionHandle) { s.LeaseID = "" }, wantErr: "without lease id"},
+		{name: "cleanup", mutate: func(s *RunSessionHandle) { s.CleanupCommand = "\t" }, wantErr: "without cleanup command"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := *valid.Session
+			tc.mutate(&session)
+			err := ValidateRunSessionForSpec(spec, RunResult{Session: &session})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err=%v want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestProviderFlagsApplyDaytonaAndIsloWithoutCoreEdits(t *testing.T) {
 	defaults := baseConfig()
 	fs := newFlagSet("test", io.Discard)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -592,6 +592,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
 		}
+		if sessionErr := ValidateRunSessionForSpec(backend.Spec(), result); sessionErr != nil {
+			if runErr == nil {
+				return sessionErr
+			}
+			fmt.Fprintf(a.Stderr, "warning: ignoring invalid delegated run session: %v\n", sessionErr)
+			result.Session = nil
+		}
 		if err := writeRunLeaseOutput(strings.TrimSpace(*leaseOutput), result.Session); err != nil {
 			if runErr == nil {
 				return err

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -510,6 +510,49 @@ func TestProviderKindRequiresBackendInterface(t *testing.T) {
 	}
 }
 
+func TestRunSessionFeatureRequiresDelegatedBackendAndValidHandle(t *testing.T) {
+	checked := 0
+	for _, name := range allBuiltInProviderNames() {
+		provider := mustProvider(t, name)
+		spec := provider.Spec()
+		if !spec.Features.Has(core.FeatureRunSession) {
+			if err := core.ValidateRunSessionForSpec(spec, core.RunResult{Session: &core.RunSessionHandle{
+				Provider:       name,
+				LeaseID:        "cbx_test",
+				CleanupCommand: "crabbox stop --provider " + name + " cbx_test",
+			}}); err == nil {
+				t.Fatalf("%s accepts a run session without %s", name, core.FeatureRunSession)
+			}
+			continue
+		}
+		if spec.Kind != core.ProviderKindDelegatedRun {
+			t.Fatalf("%s advertises %s but kind=%s", name, core.FeatureRunSession, spec.Kind)
+		}
+		cfg, ok := offlineConformanceConfig(name)
+		if !ok {
+			t.Fatalf("%s advertises %s; add an offline conformance config for it", name, core.FeatureRunSession)
+		}
+		backend, err := provider.Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
+		if err != nil {
+			t.Fatalf("%s configure error: %v", name, err)
+		}
+		if _, ok := backend.(core.DelegatedRunBackend); !ok {
+			t.Fatalf("%s advertises %s but backend %T is not DelegatedRunBackend", name, core.FeatureRunSession, backend)
+		}
+		if err := core.ValidateRunSessionForSpec(spec, core.RunResult{Session: &core.RunSessionHandle{
+			Provider:       name,
+			LeaseID:        "cbx_test",
+			CleanupCommand: "crabbox stop --provider " + name + " cbx_test",
+		}}); err != nil {
+			t.Fatalf("%s rejects a valid %s handle: %v", name, core.FeatureRunSession, err)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatalf("no providers advertised %s; conformance test is stale", core.FeatureRunSession)
+	}
+}
+
 func TestCleanupFeatureRequiresCleanupBackend(t *testing.T) {
 	checked := 0
 	for _, name := range allBuiltInProviderNames() {


### PR DESCRIPTION
## Summary
- validate delegated run session handles against provider specs before writing lease output
- require run-session providers to configure as delegated run backends in all-provider conformance
- cover missing feature and malformed session handles in core tests

## Verification
- go test -count=1 ./internal/cli -run 'TestValidateRunSessionForSpec|TestRunCommandAcceptsE2BLeaseOutput|TestWriteRunLeaseOutput|TestRunCommandPreflightsLocalOutputOptions'\n- go test -count=1 ./internal/providers/all -run TestRunSessionFeatureRequiresDelegatedBackendAndValidHandle\n- go test -count=1 ./internal/cli ./internal/providers/all\n- go test -count=1 ./...\n- go vet ./...\n- git diff --check