### PR TITLE
feat(providers): recommend cost control

### DIFF
--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -91,6 +91,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 crabbox providers recommend
 crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
+crabbox providers recommend cost-control
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
@@ -122,6 +123,9 @@ Supported use cases:
 - `byo-ssh`: existing SSH hosts.
 - `ci-proof`: CI proof runners and providers that return run proof or
   artifacts.
+- `cost-control`: providers with local execution, coordinator governance,
+  cleanup, cache reuse, reusable state, or retained proof to reduce quota and
+  hot-capacity waste.
 - `desktop`: providers with desktop/browser/code-server capabilities.
 - `fast-feedback`: providers suited to repeated test loops with reusable cache
   volumes, checkout sync, cleanup, or reusable validation evidence.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -107,6 +107,9 @@ Ship these in small PRs:
    one needs an opt-in smoke contract that says what real behavior proves. Use
    `crabbox providers recommend live-smoke` to pick candidates from offline
    lifecycle, sync, cleanup, and evidence metadata before spending capacity.
+   Use `crabbox providers recommend cost-control` when a workflow should prefer
+   local runtimes, coordinator governance, cleanup, cache reuse, or retained
+   proof before spending provider quota.
    Use `crabbox providers recommend pause-resume` when long-running sandbox or
    dev-environment state needs to be parked and resumed.
 4. Strengthen workspace reuse before runtime-specific forking.

--- a/docs/features/provider-selection.md
+++ b/docs/features/provider-selection.md
@@ -23,6 +23,7 @@ Start with the command-backed recommendation list:
 crabbox providers recommend
 crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
+crabbox providers recommend cost-control
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend live-smoke
@@ -72,6 +73,7 @@ Use these rules before adding a new adapter:
 | Pausable or resumable runtimes | `codesandbox`, `islo` | They advertise pause/resume capability and appear in `providers recommend pause-resume`. |
 | Provider preview URLs | `islo`, `e2b`, `railway` | They advertise provider-native preview URL evidence and appear in `providers recommend preview-url`. |
 | Provider live smoke | `blacksmith-testbox`, `cloudflare`, `local-container`, `apple-container`, `aws` | They advertise enough sync, cleanup, lifecycle, or evidence capability for `providers recommend live-smoke` to rank them as good opt-in smoke candidates. |
+| Cost- or quota-sensitive validation | `local-container`, `apple-container`, `multipass`, `aws`, `azure` | They advertise local execution, cache reuse, cleanup, or coordinator-governed cloud controls and appear in `providers recommend cost-control`. |
 | Fast feedback with reusable caches | `local-container`, `apple-container`, `multipass`, `blacksmith-testbox` | They advertise cache-volume, sync, cleanup, or reusable proof/session capabilities in `crabbox providers` and `providers recommend fast-feedback`. |
 | Disposable isolated execution | `agent-sandbox`, `anthropic-sandbox-runtime`, `e2b`, `smolvm`, `vercel-sandbox` | They are delegated or local sandbox providers in `crabbox providers` and `providers recommend isolated-execution`. |
 | Network-contained untrusted execution | `cloudflare`, `agent-sandbox`, `codesandbox`, `opensandbox`, `vercel-sandbox` | They keep execution inside delegated or local sandbox boundaries and appear in `providers recommend network-isolation`. |

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -394,6 +394,7 @@ func providerRecommendationUseCases() []string {
 		"artifact-download",
 		"byo-ssh",
 		"ci-proof",
+		"cost-control",
 		"desktop",
 		"fast-feedback",
 		"gpu",
@@ -429,6 +430,9 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "byo-ssh", true
 	case "ci", "ci-proof", "proof", "testbox", "repro":
 		return "ci-proof", true
+	case "cost", "cost-control", "cost-aware", "budget", "budget-control",
+		"quota", "quota-safe", "spend", "spend-control":
+		return "cost-control", true
 	case "desktop", "browser", "code", "vnc":
 		return "desktop", true
 	case "fast-feedback", "feedback", "fast-test", "fast-tests", "cache", "cached", "cache-heavy":
@@ -615,6 +619,37 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if category == "ci-proof-runner" && entry.Kind == ProviderKindSSHLease && hasFeature(FeatureCrabboxSync) {
 			add(12, "can debug through normal Crabbox sync and SSH")
+		}
+	case "cost-control":
+		if strings.HasPrefix(category, "local-") {
+			add(75, "local runtime avoids provider spend and cloud quota")
+		}
+		if entry.Coordinator == string(CoordinatorSupported) {
+			add(45, "can use coordinator spend and cleanup controls")
+		}
+		if category == "ci-proof-runner" {
+			add(35, "CI proof runner is designed for bounded validation work")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(25, "can clean up owned runtime resources")
+		}
+		if hasFeature(FeatureCacheVolume) {
+			add(20, "can reuse dependency and build caches")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(15, "can sync only the current workload")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(12, "can pause runtime state instead of keeping it hot")
+		}
+		if hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) || hasFeature(FeatureRestore) || hasFeature(FeatureSnapshot) {
+			add(10, "can reuse workspace state across runs")
+		}
+		if hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(10, "can retain proof without keeping capacity alive")
+		}
+		if hasTarget(targetLinux) {
+			add(5, "supports common Linux validation workloads")
 		}
 	case "desktop":
 		if hasFeature(FeatureDesktop) {
@@ -1104,6 +1139,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "examples:")
 	fmt.Fprintln(out, "  crabbox providers recommend artifact-download")
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
+	fmt.Fprintln(out, "  crabbox providers recommend cost-control")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -385,6 +385,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"provider recommendation use cases:",
 		"artifact-download",
 		"ci-proof",
