### PR TITLE
feat(providers): add anthropic srt live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added Nebius to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added OVHcloud to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added NVIDIA Brev to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Anthropic Sandbox Runtime to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -69,6 +69,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -106,6 +107,10 @@ Per-provider smoke prerequisites:
   is coordinator-free, creates one short-lived GPU workspace, verifies
   `nvidia-smi`, deletes the workspace with `crabbox stop`, and prints a final
   classification.
+- **Anthropic Sandbox Runtime** — `srt` and `curl` on `PATH` plus host sandbox
+  support. `scripts/live-anthropic-sandbox-runtime-smoke.sh` is coordinator-free
+  and local-only; it verifies `doctor`, one-shot command execution, allowed
+  temp-file access, denied secret reads, and denied network access.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 

--- a/docs/providers/anthropic-sandbox-runtime.md
+++ b/docs/providers/anthropic-sandbox-runtime.md
@@ -136,11 +136,14 @@ rejected through delegated-provider validation.
 Run the scripted live proof on a host with SRT installed:
 
 ```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smoke.sh
 scripts/live-anthropic-sandbox-runtime-smoke.sh
 ```
 
-The script builds `bin/crabbox`, runs `doctor`, verifies a one-shot
-`echo ok`, then creates a temporary SRT settings file that:
+The top-level script dispatches to the provider-specific script. The
+provider-specific script builds `bin/crabbox` unless `CRABBOX_BIN` is set, runs
+`doctor`, verifies a one-shot `echo ok`, then creates a temporary SRT settings
+file that:
 
 - allows writing inside one temporary directory;
 - denies reading a temporary secret file;

--- a/scripts/live-anthropic-sandbox-runtime-smoke.sh
+++ b/scripts/live-anthropic-sandbox-runtime-smoke.sh
@@ -61,9 +61,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p bin
-rm -f bin/crabbox
-go build -trimpath -o bin/crabbox ./cmd/crabbox
+crabbox_bin="${CRABBOX_BIN:-bin/crabbox}"
+if [[ -z "${CRABBOX_BIN:-}" ]]; then
+  mkdir -p "$(dirname "$crabbox_bin")"
+  rm -f "$crabbox_bin"
+  go build -trimpath -o "$crabbox_bin" ./cmd/crabbox
+fi
 
 srt_cli="${CRABBOX_ANTHROPIC_SANDBOX_RUNTIME_CLI:-srt}"
 if ! command -v "$srt_cli" >/dev/null 2>&1; then
@@ -75,13 +78,13 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 127
 fi
 
-doctor_output="$(run_capture "bin/crabbox doctor --provider anthropic-sandbox-runtime" bin/crabbox doctor --provider anthropic-sandbox-runtime)"
+doctor_output="$(run_capture "$crabbox_bin doctor --provider anthropic-sandbox-runtime" "$crabbox_bin" doctor --provider anthropic-sandbox-runtime)"
 printf '%s\n' "$doctor_output"
 
-echo_output="$(run_capture "bin/crabbox run --provider anthropic-sandbox-runtime -- echo ok" bin/crabbox run --provider anthropic-sandbox-runtime -- echo ok)"
+echo_output="$(run_capture "$crabbox_bin run --provider anthropic-sandbox-runtime -- echo ok" "$crabbox_bin" run --provider anthropic-sandbox-runtime -- echo ok)"
 printf '%s\n' "$echo_output"
 if [[ "$echo_output" != *ok* ]]; then
-  classify_validation_failure "bin/crabbox run --provider anthropic-sandbox-runtime -- echo ok" 0 "echo smoke did not print ok"
+  classify_validation_failure "$crabbox_bin run --provider anthropic-sandbox-runtime -- echo ok" 0 "echo smoke did not print ok"
   exit 1
 fi
 
