### PR TITLE
test(providers): cover wandb live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -121,7 +121,10 @@ Per-provider smoke prerequisites:
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
 - **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.
 - **Vercel Sandbox** — authenticated `sandbox` CLI on `PATH`; project and team scope may come from `CRABBOX_VERCEL_SANDBOX_PROJECT_ID` plus `CRABBOX_VERCEL_SANDBOX_TEAM_ID`, `CRABBOX_VERCEL_SANDBOX_SCOPE`, or the Vercel OIDC environment.
-- **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or `WANDB_API_KEY` (from `wandb login`). `scripts/wandb-smoke.sh` is a coordinator-free, wandb-only gate.
+- **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or
+  `WANDB_API_KEY` (from `wandb login`). `scripts/live-smoke.sh` refuses to call
+  W&B until an API key is exported, then runs `doctor`, executes one no-sync
+  command, and prints normalized inventory.
 - **Linode** — `LINODE_TOKEN` with Linode instance, image, type, SSH key, and tag access.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -161,6 +161,24 @@ the API key in the environment; never pass it as an argument.
 export CRABBOX_WANDB_API_KEY=wandb_v1_...
 export WANDB_ENTITY_NAME=my-team
 go build -trimpath -o bin/crabbox ./cmd/crabbox
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=wandb \
+CRABBOX_LIVE_COORDINATOR=0 \
+CRABBOX_LIVE_REPO=/path/to/my-app \
+scripts/live-smoke.sh
+```
+
+The shared harness exits before any W&B `doctor`, `run`, or `list` command when
+no API key is exported. With the API key and entity configured, it runs
+`doctor`, executes one no-sync command with a 60-second sandbox lifetime, and
+prints normalized W&B inventory.
+
+For manual debugging, run the same lifecycle directly:
+
+```sh
+export CRABBOX_WANDB_API_KEY=wandb_v1_...
+export WANDB_ENTITY_NAME=my-team
+go build -trimpath -o bin/crabbox ./cmd/crabbox
 
 bin/crabbox doctor --provider wandb
 bin/crabbox run --provider wandb --no-sync --wandb-max-lifetime 60 -- echo crabbox-wandb-ok

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -535,6 +535,59 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("W&B live smoke requires an API key before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-wandb-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "wandb",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_WANDB_API_KEY: "",
+      WANDB_API_KEY: "",
+      WANDB_ENTITY_NAME: "example-org",
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /wandb smoke requires CRABBOX_WANDB_API_KEY or WANDB_API_KEY/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^doctor --provider wandb/m);
+  assert.doesNotMatch(calls, /^run --provider wandb/m);
+  assert.doesNotMatch(calls, /^list --provider wandb/m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary:
- add a credentialless regression for the W&B live-smoke API-key guard before provider mutation
- document shared W&B live-smoke harness behavior and prerequisites
- update the unreleased changelog

Validation:
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for local paths, private IPs, and emails

Live provider access:
- not run; this validates the no-credentials guard path without contacting W&B/CoreWeave