### PR TITLE
feat(providers): add docker-sandbox live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Tuned `crabbox providers recommend live-smoke` to keep local runtime smoke paths visible when cloud credentials are unavailable.
 - Added Apple Container to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Local Container to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Docker Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,6 +60,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_L
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
@@ -77,6 +78,7 @@ Per-provider smoke prerequisites:
 - **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
+- **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/docker-sandbox.md
+++ b/docs/providers/docker-sandbox.md
@@ -259,6 +259,12 @@ Common blockers:
 When the host has a usable Docker Sandbox provider configuration, run:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox scripts/live-smoke.sh
+```
+
+That top-level smoke dispatches to the provider-specific script:
+
+```sh
 scripts/live-docker-sandbox-smoke.sh
 ```
 
@@ -286,7 +292,7 @@ Use this matrix when proving a fresh install or upgrade:
 | Host/runtime blockers | `crabbox doctor --provider docker-sandbox` | Surfaces virtualization, hypervisor, KVM, control-plane, quota, or capacity blockers without claiming live success. |
 | Clone mode | `crabbox warmup --provider docker-sandbox --docker-sandbox-clone ...` | Requires the main checkout of a normal Git repository workspace before calling `sbx create --clone`; linked Git worktrees are rejected. |
 | Unsupported delegated flags | Docker Sandbox run flags and config validation | Rejects unsupported agent, desktop, Tailscale, `--class`, and `--type` surfaces clearly while allowing create-time MCP passthrough. |
-| Live lifecycle | `scripts/live-docker-sandbox-smoke.sh` | Prints `classification=live_sbx_smoke_passed ... cleanup=complete` only after create, run, list, and stop complete. |
+| Live lifecycle | `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox scripts/live-smoke.sh` or `scripts/live-docker-sandbox-smoke.sh` | Prints `classification=live_sbx_smoke_passed ... cleanup=complete` only after create, run, list, and stop complete. |
 | Trust boundary handoff | `scripts/docker-sandbox-trust-boundary-smoke.sh` | Uses a fake `sbx` at the process boundary to prove Crabbox sends the workspace path, user command, and `--env-file`, while the forwarded value stays out of local argv and is present only in the env-file handoff. |
 
 Related docs:

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -974,6 +974,10 @@ if has_provider local-container || has_provider docker || has_provider container
   provider_smoke local-container --ttl 15m --idle-timeout 5m
 fi
 
+if has_provider docker-sandbox; then
+  "$root/scripts/live-docker-sandbox-smoke.sh"
+fi
+
 if has_provider multipass || has_provider mp || has_provider canonical-multipass; then
   provider_smoke multipass --ttl 15m --idle-timeout 5m
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -645,6 +645,86 @@ esac
   }
 });
 
+test("docker-sandbox live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-docker-sandbox-dispatch-"));
+  const bin = path.join(dir, "bin");
+  const tempRepo = path.join(dir, "repo");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  const slugFile = path.join(dir, "slug.txt");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(tempRepo);
+
+  writeExecutable(
+    path.join(bin, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${crabboxLog}"
+case "$1" in
+  doctor)
+    printf 'ok      sbx_version provider=docker-sandbox version=sbx client fake\n'
+    ;;
+  warmup)
+    printf '%s\n' "$5" >"${slugFile}"
+    ;;
+  run)
+    printf 'crabbox-docker-sandbox-ok\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}")"
+    printf '[{"name":"sandbox","labels":{"slug":"%s"}}]\n' "$slug"
+    ;;
+  stop)
+    printf 'stopped %s\n' "\${*: -1}"
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\n' "$*" >&2
+    exit 99
+    ;;
+esac
+SCRIPT
+chmod +x "$out"
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: tempRepo,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "docker-sandbox",
+      CRABBOX_LIVE_REPO: tempRepo,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_sbx_smoke_passed/);
+  assert.match(result.stdout, /cleanup=complete/);
+  const calls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(calls, /^doctor --provider docker-sandbox$/m);
+  assert.match(calls, /^warmup --provider docker-sandbox --slug docker-sandbox-smoke-\d{14}-\d+ --keep$/m);
+  assert.match(calls, /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- echo ok$/m);
+  assert.match(calls, /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- pwd$/m);
+  assert.match(calls, /^list --provider docker-sandbox --json$/m);
+  assert.match(calls, /^stop --provider docker-sandbox docker-sandbox-smoke-\d{14}-\d+$/m);
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- dispatch docker-sandbox through the guarded top-level live-smoke matrix
- add a fake-go/fake-crabbox regression for the dispatch path
- document the top-level Docker Sandbox smoke command and prerequisites

## Verification
- node --test scripts/live-smoke.test.js scripts/live-docker-sandbox-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...