### PR TITLE
feat(providers): add runtime capability filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
+- Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -10,12 +10,12 @@ crabbox providers
 crabbox providers --json
 crabbox providers filters
 crabbox providers filters --json
-crabbox providers --category delegated-sandbox --evidence preview-url
+crabbox providers --runtime managed-sandbox --evidence preview-url
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
+crabbox providers recommend run-evidence --runtime managed-sandbox --evidence preview-url
 crabbox providers recommend versioned-workspace
 ```
 
@@ -33,6 +33,10 @@ crabbox providers recommend versioned-workspace
   Repeatable.
 - `--feature <feature>`: keep providers that advertise this raw feature flag,
   such as `ssh`, `crabbox-sync`, `run-proof`, or `url-bridge`. Repeatable.
+- `--runtime <capability>`: keep providers that advertise this normalized
+  runtime capability, such as `ssh-host`, `delegated-command`,
+  `managed-sandbox`, `local-runtime`, `ci-runner`, `remote-dev`,
+  `worker-module`, or `interactive`. Repeatable.
 - `--workspace <capability>`: keep providers that advertise this normalized
   workspace capability, such as `checkpoint`, `fork`, `restore`, or
   `snapshot-ref`. Repeatable.
@@ -71,13 +75,14 @@ provider filter values:
   kind: delegated-run,service-control,ssh-lease
   category: brokerable-cloud,byo-ssh,ci-proof-runner,delegated-sandbox,direct-cloud,external-provider,gpu-cloud,local-runtime,local-sandbox,local-vm,self-hosted-virtualization,service-control
   target: linux,macos,windows/normal,windows/wsl2,worker-runtime
-  feature: archive-sync,browser,cache-volume,cleanup,code,crabbox-sync,desktop,module-run,pause-resume,provider-snapshot,run-artifacts,run-downloads,run-proof,run-session,ssh,tailscale,url-bridge,workspace-checkpoint,workspace-fork,workspace-restore
+  feature: archive-sync,browser,cache-volume,cleanup,code,crabbox-sync,desktop,mcp-attachments,module-run,pause-resume,provider-snapshot,run-artifacts,run-downloads,run-proof,run-session,ssh,tailscale,url-bridge,workspace-checkpoint,workspace-fork,workspace-restore
+  runtime: ci-runner,delegated-command,interactive,local-runtime,local-sandbox,managed-sandbox,remote-dev,service-control,ssh-host,worker-module
   workspace: checkpoint,fork,restore,snapshot-ref
   evidence: artifacts,downloads,preview-url,proof,session
 ```
 
 JSON output returns one object with `kind`, `category`, `target`, `feature`,
-`workspace`, and `evidence` arrays.
+`runtime`, `workspace`, and `evidence` arrays.
 
 ## `providers recommend`
 
@@ -103,7 +108,7 @@ crabbox providers recommend preview-url
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --category delegated-sandbox --evidence preview-url
+crabbox providers recommend run-evidence --runtime managed-sandbox --evidence preview-url
 crabbox providers recommend run-session
 crabbox providers recommend team-cloud
 crabbox providers recommend workspace-reuse
@@ -170,7 +175,7 @@ Recommendation flags:
 - `--use-case <name>`: pass the use case by flag instead of positionally.
 - `--limit <n>`: maximum recommendations to print. Defaults to `5`.
 - `--json`: emit recommendations as JSON.
-- `--kind`, `--category`, `--target`, `--feature`, `--workspace`,
+- `--kind`, `--category`, `--target`, `--feature`, `--runtime`, `--workspace`,
   `--evidence`: filter the candidate provider matrix before scoring. These flags
   use the same values and repeat/comma semantics as the base `providers` matrix
   command.
@@ -186,6 +191,7 @@ aws
   category: brokerable-cloud
   targets: linux,windows/normal,windows/wsl2,macos
   features: ssh,crabbox-sync,cleanup,desktop,browser,code
+  runtime: ssh-host,interactive
   coordinator: supported
 
 parallels
@@ -194,6 +200,7 @@ parallels
   category: local-vm
   targets: linux,macos,windows/normal,windows/wsl2
   features: ssh,crabbox-sync,cleanup,desktop,browser,code,workspace-checkpoint,workspace-fork,workspace-restore,provider-snapshot
+  runtime: ssh-host,local-runtime,interactive
   workspace: checkpoint,fork,restore,snapshot-ref
   coordinator: never
 
