### PR TITLE
feat(providers): propagate sandbox timing outcomes

### DIFF
--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -108,7 +108,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		result := RunResult{Total: time.Since(started), SyncDelegated: true}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:    daytonaProvider,
 				LeaseID:     leaseID,
 				Slug:        slug,
@@ -118,7 +118,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 				TotalMs:     result.Total.Milliseconds(),
 				ExitCode:    0,
 				Label:       strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -149,7 +149,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	}
 	fmt.Fprintf(b.rt.Stderr, "daytona run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	if req.TimingJSON {
-		if timingErr := writeTimingJSON(b.rt.Stderr, timingReport{
+		if timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:    daytonaProvider,
 			LeaseID:     leaseID,
 			Slug:        slug,
@@ -160,7 +160,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			TotalMs:     result.Total.Milliseconds(),
 			ExitCode:    result.ExitCode,
 			Label:       strings.TrimSpace(req.Label),
-		}); timingErr != nil {
+		}, result, err)); timingErr != nil {
 			return result, timingErr
 		}
 	}

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -135,6 +135,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -187,7 +187,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 		result := finishResult()
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workspace)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      e2bProvider,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -198,7 +198,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -229,7 +229,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 		fmt.Fprintf(b.rt.Stderr, "e2b run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      e2bProvider,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -241,7 +241,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, commandErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -562,13 +562,14 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 	client := &fakeE2BSyncClient{processCodes: []int{0, 7}}
 	restore := swapNewE2BClient(client)
 	defer restore()
+	var stderr bytes.Buffer
 	backend := &e2bBackend{
 		cfg: Config{
 			IdleTimeout: 30 * time.Minute,
 			TTL:         2 * time.Minute,
 			E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt: Runtime{Stdout: io.Discard, Stderr: &stderr},
 	}
 
 	result, err := backend.Run(context.Background(), RunRequest{
@@ -576,6 +577,7 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 		Command:       []string{"false"},
 		KeepOnFailure: true,
 		NoSync:        true,
+		TimingJSON:    true,
 	})
 	var ee ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
@@ -586,6 +588,19 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 	}
 	if len(client.deleteIDs) != 0 {
 		t.Fatalf("deleteIDs=%#v, want kept sandbox", client.deleteIDs)
+	}
+	var report map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(stderr.String()), "\n") {
+		var candidate map[string]any
+		if err := json.Unmarshal([]byte(line), &candidate); err == nil {
+			report = candidate
+		}
+	}
+	if report == nil {
+		t.Fatalf("stderr does not contain timing JSON: %q", stderr.String())
+	}
+	if report["runStatus"] != "failed" || report["errorKind"] != "command-exit" {
+		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
 	}
 }
 

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -86,6 +86,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -136,7 +136,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		if req.TimingJSON {
-			return result, writeTimingJSON(b.rt.Stderr, timingReport{
+			return result, writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -147,7 +147,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 		}
 		return result, nil
 	}
@@ -178,7 +178,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -190,7 +190,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, runErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -979,13 +979,23 @@ func TestRunSurfacesNonZeroExit(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 7}} // mkdir, user cmd exits 7
 	backend := newAPIBackend(t, f)
-	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"false"}, NoSync: true})
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"false"}, NoSync: true, TimingJSON: true})
 	if res.ExitCode != 7 {
 		t.Fatalf("exit=%d want 7", res.ExitCode)
 	}
 	ee, ok := err.(ExitError)
 	if !ok || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code 7", err)
+	}
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	var report map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+		t.Fatalf("final stderr line is not timing JSON: %q: %v", lines[len(lines)-1], err)
+	}
+	if report["runStatus"] != "failed" || report["errorKind"] != "command-exit" {
+		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
 	}
 }
 

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -55,6 +55,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -246,7 +246,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: %v\n", cleanupErr)
 			}
-			if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			report := timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -257,7 +257,11 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      result.ExitCode,
 				Label:         strings.TrimSpace(req.Label),
-			}); err != nil {
+			}, result, activityErr)
+			if activityErr != nil {
+				report = timingReportWithProviderError(report)
+			}
+			if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 				return result, err
 			}
 		}