+		"cost-control",
 		"agent-sandbox",
 		"fast-feedback",
 		"isolated-execution",
@@ -450,6 +451,59 @@ func TestProvidersRecommendArtifactDownloadAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunArtifacts) {
 		t.Fatalf("run-artifacts alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendCostControlPrefersReusableOrGovernedCapacity(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "cost-control", 64)
+	if len(recommendations) == 0 {
+		t.Fatal("expected cost-control recommendations")
+	}
+	if !strings.HasPrefix(recommendations[0].Category, "local-") {
+		t.Fatalf("top cost-control category=%q recommendations=%v", recommendations[0].Category, recommendations)
+	}
+	foundLocal := false
+	foundCoordinator := false
+	foundCleanup := false
+	for _, recommendation := range recommendations {
+		if strings.HasPrefix(recommendation.Category, "local-") {
+			foundLocal = true
+		}
+		if recommendation.Provider == "aws" || recommendation.Provider == "azure" ||
+			recommendation.Provider == "gcp" || recommendation.Provider == "hetzner" {
+			foundCoordinator = true
+		}
+		if providerRecommendationHasFeature(recommendation.Features, FeatureCleanup) {
+			foundCleanup = true
+		}
+	}
+	if !foundLocal {
+		t.Fatalf("cost-control recommendations should include local providers: %#v", recommendations)
+	}
+	if !foundCoordinator {
+		t.Fatalf("cost-control recommendations should include coordinator-governed cloud providers: %#v", recommendations)
+	}
+	if !foundCleanup {
+		t.Fatalf("cost-control recommendations should include cleanup-capable providers: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendCostControlAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "budget",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend budget error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
+		t.Fatalf("budget alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `cost-control` as a provider recommendation workflow for quota- and spend-sensitive validation
- rank local runtimes, coordinator-governed providers, cleanup, cache reuse, reusable state, and retained proof
- document when to use cost-control before spending live provider capacity

## Verification
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(CostControl|ListsUseCases|FastFeedback|TeamCloud)'`\n- `go run ./cmd/crabbox providers recommend cost-control --limit 10`\n- `go run ./cmd/crabbox providers recommend budget --limit 1 --json`\n- `scripts/check-docs.sh`\n- `go vet ./...`\n- `go test -count=1 ./...` (first run hit transient `internal/applevzhelper` readiness test; targeted rerun passed, full rerun passed)\n- `git diff --check`