### PR TITLE
feat(providers): recommend fast feedback runners

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -90,6 +90,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 ```sh
 crabbox providers recommend
 crabbox providers recommend ci-proof
+crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
@@ -108,6 +109,8 @@ Supported use cases:
 - `ci-proof`: CI proof runners and providers that return run proof or
   artifacts.
 - `desktop`: providers with desktop/browser/code-server capabilities.
+- `fast-feedback`: providers suited to repeated test loops with reusable cache
+  volumes, checkout sync, cleanup, or reusable validation evidence.
 - `gpu`: GPU-oriented execution providers.
 - `linux-vm`: general Linux VM or SSH-lease execution.
 - `local`: local containers, VMs, or local sandboxes.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -55,6 +55,7 @@ Use these rules before adding a new adapter:
 | --- | --- | --- |
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
+| Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
 | Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |
 | Local disposable Linux | `local-container`, `apple-container`, `apple-vz`, `multipass` | Fast local iteration without cloud credentials. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -394,6 +394,7 @@ func providerRecommendationUseCases() []string {
 		"byo-ssh",
 		"ci-proof",
 		"desktop",
+		"fast-feedback",
 		"gpu",
 		"linux-vm",
 		"local",
@@ -416,6 +417,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "ci-proof", true
 	case "desktop", "browser", "code", "vnc":
 		return "desktop", true
+	case "fast-feedback", "feedback", "fast-test", "fast-tests", "cache", "cached", "cache-heavy":
+		return "fast-feedback", true
 	case "gpu", "cuda", "ml":
 		return "gpu", true
 	case "linux", "linux-vm", "vm":
@@ -550,6 +553,31 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasTarget(targetMacOS) || hasTarget(targetWindows+"/"+WindowsModeNormal) {
 			add(8, "supports native desktop OS targets")
+		}
+	case "fast-feedback":
+		if hasFeature(FeatureCacheVolume) {
+			add(45, "can reuse dependency/cache volumes across runs")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(25, "can sync the current checkout")
+		}
+		if strings.HasPrefix(category, "local-") {
+			add(20, "local runtime avoids cloud credentials and queueing")
+		}
+		if category == "ci-proof-runner" {
+			add(18, "CI-shaped runner for repeated validation loops")
+		}
+		if hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(15, "can preserve validation evidence")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(10, "returns reusable run sessions")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(10, "can clean up owned runtime state")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux test workloads")
 		}
 	case "gpu":
 		if category == "gpu-cloud" {
@@ -726,6 +754,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "examples:")
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
+	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -381,10 +381,37 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "run-evidence", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "run-evidence", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestProvidersRecommendFastFeedbackPrefersCacheVolumes(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "fast-feedback", 5)
+	if len(recommendations) == 0 {
+		t.Fatal("expected fast-feedback recommendations")
+	}
+	if !strings.HasPrefix(recommendations[0].Category, "local-") {
+		t.Fatalf("top fast-feedback category=%q recommendations=%v", recommendations[0].Category, recommendations)
+	}
+	if !providerRecommendationHasFeature(recommendations[0].Features, FeatureCacheVolume) {
+		t.Fatalf("top fast-feedback recommendation missing cache-volume feature: %#v", recommendations[0])
+	}
+	foundProofRunner := false
+	for _, recommendation := range recommendations {
+		if recommendation.Provider == "blacksmith-testbox" {
+			foundProofRunner = true
+		}
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureCacheVolume) &&
+			!strings.HasPrefix(recommendation.Category, "local-") &&
+			recommendation.Category != "ci-proof-runner" {
+			t.Fatalf("fast-feedback recommendation lacks cache, local runtime, or proof-runner signal: %#v", recommendation)
+		}
+	}
+	if !foundProofRunner {
+		t.Fatalf("fast-feedback recommendations should include CI proof runners: %#v", recommendations)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a fast-feedback provider recommendation use case for cache-heavy and repeated test loops
- score existing provider capabilities around cache volumes, sync, cleanup, proof/session reuse, and local/runtime fit
- document the new recommendation workflow in provider docs and selection guidance

## Verification
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend'
- scripts/check-docs.sh
- go test -count=1 ./internal/cli
- go vet ./...
- go test -count=1 ./...
