### PR TITLE
docs(providers): cover scaleway live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Added Proxmox to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added XCP-ng to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Agent Sandbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Scaleway live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,6 +60,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_L
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
@@ -95,6 +96,14 @@ Per-provider smoke prerequisites:
   creates a short-lived `SandboxClaim`, verifies archive sync, env forwarding,
   retained-claim reuse, replacement sync, status/list, and claim deletion.
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
+- **Scaleway** — `SCW_ACCESS_KEY`, `SCW_SECRET_KEY`,
+  `SCW_DEFAULT_ORGANIZATION_ID`, `SCW_DEFAULT_PROJECT_ID`,
+  `SCW_DEFAULT_REGION`, and `SCW_DEFAULT_ZONE`, or equivalent
+  `CRABBOX_SCALEWAY_*` overrides for project/location fields.
+  `scripts/live-scaleway-smoke.sh` is coordinator-free, requires an empty
+  Crabbox-owned inventory before provisioning, creates one short-lived
+  `DEV1-S` instance by default, verifies status/run/list, stops the lease, and
+  proves the inventory is empty afterward.
 - **Docker Sandbox** — the standalone `sbx` CLI on `PATH` or configured with `CRABBOX_DOCKER_SANDBOX_CLI`; run `sbx login` first when your account requires authentication.
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
 - **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -48,6 +48,26 @@ Instances through the local Scaleway SDK profile. They are cost-bearing when
 they create live Instances, so use `doctor` and `cleanup --dry-run` before
 running live workflows.
 
+## Live Smoke
+
+The provider-specific live smoke is guarded by `CRABBOX_LIVE=1` and an explicit
+provider selection. It builds `bin/crabbox` unless `CRABBOX_BIN` points at an
+existing binary, verifies the Crabbox-owned Scaleway inventory starts empty,
+creates one short-lived Instance, proves status, command execution, list JSON,
+cleanup, and final empty inventory.
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+# or, directly:
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway scripts/live-scaleway-smoke.sh
+```
+
+The script emits `classification=environment_blocked`,
+`classification=quota_blocked`, `classification=validation_failed`, or
+`classification=cleanup_failed` on stderr when a required credential, quota,
+provider response, or cleanup invariant blocks the smoke. `SCW_ACCESS_KEY` and
+`SCW_SECRET_KEY` are redacted from captured command output before printing.
+
 `--type` is the exact Scaleway Instances commercial type, such as `DEV1-S`.
 There is no separate Scaleway size flag for the generic lease commands.
 

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -226,6 +226,50 @@ exit 99
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Scaleway live smoke dispatches to the provider-specific script", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+printf 'unexpected crabbox args: %s\\n' "$*" >&2
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "scaleway",
+      CRABBOX_LIVE_REPO: repoRoot,
+      SCW_ACCESS_KEY: "",
+      SCW_SECRET_KEY: "",
+      SCW_DEFAULT_ORGANIZATION_ID: "",
+      SCW_DEFAULT_PROJECT_ID: "",
+      SCW_DEFAULT_REGION: "",
+      SCW_DEFAULT_ZONE: "",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^classification=environment_blocked reason=SCW_ACCESS_KEY_missing/m);
+  assert.match(result.stderr, /admin active-lease check skipped/);
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^doctor --provider scaleway/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^run /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary
- document Scaleway live-smoke invocation, prerequisites, classifications, and cleanup behavior
- add an operations matrix command for the coordinator-free Scaleway smoke
- add a top-level live-smoke regression for the credentialless missing-access-key dispatch path

Verification
- git diff --check
- bash -n scripts/live-smoke.sh scripts/live-scaleway-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Notes
- No live Scaleway mutation was run because local Scaleway credentials/quota are not available; the fake-bin test covers non-mutating dispatch and environment classification.