### PR TITLE
feat(cua): add delegated-run provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added CUA delegated-run lifecycle support with archive sync, retained sandbox reuse, owned cleanup, provider docs, and opt-in live smoke classification.
 - Added direct FastAPI Cloud application and deployment inspection through `status`, `list`, and `doctor`, including configured default application support. Thanks @zozo123.
 - Added normalized provider runtime capabilities and `--runtime` filters to `crabbox providers` and `crabbox providers recommend`.
 - Added `crabbox providers recommend fanout-testing` for forkable workspace and best-of-N test selection guidance.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -61,7 +61,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 67 providers (39 SSH lease, 26 delegated run, 2 service control).
+Current built-in surface: 68 providers (39 SSH lease, 27 delegated run, 2 service control).
 
 Access terms:
 
@@ -88,6 +88,7 @@ Access terms:
 | [cloudflare-sandbox](cloudflare-sandbox.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; Cloudflare Sandbox bridge | `cloud`; GPU: no | Cloudflare Sandbox bridge; sandbox delete | Cloudflare Sandbox Linux command execution through a bridge | Requires a configured bridge URL; no SSH, browser, Tailscale, URL sessions, mounts, or checkpoints |
 | [coder](coder.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `linux`; Coder workspace | `provider-managed`; GPU: unknown | Coder CLI; workspace stop or delete | Coder-backed Linux workspace over SSH proxy | Requires the coder CLI, login, template access, and workspace quota |
 | [codesandbox](codesandbox.md) (`csb`, `code-sandbox`) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup`, `pause-resume`, `run-session` | `linux`; CodeSandbox SDK sandbox | `provider-managed`; GPU: no | CodeSandbox; sandbox delete | Managed CodeSandbox Linux development environments | Requires env-only SDK auth and a local Node bridge |
+| [cua](cua.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `cleanup` | `linux`; CUA cloud Linux sandbox | `provider-managed`; GPU: unknown | CUA; owned sandbox delete | Managed delegated Linux sandbox execution through CUA | Delegated command execution only; not a Crabbox SSH lease |
 | [daytona](daytona.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `archive-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Daytona sandbox | `provider-managed`; GPU: unknown | Daytona; sandbox delete | Managed development sandbox with delegated archive sync and execution | SSH access is short-lived; run and sync use Daytona toolbox APIs |
 | [digitalocean](digitalocean.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; DigitalOcean Droplet | `cloud`; GPU: optional | Crabbox; Droplet and key delete | Simple direct Linux VM | Direct-only; no coordinator scheduling |
 | [docker-sandbox](docker-sandbox.md) | built-in; `delegated-run` · local-sandbox | No SSH; `provider-owned` · direct only; features: `run-session`, `mcp-attachments` | `linux`; Docker Sandbox | `local`; GPU: no | Docker sbx CLI; sandbox delete | Local delegated sandbox with reusable session handles | Requires the standalone sbx CLI |

--- a/docs/providers/cua.md
+++ b/docs/providers/cua.md
@@ -3,36 +3,48 @@
 Read when:
 
 - choosing `provider: cua`;
-- configuring the CUA provider contract, image, kind, workdir, sizing, or SDK
-  bridge diagnostics;
+- configuring CUA cloud Linux sandbox runs;
+- troubleshooting CUA local claims, archive sync, cleanup, or live smoke;
 - changing `internal/providers/cua`.
 
-CUA is a delegated run provider foundation. Crabbox v1 treats CUA as a Linux
-cloud sandbox where CUA owns command and file transport and Crabbox owns
-provider selection, non-secret config, local claims, archive sync guardrails,
-cleanup commands, and normalized output.
+CUA is a delegated-run provider. Crabbox creates a CUA cloud Linux sandbox,
+uploads the repository with Crabbox archive sync, asks CUA to run commands, and
+records a local Crabbox claim for retained sandboxes. CUA owns command and file
+transport. Crabbox owns provider selection, non-secret config, safe local
+claims, sync guardrails, cleanup commands, and normalized output.
 
-This page is intentionally limited to the PLAN-01 contract. The Python SDK
-bridge, local claim reconciliation, lifecycle commands, archive sync behavior,
-and live smoke instructions are completed by later implementation phases.
+## Supported Commands
 
-## Current Contract
+```sh
+crabbox doctor --provider cua --json
+crabbox warmup --provider cua
+crabbox run --provider cua -- go test ./...
+crabbox run --provider cua --id <lease-or-slug> -- go test ./...
+crabbox list --provider cua
+crabbox status --provider cua --id <lease-or-slug>
+crabbox stop --provider cua <lease-or-slug>
+crabbox cleanup --provider cua --dry-run
+crabbox cleanup --provider cua
+```
 
-The provider is registered as `cua` with no aliases. It advertises Linux,
-delegated-run execution with archive sync and cleanup support, and it does not
-advertise SSH, desktop/browser/code, Tailscale, URL bridge, snapshots,
-checkpoints, forks, cache volumes, Actions hydration, MCP attachments, run
-artifacts, or run downloads.
-
-`crabbox doctor --provider cua --json` is non-mutating in this foundation phase.
-It validates local config and reports the bridge/lifecycle work as deferred
-without creating CUA resources.
+Fresh `run` creates a short-lived sandbox and deletes it by default after the
+command finishes. `warmup`, `run --keep`, `run --keep-on-failure`, and reused
+`run --id` keep the sandbox under a local Crabbox claim until `stop` or
+`cleanup` removes it.
 
 ## Auth And API URL
 
-Crabbox does not persist CUA API keys in config and does not accept API keys on
-argv. Later bridge code resolves credentials through CUA's environment or
-credential store, starting with `CUA_API_KEY`.
+Crabbox never stores CUA API keys in config and does not accept API keys on
+argv. The bridge passes credentials to the CUA SDK through environment only:
+
+```sh
+export CRABBOX_CUA_API_KEY=...
+# or
+export CUA_API_KEY=...
+```
+
+`CRABBOX_CUA_API_KEY` wins over `CUA_API_KEY`. Command environment forwarding
+strips CUA auth variables before running the user command inside the sandbox.
 
 The API URL is trusted local input only. It can come from `--cua-api-url`,
 `CRABBOX_CUA_API_URL`, or SDK-compatible `CUA_BASE_URL`. Repository YAML cannot
@@ -103,3 +115,109 @@ CRABBOX_CUA_FORGET_MISSING
 
 `--class` and `--type` are rejected for `provider=cua`; use CUA-specific image,
 kind, and sizing flags instead.
+
+## Lifecycle And Claims
+
+Crabbox lease IDs use the `cuabx_` prefix. CUA sandbox names use the
+`crabbox-cua-` prefix. Stop and cleanup are intentionally conservative:
+
+- `stop` resolves a local Crabbox claim by lease ID or slug before deleting;
+- `cleanup` scans local `cuabx_` claims only;
+- both validate the active CUA API scope and expected sandbox name prefix;
+- neither deletes arbitrary CUA account sandboxes from a loose name match.
+
+If the remote sandbox is already gone, Crabbox leaves the claim in place by
+default. Use `--cua-forget-missing` or `cua.forgetMissing: true` only when you
+want stop or cleanup to remove stale local claims after a missing-sandbox proof.
+
+## Sync And Command Execution
+
+CUA uses Crabbox delegated archive sync. Normal `run` uploads tracked files plus
+non-ignored untracked files according to the usual Crabbox sync rules. `sync.delete`
+is honored by extracting into a staging directory and replacing the remote
+workdir. `--sync-only`, `--no-sync`, and `--force-sync-large` are supported.
+
+The default workdir is `/workspace/crabbox`. It must be an absolute path under
+`/workspace/<dedicated-subdir>`; broad paths such as `/workspace` are rejected.
+
+Use `--shell` for shell syntax:
+
+```sh
+crabbox run --provider cua --shell 'python -m pytest && go test ./...'
+```
+
+Use plain argv for one executable:
+
+```sh
+crabbox run --provider cua -- go test ./...
+```
+
+## Unsupported In V1
+
+CUA is not a Crabbox SSH lease provider. These features are intentionally not
+advertised in v1:
+
+- SSH login, `connect`, `ssh`, `cp`, or port forwarding;
+- desktop/browser/code surfaces, screenshots, VNC, mouse, keyboard, mobile, or
+  agent-control helpers;
+- broker/coordinator support;
+- GitHub Actions hydration or Actions runner mode;
+- cache volumes, URL bridge, run artifacts, run downloads, and captured stdout
+  or stderr files;
+- macOS, Windows, Android, local CUA runtime, snapshots, checkpoints, forks, or
+  arbitrary account sandbox management.
+
+Unsupported Crabbox flags fail before CUA resources are created.
+
+## Live Smoke
+
+The CUA live smoke is opt-in because it can create paid cloud resources:
+
+```sh
+CRABBOX_CUA_LIVE=1 CRABBOX_CUA_API_KEY=... scripts/live-cua-smoke.sh
+```
+
+Without `CRABBOX_CUA_LIVE=1`, the script prints:
+
+```text
+skipped reason=missing_CRABBOX_CUA_LIVE
+```
+
+With opt-in but no credentials, it prints `environment_blocked`. With
+credentials, it builds a temporary local Crabbox binary, runs non-mutating
+doctor, creates a short-lived CUA sandbox, proves warmup/run/reuse/status/list,
+stops the sandbox, verifies cleanup, and prints exactly one final
+classification:
+
+- `live_cua_smoke_passed`
+- `skipped`
+- `environment_blocked`
+- `quota_blocked`
+- `validation_failed`
+- `cleanup_failed`
+- `diagnostic_only`
+
+The script attempts cleanup on every path after a sandbox is created. If cleanup
+cannot be proven, the final classification is `cleanup_failed` and the output
+names the retained slug/lease context needed for manual cleanup.
+
+## Troubleshooting
+
+Run non-mutating readiness first:
+
+```sh
+crabbox doctor --provider cua --json
+```
+
+Common classes:
+
+- `environment_blocked`: missing Python, unsupported Python version, missing
+  CUA SDK import, missing credentials, network/TLS failure, or auth rejection.
+- `quota_blocked`: CUA quota, rate limit, or capacity failure.
+- `validation_failed`: bad config, bad workdir, unsupported target, or unknown
+  bridge action.
+- `diagnostic_only`: live smoke could not prove the full contract and did not
+  have enough evidence to classify auth, quota, validation, or cleanup.
+
+Keep provider tokens out of repo config, command arguments, timing JSON, logs,
+claim files, and docs examples.

--- a/docs/providers/cua.md
+++ b/docs/providers/cua.md
@@ -1,0 +1,105 @@
+# CUA Provider
+
+Read when:
+
+- choosing `provider: cua`;
+- configuring the CUA provider contract, image, kind, workdir, sizing, or SDK
+  bridge diagnostics;
+- changing `internal/providers/cua`.
+
+CUA is a delegated run provider foundation. Crabbox v1 treats CUA as a Linux
+cloud sandbox where CUA owns command and file transport and Crabbox owns
+provider selection, non-secret config, local claims, archive sync guardrails,
+cleanup commands, and normalized output.
+
+This page is intentionally limited to the PLAN-01 contract. The Python SDK
+bridge, local claim reconciliation, lifecycle commands, archive sync behavior,
+and live smoke instructions are completed by later implementation phases.
+
+## Current Contract
+
+The provider is registered as `cua` with no aliases. It advertises Linux,
+delegated-run execution with archive sync and cleanup support, and it does not
+advertise SSH, desktop/browser/code, Tailscale, URL bridge, snapshots,
+checkpoints, forks, cache volumes, Actions hydration, MCP attachments, run
+artifacts, or run downloads.
+
+`crabbox doctor --provider cua --json` is non-mutating in this foundation phase.
+It validates local config and reports the bridge/lifecycle work as deferred
+without creating CUA resources.
+
+## Auth And API URL
+
+Crabbox does not persist CUA API keys in config and does not accept API keys on
+argv. Later bridge code resolves credentials through CUA's environment or
+credential store, starting with `CUA_API_KEY`.
+
+The API URL is trusted local input only. It can come from `--cua-api-url`,
+`CRABBOX_CUA_API_URL`, or SDK-compatible `CUA_BASE_URL`. Repository YAML cannot
+set the API URL. Overrides must be HTTPS, except loopback HTTP for local
+development, and must not contain userinfo, query parameters, or fragments.
+
+## Config
+
+```yaml
+provider: cua
+target: linux
+cua:
+  image: ubuntu:24.04
+  kind: container
+  region: ""
+  workdir: /workspace/crabbox
+  vcpus: 0
+  memoryMB: 0
+  diskGB: 0
+  startupTimeoutSecs: 0
+  execTimeoutSecs: 600
+  bridgeCommand: python3
+  sdkPackage: cua
+  sdkImport: cua
+  sdkFallbackImport: cua_sandbox
+  forgetMissing: false
+```
+
+Provider flags:
+
+```text
+--cua-api-url
+--cua-image
+--cua-kind
+--cua-region
+--cua-workdir
+--cua-vcpus
+--cua-memory-mb
+--cua-disk-gb
+--cua-startup-timeout-secs
+--cua-exec-timeout-secs
+--cua-bridge-command
+--cua-sdk-package
+--cua-sdk-import
+--cua-sdk-fallback-import
+--cua-forget-missing
+```
+
+Environment overrides:
+
+```text
+CRABBOX_CUA_API_URL / CUA_BASE_URL
+CRABBOX_CUA_IMAGE
+CRABBOX_CUA_KIND
+CRABBOX_CUA_REGION
+CRABBOX_CUA_WORKDIR
+CRABBOX_CUA_VCPUS
+CRABBOX_CUA_MEMORY_MB
+CRABBOX_CUA_DISK_GB
+CRABBOX_CUA_STARTUP_TIMEOUT_SECS
+CRABBOX_CUA_EXEC_TIMEOUT_SECS
+CRABBOX_CUA_BRIDGE_COMMAND
+CRABBOX_CUA_SDK_PACKAGE
+CRABBOX_CUA_SDK_IMPORT
+CRABBOX_CUA_SDK_FALLBACK_IMPORT
+CRABBOX_CUA_FORGET_MISSING
+```
+
+`--class` and `--type` are rejected for `provider=cua`; use CUA-specific image,
+kind, and sizing flags instead.

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -223,6 +223,20 @@
     "caveat": "Requires env-only SDK auth and a local Node bridge",
     "docs": "codesandbox.md"
   },
+  "cua": {
+    "status": "built-in",
+    "category": "delegated-sandbox",
+    "substrate": "CUA cloud Linux sandbox",
+    "location": "provider-managed",
+    "ssh": "no",
+    "sync": "archive-sync",
+    "gpu": "unknown",
+    "lifecycle": "CUA",
+    "cleanup": "owned sandbox delete",
+    "bestFit": "Managed delegated Linux sandbox execution through CUA",
+    "caveat": "Delegated command execution only; not a Crabbox SSH lease",
+    "docs": "cua.md"
+  },
   "coder": {
     "status": "built-in",
     "category": "direct-cloud",

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -109,6 +109,8 @@ Delegated-run providers (no SSH lease):
   `internal/providers/blacksmith`, `internal/providers/wandb`
 - Superserve delegated lifecycle, archive sync, data-plane file upload, exec,
   and live smoke: `internal/providers/superserve`, `scripts/live-superserve-smoke.sh`
+- CUA delegated lifecycle, archive sync, Python SDK bridge, owned cleanup, and
+  live smoke: `internal/providers/cua`, `docs/providers/cua.md`, `scripts/live-cua-smoke.sh`
 - Anthropic Sandbox Runtime live local enforcement smoke: `scripts/live-anthropic-sandbox-runtime-smoke.sh`
 - Azure Container Apps dynamic sessions (shares the `azure` family, but
   delegated-run): `internal/providers/azuredynamicsessions`, runner image `worker/azure-dynamic-sessions.Dockerfile`
@@ -236,5 +238,5 @@ Provider docs:
 - Release workflow and Homebrew tap fallback: `.github/workflows/release.yml`
 - GoReleaser archives and Homebrew formula config: `.goreleaser.yaml`
 - Docs command-surface check, link check, site builder, and Pages deploy: `scripts/check-command-docs.mjs`, `scripts/check-docs-links.mjs`, `scripts/build-docs-site.mjs`, `.github/workflows/pages.yml`
-- Live provider smoke coverage: `scripts/live-smoke.sh`, plus provider-specific guarded smokes such as `scripts/live-blaxel-smoke.sh`, `scripts/live-digitalocean-smoke.sh`, `scripts/live-vultr-smoke.sh`, and `scripts/live-superserve-smoke.sh`
+- Live provider smoke coverage: `scripts/live-smoke.sh`, plus provider-specific guarded smokes such as `scripts/live-blaxel-smoke.sh`, `scripts/live-cua-smoke.sh`, `scripts/live-digitalocean-smoke.sh`, `scripts/live-vultr-smoke.sh`, and `scripts/live-superserve-smoke.sh`
 - Live coordinator auth smoke coverage: `scripts/live-auth-smoke.sh`

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -177,6 +177,7 @@ type Config struct {
 	Freestyle                     FreestyleConfig
 	Tenki                         TenkiConfig
 	Tensorlake                    TensorlakeConfig
+	Cua                           CuaConfig
 	OpenComputer                  OpenComputerConfig
 	CodeSandbox                   CodeSandboxConfig
 	OpenSandbox                   OpenSandboxConfig
@@ -695,6 +696,28 @@ type TensorlakeConfig struct {
 	DiskMB         int
 	TimeoutSecs    int
 	NoInternet     bool
+}
+
+// CuaConfig configures the delegated CUA provider. API keys are intentionally
+// absent: later bridge code resolves CUA_API_KEY / credential-store auth at
+// runtime and must pass credentials only through environment or SDK stores.
+// APIURL is trusted local input only and is never loaded from repository YAML.
+type CuaConfig struct {
+	APIURL             string
+	Image              string
+	Kind               string
+	Region             string
+	Workdir            string
+	VCPUs              int
+	MemoryMB           int
+	DiskGB             int
+	StartupTimeoutSecs int
+	ExecTimeoutSecs    int
+	BridgeCommand      string
+	SDKPackage         string
+	SDKImport          string
+	SDKFallbackImport  string
+	ForgetMissing      bool
 }
 
 // OpenComputerConfig configures the delegated OpenComputer provider, which
@@ -2590,6 +2613,16 @@ func baseConfig() Config {
 			MemoryMB: 1024,
 			DiskMB:   10240,
 		},
+		Cua: CuaConfig{
+			Image:             "ubuntu:24.04",
+			Kind:              "container",
+			Workdir:           "/workspace/crabbox",
+			ExecTimeoutSecs:   600,
+			BridgeCommand:     "python3",
+			SDKPackage:        "cua",
+			SDKImport:         "cua",
+			SDKFallbackImport: "cua_sandbox",
+		},
 		OpenComputer: OpenComputerConfig{
 			// APIURL is intentionally unset here so the `oc` config file's
 			// api_url is honored before the built-in default; the provider
@@ -2859,6 +2892,7 @@ type fileConfig struct {
 	Freestyle                *fileFreestyleConfig                `yaml:"freestyle,omitempty"`
 	Tenki                    *fileTenkiConfig                    `yaml:"tenki,omitempty"`
 	Tensorlake               *fileTensorlakeConfig               `yaml:"tensorlake,omitempty"`
+	Cua                      *fileCuaConfig                      `yaml:"cua,omitempty"`
 	OpenComputer             *fileOpenComputerConfig             `yaml:"openComputer,omitempty"`
 	CodeSandbox              *fileCodeSandboxConfig              `yaml:"codeSandbox,omitempty"`
 	OpenSandbox              *fileOpenSandboxConfig              `yaml:"openSandbox,omitempty"`
@@ -3489,6 +3523,23 @@ type fileTensorlakeConfig struct {
 	DiskMB         int     `yaml:"diskMB,omitempty"`
 	TimeoutSecs    int     `yaml:"timeoutSecs,omitempty"`
 	NoInternet     *bool   `yaml:"noInternet,omitempty"`
+}
+
+type fileCuaConfig struct {
+	Image              *string `yaml:"image,omitempty"`
+	Kind               *string `yaml:"kind,omitempty"`
+	Region             *string `yaml:"region,omitempty"`
+	Workdir            *string `yaml:"workdir,omitempty"`
+	VCPUs              *int    `yaml:"vcpus,omitempty"`
+	MemoryMB           *int    `yaml:"memoryMB,omitempty"`
+	DiskGB             *int    `yaml:"diskGB,omitempty"`
+	StartupTimeoutSecs *int    `yaml:"startupTimeoutSecs,omitempty"`
+	ExecTimeoutSecs    *int    `yaml:"execTimeoutSecs,omitempty"`
+	BridgeCommand      *string `yaml:"bridgeCommand,omitempty"`
+	SDKPackage         *string `yaml:"sdkPackage,omitempty"`
+	SDKImport          *string `yaml:"sdkImport,omitempty"`
+	SDKFallbackImport  *string `yaml:"sdkFallbackImport,omitempty"`
+	ForgetMissing      *bool   `yaml:"forgetMissing,omitempty"`
 }
 
 type fileOpenComputerConfig struct {
@@ -5683,6 +5734,65 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 			cfg.Tensorlake.NoInternet = *file.Tensorlake.NoInternet
 		}
 	}
+	if file.Cua != nil {
+		if file.Cua.Image != nil {
+			cfg.Cua.Image = *file.Cua.Image
+		}
+		if file.Cua.Kind != nil {
+			cfg.Cua.Kind = *file.Cua.Kind
+		}
+		if file.Cua.Region != nil {
+			cfg.Cua.Region = *file.Cua.Region
+		}
+		if file.Cua.Workdir != nil {
+			cfg.Cua.Workdir = *file.Cua.Workdir
+		}
+		if file.Cua.VCPUs != nil {
+			if *file.Cua.VCPUs < 0 {
+				return exit(2, "cua vcpus must be non-negative")
+			}
+			cfg.Cua.VCPUs = *file.Cua.VCPUs
+		}
+		if file.Cua.MemoryMB != nil {
+			if *file.Cua.MemoryMB < 0 {
+				return exit(2, "cua memoryMB must be non-negative")
+			}
+			cfg.Cua.MemoryMB = *file.Cua.MemoryMB
+		}
+		if file.Cua.DiskGB != nil {
+			if *file.Cua.DiskGB < 0 {
+				return exit(2, "cua diskGB must be non-negative")
+			}
+			cfg.Cua.DiskGB = *file.Cua.DiskGB
+		}
+		if file.Cua.StartupTimeoutSecs != nil {
+			if *file.Cua.StartupTimeoutSecs < 0 {
+				return exit(2, "cua startupTimeoutSecs must be non-negative")
+			}
+			cfg.Cua.StartupTimeoutSecs = *file.Cua.StartupTimeoutSecs
+		}
+		if file.Cua.ExecTimeoutSecs != nil {
+			if *file.Cua.ExecTimeoutSecs < 0 {
+				return exit(2, "cua execTimeoutSecs must be non-negative")
+			}
+			cfg.Cua.ExecTimeoutSecs = *file.Cua.ExecTimeoutSecs
+		}
+		if trusted && file.Cua.BridgeCommand != nil {
+			cfg.Cua.BridgeCommand = *file.Cua.BridgeCommand
+		}
+		if trusted && file.Cua.SDKPackage != nil {
+			cfg.Cua.SDKPackage = *file.Cua.SDKPackage
+		}
+		if trusted && file.Cua.SDKImport != nil {
+			cfg.Cua.SDKImport = *file.Cua.SDKImport
+		}
+		if trusted && file.Cua.SDKFallbackImport != nil {
+			cfg.Cua.SDKFallbackImport = *file.Cua.SDKFallbackImport
+		}
+		if file.Cua.ForgetMissing != nil {
+			cfg.Cua.ForgetMissing = *file.Cua.ForgetMissing
+		}
+	}
 	if file.OpenComputer != nil {
 		if file.OpenComputer.Workdir != "" {
 			cfg.OpenComputer.Workdir = file.OpenComputer.Workdir
@@ -7498,6 +7608,39 @@ func applyEnv(cfg *Config) error {
 	if v, ok := getenvBool("CRABBOX_TENSORLAKE_NO_INTERNET"); ok {
 		cfg.Tensorlake.NoInternet = v
 	}
+	var err error
+	cfg.Cua.APIURL = getenv("CRABBOX_CUA_API_URL", getenv("CUA_BASE_URL", cfg.Cua.APIURL))
+	cfg.Cua.Image = getenv("CRABBOX_CUA_IMAGE", cfg.Cua.Image)
+	cfg.Cua.Kind = getenv("CRABBOX_CUA_KIND", cfg.Cua.Kind)
+	cfg.Cua.Region = getenv("CRABBOX_CUA_REGION", cfg.Cua.Region)
+	cfg.Cua.Workdir = getenv("CRABBOX_CUA_WORKDIR", cfg.Cua.Workdir)
+	cfg.Cua.VCPUs, err = getenvNonNegativeInt("CRABBOX_CUA_VCPUS", cfg.Cua.VCPUs)
+	if err != nil {
+		return err
+	}
+	cfg.Cua.MemoryMB, err = getenvNonNegativeInt("CRABBOX_CUA_MEMORY_MB", cfg.Cua.MemoryMB)
+	if err != nil {
+		return err
+	}
+	cfg.Cua.DiskGB, err = getenvNonNegativeInt("CRABBOX_CUA_DISK_GB", cfg.Cua.DiskGB)
+	if err != nil {
+		return err
+	}
+	cfg.Cua.StartupTimeoutSecs, err = getenvNonNegativeInt("CRABBOX_CUA_STARTUP_TIMEOUT_SECS", cfg.Cua.StartupTimeoutSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Cua.ExecTimeoutSecs, err = getenvNonNegativeInt("CRABBOX_CUA_EXEC_TIMEOUT_SECS", cfg.Cua.ExecTimeoutSecs)
+	if err != nil {
+		return err
+	}
+	cfg.Cua.BridgeCommand = getenv("CRABBOX_CUA_BRIDGE_COMMAND", cfg.Cua.BridgeCommand)
+	cfg.Cua.SDKPackage = getenv("CRABBOX_CUA_SDK_PACKAGE", cfg.Cua.SDKPackage)
+	cfg.Cua.SDKImport = getenv("CRABBOX_CUA_SDK_IMPORT", cfg.Cua.SDKImport)
+	cfg.Cua.SDKFallbackImport = getenv("CRABBOX_CUA_SDK_FALLBACK_IMPORT", cfg.Cua.SDKFallbackImport)
+	if v, ok := getenvBool("CRABBOX_CUA_FORGET_MISSING"); ok {
+		cfg.Cua.ForgetMissing = v
+	}
 	cfg.OpenComputer.APIURL = getenv("CRABBOX_OPENCOMPUTER_API_URL", getenv("OPENCOMPUTER_API_URL", cfg.OpenComputer.APIURL))
 	cfg.OpenComputer.Workdir = getenv("CRABBOX_OPENCOMPUTER_WORKDIR", cfg.OpenComputer.Workdir)
 	cfg.OpenComputer.CPU = getenvInt("CRABBOX_OPENCOMPUTER_CPU", cfg.OpenComputer.CPU)
@@ -7507,7 +7650,6 @@ func applyEnv(cfg *Config) error {
 	if v, ok := getenvBool("CRABBOX_OPENCOMPUTER_BURST"); ok {
 		cfg.OpenComputer.Burst = v
 	}
-	var err error
 	cfg.CodeSandbox.TemplateID = getenv("CRABBOX_CODESANDBOX_TEMPLATE_ID", cfg.CodeSandbox.TemplateID)
 	cfg.CodeSandbox.Workdir = getenv("CRABBOX_CODESANDBOX_WORKDIR", cfg.CodeSandbox.Workdir)
 	cfg.CodeSandbox.VMTier = getenv("CRABBOX_CODESANDBOX_VM_TIER", cfg.CodeSandbox.VMTier)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -285,6 +285,22 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_TENSORLAKE_DISK_MB",
 		"CRABBOX_TENSORLAKE_TIMEOUT_SECS",
 		"CRABBOX_TENSORLAKE_NO_INTERNET",
+		"CRABBOX_CUA_API_URL",
+		"CUA_BASE_URL",
+		"CRABBOX_CUA_IMAGE",
+		"CRABBOX_CUA_KIND",
+		"CRABBOX_CUA_REGION",
+		"CRABBOX_CUA_WORKDIR",
+		"CRABBOX_CUA_VCPUS",
+		"CRABBOX_CUA_MEMORY_MB",
+		"CRABBOX_CUA_DISK_GB",
+		"CRABBOX_CUA_STARTUP_TIMEOUT_SECS",
+		"CRABBOX_CUA_EXEC_TIMEOUT_SECS",
+		"CRABBOX_CUA_BRIDGE_COMMAND",
+		"CRABBOX_CUA_SDK_PACKAGE",
+		"CRABBOX_CUA_SDK_IMPORT",
+		"CRABBOX_CUA_SDK_FALLBACK_IMPORT",
+		"CRABBOX_CUA_FORGET_MISSING",
 		"CRABBOX_DOCKER_SANDBOX_CLI",
 		"CRABBOX_DOCKER_SANDBOX_AGENT",
 		"CRABBOX_DOCKER_SANDBOX_TEMPLATE",
@@ -4607,6 +4623,23 @@ tensorlake:
   diskMB: 30000
   timeoutSecs: 1800
   noInternet: true
+cua:
+  apiUrl: https://ignored.example.test
+  apiKey: ignored
+  image: ubuntu:cua-file
+  kind: vm
+  region: us-west
+  workdir: /workspace/cua-test
+  vcpus: 4
+  memoryMB: 8192
+  diskGB: 40
+  startupTimeoutSecs: 300
+  execTimeoutSecs: 900
+  bridgeCommand: python3.12
+  sdkPackage: cua
+  sdkImport: cua
+  sdkFallbackImport: cua_sandbox
+  forgetMissing: true
 openComputer:
   apiUrl: https://opencomputer.example.test
   workdir: /workspace/oc-test
@@ -4824,6 +4857,9 @@ ssh:
 	}
 	if cfg.Tensorlake.APIURL != "https://api.tensorlake.example.test" || cfg.Tensorlake.CLIPath != "/usr/local/bin/tl" || cfg.Tensorlake.Image != "ubuntu-22.04" || cfg.Tensorlake.Snapshot != "snap-tl" || cfg.Tensorlake.OrganizationID != "org-tl" || cfg.Tensorlake.ProjectID != "proj-tl" || cfg.Tensorlake.Namespace != "ns-tl" || cfg.Tensorlake.Workdir != "/workspace/crabbox-test" || cfg.Tensorlake.CPUs != 4 || cfg.Tensorlake.MemoryMB != 8192 || cfg.Tensorlake.DiskMB != 30000 || cfg.Tensorlake.TimeoutSecs != 1800 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("tensorlake config not loaded: %#v", cfg.Tensorlake)
+	}
+	if cfg.Cua.APIURL != "" || cfg.Cua.Image != "ubuntu:cua-file" || cfg.Cua.Kind != "vm" || cfg.Cua.Region != "us-west" || cfg.Cua.Workdir != "/workspace/cua-test" || cfg.Cua.VCPUs != 4 || cfg.Cua.MemoryMB != 8192 || cfg.Cua.DiskGB != 40 || cfg.Cua.StartupTimeoutSecs != 300 || cfg.Cua.ExecTimeoutSecs != 900 || cfg.Cua.BridgeCommand != "python3.12" || cfg.Cua.SDKPackage != "cua" || cfg.Cua.SDKImport != "cua" || cfg.Cua.SDKFallbackImport != "cua_sandbox" || !cfg.Cua.ForgetMissing {
+		t.Fatalf("cua config not loaded safely: %#v", cfg.Cua)
 	}
 	if cfg.OpenComputer.APIURL != "" || cfg.OpenComputer.Workdir != "/workspace/oc-test" || cfg.OpenComputer.CPU != 8 || cfg.OpenComputer.MemoryMB != 16384 || cfg.OpenComputer.TimeoutSecs != 600 || cfg.OpenComputer.ExecTimeoutSecs != 7200 {
 		t.Fatalf("opencomputer config not loaded: %#v", cfg.OpenComputer)
@@ -5195,6 +5231,22 @@ func TestEnvOverridesConfig(t *testing.T) {
 	t.Setenv("CRABBOX_TENSORLAKE_DISK_MB", "20480")
 	t.Setenv("CRABBOX_TENSORLAKE_TIMEOUT_SECS", "900")
 	t.Setenv("CRABBOX_TENSORLAKE_NO_INTERNET", "true")
+	t.Setenv("CUA_BASE_URL", "https://cua-file.example")
+	t.Setenv("CRABBOX_CUA_API_URL", "https://cua-env.example")
+	t.Setenv("CRABBOX_CUA_IMAGE", "ubuntu:cua-env")
+	t.Setenv("CRABBOX_CUA_KIND", "vm")
+	t.Setenv("CRABBOX_CUA_REGION", "us-central")
+	t.Setenv("CRABBOX_CUA_WORKDIR", "/workspace/cua-env")
+	t.Setenv("CRABBOX_CUA_VCPUS", "6")
+	t.Setenv("CRABBOX_CUA_MEMORY_MB", "12288")
+	t.Setenv("CRABBOX_CUA_DISK_GB", "80")
+	t.Setenv("CRABBOX_CUA_STARTUP_TIMEOUT_SECS", "240")
+	t.Setenv("CRABBOX_CUA_EXEC_TIMEOUT_SECS", "1200")
+	t.Setenv("CRABBOX_CUA_BRIDGE_COMMAND", "python3.12")
+	t.Setenv("CRABBOX_CUA_SDK_PACKAGE", "cua")
+	t.Setenv("CRABBOX_CUA_SDK_IMPORT", "cua")
+	t.Setenv("CRABBOX_CUA_SDK_FALLBACK_IMPORT", "cua_sandbox")
+	t.Setenv("CRABBOX_CUA_FORGET_MISSING", "true")
 	t.Setenv("OPENCOMPUTER_API_URL", "https://oc-file.example")
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_URL", "https://oc-env.example")
 	t.Setenv("CRABBOX_OPENCOMPUTER_WORKDIR", "/workspace/oc-env")
@@ -5412,6 +5464,9 @@ func TestEnvOverridesConfig(t *testing.T) {
 	}
 	if cfg.Tensorlake.APIKey != "tl-api-env" || cfg.Tensorlake.APIURL != "https://api.tl-env.example" || cfg.Tensorlake.CLIPath != "/opt/tl/bin/tensorlake" || cfg.Tensorlake.Image != "ubuntu:tl-env" || cfg.Tensorlake.Snapshot != "snap-tl-env" || cfg.Tensorlake.OrganizationID != "org-tl-env" || cfg.Tensorlake.ProjectID != "proj-tl-env" || cfg.Tensorlake.Namespace != "ns-tl-env" || cfg.Tensorlake.Workdir != "/workspace/tl-env" || cfg.Tensorlake.CPUs != 2.5 || cfg.Tensorlake.MemoryMB != 4096 || cfg.Tensorlake.DiskMB != 20480 || cfg.Tensorlake.TimeoutSecs != 900 || !cfg.Tensorlake.NoInternet {
 		t.Fatalf("unexpected tensorlake env: %#v", cfg.Tensorlake)
+	}
+	if cfg.Cua.APIURL != "https://cua-env.example" || cfg.Cua.Image != "ubuntu:cua-env" || cfg.Cua.Kind != "vm" || cfg.Cua.Region != "us-central" || cfg.Cua.Workdir != "/workspace/cua-env" || cfg.Cua.VCPUs != 6 || cfg.Cua.MemoryMB != 12288 || cfg.Cua.DiskGB != 80 || cfg.Cua.StartupTimeoutSecs != 240 || cfg.Cua.ExecTimeoutSecs != 1200 || cfg.Cua.BridgeCommand != "python3.12" || cfg.Cua.SDKPackage != "cua" || cfg.Cua.SDKImport != "cua" || cfg.Cua.SDKFallbackImport != "cua_sandbox" || !cfg.Cua.ForgetMissing {
+		t.Fatalf("unexpected cua env: %#v", cfg.Cua)
 	}
 	if cfg.OpenComputer.APIURL != "https://oc-env.example" || cfg.OpenComputer.Workdir != "/workspace/oc-env" || cfg.OpenComputer.CPU != 6 || cfg.OpenComputer.MemoryMB != 12288 || cfg.OpenComputer.TimeoutSecs != 1200 || cfg.OpenComputer.ExecTimeoutSecs != 2400 {
 		t.Fatalf("unexpected opencomputer env: %#v", cfg.OpenComputer)

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -20,6 +20,7 @@ var benchmarkProviderCategories = map[string]string{
 	"cloudflare-sandbox":         "delegated-sandbox",
 	"coder":                      "direct-cloud",
 	"codesandbox":                "delegated-sandbox",
+	"cua":                        "delegated-sandbox",
 	"daytona":                    "direct-cloud",
 	"digitalocean":               "direct-cloud",
 	"docker-sandbox":             "local-sandbox",

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/cloudflaresandbox"
 	_ "github.com/openclaw/crabbox/internal/providers/coder"
 	_ "github.com/openclaw/crabbox/internal/providers/codesandbox"
+	_ "github.com/openclaw/crabbox/internal/providers/cua"
 	_ "github.com/openclaw/crabbox/internal/providers/daytona"
 	_ "github.com/openclaw/crabbox/internal/providers/digitalocean"
 	_ "github.com/openclaw/crabbox/internal/providers/dockersandbox"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -62,6 +62,31 @@ func TestOpenSandboxRegistersWithoutAliasCollision(t *testing.T) {
 	}
 }
 
+func TestCuaRegistersCanonicalWithoutAliases(t *testing.T) {
+	provider, err := core.ProviderFor("cua")
+	if err != nil {
+		t.Fatalf("ProviderFor(cua): %v", err)
+	}
+	if provider.Name() != "cua" {
+		t.Fatalf("ProviderFor(cua).Name=%q", provider.Name())
+	}
+	spec := provider.Spec()
+	if spec.Kind != core.ProviderKindDelegatedRun || spec.Family != "cua" || spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("cua spec=%#v", spec)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("cua targets=%#v", spec.Targets)
+	}
+	if !spec.Features.Has(core.FeatureArchiveSync) || !spec.Features.Has(core.FeatureCleanup) {
+		t.Fatalf("cua features=%v", spec.Features)
+	}
+	for _, alias := range []string{"cua-cloud", "cua-sandbox", "trycua"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == "cua" {
+			t.Fatalf("%q alias unexpectedly resolves to cua", alias)
+		}
+	}
+}
+
 func TestNvidiaBrevRegistersCanonicalAndAliases(t *testing.T) {
 	for _, name := range []string{"nvidia-brev", "brev", "nvidia"} {
 		provider, err := core.ProviderFor(name)
@@ -1140,6 +1165,7 @@ func allBuiltInProviderNames() []string {
 		"cloudflare-sandbox",
 		"codesandbox",
 		"coder",
+		"cua",
 		"daytona",
 		"digitalocean",
 		"docker-sandbox",

--- a/internal/providers/cua/backend.go
+++ b/internal/providers/cua/backend.go
@@ -1,0 +1,61 @@
+package cua
+
+import "context"
+
+type backend struct {
+	spec ProviderSpec
+	cfg  Config
+}
+
+func (b backend) Spec() ProviderSpec { return b.spec }
+
+func (b backend) Warmup(context.Context, WarmupRequest) error {
+	return planBoundLifecycleError("warmup")
+}
+
+func (b backend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{Provider: providerName}, planBoundLifecycleError("run")
+}
+
+func (b backend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, planBoundLifecycleError("list")
+}
+
+func (b backend) Status(context.Context, StatusRequest) (StatusView, error) {
+	return StatusView{Provider: providerName}, planBoundLifecycleError("status")
+}
+
+func (b backend) Stop(context.Context, StopRequest) error {
+	return planBoundLifecycleError("stop")
+}
+
+func (b backend) Cleanup(context.Context, CleanupRequest) error {
+	return planBoundLifecycleError("cleanup")
+}
+
+func (b backend) Doctor(context.Context, DoctorRequest) (DoctorResult, error) {
+	checks := []DoctorCheck{
+		{
+			Status:  "ok",
+			Check:   "config",
+			Message: "provider=cua config=ready mutation=false",
+			Details: map[string]string{"provider": providerName, "mutation": "false"},
+		},
+		{
+			Status:  "warning",
+			Check:   "bridge",
+			Message: "provider=cua bridge=deferred plan=PLAN-02 mutation=false",
+			Details: map[string]string{"provider": providerName, "plan": "PLAN-02", "mutation": "false"},
+		},
+	}
+	return DoctorResult{
+		Provider: providerName,
+		Status:   "warning",
+		Message:  "config=ready bridge=deferred plan=PLAN-02 mutation=false",
+		Checks:   checks,
+	}, nil
+}
+
+func planBoundLifecycleError(command string) error {
+	return exit(2, "provider=cua %s lifecycle is deferred to PLAN-03; mutation=false", command)
+}

--- a/internal/providers/cua/backend.go
+++ b/internal/providers/cua/backend.go
@@ -1,6 +1,18 @@
 package cua
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+const cuaCleanupTimeout = 15 * time.Second
 
 type backend struct {
 	spec ProviderSpec
@@ -10,30 +22,646 @@ type backend struct {
 
 func (b backend) Spec() ProviderSpec { return b.spec }
 
-func (b backend) Warmup(context.Context, WarmupRequest) error {
-	return planBoundLifecycleError("warmup")
+func (b backend) client() *bridgeClient {
+	return newBridgeClient(b.cfg, b.rt)
 }
 
-func (b backend) Run(context.Context, RunRequest) (RunResult, error) {
-	return RunResult{Provider: providerName}, planBoundLifecycleError("run")
+func (b backend) Warmup(ctx context.Context, req WarmupRequest) error {
+	if req.ActionsRunner {
+		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+	}
+	if req.Options.Tailscale.Enabled {
+		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+	}
+	started := b.now()
+	leaseID, sandboxID, slug, err := b.createSandbox(ctx, b.client(), req.Repo, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return err
+	}
+	workdir, err := cuaWorkdir(b.cfg)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s workdir=%s\n", leaseID, slug, providerName, sandboxID, workdir)
+	if !req.Keep {
+		fmt.Fprintf(b.rt.Stderr, "warning: cua warmup keeps the sandbox until explicit stop\n")
+	}
+	total := b.now().Sub(started)
+	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
+	if req.TimingJSON {
+		return writeTimingJSON(b.rt.Stderr, timingReport{
+			Provider: providerName,
+			LeaseID:  leaseID,
+			Slug:     slug,
+			TotalMs:  total.Milliseconds(),
+			ExitCode: 0,
+		})
+	}
+	return nil
 }
 
-func (b backend) List(context.Context, ListRequest) ([]LeaseView, error) {
-	return nil, planBoundLifecycleError("list")
+func (b backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
+	if req.Options.Tailscale.Enabled {
+		return RunResult{}, exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+	}
+	workdir, err := cuaWorkdir(b.cfg)
+	if err != nil {
+		return RunResult{}, err
+	}
+	started := b.now()
+	client := b.client()
+	leaseID, sandboxID, slug := "", "", ""
+	acquired := false
+	if req.ID == "" {
+		leaseID, sandboxID, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
+		if err != nil {
+			return RunResult{}, err
+		}
+		acquired = true
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+	} else {
+		claim, ok, err := resolveClaim(req.ID, b.cfg)
+		if err != nil {
+			return RunResult{}, err
+		}
+		if !ok {
+			return RunResult{}, exit(4, "CUA sandbox %q is not claimed by Crabbox", req.ID)
+		}
+		leaseID, sandboxID, slug = claim.LeaseID, claimSandboxName(claim), blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		if _, err := b.verifyClaim(ctx, client, claim); err != nil {
+			return RunResult{}, err
+		}
+		if err := b.refreshLeaseActivity(claim, req.Repo.Root, req.Reclaim); err != nil {
+			return RunResult{}, err
+		}
+	}
+
+	shouldStop := acquired && !req.Keep
+	if shouldStop {
+		defer func() {
+			if cleanupErr := b.cleanupCreatedRun(ctx, client, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+				if result.ExitCode == 0 {
+					result.ExitCode = 1
+				}
+				retErr = errors.Join(retErr, cleanupErr)
+			}
+		}()
+	}
+	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+
+	syncDuration := time.Duration(0)
+	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	if !req.NoSync {
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir)
+		if err != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err
+		}
+		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	} else if err := b.ensureWorkspace(ctx, client, sandboxID, workdir); err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err
+	}
+
+	if req.SyncOnly {
+		result = RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}
+		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
+		activityErr := b.refreshLeaseActivityIfRetained(leaseID, shouldStop)
+		if cleanupErr := b.cleanupCreatedRun(ctx, client, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+			result.ExitCode = 1
+			return result, cleanupErr
+		}
+		if req.TimingJSON {
+			if err := writeTimingJSON(b.rt.Stderr, timingReport{
+				Provider:      providerName,
+				LeaseID:       leaseID,
+				Slug:          slug,
+				SyncDelegated: true,
+				SyncMs:        syncDuration.Milliseconds(),
+				SyncPhases:    syncPhases,
+				SyncSkipped:   req.NoSync,
+				TotalMs:       result.Total.Milliseconds(),
+				ExitCode:      result.ExitCode,
+				Label:         strings.TrimSpace(req.Label),
+			}); err != nil {
+				return result, err
+			}
+		}
+		return result, activityErr
+	}
+
+	command, err := buildCommand(req.Command, req.ShellMode)
+	if err != nil {
+		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err
+	}
+	commandEnv, stripped := commandEnv(req.Env)
+	if len(stripped) > 0 {
+		fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(stripped, ","))
+	}
+	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
+	}
+	commandStart := b.now()
+	var stdout, stderr bytes.Buffer
+	resp, runErr := client.Exec(ctx, sandboxID, command, workdir, commandEnv, &stdout, &stderr)
+	_, _ = io.Copy(b.rt.Stdout, &stdout)
+	_, _ = io.Copy(b.rt.Stderr, &stderr)
+	commandDuration := b.now().Sub(commandStart)
+	result = RunResult{
+		Provider:      providerName,
+		LeaseID:       leaseID,
+		Slug:          slug,
+		CommandText:   shellScriptFromArgv(command),
+		ExitCode:      resp.ExitCode,
+		Command:       commandDuration,
+		Total:         b.now().Sub(started),
+		SyncDelegated: true,
+	}
+	if runErr != nil && result.ExitCode == 0 {
+		result.ExitCode = 1
+	}
+	if req.NoSync {
+		fmt.Fprintf(b.rt.Stderr, "cua run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	} else {
+		fmt.Fprintf(b.rt.Stderr, "cua run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+	}
+	var commandErr error
+	if runErr != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		commandErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("cua run failed: %v", redactSecrets(runErr.Error()))}
+	} else if result.ExitCode != 0 {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		commandErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("cua run exited %d", result.ExitCode)}
+	}
+	if activityErr := b.refreshLeaseActivityIfRetained(leaseID, shouldStop); activityErr != nil && commandErr == nil {
+		result.ExitCode = 1
+		commandErr = activityErr
+	}
+	if cleanupErr := b.cleanupCreatedRun(ctx, client, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
+		if result.ExitCode == 0 {
+			result.ExitCode = 1
+		}
+		commandErr = errors.Join(commandErr, cleanupErr)
+	}
+	if req.TimingJSON {
+		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+			Provider:      providerName,
+			LeaseID:       leaseID,
+			Slug:          slug,
+			SyncDelegated: true,
+			SyncMs:        syncDuration.Milliseconds(),
+			SyncPhases:    syncPhases,
+			SyncSkipped:   req.NoSync,
+			CommandMs:     result.Command.Milliseconds(),
+			TotalMs:       result.Total.Milliseconds(),
+			ExitCode:      result.ExitCode,
+			Label:         strings.TrimSpace(req.Label),
+		}, result, commandErr)); err != nil {
+			return result, err
+		}
+	}
+	return result, commandErr
 }
 
-func (b backend) Status(context.Context, StatusRequest) (StatusView, error) {
-	return StatusView{Provider: providerName}, planBoundLifecycleError("status")
+func (b backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+	client := b.client()
+	claims, err := listCUALeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	views := make([]LeaseView, 0, len(claims))
+	for _, claim := range claims {
+		if claim.Provider != providerName || !b.claimMatchesActiveScope(claim) {
+			continue
+		}
+		sandboxName := claimSandboxName(claim)
+		if sandboxName == "" {
+			continue
+		}
+		sb, getErr := client.GetSandbox(ctx, sandboxName)
+		state := ""
+		if getErr != nil {
+			if !isCUANotFound(getErr) {
+				return nil, getErr
+			}
+			state = "missing-or-inaccessible"
+		} else {
+			if err := validateSandboxOwnership(claim, sb, claim.ProviderScope); err != nil {
+				return nil, err
+			}
+			state = normalizedSandboxState(sb)
+		}
+		views = append(views, b.serverFromSandbox(claim, bridgeSandboxSummary{ID: sandboxName, Name: sandboxName, Status: state}))
+	}
+	return views, nil
 }
 
-func (b backend) Stop(context.Context, StopRequest) error {
-	return planBoundLifecycleError("stop")
+func (b backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+	claim, ok, err := resolveClaim(req.ID, b.cfg)
+	if err != nil {
+		return StatusView{}, err
+	}
+	if !ok {
+		return StatusView{}, exit(4, "CUA sandbox %q is not claimed by Crabbox", req.ID)
+	}
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
+	}
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+	deadline := b.now().Add(waitTimeout)
+	for {
+		sb, getErr := b.verifyClaim(pollCtx, b.client(), claim)
+		if getErr != nil {
+			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
+				return StatusView{}, exit(5, "timed out waiting for CUA sandbox %s to become ready", claimSandboxName(claim))
+			}
+			return StatusView{}, getErr
+		}
+		state := normalizedSandboxState(sb)
+		view := StatusView{
+			ID:       claim.LeaseID,
+			Slug:     blank(claim.Slug, newLeaseSlug(claim.LeaseID)),
+			Provider: providerName,
+			TargetOS: targetLinux,
+			State:    state,
+			ServerID: claimSandboxName(claim),
+			Pond:     claim.Pond,
+			Network:  "public",
+			Ready:    isReadyState(state),
+			Labels: map[string]string{
+				"provider": providerName,
+				"lease":    claim.LeaseID,
+				"slug":     blank(claim.Slug, newLeaseSlug(claim.LeaseID)),
+				"pond":     claim.Pond,
+				"state":    state,
+			},
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if isTerminalState(state) {
+			return StatusView{}, exit(5, "CUA sandbox %s entered terminal state %q before becoming ready", claimSandboxName(claim), state)
+		}
+		if b.now().After(deadline) {
+			return StatusView{}, exit(5, "timed out waiting for CUA sandbox %s to become ready", claimSandboxName(claim))
+		}
+		select {
+		case <-pollCtx.Done():
+			if ctx.Err() == nil {
+				return StatusView{}, exit(5, "timed out waiting for CUA sandbox %s to become ready", claimSandboxName(claim))
+			}
+			return StatusView{}, pollCtx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
-func (b backend) Cleanup(context.Context, CleanupRequest) error {
-	return planBoundLifecycleError("cleanup")
+func (b backend) Stop(ctx context.Context, req StopRequest) error {
+	claim, ok, err := resolveClaim(req.ID, b.cfg)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return exit(4, "CUA sandbox %q is not claimed by Crabbox", req.ID)
+	}
+	client := b.client()
+	if _, err := b.verifyClaim(ctx, client, claim); err != nil {
+		if !isCUANotFound(err) || !b.cfg.Cua.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing CUA sandbox=%s after explicit request\n", claimSandboxName(claim))
+		removeLeaseClaim(claim.LeaseID)
+		return nil
+	}
+	if err := client.DeleteSandbox(ctx, claimSandboxName(claim)); err != nil {
+		if !isCUANotFound(err) || !b.cfg.Cua.ForgetMissing {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing CUA sandbox=%s after explicit request\n", claimSandboxName(claim))
+	}
+	removeLeaseClaim(claim.LeaseID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", claim.LeaseID, claimSandboxName(claim))
+	return nil
 }
 
-func planBoundLifecycleError(command string) error {
-	return exit(2, "provider=cua %s lifecycle is deferred to PLAN-03; mutation=false", command)
+func (b backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	claims, err := listCUALeaseClaims()
+	if err != nil {
+		return err
+	}
+	client := b.client()
+	now := b.now().UTC()
+	checked := 0
+	removed := 0
+	claimsRemoved := 0
+	for _, listed := range claims {
+		if listed.Provider != providerName || !b.claimMatchesActiveScope(listed) {
+			continue
+		}
+		claim, err := readLeaseClaim(listed.LeaseID)
+		if err != nil {
+			return err
+		}
+		if claim.LeaseID == "" || claim.Provider != providerName || !b.claimMatchesActiveScope(claim) {
+			continue
+		}
+		checked++
+		sandboxName := claimSandboxName(claim)
+		sb, getErr := client.GetSandbox(ctx, sandboxName)
+		if getErr != nil {
+			if !isCUANotFound(getErr) {
+				return getErr
+			}
+			if !b.cfg.Cua.ForgetMissing {
+				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set cua.forgetMissing to remove the claim\n", sandboxName, claim.LeaseID)
+				continue
+			}
+			if req.DryRun {
+				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				continue
+			}
+			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				return err
+			}
+			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+			claimsRemoved++
+			continue
+		}
+		if err := validateSandboxOwnership(claim, sb, claim.ProviderScope); err != nil {
+			return err
+		}
+		due, reason := claimCleanupDue(claim, now)
+		if !due {
+			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxName, claim.LeaseID, reason)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxName, claim.LeaseID, reason)
+			continue
+		}
+		if err := client.DeleteSandbox(ctx, sandboxName); err != nil && !isCUANotFound(err) {
+			return err
+		}
+		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			return err
+		}
+		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxName, claim.LeaseID, reason)
+		removed++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
+	}
+	return nil
+}
+
+func (b backend) createSandbox(ctx context.Context, client *bridgeClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+	if err := validateProviderConfig(b.cfg); err != nil {
+		return "", "", "", err
+	}
+	scope, err := cuaScope(b.cfg)
+	if err != nil {
+		return "", "", "", err
+	}
+	leaseID := newCUALeaseID()
+	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	if err != nil {
+		return "", "", "", err
+	}
+	sandboxName := newSandboxName(leaseID, slug)
+	sb, err := client.CreateSandbox(ctx, sandboxName, map[string]string{
+		"crabbox.provider": providerName,
+		"crabbox.scope":    scope,
+		"crabbox.lease":    leaseID,
+		"crabbox.slug":     slug,
+	})
+	if err != nil {
+		return "", "", "", err
+	}
+	if sb.ID == "" {
+		sb.ID = sandboxName
+	}
+	if sb.Name == "" {
+		sb.Name = sandboxName
+	}
+	if err := validateSandboxOwnership(LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: scope, CloudID: sandboxName}, sb, scope); err != nil {
+		return "", "", "", b.cleanupCreateFailure(ctx, client, sandboxName, err)
+	}
+	if err := claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, scope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim, b.serverFromSandbox(LeaseClaim{LeaseID: leaseID, Slug: slug, Pond: b.cfg.Pond}, sb)); err != nil {
+		return "", "", "", b.cleanupCreateFailure(ctx, client, sandboxName, err)
+	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return "", "", "", b.cleanupCreateFailure(ctx, client, sandboxName, err)
+	}
+	if _, err := updateLeaseClaimLabelsIfUnchanged(leaseID, claim, claimLabels(b.cfg, sandboxName, false)); err != nil {
+		return "", "", "", b.cleanupCreateFailure(ctx, client, sandboxName, err)
+	}
+	return leaseID, sandboxName, slug, nil
+}
+
+func (b backend) verifyClaim(ctx context.Context, client *bridgeClient, claim LeaseClaim) (bridgeSandboxSummary, error) {
+	scope, err := cuaScope(b.cfg)
+	if err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	if err := validateClaimScope(claim, scope); err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	sandboxName := claimSandboxName(claim)
+	if sandboxName == "" {
+		return bridgeSandboxSummary{}, exit(4, "CUA lease %q is missing its claimed sandbox name", claim.LeaseID)
+	}
+	sb, err := client.GetSandbox(ctx, sandboxName)
+	if err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	if err := validateSandboxOwnership(claim, sb, scope); err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	return sb, nil
+}
+
+func (b backend) serverFromSandbox(claim LeaseClaim, sb bridgeSandboxSummary) Server {
+	state := normalizedSandboxState(sb)
+	sandboxName := strings.TrimSpace(blank(sb.Name, sb.ID))
+	if sandboxName == "" {
+		sandboxName = claimSandboxName(claim)
+	}
+	return Server{
+		Provider: providerName,
+		CloudID:  sandboxName,
+		Name:     sandboxName,
+		Status:   state,
+		Labels: map[string]string{
+			"provider": providerName,
+			"lease":    claim.LeaseID,
+			"slug":     claim.Slug,
+			"pond":     claim.Pond,
+			"target":   targetLinux,
+			"state":    state,
+		},
+	}
+}
+
+func (b backend) claimMatchesActiveScope(claim LeaseClaim) bool {
+	scope, err := cuaScope(b.cfg)
+	return err == nil && claim.ProviderScope == scope
+}
+
+func (b backend) refreshLeaseActivity(claim LeaseClaim, repoRoot string, reclaim bool) error {
+	if claim.LeaseID == "" {
+		return nil
+	}
+	if repoRoot == "" {
+		repoRoot = claim.RepoRoot
+	}
+	timeout := b.cfg.IdleTimeout
+	if timeout <= 0 && claim.IdleTimeoutSeconds > 0 {
+		timeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	}
+	if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, timeout, reclaim); err != nil {
+		return err
+	}
+	updated, err := readLeaseClaim(claim.LeaseID)
+	if err != nil {
+		return err
+	}
+	_, err = updateLeaseClaimLabelsIfUnchanged(claim.LeaseID, updated, claimLabels(b.cfg, claimSandboxName(claim), claimIsMissing(claim)))
+	return err
+}
+
+func (b backend) refreshLeaseActivityIfRetained(leaseID string, shouldStop bool) error {
+	if shouldStop || leaseID == "" {
+		return nil
+	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return err
+	}
+	return b.refreshLeaseActivity(claim, claim.RepoRoot, false)
+}
+
+func (b backend) cleanupCreateFailure(ctx context.Context, client *bridgeClient, sandboxID string, cause error) error {
+	if sandboxID == "" {
+		return cause
+	}
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isCUANotFound(err) {
+		return errors.Join(cause, fmt.Errorf("CUA cleanup failed for sandbox %s; delete it in CUA manually: %w", sandboxID, err))
+	}
+	return cause
+}
+
+func (b backend) cleanupCreatedRun(ctx context.Context, client *bridgeClient, leaseID, sandboxID string, shouldStop *bool) error {
+	if !*shouldStop {
+		return nil
+	}
+	*shouldStop = false
+	cleanupCtx, cancel := b.cleanupContext(ctx)
+	defer cancel()
+	if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isCUANotFound(err) {
+		return fmt.Errorf("CUA delete failed for %s: %w", sandboxID, err)
+	}
+	removeLeaseClaim(leaseID)
+	return nil
+}
+
+func (b backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cuaCleanupTimeout)
+}
+
+func (b backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now()
+	}
+	return time.Now()
+}
+
+func (b backend) execTimeoutSecs() int {
+	if b.cfg.Cua.ExecTimeoutSecs > 0 {
+		return b.cfg.Cua.ExecTimeoutSecs
+	}
+	return 600
+}
+
+func normalizedSandboxState(sb bridgeSandboxSummary) string {
+	return strings.ToLower(blank(strings.TrimSpace(blank(sb.Status, sb.State)), "unknown"))
+}
+
+func isReadyState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "running", "ready", "started", "active":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTerminalState(state string) bool {
+	switch strings.TrimSpace(strings.ToLower(state)) {
+	case "terminated", "stopped", "failed", "error", "aborted", "killed", "deleted", "destroyed":
+		return true
+	default:
+		return false
+	}
+}
+
+func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
+	if claim.IdleTimeoutSeconds <= 0 {
+		return false, "idle timeout disabled"
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil {
+		return false, "invalid last-used time"
+	}
+	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
+	if now.Before(deadline) {
+		return false, "idle timeout not reached"
+	}
+	return true, "idle timeout"
+}
+
+func buildCommand(command []string, shellMode bool) ([]string, error) {
+	if len(command) == 0 {
+		return nil, errors.New("missing command")
+	}
+	if shellMode {
+		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
+	}
+	if shouldUseShell(command) || leadingEnvAssignment(command) {
+		if len(command) == 1 {
+			return []string{"bash", "-lc", command[0]}, nil
+		}
+		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	}
+	return command, nil
+}
+
+func commandEnv(env map[string]string) (map[string]string, []string) {
+	out := make(map[string]string, len(env))
+	stripped := []string{}
+	for key, value := range env {
+		upper := strings.ToUpper(strings.TrimSpace(key))
+		if upper == "CRABBOX_CUA_API_KEY" || upper == "CUA_API_KEY" || upper == "CUA_BASE_URL" || upper == "CRABBOX_CUA_API_URL" {
+			stripped = append(stripped, key)
+			continue
+		}
+		out[key] = value
+	}
+	return out, stripped
+}
+
+func bridgeFileFromReader(path string, body io.Reader) (bridgeFile, error) {
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, body); err != nil {
+		return bridgeFile{}, err
+	}
+	return bridgeFile{Path: path, ContentBase64: base64.StdEncoding.EncodeToString(buf.Bytes())}, nil
 }

--- a/internal/providers/cua/backend.go
+++ b/internal/providers/cua/backend.go
@@ -5,6 +5,7 @@ import "context"
 type backend struct {
 	spec ProviderSpec
 	cfg  Config
+	rt   Runtime
 }
 
 func (b backend) Spec() ProviderSpec { return b.spec }
@@ -31,29 +32,6 @@ func (b backend) Stop(context.Context, StopRequest) error {
 
 func (b backend) Cleanup(context.Context, CleanupRequest) error {
 	return planBoundLifecycleError("cleanup")
-}
-
-func (b backend) Doctor(context.Context, DoctorRequest) (DoctorResult, error) {
-	checks := []DoctorCheck{
-		{
-			Status:  "ok",
-			Check:   "config",
-			Message: "provider=cua config=ready mutation=false",
-			Details: map[string]string{"provider": providerName, "mutation": "false"},
-		},
-		{
-			Status:  "warning",
-			Check:   "bridge",
-			Message: "provider=cua bridge=deferred plan=PLAN-02 mutation=false",
-			Details: map[string]string{"provider": providerName, "plan": "PLAN-02", "mutation": "false"},
-		},
-	}
-	return DoctorResult{
-		Provider: providerName,
-		Status:   "warning",
-		Message:  "config=ready bridge=deferred plan=PLAN-02 mutation=false",
-		Checks:   checks,
-	}, nil
 }
 
 func planBoundLifecycleError(command string) error {

--- a/internal/providers/cua/backend_test.go
+++ b/internal/providers/cua/backend_test.go
@@ -1,0 +1,273 @@
+package cua
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type bridgeHarness struct {
+	t       *testing.T
+	actions []string
+	execs   [][]string
+	deletes []string
+	infos   map[string]bridgeSandboxSummary
+}
+
+func newBridgeHarness(t *testing.T) *bridgeHarness {
+	t.Helper()
+	return &bridgeHarness{t: t, infos: make(map[string]bridgeSandboxSummary)}
+}
+
+func (h *bridgeHarness) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	var payload bridgeRequest
+	data, err := io.ReadAll(req.Stdin)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		h.t.Fatalf("decode bridge request: %v", err)
+	}
+	h.actions = append(h.actions, payload.Action)
+	resp := bridgeResponse{OK: true}
+	switch payload.Action {
+	case "create":
+		name := payload.Sandbox.Name
+		resp.Sandbox = bridgeSandboxSummary{ID: name, Name: name, Status: "running", Metadata: payload.Sandbox.Meta}
+		h.infos[name] = resp.Sandbox
+	case "info":
+		sb, ok := h.infos[payload.SandboxID]
+		if !ok {
+			resp = bridgeResponse{OK: false, Class: "not_found", Error: &bridgeError{Code: "not_found", Class: "not_found", Message: "sandbox not found"}}
+		} else {
+			resp.Sandbox = sb
+		}
+	case "delete":
+		h.deletes = append(h.deletes, payload.SandboxID)
+		delete(h.infos, payload.SandboxID)
+	case "exec":
+		h.execs = append(h.execs, payload.Command)
+		if len(payload.Command) > 0 && strings.Contains(strings.Join(payload.Command, " "), "fail") {
+			resp.ExitCode = 7
+			resp.Stderr = "boom\n"
+		} else {
+			resp.ExitCode = 0
+			resp.Stdout = "ok\n"
+		}
+	case "upload_bytes":
+		if len(payload.Files) != 1 || payload.Files[0].Path == "" {
+			resp = bridgeResponse{OK: false, Class: "validation_failed", Error: &bridgeError{Code: "bad_upload", Class: "validation_failed", Message: "bad upload"}}
+		}
+	default:
+		resp = bridgeResponse{OK: false, Class: "validation_failed", Error: &bridgeError{Code: "unknown_action", Class: "validation_failed", Message: payload.Action}}
+	}
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	_, _ = req.Stdout.Write(encoded)
+	return LocalCommandResult{ExitCode: 0}, nil
+}
+
+func testBackend(t *testing.T, harness *bridgeHarness) backend {
+	t.Helper()
+	return backend{
+		spec: Provider{}.Spec(),
+		cfg:  testConfig(),
+		rt: Runtime{
+			Exec:   harness,
+			Stdout: io.Discard,
+			Stderr: io.Discard,
+		},
+	}
+}
+
+func TestRunFreshDeletesSandboxByDefault(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	h := newBridgeHarness(t)
+	b := testBackend(t, h)
+	result, err := b.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: t.TempDir(), Name: "demo"},
+		NoSync:  true,
+		Command: []string{"echo", "hello"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Provider != providerName || result.ExitCode != 0 || !result.SyncDelegated {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(h.deletes) != 1 || !strings.HasPrefix(h.deletes[0], sandboxNamePrefix) {
+		t.Fatalf("deletes=%#v", h.deletes)
+	}
+	if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
+		t.Fatalf("claim should be removed after fresh run, claim=%#v err=%v", claim, err)
+	}
+}
+
+func TestRunReuseUsesClaimedSandboxAndKeepsClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	h := newBridgeHarness(t)
+	b := testBackend(t, h)
+	var stdout bytes.Buffer
+	b.rt.Stdout = &stdout
+	repoRoot := t.TempDir()
+	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: repoRoot, Name: "demo"}, RequestedSlug: "reuse"}); err != nil {
+		t.Fatalf("Warmup: %v", err)
+	}
+	if len(h.deletes) != 0 {
+		t.Fatalf("warmup must retain sandbox, deletes=%#v", h.deletes)
+	}
+	if _, err := b.Run(context.Background(), RunRequest{
+		Repo:    Repo{Root: repoRoot, Name: "demo"},
+		ID:      "reuse",
+		NoSync:  true,
+		Command: []string{"true"},
+	}); err != nil {
+		t.Fatalf("reuse Run: %v", err)
+	}
+	if len(h.deletes) != 0 {
+		t.Fatalf("reuse run should not delete retained sandbox, deletes=%#v", h.deletes)
+	}
+	claim, ok, err := resolveCUALeaseClaim("reuse", b.cfg)
+	if err != nil || !ok {
+		t.Fatalf("resolve claim after reuse: ok=%v err=%v", ok, err)
+	}
+	if claim.LeaseID == "" || claimSandboxName(claim) == "" {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestStopRejectsUnownedSandboxBeforeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := testConfig()
+	scope, err := cuaScope(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeClaim(t, core.LeaseClaim{
+		LeaseID:       "cuabx_manual",
+		Slug:          "manual",
+		Provider:      providerName,
+		CloudID:       "manual-sandbox",
+		ProviderScope: scope,
+		Labels:        claimLabels(cfg, "manual-sandbox", false),
+	})
+	h := newBridgeHarness(t)
+	h.infos["manual-sandbox"] = bridgeSandboxSummary{ID: "manual-sandbox", Name: "manual-sandbox", Status: "running"}
+	b := testBackend(t, h)
+	err = b.Stop(context.Background(), StopRequest{ID: "manual"})
+	if err == nil {
+		t.Fatal("expected ownership rejection")
+	}
+	if len(h.deletes) != 0 {
+		t.Fatalf("delete should not run for unowned sandbox, deletes=%#v", h.deletes)
+	}
+}
+
+func TestCleanupDryRunOnlyTargetsExpiredClaims(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := testConfig()
+	scope, err := cuaScope(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaim(t, core.LeaseClaim{
+		LeaseID:            "cuabx_expired",
+		Slug:               "expired",
+		Provider:           providerName,
+		CloudID:            "crabbox-cua-expired-aaaaaa",
+		ProviderScope:      scope,
+		LastUsedAt:         old,
+		IdleTimeoutSeconds: 60,
+		Labels:             claimLabels(cfg, "crabbox-cua-expired-aaaaaa", false),
+	})
+	h := newBridgeHarness(t)
+	h.infos["crabbox-cua-expired-aaaaaa"] = bridgeSandboxSummary{ID: "crabbox-cua-expired-aaaaaa", Name: "crabbox-cua-expired-aaaaaa", Status: "running"}
+	var stdout bytes.Buffer
+	b := testBackend(t, h)
+	b.rt.Stdout = &stdout
+	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+		t.Fatalf("Cleanup dry-run: %v", err)
+	}
+	if len(h.deletes) != 0 {
+		t.Fatalf("dry-run must not delete, deletes=%#v", h.deletes)
+	}
+	if !strings.Contains(stdout.String(), "would delete sandbox=crabbox-cua-expired-aaaaaa") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestCommandEnvStripsCUAAuth(t *testing.T) {
+	env, stripped := commandEnv(map[string]string{
+		"CUA_API_KEY":             "secret",
+		"CRABBOX_CUA_API_KEY":     "secret",
+		"CRABBOX_CUA_SMOKE_VALUE": "ok",
+	})
+	if env["CRABBOX_CUA_SMOKE_VALUE"] != "ok" {
+		t.Fatalf("env=%#v", env)
+	}
+	if _, ok := env["CUA_API_KEY"]; ok {
+		t.Fatalf("CUA_API_KEY should be stripped: %#v", env)
+	}
+	if len(stripped) != 2 {
+		t.Fatalf("stripped=%#v", stripped)
+	}
+}
+
+func TestSyncWorkspaceUploadsArchiveAndRunsExtraction(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "proof.txt"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.email", "smoke@example.com")
+	runGit(t, repo, "config", "user.name", "Crabbox Smoke")
+	runGit(t, repo, "add", "proof.txt")
+	runGit(t, repo, "commit", "-qm", "test: seed")
+	h := newBridgeHarness(t)
+	h.infos["crabbox-cua-sync-aaaaaa"] = bridgeSandboxSummary{ID: "crabbox-cua-sync-aaaaaa", Name: "crabbox-cua-sync-aaaaaa", Status: "running"}
+	b := testBackend(t, h)
+	phases, _, err := b.syncWorkspace(context.Background(), b.client(), "crabbox-cua-sync-aaaaaa", RunRequest{Repo: Repo{Root: repo}}, "/workspace/crabbox")
+	if err != nil {
+		t.Fatalf("syncWorkspace: %v", err)
+	}
+	if len(phases) == 0 {
+		t.Fatal("expected timing phases")
+	}
+	if !containsAction(h.actions, "upload_bytes") || !containsAction(h.actions, "exec") {
+		t.Fatalf("actions=%#v", h.actions)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func containsAction(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -1,0 +1,293 @@
+package cua
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	bridgeOutputLimit = 1 << 20
+	bridgeVersion     = 1
+)
+
+//go:embed bridge_script.py
+var bridgeScript string
+
+type bridgeClient struct {
+	cfg Config
+	rt  Runtime
+}
+
+type bridgeRequest struct {
+	Version   int                 `json:"version"`
+	Action    string              `json:"action"`
+	Config    bridgeConfig        `json:"config,omitempty"`
+	SandboxID string              `json:"sandboxId,omitempty"`
+	Sandbox   bridgeSandboxConfig `json:"sandbox,omitempty"`
+	Command   []string            `json:"command,omitempty"`
+	Files     []bridgeFile        `json:"files,omitempty"`
+	Timeout   int                 `json:"timeout,omitempty"`
+}
+
+type bridgeConfig struct {
+	APIURL         string `json:"apiUrl,omitempty"`
+	Image          string `json:"image,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	Region         string `json:"region,omitempty"`
+	Workdir        string `json:"workdir,omitempty"`
+	VCPUs          int    `json:"vcpus,omitempty"`
+	MemoryMB       int    `json:"memoryMb,omitempty"`
+	DiskGB         int    `json:"diskGb,omitempty"`
+	SDKPackage     string `json:"sdkPackage,omitempty"`
+	SDKImport      string `json:"sdkImport,omitempty"`
+	FallbackImport string `json:"fallbackImport,omitempty"`
+}
+
+type bridgeSandboxConfig struct {
+	Name string            `json:"name,omitempty"`
+	ID   string            `json:"id,omitempty"`
+	Meta map[string]string `json:"metadata,omitempty"`
+}
+
+type bridgeFile struct {
+	Path          string `json:"path,omitempty"`
+	ContentBase64 string `json:"contentBase64,omitempty"`
+}
+
+type bridgeResponse struct {
+	OK        bool                   `json:"ok"`
+	Class     string                 `json:"class,omitempty"`
+	Sandbox   bridgeSandboxSummary   `json:"sandbox,omitempty"`
+	Sandboxes []bridgeSandboxSummary `json:"sandboxes,omitempty"`
+	Stdout    string                 `json:"stdout,omitempty"`
+	Stderr    string                 `json:"stderr,omitempty"`
+	ExitCode  int                    `json:"exitCode,omitempty"`
+	Doctor    bridgeDoctor           `json:"doctor,omitempty"`
+	Error     *bridgeError           `json:"error,omitempty"`
+}
+
+type bridgeSandboxSummary struct {
+	ID       string            `json:"id,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	Status   string            `json:"status,omitempty"`
+	State    string            `json:"state,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type bridgeDoctor struct {
+	PythonVersion string            `json:"pythonVersion,omitempty"`
+	ImportPath    string            `json:"importPath,omitempty"`
+	SDKVersion    string            `json:"sdkVersion,omitempty"`
+	Auth          string            `json:"auth,omitempty"`
+	BaseURL       string            `json:"baseUrl,omitempty"`
+	Checks        []bridgeCheck     `json:"checks,omitempty"`
+	Details       map[string]string `json:"details,omitempty"`
+}
+
+type bridgeCheck struct {
+	Status  string            `json:"status"`
+	Check   string            `json:"check"`
+	Message string            `json:"message,omitempty"`
+	Class   string            `json:"class,omitempty"`
+	Details map[string]string `json:"details,omitempty"`
+}
+
+type bridgeError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Class   string `json:"class,omitempty"`
+}
+
+func newBridgeClient(cfg Config, rt Runtime) *bridgeClient {
+	cfg.Provider = providerName
+	return &bridgeClient{cfg: cfg, rt: rt}
+}
+
+func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridgeResponse, error) {
+	if c.rt.Exec == nil {
+		return bridgeResponse{}, exit(2, "provider=cua bridge requires Runtime.Exec")
+	}
+	req.Version = bridgeVersion
+	req.Config = bridgeConfigForConfig(c.cfg)
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return bridgeResponse{}, err
+	}
+	timeout := bridgeTimeout(c.cfg, req)
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	var stdout, stderr bytes.Buffer
+	dir, err := bridgeWorkingDir()
+	if err != nil {
+		return bridgeResponse{}, err
+	}
+	result, runErr := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:                   bridgeCommand(c.cfg),
+		Args:                   []string{"-c", bridgeScript},
+		Env:                    bridgeEnv(c.cfg),
+		Dir:                    dir,
+		Stdin:                  bytes.NewReader(payload),
+		Stdout:                 &stdout,
+		Stderr:                 &stderr,
+		MaxCapturedOutputBytes: bridgeOutputLimit,
+		CancelGracePeriod:      2 * time.Second,
+	})
+	if runErr != nil || result.ExitCode != 0 {
+		return bridgeResponse{}, bridgeCommandError(result.ExitCode, stdout.String(), stderr.String(), runErr)
+	}
+	data := bytes.TrimSpace(stdout.Bytes())
+	if len(data) == 0 {
+		return bridgeResponse{}, fmt.Errorf("provider=cua bridge returned empty JSON output")
+	}
+	var resp bridgeResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return bridgeResponse{}, fmt.Errorf("decode provider=cua bridge JSON: %w", err)
+	}
+	resp = redactBridgeResponse(resp)
+	return resp, nil
+}
+
+func bridgeConfigForConfig(cfg Config) bridgeConfig {
+	apiURL, _ := cuaAPIURL(cfg)
+	workdir, _ := cuaWorkdir(cfg)
+	return bridgeConfig{
+		APIURL:         apiURL,
+		Image:          strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
+		Kind:           strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
+		Region:         strings.TrimSpace(cfg.Cua.Region),
+		Workdir:        workdir,
+		VCPUs:          cfg.Cua.VCPUs,
+		MemoryMB:       cfg.Cua.MemoryMB,
+		DiskGB:         cfg.Cua.DiskGB,
+		SDKPackage:     strings.TrimSpace(blank(cfg.Cua.SDKPackage, defaultSDKPackage)),
+		SDKImport:      strings.TrimSpace(blank(cfg.Cua.SDKImport, defaultSDKImport)),
+		FallbackImport: strings.TrimSpace(blank(cfg.Cua.SDKFallbackImport, defaultSDKFallbackImport)),
+	}
+}
+
+func bridgeCommand(cfg Config) string {
+	return strings.TrimSpace(blank(cfg.Cua.BridgeCommand, defaultBridgeCommand))
+}
+
+func bridgeTimeout(cfg Config, req bridgeRequest) time.Duration {
+	seconds := cfg.Cua.ExecTimeoutSecs
+	if req.Action == "doctor" {
+		seconds = 15
+	}
+	if req.Timeout > 0 {
+		seconds = req.Timeout
+	}
+	if seconds <= 0 {
+		seconds = 600
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func bridgeWorkingDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(base) == "" {
+		base = os.TempDir()
+	}
+	dir := filepath.Join(base, "crabbox", "cua-bridge")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create provider=cua bridge working directory: %w", err)
+	}
+	return dir, nil
+}
+
+func bridgeEnv(cfg Config) []string {
+	env := make([]string, 0, 12)
+	for _, key := range []string{"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "SystemRoot", "SYSTEMROOT", "COMSPEC", "PATHEXT"} {
+		if value := os.Getenv(key); value != "" {
+			env = upsertEnv(env, key, value)
+		}
+	}
+	if key := os.Getenv("CRABBOX_CUA_API_KEY"); key != "" {
+		env = upsertEnv(env, "CUA_API_KEY", key)
+	} else if key := os.Getenv("CUA_API_KEY"); key != "" {
+		env = upsertEnv(env, "CUA_API_KEY", key)
+	}
+	if apiURL, err := cuaAPIURL(cfg); err == nil && apiURL != "" {
+		env = upsertEnv(env, "CUA_BASE_URL", apiURL)
+	}
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_PACKAGE", strings.TrimSpace(blank(cfg.Cua.SDKPackage, defaultSDKPackage)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKImport, defaultSDKImport)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_FALLBACK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKFallbackImport, defaultSDKFallbackImport)))
+	return env
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func bridgeCommandError(exitCode int, stdout, stderr string, runErr error) error {
+	parts := []string{}
+	if runErr != nil {
+		parts = append(parts, runErr.Error())
+	}
+	if exitCode != 0 {
+		parts = append(parts, fmt.Sprintf("exit=%d", exitCode))
+	}
+	if text := strings.TrimSpace(stdout); text != "" {
+		parts = append(parts, "stdout="+limitErrorText(text))
+	}
+	if text := strings.TrimSpace(stderr); text != "" {
+		parts = append(parts, "stderr="+limitErrorText(text))
+	}
+	return fmt.Errorf("provider=cua bridge failed: %s", redactSecrets(strings.Join(parts, " ")))
+}
+
+func redactBridgeResponse(resp bridgeResponse) bridgeResponse {
+	resp.Stdout = redactSecrets(resp.Stdout)
+	resp.Stderr = redactSecrets(resp.Stderr)
+	if resp.Error != nil {
+		resp.Error.Message = redactSecrets(resp.Error.Message)
+	}
+	for i := range resp.Doctor.Checks {
+		resp.Doctor.Checks[i].Message = redactSecrets(resp.Doctor.Checks[i].Message)
+	}
+	return resp
+}
+
+func redactSecrets(value string) string {
+	out := value
+	for _, secret := range []string{os.Getenv("CRABBOX_CUA_API_KEY"), os.Getenv("CUA_API_KEY")} {
+		if secret = strings.TrimSpace(secret); secret != "" {
+			out = strings.ReplaceAll(out, secret, "[redacted]")
+		}
+	}
+	return out
+}
+
+func limitErrorText(value string) string {
+	value = strings.TrimSpace(value)
+	const limit = 512
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "...[truncated]"
+}
+
+func hashScope(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,8 +16,9 @@ import (
 )
 
 const (
-	bridgeOutputLimit = 1 << 20
-	bridgeVersion     = 1
+	bridgeOutputLimit     = 1 << 20
+	bridgeExecOutputLimit = 64 << 20
+	bridgeVersion         = 1
 )
 
 //go:embed bridge_script.py
@@ -34,6 +36,8 @@ type bridgeRequest struct {
 	SandboxID string              `json:"sandboxId,omitempty"`
 	Sandbox   bridgeSandboxConfig `json:"sandbox,omitempty"`
 	Command   []string            `json:"command,omitempty"`
+	Env       map[string]string   `json:"env,omitempty"`
+	Workdir   string              `json:"workdir,omitempty"`
 	Files     []bridgeFile        `json:"files,omitempty"`
 	Timeout   int                 `json:"timeout,omitempty"`
 }
@@ -47,6 +51,8 @@ type bridgeConfig struct {
 	VCPUs          int    `json:"vcpus,omitempty"`
 	MemoryMB       int    `json:"memoryMb,omitempty"`
 	DiskGB         int    `json:"diskGb,omitempty"`
+	StartupTimeout int    `json:"startupTimeoutSecs,omitempty"`
+	ExecTimeout    int    `json:"execTimeoutSecs,omitempty"`
 	SDKPackage     string `json:"sdkPackage,omitempty"`
 	SDKImport      string `json:"sdkImport,omitempty"`
 	FallbackImport string `json:"fallbackImport,omitempty"`
@@ -112,6 +118,129 @@ func newBridgeClient(cfg Config, rt Runtime) *bridgeClient {
 	return &bridgeClient{cfg: cfg, rt: rt}
 }
 
+func (c *bridgeClient) CreateSandbox(ctx context.Context, name string, metadata map[string]string) (bridgeSandboxSummary, error) {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{
+		Action: "create",
+		Sandbox: bridgeSandboxConfig{
+			Name: name,
+			Meta: metadata,
+		},
+	})
+	if err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	if err := bridgeResponseError("create", resp); err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	return resp.Sandbox, nil
+}
+
+func (c *bridgeClient) ListSandboxes(ctx context.Context) ([]bridgeSandboxSummary, error) {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{Action: "list"})
+	if err != nil {
+		return nil, err
+	}
+	if err := bridgeResponseError("list", resp); err != nil {
+		return nil, err
+	}
+	return resp.Sandboxes, nil
+}
+
+func (c *bridgeClient) GetSandbox(ctx context.Context, sandboxID string) (bridgeSandboxSummary, error) {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{Action: "info", SandboxID: sandboxID})
+	if err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	if err := bridgeResponseError("info", resp); err != nil {
+		return bridgeSandboxSummary{}, err
+	}
+	return resp.Sandbox, nil
+}
+
+func (c *bridgeClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{Action: "delete", SandboxID: sandboxID})
+	if err != nil {
+		return err
+	}
+	return bridgeResponseError("delete", resp)
+}
+
+func (c *bridgeClient) UploadBytes(ctx context.Context, sandboxID string, file bridgeFile) error {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{Action: "upload_bytes", SandboxID: sandboxID, Files: []bridgeFile{file}})
+	if err != nil {
+		return err
+	}
+	return bridgeResponseError("upload_bytes", resp)
+}
+
+func (c *bridgeClient) Exec(ctx context.Context, sandboxID string, command []string, workdir string, env map[string]string, stdout, stderr *bytes.Buffer) (bridgeResponse, error) {
+	resp, err := c.RoundTrip(ctx, bridgeRequest{
+		Action:    "exec",
+		SandboxID: sandboxID,
+		Command:   command,
+		Workdir:   workdir,
+		Env:       env,
+	})
+	if err != nil {
+		return bridgeResponse{}, err
+	}
+	if stdout != nil && resp.Stdout != "" {
+		stdout.WriteString(resp.Stdout)
+	}
+	if stderr != nil && resp.Stderr != "" {
+		stderr.WriteString(resp.Stderr)
+	}
+	if err := bridgeResponseError("exec", resp); err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+type bridgeActionError struct {
+	action string
+	code   string
+	class  string
+	msg    string
+}
+
+func (e *bridgeActionError) Error() string {
+	parts := []string{"provider=cua", "bridge", e.action}
+	if e.code != "" {
+		parts = append(parts, "code="+e.code)
+	}
+	if e.class != "" {
+		parts = append(parts, "class="+e.class)
+	}
+	if e.msg != "" {
+		parts = append(parts, e.msg)
+	}
+	return redactSecrets(strings.Join(parts, " "))
+}
+
+func bridgeResponseError(action string, resp bridgeResponse) error {
+	if resp.OK {
+		return nil
+	}
+	if resp.Error == nil {
+		return &bridgeActionError{action: action, class: strings.TrimSpace(resp.Class), msg: "operation failed"}
+	}
+	return &bridgeActionError{
+		action: action,
+		code:   strings.TrimSpace(resp.Error.Code),
+		class:  strings.TrimSpace(blank(resp.Error.Class, resp.Class)),
+		msg:    strings.TrimSpace(resp.Error.Message),
+	}
+}
+
+func isCUANotFound(err error) bool {
+	var actionErr *bridgeActionError
+	if !errors.As(err, &actionErr) {
+		return false
+	}
+	text := strings.ToLower(actionErr.code + " " + actionErr.class + " " + actionErr.msg)
+	return strings.Contains(text, "not_found") || strings.Contains(text, "not found") || strings.Contains(text, "404")
+}
+
 func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridgeResponse, error) {
 	if c.rt.Exec == nil {
 		return bridgeResponse{}, exit(2, "provider=cua bridge requires Runtime.Exec")
@@ -141,7 +270,7 @@ func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridge
 		Stdin:                  bytes.NewReader(payload),
 		Stdout:                 &stdout,
 		Stderr:                 &stderr,
-		MaxCapturedOutputBytes: bridgeOutputLimit,
+		MaxCapturedOutputBytes: bridgeOutputLimitForRequest(req),
 		CancelGracePeriod:      2 * time.Second,
 	})
 	if runErr != nil || result.ExitCode != 0 {
@@ -159,6 +288,13 @@ func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridge
 	return resp, nil
 }
 
+func bridgeOutputLimitForRequest(req bridgeRequest) int {
+	if req.Action == "exec" {
+		return bridgeExecOutputLimit
+	}
+	return bridgeOutputLimit
+}
+
 func bridgeConfigForConfig(cfg Config) bridgeConfig {
 	apiURL, _ := cuaAPIURL(cfg)
 	workdir, _ := cuaWorkdir(cfg)
@@ -171,6 +307,8 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 		VCPUs:          cfg.Cua.VCPUs,
 		MemoryMB:       cfg.Cua.MemoryMB,
 		DiskGB:         cfg.Cua.DiskGB,
+		StartupTimeout: cfg.Cua.StartupTimeoutSecs,
+		ExecTimeout:    cfg.Cua.ExecTimeoutSecs,
 		SDKPackage:     strings.TrimSpace(blank(cfg.Cua.SDKPackage, defaultSDKPackage)),
 		SDKImport:      strings.TrimSpace(blank(cfg.Cua.SDKImport, defaultSDKImport)),
 		FallbackImport: strings.TrimSpace(blank(cfg.Cua.SDKFallbackImport, defaultSDKFallbackImport)),

--- a/internal/providers/cua/bridge_script.py
+++ b/internal/providers/cua/bridge_script.py
@@ -1,6 +1,10 @@
 import importlib
+import asyncio
+import base64
 import json
 import os
+import re
+import shlex
 import sys
 import traceback
 
@@ -87,6 +91,65 @@ def summarize_sandbox(value):
     }
 
 
+def image_for_config(mod, cfg):
+    image_cls = getattr(mod, "Image", None)
+    if image_cls is None:
+        image_cls = importlib.import_module("cua_sandbox").Image
+    raw = str(cfg.get("image") or "ubuntu:24.04").strip()
+    kind = str(cfg.get("kind") or "container").strip().lower() or "container"
+    if raw.startswith("ubuntu:"):
+        return image_cls.linux("ubuntu", raw.split(":", 1)[1] or "24.04", kind=kind)
+    if raw == "ubuntu":
+        return image_cls.linux("ubuntu", "24.04", kind=kind)
+    if hasattr(image_cls, "from_registry"):
+        img = image_cls.from_registry(raw)
+        if getattr(img, "kind", None) is None:
+            img = image_cls.from_dict({**img.to_dict(), "kind": kind})
+        return img
+    return image_cls.linux("ubuntu", "24.04", kind=kind)
+
+
+def sandbox_kwargs(cfg):
+    kwargs = {"local": False}
+    if cfg.get("region"):
+        kwargs["region"] = str(cfg.get("region"))
+    if int(cfg.get("vcpus") or 0) > 0:
+        kwargs["cpu"] = int(cfg.get("vcpus"))
+    if int(cfg.get("memoryMb") or 0) > 0:
+        kwargs["memory_mb"] = int(cfg.get("memoryMb"))
+    if int(cfg.get("diskGb") or 0) > 0:
+        kwargs["disk_gb"] = int(cfg.get("diskGb"))
+    if int(cfg.get("startupTimeoutSecs") or 0) > 0:
+        kwargs["time_to_start"] = int(cfg.get("startupTimeoutSecs"))
+    return kwargs
+
+
+def command_text(argv):
+    values = [str(v) for v in (argv or [])]
+    if not values:
+        return ""
+    if len(values) == 1:
+        return values[0]
+    return shlex.join(values)
+
+
+def valid_env_name(name):
+    return re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name or "") is not None
+
+
+def error_response(exc, klass="environment_blocked"):
+    code = exc.__class__.__name__
+    message = str(exc)
+    lower = message.lower()
+    if "not found" in lower or "404" in lower:
+        klass = "not_found"
+    elif "quota" in lower or "capacity" in lower or "rate limit" in lower or "429" in lower:
+        klass = "quota_blocked"
+    elif "unauthorized" in lower or "forbidden" in lower or "api key" in lower:
+        klass = "environment_blocked"
+    return {"ok": False, "class": klass, "error": {"code": code, "message": message, "class": klass}}
+
+
 def auth_state():
     if os.environ.get("CUA_API_KEY"):
         return "env"
@@ -140,31 +203,133 @@ def doctor(req, mod, import_path, import_error):
 
 
 def list_sandboxes(mod):
-    cls = sandbox_class(mod)
-    if cls is None or not hasattr(cls, "list"):
-        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_list", "message": "CUA SDK Sandbox.list is unavailable", "class": "environment_blocked"}}
-    values = cls.list()
-    return {"ok": True, "sandboxes": [summarize_sandbox(v) for v in (values or [])]}
+    async def _run():
+        cls = sandbox_class(mod)
+        if cls is None or not hasattr(cls, "list"):
+            return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_list", "message": "CUA SDK Sandbox.list is unavailable", "class": "environment_blocked"}}
+        values = await cls.list()
+        return {"ok": True, "sandboxes": [summarize_sandbox(v) for v in (values or [])]}
+
+    return asyncio.run(_run())
 
 
 def info(req, mod):
-    cls = sandbox_class(mod)
-    sid = str(req.get("sandboxId") or "").strip()
-    if not sid:
-        return {"ok": False, "class": "validation_failed", "error": {"code": "missing_sandbox_id", "message": "sandboxId is required", "class": "validation_failed"}}
-    if cls is None:
-        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_sandbox", "message": "CUA SDK Sandbox is unavailable", "class": "environment_blocked"}}
-    if hasattr(cls, "get_info"):
-        value = cls.get_info(sid)
-    elif hasattr(cls, "connect"):
-        value = cls.connect(sid).get_info()
-    else:
-        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_info", "message": "CUA SDK info operation is unavailable", "class": "environment_blocked"}}
-    return {"ok": True, "sandbox": summarize_sandbox(value)}
+    async def _run():
+        cls = sandbox_class(mod)
+        sid = str(req.get("sandboxId") or "").strip()
+        if not sid:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "missing_sandbox_id", "message": "sandboxId is required", "class": "validation_failed"}}
+        if cls is None:
+            return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_sandbox", "message": "CUA SDK Sandbox is unavailable", "class": "environment_blocked"}}
+        if hasattr(cls, "get_info"):
+            value = await cls.get_info(sid)
+        elif hasattr(cls, "connect"):
+            sb = await cls.connect(sid)
+            try:
+                value = {"id": sid, "name": getattr(sb, "name", sid), "status": "running", "state": "running"}
+            finally:
+                await sb.disconnect()
+        else:
+            return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_info", "message": "CUA SDK info operation is unavailable", "class": "environment_blocked"}}
+        return {"ok": True, "sandbox": summarize_sandbox(value)}
+
+    return asyncio.run(_run())
 
 
-def unsupported(action):
-    return {"ok": False, "class": "diagnostic_only", "error": {"code": "action_deferred", "message": f"CUA bridge action {action} is deferred to lifecycle implementation", "class": "diagnostic_only"}}
+def create(req, mod):
+    async def _run():
+        cls = sandbox_class(mod)
+        if cls is None or not hasattr(cls, "create"):
+            return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_create", "message": "CUA SDK Sandbox.create is unavailable", "class": "environment_blocked"}}
+        cfg = req.get("config") or {}
+        name = str((req.get("sandbox") or {}).get("name") or "").strip()
+        if not name:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "missing_sandbox_name", "message": "sandbox.name is required", "class": "validation_failed"}}
+        try:
+            sb = await cls.create(image_for_config(mod, cfg), name=name, **sandbox_kwargs(cfg))
+            try:
+                return {"ok": True, "sandbox": summarize_sandbox({"id": name, "name": getattr(sb, "name", name), "status": "running", "metadata": (req.get("sandbox") or {}).get("metadata") or {}})}
+            finally:
+                await sb.disconnect()
+        except Exception as exc:
+            return error_response(exc)
+
+    return asyncio.run(_run())
+
+
+def delete(req, mod):
+    async def _run():
+        cls = sandbox_class(mod)
+        sid = str(req.get("sandboxId") or "").strip()
+        if not sid:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "missing_sandbox_id", "message": "sandboxId is required", "class": "validation_failed"}}
+        if cls is None or not hasattr(cls, "delete"):
+            return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_delete", "message": "CUA SDK Sandbox.delete is unavailable", "class": "environment_blocked"}}
+        try:
+            await cls.delete(sid)
+            return {"ok": True, "sandbox": summarize_sandbox({"id": sid, "name": sid, "status": "deleted"})}
+        except Exception as exc:
+            return error_response(exc)
+
+    return asyncio.run(_run())
+
+
+def upload_bytes(req, mod):
+    async def _run():
+        cls = sandbox_class(mod)
+        sid = str(req.get("sandboxId") or "").strip()
+        files = req.get("files") or []
+        if not sid or not files:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "missing_upload_input", "message": "sandboxId and files are required", "class": "validation_failed"}}
+        sb = None
+        try:
+            sb = await cls.connect(sid)
+            for item in files:
+                path = str(item.get("path") or "").strip()
+                content = base64.b64decode(str(item.get("contentBase64") or ""))
+                await sb.files.write_bytes(path, content)
+            return {"ok": True, "sandbox": summarize_sandbox({"id": sid, "name": sid, "status": "running"})}
+        except Exception as exc:
+            return error_response(exc)
+        finally:
+            if sb is not None:
+                await sb.disconnect()
+
+    return asyncio.run(_run())
+
+
+def exec_command(req, mod):
+    async def _run():
+        cls = sandbox_class(mod)
+        sid = str(req.get("sandboxId") or "").strip()
+        command = command_text(req.get("command") or [])
+        if not sid or not command:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "missing_exec_input", "message": "sandboxId and command are required", "class": "validation_failed"}}
+        timeout = int(req.get("timeout") or (req.get("config") or {}).get("execTimeoutSecs") or 600)
+        workdir = str(req.get("workdir") or "").strip()
+        env = {str(k): str(v) for k, v in (req.get("env") or {}).items()}
+        invalid_env = sorted(k for k in env if not valid_env_name(k))
+        if invalid_env:
+            return {"ok": False, "class": "validation_failed", "error": {"code": "invalid_env_name", "message": "invalid environment variable name: " + ", ".join(invalid_env), "class": "validation_failed"}}
+        env_prefix = ""
+        if env:
+            env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in sorted(env.items())) + " "
+        if workdir:
+            script = "cd " + shlex.quote(workdir) + " && " + env_prefix + command
+        else:
+            script = env_prefix + command
+        sb = None
+        try:
+            sb = await cls.connect(sid)
+            result = await sb.shell.run(script, timeout=timeout)
+            return {"ok": True, "stdout": result.stdout, "stderr": result.stderr, "exitCode": int(result.returncode), "sandbox": summarize_sandbox({"id": sid, "name": sid, "status": "running"})}
+        except Exception as exc:
+            return error_response(exc)
+        finally:
+            if sb is not None:
+                await sb.disconnect()
+
+    return asyncio.run(_run())
 
 
 def main():
@@ -185,8 +350,14 @@ def main():
             emit(list_sandboxes(mod))
         if action == "info":
             emit(info(req, mod))
-        if action in {"create", "delete", "upload_bytes", "exec"}:
-            emit(unsupported(action))
+        if action == "create":
+            emit(create(req, mod))
+        if action == "delete":
+            emit(delete(req, mod))
+        if action == "upload_bytes":
+            emit(upload_bytes(req, mod))
+        if action == "exec":
+            emit(exec_command(req, mod))
         emit({"ok": False, "class": "validation_failed", "error": {"code": "unknown_action", "message": f"unknown CUA bridge action {action}", "class": "validation_failed"}})
     except SystemExit:
         raise

--- a/internal/providers/cua/bridge_script.py
+++ b/internal/providers/cua/bridge_script.py
@@ -1,0 +1,198 @@
+import importlib
+import json
+import os
+import sys
+import traceback
+
+
+def emit(value, code=0):
+    sys.stdout.write(json.dumps(value, separators=(",", ":")))
+    sys.stdout.flush()
+    raise SystemExit(code)
+
+
+def check(status, name, message="", klass="", details=None):
+    item = {"status": status, "check": name}
+    if message:
+        item["message"] = message
+    if klass:
+        item["class"] = klass
+    if details:
+        item["details"] = details
+    return item
+
+
+def import_sdk(preferred, fallback):
+    errors = []
+    for path in [preferred, fallback]:
+        path = str(path or "").strip()
+        if not path:
+            continue
+        try:
+            mod = importlib.import_module(path)
+            return mod, path, ""
+        except Exception as exc:
+            errors.append(f"{path}: {exc.__class__.__name__}: {exc}")
+    return None, "", "; ".join(errors)
+
+
+def version_tuple():
+    return (sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+
+
+def python_supported(import_path):
+    major, minor, _ = version_tuple()
+    if import_path == "cua_sandbox":
+        return (major, minor) >= (3, 11), "3.11+"
+    return (major, minor) >= (3, 12), "3.12+"
+
+
+def sdk_version(mod):
+    return str(getattr(mod, "__version__", "") or "")
+
+
+def sdk_configure(mod, cfg):
+    configure = getattr(mod, "configure", None)
+    if callable(configure):
+        base_url = cfg.get("apiUrl") or os.environ.get("CUA_BASE_URL") or ""
+        if base_url:
+            try:
+                configure(base_url=base_url)
+            except TypeError:
+                configure(api_url=base_url)
+
+
+def sandbox_class(mod):
+    sandbox = getattr(mod, "Sandbox", None)
+    if sandbox is None:
+        sandbox_mod = getattr(mod, "sandbox", None)
+        sandbox = getattr(sandbox_mod, "Sandbox", None)
+    return sandbox
+
+
+def summarize_sandbox(value):
+    if isinstance(value, dict):
+        data = value
+    else:
+        data = {}
+        for key in ["id", "sandbox_id", "name", "status", "state", "metadata", "tags"]:
+            if hasattr(value, key):
+                data[key] = getattr(value, key)
+    return {
+        "id": str(data.get("id") or data.get("sandbox_id") or data.get("name") or ""),
+        "name": str(data.get("name") or data.get("id") or data.get("sandbox_id") or ""),
+        "status": str(data.get("status") or data.get("state") or ""),
+        "state": str(data.get("state") or data.get("status") or ""),
+        "metadata": data.get("metadata") or data.get("tags") or {},
+    }
+
+
+def auth_state():
+    if os.environ.get("CUA_API_KEY"):
+        return "env"
+    return "credential_store_or_missing"
+
+
+def doctor(req, mod, import_path, import_error):
+    cfg = req.get("config") or {}
+    checks = []
+    pyver = ".".join(str(v) for v in version_tuple())
+    details = {
+        "mutation": "false",
+        "sdkPackage": str(cfg.get("sdkPackage") or os.environ.get("CRABBOX_CUA_SDK_PACKAGE") or ""),
+    }
+    if not mod:
+        checks.append(check("failed", "sdk", f"CUA SDK import failed: {import_error}", "environment_blocked"))
+        return {
+            "ok": False,
+            "class": "environment_blocked",
+            "doctor": {"pythonVersion": pyver, "auth": auth_state(), "baseUrl": str(cfg.get("apiUrl") or ""), "checks": checks, "details": details},
+        }
+    supported, required = python_supported(import_path)
+    if supported:
+        checks.append(check("ok", "python", f"python={pyver} required={required}", details={"required": required}))
+    else:
+        checks.append(check("failed", "python", f"python={pyver} required={required}", "environment_blocked", {"required": required}))
+    checks.append(check("ok", "sdk", f"import={import_path}", details={"import": import_path, "version": sdk_version(mod)}))
+    auth = auth_state()
+    if auth == "env":
+        checks.append(check("ok", "auth", "auth=env mutation=false", details={"source": "env"}))
+    else:
+        checks.append(check("failed", "auth", "auth=missing_or_credential_store_unverified mutation=false", "environment_blocked", {"source": "credential_store_or_missing"}))
+    if cfg.get("apiUrl"):
+        checks.append(check("ok", "api_url", "api_url=configured mutation=false", details={"baseUrl": str(cfg.get("apiUrl"))}))
+    else:
+        checks.append(check("ok", "api_url", "api_url=sdk_default mutation=false"))
+    ok = all(item["status"] != "failed" for item in checks)
+    return {
+        "ok": ok,
+        "class": "" if ok else "environment_blocked",
+        "doctor": {
+            "pythonVersion": pyver,
+            "importPath": import_path,
+            "sdkVersion": sdk_version(mod),
+            "auth": auth,
+            "baseUrl": str(cfg.get("apiUrl") or os.environ.get("CUA_BASE_URL") or ""),
+            "checks": checks,
+            "details": details,
+        },
+    }
+
+
+def list_sandboxes(mod):
+    cls = sandbox_class(mod)
+    if cls is None or not hasattr(cls, "list"):
+        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_list", "message": "CUA SDK Sandbox.list is unavailable", "class": "environment_blocked"}}
+    values = cls.list()
+    return {"ok": True, "sandboxes": [summarize_sandbox(v) for v in (values or [])]}
+
+
+def info(req, mod):
+    cls = sandbox_class(mod)
+    sid = str(req.get("sandboxId") or "").strip()
+    if not sid:
+        return {"ok": False, "class": "validation_failed", "error": {"code": "missing_sandbox_id", "message": "sandboxId is required", "class": "validation_failed"}}
+    if cls is None:
+        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_sandbox", "message": "CUA SDK Sandbox is unavailable", "class": "environment_blocked"}}
+    if hasattr(cls, "get_info"):
+        value = cls.get_info(sid)
+    elif hasattr(cls, "connect"):
+        value = cls.connect(sid).get_info()
+    else:
+        return {"ok": False, "class": "environment_blocked", "error": {"code": "sdk_missing_info", "message": "CUA SDK info operation is unavailable", "class": "environment_blocked"}}
+    return {"ok": True, "sandbox": summarize_sandbox(value)}
+
+
+def unsupported(action):
+    return {"ok": False, "class": "diagnostic_only", "error": {"code": "action_deferred", "message": f"CUA bridge action {action} is deferred to lifecycle implementation", "class": "diagnostic_only"}}
+
+
+def main():
+    try:
+        req = json.load(sys.stdin)
+        cfg = req.get("config") or {}
+        preferred = cfg.get("sdkImport") or os.environ.get("CRABBOX_CUA_SDK_IMPORT") or "cua"
+        fallback = cfg.get("fallbackImport") or os.environ.get("CRABBOX_CUA_SDK_FALLBACK_IMPORT") or "cua_sandbox"
+        mod, import_path, import_error = import_sdk(preferred, fallback)
+        if mod is not None:
+            sdk_configure(mod, cfg)
+        action = str(req.get("action") or "").strip()
+        if action == "doctor":
+            emit(doctor(req, mod, import_path, import_error))
+        if mod is None:
+            emit({"ok": False, "class": "environment_blocked", "error": {"code": "sdk_import_failed", "message": import_error, "class": "environment_blocked"}})
+        if action == "list":
+            emit(list_sandboxes(mod))
+        if action == "info":
+            emit(info(req, mod))
+        if action in {"create", "delete", "upload_bytes", "exec"}:
+            emit(unsupported(action))
+        emit({"ok": False, "class": "validation_failed", "error": {"code": "unknown_action", "message": f"unknown CUA bridge action {action}", "class": "validation_failed"}})
+    except SystemExit:
+        raise
+    except Exception as exc:
+        emit({"ok": False, "class": "environment_blocked", "error": {"code": exc.__class__.__name__, "message": str(exc), "class": "environment_blocked"}, "stderr": traceback.format_exc()}, 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/providers/cua/bridge_test.go
+++ b/internal/providers/cua/bridge_test.go
@@ -88,7 +88,7 @@ func TestBridgeSendsJSONOnStdinAndMapsSecretOnlyToSDKEnv(t *testing.T) {
 		if err := json.Unmarshal([]byte(requestBody(t, req)), &payload); err != nil {
 			t.Fatalf("stdin payload: %v", err)
 		}
-		if payload.Action != "doctor" || payload.Version != bridgeVersion || payload.Config.APIURL != "https://api.cua.example/v1" {
+		if payload.Action != "doctor" || payload.Version != bridgeVersion || payload.Config.APIURL != "https://api.cua.example/v1" || payload.Config.ExecTimeout != 60 {
 			t.Fatalf("payload=%#v", payload)
 		}
 		_, _ = io.WriteString(req.Stdout, `{"ok":true,"doctor":{"importPath":"cua","auth":"env","checks":[{"status":"ok","check":"sdk"}]}}`)
@@ -131,6 +131,20 @@ func TestBridgeRedactsSecretFromCommandFailure(t *testing.T) {
 	}
 }
 
+func TestBridgeExecUsesRunOutputCaptureLimit(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if req.MaxCapturedOutputBytes != bridgeExecOutputLimit {
+			t.Fatalf("exec output limit=%d want %d", req.MaxCapturedOutputBytes, bridgeExecOutputLimit)
+		}
+		_, _ = io.WriteString(req.Stdout, `{"ok":true,"exitCode":0}`)
+		return LocalCommandResult{ExitCode: 0}, nil
+	}}
+	client := newBridgeClient(testConfig(), Runtime{Exec: runner})
+	if _, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "exec", SandboxID: "crabbox-cua-test", Command: []string{"true"}}); err != nil {
+		t.Fatalf("RoundTrip exec: %v", err)
+	}
+}
+
 func TestBridgeRejectsMalformedJSON(t *testing.T) {
 	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stdout, `not-json`)
@@ -143,10 +157,16 @@ func TestBridgeRejectsMalformedJSON(t *testing.T) {
 }
 
 func TestBridgeScriptKeepsLifecycleActionsExplicitlyDispatched(t *testing.T) {
-	for _, snippet := range []string{`action == "doctor"`, `action == "list"`, `action == "info"`, `{"create", "delete", "upload_bytes", "exec"}`} {
+	for _, snippet := range []string{`action == "doctor"`, `action == "list"`, `action == "info"`, `action == "create"`, `action == "delete"`, `action == "upload_bytes"`, `action == "exec"`} {
 		if !strings.Contains(bridgeScript, snippet) {
 			t.Fatalf("bridge script missing %q", snippet)
 		}
+	}
+	if !strings.Contains(bridgeScript, `" && " + env_prefix + command`) {
+		t.Fatalf("bridge script must apply forwarded env to the user command after cd")
+	}
+	if !strings.Contains(bridgeScript, `invalid_env`) || !strings.Contains(bridgeScript, `valid_env_name`) {
+		t.Fatalf("bridge script must validate forwarded env names before shell construction")
 	}
 	if strings.Contains(bridgeScript, "CUA_API_BASE") {
 		t.Fatalf("bridge script must use SDK CUA_BASE_URL, not CLI-only CUA_API_BASE")

--- a/internal/providers/cua/bridge_test.go
+++ b/internal/providers/cua/bridge_test.go
@@ -1,0 +1,154 @@
+package cua
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls []LocalCommandRequest
+	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+}
+
+func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	if r.fn != nil {
+		return r.fn(req)
+	}
+	return LocalCommandResult{ExitCode: 0}, nil
+}
+
+func (r *recordingRunner) onlyCall(t *testing.T) LocalCommandRequest {
+	t.Helper()
+	if len(r.calls) != 1 {
+		t.Fatalf("calls=%d want 1", len(r.calls))
+	}
+	return r.calls[0]
+}
+
+func testConfig() Config {
+	return Config{Provider: providerName, Cua: core.CuaConfig{
+		APIURL:            "https://api.cua.example/v1/",
+		Image:             defaultImage,
+		Kind:              defaultKind,
+		Workdir:           defaultWorkdir,
+		ExecTimeoutSecs:   60,
+		BridgeCommand:     defaultBridgeCommand,
+		SDKPackage:        defaultSDKPackage,
+		SDKImport:         defaultSDKImport,
+		SDKFallbackImport: defaultSDKFallbackImport,
+	}}
+}
+
+func requestBody(t *testing.T, req LocalCommandRequest) string {
+	t.Helper()
+	data, err := io.ReadAll(req.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func envContains(env []string, value string) bool {
+	for _, item := range env {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBridgeSendsJSONOnStdinAndMapsSecretOnlyToSDKEnv(t *testing.T) {
+	secret := "cua-secret-value"
+	t.Setenv("CRABBOX_CUA_API_KEY", secret)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		for _, arg := range req.Args {
+			if strings.Contains(arg, secret) {
+				t.Fatalf("secret leaked into argv: %#v", req.Args)
+			}
+		}
+		if !envContains(req.Env, "CUA_API_KEY="+secret) {
+			t.Fatalf("bridge env missing SDK API key: %#v", req.Env)
+		}
+		if envContains(req.Env, "AWS_SECRET_ACCESS_KEY=ambient-secret") {
+			t.Fatalf("bridge env inherited unrelated ambient secret: %#v", req.Env)
+		}
+		if strings.TrimSpace(req.Dir) == "" || !strings.Contains(req.Dir, "cua-bridge") {
+			t.Fatalf("bridge must run from a trusted cache directory, got %q", req.Dir)
+		}
+		var payload bridgeRequest
+		if err := json.Unmarshal([]byte(requestBody(t, req)), &payload); err != nil {
+			t.Fatalf("stdin payload: %v", err)
+		}
+		if payload.Action != "doctor" || payload.Version != bridgeVersion || payload.Config.APIURL != "https://api.cua.example/v1" {
+			t.Fatalf("payload=%#v", payload)
+		}
+		_, _ = io.WriteString(req.Stdout, `{"ok":true,"doctor":{"importPath":"cua","auth":"env","checks":[{"status":"ok","check":"sdk"}]}}`)
+		return LocalCommandResult{ExitCode: 0}, nil
+	}}
+	client := newBridgeClient(testConfig(), Runtime{Exec: runner})
+	resp, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "doctor"})
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if !resp.OK || resp.Doctor.ImportPath != "cua" {
+		t.Fatalf("resp=%#v", resp)
+	}
+	call := runner.onlyCall(t)
+	if call.Name != defaultBridgeCommand {
+		t.Fatalf("command=%q", call.Name)
+	}
+	if !reflect.DeepEqual(call.Args[:1], []string{"-c"}) {
+		t.Fatalf("args=%#v", call.Args)
+	}
+	if !strings.Contains(call.Args[1], "def doctor") {
+		t.Fatalf("embedded script missing doctor implementation")
+	}
+}
+
+func TestBridgeRedactsSecretFromCommandFailure(t *testing.T) {
+	secret := "cua-secret-value"
+	t.Setenv("CRABBOX_CUA_API_KEY", secret)
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		_, _ = io.WriteString(req.Stderr, "denied "+secret)
+		return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
+	}}
+	client := newBridgeClient(testConfig(), Runtime{Exec: runner})
+	_, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "doctor"})
+	if err == nil {
+		t.Fatal("expected bridge failure")
+	}
+	if strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("error was not redacted: %v", err)
+	}
+}
+
+func TestBridgeRejectsMalformedJSON(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		_, _ = io.WriteString(req.Stdout, `not-json`)
+		return LocalCommandResult{ExitCode: 0}, nil
+	}}
+	client := newBridgeClient(testConfig(), Runtime{Exec: runner})
+	if _, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "doctor"}); err == nil {
+		t.Fatal("expected malformed JSON error")
+	}
+}
+
+func TestBridgeScriptKeepsLifecycleActionsExplicitlyDispatched(t *testing.T) {
+	for _, snippet := range []string{`action == "doctor"`, `action == "list"`, `action == "info"`, `{"create", "delete", "upload_bytes", "exec"}`} {
+		if !strings.Contains(bridgeScript, snippet) {
+			t.Fatalf("bridge script missing %q", snippet)
+		}
+	}
+	if strings.Contains(bridgeScript, "CUA_API_BASE") {
+		t.Fatalf("bridge script must use SDK CUA_BASE_URL, not CLI-only CUA_API_BASE")
+	}
+}

--- a/internal/providers/cua/claims.go
+++ b/internal/providers/cua/claims.go
@@ -1,0 +1,172 @@
+package cua
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	core "github.com/openclaw/crabbox/internal/cli"
+	"strings"
+	"time"
+)
+
+const (
+	leasePrefix       = "cuabx_"
+	sandboxNamePrefix = "crabbox-cua-"
+	scopePrefix       = "cua-api-sha256:"
+	labelSandboxName  = "cua.sandbox.name"
+	labelImage        = "cua.image"
+	labelKind         = "cua.kind"
+	labelRegion       = "cua.region"
+	labelWorkdir      = "cua.workdir"
+	labelMissing      = "cua.missing"
+)
+
+func newCUALeaseID() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return leasePrefix + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000"), ".", "")
+	}
+	return leasePrefix + hex.EncodeToString(b[:])
+}
+
+func cuaScope(cfg Config) (string, error) {
+	apiURL, err := cuaAPIURL(cfg)
+	if err != nil {
+		return "", err
+	}
+	if apiURL == "" {
+		apiURL = "sdk-default"
+	}
+	return scopePrefix + hashScope(apiURL), nil
+}
+
+func newSandboxName(leaseID, slug string) string {
+	base := normalizeLeaseSlug(slug)
+	if base == "" {
+		base = normalizeLeaseSlug(leaseID)
+	}
+	base = strings.TrimPrefix(base, strings.TrimSuffix(sandboxNamePrefix, "-")+"-")
+	const suffixLen = 6
+	maxBase := 63 - len(sandboxNamePrefix) - suffixLen - 1
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+	}
+	if base == "" {
+		base = "lease"
+	}
+	return fmt.Sprintf("%s%s-%s", sandboxNamePrefix, base, hashScope(leaseID)[:suffixLen])
+}
+
+func claimLabels(cfg Config, sandboxName string, missing bool) map[string]string {
+	workdir, _ := cuaWorkdir(cfg)
+	labels := map[string]string{
+		labelSandboxName: sandboxName,
+		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
+		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
+		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
+		labelWorkdir:     workdir,
+	}
+	if missing {
+		labels[labelMissing] = "true"
+	}
+	return labels
+}
+
+func claimSandboxName(claim LeaseClaim) string {
+	if claim.CloudID != "" {
+		return claim.CloudID
+	}
+	if claim.Labels != nil {
+		return strings.TrimSpace(claim.Labels[labelSandboxName])
+	}
+	return ""
+}
+
+func resolveClaim(identifier string, cfg Config) (LeaseClaim, bool, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return LeaseClaim{}, false, exit(2, "provider=cua requires a Crabbox-created sandbox slug or %s lease id", leasePrefix)
+	}
+	if claim, ok, err := resolveCUALeaseClaim(identifier, cfg); err != nil || ok {
+		return claim, ok, err
+	}
+	return LeaseClaim{}, false, exit(4, "CUA sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s lease id", identifier, leasePrefix)
+}
+
+func resolveCUALeaseClaim(identifier string, cfg Config) (LeaseClaim, bool, error) {
+	scope, err := cuaScope(cfg)
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	if claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(identifier, providerName); err != nil {
+		return LeaseClaim{}, false, err
+	} else if ok {
+		if !exact && !strings.HasPrefix(claim.LeaseID, leasePrefix) {
+			return LeaseClaim{}, false, nil
+		}
+		if err := validateClaimScope(claim, scope); err != nil {
+			return LeaseClaim{}, false, err
+		}
+		return claim, true, nil
+	}
+	if !strings.HasPrefix(identifier, leasePrefix) {
+		exact := leasePrefix + identifier
+		if claim, err := core.ReadLeaseClaim(exact); err != nil {
+			return LeaseClaim{}, false, err
+		} else if claim.LeaseID == exact && claim.Provider == providerName {
+			if err := validateClaimScope(claim, scope); err != nil {
+				return LeaseClaim{}, false, err
+			}
+			return claim, true, nil
+		}
+	}
+	return LeaseClaim{}, false, nil
+}
+
+func validateClaimScope(claim LeaseClaim, expected string) error {
+	if claim.Provider != providerName {
+		return exit(4, "lease %q is not a CUA claim", claim.LeaseID)
+	}
+	if claim.ProviderScope != expected {
+		return exit(4, "CUA lease %q belongs to a different API scope; restore the API URL used to create it", claim.LeaseID)
+	}
+	return nil
+}
+
+func validateSandboxOwnership(claim LeaseClaim, sandbox bridgeSandboxSummary, expectedScope string) error {
+	if err := validateClaimScope(claim, expectedScope); err != nil {
+		return err
+	}
+	expectedName := claimSandboxName(claim)
+	if expectedName == "" {
+		return exit(4, "CUA lease %q is missing its claimed sandbox name", claim.LeaseID)
+	}
+	actualName := strings.TrimSpace(blank(sandbox.Name, sandbox.ID))
+	if actualName != "" && actualName != expectedName {
+		return exit(4, "CUA sandbox %q does not match local claim %q", actualName, expectedName)
+	}
+	if !strings.HasPrefix(expectedName, sandboxNamePrefix) {
+		return exit(4, "CUA sandbox %q is not in the Crabbox-owned name prefix", expectedName)
+	}
+	return nil
+}
+
+func claimIsMissing(claim LeaseClaim) bool {
+	return claim.Labels != nil && claim.Labels[labelMissing] == "true"
+}
+
+func normalizeLeaseSlug(value string) string {
+	return strings.TrimSpace(coreNormalizeLeaseSlug(value))
+}
+
+func coreNormalizeLeaseSlug(value string) string {
+	return strings.ToLower(strings.Trim(strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			if r >= 'A' && r <= 'Z' {
+				return r + ('a' - 'A')
+			}
+			return r
+		}
+		return '-'
+	}, value), "-"))
+}

--- a/internal/providers/cua/claims_test.go
+++ b/internal/providers/cua/claims_test.go
@@ -1,0 +1,108 @@
+package cua
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCUALeaseIDAndSandboxNameUseProviderPrefix(t *testing.T) {
+	leaseID := newCUALeaseID()
+	if !strings.HasPrefix(leaseID, leasePrefix) {
+		t.Fatalf("leaseID=%q missing %q", leaseID, leasePrefix)
+	}
+	name := newSandboxName(leaseID, "My App")
+	if !strings.HasPrefix(name, sandboxNamePrefix) || strings.Contains(name, " ") {
+		t.Fatalf("sandbox name=%q", name)
+	}
+}
+
+func TestCUAScopeNormalizesAPIURL(t *testing.T) {
+	a := testConfig()
+	a.Cua.APIURL = "https://API.CUA.EXAMPLE:443/v1/"
+	b := testConfig()
+	b.Cua.APIURL = "https://api.cua.example/v1"
+	scopeA, err := cuaScope(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scopeB, err := cuaScope(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scopeA != scopeB || !strings.HasPrefix(scopeA, scopePrefix) {
+		t.Fatalf("scopes=%q %q", scopeA, scopeB)
+	}
+}
+
+func TestResolveClaimFiltersProviderAndScope(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := testConfig()
+	scope, err := cuaScope(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeClaim(t, core.LeaseClaim{
+		LeaseID:       "cuabx_111111111111",
+		Slug:          "demo",
+		Provider:      providerName,
+		CloudID:       "crabbox-cua-demo-111111",
+		ProviderScope: scope,
+		Labels:        claimLabels(cfg, "crabbox-cua-demo-111111", true),
+	})
+	claim, ok, err := resolveCUALeaseClaim("demo", cfg)
+	if err != nil {
+		t.Fatalf("resolve claim: %v", err)
+	}
+	if !ok || claim.LeaseID != "cuabx_111111111111" || !claimIsMissing(claim) {
+		t.Fatalf("claim=%#v ok=%v", claim, ok)
+	}
+	other := cfg
+	other.Cua.APIURL = "https://other.cua.example"
+	if _, _, err := resolveCUALeaseClaim("demo", other); err == nil {
+		t.Fatal("expected scope mismatch rejection")
+	}
+}
+
+func TestValidateSandboxOwnershipFailsClosed(t *testing.T) {
+	cfg := testConfig()
+	scope, err := cuaScope(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := core.LeaseClaim{
+		LeaseID:       "cuabx_222222222222",
+		Provider:      providerName,
+		ProviderScope: scope,
+		CloudID:       "crabbox-cua-demo-222222",
+	}
+	if err := validateSandboxOwnership(claim, bridgeSandboxSummary{Name: "crabbox-cua-demo-222222"}, scope); err != nil {
+		t.Fatalf("expected ownership to pass: %v", err)
+	}
+	if err := validateSandboxOwnership(claim, bridgeSandboxSummary{Name: "someone-else"}, scope); err == nil {
+		t.Fatal("expected name mismatch rejection")
+	}
+	claim.CloudID = "manual-sandbox"
+	if err := validateSandboxOwnership(claim, bridgeSandboxSummary{Name: "manual-sandbox"}, scope); err == nil {
+		t.Fatal("expected prefix mismatch rejection")
+	}
+}
+
+func writeClaim(t *testing.T, claim core.LeaseClaim) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, claim.LeaseID+".json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -23,6 +23,10 @@ type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type CleanupRequest = core.CleanupRequest
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+type Repo = core.Repo
+type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName             = "cua"

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -1,0 +1,50 @@
+package cua
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type CuaConfig = core.CuaConfig
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type DoctorCheck = core.DoctorCheck
+type WarmupRequest = core.WarmupRequest
+type RunRequest = core.RunRequest
+type RunResult = core.RunResult
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type StatusRequest = core.StatusRequest
+type StatusView = core.StatusView
+type StopRequest = core.StopRequest
+type CleanupRequest = core.CleanupRequest
+
+const (
+	providerName             = "cua"
+	defaultImage             = "ubuntu:24.04"
+	defaultKind              = "container"
+	defaultRegion            = ""
+	defaultWorkdir           = "/workspace/crabbox"
+	defaultBridgeCommand     = "python3"
+	defaultSDKPackage        = "cua"
+	defaultSDKImport         = "cua"
+	defaultSDKFallbackImport = "cua_sandbox"
+	targetLinux              = core.TargetLinux
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	return core.FlagWasSet(fs, name)
+}
+
+func blank(value, fallback string) string {
+	return core.Blank(value, fallback)
+}

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -2,6 +2,8 @@ package cua
 
 import (
 	"flag"
+	"io"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -25,8 +27,12 @@ type StopRequest = core.StopRequest
 type CleanupRequest = core.CleanupRequest
 type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
+type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
+type ExitError = core.ExitError
+type timingReport = core.TimingReport
+type timingPhase = core.TimingPhase
 
 const (
 	providerName             = "cua"
@@ -51,4 +57,72 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
+}
+
+func writeTimingJSON(w io.Writer, report timingReport) error {
+	return core.WriteTimingJSON(w, report)
+}
+
+func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
+	return core.TimingReportWithRunResult(report, result, err)
+}
+
+func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
+}
+
+func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
+	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+}
+
+func newLeaseSlug(leaseID string) string {
+	return core.NewLeaseSlug(leaseID)
+}
+
+func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
+	return core.AllocateClaimLeaseSlug(leaseID, requested)
+}
+
+func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, core.SSHTarget{})
+}
+
+func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
+	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
+}
+
+func readLeaseClaim(leaseID string) (LeaseClaim, error) {
+	return core.ReadLeaseClaim(leaseID)
+}
+
+func listCUALeaseClaims() ([]LeaseClaim, error) {
+	return core.ListLeaseClaimsWithPrefix(leasePrefix)
+}
+
+func removeLeaseClaim(leaseID string) {
+	core.RemoveLeaseClaim(leaseID)
+}
+
+func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
+}
+
+func updateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labels map[string]string) (LeaseClaim, error) {
+	return core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, expected, labels)
+}
+
+func shellQuote(value string) string {
+	return core.ShellQuote(value)
+}
+
+func shellScriptFromArgv(command []string) string {
+	return core.ShellScriptFromArgv(command)
+}
+
+func shouldUseShell(command []string) bool {
+	return core.ShouldUseShell(command)
+}
+
+func leadingEnvAssignment(command []string) bool {
+	return core.LeadingEnvAssignment(command)
 }

--- a/internal/providers/cua/doctor.go
+++ b/internal/providers/cua/doctor.go
@@ -1,0 +1,65 @@
+package cua
+
+import (
+	"context"
+	"strings"
+)
+
+func (b backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+	client := newBridgeClient(b.cfg, b.rt)
+	resp, err := client.RoundTrip(ctx, bridgeRequest{Action: "doctor"})
+	checks := []DoctorCheck{{
+		Status:  "ok",
+		Check:   "config",
+		Message: "provider=cua config=ready mutation=false",
+		Details: map[string]string{"provider": providerName, "mutation": "false"},
+	}}
+	if err != nil {
+		checks = append(checks, DoctorCheck{
+			Status:  "failed",
+			Check:   "bridge",
+			Message: redactSecrets(err.Error()),
+			Details: map[string]string{"provider": providerName, "class": "environment_blocked", "mutation": "false"},
+		})
+		return DoctorResult{Provider: providerName, Status: "failed", Message: "bridge=failed mutation=false", Checks: checks}, nil
+	}
+	for _, item := range resp.Doctor.Checks {
+		status := strings.TrimSpace(item.Status)
+		if status == "" {
+			status = "ok"
+		}
+		details := map[string]string{"provider": providerName, "mutation": "false"}
+		if item.Class != "" {
+			details["class"] = item.Class
+		}
+		for key, value := range item.Details {
+			details[key] = value
+		}
+		checks = append(checks, DoctorCheck{
+			Status:  status,
+			Check:   strings.TrimSpace(blank(item.Check, "bridge")),
+			Message: redactSecrets(item.Message),
+			Details: details,
+		})
+	}
+	if resp.Error != nil {
+		checks = append(checks, DoctorCheck{
+			Status:  "failed",
+			Check:   strings.TrimSpace(blank(resp.Error.Code, "bridge")),
+			Message: redactSecrets(resp.Error.Message),
+			Details: map[string]string{"provider": providerName, "class": blank(resp.Error.Class, "environment_blocked"), "mutation": "false"},
+		})
+	}
+	status := aggregateStatus(checks)
+	message := "bridge=ready mutation=false"
+	if status != "ok" {
+		message = "bridge=classified mutation=false"
+	}
+	if resp.Doctor.ImportPath != "" {
+		message += " import=" + resp.Doctor.ImportPath
+	}
+	if resp.Doctor.Auth != "" {
+		message += " auth=" + resp.Doctor.Auth
+	}
+	return DoctorResult{Provider: providerName, Status: status, Message: message, Checks: checks}, nil
+}

--- a/internal/providers/cua/doctor_status.go
+++ b/internal/providers/cua/doctor_status.go
@@ -1,0 +1,15 @@
+package cua
+
+func aggregateStatus(checks []DoctorCheck) string {
+	for _, check := range checks {
+		if check.Status == "failed" || check.Status == "missing" {
+			return "failed"
+		}
+	}
+	for _, check := range checks {
+		if check.Status == "warning" {
+			return "warning"
+		}
+	}
+	return "ok"
+}

--- a/internal/providers/cua/doctor_test.go
+++ b/internal/providers/cua/doctor_test.go
@@ -1,0 +1,42 @@
+package cua
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDoctorUsesBridgeClassification(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		_, _ = io.WriteString(req.Stdout, `{"ok":false,"class":"environment_blocked","doctor":{"pythonVersion":"3.11.9","importPath":"cua_sandbox","auth":"credential_store_or_missing","checks":[{"status":"ok","check":"python","message":"python=3.11.9 required=3.11+"},{"status":"ok","check":"sdk","message":"import=cua_sandbox","details":{"import":"cua_sandbox"}},{"status":"failed","check":"auth","message":"auth=missing_or_credential_store_unverified mutation=false","class":"environment_blocked"}]}}`)
+		return LocalCommandResult{ExitCode: 0}, nil
+	}}
+	result, err := (backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: Runtime{Exec: runner}}).Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if result.Status != "failed" || !strings.Contains(result.Message, "import=cua_sandbox") {
+		t.Fatalf("result=%#v", result)
+	}
+	if len(result.Checks) != 4 {
+		t.Fatalf("checks=%#v", result.Checks)
+	}
+	auth := result.Checks[len(result.Checks)-1]
+	if auth.Check != "auth" || auth.Details["class"] != "environment_blocked" || auth.Details["mutation"] != "false" {
+		t.Fatalf("auth check=%#v", auth)
+	}
+}
+
+func TestDoctorClassifiesBridgeTransportFailureWithoutReturningError(t *testing.T) {
+	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		return LocalCommandResult{ExitCode: 127}, nil
+	}}
+	result, err := (backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: Runtime{Exec: runner}}).Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatalf("Doctor returned transport error instead of classified result: %v", err)
+	}
+	if result.Status != "failed" || result.Checks[len(result.Checks)-1].Details["class"] != "environment_blocked" {
+		t.Fatalf("result=%#v", result)
+	}
+}

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -1,0 +1,211 @@
+package cua
+
+import (
+	"flag"
+	"net"
+	"net/url"
+	"path"
+	"strings"
+)
+
+type flagValues struct {
+	APIURL             *string
+	Image              *string
+	Kind               *string
+	Region             *string
+	Workdir            *string
+	VCPUs              *int
+	MemoryMB           *int
+	DiskGB             *int
+	StartupTimeoutSecs *int
+	ExecTimeoutSecs    *int
+	BridgeCommand      *string
+	SDKPackage         *string
+	SDKImport          *string
+	SDKFallbackImport  *string
+	ForgetMissing      *bool
+}
+
+func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
+	cfg := defaults.Cua
+	return flagValues{
+		APIURL:             fs.String("cua-api-url", cfg.APIURL, "Trusted CUA API base URL; not accepted from repository config"),
+		Image:              fs.String("cua-image", cfg.Image, "CUA Linux sandbox image"),
+		Kind:               fs.String("cua-kind", cfg.Kind, "CUA sandbox kind: container or vm"),
+		Region:             fs.String("cua-region", cfg.Region, "CUA deployment region (empty = service default/policy)"),
+		Workdir:            fs.String("cua-workdir", cfg.Workdir, "Absolute working directory inside the sandbox"),
+		VCPUs:              fs.Int("cua-vcpus", cfg.VCPUs, "CUA sandbox vCPU count (0 = service default)"),
+		MemoryMB:           fs.Int("cua-memory-mb", cfg.MemoryMB, "CUA sandbox memory in MB (0 = service default)"),
+		DiskGB:             fs.Int("cua-disk-gb", cfg.DiskGB, "CUA sandbox disk in GB (0 = service default)"),
+		StartupTimeoutSecs: fs.Int("cua-startup-timeout-secs", cfg.StartupTimeoutSecs, "CUA sandbox startup timeout in seconds (0 = Crabbox default)"),
+		ExecTimeoutSecs:    fs.Int("cua-exec-timeout-secs", cfg.ExecTimeoutSecs, "CUA command timeout in seconds (0 = Crabbox default 600)"),
+		BridgeCommand:      fs.String("cua-bridge-command", cfg.BridgeCommand, "trusted local Python command for the future CUA SDK bridge"),
+		SDKPackage:         fs.String("cua-sdk-package", cfg.SDKPackage, "trusted local Python package name for CUA SDK diagnostics"),
+		SDKImport:          fs.String("cua-sdk-import", cfg.SDKImport, "trusted local Python import path for CUA SDK diagnostics"),
+		SDKFallbackImport:  fs.String("cua-sdk-fallback-import", cfg.SDKFallbackImport, "trusted local fallback import path for CUA SDK diagnostics"),
+		ForgetMissing:      fs.Bool("cua-forget-missing", cfg.ForgetMissing, "remove the local claim when stop gets 404 (explicit stale-claim cleanup)"),
+	}
+}
+
+func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
+		if flagWasSet(fs, "class") {
+			return exit(2, "--class is not supported for provider=cua; use --cua-vcpus and --cua-memory-mb")
+		}
+		if flagWasSet(fs, "type") {
+			return exit(2, "--type is not supported for provider=cua; use --cua-image and --cua-kind")
+		}
+	}
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "cua-api-url") {
+		cfg.Cua.APIURL = *v.APIURL
+	}
+	if flagWasSet(fs, "cua-image") {
+		cfg.Cua.Image = *v.Image
+	}
+	if flagWasSet(fs, "cua-kind") {
+		cfg.Cua.Kind = *v.Kind
+	}
+	if flagWasSet(fs, "cua-region") {
+		cfg.Cua.Region = *v.Region
+	}
+	if flagWasSet(fs, "cua-workdir") {
+		cfg.Cua.Workdir = *v.Workdir
+	}
+	if flagWasSet(fs, "cua-vcpus") {
+		cfg.Cua.VCPUs = *v.VCPUs
+	}
+	if flagWasSet(fs, "cua-memory-mb") {
+		cfg.Cua.MemoryMB = *v.MemoryMB
+	}
+	if flagWasSet(fs, "cua-disk-gb") {
+		cfg.Cua.DiskGB = *v.DiskGB
+	}
+	if flagWasSet(fs, "cua-startup-timeout-secs") {
+		cfg.Cua.StartupTimeoutSecs = *v.StartupTimeoutSecs
+	}
+	if flagWasSet(fs, "cua-exec-timeout-secs") {
+		cfg.Cua.ExecTimeoutSecs = *v.ExecTimeoutSecs
+	}
+	if flagWasSet(fs, "cua-bridge-command") {
+		cfg.Cua.BridgeCommand = *v.BridgeCommand
+	}
+	if flagWasSet(fs, "cua-sdk-package") {
+		cfg.Cua.SDKPackage = *v.SDKPackage
+	}
+	if flagWasSet(fs, "cua-sdk-import") {
+		cfg.Cua.SDKImport = *v.SDKImport
+	}
+	if flagWasSet(fs, "cua-sdk-fallback-import") {
+		cfg.Cua.SDKFallbackImport = *v.SDKFallbackImport
+	}
+	if flagWasSet(fs, "cua-forget-missing") {
+		cfg.Cua.ForgetMissing = *v.ForgetMissing
+	}
+	return validateProviderConfig(*cfg)
+}
+
+func validateProviderConfig(cfg Config) error {
+	if _, err := cuaAPIURL(cfg); err != nil {
+		return err
+	}
+	if _, err := cuaWorkdir(cfg); err != nil {
+		return err
+	}
+	kind := strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind)))
+	if kind != "container" && kind != "vm" {
+		return exit(2, "%s kind must be container or vm", providerName)
+	}
+	if cfg.Cua.VCPUs < 0 {
+		return exit(2, "%s vcpus must be non-negative", providerName)
+	}
+	if cfg.Cua.MemoryMB < 0 {
+		return exit(2, "%s memoryMB must be non-negative", providerName)
+	}
+	if cfg.Cua.DiskGB < 0 {
+		return exit(2, "%s diskGB must be non-negative", providerName)
+	}
+	if cfg.Cua.StartupTimeoutSecs < 0 {
+		return exit(2, "%s startupTimeoutSecs must be non-negative", providerName)
+	}
+	if cfg.Cua.ExecTimeoutSecs < 0 {
+		return exit(2, "%s execTimeoutSecs must be non-negative", providerName)
+	}
+	if strings.TrimSpace(cfg.Cua.BridgeCommand) == "" {
+		return exit(2, "%s bridgeCommand must not be empty", providerName)
+	}
+	if strings.TrimSpace(cfg.Cua.SDKPackage) == "" {
+		return exit(2, "%s sdkPackage must not be empty", providerName)
+	}
+	if strings.TrimSpace(cfg.Cua.SDKImport) == "" {
+		return exit(2, "%s sdkImport must not be empty", providerName)
+	}
+	return nil
+}
+
+func cuaWorkdir(cfg Config) (string, error) {
+	workdir := strings.TrimSpace(blank(cfg.Cua.Workdir, defaultWorkdir))
+	if !path.IsAbs(workdir) {
+		return "", exit(2, "%s workdir must be absolute", providerName)
+	}
+	clean := path.Clean(workdir)
+	if clean == "/workspace" {
+		return "", exit(2, "%s workdir %q is too broad; choose a dedicated subdirectory", providerName, clean)
+	}
+	if !strings.HasPrefix(clean, "/workspace/") {
+		return "", exit(2, "%s workdir %q must be under /workspace/<dedicated-subdir>", providerName, clean)
+	}
+	return clean, nil
+}
+
+func cuaAPIURL(cfg Config) (string, error) {
+	raw := strings.TrimSpace(cfg.Cua.APIURL)
+	if raw == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", exit(2, "%s API URL must be an absolute HTTP(S) URL", providerName)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+		return "", exit(2, "%s API URL must use HTTPS except for loopback development endpoints", providerName)
+	}
+	host := canonicalHostname(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func canonicalHostname(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.String()
+	}
+	return strings.TrimSuffix(host, ".")
+}

--- a/internal/providers/cua/flags_test.go
+++ b/internal/providers/cua/flags_test.go
@@ -1,0 +1,149 @@
+package cua
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderFlagsApplyAndValidate(t *testing.T) {
+	cfg := core.Config{Provider: providerName, Cua: core.CuaConfig{
+		Image:             defaultImage,
+		Kind:              defaultKind,
+		Workdir:           defaultWorkdir,
+		ExecTimeoutSecs:   600,
+		BridgeCommand:     defaultBridgeCommand,
+		SDKPackage:        defaultSDKPackage,
+		SDKImport:         defaultSDKImport,
+		SDKFallbackImport: defaultSDKFallbackImport,
+	}}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := Provider{}.RegisterFlags(fs, cfg)
+	if err := fs.Parse([]string{
+		"--cua-api-url", "https://API.CUA.EXAMPLE:443/v1/",
+		"--cua-image", "ubuntu:24.04",
+		"--cua-kind", "vm",
+		"--cua-region", "us-west",
+		"--cua-workdir", "/workspace/app",
+		"--cua-vcpus", "4",
+		"--cua-memory-mb", "8192",
+		"--cua-disk-gb", "40",
+		"--cua-startup-timeout-secs", "300",
+		"--cua-exec-timeout-secs", "120",
+		"--cua-bridge-command", "python3.12",
+		"--cua-sdk-package", "cua",
+		"--cua-sdk-import", "cua",
+		"--cua-sdk-fallback-import", "cua_sandbox",
+		"--cua-forget-missing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Cua.APIURL != "https://API.CUA.EXAMPLE:443/v1/" ||
+		cfg.Cua.Image != "ubuntu:24.04" ||
+		cfg.Cua.Kind != "vm" ||
+		cfg.Cua.Region != "us-west" ||
+		cfg.Cua.Workdir != "/workspace/app" ||
+		cfg.Cua.VCPUs != 4 ||
+		cfg.Cua.MemoryMB != 8192 ||
+		cfg.Cua.DiskGB != 40 ||
+		cfg.Cua.StartupTimeoutSecs != 300 ||
+		cfg.Cua.ExecTimeoutSecs != 120 ||
+		cfg.Cua.BridgeCommand != "python3.12" ||
+		cfg.Cua.SDKPackage != "cua" ||
+		cfg.Cua.SDKImport != "cua" ||
+		cfg.Cua.SDKFallbackImport != "cua_sandbox" ||
+		!cfg.Cua.ForgetMissing {
+		t.Fatalf("cfg.Cua=%#v", cfg.Cua)
+	}
+}
+
+func TestValidateProviderConfigRejectsUnsafeValues(t *testing.T) {
+	base := core.CuaConfig{
+		Image:             defaultImage,
+		Kind:              defaultKind,
+		Workdir:           defaultWorkdir,
+		BridgeCommand:     defaultBridgeCommand,
+		SDKPackage:        defaultSDKPackage,
+		SDKImport:         defaultSDKImport,
+		SDKFallbackImport: defaultSDKFallbackImport,
+	}
+	tests := []struct {
+		name string
+		edit func(*core.CuaConfig)
+	}{
+		{name: "api-url-userinfo", edit: func(cfg *core.CuaConfig) { cfg.APIURL = "https://token@example.test" }},
+		{name: "api-url-query", edit: func(cfg *core.CuaConfig) { cfg.APIURL = "https://api.example.test?token=abc" }},
+		{name: "api-url-fragment", edit: func(cfg *core.CuaConfig) { cfg.APIURL = "https://api.example.test/#frag" }},
+		{name: "api-url-http", edit: func(cfg *core.CuaConfig) { cfg.APIURL = "http://api.example.test" }},
+		{name: "kind", edit: func(cfg *core.CuaConfig) { cfg.Kind = "desktop" }},
+		{name: "vcpus", edit: func(cfg *core.CuaConfig) { cfg.VCPUs = -1 }},
+		{name: "memory", edit: func(cfg *core.CuaConfig) { cfg.MemoryMB = -1 }},
+		{name: "disk", edit: func(cfg *core.CuaConfig) { cfg.DiskGB = -1 }},
+		{name: "startup", edit: func(cfg *core.CuaConfig) { cfg.StartupTimeoutSecs = -1 }},
+		{name: "exec", edit: func(cfg *core.CuaConfig) { cfg.ExecTimeoutSecs = -1 }},
+		{name: "workdir-relative", edit: func(cfg *core.CuaConfig) { cfg.Workdir = "relative" }},
+		{name: "workdir-broad", edit: func(cfg *core.CuaConfig) { cfg.Workdir = "/workspace" }},
+		{name: "workdir-outside", edit: func(cfg *core.CuaConfig) { cfg.Workdir = "/tmp/app" }},
+		{name: "bridge-command-empty", edit: func(cfg *core.CuaConfig) { cfg.BridgeCommand = "" }},
+		{name: "sdk-package-empty", edit: func(cfg *core.CuaConfig) { cfg.SDKPackage = "" }},
+		{name: "sdk-import-empty", edit: func(cfg *core.CuaConfig) { cfg.SDKImport = "" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.edit(&cfg)
+			err := validateProviderConfig(core.Config{Cua: cfg})
+			if err == nil {
+				t.Fatalf("validateProviderConfig(%#v) succeeded", cfg)
+			}
+			if strings.Contains(err.Error(), "token=abc") {
+				t.Fatalf("error leaked URL query secret: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateProviderConfigAllowsLoopbackAPIURL(t *testing.T) {
+	cfg := core.Config{Cua: core.CuaConfig{
+		APIURL:            "http://localhost:8080/v1/",
+		Image:             defaultImage,
+		Kind:              defaultKind,
+		Workdir:           defaultWorkdir,
+		BridgeCommand:     defaultBridgeCommand,
+		SDKPackage:        defaultSDKPackage,
+		SDKImport:         defaultSDKImport,
+		SDKFallbackImport: defaultSDKFallbackImport,
+	}}
+	if err := validateProviderConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProviderRejectsGenericClassAndTypeFlags(t *testing.T) {
+	for _, args := range [][]string{{"--class", "large"}, {"--type", "gpu"}} {
+		cfg := core.Config{Provider: providerName, Cua: core.CuaConfig{
+			Image:             defaultImage,
+			Kind:              defaultKind,
+			Workdir:           defaultWorkdir,
+			BridgeCommand:     defaultBridgeCommand,
+			SDKPackage:        defaultSDKPackage,
+			SDKImport:         defaultSDKImport,
+			SDKFallbackImport: defaultSDKFallbackImport,
+		}}
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("class", "", "")
+		fs.String("type", "", "")
+		values := Provider{}.RegisterFlags(fs, cfg)
+		if err := fs.Parse(args); err != nil {
+			t.Fatal(err)
+		}
+		if err := (Provider{}).ApplyFlags(&cfg, fs, values); err == nil {
+			t.Fatalf("ApplyFlags(%v) succeeded", args)
+		}
+	}
+}

--- a/internal/providers/cua/provider.go
+++ b/internal/providers/cua/provider.go
@@ -1,0 +1,62 @@
+package cua
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() {
+	core.RegisterProvider(Provider{})
+}
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) ServerTypeForConfig(core.Config) string { return "" }
+func (Provider) ServerTypeForClass(string) string       { return "" }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:        providerName,
+		Family:      providerName,
+		Kind:        core.ProviderKindDelegatedRun,
+		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return RegisterProviderFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return ApplyProviderFlags(cfg, fs, values)
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	return validateProviderConfig(cfg)
+}
+
+func (p Provider) Configure(cfg core.Config, _ core.Runtime) (core.Backend, error) {
+	if err := p.ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	cfg.Provider = providerName
+	return backend{spec: p.Spec(), cfg: cfg}, nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}

--- a/internal/providers/cua/provider.go
+++ b/internal/providers/cua/provider.go
@@ -41,12 +41,12 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return validateProviderConfig(cfg)
 }
 
-func (p Provider) Configure(cfg core.Config, _ core.Runtime) (core.Backend, error) {
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, err
 	}
 	cfg.Provider = providerName
-	return backend{spec: p.Spec(), cfg: cfg}, nil
+	return backend{spec: p.Spec(), cfg: cfg, rt: rt}, nil
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {

--- a/internal/providers/cua/provider_test.go
+++ b/internal/providers/cua/provider_test.go
@@ -1,0 +1,99 @@
+package cua
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProviderSpecAndRegistration(t *testing.T) {
+	p := Provider{}
+	if p.Name() != providerName {
+		t.Fatalf("Name=%q want %q", p.Name(), providerName)
+	}
+	if len(p.Aliases()) != 0 {
+		t.Fatalf("Aliases=%v, want none", p.Aliases())
+	}
+	spec := p.Spec()
+	if spec.Name != providerName || spec.Family != providerName {
+		t.Fatalf("spec identity=%#v", spec)
+	}
+	if spec.Kind != core.ProviderKindDelegatedRun {
+		t.Fatalf("Kind=%q want delegated-run", spec.Kind)
+	}
+	if len(spec.Targets) != 1 || spec.Targets[0].OS != core.TargetLinux {
+		t.Fatalf("Targets=%#v", spec.Targets)
+	}
+	for _, feature := range []core.Feature{core.FeatureArchiveSync, core.FeatureCleanup} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("Features=%#v missing %s", spec.Features, feature)
+		}
+	}
+	for _, feature := range []core.Feature{
+		core.FeatureSSH,
+		core.FeatureDesktop,
+		core.FeatureBrowser,
+		core.FeatureCode,
+		core.FeatureTailscale,
+		core.FeatureURLBridge,
+		core.FeatureCheckpoint,
+		core.FeatureFork,
+		core.FeatureSnapshot,
+		core.FeatureCacheVolume,
+		core.FeatureRunSession,
+		core.FeatureRunArtifacts,
+		core.FeatureRunDownloads,
+		core.FeatureMCP,
+	} {
+		if spec.Features.Has(feature) {
+			t.Fatalf("Features=%#v unexpectedly advertises %s", spec.Features, feature)
+		}
+	}
+	if spec.Coordinator != core.CoordinatorNever {
+		t.Fatalf("Coordinator=%q want never", spec.Coordinator)
+	}
+	got, err := core.ProviderFor(providerName)
+	if err != nil {
+		t.Fatalf("ProviderFor(cua): %v", err)
+	}
+	if got.Name() != providerName {
+		t.Fatalf("ProviderFor(cua).Name=%q", got.Name())
+	}
+	for _, alias := range []string{"cua-cloud", "cua-sandbox", "trycua"} {
+		if got, err := core.ProviderFor(alias); err == nil && got.Name() == providerName {
+			t.Fatalf("alias %q unexpectedly resolves to cua", alias)
+		}
+	}
+}
+
+func TestProviderMetadataEntry(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "providers", "provider-metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata map[string]struct {
+		Category  string `json:"category"`
+		Substrate string `json:"substrate"`
+		SSH       string `json:"ssh"`
+		Sync      string `json:"sync"`
+		GPU       string `json:"gpu"`
+		Cleanup   string `json:"cleanup"`
+		Docs      string `json:"docs"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := metadata[providerName]
+	if !ok {
+		t.Fatalf("provider metadata missing %q", providerName)
+	}
+	if entry.Category != "delegated-sandbox" || entry.SSH != "no" || entry.Sync != "archive-sync" || entry.GPU != "unknown" || entry.Docs != "cua.md" {
+		t.Fatalf("unexpected cua metadata: %#v", entry)
+	}
+	if entry.Substrate == "" || entry.Cleanup == "" {
+		t.Fatalf("incomplete cua metadata: %#v", entry)
+	}
+}

--- a/internal/providers/cua/sync.go
+++ b/internal/providers/cua/sync.go
@@ -1,0 +1,52 @@
+package cua
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func (b backend) syncWorkspace(ctx context.Context, client *bridgeClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config:              b.cfg,
+		Repo:                req.Repo,
+		ForceSyncLarge:      req.ForceSyncLarge,
+		Workdir:             workdir,
+		TempPattern:         "crabbox-cua-sync-*.tgz",
+		RemoteArchiveDir:    "/tmp",
+		RemoteArchivePrefix: "crabbox-cua-sync-",
+		PhaseName:           "cua_sync",
+		Provider:            providerName,
+		Stderr:              b.rt.Stderr,
+		Now:                 b.now,
+		CleanupContext:      b.cleanupContext,
+		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
+			file, err := bridgeFileFromReader(remoteArchive, body)
+			if err != nil {
+				return err
+			}
+			return client.UploadBytes(uploadCtx, sandboxID, file)
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, sandboxID, command)
+		},
+	})
+}
+
+func (b backend) execShell(ctx context.Context, client *bridgeClient, sandboxID, command string) error {
+	resp, err := client.Exec(ctx, sandboxID, []string{"bash", "-lc", command}, "", nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.ExitCode != 0 {
+		return exit(resp.ExitCode, "CUA exec %q exited %d: %s", command, resp.ExitCode, strings.TrimSpace(resp.Stderr))
+	}
+	return nil
+}
+
+func (b backend) ensureWorkspace(ctx context.Context, client *bridgeClient, sandboxID, workdir string) error {
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir))
+}

--- a/scripts/live-cua-smoke.sh
+++ b/scripts/live-cua-smoke.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+classification_emitted=0
+repo_root=""
+bin=""
+smoke_root=""
+smoke_repo=""
+slug="crabbox-cua-smoke-$$"
+sandbox_maybe_created=0
+
+classify_and_exit() {
+  trap - ERR
+  if [[ $classification_emitted -ne 0 ]]; then
+    exit 1
+  fi
+  local classification="$1"
+  local message="${2:-}"
+  local cleanup_output=""
+  if [[ $sandbox_maybe_created -ne 0 ]]; then
+    if cleanup_output="$(cleanup_created_sandbox 2>&1)"; then
+      sandbox_maybe_created=0
+    else
+      classification="cleanup_failed"
+      message="slug=$slug $(redact "$cleanup_output")"
+    fi
+  fi
+  classification_emitted=1
+  if [[ -n "$message" ]]; then
+    printf '%s %s\n' "$classification" "$message"
+  else
+    printf '%s\n' "$classification"
+  fi
+  case "$classification" in
+    live_cua_smoke_passed|skipped|environment_blocked|quota_blocked|diagnostic_only) exit 0 ;;
+    validation_failed|cleanup_failed) exit 1 ;;
+    *) exit 1 ;;
+  esac
+}
+
+classify_unexpected_failure() {
+  local status="$1"
+  local line="$2"
+  classify_and_exit diagnostic_only "unexpected_failure status=$status line=$line"
+}
+
+classify_failure_output() {
+  local output="$1"
+  if grep -Eiq 'quota|capacity|rate limit|too many requests|429|insufficient' <<<"$output"; then
+    classify_and_exit quota_blocked "$(redact "$output")"
+  fi
+  if grep -Eiq 'api key|unauthorized|forbidden|permission|connection refused|no such host|timeout|TLS|x509|python|import|module' <<<"$output"; then
+    classify_and_exit environment_blocked "$(redact "$output")"
+  fi
+  if grep -Eiq 'validation|invalid|unsupported|missing command|workdir|target' <<<"$output"; then
+    classify_and_exit validation_failed "$(redact "$output")"
+  fi
+  classify_and_exit diagnostic_only "$(redact "$output")"
+}
+
+redact() {
+  sed -E 's/(CRABBOX_CUA_API_KEY|CUA_API_KEY)=([^[:space:]]+)/\1=[redacted]/g; s/(cua_[A-Za-z0-9._-]{8,})/[redacted]/g; s/(sk-[A-Za-z0-9._-]{8,})/[redacted]/g' <<<"$1"
+}
+
+cleanup() {
+  cleanup_created_sandbox >/dev/null 2>&1 || true
+  if [[ -n "$smoke_root" ]]; then
+    rm -rf -- "$smoke_root"
+  fi
+}
+
+cleanup_created_sandbox() {
+  if [[ $sandbox_maybe_created -eq 0 || -z "$bin" || ! -x "$bin" ]]; then
+    return 0
+  fi
+  trap - ERR
+  "$bin" stop --provider cua --cua-forget-missing "$slug"
+  local cleanup_status=$?
+  trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+  if [[ $cleanup_status -eq 0 ]]; then
+    sandbox_maybe_created=0
+  fi
+  return "$cleanup_status"
+}
+trap cleanup EXIT
+trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "${CRABBOX_CUA_LIVE:-0}" != "1" ]]; then
+  classify_and_exit skipped "reason=missing_CRABBOX_CUA_LIVE"
+fi
+
+if [[ -z "${CRABBOX_CUA_API_KEY:-${CUA_API_KEY:-}}" ]]; then
+  classify_and_exit environment_blocked "reason=missing_CRABBOX_CUA_API_KEY_or_CUA_API_KEY"
+fi
+
+bin="${CRABBOX_BIN:-$repo_root/bin/crabbox}"
+smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/crabbox-cua-smoke.XXXXXX")"
+smoke_repo="$smoke_root/repo"
+export XDG_STATE_HOME="$smoke_root/state"
+export CRABBOX_CUA_SMOKE_VALUE="forwarded-ok"
+
+mkdir -p "$(dirname "$bin")"
+go build -trimpath -o "$bin" ./cmd/crabbox
+
+mkdir -p "$smoke_repo"
+cd "$smoke_repo"
+git init -q
+git config user.email smoke@example.com
+git config user.name "Crabbox CUA Smoke"
+printf 'provider: cua\nsync:\n  delete: true\n' >.crabbox.yaml
+printf 'v1\n' >proof.txt
+printf 'remove-me\n' >stale.txt
+git add .crabbox.yaml proof.txt stale.txt
+git commit -qm "test: seed CUA smoke fixture"
+
+trap - ERR
+if doctor_output="$("$bin" doctor --provider cua --json 2>&1)"; then
+  doctor_status=0
+else
+  doctor_status=$?
+fi
+trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+if [[ $doctor_status -ne 0 ]]; then
+  classify_failure_output "$doctor_output"
+fi
+
+trap - ERR
+if warmup_output="$("$bin" warmup --provider cua --slug "$slug" --timing-json 2>&1)"; then
+  warmup_status=0
+else
+  warmup_status=$?
+fi
+trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+if [[ $warmup_status -ne 0 ]]; then
+  classify_failure_output "$warmup_output"
+fi
+sandbox_maybe_created=1
+
+"$bin" status --provider cua --id "$slug" --wait --wait-timeout 300s >/dev/null
+"$bin" list --provider cua --json >/dev/null
+
+trap - ERR
+if run_output="$("$bin" run --provider cua --id "$slug" --timing-json \
+  --allow-env CRABBOX_CUA_SMOKE_VALUE -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v1 && test -f stale.txt && test "$CRABBOX_CUA_SMOKE_VALUE" = forwarded-ok && printf CUA_SMOKE_V1_OK' 2>&1)"; then
+  run_status=0
+else
+  run_status=$?
+fi
+trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+if [[ $run_status -ne 0 ]]; then
+  classify_failure_output "$run_output"
+fi
+if ! grep -q 'CUA_SMOKE_V1_OK' <<<"$run_output" || ! grep -q '"syncDelegated":true' <<<"$run_output"; then
+  classify_and_exit diagnostic_only "initial run succeeded but sync proof was incomplete"
+fi
+
+printf 'v2\n' >proof.txt
+printf 'second\n' >second.txt
+git add proof.txt second.txt
+git rm -q stale.txt
+
+trap - ERR
+if reuse_output="$("$bin" run --provider cua --id "$slug" --timing-json -- \
+  /bin/sh -lc 'test "$(cat proof.txt)" = v2 && test -f second.txt && test ! -e stale.txt && printf CUA_SMOKE_V2_OK' 2>&1)"; then
+  reuse_status=0
+else
+  reuse_status=$?
+fi
+trap 'classify_unexpected_failure "$?" "$LINENO"' ERR
+if [[ $reuse_status -ne 0 ]]; then
+  classify_failure_output "$reuse_output"
+fi
+if ! grep -q 'CUA_SMOKE_V2_OK' <<<"$reuse_output" || ! grep -q '"syncDelegated":true' <<<"$reuse_output"; then
+  classify_and_exit diagnostic_only "reuse run succeeded but replacement proof was incomplete"
+fi
+
+"$bin" stop --provider cua "$slug" >/dev/null
+sandbox_maybe_created=0
+trap - EXIT
+rm -rf -- "$smoke_root"
+
+classify_and_exit live_cua_smoke_passed

