### PR TITLE
feat(providers): recommend web app smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added `crabbox providers recommend resource-observability` for coordinator usage/cost visibility, SSH resource telemetry, retained run evidence, reusable sessions, and preview URL guidance.
 - Added `crabbox providers recommend code-interpreter` for generated-code and script execution guidance across delegated and local sandbox providers.
 - Added `crabbox providers recommend disposable-execution` for cleanup-capable temporary sandbox guidance across delegated and local sandbox providers.
+- Added `crabbox providers recommend web-app-smoke` for app and service smoke guidance across provider URLs, SSH tunnels, tailnet reachability, browser/code/desktop access, sessions, and retained outputs.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -129,6 +129,7 @@ crabbox providers recommend team-cloud
 crabbox providers recommend workspace-reuse
 crabbox providers recommend versioned-workspace
 crabbox providers recommend warm-start
+crabbox providers recommend web-app-smoke
 crabbox providers recommend forkable-workspace --workspace fork
 crabbox providers recommend versioned-workspace --target macos --workspace fork
 crabbox providers recommend worker-runtime --json
@@ -213,6 +214,10 @@ Supported use cases:
   setup overhead. Aliases include `warm-pool`, `prewarm`, and
   `low-latency-start`. This is provider selection guidance over existing
   reuse signals, not a guarantee of native warm-pool APIs.
+- `web-app-smoke`: providers that can expose or reach app/service smoke
+  targets through provider-native URLs, SSH tunnels, tailnet planes,
+  browser/code/desktop access, sessions, or retained outputs. Aliases include
+  `web-smoke`, `app-smoke`, `service-smoke`, and `browser-smoke`.
 - `windows`: native Windows and WSL2 targets.
 - `worker-runtime`: Worker/module-runtime execution.
 

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -135,6 +135,9 @@ Ship these in small PRs:
    workloads should prefer cleanup-capable delegated or local sandboxes before
    retaining only the proof, outputs, session, or preview metadata needed for
    inspection.
+   Use `crabbox providers recommend web-app-smoke` when app or service smoke
+   tests need provider-native URLs, SSH tunnels, tailnet reachability,
+   browser/code/desktop access, sessions, or retained outputs.
 3. Add live smoke docs where credentials are required.
    Provider adapters can be valuable before broad live access exists, but each
    one needs an opt-in smoke contract that says what real behavior proves. Use

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -474,6 +474,7 @@ func providerRecommendationUseCases() []string {
 		"team-cloud",
 		"versioned-workspace",
 		"warm-start",
+		"web-app-smoke",
 		"windows",
 		"worker-runtime",
 	}
@@ -577,6 +578,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		"prewarm", "pre-warm", "prewarmed", "pre-warmed", "low-latency-start",
 		"low-latency", "reuse-state", "reuse-runtime":
 		return "warm-start", true
+	case "web-app-smoke", "web-smoke", "app-smoke", "service-smoke",
+		"preview-smoke", "browser-smoke", "url-smoke", "http-smoke",
+		"web-preview-smoke":
+		return "web-app-smoke", true
 	case "windows", "win":
 		return "windows", true
 	case "worker", "worker-runtime", "module", "module-run":
@@ -1413,6 +1418,52 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
 			add(6, "supports common warm-start targets")
 		}
