### PR TITLE
feat(providers): recommend preview URL providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -95,6 +95,7 @@ crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend preview-url
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
 crabbox providers recommend run-evidence
@@ -129,6 +130,8 @@ Supported use cases:
 - `macos`: macOS targets.
 - `mcp-sandbox`: sandboxes that can attach MCP server references when creating
   the run environment.
+- `preview-url`: providers that can expose provider-native preview URLs for app
+  or service smoke workflows.
 - `reachability`: providers with a bidirectional tailnet plane, provider-native
   HTTPS endpoints, outbound-only tailnet egress, or operator-side SSH tunnels.
 - `remote-dev`: managed developer environments and SSH-capable remote

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -93,6 +93,8 @@ Ship these in small PRs:
 2. Improve evidence parity for delegated sandboxes.
    The biggest practical gap versus hosted sandbox products is not launch; it is
    consistent proof, artifacts, downloads, preview URLs, logs, and error status.
+   Use `crabbox providers recommend preview-url` when the workflow specifically
+   needs provider-native app or service URLs.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -26,6 +26,7 @@ crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend preview-url
 crabbox providers recommend remote-dev
 crabbox providers recommend forkable-workspace --workspace fork
 ```
@@ -62,6 +63,7 @@ Use these rules before adding a new adapter:
 | --- | --- | --- |
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
+| Provider preview URLs | `islo`, `e2b`, `railway` | They advertise provider-native preview URL evidence and appear in `providers recommend preview-url`. |
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -402,6 +402,7 @@ func providerRecommendationUseCases() []string {
 		"local",
 		"macos",
 		"mcp-sandbox",
+		"preview-url",
 		"reachability",
 		"remote-dev",
 		"run-evidence",
@@ -441,6 +442,8 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "macos", true
 	case "mcp", "mcp-sandbox", "mcp-attachments", "tool-sandbox", "tool-sandboxes":
 		return "mcp-sandbox", true
+	case "preview", "preview-url", "preview-urls", "url-bridge", "app-preview", "app-previews", "web-preview", "web-previews":
+		return "preview-url", true
 	case "reachability", "reachable", "network", "networking", "ports", "port", "pond":
 		return "reachability", true
 	case "remote-dev", "remote-development",
@@ -448,7 +451,7 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		"cloud-dev", "cloud-development", "cde",
 		"codespace", "codespaces", "remote-workspace":
 		return "remote-dev", true
-	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download", "preview", "preview-url", "url-bridge":
+	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download":
 		return "run-evidence", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
 		return "self-hosted", true
@@ -738,6 +741,32 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux MCP workloads")
 		}
+	case "preview-url":
+		if !hasFeature(FeatureURLBridge) {
+			break
+		}
+		add(80, "can expose provider-native preview URLs")
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(30, "provider owns preview run execution")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(20, "returns reusable preview sessions")
+		}
+		if hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunArtifacts) {
+			add(14, "can pair previews with downloadable evidence")
+		}
+		if hasFeature(FeatureArchiveSync) || hasFeature(FeatureCrabboxSync) {
+			add(12, "can sync a preview workload")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(8, "supports pausing preview sandboxes")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(8, "can clean up preview resources")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux preview workloads")
+		}
 	case "reachability":
 		if capabilities.Tailscale {
 			add(45, "can join a tailnet as a bidirectional peer")
@@ -944,6 +973,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
+	fmt.Fprintln(out, "  crabbox providers recommend preview-url")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -389,6 +389,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"isolated-execution",
 		"live-smoke",
 		"mcp-sandbox",
+		"preview-url",
 		"reachability",
 		"remote-dev",
 		"run-evidence",
@@ -688,6 +689,47 @@ func TestProvidersRecommendRemoteDevAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !isRemoteDevProvider(entries[0].Provider) {
 		t.Fatalf("codespaces alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendPreviewURLPrefersURLBridgeProviders(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "preview-url", 3)
+	if len(recommendations) == 0 {
+		t.Fatal("expected preview-url recommendations")
+	}
+	found := map[string]bool{}
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge) {
+			t.Fatalf("preview-url recommendation lacks url-bridge feature: %#v", recommendation)
+		}
+		if !containsString(recommendation.Evidence, "preview-url") {
+			t.Fatalf("preview-url recommendation lacks preview-url evidence: %#v", recommendation)
+		}
+		found[recommendation.Provider] = true
+	}
+	for _, provider := range []string{"e2b", "islo"} {
+		if !found[provider] {
+			t.Fatalf("preview-url recommendations should include %s: %#v", provider, recommendations)
+		}
+	}
+}
+
+func TestProvidersRecommendPreviewURLAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "app-preview",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend app-preview error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureURLBridge) {
+		t.Fatalf("app-preview alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add a preview-url provider recommendation use case for app/service preview workflows.
- Rank providers that advertise URL bridge / preview URL evidence, with delegated-run/session/evidence tie breakers.
- Document the new workflow in provider command docs, provider selection, and the provider landscape roadmap.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend preview-url --limit 5
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./internal/applevzhelper -run TestRunStartReportsHelperExitWithoutWaitingForReadinessTimeout
- go test -count=1 ./...
- git diff --check

Note
- The first full go test run hit a transient Apple VZ helper readiness assertion; the exact test passed on rerun and the full suite passed on rerun.