### PR TITLE
feat(providers): add nvidia brev live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added DigitalOcean to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Nebius to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added OVHcloud to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added NVIDIA Brev to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -68,6 +68,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -100,6 +101,11 @@ Per-provider smoke prerequisites:
   empty Crabbox-owned OVH inventory, creates one short-lived `b3-8` instance by
   default, verifies status and `echo ok`, stops the lease, runs dry-run cleanup,
   and prints a final classification.
+- **NVIDIA Brev** — authenticated `brev` CLI on `PATH` plus enough GPU quota
+  and capacity for the selected workspace type. `scripts/live-nvidia-brev-smoke.sh`
+  is coordinator-free, creates one short-lived GPU workspace, verifies
+  `nvidia-smi`, deletes the workspace with `crabbox stop`, and prints a final
+  classification.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 

--- a/docs/providers/nvidia-brev.md
+++ b/docs/providers/nvidia-brev.md
@@ -256,13 +256,16 @@ The repository live smoke is intentionally separate from default CI because it
 can create a billable GPU workspace:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
 CRABBOX_NVIDIA_BREV_LIVE=1 scripts/live-nvidia-brev-smoke.sh
 ```
 
-The script builds or reuses `bin/crabbox`, runs `doctor`, creates one workspace
-with `--keep=false` so partial acquisition failures roll back, proves
-`nvidia-smi` through `crabbox run`, lists the lease, and then deletes the lease
-with `crabbox stop`. It prints a stable classification:
+The top-level script dispatches to the provider-specific script with
+`CRABBOX_NVIDIA_BREV_LIVE=1`. The provider-specific script builds or reuses
+`bin/crabbox`, runs `doctor`, creates one workspace with `--keep=false` so
+partial acquisition failures roll back, proves `nvidia-smi` through
+`crabbox run`, lists the lease, and then deletes the lease with `crabbox stop`.
+It prints a stable classification:
 
 - `live_nvidia_brev_smoke_passed` when the full GPU path passes;
 - `environment_blocked` for missing CLI/auth/configuration;

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -914,6 +914,10 @@ if has_provider ovh; then
   "$root/scripts/live-ovh-smoke.sh"
 fi
 
+if has_provider nvidia-brev || has_provider brev || has_provider nvidia; then
+  CRABBOX_NVIDIA_BREV_LIVE=1 "$root/scripts/live-nvidia-brev-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1446,6 +1446,86 @@ esac
   assert.equal(seen[9], "list --provider ovh --json");
 });
 
+test("nvidia brev live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nvidia-brev-dispatch-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  const slugFile = path.join(dir, "slug.txt");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$1" in
+  doctor)
+    printf 'auth=ready control_plane=ready inventory=ready leases=0 runtime=unchecked\\n'
+    ;;
+  list)
+    slug="$(cat "${slugFile}" 2>/dev/null || true)"
+    if [[ -z "$slug" || -f "${slugFile}.stopped" ]]; then
+      printf '[]\\n'
+    else
+      printf '[{"labels":{"slug":"%s"},"provider":"nvidia-brev"}]\\n' "$slug"
+    fi
+    ;;
+  warmup)
+    requested_slug=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --slug)
+          requested_slug="\${2:-}"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    printf '%s\\n' "$requested_slug" >"${slugFile}"
+    ;;
+  status)
+    printf 'status=ready\\n'
+    ;;
+  run)
+    printf 'NVIDIA-SMI 555.55.55\\n'
+    ;;
+  stop)
+    printf stopped >"${slugFile}.stopped"
+    ;;
+  *)
+    printf 'unexpected args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "nvidia-brev",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_nvidia_brev_smoke_passed slug=nbrev-smoke-/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen[0], "doctor --provider nvidia-brev --nvidia-brev-cli brev");
+  assert.equal(seen[1], "list --provider nvidia-brev --nvidia-brev-cli brev --json");
+  assert.match(seen[2], /^warmup --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --slug nbrev-smoke-\d+-\d+-[0-9a-f]{8} --keep=false --ttl 20m --idle-timeout 5m$/);
+  assert.match(seen[3], /^status --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/);
+  assert.match(seen[4], /^run --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- nvidia-smi$/);
+  assert.equal(seen[5], "list --provider nvidia-brev --nvidia-brev-cli brev --json");
+  assert.match(seen[6], /^stop --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete nbrev-smoke-\d+-\d+-[0-9a-f]{8}$/);
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- dispatch `CRABBOX_LIVE_PROVIDERS=nvidia-brev|brev|nvidia` from the guarded top-level live smoke matrix
- set `CRABBOX_NVIDIA_BREV_LIVE=1` only from the selected top-level provider path
- document the top-level NVIDIA Brev smoke path in provider and operations docs

## Verification
- `node --test scripts/live-nvidia-brev-smoke.test.js scripts/live-smoke.test.js`
- `bash -n scripts/live-smoke.sh scripts/live-nvidia-brev-smoke.sh`
- `git diff --check`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`

Live NVIDIA Brev provider smoke was not run because this environment does not have Brev GPU workspace access/quota.