### PR TITLE
feat(providers): recommend reachable app providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -92,6 +92,7 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend reachability
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
 crabbox providers recommend versioned-workspace
@@ -115,6 +116,8 @@ Supported use cases:
 - `linux-vm`: general Linux VM or SSH-lease execution.
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.
+- `reachability`: providers with a bidirectional tailnet plane, provider-native
+  HTTPS endpoints, outbound-only tailnet egress, or operator-side SSH tunnels.
 - `run-evidence`: providers that can return run proof, collect artifacts,
   materialize downloads, or expose preview URLs.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -56,6 +56,7 @@ Use these rules before adding a new adapter:
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
+| Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
 | Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |
 | Local disposable Linux | `local-container`, `apple-container`, `apple-vz`, `multipass` | Fast local iteration without cloud credentials. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -399,6 +399,7 @@ func providerRecommendationUseCases() []string {
 		"linux-vm",
 		"local",
 		"macos",
+		"reachability",
 		"run-evidence",
 		"self-hosted",
 		"versioned-workspace",
@@ -427,6 +428,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "local", true
 	case "mac", "macos", "darwin":
 		return "macos", true
+	case "reachability", "reachable", "network", "networking", "ports", "port", "pond":
+		return "reachability", true
 	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download", "preview", "preview-url", "url-bridge":
 		return "run-evidence", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
@@ -481,6 +484,7 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		reasons = append(reasons, reason)
 	}
 	category := benchmarkProviderCategories[entry.Provider]
+	capabilities := providerCapabilities(entry.Provider)
 	hasTarget := func(target string) bool { return providerRecommendationHasString(entry.Targets, target) }
 	hasFeature := func(feature Feature) bool { return providerRecommendationHasFeature(entry.Features, feature) }
 	switch useCase {
@@ -634,6 +638,22 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureSnapshot) || hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) {
 			add(10, "supports provider state reuse")
 		}
+	case "reachability":
+		if capabilities.Tailscale {
+			add(45, "can join a tailnet as a bidirectional peer")
+		}
+		if capabilities.URLBridge {
+			add(55, "can expose provider-native HTTPS endpoints")
+		}
+		if capabilities.SSHMesh {
+			add(20, "can build operator-side SSH tunnels")
+		}
+		if capabilities.TailscaleEgress {
+			add(10, "can use outbound-only tailnet egress")
+		}
+		if hasFeature(FeatureBrowser) || hasFeature(FeatureCode) {
+			add(8, "can pair reachability with interactive browser or code surfaces")
+		}
 	case "run-evidence":
 		hasEvidenceCapability := hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) || hasFeature(FeatureURLBridge)
 		if !hasEvidenceCapability {
@@ -756,6 +776,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 }

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -381,7 +381,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "run-evidence", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "reachability", "run-evidence", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
@@ -435,6 +435,37 @@ func TestProvidersRecommendRunEvidence(t *testing.T) {
 		if recommendation.Provider == "wandb" {
 			t.Fatalf("run-evidence should not recommend session-only providers: %#v", recommendation)
 		}
+	}
+}
+
+func TestProvidersRecommendReachabilityUsesTransportCapabilities(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "reachability", 12)
+	if len(recommendations) == 0 {
+		t.Fatal("expected reachability recommendations")
+	}
+	top := providerCapabilities(recommendations[0].Provider)
+	if !top.Tailscale && !top.URLBridge && !top.SSHMesh {
+		t.Fatalf("top reachability recommendation lacks transport capabilities: %#v", recommendations[0])
+	}
+	foundTailnet := false
+	foundURLBridge := false
+	for _, recommendation := range recommendations {
+		capabilities := providerCapabilities(recommendation.Provider)
+		if capabilities.Tailscale {
+			foundTailnet = true
+		}
+		if capabilities.URLBridge {
+			foundURLBridge = true
+		}
+		if !capabilities.Tailscale && !capabilities.TailscaleEgress && !capabilities.URLBridge && !capabilities.SSHMesh {
+			t.Fatalf("reachability recommendation lacks any transport plane: %#v", recommendation)
+		}
+	}
+	if !foundTailnet {
+		t.Fatalf("reachability recommendations should include tailnet peer providers: %#v", recommendations)
+	}
+	if !foundURLBridge {
+		t.Fatalf("reachability recommendations should include URL bridge providers: %#v", recommendations)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a reachability provider recommendation use case backed by existing pond transport capabilities
- score bidirectional tailnet peers, URL bridges, outbound-only tailnet egress, and SSH tunnel planes
- document the new workflow in provider command docs and provider selection guidance

## Verification
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend'
- go run ./cmd/crabbox providers recommend reachability --limit 8
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
