### PR TITLE
feat(providers): recommend artifact download providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -89,6 +89,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 
 ```sh
 crabbox providers recommend
+crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend isolated-execution
@@ -113,6 +114,8 @@ Supported use cases:
 
 - `agent-sandbox`: delegated sandboxes and managed devboxes for agent code
   execution.
+- `artifact-download`: providers that can collect run artifacts or materialize
+  downloads from provider-owned execution.
 - `byo-ssh`: existing SSH hosts.
 - `ci-proof`: CI proof runners and providers that return run proof or
   artifacts.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -93,6 +93,8 @@ Ship these in small PRs:
 2. Improve evidence parity for delegated sandboxes.
    The biggest practical gap versus hosted sandbox products is not launch; it is
    consistent proof, artifacts, downloads, preview URLs, logs, and error status.
+   Use `crabbox providers recommend artifact-download` when a workflow needs
+   retained files or downloadable results from provider-owned execution.
    Use `crabbox providers recommend preview-url` when the workflow specifically
    needs provider-native app or service URLs.
 3. Add live smoke docs where credentials are required.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -21,6 +21,7 @@ Start with the command-backed recommendation list:
 
 ```sh
 crabbox providers recommend
+crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
@@ -62,6 +63,7 @@ Use these rules before adding a new adapter:
 | Workflow | Prefer | Why |
 | --- | --- | --- |
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
+| Run artifacts and downloads | `blacksmith-testbox`, `islo` | They advertise artifact or download evidence and appear in `providers recommend artifact-download`. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Provider preview URLs | `islo`, `e2b`, `railway` | They advertise provider-native preview URL evidence and appear in `providers recommend preview-url`. |
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -391,6 +391,7 @@ func providerFieldContainsAll(values, wants []string) bool {
 func providerRecommendationUseCases() []string {
 	return []string{
 		"agent-sandbox",
+		"artifact-download",
 		"byo-ssh",
 		"ci-proof",
 		"desktop",
@@ -418,6 +419,9 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "agent", "agents", "agent-sandbox", "sandbox", "sandboxes", "devbox", "devboxes":
 		return "agent-sandbox", true
+	case "artifact-download", "artifact-downloads", "downloadable-artifacts",
+		"run-artifacts", "run-downloads", "evidence-downloads":
+		return "artifact-download", true
 	case "byo", "byo-ssh", "ssh", "static", "static-ssh":
 		return "byo-ssh", true
 	case "ci", "ci-proof", "proof", "testbox", "repro":
@@ -539,6 +543,34 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if entry.Kind == ProviderKindSSHLease && hasTarget(targetLinux) && category == "direct-cloud" {
 			add(18, "managed Linux devbox with normal Crabbox SSH workflow")
+		}
+	case "artifact-download":
+		if !hasFeature(FeatureRunArtifacts) && !hasFeature(FeatureRunDownloads) {
+			break
+		}
+		if hasFeature(FeatureRunArtifacts) {
+			add(80, "can collect provider run artifacts")
+		}
+		if hasFeature(FeatureRunDownloads) {
+			add(75, "can materialize provider run downloads")
+		}
+		if hasFeature(FeatureRunProof) {
+			add(22, "can pair downloads with provider run proof")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(18, "returns reusable sessions for later artifact inspection")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(14, "can pair artifacts with provider-native preview URLs")
+		}
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(12, "provider owns artifact-producing command execution")
+		}
+		if category == "ci-proof-runner" {
+			add(12, "CI proof runner is designed to retain validation outputs")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux artifact workloads")
 		}
 	case "byo-ssh":
 		if category == "byo-ssh" {
@@ -966,6 +998,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "examples:")
+	fmt.Fprintln(out, "  crabbox providers recommend artifact-download")
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -383,6 +383,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 	text := stdout.String()
 	for _, want := range []string{
 		"provider recommendation use cases:",
+		"artifact-download",
 		"ci-proof",
 		"agent-sandbox",
 		"fast-feedback",
@@ -400,6 +401,52 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers recommend output missing %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestProvidersRecommendArtifactDownloadPrefersArtifactProviders(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "artifact-download", 4)
+	if len(recommendations) == 0 {
+		t.Fatal("expected artifact-download recommendations")
+	}
+	found := map[string]bool{}
+	for _, recommendation := range recommendations {
+		hasArtifact := providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts)
+		hasDownload := providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads)
+		if !hasArtifact && !hasDownload {
+			t.Fatalf("artifact-download recommendation lacks artifact/download capability: %#v", recommendation)
+		}
+		if hasArtifact && !containsString(recommendation.Evidence, "artifacts") {
+			t.Fatalf("artifact-download recommendation missing artifacts evidence: %#v", recommendation)
+		}
+		if hasDownload && !containsString(recommendation.Evidence, "downloads") {
+			t.Fatalf("artifact-download recommendation missing downloads evidence: %#v", recommendation)
+		}
+		found[recommendation.Provider] = true
+	}
+	for _, provider := range []string{"blacksmith-testbox", "islo"} {
+		if !found[provider] {
+			t.Fatalf("artifact-download recommendations should include %s: %#v", provider, recommendations)
+		}
+	}
+}
+
+func TestProvidersRecommendArtifactDownloadAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "run-artifacts",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend run-artifacts error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunArtifacts) {
+		t.Fatalf("run-artifacts alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add an artifact-download provider recommendation use case for retained artifacts and downloadable run results.
- Rank providers with run-artifacts or run-downloads evidence, with proof/session/preview tie breakers.
- Document the new workflow in provider command docs, provider selection, and the provider landscape roadmap.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend artifact-download --limit 5
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check