### PR TITLE
feat(providers): recommend fanout testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
+- Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -98,6 +98,7 @@ crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
 crabbox providers recommend cost-control
 crabbox providers recommend fast-feedback --feature cache-volume
+crabbox providers recommend fanout-testing --workspace fork
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
@@ -135,6 +136,11 @@ Supported use cases:
 - `desktop`: providers with desktop/browser/code-server capabilities.
 - `fast-feedback`: providers suited to repeated test loops with reusable cache
   volumes, checkout sync, cleanup, or reusable validation evidence.
+- `fanout-testing`: providers that can fork a prepared workspace for parallel
+  branch, best-of-N, or snapshot-fanout experiments. Aliases include
+  `best-of-n`, `parallel-testing`, and `snapshot-fanout`. This is provider
+  selection guidance over existing fork/checkpoint capabilities, not a
+  Mitos-style live microVM swarm API.
 - `gpu`: GPU-oriented execution providers.
 - `isolated-execution`: delegated and local sandbox providers for disposable or
   untrusted command execution. This is routing guidance, not a security

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -63,6 +63,8 @@ The better path is to make the generic seams real first:
   portable across delegated sandboxes and proof runners.
 - `remote-dev`, `mcp-sandbox`, `isolated-execution`, and
   `versioned-workspace` keep recommendations workflow-oriented.
+- `fanout-testing` and its `best-of-n` alias route operators to existing
+  fork-capable providers without adding a Mitos-only live-fork API.
 
 Revisit Mitos only when there is a concrete use case that needs live microVM
 forking and the provider contract can be tested with offline unit coverage plus
@@ -123,6 +125,8 @@ Ship these in small PRs:
    through the CLI before adding live microVM fan-out. Use
    `crabbox providers recommend workspace-reuse` as the workflow entry point
    when the operator cares about reusable state more than a specific fork API.
+   Use `crabbox providers recommend fanout-testing` when the workflow needs
+   parallel branch or best-of-N experimentation from forkable state.
 5. Keep edge/worker execution separate from Linux sandboxes.
    A Worker module runtime is not the same thing as a Linux shell. Make the
    target and feature names say that clearly.

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -416,6 +416,7 @@ func providerRecommendationUseCases() []string {
 		"cost-control",
 		"desktop",
 		"fast-feedback",
+		"fanout-testing",
 		"gpu",
 		"isolated-execution",
 		"linux-vm",
@@ -456,6 +457,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "desktop", true
 	case "fast-feedback", "feedback", "fast-test", "fast-tests", "cache", "cached", "cache-heavy":
 		return "fast-feedback", true
+	case "fanout", "fanout-testing", "best-of-n", "best-of-n-testing",
+		"parallel-testing", "parallel-exploration", "branch-race",
+		"snapshot-fanout", "fork-fanout":
+		return "fanout-testing", true
 	case "gpu", "cuda", "ml":
 		return "gpu", true
 	case "isolated", "isolated-execution", "isolation", "secure", "secure-sandbox", "untrusted", "untrusted-code":
@@ -712,6 +717,38 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux test workloads")
+		}
+	case "fanout-testing":
+		if !hasFeature(FeatureFork) {
+			break
+		}
+		add(90, "can fork workspaces for parallel exploration")
+		if hasFeature(FeatureCheckpoint) {
+			add(35, "can checkpoint a prepared baseline")
+		}
+		if hasFeature(FeatureRestore) {
+			add(25, "can restore workspace state after experiments")
+		}
+		if hasFeature(FeatureSnapshot) {
+			add(18, "exposes provider-native snapshot identifiers")
+		}
+		if providerRecommendationHasString(entry.Runtime, "local-runtime") {
+			add(20, "local runtime avoids cloud quota for fanout")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(18, "can clean up forked workspace resources")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(16, "can seed fanout from the current checkout")
+		}
+		if hasFeature(FeatureCacheVolume) {
+			add(12, "can reuse dependency/cache state across branches")
+		}
+		if hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(10, "can retain evidence from competing runs")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetMacOS) {
+			add(8, "supports common fanout test targets")
 		}
 	case "gpu":
 		if category == "gpu-cloud" {
@@ -1163,6 +1200,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend cost-control")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
+	fmt.Fprintln(out, "  crabbox providers recommend fanout-testing --workspace fork")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -420,6 +420,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"cost-control",
 		"agent-sandbox",
 		"fast-feedback",
+		"fanout-testing",
 		"isolated-execution",
 		"live-smoke",
 		"mcp-sandbox",
@@ -563,6 +564,50 @@ func TestProvidersRecommendFastFeedbackPrefersCacheVolumes(t *testing.T) {
 	}
 	if !foundProofRunner {
 		t.Fatalf("fast-feedback recommendations should include CI proof runners: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendFanoutTestingRequiresForkableWorkspaces(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "fanout-testing", 8)
+	if len(recommendations) == 0 {
+		t.Fatal("expected fanout-testing recommendations")
+	}
+	if recommendations[0].Provider != "parallels" {
+		t.Fatalf("top fanout-testing provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	foundLocalContainer := false
+	for _, recommendation := range recommendations {
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureFork) {
+			t.Fatalf("fanout-testing recommendation lacks fork feature: %#v", recommendation)
+		}
+		if !containsString(recommendation.Workspace, "fork") {
+			t.Fatalf("fanout-testing recommendation missing fork workspace capability: %#v", recommendation)
+		}
+		if recommendation.Provider == "local-container" {
+			foundLocalContainer = true
+		}
+	}
+	if !foundLocalContainer {
+		t.Fatalf("fanout-testing recommendations should include local-container: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendBestOfNAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "best-of-n",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend best-of-n error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureFork) {
+		t.Fatalf("best-of-n alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a fanout-testing provider recommendation use case for forkable workspaces
- support best-of-n and related aliases without adding Mitos-specific provider support
- document the workflow in provider docs and the provider landscape roadmap

## Verification
- git diff --check
- go test -count=1 ./internal/cli -run 'TestProvidersRecommend(FanoutTesting|BestOfN|ListsUseCases)|TestProvidersRecommendCommandAppliesFilters'
- go test -count=1 ./internal/cli
- go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(FanoutTesting|BestOfN)'
- go run ./cmd/crabbox providers recommend fanout-testing --json
- go run ./cmd/crabbox providers recommend best-of-n --workspace fork --json