### PR TITLE
feat(providers): add forkable workspace recommendation alias

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -98,6 +98,7 @@ crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
 crabbox providers recommend team-cloud
 crabbox providers recommend versioned-workspace
+crabbox providers recommend forkable-workspace --workspace fork
 crabbox providers recommend versioned-workspace --target macos --workspace fork
 crabbox providers recommend worker-runtime --json
 ```
@@ -129,7 +130,8 @@ Supported use cases:
 - `team-cloud`: brokerable or direct cloud providers for shared team workflows,
   coordinator-mediated spend/cleanup, and normal SSH debugging.
 - `versioned-workspace`: providers with native checkpoint, fork, restore, or
-  snapshot-reference capabilities.
+  snapshot-reference capabilities. Aliases include `forkable-workspace`,
+  `durable-workspace`, and `stateful-workspace`.
 - `windows`: native Windows and WSL2 targets.
 - `worker-runtime`: Worker/module-runtime execution.
 

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -21,6 +21,7 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
+crabbox providers recommend forkable-workspace --workspace fork
 ```
 
 The recommendation command uses the built-in provider spec and checked-in
@@ -65,7 +66,7 @@ Use these rules before adding a new adapter:
 | Native desktop/browser/code-server | `aws`, `azure`, `hetzner`, `parallels`, `local-container`, `ssh` | These advertise the interactive lease features. |
 | GPU-oriented run | `runpod`, `nvidia-brev`, cloud VM providers with GPU types, `modal`, `wandb` | Pick SSH leases for normal debugging, delegated runs for provider-owned ML execution. |
 | Worker/module execution | `cloudflare-dynamic-workers` | It advertises the `worker-runtime` target and `module-run` feature. |
-| Versioned workspace reuse | `parallels`, `local-container` | They advertise normalized checkpoint/fork/restore/snapshot-reference capabilities in `crabbox providers` and `providers recommend versioned-workspace`. |
+| Versioned workspace reuse | `parallels`, `local-container` | They advertise normalized checkpoint/fork/restore/snapshot-reference capabilities in `crabbox providers` and `providers recommend versioned-workspace`; `forkable-workspace` is an alias for the same workflow. |
 | Self-hosted virtualization | `proxmox`, `xcp-ng`, `incus`, `kubevirt`, `external`, `ssh` | Keeps private infrastructure behind explicit provider boundaries. |
 
 ## Related external systems

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -440,7 +440,11 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "self-hosted", true
 	case "team", "team-cloud", "shared-cloud", "brokered-cloud", "coordinator", "coordinated-cloud", "managed-cloud":
 		return "team-cloud", true
-	case "versioned-workspace", "workspace", "workspaces", "checkpoint", "checkpoints", "snapshot", "snapshots", "fork", "forks":
+	case "versioned-workspace", "workspace", "workspaces",
+		"checkpoint", "checkpoints", "snapshot", "snapshots",
+		"fork", "forks", "forkable", "forkable-workspace",
+		"forkable-workspaces", "durable-workspace", "stateful-workspace",
+		"snapshot-fork":
 		return "versioned-workspace", true
 	case "windows", "win":
 		return "windows", true
@@ -831,6 +835,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
+	fmt.Fprintln(out, "  crabbox providers recommend forkable-workspace --workspace fork")
 }
 
 func printProviderRecommendations(out io.Writer, useCase string, entries []providerRecommendationEntry) {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -581,6 +581,29 @@ func TestProvidersRecommendVersionedWorkspace(t *testing.T) {
 	}
 }
 
+func TestProvidersRecommendForkableWorkspaceAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "forkable-workspace",
+		"--workspace", "fork",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend forkable-workspace error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entry count=%d entries=%#v", len(entries), entries)
+	}
+	if !containsString(entries[0].Workspace, "fork") {
+		t.Fatalf("forkable-workspace alias entry missing fork workspace capability: %#v", entries[0])
+	}
+}
+
 func TestProvidersRecommendCIPrefersProofRunner(t *testing.T) {
 	recommendations := recommendProvidersForUseCase(providerMatrix(), "ci-proof", 3)
 	if len(recommendations) == 0 {


### PR DESCRIPTION
## Summary
- add forkable/durable/stateful workspace aliases for the versioned-workspace provider recommender
- show forkable-workspace in provider recommendation examples
- document that forkable-workspace routes to the normalized checkpoint/fork/restore/snapshot workflow

## Verification
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend'
- go run ./cmd/crabbox providers recommend forkable-workspace --workspace fork --limit 3
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check