### PR TITLE
feat(providers): add lifecycle filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.
 - Added normalized provider reachability capabilities and `--reachability` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend offline-validation` for credentialless local, BYO SSH, and external-provider validation guidance.
+- Added normalized provider lifecycle capabilities and `--lifecycle` filters to `crabbox providers` and `crabbox providers recommend`.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -11,6 +11,7 @@ crabbox providers --json
 crabbox providers filters
 crabbox providers filters --json
 crabbox providers --reachability provider-url --evidence preview-url
+crabbox providers --lifecycle cleanup --lifecycle workspace-state
 crabbox providers --target linux --workspace checkpoint --workspace fork --json
 crabbox providers recommend ci-proof
 crabbox providers recommend agent-sandbox --json
@@ -46,6 +47,9 @@ crabbox providers recommend versioned-workspace
 - `--evidence <capability>`: keep providers that advertise this normalized
   evidence capability, such as `proof`, `artifacts`, `downloads`,
   `preview-url`, or `session`. Repeatable.
+- `--lifecycle <capability>`: keep providers that advertise this normalized
+  lifecycle capability, such as `cleanup`, `pause-resume`, `run-session`,
+  `workspace-state`, or `coordinator-governed`. Repeatable.
 
 Repeated filters are combined with AND semantics. Comma-separated values are also
 accepted, so `--workspace checkpoint,fork` means the same thing as passing
@@ -83,10 +87,11 @@ provider filter values:
   reachability: provider-url,ssh-tunnel,tailnet-egress,tailnet-peer
   workspace: checkpoint,fork,restore,snapshot-ref
   evidence: artifacts,downloads,preview-url,proof,session
+  lifecycle: cleanup,coordinator-governed,pause-resume,run-session,workspace-state
 ```
 
 JSON output returns one object with `kind`, `category`, `target`, `feature`,
-`runtime`, `reachability`, `workspace`, and `evidence` arrays.
+`runtime`, `reachability`, `workspace`, `evidence`, and `lifecycle` arrays.
 
 ## `providers recommend`
 
@@ -192,9 +197,9 @@ Recommendation flags:
 - `--limit <n>`: maximum recommendations to print. Defaults to `5`.
 - `--json`: emit recommendations as JSON.
 - `--kind`, `--category`, `--target`, `--feature`, `--runtime`,
-  `--reachability`, `--workspace`, `--evidence`: filter the candidate provider
-  matrix before scoring. These flags use the same values and repeat/comma
-  semantics as the base `providers` matrix command.
+  `--reachability`, `--workspace`, `--evidence`, `--lifecycle`: filter the
+  candidate provider matrix before scoring. These flags use the same values and
+  repeat/comma semantics as the base `providers` matrix command.
 
 ## Output
 
@@ -220,6 +225,7 @@ parallels
   runtime: ssh-host,local-runtime,interactive
   reachability: ssh-tunnel
   workspace: checkpoint,fork,restore,snapshot-ref
+  lifecycle: cleanup,workspace-state
   coordinator: never
 
 blacksmith-testbox
@@ -230,6 +236,7 @@ blacksmith-testbox
   features: cache-volume,run-proof,run-session,run-artifacts
   runtime: delegated-command,ci-runner
   evidence: proof,artifacts,session
+  lifecycle: run-session
   coordinator: never
   aliases: blacksmith
 
@@ -242,6 +249,7 @@ e2b
   runtime: delegated-command,managed-sandbox
   reachability: provider-url
   evidence: preview-url,session
+  lifecycle: run-session
   coordinator: never
 
 wandb
@@ -271,6 +279,7 @@ hostinger
   features: ssh,crabbox-sync,cleanup
   runtime: ssh-host
   reachability: ssh-tunnel
