### PR TITLE
feat(providers): include outcomes in provider timing

### DIFF
--- a/internal/providers/anthropicsandboxruntime/backend.go
+++ b/internal/providers/anthropicsandboxruntime/backend.go
@@ -58,7 +58,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	result = core.FinalizeRunResult(result, runErr)
 	fmt.Fprintf(b.rt.Stderr, "anthropic-sandbox-runtime run summary sync_delegated=true command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			SyncDelegated: true,
 			SyncSkipped:   true,
@@ -66,7 +66,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, runErr)
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/anthropicsandboxruntime/backend_test.go
+++ b/internal/providers/anthropicsandboxruntime/backend_test.go
@@ -154,10 +154,12 @@ func TestRunReturnsNonZeroExitWithoutPersistentSession(t *testing.T) {
 		}
 		return LocalCommandResult{ExitCode: 7, Stderr: "boom\n"}, errors.New("exit status 7")
 	}}
-	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
+	var stderr bytes.Buffer
+	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
-		Command: []string{"false"},
+		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+		Command:    []string{"false"},
+		TimingJSON: true,
 	})
 	var exitErr core.ExitError
 	if !core.AsExitError(err, &exitErr) || exitErr.Code != 7 {
@@ -168,6 +170,9 @@ func TestRunReturnsNonZeroExitWithoutPersistentSession(t *testing.T) {
 	}
 	if result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorCommandExit {
 		t.Fatalf("status/error=%q/%q", result.Status, result.ErrorKind)
+	}
+	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
+		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
 	}
 }
 

--- a/internal/providers/anthropicsandboxruntime/core.go
+++ b/internal/providers/anthropicsandboxruntime/core.go
@@ -41,6 +41,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -203,7 +203,7 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		fmt.Fprintf(b.rt.Stderr, "%s run summary sync=%s command=%s total=%s exit=%d\n", providerName, syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -215,7 +215,8 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, commandErr)
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -853,6 +853,9 @@ func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
 	if !strings.Contains(stderr.String(), `"exitCode":1`) {
 		t.Fatalf("stderr = %q, want timing exitCode=1", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
+		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
+	}
 }
 
 func TestCloudflareRunCleanupDestroyUsesBoundedContext(t *testing.T) {

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -88,6 +88,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func finalizeRunResult(result RunResult, err error) RunResult {
 	return core.FinalizeRunResult(result, err)
 }

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -143,7 +143,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -155,7 +155,8 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, runErr)
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -548,11 +548,15 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 			},
 		},
 	)
-	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
+	var stderr bytes.Buffer
+	rt := newTestRuntime(runner)
+	rt.Stderr = &stderr
+	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
 	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
-		Command: []string{"false"},
-		NoSync:  true,
+		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+		Command:    []string{"false"},
+		NoSync:     true,
+		TimingJSON: true,
 	}
 	result, err := backend.Run(context.Background(), req)
 	if result.ExitCode != 7 {
@@ -560,6 +564,9 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	}
 	if result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorCommandExit {
 		t.Fatalf("status/error=%q/%q", result.Status, result.ErrorKind)
+	}
+	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
+		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
 	}
 	var ee ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -62,6 +62,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func finalizeRunResult(result RunResult, err error) RunResult {
 	return core.FinalizeRunResult(result, err)
 }

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -150,7 +150,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		fmt.Fprintf(b.rt.Stderr, "windows-sandbox run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			Slug:          result.Slug,
 			SyncDelegated: true,
@@ -161,7 +161,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, execErr)
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -386,11 +386,13 @@ func TestRunKeepsWorkspaceOnFailureWithKeepOnFailure(t *testing.T) {
 	runner := &recordingRunner{result: LocalCommandResult{ExitCode: 7}, err: errors.New("exit status 7")}
 	cfg := core.BaseConfig()
 	cfg.WindowsSandbox.TempRoot = t.TempDir()
-	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	var stderr strings.Builder
+	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: &stderr, Exec: runner})
 	result, err := be.(*backend).Run(context.Background(), RunRequest{
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"cmd.exe", "/c", "exit 7"},
+		TimingJSON:    true,
 	})
 	if err == nil {
 		t.Fatal("expected run error")
@@ -400,6 +402,9 @@ func TestRunKeepsWorkspaceOnFailureWithKeepOnFailure(t *testing.T) {
 	}
 	if result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorCommandExit {
 		t.Fatalf("status/error=%q/%q", result.Status, result.ErrorKind)
+	}
+	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
+		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
 	}
 	entries, readErr := os.ReadDir(cfg.WindowsSandbox.TempRoot)
 	if readErr != nil {

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -47,6 +47,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func finalizeRunResult(result RunResult, err error) RunResult {
 	return core.FinalizeRunResult(result, err)
 }


### PR DESCRIPTION
## Summary
- use normalized RunResult outcomes when Cloudflare, Tensorlake, Anthropic Sandbox Runtime, and Windows Sandbox emit provider-owned timing JSON
- keep provider timing JSON aligned with the runStatus/errorKind returned from each provider
- add provider tests covering failed command timing output

## Verification
- git diff --check
- go test -count=1 ./internal/providers/cloudflare -run 'TestCloudflareRunReturnsErrorWhenCommandStreamFailsAfterPrepare|TestCloudflareRunCleanupDestroyUsesBoundedContext'
- go test -count=1 ./internal/providers/tensorlake -run 'TestRunSurfacesCommandExitCodeWithoutWrappingError|TestRunTimingJSONIncludesSlug|TestRunTimingJSONUsesClaimSlugForReusedSandbox'
- go test -count=1 ./internal/providers/anthropicsandboxruntime -run 'TestRunReturnsNonZeroExitWithoutPersistentSession|TestRunBuildsSRTCommandAndStreamsOutput'
- go test -count=1 ./internal/providers/windowssandbox -run 'TestRunKeepsWorkspaceOnFailureWithKeepOnFailure|TestRunInvokesHostRunnerWithNoSync'
- go test -count=1 ./internal/providers/cloudflare ./internal/providers/tensorlake ./internal/providers/anthropicsandboxruntime ./internal/providers/windowssandbox