### PR TITLE
feat(providers): recommend interactive debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `crabbox providers recommend code-interpreter` for generated-code and script execution guidance across delegated and local sandbox providers.
 - Added `crabbox providers recommend disposable-execution` for cleanup-capable temporary sandbox guidance across delegated and local sandbox providers.
 - Added `crabbox providers recommend web-app-smoke` for app and service smoke guidance across provider URLs, SSH tunnels, tailnet reachability, browser/code/desktop access, sessions, and retained outputs.
+- Added `crabbox providers recommend interactive-debug` for live inspection guidance across synced SSH, browser/code/desktop access, reusable sessions, provider URLs, and retained evidence.
 
 ### Fixed
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -111,6 +111,7 @@ crabbox providers recommend disposable-execution
 crabbox providers recommend fast-feedback --feature cache-volume
 crabbox providers recommend failure-diagnostics
 crabbox providers recommend fanout-testing --workspace fork
+crabbox providers recommend interactive-debug
 crabbox providers recommend isolated-execution
 crabbox providers recommend linux-vm --limit 8
 crabbox providers recommend live-smoke
@@ -169,6 +170,10 @@ Supported use cases:
   selection guidance over existing fork/checkpoint capabilities, not a
   Mitos-style live microVM swarm API.
 - `gpu`: GPU-oriented execution providers.
+- `interactive-debug`: providers with live inspection surfaces such as
+  synced SSH, browser/code/desktop access, reusable sessions, provider URLs, or
+  retained evidence after debugging. Aliases include `live-debug`,
+  `debug-session`, `ssh-debug`, and `browser-debug`.
 - `isolated-execution`: delegated and local sandbox providers for disposable or
   untrusted command execution. This is routing guidance, not a security
   certification for a specific provider.

--- a/docs/features/provider-landscape.md
+++ b/docs/features/provider-landscape.md
@@ -116,6 +116,9 @@ Ship these in small PRs:
    Use `crabbox providers recommend failure-diagnostics` when failed-run triage
    needs proof, reusable sessions, retained outputs, preview URLs, or SSH access
    to a synced checkout.