+  lifecycle: cleanup
   coordinator: never
 ```
 
@@ -295,6 +304,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "features": ["ssh", "crabbox-sync", "cleanup"],
     "runtime": ["ssh-host"],
     "reachability": ["ssh-tunnel"],
+    "lifecycle": ["cleanup"],
     "coordinator": "never"
   },
   {
@@ -307,6 +317,7 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
     "runtime": ["delegated-command", "ci-runner"],
     "evidence": ["proof", "artifacts", "session"],
+    "lifecycle": ["run-session"],
     "coordinator": "never"
   }
 ]
@@ -362,6 +373,10 @@ Direct self-hosted SSH-lease providers such as `proxmox` and `xcp-ng` report
   feature flags. Possible values are `proof`, `artifacts`, `downloads`,
   `preview-url`, and `session`. The field is omitted when a provider does not
   advertise any run evidence or preview capabilities.
+- `lifecycle`: normalized lifecycle controls derived from provider metadata and
+  feature flags. Possible values are `cleanup`, `pause-resume`, `run-session`,
+  `workspace-state`, and `coordinator-governed`. The field is omitted when a
+  provider does not advertise any lifecycle controls.
 - `coordinator`: whether the provider can route leases through the broker.
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
@@ -379,6 +394,7 @@ Recommendation JSON returns ranked objects:
     "features": ["cache-volume", "run-proof", "run-session", "run-artifacts"],
     "runtime": ["delegated-command", "ci-runner"],
     "evidence": ["proof", "artifacts", "session"],
+    "lifecycle": ["run-session"],
     "score": 158,
     "reasons": [
       "CI proof runner",

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -64,6 +64,9 @@ The better path is to make the generic seams real first:
 - `mcp-attachments` stays a capability, not a Mitos-only command mode.
 - `run-proof`, `run-artifacts`, `run-downloads`, and `url-bridge` keep evidence
   portable across delegated sandboxes and proof runners.
+- `lifecycle` filter values like `cleanup`, `pause-resume`, `run-session`,
+  `workspace-state`, and `coordinator-governed` expose stateful sandbox and
+  devbox controls without baking in one provider's lifecycle API.
 - `reachability` filter values describe access planes without claiming a
   provider-specific network isolation model.
 - `remote-dev`, `mcp-sandbox`, `isolated-execution`, and

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -22,6 +22,7 @@ type providerMatrixEntry struct {
 	Reachability []string     `json:"reachability,omitempty"`
 	Workspace    []string     `json:"workspace,omitempty"`
 	Evidence     []string     `json:"evidence,omitempty"`
+	Lifecycle    []string     `json:"lifecycle,omitempty"`
 	Coordinator  string       `json:"coordinator"`
 }
 
@@ -35,6 +36,7 @@ type providerRecommendationEntry struct {
 	Reachability []string     `json:"reachability,omitempty"`
 	Workspace    []string     `json:"workspace,omitempty"`
 	Evidence     []string     `json:"evidence,omitempty"`
+	Lifecycle    []string     `json:"lifecycle,omitempty"`
 	Score        int          `json:"score"`
 	Reasons      []string     `json:"reasons"`
 }
@@ -48,6 +50,7 @@ type providerFilterValuesEntry struct {
 	Reachability []string `json:"reachability"`
 	Workspace    []string `json:"workspace"`
 	Evidence     []string `json:"evidence"`
+	Lifecycle    []string `json:"lifecycle"`
 }
 
 type providerMatrixFilters struct {
@@ -59,6 +62,7 @@ type providerMatrixFilters struct {
 	Reachability []string
 	Workspaces   []string
 	Evidence     []string
+	Lifecycle    []string
 }
 
 type providerMatrixFilterFlagValues struct {
@@ -70,6 +74,7 @@ type providerMatrixFilterFlagValues struct {
 	Reachability stringListFlag
 	Workspaces   stringListFlag
 	Evidence     stringListFlag
+	Lifecycle    stringListFlag
 }
 
 func (a App) providers(_ context.Context, args []string) error {
@@ -86,7 +91,7 @@ func (a App) providers(_ context.Context, args []string) error {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--runtime CAPABILITY] [--reachability CAPABILITY] [--workspace CAPABILITY] [--evidence CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
+		return exit(2, "usage: crabbox providers [--json] [--kind KIND] [--category CATEGORY] [--target TARGET] [--feature FEATURE] [--runtime CAPABILITY] [--reachability CAPABILITY] [--workspace CAPABILITY] [--evidence CAPABILITY] [--lifecycle CAPABILITY] OR crabbox providers filters [--json] OR crabbox providers recommend <use-case> [--limit N] [--json]")
 	}
 	entries := providerMatrix()
 	filters := filterFlags.filters()
@@ -205,6 +210,7 @@ func providerMatrix() []providerMatrixEntry {
 			Reachability: reachabilityCapabilitiesForProvider(firstNonBlank(spec.Name, provider.Name())),
 			Workspace:    workspaceCapabilitiesForFeatures(spec.Features),
 			Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
+			Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
 			Coordinator:  string(spec.Coordinator),
 		})
 	}
@@ -221,6 +227,7 @@ func registerProviderMatrixFilterFlags(fs *flag.FlagSet) *providerMatrixFilterFl
 	fs.Var(&values.Reachability, "reachability", "filter by normalized reachability capability; repeatable")
 	fs.Var(&values.Workspaces, "workspace", "filter by normalized workspace capability; repeatable")
 	fs.Var(&values.Evidence, "evidence", "filter by normalized evidence capability; repeatable")
+	fs.Var(&values.Lifecycle, "lifecycle", "filter by normalized lifecycle capability; repeatable")
 	return values
 }
 
@@ -237,6 +244,7 @@ func (values *providerMatrixFilterFlagValues) filters() providerMatrixFilters {
 		Reachability: providerFilterValues(values.Reachability),
 		Workspaces:   providerFilterValues(values.Workspaces),
 		Evidence:     providerFilterValues(values.Evidence),
+		Lifecycle:    providerFilterValues(values.Lifecycle),
 	}
 }
 
@@ -263,6 +271,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		"reachability": {},
 		"workspace":    {},
 		"evidence":     {},
+		"lifecycle":    {},
 	}
 	for _, entry := range entries {
 		addProviderFilterAllowed(allowed["kind"], []string{string(entry.Kind)})
@@ -273,6 +282,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		addProviderFilterAllowed(allowed["reachability"], entry.Reachability)
 		addProviderFilterAllowed(allowed["workspace"], entry.Workspace)
 		addProviderFilterAllowed(allowed["evidence"], entry.Evidence)
+		addProviderFilterAllowed(allowed["lifecycle"], entry.Lifecycle)
 	}
 	return providerFilterValuesEntry{
 		Kind:         sortedProviderFilterValues(allowed["kind"]),
@@ -283,6 +293,7 @@ func providerMatrixFilterValues(entries []providerMatrixEntry) providerFilterVal
 		Reachability: sortedProviderFilterValues(allowed["reachability"]),
 		Workspace:    sortedProviderFilterValues(allowed["workspace"]),
 		Evidence:     sortedProviderFilterValues(allowed["evidence"]),
+		Lifecycle:    sortedProviderFilterValues(allowed["lifecycle"]),
 	}
 }
 
@@ -317,7 +328,10 @@ func validateProviderMatrixFilters(filters providerMatrixFilters, entries []prov
 	if err := check("workspace", filters.Workspaces); err != nil {
 		return err
 	}
-	return check("evidence", filters.Evidence)
+	if err := check("evidence", filters.Evidence); err != nil {
+		return err
+	}
+	return check("lifecycle", filters.Lifecycle)
 }
 
 func providerMatrixFilterAllowedValues(entries []providerMatrixEntry) map[string]map[string]bool {
@@ -331,6 +345,7 @@ func providerMatrixFilterAllowedValues(entries []providerMatrixEntry) map[string
 		"reachability": providerFilterAllowedSet(values.Reachability),
 		"workspace":    providerFilterAllowedSet(values.Workspace),
 		"evidence":     providerFilterAllowedSet(values.Evidence),
+		"lifecycle":    providerFilterAllowedSet(values.Lifecycle),
 	}
 }
 
@@ -370,6 +385,7 @@ func printProviderFilterValues(out io.Writer, values providerFilterValuesEntry) 
 	fmt.Fprintf(out, "  reachability: %s\n", providerFilterValueLine(values.Reachability))
 	fmt.Fprintf(out, "  workspace: %s\n", providerFilterValueLine(values.Workspace))
 	fmt.Fprintf(out, "  evidence: %s\n", providerFilterValueLine(values.Evidence))
+	fmt.Fprintf(out, "  lifecycle: %s\n", providerFilterValueLine(values.Lifecycle))
 }
 
 func providerFilterValueLine(values []string) string {
@@ -394,7 +410,7 @@ func filterProviderMatrix(entries []providerMatrixEntry, filters providerMatrixF
 }
 
 func providerMatrixFiltersEmpty(filters providerMatrixFilters) bool {
-	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Runtimes) == 0 && len(filters.Reachability) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0
+	return len(filters.Kinds) == 0 && len(filters.Categories) == 0 && len(filters.Targets) == 0 && len(filters.Features) == 0 && len(filters.Runtimes) == 0 && len(filters.Reachability) == 0 && len(filters.Workspaces) == 0 && len(filters.Evidence) == 0 && len(filters.Lifecycle) == 0
 }
 
 func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatrixFilters) bool {
@@ -405,7 +421,8 @@ func providerEntryMatchesFilters(entry providerMatrixEntry, filters providerMatr
 		providerFieldContainsAll(entry.Runtime, filters.Runtimes) &&
 		providerFieldContainsAll(entry.Reachability, filters.Reachability) &&
 		providerFieldContainsAll(entry.Workspace, filters.Workspaces) &&
-		providerFieldContainsAll(entry.Evidence, filters.Evidence)
+		providerFieldContainsAll(entry.Evidence, filters.Evidence) &&
+		providerFieldContainsAll(entry.Lifecycle, filters.Lifecycle)
 }
 
 func providerFieldContainsAll(values, wants []string) bool {
@@ -559,6 +576,7 @@ func recommendProvidersForUseCase(entries []providerMatrixEntry, useCase string,
 			Reachability: append([]string(nil), entry.Reachability...),
 			Workspace:    append([]string(nil), entry.Workspace...),
 			Evidence:     append([]string(nil), entry.Evidence...),
+			Lifecycle:    append([]string(nil), entry.Lifecycle...),
 			Score:        score,
 			Reasons:      reasons,
 		})
@@ -1299,6 +1317,9 @@ func printProviderRecommendations(out io.Writer, useCase string, entries []provi
 		if len(entry.Evidence) > 0 {
 			fmt.Fprintf(out, "  evidence: %s\n", commaOrDash(entry.Evidence))
 		}
+		if len(entry.Lifecycle) > 0 {
+			fmt.Fprintf(out, "  lifecycle: %s\n", commaOrDash(entry.Lifecycle))
+		}
 		fmt.Fprintf(out, "  reasons: %s\n", strings.Join(entry.Reasons, "; "))
 	}
 }
@@ -1322,6 +1343,9 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		}
 		if len(entry.Evidence) > 0 {
 			fmt.Fprintf(out, "  evidence: %s\n", commaOrDash(entry.Evidence))
+		}
+		if len(entry.Lifecycle) > 0 {
+			fmt.Fprintf(out, "  lifecycle: %s\n", commaOrDash(entry.Lifecycle))
 		}
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
@@ -1431,6 +1455,26 @@ func evidenceCapabilitiesForFeatures(features []Feature) []string {
 	add(FeatureRunDownloads, "downloads")
 	add(FeatureURLBridge, "preview-url")
 	add(FeatureRunSession, "session")
+	return out
+}
+
+func lifecycleCapabilitiesForProvider(coordinator CoordinatorMode, features []Feature) []string {
+	var out []string
+	addFeature := func(feature Feature, capability string) {
+		if FeatureSet(features).Has(feature) {
+			out = append(out, capability)
+		}
+	}
+	if coordinator == CoordinatorSupported {
+		out = append(out, "coordinator-governed")
+	}
+	addFeature(FeatureCleanup, "cleanup")
+	addFeature(FeaturePauseResume, "pause-resume")
+	addFeature(FeatureRunSession, "run-session")
+	if FeatureSet(features).Has(FeatureCheckpoint) || FeatureSet(features).Has(FeatureFork) ||
+		FeatureSet(features).Has(FeatureRestore) || FeatureSet(features).Has(FeatureSnapshot) {
+		out = append(out, "workspace-state")
+	}
 	return out
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -123,6 +123,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if !containsString(aws.Reachability, "ssh-tunnel") {
 		t.Fatalf("aws reachability=%v missing ssh-tunnel", aws.Reachability)
 	}
+	for _, capability := range []string{"coordinator-governed", "cleanup"} {
+		if !containsString(aws.Lifecycle, capability) {
+			t.Fatalf("aws lifecycle=%v missing %s", aws.Lifecycle, capability)
+		}
+	}
 	if incus.Kind != ProviderKindSSHLease || incus.Family != "local-vm" {
 		t.Fatalf("incus kind/family=%q/%q", incus.Kind, incus.Family)
 	}
@@ -205,6 +210,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if !containsString(localContainer.Workspace, "checkpoint") || !containsString(localContainer.Workspace, "fork") {
 		t.Fatalf("local-container workspace=%v", localContainer.Workspace)
 	}
+	for _, capability := range []string{"cleanup", "workspace-state"} {
+		if !containsString(localContainer.Lifecycle, capability) {
+			t.Fatalf("local-container lifecycle=%v missing %s", localContainer.Lifecycle, capability)
+		}
+	}
 	for _, capability := range []string{"checkpoint", "fork", "restore", "snapshot-ref"} {
 		if !containsString(parallels.Workspace, capability) {
 			t.Fatalf("parallels workspace=%v missing %s", parallels.Workspace, capability)
@@ -215,6 +225,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 			t.Fatalf("blacksmith evidence=%v missing %s", blacksmith.Evidence, capability)
 		}
 	}
+	if !containsString(blacksmith.Lifecycle, "run-session") {
+		t.Fatalf("blacksmith lifecycle=%v missing run-session", blacksmith.Lifecycle)
+	}
 	for _, capability := range []string{"delegated-command", "ci-runner"} {
 		if !containsString(blacksmith.Runtime, capability) {
 			t.Fatalf("blacksmith runtime=%v missing %s", blacksmith.Runtime, capability)
@@ -224,6 +237,9 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 		if !containsString(e2b.Evidence, capability) {
 			t.Fatalf("e2b evidence=%v missing %s", e2b.Evidence, capability)
 		}
+	}
+	if !containsString(e2b.Lifecycle, "run-session") {
+		t.Fatalf("e2b lifecycle=%v missing run-session", e2b.Lifecycle)
 	}
 	if !containsString(e2b.Reachability, "provider-url") {
 		t.Fatalf("e2b reachability=%v missing provider-url", e2b.Reachability)
@@ -236,6 +252,11 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	for _, capability := range []string{"downloads", "preview-url", "session"} {
 		if !containsString(islo.Evidence, capability) {
 			t.Fatalf("islo evidence=%v missing %s", islo.Evidence, capability)
+		}
+	}
+	for _, capability := range []string{"pause-resume", "run-session"} {
+		if !containsString(islo.Lifecycle, capability) {
+			t.Fatalf("islo lifecycle=%v missing %s", islo.Lifecycle, capability)
 		}
 	}
 	for _, capability := range []string{"tailnet-egress", "provider-url"} {
@@ -271,11 +292,20 @@ func TestProvidersCommandJSON(t *testing.T) {
 		if entry.Provider == "aws" && !containsString(entry.Reachability, "ssh-tunnel") {
 			t.Fatalf("aws json missing ssh-tunnel reachability: %#v", entry)
 		}
+		if entry.Provider == "aws" && !containsString(entry.Lifecycle, "coordinator-governed") {
+			t.Fatalf("aws json missing coordinator-governed lifecycle: %#v", entry)
+		}
 		if entry.Provider == "parallels" && !containsString(entry.Workspace, "snapshot-ref") {
 			t.Fatalf("parallels json missing workspace snapshot-ref: %#v", entry)
 		}
+		if entry.Provider == "parallels" && !containsString(entry.Lifecycle, "workspace-state") {
+			t.Fatalf("parallels json missing workspace-state lifecycle: %#v", entry)
+		}
 		if entry.Provider == "blacksmith-testbox" && !containsString(entry.Evidence, "proof") {
 			t.Fatalf("blacksmith json missing evidence proof: %#v", entry)
+		}
+		if entry.Provider == "blacksmith-testbox" && !containsString(entry.Lifecycle, "run-session") {
+			t.Fatalf("blacksmith json missing run-session lifecycle: %#v", entry)
 		}
 	}
 }
@@ -287,7 +317,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 		t.Fatalf("providers error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
-	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: ", "  runtime: ssh-host,interactive\n", "  reachability: ssh-tunnel\n"} {
+	for _, want := range []string{"aws\n", "  family: aws\n", "  kind: ssh-lease\n", "  category: brokerable-cloud\n", "  features: ", "  runtime: ssh-host,interactive\n", "  reachability: ssh-tunnel\n", "  lifecycle: coordinator-governed,cleanup\n"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers output missing %q:\n%s", want, text)
 		}
@@ -301,8 +331,14 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	if !strings.Contains(text, "parallels\n") || !strings.Contains(text, "  workspace: checkpoint,fork,restore,snapshot-ref\n") {
 		t.Fatalf("providers output missing workspace contract:\n%s", text)
 	}
+	if !strings.Contains(text, "parallels\n") || !strings.Contains(text, "  lifecycle: cleanup,workspace-state\n") {
+		t.Fatalf("providers output missing lifecycle contract:\n%s", text)
+	}
 	if !strings.Contains(text, "blacksmith-testbox\n") || !strings.Contains(text, "  evidence: proof,artifacts,session\n") {
 		t.Fatalf("providers output missing evidence contract:\n%s", text)
+	}
+	if !strings.Contains(text, "blacksmith-testbox\n") || !strings.Contains(text, "  lifecycle: run-session\n") {
+		t.Fatalf("providers output missing run-session lifecycle:\n%s", text)
 	}
 }
 
@@ -315,6 +351,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		"--runtime", "managed-sandbox",
 		"--reachability", "provider-url",
 		"--evidence", "preview-url",
+		"--lifecycle", "run-session",
 		"--json",
 	})
 	if err != nil {
@@ -328,7 +365,7 @@ func TestProvidersCommandFiltersJSON(t *testing.T) {
 		t.Fatal("expected delegated preview providers")
 	}
 	for _, entry := range entries {
-		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Reachability, "provider-url") || !containsString(entry.Evidence, "preview-url") {
+		if entry.Kind != ProviderKindDelegatedRun || entry.Category != "delegated-sandbox" || !containsString(entry.Targets, targetLinux) || !containsString(entry.Runtime, "managed-sandbox") || !containsString(entry.Reachability, "provider-url") || !containsString(entry.Evidence, "preview-url") || !containsString(entry.Lifecycle, "run-session") {
 			t.Fatalf("entry escaped filters: %#v", entry)
 		}
 	}
@@ -338,19 +375,20 @@ func TestProvidersCommandFiltersRequireAllCapabilities(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
 		"--workspace", "checkpoint,fork",
+		"--lifecycle", "cleanup,workspace-state",
 	})
 	if err != nil {
 		t.Fatalf("providers workspace filter error=%v stderr=%q", err, stderr.String())
 	}
 	text := stdout.String()
 	if !strings.Contains(text, "local-container\n") {
-		t.Fatalf("workspace filter should include local-container:\n%s", text)
+		t.Fatalf("workspace/lifecycle filter should include local-container:\n%s", text)
 	}
 	if !strings.Contains(text, "parallels\n") {
-		t.Fatalf("workspace filter should include parallels:\n%s", text)
+		t.Fatalf("workspace/lifecycle filter should include parallels:\n%s", text)
 	}
 	if strings.Contains(text, "blacksmith-testbox\n") {
-		t.Fatalf("workspace filter should exclude providers without workspace capabilities:\n%s", text)
+		t.Fatalf("workspace/lifecycle filter should exclude providers without workspace capabilities:\n%s", text)
 	}
 }
 
@@ -362,6 +400,18 @@ func TestProvidersCommandRejectsUnknownFilter(t *testing.T) {
 		t.Fatalf("providers unknown filter error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 	}
 	if !strings.Contains(err.Error(), `unknown provider runtime filter "microvm-fork"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProvidersCommandRejectsUnknownLifecycleFilter(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"--lifecycle", "immortal"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("providers unknown lifecycle filter error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(err.Error(), `unknown provider lifecycle filter "immortal"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -385,6 +435,8 @@ func TestProvidersFiltersCommandHumanOutput(t *testing.T) {
 		"provider-url",
 		"  evidence: ",
 		"preview-url",
+		"  lifecycle: ",
+		"run-session",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("providers filters output missing %q:\n%s", want, text)
@@ -413,6 +465,7 @@ func TestProvidersFiltersCommandJSON(t *testing.T) {
 		{name: "reachability", values: values.Reachability, want: "provider-url"},
 		{name: "evidence", values: values.Evidence, want: "preview-url"},
 		{name: "workspace", values: values.Workspace, want: "fork"},
+		{name: "lifecycle", values: values.Lifecycle, want: "workspace-state"},
 	} {
 		if !containsString(tc.values, tc.want) {
 			t.Fatalf("%s values=%v missing %q", tc.name, tc.values, tc.want)


### PR DESCRIPTION
Summary:\n- add normalized provider lifecycle capabilities to the provider matrix and recommendations\n- support --lifecycle filters for matrix and recommendation commands\n- document lifecycle values and update the provider landscape guidance\n\nVerification:\n- go test -count=1 ./internal/cli -run 'TestProviderMatrixIncludesCapabilities|TestProvidersCommand(JSON|HumanOutput|FiltersJSON|FiltersRequireAllCapabilities|RejectsUnknownFilter|RejectsUnknownLifecycleFilter)|TestProvidersFiltersCommand(HumanOutput|JSON)'\n- go run ./cmd/crabbox providers filters --json\n- go run ./cmd/crabbox providers --lifecycle cleanup --lifecycle workspace-state --json\n- go run ./cmd/crabbox providers recommend versioned-workspace --lifecycle workspace-state --limit 2 --json\n- git diff --check\n- go test -race -count=1 ./internal/cli -run 'TestProviderMatrixIncludesCapabilities|TestProvidersCommandFiltersJSON|TestProvidersCommandRejectsUnknownLifecycleFilter'\n- go test -count=1 ./internal/cli\n- scripts/check-docs.sh