### PR TITLE
test(providers): cover e2b live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -81,7 +81,10 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=agent-sandbox CRABBOX_LIVE_COORDINATOR=0 s
 Per-provider smoke prerequisites:
 
 - **Blacksmith** — a workflow containing a `useblacksmith/testbox`, `useblacksmith/begin-testbox`, or `useblacksmith/run-testbox` step; set `CRABBOX_BLACKSMITH_WORKFLOW` when the default path is wrong.
-- **E2B** — `E2B_API_KEY`.
+- **E2B** — `CRABBOX_E2B_API_KEY` or `E2B_API_KEY`.
+  `scripts/live-smoke.sh` refuses to call E2B until an API key is exported, then
+  creates one sandbox, runs one no-sync command, lists normalized inventory, and
+  stops the lease.
 - **Modal** — an authenticated Modal Python client (`python3 -m modal setup` or Modal token env vars).
 - **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`,
   and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -125,6 +125,22 @@ code. Keep the API key in the environment; never pass it as an argument.
 ```sh
 export E2B_API_KEY=e2b_...
 go build -trimpath -o bin/crabbox ./cmd/crabbox
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_PROVIDERS=e2b \
+CRABBOX_LIVE_REPO=/path/to/my-app \
+scripts/live-smoke.sh
+```
+
+The shared harness exits before any E2B `warmup`, `status`, `run`, `list`, or
+`stop` command when no API key is exported. With the key configured, it creates
+one E2B sandbox from the selected template, waits for readiness, runs one
+no-sync command, lists normalized E2B inventory, and stops the lease.
+
+For manual debugging, run the same lifecycle directly:
+
+```sh
+export E2B_API_KEY=e2b_...
+go build -trimpath -o bin/crabbox ./cmd/crabbox
 
 bin/crabbox warmup --provider e2b --e2b-template base --timing-json
 lease=<slug-or-cbx_id-from-warmup-output>

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -276,6 +276,12 @@ e2b_smoke() {
   need_tool jq
   need_tool rg
 
+  local e2b_api_key="${CRABBOX_E2B_API_KEY:-${E2B_API_KEY:-}}"
+  if [[ -z "$e2b_api_key" ]]; then
+    echo "e2b smoke requires CRABBOX_E2B_API_KEY or E2B_API_KEY" >&2
+    return 2
+  fi
+
   local lease=""
   local slug=""
   cleanup() {

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -656,6 +656,61 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("E2B live smoke requires an API key before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-e2b-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(path.join(bin, "rg"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_E2B_API_KEY: "",
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "e2b",
+      CRABBOX_LIVE_REPO: repoRoot,
+      E2B_API_KEY: "",
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /e2b smoke requires CRABBOX_E2B_API_KEY or E2B_API_KEY/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^warmup --provider e2b/m);
+  assert.doesNotMatch(calls, /^status --provider e2b/m);
+  assert.doesNotMatch(calls, /^run --provider e2b/m);
+  assert.doesNotMatch(calls, /^list --provider e2b/m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
Summary:
- add an E2B live-smoke API-key preflight before warmup or provider mutation
- add a credentialless regression for the guarded E2B path
- document shared E2B live-smoke harness behavior and update the changelog

Validation:
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for local paths, private IPs, and emails

Live provider access:
- not run; this validates the no-credentials guard path without contacting E2B