### PR TITLE
test(providers): cover blacksmith live smoke workflow guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Blacksmith Testbox live-smoke documentation and workflow preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -80,7 +80,12 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=agent-sandbox CRABBOX_LIVE_COORDINATOR=0 s
 
 Per-provider smoke prerequisites:
 
-- **Blacksmith** — a workflow containing a `useblacksmith/testbox`, `useblacksmith/begin-testbox`, or `useblacksmith/run-testbox` step; set `CRABBOX_BLACKSMITH_WORKFLOW` when the default path is wrong.
+- **Blacksmith** — a workflow containing a `useblacksmith/testbox`,
+  `useblacksmith/begin-testbox`, or `useblacksmith/run-testbox` step; set
+  `CRABBOX_BLACKSMITH_WORKFLOW` when the default path is wrong.
+  `scripts/live-smoke.sh` refuses to call Blacksmith until it can derive an org
+  and validate the selected Testbox workflow, then lists inventory and runs one
+  delegated command through the configured workflow/job/ref.
 - **E2B** — `CRABBOX_E2B_API_KEY` or `E2B_API_KEY`.
   `scripts/live-smoke.sh` refuses to call E2B until an API key is exported, then
   creates one sandbox, runs one no-sync command, lists normalized inventory, and

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -70,6 +70,21 @@ crabbox warmup \
 `blacksmith` is accepted as an alias, but docs and scripts should prefer
 `blacksmith-testbox`.
 
+## Live Smoke
+
+Run the shared smoke only when the selected workflow is a real Testbox workflow:
+
+```sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=blacksmith-testbox CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+```
+
+The smoke exits before any Blacksmith `list` or `run` call when it cannot derive
+an org, when the configured workflow file is missing, or when that workflow file
+does not contain a `useblacksmith/testbox`, `useblacksmith/begin-testbox`, or
+`useblacksmith/run-testbox` step. With a valid org and workflow, it lists the
+current inventory and runs one delegated `echo blacksmith-crabbox-ok && pwd`
+command through the configured workflow/job/ref.
+
 ## Auth
 
 Authentication lives entirely in the `blacksmith` CLI. Log in once before using

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1049,6 +1049,72 @@ exit 99
   assert.match(result.stderr, /requires CRABBOX_BLACKSMITH_ORG, blacksmith\.org, or actions\.repo/);
 });
 
+test("blacksmith live smoke requires a Testbox workflow before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-blacksmith-workflow-"));
+  const repo = path.join(dir, "repo");
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const config = path.join(dir, "crabbox.yaml");
+  const workflow = path.join(repo, ".github", "workflows", "ci.yml");
+  const log = path.join(dir, "crabbox.log");
+  fs.mkdirSync(path.dirname(workflow), { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    workflow,
+    `name: CI
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo no-testbox
+`,
+    "utf8",
+  );
+  fs.writeFileSync(
+    config,
+    `blacksmith:
+  org: example-org
+  workflow: .github/workflows/ci.yml
+  job: test
+`,
+    "utf8",
+  );
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"${log}"
+printf 'unexpected crabbox args: %s\\n' "$*" >&2
+exit 99
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: config,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "blacksmith-testbox",
+      CRABBOX_LIVE_REPO: repo,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(
+    result.stderr,
+    /blacksmith-testbox smoke requires \.github\/workflows\/ci\.yml to contain a useblacksmith\/testbox/,
+  );
+  const calls = fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "";
+  assert.doesNotMatch(calls, /^list --provider blacksmith-testbox/m);
+  assert.doesNotMatch(calls, /^run --provider blacksmith-testbox/m);
+  assert.doesNotMatch(calls, /^stop /m);
+});
+
 test("blacksmith live smoke derives organization from actions repo", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-blacksmith-actions-org-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add a Blacksmith live-smoke regression proving invalid Testbox workflow selection exits before provider mutation
- document the Blacksmith shared smoke org/workflow preflight on the provider and operations pages
- add the unreleased changelog entry for Blacksmith live-smoke guard coverage

## Validation
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh
- diff scrub for private paths, private IPs, and email-like secrets

## Live provider access
- Not run against Blacksmith live capacity; this PR adds credentialless workflow preflight coverage and documents the opt-in live smoke contract.