### PR TITLE
test(providers): cover incus live smoke preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,6 +125,10 @@ Per-provider smoke prerequisites:
   `WANDB_API_KEY` (from `wandb login`). `scripts/live-smoke.sh` refuses to call
   W&B until an API key is exported, then runs `doctor`, executes one no-sync
   command, and prints normalized inventory.
+- **Incus** — local `jq` and `rg`, plus Crabbox config or env resolving
+  `incus.socket`, `incus.address`, or `incus.remote`. `scripts/live-smoke.sh`
+  refuses to call Incus until local preflight tools are available, then proves
+  delete-on-release and retained-reuse SSH lease lifecycles.
 - **Linode** — `LINODE_TOKEN` with Linode instance, image, type, SSH key, and tag access.
 - **DigitalOcean** — `DIGITALOCEAN_TOKEN` with account-read, Droplet, image-read, SSH key, and tag scopes. `scripts/live-digitalocean-smoke.sh` is coordinator-free, requires an empty Crabbox-owned inventory, creates a small short-lived Droplet, verifies status and execution, and prints a final cleanup classification.
 - **Nebius** — authenticated Nebius CLI profile plus `nebius.parentId` and

--- a/docs/providers/incus.md
+++ b/docs/providers/incus.md
@@ -272,13 +272,18 @@ The default live-smoke matrix still skips Incus. Opt in explicitly:
 ```sh
 go build -trimpath -o bin/crabbox ./cmd/crabbox
 CRABBOX_BIN=bin/crabbox CRABBOX_LIVE_DOCTOR_PROVIDERS=incus scripts/live-doctor-smoke.sh
-CRABBOX_LIVE=1 CRABBOX_BIN=bin/crabbox CRABBOX_LIVE_PROVIDERS=incus CRABBOX_LIVE_REPO=$PWD scripts/live-smoke.sh
+CRABBOX_LIVE=1 \
+CRABBOX_BIN=bin/crabbox \
+CRABBOX_LIVE_PROVIDERS=incus \
+CRABBOX_LIVE_REPO=$PWD \
+scripts/live-smoke.sh
 ```
 
 The doctor smoke only proves daemon/control-plane readiness. The full live
-smoke proves `warmup`, `status --wait`, `run`, `list`, `stop`, and one retained
-reuse cycle from the Mac, then forces a final delete so repeat runs do not
-strand test instances.
+smoke first requires local `jq` and `rg` before it calls Incus. It then proves
+`doctor`, `warmup`, `status --wait`, `run`, `list`, `stop`, and one retained
+reuse cycle from the Mac, then forces a final delete so repeat runs do not strand
+test instances.
 
 ## Limits
 

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -382,10 +382,19 @@ test("Namespace Devbox live smoke requires the devbox CLI before provider mutati
   const fakeCrabbox = path.join(dir, "crabbox");
   const log = path.join(dir, "calls.log");
   fs.mkdirSync(bin);
+  writeExecutable(
+    path.join(bin, "dirname"),
+    `#!/bin/bash
+case "$1" in
+  */*) printf '%s\\n' "\${1%/*}" ;;
+  *) printf '.\\n' ;;
+esac
+`,
+  );
   writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
   writeExecutable(
     fakeCrabbox,
-    `#!/usr/bin/env bash
+    `#!/bin/bash
 set -euo pipefail
 printf '%s\\n' "$*" >>"${log}"
 case "$*" in
@@ -400,7 +409,7 @@ esac
 `,
   );
 
-  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+  const result = spawnSync("/bin/bash", ["scripts/live-smoke.sh"], {
     cwd: repoRoot,
     env: {
       ...process.env,
@@ -409,7 +418,7 @@ esac
       CRABBOX_LIVE_COORDINATOR: "0",
       CRABBOX_LIVE_PROVIDERS: "namespace-devbox",
       CRABBOX_LIVE_REPO: repoRoot,
-      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+      PATH: bin,
     },
     encoding: "utf8",
   });
@@ -541,10 +550,19 @@ test("W&B live smoke requires an API key before provider mutation", () => {
   const fakeCrabbox = path.join(dir, "crabbox");
   const log = path.join(dir, "calls.log");
   fs.mkdirSync(bin);
+  writeExecutable(
+    path.join(bin, "dirname"),
+    `#!/bin/bash
+case "$1" in
+  */*) printf '%s\\n' "\${1%/*}" ;;
+  *) printf '.\\n' ;;
+esac
+`,
+  );
   writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
   writeExecutable(
     fakeCrabbox,
-    `#!/usr/bin/env bash
+    `#!/bin/bash
 set -euo pipefail
 printf '%s\\n' "$*" >>"${log}"
 case "$*" in
@@ -586,6 +604,56 @@ esac
   assert.doesNotMatch(calls, /^doctor --provider wandb/m);
   assert.doesNotMatch(calls, /^run --provider wandb/m);
   assert.doesNotMatch(calls, /^list --provider wandb/m);
+});
+
+test("Incus live smoke requires rg before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-incus-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("/bin/bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "incus",
+      CRABBOX_LIVE_REPO: repoRoot,
+      HOME: dir,
+      PATH: bin,
+      TMPDIR: dir,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /missing required tool: rg/);
+  const calls = fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "";
+  assert.doesNotMatch(calls, /^doctor --provider incus/m);
+  assert.doesNotMatch(calls, /^warmup --provider incus/m);
+  assert.doesNotMatch(calls, /^status --provider incus/m);
+  assert.doesNotMatch(calls, /^run --provider incus/m);
+  assert.doesNotMatch(calls, /^list --provider incus/m);
+  assert.doesNotMatch(calls, /^stop /m);
 });
 
 test("Tenki live smoke proves paused status waits do not resume the session", () => {


### PR DESCRIPTION
Summary:
- add a credentialless regression for the Incus live-smoke local-tool preflight before provider mutation
- document shared Incus live-smoke harness prerequisites and retained lifecycle coverage
- update the unreleased changelog

Validation:
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for local paths, private IPs, and emails

Live provider access:
- not run; this validates the local preflight guard path without contacting or mutating Incus resources