### PR TITLE
feat(providers): recommend isolated execution providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -91,6 +91,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend fast-feedback --feature cache-volume
+crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend reachability
 crabbox providers recommend run-evidence
@@ -113,6 +114,9 @@ Supported use cases:
 - `fast-feedback`: providers suited to repeated test loops with reusable cache
   volumes, checkout sync, cleanup, or reusable validation evidence.
 - `gpu`: GPU-oriented execution providers.
+- `isolated-execution`: delegated and local sandbox providers for disposable or
+  untrusted command execution. This is routing guidance, not a security
+  certification for a specific provider.
 - `linux-vm`: general Linux VM or SSH-lease execution.
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -56,6 +56,7 @@ Use these rules before adding a new adapter:
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
+| Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
 | Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
 | Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -396,6 +396,7 @@ func providerRecommendationUseCases() []string {
 		"desktop",
 		"fast-feedback",
 		"gpu",
+		"isolated-execution",
 		"linux-vm",
 		"local",
 		"macos",
@@ -422,6 +423,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "fast-feedback", true
 	case "gpu", "cuda", "ml":
 		return "gpu", true
+	case "isolated", "isolated-execution", "isolation", "secure", "secure-sandbox", "untrusted", "untrusted-code":
+		return "isolated-execution", true
 	case "linux", "linux-vm", "vm":
 		return "linux-vm", true
 	case "local", "local-vm", "local-runtime", "local-sandbox":
@@ -595,6 +598,28 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasFeature(FeatureRunSession) {
 			add(8, "supports reusable run sessions")
+		}
+	case "isolated-execution":
+		if category == "delegated-sandbox" {
+			add(55, "delegated sandbox provider")
+		}
+		if category == "local-sandbox" {
+			add(45, "local policy-constrained sandbox")
+		}
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(30, "provider owns command execution boundary")
+		}
+		if hasFeature(FeatureArchiveSync) {
+			add(15, "accepts bounded archive sync instead of a long-lived SSH lease")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(12, "can clean up provider-owned sandbox state")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux sandbox workloads")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(6, "returns sandbox run sessions for inspection")
 		}
 	case "linux-vm":
 		if hasTarget(targetLinux) {
@@ -775,6 +800,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
+	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -381,7 +381,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "reachability", "run-evidence", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "isolated-execution", "reachability", "run-evidence", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
@@ -466,6 +466,62 @@ func TestProvidersRecommendReachabilityUsesTransportCapabilities(t *testing.T) {
 	}
 	if !foundURLBridge {
 		t.Fatalf("reachability recommendations should include URL bridge providers: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendIsolatedExecutionPrefersDelegatedSandboxes(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "isolated-execution", 8)
+	if len(recommendations) == 0 {
+		t.Fatal("expected isolated-execution recommendations")
+	}
+	if recommendations[0].Kind != ProviderKindDelegatedRun {
+		t.Fatalf("top isolated-execution kind=%q recommendations=%v", recommendations[0].Kind, recommendations)
+	}
+	if recommendations[0].Category != "delegated-sandbox" && recommendations[0].Category != "local-sandbox" {
+		t.Fatalf("top isolated-execution category=%q recommendations=%v", recommendations[0].Category, recommendations)
+	}
+	for _, recommendation := range recommendations {
+		if recommendation.Category != "delegated-sandbox" && recommendation.Category != "local-sandbox" {
+			t.Fatalf("isolated-execution recommendation escaped sandbox categories: %#v", recommendation)
+		}
+	}
+}
+
+func TestProvidersRecommendIsolatedExecutionIncludesLocalSandboxes(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "isolated-execution", 64)
+	if len(recommendations) == 0 {
+		t.Fatal("expected isolated-execution recommendations")
+	}
+	foundLocalSandbox := false
+	foundDelegatedSandbox := false
+	for _, recommendation := range recommendations {
+		switch recommendation.Category {
+		case "local-sandbox":
+			foundLocalSandbox = true
+		case "delegated-sandbox":
+			foundDelegatedSandbox = true
+		}
+	}
+	if !foundLocalSandbox {
+		t.Fatalf("isolated-execution recommendations should include local sandbox providers: %#v", recommendations)
+	}
+	if !foundDelegatedSandbox {
+		t.Fatalf("isolated-execution recommendations should include delegated sandbox providers: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendIsolatedExecutionAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "secure-sandbox", "--limit", "1", "--json"})
+	if err != nil {
+		t.Fatalf("providers recommend secure-sandbox error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || entries[0].Kind != ProviderKindDelegatedRun {
+		t.Fatalf("secure-sandbox alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an isolated-execution provider recommendation use case for delegated and local sandbox providers
- support aliases like secure-sandbox and untrusted-code while avoiding a security-certification claim
- document the new workflow in provider command docs and provider selection guidance

## Verification
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend'
- go run ./cmd/crabbox providers recommend secure-sandbox --limit 5
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
