### PR TITLE
feat(providers): add linode live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added SmolVM to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Superserve to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Vercel Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Linode to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -64,6 +64,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
@@ -86,6 +87,7 @@ Per-provider smoke prerequisites:
 - **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.
 - **Vercel Sandbox** — authenticated `sandbox` CLI on `PATH`; project and team scope may come from `CRABBOX_VERCEL_SANDBOX_PROJECT_ID` plus `CRABBOX_VERCEL_SANDBOX_TEAM_ID`, `CRABBOX_VERCEL_SANDBOX_SCOPE`, or the Vercel OIDC environment.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
+- **Linode** — `LINODE_TOKEN` with Linode instance, image, type, SSH key, and tag access.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and
   `nebius.subnetId`. `scripts/live-nebius-smoke.sh` is coordinator-free,

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -171,10 +171,17 @@ create ingress rules in this phase.
 The repeatable live check is opt-in:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
+```
+
+The top-level smoke dispatches to the provider-specific script:
+
+```sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-linode-smoke.sh
 ```
 
-The script builds `bin/crabbox`, uses `LINODE_TOKEN` from the environment,
+The script builds `bin/crabbox` unless `CRABBOX_BIN` points at an existing
+binary, uses `LINODE_TOKEN` from the environment,
 requires an empty Crabbox-owned Linode inventory, creates a small
 `g6-standard-1` instance, waits for ready status, runs `echo ok`, verifies
 `list --json`, stops the lease, runs dry-run cleanup, and verifies the

--- a/scripts/live-linode-smoke.sh
+++ b/scripts/live-linode-smoke.sh
@@ -175,6 +175,7 @@ local_testbox_key_snapshot() {
 
 cleanup_armed=0
 slug="linode-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin=""
 config_file=""
 initial_local_key_snapshot=""
 
@@ -188,7 +189,7 @@ cleanup() {
     local cleanup_poll_seconds=2
     for ((attempt = 1; attempt <= cleanup_attempts; attempt++)); do
       set +e
-      cleanup_output="$(bin/crabbox stop --provider linode "$slug" 2>&1)"
+      cleanup_output="$("$crabbox_bin" stop --provider linode "$slug" 2>&1)"
       cleanup_status=$?
       set -e
       if [ "$cleanup_status" -eq 0 ]; then
@@ -222,7 +223,7 @@ cleanup() {
       fi
     done
     if [ "$cleanup_status" -ne 0 ]; then
-      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider linode $slug" "$cleanup_status" "$slug" >&2
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider linode $slug" "$cleanup_status" "$slug" >&2
       printf '%s\n' "$cleanup_output" >&2
       if [ "$status" -eq 0 ]; then
         status="$cleanup_status"
@@ -251,8 +252,11 @@ if [[ -z "${LINODE_TOKEN:-}" ]]; then
   exit 0
 fi
 
-mkdir -p bin
-go build -trimpath -o bin/crabbox ./cmd/crabbox
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
 
 config_file="$(mktemp)"
 cat >"$config_file" <<'YAML'
@@ -268,23 +272,23 @@ export CRABBOX_CONFIG="$config_file"
 export CRABBOX_COORDINATOR=
 export LINODE_TOKEN
 
-doctor_output="$(run_capture "bin/crabbox doctor --provider linode" bin/crabbox doctor --provider linode)"
+doctor_output="$(run_capture "$crabbox_bin doctor --provider linode" "$crabbox_bin" doctor --provider linode)"
 printf '%s\n' "$doctor_output"
-initial_list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
-validate_list_json_empty "bin/crabbox list --provider linode --json" "$initial_list_output"
+initial_list_output="$(run_capture "$crabbox_bin list --provider linode --json" "$crabbox_bin" list --provider linode --json)"
+validate_list_json_empty "$crabbox_bin list --provider linode --json" "$initial_list_output"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
-run_capture "bin/crabbox warmup --provider linode --slug $slug --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider linode --slug "$slug" --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m >/dev/null
-run_capture "bin/crabbox status --provider linode --id $slug --wait --wait-timeout 300s" bin/crabbox status --provider linode --id "$slug" --wait --wait-timeout 300s >/dev/null
-run_capture "bin/crabbox run --provider linode --id $slug --no-sync -- echo ok" bin/crabbox run --provider linode --id "$slug" --no-sync -- echo ok >/dev/null
-list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
+run_capture "$crabbox_bin warmup --provider linode --slug $slug --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider linode --slug "$slug" --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "$crabbox_bin status --provider linode --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider linode --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_capture "$crabbox_bin run --provider linode --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider linode --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "$crabbox_bin list --provider linode --json" "$crabbox_bin" list --provider linode --json)"
 printf '%s\n' "$list_output"
-validate_list_json_contains_slug "bin/crabbox list --provider linode --json" "$list_output"
-run_capture "bin/crabbox stop --provider linode $slug" bin/crabbox stop --provider linode "$slug" >/dev/null
+validate_list_json_contains_slug "$crabbox_bin list --provider linode --json" "$list_output"
+run_capture "$crabbox_bin stop --provider linode $slug" "$crabbox_bin" stop --provider linode "$slug" >/dev/null
 cleanup_armed=0
-cleanup_output="$(run_capture "bin/crabbox cleanup --provider linode --dry-run" bin/crabbox cleanup --provider linode --dry-run)"
-post_list_output="$(run_capture "bin/crabbox list --provider linode --json" bin/crabbox list --provider linode --json)"
-validate_list_json_empty "bin/crabbox list --provider linode --json" "$post_list_output"
+cleanup_output="$(run_capture "$crabbox_bin cleanup --provider linode --dry-run" "$crabbox_bin" cleanup --provider linode --dry-run)"
+post_list_output="$(run_capture "$crabbox_bin list --provider linode --json" "$crabbox_bin" list --provider linode --json)"
+validate_list_json_empty "$crabbox_bin list --provider linode --json" "$post_list_output"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"
 printf 'classification=live_linode_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -898,6 +898,10 @@ if has_provider scaleway; then
   "$root/scripts/live-scaleway-smoke.sh"
 fi
 
+if has_provider linode; then
+  "$root/scripts/live-linode-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1063,6 +1063,97 @@ esac
   assert.match(seen, /^sandbox list --all --name-prefix test --sort-by name --limit 50$/m);
 });
 
+test("linode live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${LINODE_TOKEN:-}" != "linode_fake_value" ]]; then
+  printf 'missing Linode auth\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 runtime=unchecked default_type=g6-standard-1 region=us-ord image=linode/ubuntu24.04\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  warmup)
+    requested_slug=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --slug)
+          requested_slug="\${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\\n' "$requested_slug" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip server id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "linode",
+      LINODE_TOKEN: "linode_fake_value",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_linode_smoke_passed slug=linode-smoke-/);
+  assert.doesNotMatch(result.stdout + result.stderr, /linode_fake_value/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider linode");
+  assert.equal(seen[1], "list --provider linode --json");
+  assert.match(seen[2], /^warmup --provider linode --slug linode-smoke-\d{14}-\d+ --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider linode --id linode-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider linode --id linode-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider linode --json");
+  assert.match(seen[6], /^stop --provider linode linode-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "cleanup --provider linode --dry-run");
+  assert.equal(seen[8], "list --provider linode --json");
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route Linode through the guarded top-level live-smoke dispatcher
- let the Linode live-smoke script honor CRABBOX_BIN for hermetic test dispatch
- add a fake-crabbox regression for the top-level Linode smoke path
- document the top-level command and Linode prerequisite

## Verification
- node --test scripts/live-smoke.test.js scripts/live-linode-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...

Live Linode provider access was not available, so this PR verifies the guarded dispatch and provider-specific lifecycle through fake Crabbox tooling.