### PR TITLE
feat(providers): add phala live smoke dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added Nebius to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added OVHcloud to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added NVIDIA Brev to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Phala to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Anthropic Sandbox Runtime to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added OpenSandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Proxmox to the guarded `scripts/live-smoke.sh` provider smoke matrix.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -69,6 +69,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=ovh scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nvidia-brev scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=phala CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=opensandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=proxmox CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
@@ -110,6 +111,11 @@ Per-provider smoke prerequisites:
   is coordinator-free, creates one short-lived GPU workspace, verifies
   `nvidia-smi`, deletes the workspace with `crabbox stop`, and prints a final
   classification.
+- **Phala** — authenticated `phala` CLI on `PATH` (or `CRABBOX_PHALA_CLI`),
+  Phala auth, and enough confidential CVM quota. `scripts/live-phala-smoke.sh`
+  is coordinator-free, classifies missing auth/quota before or during
+  provisioning, verifies sync/env forwarding on a tiny Git fixture, and
+  hard-deletes any created CVM on failure.
 - **Anthropic Sandbox Runtime** — `srt` and `curl` on `PATH` plus host sandbox
   support. `scripts/live-anthropic-sandbox-runtime-smoke.sh` is coordinator-free
   and local-only; it verifies `doctor`, one-shot command execution, allowed

--- a/docs/providers/phala.md
+++ b/docs/providers/phala.md
@@ -39,6 +39,26 @@ The SSH transport uses Crabbox's native TLS client to tunnel through the
 gateway's authenticated TLS endpoint rather than dialing a raw TCP port (see
 [Lifecycle](#lifecycle)).
 
+## Live smoke
+
+The provider-specific live smoke is guarded by `CRABBOX_LIVE=1` and an explicit
+provider selection. It builds `bin/crabbox` unless `CRABBOX_BIN` is set, runs
+`doctor`, provisions a short-lived confidential CVM, proves sync/env forwarding
+with a tiny Git fixture, then stops the lease. If a CVM ID is observed during a
+failed run, cleanup also calls the Phala CLI directly.
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=phala CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
+# or, directly:
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=phala CRABBOX_BIN=./bin/crabbox scripts/live-phala-smoke.sh
+```
+
+The script emits one machine-readable classification:
+`live_phala_smoke_passed`, `environment_blocked`, `quota_blocked`, or
+`diagnostic_only`. Missing auth, unavailable CLI state, TLS/connectivity
+problems, or quota/balance failures are reported without pretending a live
+mutation succeeded.
+
 ## Configuration
 
 ```yaml

--- a/scripts/live-phala-smoke.sh
+++ b/scripts/live-phala-smoke.sh
@@ -84,7 +84,7 @@ if [[ "${CRABBOX_LIVE:-}" != "1" ]]; then
   classify_and_exit environment_blocked "reason=CRABBOX_LIVE_not_enabled missing=CRABBOX_LIVE=1"
 fi
 
-if [[ "$providers" != *",phala,"* ]]; then
+if [[ "$providers" != *",phala,"* && "$providers" != *",phala-cloud,"* && "$providers" != *",dstack,"* ]]; then
   classify_and_exit environment_blocked "reason=provider_not_selected missing=CRABBOX_LIVE_PROVIDERS=phala"
 fi
 

--- a/scripts/live-phala-smoke.test.js
+++ b/scripts/live-phala-smoke.test.js
@@ -95,6 +95,45 @@ esac
   assert.doesNotMatch(calls, /\brun --provider phala/);
 });
 
+test("Phala smoke accepts provider aliases", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-phala-alias-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >>"${crabboxLog}"
+case "$1" in
+  doctor)
+    printf 'phala status failed: not logged in; run phala login\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-phala-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "dstack",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^environment_blocked .*not logged in/m);
+  const calls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(calls, /doctor --provider phala/);
+  assert.doesNotMatch(result.stdout, /provider_not_selected/);
+});
+
 test("Phala smoke classifies an unfunded account as quota_blocked", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-phala-unfunded-"));
   const fakeCrabbox = path.join(dir, "crabbox");

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -969,17 +969,7 @@ if has_provider namespace-instance || has_provider namespace-compute; then
 fi
 
 if has_provider phala || has_provider phala-cloud || has_provider dstack; then
-  run_in_repo "$cb" doctor --provider phala
-  phala_baseline="$(run_in_repo "$cb" list --provider phala --json | jq -c 'map(.CloudID) | sort')"
-  provider_smoke phala \
-    --class "${CRABBOX_LIVE_PHALA_CLASS:-standard}" \
-    --ttl "${CRABBOX_LIVE_PHALA_TTL:-15m}" \
-    --idle-timeout 5m
-  phala_after="$(run_in_repo "$cb" list --provider phala --json | jq -c 'map(.CloudID) | sort')"
-  if [[ "$phala_after" != "$phala_baseline" ]]; then
-    echo "Phala smoke changed the pre-existing Crabbox-owned inventory" >&2
-    exit 1
-  fi
+  "$root/scripts/live-phala-smoke.sh"
 fi
 
 if has_provider semaphore; then

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -138,6 +138,52 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Phala live smoke dispatches to the provider-specific confidential VM script", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-phala-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$1" in
+  doctor)
+    printf 'phala status failed: not logged in; run phala login\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "phala",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^environment_blocked .*not logged in/m);
+  assert.match(result.stderr, /admin active-lease check skipped/);
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^doctor --provider phala$/m);
+  assert.doesNotMatch(calls, /^list --provider phala/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^run /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary
- route top-level Phala live smoke through the provider-specific confidential VM script
- document the Phala live-smoke command, prerequisites, classifications, and cleanup behavior
- cover credentialless top-level dispatch plus provider alias acceptance

Verification
- git diff --check
- bash -n scripts/live-smoke.sh scripts/live-phala-smoke.sh
- node --test scripts/live-smoke.test.js scripts/live-phala-smoke.test.js
- scripts/check-docs.sh

Notes
- No live Phala mutation was run because local provider credentials/quota are not available; fake-bin coverage proves the credentialless classification path and dispatch behavior.