### PR TITLE
feat(providers): recommend code interpreters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `crabbox providers recommend failure-diagnostics` for failed-run triage guidance across proof, session, artifact, download, preview, and SSH-debuggable providers.
 - Added `crabbox providers recommend warm-start` for low-latency repeated-run guidance across local runtimes, cache volumes, retained sessions, pause/resume, and workspace-state providers.
 - Added `crabbox providers recommend resource-observability` for coordinator usage/cost visibility, SSH resource telemetry, retained run evidence, reusable sessions, and preview URL guidance.
+- Added `crabbox providers recommend code-interpreter` for generated-code and script execution guidance across delegated and local sandbox providers.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -105,6 +105,7 @@ It is selection guidance, not a readiness check; run `crabbox doctor --provider
 crabbox providers recommend
 crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
+crabbox providers recommend code-interpreter
 crabbox providers recommend cost-control
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend failure-diagnostics
@@ -143,6 +144,10 @@ Supported use cases:
 - `byo-ssh`: existing SSH hosts.
 - `ci-proof`: CI proof runners and providers that return run proof or
   artifacts.
+- `code-interpreter`: delegated or local sandboxes for generated-code and
+  script execution with sessions, archive sync, retained outputs, preview URLs,
+  MCP attachments, or module execution. Aliases include `python-sandbox`,
+  `ai-code-runner`, `generated-code`, and `script-runner`.
 - `cost-control`: providers with local execution, coordinator governance,
   cleanup, cache reuse, reusable state, or retained proof to reduce quota and
   hot-capacity waste.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -127,6 +127,10 @@ Ship these in small PRs:
    Use `crabbox providers recommend resource-observability` when the workflow
    needs coordinator usage/cost visibility, SSH resource telemetry, retained run
    evidence, reusable sessions, or preview URLs for later inspection.
+   Use `crabbox providers recommend code-interpreter` when generated-code or
+   script execution should prefer delegated or local sandboxes with sessions,
+   archive sync, retained outputs, preview URLs, MCP attachments, or module
+   execution.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -447,6 +447,7 @@ func providerRecommendationUseCases() []string {
 		"artifact-download",
 		"byo-ssh",
 		"ci-proof",
+		"code-interpreter",
 		"cost-control",
 		"desktop",
 		"fast-feedback",
@@ -488,6 +489,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "byo-ssh", true
 	case "ci", "ci-proof", "proof", "testbox", "repro":
 		return "ci-proof", true
+	case "code-interpreter", "code-interpreters", "code-execution",
+		"ai-code", "ai-code-runner", "generated-code", "generated-code-runner",
+		"python-sandbox", "script-runner", "notebook-sandbox":
+		return "code-interpreter", true
 	case "cost", "cost-control", "cost-aware", "budget", "budget-control",
 		"quota", "quota-safe", "spend", "spend-control":
 		return "cost-control", true
@@ -702,6 +707,45 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if category == "ci-proof-runner" && entry.Kind == ProviderKindSSHLease && hasFeature(FeatureCrabboxSync) {
 			add(12, "can debug through normal Crabbox sync and SSH")
+		}
+	case "code-interpreter":
+		isSandboxRuntime := category == "delegated-sandbox" || category == "local-sandbox"
+		hasExecutionSignal := hasFeature(FeatureArchiveSync) || hasFeature(FeatureRunSession) ||
+			hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunArtifacts) ||
+			hasFeature(FeatureURLBridge) || hasFeature(FeatureMCP) ||
+			hasFeature(FeatureModuleRun)
+		if !isSandboxRuntime || !hasExecutionSignal {
+			break
+		}
+		if category == "delegated-sandbox" {
+			add(50, "delegated sandbox for provider-owned code execution")
+		}
+		if category == "local-sandbox" {
+			add(40, "local sandbox for credentialless code execution")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(30, "returns reusable interpreter sessions")
+		}
+		if hasFeature(FeatureArchiveSync) {
+			add(24, "can seed generated-code workloads from an archive")
+		}
+		if hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunArtifacts) {
+			add(22, "can retain generated outputs")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(16, "can expose generated app or notebook previews")
+		}
+		if hasFeature(FeatureMCP) {
+			add(14, "can attach MCP tools to the sandbox")
+		}
+		if hasFeature(FeatureModuleRun) {
+			add(12, "can execute module source directly")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(10, "can clean up disposable interpreter resources")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
+			add(8, "supports common interpreter execution targets")
 		}
 	case "cost-control":
 		if strings.HasPrefix(category, "local-") {
@@ -1403,6 +1447,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "examples:")
 	fmt.Fprintln(out, "  crabbox providers recommend artifact-download")
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
+	fmt.Fprintln(out, "  crabbox providers recommend code-interpreter")
 	fmt.Fprintln(out, "  crabbox providers recommend cost-control")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -493,6 +493,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"provider recommendation use cases:",
 		"artifact-download",
 		"ci-proof",
+		"code-interpreter",
 		"cost-control",
 		"agent-sandbox",
 		"fast-feedback",
@@ -564,6 +565,63 @@ func TestProvidersRecommendArtifactDownloadAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunArtifacts) {
 		t.Fatalf("run-artifacts alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendCodeInterpreterPrefersSandboxExecution(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "code-interpreter", 12)
+	if len(recommendations) == 0 {
+		t.Fatal("expected code-interpreter recommendations")
+	}
+	foundDelegatedSandbox := false
+	foundLocalSandbox := false
+	foundSession := false
+	foundSeededWorkload := false
+	foundOutputsOrPreview := false
+	for _, recommendation := range recommendations {
+		hasSession := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession)
+		hasArchiveSync := providerRecommendationHasFeature(recommendation.Features, FeatureArchiveSync)
+		hasOutputsOrPreview := providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		hasMCPOrModule := providerRecommendationHasFeature(recommendation.Features, FeatureMCP) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureModuleRun)
+		if recommendation.Category != "delegated-sandbox" && recommendation.Category != "local-sandbox" {
+			t.Fatalf("code-interpreter recommendation escaped sandbox categories: %#v", recommendation)
+		}
+		if !hasSession && !hasArchiveSync && !hasOutputsOrPreview && !hasMCPOrModule {
+			t.Fatalf("code-interpreter recommendation lacks interpreter execution signal: %#v", recommendation)
+		}
+		foundDelegatedSandbox = foundDelegatedSandbox || recommendation.Category == "delegated-sandbox"
+		foundLocalSandbox = foundLocalSandbox || recommendation.Category == "local-sandbox"
+		foundSession = foundSession || hasSession
+		foundSeededWorkload = foundSeededWorkload || hasArchiveSync
+		foundOutputsOrPreview = foundOutputsOrPreview || hasOutputsOrPreview
+	}
+	if !foundDelegatedSandbox || !foundLocalSandbox || !foundSession || !foundSeededWorkload || !foundOutputsOrPreview {
+		t.Fatalf("code-interpreter should include delegated/local sandboxes, sessions, seeded workloads, and outputs/previews: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendPythonSandboxAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "python-sandbox",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend python-sandbox error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("python-sandbox alias entries=%#v", entries)
+	}
+	if entries[0].Category != "delegated-sandbox" && entries[0].Category != "local-sandbox" {
+		t.Fatalf("python-sandbox alias should prefer sandbox providers: %#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `crabbox providers recommend code-interpreter` for generated-code and script execution workflows
- rank delegated/local sandbox providers with sessions, archive sync, retained outputs, preview URLs, MCP attachments, module execution, and cleanup
- document aliases like `python-sandbox`, `ai-code-runner`, `generated-code`, and `script-runner`

## Verification
- `git diff --check`
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(CodeInterpreter|PythonSandboxAlias|ListsUseCases)'`\n- `go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(CodeInterpreter|PythonSandboxAlias)'`\n- `go test -count=1 ./internal/cli -run '^TestControllerTrackedChildWaitsForDurableLaunchGate$'`\n- `go test -count=1 ./internal/cli` after rerun; first full package attempt hit `TestControllerTrackedChildWaitsForDurableLaunchGate`, which passed directly before the full rerun passed\n- `scripts/check-docs.sh`\n- `go run ./cmd/crabbox providers recommend code-interpreter --json`\n- `go run ./cmd/crabbox providers recommend python-sandbox --limit 1 --json`\n- `go run ./cmd/crabbox providers recommend code-interpreter --runtime managed-sandbox --evidence session --limit 3 --json`\n\n## Notes\n- This is provider-neutral recommendation logic over existing matrix signals. It does not add a vendor SDK integration and does not require live provider credentials.