### PR TITLE
feat(providers): add digitalocean live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added Superserve to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Vercel Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Linode to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added DigitalOcean to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -65,7 +65,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
-CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
 
@@ -107,10 +107,10 @@ rm -f "$tmp"
 ```
 
 Use `--provider aws` with AWS SDK credentials for the direct AWS equivalent.
-Use `scripts/live-digitalocean-smoke.sh` for the repeatable direct DigitalOcean
-equivalent; it builds `bin/crabbox`, creates a guarded `digitalocean` scratch
-config, and verifies the Crabbox-owned inventory is empty before create and
-after stop/cleanup.
+Use `scripts/live-smoke.sh` or `scripts/live-digitalocean-smoke.sh` for the
+repeatable direct DigitalOcean equivalent; it builds or reuses `bin/crabbox`,
+creates a guarded `digitalocean` scratch config, and verifies the Crabbox-owned
+inventory is empty before create and after stop/cleanup.
 Use `scripts/live-nebius-smoke.sh` for the repeatable direct Nebius equivalent;
 it builds or reuses `bin/crabbox`, uses the documented Nebius config and CLI
 profile, creates a unique `nebius-smoke-*` lease, and verifies the slug is absent

--- a/docs/providers/digitalocean.md
+++ b/docs/providers/digitalocean.md
@@ -175,10 +175,17 @@ crabbox cleanup --provider digitalocean
 The repeatable live check is opt-in:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
+```
+
+The top-level smoke dispatches to the provider-specific script:
+
+```sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-digitalocean-smoke.sh
 ```
 
