### PR TITLE
feat(providers): add superserve live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added Local Container to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Docker Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added SmolVM to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Superserve to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,6 +62,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBO
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
@@ -81,6 +82,7 @@ Per-provider smoke prerequisites:
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
 - **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
+- **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/superserve.md
+++ b/docs/providers/superserve.md
@@ -172,6 +172,15 @@ short-lived Superserve sandbox:
 CRABBOX_LIVE=1 \
 CRABBOX_LIVE_PROVIDERS=superserve \
 CRABBOX_SUPERSERVE_API_KEY=ss_live_... \
+scripts/live-smoke.sh
+```
+
+The top-level smoke dispatches to the provider-specific script:
+
+```sh
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=superserve \
+CRABBOX_SUPERSERVE_API_KEY=ss_live_... \
 scripts/live-superserve-smoke.sh
 ```
 

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -982,6 +982,10 @@ if has_provider smolvm || has_provider smol || has_provider smolmachines || has_
   CRABBOX_SMOLVM_LIVE_SMOKE=1 "$root/scripts/live-smolvm-smoke.sh"
 fi
 
+if has_provider superserve; then
+  "$root/scripts/live-superserve-smoke.sh"
+fi
+
 if has_provider multipass || has_provider mp || has_provider canonical-multipass; then
   provider_smoke multipass --ttl 15m --idle-timeout 5m
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -818,6 +818,104 @@ esac
   assert.match(seen, /^stop --provider smolvm smolvm-live-smoke-/m);
 });
 
+test("superserve live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-superserve-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const state = path.join(dir, "lease.state");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf '{"ok":true,"provider":"superserve"}\\n'
+    ;;
+  run)
+    if [[ "$*" == *"SUPERSERVE_SMOKE_V1_OK"* ]]; then
+      requested_slug=""
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --slug)
+            requested_slug="\${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+      printf '%s\\n' "$requested_slug" >"${state}"
+      printf 'SUPERSERVE_SMOKE_STDOUT\\n'
+      printf 'SUPERSERVE_SMOKE_STDERR\\n' >&2
+      printf 'SUPERSERVE_SMOKE_V1_OK\\n'
+      printf '{"provider":"superserve","leaseId":"ssbx_test"}\\n' >&2
+    elif [[ "$*" == *"SUPERSERVE_SMOKE_V2_OK"* ]]; then
+      test -f "${state}"
+      printf 'SUPERSERVE_SMOKE_V2_OK\\n'
+      printf '{"provider":"superserve","leaseId":"ssbx_test"}\\n' >&2
+    elif [[ "$*" == *"SUPERSERVE_SMOKE_EXIT_23"* ]]; then
+      test -f "${state}"
+      printf 'SUPERSERVE_SMOKE_EXIT_23\\n'
+      exit 23
+    else
+      printf 'unexpected run command\\n' >&2
+      exit 64
+    fi
+    ;;
+  status)
+    test -f "${state}"
+    printf '{"id":"ssbx_test","slug":"%s","provider":"superserve","state":"running"}\\n' "$(cat "${state}")"
+    ;;
+  list)
+    if [[ -f "${state}" ]]; then
+      printf '[{"provider":"superserve","slug":"%s","state":"running"}]\\n' "$(cat "${state}")"
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  stop)
+    rm -f "${state}"
+    ;;
+  *)
+    printf 'unexpected command %s\\n' "$1" >&2
+    exit 64
+    ;;
+esac
+`,
+  );
+
+  const apiKey = "ss_live_fake_value";
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "superserve",
+      CRABBOX_SUPERSERVE_API_KEY: apiKey,
+      CRABBOX_SUPERSERVE_CLEANUP_RETRY_DELAY_SECONDS: "0",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_superserve_smoke_passed/);
+  assert.match(result.stdout, /cleanup=confirmed provider=superserve slug=ss-live-/);
+  assert.doesNotMatch(result.stdout + result.stderr, new RegExp(apiKey));
+  assert.equal(fs.existsSync(state), false);
+  const seen = fs.readFileSync(calls, "utf8");
+  assert.match(seen, /^doctor --provider superserve --json$/m);
+  assert.match(seen, /^run --provider superserve --keep --slug ss-live-/m);
+  assert.match(seen, /^status --provider superserve --id ss-live-.* --wait --json$/m);
+  assert.match(seen, /^run --provider superserve --id ss-live-.* --no-sync -- /m);
+  assert.match(seen, /^stop --provider superserve ss-live-/m);
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route Superserve through the guarded top-level live-smoke dispatcher
- add a fake-crabbox regression for the retained Superserve lifecycle dispatch
- document the top-level smoke command and required Superserve API key env vars

## Verification
- node --test scripts/live-smoke.test.js scripts/live-superserve-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...

Live Superserve provider access was not available, so this PR verifies the guarded dispatch and provider-specific lifecycle through the existing fake CLI smoke harness.