### PR TITLE
feat(providers): recommend pausable providers

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -96,6 +96,7 @@ crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
@@ -134,6 +135,8 @@ Supported use cases:
 - `macos`: macOS targets.
 - `mcp-sandbox`: sandboxes that can attach MCP server references when creating
   the run environment.
+- `pause-resume`: providers that can pause and resume provider-owned runtime or
+  workspace state.
 - `preview-url`: providers that can expose provider-native preview URLs for app
   or service smoke workflows.
 - `reachability`: providers with a bidirectional tailnet plane, provider-native

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -31,7 +31,7 @@ That means:
 | --- | --- | --- | --- |
 | CI proof runners | Blacksmith Testbox, Semaphore, GitHub Actions-style runners | Strong fit. Crabbox already separates proof-runner semantics from generic VM semantics through `ci-proof-runner` providers and `providers recommend ci-proof`. | Keep run proof, artifacts, downloads, and status records normalized across providers. |
 | Hosted agent sandboxes | E2B, Vercel Sandbox, Modal Sandboxes, Cloudflare Sandbox SDK, OpenSandbox, smolvm, Upstash Box | Good fit when the provider owns process execution and files. These map to `delegated-run` better than SSH leases. | Improve artifact/download parity, preview URL reporting, timeout/error taxonomy, and optional MCP attachment routing. |
-| Remote developer environments | Daytona, Namespace Devbox, CodeSandbox, Morph, OpenComputer, Codespaces-like tools | Good fit when Crabbox can either SSH into the workspace or delegate a command with archive sync. `providers recommend remote-dev` is the routing surface. | Add clearer live smoke docs per provider and keep local-editor, remote-compute flows distinct from CI proof. |
+| Remote developer environments | Daytona, Namespace Devbox, CodeSandbox, Morph, OpenComputer, Codespaces-like tools | Good fit when Crabbox can either SSH into the workspace or delegate a command with archive sync. `providers recommend remote-dev` is the routing surface. | Add clearer live smoke docs per provider, surface pause/resume support, and keep local-editor, remote-compute flows distinct from CI proof. |
 | Forkable/versioned workspaces | Mitos, Firecracker snapshot systems, local-container, Parallels | Partial fit. Crabbox already has provider-neutral checkpoint/fork/restore capability names, but only local providers advertise them today. | Harden `versioned-workspace` behavior before adding any runtime-specific fork API. Do not add Mitos-only flags. |
 | Worker and module runtimes | Cloudflare Dynamic Workers, Cloudflare Sandbox SDK, Vercel/edge-adjacent runtimes | Narrow fit. `cloudflare-dynamic-workers` is a module-run provider; generic container sandboxes need a separate lifecycle and file/process contract. | Keep worker-runtime separate from Linux sandbox execution unless the provider can expose files, process status, logs, preview URLs, and cleanup. |
 | Self-hosted virtualization | Proxmox, XCP-ng, Incus, KubeVirt, local VMs | Strong fit when Crabbox gets a normal SSH lease and lifecycle hooks. | Keep provider-specific reconciliation behind adapters; no provider-specific branching in core. |
@@ -104,6 +104,8 @@ Ship these in small PRs:
    one needs an opt-in smoke contract that says what real behavior proves. Use
    `crabbox providers recommend live-smoke` to pick candidates from offline
    lifecycle, sync, cleanup, and evidence metadata before spending capacity.
+   Use `crabbox providers recommend pause-resume` when long-running sandbox or
+   dev-environment state needs to be parked and resumed.
 4. Strengthen workspace reuse before runtime-specific forking.
    Checkpoint, fork, restore, and provider snapshot semantics should be testable
    through the CLI before adding live microVM fan-out.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -27,6 +27,7 @@ crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend remote-dev
 crabbox providers recommend run-session
@@ -67,6 +68,7 @@ Use these rules before adding a new adapter:
 | Run artifacts and downloads | `blacksmith-testbox`, `islo` | They advertise artifact or download evidence and appear in `providers recommend artifact-download`. |
 | Run evidence and previews | `blacksmith-testbox`, `islo`, `e2b` | They advertise normalized proof, artifact, download, or preview-url capabilities in `crabbox providers` and `providers recommend run-evidence`. |
 | Inspectable run sessions | `blacksmith-testbox`, `islo`, `e2b`, `cloudflare-dynamic-workers` | They advertise reusable session evidence and appear in `providers recommend run-session`. |
