### PR TITLE
feat(providers): add nebius live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added Vercel Sandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Linode to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added DigitalOcean to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Nebius to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -66,7 +66,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scri
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
-CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -111,10 +111,10 @@ Use `scripts/live-smoke.sh` or `scripts/live-digitalocean-smoke.sh` for the
 repeatable direct DigitalOcean equivalent; it builds or reuses `bin/crabbox`,
 creates a guarded `digitalocean` scratch config, and verifies the Crabbox-owned
 inventory is empty before create and after stop/cleanup.
-Use `scripts/live-nebius-smoke.sh` for the repeatable direct Nebius equivalent;
-it builds or reuses `bin/crabbox`, uses the documented Nebius config and CLI
-profile, creates a unique `nebius-smoke-*` lease, and verifies the slug is absent
-after stop and dry-run cleanup.
+Use `scripts/live-smoke.sh` or `scripts/live-nebius-smoke.sh` for the repeatable
+direct Nebius equivalent; it builds or reuses `bin/crabbox`, uses the documented
+Nebius config and CLI profile, creates a unique `nebius-smoke-*` lease, and
+verifies the slug is absent after stop and dry-run cleanup.
 
 ## Deployment
 

--- a/docs/providers/nebius.md
+++ b/docs/providers/nebius.md
@@ -267,6 +267,12 @@ crabbox run \
 The repeatable live check is opt-in because it creates a billable Nebius VM:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
+```
+
+The top-level smoke dispatches to the provider-specific script:
+
+```sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-nebius-smoke.sh
 ```
 

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -906,6 +906,10 @@ if has_provider digitalocean || has_provider do; then
   "$root/scripts/live-digitalocean-smoke.sh"
 fi
 
+if has_provider nebius; then
+  "$root/scripts/live-nebius-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1265,6 +1265,91 @@ esac
   assert.equal(seen[8], "list --provider digitalocean --json");
 });
 
+test("nebius live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready leases=0 runtime=unchecked\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"crabbox_slug":"%s"},"provider":"nebius"}]\\n' "$slug"
+    fi
+    ;;
+  warmup)
+    requested_slug=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --slug)
+          requested_slug="\${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\\n' "$requested_slug" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip nebius instance id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "nebius",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_nebius_smoke_passed slug=nebius-smoke-/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider nebius");
+  assert.equal(seen[1], "list --provider nebius --json");
+  assert.match(seen[2], /^warmup --provider nebius --slug nebius-smoke-\d+-\d+-[0-9a-f]{8} --keep --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider nebius --json");
+  assert.match(seen[6], /^stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}$/);
+  assert.equal(seen[7], "cleanup --provider nebius --dry-run");
+  assert.equal(seen[8], "list --provider nebius --json");
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route Nebius through the guarded top-level live-smoke dispatcher
- add a fake-crabbox regression for the top-level Nebius smoke path
- document the top-level Nebius smoke command

## Verification
- node --test scripts/live-smoke.test.js scripts/live-nebius-smoke.test.js
- scripts/check-docs.sh
- git diff --check
- git diff | rg -n '/Users|vincent|192\.168|10\.|100\.|secret|token|password|OPENCLAW|Peter' || true
- go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...

Live Nebius provider access was not available, so this PR verifies the guarded dispatch and provider-specific lifecycle through fake Crabbox tooling.