### PR TITLE
feat(providers): add reachability filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.
+- Added normalized provider reachability capabilities and `--reachability` filters to `crabbox providers` and `crabbox providers recommend`.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -10,12 +10,12 @@ crabbox providers
 crabbox providers --json
 crabbox providers filters
 crabbox providers filters --json
-crabbox providers --runtime managed-sandbox --evidence preview-url
+crabbox providers --reachability provider-url --evidence preview-url
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --runtime managed-sandbox --evidence preview-url
+crabbox providers recommend run-evidence --reachability provider-url --evidence preview-url
 crabbox providers recommend versioned-workspace
 ```
 
@@ -37,6 +37,9 @@ crabbox providers recommend versioned-workspace
   runtime capability, such as `ssh-host`, `delegated-command`,
   `managed-sandbox`, `local-runtime`, `ci-runner`, `remote-dev`,
   `worker-module`, or `interactive`. Repeatable.
+- `--reachability <capability>`: keep providers that advertise this normalized
+  access-plane capability, such as `ssh-tunnel`, `tailnet-peer`,
+  `tailnet-egress`, or `provider-url`. Repeatable.
 - `--workspace <capability>`: keep providers that advertise this normalized
   workspace capability, such as `checkpoint`, `fork`, `restore`, or
   `snapshot-ref`. Repeatable.
@@ -77,12 +80,13 @@ provider filter values:
   target: linux,macos,windows/normal,windows/wsl2,worker-runtime
   feature: archive-sync,browser,cache-volume,cleanup,code,crabbox-sync,desktop,mcp-attachments,module-run,pause-resume,provider-snapshot,run-artifacts,run-downloads,run-proof,run-session,ssh,tailscale,url-bridge,workspace-checkpoint,workspace-fork,workspace-restore
   runtime: ci-runner,delegated-command,interactive,local-runtime,local-sandbox,managed-sandbox,remote-dev,service-control,ssh-host,worker-module
+  reachability: provider-url,ssh-tunnel,tailnet-egress,tailnet-peer
   workspace: checkpoint,fork,restore,snapshot-ref
   evidence: artifacts,downloads,preview-url,proof,session
 ```
 
 JSON output returns one object with `kind`, `category`, `target`, `feature`,
-`runtime`, `workspace`, and `evidence` arrays.
+`runtime`, `reachability`, `workspace`, and `evidence` arrays.
 
 ## `providers recommend`
 
@@ -109,7 +113,7 @@ crabbox providers recommend preview-url
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
 crabbox providers recommend run-evidence
-crabbox providers recommend run-evidence --runtime managed-sandbox --evidence preview-url
+crabbox providers recommend run-evidence --reachability provider-url --evidence preview-url
 crabbox providers recommend run-session
 crabbox providers recommend team-cloud
 crabbox providers recommend workspace-reuse
@@ -181,10 +185,10 @@ Recommendation flags:
 - `--use-case <name>`: pass the use case by flag instead of positionally.
 - `--limit <n>`: maximum recommendations to print. Defaults to `5`.
 - `--json`: emit recommendations as JSON.
-- `--kind`, `--category`, `--target`, `--feature`, `--runtime`, `--workspace`,
-  `--evidence`: filter the candidate provider matrix before scoring. These flags
-  use the same values and repeat/comma semantics as the base `providers` matrix
-  command.
+- `--kind`, `--category`, `--target`, `--feature`, `--runtime`,
+  `--reachability`, `--workspace`, `--evidence`: filter the candidate provider
+  matrix before scoring. These flags use the same values and repeat/comma
+  semantics as the base `providers` matrix command.
 
 ## Output
 
@@ -198,6 +202,7 @@ aws
   targets: linux,windows/normal,windows/wsl2,macos
   features: ssh,crabbox-sync,cleanup,desktop,browser,code
   runtime: ssh-host,interactive
+  reachability: ssh-tunnel
   coordinator: supported
 
 parallels