+| Pausable or resumable runtimes | `codesandbox`, `islo` | They advertise pause/resume capability and appear in `providers recommend pause-resume`. |
 | Provider preview URLs | `islo`, `e2b`, `railway` | They advertise provider-native preview URL evidence and appear in `providers recommend preview-url`. |
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -403,6 +403,7 @@ func providerRecommendationUseCases() []string {
 		"local",
 		"macos",
 		"mcp-sandbox",
+		"pause-resume",
 		"preview-url",
 		"reachability",
 		"remote-dev",
@@ -447,6 +448,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "macos", true
 	case "mcp", "mcp-sandbox", "mcp-attachments", "tool-sandbox", "tool-sandboxes":
 		return "mcp-sandbox", true
+	case "pause-resume", "pause", "resume", "suspend", "suspended",
+		"pausable", "pausable-workspace", "pausable-workspaces",
+		"resumable", "resumable-workspace", "resumable-workspaces":
+		return "pause-resume", true
 	case "preview", "preview-url", "preview-urls", "url-bridge", "app-preview", "app-previews", "web-preview", "web-previews":
 		return "preview-url", true
 	case "reachability", "reachable", "network", "networking", "ports", "port", "pond":
@@ -778,6 +783,32 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux MCP workloads")
 		}
+	case "pause-resume":
+		if !hasFeature(FeaturePauseResume) {
+			break
+		}
+		add(80, "supports pausing and resuming provider-owned runtime state")
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(25, "provider owns resumable sandbox execution")
+		}
+		if hasFeature(FeatureArchiveSync) || hasFeature(FeatureCrabboxSync) {
+			add(18, "can seed resumable state from the current checkout")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(16, "can clean up paused runtime resources")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(14, "returns sessions for paused runtime inspection")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(12, "can expose preview URLs before or after resume")
+		}
+		if hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunArtifacts) {
+			add(10, "can preserve outputs from resumable runs")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux resumable workloads")
+		}
 	case "preview-url":
 		if !hasFeature(FeatureURLBridge) {
 			break
@@ -1040,6 +1071,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
+	fmt.Fprintln(out, "  crabbox providers recommend pause-resume")
 	fmt.Fprintln(out, "  crabbox providers recommend preview-url")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -390,6 +390,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"isolated-execution",
 		"live-smoke",
 		"mcp-sandbox",
+		"pause-resume",
 		"preview-url",
 		"reachability",
 		"remote-dev",
@@ -833,6 +834,44 @@ func TestProvidersRecommendPreviewURLAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureURLBridge) {
 		t.Fatalf("app-preview alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendPauseResumePrefersResumableProviders(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "pause-resume", 64)
+	if len(recommendations) == 0 {
+		t.Fatal("expected pause-resume recommendations")
+	}
+	found := map[string]bool{}
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeaturePauseResume) {
+			t.Fatalf("pause-resume recommendation lacks pause-resume feature: %#v", recommendation)
+		}
+		found[recommendation.Provider] = true
+	}
+	for _, provider := range []string{"islo"} {
+		if !found[provider] {
+			t.Fatalf("pause-resume recommendations should include %s: %#v", provider, recommendations)
+		}
+	}
+}
+
+func TestProvidersRecommendPauseResumeAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "resumable-workspace",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend resumable-workspace error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeaturePauseResume) {
+		t.Fatalf("resumable-workspace alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary
- Add a pause-resume provider recommendation use case for pausable/resumable sandbox and workspace state.
- Rank providers that advertise pause-resume, with sync, cleanup, session, preview, and output-retention tie breakers.
- Document the new workflow in provider command docs, provider selection, and the provider landscape roadmap.

Verification
- go test -count=1 ./internal/cli -run TestProvidersRecommend
- go run ./cmd/crabbox providers recommend pause-resume --limit 5
- scripts/check-docs.sh
- go vet ./...
- go test -count=1 ./...
- git diff --check