### PR TITLE
feat(providers): recommend inspectable run sessions

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -101,6 +101,7 @@ crabbox providers recommend reachability
 crabbox providers recommend remote-dev
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
+crabbox providers recommend run-session
 crabbox providers recommend team-cloud
 crabbox providers recommend versioned-workspace
 crabbox providers recommend forkable-workspace --workspace fork
@@ -141,6 +142,8 @@ Supported use cases:
   workspaces for local-editor, remote-compute workflows.
 - `run-evidence`: providers that can return run proof, collect artifacts,
   materialize downloads, or expose preview URLs.
+- `run-session`: providers that return reusable run/session handles for later
+  inspection, logs, previews, artifacts, or downloads.
 - `self-hosted`: private virtualization, external providers, and BYO SSH.
 - `team-cloud`: brokerable or direct cloud providers for shared team workflows,
   coordinator-mediated spend/cleanup, and normal SSH debugging.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -93,6 +93,8 @@ Ship these in small PRs:
 2. Improve evidence parity for delegated sandboxes.
    The biggest practical gap versus hosted sandbox products is not launch; it is
    consistent proof, artifacts, downloads, preview URLs, logs, and error status.
+   Use `crabbox providers recommend run-session` when the workflow needs a
+   reusable provider session handle for later inspection.
    Use `crabbox providers recommend artifact-download` when a workflow needs
    retained files or downloadable results from provider-owned execution.
    Use `crabbox providers recommend preview-url` when the workflow specifically

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -29,6 +29,7 @@ crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
 crabbox providers recommend preview-url
 crabbox providers recommend remote-dev
+crabbox providers recommend run-session
 crabbox providers recommend forkable-workspace --workspace fork
 ```
 
@@ -65,6 +66,7 @@ Use these rules before adding a new adapter:
 | CI reproduction with durable proof | `blacksmith-testbox`, `semaphore` | They map to CI/proof-runner semantics instead of generic devbox semantics. |
 | Run artifacts and downloads | `blacksmith-testbox`, `islo` | They advertise artifact or download evidence and appear in `providers recommend artifact-download`. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
+| Inspectable run sessions | `blacksmith-testbox`, `islo`, `e2b`, `cloudflare-dynamic-workers` | They advertise reusable session evidence and appear in `providers recommend run-session`. |
 | Provider preview URLs | `islo`, `e2b`, `railway` | They advertise provider-native preview URL evidence and appear in `providers recommend preview-url`. |
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -407,6 +407,7 @@ func providerRecommendationUseCases() []string {
 		"reachability",
 		"remote-dev",
 		"run-evidence",
+		"run-session",
 		"self-hosted",
 		"team-cloud",
 		"versioned-workspace",
@@ -457,6 +458,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "remote-dev", true
 	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download":
 		return "run-evidence", true
+	case "run-session", "run-sessions", "session", "sessions",
+		"inspectable-run", "inspectable-runs", "reusable-run", "reusable-runs",
+		"session-inspection":
+		return "run-session", true
 	case "self-hosted", "selfhosted", "homelab", "virtualization":
 		return "self-hosted", true
 	case "team", "team-cloud", "shared-cloud", "brokered-cloud", "coordinator", "coordinated-cloud", "managed-cloud":
@@ -869,6 +874,35 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasFeature(FeatureRunSession) {
 			add(15, "returns reusable run sessions for later inspection")
 		}
+	case "run-session":
+		if !hasFeature(FeatureRunSession) {
+			break
+		}
+		add(80, "returns reusable run sessions for later inspection")
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(25, "provider owns inspectable command execution")
+		}
+		if hasFeature(FeatureRunProof) {
+			add(22, "can pair sessions with provider run proof")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(18, "can pair sessions with retained run outputs")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(16, "can pair sessions with provider-native preview URLs")
+		}
+		if hasFeature(FeatureArchiveSync) || hasFeature(FeatureCrabboxSync) {
+			add(12, "can sync an inspectable run workload")
+		}
+		if hasFeature(FeatureMCP) {
+			add(10, "can inspect MCP-attached sandbox sessions")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(8, "can clean up session-owned resources")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
+			add(8, "supports common inspectable run targets")
+		}
 	case "self-hosted":
 		if category == "self-hosted-virtualization" {
 			add(80, "self-hosted virtualization provider")
@@ -1010,6 +1044,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
+	fmt.Fprintln(out, "  crabbox providers recommend run-session")
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 	fmt.Fprintln(out, "  crabbox providers recommend forkable-workspace --workspace fork")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -394,6 +394,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"reachability",
 		"remote-dev",
 		"run-evidence",
+		"run-session",
 		"team-cloud",
 		"versioned-workspace",
 		"worker-runtime",
@@ -497,6 +498,61 @@ func TestProvidersRecommendRunEvidence(t *testing.T) {
 		if recommendation.Provider == "wandb" {
 			t.Fatalf("run-evidence should not recommend session-only providers: %#v", recommendation)
 		}
+	}
+}
+
+func TestProvidersRecommendRunSessionPrefersInspectableRuns(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "run-session", 8)
+	if len(recommendations) == 0 {
+		t.Fatal("expected run-session recommendations")
+	}
+	foundProof := false
+	foundPreview := false
+	foundWorker := false
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureRunSession) {
+			t.Fatalf("run-session recommendation lacks run-session feature: %#v", recommendation)
+		}
+		if !containsString(recommendation.Evidence, "session") {
+			t.Fatalf("run-session recommendation lacks session evidence: %#v", recommendation)
+		}
+		if providerRecommendationHasFeature(recommendation.Features, FeatureRunProof) {
+			foundProof = true
+		}
+		if providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge) {
+			foundPreview = true
+		}
+		if providerRecommendationHasString(recommendation.Targets, targetWorkerRuntime) {
+			foundWorker = true
+		}
+	}
+	if !foundProof {
+		t.Fatalf("run-session recommendations should include proof-capable sessions: %#v", recommendations)
+	}
+	if !foundPreview {
+		t.Fatalf("run-session recommendations should include preview-capable sessions: %#v", recommendations)
+	}
+	if !foundWorker {
+		t.Fatalf("run-session recommendations should include worker runtime sessions: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendRunSessionAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "inspectable-run",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend inspectable-run error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunSession) {
+		t.Fatalf("inspectable-run alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add a run-session provider recommendation use case for reusable inspectable run handles.
- Rank providers that advertise session evidence, with proof, artifacts/downloads, preview URLs, worker runtime, cleanup, and MCP-session tie breakers.
- Document the new workflow in provider command docs, provider selection, and the provider landscape roadmap.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend run-session --limit 8
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check