@@ -207,6 +212,7 @@ parallels
   targets: linux,macos,windows/normal,windows/wsl2
   features: ssh,crabbox-sync,cleanup,desktop,browser,code,workspace-checkpoint,workspace-fork,workspace-restore,provider-snapshot
   runtime: ssh-host,local-runtime,interactive
+  reachability: ssh-tunnel
   workspace: checkpoint,fork,restore,snapshot-ref
   coordinator: never
 
@@ -228,6 +234,7 @@ e2b
   targets: linux
   features: url-bridge,run-session
   runtime: delegated-command,managed-sandbox
+  reachability: provider-url
   evidence: preview-url,session
   coordinator: never
 
@@ -257,6 +264,7 @@ hostinger
   targets: linux
   features: ssh,crabbox-sync,cleanup
   runtime: ssh-host
+  reachability: ssh-tunnel
   coordinator: never
 ```
 
@@ -280,6 +288,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "targets": ["linux"],
     "features": ["ssh", "crabbox-sync", "cleanup"],
     "runtime": ["ssh-host"],
+    "reachability": ["ssh-tunnel"],
     "coordinator": "never"
   },
   {
@@ -334,6 +343,11 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
   `delegated-command`, `managed-sandbox`, `local-runtime`, `local-sandbox`,
   `ci-runner`, `remote-dev`, `worker-module`, `interactive`, and
   `service-control`. These are routing hints, not isolation certifications.
+- `reachability`: normalized access-plane capabilities derived from provider
+  transport features. Possible values are `ssh-tunnel`, `tailnet-peer`,
+  `tailnet-egress`, and `provider-url`. These say how an operator or workflow
+  can reach a lease or provider-owned endpoint; they are not exposure or
+  isolation guarantees.
 - `workspace`: normalized versioned-workspace capabilities derived from feature
   flags. Possible values are `checkpoint`, `fork`, `restore`, and
   `snapshot-ref`. The field is omitted when a provider does not advertise any

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -24,6 +24,9 @@ That means:
 - keep runtime-shape labels provider-neutral (`managed-sandbox`,
   `delegated-command`, `ssh-host`, `worker-module`) instead of copying one
   vendor's control-plane terms;
+- keep reachability labels provider-neutral (`provider-url`, `ssh-tunnel`,
+  `tailnet-peer`, `tailnet-egress`) so preview URL, tailnet, and SSH tunnel
+  workflows can be compared without provider-specific docs scraping;
 - use `ssh` or `external` for tools that already produce a normal host contract;
 - defer first-class support for runtimes whose useful behavior is still too
   product-specific to test offline.
@@ -61,6 +64,8 @@ The better path is to make the generic seams real first:
 - `mcp-attachments` stays a capability, not a Mitos-only command mode.
 - `run-proof`, `run-artifacts`, `run-downloads`, and `url-bridge` keep evidence
   portable across delegated sandboxes and proof runners.
+- `reachability` filter values describe access planes without claiming a
+  provider-specific network isolation model.
 - `remote-dev`, `mcp-sandbox`, `isolated-execution`, and
   `versioned-workspace` keep recommendations workflow-oriented.
 - `fanout-testing` and its `best-of-n` alias route operators to existing
@@ -107,6 +112,9 @@ Ship these in small PRs:
    retained files or downloadable results from provider-owned execution.
    Use `crabbox providers recommend preview-url` when the workflow specifically
    needs provider-native app or service URLs.
+   Use `crabbox providers --reachability provider-url` or
+   `crabbox providers recommend reachability --reachability tailnet-peer` when
+   the operator needs an explicit access plane.
    Use `crabbox providers recommend network-isolation` when the workflow runs
    untrusted code and network exposure should stay inside a delegated or local
    sandbox boundary.

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -11,60 +11,65 @@ import (
 )
 
 type providerMatrixEntry struct {
-	Provider    string       `json:"provider"`
-	Family      string       `json:"family"`
-	Aliases     []string     `json:"aliases,omitempty"`
-	Kind        ProviderKind `json:"kind"`
-	Category    string       `json:"category,omitempty"`
-	Targets     []string     `json:"targets"`
-	Features    []Feature    `json:"features"`
-	Runtime     []string     `json:"runtime,omitempty"`
-	Workspace   []string     `json:"workspace,omitempty"`
-	Evidence    []string     `json:"evidence,omitempty"`
-	Coordinator string       `json:"coordinator"`
+	Provider     string       `json:"provider"`
+	Family       string       `json:"family"`
+	Aliases      []string     `json:"aliases,omitempty"`
+	Kind         ProviderKind `json:"kind"`
+	Category     string       `json:"category,omitempty"`
+	Targets      []string     `json:"targets"`
+	Features     []Feature    `json:"features"`
+	Runtime      []string     `json:"runtime,omitempty"`
+	Reachability []string     `json:"reachability,omitempty"`
+	Workspace    []string     `json:"workspace,omitempty"`
+	Evidence     []string     `json:"evidence,omitempty"`
+	Coordinator  string       `json:"coordinator"`
 }
 
 type providerRecommendationEntry struct {
-	Provider  string       `json:"provider"`
-	Kind      ProviderKind `json:"kind"`
-	Category  string       `json:"category,omitempty"`
-	Targets   []string     `json:"targets"`
-	Features  []Feature    `json:"features"`
-	Runtime   []string     `json:"runtime,omitempty"`
-	Workspace []string     `json:"workspace,omitempty"`
-	Evidence  []string     `json:"evidence,omitempty"`
-	Score     int          `json:"score"`
-	Reasons   []string     `json:"reasons"`
+	Provider     string       `json:"provider"`
+	Kind         ProviderKind `json:"kind"`
+	Category     string       `json:"category,omitempty"`
+	Targets      []string     `json:"targets"`
+	Features     []Feature    `json:"features"`
+	Runtime      []string     `json:"runtime,omitempty"`
+	Reachability []string     `json:"reachability,omitempty"`
+	Workspace    []string     `json:"workspace,omitempty"`
+	Evidence     []string     `json:"evidence,omitempty"`
+	Score        int          `json:"score"`
+	Reasons      []string     `json:"reasons"`
 }
 
 type providerFilterValuesEntry struct {
-	Kind      []string `json:"kind"`
-	Category  []string `json:"category"`
-	Target    []string `json:"target"`
-	Feature   []string `json:"feature"`
-	Runtime   []string `json:"runtime"`
-	Workspace []string `json:"workspace"`
-	Evidence  []string `json:"evidence"`
+	Kind         []string `json:"kind"`
+	Category     []string `json:"category"`
+	Target       []string `json:"target"`
+	Feature      []string `json:"feature"`
+	Runtime      []string `json:"runtime"`
+	Reachability []string `json:"reachability"`
+	Workspace    []string `json:"workspace"`
+	Evidence     []string `json:"evidence"`
 }
 
 type providerMatrixFilters struct {
-	Kinds      []string
-	Categories []string
-	Targets    []string
-	Features   []string
-	Runtimes   []string
-	Workspaces []string
-	Evidence   []string
+	Kinds        []string
+	Categories   []string
+	Targets      []string
+	Features     []string
+	Runtimes     []string
+	Reachability []string
+	Workspaces   []string
+	Evidence     []string
 }
 
 type providerMatrixFilterFlagValues struct {
-	Kinds      stringListFlag
-	Categories stringListFlag
-	Targets    stringListFlag
-	Features   stringListFlag
-	Runtimes   stringListFlag
-	Workspaces stringListFlag
-	Evidence   stringListFlag
+	Kinds        stringListFlag
+	Categories   stringListFlag
+	Targets      stringListFlag
+	Features     stringListFlag
+	Runtimes     stringListFlag
+	Reachability stringListFlag
+	Workspaces   stringListFlag
+	Evidence     stringListFlag
 }
 
 func (a App) providers(_ context.Context, args []string) error {
@@ -81,7 +86,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--runtime CAPABILITY] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--runtime CAPABILITY] [--reachability CAPABILITY] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	filters := filterFlags.filters()
@@ -189,17 +194,18 @@ func providerMatrix() []providerMatrixEntry {
 		category := benchmarkProviderCategories[firstNonBlank(spec.Name, provider.Name())]
 		targets := formatProviderTargets(spec.Targets)
 		entries = append(entries, providerMatrixEntry{
-			Provider:    firstNonBlank(spec.Name, provider.Name()),
-			Family:      firstNonBlank(spec.Family, provider.Name()),
-			Aliases:     append([]string(nil), provider.Aliases()...),
-			Kind:        spec.Kind,
-			Category:    category,
-			Targets:     targets,
-			Features:    append(FeatureSet{}, spec.Features...),
-			Runtime:     runtimeCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name()), spec.Kind, category, targets, spec.Features),
-			Workspace:   workspaceCapabilitiesForFeatures(spec.Features),
-			Evidence:    evidenceCapabilitiesForFeatures(spec.Features),
-			Coordinator: string(spec.Coordinator),
+			Provider:     firstNonBlank(spec.Name, provider.Name()),
+			Family:       firstNonBlank(spec.Family, provider.Name()),
+			Aliases:      append([]string(nil), provider.Aliases()...),
+			Kind:         spec.Kind,
+			Category:     category,
+			Targets:      targets,
+			Features:     append(FeatureSet{}, spec.Features...),
+			Runtime:      runtimeCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name()), spec.Kind, category, targets, spec.Features),
+			Reachability: reachabilityCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name())),
+			Workspace:    workspaceCapabilitiesForFeatures(spec.Features),
+			Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
+			Coordinator:  string(spec.Coordinator),
 		})
 	}
 	return entries
@@ -212,6 +218,7 @@ func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFl
 	fs.Var(&values.Targets, "target", "filter by target such as linux or worker-runtime; repeatable")
 	fs.Var(&values.Features, "feature", "filter by raw feature flag such as ssh or run-proof; repeatable")
 	fs.Var(&values.Runtimes, "runtime", "filter by normalized runtime capability; repeatable")
+	fs.Var(&values.Reachability, "reachability", "filter by normalized reachability capability; repeatable")
 	fs.Var(&values.Workspaces, "workspace", "filter by normalized workspace capability; repeatable")
 	fs.Var(&values.Evidence, "evidence", "filter by normalized evidence capability; repeatable")
 	return values
@@ -222,13 +229,14 @@ func (values *providerMatrixFilterFlagValues) filters() providerMatrixFilters {
 		return providerMatrixFilters{}
 	}
 	return providerMatrixFilters{
-		Kinds:      providerFilterValues(values.Kinds),
-		Categories: providerFilterValues(values.Categories),
-		Targets:    providerFilterValues(values.Targets),
-		Features:   providerFilterValues(values.Features),
-		Runtimes:   providerFilterValues(values.Runtimes),
-		Workspaces: providerFilterValues(values.Workspaces),
-		Evidence:   providerFilterValues(values.Evidence),
+		Kinds:        providerFilterValues(values.Kinds),
+		Categories:   providerFilterValues(values.Categories),
+		Targets:      providerFilterValues(values.Targets),
+		Features:     providerFilterValues(values.Features),
+		Runtimes:     providerFilterValues(values.Runtimes),
+		Reachability: providerFilterValues(values.Reachability),
+		Workspaces:   providerFilterValues(values.Workspaces),
+		Evidence:     providerFilterValues(values.Evidence),
 	}
 }
 
@@ -247,13 +255,14 @@ func providerFilterValues(values stringListFlag) []string {
 
 func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterValuesEntry {
 	allowed := map[string]map[string]bool{
-		"kind":      {},
-		"category":  {},
-		"target":    {},
-		"feature":   {},
-		"runtime":   {},
-		"workspace": {},
-		"evidence":  {},
+		"kind":         {},
+		"category":     {},
+		"target":       {},
+		"feature":      {},
+		"runtime":      {},
+		"reachability": {},
+		"workspace":    {},
+		"evidence":     {},
 	}
 	for _, entry := range entries {
 		addProviderFilterAllowed(allowed["kind"], []string{string(entry.Kind)})
@@ -261,17 +270,19 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		addProviderFilterAllowed(allowed["target"], entry.Targets)
 		addProviderFilterAllowed(allowed["feature"], featuresToStrings(entry.Features))
 		addProviderFilterAllowed(allowed["runtime"], entry.Runtime)
+		addProviderFilterAllowed(allowed["reachability"], entry.Reachability)
 		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
 		addProviderFilterAllowed(allowed["evidence"], entry.Evidence)
 	}
 	return providerFilterValuesEntry{
-		Kind:      sortedProviderFilterValues(allowed["kind"]),
-		Category:  sortedProviderFilterValues(allowed["category"]),
-		Target:    sortedProviderFilterValues(allowed["target"]),
-		Feature:   sortedProviderFilterValues(allowed["feature"]),
-		Runtime:   sortedProviderFilterValues(allowed["runtime"]),
-		Workspace: sortedProviderFilterValues(allowed["workspace"]),
-		Evidence:  sortedProviderFilterValues(allowed["evidence"]),
+		Kind:         sortedProviderFilterValues(allowed["kind"]),
+		Category:     sortedProviderFilterValues(allowed["category"]),
+		Target:       sortedProviderFilterValues(allowed["target"]),
+		Feature:      sortedProviderFilterValues(allowed["feature"]),
+		Runtime:      sortedProviderFilterValues(allowed["runtime"]),
+		Reachability: sortedProviderFilterValues(allowed["reachability"]),
+		Workspace:    sortedProviderFilterValues(allowed["workspace"]),
+		Evidence:     sortedProviderFilterValues(allowed["evidence"]),
 	}
 }
 
@@ -300,6 +311,9 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 	if err := check("runtime", filters.Runtimes); err != nil {
 		return err
 	}
+	if err := check("reachability", filters.Reachability); err != nil {
+		return err
+	}
 	if err := check("workspace", filters.Workspaces); err != nil {
 		return err
 	}
@@ -309,13 +323,14 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 func providerMatrixFilterAllowedValues(entries []providerMatrixEntry) map[string]map[string]bool {
 	values := providerMatrixFilterValues(entries)
 	return map[string]map[string]bool{
-		"kind":      providerFilterAllowedSet(values.Kind),
-		"category":  providerFilterAllowedSet(values.Category),
-		"target":    providerFilterAllowedSet(values.Target),
-		"feature":   providerFilterAllowedSet(values.Feature),
-		"runtime":   providerFilterAllowedSet(values.Runtime),
-		"workspace": providerFilterAllowedSet(values.Workspace),
-		"evidence":  providerFilterAllowedSet(values.Evidence),
+		"kind":         providerFilterAllowedSet(values.Kind),
+		"category":     providerFilterAllowedSet(values.Category),
+		"target":       providerFilterAllowedSet(values.Target),
+		"feature":      providerFilterAllowedSet(values.Feature),
+		"runtime":      providerFilterAllowedSet(values.Runtime),
+		"reachability": providerFilterAllowedSet(values.Reachability),
+		"workspace":    providerFilterAllowedSet(values.Workspace),
+		"evidence":     providerFilterAllowedSet(values.Evidence),
 	}
 }
 
@@ -352,6 +367,7 @@ func printProviderFilterValues(out io.Writer, values providerFilterValuesEntry) 
 	fmt.Fprintf(out, "  target: %s\n", providerFilterValueLine(values.Target))
 	fmt.Fprintf(out, "  feature: %s\n", providerFilterValueLine(values.Feature))
 	fmt.Fprintf(out, "  runtime: %s\n", providerFilterValueLine(values.Runtime))
+	fmt.Fprintf(out, "  reachability: %s\n", providerFilterValueLine(values.Reachability))
 	fmt.Fprintf(out, "  workspace: %s\n", providerFilterValueLine(values.Workspace))
 	fmt.Fprintf(out, "  evidence: %s\n", providerFilterValueLine(values.Evidence))
 }
@@ -378,7 +394,7 @@ func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixF
 }
 
 func providerMatrixFiltersEmpty(filters providerMatrixFilters) bool {
-	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Runtimes) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
+	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Runtimes) == 0 && len(filters.Reachability) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
 }
 
 func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatrixFilters) bool {
@@ -387,6 +403,7 @@ func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatr
 		providerFieldContainsAll(entry.Targets, filters.Targets) &&
 		providerFieldContainsAll(featuresToStrings(entry.Features), filters.Features) &&
 		providerFieldContainsAll(entry.Runtime, filters.Runtimes) &&
+		providerFieldContainsAll(entry.Reachability, filters.Reachability) &&
 		providerFieldContainsAll(entry.Workspace, filters.Workspaces) &&
 		providerFieldContainsAll(entry.Evidence, filters.Evidence)
 }
@@ -528,16 +545,17 @@ func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string,
 			continue
 		}
 		recommendations = append(recommendations, providerRecommendationEntry{
-			Provider:  entry.Provider,
-			Kind:      entry.Kind,
-			Category:  benchmarkProviderCategories[entry.Provider],
-			Targets:   append([]string(nil), entry.Targets...),
-			Features:  append([]Feature(nil), entry.Features...),
-			Runtime:   append([]string(nil), entry.Runtime...),
-			Workspace: append([]string(nil), entry.Workspace...),
-			Evidence:  append([]string(nil), entry.Evidence...),
-			Score:     score,
-			Reasons:   reasons,
+			Provider:     entry.Provider,
+			Kind:         entry.Kind,
+			Category:     benchmarkProviderCategories[entry.Provider],
+			Targets:      append([]string(nil), entry.Targets...),
+			Features:     append([]Feature(nil), entry.Features...),
+			Runtime:      append([]string(nil), entry.Runtime...),
+			Reachability: append([]string(nil), entry.Reachability...),
+			Workspace:    append([]string(nil), entry.Workspace...),
+			Evidence:     append([]string(nil), entry.Evidence...),
+			Score:        score,
+			Reasons:      reasons,
 		})
 	}
 	sort.SliceStable(recommendations, func(i, j int) bool {
@@ -1229,6 +1247,9 @@ func printProviderRecommendations(out io.Writer, useCase string, entries []provi
 		if len(entry.Runtime) > 0 {
 			fmt.Fprintf(out, "  runtime: %s\n", commaOrDash(entry.Runtime))
 		}
+		if len(entry.Reachability) > 0 {
+			fmt.Fprintf(out, "  reachability: %s\n", commaOrDash(entry.Reachability))
+		}
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
 		}
@@ -1249,6 +1270,9 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  features: %s\n", commaOrDash(featuresToStrings(entry.Features)))
 		if len(entry.Runtime) > 0 {
 			fmt.Fprintf(out, "  runtime: %s\n", commaOrDash(entry.Runtime))
+		}
+		if len(entry.Reachability) > 0 {
+			fmt.Fprintf(out, "  reachability: %s\n", commaOrDash(entry.Reachability))
 		}
 		if len(entry.Workspace) > 0 {
 			fmt.Fprintf(out, "  workspace: %s\n", commaOrDash(entry.Workspace))
@@ -1330,6 +1354,24 @@ func runtimeCapabilitiesForProvider(provider string, kind ProviderKind, category
 	}
 	if FeatureSet(features).Has(FeatureDesktop) || FeatureSet(features).Has(FeatureBrowser) || FeatureSet(features).Has(FeatureCode) {
 		add("interactive")
+	}
+	return out
+}
+
+func reachabilityCapabilitiesForProvider(provider string) []string {
+	capabilities := providerCapabilities(provider)
+	var out []string
+	if capabilities.Tailscale {
+		out = append(out, "tailnet-peer")
+	}
+	if capabilities.TailscaleEgress {
+		out = append(out, "tailnet-egress")
+	}
+	if capabilities.URLBridge {
+		out = append(out, "provider-url")
+	}
+	if capabilities.SSHMesh {
+		out = append(out, "ssh-tunnel")
 	}
 	return out
 }

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -120,6 +120,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 			t.Fatalf("aws runtime=%v missing %s", aws.Runtime, capability)
 		}
 	}
+	if !containsString(aws.Reachability, "ssh-tunnel") {
+		t.Fatalf("aws reachability=%v missing ssh-tunnel", aws.Reachability)
+	}
 	if incus.Kind != ProviderKindSSHLease || incus.Family != "local-vm" {
 		t.Fatalf("incus kind/family=%q/%q", incus.Kind, incus.Family)
 	}
@@ -161,6 +164,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	for _, feature := range []Feature{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale} {
 		if !containsFeature(scaleway.Features, feature) {
 			t.Fatalf("scaleway features=%v missing %s", scaleway.Features, feature)
+		}
+	}
+	for _, capability := range []string{"tailnet-peer", "ssh-tunnel"} {
+		if !containsString(scaleway.Reachability, capability) {
+			t.Fatalf("scaleway reachability=%v missing %s", scaleway.Reachability, capability)
 		}
 	}
 	if moduleRuntime == nil {
@@ -217,6 +225,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 			t.Fatalf("e2b evidence=%v missing %s", e2b.Evidence, capability)
 		}
 	}
+	if !containsString(e2b.Reachability, "provider-url") {
+		t.Fatalf("e2b reachability=%v missing provider-url", e2b.Reachability)
+	}
 	for _, capability := range []string{"delegated-command", "managed-sandbox"} {
 		if !containsString(e2b.Runtime, capability) {
 			t.Fatalf("e2b runtime=%v missing %s", e2b.Runtime, capability)
@@ -225,6 +236,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	for _, capability := range []string{"downloads", "preview-url", "session"} {
 		if !containsString(islo.Evidence, capability) {
 			t.Fatalf("islo evidence=%v missing %s", islo.Evidence, capability)
+		}
+	}
+	for _, capability := range []string{"tailnet-egress", "provider-url"} {
+		if !containsString(islo.Reachability, capability) {
+			t.Fatalf("islo reachability=%v missing %s", islo.Reachability, capability)
 		}
 	}
 }
@@ -252,6 +268,9 @@ func TestProvidersCommandJSON(t *testing.T) {
 		if entry.Provider == "aws" && !containsString(entry.Runtime, "ssh-host") {
 			t.Fatalf("aws json missing ssh-host runtime: %#v", entry)
 		}
+		if entry.Provider == "aws" && !containsString(entry.Reachability, "ssh-tunnel") {
+			t.Fatalf("aws json missing ssh-tunnel reachability: %#v", entry)
+		}
 		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
 			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
 		}
@@ -268,7 +287,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 		t.Fatalf("providers error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: ", "  runtime: ssh-host,interactive\n"} {
+	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: ", "  runtime: ssh-host,interactive\n", "  reachability: ssh-tunnel\n"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers output missing %q:\n%s", want, text)
 		}
@@ -294,6 +313,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		"--category", "delegated-sandbox",
 		"--target", "linux",
 		"--runtime", "managed-sandbox",
+		"--reachability", "provider-url",
 		"--evidence", "preview-url",
 		"--json",
 	})
@@ -308,7 +328,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		t.Fatal("expected delegated preview providers")
 	}
 	for _, entry := range entries {
-		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Evidence, "preview-url") {
+		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Reachability, "provider-url") || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("entry escaped filters: %#v", entry)
 		}
 	}
@@ -361,6 +381,8 @@ func TestProvidersFiltersCommandHumanOutput(t *testing.T) {
 		"delegated-sandbox",
 		"  runtime: ",
 		"managed-sandbox",
+		"  reachability: ",
+		"provider-url",
 		"  evidence: ",
 		"preview-url",
 	} {
@@ -388,6 +410,7 @@ func TestProvidersFiltersCommandJSON(t *testing.T) {
 		{name: "kind", values: values.Kind, want: "delegated-run"},
 		{name: "category", values: values.Category, want: "delegated-sandbox"},
 		{name: "runtime", values: values.Runtime, want: "managed-sandbox"},
+		{name: "reachability", values: values.Reachability, want: "provider-url"},
 		{name: "evidence", values: values.Evidence, want: "preview-url"},
 		{name: "workspace", values: values.Workspace, want: "fork"},
 	} {
@@ -710,6 +733,9 @@ func TestProvidersRecommendReachabilityUsesTransportCapabilities(t *testing.T) {
 		}
 		if !capabilities.Tailscale && !capabilities.TailscaleEgress && !capabilities.URLBridge && !capabilities.SSHMesh {
 			t.Fatalf("reachability recommendation lacks any transport plane: %#v", recommendation)
+		}
+		if len(recommendation.Reachability) == 0 {
+			t.Fatalf("reachability recommendation missing normalized reachability capabilities: %#v", recommendation)
 		}
 	}
 	if !foundTailnet {
@@ -1172,6 +1198,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 		"recommend", "run-evidence",
 		"--category", "delegated-sandbox",
 		"--runtime", "managed-sandbox",
+		"--reachability", "provider-url",
 		"--evidence", "preview-url",
 		"--json",
 	})
@@ -1186,7 +1213,7 @@ func TestProvidersRecommendCommandAppliesFilters(t *testing.T) {
 		t.Fatal("expected filtered run-evidence recommendations")
 	}
 	for _, entry := range entries {
-		if entry.Category != "delegated-sandbox" || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Evidence, "preview-url") {
+		if entry.Category != "delegated-sandbox" || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Reachability, "provider-url") || !containsString(entry.Evidence, "preview-url") {
 			t.Fatalf("recommendation escaped filters: %#v", entry)
 		}
 	}


### PR DESCRIPTION
## Summary
- add normalized reachability capabilities to providers matrix and recommendation JSON
- add --reachability filters for provider matrix and recommendations
- document provider-url, ssh-tunnel, tailnet-peer, and tailnet-egress as provider-neutral access-plane labels

## Verification
- git diff --check
- go test -count=1 ./internal/cli -run 'TestProviderMatrixIncludesCapabilities|TestProvidersCommand(JSON|HumanOutput|FiltersJSON|RejectsUnknownFilter)|TestProvidersFiltersCommand(HumanOutput|JSON)|TestProvidersRecommendReachabilityUsesTransportCapabilities|TestProvidersRecommendCommandAppliesFilters'
- go run ./cmd/crabbox providers --reachability provider-url --evidence preview-url --json
- go run ./cmd/crabbox providers recommend reachability --reachability tailnet-peer --json
- go run ./cmd/crabbox providers filters --json
- go test -count=1 ./internal/cli
- go test -race -count=1 ./internal/cli -run 'TestProviderMatrixIncludesCapabilities|TestProvidersCommandFiltersJSON|TestProvidersRecommendReachabilityUsesTransportCapabilities|TestProvidersRecommendCommandAppliesFilters'