### PR TITLE
test(providers): cover external live smoke config guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Added Blacksmith Testbox live-smoke documentation and workflow preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added W&B live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Incus live-smoke documentation and preflight regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added External live-smoke documentation and configuration preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added E2B live-smoke documentation and API-key preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Modal live-smoke documentation and Python-client preflight coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Tenki live-smoke documentation and CLI-auth preflight coverage for the guarded `scripts/live-smoke.sh` matrix.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,7 +125,12 @@ Per-provider smoke prerequisites:
   `SandboxWarmPool`. `scripts/live-agent-sandbox-smoke.sh` is coordinator-free,
   creates a short-lived `SandboxClaim`, verifies archive sync, env forwarding,
   retained-claim reuse, replacement sync, status/list, and claim deletion.
-- **External** — a configured provider executable through `external.command` or `CRABBOX_LIVE_EXTERNAL_COMMAND`.
+- **External** — a configured provider executable through `external.command` or
+  `CRABBOX_LIVE_EXTERNAL_COMMAND`, or a declarative
+  `external.lifecycle.acquire` configuration. `scripts/live-smoke.sh` refuses
+  to call External lifecycle commands until one path is configured, then runs
+  the normal SSH lease lifecycle, lists normalized inventory, and stops the
+  lease.
 - **Morph** — `CRABBOX_MORPH_API_KEY`, `MORPH_API_KEY`, or `morph.apiKey`,
   plus `CRABBOX_LIVE_MORPH_SNAPSHOT`. `scripts/live-smoke.sh` refuses to call
   Morph until both are configured, then creates one delete-on-release instance,

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1268,6 +1268,50 @@ esac
   assert.doesNotMatch(crabboxCalls, /external_command=[^ \n]+/);
 });
 
+test("external live smoke requires configuration before provider mutation", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-external-noconfig-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  const config = path.join(dir, "crabbox.yaml");
+  fs.mkdirSync(bin);
+  fs.writeFileSync(config, "provider: external\n", "utf8");
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+exit 99
+`,
+  );
+
+  const env = { ...process.env };
+  delete env.CRABBOX_EXTERNAL_COMMAND;
+  delete env.CRABBOX_LIVE_EXTERNAL_COMMAND;
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...env,
+      PATH: `${bin}${path.delimiter}${env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: config,
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "external",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0, "expected non-zero exit when external config is missing");
+  assert.match(result.stderr, /external command or external\.lifecycle\.acquire configuration/);
+  const calls = fs.existsSync(crabboxLog) ? fs.readFileSync(crabboxLog, "utf8") : "";
+  assert.equal(calls, "", "no crabbox provider call may be issued when external config is missing");
+});
+
 test("default live smoke keeps Morph opt-in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-default-providers-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary
- add an External live-smoke regression for missing executable/lifecycle config before provider mutation
- document External live-smoke prerequisites in operations
- add the Unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Live External provider smoke was not run; this is credentialless preflight coverage.