### PR TITLE
test(providers): cover kubevirt live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added XCP-ng to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Agent Sandbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Scaleway live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added KubeVirt live-smoke dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/providers/kubevirt.md
+++ b/docs/providers/kubevirt.md
@@ -210,7 +210,10 @@ The live harness also needs `jq` and `rg` on the operator machine. Use
 Kubernetes context. Use `CRABBOX_LIVE_KUBEVIRT_NAMESPACE` when the configured
 namespace is not the target namespace. `CRABBOX_LIVE_COMMAND` overrides the
 remote smoke command; by default it accepts either a Go repo (`go.mod`) or a
-Node repo (`package.json`).
+Node repo (`package.json`). After local helper tools are available, the harness
+refuses to run before `doctor`, `warmup`, or any mutating provider command
+unless a VM template is configured through `CRABBOX_LIVE_KUBEVIRT_TEMPLATE`,
+`CRABBOX_KUBEVIRT_TEMPLATE`, or `kubevirt.template`.
 
 ## Troubleshooting
 

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -270,6 +270,63 @@ exit 99
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("KubeVirt live smoke requires an explicit VM template before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-kubevirt-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "kubectl"), "#!/usr/bin/env bash\nexit 99\n");
+  writeExecutable(path.join(bin, "virtctl"), "#!/usr/bin/env bash\nexit 99\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  "config show --json")
+    printf '{}\\n'
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "kubevirt",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_LIVE_KUBEVIRT_TEMPLATE: "",
+      CRABBOX_KUBEVIRT_TEMPLATE: "",
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /kubevirt smoke requires CRABBOX_LIVE_KUBEVIRT_TEMPLATE, CRABBOX_KUBEVIRT_TEMPLATE, or kubevirt\.template/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^doctor --provider kubevirt/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^run /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary
- add a top-level live-smoke regression for KubeVirt
- prove the harness refuses to reach doctor/warmup/run/stop before a VM template is configured
- document that template guard in the KubeVirt provider live harness notes

Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Notes
- No live KubeVirt mutation was run because local cluster credentials/template access are not available; the fake-bin test covers the non-mutating template guard.