### PR TITLE
test(providers): cover semaphore live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Added KubeVirt live-smoke dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,7 +83,11 @@ Per-provider smoke prerequisites:
 - **Blacksmith** — a workflow containing a `useblacksmith/testbox`, `useblacksmith/begin-testbox`, or `useblacksmith/run-testbox` step; set `CRABBOX_BLACKSMITH_WORKFLOW` when the default path is wrong.
 - **E2B** — `E2B_API_KEY`.
 - **Modal** — an authenticated Modal Python client (`python3 -m modal setup` or Modal token env vars).
-- **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`, and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.
+- **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`,
+  and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.
+  `scripts/live-smoke.sh` refuses to call Semaphore until those values are
+  configured, then creates one testbox, runs one no-sync command, lists
+  normalized inventory, and stops the lease.
 - **Daytona** — `CRABBOX_DAYTONA_SNAPSHOT`, `DAYTONA_SNAPSHOT`, or
   `daytona.snapshot`. `scripts/live-smoke.sh` refuses to call Daytona until a
   snapshot is configured, then runs one delegated command and normalized list

--- a/docs/providers/semaphore.md
+++ b/docs/providers/semaphore.md
@@ -43,6 +43,18 @@ export CRABBOX_SEMAPHORE_PROJECT=my-app
 export CRABBOX_SEMAPHORE_TOKEN=...
 
 go build -trimpath -o bin/crabbox ./cmd/crabbox
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=semaphore CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+```
+
+The shared harness exits before any Semaphore `warmup`, `run`, `list`, or `stop`
+command when host, project, or token configuration is missing. With those values
+configured, it creates one short-lived Semaphore testbox, waits for SSH, verifies
+one no-sync command, lists normalized Semaphore inventory, and stops the lease.
+
+For manual debugging, run the same lifecycle directly:
+
+```sh
+go build -trimpath -o bin/crabbox ./cmd/crabbox
 
 bin/crabbox warmup --provider semaphore --semaphore-idle-timeout 10m
 lease=<slug-or-sem_id-from-warmup-output>

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -424,6 +424,59 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Semaphore live smoke requires host before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-semaphore-"));
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "semaphore",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_SEMAPHORE_HOST: "",
+      CRABBOX_SEMAPHORE_PROJECT: "",
+      CRABBOX_SEMAPHORE_TOKEN: "",
+      SEMAPHORE_API_TOKEN: "",
+      SEMAPHORE_HOST: "",
+      SEMAPHORE_PROJECT: "",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /semaphore smoke requires CRABBOX_SEMAPHORE_HOST, SEMAPHORE_HOST, or semaphore\.host/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^warmup --provider semaphore/m);
+  assert.doesNotMatch(calls, /^run --provider semaphore/m);
+  assert.doesNotMatch(calls, /^list --provider semaphore/m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Semaphore live-smoke regression proving missing host config exits before provider mutation
- document the shared Semaphore live-smoke harness and guarded behavior
- add the unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

No live Semaphore provider mutation was run; this slice verifies the credentialless missing-config guard.
