### PR TITLE
feat(providers): propagate runner timing outcomes

### DIFF
--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -145,7 +145,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	fmt.Fprintf(b.rt.Stderr, "docker-sandbox run summary sync_delegated=true command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -156,7 +156,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, runErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -3,6 +3,7 @@ package dockersandbox
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -459,6 +460,17 @@ func TestRunEnvSummaryTimingAndNoEnvBranches(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "env forwarding") || !strings.Contains(stderr.String(), `"provider":"docker-sandbox"`) {
 		t.Fatalf("stderr=%s missing env summary or timing JSON", stderr.String())
+	}
+	var report struct {
+		RunStatus string `json:"runStatus"`
+		ErrorKind string `json:"errorKind"`
+	}
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+		t.Fatalf("timing json: %v\nstderr=%s", err, stderr.String())
+	}
+	if report.RunStatus != "succeeded" || report.ErrorKind != "" {
+		t.Fatalf("timing outcome status=%q kind=%q", report.RunStatus, report.ErrorKind)
 	}
 	execCall := findCall(runner, "exec")
 	if execCall == nil {

--- a/internal/providers/dockersandbox/core.go
+++ b/internal/providers/dockersandbox/core.go
@@ -61,6 +61,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -195,7 +195,7 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 		}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workspace)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      freestyleProvider,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -206,7 +206,7 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -229,7 +229,7 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 		fmt.Fprintf(b.rt.Stderr, "freestyle run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      freestyleProvider,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -241,7 +241,7 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, runErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/freestyle/core.go
+++ b/internal/providers/freestyle/core.go
@@ -22,6 +22,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -127,7 +127,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		result := finishResult()
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -138,7 +138,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -178,7 +178,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		fmt.Fprintf(b.rt.Stderr, "modal run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -190,7 +190,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, commandErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -3,6 +3,7 @@ package modal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -358,6 +359,7 @@ func TestKeepOnFailureRetainsSandbox(t *testing.T) {
 		Command:       []string{"false"},
 		NoSync:        true,
 		KeepOnFailure: true,
+		TimingJSON:    true,
 	}
 	result, err := backend.Run(context.Background(), req)
 	if result.ExitCode != 7 {
@@ -375,6 +377,19 @@ func TestKeepOnFailureRetainsSandbox(t *testing.T) {
 	}
 	if result.Session == nil || !result.Session.Kept || result.Session.CleanupCommand == "" {
 		t.Fatalf("session=%#v", result.Session)
+	}
+	var report map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(stderr.String()), "\n") {
+		var candidate map[string]any
+		if err := json.Unmarshal([]byte(line), &candidate); err == nil {
+			report = candidate
+		}
+	}
+	if report == nil {
+		t.Fatalf("stderr does not contain timing JSON: %q", stderr.String())
+	}
+	if report["runStatus"] != "failed" || report["errorKind"] != "command-exit" {
+		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
 	}
 }
 

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -85,6 +85,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -117,7 +117,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -128,7 +128,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -170,7 +170,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		fmt.Fprintf(b.rt.Stderr, "smolvm run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -182,7 +182,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, commandErr)); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -81,6 +81,10 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -118,7 +118,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
+			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider:      providerName,
 				LeaseID:       leaseID,
 				Slug:          slug,
@@ -129,7 +129,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				TotalMs:       result.Total.Milliseconds(),
 				ExitCode:      0,
 				Label:         strings.TrimSpace(req.Label),
-			})
+			}, result, nil))
 			return result, err
 		}
 		return result, nil
@@ -179,7 +179,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		fmt.Fprintf(b.rt.Stderr, "upstash-box run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), finalExitCode)
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
+		timingErr := commandErr
+		if timingErr == nil {
+			timingErr = envCleanupErr
+		}
+		report := timingReportWithRunResult(timingReport{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
@@ -191,7 +195,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			TotalMs:       result.Total.Milliseconds(),
 			ExitCode:      finalExitCode,
 			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
+		}, result, timingErr)
+		if commandErr == nil && envCleanupErr != nil {
+			report = timingReportWithProviderError(report)
+		}
+		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -495,11 +495,12 @@ func TestRunEnvCleanupUsesBoundedContext(t *testing.T) {
 	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
 	start := time.Now()
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
-		Command: []string{"echo", "hello"},
-		Env:     map[string]string{"TOKEN": "secret"},
-		NoSync:  true,
-		Keep:    true,
+		Repo:       Repo{Name: "repo", Root: t.TempDir()},
+		Command:    []string{"echo", "hello"},
+		Env:        map[string]string{"TOKEN": "secret"},
+		NoSync:     true,
+		Keep:       true,
+		TimingJSON: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "upstash-box env cleanup failed for box_1: context deadline exceeded") {
 		t.Fatalf("err=%v, want bounded env cleanup failure", err)
@@ -509,6 +510,18 @@ func TestRunEnvCleanupUsesBoundedContext(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("Run took %s, want bounded cleanup", elapsed)
+	}
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	var report struct {
+		ExitCode  int    `json:"exitCode"`
+		RunStatus string `json:"runStatus"`
+		ErrorKind string `json:"errorKind"`
+	}
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+		t.Fatalf("timing json: %v\nstderr=%s", err, stderr.String())
+	}
+	if report.ExitCode != 5 || report.RunStatus != "failed" || report.ErrorKind != "provider-error" {
+		t.Fatalf("timing outcome exit=%d status=%q kind=%q", report.ExitCode, report.RunStatus, report.ErrorKind)
 	}
 }
 

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -83,6 +83,16 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
+func timingReportWithProviderError(report timingReport) timingReport {
+	report.RunStatus = core.RunStatusFailed
+	report.ErrorKind = core.RunErrorProvider
+	return report
+}
+
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }


### PR DESCRIPTION
## Summary
- propagate normalized runStatus/errorKind into Docker Sandbox, Freestyle, Modal, SmolVM, and UpstashBox timing JSON
- preserve provider-error classification for UpstashBox env cleanup failures
- add timing JSON regression coverage for Docker Sandbox, Modal, and UpstashBox

## Verification
- git diff --check
- go test -count=1 ./internal/providers/dockersandbox ./internal/providers/freestyle ./internal/providers/modal ./internal/providers/smolvm ./internal/providers/upstashbox
- go test -race -count=1 ./internal/providers/dockersandbox ./internal/providers/freestyle ./internal/providers/modal ./internal/providers/smolvm ./internal/providers/upstashbox