### PR TITLE
docs(providers): map competitor landscape

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ Pick whichever matches your intent:
 - **Pick or add a target:** [Provider reference](providers/README.md),
   [Providers feature overview](features/providers.md),
   [Provider selection](features/provider-selection.md),
+  [Provider landscape](features/provider-landscape.md),
   [Provider authoring](features/provider-authoring.md),
   [Provider backends](provider-backends.md),
   [Capacity fallback](features/capacity-fallback.md),

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -41,6 +41,8 @@ Read when:
 - [Providers](providers.md): provider overview, target matrix, classes, and fallback.
 - [Provider selection](provider-selection.md): choose a provider, compare adjacent
   systems, and decide when not to add a first-class adapter.
+- [Provider landscape](provider-landscape.md): competitor map, support stance,
+  and provider capability roadmap.
 - [Provider reference](../providers/README.md): per-adapter pages for every registered provider.
 - [Capacity and fallback](capacity-fallback.md): class chains, market spot/on-demand, and region/AZ routing.
 - [Provider backends](../provider-backends.md): contract reference for backend interfaces and registration.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -1,0 +1,119 @@
+# Provider Landscape
+
+Read when:
+
+- comparing Crabbox with adjacent sandbox, dev-environment, or microVM tools;
+- deciding whether a competitor should become a first-class provider;
+- planning provider capability work without live provider credentials.
+
+This is a product and architecture map, not a benchmark. External products move
+quickly, so use this page to decide the next Crabbox seam to harden, then verify
+current behavior against the provider docs before adding code.
+
+## Core Position
+
+Crabbox should own the provider-neutral contract: selecting a target, syncing a
+checkout, running commands, returning proof, exposing reachability, and cleaning
+up capacity. It should not copy every adjacent product's control plane.
+
+That means:
+
+- support stable execution substrates as providers;
+- expose shared workflow capabilities through `crabbox providers` and
+  `crabbox providers recommend`;
+- use `ssh` or `external` for tools that already produce a normal host contract;
+- defer first-class support for runtimes whose useful behavior is still too
+  product-specific to test offline.
+
+## Landscape
+
+| Segment | External systems | Crabbox fit today | Improve next |
+| --- | --- | --- | --- |
+| CI proof runners | Blacksmith Testbox, Semaphore, GitHub Actions-style runners | Strong fit. Crabbox already separates proof-runner semantics from generic VM semantics through `ci-proof-runner` providers and `providers recommend ci-proof`. | Keep run proof, artifacts, downloads, and status records normalized across providers. |
+| Hosted agent sandboxes | E2B, Vercel Sandbox, Modal Sandboxes, Cloudflare Sandbox SDK, OpenSandbox, smolvm, Upstash Box | Good fit when the provider owns process execution and files. These map to `delegated-run` better than SSH leases. | Improve artifact/download parity, preview URL reporting, timeout/error taxonomy, and optional MCP attachment routing. |
+| Remote developer environments | Daytona, Namespace Devbox, CodeSandbox, Morph, OpenComputer, Codespaces-like tools | Good fit when Crabbox can either SSH into the workspace or delegate a command with archive sync. `providers recommend remote-dev` is the routing surface. | Add clearer live smoke docs per provider and keep local-editor, remote-compute flows distinct from CI proof. |
+| Forkable/versioned workspaces | Mitos, Firecracker snapshot systems, local-container, Parallels | Partial fit. Crabbox already has provider-neutral checkpoint/fork/restore capability names, but only local providers advertise them today. | Harden `versioned-workspace` behavior before adding any runtime-specific fork API. Do not add Mitos-only flags. |
+| Worker and module runtimes | Cloudflare Dynamic Workers, Cloudflare Sandbox SDK, Vercel/edge-adjacent runtimes | Narrow fit. `cloudflare-dynamic-workers` is a module-run provider; generic container sandboxes need a separate lifecycle and file/process contract. | Keep worker-runtime separate from Linux sandbox execution unless the provider can expose files, process status, logs, preview URLs, and cleanup. |
+| Self-hosted virtualization | Proxmox, XCP-ng, Incus, KubeVirt, local VMs | Strong fit when Crabbox gets a normal SSH lease and lifecycle hooks. | Keep provider-specific reconciliation behind adapters; no provider-specific branching in core. |
+| GPU and ML execution | RunPod, NVIDIA Brev, W&B, Modal, cloud GPU VMs | Mixed fit. SSH leases are best for debugging; delegated providers are best for provider-owned jobs. | Normalize result evidence and cost/usage metadata before chasing more GPU-specific launch paths. |
+
+## Mitos Decision
+
+Do not add first-class Mitos support yet.
+
+Mitos is strategically interesting because it targets forkable Firecracker
+microVM swarms, MCP, and copy-on-write fan-out from a warm running machine. That
+is a different contract from most Crabbox providers. If Crabbox adds `mitos`
+today, the likely failure mode is ugly: Mitos-specific flags, Kubernetes and KVM
+assumptions leaking into core, and tests that cannot prove the useful behavior
+without a live cluster.
+
+The better path is to make the generic seams real first:
+
+- `workspace-checkpoint`, `workspace-fork`, `workspace-restore`, and
+  `provider-snapshot` keep forkable workspace language provider-neutral.
+- `mcp-attachments` stays a capability, not a Mitos-only command mode.
+- `run-proof`, `run-artifacts`, `run-downloads`, and `url-bridge` keep evidence
+  portable across delegated sandboxes and proof runners.
+- `remote-dev`, `mcp-sandbox`, `isolated-execution`, and
+  `versioned-workspace` keep recommendations workflow-oriented.
+
+Revisit Mitos only when there is a concrete use case that needs live microVM
+forking and the provider contract can be tested with offline unit coverage plus
+an opt-in live smoke. Until then, document it as an observed adjacent system.
+
+## Support Matrix
+
+| System | Support stance | Why |
+| --- | --- | --- |
+| Mitos | Observe, do not support directly yet. | Its main differentiator is live microVM forking. Crabbox needs generic fork/checkpoint semantics hardened before a Mitos adapter would be clean. |
+| E2B | Supported as `e2b`. | Delegated sandbox execution maps cleanly to provider-owned sessions and URL bridge behavior. |
+| Vercel Sandbox | Supported as `vercel-sandbox`. | Ephemeral Linux sandbox execution fits `delegated-run`; keep adding evidence and artifact parity before more surface area. |
+| Modal | Supported as `modal`. | Provider-owned container execution fits delegated runs, especially Python and ML-shaped workloads. |
+| Cloudflare Sandbox SDK | Candidate, not the same as current Cloudflare providers. | The SDK can be a good delegated-run backend if the lifecycle, file, process, preview, and cleanup contract is stable enough. |
+| Cloudflare Dynamic Workers | Supported as `cloudflare-dynamic-workers`. | Worker/module execution is a separate target from Linux sandbox execution. |
+| Daytona | Supported as `daytona`. | Managed dev environment with SSH-shaped execution fits remote-dev routing. |
+| Namespace Devbox | Supported as `namespace-devbox`. | SSH lease plus sync/cleanup behavior fits remote-dev routing. |
+| CodeSandbox | Supported as `codesandbox`. | Delegated workspace execution and pause/resume fit remote-dev routing. |
+| Morph | Supported as `morph`. | Managed SSH lease fits local-editor, remote-compute workflows. |
+| OpenComputer | Supported as `opencomputer`. | Delegated Linux execution fits remote-dev and sandbox routing, but evidence parity should improve. |
+| DevPod | Do not support directly. | It is already a provider-agnostic dev environment layer. Use the resulting SSH/container target through `ssh`, `local-container`, or `external`. |
+| Coder | Do not support directly by default. | A Coder workspace should enter Crabbox as a stable host or external provider unless there is a narrow lifecycle contract to own. |
+| Kubernetes Agent Sandbox | Supported as `agent-sandbox`. | SandboxClaim-style delegated execution belongs behind the existing Kubernetes-native adapter. |
+| OpenSandbox, Microsandbox, Moru-like runtimes | Candidate only. | Add only when one has a stable lifecycle and evidence contract that is meaningfully different from existing delegated sandboxes. |
+
+## Roadmap
+
+Ship these in small PRs:
+
+1. Keep recommendation surfaces workflow-first.
+   `ci-proof`, `run-evidence`, `fast-feedback`, `isolated-execution`,
+   `mcp-sandbox`, `remote-dev`, `team-cloud`, and `versioned-workspace` should
+   stay the public routing vocabulary.
+2. Improve evidence parity for delegated sandboxes.
+   The biggest practical gap versus hosted sandbox products is not launch; it is
+   consistent proof, artifacts, downloads, preview URLs, logs, and error status.
+3. Add live smoke docs where credentials are required.
+   Provider adapters can be valuable before broad live access exists, but each
+   one needs an opt-in smoke contract that says what real behavior proves.
+4. Strengthen workspace reuse before runtime-specific forking.
+   Checkpoint, fork, restore, and provider snapshot semantics should be testable
+   through the CLI before adding live microVM fan-out.
+5. Keep edge/worker execution separate from Linux sandboxes.
+   A Worker module runtime is not the same thing as a Linux shell. Make the
+   target and feature names say that clearly.
+
+## Add-Provider Bar
+
+Add a first-class provider when the PR can prove:
+
+- stable lifecycle: create, inspect, run or attach, release, cleanup;
+- honest `ProviderSpec.Kind`, category, targets, and feature flags;
+- documented auth from env/config, never command-line secrets;
+- offline tests for parsing, command construction, status/list rendering, and
+  provider errors;
+- opt-in live smoke when credentials or quota are required;
+- docs that explain when to use the provider and when to choose an existing
+  workflow instead.
+
+If the bar is not met, use `ssh` or `external` and document the manual contract.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -6,6 +6,9 @@ Read when:
 - comparing a Crabbox provider with an external sandbox or dev-environment tool;
 - deciding whether a new provider belongs in Crabbox.
 
