### PR TITLE
feat(run): normalize delegated timing outcomes

### DIFF
--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -759,7 +759,7 @@ func timingReportFromDelegatedRunResult(req RunRequest, result RunResult, provid
 			exitCode = 1
 		}
 	}
-	return timingReport{
+	report := timingReport{
 		Provider:      firstNonBlank(result.Provider, provider),
 		LeaseID:       result.LeaseID,
 		Slug:          result.Slug,
@@ -771,4 +771,5 @@ func timingReportFromDelegatedRunResult(req RunRequest, result RunResult, provid
 		Label:         req.Label,
 		Artifacts:     result.Artifacts,
 	}
+	return TimingReportWithRunResult(report, result, runErr)
 }

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -75,6 +75,21 @@ func (b benchmarkTimingTestBackend) Status(context.Context, StatusRequest) (Stat
 }
 func (b benchmarkTimingTestBackend) Stop(context.Context, StopRequest) error { return nil }
 
+func TestTimingReportFromDelegatedRunResultClassifiesRunError(t *testing.T) {
+	report := timingReportFromDelegatedRunResult(RunRequest{}, RunResult{
+		Provider:      "sandbox-test",
+		SyncDelegated: true,
+		Command:       250 * time.Millisecond,
+		Total:         time.Second,
+	}, "fallback", context.DeadlineExceeded)
+	if report.ExitCode != 1 {
+		t.Fatalf("ExitCode=%d, want 1", report.ExitCode)
+	}
+	if report.RunStatus != RunStatusTimedOut || report.ErrorKind != RunErrorTimeout {
+		t.Fatalf("runStatus/errorKind=%q/%q", report.RunStatus, report.ErrorKind)
+	}
+}
+
 func TestBenchRecordAppendsTimingJSONRecord(t *testing.T) {
 	dir := t.TempDir()
 	inputPath := filepath.Join(dir, "timing.json")

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -69,6 +69,21 @@ func finalizeTimingReport(report TimingReport) TimingReport {
 	return report
 }
 
+// TimingReportWithRunResult copies normalized run outcome fields onto a timing report.
+func TimingReportWithRunResult(report TimingReport, result RunResult, err error) TimingReport {
+	result = FinalizeRunResult(result, err)
+	if report.ExitCode == 0 && result.ExitCode != 0 {
+		report.ExitCode = result.ExitCode
+	}
+	if report.RunStatus == "" {
+		report.RunStatus = result.Status
+	}
+	if report.ErrorKind == "" {
+		report.ErrorKind = result.ErrorKind
+	}
+	return report
+}
+
 func encodeTimingJSON(w io.Writer, report TimingReport) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetEscapeHTML(false)

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -227,6 +227,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		}
 	}
 	report := delegatedTimingReport(blacksmithTestboxProvider, leaseID, slug, "blacksmith-testbox owns sync", commandDuration, commandPhases, total, code)
+	report = core.TimingReportWithRunResult(report, result, nil)
 	if code != 0 {
 		classificationInput := string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes())
 		if artifactErr != nil {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -968,6 +968,7 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 		Command:               []string{"true"},
 		RequiredArtifactGlobs: []string{"reports/manifest.json"},
 		KeepOnFailure:         true,
+		TimingJSON:            true,
 	})
 	var exitErr ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
@@ -980,7 +981,7 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 		t.Fatalf("session=%#v, want kept after artifact failure", result.Session)
 	}
 	got := stderr.String()
-	for _, want := range []string{"blacksmith artifact retrieval failed", "missing required artifact reports/manifest.json", "blacksmith run summary", "exit=7", "failure-bundle local=", "keep-on-failure: kept lease=tbx_artifactfail"} {
+	for _, want := range []string{"blacksmith artifact retrieval failed", "missing required artifact reports/manifest.json", "blacksmith run summary", "exit=7", `"runStatus":"failed"`, `"errorKind":"command-exit"`, "failure-bundle local=", "keep-on-failure: kept lease=tbx_artifactfail"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q in:\n%s", want, got)
 		}


### PR DESCRIPTION
## Summary
- add a core helper to copy normalized RunResult outcome fields onto timing reports
- route central delegated timing records through the normalized outcome path
- make Blacksmith provider-owned timing JSON include runStatus/errorKind for artifact-failure exits

## Verification
- git diff --check
- go test -count=1 ./internal/cli -run 'TestTimingReportFromDelegatedRunResultClassifiesRunError|TestRunDelegatedTimingJSONEmittedOnceWhileRecording|TestTimingJSON(PreservesProviderOutcome|DefaultsSuccessfulRunStatus|Shape)'
- go test -count=1 ./internal/providers/blacksmith -run 'TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure|TestBlacksmithRunProofArtifactsPersistSuccessStreams'
- go test -count=1 ./internal/cli ./internal/providers/blacksmith