@@ -203,6 +210,7 @@ blacksmith-testbox
   category: ci-proof-runner
   targets: linux
   features: cache-volume,run-proof,run-session,run-artifacts
+  runtime: delegated-command,ci-runner
   evidence: proof,artifacts,session
   coordinator: never
   aliases: blacksmith
@@ -213,6 +221,7 @@ e2b
   category: delegated-sandbox
   targets: linux
   features: url-bridge,run-session
+  runtime: delegated-command,managed-sandbox
   evidence: preview-url,session
   coordinator: never
 
@@ -222,6 +231,7 @@ wandb
   category: gpu-cloud
   targets: linux
   features: -
+  runtime: delegated-command
   coordinator: never
   aliases: weights-and-biases
 
@@ -231,6 +241,7 @@ module-runtime-example
   category: -
   targets: worker-runtime
   features: module-run
+  runtime: delegated-command,worker-module
   coordinator: never
 
 hostinger
@@ -239,6 +250,7 @@ hostinger
   category: direct-cloud
   targets: linux
   features: ssh,crabbox-sync,cleanup
+  runtime: ssh-host
   coordinator: never
 ```
 
@@ -261,6 +273,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "category": "direct-cloud",
     "targets": ["linux"],
     "features": ["ssh", "crabbox-sync", "cleanup"],
+    "runtime": ["ssh-host"],
     "coordinator": "never"
   },
   {
@@ -271,6 +284,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "aliases": ["blacksmith"],
     "targets": ["linux"],
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
+    "runtime": ["delegated-command", "ci-runner"],
     "evidence": ["proof", "artifacts", "session"],
     "coordinator": "never"
   }
@@ -305,10 +319,15 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
 - `features`: advertised capability flags. Possible values include `ssh`,
   `crabbox-sync`, `archive-sync`, `cleanup`, `desktop`, `browser`, `code`,
   `tailscale`, `url-bridge`, `workspace-checkpoint`, `workspace-fork`,
-  `workspace-restore`, `provider-snapshot`, `run-proof`, `run-session`, and
-  `module-run`. `module-run` means delegated `crabbox run --script` or
-  `--script-stdin` source-module execution; it does not imply POSIX command
-  argv, archive sync, ports, or SSH access.
+  `workspace-restore`, `provider-snapshot`, `run-proof`, `run-session`,
+  `mcp-attachments`, and `module-run`. `module-run` means delegated
+  `crabbox run --script` or `--script-stdin` source-module execution; it does
+  not imply POSIX command argv, archive sync, ports, or SSH access.
+- `runtime`: normalized execution-shape capabilities derived from kind,
+  category, targets, and features. Possible values are `ssh-host`,
+  `delegated-command`, `managed-sandbox`, `local-runtime`, `local-sandbox`,
+  `ci-runner`, `remote-dev`, `worker-module`, `interactive`, and
+  `service-control`. These are routing hints, not isolation certifications.
 - `workspace`: normalized versioned-workspace capabilities derived from feature
   flags. Possible values are `checkpoint`, `fork`, `restore`, and
   `snapshot-ref`. The field is omitted when a provider does not advertise any
@@ -332,6 +351,7 @@ Recommendation JSON returns ranked objects:
     "category": "ci-proof-runner",
     "targets": ["linux"],
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
+    "runtime": ["delegated-command", "ci-runner"],
     "evidence": ["proof", "artifacts", "session"],
     "score": 158,
     "reasons": [

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -21,6 +21,9 @@ That means:
 - support stable execution substrates as providers;
 - expose shared workflow capabilities through `crabbox providers` and
   `crabbox providers recommend`;
+- keep runtime-shape labels provider-neutral (`managed-sandbox`,
+  `delegated-command`, `ssh-host`, `worker-module`) instead of copying one
+  vendor's control-plane terms;
 - use `ssh` or `external` for tools that already produce a normal host contract;
 - defer first-class support for runtimes whose useful behavior is still too
   product-specific to test offline.
@@ -52,6 +55,9 @@ The better path is to make the generic seams real first:
 
 - `workspace-checkpoint`, `workspace-fork`, `workspace-restore`, and
   `provider-snapshot` keep forkable workspace language provider-neutral.
+- `runtime` filter values like `managed-sandbox`, `delegated-command`, and
+  `worker-module` describe the execution shape without implying Mitos-style
+  live microVM forking.
 - `mcp-attachments` stays a capability, not a Mitos-only command mode.
 - `run-proof`, `run-artifacts`, `run-downloads`, and `url-bridge` keep evidence
   portable across delegated sandboxes and proof runners.

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -18,6 +18,7 @@ type providerMatrixEntry struct {
 	Category    string       `json:"category,omitempty"`
 	Targets     []string     `json:"targets"`
 	Features    []Feature    `json:"features"`
+	Runtime     []string     `json:"runtime,omitempty"`
 	Workspace   []string     `json:"workspace,omitempty"`
 	Evidence    []string     `json:"evidence,omitempty"`
 	Coordinator string       `json:"coordinator"`
@@ -29,6 +30,7 @@ type providerRecommendationEntry struct {
 	Category  string       `json:"category,omitempty"`
 	Targets   []string     `json:"targets"`
 	Features  []Feature    `json:"features"`
+	Runtime   []string     `json:"runtime,omitempty"`
 	Workspace []string     `json:"workspace,omitempty"`
 	Evidence  []string     `json:"evidence,omitempty"`
 	Score     int          `json:"score"`
@@ -40,6 +42,7 @@ type providerFilterValuesEntry struct {
 	Category  []string `json:"category"`
 	Target    []string `json:"target"`
 	Feature   []string `json:"feature"`
+	Runtime   []string `json:"runtime"`
 	Workspace []string `json:"workspace"`
 	Evidence  []string `json:"evidence"`
 }
@@ -49,6 +52,7 @@ type providerMatrixFilters struct {
 	Categories []string
 	Targets    []string
 	Features   []string
+	Runtimes   []string
 	Workspaces []string
 	Evidence   []string
 }
@@ -58,6 +62,7 @@ type providerMatrixFilterFlagValues struct {
 	Categories stringListFlag
 	Targets    stringListFlag
 	Features   stringListFlag
+	Runtimes   stringListFlag
 	Workspaces stringListFlag
 	Evidence   stringListFlag
 }
@@ -76,7 +81,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--runtime CAPABILITY] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	filters := filterFlags.filters()
@@ -181,14 +186,17 @@ func providerMatrix() []providerMatrixEntry {
 	entries := make([]providerMatrixEntry, 0, len(providers))
 	for _, provider := range providers {
 		spec := provider.Spec()
+		category := benchmarkProviderCategories[firstNonBlank(spec.Name, provider.Name())]
+		targets := formatProviderTargets(spec.Targets)
 		entries = append(entries, providerMatrixEntry{
 			Provider:    firstNonBlank(spec.Name, provider.Name()),
 			Family:      firstNonBlank(spec.Family, provider.Name()),
 			Aliases:     append([]string(nil), provider.Aliases()...),
 			Kind:        spec.Kind,
-			Category:    benchmarkProviderCategories[firstNonBlank(spec.Name, provider.Name())],
-			Targets:     formatProviderTargets(spec.Targets),
+			Category:    category,
+			Targets:     targets,
 			Features:    append(FeatureSet{}, spec.Features...),
+			Runtime:     runtimeCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name()), spec.Kind, category, targets, spec.Features),
 			Workspace:   workspaceCapabilitiesForFeatures(spec.Features),
 			Evidence:    evidenceCapabilitiesForFeatures(spec.Features),
 			Coordinator: string(spec.Coordinator),
@@ -203,6 +211,7 @@ func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFl
 	fs.Var(&values.Categories, "category", "filter by provider category; repeatable")
 	fs.Var(&values.Targets, "target", "filter by target such as linux or worker-runtime; repeatable")
 	fs.Var(&values.Features, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
+	fs.Var(&values.Runtimes, "runtime", "filter by normalized runtime capability; repeatable")
 	fs.Var(&values.Workspaces, "workspace", "filter by normalized workspace capability; repeatable")
 	fs.Var(&values.Evidence, "evidence", "filter by normalized evidence capability; repeatable")
 	return values
@@ -217,6 +226,7 @@ func (values *providerMatrixFilterFlagValues) filters() providerMatrixFilters {
 		Categories: providerFilterValues(values.Categories),
 		Targets:    providerFilterValues(values.Targets),
 		Features:   providerFilterValues(values.Features),
+		Runtimes:   providerFilterValues(values.Runtimes),
 		Workspaces: providerFilterValues(values.Workspaces),
 		Evidence:   providerFilterValues(values.Evidence),
 	}
@@ -241,6 +251,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		"category":  {},
 		"target":    {},
 		"feature":   {},
+		"runtime":   {},
 		"workspace": {},
 		"evidence":  {},
 	}
@@ -249,6 +260,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		addProviderFilterAllowed(allowed["category"], []string{entry.Category})
 		addProviderFilterAllowed(allowed["target"], entry.Targets)
 		addProviderFilterAllowed(allowed["feature"], featuresToStrings(entry.Features))
+		addProviderFilterAllowed(allowed["runtime"], entry.Runtime)
 		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
 		addProviderFilterAllowed(allowed["evidence"], entry.Evidence)
 	}
@@ -257,6 +269,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		Category:  sortedProviderFilterValues(allowed["category"]),
 		Target:    sortedProviderFilterValues(allowed["target"]),
 		Feature:   sortedProviderFilterValues(allowed["feature"]),
+		Runtime:   sortedProviderFilterValues(allowed["runtime"]),
 		Workspace: sortedProviderFilterValues(allowed["workspace"]),
 		Evidence:  sortedProviderFilterValues(allowed["evidence"]),
 	}
@@ -284,6 +297,9 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 	if err := check("feature", filters.Features); err != nil {
 		return err
 	}
+	if err := check("runtime", filters.Runtimes); err != nil {
+		return err
+	}
 	if err := check("workspace", filters.Workspaces); err != nil {
 		return err
 	}
@@ -297,6 +313,7 @@ func providerMatrixFilterAllowedValues(entries []providerMatrixEntry) map[string
 		"category":  providerFilterAllowedSet(values.Category),
 		"target":    providerFilterAllowedSet(values.Target),
 		"feature":   providerFilterAllowedSet(values.Feature),
+		"runtime":   providerFilterAllowedSet(values.Runtime),
 		"workspace": providerFilterAllowedSet(values.Workspace),
 		"evidence":  providerFilterAllowedSet(values.Evidence),
 	}
@@ -334,6 +351,7 @@ func printProviderFilterValues(out io.Writer, values providerFilterValuesEntry) 
 	fmt.Fprintf(out, "  category: %s\n", providerFilterValueLine(values.Category))
 	fmt.Fprintf(out, "  target: %s\n", providerFilterValueLine(values.Target))
 	fmt.Fprintf(out, "  feature: %s\n", providerFilterValueLine(values.Feature))
+	fmt.Fprintf(out, "  runtime: %s\n", providerFilterValueLine(values.Runtime))
 	fmt.Fprintf(out, "  workspace: %s\n", providerFilterValueLine(values.Workspace))
 	fmt.Fprintf(out, "  evidence: %s\n", providerFilterValueLine(values.Evidence))
 }
@@ -360,7 +378,7 @@ func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixF
 }
 
 func providerMatrixFiltersEmpty(filters providerMatrixFilters) bool {
-	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
+	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Runtimes) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
 }
 
 func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatrixFilters) bool {
@@ -368,6 +386,7 @@ func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatr
 		providerFieldContainsAll([]string{entry.Category}, filters.Categories) &&
 		providerFieldContainsAll(entry.Targets, filters.Targets) &&
 		providerFieldContainsAll(featuresToStrings(entry.Features), filters.Features) &&
+		providerFieldContainsAll(entry.Runtime, filters.Runtimes) &&
 		providerFieldContainsAll(entry.Workspace, filters.Workspaces) &&
 		providerFieldContainsAll(entry.Evidence, filters.Evidence)
 }
@@ -509,6 +528,7 @@ func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string,
 			Category:  benchmarkProviderCategories[entry.Provider],
 			Targets:   append([]string(nil), entry.Targets...),
 			Features:  append([]Feature(nil), entry.Features...),
+			Runtime:   append([]string(nil), entry.Runtime...),
 			Workspace: append([]string(nil), entry.Workspace...),
 			Evidence:  append([]string(nil), entry.Evidence...),
 			Score:     score,
@@ -1168,6 +1188,9 @@ func printProviderRecommendations(out io.Writer, useCase string, entries []provi
 		fmt.Fprintf(out, "  category: %s\n", blank(entry.Category, "-"))
 		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
+		if len(entry.Runtime) > 0 {
+			fmt.Fprintf(out, "  runtime: %s\n", commaOrDash(entry.Runtime))
+		}
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
 		}
@@ -1186,6 +1209,9 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  category: %s\n", blank(entry.Category, "-"))
 		fmt.Fprintf(out, "  targets: %s\n", commaOrDash(entry.Targets))
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
+		if len(entry.Runtime) > 0 {
+			fmt.Fprintf(out, "  runtime: %s\n", commaOrDash(entry.Runtime))
+		}
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
 		}
@@ -1225,6 +1251,48 @@ func workspaceCapabilitiesForFeatures(features []Feature) []string {
 	add(FeatureFork, "fork")
 	add(FeatureRestore, "restore")
 	add(FeatureSnapshot, "snapshot-ref")
+	return out
+}
+
+func runtimeCapabilitiesForProvider(provider string, kind ProviderKind, category string, targets []string, features []Feature) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(capability string) {
+		if capability == "" || seen[capability] {
+			return
+		}
+		seen[capability] = true
+		out = append(out, capability)
+	}
+	switch kind {
+	case ProviderKindSSHLease:
+		add("ssh-host")
+	case ProviderKindDelegatedRun:
+		add("delegated-command")
+	case ProviderKindServiceControl:
+		add("service-control")
+	}
+	if strings.HasPrefix(category, "local-") {
+		add("local-runtime")
+	}
+	if category == "delegated-sandbox" {
+		add("managed-sandbox")
+	}
+	if category == "local-sandbox" {
+		add("local-sandbox")
+	}
+	if category == "ci-proof-runner" {
+		add("ci-runner")
+	}
+	if isRemoteDevProvider(provider) {
+		add("remote-dev")
+	}
+	if providerRecommendationHasString(targets, targetWorkerRuntime) || FeatureSet(features).Has(FeatureModuleRun) {
+		add("worker-module")
+	}
+	if FeatureSet(features).Has(FeatureDesktop) || FeatureSet(features).Has(FeatureBrowser) || FeatureSet(features).Has(FeatureCode) {
+		add("interactive")
+	}
 	return out
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -115,6 +115,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if !containsFeature(aws.Features, FeatureSSH) || !containsFeature(aws.Features, FeatureDesktop) {
 		t.Fatalf("aws features=%v", aws.Features)
 	}
+	for _, capability := range []string{"ssh-host", "interactive"} {
+		if !containsString(aws.Runtime, capability) {
+			t.Fatalf("aws runtime=%v missing %s", aws.Runtime, capability)
+		}
+	}
 	if incus.Kind != ProviderKindSSHLease || incus.Family != "local-vm" {
 		t.Fatalf("incus kind/family=%q/%q", incus.Kind, incus.Family)
 	}
@@ -167,6 +172,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if !containsFeature(moduleRuntime.Features, FeatureModuleRun) {
 		t.Fatalf("module-runtime-test features=%v missing %s", moduleRuntime.Features, FeatureModuleRun)
 	}
+	for _, capability := range []string{"delegated-command", "worker-module"} {
+		if !containsString(moduleRuntime.Runtime, capability) {
+			t.Fatalf("module-runtime-test runtime=%v missing %s", moduleRuntime.Runtime, capability)
+		}
+	}
 	if nvidiaBrev.Kind != ProviderKindSSHLease || nvidiaBrev.Family != "nvidia-brev" || nvidiaBrev.Coordinator != string(CoordinatorNever) {
 		t.Fatalf("nvidia-brev kind/family/coordinator=%q/%q/%q", nvidiaBrev.Kind, nvidiaBrev.Family, nvidiaBrev.Coordinator)
 	}
@@ -178,6 +188,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	}
 	if !containsString(nvidiaBrev.Aliases, "brev") || !containsString(nvidiaBrev.Aliases, "nvidia") {
 		t.Fatalf("nvidia-brev aliases=%v", nvidiaBrev.Aliases)
+	}
+	for _, capability := range []string{"local-runtime", "ssh-host"} {
+		if !containsString(localContainer.Runtime, capability) {
+			t.Fatalf("local-container runtime=%v missing %s", localContainer.Runtime, capability)
+		}
 	}
 	if !containsString(localContainer.Workspace, "checkpoint") || !containsString(localContainer.Workspace, "fork") {
 		t.Fatalf("local-container workspace=%v", localContainer.Workspace)
@@ -192,9 +207,19 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 			t.Fatalf("blacksmith evidence=%v missing %s", blacksmith.Evidence, capability)
 		}
 	}
+	for _, capability := range []string{"delegated-command", "ci-runner"} {
+		if !containsString(blacksmith.Runtime, capability) {
+			t.Fatalf("blacksmith runtime=%v missing %s", blacksmith.Runtime, capability)
+		}
+	}
 	for _, capability := range []string{"preview-url", "session"} {
 		if !containsString(e2b.Evidence, capability) {
 			t.Fatalf("e2b evidence=%v missing %s", e2b.Evidence, capability)
+		}
+	}
+	for _, capability := range []string{"delegated-command", "managed-sandbox"} {
+		if !containsString(e2b.Runtime, capability) {
+			t.Fatalf("e2b runtime=%v missing %s", e2b.Runtime, capability)
 		}
 	}
 	for _, capability := range []string{"downloads", "preview-url", "session"} {
@@ -224,6 +249,9 @@ func TestProvidersCommandJSON(t *testing.T) {
 		if entry.Provider == "aws" && entry.Category != "brokerable-cloud" {
 			t.Fatalf("aws json category=%q", entry.Category)
 		}
+		if entry.Provider == "aws" && !containsString(entry.Runtime, "ssh-host") {
+			t.Fatalf("aws json missing ssh-host runtime: %#v", entry)
+		}
 		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
 			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
 		}
@@ -240,7 +268,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 		t.Fatalf("providers error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: "} {
+	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: ", "  runtime: ssh-host,interactive\n"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers output missing %q:\n%s", want, text)
 		}
@@ -265,6 +293,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		"--kind", "delegated-run",
 		"--category", "delegated-sandbox",
 		"--target", "linux",
+		"--runtime", "managed-sandbox",
 		"--evidence", "preview-url",
 		"--json",
 	})
@@ -279,7 +308,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		t.Fatal("expected delegated preview providers")
 	}
 	for _, entry := range entries {
-		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Evidence, "preview-url") {
+		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("entry escaped filters: %#v", entry)
 		}
 	}
@@ -307,12 +336,12 @@ func TestProvidersCommandFiltersRequireAllCapabilities(t *testing.T) {
 
 func TestProvidersCommandRejectsUnknownFilter(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"--evidence", "memory-fork"})
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"--runtime", "microvm-fork"})
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("providers unknown filter error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(err.Error(), `unknown provider evidence filter "memory-fork"`) {
+	if !strings.Contains(err.Error(), `unknown provider runtime filter "microvm-fork"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -330,6 +359,8 @@ func TestProvidersFiltersCommandHumanOutput(t *testing.T) {
 		"delegated-run",
 		"  category: ",
 		"delegated-sandbox",
+		"  runtime: ",
+		"managed-sandbox",
 		"  evidence: ",
 		"preview-url",
 	} {
@@ -356,6 +387,7 @@ func TestProvidersFiltersCommandJSON(t *testing.T) {
 	}{
 		{name: "kind", values: values.Kind, want: "delegated-run"},
 		{name: "category", values: values.Category, want: "delegated-sandbox"},
+		{name: "runtime", values: values.Runtime, want: "managed-sandbox"},
 		{name: "evidence", values: values.Evidence, want: "preview-url"},
 		{name: "workspace", values: values.Workspace, want: "fork"},
 	} {
@@ -1094,6 +1126,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
 		"recommend", "run-evidence",
 		"--category", "delegated-sandbox",
+		"--runtime", "managed-sandbox",
 		"--evidence", "preview-url",
 		"--json",
 	})
@@ -1108,7 +1141,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 		t.Fatal("expected filtered run-evidence recommendations")
 	}
 	for _, entry := range entries {
-		if entry.Category != "delegated-sandbox" || !containsString(entry.Evidence, "preview-url") {
+		if entry.Category != "delegated-sandbox" || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("recommendation escaped filters: %#v", entry)
 		}
 	}


### PR DESCRIPTION
## Summary
- add normalized provider runtime capabilities to providers matrix and recommendation JSON
- add --runtime filters for providers and providers recommend
- document runtime filter values and the no-Mitos provider-neutral positioning

## Verification
- git diff --check
- go test -count=1 ./internal/cli -run 'TestProviders'
- go test -count=1 ./internal/cli
- go test -race -count=1 ./internal/cli -run 'TestProviders'
- go run ./cmd/crabbox providers --runtime managed-sandbox --evidence preview-url --json
- go run ./cmd/crabbox providers filters --json