+For a deeper competitor and roadmap view, read
+[Provider landscape](provider-landscape.md).
+
 Crabbox should support provider families, not every interesting runtime by name.
 Prefer the provider that fits the workflow and its evidence requirements. Add a
 new first-class provider only when the runtime exposes a stable lifecycle,

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -144,7 +144,7 @@ Provider docs:
 
 - Per-provider feature notes: `docs/features/aws.md`, `docs/features/azure.md`, `docs/features/hetzner.md`, `docs/features/blacksmith-testbox.md`, `docs/features/namespace-devbox.md`, `docs/features/namespace-devbox-setup.md`, `docs/features/semaphore.md`, `docs/features/sprites.md`, `docs/features/daytona.md`, `docs/features/islo.md`, `docs/features/e2b.md`
 - Per-provider reference: `docs/providers/README.md` plus one file per provider under `docs/providers/`, including `docs/providers/apple-vz.md` for the local Apple Silicon `Virtualization.framework` path, `docs/providers/digitalocean.md` for the direct Droplet provider, `docs/providers/ovh.md` for the direct OVHcloud provider, `docs/providers/incus.md` for the separate local live validation contract, and `docs/providers/superserve.md` for delegated Superserve execution and live proof
-- Provider selection and backend authoring guide: `docs/features/provider-selection.md`, `docs/provider-backends.md`, `docs/features/provider-authoring.md`
+- Provider selection, landscape, and backend authoring guide: `docs/features/provider-selection.md`, `docs/features/provider-landscape.md`, `docs/provider-backends.md`, `docs/features/provider-authoring.md`
 - Tailscale contract: `docs/features/tailscale.md`
 
 ## Capabilities, Desktop, And Access Bridges


### PR DESCRIPTION
Summary
- Add a provider landscape doc that compares Crabbox against adjacent sandbox, CDE, worker, GPU, and forkable microVM systems.
- Record the support stance for Mitos: observe, do not add first-class support yet, and harden provider-neutral fork/checkpoint/evidence seams first.
- Link the new landscape page from the provider selection guide and docs indexes.

Verification
- scripts/check-docs.sh
- git diff --check
- go run ./cmd/crabbox providers recommend remote-dev --limit 5
- go run ./cmd/crabbox providers recommend versioned-workspace --workspace fork --limit 5