### PR TITLE
test(providers): enforce archive sync force guard

### DIFF
--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -401,6 +401,9 @@ func TestArchiveSyncFeatureGatesDelegatedSyncOptions(t *testing.T) {
 		if err == nil {
 			t.Fatalf("%s accepts --sync-only without %s", name, core.FeatureArchiveSync)
 		}
+		if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ForceSyncLarge: true}); err == nil {
+			t.Fatalf("%s accepts --force-sync-large without %s", name, core.FeatureArchiveSync)
+		}
 	}
 	if checked == 0 {
 		t.Fatalf("no providers advertised %s; conformance test is stale", core.FeatureArchiveSync)


### PR DESCRIPTION
Summary:
- extend the archive-sync all-provider conformance test to reject --force-sync-large when a delegated provider does not advertise archive-sync
- keep the existing positive path for archive-sync providers unchanged

Verification:
- go test -count=1 ./internal/providers/all -run TestArchiveSyncFeatureGatesDelegatedSyncOptions
- go test -count=1 ./internal/providers/all
- go test -count=1 ./...
- go vet ./...
- git diff --check