+   Use `crabbox providers recommend interactive-debug` when triage needs a live
+   inspection surface such as synced SSH, browser/code/desktop access, reusable
+   sessions, provider URLs, or retained evidence after the debug session.
    Use `crabbox providers recommend preview-url` when the workflow specifically
    needs provider-native app or service URLs.
    Use `crabbox providers --reachability provider-url` or

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -455,6 +455,7 @@ func providerRecommendationUseCases() []string {
 		"failure-diagnostics",
 		"fanout-testing",
 		"gpu",
+		"interactive-debug",
 		"isolated-execution",
 		"linux-vm",
 		"live-smoke",
@@ -517,6 +518,10 @@ func normalizeProviderRecommendationUseCase(value string) (string, bool) {
 		return "fanout-testing", true
 	case "gpu", "cuda", "ml":
 		return "gpu", true
+	case "interactive-debug", "interactive-debugging", "live-debug",
+		"live-debugging", "debug-session", "debug-sessions",
+		"ssh-debug", "browser-debug", "code-debug", "inspectable-debug":
+		return "interactive-debug", true
 	case "isolated", "isolated-execution", "isolation", "secure", "secure-sandbox", "untrusted", "untrusted-code":
 		return "isolated-execution", true
 	case "linux", "linux-vm", "vm":
@@ -900,6 +905,47 @@ func scoreProviderRecommendation(entry providerMatrixEntry, useCase string) (int
 		}
 		if hasTarget(targetLinux) || hasTarget(targetWorkerRuntime) {
 			add(6, "supports common diagnostic run targets")
+		}
+	case "interactive-debug":
+		hasDebugSurface := (hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync)) ||
+			hasFeature(FeatureDesktop) || hasFeature(FeatureBrowser) ||
+			hasFeature(FeatureCode) || hasFeature(FeatureRunSession) ||
+			hasFeature(FeatureURLBridge)
+		if !hasDebugSurface {
+			break
+		}
+		if hasFeature(FeatureSSH) && hasFeature(FeatureCrabboxSync) {
+			add(45, "can debug a synced checkout through SSH")
+		}
+		if hasFeature(FeatureBrowser) {
+			add(35, "can inspect browser-visible behavior")
+		}
+		if hasFeature(FeatureCode) {
+			add(30, "can inspect and edit through code-server access")
+		}
+		if hasFeature(FeatureDesktop) {
+			add(24, "can inspect interactive desktop state")
+		}
+		if hasFeature(FeatureRunSession) {
+			add(26, "returns reusable sessions for interactive inspection")
+		}
+		if hasFeature(FeatureURLBridge) {
+			add(20, "can expose provider-native URLs during debugging")
+		}
+		if capabilities.Tailscale || capabilities.SSHMesh {
+			add(14, "has a routable operator access plane")
+		}
+		if hasFeature(FeatureRunArtifacts) || hasFeature(FeatureRunDownloads) || hasFeature(FeatureRunProof) {
+			add(12, "can retain evidence after the debug session")
+		}
+		if hasFeature(FeaturePauseResume) {
+			add(10, "can preserve runtime state while debugging")
+		}
+		if hasFeature(FeatureCleanup) {
+			add(8, "can clean up debug resources")
+		}
+		if hasTarget(targetLinux) || hasTarget(targetWindows) || hasTarget(targetMacOS) || hasTarget(targetWorkerRuntime) {
+			add(6, "supports common interactive debug targets")
 		}
 	case "fanout-testing":
 		if !hasFeature(FeatureFork) {
@@ -1541,6 +1587,7 @@ func printProviderRecommendationUseCases(out io.Writer) {
 	fmt.Fprintln(out, "  crabbox providers recommend fast-feedback --feature cache-volume")
 	fmt.Fprintln(out, "  crabbox providers recommend failure-diagnostics")
 	fmt.Fprintln(out, "  crabbox providers recommend fanout-testing --workspace fork")
+	fmt.Fprintln(out, "  crabbox providers recommend interactive-debug")
 	fmt.Fprintln(out, "  crabbox providers recommend isolated-execution")
 	fmt.Fprintln(out, "  crabbox providers recommend linux-vm --limit 8")
 	fmt.Fprintln(out, "  crabbox providers recommend live-smoke")

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -500,6 +500,7 @@ func TestProvidersRecommendListsUseCases(t *testing.T) {
 		"fast-feedback",
 		"failure-diagnostics",
 		"fanout-testing",
+		"interactive-debug",
 		"isolated-execution",
 		"live-smoke",
 		"mcp-sandbox",
@@ -987,6 +988,68 @@ func TestProvidersRecommendFailedRunAlias(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Provider != "blacksmith-testbox" {
 		t.Fatalf("failed-run alias entries=%#v", entries)
+	}
+}
+
+func TestProvidersRecommendInteractiveDebugSurfaces(t *testing.T) {
+	recommendations := recommendProvidersForUseCase(providerMatrix(), "interactive-debug", 16)
+	if len(recommendations) == 0 {
+		t.Fatal("expected interactive-debug recommendations")
+	}
+	foundSSH := false
+	foundInteractive := false
+	foundSession := false
+	foundURLBridge := false
+	foundEvidence := false
+	for _, recommendation := range recommendations {
+		hasSSHDebug := providerRecommendationHasFeature(recommendation.Features, FeatureSSH) &&
+			providerRecommendationHasFeature(recommendation.Features, FeatureCrabboxSync)
+		hasInteractive := providerRecommendationHasFeature(recommendation.Features, FeatureBrowser) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureCode) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureDesktop)
+		hasSession := providerRecommendationHasFeature(recommendation.Features, FeatureRunSession)
+		hasURLBridge := providerRecommendationHasFeature(recommendation.Features, FeatureURLBridge)
+		hasEvidence := providerRecommendationHasFeature(recommendation.Features, FeatureRunArtifacts) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunDownloads) ||
+			providerRecommendationHasFeature(recommendation.Features, FeatureRunProof)
+		if !hasSSHDebug && !hasInteractive && !hasSession && !hasURLBridge {
+			t.Fatalf("interactive-debug recommendation lacks debug surface: %#v", recommendation)
+		}
+		foundSSH = foundSSH || hasSSHDebug
+		foundInteractive = foundInteractive || hasInteractive
+		foundSession = foundSession || hasSession
+		foundURLBridge = foundURLBridge || hasURLBridge
+		foundEvidence = foundEvidence || hasEvidence
+	}
+	if !foundSSH || !foundInteractive || !foundSession || !foundURLBridge || !foundEvidence {
+		t.Fatalf("interactive-debug should include SSH, interactive, session, URL bridge, and evidence signals: %#v", recommendations)
+	}
+}
+
+func TestProvidersRecommendLiveDebugAlias(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", "live-debug",
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend live-debug error=%v stderr=%q", err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("live-debug alias entries=%#v", entries)
+	}
+	hasSSHDebug := providerRecommendationHasFeature(entries[0].Features, FeatureSSH) &&
+		providerRecommendationHasFeature(entries[0].Features, FeatureCrabboxSync)
+	hasInteractive := providerRecommendationHasFeature(entries[0].Features, FeatureBrowser) ||
+		providerRecommendationHasFeature(entries[0].Features, FeatureCode) ||
+		providerRecommendationHasFeature(entries[0].Features, FeatureDesktop)
+	if !hasSSHDebug && !hasInteractive && !providerRecommendationHasFeature(entries[0].Features, FeatureRunSession) {
+		t.Fatalf("live-debug alias should prefer live inspection providers: %#v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add the `interactive-debug` provider recommendation use case and aliases such as `live-debug`
- score providers with synced SSH, browser/code/desktop access, reusable sessions, provider URLs, retained evidence, pause/resume, and cleanup
- document the new use case in command docs, provider landscape notes, and changelog

## Verification
- `git diff --check`
- `go test -count=1 ./internal/cli -run 'TestProvidersRecommend(InteractiveDebug|LiveDebugAlias|ListsUseCases)'`
- `go test -count=1 ./internal/cli`
- `scripts/check-docs.sh`
- `go run ./cmd/crabbox providers recommend interactive-debug --json`
- `go run ./cmd/crabbox providers recommend live-debug --limit 1 --json`
