### PR TITLE
feat(providers): recommend failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added normalized provider reachability capabilities and `--reachability` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend offline-validation` for credentialless local, BYO SSH, and external-provider validation guidance.
 - Added normalized provider lifecycle capabilities and `--lifecycle` filters to `crabbox providers` and `crabbox providers recommend`.
+- Added `crabbox providers recommend failure-diagnostics` for failed-run triage guidance across proof, session, artifact, download, preview, and SSH-debuggable providers.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -107,6 +107,7 @@ crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
 crabbox providers recommend cost-control
 crabbox providers recommend fast-feedback --feature cache-volume
+crabbox providers recommend failure-diagnostics
 crabbox providers recommend fanout-testing --workspace fork
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
@@ -146,6 +147,9 @@ Supported use cases:
 - `desktop`: providers with desktop/browser/code-server capabilities.
 - `fast-feedback`: providers suited to repeated test loops with reusable cache
   volumes, checkout sync, cleanup, or reusable validation evidence.
+- `failure-diagnostics`: providers with proof, sessions, artifacts, downloads,
+  preview URLs, or SSH/sync support useful for debugging failed runs. Aliases
+  include `failed-run`, `failure-triage`, and `run-debugging`.
 - `fanout-testing`: providers that can fork a prepared workspace for parallel
   branch, best-of-N, or snapshot-fanout experiments. Aliases include
   `best-of-n`, `parallel-testing`, and `snapshot-fanout`. This is provider

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -113,6 +113,9 @@ Ship these in small PRs:
    reusable provider session handle for later inspection.
    Use `crabbox providers recommend artifact-download` when a workflow needs
    retained files or downloadable results from provider-owned execution.
+   Use `crabbox providers recommend failure-diagnostics` when failed-run triage
+   needs proof, reusable sessions, retained outputs, preview URLs, or SSH access
+   to a synced checkout.
    Use `crabbox providers recommend preview-url` when the workflow specifically
    needs provider-native app or service URLs.
    Use `crabbox providers --reachability provider-url` or

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -450,6 +450,7 @@ func providerRecommendationUseCases() []string {
 		"cost-control",
 		"desktop",
 		"fast-feedback",
+		"failure-diagnostics",
 		"fanout-testing",
 		"gpu",
 		"isolated-execution",
@@ -492,6 +493,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "desktop", true
 	case "fast-feedback", "feedback", "fast-test", "fast-tests", "cache", "cached", "cache-heavy":
 		return "fast-feedback", true
+	case "failure-diagnostics", "failure-diagnostic", "failed-run", "failed-runs",
+		"failure-triage", "run-debugging", "debuggable-run", "debuggable-runs",
+		"debuggability", "postmortem", "post-mortem":
+		return "failure-diagnostics", true
 	case "fanout", "fanout-testing", "best-of-n", "best-of-n-testing",
 		"parallel-testing", "parallel-exploration", "branch-race",
 		"snapshot-fanout", "fork-fanout":
@@ -758,6 +763,47 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux test workloads")
+		}
+	case "failure-diagnostics":
+		hasDiagnostics := hasFeature(FeatureRunProof) || hasFeature(FeatureRunSession) ||
+			hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) ||
+			hasFeature(FeatureURLBridge) ||
+			(hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync))
+		if !hasDiagnostics {
+			break
+		}
+		if hasFeature(FeatureRunProof) {
+			add(45, "returns provider run proof")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(35, "keeps inspectable run or session handles")
+		}
+		if hasFeature(FeatureRunArtifacts) {
+			add(30, "can retain failure artifacts")
+		}
+		if hasFeature(FeatureRunDownloads) {
+			add(25, "can materialize diagnostic downloads")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(22, "can expose provider-native preview URLs")
+		}
+		if category == "ci-proof-runner" {
+			add(20, "CI proof runner is optimized for reproducible failure evidence")
+		}
+		if hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync) {
+			add(16, "supports SSH debugging against a synced checkout")
+		}
+		if entry.Kind == ProviderKindDelegatedRun {
+			add(10, "provider owns command execution and inspection")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(8, "can preserve runtime state during failure triage")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(8, "can clean up diagnostic resources")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
+			add(6, "supports common diagnostic run targets")
 		}
 	case "fanout-testing":
 		if !hasFeature(FeatureFork) {
@@ -1278,6 +1324,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend cost-control")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
+	fmt.Fprintln(out, "  crabbox providers recommend failure-diagnostics")
 	fmt.Fprintln(out, "  crabbox providers recommend fanout-testing --workspace fork")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -496,6 +496,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"cost-control",
 		"agent-sandbox",
 		"fast-feedback",
+		"failure-diagnostics",
 		"fanout-testing",
 		"isolated-execution",
 		"live-smoke",
@@ -699,6 +700,60 @@ func TestProvidersRecommendFastFeedbackPrefersCacheVolumes(t *testing.T) {
 	}
 	if !foundProofRunner {
 		t.Fatalf("fast-feedback recommendations should include CI proof runners: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendFailureDiagnosticsPrefersInspectableEvidence(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "failure-diagnostics", 8)
+	if len(recommendations) == 0 {
+		t.Fatal("expected failure-diagnostics recommendations")
+	}
+	if recommendations[0].Provider != "blacksmith-testbox" {
+		t.Fatalf("top failure-diagnostics provider=%q recommendations=%v", recommendations[0].Provider, recommendations)
+	}
+	foundProof := false
+	foundSession := false
+	foundDownload := false
+	foundPreview := false
+	foundSSHDebug := false
+	for _, recommendation := range recommendations {
+		hasProof := providerRecommendationHasFeature(recommendation.Features, FeatureRunProof)
+		hasSession := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession)
+		hasArtifact := providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts)
+		hasDownload := providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads)
+		hasPreview := providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		hasSSHDebug := providerRecommendationHasFeature(recommendation.Features, FeatureSSH) &&
+			providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync)
+		if !hasProof && !hasSession && !hasArtifact && !hasDownload && !hasPreview && !hasSSHDebug {
+			t.Fatalf("failure-diagnostics recommendation lacks diagnostic signal: %#v", recommendation)
+		}
+		foundProof = foundProof || hasProof
+		foundSession = foundSession || hasSession
+		foundDownload = foundDownload || hasDownload
+		foundPreview = foundPreview || hasPreview
+		foundSSHDebug = foundSSHDebug || hasSSHDebug
+	}
+	if !foundProof || !foundSession || !foundDownload || !foundPreview || !foundSSHDebug {
+		t.Fatalf("failure-diagnostics should include proof, session, download, preview, and SSH-debuggable providers: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendFailedRunAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "failed-run",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend failed-run error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 || entries[0].Provider != "blacksmith-testbox" {
+		t.Fatalf("failed-run alias entries=%#v", entries)
 	}
 }
 


### PR DESCRIPTION
Summary:\n- add a failure-diagnostics provider recommendation use case and aliases\n- rank providers by proof, sessions, artifacts, downloads, preview URLs, and SSH/sync debugging signals\n- document the workflow in provider command docs and the provider landscape\n\nVerification:\n- go test -count=1 ./internal/cli -run 'TestProvidersRecommend(FailureDiagnostics|FailedRunAlias|ListsUseCases)'\n- go run ./cmd/crabbox providers recommend failure-diagnostics --json\n- go run ./cmd/crabbox providers recommend failed-run --limit 1 --json\n- go run ./cmd/crabbox providers recommend failure-diagnostics --evidence session --limit 3 --json\n- git diff --check\n- go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(FailureDiagnostics|FailedRunAlias)'\n- scripts/check-docs.sh\n- go test -count=1 ./internal/cli