### PR TITLE
feat(providers): recommend mcp sandboxes

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -93,6 +93,7 @@ crabbox providers recommend ci-proof
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend mcp-sandbox
 crabbox providers recommend reachability
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
@@ -122,6 +123,8 @@ Supported use cases:
 - `linux-vm`: general Linux VM or SSH-lease execution.
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.
+- `mcp-sandbox`: sandboxes that can attach MCP server references when creating
+  the run environment.
 - `reachability`: providers with a bidirectional tailnet plane, provider-native
   HTTPS endpoints, outbound-only tailnet egress, or operator-side SSH tunnels.
 - `run-evidence`: providers that can return run proof, collect artifacts,

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -21,6 +21,7 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
+crabbox providers recommend mcp-sandbox
 crabbox providers recommend forkable-workspace --workspace fork
 ```
 
@@ -58,6 +59,7 @@ Use these rules before adding a new adapter:
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
+| MCP-attached sandbox runs | `docker-sandbox` | It advertises `mcp-attachments` in `crabbox providers` and `providers recommend mcp-sandbox`. |
 | Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |
 | Shared team cloud leases | `aws`, `azure`, `gcp`, `hetzner` | They advertise brokerable cloud, cleanup, SSH, and sync capabilities in `crabbox providers` and `providers recommend team-cloud`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -400,6 +400,7 @@ func providerRecommendationUseCases() []string {
 		"linux-vm",
 		"local",
 		"macos",
+		"mcp-sandbox",
 		"reachability",
 		"run-evidence",
 		"self-hosted",
@@ -432,6 +433,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "local", true
 	case "mac", "macos", "darwin":
 		return "macos", true
+	case "mcp", "mcp-sandbox", "mcp-attachments", "tool-sandbox", "tool-sandboxes":
+		return "mcp-sandbox", true
 	case "reachability", "reachable", "network", "networking", "ports", "port", "pond":
 		return "reachability", true
 	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download", "preview", "preview-url", "url-bridge":
@@ -670,6 +673,23 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureSnapshot) || hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) {
 			add(10, "supports provider state reuse")
 		}
+	case "mcp-sandbox":
+		if !hasFeature(FeatureMCP) {
+			break
+		}
+		add(80, "can attach MCP servers at sandbox creation")
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(25, "provider owns sandbox command execution")
+		}
+		if category == "local-sandbox" {
+			add(18, "local sandbox avoids cloud credentials")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(14, "returns reusable run sessions")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux MCP workloads")
+		}
 	case "reachability":
 		if capabilities.Tailscale {
 			add(45, "can join a tailnet as a bidirectional peer")
@@ -831,6 +851,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -381,7 +381,19 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		t.Fatalf("providers recommend error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"provider recommendation use cases:", "ci-proof", "agent-sandbox", "fast-feedback", "isolated-execution", "reachability", "run-evidence", "team-cloud", "versioned-workspace", "worker-runtime"} {
+	for _, want := range []string{
+		"provider recommendation use cases:",
+		"ci-proof",
+		"agent-sandbox",
+		"fast-feedback",
+		"isolated-execution",
+		"mcp-sandbox",
+		"reachability",
+		"run-evidence",
+		"team-cloud",
+		"versioned-workspace",
+		"worker-runtime",
+	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
@@ -601,6 +613,40 @@ func TestProvidersRecommendForkableWorkspaceAlias(t *testing.T) {
 	}
 	if !containsString(entries[0].Workspace, "fork") {
 		t.Fatalf("forkable-workspace alias entry missing fork workspace capability: %#v", entries[0])
+	}
+}
+
+func TestProvidersRecommendMCPSandbox(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "mcp-sandbox", 5)
+	if len(recommendations) == 0 {
+		t.Fatal("expected mcp-sandbox recommendations")
+	}
+	if recommendations[0].Provider != "docker-sandbox" {
+		t.Fatalf("top mcp-sandbox provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureMCP) {
+			t.Fatalf("mcp-sandbox recommendation lacks MCP attachments feature: %#v", recommendation)
+		}
+	}
+}
+
+func TestProvidersRecommendMCPSandboxAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "mcp",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend mcp error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureMCP) {
+		t.Fatalf("mcp alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `mcp-sandbox` provider recommendation use case and aliases
- rank only providers that advertise `mcp-attachments`
- document the MCP-attached sandbox workflow in provider selection docs

## Verification
- `go test -count=1 ./internal/cli -run TestProvidersRecommend`
- `go run ./cmd/crabbox providers recommend mcp-sandbox --limit 5`
- `scripts/check-docs.sh`
- `go vet ./...`
- `go test -count=1 ./internal/cli -run ^TestRunInteractiveSSHRetriesFallbackPorts$ -v`
- `go test -count=1 ./...` (first run hit transient `TestRunInteractiveSSHRetriesFallbackPorts`; exact rerun passed, second full run passed)
- `git diff --check`