### PR TITLE
feat(providers): recommend resource observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added normalized provider lifecycle capabilities and `--lifecycle` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend failure-diagnostics` for failed-run triage guidance across proof, session, artifact, download, preview, and SSH-debuggable providers.
 - Added `crabbox providers recommend warm-start` for low-latency repeated-run guidance across local runtimes, cache volumes, retained sessions, pause/resume, and workspace-state providers.
+- Added `crabbox providers recommend resource-observability` for coordinator usage/cost visibility, SSH resource telemetry, retained run evidence, reusable sessions, and preview URL guidance.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -119,6 +119,7 @@ crabbox providers recommend pause-resume
 crabbox providers recommend preview-url
 crabbox providers recommend reachability
 crabbox providers recommend remote-dev
+crabbox providers recommend resource-observability
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --reachability provider-url --evidence preview-url
 crabbox providers recommend run-session
@@ -183,6 +184,10 @@ Supported use cases:
   HTTPS endpoints, outbound-only tailnet egress, or operator-side SSH tunnels.
 - `remote-dev`: managed developer environments and SSH-capable remote
   workspaces for local-editor, remote-compute workflows.
+- `resource-observability`: providers with coordinator-backed usage/cost
+  visibility, SSH resource telemetry, run proof, retained outputs, sessions, or
+  preview URLs for later inspection. Aliases include `telemetry`,
+  `usage-observability`, `metering`, and `cost-visibility`.
 - `run-evidence`: providers that can return run proof, collect artifacts,
   materialize downloads, or expose preview URLs.
 - `run-session`: providers that return reusable run/session handles for later

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -124,6 +124,9 @@ Ship these in small PRs:
    Use `crabbox providers recommend network-isolation` when the workflow runs
    untrusted code and network exposure should stay inside a delegated or local
    sandbox boundary.
+   Use `crabbox providers recommend resource-observability` when the workflow
+   needs coordinator usage/cost visibility, SSH resource telemetry, retained run
+   evidence, reusable sessions, or preview URLs for later inspection.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -465,6 +465,7 @@ func providerRecommendationUseCases() []string {
 		"preview-url",
 		"reachability",
 		"remote-dev",
+		"resource-observability",
 		"run-evidence",
 		"run-session",
 		"self-hosted",
@@ -539,6 +540,11 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		"cloud-dev", "cloud-development", "cde",
 		"codespace", "codespaces", "remote-workspace":
 		return "remote-dev", true
+	case "resource-observability", "resource-observe", "observability",
+		"resource-telemetry", "telemetry", "usage-observability",
+		"usage-visibility", "usage-metadata", "metering",
+		"cost-observability", "cost-visibility", "billing-visibility":
+		return "resource-observability", true
 	case "run-evidence", "evidence", "artifacts", "artifact", "downloads", "download":
 		return "run-evidence", true
 	case "run-session", "run-sessions", "session", "sessions",
@@ -1146,6 +1152,39 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) {
 			add(8, "supports common Linux development workloads")
 		}
+	case "resource-observability":
+		hasTelemetrySignal := entry.Coordinator == string(CoordinatorSupported) ||
+			(hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync)) ||
+			hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) ||
+			hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunSession) ||
+			hasFeature(FeatureURLBridge)
+		if !hasTelemetrySignal {
+			break
+		}
+		if entry.Coordinator == string(CoordinatorSupported) {
+			add(45, "coordinator can centralize lease usage and cost visibility")
+		}
+		if hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync) {
+			add(35, "SSH sync providers can report host resource telemetry during runs")
+		}
+		if hasFeature(FeatureRunProof) {
+			add(28, "retains proof suitable for run-level audit trails")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(24, "retains artifacts or downloads for later inspection")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(20, "returns reusable sessions for post-run inspection")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(12, "can expose preview URLs alongside run records")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(10, "can close the resource lifecycle after observation")
+		}
+		if strings.HasPrefix(category, "local-") {
+			add(8, "local runtime makes resource inspection credentialless")
+		}
 	case "run-evidence":
 		hasEvidenceCapability := hasFeature(FeatureRunProof) || hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) || hasFeature(FeatureURLBridge)
 		if !hasEvidenceCapability {
@@ -1379,6 +1418,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend preview-url")
 	fmt.Fprintln(out, "  crabbox providers recommend reachability")
 	fmt.Fprintln(out, "  crabbox providers recommend remote-dev")
+	fmt.Fprintln(out, "  crabbox providers recommend resource-observability")
 	fmt.Fprintln(out, "  crabbox providers recommend run-evidence")
 	fmt.Fprintln(out, "  crabbox providers recommend run-session")
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -507,6 +507,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"preview-url",
 		"reachability",
 		"remote-dev",
+		"resource-observability",
 		"run-evidence",
 		"run-session",
 		"team-cloud",
@@ -880,6 +881,61 @@ func TestProvidersRecommendRunEvidence(t *testing.T) {
 		if recommendation.Provider == "wandb" {
 			t.Fatalf("run-evidence should not recommend session-only providers: %#v", recommendation)
 		}
+	}
+}
+
+func TestProvidersRecommendResourceObservability(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "resource-observability", 16)
+	if len(recommendations) == 0 {
+		t.Fatal("expected resource-observability recommendations")
+	}
+	foundCoordinator := false
+	foundSSHTelemetry := false
+	foundRunSession := false
+	foundRunEvidence := false
+	for _, recommendation := range recommendations {
+		hasCoordinator := recommendation.Provider == "aws" || recommendation.Provider == "azure" ||
+			recommendation.Provider == "gcp" || recommendation.Provider == "hetzner"
+		hasSSHTelemetry := providerRecommendationHasFeature(recommendation.Features, FeatureSSH) &&
+			providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync)
+		hasRunEvidence := providerRecommendationHasFeature(recommendation.Features, FeatureRunProof) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		hasRunSession := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession)
+		if !hasCoordinator && !hasSSHTelemetry && !hasRunEvidence && !hasRunSession {
+			t.Fatalf("resource-observability recommendation lacks telemetry or evidence signal: %#v", recommendation)
+		}
+		foundCoordinator = foundCoordinator || hasCoordinator
+		foundSSHTelemetry = foundSSHTelemetry || hasSSHTelemetry
+		foundRunSession = foundRunSession || hasRunSession
+		foundRunEvidence = foundRunEvidence || hasRunEvidence
+	}
+	if !foundCoordinator || !foundSSHTelemetry || !foundRunSession || !foundRunEvidence {
+		t.Fatalf("resource-observability should include coordinator, SSH telemetry, run-session, and run-evidence providers: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendTelemetryAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "telemetry",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend telemetry error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("telemetry alias entries=%#v", entries)
+	}
+	if entries[0].Provider != "aws" && entries[0].Provider != "azure" &&
+		entries[0].Provider != "gcp" && entries[0].Provider != "hetzner" {
+		t.Fatalf("telemetry alias should prefer coordinator-backed SSH providers: %#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `crabbox providers recommend resource-observability` for usage, telemetry, and inspection-oriented provider selection
- rank coordinator-backed usage/cost visibility, SSH resource telemetry, retained run evidence, reusable sessions, and preview URLs
- document aliases like `telemetry`, `usage-observability`, `metering`, and `cost-visibility`

## Verification
- `git diff --check`
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(ResourceObservability|TelemetryAlias|ListsUseCases)'`\n- `go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(ResourceObservability|TelemetryAlias)'`\n- `go test -count=1 ./internal/cli`\n- `scripts/check-docs.sh`\n- `go run ./cmd/crabbox providers recommend resource-observability --json`\n- `go run ./cmd/crabbox providers recommend telemetry --limit 1 --json`\n- `go run ./cmd/crabbox providers recommend resource-observability --evidence session --limit 3 --json`\n\n## Notes\n- This is provider-neutral recommendation logic over existing Crabbox matrix signals. It does not require live provider credentials.