### PR TITLE
fix(worker): revoke live viewers after share removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Fixed
 
+- Revoked active WebVNC and Code viewers when their lease share access is removed while preserving owner, admin, and still-authorized sessions. Thanks @coygeek.
 - Prevented E2B and Upstash Box credentials from following redirects outside each request's trusted origin while preserving same-origin redirects. Thanks @coygeek.
 - Prevented SmolVM API credentials from following redirects outside the configured API origin while preserving same-origin redirects. Thanks @coygeek.
 - Made direct and brokered Azure Windows desktop leases converge on working SSH/SFTP, first-logon readiness, terminal extension state, retryable disk cleanup, and actionable bootstrap diagnostics. Thanks @fcoury-oai.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -637,6 +637,8 @@ type BridgeAttachment =
       id: string;
       agentID: string;
       owner: string;
+      org?: string;
+      admin?: boolean;
       label: string;
     }
   | { kind: "code-agent"; leaseID: string }
@@ -645,6 +647,9 @@ type BridgeAttachment =
       leaseID: string;
       id: string;
       auth: AuthContext["auth"];
+      owner?: string;
+      org?: string;
+      admin?: boolean;
       portalSessionHash?: string;
     }
   | { kind: "egress-host"; leaseID: string; sessionID: string }
@@ -687,6 +692,8 @@ interface WebVNCViewerSession {
   agentID: string;
   socket: WebSocket;
   owner: string;
+  org?: string;
+  admin?: boolean;
   label: string;
   connectedAt: string;
 }