+	case "web-app-smoke":
+		hasAccessPlane := capabilities.URLBridge || capabilities.SSHMesh ||
+			capabilities.Tailscale || capabilities.TailscaleEgress ||
+			hasFeature(FeatureBrowser) || hasFeature(FeatureCode) || hasFeature(FeatureDesktop)
+		if !hasAccessPlane {
+			break
+		}
+		if capabilities.URLBridge {
+			add(70, "can expose provider-native app or service URLs")
+		}
+		if capabilities.SSHMesh && hasFeature(FeatureCrabboxSync) {
+			add(32, "can smoke a synced web app through operator-side SSH tunnels")
+		}
+		if capabilities.Tailscale {
+			add(28, "can reach services over a bidirectional tailnet plane")
+		}
+		if hasFeature(FeatureBrowser) {
+			add(25, "can pair smoke tests with browser access")
+		}
+		if hasFeature(FeatureCode) {
+			add(18, "can inspect web app state through code-server access")
+		}
+		if hasFeature(FeatureDesktop) {
+			add(14, "can inspect interactive desktop app state")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(20, "returns reusable sessions for post-smoke inspection")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) {
+			add(16, "can retain smoke outputs or downloads")
+		}
+		if hasFeature(FeatureCrabboxSync) || hasFeature(FeatureArchiveSync) {
+			add(14, "can seed the web app workload from the current checkout")
+		}
+		if capabilities.TailscaleEgress {
+			add(10, "can use outbound-only tailnet egress for web smoke flows")
+		}
+		if category == "delegated-sandbox" {
+			add(18, "delegated sandbox can host app smoke workloads")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(10, "can clean up smoke resources")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
+			add(8, "supports common web app smoke targets")
+		}
 	case "windows":
 		if hasTarget(targetWindows + "/" + WindowsModeNormal) {
 			add(80, "supports native Windows")
@@ -1506,6 +1557,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend team-cloud")
 	fmt.Fprintln(out, "  crabbox providers recommend versioned-workspace")
 	fmt.Fprintln(out, "  crabbox providers recommend warm-start")
+	fmt.Fprintln(out, "  crabbox providers recommend web-app-smoke")
 	fmt.Fprintln(out, "  crabbox providers recommend forkable-workspace --workspace fork")
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -515,6 +515,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"team-cloud",
 		"versioned-workspace",
 		"warm-start",
+		"web-app-smoke",
 		"worker-runtime",
 	} {
 		if !strings.Contains(text, want) {
@@ -908,6 +909,65 @@ func TestProvidersRecommendWarmPoolAlias(t *testing.T) {
 	}
 	if entries[0].Provider != "local-container" && entries[0].Provider != "parallels" {
 		t.Fatalf("warm-pool alias should prefer local reusable state providers: %#v", entries)
+	}
+}
+
+func TestProvidersRecommendWebAppSmokeUsesReachableAppSurfaces(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "web-app-smoke", 16)
+	if len(recommendations) == 0 {
+		t.Fatal("expected web-app-smoke recommendations")
+	}
+	foundURLBridge := false
+	foundInteractive := false
+	foundSSHTunnel := false
+	foundTailnet := false
+	foundSessionOrEvidence := false
+	for _, recommendation := range recommendations {
+		capabilities := providerCapabilities(recommendation.Provider)
+		hasInteractive := providerRecommendationHasFeature(recommendation.Features, FeatureBrowser) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureCode) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureDesktop)
+		hasSessionOrEvidence := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads)
+		if !capabilities.URLBridge && !capabilities.SSHMesh && !capabilities.Tailscale &&
+			!capabilities.TailscaleEgress && !hasInteractive {
+			t.Fatalf("web-app-smoke recommendation lacks web access plane: %#v", recommendation)
+		}
+		foundURLBridge = foundURLBridge || capabilities.URLBridge
+		foundInteractive = foundInteractive || hasInteractive
+		foundSSHTunnel = foundSSHTunnel || capabilities.SSHMesh
+		foundTailnet = foundTailnet || capabilities.Tailscale || capabilities.TailscaleEgress
+		foundSessionOrEvidence = foundSessionOrEvidence || hasSessionOrEvidence
+	}
+	if !foundURLBridge || !foundInteractive || !foundSSHTunnel || !foundTailnet || !foundSessionOrEvidence {
+		t.Fatalf("web-app-smoke should include URL bridge, interactive, SSH/tunnel, tailnet, and session/evidence signals: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendBrowserSmokeAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "browser-smoke",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend browser-smoke error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("browser-smoke alias entries=%#v", entries)
+	}
+	capabilities := providerCapabilities(entries[0].Provider)
+	hasInteractive := providerRecommendationHasFeature(entries[0].Features, FeatureBrowser) ||
+		providerRecommendationHasFeature(entries[0].Features, FeatureCode) ||
+		providerRecommendationHasFeature(entries[0].Features, FeatureDesktop)
+	if !capabilities.URLBridge && !capabilities.SSHMesh && !capabilities.Tailscale && !hasInteractive {
+		t.Fatalf("browser-smoke alias should prefer reachable app providers: %#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `crabbox providers recommend web-app-smoke` for app and service smoke workflows
- rank provider-native URLs, SSH tunnels, tailnet reachability, browser/code/desktop access, reusable sessions, retained outputs, sync, and cleanup
- document aliases like `web-smoke`, `app-smoke`, `service-smoke`, and `browser-smoke`

## Verification
- `git diff --check`
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(WebAppSmoke|BrowserSmokeAlias|ListsUseCases)'`\n- `go test -race -count=1 ./internal/cli -run 'TestProvidersRecommend(WebAppSmoke|BrowserSmokeAlias)'`\n- `go test -count=1 ./internal/cli`\n- `scripts/check-docs.sh`\n- `go run ./cmd/crabbox providers recommend web-app-smoke --json`\n- `go run ./cmd/crabbox providers recommend browser-smoke --limit 1 --json`\n- `go run ./cmd/crabbox providers recommend web-app-smoke --reachability provider-url --limit 3 --json`\n\n## Notes\n- This is provider-neutral recommendation logic over existing reachability, evidence, and lifecycle signals. It does not require live provider credentials.