### PR TITLE
test(providers): cover tenki live smoke guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Modal live-smoke documentation and Python-client preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Tenki live-smoke documentation and CLI-auth preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,7 +108,11 @@ Per-provider smoke prerequisites:
   in the environment. `scripts/live-smoke.sh` refuses to call Sprites until the
   CLI is available, then creates one sprite, verifies SSH, runs one command,
   lists normalized inventory, and stops the lease.
-- **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and complete the browser flow.
+- **Tenki** — the authenticated `tenki` CLI on `PATH`; run `tenki login` and
+  complete the browser flow. `scripts/live-smoke.sh` refuses to call Crabbox
+  Tenki lifecycle commands until `tenki status --json` reports a logged-in CLI,
+  then creates one session, runs one no-sync command, verifies paused-session
+  status waits do not resume it, and stops the lease.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
 - **Agent Sandbox** — `kubectl`, an absolute kubeconfig or inherited
   `KUBECONFIG`, an explicit context, a namespace, and a configured

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -170,6 +170,12 @@ CRABBOX_LIVE_PROVIDERS=tenki \
 scripts/live-smoke.sh
 ```
 
+The smoke exits before any Crabbox `doctor`, `warmup`, `status`, `run`, `list`,
+or `stop` call when `tenki status --json` does not report a logged-in CLI. With
+an authenticated CLI, it creates one sandbox session, waits for status, runs one
+no-sync command, pauses the Tenki session directly, verifies a Crabbox
+`status --wait` timeout does not resume it, then stops the lease.
+
 Expected results:
 
 - `warmup` prints `provider=tenki`, the Crabbox lease ID, slug, and Tenki session

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -772,6 +772,102 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Tenki live smoke requires authenticated CLI before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-auth-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const fakeTenki = path.join(bin, "tenki");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  const tenkiLog = path.join(dir, "tenki.log");
+  fs.mkdirSync(bin);
+  writeExecutable(path.join(bin, "rg"), "#!/usr/bin/env bash\nexit 0\n");
+  writeExecutable(
+    path.join(bin, "jq"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+input="$(cat)"
+case "$*" in
+  *'startswith("Logged in")'*)
+    case "$input" in
+      *'"status":"Logged in'*) exit 0 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+  );
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${crabboxLog}"
+case "$*" in
+  "config path")
+    exit 0
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+  writeExecutable(
+    fakeTenki,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${tenkiLog}"
+case "$1" in
+  status)
+    printf '{"status":"Logged out"}\\n'
+    ;;
+  *)
+    printf 'unexpected tenki args: %s\\n' "$*" >&2
+    exit 97
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "tenki",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_TENKI_ENDPOINT: "https://sandbox.tenki.test",
+      TENKI_CLI: fakeTenki,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /tenki smoke requires an authenticated Tenki CLI; run tenki login/,
+  );
+  const crabboxCalls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(crabboxCalls, /^config path$/m);
+  assert.doesNotMatch(crabboxCalls, /^doctor --provider tenki/m);
+  assert.doesNotMatch(crabboxCalls, /^warmup --provider tenki/m);
+  assert.doesNotMatch(crabboxCalls, /^status --provider tenki/m);
+  assert.doesNotMatch(crabboxCalls, /^run --provider tenki/m);
+  assert.doesNotMatch(crabboxCalls, /^list --provider tenki/m);
+  assert.doesNotMatch(crabboxCalls, /^stop /m);
+
+  const tenkiCalls = fs.readFileSync(tenkiLog, "utf8");
+  assert.match(tenkiCalls, /^status --json$/m);
+  assert.doesNotMatch(tenkiCalls, /^--version$/m);
+  assert.doesNotMatch(tenkiCalls, /^sandbox /m);
+});
+
 test("Tenki live smoke proves paused status waits do not resume the session", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-tenki-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Tenki live-smoke regression proving unauthenticated CLI state exits before Crabbox provider mutation
- document the Tenki shared smoke auth preflight and paused-session proof
- add the unreleased changelog entry for Tenki live-smoke guard coverage

## Validation
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for private paths, private IPs, and email-like secrets

## Live provider access
- Not run against Tenki live capacity; this PR adds credentialless preflight coverage and documents the opt-in live smoke contract.