### PR TITLE
feat(providers): recommend offline validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.
 - Added normalized provider reachability capabilities and `--reachability` filters to `crabbox providers` and `crabbox providers recommend`.
+- Added `crabbox providers recommend offline-validation` for credentialless local, BYO SSH, and external-provider validation guidance.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -108,6 +108,7 @@ crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
 crabbox providers recommend mcp-sandbox
 crabbox providers recommend network-isolation
+crabbox providers recommend offline-validation
 crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend reachability
@@ -159,6 +160,11 @@ Supported use cases:
 - `network-isolation`: delegated and local sandboxes for contained untrusted
   execution when network exposure should stay narrow. This is routing guidance,
   not a security certification for a specific provider.
+- `offline-validation`: local, BYO SSH, or external-provider paths for
+  validation when cloud/provider credentials are unavailable. Aliases include
+  `no-credentials`, `credentialless`, and `local-first`. This is selection
+  guidance; local providers may still need Docker, a VM runtime, or other local
+  engine software installed.
 - `pause-resume`: providers that can pause and resume provider-owned runtime or
   workspace state.
 - `preview-url`: providers that can expose provider-native preview URLs for app

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -126,6 +126,10 @@ Ship these in small PRs:
    Use `crabbox providers recommend cost-control` when a workflow should prefer
    local runtimes, coordinator governance, cleanup, cache reuse, or retained
    proof before spending provider quota.
+   Use `crabbox providers recommend offline-validation` when live provider
+   credentials or quota are not available yet; it prefers local runtimes,
+   local sandboxes/VMs, BYO SSH hosts, and external-provider contracts over
+   cloud API-backed leases.
    Use `crabbox providers recommend pause-resume` when long-running sandbox or
    dev-environment state needs to be parked and resumed.
 4. Strengthen workspace reuse before runtime-specific forking.

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -442,6 +442,7 @@ func providerRecommendationUseCases() []string {
 		"macos",
 		"mcp-sandbox",
 		"network-isolation",
+		"offline-validation",
 		"pause-resume",
 		"preview-url",
 		"reachability",
@@ -498,6 +499,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		"egress-control", "egress-controlled", "contained-execution",
 		"contained-sandbox", "contained-sandboxes":
 		return "network-isolation", true
+	case "offline", "offline-validation", "offline-smoke", "no-credentials",
+		"no-provider-credentials", "credentialless", "without-credentials",
+		"local-first", "local-validation":
+		return "offline-validation", true
 	case "pause-resume", "pause", "resume", "suspend", "suspended",
 		"pausable", "pausable-workspace", "pausable-workspaces",
 		"resumable", "resumable-workspace", "resumable-workspaces":
@@ -933,6 +938,43 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux sandbox workloads")
 		}
+	case "offline-validation":
+		offlineCandidate := true
+		switch {
+		case category == "local-runtime":
+			add(95, "local runtime can validate without provider credentials")
+		case category == "local-sandbox":
+			add(90, "local sandbox can run disposable validation without provider credentials")
+		case category == "local-vm":
+			add(82, "local VM can validate without cloud credentials")
+		case category == "byo-ssh":
+			add(55, "bring-your-own SSH host avoids provider API credentials")
+		case category == "external-provider":
+			add(35, "external provider can wrap private infrastructure")
+		default:
+			offlineCandidate = false
+		}
+		if !offlineCandidate {
+			break
+		}
+		if strings.HasPrefix(category, "local-") && hasFeature(FeatureCacheVolume) {
+			add(16, "can reuse local dependency/cache state")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(16, "can sync the current checkout")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(14, "can clean up local validation resources")
+		}
+		if hasFeature(FeatureMCP) {
+			add(10, "can exercise MCP-attached sandbox flows locally")
+		}
+		if hasFeature(FeatureCheckpoint) || hasFeature(FeatureFork) || hasFeature(FeatureRestore) || hasFeature(FeatureSnapshot) {
+			add(8, "can reuse local workspace state across validation runs")
+		}
+		if hasTarget(targetLinux) {
+			add(8, "supports common Linux validation workloads")
+		}
 	case "pause-resume":
 		if !hasFeature(FeaturePauseResume) {
 			break
@@ -1224,6 +1266,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend mcp-sandbox")
 	fmt.Fprintln(out, "  crabbox providers recommend network-isolation")
+	fmt.Fprintln(out, "  crabbox providers recommend offline-validation")
 	fmt.Fprintln(out, "  crabbox providers recommend pause-resume")
 	fmt.Fprintln(out, "  crabbox providers recommend preview-url")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -448,6 +448,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"live-smoke",
 		"mcp-sandbox",
 		"network-isolation",
+		"offline-validation",
 		"pause-resume",
 		"preview-url",
 		"reachability",
@@ -560,6 +561,64 @@ func TestProvidersRecommendCostControlAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
 		t.Fatalf("budget alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendOfflineValidationPrefersCredentiallessProviders(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "offline-validation", 16)
+	if len(recommendations) == 0 {
+		t.Fatal("expected offline-validation recommendations")
+	}
+	if !strings.HasPrefix(recommendations[0].Category, "local-") {
+		t.Fatalf("top offline-validation category=%q recommendations=%v", recommendations[0].Category, recommendations)
+	}
+	foundLocalRuntime := false
+	foundLocalSandbox := false
+	foundLocalVM := false
+	foundBYO := false
+	for _, recommendation := range recommendations {
+		switch {
+		case strings.HasPrefix(recommendation.Category, "local-"):
+			if recommendation.Category == "local-runtime" {
+				foundLocalRuntime = true
+			}
+			if recommendation.Category == "local-sandbox" {
+				foundLocalSandbox = true
+			}
+			if recommendation.Category == "local-vm" {
+				foundLocalVM = true
+			}
+		case recommendation.Category == "byo-ssh":
+			foundBYO = true
+		case recommendation.Category == "external-provider":
+		default:
+			t.Fatalf("offline-validation recommendation requires provider credentials: %#v", recommendation)
+		}
+	}
+	if !foundLocalRuntime || !foundLocalSandbox || !foundLocalVM {
+		t.Fatalf("offline-validation should include local runtime, sandbox, and VM providers: %#v", recommendations)
+	}
+	if !foundBYO {
+		t.Fatalf("offline-validation should include BYO SSH fallback: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendNoCredentialsAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "no-credentials",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend no-credentials error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
+		t.Fatalf("no-credentials alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary:\n- add an offline-validation provider recommendation use case and credentialless aliases\n- rank local runtimes/sandboxes/VMs first, with BYO SSH and external-provider fallbacks\n- document the workflow and changelog entry\n\nVerification:\n- go test -count=1 ./internal/cli -run 'TestProvidersRecommend(OfflineValidation|NoCredentials|ListsUseCases)'\n- go run ./cmd/crabbox providers recommend offline-validation --json\n- go run ./cmd/crabbox providers recommend no-credentials --limit 1 --json\n- git diff --check\n- go test -count=1 ./internal/cli\n- go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(OfflineValidation|NoCredentials)'