### PR TITLE
feat(providers): add opensandbox live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added OVHcloud to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added NVIDIA Brev to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Anthropic Sandbox Runtime to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added OpenSandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -70,6 +70,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=opensandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -111,6 +112,11 @@ Per-provider smoke prerequisites:
   support. `scripts/live-anthropic-sandbox-runtime-smoke.sh` is coordinator-free
   and local-only; it verifies `doctor`, one-shot command execution, allowed
   temp-file access, denied secret reads, and denied network access.
+- **OpenSandbox** — `CRABBOX_OPENSANDBOX_API_KEY` or `OPEN_SANDBOX_API_KEY`,
+  plus `CRABBOX_OPENSANDBOX_API_URL` or `OPEN_SANDBOX_API_URL`.
+  `scripts/live-opensandbox-smoke.sh` is coordinator-free, proves archive sync,
+  off-argv environment forwarding, retained sandbox reuse, staged `sync.delete`
+  replacement, list/status, and cleanup.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 

--- a/docs/providers/opensandbox.md
+++ b/docs/providers/opensandbox.md
@@ -210,6 +210,12 @@ CRABBOX_OPENSANDBOX_API_URL=... \
 scripts/live-opensandbox-smoke.sh
 ```
 
+It can also be selected through the guarded top-level provider matrix:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=opensandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+```
+
 It prints exactly one classification:
 
 - `live_opensandbox_smoke_passed`

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -922,6 +922,10 @@ if has_provider anthropic-sandbox-runtime || has_provider srt; then
   "$root/scripts/live-anthropic-sandbox-runtime-smoke.sh"
 fi
 
+if has_provider opensandbox; then
+  "$root/scripts/live-opensandbox-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -12,6 +12,24 @@ function writeExecutable(file, body) {
   fs.chmodSync(file, 0o755);
 }
 
+test("OpenSandbox live smoke dispatches to the provider-specific script", () => {
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "opensandbox",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /environment_blocked missing CRABBOX_OPENSANDBOX_API_KEY or OPEN_SANDBOX_API_KEY/);
+  assert.match(result.stderr, /admin active-lease check skipped/);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route `CRABBOX_LIVE_PROVIDERS=opensandbox` through the guarded top-level live smoke matrix
- document the top-level OpenSandbox smoke invocation and prerequisites
- add a regression test for matrix dispatch without requiring live OpenSandbox credentials

## Verification
- `node --test scripts/live-smoke.test.js`
- `bash -n scripts/live-smoke.sh scripts/live-opensandbox-smoke.sh`
- `git diff --check`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`

Live OpenSandbox execution was not run because this environment does not have `CRABBOX_OPENSANDBOX_API_KEY` / `CRABBOX_OPENSANDBOX_API_URL`. The dispatch path is covered by the credentialless classification regression.