--- a/scripts/live-cua-smoke.test.js
+++ b/scripts/live-cua-smoke.test.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const script = path.join(import.meta.dirname, "live-cua-smoke.sh");
+
+test("CUA live smoke skips without explicit live opt-in", () => {
+  const result = spawnSync("bash", [script], {
+    env: {
+      ...process.env,
+      CRABBOX_CUA_LIVE: "",
+      CRABBOX_CUA_API_KEY: "",
+      CUA_API_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^skipped reason=missing_CRABBOX_CUA_LIVE\n$/);
+});
+
+test("CUA live smoke classifies opt-in without credentials as environment_blocked", () => {
+  const result = spawnSync("bash", [script], {
+    env: {
+      ...process.env,
+      CRABBOX_CUA_LIVE: "1",
+      CRABBOX_CUA_API_KEY: "",
+      CUA_API_KEY: "",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^environment_blocked reason=missing_CRABBOX_CUA_API_KEY_or_CUA_API_KEY\n$/);
+});

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -1042,6 +1042,10 @@ if has_provider opensandbox; then
   "$root/scripts/live-opensandbox-smoke.sh"
 fi
 
+if has_provider cua; then
+  "$root/scripts/live-cua-smoke.sh"
+fi
+
 if has_provider proxmox; then
   "$root/scripts/proxmox-live-smoke.sh"
 fi


### PR DESCRIPTION
## Summary
- add the CUA delegated-run provider with config, bridge, claims, doctor, archive sync, retained reuse, stop, and cleanup lifecycle support
- register CUA in provider metadata, docs, generated matrix, source map, changelog, and live smoke dispatch
- add opt-in `scripts/live-cua-smoke.sh` coverage with explicit skip/environment/quota/validation/cleanup classifications

## Verification
- `go test -count=1 ./internal/providers/cua ./internal/providers/all ./internal/cli`
- `go test -count=1 ./...`
- `go vet ./...`
- `node scripts/generate-provider-matrix.mjs`
- `node scripts/check-provider-matrix.mjs`
- `bash scripts/check-docs.sh`
- `go build -trimpath -o /tmp/crabbox-cua-integrated ./cmd/crabbox`
- `(cd /tmp && /tmp/crabbox-cua-integrated providers)`
- `(cd /tmp && /tmp/crabbox-cua-integrated doctor --provider cua --json)` classified local environment as blocked because the CUA Python SDK is not installed
- `scripts/live-cua-smoke.sh` classified `skipped reason=missing_CRABBOX_CUA_LIVE` with no live resources created
- `autoreview --mode branch --base origin/main --engine copilot --model auto` reported no accepted/actionable findings

## Notes
- Codex AutoReview with `gpt-5.5` was quota-blocked during closeout; Claude fallback was unavailable because Claude Code was not logged in. The structured Copilot AutoReview fallback passed cleanly.
- Direct push to `openclaw/crabbox` was denied for the authenticated account, so this branch is published from the fork.