@@ -1041,7 +1048,7 @@ export class FleetCoordinator {
     const leases = await this.state.storage.list<LeaseRecord>({ prefix: "lease:" });
     const now = Date.now();
     const revoked = new Map<string, string>();
-    const revokedCodeViewers = new Map<WebSocket, string>();
+    const revokedViewers = new Map<WebSocket, string>();
     const codeViewersToCheck: Array<{ socket: WebSocket; portalSessionHash?: string }> = [];
     for (const socket of this.restoredLeaseBridgeSockets) {
       const attachment = this.bridgeAttachment(socket);
@@ -1054,6 +1061,14 @@ export class FleetCoordinator {
           attachment.leaseID,
           lease && leaseIsLive(lease) ? "lease expired" : "lease ended",
         );
+        continue;
+      }
+      if (
+        (attachment.kind === "webvnc-viewer" ||
+          (attachment.kind === "code-viewer" && completeBridgePrincipal(attachment))) &&
+        !this.leaseViewerAuthorized(lease, attachment)
+      ) {
+        revokedViewers.set(socket, "lease access revoked");
         continue;
       }
       if (attachment.kind === "code-viewer" && attachment.auth === "github") {
@@ -1075,7 +1090,7 @@ export class FleetCoordinator {
     );
     for (const { socket, revoked: portalSessionRevoked } of codeViewerRevocations) {
       if (portalSessionRevoked) {
-        revokedCodeViewers.set(socket, "portal session ended");
+        revokedViewers.set(socket, "portal session ended");
       }
     }
     for (const [leaseID, reason] of revoked) {
@@ -1089,13 +1104,15 @@ export class FleetCoordinator {
         closeSocket(socket, 1008, reason);
       }
     }
-    for (const [socket, reason] of revokedCodeViewers) {
+    for (const [socket, reason] of revokedViewers) {
       const attachment = this.bridgeAttachment(socket);
-      if (attachment?.kind !== "code-viewer") {
-        continue;
+      if (attachment?.kind === "webvnc-viewer") {
+        this.clearWebVNCViewer(attachment.leaseID, attachment.id, socket);
+        closeSocket(socket, 1008, reason);
+      } else if (attachment?.kind === "code-viewer") {
+        this.clearCodeViewer(attachment.leaseID, attachment.id, socket, 1008, reason);
+        closeSocket(socket, 1008, reason);
       }
-      this.clearCodeViewer(attachment.leaseID, attachment.id, socket, 1008, reason);
-      closeSocket(socket, 1008, reason);
     }
     this.restoredLeaseBridgeSockets.clear();
   }
@@ -1186,6 +1203,8 @@ export class FleetCoordinator {
           agentID: attachment.agentID,
           socket,
           owner: attachment.owner,
+          ...(attachment.org ? { org: attachment.org } : {}),
+          ...(attachment.admin !== undefined ? { admin: attachment.admin } : {}),
           label: attachment.label,
           connectedAt: new Date().toISOString(),
         });
@@ -4329,12 +4348,14 @@ export class FleetCoordinator {
     }
     if (method === "PUT") {
       const input = await readJson<Partial<LeaseShare>>(request);
+      const previousShare = normalizedLeaseShare(lease.share);
       lease.share = sanitizeLeaseShare(input, requestOwner(request));
       lease.updatedAt = new Date().toISOString();
-      await this.putLease(lease);
+      await this.putLeaseShareAndRevokeViewers(lease, previousShare);
       return json({ leaseID: lease.id, share: normalizedLeaseShare(lease.share) });
     }
     if (method === "DELETE") {
+      const previousShare = normalizedLeaseShare(lease.share);
       const input = await optionalJson<{ user?: string; org?: boolean }>(request);
       const share = normalizedLeaseShare(lease.share);
       const user = normalizeShareUser(input.user);
@@ -4350,10 +4371,73 @@ export class FleetCoordinator {
         lease.share = sanitizeLeaseShare(share, requestOwner(request));
       }
       lease.updatedAt = new Date().toISOString();
-      await this.putLease(lease);
+      await this.putLeaseShareAndRevokeViewers(lease, previousShare);
       return json({ leaseID: lease.id, share: normalizedLeaseShare(lease.share) });
     }
     return json({ error: "not_found" }, { status: 404 });
+  }
+
+  private async putLeaseShareAndRevokeViewers(
+    lease: LeaseRecord,
+    previousShare: NormalizedLeaseShare,
+  ): Promise<void> {
+    await this.withBridgeTicketLock(async () => {
+      await this.putLease(lease);
+      if (leaseShareAccessShrank(previousShare, normalizedLeaseShare(lease.share))) {
+        this.revokeUnauthorizedLeaseViewers(lease);
+      }
+    });
+  }
+
+  private revokeUnauthorizedLeaseViewers(lease: LeaseRecord): void {
+    const code = 1008;
+    const reason = "lease access revoked";
+    for (const viewer of this.openWebVNCViewers(lease.id)) {
+      if (this.leaseViewerAuthorized(lease, viewer)) {
+        continue;
+      }
+      this.clearWebVNCViewer(lease.id, viewer.id, viewer.socket);
+      closeSocket(viewer.socket, code, reason);
+    }
+    for (const [id, viewer] of this.codeViewers) {
+      const attachment = this.bridgeAttachment(viewer);
+      if (
+        attachment?.kind !== "code-viewer" ||
+        attachment.leaseID !== lease.id ||
+        !completeBridgePrincipal(attachment) ||
+        this.leaseViewerAuthorized(lease, attachment)
+      ) {
+        continue;
+      }
+      this.clearCodeViewer(lease.id, id, viewer, code, reason);
+      closeSocket(viewer, code, reason);
+    }
+  }
+
+  private leaseViewerAuthorized(
+    lease: LeaseRecord,
+    principal: { owner?: string; org?: string; admin?: boolean },
+  ): boolean {
+    if (principal.admin === true) {
+      return true;
+    }
+    if (principal.owner && principal.org) {
+      return (
+        this.leaseAccessRoleForPrincipal(lease, {
+          owner: principal.owner,
+          org: principal.org,
+          admin: false,
+        }) !== undefined
+      );
+    }
+    if (!principal.owner) {
+      return false;
+    }
+    // Restored pre-hardening WebVNC attachments have no org binding.
+    return (
+      principal.owner === lease.owner ||
+      normalizedLeaseShare(lease.share).users[normalizeShareUser(principal.owner)] !== undefined
+    );
   }
 
   private whoami(request: Request): Response {
@@ -5504,9 +5588,10 @@ export class FleetCoordinator {
     const url = new URL(request.url);
     if (request.headers.get("content-type")?.includes("application/json")) {
       const input = await readJson<Partial<LeaseShare>>(request);
+      const previousShare = normalizedLeaseShare(lease.share);
       lease.share = sanitizeLeaseShare(input, requestOwner(request));
       lease.updatedAt = new Date().toISOString();
-      await this.putLease(lease);
+      await this.putLeaseShareAndRevokeViewers(lease, previousShare);
       return json({
         leaseID: lease.id,
         slug: lease.slug || lease.id,
@@ -5517,6 +5602,7 @@ export class FleetCoordinator {
     }
     const form = await request.formData();
     const action = String(form.get("action") || "");
+    const previousShare = normalizedLeaseShare(lease.share);
     const share = normalizedLeaseShare(lease.share);
     if (action === "add-user") {
       const user = normalizeShareUser(String(form.get("user") || ""));
@@ -5542,7 +5628,7 @@ export class FleetCoordinator {
     }
     lease.share = sanitizeLeaseShare(share, requestOwner(request));
     lease.updatedAt = new Date().toISOString();
-    await this.putLease(lease);
+    await this.putLeaseShareAndRevokeViewers(lease, previousShare);
     const embedded = url.searchParams.get("embed") === "1";
     return new Response(null, {
       status: 303,
@@ -7160,6 +7246,10 @@ export class FleetCoordinator {
     portalSessionHash?: string,
   ): Promise<Response> {
     return await this.withBridgeTicketLock(async () => {
+      const currentLease = await this.resolvePortalLease(lease.id, request);
+      if (!currentLease) {
+        return notFound();
+      }
       if (
         (auth === "github" && !validPortalSessionHash(portalSessionHash)) ||
         (portalSessionHash && (await this.codeViewerPortalSessionRevoked(portalSessionHash)))
@@ -7178,6 +7268,9 @@ export class FleetCoordinator {
         leaseID: lease.id,
         id,
         auth,
+        owner: requestOwner(request),
+        org: requestOrg(request, this.env),
+        admin: isAdminRequest(request),
         ...(portalSessionHash ? { portalSessionHash } : {}),
       });
       const url = new URL(request.url);
@@ -7471,63 +7564,71 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    const lease = await this.resolvePortalLease(identifier, request);
-    if (!lease) {
-      return notFound();
-    }
-    const error = webVNCLeaseError(lease);
-    if (error) {
-      return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
-    }
-    const agent = this.claimIdleWebVNCAgent(lease.id);
-    if (!agent) {
-      const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
-      const command = canManage ? webVNCBridgeCommand(lease) : "";
-      return json(
-        {
-          error: "webvnc_bridge_missing",
-          message: canManage
-            ? `No WebVNC backend is available yet; start or refresh the bridge with: ${command}`
-            : "No WebVNC backend is available yet; ask a lease manager to start or refresh the bridge.",
-          command,
-        },
-        { status: 409 },
-      );
-    }
-    const url = new URL(request.url);
-    const requestedViewerID = url.searchParams.get("viewer") || "";
-    const viewerID = validWebVNCSessionID(requestedViewerID)
-      ? requestedViewerID
-      : newWebVNCSessionID("viewer");
+    return await this.withBridgeTicketLock(async () => {
+      const lease = await this.resolvePortalLease(identifier, request);
+      if (!lease) {
+        return notFound();
+      }
+      const error = webVNCLeaseError(lease);
+      if (error) {
+        return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
+      }
+      const agent = this.claimIdleWebVNCAgent(lease.id);
+      if (!agent) {
+        const canManage = this.leaseManageableByRequest(lease, request, isAdminRequest(request));
+        const command = canManage ? webVNCBridgeCommand(lease) : "";
+        return json(
+          {
+            error: "webvnc_bridge_missing",
+            message: canManage
+              ? `No WebVNC backend is available yet; start or refresh the bridge with: ${command}`
+              : "No WebVNC backend is available yet; ask a lease manager to start or refresh the bridge.",
+            command,
+          },
+          { status: 409 },
+        );
+      }
+      const url = new URL(request.url);
+      const requestedViewerID = url.searchParams.get("viewer") || "";
+      const viewerID = validWebVNCSessionID(requestedViewerID)
+        ? requestedViewerID
+        : newWebVNCSessionID("viewer");
 
-    const upgrade = this.state.createWebSocketUpgrade();
-    const viewer = upgrade.socket;
-    const owner = requestOwner(request);
-    const label = webVNCViewerLabel(owner);
+      const upgrade = this.state.createWebSocketUpgrade();
+      const viewer = upgrade.socket;
+      const owner = requestOwner(request);
+      const org = requestOrg(request, this.env);
+      const admin = isAdminRequest(request);
+      const label = webVNCViewerLabel(owner);
 
-    this.trackWebVNCViewer(lease.id, {
-      id: viewerID,
-      agentID: agent.id,
-      socket: viewer,
-      owner,
-      label,
-      connectedAt: new Date().toISOString(),
+      this.trackWebVNCViewer(lease.id, {
+        id: viewerID,
+        agentID: agent.id,
+        socket: viewer,
+        owner,
+        org,
+        admin,
+        label,
+        connectedAt: new Date().toISOString(),
+      });
+      if (!this.activeWebVNCControllerID(lease.id)) {
+        this.webVNCControllers.set(lease.id, viewerID);
+        this.recordWebVNCEvent(lease.id, "control_taken", `${label} is controlling`);
+      }
+      this.recordWebVNCEvent(lease.id, "viewer_connected", label);
+      this.acceptBridgeWebSocket(viewer, {
+        kind: "webvnc-viewer",
+        leaseID: lease.id,
+        id: viewerID,
+        agentID: agent.id,
+        owner,
+        org,
+        admin,
+        label,
+      });
+      flushPendingWebVNC(this.pendingWebVNCToViewer, webVNCBufferKey(lease.id, agent.id), viewer);
+      return upgrade.response;
     });
-    if (!this.activeWebVNCControllerID(lease.id)) {
-      this.webVNCControllers.set(lease.id, viewerID);
-      this.recordWebVNCEvent(lease.id, "control_taken", `${label} is controlling`);
-    }
-    this.recordWebVNCEvent(lease.id, "viewer_connected", label);
-    this.acceptBridgeWebSocket(viewer, {
-      kind: "webvnc-viewer",
-      leaseID: lease.id,
-      id: viewerID,
-      agentID: agent.id,
-      owner,
-      label,
-    });
-    flushPendingWebVNC(this.pendingWebVNCToViewer, webVNCBufferKey(lease.id, agent.id), viewer);
-    return upgrade.response;
   }
 
   private clearWebVNCAgent(leaseID: string, agentID: string, socket: WebSocket): void {
@@ -10316,15 +10417,23 @@ export class FleetCoordinator {
     request: Request,
     admin: boolean,
   ): "owner" | LeaseShareRole | undefined {
-    if (
-      admin ||
-      (lease.owner === requestOwner(request) && lease.org === requestOrg(request, this.env))
-    ) {
+    return this.leaseAccessRoleForPrincipal(lease, {
+      owner: requestOwner(request),
+      org: requestOrg(request, this.env),
+      admin,
+    });
+  }
+
+  private leaseAccessRoleForPrincipal(
+    lease: LeaseRecord,
+    principal: { owner: string; org: string; admin: boolean },
+  ): "owner" | LeaseShareRole | undefined {
+    if (principal.admin || (lease.owner === principal.owner && lease.org === principal.org)) {
       return "owner";
     }
     const share = normalizedLeaseShare(lease.share);
-    const userRole = share.users[normalizeShareUser(requestOwner(request))];
-    const orgRole = lease.org === requestOrg(request, this.env) ? share.org : undefined;
+    const userRole = share.users[normalizeShareUser(principal.owner)];
+    const orgRole = lease.org === principal.org ? share.org : undefined;
     if (userRole === "manage" || orgRole === "manage") {
       return "manage";
     }
@@ -12968,6 +13077,7 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
         validWebVNCSessionID(attachment.id) &&
         validWebVNCSessionID(attachment.agentID) &&
         typeof attachment.owner === "string" &&
+        validOptionalBridgePrincipal(attachment) &&
         typeof attachment.label === "string"
         ? attachment
         : undefined;
@@ -12993,6 +13103,7 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
       return (attachment.auth === "bearer" ||
         attachment.auth === "github" ||
         attachment.auth === "proxy") &&
+        validOptionalBridgePrincipal(attachment) &&
         (attachment.auth !== "github" || validPortalSessionHash(attachment.portalSessionHash))
         ? attachment
         : undefined;
@@ -13024,6 +13135,31 @@ function bridgeAttachment(value: unknown): BridgeAttachment | undefined {
     default:
       return undefined;
   }
+}
+
+function validOptionalBridgePrincipal(value: {
+  owner?: unknown;
+  org?: unknown;
+  admin?: unknown;
+}): boolean {
+  const absent = value.org === undefined && value.admin === undefined;
+  const complete =
+    typeof value.owner === "string" &&
+    typeof value.org === "string" &&
+    typeof value.admin === "boolean";
+  return absent || complete;
+}
+
+function completeBridgePrincipal(value: {
+  owner?: unknown;
+  org?: unknown;
+  admin?: unknown;
+}): value is { owner: string; org: string; admin: boolean } {
+  return (
+    typeof value.owner === "string" &&
+    typeof value.org === "string" &&
+    typeof value.admin === "boolean"
+  );
 }
 
 function bridgeTags(attachment: BridgeAttachment): string[] {
@@ -14074,6 +14210,16 @@ function normalizedLeaseShare(share: LeaseShare | undefined): NormalizedLeaseSha
     normalized.updatedBy = share.updatedBy;
   }
   return normalized;
+}
+
+function leaseShareAccessShrank(
+  previous: NormalizedLeaseShare,
+  current: NormalizedLeaseShare,
+): boolean {
+  if (previous.org && !current.org) {
+    return true;
+  }
+  return Object.keys(previous.users).some((user) => current.users[user] === undefined);
 }
 
 function sanitizeLeaseShare(input: Partial<LeaseShare>, updatedBy: string): LeaseShare | undefined {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -276,6 +276,102 @@ describe("runtime adapter relay", () => {
     expect(agent.sentJSON()).toHaveLength(2);
   });
 
+  it("reconciles hibernated viewer principals against the current lease share", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_000000000001",
+      provider: "external",
+      lifecycle: "registered",
+      state: "active",
+      owner: "owner@example.com",
+      org: "example-org",
+      share: { users: { "retained@example.com": "use" } },
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+    const revokedCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code-revoked",
+      auth: "bearer",
+      owner: "revoked@example.com",
+      org: "other-org",
+      admin: false,
+    });
+    const ownerCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID: lease.id,
+      id: "code-owner",
+      auth: "bearer",
+      owner: "owner@example.com",
+      org: "example-org",
+      admin: false,
+    });
+    const revokedWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_revoked",
+      capabilities: new Set<string>(),
+    });
+    const revokedWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_revoked",
+      agentID: "agent_revoked",
+      owner: "revoked@example.com",
+      label: "revoked@example.com",
+    });
+    const retainedWebAgent = new FakeWebSocket({
+      kind: "webvnc-agent",
+      leaseID: lease.id,
+      id: "agent_retained",
+      capabilities: new Set<string>(),
+    });
+    const retainedWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID: lease.id,
+      id: "viewer_retained",
+      agentID: "agent_retained",
+      owner: "owner@example.com",
+      label: "owner@example.com",
+    });
+    const fleet = new FleetDurableObject(
+      {
+        storage,
+        getWebSockets: () =>
+          [
+            codeAgent,
+            revokedCodeViewer,
+            ownerCodeViewer,
+            revokedWebAgent,
+            revokedWebViewer,
+            retainedWebAgent,
+            retainedWebViewer,
+          ] as unknown as WebSocket[],
+      } as unknown as DurableObjectState,
+      { CRABBOX_DEFAULT_ORG: "default-org" } as Env,
+    );
+
+    expect((await fleet.fetch(request("GET", "/v1/health"))).status).toBe(200);
+    expect(revokedCodeViewer.closeCode).toBe(1008);
+    expect(revokedCodeViewer.closeReason).toBe("lease access revoked");
+    expect(ownerCodeViewer.closeCode).toBeUndefined();
+    expect(revokedWebViewer.closeCode).toBe(1008);
+    expect(revokedWebViewer.closeReason).toBe("lease access revoked");
+    expect(revokedWebAgent.closeCode).toBe(1011);
+    expect(retainedWebViewer.closeCode).toBeUndefined();
+    expect(retainedWebAgent.closeCode).toBeUndefined();
+    expect(codeAgent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: "code-revoked",
+        code: 1008,
+        reason: "lease access revoked",
+      },
+    ]);
+  });
+
   it("fails closed ambiguous and invalid hibernated bridge sockets", () => {
     const storage = new MemoryStorage();
     const list = vi.spyOn(storage, "list");
@@ -7746,6 +7842,312 @@ describe("fleet lease identity and idle", () => {
       request("GET", "/v1/leases/blue-lobster", { headers: strangerHeaders }),
     );
     expect(stranger.status).toBe(404);
+  });
+
+  it("revokes only unauthorized live viewers after an API share removal", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000001";
+    const ownerHeaders = {
+      "x-crabbox-owner": "owner@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "shared-live-viewers",
+        owner: "owner@example.com",
+        org: "example-org",
+        desktop: true,
+        code: true,
+        share: {
+          users: {
+            "revoked@example.com": "use",
+            "retained@example.com": "use",
+          },
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    const revokedWebAgent = new FakeWebSocket();
+    const retainedWebAgent = new FakeWebSocket();
+    const ownerWebAgent = new FakeWebSocket();
+    const revokedWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_revoked",
+      agentID: "agent_revoked",
+      owner: "revoked@example.com",
+      org: "other-org",
+      admin: false,
+      label: "revoked@example.com",
+    });
+    const retainedWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_retained",
+      agentID: "agent_retained",
+      owner: "retained@example.com",
+      org: "other-org",
+      admin: false,
+      label: "retained@example.com",
+    });
+    const ownerWebViewer = new FakeWebSocket({
+      kind: "webvnc-viewer",
+      leaseID,
+      id: "viewer_owner",
+      agentID: "agent_owner",
+      owner: "owner@example.com",
+      org: "example-org",
+      admin: false,
+      label: "owner@example.com",
+    });
+    const revokedCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-revoked",
+      auth: "bearer",
+      owner: "revoked@example.com",
+      org: "other-org",
+      admin: false,
+    });
+    const retainedCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-retained",
+      auth: "bearer",
+      owner: "retained@example.com",
+      org: "other-org",
+      admin: false,
+    });
+    const ownerCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-owner",
+      auth: "bearer",
+      owner: "owner@example.com",
+      org: "example-org",
+      admin: false,
+    });
+    const adminCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-admin",
+      auth: "bearer",
+      owner: "admin@example.com",
+      org: "other-org",
+      admin: true,
+    });
+    const legacyCodeViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-legacy",
+      auth: "github",
+      portalSessionHash: "a".repeat(64),
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const relay = fleet as unknown as {
+      webVNCAgents: Map<string, Map<string, WebSocket>>;
+      webVNCViewers: Map<
+        string,
+        Map<
+          string,
+          {
+            id: string;
+            agentID: string;
+            socket: WebSocket;
+            owner: string;
+            org?: string;
+            admin?: boolean;
+            label: string;
+            connectedAt: string;
+          }
+        >
+      >;
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+    };
+    relay.webVNCAgents.set(
+      leaseID,
+      new Map([
+        ["agent_revoked", revokedWebAgent as unknown as WebSocket],
+        ["agent_retained", retainedWebAgent as unknown as WebSocket],
+        ["agent_owner", ownerWebAgent as unknown as WebSocket],
+      ]),
+    );
+    relay.webVNCViewers.set(
+      leaseID,
+      new Map([
+        [
+          "viewer_revoked",
+          {
+            id: "viewer_revoked",
+            agentID: "agent_revoked",
+            socket: revokedWebViewer as unknown as WebSocket,
+            owner: "revoked@example.com",
+            org: "other-org",
+            admin: false,
+            label: "revoked@example.com",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+        [
+          "viewer_retained",
+          {
+            id: "viewer_retained",
+            agentID: "agent_retained",
+            socket: retainedWebViewer as unknown as WebSocket,
+            owner: "retained@example.com",
+            org: "other-org",
+            admin: false,
+            label: "retained@example.com",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+        [
+          "viewer_owner",
+          {
+            id: "viewer_owner",
+            agentID: "agent_owner",
+            socket: ownerWebViewer as unknown as WebSocket,
+            owner: "owner@example.com",
+            org: "example-org",
+            admin: false,
+            label: "owner@example.com",
+            connectedAt: new Date().toISOString(),
+          },
+        ],
+      ]),
+    );
+    relay.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+    relay.codeViewers.set("code-revoked", revokedCodeViewer as unknown as WebSocket);
+    relay.codeViewers.set("code-retained", retainedCodeViewer as unknown as WebSocket);
+    relay.codeViewers.set("code-owner", ownerCodeViewer as unknown as WebSocket);
+    relay.codeViewers.set("code-admin", adminCodeViewer as unknown as WebSocket);
+    relay.codeViewers.set("code-legacy", legacyCodeViewer as unknown as WebSocket);
+
+    const removed = await fleet.fetch(
+      request("DELETE", "/v1/leases/shared-live-viewers/share", {
+        headers: ownerHeaders,
+        body: { user: "revoked@example.com" },
+      }),
+    );
+    expect(removed.status).toBe(200);
+    expect(revokedWebViewer.closeCode).toBe(1008);
+    expect(revokedWebViewer.closeReason).toBe("lease access revoked");
+    expect(revokedWebAgent.closeCode).toBe(1011);
+    expect(retainedWebViewer.closeCode).toBeUndefined();
+    expect(ownerWebViewer.closeCode).toBeUndefined();
+    expect(relay.webVNCViewers.get(leaseID)?.has("viewer_revoked")).toBe(false);
+    expect(relay.webVNCViewers.get(leaseID)?.has("viewer_retained")).toBe(true);
+    expect(relay.webVNCViewers.get(leaseID)?.has("viewer_owner")).toBe(true);
+
+    expect(revokedCodeViewer.closeCode).toBe(1008);
+    expect(revokedCodeViewer.closeReason).toBe("lease access revoked");
+    expect(retainedCodeViewer.closeCode).toBeUndefined();
+    expect(ownerCodeViewer.closeCode).toBeUndefined();
+    expect(adminCodeViewer.closeCode).toBeUndefined();
+    expect(legacyCodeViewer.closeCode).toBeUndefined();
+    expect(relay.codeViewers.has("code-revoked")).toBe(false);
+    expect(relay.codeViewers.has("code-retained")).toBe(true);
+    expect(relay.codeViewers.has("code-owner")).toBe(true);
+    expect(relay.codeViewers.has("code-admin")).toBe(true);
+    expect(relay.codeViewers.has("code-legacy")).toBe(true);
+    expect(codeAgent.sentJSON()).toEqual([
+      {
+        type: "ws_close",
+        id: "code-revoked",
+        code: 1008,
+        reason: "lease access revoked",
+      },
+    ]);
+
+    await fleet.webSocketMessage(
+      retainedCodeViewer as unknown as WebSocket,
+      JSON.stringify({ retained: true }),
+    );
+    expect(codeAgent.sentJSON()).toHaveLength(2);
+    expect(codeAgent.sentJSON()[1]).toMatchObject({ type: "ws_data", id: "code-retained" });
+    await fleet.webSocketMessage(
+      retainedWebViewer as unknown as WebSocket,
+      JSON.stringify({ retained: true }),
+    );
+    expect(retainedWebAgent.sentJSON()).toEqual([{ retained: true }]);
+  });
+
+  it("revokes org-only live viewers after a portal share update", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const leaseID = "cbx_000000000001";
+    storage.seed(
+      `lease:${leaseID}`,
+      testLease({
+        id: leaseID,
+        slug: "portal-share-viewers",
+        owner: "owner@example.com",
+        org: "example-org",
+        code: true,
+        share: {
+          users: { "explicit@example.com": "use" },
+          org: "use",
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const orgViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-org",
+      auth: "bearer",
+      owner: "org-viewer@example.com",
+      org: "example-org",
+      admin: false,
+    });
+    const explicitViewer = new FakeWebSocket({
+      kind: "code-viewer",
+      leaseID,
+      id: "code-explicit",
+      auth: "bearer",
+      owner: "explicit@example.com",
+      org: "other-org",
+      admin: false,
+    });
+    const codeAgent = new FakeWebSocket({ kind: "code-agent", leaseID });
+    const relay = fleet as unknown as {
+      codeAgents: Map<string, WebSocket>;
+      codeViewers: Map<string, WebSocket>;
+    };
+    relay.codeAgents.set(leaseID, codeAgent as unknown as WebSocket);
+    relay.codeViewers.set("code-org", orgViewer as unknown as WebSocket);
+    relay.codeViewers.set("code-explicit", explicitViewer as unknown as WebSocket);
+
+    const updated = await fleet.fetch(
+      request("POST", "/portal/leases/portal-share-viewers/share?format=json", {
+        headers: {
+          "x-crabbox-owner": "owner@example.com",
+          "x-crabbox-org": "example-org",
+        },
+        body: { users: { "explicit@example.com": "use" } },
+      }),
+    );
+    expect(updated.status).toBe(200);
+    expect(orgViewer.closeCode).toBe(1008);
+    expect(orgViewer.closeReason).toBe("lease access revoked");
+    expect(explicitViewer.closeCode).toBeUndefined();
+    expect(relay.codeViewers.has("code-org")).toBe(false);
+    expect(relay.codeViewers.has("code-explicit")).toBe(true);
+
+    const revokedPage = await fleet.fetch(
+      request("GET", "/portal/leases/portal-share-viewers/code/", {
+        headers: {
+          "x-crabbox-owner": "org-viewer@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(revokedPage.status).toBe(404);
   });
 
   it("requires manage access for shared lease heartbeat and Tailscale metadata updates", async () => {


### PR DESCRIPTION
## Summary

- Bind WebVNC and Code viewer sockets to their authenticated owner, org, and admin principal.
- Serialize viewer attachment with lease-share persistence, then close only viewers that no longer have current lease access.
- Reconcile principal-bound hibernated sockets against the current share and re-authorize Code attachment inside the lock.
- Preserve lease-owner, admin, explicit-user, surviving org-share, share-expansion, and `manage`/`use` sessions.

This is compatibility-preserving hardening. Pre-hardening WebVNC attachments use an owner-only fallback during restoration. Pre-hardening Code attachments lack a recoverable principal and remain under their existing portal-session revocation behavior; newly attached Code sockets are principal-bound and precisely revocable.

## Verification

- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm test --prefix worker`: 650 passed
- `npm run build --prefix worker`: Wrangler dry-run passed
- Route-to-socket regressions cover API user removal, portal org-share removal, retained frame forwarding, Code agent close notification, and hibernated viewer reconciliation.
- Autoreview: clean after resolving findings for legacy restored WebVNC authorization and legacy Code compatibility.

Closes https://github.com/openclaw/crabbox/issues/604