@@ -319,7 +323,11 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", cleanupErr)
 		}
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		timingErr := commandErr
+		if timingErr == nil {
+			timingErr = activityErr
+		}
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -331,7 +339,11 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, timingErr)
+		if commandErr == nil && activityErr != nil {
+			report = timingReportWithProviderError(report)
+		}
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -602,6 +602,9 @@ func TestRunTimingJSONRemainsFinalLineWhenActivityRefreshFails(t *testing.T) {
 	if report["exitCode"] != float64(1) {
 		t.Fatalf("timing exitCode=%v want 1", report["exitCode"])
 	}
+	if report["runStatus"] != "failed" || report["errorKind"] != "provider-error" {
+		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
+	}
 }
 
 func TestRunTimingJSONRemainsFinalLineWhenCleanupFails(t *testing.T) {

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -66,6 +66,16 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
+func timingReportWithProviderError(report timingReport) timingReport {
+	report.RunStatus = core.RunStatusFailed
+	report.ErrorKind = core.RunErrorProvider
+	return report
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -170,7 +170,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			return result, cleanupErr
 		}
 		if req.TimingJSON {
-			if err := writeTimingJSON(b.rt.Stderr, timingReport{
+			report := timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -181,7 +181,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      result.ExitCode,
 				Label:         strings.TrimSpace(req.Label),
-			}); err != nil {
+			}, result, activityErr)
+			if activityErr != nil {
+				report = timingReportWithProviderError(report)
+			}
+			if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 				return result, err
 			}
 		}
@@ -248,7 +252,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		commandErr = errors.Join(commandErr, cleanupErr)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		timingErr := commandErr
+		if timingErr == nil {
+			timingErr = activityErr
+		}
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -260,7 +268,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, timingErr)
+		if commandErr == nil && activityErr != nil {
+			report = timingReportWithProviderError(report)
+		}
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/vercelsandbox/backend_test.go
+++ b/internal/providers/vercelsandbox/backend_test.go
@@ -3,6 +3,7 @@ package vercelsandbox
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -487,12 +488,14 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	fake.exitCode = 7
-	backend := testBackend(fake, io.Discard, io.Discard)
+	var stderr bytes.Buffer
+	backend := testBackend(fake, io.Discard, &stderr)
 	result, err := backend.Run(context.Background(), RunRequest{
 		Repo:          Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"false"},
+		TimingJSON:    true,
 	})
 	if err == nil || result.ExitCode != 7 {
 		t.Fatalf("result=%#v err=%v", result, err)
@@ -509,6 +512,14 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	}
 	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID == "" {
 		t.Fatalf("claim should be retained: claim=%#v err=%v", claim, err)
+	}
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	var report map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+		t.Fatalf("final stderr line is not timing JSON: %q: %v", lines[len(lines)-1], err)
+	}
+	if report["runStatus"] != "failed" || report["errorKind"] != "command-exit" {
+		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
 	}
 }
 

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -57,6 +57,16 @@ func writeTimingJSON(w io.Writer, report core.TimingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report core.TimingReport, result RunResult, err error) core.TimingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
+func timingReportWithProviderError(report core.TimingReport) core.TimingReport {
+	report.RunStatus = core.RunStatusFailed
+	report.ErrorKind = core.RunErrorProvider
+	return report
+}
+
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }


### PR DESCRIPTION
## Summary
- propagate normalized runStatus/errorKind into E2B, Daytona, Vercel Sandbox, OpenComputer, and OpenSandbox timing JSON
- keep provider-side activity refresh failures classified as provider errors for Vercel Sandbox and OpenSandbox
- add timing JSON regression coverage for command exits and provider-side activity refresh failures

## Verification
- git diff --check
- go test -count=1 ./internal/cli ./internal/providers/e2b ./internal/providers/daytona ./internal/providers/vercelsandbox ./internal/providers/opencomputer ./internal/providers/opensandbox
- go test -race -count=1 ./internal/cli ./internal/providers/anthropicsandboxruntime ./internal/providers/cloudflare ./internal/providers/windowssandbox ./internal/providers/e2b ./internal/providers/opencomputer ./internal/providers/opensandbox ./internal/providers/vercelsandbox ./internal/providers/daytona