### PR TITLE
test(providers): cover modal live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Modal live-smoke documentation and Python-client preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -85,7 +85,11 @@ Per-provider smoke prerequisites:
   `scripts/live-smoke.sh` refuses to call E2B until an API key is exported, then
   creates one sandbox, runs one no-sync command, lists normalized inventory, and
   stops the lease.
-- **Modal** — an authenticated Modal Python client (`python3 -m modal setup` or Modal token env vars).
+- **Modal** — an authenticated Modal Python client (`python3 -m modal setup`
+  or Modal token env vars). `scripts/live-smoke.sh` refuses to call Modal until
+  the configured Python binary can import the Modal client, then creates one
+  sandbox, waits for status, runs one no-sync command, lists normalized
+  inventory, and stops the lease.
 - **Semaphore** — `CRABBOX_SEMAPHORE_HOST`, `CRABBOX_SEMAPHORE_PROJECT`,
   and `CRABBOX_SEMAPHORE_TOKEN`, or the equivalent user config.
   `scripts/live-smoke.sh` refuses to call Semaphore until those values are

--- a/docs/providers/modal.md
+++ b/docs/providers/modal.md
@@ -50,6 +50,20 @@ crabbox status --provider modal --id swift-crab
 crabbox stop --provider modal swift-crab
 ```
 
+## Live Smoke
+
+Run the shared smoke only after the Modal Python client is installed and
+authenticated:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=modal CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+```
+
+The smoke exits before any Modal `warmup`, `status`, `run`, `list`, or `stop`
+call when the configured Python binary cannot import the Modal client. With a
+working client and auth state, it creates one sandbox, waits for status, runs
+one no-sync command, lists normalized inventory, and stops the lease.
+
 ## Config
 
 ```yaml

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -711,6 +711,67 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Modal live smoke requires the Python client before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-modal-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(dir, "crabbox");
+  const log = path.join(dir, "calls.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "jq"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(path.join(bin, "rg"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    path.join(bin, "python3"),
+    `#!/usr/bin/env bash
+printf 'missing modal client\\n' >&2
+exit 1
+`,
+  );
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "modal",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_MODAL_PYTHON: "",
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /modal smoke requires the Modal Python client for python3/,
+  );
+  const calls = fs.readFileSync(log, "utf8");
+  assert.match(calls, /^config path$/m);
+  assert.doesNotMatch(calls, /^warmup --provider modal/m);
+  assert.doesNotMatch(calls, /^status --provider modal/m);
+  assert.doesNotMatch(calls, /^run --provider modal/m);
+  assert.doesNotMatch(calls, /^list --provider modal/m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Modal live-smoke regression proving the Python-client prerequisite exits before provider mutation
- document the Modal shared smoke contract on the provider page and operations checklist
- add the unreleased changelog entry for Modal live-smoke guard coverage

## Validation
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for private paths, private IPs, and email-like secrets

## Live provider access
- Not run against Modal live capacity; this PR adds credentialless preflight coverage and documents the opt-in live smoke contract.