### PR TITLE
fix(providers): constrain credential redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### Fixed
 
+- Prevented E2B and Upstash Box credentials from following redirects outside each request's trusted origin while preserving same-origin redirects. Thanks @coygeek.
 - Prevented SmolVM API credentials from following redirects outside the configured API origin while preserving same-origin redirects. Thanks @coygeek.
 - Made direct and brokered Azure Windows desktop leases converge on working SSH/SFTP, first-logon readiness, terminal extension state, retryable disk cleanup, and actionable bootstrap diagnostics. Thanks @fcoury-oai.
 

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -307,6 +308,117 @@ func TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape(t *testing.T) {
 	}
 	if !deleteHit {
 		t.Fatal("delete endpoint was not called")
+	}
+}
+
+func TestE2BAPIClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s key=%q", r.Method, r.URL.Path, r.Header.Get("X-API-Key"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: trusted.URL}}, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.ListSandboxes(t.Context(), nil)
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("ListSandboxes error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestE2BEnvdClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s token=%q", r.Method, r.URL.Path, r.Header.Get("X-Access-Token"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+	trustedURL, err := url.Parse(trusted.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, trusted.URL+"/envd", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Access-Token", "envd-token")
+	resp, err := secureE2BHTTPClient(trusted.Client(), trustedURL).Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("envd request error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestE2BClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/sandboxes":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedKey = r.Header.Get("X-API-Key")
+			_ = json.NewEncoder(w).Encode([]e2bSandbox{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := api.ListSandboxes(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if redirectedKey != "e2b_test" {
+		t.Fatalf("redirected key = %q", redirectedKey)
+	}
+}
+
+func TestE2BClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = api.ListSandboxes(t.Context(), nil)
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("ListSandboxes error = %v, caller checks = %d", err, callerChecks)
 	}
 }
 

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -143,6 +144,45 @@ func isE2BLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+func secureE2BHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
+	client := *source
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameE2BOrigin(trusted, req.URL) {
+			return fmt.Errorf("e2b refused cross-origin redirect to %s", req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameE2BOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveE2BPort(a) == effectiveE2BPort(b)
+}
+
+func effectiveE2BPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
 func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {
 	body := map[string]any{
 		"templateID":            req.TemplateID,
@@ -263,7 +303,7 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 		}
 		_ = pw.Close()
 	}()
-	resp, err := c.httpClient.Do(req)
+	resp, err := secureE2BHTTPClient(c.httpClient, req.URL).Do(req)
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		_ = pw.CloseWithError(err)
@@ -317,7 +357,7 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
 		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := secureE2BHTTPClient(c.httpClient, httpReq.URL).Do(httpReq)
 	if err != nil {
 		return 1, err
 	}
@@ -356,7 +396,7 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := secureE2BHTTPClient(c.httpClient, req.URL).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -161,6 +161,83 @@ func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 	}
 }
 
+func TestClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
+	var targetRequests int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetRequests++
+		t.Errorf("redirect target received %s %s key=%q", r.Method, r.URL.Path, r.Header.Get("X-Box-Api-Key"))
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer target.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer trusted.Close()
+
+	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: trusted.URL}}, Runtime{HTTP: trusted.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = apiClient.ListBoxes(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("ListBoxes error = %v, want cross-origin refusal", err)
+	}
+	if targetRequests != 0 {
+		t.Fatalf("redirect target received %d requests, want 0", targetRequests)
+	}
+}
+
+func TestClientFollowsSameOriginRedirect(t *testing.T) {
+	var redirectedKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/box":
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+		case "/redirected":
+			redirectedKey = r.Header.Get("X-Box-Api-Key")
+			_ = json.NewEncoder(w).Encode([]boxData{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := apiClient.ListBoxes(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if redirectedKey != "box_key" {
+		t.Fatalf("redirected key = %q", redirectedKey)
+	}
+}
+
+func TestClientPreservesCallerRedirectPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	callerErr := errors.New("caller refused redirect")
+	callerChecks := 0
+	httpClient := server.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		callerChecks++
+		return callerErr
+	}
+	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, Runtime{HTTP: httpClient})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = apiClient.ListBoxes(t.Context())
+	if !errors.Is(err, callerErr) || callerChecks != 1 {
+		t.Fatalf("ListBoxes error = %v, caller checks = %d", err, callerChecks)
+	}
+}
+
 func TestClientRedactsAPIKeyFromErrors(t *testing.T) {
 	const apiKey = "box_secret_live_proof"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -73,7 +74,47 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 		httpClient = defaultUpstashBoxHTTPClient()
 	}
 	base := strings.TrimRight(blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com"), "/")
-	return &client{apiKey: apiKey, base: base, http: httpClient}, nil
+	return &client{apiKey: apiKey, base: base, http: secureUpstashBoxHTTPClient(httpClient, base)}, nil
+}
+
+func secureUpstashBoxHTTPClient(source *http.Client, apiURL string) *http.Client {
+	client := *source
+	trusted, _ := url.Parse(apiURL)
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameUpstashBoxOrigin(trusted, req.URL) {
+			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameUpstashBoxOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveUpstashBoxPort(a) == effectiveUpstashBoxPort(b)
+}
+
+func effectiveUpstashBoxPort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 func upstashBoxCleanupContext() (context.Context, context.CancelFunc) {


### PR DESCRIPTION
## Summary

- Harden E2B control-plane and per-sandbox envd requests against credential replay across origins.
- Harden Upstash Box API requests against credential replay across origins.
- Preserve same-origin redirects, custom endpoints, caller transports and timeouts, caller redirect hooks, and the standard 10-redirect limit.

This is compatibility-preserving hardening. It does not tighten endpoint configuration or change initial credential routing; it only refuses a redirect when scheme, hostname, or effective port changes.

## Verification

- `go test -count=1 ./internal/providers/e2b ./internal/providers/upstashbox`
- `go test -race -count=1 ./internal/providers/e2b ./internal/providers/upstashbox`
- `go vet ./...`
- Autoreview: clean, no accepted/actionable findings
- E2E redirect tests: real HTTP redirect chains verify cross-origin targets receive zero requests; same-origin redirects retain credentials
- Full `go test -count=1 ./...`: changed packages passed; unrelated Apple VZ timing and umask-sensitive CLI tests failed once, then each exact test passed 3/3 under `umask 022`

Closes https://github.com/openclaw/crabbox/issues/598
