### PR TITLE
test(providers): cover sprites live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -97,7 +97,10 @@ Per-provider smoke prerequisites:
   then creates a delete-on-release Devbox, runs one no-sync command, and prints a
   normalized list proof.
 - **Namespace Compute** — the authenticated `nsc` CLI on `PATH`; run `nsc login` first.
-- **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token in the environment.
+- **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token
+  in the environment. `scripts/live-smoke.sh` refuses to call Sprites until the
+  CLI is available, then creates one sprite, verifies SSH, runs one command,
+  lists normalized inventory, and stops the lease.
 - **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
 - **Agent Sandbox** — `kubectl`, an absolute kubeconfig or inherited

--- a/docs/providers/sprites.md
+++ b/docs/providers/sprites.md
@@ -125,6 +125,23 @@ command, or cleanup behavior.
 ```sh
 export SPRITES_TOKEN=...
 go build -trimpath -o bin/crabbox ./cmd/crabbox
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=sprites \
+CRABBOX_LIVE_REPO=/path/to/my-app \
+scripts/live-smoke.sh
+```
+
+The shared harness exits before any Sprites `warmup`, `status`, `ssh`, `run`,
+`list`, or `stop` command when the authenticated `sprite` CLI is missing. With
+the CLI and token configured, it creates one short-lived sprite, waits for SSH,
+verifies `ssh`, runs one command, lists normalized Sprites inventory, and stops
+the lease.
+
+For manual debugging, run the same lifecycle directly:
+
+```sh
+export SPRITES_TOKEN=...
+go build -trimpath -o bin/crabbox ./cmd/crabbox
 
 bin/crabbox warmup --provider sprites --timing-json
 lease=<slug-or-cbx_id-from-warmup-output>

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -477,6 +477,64 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Sprites live smoke requires the sprite CLI before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-sprites-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(path.join(bin, "rg"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "sprites",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_SPRITES_TOKEN: "",
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+      SETUP_SPRITE_TOKEN: "",
+      SPRITE_TOKEN: "",
+      SPRITES_TOKEN: "",
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /sprites smoke requires the authenticated Sprites sprite CLI on PATH/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^warmup --provider sprites/m);
+  assert.doesNotMatch(calls, /^status --provider sprites/m);
+  assert.doesNotMatch(calls, /^ssh --provider sprites/m);
+  assert.doesNotMatch(calls, /^run --provider sprites/m);
+  assert.doesNotMatch(calls, /^list --provider sprites/m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary:
- add a credentialless regression for the Sprites live-smoke guard before provider mutation
- document shared Sprites live-smoke harness behavior and prerequisites
- update the unreleased changelog

Validation:
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for local paths, private IPs, and emails

Live provider access:
- not run; this change intentionally validates the no-credentials/no-sprite-CLI guard path without mutating Sprites resources