### PR TITLE
docs(providers): cover agent sandbox live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added OpenSandbox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Proxmox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added XCP-ng to the guarded `scripts/live-smoke.sh` provider smoke matrix.
+- Added Agent Sandbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -74,6 +74,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=anthropic-sandbox-runtime scripts/live-smo
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=opensandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=proxmox CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=xcp-ng CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=agent-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 ```
 
 Per-provider smoke prerequisites:
@@ -88,6 +89,11 @@ Per-provider smoke prerequisites:
 - **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token in the environment.
 - **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
+- **Agent Sandbox** — `kubectl`, an absolute kubeconfig or inherited
+  `KUBECONFIG`, an explicit context, a namespace, and a configured
+  `SandboxWarmPool`. `scripts/live-agent-sandbox-smoke.sh` is coordinator-free,
+  creates a short-lived `SandboxClaim`, verifies archive sync, env forwarding,
+  retained-claim reuse, replacement sync, status/list, and claim deletion.
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
 - **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.

--- a/docs/providers/agent-sandbox.md
+++ b/docs/providers/agent-sandbox.md
@@ -85,6 +85,27 @@ crabbox stop --provider agent-sandbox linux-pool-smoke
 crabbox cleanup --provider agent-sandbox --dry-run
 ```
 
+## Live Smoke
+
+The provider-specific live smoke is guarded by `CRABBOX_LIVE=1` and an explicit
+provider selection. It builds `bin/crabbox` unless `CRABBOX_BIN` points at an
+existing binary, verifies `doctor`, creates a short-lived `SandboxClaim`,
+proves archive sync and env forwarding with a tiny Git fixture, reuses the
+retained claim for a replacement-sync proof, checks status/list, then deletes
+the claim.
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=agent-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+# or, directly:
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=agent-sandbox scripts/live-agent-sandbox-smoke.sh
+```
+
+The script emits one machine-readable classification:
+`live_agent_sandbox_smoke_passed`, `environment_blocked`, `quota_blocked`, or
+`diagnostic_only`. Missing kubeconfig, context, warm pool, RBAC, cluster
+connectivity, and API readiness issues are reported without pretending a live
+mutation succeeded.
+
 `warmup` keeps the sandbox available until explicit `stop` or the configured
 Crabbox TTL expires. At expiry, the controller tears down the sandbox workload
 but retains the `SandboxClaim` as an exact cleanup handle.

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -184,6 +184,48 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Agent Sandbox live smoke dispatches to the provider-specific Kubernetes script", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-agent-sandbox-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const home = path.join(dir, "home");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(home);
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+printf 'unexpected crabbox args: %s\\n' "$*" >&2
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "agent-sandbox",
+      CRABBOX_LIVE_REPO: repoRoot,
+      HOME: home,
+      KUBECONFIG: "",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^environment_blocked reason=missing_kubeconfig/m);
+  assert.match(result.stderr, /admin active-lease check skipped/);
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^doctor --provider agent-sandbox/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^run /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary
- document Agent Sandbox live-smoke invocation, prerequisites, classifications, and cleanup behavior
- add an operations matrix command for the coordinator-free Agent Sandbox smoke
- add a top-level live-smoke regression for the credentialless missing-kubeconfig dispatch path

Verification
- git diff --check
- bash -n scripts/live-smoke.sh scripts/live-agent-sandbox-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Notes
- No live Agent Sandbox mutation was run because local Kubernetes/Agent Sandbox credentials and warm pools are not available; the fake-bin test covers non-mutating dispatch and environment classification.