### PR TITLE
fix(smolvm): constrain credential redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### Fixed
 
+- Prevented SmolVM API credentials from following redirects outside the configured API origin while preserving same-origin redirects. Thanks @coygeek.
 - Made direct and brokered Azure Windows desktop leases converge on working SSH/SFTP, first-logon readiness, terminal extension state, retryable disk cleanup, and actionable bootstrap diagnostics. Thanks @fcoury-oai.
 
 ## 0.33.0 - 2026-06-22

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -214,6 +215,118 @@ func TestNewAPINormalizesBaseURL(t *testing.T) {
 	}
 	if c.base != "https://eu.smolmachines.com/base" {
 		t.Fatalf("base = %q, want normalized base URL", c.base)
+	}
+}
+
+func TestSmolvmClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s auth=%q", r.Method, r.URL.Path, r.Header.Get("Authorization"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	cfg := Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: trusted.URL}}
+	apiClient, err := newAPI(cfg, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = apiClient.ListMachines(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("ListMachines error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestSmolvmClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/machines":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedAuth = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode([]machineData{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}}
+	apiClient, err := newAPI(cfg, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := apiClient.ListMachines(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if redirectedAuth != "Bearer smk_key" {
+		t.Fatalf("redirected auth = %q", redirectedAuth)
+	}
+}
+
+func TestSmolvmClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	apiClient, err := newAPI(
+		Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}},
+		Runtime{HTTP: httpClient},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = apiClient.ListMachines(context.Background())
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("ListMachines error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
+func TestSameSmolvmOrigin(t *testing.T) {
+	base, err := url.Parse("https://api.smolmachines.com/v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "same origin", url: "https://api.smolmachines.com/redirected", want: true},
+		{name: "explicit default port", url: "https://api.smolmachines.com:443/redirected", want: true},
+		{name: "scheme downgrade", url: "http://api.smolmachines.com/redirected", want: false},
+		{name: "different port", url: "https://api.smolmachines.com:8443/redirected", want: false},
+		{name: "subdomain", url: "https://sub.api.smolmachines.com/redirected", want: false},
+		{name: "different host", url: "https://attacker.example/redirected", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			redirected, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := sameSmolvmOrigin(base, redirected); got != tc.want {
+				t.Fatalf("sameSmolvmOrigin(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -162,7 +163,48 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	if !trustedSmolvmAPIHost(parsed) && !customSmolvmBaseURLAllowed() {
 		return nil, exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
 	}
-	return &client{apiKey: apiKey, base: strings.TrimRight(parsed.String(), "/"), http: httpClient}, nil
+	base = strings.TrimRight(parsed.String(), "/")
+	return &client{apiKey: apiKey, base: base, http: secureSmolvmHTTPClient(httpClient, base)}, nil
+}
+
+func secureSmolvmHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameSmolvmOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameSmolvmOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveSmolvmPort(a) == effectiveSmolvmPort(b)
+}
+
+func effectiveSmolvmPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func trustedSmolvmAPIHost(parsed *url.URL) bool {


### PR DESCRIPTION
## Summary

- constrain SmolVM credential-bearing redirects to the configured API origin
- preserve same-origin redirects, caller-provided redirect policy, custom base URLs, and the standard redirect limit
- add HTTP redirect-chain regression coverage for blocked and allowed destinations

This is credential-destination hardening. It does not remove supported SmolVM endpoint or redirect functionality.

Closes https://github.com/openclaw/crabbox/issues/597

## Verification

- `go test ./internal/providers/smolvm`
- `go test -race -count=1 ./internal/providers/smolvm`
- real `httptest` redirect chain confirms an alternate-port destination receives zero requests
- same-origin redirect test confirms the bearer token and normal request continue to work
- caller redirect-policy test confirms the supplied hook still runs
- `go vet ./...`
- full `go test ./...` passed every package except one unrelated Windows WSL2 bootstrap test timeout; the exact test then passed 3/3 on immediate rerun
- Codex autoreview: clean, no accepted/actionable findings

No live SmolVM call is required for this redirect policy: a public endpoint does not provide a controlled hostile redirect, while the local HTTP E2E exercises the exact credential-forwarding boundary.