-The script builds `bin/crabbox`, uses `DIGITALOCEAN_TOKEN` from the environment,
+The script builds `bin/crabbox` unless `CRABBOX_BIN` points at an existing
+binary, uses `DIGITALOCEAN_TOKEN` from the environment,
 requires an empty Crabbox-owned DigitalOcean inventory, creates a small
 `s-1vcpu-1gb` Droplet, waits for ready status, runs `echo ok`, verifies
 `list --json`, stops the lease, runs dry-run cleanup, and verifies the

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -2266,24 +2265,6 @@ func TestWindowsWSL2RemoteCapabilityPreflightUsesBoundedWrapper(t *testing.T) {
 	if !strings.Contains(payload, `preflight_cmd '\''node'\'' '\''node'\'' node --version`) {
 		t.Fatalf("WSL2 preflight payload missing node probe in %q", payload)
 	}
-}
-
-func wsl2CommandPayload(t *testing.T, decoded string) string {
-	t.Helper()
-	start := strings.Index(decoded, `[Convert]::FromBase64String("`)
-	if start < 0 {
-		t.Fatalf("WSL2 command missing base64 payload: %q", decoded)
-	}
-	start += len(`[Convert]::FromBase64String("`)
-	end := strings.Index(decoded[start:], `")`)
-	if end < 0 {
-		t.Fatalf("WSL2 command has unterminated base64 payload: %q", decoded)
-	}
-	raw, err := base64.StdEncoding.DecodeString(decoded[start : start+end])
-	if err != nil {
-		t.Fatalf("WSL2 command payload is not base64: %v", err)
-	}
-	return string(raw)
 }
 
 func TestRemotePreflightNonePrintsWorkspaceOnly(t *testing.T) {

--- a/scripts/live-digitalocean-smoke.sh
+++ b/scripts/live-digitalocean-smoke.sh
@@ -211,6 +211,7 @@ local_testbox_key_snapshot() {
 
 cleanup_armed=0
 slug="digitalocean-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin=""
 config_file=""
 initial_managed_key_snapshot=""
 initial_local_key_snapshot=""
@@ -223,7 +224,7 @@ cleanup() {
     local attempt
     for attempt in 1 2 3; do
       set +e
-      cleanup_output="$(bin/crabbox stop --provider digitalocean "$slug" 2>&1)"
+      cleanup_output="$("$crabbox_bin" stop --provider digitalocean "$slug" 2>&1)"
       cleanup_status=$?
       set -e
       if [ "$cleanup_status" -eq 0 ]; then
@@ -261,7 +262,7 @@ cleanup() {
       sleep 2
     done
     if [ "$cleanup_status" -ne 0 ]; then
-      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider digitalocean $slug" "$cleanup_status" "$slug" >&2
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider digitalocean $slug" "$cleanup_status" "$slug" >&2
       printf '%s\n' "$cleanup_output" >&2
       if [ "$status" -eq 0 ]; then
         status="$cleanup_status"
@@ -290,8 +291,11 @@ if [[ -z "${DIGITALOCEAN_TOKEN:-}" ]]; then
   exit 0
 fi
 
-mkdir -p bin
-go build -trimpath -o bin/crabbox ./cmd/crabbox
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
 
 config_file="$(mktemp)"
 cat >"$config_file" <<'YAML'
@@ -306,24 +310,24 @@ export CRABBOX_CONFIG="$config_file"
 export CRABBOX_COORDINATOR=
 export DIGITALOCEAN_TOKEN
 
-doctor_output="$(run_capture "bin/crabbox doctor --provider digitalocean" bin/crabbox doctor --provider digitalocean)"
+doctor_output="$(run_capture "$crabbox_bin doctor --provider digitalocean" "$crabbox_bin" doctor --provider digitalocean)"
 printf '%s\n' "$doctor_output"
-initial_list_output="$(run_capture "bin/crabbox list --provider digitalocean --json" bin/crabbox list --provider digitalocean --json)"
-validate_list_json_empty "bin/crabbox list --provider digitalocean --json" "$initial_list_output"
+initial_list_output="$(run_capture "$crabbox_bin list --provider digitalocean --json" "$crabbox_bin" list --provider digitalocean --json)"
+validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$initial_list_output"
 initial_managed_key_snapshot="$(run_capture "digitalocean managed SSH key snapshot" raw_digitalocean_managed_key_snapshot)"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
-run_capture "bin/crabbox warmup --provider digitalocean --slug $slug --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider digitalocean --slug "$slug" --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m >/dev/null
-run_capture "bin/crabbox status --provider digitalocean --id $slug --wait --wait-timeout 300s" bin/crabbox status --provider digitalocean --id "$slug" --wait --wait-timeout 300s >/dev/null
-run_capture "bin/crabbox run --provider digitalocean --id $slug --no-sync -- echo ok" bin/crabbox run --provider digitalocean --id "$slug" --no-sync -- echo ok >/dev/null
-list_output="$(run_capture "bin/crabbox list --provider digitalocean --json" bin/crabbox list --provider digitalocean --json)"
+run_capture "$crabbox_bin warmup --provider digitalocean --slug $slug --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider digitalocean --slug "$slug" --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "$crabbox_bin status --provider digitalocean --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider digitalocean --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_capture "$crabbox_bin run --provider digitalocean --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider digitalocean --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "$crabbox_bin list --provider digitalocean --json" "$crabbox_bin" list --provider digitalocean --json)"
 printf '%s\n' "$list_output"
-validate_list_json_contains_slug "bin/crabbox list --provider digitalocean --json" "$list_output"
-run_capture "bin/crabbox stop --provider digitalocean $slug" bin/crabbox stop --provider digitalocean "$slug" >/dev/null
+validate_list_json_contains_slug "$crabbox_bin list --provider digitalocean --json" "$list_output"
+run_capture "$crabbox_bin stop --provider digitalocean $slug" "$crabbox_bin" stop --provider digitalocean "$slug" >/dev/null
 cleanup_armed=0
-cleanup_output="$(run_capture "bin/crabbox cleanup --provider digitalocean --dry-run" bin/crabbox cleanup --provider digitalocean --dry-run)"
-post_list_output="$(run_capture "bin/crabbox list --provider digitalocean --json" bin/crabbox list --provider digitalocean --json)"
-validate_list_json_empty "bin/crabbox list --provider digitalocean --json" "$post_list_output"
+cleanup_output="$(run_capture "$crabbox_bin cleanup --provider digitalocean --dry-run" "$crabbox_bin" cleanup --provider digitalocean --dry-run)"
+post_list_output="$(run_capture "$crabbox_bin list --provider digitalocean --json" "$crabbox_bin" list --provider digitalocean --json)"
+validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$post_list_output"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"
 printf 'classification=live_digitalocean_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -902,6 +902,10 @@ if has_provider linode; then
   "$root/scripts/live-linode-smoke.sh"
 fi
 
+if has_provider digitalocean || has_provider do; then
+  "$root/scripts/live-digitalocean-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1154,6 +1154,117 @@ esac
   assert.equal(seen[8], "list --provider linode --json");
 });
 
+test("digitalocean live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-digitalocean-dispatch-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const fakePython = path.join(bin, "python3");
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+  const realPython = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(realPython, "python3 is required for DigitalOcean dispatch smoke");
+  fs.mkdirSync(bin);
+
+  writeExecutable(
+    fakePython,
+    `#!/usr/bin/env bash
+if [[ "$*" == *"/account/keys"* ]]; then
+  printf '[]\\n'
+  exit 0
+fi
+if [[ "$*" == *"urllib.request"* ]]; then
+  exit 1
+fi
+exec ${JSON.stringify(realPython)} "$@"
+`,
+  );
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${DIGITALOCEAN_TOKEN:-}" != "digitalocean_fake_value" ]]; then
+  printf 'missing DigitalOcean auth\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 runtime=unchecked default_type=s-1vcpu-1gb region=nyc3 image=ubuntu-24-04-x64\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"}}]\\n' "$slug"
+    fi
+    ;;
+  warmup)
+    requested_slug=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --slug)
+          requested_slug="\${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\\n' "$requested_slug" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip server id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "digitalocean",
+      DIGITALOCEAN_TOKEN: "digitalocean_fake_value",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_digitalocean_smoke_passed slug=digitalocean-smoke-/);
+  assert.doesNotMatch(result.stdout + result.stderr, /digitalocean_fake_value/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider digitalocean");
+  assert.equal(seen[1], "list --provider digitalocean --json");
+  assert.match(seen[2], /^warmup --provider digitalocean --slug digitalocean-smoke-\d{14}-\d+ --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider digitalocean --json");
+  assert.match(seen[6], /^stop --provider digitalocean digitalocean-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "cleanup --provider digitalocean --dry-run");
+  assert.equal(seen[8], "list --provider digitalocean --json");
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route DigitalOcean through the guarded top-level live-smoke dispatcher
- let the DigitalOcean live-smoke script honor CRABBOX_BIN for hermetic test dispatch
- add a fake-crabbox regression for the top-level DigitalOcean smoke path, including managed SSH key snapshot preflight
- remove an unused WSL2 test helper that current CI deadcode now rejects
- document the top-level command and DigitalOcean smoke behavior

## Verification
- node --test scripts/live-smoke.test.js scripts/live-digitalocean-smoke.test.js
- go test ./internal/cli
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...

Live DigitalOcean provider access was not available, so this PR verifies the guarded dispatch and provider-specific lifecycle through fake Crabbox tooling.