### PR TITLE
test(providers): cover daytona live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Added Agent Sandbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Scaleway live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added KubeVirt live-smoke dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -84,7 +84,10 @@ Per-provider smoke prerequisites:
 - **E2B** — `E2B_API_KEY`.
 - **Modal** — an authenticated Modal Python client (`python3 -m modal setup` or Modal token env vars).
 - **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`, and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.
-- **Daytona** — `CRABBOX_DAYTONA_SNAPSHOT`, `DAYTONA_SNAPSHOT`, or `daytona.snapshot`.
+- **Daytona** — `CRABBOX_DAYTONA_SNAPSHOT`, `DAYTONA_SNAPSHOT`, or
+  `daytona.snapshot`. `scripts/live-smoke.sh` refuses to call Daytona until a
+  snapshot is configured, then runs one delegated command and normalized list
+  proof.
 - **Namespace** — the authenticated `devbox` CLI on `PATH`.
 - **Namespace Compute** — the authenticated `nsc` CLI on `PATH`; run `nsc login` first.
 - **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token in the environment.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -29,6 +29,21 @@ crabbox ssh --provider daytona --id swift-crab
 crabbox stop --provider daytona swift-crab
 ```
 
+## Live Smoke
+
+The shared live-smoke harness can validate Daytona without a coordinator:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=daytona CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+```
+
+The smoke requires a snapshot through `CRABBOX_DAYTONA_SNAPSHOT`,
+`DAYTONA_SNAPSHOT`, or `daytona.snapshot`. It exits before any Daytona `run`,
+`list`, `warmup`, or `stop` command when the snapshot is missing, so
+credentialless machines can verify the guard without mutating provider state.
+With a snapshot configured, the harness runs one delegated Daytona command and
+then lists normalized Daytona inventory.
+
 ## Auth
 
 Crabbox reads the active Daytona CLI profile when no Daytona auth values are set

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -327,6 +327,55 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Daytona live smoke requires an explicit snapshot before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-daytona-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_DAYTONA_SNAPSHOT: "",
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "daytona",
+      CRABBOX_LIVE_REPO: repoRoot,
+      DAYTONA_SNAPSHOT: "",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /daytona smoke requires CRABBOX_DAYTONA_SNAPSHOT, DAYTONA_SNAPSHOT, or daytona\.snapshot/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^run --provider daytona/m);
+  assert.doesNotMatch(calls, /^list --provider daytona/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Daytona live-smoke regression proving missing snapshot config exits before provider mutation
- document Daytona live-smoke prerequisites and guarded behavior in provider and operations docs
- add the unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

No live Daytona provider mutation was run; this slice verifies the credentialless missing-snapshot guard.
