### PR TITLE
feat(providers): add ovh live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added Linode to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added DigitalOcean to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Nebius to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added OVHcloud to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -67,6 +67,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -94,6 +95,11 @@ Per-provider smoke prerequisites:
   requires explicit `CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius`, creates one
   short-lived CPU-default VM, verifies status and `echo ok`, stops the lease,
   runs dry-run cleanup, and prints a final classification.
+- **OVHcloud** — OVH application credentials plus `ovh.projectId` and
+  `ovh.region`. `scripts/live-ovh-smoke.sh` is coordinator-free, requires an
+  empty Crabbox-owned OVH inventory, creates one short-lived `b3-8` instance by
+  default, verifies status and `echo ok`, stops the lease, runs dry-run cleanup,
+  and prints a final classification.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 
@@ -115,6 +121,11 @@ Use `scripts/live-smoke.sh` or `scripts/live-nebius-smoke.sh` for the repeatable
 direct Nebius equivalent; it builds or reuses `bin/crabbox`, uses the documented
 Nebius config and CLI profile, creates a unique `nebius-smoke-*` lease, and
 verifies the slug is absent after stop and dry-run cleanup.
+Use `scripts/live-smoke.sh` or `scripts/live-ovh-smoke.sh` for the repeatable
+direct OVHcloud equivalent; it builds or reuses `bin/crabbox`, uses the
+documented OVH credentials and project settings, creates a unique
+`ovh-smoke-*` lease, and verifies the Crabbox-owned inventory is empty after
+stop and dry-run cleanup.
 
 ## Deployment
 

