### PR TITLE
feat(providers): recommend live smoke candidates

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -93,6 +93,7 @@ crabbox providers recommend ci-proof
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
+crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
@@ -122,6 +123,8 @@ Supported use cases:
   untrusted command execution. This is routing guidance, not a security
   certification for a specific provider.
 - `linux-vm`: general Linux VM or SSH-lease execution.
+- `live-smoke`: providers with enough lifecycle, sync, cleanup, or evidence
+  signals to be good candidates for opt-in live smoke validation.
 - `local`: local containers, VMs, or local sandboxes.
 - `macos`: macOS targets.
 - `mcp-sandbox`: sandboxes that can attach MCP server references when creating

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -95,7 +95,9 @@ Ship these in small PRs:
    consistent proof, artifacts, downloads, preview URLs, logs, and error status.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
-   one needs an opt-in smoke contract that says what real behavior proves.
+   one needs an opt-in smoke contract that says what real behavior proves. Use
+   `crabbox providers recommend live-smoke` to pick candidates from offline
+   lifecycle, sync, cleanup, and evidence metadata before spending capacity.
 4. Strengthen workspace reuse before runtime-specific forking.
    Checkpoint, fork, restore, and provider snapshot semantics should be testable
    through the CLI before adding live microVM fan-out.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -24,6 +24,7 @@ crabbox providers recommend
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
+crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
 crabbox providers recommend remote-dev
 crabbox providers recommend forkable-workspace --workspace fork
@@ -61,6 +62,7 @@ Use these rules before adding a new adapter:
 | --- | --- | --- |
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
+| Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
 | MCP-attached sandbox runs | `docker-sandbox` | It advertises `mcp-attachments` in `crabbox providers` and `providers recommend mcp-sandbox`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -398,6 +398,7 @@ func providerRecommendationUseCases() []string {
 		"gpu",
 		"isolated-execution",
 		"linux-vm",
+		"live-smoke",
 		"local",
 		"macos",
 		"mcp-sandbox",
@@ -430,6 +431,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "isolated-execution", true
 	case "linux", "linux-vm", "vm":
 		return "linux-vm", true
+	case "live-smoke", "live-smokes", "provider-smoke", "provider-smokes",
+		"smoke", "smokes", "smoke-test", "smoke-tests",
+		"live-validation", "live-validate", "live-proof":
+		return "live-smoke", true
 	case "local", "local-vm", "local-runtime", "local-sandbox":
 		return "local", true
 	case "mac", "macos", "darwin":
@@ -655,6 +660,43 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if category == "direct-cloud" {
 			add(14, "direct cloud lease path")
+		}
+	case "live-smoke":
+		if hasFeature(FeatureCleanup) {
+			add(30, "can clean up provider-owned smoke resources")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(24, "can sync a smoke workload")
+		}
+		if entry.Kind == ProviderKindSSHLease && hasFeature(FeatureSSH) {
+			add(22, "normal SSH lifecycle can run generic smoke commands")
+		}
+		if entry.Kind == ProviderKindDelegatedRun && (hasFeature(FeatureRunSession) || hasFeature(FeatureArchiveSync) || hasFeature(FeatureRunProof)) {
+			add(18, "delegated run lifecycle can execute smoke commands")
+		}
+		if hasFeature(FeatureRunProof) {
+			add(35, "returns provider smoke proof")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(24, "can preserve smoke artifacts or downloads")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(20, "can expose smoke preview URLs")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(14, "returns reusable smoke sessions")
+		}
+		if strings.HasPrefix(category, "local-") {
+			add(14, "can smoke without cloud credentials")
+		}
+		if category == "ci-proof-runner" {
+			add(25, "CI proof runner is designed for validation smoke")
+		}
+		if category == "brokerable-cloud" || category == "direct-cloud" || category == "delegated-sandbox" || category == "ci-proof-runner" {
+			add(12, "provider class is useful for opt-in live validation")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux smoke workloads")
 		}
 	case "local":
 		if strings.HasPrefix(category, "local-") {
@@ -900,6 +942,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
+	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -387,6 +387,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"agent-sandbox",
 		"fast-feedback",
 		"isolated-execution",
+		"live-smoke",
 		"mcp-sandbox",
 		"reachability",
 		"remote-dev",
@@ -687,6 +688,53 @@ func TestProvidersRecommendRemoteDevAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !isRemoteDevProvider(entries[0].Provider) {
 		t.Fatalf("codespaces alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendLiveSmokePrefersProvableLifecycle(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "live-smoke", 8)
+	if len(recommendations) == 0 {
+		t.Fatal("expected live-smoke recommendations")
+	}
+	foundEvidence := false
+	for _, recommendation := range recommendations {
+		if recommendation.Kind == ProviderKindServiceControl {
+			t.Fatalf("live-smoke should not prefer service-control providers: %#v", recommendation)
+		}
+		hasSync := providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureArchiveSync)
+		hasEvidence := providerRecommendationHasFeature(recommendation.Features, FeatureRunProof) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		if hasEvidence {
+			foundEvidence = true
+		}
+		if !hasSync && !hasEvidence {
+			t.Fatalf("live-smoke recommendation lacks sync or evidence capability: %#v", recommendation)
+		}
+	}
+	if !foundEvidence {
+		t.Fatalf("live-smoke recommendations should include at least one evidence-capable provider: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendLiveSmokeAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "provider-smoke",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend provider-smoke error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || entries[0].Score <= 0 {
+		t.Fatalf("provider-smoke alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add a live-smoke provider recommendation use case for opt-in live validation candidates.
- Score providers by cleanup, sync, lifecycle, evidence, local/no-credential, and proof-runner signals.
- Document the new use case in provider command docs, provider selection, and the provider landscape roadmap.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend live-smoke --limit 10
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check