### PR TITLE
feat(providers): add vercel sandbox live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added Docker Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added SmolVM to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Superserve to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Vercel Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,6 +63,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBO
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
@@ -83,6 +84,7 @@ Per-provider smoke prerequisites:
 - **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
 - **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.
+- **Vercel Sandbox** — authenticated `sandbox` CLI on `PATH`; project and team scope may come from `CRABBOX_VERCEL_SANDBOX_PROJECT_ID` plus `CRABBOX_VERCEL_SANDBOX_TEAM_ID`, `CRABBOX_VERCEL_SANDBOX_SCOPE`, or the Vercel OIDC environment.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/vercel-sandbox.md
+++ b/docs/providers/vercel-sandbox.md
@@ -265,6 +265,16 @@ CRABBOX_LIVE=1 \
 CRABBOX_LIVE_PROVIDERS=vercel-sandbox \
 CRABBOX_VERCEL_SANDBOX_PROJECT_ID=prj_example \
 CRABBOX_VERCEL_SANDBOX_TEAM_ID=team_example \
+scripts/live-smoke.sh
+```
+
+The top-level smoke dispatches to the provider-specific script:
+
+```sh
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=vercel-sandbox \
+CRABBOX_VERCEL_SANDBOX_PROJECT_ID=prj_example \
+CRABBOX_VERCEL_SANDBOX_TEAM_ID=team_example \
 scripts/live-vercel-sandbox-smoke.sh
 ```
 

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -986,6 +986,10 @@ if has_provider superserve; then
   "$root/scripts/live-superserve-smoke.sh"
 fi
 
+if has_provider vercel-sandbox; then
+  "$root/scripts/live-vercel-sandbox-smoke.sh"
+fi
+
 if has_provider multipass || has_provider mp || has_provider canonical-multipass; then
   provider_smoke multipass --ttl 15m --idle-timeout 5m
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -916,6 +916,153 @@ esac
   assert.match(seen, /^stop --provider superserve ss-live-/m);
 });
 
+test("vercel-sandbox live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-vercel-sandbox-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const fakeSandbox = path.join(dir, "sandbox");
+  const calls = path.join(dir, "calls.log");
+  const state = path.join(dir, "lease.state");
+  const remoteStopped = path.join(dir, "remote-stopped.state");
+
+  writeExecutable(
+    fakeSandbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'sandbox %s\\n' "$*" >>"${calls}"
+case "\${1:-}" in
+  --help)
+    printf 'sandbox help\\n'
+    ;;
+  list)
+    if [[ -f "${remoteStopped}" && "\${FAKE_SANDBOX_STALE_LIST:-0}" == "1" ]]; then
+      printf 'NAME STATUS\\n'
+      printf 'test stopped\\n'
+    else
+      printf 'No sandboxes found\\n'
+    fi
+    ;;
+  stop)
+    : >"${remoteStopped}"
+    printf 'Stopped %s\\n' "\${*: -1}"
+    ;;
+  rm)
+    rm -f "${remoteStopped}"
+    printf 'Removed %s\\n' "\${*: -1}"
+    ;;
+  *)
+    printf 'unexpected sandbox command %s\\n' "\${1:-}" >&2
+    exit 64
+    ;;
+esac
+`,
+  );
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'crabbox %s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf '{"ok":true,"provider":"vercel-sandbox"}\\n'
+    ;;
+  run)
+    if [[ "$*" == *"VERCEL_SANDBOX_SMOKE_V1_OK"* ]]; then
+      requested_slug=""
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+          --slug)
+            requested_slug="\${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+      printf '%s\\n' "$requested_slug" >"${state}"
+      printf 'VERCEL_SANDBOX_SMOKE_STDOUT\\n'
+      printf 'VERCEL_SANDBOX_SMOKE_STDERR\\n' >&2
+      printf 'VERCEL_SANDBOX_SMOKE_V1_OK\\n'
+      printf '{"provider":"vercel-sandbox","leaseId":"vsbx_test"}\\n' >&2
+    elif [[ "$*" == *"VERCEL_SANDBOX_SMOKE_V2_OK"* ]]; then
+      test -f "${state}"
+      printf 'VERCEL_SANDBOX_SMOKE_V2_OK\\n'
+      printf '{"provider":"vercel-sandbox","leaseId":"vsbx_test"}\\n' >&2
+    elif [[ "$*" == *"VERCEL_SANDBOX_STREAM_START"* ]]; then
+      test -f "${state}"
+      printf 'VERCEL_SANDBOX_STREAM_START\\n'
+      sleep 0.3
+      printf 'VERCEL_SANDBOX_STREAM_END\\n'
+    elif [[ "$*" == *"VERCEL_SANDBOX_SMOKE_EXIT_23"* ]]; then
+      test -f "${state}"
+      printf 'VERCEL_SANDBOX_SMOKE_EXIT_23\\n'
+      exit 23
+    else
+      printf 'unexpected run command\\n' >&2
+      exit 64
+    fi
+    ;;
+  status)
+    test -f "${state}"
+    printf '{"id":"vsbx_test","slug":"%s","provider":"vercel-sandbox","state":"running"}\\n' "$(cat "${state}")"
+    ;;
+  list)
+    if [[ -f "${state}" ]]; then
+      printf '[{"provider":"vercel-sandbox","slug":"%s","state":"running"}]\\n' "$(cat "${state}")"
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  stop)
+    rm -f "${state}"
+    ;;
+  *)
+    printf 'unexpected command %s\\n' "$1" >&2
+    exit 64
+    ;;
+esac
+`,
+  );
+
+  const authValue = "vercel_fake_redaction_value";
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${dir}${path.delimiter}${process.env.PATH}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "vercel-sandbox",
+      CRABBOX_VERCEL_SANDBOX_AUTH_TOKEN: authValue,
+      CRABBOX_VERCEL_SANDBOX_CLEANUP_RETRY_DELAY_SECONDS: "0",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_vercel_sandbox_smoke_passed/);
+  assert.match(result.stdout, /session_stop=confirmed provider=vercel-sandbox sandbox=test/);
+  assert.match(result.stdout, /streaming=confirmed provider=vercel-sandbox sandbox=test/);
+  assert.match(result.stdout, /cleanup=confirmed provider=vercel-sandbox slug=vs-live-.* sandbox=test/);
+  assert.doesNotMatch(result.stdout + result.stderr, new RegExp(authValue));
+  assert.equal(fs.existsSync(state), false);
+  const seen = fs.readFileSync(calls, "utf8");
+  assert.match(seen, /^sandbox --help$/m);
+  assert.match(seen, /^sandbox list --all --limit 1$/m);
+  assert.match(seen, /^crabbox doctor --provider vercel-sandbox --json$/m);
+  assert.match(seen, /^crabbox run --provider vercel-sandbox --keep --slug vs-live-/m);
+  assert.match(seen, /^crabbox status --provider vercel-sandbox --id vs-live-.* --wait --json$/m);
+  assert.match(seen, /^sandbox stop test$/m);
+  assert.match(seen, /^crabbox run --provider vercel-sandbox --id vs-live-.*VERCEL_SANDBOX_SMOKE_V2_OK/m);
+  assert.match(seen, /^crabbox run --provider vercel-sandbox --id vs-live-.*VERCEL_SANDBOX_STREAM_START/m);
+  assert.match(seen, /^crabbox run --provider vercel-sandbox --id vs-live-.* --no-sync -- /m);
+  assert.match(seen, /^crabbox stop --provider vercel-sandbox vs-live-/m);
+  assert.match(seen, /^sandbox list --all --name-prefix test --sort-by name --limit 50$/m);
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route Vercel Sandbox through the guarded top-level live-smoke dispatcher
- add a fake-crabbox and fake-sandbox regression for the retained Vercel lifecycle dispatch
- document the top-level Vercel Sandbox smoke command and prerequisites

## Verification
- node --test scripts/live-smoke.test.js scripts/live-vercel-sandbox-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...

Live Vercel provider access was not available, so this PR verifies the guarded dispatch and provider-specific lifecycle with fake Crabbox and sandbox CLI tools.