### PR TITLE
feat(providers): add smolvm live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added Apple Container to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Local Container to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Docker Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added SmolVM to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,6 +61,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_L
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
@@ -79,6 +80,7 @@ Per-provider smoke prerequisites:
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
 - **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
+- **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -127,6 +127,12 @@ Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you
 Run the guarded hosted lifecycle smoke with an exported API key:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm scripts/live-smoke.sh
+```
+
+That top-level smoke dispatches to the provider-specific script:
+
+```sh
 CRABBOX_SMOLVM_LIVE_SMOKE=1 scripts/live-smolvm-smoke.sh
 ```
 

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -978,6 +978,10 @@ if has_provider docker-sandbox; then
   "$root/scripts/live-docker-sandbox-smoke.sh"
 fi
 
+if has_provider smolvm || has_provider smol || has_provider smolmachines || has_provider smolfleet; then
+  CRABBOX_SMOLVM_LIVE_SMOKE=1 "$root/scripts/live-smolvm-smoke.sh"
+fi
+
 if has_provider multipass || has_provider mp || has_provider canonical-multipass; then
   provider_smoke multipass --ttl 15m --idle-timeout 5m
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -725,6 +725,99 @@ chmod +x "$out"
   assert.match(calls, /^stop --provider docker-sandbox docker-sandbox-smoke-\d{14}-\d+$/m);
 });
 
+test("smolvm live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-smolvm-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const state = path.join(dir, "lease.state");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  run)
+    if [[ "$*" == *"SMOLVM_SMOKE_V1_OK"* ]]; then
+      requested_slug=""
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --slug)
+            requested_slug="\${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+      printf '%s\\n' "$requested_slug" >"${state}"
+      printf 'SMOLVM_SMOKE_V1_OK\\n'
+      printf '{"provider":"smolvm","leaseId":"cbx_test"}\\n' >&2
+    elif [[ "$*" == *"SMOLVM_SMOKE_V2_OK"* ]]; then
+      test -f "${state}"
+      printf 'SMOLVM_SMOKE_V2_OK\\n'
+      printf '{"provider":"smolvm","leaseId":"cbx_test"}\\n' >&2
+    elif [[ "$*" == *"SMOLVM_SMOKE_EXIT_23"* ]]; then
+      test -f "${state}"
+      printf 'SMOLVM_SMOKE_EXIT_23\\n'
+      exit 23
+    else
+      printf 'unexpected run command\\n' >&2
+      exit 64
+    fi
+    ;;
+  status)
+    test -f "${state}"
+    printf '{"id":"cbx_test","slug":"%s","provider":"smolvm","state":"running"}\\n' "$(cat "${state}")"
+    ;;
+  list)
+    if [[ -f "${state}" ]]; then
+      printf '[{"Provider":"smolvm","slug":"%s","state":"running"}]\\n' "$(cat "${state}")"
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  doctor)
+    printf '{"ok":true,"provider":"smolvm"}\\n'
+    ;;
+  stop)
+    rm -f "${state}"
+    ;;
+  *)
+    printf 'unexpected command %s\\n' "$1" >&2
+    exit 64
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "smolvm",
+      CRABBOX_SMOLVM_API_KEY: "smk_test",
+      CRABBOX_SMOLVM_CLEANUP_RETRY_DELAY_SECONDS: "0",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_smolvm_smoke_passed/);
+  assert.equal(fs.existsSync(state), false);
+  const seen = fs.readFileSync(calls, "utf8");
+  assert.match(seen, /^run --provider smolvm --keep --slug smolvm-live-smoke-/m);
+  assert.match(seen, /^status --provider smolvm --id smolvm-live-smoke-.* --wait --json$/m);
+  assert.match(seen, /^doctor --provider smolvm --json$/m);
+  assert.match(seen, /^run --provider smolvm --id smolvm-live-smoke-.* --no-sync -- /m);
+  assert.match(seen, /^stop --provider smolvm smolvm-live-smoke-/m);
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- dispatch SmolVM through the guarded top-level live-smoke matrix
- bridge CRABBOX_LIVE_PROVIDERS=smolvm to the provider-specific SmolVM lifecycle smoke
- document the top-level SmolVM smoke command and API key prerequisite

## Verification
- node --test scripts/live-smoke.test.js scripts/live-smolvm-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...