### PR TITLE
feat(providers): recommend network isolation

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -96,6 +96,7 @@ crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend network-isolation
 crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend reachability
@@ -135,6 +136,9 @@ Supported use cases:
 - `macos`: macOS targets.
 - `mcp-sandbox`: sandboxes that can attach MCP server references when creating
   the run environment.
+- `network-isolation`: delegated and local sandboxes for contained untrusted
+  execution when network exposure should stay narrow. This is routing guidance,
+  not a security certification for a specific provider.
 - `pause-resume`: providers that can pause and resume provider-owned runtime or
   workspace state.
 - `preview-url`: providers that can expose provider-native preview URLs for app

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -99,6 +99,9 @@ Ship these in small PRs:
    retained files or downloadable results from provider-owned execution.
    Use `crabbox providers recommend preview-url` when the workflow specifically
    needs provider-native app or service URLs.
+   Use `crabbox providers recommend network-isolation` when the workflow runs
+   untrusted code and network exposure should stay inside a delegated or local
+   sandbox boundary.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -27,6 +27,7 @@ crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
+crabbox providers recommend network-isolation
 crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend remote-dev
@@ -73,6 +74,7 @@ Use these rules before adding a new adapter:
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
+| Network-contained untrusted execution | `cloudflare`, `agent-sandbox`, `codesandbox`, `opensandbox`, `vercel-sandbox` | They keep execution inside delegated or local sandbox boundaries and appear in `providers recommend network-isolation`. |
 | MCP-attached sandbox runs | `docker-sandbox` | It advertises `mcp-attachments` in `crabbox providers` and `providers recommend mcp-sandbox`. |
 | Remote developer environments | `namespace-devbox`, `daytona`, `morph`, `codesandbox`, `opencomputer` | They are managed dev-environment substrates with checkout sync, SSH or provider-owned workspace access, and `providers recommend remote-dev` routing. |
 | Shared app reachability | `hetzner`, `azure`, `gcp`, `islo`, `e2b` | They advertise tailnet, URL bridge, or SSH tunnel planes in `crabbox providers` and `providers recommend reachability`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -403,6 +403,7 @@ func providerRecommendationUseCases() []string {
 		"local",
 		"macos",
 		"mcp-sandbox",
+		"network-isolation",
 		"pause-resume",
 		"preview-url",
 		"reachability",
@@ -448,6 +449,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "macos", true
 	case "mcp", "mcp-sandbox", "mcp-attachments", "tool-sandbox", "tool-sandboxes":
 		return "mcp-sandbox", true
+	case "network-isolation", "network-isolated", "network-containment",
+		"egress-control", "egress-controlled", "contained-execution",
+		"contained-sandbox", "contained-sandboxes":
+		return "network-isolation", true
 	case "pause-resume", "pause", "resume", "suspend", "suspended",
 		"pausable", "pausable-workspace", "pausable-workspaces",
 		"resumable", "resumable-workspace", "resumable-workspaces":
@@ -783,6 +788,40 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux MCP workloads")
 		}
+	case "network-isolation":
+		if category != "delegated-sandbox" && category != "local-sandbox" {
+			break
+		}
+		if category == "delegated-sandbox" {
+			add(65, "delegated sandbox boundary for untrusted execution")
+		}
+		if category == "local-sandbox" {
+			add(55, "local policy-constrained sandbox boundary")
+		}
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(28, "provider owns the command execution boundary")
+		}
+		if hasFeature(FeatureArchiveSync) {
+			add(20, "accepts bounded archive sync instead of a long-lived SSH lease")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(18, "can clean up provider-owned sandbox state")
+		}
+		if capabilities.TailscaleEgress {
+			add(12, "uses outbound-only tailnet egress")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(10, "returns sandbox sessions for later inspection")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(8, "can expose provider-native URLs without SSH tunneling")
+		}
+		if hasFeature(FeatureMCP) {
+			add(8, "can attach MCP servers within the sandbox boundary")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux sandbox workloads")
+		}
 	case "pause-resume":
 		if !hasFeature(FeaturePauseResume) {
 			break
@@ -1071,6 +1110,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
+	fmt.Fprintln(out, "  crabbox providers recommend network-isolation")
 	fmt.Fprintln(out, "  crabbox providers recommend pause-resume")
 	fmt.Fprintln(out, "  crabbox providers recommend preview-url")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -390,6 +390,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"isolated-execution",
 		"live-smoke",
 		"mcp-sandbox",
+		"network-isolation",
 		"pause-resume",
 		"preview-url",
 		"reachability",
@@ -641,6 +642,50 @@ func TestProvidersRecommendIsolatedExecutionAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Kind != ProviderKindDelegatedRun {
 		t.Fatalf("secure-sandbox alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendNetworkIsolationPrefersSandboxBoundaries(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "network-isolation", 64)
+	if len(recommendations) == 0 {
+		t.Fatal("expected network-isolation recommendations")
+	}
+	foundLocalSandbox := false
+	foundDelegatedSandbox := false
+	for _, recommendation := range recommendations {
+		switch recommendation.Category {
+		case "delegated-sandbox":
+			foundDelegatedSandbox = true
+		case "local-sandbox":
+			foundLocalSandbox = true
+		default:
+			t.Fatalf("network-isolation recommendation escaped sandbox categories: %#v", recommendation)
+		}
+	}
+	if !foundDelegatedSandbox {
+		t.Fatalf("network-isolation recommendations should include delegated sandboxes: %#v", recommendations)
+	}
+	if !foundLocalSandbox {
+		t.Fatalf("network-isolation recommendations should include local sandboxes: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendNetworkIsolationAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "egress-control",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend egress-control error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || entries[0].Category != "delegated-sandbox" {
+		t.Fatalf("egress-control alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `network-isolation` as a provider recommendation workflow for contained untrusted execution
- rank delegated/local sandbox boundaries, bounded archive sync, cleanup, session evidence, and egress-only transport signals
- document when to use this separately from generic reachability

## Verification
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(NetworkIsolation|ListsUseCases|IsolatedExecution|Reachability)'`\n- `go run ./cmd/crabbox providers recommend network-isolation --limit 8`\n- `go run ./cmd/crabbox providers recommend egress-control --limit 1 --json`\n- `scripts/check-docs.sh`\n- `go vet ./...`\n- `go test -count=1 ./...`\n- `git diff --check`