### PR TITLE
feat(providers): recommend team cloud providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -96,6 +96,7 @@ crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend reachability
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
+crabbox providers recommend team-cloud
 crabbox providers recommend versioned-workspace
 crabbox providers recommend versioned-workspace --target macos --workspace fork
 crabbox providers recommend worker-runtime --json
@@ -125,6 +126,8 @@ Supported use cases:
 - `run-evidence`: providers that can return run proof, collect artifacts,
   materialize downloads, or expose preview URLs.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.
+- `team-cloud`: brokerable or direct cloud providers for shared team workflows,
+  coordinator-mediated spend/cleanup, and normal SSH debugging.
 - `versioned-workspace`: providers with native checkpoint, fork, restore, or
   snapshot-reference capabilities.
 - `windows`: native Windows and WSL2 targets.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -58,6 +58,7 @@ Use these rules before adding a new adapter:
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
 | Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |
+| Shared team cloud leases | `aws`, `azure`, `gcp`, `hetzner` | They advertise brokerable cloud, cleanup, SSH, and sync capabilities in `crabbox providers` and `providers recommend team-cloud`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |
 | Existing owned machine | `ssh` | No provider lifecycle is needed; Crabbox only syncs and runs. |
 | Local disposable Linux | `local-container`, `apple-container`, `apple-vz`, `multipass` | Fast local iteration without cloud credentials. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -403,6 +403,7 @@ func providerRecommendationUseCases() []string {
 		"reachability",
 		"run-evidence",
 		"self-hosted",
+		"team-cloud",
 		"versioned-workspace",
 		"windows",
 		"worker-runtime",
@@ -437,6 +438,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "run-evidence", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
 		return "self-hosted", true
+	case "team", "team-cloud", "shared-cloud", "brokered-cloud", "coordinator", "coordinated-cloud", "managed-cloud":
+		return "team-cloud", true
 	case "versioned-workspace", "workspace", "workspaces", "checkpoint", "checkpoints", "snapshot", "snapshots", "fork", "forks":
 		return "versioned-workspace", true
 	case "windows", "win":
@@ -715,6 +718,28 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureCleanup) {
 			add(10, "can clean up owned resources")
 		}
+	case "team-cloud":
+		if category == "brokerable-cloud" {
+			add(80, "brokerable cloud provider for shared coordinator control")
+		}
+		if entry.Coordinator == string(CoordinatorSupported) {
+			add(35, "can use Crabbox coordinator spend and cleanup controls")
+		}
+		if category == "direct-cloud" {
+			add(25, "direct cloud provider with owned-account lifecycle")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(20, "can clean up owned cloud resources")
+		}
+		if hasFeature(FeatureCrabboxSync) {
+			add(15, "uses normal Crabbox sync and run")
+		}
+		if hasFeature(FeatureSSH) {
+			add(10, "supports SSH debugging")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux team workloads")
+		}
 	case "versioned-workspace":
 		hasWorkspaceCapability := hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) || hasFeature(FeatureRestore) || hasFeature(FeatureSnapshot)
 		if !hasWorkspaceCapability {
@@ -804,6 +829,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
+	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -381,7 +381,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "isolated-execution", "reachability", "run-evidence", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "isolated-execution", "reachability", "run-evidence", "team-cloud", "versioned-workspace", "worker-runtime"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
@@ -522,6 +522,42 @@ func TestProvidersRecommendIsolatedExecutionAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Kind != ProviderKindDelegatedRun {
 		t.Fatalf("secure-sandbox alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendTeamCloudPrefersBrokerableProviders(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "team-cloud", 4)
+	if len(recommendations) == 0 {
+		t.Fatal("expected team-cloud recommendations")
+	}
+	for _, recommendation := range recommendations {
+		if recommendation.Category != "brokerable-cloud" {
+			t.Fatalf("team-cloud top recommendations should be brokerable cloud providers: %#v", recommendations)
+		}
+		if recommendation.Kind != ProviderKindSSHLease {
+			t.Fatalf("team-cloud recommendation should be SSH lease: %#v", recommendation)
+		}
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureCleanup) {
+			t.Fatalf("team-cloud recommendation missing cleanup feature: %#v", recommendation)
+		}
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync) {
+			t.Fatalf("team-cloud recommendation missing crabbox-sync feature: %#v", recommendation)
+		}
+	}
+}
+
+func TestProvidersRecommendTeamCloudAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "brokered-cloud", "--limit", "1", "--json"})
+	if err != nil {
+		t.Fatalf("providers recommend brokered-cloud error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || entries[0].Category != "brokerable-cloud" {
+		t.Fatalf("brokered-cloud alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a team-cloud provider recommendation use case for shared cloud lease workflows
- rank brokerable coordinator-capable clouds first, with direct-cloud providers as lower-scored fallback
- document the workflow in provider command docs and provider selection guidance

## Verification
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend'
- go run ./cmd/crabbox providers recommend team-cloud --limit 8
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
