### PR TITLE
docs: note Tart SSH readiness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@
 
 ### Fixed
 
+- Fixed Tart SSH readiness on hosts where OpenSSH can reach the guest but Go's raw TCP probe cannot. Thanks @kmcquade.
 - Fixed `stop` and `pond release` to preserve claims, SSH credentials, lifecycle metadata, and restart routing when providers intentionally retain reusable stopped resources.
 - Fixed external lease commands to reuse each lease's persisted provider routing after the current external configuration changes.
 - Fixed `local-container` stop cleanup when a Docker container was removed externally, including stale claim and stored-key removal. Thanks @hxy91819.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Fixed
 
+- Fixed Tart SSH readiness on hosts where OpenSSH can reach the guest but Go's raw TCP probe cannot. Thanks @kmcquade.
 - Revoked active WebVNC and Code viewers when their lease share access is removed while preserving owner, admin, and still-authorized sessions. Thanks @coygeek.
 - Prevented E2B and Upstash Box credentials from following redirects outside each request's trusted origin while preserving same-origin redirects. Thanks @coygeek.
 - Prevented SmolVM API credentials from following redirects outside the configured API origin while preserving same-origin redirects. Thanks @coygeek.
@@ -240,7 +241,6 @@
 
 ### Fixed
 
-- Fixed Tart SSH readiness on hosts where OpenSSH can reach the guest but Go's raw TCP probe cannot. Thanks @kmcquade.
 - Fixed `stop` and `pond release` to preserve claims, SSH credentials, lifecycle metadata, and restart routing when providers intentionally retain reusable stopped resources.
 - Fixed external lease commands to reuse each lease's persisted provider routing after the current external configuration changes.
 - Fixed `local-container` stop cleanup when a Docker container was removed externally, including stale claim and stored-key removal. Thanks @hxy91819.


### PR DESCRIPTION
## Summary

- Add the maintainer-owned changelog entry for the Tart SSH readiness fix landed in https://github.com/openclaw/crabbox/pull/653.
- Credit reporter @kmcquade from https://github.com/openclaw/crabbox/issues/644.

## Validation

- `git diff --check`
- `bash scripts/check-docs.sh`
- Autoreview clean: no accepted/actionable findings, patch correct at 0.96 confidence

The entry is under the current `Unreleased` / `Fixed` section.