@@ -106,7 +109,7 @@ cat >"$settings" <<JSON
 JSON
 
 allowed_output="$(run_capture "bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings <settings> -- sh -lc <allowed-write-read>" \
-  bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- sh -lc "printf ok > '$allowed_file' && cat '$allowed_file'")"
+  "$crabbox_bin" run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- sh -lc "printf ok > '$allowed_file' && cat '$allowed_file'")"
 printf '%s\n' "$allowed_output"
 if [[ "$allowed_output" != *ok* ]]; then
   classify_validation_failure "allowed write/read" 0 "allowed write/read did not print ok"
@@ -115,10 +118,10 @@ fi
 
 expect_failure "bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings <settings> -- cat <denied-secret>" \
   "" \
-  bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- cat "$secret"
+  "$crabbox_bin" run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- cat "$secret"
 
 expect_failure "bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings <settings> -- curl https://example.com" \
   "" \
-  bin/crabbox run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- curl -sS --max-time 3 https://example.com
+  "$crabbox_bin" run --provider anthropic-sandbox-runtime --anthropic-sandbox-runtime-settings "$settings" -- curl -sS --max-time 3 https://example.com
 
 printf 'classification=live_anthropic_sandbox_runtime_smoke_passed cleanup=complete\n'

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -918,6 +918,10 @@ if has_provider nvidia-brev || has_provider brev || has_provider nvidia; then
   CRABBOX_NVIDIA_BREV_LIVE=1 "$root/scripts/live-nvidia-brev-smoke.sh"
 fi
 
+if has_provider anthropic-sandbox-runtime || has_provider srt; then
+  "$root/scripts/live-anthropic-sandbox-runtime-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1526,6 +1526,71 @@ esac
   assert.match(seen[6], /^stop --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete nbrev-smoke-\d+-\d+-[0-9a-f]{8}$/);
 });
 
+test("anthropic sandbox runtime live smoke dispatches to the provider-specific smoke", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-srt-dispatch-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "srt"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(path.join(bin, "curl"), "#!/usr/bin/env bash\nexit 0\n");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${calls}"
+case "$*" in
+  "doctor --provider anthropic-sandbox-runtime")
+    printf 'ok      srt_help provider=anthropic-sandbox-runtime mutation=false\\n'
+    ;;
+  "run --provider anthropic-sandbox-runtime -- echo ok")
+    printf 'ok\\n'
+    ;;
+  run\\ --provider\\ anthropic-sandbox-runtime\\ --anthropic-sandbox-runtime-settings*allowed*)
+    printf 'ok\\n'
+    ;;
+  run\\ --provider\\ anthropic-sandbox-runtime\\ --anthropic-sandbox-runtime-settings*cat*)
+    printf 'Operation not permitted\\n' >&2
+    exit 5
+    ;;
+  run\\ --provider\\ anthropic-sandbox-runtime\\ --anthropic-sandbox-runtime-settings*curl*)
+    printf 'Connection blocked by network allowlist\\n' >&2
+    exit 7
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", [path.join(repoRoot, "scripts", "live-smoke.sh")], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "anthropic-sandbox-runtime",
+      TMPDIR: dir,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_anthropic_sandbox_runtime_smoke_passed/);
+  assert.match(result.stderr, /Operation not permitted/);
+  assert.match(result.stderr, /Connection blocked by network allowlist/);
+  const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
+  assert.equal(seen.length, 5, JSON.stringify(seen));
+  assert.equal(seen[0], "doctor --provider anthropic-sandbox-runtime");
+  assert.equal(seen[1], "run --provider anthropic-sandbox-runtime -- echo ok");
+});
+
 test("multipass live smoke uses the generic SSH lease lifecycle", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-multipass-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- dispatch `CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime|srt` from the guarded top-level live smoke matrix
- let the Anthropic Sandbox Runtime smoke honor `CRABBOX_BIN` for hermetic dispatch tests
- document the top-level SRT live smoke path in provider and operations docs

## Verification
- `node --test scripts/live-anthropic-sandbox-runtime-smoke.test.js scripts/live-smoke.test.js`
- `bash -n scripts/live-smoke.sh scripts/live-anthropic-sandbox-runtime-smoke.sh`
- `git diff --check`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`

Live SRT provider smoke was not run against the real runtime because this environment does not have Anthropic Sandbox Runtime host setup available.