### PR TITLE
test(providers): cover namespace compute live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Added KubeVirt live-smoke dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added Namespace Compute live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Blacksmith Testbox live-smoke documentation and workflow preflight coverage for the guarded `scripts/live-smoke.sh` matrix.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,6 +54,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=e2b               CRABBOX_LIVE_REPO=/path/
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=modal             CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=daytona           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-devbox  CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-instance CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=semaphore         CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=sprites           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
@@ -110,6 +111,9 @@ Per-provider smoke prerequisites:
   then creates a delete-on-release Devbox, runs one no-sync command, and prints a
   normalized list proof.
 - **Namespace Compute** — the authenticated `nsc` CLI on `PATH`; run `nsc login` first.
+  `scripts/live-smoke.sh` runs `doctor`, snapshots existing Crabbox-owned
+  inventory, creates one short-lived Compute Instance, runs the normal SSH lease
+  lifecycle, stops the lease, and fails if the post-smoke inventory changed.
 - **Sprites** — the authenticated `sprite` CLI on `PATH` plus a Sprites token
   in the environment. `scripts/live-smoke.sh` refuses to call Sprites until the
   CLI is available, then creates one sprite, verifies SSH, runs one command,

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -433,6 +433,95 @@ esac
   assert.doesNotMatch(calls, /^stop /m);
 });
 
+test("Namespace Compute live smoke uses the generic SSH lease lifecycle", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-namespace-compute-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const crabboxLog = path.join(dir, "crabbox.log");
+  fs.mkdirSync(bin);
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  warmup|status|inspect|ssh|cache|run|history|stop)
+    if [[ "\${CRABBOX_PROVIDER:-}" != "namespace-instance" ]]; then
+      printf 'missing namespace-instance provider environment for: %s\\n' "$*" >&2
+      exit 97
+    fi
+    ;;
+esac
+printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+case "$1" in
+  doctor)
+    printf 'ok provider=namespace-instance\\n'
+    ;;
+  list)
+    printf '[{"CloudID":"nsc-existing","Provider":"namespace-instance","State":"ready"}]\\n'
+    ;;
+  warmup)
+    printf 'provisioning provider=namespace-instance lease=cbx_123456789abc slug=namespace-compute-smoke-test\\n'
+    printf 'provisioned lease=cbx_123456789abc slug=namespace-compute-smoke-test state=ready\\n'
+    ;;
+  status)
+    printf 'lease=cbx_123456789abc slug=namespace-compute-smoke-test provider=namespace-instance state=ready ready=true\\n'
+    ;;
+  inspect)
+    printf '{"id":"cbx_123456789abc","slug":"namespace-compute-smoke-test","provider":"namespace-instance","state":"ready","serverType":"4x8","host":"127.0.0.1","ready":true,"lastTouchedAt":"2026-06-11T00:00:00Z","expiresAt":"2026-06-11T00:10:00Z"}\\n'
+    ;;
+  ssh)
+    exit 0
+    ;;
+  cache)
+    printf '[]\\n'
+    ;;
+  run)
+    printf 'crabbox-live-ok\\n'
+    ;;
+  history)
+    printf 'history ok\\n'
+    ;;
+  stop)
+    printf 'stopped %s\\n' "\${*: -1}"
+    ;;
+  admin)
+    printf '[]\\n'
+    ;;
+  *)
+    printf 'unexpected crabbox args: %s\\n' "$*" >&2
+    exit 99
+    ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+      CRABBOX_FAKE_LOG: crabboxLog,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_PROVIDERS: "namespace-instance",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /crabbox-live-ok/);
+  const calls = fs.readFileSync(crabboxLog, "utf8");
+  assert.match(calls, /^doctor --provider namespace-instance$/m);
+  assert.equal((calls.match(/^list --provider namespace-instance --json$/gm) ?? []).length, 2);
+  assert.match(calls, /^warmup --provider namespace-instance --class standard --ttl 10m --idle-timeout 5m$/m);
+  for (const command of ["status", "inspect", "ssh", "cache", "run", "history", "stop"]) {
+    assert.match(calls, new RegExp(`^${command}(?: |$)`, "m"));
+  }
+});
+
 test("Semaphore live smoke requires host before provider mutation", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-semaphore-"));
   const fakeCrabbox = path.join(dir, "crabbox");


### PR DESCRIPTION
## Summary
- add Namespace Compute live-smoke regression coverage for the generic SSH lifecycle path
- document the namespace-instance live-smoke command and inventory safety check
- add the Unreleased changelog entry

## Verification
- git diff --check
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh

Live Namespace Compute smoke was not run; this is credentialless dispatch coverage.