### PR TITLE
docs(providers): cover local runtime live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added Daytona live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Namespace Devbox live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Namespace Compute live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
+- Added local runtime live-smoke documentation coverage for Apple Container, Local Container, Multipass, Tart, and Apple VZ.
 - Added Semaphore live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Sprites live-smoke documentation and dispatch regression coverage for the guarded `scripts/live-smoke.sh` matrix.
 - Added Blacksmith Testbox live-smoke documentation and workflow preflight coverage for the guarded `scripts/live-smoke.sh` matrix.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -67,6 +67,11 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=docker-sandbox CRABBOX_LIVE_COORDINATOR=0 
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=smolvm CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=superserve CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=vercel-sandbox CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=apple-container CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=local-container CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=multipass CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tart CRABBOX_LIVE_COORDINATOR=0 scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=apple-vz CRABBOX_LIVE_COORDINATOR=0 CRABBOX_BIN=./bin/crabbox scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=linode scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=digitalocean scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=nebius scripts/live-smoke.sh
@@ -152,6 +157,23 @@ Per-provider smoke prerequisites:
 - **SmolVM** — `CRABBOX_SMOLVM_API_KEY`, `SMOLMACHINES_API_KEY`, or `SMK_API_KEY`.
 - **Superserve** — `CRABBOX_SUPERSERVE_API_KEY` or `SUPERSERVE_API_KEY`.
 - **Vercel Sandbox** — authenticated `sandbox` CLI on `PATH`; project and team scope may come from `CRABBOX_VERCEL_SANDBOX_PROJECT_ID` plus `CRABBOX_VERCEL_SANDBOX_TEAM_ID`, `CRABBOX_VERCEL_SANDBOX_SCOPE`, or the Vercel OIDC environment.
+- **Apple Container** — Apple silicon macOS with Apple's `container` CLI on
+  `PATH` and `container system start` already run. `scripts/live-smoke.sh` uses
+  the normal SSH lease lifecycle with a short TTL and no coordinator.
+- **Local Container** — a working Docker-compatible CLI and daemon such as
+  Docker Desktop, OrbStack, or Colima. `scripts/live-smoke.sh` uses the normal
+  SSH lease lifecycle with a short TTL and no coordinator.
+- **Multipass** — Canonical Multipass installed locally and able to launch
+  Ubuntu VMs. `scripts/live-smoke.sh` uses the normal SSH lease lifecycle with a
+  short TTL and no coordinator.
+- **Tart** — Apple silicon macOS with the `tart` CLI installed, a reachable base
+  image, and guest login credentials configured when the selected image needs a
+  password. `scripts/live-smoke.sh` uses the normal SSH lease lifecycle with a
+  longer TTL and no coordinator.
+- **Apple VZ** — Apple silicon macOS, a locally built Crabbox binary
+  (`CRABBOX_BIN`), and the bundled or explicit `crabbox-apple-vz-helper`.
+  `scripts/live-smoke.sh` uses the normal SSH lease lifecycle and preserves
+  `CRABBOX_LIVE_APPLE_VZ_HELPER` for the whole run when set.
 - **W&B** — `WANDB_ENTITY_NAME` plus `CRABBOX_WANDB_API_KEY` or
   `WANDB_API_KEY` (from `wandb login`). `scripts/live-smoke.sh` refuses to call
   W&B until an API key is exported, then runs `doctor`, executes one no-sync

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -12,6 +12,16 @@ function writeExecutable(file, body) {
   fs.chmodSync(file, 0o755);
 }
 
+test("operations docs cover local runtime live-smoke dispatches", () => {
+  const docs = fs.readFileSync(path.join(repoRoot, "docs", "operations.md"), "utf8");
+  for (const provider of ["apple-container", "local-container", "multipass", "tart", "apple-vz"]) {
+    assert.match(docs, new RegExp(`CRABBOX_LIVE_PROVIDERS=${provider}\\b`));
+  }
+  for (const heading of ["Apple Container", "Local Container", "Multipass", "Tart", "Apple VZ"]) {
+    assert.match(docs, new RegExp(`\\*\\*${heading}\\*\\*`));
+  }
+});
+
 test("OpenSandbox live smoke dispatches to the provider-specific script", () => {
   const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
     cwd: repoRoot,


### PR DESCRIPTION
## Summary
- document local runtime live-smoke commands for Apple Container, Local Container, Multipass, Tart, and Apple VZ
- add per-provider operations prerequisites for those local runtimes
- add a regression that keeps the operations docs aligned with those live-smoke dispatches

## Verification
- bash -n scripts/live-smoke.sh
- node --test scripts/live-smoke.test.js
- scripts/check-docs.sh