### PR TITLE
test(providers): enforce interactive feature contracts

### DIFF
--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1069,14 +1069,45 @@ func TestLeaseCreateFlagsRejectSnapshotSandboxResourceNoops(t *testing.T) {
 }
 
 func TestValidateRequestedCapabilitiesUsesProviderSpec(t *testing.T) {
-	cfg := baseConfig()
-	cfg.Provider = "blacksmith-testbox"
-	cfg.Desktop = true
-	if err := validateRequestedCapabilities(cfg); err == nil {
-		t.Fatal("expected blacksmith desktop capability rejection")
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{
+			name: "desktop",
+			mutate: func(cfg *Config) {
+				cfg.Desktop = true
+			},
+			want: "desktop/VNC is not supported",
+		},
+		{
+			name: "browser",
+			mutate: func(cfg *Config) {
+				cfg.Browser = true
+			},
+			want: "browser provisioning is not supported",
+		},
+		{
+			name: "code",
+			mutate: func(cfg *Config) {
+				cfg.Code = true
+			},
+			want: "web code is not supported",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = "blacksmith-testbox"
+			tc.mutate(&cfg)
+			err := validateRequestedCapabilities(cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v want %q", err, tc.want)
+			}
+		})
 	}
 
-	cfg = baseConfig()
+	cfg := baseConfig()
 	cfg.Provider = "hetzner"
 	cfg.Desktop = true
 	if err := validateRequestedCapabilities(cfg); err != nil {

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -553,6 +553,46 @@ func TestRunSessionFeatureRequiresDelegatedBackendAndValidHandle(t *testing.T) {
 	}
 }
 
+func TestInteractiveLeaseFeaturesRequireSSHLeaseBackends(t *testing.T) {
+	counts := map[core.Feature]int{
+		core.FeatureDesktop: 0,
+		core.FeatureBrowser: 0,
+		core.FeatureCode:    0,
+	}
+	for _, name := range allBuiltInProviderNames() {
+		provider := mustProvider(t, name)
+		spec := provider.Spec()
+		features := []core.Feature{core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode}
+		if !hasAnyFeature(spec.Features, features...) {
+			continue
+		}
+		if spec.Kind != core.ProviderKindSSHLease || !spec.Features.Has(core.FeatureSSH) {
+			t.Fatalf("%s advertises interactive lease features %v but kind=%s features=%v", name, features, spec.Kind, spec.Features)
+		}
+		cfg, ok := offlineConformanceConfig(name)
+		if !ok {
+			t.Fatalf("%s advertises interactive lease features %v; add an offline conformance config for it", name, spec.Features)
+		}
+		backend, err := provider.Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
+		if err != nil {
+			t.Fatalf("%s configure error: %v", name, err)
+		}
+		if _, ok := backend.(core.SSHLeaseBackend); !ok {
+			t.Fatalf("%s advertises interactive lease features %v but backend %T is not SSHLeaseBackend", name, spec.Features, backend)
+		}
+		for _, feature := range features {
+			if spec.Features.Has(feature) {
+				counts[feature]++
+			}
+		}
+	}
+	for _, feature := range []core.Feature{core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode} {
+		if counts[feature] == 0 {
+			t.Fatalf("no providers advertised %s; conformance test is stale", feature)
+		}
+	}
+}
+
 func TestCleanupFeatureRequiresCleanupBackend(t *testing.T) {
 	checked := 0
 	for _, name := range allBuiltInProviderNames() {


### PR DESCRIPTION
## Summary
- extend requested capability validation coverage across desktop, browser, and code features
- add all-provider conformance coverage that interactive lease features configure as SSH lease backends
- keep the guard stale-proof by requiring at least one provider for each interactive feature

## Verification
- go test -count=1 ./internal/cli -run TestValidateRequestedCapabilitiesUsesProviderSpec
- go test -count=1 ./internal/providers/all -run TestInteractiveLeaseFeaturesRequireSSHLeaseBackends
- go test -count=1 ./internal/cli ./internal/providers/all
- go test -count=1 ./...
- go vet ./...
- git diff --check