### PR TITLE
feat(providers): recommend remote dev environments

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -95,6 +95,7 @@ crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend mcp-sandbox
 crabbox providers recommend reachability
+crabbox providers recommend remote-dev
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
 crabbox providers recommend team-cloud
@@ -127,6 +128,8 @@ Supported use cases:
   the run environment.
 - `reachability`: providers with a bidirectional tailnet plane, provider-native
   HTTPS endpoints, outbound-only tailnet egress, or operator-side SSH tunnels.
+- `remote-dev`: managed developer environments and SSH-capable remote
+  workspaces for local-editor, remote-compute workflows.
 - `run-evidence`: providers that can return run proof, collect artifacts,
   materialize downloads, or expose preview URLs.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -22,6 +22,7 @@ crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend remote-dev
 crabbox providers recommend forkable-workspace --workspace fork
 ```
 
@@ -60,6 +61,7 @@ Use these rules before adding a new adapter:
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
 | MCP-attached sandbox runs | `docker-sandbox` | It advertises `mcp-attachments` in `crabbox providers` and `providers recommend mcp-sandbox`. |
+| Remote developer environments | `namespace-devbox`, `daytona`, `morph`, `codesandbox`, `opencomputer` | They are managed dev-environment substrates with checkout sync, SSH or provider-owned workspace access, and `providers recommend remote-dev` routing. |
 | Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |
 | Shared team cloud leases | `aws`, `azure`, `gcp`, `hetzner` | They advertise brokerable cloud, cleanup, SSH, and sync capabilities in `crabbox providers` and `providers recommend team-cloud`. |
 | Generic Linux command execution | `aws`, `azure`, `gcp`, `hetzner`, `digitalocean`, `linode`, `ssh` | SSH leases keep the normal Crabbox sync/run/debug path. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -402,6 +402,7 @@ func providerRecommendationUseCases() []string {
 		"macos",
 		"mcp-sandbox",
 		"reachability",
+		"remote-dev",
 		"run-evidence",
 		"self-hosted",
 		"team-cloud",
@@ -437,6 +438,11 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "mcp-sandbox", true
 	case "reachability", "reachable", "network", "networking", "ports", "port", "pond":
 		return "reachability", true
+	case "remote-dev", "remote-development",
+		"dev-environment", "dev-environments",
+		"cloud-dev", "cloud-development", "cde",
+		"codespace", "codespaces", "remote-workspace":
+		return "remote-dev", true
 	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download", "preview", "preview-url", "url-bridge":
 		return "run-evidence", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
@@ -706,6 +712,40 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureBrowser) || hasFeature(FeatureCode) {
 			add(8, "can pair reachability with interactive browser or code surfaces")
 		}
+	case "remote-dev":
+		if isRemoteDevProvider(entry.Provider) {
+			add(65, "managed developer environment provider")
+		}
+		if entry.Kind == ProviderKindSSHLease && hasFeature(FeatureSSH) {
+			add(28, "normal SSH developer access")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(24, "can sync the current checkout")
+		}
+		if category == "direct-cloud" {
+			add(20, "provider-managed remote development capacity")
+		}
+		if category == "delegated-sandbox" && hasFeature(FeatureArchiveSync) {
+			add(16, "provider-owned workspace with archive sync")
+		}
+		if category == "brokerable-cloud" {
+			add(12, "can use coordinator spend and cleanup controls")
+		}
+		if category == "self-hosted-virtualization" || category == "local-vm" || category == "byo-ssh" {
+			add(10, "works as a private development environment target")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(20, "supports pause and resume")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(12, "can clean up owned workspace resources")
+		}
+		if hasFeature(FeatureBrowser) || hasFeature(FeatureCode) || hasFeature(FeatureDesktop) {
+			add(8, "can expose interactive development surfaces")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux development workloads")
+		}
 	case "run-evidence":
 		hasEvidenceCapability := hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) || hasFeature(FeatureURLBridge)
 		if !hasEvidenceCapability {
@@ -821,6 +861,15 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 	return score, reasons
 }
 
+func isRemoteDevProvider(provider string) bool {
+	switch provider {
+	case "codesandbox", "daytona", "morph", "namespace-devbox", "opencomputer":
+		return true
+	default:
+		return false
+	}
+}
+
 func providerRecommendationHasString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -853,6 +902,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
+	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -389,6 +389,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"isolated-execution",
 		"mcp-sandbox",
 		"reachability",
+		"remote-dev",
 		"run-evidence",
 		"team-cloud",
 		"versioned-workspace",
@@ -647,6 +648,45 @@ func TestProvidersRecommendMCPSandboxAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureMCP) {
 		t.Fatalf("mcp alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendRemoteDevPrefersManagedDevEnvironments(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "remote-dev", 3)
+	if len(recommendations) == 0 {
+		t.Fatal("expected remote-dev recommendations")
+	}
+	found := map[string]bool{}
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync) &&
+			!providerRecommendationHasFeature(recommendation.Features, FeatureArchiveSync) {
+			t.Fatalf("remote-dev recommendation cannot sync workspace: %#v", recommendation)
+		}
+		found[recommendation.Provider] = true
+	}
+	for _, provider := range []string{"daytona", "morph", "namespace-devbox"} {
+		if !found[provider] {
+			t.Fatalf("remote-dev recommendations should include %s: %#v", provider, recommendations)
+		}
+	}
+}
+
+func TestProvidersRecommendRemoteDevAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "codespaces",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend codespaces error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !isRemoteDevProvider(entries[0].Provider) {
+		t.Fatalf("codespaces alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add remote-dev provider recommendation routing and aliases for cloud/CDE-style workflows.
- Prefer managed developer environment substrates, then SSH/cloud fallback targets with sync and cleanup capability.
- Document the new use case in provider command docs and provider-selection guidance.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend remote-dev --limit 8
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check