### PR TITLE
feat(providers): recommend disposable execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `crabbox providers recommend warm-start` for low-latency repeated-run guidance across local runtimes, cache volumes, retained sessions, pause/resume, and workspace-state providers.
 - Added `crabbox providers recommend resource-observability` for coordinator usage/cost visibility, SSH resource telemetry, retained run evidence, reusable sessions, and preview URL guidance.
 - Added `crabbox providers recommend code-interpreter` for generated-code and script execution guidance across delegated and local sandbox providers.
+- Added `crabbox providers recommend disposable-execution` for cleanup-capable temporary sandbox guidance across delegated and local sandbox providers.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -107,6 +107,7 @@ crabbox providers recommend artifact-download
 crabbox providers recommend ci-proof
 crabbox providers recommend code-interpreter
 crabbox providers recommend cost-control
+crabbox providers recommend disposable-execution
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend failure-diagnostics
 crabbox providers recommend fanout-testing --workspace fork
@@ -152,6 +153,10 @@ Supported use cases:
   cleanup, cache reuse, reusable state, or retained proof to reduce quota and
   hot-capacity waste.
 - `desktop`: providers with desktop/browser/code-server capabilities.
+- `disposable-execution`: delegated or local sandboxes that advertise cleanup
+  for temporary workloads, with optional archive sync, sessions, retained
+  outputs, preview URLs, or pause/resume before release. Aliases include
+  `ephemeral-sandbox`, `throwaway-sandbox`, and `auto-cleanup`.
 - `fast-feedback`: providers suited to repeated test loops with reusable cache
   volumes, checkout sync, cleanup, or reusable validation evidence.
 - `failure-diagnostics`: providers with proof, sessions, artifacts, downloads,

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -131,6 +131,10 @@ Ship these in small PRs:
    script execution should prefer delegated or local sandboxes with sessions,
    archive sync, retained outputs, preview URLs, MCP attachments, or module
    execution.
