### PR TITLE
test(providers): cover morph live smoke snapshot guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Modal live-smoke documentation and Python-client preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Tenki live-smoke documentation and CLI-auth preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Morph live-smoke documentation and snapshot preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Multipass to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added Tart to the guarded `scripts/live-smoke.sh` provider smoke matrix.
 - Added run-session metadata for Vercel Sandbox runs so retained and reused sandboxes can be written through `--lease-output`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,6 +60,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_L
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=morph CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_MORPH_SNAPSHOT=snapshot_xxx scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=scaleway CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
@@ -125,6 +126,11 @@ Per-provider smoke prerequisites:
   creates a short-lived `SandboxClaim`, verifies archive sync, env forwarding,
   retained-claim reuse, replacement sync, status/list, and claim deletion.
 - **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
+- **Morph** — `CRABBOX_MORPH_API_KEY`, `MORPH_API_KEY`, or `morph.apiKey`,
+  plus `CRABBOX_LIVE_MORPH_SNAPSHOT`. `scripts/live-smoke.sh` refuses to call
+  Morph until both are configured, then creates one delete-on-release instance,
+  runs the normal SSH lease lifecycle, lists normalized inventory, and stops the
+  lease.
 - **Scaleway** — `SCW_ACCESS_KEY`, `SCW_SECRET_KEY`,
   `SCW_DEFAULT_ORGANIZATION_ID`, `SCW_DEFAULT_PROJECT_ID`,
   `SCW_DEFAULT_REGION`, and `SCW_DEFAULT_ZONE`, or equivalent

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -3055,3 +3055,44 @@ exit 0
   const calls = fs.existsSync(crabboxLog) ? fs.readFileSync(crabboxLog, "utf8") : "";
   assert.doesNotMatch(calls, /--provider morph/, "no morph-specific crabbox call may be issued when the key is missing");
 });
+
+test("morph live smoke requires a snapshot before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-morph-nosnapshot-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  fs.mkdirSync(bin);
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+exit 99
+`,
+  );
+
+  const env = { ...process.env };
+  delete env.CRABBOX_LIVE_MORPH_SNAPSHOT;
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      PATH: `${bin}${path.delimiter}${env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "morph",
+      CRABBOX_LIVE_REPO: repoRoot,
+      CRABBOX_MORPH_API_KEY: "dummy-morph-key",
+    },
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0, "expected non-zero exit when morph snapshot is missing");
+  assert.match(result.stderr, /CRABBOX_LIVE_MORPH_SNAPSHOT/);
+  const calls = fs.existsSync(crabboxLog) ? fs.readFileSync(crabboxLog, "utf8") : "";
+  assert.doesNotMatch(calls, /--provider morph/, "no morph-specific crabbox call may be issued when the snapshot is missing");
+});


### PR DESCRIPTION
## Summary
- add a Morph live-smoke regression for missing CRABBOX_LIVE_MORPH_SNAPSHOT before any provider mutation
- document the Morph live-smoke command and prerequisites in operations
- add the Unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Live Morph API smoke was not run; this is credentialless preflight coverage.