### PR TITLE
test(providers): cover namespace live smoke guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
   release-check:
     name: Release Check
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Check out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Added Scaleway live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added KubeVirt live-smoke dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -89,6 +89,9 @@ Per-provider smoke prerequisites:
   snapshot is configured, then runs one delegated command and normalized list
   proof.
 - **Namespace** — the authenticated `devbox` CLI on `PATH`.
+  `scripts/live-smoke.sh` refuses to call Namespace until `devbox` is available,
+  then creates a delete-on-release Devbox, runs one no-sync command, and prints a
+  normalized list proof.
 - **Namespace Compute** — the authenticated `nsc` CLI on `PATH`; run `nsc login` first.
 - **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token in the environment.
 - **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.

--- a/docs/providers/namespace-devbox.md
+++ b/docs/providers/namespace-devbox.md
@@ -44,6 +44,22 @@ crabbox stop --provider namespace-devbox swift-crab
 
 Aliases for the provider name: `namespace`, `namespace-devboxes`.
 
+## Live Smoke
+
+The shared live-smoke harness can validate Namespace Devbox without a
+coordinator:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-devbox CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+```
+
+The smoke requires the authenticated Namespace `devbox` CLI on `PATH`. It exits
+before any Namespace `run`, `list`, `warmup`, or `stop` command when the CLI is
+missing, so credentialless machines can verify the guard without mutating
+provider state. With `devbox` available and logged in, the harness creates a
+delete-on-release Devbox with size `S` by default, runs one no-sync command, and
+then lists normalized Namespace inventory.
+
 ## Configuration
 
 ```yaml

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -376,6 +376,54 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Namespace Devbox live smoke requires the devbox CLI before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-namespace-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "namespace-devbox",
+      CRABBOX_LIVE_REPO: repoRoot,
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /namespace-devbox smoke requires the Namespace devbox CLI on PATH/);
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^run --provider namespace-devbox/m);
+  assert.doesNotMatch(calls, /^list --provider namespace-devbox/m);
+  assert.doesNotMatch(calls, /^warmup /m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Namespace Devbox live-smoke regression proving missing `devbox` exits before provider mutation
- document Namespace live-smoke prerequisites and guarded behavior in provider and operations docs
- add the unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

No live Namespace provider mutation was run; this slice verifies the credentialless missing-CLI guard.