--- a/docs/providers/ovh.md
+++ b/docs/providers/ovh.md
@@ -177,14 +177,16 @@ crabbox cleanup --provider ovh
 The repeatable live check is opt-in:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-ovh-smoke.sh
 ```
 
-The script builds `bin/crabbox`, reads OVH credentials and project settings from
-the environment, requires an empty Crabbox-owned OVH inventory, creates a small
-`b3-8` instance by default, waits for ready status, runs `echo ok`, verifies
-`list --json`, stops the lease, runs dry-run cleanup, and verifies the
-Crabbox-owned inventory is empty afterward.
+The top-level script dispatches to the provider-specific script. The
+provider-specific script builds `bin/crabbox` unless `CRABBOX_BIN` is set, reads
+OVH credentials and project settings from the environment, requires an empty
+Crabbox-owned OVH inventory, creates a small `b3-8` instance by default, waits
+for ready status, runs `echo ok`, verifies `list --json`, stops the lease, runs
+dry-run cleanup, and verifies the Crabbox-owned inventory is empty afterward.
 
 Optional smoke overrides:
 

--- a/scripts/live-ovh-smoke.sh
+++ b/scripts/live-ovh-smoke.sh
@@ -136,6 +136,7 @@ validate_doctor_inventory_empty() {
 
 cleanup_armed=0
 slug="ovh-smoke-$(date +%Y%m%d%H%M%S)-$$"
+crabbox_bin=""
 config_file=""
 
 cleanup() {
@@ -147,7 +148,7 @@ cleanup() {
     local cleanup_attempts="${CRABBOX_OVH_CLEANUP_ATTEMPTS:-65}"
     for ((attempt = 1; attempt <= cleanup_attempts; attempt++)); do
       set +e
-      cleanup_output="$(bin/crabbox stop --provider ovh "$slug" 2>&1)"
+      cleanup_output="$("$crabbox_bin" stop --provider ovh "$slug" 2>&1)"
       cleanup_status=$?
       set -e
       if [ "$cleanup_status" -eq 0 ]; then
@@ -159,7 +160,7 @@ cleanup() {
       fi
     done
     if [ "$cleanup_status" -ne 0 ]; then
-      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "bin/crabbox stop --provider ovh $slug" "$cleanup_status" "$slug" >&2
+      printf 'classification=cleanup_failed command=%q exit=%s slug=%s\n' "$crabbox_bin stop --provider ovh $slug" "$cleanup_status" "$slug" >&2
       printf '%s\n' "$cleanup_output" >&2
       if [ "$status" -eq 0 ]; then
         status="$cleanup_status"
@@ -207,7 +208,11 @@ if [[ -z "$ovh_region" ]]; then
 fi
 
 mkdir -p bin
-go build -trimpath -o bin/crabbox ./cmd/crabbox
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
 
 config_file="$(mktemp)"
 cat >"$config_file" <<YAML
@@ -227,23 +232,23 @@ export OVH_APPLICATION_KEY
 export OVH_APPLICATION_SECRET
 export OVH_CONSUMER_KEY
 
-doctor_output="$(run_capture "bin/crabbox doctor --provider ovh" bin/crabbox doctor --provider ovh)"
-validate_doctor_inventory_empty "bin/crabbox doctor --provider ovh" "$doctor_output"
+doctor_output="$(run_capture "$crabbox_bin doctor --provider ovh" "$crabbox_bin" doctor --provider ovh)"
+validate_doctor_inventory_empty "$crabbox_bin doctor --provider ovh" "$doctor_output"
 printf '%s\n' "$doctor_output"
-initial_list_output="$(run_capture "bin/crabbox list --provider ovh --json" bin/crabbox list --provider ovh --json)"
-validate_list_json_empty "bin/crabbox list --provider ovh --json" "$initial_list_output"
+initial_list_output="$(run_capture "$crabbox_bin list --provider ovh --json" "$crabbox_bin" list --provider ovh --json)"
+validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$initial_list_output"
 cleanup_armed=1
-run_capture "bin/crabbox warmup --provider ovh --slug $slug --keep --type $ovh_flavor --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider ovh --slug "$slug" --keep --type "$ovh_flavor" --ttl 20m --idle-timeout 5m >/dev/null
-run_capture "bin/crabbox status --provider ovh --id $slug --wait --wait-timeout 300s" bin/crabbox status --provider ovh --id "$slug" --wait --wait-timeout 300s >/dev/null
-run_capture "bin/crabbox run --provider ovh --id $slug --no-sync -- echo ok" bin/crabbox run --provider ovh --id "$slug" --no-sync -- echo ok >/dev/null
-list_output="$(run_capture "bin/crabbox list --provider ovh --json" bin/crabbox list --provider ovh --json)"
+run_capture "$crabbox_bin warmup --provider ovh --slug $slug --keep --type $ovh_flavor --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider ovh --slug "$slug" --keep --type "$ovh_flavor" --ttl 20m --idle-timeout 5m >/dev/null
+run_capture "$crabbox_bin status --provider ovh --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider ovh --id "$slug" --wait --wait-timeout 300s >/dev/null
+run_capture "$crabbox_bin run --provider ovh --id $slug --no-sync -- echo ok" "$crabbox_bin" run --provider ovh --id "$slug" --no-sync -- echo ok >/dev/null
+list_output="$(run_capture "$crabbox_bin list --provider ovh --json" "$crabbox_bin" list --provider ovh --json)"
 printf '%s\n' "$list_output"
-validate_list_json_contains_slug "bin/crabbox list --provider ovh --json" "$list_output"
-run_capture "bin/crabbox stop --provider ovh $slug" bin/crabbox stop --provider ovh "$slug" >/dev/null
+validate_list_json_contains_slug "$crabbox_bin list --provider ovh --json" "$list_output"
+run_capture "$crabbox_bin stop --provider ovh $slug" "$crabbox_bin" stop --provider ovh "$slug" >/dev/null
 cleanup_armed=0
 post_doctor_output=""
 for attempt in {1..30}; do
-  post_doctor_output="$(run_capture "bin/crabbox doctor --provider ovh" bin/crabbox doctor --provider ovh)"
+  post_doctor_output="$(run_capture "$crabbox_bin doctor --provider ovh" "$crabbox_bin" doctor --provider ovh)"
   if doctor_inventory_empty "$post_doctor_output"; then
     break
   fi
@@ -251,10 +256,10 @@ for attempt in {1..30}; do
     sleep 2
   fi
 done
-validate_doctor_inventory_empty "bin/crabbox doctor --provider ovh" "$post_doctor_output"
-cleanup_output="$(run_capture "bin/crabbox cleanup --provider ovh --dry-run" bin/crabbox cleanup --provider ovh --dry-run)"
-post_list_output="$(run_capture "bin/crabbox list --provider ovh --json" bin/crabbox list --provider ovh --json)"
-validate_list_json_empty "bin/crabbox list --provider ovh --json" "$post_list_output"
+validate_doctor_inventory_empty "$crabbox_bin doctor --provider ovh" "$post_doctor_output"
+cleanup_output="$(run_capture "$crabbox_bin cleanup --provider ovh --dry-run" "$crabbox_bin" cleanup --provider ovh --dry-run)"
+post_list_output="$(run_capture "$crabbox_bin list --provider ovh --json" "$crabbox_bin" list --provider ovh --json)"
+validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$post_list_output"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_doctor_output"
 printf '%s\n' "$post_list_output"

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -910,6 +910,10 @@ if has_provider nebius; then
   "$root/scripts/live-nebius-smoke.sh"
 fi
 
+if has_provider ovh; then
+  "$root/scripts/live-ovh-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1350,6 +1350,102 @@ esac
   assert.equal(seen[8], "list --provider nebius --json");
 });
 
+test("ovh live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-ovh-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+if [[ "\${OVH_APPLICATION_KEY:-}" != "ovh_app_fake" || "\${OVH_APPLICATION_SECRET:-}" != "ovh_secret_fake" || "\${OVH_CONSUMER_KEY:-}" != "ovh_consumer_fake" ]]; then
+  printf 'missing OVH auth\\n' >&2
+  exit 91
+fi
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready mutation=false leases=0 endpoint=https://api.us.ovhcloud.com/1.0 region=BHS5 image=Ubuntu 24.04 flavor=b3-8\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"},"provider":"ovh"}]\\n' "$slug"
+    fi
+    ;;
+  warmup)
+    requested_slug=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --slug)
+          requested_slug="\${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\\n' "$requested_slug" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'ok\\n'
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  cleanup)
+    printf 'skip server id=none name=none reason=missing labels\\n'
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "ovh",
+      OVH_APPLICATION_KEY: "ovh_app_fake",
+      OVH_APPLICATION_SECRET: "ovh_secret_fake",
+      OVH_CONSUMER_KEY: "ovh_consumer_fake",
+      CRABBOX_OVH_PROJECT_ID: "project-test",
+      CRABBOX_OVH_REGION: "BHS5",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_ovh_smoke_passed slug=ovh-smoke-/);
+  assert.doesNotMatch(result.stdout + result.stderr, /ovh_secret_fake|ovh_consumer_fake/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider ovh");
+  assert.equal(seen[1], "list --provider ovh --json");
+  assert.match(seen[2], /^warmup --provider ovh --slug ovh-smoke-\d{14}-\d+ --keep --type b3-8 --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider ovh --id ovh-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider ovh --id ovh-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.equal(seen[5], "list --provider ovh --json");
+  assert.match(seen[6], /^stop --provider ovh ovh-smoke-\d{14}-\d+$/);
+  assert.equal(seen[7], "doctor --provider ovh");
+  assert.equal(seen[8], "cleanup --provider ovh --dry-run");
+  assert.equal(seen[9], "list --provider ovh --json");
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- dispatch `CRABBOX_LIVE_PROVIDERS=ovh` from the guarded top-level live smoke matrix
- let `scripts/live-ovh-smoke.sh` honor `CRABBOX_BIN` for hermetic dispatch tests
- document the top-level OVH live smoke path in provider and operations docs

## Verification
- `node --test scripts/live-ovh-smoke.test.js scripts/live-smoke.test.js`
- `bash -n scripts/live-smoke.sh scripts/live-ovh-smoke.sh`
- `git diff --check`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`

Live OVH provider smoke was not run because this environment does not have OVH credentials/project quota.