+   Use `crabbox providers recommend disposable-execution` when temporary
+   workloads should prefer cleanup-capable delegated or local sandboxes before
+   retaining only the proof, outputs, session, or preview metadata needed for
+   inspection.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -450,6 +450,7 @@ func providerRecommendationUseCases() []string {
 		"code-interpreter",
 		"cost-control",
 		"desktop",
+		"disposable-execution",
 		"fast-feedback",
 		"failure-diagnostics",
 		"fanout-testing",
@@ -498,6 +499,11 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "cost-control", true
 	case "desktop", "browser", "code", "vnc":
 		return "desktop", true
+	case "disposable-execution", "disposable", "ephemeral-execution",
+		"ephemeral-sandbox", "ephemeral-sandboxes", "throwaway",
+		"throwaway-sandbox", "throwaway-sandboxes", "auto-cleanup",
+		"clean-sandbox", "cleanup-sandbox", "temporary-sandbox":
+		return "disposable-execution", true
 	case "fast-feedback", "feedback", "fast-test", "fast-tests", "cache", "cached", "cache-heavy":
 		return "fast-feedback", true
 	case "failure-diagnostics", "failure-diagnostic", "failed-run", "failed-runs",
@@ -746,6 +752,36 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
 			add(8, "supports common interpreter execution targets")
+		}
+	case "disposable-execution":
+		isSandboxRuntime := category == "delegated-sandbox" || category == "local-sandbox"
+		if !isSandboxRuntime || !hasFeature(FeatureCleanup) {
+			break
+		}
+		if category == "delegated-sandbox" {
+			add(55, "delegated sandbox for provider-owned disposable execution")
+		}
+		if category == "local-sandbox" {
+			add(45, "local sandbox for credentialless disposable execution")
+		}
+		add(45, "can clean up disposable sandbox resources")
+		if hasFeature(FeatureArchiveSync) {
+			add(24, "can seed a temporary workload from the current checkout")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(18, "returns a run session before cleanup")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(16, "can retain outputs before deleting runtime resources")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(12, "can expose temporary app previews")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(8, "can pause disposable state before release when needed")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
+			add(8, "supports common disposable execution targets")
 		}
 	case "cost-control":
 		if strings.HasPrefix(category, "local-") {
@@ -1449,6 +1485,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend ci-proof")
 	fmt.Fprintln(out, "  crabbox providers recommend code-interpreter")
 	fmt.Fprintln(out, "  crabbox providers recommend cost-control")
+	fmt.Fprintln(out, "  crabbox providers recommend disposable-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend agent-sandbox --json")
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend failure-diagnostics")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -496,6 +496,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"code-interpreter",
 		"cost-control",
 		"agent-sandbox",
+		"disposable-execution",
 		"fast-feedback",
 		"failure-diagnostics",
 		"fanout-testing",
@@ -675,6 +676,60 @@ func TestProvidersRecommendCostControlAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
 		t.Fatalf("budget alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendDisposableExecutionRequiresCleanupSandboxes(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "disposable-execution", 12)
+	if len(recommendations) == 0 {
+		t.Fatal("expected disposable-execution recommendations")
+	}
+	foundDelegatedSandbox := false
+	foundSeededWorkload := false
+	foundSessionOrEvidence := false
+	for _, recommendation := range recommendations {
+		if recommendation.Category != "delegated-sandbox" && recommendation.Category != "local-sandbox" {
+			t.Fatalf("disposable-execution recommendation escaped sandbox categories: %#v", recommendation)
+		}
+		if !providerRecommendationHasFeature(recommendation.Features, FeatureCleanup) {
+			t.Fatalf("disposable-execution recommendation lacks cleanup feature: %#v", recommendation)
+		}
+		hasArchiveSync := providerRecommendationHasFeature(recommendation.Features, FeatureArchiveSync)
+		hasSessionOrEvidence := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		foundDelegatedSandbox = foundDelegatedSandbox || recommendation.Category == "delegated-sandbox"
+		foundSeededWorkload = foundSeededWorkload || hasArchiveSync
+		foundSessionOrEvidence = foundSessionOrEvidence || hasSessionOrEvidence
+	}
+	if !foundDelegatedSandbox || !foundSeededWorkload || !foundSessionOrEvidence {
+		t.Fatalf("disposable-execution should include delegated sandboxes, seeded workloads, and inspectable outputs: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendEphemeralSandboxAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "ephemeral-sandbox",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend ephemeral-sandbox error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ephemeral-sandbox alias entries=%#v", entries)
+	}
+	if entries[0].Category != "delegated-sandbox" && entries[0].Category != "local-sandbox" {
+		t.Fatalf("ephemeral-sandbox alias should prefer sandbox providers: %#v", entries)
+	}
+	if !providerRecommendationHasFeature(entries[0].Features, FeatureCleanup) {
+		t.Fatalf("ephemeral-sandbox alias should require cleanup: %#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `crabbox providers recommend disposable-execution` for temporary cleanup-capable sandbox workflows
- rank delegated/local sandbox providers that advertise cleanup, archive sync, sessions, retained outputs, preview URLs, and pause/resume
- document aliases like `ephemeral-sandbox`, `throwaway-sandbox`, and `auto-cleanup`

## Verification
- `git diff --check`
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(DisposableExecution|EphemeralSandboxAlias|ListsUseCases)'`\n- `go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(DisposableExecution|EphemeralSandboxAlias)'`\n- `go test -count=1 ./internal/cli`\n- `scripts/check-docs.sh`\n- `go run ./cmd/crabbox providers recommend disposable-execution --json`\n- `go run ./cmd/crabbox providers recommend ephemeral-sandbox --limit 1 --json`\n- `go run ./cmd/crabbox providers recommend disposable-execution --runtime managed-sandbox --lifecycle cleanup --limit 5 --json`\n\n## Notes\n- This is provider-neutral recommendation logic over existing matrix signals. It does not require live provider credentials.