### PR TITLE
feat(providers): expose vercel sandbox sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added `crabbox providers recommend disposable-execution` for cleanup-capable temporary sandbox guidance across delegated and local sandbox providers.
 - Added `crabbox providers recommend web-app-smoke` for app and service smoke guidance across provider URLs, SSH tunnels, tailnet reachability, browser/code/desktop access, sessions, and retained outputs.
 - Added `crabbox providers recommend interactive-debug` for live inspection guidance across synced SSH, browser/code/desktop access, reusable sessions, provider URLs, and retained evidence.
+- Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.
 
 ### Fixed
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -126,7 +126,7 @@ Access terms:
 | [tenki](tenki.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Tenki sandbox VM | `provider-managed`; GPU: unknown | Tenki; sandbox release | Managed Linux sandbox with SSH proxy | Gateway auth uses Tenki-managed key and certificate files |
 | [tensorlake](tensorlake.md) (`tl`, `tensorlake-sbx`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `provider-owned` · direct only; features: none | `linux`; Tensorlake Firecracker sandbox | `provider-managed`; GPU: unknown | Tensorlake; provider sandbox cleanup | Hosted Firecracker-backed delegated execution | Does not expose raw Firecracker provisioning |
 | [upstash-box](upstash-box.md) (`upstash`, `box`, `upstashbox`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `linux`; Upstash Box sandbox | `provider-managed`; GPU: no | Upstash; sandbox cleanup | Hosted short-lived delegated sandbox | No normal SSH access or coordinator routing |
-| [vercel-sandbox](vercel-sandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; Vercel Sandbox microVM | `provider-managed`; GPU: no | Vercel Sandbox; sandbox delete | Hosted delegated Linux microVM execution | Requires SDK bridge support and Vercel Sandbox auth |
+| [vercel-sandbox](vercel-sandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup`, `run-session` | `linux`; Vercel Sandbox microVM | `provider-managed`; GPU: no | Vercel Sandbox; sandbox delete | Hosted delegated Linux microVM execution | Requires SDK bridge support and Vercel Sandbox auth |
 | [wandb](wandb.md) (`weights-and-biases`) | built-in; `delegated-run` · gpu-cloud | No SSH; `provider-owned` · direct only; features: `run-session` | `linux`; Weights & Biases run sandbox | `provider-managed`; GPU: optional | Weights & Biases; run termination | Delegated ML or GPU run environment | Execution follows the W&B run contract |
 | [windows-sandbox](windows-sandbox.md) (`wsb`, `windows-sandbox-provider`) | built-in; `delegated-run` · local-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync` | `windows/normal`; Windows Sandbox | `local`; GPU: optional | Windows host; sandbox close | Disposable native Windows command execution | Requires Windows Sandbox and local host automation |
 | [xcp-ng](xcp-ng.md) | built-in; `ssh-lease` · self-hosted-virtualization | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; XCP-ng VM clone | `self-hosted`; GPU: optional | Crabbox; VM delete | Self-hosted Linux VM pool over XAPI | Normal leases require prepared Linux templates |
@@ -155,9 +155,10 @@ Access terms:
   sandbox lifecycle and a sandbox data plane for file upload and command
   execution. It has no aliases in v1.
 - Vercel Sandbox is a delegated-run provider using Vercel's Sandbox SDK bridge
-  for lifecycle, archive upload, command execution, and deletion. The `sandbox`
-  CLI is used only for login/readiness checks and manual debugging because
-  Crabbox does not rely on it as a stable lifecycle JSON contract.
+  for lifecycle, archive upload, command execution, session handles, and
+  deletion. The `sandbox` CLI is used only for login/readiness checks and manual
+  debugging because Crabbox does not rely on it as a stable lifecycle JSON
+  contract.
 - Anthropic Sandbox Runtime is a local one-shot delegated-run provider driven
   by the standalone `srt` CLI. It has no SSH lease, no persistent lifecycle,
   and no remote sync surface.

--- a/docs/providers/vercel-sandbox.md
+++ b/docs/providers/vercel-sandbox.md
@@ -232,6 +232,9 @@ egress and cannot be combined with allow/deny entries. `ports` accepts ports or
 - Desktop / browser / code / VNC: no.
 - Actions hydration: no.
 - Coordinator broker: no, Vercel Sandbox runs direct from the CLI.
+- Run session: yes, `run` returns a reusable Crabbox lease/session handle for
+  `--lease-output`, retained failure inspection, and later `run --id`,
+  `status`, or `stop`.
 - Pause/resume: retained sessions resume automatically for sync and execution;
   explicit pause/resume commands are not advertised in v1.
 - Ports, snapshots, and persistence: configuration is accepted and passed to

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -121,9 +121,18 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		}
 	}
 	shouldStop := acquired && !req.Keep
+	cleanedUp := false
+	cleanupCreated := func() error {
+		cleanupPending := shouldStop
+		err := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop)
+		if cleanupPending && err == nil {
+			cleanedUp = true
+		}
+		return err
+	}
 	if shouldStop {
 		defer func() {
-			if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+			if cleanupErr := cleanupCreated(); cleanupErr != nil {
 				if result.ExitCode == 0 {
 					result.ExitCode = 1
 				}
@@ -135,6 +144,19 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			}
 		}()
 	}
+	session := &RunSessionHandle{
+		Provider:       providerName,
+		LeaseID:        leaseID,
+		Slug:           slug,
+		Reused:         !acquired,
+		Kept:           !shouldStop,
+		CleanupCommand: vercelSandboxCleanupCommand(leaseID),
+	}
+	finishResult := func(result RunResult) RunResult {
+		result.Session = session
+		result.Session.Kept = !cleanedUp && !shouldStop
+		return result
+	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
 
 	syncDuration := time.Duration(0)
@@ -143,32 +165,34 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err
+			return finishResult(RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}), err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
 		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return RunResult{}, err
+		return finishResult(RunResult{}), err
 	}
 
 	if req.SyncOnly {
-		result = RunResult{
+		result = finishResult(RunResult{
 			Provider:      providerName,
 			LeaseID:       leaseID,
 			Slug:          slug,
 			Total:         b.now().Sub(started),
 			SyncDelegated: true,
-		}
+		})
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		activityErr := b.refreshLeaseActivityIfRetained(leaseID, shouldStop)
 		if activityErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: refresh vercel-sandbox lease activity failed lease=%s: %v\n", leaseID, activityErr)
 			result.ExitCode = 1
 		}
-		if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+		if cleanupErr := cleanupCreated(); cleanupErr != nil {
 			result.ExitCode = 1
+			result = finishResult(result)
 			return result, cleanupErr
 		}
+		result = finishResult(result)
 		if req.TimingJSON {
 			report := timingReportWithRunResult(timingReport{
 				Provider:      providerName,
@@ -194,7 +218,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 
 	command, err := buildCommand(req.Command, req.ShellMode)
 	if err != nil {
-		return RunResult{}, err
+		return finishResult(RunResult{}), err
 	}
 	commandText := commandScript(command)
 	commandEnv, strippedAuthEnv := vercelSandboxCommandEnv(req.Env)
@@ -212,7 +236,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		TimeoutSecs: b.execTimeoutSecs(),
 	}, b.rt.Stdout, b.rt.Stderr)
 	commandDuration := b.now().Sub(commandStart)
-	result = RunResult{
+	result = finishResult(RunResult{
 		Provider:      providerName,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -221,7 +245,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		Command:       commandDuration,
 		Total:         b.now().Sub(started),
 		SyncDelegated: true,
-	}
+	})
 	if req.NoSync {
 		fmt.Fprintf(b.rt.Stderr, "vercel-sandbox run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	} else {
@@ -245,12 +269,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			result.ExitCode = 1
 		}
 	}
-	if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+	if cleanupErr := cleanupCreated(); cleanupErr != nil {
 		if result.ExitCode == 0 {
 			result.ExitCode = 1
 		}
 		commandErr = errors.Join(commandErr, cleanupErr)
 	}
+	result = finishResult(result)
 	if req.TimingJSON {
 		timingErr := commandErr
 		if timingErr == nil {

--- a/internal/providers/vercelsandbox/backend_test.go
+++ b/internal/providers/vercelsandbox/backend_test.go
@@ -199,6 +199,9 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	if result.ExitCode != 0 || !result.SyncDelegated || result.Provider != providerName {
 		t.Fatalf("result=%#v", result)
 	}
+	if result.Session == nil || result.Session.Provider != providerName || result.Session.Reused || result.Session.Kept || !strings.Contains(result.Session.CleanupCommand, "crabbox stop --provider vercel-sandbox") {
+		t.Fatalf("unexpected one-shot session handle: %#v", result.Session)
+	}
 	if len(fake.sandboxes) != 0 {
 		t.Fatalf("one-shot sandbox not deleted: %#v", fake.sandboxes)
 	}
@@ -240,6 +243,9 @@ func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	}
 	if result.LeaseID != leaseID {
 		t.Fatalf("lease=%q want %q", result.LeaseID, leaseID)
+	}
+	if result.Session == nil || result.Session.LeaseID != leaseID || !result.Session.Reused || !result.Session.Kept {
+		t.Fatalf("unexpected retained session handle: %#v", result.Session)
 	}
 	if _, err := readLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim not retained: %v", err)
@@ -499,6 +505,9 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	})
 	if err == nil || result.ExitCode != 7 {
 		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Session == nil || !result.Session.Kept || result.Session.CleanupCommand == "" {
+		t.Fatalf("keep-on-failure should return retained session handle: %#v", result.Session)
 	}
 	if len(fake.sandboxes) != 1 {
 		t.Fatalf("sandbox should be retained on failure: %#v", fake.sandboxes)

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -18,6 +18,7 @@ type DoctorCheck = core.DoctorCheck
 type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
+type RunSessionHandle = core.RunSessionHandle
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
@@ -125,4 +126,8 @@ func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, s
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func vercelSandboxCleanupCommand(leaseID string) string {
+	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
 }

--- a/internal/providers/vercelsandbox/flags_test.go
+++ b/internal/providers/vercelsandbox/flags_test.go
@@ -16,7 +16,7 @@ func TestVercelSandboxProviderSpec(t *testing.T) {
 	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
 		t.Fatalf("targets=%#v", spec.Targets)
 	}
-	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureCleanup) {
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureCleanup) || !spec.Features.Has(core.FeatureRunSession) {
 		t.Fatalf("features=%v", spec.Features)
 	}
 	if aliases := (Provider{}).Aliases(); len(aliases) != 0 {

--- a/internal/providers/vercelsandbox/provider.go
+++ b/internal/providers/vercelsandbox/provider.go
@@ -24,7 +24,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Family:      providerFamily,
 		Kind:        core.ProviderKindDelegatedRun,
 		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup},
+		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
 		Coordinator: core.CoordinatorNever,
 	}
 }


### PR DESCRIPTION
## Summary
- advertise Vercel Sandbox as a `run-session` provider
- return Crabbox run session handles for one-shot, retained, and reused Vercel Sandbox runs
- update provider docs, generated provider matrix, and changelog

## Verification
- `go test -count=1 ./internal/providers/vercelsandbox`
- `go test -count=1 ./internal/providers/all ./internal/cli -run 'TestRunSessionFeatureRequiresDelegatedBackendAndValidHandle|TestProvidersRecommend(RunSession|ListsUseCases)|TestRun(OneShotSyncsExecutesAndDeletes|KeepOnFailureRetainsClaim)|TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim|TestProviderSpec'`
- `go test -race -count=1 ./internal/providers/vercelsandbox`
- `go test -count=1 ./internal/cli`
- `scripts/check-docs.sh`
- `go run ./cmd/crabbox providers recommend run-session --json`
