### PR TITLE
feat(providers): add proxmox live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added NVIDIA Brev to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Anthropic Sandbox Runtime to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added OpenSandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Proxmox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,6 +71,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=opensandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=proxmox CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -117,6 +118,10 @@ Per-provider smoke prerequisites:
   `scripts/live-opensandbox-smoke.sh` is coordinator-free, proves archive sync,
   off-argv environment forwarding, retained sandbox reuse, staged `sync.delete`
   replacement, list/status, and cleanup.
+- **Proxmox** — a locally built Crabbox binary (`CRABBOX_BIN`), Proxmox API
+  credentials/config, and `jq`/`perl`. `scripts/proxmox-live-smoke.sh` is
+  coordinator-free and read-only by default; set `CRABBOX_PROXMOX_LIVE_SMOKE=1`
+  only after `doctor` is green to run the guarded warmup/status/ssh/stop proof.
 
 For a direct-provider smoke (no coordinator), disable the broker with a scratch config and run the same lease lifecycle manually:
 

--- a/docs/providers/proxmox.md
+++ b/docs/providers/proxmox.md
@@ -306,6 +306,13 @@ go build -trimpath -o bin/crabbox ./cmd/crabbox
 CRABBOX_BIN=./bin/crabbox scripts/proxmox-live-smoke.sh
 ```
 
+The same proof script can be selected through the guarded top-level live smoke
+matrix:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=proxmox CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
+```
+
 The read-only path runs `doctor --provider proxmox --json`, validates the JSON
 shape, runs `list --provider proxmox --json`, and writes raw plus redacted logs
 under a temporary proof directory. If you also set

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -926,6 +926,10 @@ if has_provider opensandbox; then
   "$root/scripts/live-opensandbox-smoke.sh"
 fi
 
+if has_provider proxmox; then
+  "$root/scripts/proxmox-live-smoke.sh"
+fi
+
 if has_provider blacksmith-testbox; then
   blacksmith_smoke
 fi

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -30,6 +30,61 @@ test("OpenSandbox live smoke dispatches to the provider-specific script", () => 
   assert.match(result.stderr, /admin active-lease check skipped/);
 });
 
+test("Proxmox live smoke dispatches to the provider-specific proof script", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-proxmox-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const proof = path.join(dir, "proof");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(proof, { mode: 0o700 });
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$1" in
+  config)
+    printf '{}\\n'
+    ;;
+  doctor)
+    printf '{"ok":true,"provider":"proxmox","checks":[]}\\n'
+    ;;
+  list)
+    printf '[]\\n'
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "proxmox",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_PROXMOX_LIVE_SMOKE_DIR: proof,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=external_user_owned/);
+  assert.match(result.stdout, /proof_dir=<proof-dir>/);
+  assert.match(result.stderr, /admin active-lease check skipped/);
+
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^doctor --provider proxmox --json$/m);
+  assert.match(calls, /^list --provider proxmox --json$/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- route `CRABBOX_LIVE_PROVIDERS=proxmox` through the guarded top-level live smoke matrix
- document the Proxmox top-level smoke invocation and prerequisites
- add a regression test proving the top-level matrix invokes the read-only Proxmox proof path without mutation

## Verification
- `node --test scripts/live-smoke.test.js scripts/proxmox-live-smoke.test.js`
- `bash -n scripts/live-smoke.sh scripts/proxmox-live-smoke.sh`
- `git diff --check`
- `scripts/check-docs.sh`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`

Live Proxmox mutation was not run because this environment does not have Proxmox provider credentials/config. The new top-level dispatch regression uses the existing read-only proof path and asserts no warmup/stop commands are issued.